### PR TITLE
Add CuTeDSL scatter_add override for the expanded-1D-index pattern

### DIFF
--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -412,12 +412,18 @@ class TestPublicBindings(TestCase):
 
         errors = []
         for mod, exc in failures:
+            # Prefixes for modules whose top-level imports pull in optional
+            # runtime deps (cutlass, cuda-python, triton) that aren't
+            # available in CPU-only CI. Registrations are no-ops when the
+            # runtime is missing, so it's safe to skip them here.
+            cuda_dep_prefixes = (
+                "torch._native.ops.scatter_add.",
+                "torch._vendor.quack",
+            )
             if (
                 mod in private_allowlist
                 or (mod.startswith("torch._native.ops.") and "triton" in mod)
-                # torch._vendor.quack depends on cutlass / cuda-python, which
-                # are only installed on CUDA-enabled x86 Linux builds.
-                or mod.startswith("torch._vendor.quack")
+                or mod.startswith(cuda_dep_prefixes)
             ):
                 if self._is_mod_public(mod):
                     raise AssertionError(

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -611,6 +611,17 @@ class TestScatterAddOverrideConds(TestCase):
             self.assertFalse(self.impl._tma_cond(self_t, 0, idx, src))
             self.assertFalse(self.impl._vs_cond(self_t, 0, idx, src))
 
+    def test_rejects_empty_self(self):
+        # self.shape[0] == 0 with a non-empty src would have every index
+        # out of range. Cond must reject so aten raises the index error
+        # instead of our kernel silently writing OOB.
+        self_t = torch.zeros(0, 128, device="cuda", dtype=torch.float32)
+        src = torch.randn(5, 128, device="cuda", dtype=torch.float32)
+        idx = _expanded_idx(
+            torch.zeros(5, device="cuda", dtype=torch.int64), (128,)
+        )
+        self.assertEqual(self._conds(self_t, idx, src), (False, False))
+
 
 @unittest.skipUnless(TEST_CUDA, "needs CUDA")
 @skipIfNoCuteDSL
@@ -684,6 +695,18 @@ class TestScatterAddOverrideCorrectness(TestCase):
         got = torch.scatter_add(self_t, 0, idx, src)
         self.assertEqual(got[0], src.sum(0), atol=1e-3, rtol=1e-3)
         self.assertEqual(got[1:].abs().sum().item(), 0)
+
+    def test_deterministic_mode_uses_aten(self):
+        # Under use_deterministic_algorithms(True), the cond rejects and
+        # scatter_add falls through to aten's deterministic path. Verify
+        # end-to-end numerics match a naive reference.
+        torch.manual_seed(0)
+        self_t, idx, src, idx_1d = _make_override_triple(200, 100, (128,))
+        ref = _naive_scatter_add(self_t, idx_1d, src)
+        with DeterministicGuard(True):
+            got = torch.scatter_add(self_t, 0, idx, src)
+        self.assertEqual(got, ref)
+
 
 
 instantiate_parametrized_tests(TestScatterAddOverrideConds)

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -1,12 +1,14 @@
 # Owner(s): ["module: scatter & gather ops"]
 
 import random
+import unittest
 
 import torch
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import \
-    (parametrize, run_tests, TestCase, DeterministicGuard, TEST_WITH_ROCM, serialTest)
+    (instantiate_parametrized_tests, parametrize, run_tests, skipIfNoCuteDSL,
+     subtest, TestCase, DeterministicGuard, TEST_CUDA, TEST_WITH_ROCM, serialTest)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, onlyCPU, dtypes, dtypesIfCUDA,
      toleranceOverride, tol,)
@@ -460,6 +462,230 @@ class TestScatterGather(TestCase):
         helper([50, 1], 100)
         helper([50, 8, 7], 100)
         helper([50, 3, 4, 5], 100)
+
+# ---------------------------------------------------------------------------
+# CuTeDSL scatter_add override tests. Two surfaces:
+#   (a) dispatch conds: call the eligibility predicates directly to verify
+#       the routing matrix (dtypes, shapes, outer-strided, int32 index,
+#       deterministic mode). No kernel execution.
+#   (b) correctness: run torch.scatter_add on shapes the conds accept and
+#       compare to a naive reference. Covers both TMA and vec-scatter
+#       paths via the shape parameters.
+# ---------------------------------------------------------------------------
+
+
+def _expanded_idx(index_1d, trailing_shape):
+    """Build the expanded-1D index (stride 0 on every axis > 0)."""
+    idx = index_1d
+    for s in trailing_shape:
+        idx = idx.unsqueeze(-1).expand(*idx.shape, s)
+    return idx
+
+
+def _make_override_triple(
+    M_out, M_src, shape_tail, *, dtype=torch.float32,
+    idx_dtype=torch.int64, outer_pad_self=0, outer_pad_src=0,
+):
+    """Build a (self, idx_2d, src, idx_1d) triple for the expanded-1D
+    scatter_add pattern. ``outer_pad_*`` widens the allocated buffer's
+    inner dim, then slices, producing a view with stride(-1)==1 but
+    outer stride != prod(shape[1:]).
+    """
+    N = 1
+    for s in shape_tail:
+        N *= s
+    if outer_pad_self:
+        big = torch.zeros(M_out, N + outer_pad_self, device="cuda", dtype=dtype)
+        self_t = big[:, :N].view(M_out, *shape_tail)
+    else:
+        self_t = torch.zeros(M_out, *shape_tail, device="cuda", dtype=dtype)
+    if outer_pad_src:
+        big = torch.randn(M_src, N + outer_pad_src, device="cuda", dtype=dtype)
+        src = big[:, :N].view(M_src, *shape_tail)
+    else:
+        src = torch.randn(M_src, *shape_tail, device="cuda", dtype=dtype)
+    index_1d = torch.randint(0, M_out, (M_src,), device="cuda", dtype=idx_dtype)
+    return self_t, _expanded_idx(index_1d, shape_tail), src, index_1d
+
+
+def _naive_scatter_add(self_t, idx_1d, src, alpha=1.0):
+    """Reference implementation. Works on any stride pattern."""
+    ref = self_t.clone().float()
+    src_f = src.float()
+    for i, r in enumerate(idx_1d.tolist()):
+        ref[r] += alpha * src_f[i]
+    return ref.to(self_t.dtype)
+
+
+def _override_tol(dtype):
+    return 1e-4 if dtype == torch.float32 else 0.5
+
+
+@unittest.skipUnless(TEST_CUDA, "needs CUDA")
+@skipIfNoCuteDSL
+class TestScatterAddOverrideConds(TestCase):
+    """Unit tests for the dispatch predicates in
+    torch._native.ops.scatter_add.cutedsl_impl."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        from torch._native.ops.scatter_add import cutedsl_impl
+        cls.impl = cutedsl_impl
+        cutedsl_impl.register_to_dispatch()
+
+    def _conds(self, self_t, idx, src):
+        return (
+            self.impl._is_tma_supported(self_t, 0, idx, src),
+            self.impl._is_vec_scatter_supported(self_t, 0, idx, src),
+        )
+
+    @parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+    @parametrize("N", [128, 256, 512, 1024])
+    def test_accepts_contig_supported_shapes(self, dtype, N):
+        self_t, idx, src, _ = _make_override_triple(100, 50, (N,), dtype=dtype)
+        tma, vec = self._conds(self_t, idx, src)
+        self.assertTrue(tma)
+        self.assertTrue(vec)
+
+    def test_tma_rejects_partial_chunk(self):
+        # fp32 D=129 -> row_bytes=516, not a multiple of 512 -> TMA rejects.
+        # 129 % 4 != 0 -> vec also rejects.
+        self_t, idx, src, _ = _make_override_triple(100, 50, (129,))
+        self.assertEqual(self._conds(self_t, idx, src), (False, False))
+
+    def test_vec_accepts_non_tma_shape(self):
+        # bf16 D=264 -> row_bytes=528, TMA rejects; 264 % 8 == 0 vec accepts.
+        self_t, idx, src, _ = _make_override_triple(100, 50, (264,), dtype=torch.bfloat16)
+        self.assertEqual(self._conds(self_t, idx, src), (False, True))
+
+    def test_rejects_unsupported_dtype(self):
+        self_t, idx, src, _ = _make_override_triple(100, 50, (128,), dtype=torch.float64)
+        self.assertEqual(self._conds(self_t, idx, src), (False, False))
+
+    def test_rejects_dim_nonzero(self):
+        self_t, idx, src, _ = _make_override_triple(100, 50, (128,))
+        self.assertFalse(self.impl._is_tma_supported(self_t, 1, idx, src))
+        self.assertFalse(self.impl._is_vec_scatter_supported(self_t, 1, idx, src))
+
+    def test_rejects_non_expanded_index(self):
+        # Materialized 2D index (not a broadcast view) has nonzero stride
+        # on every axis -> the stride(i) == 0 check fails.
+        self_t = torch.zeros(100, 128, device="cuda")
+        src = torch.randn(50, 128, device="cuda")
+        bad_idx = torch.randint(0, 100, (50, 128), device="cuda", dtype=torch.int64)
+        self.assertEqual(self._conds(self_t, bad_idx, src), (False, False))
+
+    def test_rejects_inner_non_contig(self):
+        # permute(1, 0) -> trailing axis has stride 100 (not 1).
+        big_self = torch.zeros(128, 100, device="cuda").permute(1, 0)
+        big_src = torch.randn(128, 50, device="cuda").permute(1, 0)
+        idx = _expanded_idx(
+            torch.randint(0, 100, (50,), device="cuda", dtype=torch.int64), (128,)
+        )
+        self.assertEqual(self._conds(big_self, idx, big_src), (False, False))
+
+    def test_accepts_outer_strided(self):
+        self_t, idx, src, _ = _make_override_triple(
+            100, 50, (128,), outer_pad_self=64
+        )
+        self.assertFalse(self_t.is_contiguous())
+        self.assertEqual(self._conds(self_t, idx, src), (True, True))
+
+    @parametrize("idx_dtype", [torch.int32, torch.int64])
+    def test_accepts_int32_and_int64_index(self, idx_dtype):
+        self_t, idx, src, _ = _make_override_triple(
+            100, 50, (128,), idx_dtype=idx_dtype
+        )
+        self.assertEqual(self._conds(self_t, idx, src), (True, True))
+
+    def test_rejects_deterministic_mode(self):
+        # The determinism gate lives in _base_cond_ok (the shared
+        # prelude), not the per-path support_check. Call the wrapped
+        # cond to exercise the full dispatch-layer predicate.
+        self_t, idx, src, _ = _make_override_triple(100, 50, (128,))
+        with DeterministicGuard(True):
+            self.assertFalse(self.impl._tma_cond(self_t, 0, idx, src))
+            self.assertFalse(self.impl._vs_cond(self_t, 0, idx, src))
+
+
+@unittest.skipUnless(TEST_CUDA, "needs CUDA")
+@skipIfNoCuteDSL
+class TestScatterAddOverrideCorrectness(TestCase):
+    """End-to-end: torch.scatter_add vs a naive reference on shapes the
+    conds accept (TMA-eligible and vec-scatter-only)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        from torch._native.ops.scatter_add import cutedsl_impl
+        cutedsl_impl.register_to_dispatch()
+
+    @parametrize("dtype,shape_tail", [
+        subtest((torch.float32, (128,)), name="fp32_N128"),       # TMA
+        subtest((torch.float32, (1024,)), name="fp32_N1024"),     # TMA, chunked
+        subtest((torch.bfloat16, (128,)), name="bf16_N128"),
+        subtest((torch.bfloat16, (1024,)), name="bf16_N1024"),
+        subtest((torch.float16, (256,)), name="fp16_N256"),
+        subtest((torch.float32, (264,)), name="fp32_N264_vec"),   # vec only
+        subtest((torch.bfloat16, (264,)), name="bf16_N264_vec"),
+        subtest((torch.float32, (4, 32)), name="fp32_3d"),        # nD flatten
+    ])
+    def test_matches_reference(self, dtype, shape_tail):
+        torch.manual_seed(0)
+        self_t, idx, src, idx_1d = _make_override_triple(200, 100, shape_tail, dtype=dtype)
+        got = torch.scatter_add(self_t, 0, idx, src)
+        ref = _naive_scatter_add(
+            self_t.reshape(self_t.shape[0], -1),
+            idx_1d,
+            src.reshape(src.shape[0], -1),
+        ).reshape(self_t.shape)
+        tol = _override_tol(dtype)
+        self.assertEqual(got, ref, atol=tol, rtol=tol)
+
+    @parametrize("variant", ["functional", "out", "inplace"])
+    def test_op_variants(self, variant):
+        torch.manual_seed(0)
+        self_t, idx, src, idx_1d = _make_override_triple(200, 100, (128,))
+        ref = _naive_scatter_add(self_t, idx_1d, src)
+        if variant == "functional":
+            got = torch.scatter_add(self_t, 0, idx, src)
+        elif variant == "out":
+            got = torch.empty_like(self_t)
+            torch.scatter_add(self_t, 0, idx, src, out=got)
+        else:
+            got = self_t.clone()
+            ret = got.scatter_add_(0, idx, src)
+            self.assertIs(ret, got)
+        self.assertEqual(got, ref)
+
+    @parametrize("outer_pad_self,outer_pad_src", [(64, 0), (0, 64), (64, 64)])
+    def test_outer_strided(self, outer_pad_self, outer_pad_src):
+        torch.manual_seed(0)
+        self_t, idx, src, idx_1d = _make_override_triple(
+            200, 100, (128,),
+            outer_pad_self=outer_pad_self, outer_pad_src=outer_pad_src,
+        )
+        got = torch.scatter_add(self_t, 0, idx, src)
+        ref = _naive_scatter_add(self_t, idx_1d, src)
+        self.assertEqual(got, ref)
+
+    def test_repeated_index_accumulates(self):
+        # All indices target row 0: result[0] == sum(src).
+        torch.manual_seed(0)
+        src = torch.randn(64, 128, device="cuda")
+        self_t = torch.zeros(10, 128, device="cuda")
+        idx = _expanded_idx(
+            torch.zeros(64, device="cuda", dtype=torch.int64), (128,)
+        )
+        got = torch.scatter_add(self_t, 0, idx, src)
+        self.assertEqual(got[0], src.sum(0), atol=1e-3, rtol=1e-3)
+        self.assertEqual(got[1:].abs().sum().item(), 0)
+
+
+instantiate_parametrized_tests(TestScatterAddOverrideConds)
+instantiate_parametrized_tests(TestScatterAddOverrideCorrectness)
+
 
 # Generic Device Test Framework instantiation, see
 #   https://github.com/pytorch/pytorch/wiki/Running-and-writing-tests

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -548,16 +548,19 @@ class TestScatterAddOverrideConds(TestCase):
         self.assertTrue(tma)
         self.assertTrue(vec)
 
-    def test_tma_rejects_partial_chunk(self):
-        # fp32 D=129 -> row_bytes=516, not a multiple of 512 -> TMA rejects.
+    def test_rejects_row_bytes_not_16_aligned(self):
+        # fp32 D=129 -> row_bytes=516, 516 % 16 != 0 -> TMA rejects
+        # (cp.reduce.async.bulk requires 16-aligned gmem operands).
         # 129 % 4 != 0 -> vec also rejects.
         self_t, idx, src, _ = _make_override_triple(100, 50, (129,))
         self.assertEqual(self._conds(self_t, idx, src), (False, False))
 
-    def test_vec_accepts_non_tma_shape(self):
-        # bf16 D=264 -> row_bytes=528, TMA rejects; 264 % 8 == 0 vec accepts.
+    def test_tma_accepts_row_not_chunk_multiple(self):
+        # bf16 D=264 -> row_bytes=528, 16-aligned but not a multiple of
+        # chunk_bytes (512). TMA descriptor handles the partial final
+        # chunk via OOB-clamp-to-zero; cond should accept.
         self_t, idx, src, _ = _make_override_triple(100, 50, (264,), dtype=torch.bfloat16)
-        self.assertEqual(self._conds(self_t, idx, src), (False, True))
+        self.assertEqual(self._conds(self_t, idx, src), (True, True))
 
     def test_rejects_unsupported_dtype(self):
         self_t, idx, src, _ = _make_override_triple(100, 50, (128,), dtype=torch.float64)
@@ -622,13 +625,13 @@ class TestScatterAddOverrideCorrectness(TestCase):
         cutedsl_impl.register_to_dispatch()
 
     @parametrize("dtype,shape_tail", [
-        subtest((torch.float32, (128,)), name="fp32_N128"),       # TMA
-        subtest((torch.float32, (1024,)), name="fp32_N1024"),     # TMA, chunked
+        subtest((torch.float32, (128,)), name="fp32_N128"),       # TMA, single chunk
+        subtest((torch.float32, (1024,)), name="fp32_N1024"),     # TMA, full chunks
         subtest((torch.bfloat16, (128,)), name="bf16_N128"),
         subtest((torch.bfloat16, (1024,)), name="bf16_N1024"),
         subtest((torch.float16, (256,)), name="fp16_N256"),
-        subtest((torch.float32, (264,)), name="fp32_N264_vec"),   # vec only
-        subtest((torch.bfloat16, (264,)), name="bf16_N264_vec"),
+        subtest((torch.float32, (132,)), name="fp32_N132_partial"),   # TMA partial final chunk
+        subtest((torch.bfloat16, (264,)), name="bf16_N264_partial"),  # TMA partial final chunk
         subtest((torch.float32, (4, 32)), name="fp32_3d"),        # nD flatten
     ])
     def test_matches_reference(self, dtype, shape_tail):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2465,6 +2465,7 @@ class TestImports(TestCase):
                            "torch.onnx._internal",  # depends on onnx-script
                            "torch._inductor.runtime.triton_helpers",  # depends on triton
                            "torch._native.ops.bmm_outer_product.triton_kernels",  # depends on triton
+                           "torch._native.ops.scatter_add",  # depends on cutlass
                            "torch._inductor.codegen.cuda",  # depends on cutlass
                            "torch._inductor.codegen.cutedsl",  # depends on cutlass
                            "torch.distributed.benchmarks",  # depends on RPC and DDP Optim

--- a/torch/_native/ops/__init__.py
+++ b/torch/_native/ops/__init__.py
@@ -1,1 +1,1 @@
-from . import bmm_outer_product
+from . import bmm_outer_product, scatter_add

--- a/torch/_native/ops/scatter_add/__init__.py
+++ b/torch/_native/ops/scatter_add/__init__.py
@@ -1,0 +1,4 @@
+from .cutedsl_impl import register_to_dispatch
+
+
+register_to_dispatch()

--- a/torch/_native/ops/scatter_add/_ptx.py
+++ b/torch/_native/ops/scatter_add/_ptx.py
@@ -1,0 +1,115 @@
+"""Inline-PTX helpers shared across the TMA and vec-scatter kernels.
+
+Each helper wraps ``llvm.inline_asm`` with the options we always use
+(AT&T dialect, side-effecting) and normalizes argument types (cute's
+``Numeric`` wrappers get converted to ``ir.Value`` automatically). This
+keeps the kernel files focused on algorithm instead of MLIR plumbing.
+"""
+
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op, T
+
+
+def as_ir(v, *, loc=None, ip=None):
+    """Normalize ``v`` to ``ir.Value``: cute Numeric wrappers (Int32,
+    Float16, etc.) get unwrapped via ``.ir_value()``; other values pass
+    through unchanged (they're already ir.Values)."""
+    if hasattr(v, "ir_value"):
+        return v.ir_value(loc=loc, ip=ip)
+    return v
+
+
+def _inline_asm(result_type, operands, asm, constraint, *, loc=None, ip=None):
+    """``llvm.inline_asm`` with the flags we always use."""
+    return llvm.inline_asm(
+        result_type,
+        operands,
+        asm,
+        constraint,
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cvta_smem(ptr, *, loc=None, ip=None):
+    """Shared-memory ptr -> its ``.shared::cta`` state-space u64 address."""
+    raw = ptr.toint(loc=loc, ip=ip).ir_value()
+    # cvta is pure, not side-effecting; use inline_asm directly.
+    return llvm.inline_asm(
+        T.i64(),
+        [raw],
+        "cvta.to.shared::cta.u64 $0, $1;",
+        "=l,l",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def bulk_load(smem_u64, gmem_addr_u64, size_bytes, mbar_u64, *, loc=None, ip=None):
+    """PTX ``cp.async.bulk.shared::cta.global.mbarrier``: issue a TMA
+    load of ``size_bytes`` from ``gmem_addr_u64`` to ``smem_u64``, and
+    signal ``mbar_u64`` on completion."""
+    _inline_asm(
+        None,
+        [
+            as_ir(smem_u64, loc=loc, ip=ip),
+            as_ir(gmem_addr_u64, loc=loc, ip=ip),
+            as_ir(size_bytes, loc=loc, ip=ip),
+            as_ir(mbar_u64, loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes"
+        " [$0], [$1], $2, [$3];",
+        "l,l,r,l",
+        loc=loc,
+        ip=ip,
+    )
+
+
+def make_bulk_reduce_add(ptx_suffix: str):
+    """Emit ``cp.reduce.async.bulk.global.shared::cta.bulk_group.add.<suffix>``.
+    Suffix selects the dtype: ``f32`` / ``noftz.f16`` / ``noftz.bf16``."""
+
+    @dsl_user_op
+    def _op(gmem_addr_u64, smem_u64, size_bytes, *, loc=None, ip=None):
+        _inline_asm(
+            None,
+            [
+                as_ir(gmem_addr_u64, loc=loc, ip=ip),
+                as_ir(smem_u64, loc=loc, ip=ip),
+                as_ir(size_bytes, loc=loc, ip=ip),
+            ],
+            f"cp.reduce.async.bulk.global.shared::cta.bulk_group.add.{ptx_suffix}"
+            " [$0], [$1], $2;",
+            "l,l,r",
+            loc=loc,
+            ip=ip,
+        )
+
+    return _op
+
+
+def make_packed_half_atomic_add(ptx_suffix: str):
+    """Emit ``red.global.add.noftz.<suffix>`` with a single ``i32`` packed
+    register holding two halves. Used by the vec-scatter kernel for
+    ``f16x2`` / ``bf16x2`` paired atomics."""
+
+    @dsl_user_op
+    def _op(gmem_ptr_i64, packed_i32, *, loc=None, ip=None):
+        _inline_asm(
+            None,
+            [as_ir(gmem_ptr_i64, loc=loc, ip=ip), as_ir(packed_i32, loc=loc, ip=ip)],
+            f"red.global.add.noftz.{ptx_suffix} [$0], $1;",
+            "l,r",
+            loc=loc,
+            ip=ip,
+        )
+
+    return _op

--- a/torch/_native/ops/scatter_add/_ptx.py
+++ b/torch/_native/ops/scatter_add/_ptx.py
@@ -52,27 +52,6 @@ def cvta_smem(ptr, *, loc=None, ip=None):
     )
 
 
-@dsl_user_op
-def bulk_load(smem_u64, gmem_addr_u64, size_bytes, mbar_u64, *, loc=None, ip=None):
-    """PTX ``cp.async.bulk.shared::cta.global.mbarrier``: issue a TMA
-    load of ``size_bytes`` from ``gmem_addr_u64`` to ``smem_u64``, and
-    signal ``mbar_u64`` on completion."""
-    _inline_asm(
-        None,
-        [
-            as_ir(smem_u64, loc=loc, ip=ip),
-            as_ir(gmem_addr_u64, loc=loc, ip=ip),
-            as_ir(size_bytes, loc=loc, ip=ip),
-            as_ir(mbar_u64, loc=loc, ip=ip),
-        ],
-        "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes"
-        " [$0], [$1], $2, [$3];",
-        "l,l,r,l",
-        loc=loc,
-        ip=ip,
-    )
-
-
 def make_bulk_reduce_add(ptx_suffix: str):
     """Emit ``cp.reduce.async.bulk.global.shared::cta.bulk_group.add.<suffix>``.
     Suffix selects the dtype: ``f32`` / ``noftz.f16`` / ``noftz.bf16``."""

--- a/torch/_native/ops/scatter_add/cutedsl_impl.py
+++ b/torch/_native/ops/scatter_add/cutedsl_impl.py
@@ -88,20 +88,16 @@ def _inner_contiguous(t: torch.Tensor) -> bool:
     """True iff ``t.shape[1:]`` is packed contiguously (so flattening to
     ``(t.shape[0], prod(t.shape[1:]))`` is a valid view), regardless of
     the outer stride. Covers slices like ``X[:, :K]`` of a wider buffer.
+
+    Empty outer axis returns ``False``: the kernel has no work to do,
+    and letting it through means ``select(0, 0)`` below would raise.
     """
     if t.ndim == 0:
         return False
     if t.ndim == 1:
         return t.stride(0) == 1
     if t.shape[0] == 0:
-        # select(0, 0) would raise on an empty outer axis. Check the
-        # inner layout by checking strides directly.
-        expected = 1
-        for d in range(t.ndim - 1, 0, -1):
-            if t.stride(d) != expected:
-                return False
-            expected *= t.shape[d]
-        return True
+        return False
     return t.select(0, 0).is_contiguous()
 
 
@@ -140,12 +136,8 @@ def _expanded_1d_inner_size(
     for i in range(1, index.ndim):
         if index.stride(i) != 0:
             return None
-    if src.shape[0] == 0 or self.shape[0] == 0:
-        # src.shape[0] == 0 is a no-op; self.shape[0] == 0 means every
-        # index is out of range. Either way, decline and let aten
-        # handle (and for self.shape[0] == 0, raise the proper index
-        # error -- our kernel would silently write OOB).
-        return None
+    # shape[0] == 0 on self or src is already rejected by
+    # ``_inner_contiguous`` above.
     N = math.prod(src.shape[1:])
     if N == 0:
         return None

--- a/torch/_native/ops/scatter_add/cutedsl_impl.py
+++ b/torch/_native/ops/scatter_add/cutedsl_impl.py
@@ -140,7 +140,11 @@ def _expanded_1d_inner_size(
     for i in range(1, index.ndim):
         if index.stride(i) != 0:
             return None
-    if src.shape[0] == 0:
+    if src.shape[0] == 0 or self.shape[0] == 0:
+        # src.shape[0] == 0 is a no-op; self.shape[0] == 0 means every
+        # index is out of range. Either way, decline and let aten
+        # handle (and for self.shape[0] == 0, raise the proper index
+        # error -- our kernel would silently write OOB).
         return None
     N = math.prod(src.shape[1:])
     if N == 0:

--- a/torch/_native/ops/scatter_add/cutedsl_impl.py
+++ b/torch/_native/ops/scatter_add/cutedsl_impl.py
@@ -1,0 +1,319 @@
+"""CuTeDSL override registrations for ``aten::scatter_add``.
+
+Two kernels for the ``index.unsqueeze(-1).expand(-1, ...)`` expanded-1D
+pattern (dim=0, same shape for self/src/index, contiguous), tried in order:
+
+1. **TMA** (``tma_kernel.py``, sm_90+): uses ``cp.reduce.async.bulk`` to
+   offload the whole reduction to the TMA unit, 3-7x faster than aten on
+   high-contention embedding-bag-grad-style workloads.
+2. **vec-scatter** (``vec_scatter_kernel.py``, any SM): warp-per-row
+   scheduling with ``atomicAdd`` (scalar fp32, paired x2 halves). Covers
+   pre-sm_90, and sm_90+ shapes where the TMA alignment constraint isn't
+   met.
+
+Anything else (non-expanded index, dim != 0, non-contiguous inputs,
+deterministic mode) falls through to aten. Aten is competitive or better
+on those shapes, so we intentionally don't override them.
+
+In-place (``scatter_add_``) is registered explicitly; PyTorch's
+structured-delegate from ``scatter_add_`` to ``scatter_add.out`` happens
+below the dispatcher, so overriding the ``.out`` variant alone doesn't
+intercept the in-place method.
+"""
+
+import functools
+import importlib.util
+import math
+
+import torch
+
+from ... import cutedsl_utils as cu
+from ...registry import _OpCondFn, _OpImplFn
+
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+
+@functools.cache
+def _has_cutedsl() -> bool:
+    try:
+        return (
+            importlib.util.find_spec("cutlass") is not None
+            and importlib.util.find_spec("tvm_ffi") is not None
+        )
+    except ModuleNotFoundError:
+        return False
+
+
+@functools.cache
+def _has_sm90_plus() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability(0)
+    return major >= 9
+
+
+def _deterministic() -> bool:
+    # Our kernels use non-deterministic atomicAdd. Under
+    # torch.use_deterministic_algorithms(True), aten's scatter_add falls
+    # into _scatter_via_index_put instead; we must decline to preserve
+    # that behavior.
+    return torch.are_deterministic_algorithms_enabled()
+
+
+def _any_cow(*tensors: torch.Tensor) -> bool:
+    return any(
+        torch._C._is_cow_tensor(t)  # pyrefly: ignore[missing-attribute]
+        for t in tensors
+    )
+
+
+def _base_cond_ok(*tensors: torch.Tensor) -> bool:
+    """Pre-checks shared by every path: env sanity, all CUDA, non-COW."""
+    if not _has_cutedsl() or _deterministic():
+        return False
+    if not all(t.is_cuda for t in tensors):
+        return False
+    if _any_cow(*tensors):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Expanded-1D helpers, shared by TMA and vec-scatter paths.
+# ---------------------------------------------------------------------------
+
+
+def _expanded_1d_inner_size(
+    self: torch.Tensor, dim: int, index: torch.Tensor, src: torch.Tensor
+) -> int | None:
+    """Return ``prod(src.shape[1:])`` when the ``index.unsqueeze(-1)
+    .expand(-1, ...)`` fast-path pattern applies, else ``None``.
+
+    Requirements:
+      - dim == 0
+      - self, src, index have the same rank (>= 2) and shape
+      - self, src are contiguous, matching trailing shape
+      - index.stride(i) == 0 for every axis i > 0 (the broadcast)
+      - dtype in ``_SUPPORTED_DTYPES`` and self.dtype == src.dtype
+      - index.dtype == int64
+    """
+    if self.dtype not in _SUPPORTED_DTYPES or self.dtype != src.dtype:
+        return None
+    if index.dtype != torch.int64:
+        return None
+    if dim != 0:
+        return None
+    if self.ndim != src.ndim or self.ndim != index.ndim or self.ndim < 2:
+        return None
+    if not (self.is_contiguous() and src.is_contiguous()):
+        return None
+    if index.shape != src.shape or self.shape[1:] != src.shape[1:]:
+        return None
+    for i in range(1, index.ndim):
+        if index.stride(i) != 0:
+            return None
+    if src.shape[0] == 0:
+        return None
+    N = math.prod(src.shape[1:])
+    if N == 0:
+        return None
+    return N
+
+
+def _flatten_for_expanded_1d(
+    self: torch.Tensor, index: torch.Tensor, src: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Reshape eligible nD inputs to (self_2d, index_1d, src_2d).
+
+    Caller must have verified eligibility via ``_expanded_1d_inner_size``.
+    All reshapes are views (self/src are contiguous by that cond), and the
+    1D index view is taken by selecting element 0 of every broadcast axis.
+    """
+    N = math.prod(src.shape[1:])
+    self_2d = self.view(self.shape[0], N)
+    src_2d = src.view(src.shape[0], N)
+    index_1d = index
+    for _ in range(index.ndim - 1):
+        index_1d = index_1d.select(-1, 0)
+    if not index_1d.is_contiguous():
+        index_1d = index_1d.contiguous()
+    return self_2d, index_1d, src_2d
+
+
+# ---------------------------------------------------------------------------
+# Path-specific eligibility checks.
+# ---------------------------------------------------------------------------
+
+
+def _is_tma_supported(
+    self: torch.Tensor, dim: int, index: torch.Tensor, src: torch.Tensor
+) -> bool:
+    if not _has_sm90_plus():
+        return False
+    N = _expanded_1d_inner_size(self, dim, index, src)
+    if N is None:
+        return False
+    # cp.async.bulk needs the transfer byte count to be 16-aligned. The
+    # kernel handles partial final chunks, so the only hard constraint is
+    # D * elem_size % 16 == 0.
+    from .tma_kernel import min_d_divisor_for
+
+    return N % min_d_divisor_for(self.dtype) == 0
+
+
+def _is_vec_scatter_supported(
+    self: torch.Tensor, dim: int, index: torch.Tensor, src: torch.Tensor
+) -> bool:
+    N = _expanded_1d_inner_size(self, dim, index, src)
+    if N is None:
+        return False
+    # Each lane owns vec_elems consecutive elements; the loop is either
+    # fully in-bounds or fully skipped per lane. Only requirement is
+    # D % vec_elems == 0 (fp32: %4, halves: %8).
+    from .vec_scatter_kernel import vec_elems_for
+
+    return N % vec_elems_for(self.dtype) == 0
+
+
+# ---------------------------------------------------------------------------
+# Cond / impl factories. ``_make_cond`` wraps a support check in the shared
+# dispatch boilerplate; ``_make_impls`` produces the (functional, .out,
+# in-place) triple for a given kernel.
+# ---------------------------------------------------------------------------
+
+
+def _make_cond(
+    support_check,
+    *,
+    requires_out: bool = False,
+) -> _OpCondFn:
+    """Build a cond function that runs ``support_check`` behind the shared
+    boilerplate (cutedsl availability, non-deterministic mode, CUDA tensors,
+    non-COW, dtype/shape match on ``out`` when present)."""
+    if requires_out:
+
+        def _cond(self, dim, index, src, *, out):
+            if not _base_cond_ok(self, index, src, out):
+                return False
+            if out.dtype != self.dtype or out.shape != self.shape:
+                return False
+            if out.ndim == 0:
+                return False
+            # Our kernels write out with stride(-1) == 1.
+            if not out.is_contiguous() or out.stride(-1) != 1:
+                return False
+            return support_check(self, dim, index, src)
+
+        return _cond
+
+    def _cond(self, dim, index, src, *args, **kwargs):
+        if not _base_cond_ok(self, index, src):
+            return False
+        return support_check(self, dim, index, src)
+
+    return _cond
+
+
+def _copy_if_distinct(out: torch.Tensor, self: torch.Tensor) -> None:
+    """Seed ``out`` with ``self``'s values when they're separate buffers.
+    Cond guarantees shape match, so no resize is needed."""
+    if out.data_ptr() != self.data_ptr():
+        out.copy_(self)
+
+
+def _make_impls(kernel_getter):
+    """Build (functional, out, in-place) impl callables for an
+    expanded-1D-pattern kernel. ``kernel_getter`` is a zero-arg callable
+    that lazily imports and returns the ``*_scatter_add_into`` kernel; we
+    defer the import so the DSL runtime isn't pulled in at registration
+    time.
+    """
+
+    def _run(dst: torch.Tensor, self, index, src) -> torch.Tensor:
+        # Caller guarantees self/src/index pass _expanded_1d_inner_size.
+        _, index_1d, src_2d = _flatten_for_expanded_1d(self, index, src)
+        dst_2d = dst.view(dst.shape[0], src_2d.shape[1])
+        kernel_getter()(dst_2d, index_1d, src_2d)
+        return dst
+
+    def impl(self, dim, index, src, *args, **kwargs):
+        return _run(self.clone(), self, index, src)
+
+    def out_impl(self, dim, index, src, *, out):
+        _copy_if_distinct(out, self)
+        return _run(out, self, index, src)
+
+    def inplace_impl(self, dim, index, src, *args, **kwargs):
+        return _run(self, self, index, src)
+
+    return impl, out_impl, inplace_impl
+
+
+def _tma_kernel():
+    from .tma_kernel import tma_scatter_add_into
+
+    return tma_scatter_add_into
+
+
+def _vs_kernel():
+    from .vec_scatter_kernel import vec_scatter_add_into
+
+    return vec_scatter_add_into
+
+
+_tma_impl, _tma_out_impl, _tma_inplace_impl = _make_impls(_tma_kernel)
+_vs_impl, _vs_out_impl, _vs_inplace_impl = _make_impls(_vs_kernel)
+
+_tma_cond = _make_cond(_is_tma_supported)
+_tma_out_cond = _make_cond(_is_tma_supported, requires_out=True)
+_vs_cond = _make_cond(_is_vec_scatter_supported)
+_vs_out_cond = _make_cond(_is_vec_scatter_supported, requires_out=True)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+# Dispatch priority is first-registered-wins. TMA's cond is strictly
+# narrower than vec-scatter's (TMA only fires on sm_90+ with stricter D
+# alignment), so TMA goes first.
+_PATHS = (
+    # (cond, impl, out_cond, out_impl, inplace_impl)
+    (_tma_cond, _tma_impl, _tma_out_cond, _tma_out_impl, _tma_inplace_impl),
+    (_vs_cond, _vs_impl, _vs_out_cond, _vs_out_impl, _vs_inplace_impl),
+)
+
+
+def _register_path(
+    dispatch_key: str,
+    cond: _OpCondFn,
+    impl: _OpImplFn,
+    out_cond: _OpCondFn,
+    out_impl: _OpImplFn,
+    inplace_impl: _OpImplFn,
+) -> None:
+    # scatter_add_ has its own dispatcher entry separate from scatter_add
+    # and scatter_add.out; it's structured-delegated to .out below the
+    # dispatcher layer, so overriding .out alone doesn't catch it.
+    for op_symbol, cond_fn, impl_fn in (
+        ("scatter_add", cond, impl),
+        ("scatter_add.out", out_cond, out_impl),
+        ("scatter_add_", cond, inplace_impl),
+    ):
+        cu.register_op_override(
+            "aten",
+            op_symbol,
+            dispatch_key,
+            cond=cond_fn,
+            impl=impl_fn,
+            allow_multiple_override=True,
+        )
+
+
+def register_to_dispatch() -> None:
+    if not _has_cutedsl():
+        return
+    for path in _PATHS:
+        _register_path("CUDA", *path)

--- a/torch/_native/ops/scatter_add/cutedsl_impl.py
+++ b/torch/_native/ops/scatter_add/cutedsl_impl.py
@@ -84,6 +84,18 @@ def _base_cond_ok(*tensors: torch.Tensor) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _inner_contiguous(t: torch.Tensor) -> bool:
+    """True iff ``t.shape[1:]`` is packed contiguously (so flattening to
+    ``(t.shape[0], prod(t.shape[1:]))`` is a valid view), regardless of
+    the outer stride. Covers slices like ``X[:, :K]`` of a wider buffer.
+    """
+    if t.ndim == 0:
+        return False
+    if t.ndim == 1:
+        return t.stride(0) == 1
+    return t.select(0, 0).is_contiguous()
+
+
 def _expanded_1d_inner_size(
     self: torch.Tensor, dim: int, index: torch.Tensor, src: torch.Tensor
 ) -> int | None:
@@ -93,20 +105,26 @@ def _expanded_1d_inner_size(
     Requirements:
       - dim == 0
       - self, src, index have the same rank (>= 2) and shape
-      - self, src are contiguous, matching trailing shape
+      - self, src have inner-dim stride 1 (outer row stride can differ
+        from prod(shape[1:]) -- e.g. a slice like ``X[:, :K]`` of a
+        wider buffer works)
       - index.stride(i) == 0 for every axis i > 0 (the broadcast)
       - dtype in ``_SUPPORTED_DTYPES`` and self.dtype == src.dtype
-      - index.dtype == int64
+      - index.dtype in {int32, int64} (int32 is cast to int64 on the
+        host before the kernel launches)
     """
     if self.dtype not in _SUPPORTED_DTYPES or self.dtype != src.dtype:
         return None
-    if index.dtype != torch.int64:
+    if index.dtype not in (torch.int32, torch.int64):
         return None
     if dim != 0:
         return None
     if self.ndim != src.ndim or self.ndim != index.ndim or self.ndim < 2:
         return None
-    if not (self.is_contiguous() and src.is_contiguous()):
+    # Inner-dim stride 1, plus ensure inner dims pack contiguously so we
+    # can flatten shape[1:] into a single N. A simple sufficient check:
+    # stride of each inner axis == product of strides below it.
+    if not _inner_contiguous(self) or not _inner_contiguous(src):
         return None
     if index.shape != src.shape or self.shape[1:] != src.shape[1:]:
         return None
@@ -121,21 +139,37 @@ def _expanded_1d_inner_size(
     return N
 
 
+def _flatten_2d_view(t: torch.Tensor) -> torch.Tensor:
+    """Flatten ``t.shape[1:]`` into a single N. Preserves the outer row
+    stride (so a slice like ``X[:, :K]`` stays a view of the wider
+    buffer). Caller must have verified ``_inner_contiguous(t)``.
+    """
+    if t.ndim == 2:
+        return t
+    N = math.prod(t.shape[1:])
+    # Outer stride carries through unchanged; inner dims collapse to
+    # stride 1 because they were packed (cond-enforced).
+    return t.as_strided((t.shape[0], N), (t.stride(0), 1))
+
+
 def _flatten_for_expanded_1d(
     self: torch.Tensor, index: torch.Tensor, src: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Reshape eligible nD inputs to (self_2d, index_1d, src_2d).
 
     Caller must have verified eligibility via ``_expanded_1d_inner_size``.
-    All reshapes are views (self/src are contiguous by that cond), and the
-    1D index view is taken by selecting element 0 of every broadcast axis.
+    All reshapes are views; the 1D index view is taken by selecting
+    element 0 of every broadcast axis.
     """
-    N = math.prod(src.shape[1:])
-    self_2d = self.view(self.shape[0], N)
-    src_2d = src.view(src.shape[0], N)
+    self_2d = _flatten_2d_view(self)
+    src_2d = _flatten_2d_view(src)
     index_1d = index
     for _ in range(index.ndim - 1):
         index_1d = index_1d.select(-1, 0)
+    if index_1d.dtype != torch.int64:
+        # Kernel expects int64. aten accepts both int32 and int64; we
+        # widen on the host so the kernel stays dtype-specialized.
+        index_1d = index_1d.to(torch.int64)
     if not index_1d.is_contiguous():
         index_1d = index_1d.contiguous()
     return self_2d, index_1d, src_2d
@@ -154,12 +188,12 @@ def _is_tma_supported(
     N = _expanded_1d_inner_size(self, dim, index, src)
     if N is None:
         return False
-    # cp.async.bulk needs the transfer byte count to be 16-aligned. The
-    # kernel handles partial final chunks, so the only hard constraint is
-    # D * elem_size % 16 == 0.
-    from .tma_kernel import min_d_divisor_for
+    # TMA transfer size is baked in at compile time (chunk_bytes =
+    # min(row_bytes, 512)); row_bytes must evenly divide by chunk_bytes
+    # and chunk_bytes must be 16-byte aligned.
+    from .tma_kernel import row_shape_supported
 
-    return N % min_d_divisor_for(self.dtype) == 0
+    return row_shape_supported(self.dtype, N)
 
 
 def _is_vec_scatter_supported(
@@ -200,8 +234,10 @@ def _make_cond(
                 return False
             if out.ndim == 0:
                 return False
-            # Our kernels write out with stride(-1) == 1.
-            if not out.is_contiguous() or out.stride(-1) != 1:
+            # Kernels read/write ``out`` with inner-dim stride 1; outer
+            # stride can differ from prod(shape[1:]) (same relaxation as
+            # self/src). Inner dims must be packed for the 2D view.
+            if not _inner_contiguous(out):
                 return False
             return support_check(self, dim, index, src)
 
@@ -230,22 +266,21 @@ def _make_impls(kernel_getter):
     time.
     """
 
-    def _run(dst: torch.Tensor, self, index, src) -> torch.Tensor:
-        # Caller guarantees self/src/index pass _expanded_1d_inner_size.
-        _, index_1d, src_2d = _flatten_for_expanded_1d(self, index, src)
-        dst_2d = dst.view(dst.shape[0], src_2d.shape[1])
+    def _run(dst: torch.Tensor, index, src) -> torch.Tensor:
+        # Caller guarantees dst/src/index pass _expanded_1d_inner_size.
+        dst_2d, index_1d, src_2d = _flatten_for_expanded_1d(dst, index, src)
         kernel_getter()(dst_2d, index_1d, src_2d)
         return dst
 
     def impl(self, dim, index, src, *args, **kwargs):
-        return _run(self.clone(), self, index, src)
+        return _run(self.clone(), index, src)
 
     def out_impl(self, dim, index, src, *, out):
         _copy_if_distinct(out, self)
-        return _run(out, self, index, src)
+        return _run(out, index, src)
 
     def inplace_impl(self, dim, index, src, *args, **kwargs):
-        return _run(self, self, index, src)
+        return _run(self, index, src)
 
     return impl, out_impl, inplace_impl
 

--- a/torch/_native/ops/scatter_add/cutedsl_impl.py
+++ b/torch/_native/ops/scatter_add/cutedsl_impl.py
@@ -93,6 +93,15 @@ def _inner_contiguous(t: torch.Tensor) -> bool:
         return False
     if t.ndim == 1:
         return t.stride(0) == 1
+    if t.shape[0] == 0:
+        # select(0, 0) would raise on an empty outer axis. Check the
+        # inner layout by checking strides directly.
+        expected = 1
+        for d in range(t.ndim - 1, 0, -1):
+            if t.stride(d) != expected:
+                return False
+            expected *= t.shape[d]
+        return True
     return t.select(0, 0).is_contiguous()
 
 

--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -359,7 +359,12 @@ def _compile_tma_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
         Int32(0),  # grid_x
         Int32(0),  # grid_y
         Int64(0),  # out_row_stride
-        options="--enable-tvm-ffi",
+        # ``--enable-assertions`` keeps the ``cute_testing.assert_``
+        # bounds checks on ``r`` live in production. Cost is roughly
+        # +1-10% (geomean +7.7%) on most shapes; the safety net is
+        # worth it because an OOB ``r`` would otherwise silently
+        # corrupt unrelated gmem via ``cp.reduce.async.bulk``.
+        options="--enable-tvm-ffi --enable-assertions",
     )
 
 

--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -1,33 +1,47 @@
 """TMA-based scatter_add for the ``index.unsqueeze(-1).expand(-1, N)`` pattern.
 
 Port of the CUDA C++ kernel from https://github.com/pytorch/pytorch/pull/182675
-to CuTeDSL. Each warp handles one source row (within an assigned D-range):
-a TMA bulk load (``cute.copy`` with ``CopyBulkG2SOp``) stages
+to CuTeDSL. Each CTA (one warp) handles one source row (within an assigned
+chunk-index range): a tile-mode TMA bulk load (``cute.copy`` with
+``CopyBulkTensorTileG2SOp`` via ``make_tiled_tma_atom``) stages
 ``src[i, d_start:d_end]`` into smem, then
 ``cp.reduce.async.bulk.global.shared::cta.bulk_group.add`` deposits the
 reduction into ``out[index[i], d_start:d_end]``.
 
-Chunks along D in ``chunk_bytes``-sized slices, double-buffered so the
-next chunk's load overlaps the current chunk's reduce. ``chunk_bytes`` is
-``min(row_bytes, _MAX_CHUNK_BYTES)`` at compile time: small rows travel
-as a single chunk, large rows chunk at 512B. Because ``cute.copy``
-derives the transfer size from the tensor shape, ``chunk_bytes`` must
-evenly divide ``row_bytes`` -- the host cond enforces this.
+Using the tile-mode TMA with a descriptor over the full ``(M_src, N)``
+source tensor lets TMA clamp out-of-range column reads to zero, so the
+final partial chunk (when ``N`` isn't a multiple of ``chunk_elems``) is
+handled natively -- we just reduce only the valid byte count on the
+store side. That widens coverage to any ``row_bytes`` that's 16-byte
+aligned (the ``cp.reduce.async.bulk`` gmem operand requirement).
 
-Grid layout is 2D to maintain SM utilization for shapes with small N and
-large D: ``(grid_x, grid_y)``, where ``grid_y`` partitions the D axis
-into disjoint chunks and each warp iterates only its assigned chunk.
-When N is large the host sets ``grid_y = 1`` so the inner chunk loop
-recovers the classic schedule. When N is tiny (say 100 rows, D=640K),
-``grid_y`` grows so the grid still fills the machine.
+Synchronization between the load and the reduce uses
+``cutlass.pipeline.PipelineTmaAsync`` with ``num_stages=2``: producer
+``acquire``/``commit`` guards the TMA issue, consumer ``wait``/``release``
+guards the reduce. Producer and consumer cooperative groups are both
+``Agent.Thread, size=1`` -- the single driver thread inside the warp
+does both roles. ``PipelineState.advance()`` handles the stage index +
+phase bit.
+
+Chunks along D at a compile-time ``chunk_elems``: small rows travel as
+a single chunk, large rows chunk at 512 B. The TMA descriptor OOB-clamp
+handles rows whose length isn't a multiple of ``chunk_elems``.
+
+Grid layout is 2D to maintain SM utilization for shapes with small N
+and large D: ``(grid_x, grid_y)``, where ``grid_y`` partitions the
+chunk-index axis. When N is large the host sets ``grid_y = 1`` so the
+inner chunk loop recovers the classic schedule. When N is tiny (say
+100 rows, D=640K), ``grid_y`` grows so the grid still fills the
+machine.
 
 Restrictions (enforced by the host cond in ``cutedsl_impl.py``):
   - sm_90+ (cp.reduce.async.bulk availability)
-  - dim == 0, rank >= 2, self/src contiguous
+  - dim == 0, rank >= 2, self/src inner-contiguous
   - index is the expanded-1D pattern (same shape as src, stride 0 on every
     axis except 0)
   - dtype in {fp32, fp16, bf16}
-  - row_bytes is a multiple of ``min(row_bytes, 512)``
+  - ``row_bytes % 16 == 0`` (for both the TMA load operand and the
+    cp.reduce.async.bulk gmem operand)
 """
 
 import math
@@ -74,57 +88,60 @@ def _reduce_op_for(dtype):
 
 def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bool):
     """Build a dtype-specialized kernel closure. dtype/elem_bytes/chunk_elems
-    are Python-time constants that the preprocessor folds at cute.compile
-    time.
+    /contig are Python-time constants that the preprocessor folds at
+    cute.compile time.
 
-    ``chunk_elems`` is baked in at compile time, so the bulk-load transfer
-    size is fixed. That lets us use ``cute.copy(CopyBulkG2SOp(), ...)``
-    for the load and ``PipelineTmaAsync`` (tx_count = chunk_bytes) for
-    the producer/consumer synchronization. The bulk-reduce side still
-    emits raw PTX because cutedsl only ships a tile-mode TMA reduce op,
-    which requires a TMA descriptor and doesn't fit our dynamic per-row
-    gather.
+    ``chunk_elems`` is baked in at compile time. The TMA descriptor
+    built in ``_launch`` (via ``make_tiled_tma_atom`` on the source
+    tensor) enables OOB-clamp-to-zero for reads past column ``N``; the
+    reduce side then writes only the actual valid byte count, so
+    partial final chunks are handled natively.
 
     One CTA = one warp. The single driver thread (tidx == 0) serves as
     both producer (issues the TMA load) and consumer (issues the
     bulk-reduce). Both CooperativeGroups are ``Agent.Thread, size=1``
     so the mbarrier arrive counts match the single-threaded flow.
 
-    ``contig`` toggles a fast path: when True, row offset is computed as
-    ``entry_id * D`` using the compile-time D, avoiding a runtime
-    stride multiply. When False the kernel takes runtime row-stride
-    arguments so outer-strided tensors (e.g. slices) work.
+    ``contig`` gates a fast path on the reduce side: when True, the
+    output row stride is D at compile time, avoiding a runtime stride
+    multiply. When False the kernel takes a runtime
+    ``out_row_stride`` arg so outer-strided outputs (e.g. slices) work.
+    The TMA load always goes through the descriptor and doesn't use
+    ``contig``.
     """
 
     chunk_bytes = chunk_elems * elem_bytes
 
     @cute.kernel
     def _kernel(
-        mSrc: cute.Tensor,
+        tma_atom: cute.CopyAtom,
+        tma_tensor_src: cute.Tensor,  # TMA-view of mSrc
         mIndex: cute.Tensor,
         mOut: cute.Tensor,
         num_entries: Int32,
         D: Int32,
-        d_tile_size: Int32,
-        src_row_stride: Int64,
+        chunk_tile_size: Int32,  # number of chunks per grid_y slot
         out_row_stride: Int64,
     ):
         tidx, _, _ = cute.arch.thread_idx()
         bidx, bidy, _ = cute.arch.block_idx()
         gdim_x, _, _ = cute.arch.grid_dim()
 
-        load_atom = cute.make_copy_atom(cpasync.CopyBulkG2SOp(), dtype)
+        # Chunk-index range assigned to this CTA. bidy partitions the
+        # chunk axis into disjoint slices of chunk_tile_size; when
+        # chunk_tile_size == num_chunks, grid_y == 1 and every CTA sees
+        # the whole D.
+        num_chunks = (D + Int32(chunk_elems) - Int32(1)) // Int32(chunk_elems)
+        chunk_start = bidy * chunk_tile_size
+        chunk_end = chunk_start + chunk_tile_size
+        if chunk_end > num_chunks:
+            chunk_end = num_chunks
 
-        d_start = bidy * d_tile_size
-        d_end = d_start + d_tile_size
-        if d_end > D:
-            d_end = D
-
-        # For the contiguous fast path, row stride is just D; the
-        # runtime stride args get ignored.
+        # Reduce-side out-row stride: compile-time D (contig) or runtime.
         if const_expr(contig):
-            src_row_stride = Int64(D)
-            out_row_stride = Int64(D)
+            out_rs = Int64(D)
+        else:
+            out_rs = out_row_stride
 
         smem = cutlass.utils.SmemAllocator()
         sBuf = smem.allocate_tensor(
@@ -143,6 +160,19 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bo
             tidx=tidx,
         )
 
+        # Tile the source (M, N) by (1, chunk_elems) to get
+        # (1, chunk_elems, M, num_chunks); tma_partition collapses and
+        # returns tma_gmem[None, row_idx, chunk_idx] and tma_smem[None,
+        # stage].
+        tiled_gmem = cute.local_tile(tma_tensor_src, (1, chunk_elems), (None, None))
+        tma_smem, tma_gmem = cpasync.tma_partition(
+            tma_atom,
+            Int32(0),
+            cute.make_layout(1),
+            cute.group_modes(sBuf, 0, 1),
+            cute.group_modes(tiled_gmem, 0, 2),
+        )
+
         producer_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Producer, 2
         )
@@ -155,38 +185,40 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bo
             entry_id = base
             r = Int64(mIndex[entry_id])
 
-            off = d_start
-            while off < d_end:
+            chunk_idx = chunk_start
+            while chunk_idx < chunk_end:
                 if tidx == Int32(0):
                     pipe.producer_acquire(producer_state)
-                    src_slice = cute.make_tensor(
-                        mSrc.iterator + (Int64(entry_id) * src_row_stride + Int64(off)),
-                        cute.make_layout(chunk_elems),
-                    )
-                    dst_slice = cute.make_tensor(
-                        sBuf.iterator + producer_state.index * Int32(chunk_elems),
-                        cute.make_layout(chunk_elems),
-                    )
                     cute.copy(
-                        load_atom,
-                        src_slice,
-                        dst_slice,
-                        mbar_ptr=pipe.producer_get_barrier(producer_state),
+                        tma_atom,
+                        tma_gmem[None, entry_id, chunk_idx],
+                        tma_smem[None, producer_state.index],
+                        tma_bar_ptr=pipe.producer_get_barrier(producer_state),
                     )
                     pipe.producer_commit(producer_state)
 
                     pipe.consumer_wait(consumer_state)
                     cbuf_ptr = sBuf.iterator + consumer_state.index * Int32(chunk_elems)
-                    dst_off = r * out_row_stride + Int64(off)
+
+                    # Partial-chunk handling: actual valid element count
+                    # is min(chunk_elems, D - off). TMA OOB-clamped the
+                    # tail to 0 in smem, we reduce only the valid bytes.
+                    off = chunk_idx * Int32(chunk_elems)
+                    cur_elems = D - off
+                    if cur_elems > Int32(chunk_elems):
+                        cur_elems = Int32(chunk_elems)
+                    cur_bytes = cur_elems * Int32(elem_bytes)
+
+                    dst_off = r * out_rs + Int64(off)
                     gmem_dst_u64 = Int64((mOut.iterator + dst_off).toint())
-                    reduce_op(gmem_dst_u64, cvta_smem(cbuf_ptr), Int32(chunk_bytes))
+                    reduce_op(gmem_dst_u64, cvta_smem(cbuf_ptr), cur_bytes)
                     cute.arch.cp_async_bulk_commit_group()
                     cute.arch.cp_async_bulk_wait_group(0, read=False)
                     pipe.consumer_release(consumer_state)
 
                 producer_state.advance()
                 consumer_state.advance()
-                off = off + Int32(chunk_elems)
+                chunk_idx = chunk_idx + Int32(1)
 
             base = base + gdim_x
 
@@ -198,20 +230,28 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bo
         stream: cuda.CUstream,
         num_entries: Int32,
         D: Int32,
-        d_tile_size: Int32,
+        chunk_tile_size: Int32,
         grid_x: Int32,
         grid_y: Int32,
-        src_row_stride: Int64,
         out_row_stride: Int64,
     ):
-        _kernel(
+        # Build the tile-mode TMA descriptor. Shape (M_src, N) comes
+        # from mSrc; TMA clamps OOB column reads to 0, so rows with
+        # ``N % chunk_elems != 0`` are handled natively on the load.
+        tma_atom, tma_tensor_src = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
             mSrc,
+            cute.make_layout((1, chunk_elems)),
+            (1, chunk_elems),
+        )
+        _kernel(
+            tma_atom,
+            tma_tensor_src,
             mIndex,
             mOut,
             num_entries,
             D,
-            d_tile_size,
-            src_row_stride,
+            chunk_tile_size,
             out_row_stride,
         ).launch(
             grid=[grid_x, grid_y, 1],
@@ -224,10 +264,15 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bo
 
 def _chunk_elems_for(torch_dtype: torch.dtype, N: int) -> int:
     """Compile-time ``chunk_elems``: whole row if it fits in
-    ``_MAX_CHUNK_BYTES``, else ``_MAX_CHUNK_BYTES // elem_bytes``."""
+    ``_MAX_CHUNK_BYTES``, else ``_MAX_CHUNK_BYTES // elem_bytes``.
+    Rounded down to a multiple of ``16 / elem_bytes`` so the final
+    partial chunk (if any) still satisfies the 16-byte reduce
+    alignment."""
     elem_bytes = torch.tensor([], dtype=torch_dtype).element_size()
     row_bytes = N * elem_bytes
     chunk_bytes = min(row_bytes, _MAX_CHUNK_BYTES)
+    # Ensure chunk_bytes itself is 16-aligned (true for 512, true for
+    # any small row since cond requires row_bytes % 16 == 0).
     return chunk_bytes // elem_bytes
 
 
@@ -260,15 +305,15 @@ def _compile_tma_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
         Int32(0),
         Int32(0),
         Int64(0),
-        Int64(0),
         options="--enable-tvm-ffi",
     )
 
 
 def min_d_divisor_for(dtype: torch.dtype) -> int:
-    """Smallest value D must be divisible by so ``cp.async.bulk`` transfers
-    stay 16-byte-aligned: ``D * sizeof(dtype) % 16 == 0``, i.e.
-    ``D % (16 / gcd(16, sizeof(dtype))) == 0``.
+    """Smallest value D must be divisible by so ``cp.reduce.async.bulk``
+    gmem operands stay 16-byte aligned: ``D * sizeof(dtype) % 16 == 0``,
+    i.e. ``D % (16 / gcd(16, sizeof(dtype))) == 0``. fp32: %4,
+    bf16/fp16: %8.
     """
     esize = torch.tensor([], dtype=dtype).element_size()
     return 16 // math.gcd(16, esize)
@@ -277,30 +322,26 @@ def min_d_divisor_for(dtype: torch.dtype) -> int:
 def row_shape_supported(dtype: torch.dtype, N: int) -> bool:
     """Host-side check: can the TMA kernel handle an N-element row?
 
-    chunk_bytes is chosen at compile time as ``min(row_bytes, 512)``, and
-    ``cute.copy``'s transfer size is tied to the tensor shape, so every
-    chunk must be full-sized. That means ``row_bytes`` must be a multiple
-    of ``chunk_bytes`` (always true when row_bytes < 512) and
-    ``chunk_bytes`` must itself be 16-byte aligned.
+    Only requirement is that ``row_bytes = N * elem_size`` is a multiple
+    of 16, which is the PTX operand alignment for both the tile-mode
+    TMA load (per-row stride must be 16-aligned) and
+    ``cp.reduce.async.bulk`` (gmem address + byte count must be
+    16-aligned). Rows that aren't multiples of ``chunk_elems`` are
+    handled via the TMA descriptor's OOB-clamp-to-zero behavior.
     """
     esize = torch.tensor([], dtype=dtype).element_size()
-    row_bytes = N * esize
-    chunk_bytes = min(row_bytes, _MAX_CHUNK_BYTES)
-    if chunk_bytes % 16 != 0:
-        return False
-    return row_bytes % chunk_bytes == 0
+    return (N * esize) % 16 == 0
 
 
 def _plan_grid(M: int, D: int, chunk_elems: int, sm: int) -> tuple[int, int, int]:
-    """Pick ``(grid_x, grid_y, d_tile_size)``.
+    """Pick ``(grid_x, grid_y, chunk_tile_size)``.
 
-    Strategy: keep the classic 1D schedule (grid_y=1, whole D per warp with
-    internal double-buffering) whenever the row-axis alone saturates the
-    GPU. When N is too small for that, split D across the y-axis so every
-    SM gets work. The y-tile size is ``chunk_elems`` so warps don't lose
-    the within-warp pipeline completely, but several chunks' worth of
-    D-tiles go to different CTAs in parallel.
+    Strategy: keep the classic 1D schedule (grid_y=1, whole chunk range
+    per CTA with internal double-buffering) whenever the row-axis alone
+    saturates the GPU. When M is too small for that, split the
+    chunk-axis across grid_y so every SM gets work.
     """
+    n_chunks = (D + chunk_elems - 1) // chunk_elems
     # 1 warp per CTA: need many more CTAs than an 8-warp layout to keep
     # occupancy up. sm*32 target with a sm*64 clamp works well across
     # uniform / high_cont / few_idx on B200.
@@ -308,20 +349,15 @@ def _plan_grid(M: int, D: int, chunk_elems: int, sm: int) -> tuple[int, int, int
     target_ctas = sm * 32
     if row_ctas >= target_ctas:
         grid_x = min(row_ctas, sm * 64)
-        return grid_x, 1, D
-    # Split D across y until we hit the target, but don't shrink tiles
-    # below chunk_elems (that would break the within-warp pipeline).
-    n_d_tiles = (D + chunk_elems - 1) // chunk_elems
+        return grid_x, 1, n_chunks
+    # Split the chunk axis until we hit the target.
     want_y = max(1, target_ctas // max(row_ctas, 1))
-    grid_y = min(n_d_tiles, want_y)
-    # d_tile_size rounded up to chunk_elems multiples; last tile may be
-    # shorter (handled by d_end clamp in the kernel).
-    tiles_per_y = (n_d_tiles + grid_y - 1) // grid_y
-    d_tile_size = tiles_per_y * chunk_elems
-    # Recompute grid_y now that each y-slot holds tiles_per_y chunks.
-    grid_y = (D + d_tile_size - 1) // d_tile_size
+    grid_y = min(n_chunks, want_y)
+    chunk_tile_size = (n_chunks + grid_y - 1) // grid_y
+    # Recompute grid_y now that each y-slot holds chunk_tile_size chunks.
+    grid_y = (n_chunks + chunk_tile_size - 1) // chunk_tile_size
     grid_x = row_ctas
-    return grid_x, grid_y, d_tile_size
+    return grid_x, grid_y, chunk_tile_size
 
 
 def tma_scatter_add_into(
@@ -331,10 +367,10 @@ def tma_scatter_add_into(
 ) -> None:
     """In-place: ``out[index_1d[i], :] += src[i, :]`` for every i.
 
-    ``out`` and ``src`` are 2D (M_out, N) and (M_src, N) with inner-dim
-    stride 1; the outer row stride can differ from N (e.g. a slice of a
-    wider buffer). ``index_1d`` is 1D int64 of length M_src. N must
-    satisfy ``row_shape_supported``; the cond checks this.
+    ``out`` / ``src`` are 2D with inner-dim stride 1 (outer row stride
+    can differ from N, e.g. a slice of a wider buffer). ``index_1d`` is
+    1D int64 of length M_src. ``row_bytes = N * elem_size`` must be a
+    multiple of 16; the host cond enforces this.
     """
     M, N = src.shape
     chunk_elems = _chunk_elems_for(src.dtype, N)
@@ -342,16 +378,15 @@ def tma_scatter_add_into(
     compiled = _compile_tma_scatter(src.dtype, N, contig)
     sm = torch.cuda.get_device_properties(out.device).multi_processor_count
 
-    grid_x, grid_y, d_tile_size = _plan_grid(M, N, chunk_elems, sm)
+    grid_x, grid_y, chunk_tile_size = _plan_grid(M, N, chunk_elems, sm)
     compiled(
         src,
         index_1d,
         out,
         M,
         N,
-        d_tile_size,
+        chunk_tile_size,
         grid_x,
         grid_y,
-        src.stride(0),
         out.stride(0),
     )

--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -2,20 +2,24 @@
 
 Port of the CUDA C++ kernel from https://github.com/pytorch/pytorch/pull/182675
 to CuTeDSL. Each warp handles one source row (within an assigned D-range):
-a TMA bulk load stages ``src[i, d_start:d_end]`` into smem, then
+a TMA bulk load (``cute.copy`` with ``CopyBulkG2SOp``) stages
+``src[i, d_start:d_end]`` into smem, then
 ``cp.reduce.async.bulk.global.shared::cta.bulk_group.add`` deposits the
 reduction into ``out[index[i], d_start:d_end]``.
 
-Chunks along D in 512-byte slices, double-buffered so the next chunk's
-load overlaps the current chunk's reduce.
+Chunks along D in ``chunk_bytes``-sized slices, double-buffered so the
+next chunk's load overlaps the current chunk's reduce. ``chunk_bytes`` is
+``min(row_bytes, _MAX_CHUNK_BYTES)`` at compile time: small rows travel
+as a single chunk, large rows chunk at 512B. Because ``cute.copy``
+derives the transfer size from the tensor shape, ``chunk_bytes`` must
+evenly divide ``row_bytes`` -- the host cond enforces this.
 
 Grid layout is 2D to maintain SM utilization for shapes with small N and
 large D: ``(grid_x, grid_y)``, where ``grid_y`` partitions the D axis
 into disjoint chunks and each warp iterates only its assigned chunk.
 When N is large the host sets ``grid_y = 1`` so the inner chunk loop
-recovers the original schedule (double-buffered all of D within each
-warp). When N is tiny (say 100 rows, D=640K), ``grid_y`` grows so the
-grid still fills the machine.
+recovers the classic schedule. When N is tiny (say 100 rows, D=640K),
+``grid_y`` grows so the grid still fills the machine.
 
 Restrictions (enforced by the host cond in ``cutedsl_impl.py``):
   - sm_90+ (cp.reduce.async.bulk availability)
@@ -23,7 +27,7 @@ Restrictions (enforced by the host cond in ``cutedsl_impl.py``):
   - index is the expanded-1D pattern (same shape as src, stride 0 on every
     axis except 0)
   - dtype in {fp32, fp16, bf16}
-  - N * elem_size % 16 == 0 (16-byte TMA alignment)
+  - row_bytes is a multiple of ``min(row_bytes, 512)``
 """
 
 import math
@@ -32,18 +36,18 @@ import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import BFloat16, Float16, Float32, Int32, Int64, Uint64
+import cutlass.cute.nvgpu.cpasync as cpasync
+import cutlass.pipeline as pipeline
+from cutlass import BFloat16, const_expr, Float16, Float32, Int32, Int64
 
 import torch
 from torch._vendor.quack.cache_utils import jit_cache
 
-from ._ptx import bulk_load, cvta_smem, make_bulk_reduce_add
+from ._ptx import cvta_smem, make_bulk_reduce_add
 
 
-# Tile size on the wire: 512 bytes per chunk.
-_CHUNK_BYTES = 512
-_WARPS_PER_BLOCK = 8
-_THREADS_PER_BLOCK = 32 * _WARPS_PER_BLOCK
+_MAX_CHUNK_BYTES = 512
+_THREADS_PER_CTA = 32  # one warp per CTA
 
 
 _TORCH_TO_CUTE = {
@@ -68,10 +72,31 @@ def _reduce_op_for(dtype):
     raise ValueError(f"unsupported dtype: {dtype}")
 
 
-def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op):
+def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bool):
     """Build a dtype-specialized kernel closure. dtype/elem_bytes/chunk_elems
     are Python-time constants that the preprocessor folds at cute.compile
-    time."""
+    time.
+
+    ``chunk_elems`` is baked in at compile time, so the bulk-load transfer
+    size is fixed. That lets us use ``cute.copy(CopyBulkG2SOp(), ...)``
+    for the load and ``PipelineTmaAsync`` (tx_count = chunk_bytes) for
+    the producer/consumer synchronization. The bulk-reduce side still
+    emits raw PTX because cutedsl only ships a tile-mode TMA reduce op,
+    which requires a TMA descriptor and doesn't fit our dynamic per-row
+    gather.
+
+    One CTA = one warp. The single driver thread (tidx == 0) serves as
+    both producer (issues the TMA load) and consumer (issues the
+    bulk-reduce). Both CooperativeGroups are ``Agent.Thread, size=1``
+    so the mbarrier arrive counts match the single-threaded flow.
+
+    ``contig`` toggles a fast path: when True, row offset is computed as
+    ``entry_id * D`` using the compile-time D, avoiding a runtime
+    stride multiply. When False the kernel takes runtime row-stride
+    arguments so outer-strided tensors (e.g. slices) work.
+    """
+
+    chunk_bytes = chunk_elems * elem_bytes
 
     @cute.kernel
     def _kernel(
@@ -81,131 +106,89 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op):
         num_entries: Int32,
         D: Int32,
         d_tile_size: Int32,
+        src_row_stride: Int64,
+        out_row_stride: Int64,
     ):
         tidx, _, _ = cute.arch.thread_idx()
         bidx, bidy, _ = cute.arch.block_idx()
         gdim_x, _, _ = cute.arch.grid_dim()
 
-        warp_in_block = tidx // Int32(32)
-        lane = tidx - warp_in_block * Int32(32)
+        load_atom = cute.make_copy_atom(cpasync.CopyBulkG2SOp(), dtype)
 
-        # Assigned D-range for this CTA. bidy partitions D into disjoint
-        # slices of d_tile_size; grid_y == ceil(D / d_tile_size). When
-        # d_tile_size == D (the large-N case), grid_y == 1 and every CTA
-        # sees the whole D.
         d_start = bidy * d_tile_size
         d_end = d_start + d_tile_size
         if d_end > D:
             d_end = D
 
+        # For the contiguous fast path, row stride is just D; the
+        # runtime stride args get ignored.
+        if const_expr(contig):
+            src_row_stride = Int64(D)
+            out_row_stride = Int64(D)
+
         smem = cutlass.utils.SmemAllocator()
-        mbar_array = smem.allocate_array(Uint64, num_elems=_WARPS_PER_BLOCK * 2)
-        # 128-byte alignment so each warp's sub-buffer is TMA-aligned.
-        # allocate_tensor takes byte_alignment positionally; allocate_array
-        # on cutedsl < 4.5 does not support the keyword.
-        sAll = smem.allocate_tensor(
+        sBuf = smem.allocate_tensor(
             dtype,
-            cute.make_layout(_WARPS_PER_BLOCK * 2 * chunk_elems),
+            cute.make_layout((chunk_elems, 2)),
             128,
         )
-        sAll_ptr = sAll.iterator
+        mbar_storage = smem.allocate_array(cutlass.Uint64, num_elems=2 * 2)
 
-        warp_base = warp_in_block * Int32(2 * chunk_elems)
-        buf0_ptr = sAll_ptr + warp_base
-        buf1_ptr = sAll_ptr + (warp_base + Int32(chunk_elems))
-        buf0_u64 = cvta_smem(buf0_ptr)
-        buf1_u64 = cvta_smem(buf1_ptr)
+        pipe = pipeline.PipelineTmaAsync.create(
+            num_stages=2,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, size=1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, size=1),
+            tx_count=chunk_bytes,
+            barrier_storage=mbar_storage,
+            tidx=tidx,
+        )
 
-        mbar0_ptr = mbar_array + warp_in_block * Int32(2)
-        mbar1_ptr = mbar0_ptr + Int32(1)
+        producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, 2
+        )
+        consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, 2
+        )
 
-        if lane == Int32(0):
-            cute.arch.mbarrier_init(mbar0_ptr, 1)
-            cute.arch.mbarrier_init(mbar1_ptr, 1)
-        cute.arch.sync_threads()
-
-        mbar0_phase = Int32(0)
-        mbar1_phase = Int32(0)
-
-        entries_per_block = Int32(_WARPS_PER_BLOCK)
-        base = bidx * entries_per_block
+        base = bidx
         while base < num_entries:
-            entry_id = base + warp_in_block
-            if entry_id < num_entries:
-                # aten passes int64 index. Read first element of the row
-                # (all elements along axis 1 are identical: the cond
-                # requires index.stride(1) == 0).
-                idx_t = cute.make_tensor(
-                    mIndex.iterator + Int64(entry_id) * Int64(mIndex.stride[0]),
-                    cute.make_layout(1),
-                )
-                r = Int64(idx_t[0])
+            entry_id = base
+            r = Int64(mIndex[entry_id])
 
-                # Iterate chunks within [d_start, d_end) with double-buffering.
-                phase = Int32(0)
-                off = d_start
-                while off < d_end:
-                    cur_elems = d_end - off
-                    if cur_elems > Int32(chunk_elems):
-                        cur_elems = Int32(chunk_elems)
-                    cur_bytes = cur_elems * Int32(elem_bytes)
+            off = d_start
+            while off < d_end:
+                if tidx == Int32(0):
+                    pipe.producer_acquire(producer_state)
+                    src_slice = cute.make_tensor(
+                        mSrc.iterator + (Int64(entry_id) * src_row_stride + Int64(off)),
+                        cute.make_layout(chunk_elems),
+                    )
+                    dst_slice = cute.make_tensor(
+                        sBuf.iterator + producer_state.index * Int32(chunk_elems),
+                        cute.make_layout(chunk_elems),
+                    )
+                    cute.copy(
+                        load_atom,
+                        src_slice,
+                        dst_slice,
+                        mbar_ptr=pipe.producer_get_barrier(producer_state),
+                    )
+                    pipe.producer_commit(producer_state)
 
-                    cur = phase & Int32(1)
-
-                    if phase >= Int32(2) and lane == Int32(0):
-                        cute.arch.cp_async_bulk_wait_group(1, read=False)
-
-                    if lane == Int32(0):
-                        if cur == Int32(0):
-                            cute.arch.mbarrier_arrive_and_expect_tx(
-                                mbar0_ptr, cur_bytes
-                            )
-                        else:
-                            cute.arch.mbarrier_arrive_and_expect_tx(
-                                mbar1_ptr, cur_bytes
-                            )
-
-                        src_off = Int64(entry_id) * Int64(D) + Int64(off)
-                        gmem_src_u64 = Int64((mSrc.iterator + src_off).toint())
-
-                        if cur == Int32(0):
-                            bulk_load(
-                                buf0_u64,
-                                gmem_src_u64,
-                                cur_bytes,
-                                cvta_smem(mbar0_ptr),
-                            )
-                        else:
-                            bulk_load(
-                                buf1_u64,
-                                gmem_src_u64,
-                                cur_bytes,
-                                cvta_smem(mbar1_ptr),
-                            )
-
-                    if cur == Int32(0):
-                        cute.arch.mbarrier_wait(mbar0_ptr, mbar0_phase & Int32(1))
-                        mbar0_phase = mbar0_phase + Int32(1)
-                    else:
-                        cute.arch.mbarrier_wait(mbar1_ptr, mbar1_phase & Int32(1))
-                        mbar1_phase = mbar1_phase + Int32(1)
-
-                    if lane == Int32(0):
-                        dst_off = r * Int64(D) + Int64(off)
-                        gmem_dst_u64 = Int64((mOut.iterator + dst_off).toint())
-                        if cur == Int32(0):
-                            reduce_op(gmem_dst_u64, buf0_u64, cur_bytes)
-                        else:
-                            reduce_op(gmem_dst_u64, buf1_u64, cur_bytes)
-                        cute.arch.cp_async_bulk_commit_group()
-
-                    off = off + Int32(chunk_elems)
-                    phase = phase + Int32(1)
-
-                if lane == Int32(0):
+                    pipe.consumer_wait(consumer_state)
+                    cbuf_ptr = sBuf.iterator + consumer_state.index * Int32(chunk_elems)
+                    dst_off = r * out_row_stride + Int64(off)
+                    gmem_dst_u64 = Int64((mOut.iterator + dst_off).toint())
+                    reduce_op(gmem_dst_u64, cvta_smem(cbuf_ptr), Int32(chunk_bytes))
+                    cute.arch.cp_async_bulk_commit_group()
                     cute.arch.cp_async_bulk_wait_group(0, read=False)
+                    pipe.consumer_release(consumer_state)
 
-            base = base + gdim_x * entries_per_block
+                producer_state.advance()
+                consumer_state.advance()
+                off = off + Int32(chunk_elems)
+
+            base = base + gdim_x
 
     @cute.jit
     def _launch(
@@ -218,30 +201,50 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op):
         d_tile_size: Int32,
         grid_x: Int32,
         grid_y: Int32,
+        src_row_stride: Int64,
+        out_row_stride: Int64,
     ):
-        _kernel(mSrc, mIndex, mOut, num_entries, D, d_tile_size).launch(
+        _kernel(
+            mSrc,
+            mIndex,
+            mOut,
+            num_entries,
+            D,
+            d_tile_size,
+            src_row_stride,
+            out_row_stride,
+        ).launch(
             grid=[grid_x, grid_y, 1],
-            block=[_THREADS_PER_BLOCK, 1, 1],
+            block=[_THREADS_PER_CTA, 1, 1],
             stream=stream,
         )
 
     return _launch
 
 
+def _chunk_elems_for(torch_dtype: torch.dtype, N: int) -> int:
+    """Compile-time ``chunk_elems``: whole row if it fits in
+    ``_MAX_CHUNK_BYTES``, else ``_MAX_CHUNK_BYTES // elem_bytes``."""
+    elem_bytes = torch.tensor([], dtype=torch_dtype).element_size()
+    row_bytes = N * elem_bytes
+    chunk_bytes = min(row_bytes, _MAX_CHUNK_BYTES)
+    return chunk_bytes // elem_bytes
+
+
 @jit_cache
-def _compile_tma_scatter(torch_dtype: torch.dtype, N: int):
+def _compile_tma_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
     dtype = _TORCH_TO_CUTE[torch_dtype]
     elem_bytes = dtype.width // 8
-    chunk_elems = _CHUNK_BYTES // elem_bytes
+    chunk_elems = _chunk_elems_for(torch_dtype, N)
     reduce_op = _reduce_op_for(dtype)
-    launcher = _make_kernel(dtype, elem_bytes, chunk_elems, reduce_op)
+    launcher = _make_kernel(dtype, elem_bytes, chunk_elems, reduce_op, contig)
 
     mSrc_fake = cute.runtime.make_fake_tensor(
         dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
     )
-    mIndex_fake = cute.runtime.make_fake_tensor(
-        Int64, (cute.sym_int(),), stride=(cute.sym_int64(),)
-    )
+    # Index is guaranteed contiguous by _flatten_for_expanded_1d; fix
+    # stride=1 so `mIndex[i]` doesn't emit a runtime stride multiply.
+    mIndex_fake = cute.runtime.make_fake_tensor(Int64, (cute.sym_int(),), stride=(1,))
     mOut_fake = cute.runtime.make_fake_tensor(
         dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
     )
@@ -256,6 +259,8 @@ def _compile_tma_scatter(torch_dtype: torch.dtype, N: int):
         Int32(0),
         Int32(0),
         Int32(0),
+        Int64(0),
+        Int64(0),
         options="--enable-tvm-ffi",
     )
 
@@ -269,6 +274,23 @@ def min_d_divisor_for(dtype: torch.dtype) -> int:
     return 16 // math.gcd(16, esize)
 
 
+def row_shape_supported(dtype: torch.dtype, N: int) -> bool:
+    """Host-side check: can the TMA kernel handle an N-element row?
+
+    chunk_bytes is chosen at compile time as ``min(row_bytes, 512)``, and
+    ``cute.copy``'s transfer size is tied to the tensor shape, so every
+    chunk must be full-sized. That means ``row_bytes`` must be a multiple
+    of ``chunk_bytes`` (always true when row_bytes < 512) and
+    ``chunk_bytes`` must itself be 16-byte aligned.
+    """
+    esize = torch.tensor([], dtype=dtype).element_size()
+    row_bytes = N * esize
+    chunk_bytes = min(row_bytes, _MAX_CHUNK_BYTES)
+    if chunk_bytes % 16 != 0:
+        return False
+    return row_bytes % chunk_bytes == 0
+
+
 def _plan_grid(M: int, D: int, chunk_elems: int, sm: int) -> tuple[int, int, int]:
     """Pick ``(grid_x, grid_y, d_tile_size)``.
 
@@ -279,11 +301,13 @@ def _plan_grid(M: int, D: int, chunk_elems: int, sm: int) -> tuple[int, int, int
     the within-warp pipeline completely, but several chunks' worth of
     D-tiles go to different CTAs in parallel.
     """
-    row_ctas = (M + _WARPS_PER_BLOCK - 1) // _WARPS_PER_BLOCK
-    target_ctas = sm * 4  # modest oversubscription per SM
+    # 1 warp per CTA: need many more CTAs than an 8-warp layout to keep
+    # occupancy up. sm*32 target with a sm*64 clamp works well across
+    # uniform / high_cont / few_idx on B200.
+    row_ctas = M
+    target_ctas = sm * 32
     if row_ctas >= target_ctas:
-        # Row axis alone saturates; keep the classic schedule.
-        grid_x = min(row_ctas, sm * 8)
+        grid_x = min(row_ctas, sm * 64)
         return grid_x, 1, D
     # Split D across y until we hit the target, but don't shrink tiles
     # below chunk_elems (that would break the within-warp pipeline).
@@ -307,15 +331,27 @@ def tma_scatter_add_into(
 ) -> None:
     """In-place: ``out[index_1d[i], :] += src[i, :]`` for every i.
 
-    ``out`` and ``src`` must be contiguous (M_out, N) and (M_src, N);
-    ``index_1d`` is 1D int64 of length M_src. N must satisfy
-    ``min_d_divisor_for(src.dtype)``; the cond checks this.
+    ``out`` and ``src`` are 2D (M_out, N) and (M_src, N) with inner-dim
+    stride 1; the outer row stride can differ from N (e.g. a slice of a
+    wider buffer). ``index_1d`` is 1D int64 of length M_src. N must
+    satisfy ``row_shape_supported``; the cond checks this.
     """
     M, N = src.shape
-    elem_bytes = torch.tensor([], dtype=src.dtype).element_size()
-    chunk_elems = _CHUNK_BYTES // elem_bytes
-    compiled = _compile_tma_scatter(src.dtype, N)
+    chunk_elems = _chunk_elems_for(src.dtype, N)
+    contig = src.stride(0) == N and out.stride(0) == N
+    compiled = _compile_tma_scatter(src.dtype, N, contig)
     sm = torch.cuda.get_device_properties(out.device).multi_processor_count
 
     grid_x, grid_y, d_tile_size = _plan_grid(M, N, chunk_elems, sm)
-    compiled(src, index_1d, out, M, N, d_tile_size, grid_x, grid_y)
+    compiled(
+        src,
+        index_1d,
+        out,
+        M,
+        N,
+        d_tile_size,
+        grid_x,
+        grid_y,
+        src.stride(0),
+        out.stride(0),
+    )

--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -1,0 +1,321 @@
+"""TMA-based scatter_add for the ``index.unsqueeze(-1).expand(-1, N)`` pattern.
+
+Port of the CUDA C++ kernel from https://github.com/pytorch/pytorch/pull/182675
+to CuTeDSL. Each warp handles one source row (within an assigned D-range):
+a TMA bulk load stages ``src[i, d_start:d_end]`` into smem, then
+``cp.reduce.async.bulk.global.shared::cta.bulk_group.add`` deposits the
+reduction into ``out[index[i], d_start:d_end]``.
+
+Chunks along D in 512-byte slices, double-buffered so the next chunk's
+load overlaps the current chunk's reduce.
+
+Grid layout is 2D to maintain SM utilization for shapes with small N and
+large D: ``(grid_x, grid_y)``, where ``grid_y`` partitions the D axis
+into disjoint chunks and each warp iterates only its assigned chunk.
+When N is large the host sets ``grid_y = 1`` so the inner chunk loop
+recovers the original schedule (double-buffered all of D within each
+warp). When N is tiny (say 100 rows, D=640K), ``grid_y`` grows so the
+grid still fills the machine.
+
+Restrictions (enforced by the host cond in ``cutedsl_impl.py``):
+  - sm_90+ (cp.reduce.async.bulk availability)
+  - dim == 0, rank >= 2, self/src contiguous
+  - index is the expanded-1D pattern (same shape as src, stride 0 on every
+    axis except 0)
+  - dtype in {fp32, fp16, bf16}
+  - N * elem_size % 16 == 0 (16-byte TMA alignment)
+"""
+
+import math
+
+import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import BFloat16, Float16, Float32, Int32, Int64, Uint64
+
+import torch
+from torch._vendor.quack.cache_utils import jit_cache
+
+from ._ptx import bulk_load, cvta_smem, make_bulk_reduce_add
+
+
+# Tile size on the wire: 512 bytes per chunk.
+_CHUNK_BYTES = 512
+_WARPS_PER_BLOCK = 8
+_THREADS_PER_BLOCK = 32 * _WARPS_PER_BLOCK
+
+
+_TORCH_TO_CUTE = {
+    torch.float32: Float32,
+    torch.float16: Float16,
+    torch.bfloat16: BFloat16,
+}
+
+
+_bulk_reduce_add_f32 = make_bulk_reduce_add("f32")
+_bulk_reduce_add_f16 = make_bulk_reduce_add("noftz.f16")
+_bulk_reduce_add_bf16 = make_bulk_reduce_add("noftz.bf16")
+
+
+def _reduce_op_for(dtype):
+    if dtype is Float32:
+        return _bulk_reduce_add_f32
+    if dtype is Float16:
+        return _bulk_reduce_add_f16
+    if dtype is BFloat16:
+        return _bulk_reduce_add_bf16
+    raise ValueError(f"unsupported dtype: {dtype}")
+
+
+def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op):
+    """Build a dtype-specialized kernel closure. dtype/elem_bytes/chunk_elems
+    are Python-time constants that the preprocessor folds at cute.compile
+    time."""
+
+    @cute.kernel
+    def _kernel(
+        mSrc: cute.Tensor,
+        mIndex: cute.Tensor,
+        mOut: cute.Tensor,
+        num_entries: Int32,
+        D: Int32,
+        d_tile_size: Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, _ = cute.arch.block_idx()
+        gdim_x, _, _ = cute.arch.grid_dim()
+
+        warp_in_block = tidx // Int32(32)
+        lane = tidx - warp_in_block * Int32(32)
+
+        # Assigned D-range for this CTA. bidy partitions D into disjoint
+        # slices of d_tile_size; grid_y == ceil(D / d_tile_size). When
+        # d_tile_size == D (the large-N case), grid_y == 1 and every CTA
+        # sees the whole D.
+        d_start = bidy * d_tile_size
+        d_end = d_start + d_tile_size
+        if d_end > D:
+            d_end = D
+
+        smem = cutlass.utils.SmemAllocator()
+        mbar_array = smem.allocate_array(Uint64, num_elems=_WARPS_PER_BLOCK * 2)
+        # 128-byte alignment so each warp's sub-buffer is TMA-aligned.
+        # allocate_tensor takes byte_alignment positionally; allocate_array
+        # on cutedsl < 4.5 does not support the keyword.
+        sAll = smem.allocate_tensor(
+            dtype,
+            cute.make_layout(_WARPS_PER_BLOCK * 2 * chunk_elems),
+            128,
+        )
+        sAll_ptr = sAll.iterator
+
+        warp_base = warp_in_block * Int32(2 * chunk_elems)
+        buf0_ptr = sAll_ptr + warp_base
+        buf1_ptr = sAll_ptr + (warp_base + Int32(chunk_elems))
+        buf0_u64 = cvta_smem(buf0_ptr)
+        buf1_u64 = cvta_smem(buf1_ptr)
+
+        mbar0_ptr = mbar_array + warp_in_block * Int32(2)
+        mbar1_ptr = mbar0_ptr + Int32(1)
+
+        if lane == Int32(0):
+            cute.arch.mbarrier_init(mbar0_ptr, 1)
+            cute.arch.mbarrier_init(mbar1_ptr, 1)
+        cute.arch.sync_threads()
+
+        mbar0_phase = Int32(0)
+        mbar1_phase = Int32(0)
+
+        entries_per_block = Int32(_WARPS_PER_BLOCK)
+        base = bidx * entries_per_block
+        while base < num_entries:
+            entry_id = base + warp_in_block
+            if entry_id < num_entries:
+                # aten passes int64 index. Read first element of the row
+                # (all elements along axis 1 are identical: the cond
+                # requires index.stride(1) == 0).
+                idx_t = cute.make_tensor(
+                    mIndex.iterator + Int64(entry_id) * Int64(mIndex.stride[0]),
+                    cute.make_layout(1),
+                )
+                r = Int64(idx_t[0])
+
+                # Iterate chunks within [d_start, d_end) with double-buffering.
+                phase = Int32(0)
+                off = d_start
+                while off < d_end:
+                    cur_elems = d_end - off
+                    if cur_elems > Int32(chunk_elems):
+                        cur_elems = Int32(chunk_elems)
+                    cur_bytes = cur_elems * Int32(elem_bytes)
+
+                    cur = phase & Int32(1)
+
+                    if phase >= Int32(2) and lane == Int32(0):
+                        cute.arch.cp_async_bulk_wait_group(1, read=False)
+
+                    if lane == Int32(0):
+                        if cur == Int32(0):
+                            cute.arch.mbarrier_arrive_and_expect_tx(
+                                mbar0_ptr, cur_bytes
+                            )
+                        else:
+                            cute.arch.mbarrier_arrive_and_expect_tx(
+                                mbar1_ptr, cur_bytes
+                            )
+
+                        src_off = Int64(entry_id) * Int64(D) + Int64(off)
+                        gmem_src_u64 = Int64((mSrc.iterator + src_off).toint())
+
+                        if cur == Int32(0):
+                            bulk_load(
+                                buf0_u64,
+                                gmem_src_u64,
+                                cur_bytes,
+                                cvta_smem(mbar0_ptr),
+                            )
+                        else:
+                            bulk_load(
+                                buf1_u64,
+                                gmem_src_u64,
+                                cur_bytes,
+                                cvta_smem(mbar1_ptr),
+                            )
+
+                    if cur == Int32(0):
+                        cute.arch.mbarrier_wait(mbar0_ptr, mbar0_phase & Int32(1))
+                        mbar0_phase = mbar0_phase + Int32(1)
+                    else:
+                        cute.arch.mbarrier_wait(mbar1_ptr, mbar1_phase & Int32(1))
+                        mbar1_phase = mbar1_phase + Int32(1)
+
+                    if lane == Int32(0):
+                        dst_off = r * Int64(D) + Int64(off)
+                        gmem_dst_u64 = Int64((mOut.iterator + dst_off).toint())
+                        if cur == Int32(0):
+                            reduce_op(gmem_dst_u64, buf0_u64, cur_bytes)
+                        else:
+                            reduce_op(gmem_dst_u64, buf1_u64, cur_bytes)
+                        cute.arch.cp_async_bulk_commit_group()
+
+                    off = off + Int32(chunk_elems)
+                    phase = phase + Int32(1)
+
+                if lane == Int32(0):
+                    cute.arch.cp_async_bulk_wait_group(0, read=False)
+
+            base = base + gdim_x * entries_per_block
+
+    @cute.jit
+    def _launch(
+        mSrc: cute.Tensor,
+        mIndex: cute.Tensor,
+        mOut: cute.Tensor,
+        stream: cuda.CUstream,
+        num_entries: Int32,
+        D: Int32,
+        d_tile_size: Int32,
+        grid_x: Int32,
+        grid_y: Int32,
+    ):
+        _kernel(mSrc, mIndex, mOut, num_entries, D, d_tile_size).launch(
+            grid=[grid_x, grid_y, 1],
+            block=[_THREADS_PER_BLOCK, 1, 1],
+            stream=stream,
+        )
+
+    return _launch
+
+
+@jit_cache
+def _compile_tma_scatter(torch_dtype: torch.dtype, N: int):
+    dtype = _TORCH_TO_CUTE[torch_dtype]
+    elem_bytes = dtype.width // 8
+    chunk_elems = _CHUNK_BYTES // elem_bytes
+    reduce_op = _reduce_op_for(dtype)
+    launcher = _make_kernel(dtype, elem_bytes, chunk_elems, reduce_op)
+
+    mSrc_fake = cute.runtime.make_fake_tensor(
+        dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
+    )
+    mIndex_fake = cute.runtime.make_fake_tensor(
+        Int64, (cute.sym_int(),), stride=(cute.sym_int64(),)
+    )
+    mOut_fake = cute.runtime.make_fake_tensor(
+        dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
+    )
+    return cute.compile(
+        launcher,
+        mSrc_fake,
+        mIndex_fake,
+        mOut_fake,
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        Int32(0),
+        Int32(0),
+        Int32(0),
+        Int32(0),
+        Int32(0),
+        options="--enable-tvm-ffi",
+    )
+
+
+def min_d_divisor_for(dtype: torch.dtype) -> int:
+    """Smallest value D must be divisible by so ``cp.async.bulk`` transfers
+    stay 16-byte-aligned: ``D * sizeof(dtype) % 16 == 0``, i.e.
+    ``D % (16 / gcd(16, sizeof(dtype))) == 0``.
+    """
+    esize = torch.tensor([], dtype=dtype).element_size()
+    return 16 // math.gcd(16, esize)
+
+
+def _plan_grid(M: int, D: int, chunk_elems: int, sm: int) -> tuple[int, int, int]:
+    """Pick ``(grid_x, grid_y, d_tile_size)``.
+
+    Strategy: keep the classic 1D schedule (grid_y=1, whole D per warp with
+    internal double-buffering) whenever the row-axis alone saturates the
+    GPU. When N is too small for that, split D across the y-axis so every
+    SM gets work. The y-tile size is ``chunk_elems`` so warps don't lose
+    the within-warp pipeline completely, but several chunks' worth of
+    D-tiles go to different CTAs in parallel.
+    """
+    row_ctas = (M + _WARPS_PER_BLOCK - 1) // _WARPS_PER_BLOCK
+    target_ctas = sm * 4  # modest oversubscription per SM
+    if row_ctas >= target_ctas:
+        # Row axis alone saturates; keep the classic schedule.
+        grid_x = min(row_ctas, sm * 8)
+        return grid_x, 1, D
+    # Split D across y until we hit the target, but don't shrink tiles
+    # below chunk_elems (that would break the within-warp pipeline).
+    n_d_tiles = (D + chunk_elems - 1) // chunk_elems
+    want_y = max(1, target_ctas // max(row_ctas, 1))
+    grid_y = min(n_d_tiles, want_y)
+    # d_tile_size rounded up to chunk_elems multiples; last tile may be
+    # shorter (handled by d_end clamp in the kernel).
+    tiles_per_y = (n_d_tiles + grid_y - 1) // grid_y
+    d_tile_size = tiles_per_y * chunk_elems
+    # Recompute grid_y now that each y-slot holds tiles_per_y chunks.
+    grid_y = (D + d_tile_size - 1) // d_tile_size
+    grid_x = row_ctas
+    return grid_x, grid_y, d_tile_size
+
+
+def tma_scatter_add_into(
+    out: torch.Tensor,
+    index_1d: torch.Tensor,
+    src: torch.Tensor,
+) -> None:
+    """In-place: ``out[index_1d[i], :] += src[i, :]`` for every i.
+
+    ``out`` and ``src`` must be contiguous (M_out, N) and (M_src, N);
+    ``index_1d`` is 1D int64 of length M_src. N must satisfy
+    ``min_d_divisor_for(src.dtype)``; the cond checks this.
+    """
+    M, N = src.shape
+    elem_bytes = torch.tensor([], dtype=src.dtype).element_size()
+    chunk_elems = _CHUNK_BYTES // elem_bytes
+    compiled = _compile_tma_scatter(src.dtype, N)
+    sm = torch.cuda.get_device_properties(out.device).multi_processor_count
+
+    grid_x, grid_y, d_tile_size = _plan_grid(M, N, chunk_elems, sm)
+    compiled(src, index_1d, out, M, N, d_tile_size, grid_x, grid_y)

--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -23,6 +23,12 @@ guards the reduce. Producer and consumer cooperative groups are both
 does both roles. ``PipelineState.advance()`` handles the stage index +
 phase bit.
 
+The pipeline is software-pipelined across the flat sequence of
+``(entry, chunk)`` pairs: each loop iteration issues the TMA load for
+the current pair and consumes the previous one, keeping one TMA load
+in flight alongside an in-progress bulk-reduce. An epilogue drains
+the final outstanding load.
+
 Chunks along D at a compile-time ``chunk_elems``: small rows travel as
 a single chunk, large rows chunk at 512 B. The TMA descriptor OOB-clamp
 handles rows whose length isn't a multiple of ``chunk_elems``.
@@ -51,6 +57,7 @@ import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.cpasync as cpasync
+import cutlass.cute.testing as cute_testing
 import cutlass.pipeline as pipeline
 from cutlass import BFloat16, const_expr, Float16, Float32, Int32, Int64
 
@@ -86,10 +93,12 @@ def _reduce_op_for(dtype):
     raise ValueError(f"unsupported dtype: {dtype}")
 
 
-def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bool):
-    """Build a dtype-specialized kernel closure. dtype/elem_bytes/chunk_elems
-    /contig are Python-time constants that the preprocessor folds at
-    cute.compile time.
+def _make_kernel(
+    dtype, elem_bytes: int, N: int, chunk_elems: int, reduce_op, contig: bool
+):
+    """Build a dtype-specialized kernel closure. dtype/elem_bytes/N
+    /chunk_elems/contig are Python-time constants that the preprocessor
+    folds at cute.compile time.
 
     ``chunk_elems`` is baked in at compile time. The TMA descriptor
     built in ``_launch`` (via ``make_tiled_tma_atom`` on the source
@@ -111,6 +120,9 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bo
     """
 
     chunk_bytes = chunk_elems * elem_bytes
+    # Compile-time derived values. num_chunks covers row_bytes with
+    # partial final chunk handled by TMA OOB clamp.
+    num_chunks = (N + chunk_elems - 1) // chunk_elems
 
     @cute.kernel
     def _kernel(
@@ -118,28 +130,29 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bo
         tma_tensor_src: cute.Tensor,  # TMA-view of mSrc
         mIndex: cute.Tensor,
         mOut: cute.Tensor,
-        num_entries: Int32,
-        D: Int32,
-        chunk_tile_size: Int32,  # number of chunks per grid_y slot
+        chunks_per_cta: Int32,
         out_row_stride: Int64,
     ):
         tidx, _, _ = cute.arch.thread_idx()
         bidx, bidy, _ = cute.arch.block_idx()
         gdim_x, _, _ = cute.arch.grid_dim()
 
-        # Chunk-index range assigned to this CTA. bidy partitions the
-        # chunk axis into disjoint slices of chunk_tile_size; when
-        # chunk_tile_size == num_chunks, grid_y == 1 and every CTA sees
-        # the whole D.
-        num_chunks = (D + Int32(chunk_elems) - Int32(1)) // Int32(chunk_elems)
-        chunk_start = bidy * chunk_tile_size
-        chunk_end = chunk_start + chunk_tile_size
-        if chunk_end > num_chunks:
-            chunk_end = num_chunks
+        # num_entries (M_src) comes from mIndex's shape; mIndex is 1D
+        # of length M_src after host-side flattening.
+        num_entries = mIndex.shape[0]
 
-        # Reduce-side out-row stride: compile-time D (contig) or runtime.
+        # Chunk-index range assigned to this CTA. bidy partitions the
+        # chunk axis into disjoint slices of chunks_per_cta; when
+        # chunks_per_cta == num_chunks, grid_y == 1 and every CTA sees
+        # the whole D.
+        chunk_start = bidy * chunks_per_cta
+        chunk_end = chunk_start + chunks_per_cta
+        if chunk_end > Int32(num_chunks):
+            chunk_end = Int32(num_chunks)
+
+        # Reduce-side out-row stride: compile-time N (contig) or runtime.
         if const_expr(contig):
-            out_rs = Int64(D)
+            out_rs = Int64(N)
         else:
             out_rs = out_row_stride
 
@@ -180,14 +193,34 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bo
             pipeline.PipelineUserType.Consumer, 2
         )
 
+        # Software-pipelined schedule: at each iteration, issue the TMA
+        # load for the current (entry, chunk) pair, then consume the
+        # previous pair (bulk-reduce). With num_stages=2 this keeps one
+        # TMA load in flight while a bulk-reduce is running. Final
+        # iteration's load is drained in an epilogue after the main loop.
+        # pair_count is a runtime Int32 so the ``pair_count > 0`` branch
+        # stays in the compiled IR (a Python bool would be baked in at
+        # trace time).
+        pair_count = Int32(0)
+        prev_chunk_idx = Int32(0)
+        prev_r = Int64(0)
+
         base = bidx
         while base < num_entries:
             entry_id = base
-            r = Int64(mIndex[entry_id])
 
             chunk_idx = chunk_start
             while chunk_idx < chunk_end:
                 if tidx == Int32(0):
+                    r = Int64(mIndex[entry_id])
+                    # Bounds check: index values must be valid output
+                    # rows. Compiling with ``--enable-assertions`` turns
+                    # this into a device-side trap; otherwise it folds
+                    # away. Driver thread only -- no need to replicate
+                    # the check across all 32 lanes.
+                    cute_testing.assert_(r >= Int64(0))
+                    cute_testing.assert_(r < Int64(mOut.shape[0]))
+
                     pipe.producer_acquire(producer_state)
                     cute.copy(
                         tma_atom,
@@ -196,31 +229,58 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bo
                         tma_bar_ptr=pipe.producer_get_barrier(producer_state),
                     )
                     pipe.producer_commit(producer_state)
+                    producer_state.advance()
 
-                    pipe.consumer_wait(consumer_state)
-                    cbuf_ptr = sBuf.iterator + consumer_state.index * Int32(chunk_elems)
+                    if pair_count > Int32(0):
+                        pipe.consumer_wait(consumer_state)
+                        cbuf_ptr = sBuf.iterator + consumer_state.index * Int32(
+                            chunk_elems
+                        )
 
-                    # Partial-chunk handling: actual valid element count
-                    # is min(chunk_elems, D - off). TMA OOB-clamped the
-                    # tail to 0 in smem, we reduce only the valid bytes.
-                    off = chunk_idx * Int32(chunk_elems)
-                    cur_elems = D - off
-                    if cur_elems > Int32(chunk_elems):
-                        cur_elems = Int32(chunk_elems)
-                    cur_bytes = cur_elems * Int32(elem_bytes)
+                        # Partial-chunk handling: actual valid element
+                        # count is min(chunk_elems, N - off). TMA
+                        # OOB-clamped the tail to 0 in smem, we reduce
+                        # only the valid bytes.
+                        off = prev_chunk_idx * Int32(chunk_elems)
+                        cur_elems = Int32(N) - off
+                        if cur_elems > Int32(chunk_elems):
+                            cur_elems = Int32(chunk_elems)
+                        cur_bytes = cur_elems * Int32(elem_bytes)
 
-                    dst_off = r * out_rs + Int64(off)
-                    gmem_dst_u64 = Int64((mOut.iterator + dst_off).toint())
-                    reduce_op(gmem_dst_u64, cvta_smem(cbuf_ptr), cur_bytes)
-                    cute.arch.cp_async_bulk_commit_group()
-                    cute.arch.cp_async_bulk_wait_group(0, read=False)
-                    pipe.consumer_release(consumer_state)
+                        dst_off = prev_r * out_rs + Int64(off)
+                        gmem_dst_u64 = Int64((mOut.iterator + dst_off).toint())
+                        reduce_op(gmem_dst_u64, cvta_smem(cbuf_ptr), cur_bytes)
+                        cute.arch.cp_async_bulk_commit_group()
+                        cute.arch.cp_async_bulk_wait_group(0, read=False)
+                        pipe.consumer_release(consumer_state)
+                        consumer_state.advance()
 
-                producer_state.advance()
-                consumer_state.advance()
+                    prev_chunk_idx = chunk_idx
+                    prev_r = r
+                    pair_count = pair_count + Int32(1)
+
                 chunk_idx = chunk_idx + Int32(1)
 
             base = base + gdim_x
+
+        # Epilogue: drain the last outstanding TMA load.
+        if tidx == Int32(0):
+            if pair_count > Int32(0):
+                pipe.consumer_wait(consumer_state)
+                cbuf_ptr = sBuf.iterator + consumer_state.index * Int32(chunk_elems)
+
+                off = prev_chunk_idx * Int32(chunk_elems)
+                cur_elems = Int32(N) - off
+                if cur_elems > Int32(chunk_elems):
+                    cur_elems = Int32(chunk_elems)
+                cur_bytes = cur_elems * Int32(elem_bytes)
+
+                dst_off = prev_r * out_rs + Int64(off)
+                gmem_dst_u64 = Int64((mOut.iterator + dst_off).toint())
+                reduce_op(gmem_dst_u64, cvta_smem(cbuf_ptr), cur_bytes)
+                cute.arch.cp_async_bulk_commit_group()
+                cute.arch.cp_async_bulk_wait_group(0, read=False)
+                pipe.consumer_release(consumer_state)
 
     @cute.jit
     def _launch(
@@ -228,9 +288,7 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bo
         mIndex: cute.Tensor,
         mOut: cute.Tensor,
         stream: cuda.CUstream,
-        num_entries: Int32,
-        D: Int32,
-        chunk_tile_size: Int32,
+        chunks_per_cta: Int32,
         grid_x: Int32,
         grid_y: Int32,
         out_row_stride: Int64,
@@ -249,9 +307,7 @@ def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op, contig: bo
             tma_tensor_src,
             mIndex,
             mOut,
-            num_entries,
-            D,
-            chunk_tile_size,
+            chunks_per_cta,
             out_row_stride,
         ).launch(
             grid=[grid_x, grid_y, 1],
@@ -282,7 +338,7 @@ def _compile_tma_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
     elem_bytes = dtype.width // 8
     chunk_elems = _chunk_elems_for(torch_dtype, N)
     reduce_op = _reduce_op_for(dtype)
-    launcher = _make_kernel(dtype, elem_bytes, chunk_elems, reduce_op, contig)
+    launcher = _make_kernel(dtype, elem_bytes, N, chunk_elems, reduce_op, contig)
 
     mSrc_fake = cute.runtime.make_fake_tensor(
         dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
@@ -299,12 +355,10 @@ def _compile_tma_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
         mIndex_fake,
         mOut_fake,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
-        Int32(0),
-        Int32(0),
-        Int32(0),
-        Int32(0),
-        Int32(0),
-        Int64(0),
+        Int32(0),  # chunks_per_cta
+        Int32(0),  # grid_x
+        Int32(0),  # grid_y
+        Int64(0),  # out_row_stride
         options="--enable-tvm-ffi",
     )
 
@@ -334,7 +388,7 @@ def row_shape_supported(dtype: torch.dtype, N: int) -> bool:
 
 
 def _plan_grid(M: int, D: int, chunk_elems: int, sm: int) -> tuple[int, int, int]:
-    """Pick ``(grid_x, grid_y, chunk_tile_size)``.
+    """Pick ``(grid_x, grid_y, chunks_per_cta)``.
 
     Strategy: keep the classic 1D schedule (grid_y=1, whole chunk range
     per CTA with internal double-buffering) whenever the row-axis alone
@@ -353,11 +407,11 @@ def _plan_grid(M: int, D: int, chunk_elems: int, sm: int) -> tuple[int, int, int
     # Split the chunk axis until we hit the target.
     want_y = max(1, target_ctas // max(row_ctas, 1))
     grid_y = min(n_chunks, want_y)
-    chunk_tile_size = (n_chunks + grid_y - 1) // grid_y
-    # Recompute grid_y now that each y-slot holds chunk_tile_size chunks.
-    grid_y = (n_chunks + chunk_tile_size - 1) // chunk_tile_size
+    chunks_per_cta = (n_chunks + grid_y - 1) // grid_y
+    # Recompute grid_y now that each y-slot holds chunks_per_cta chunks.
+    grid_y = (n_chunks + chunks_per_cta - 1) // chunks_per_cta
     grid_x = row_ctas
-    return grid_x, grid_y, chunk_tile_size
+    return grid_x, grid_y, chunks_per_cta
 
 
 def tma_scatter_add_into(
@@ -378,14 +432,12 @@ def tma_scatter_add_into(
     compiled = _compile_tma_scatter(src.dtype, N, contig)
     sm = torch.cuda.get_device_properties(out.device).multi_processor_count
 
-    grid_x, grid_y, chunk_tile_size = _plan_grid(M, N, chunk_elems, sm)
+    grid_x, grid_y, chunks_per_cta = _plan_grid(M, N, chunk_elems, sm)
     compiled(
         src,
         index_1d,
         out,
-        M,
-        N,
-        chunk_tile_size,
+        chunks_per_cta,
         grid_x,
         grid_y,
         out.stride(0),

--- a/torch/_native/ops/scatter_add/vec_scatter_kernel.py
+++ b/torch/_native/ops/scatter_add/vec_scatter_kernel.py
@@ -1,0 +1,223 @@
+"""Vectorized scatter_add with per-element atomics (pre-sm_90 fallback).
+
+Same input restriction as the TMA path (expanded-1D index, dim=0, 2D
+contiguous tensors), but works everywhere scalar atomicAdd does. Matches
+the fallback path in https://github.com/pytorch/pytorch/pull/182675.
+
+Algorithm: warp-per-source-row. Each warp reads ``idx[entry]`` once, then
+the 32 lanes chunk through N with vectorized gather (4 fp32 or 8 halves
+per lane per step) and issue atomics into ``out[ind, :]``:
+
+- fp32: per-element ``atomicAdd``.
+- fp16/bf16: paired x2 atomics
+  (``red.global.add.noftz.{f16x2,bf16x2}``), one instruction per pair.
+  Matches the instruction count aten gets from ``atomicAdd(__half2*, ...)``.
+"""
+
+import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]
+import cutlass
+import cutlass.cute as cute
+from cutlass import BFloat16, const_expr, Float16, Float32, Int32, Int64
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm, vector as mlir_vector
+from cutlass.cutlass_dsl import dsl_user_op, T
+
+import torch
+from torch._vendor.quack.cache_utils import jit_cache
+
+from ._ptx import make_packed_half_atomic_add
+
+
+_WARPS_PER_BLOCK = 8
+_THREADS_PER_BLOCK = 32 * _WARPS_PER_BLOCK
+_VEC_BYTES = 16  # 16-byte vector gather = LDG.128
+
+_TORCH_TO_CUTE = {
+    torch.float32: Float32,
+    torch.float16: Float16,
+    torch.bfloat16: BFloat16,
+}
+
+
+def _pack_half2_as_i32(val_a, val_b, elem_mlir_type, *, loc=None, ip=None):
+    """Build a <2 x elem> vector from two scalar halves and bitcast to i32.
+    Matches the layout PTX red.global.add.noftz.{f16x2,bf16x2} expects."""
+    vec_type = ir.VectorType.get([2], elem_mlir_type, loc=loc)
+    vec = mlir_vector.from_elements(
+        vec_type,
+        [val_a.ir_value(loc=loc, ip=ip), val_b.ir_value(loc=loc, ip=ip)],
+        loc=loc,
+        ip=ip,
+    )
+    return llvm.bitcast(T.i32(), vec, loc=loc, ip=ip)
+
+
+_packed_atomic_add_f16x2 = make_packed_half_atomic_add("f16x2")
+_packed_atomic_add_bf16x2 = make_packed_half_atomic_add("bf16x2")
+
+
+@dsl_user_op
+def _atomic_add_f16x2(ptr, val_a: Float16, val_b: Float16, *, loc=None, ip=None):
+    """Packed x2 f16 atomic add. Equivalent to atomicAdd(__half2*, ...)."""
+    gmem_ptr_i64 = ptr.toint(loc=loc, ip=ip).ir_value()
+    packed = _pack_half2_as_i32(val_a, val_b, Float16.mlir_type, loc=loc, ip=ip)
+    _packed_atomic_add_f16x2(gmem_ptr_i64, packed, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def _atomic_add_bf16x2(ptr, val_a: BFloat16, val_b: BFloat16, *, loc=None, ip=None):
+    """Packed x2 bf16 atomic add (sm_90+)."""
+    gmem_ptr_i64 = ptr.toint(loc=loc, ip=ip).ir_value()
+    packed = _pack_half2_as_i32(val_a, val_b, BFloat16.mlir_type, loc=loc, ip=ip)
+    _packed_atomic_add_bf16x2(gmem_ptr_i64, packed, loc=loc, ip=ip)
+
+
+def _make_kernel(dtype, elem_bytes: int, vec_elems: int):
+    """Build a dtype-specialized vectorized scatter-add kernel.
+
+    Each warp handles one source row. 32 lanes chunk through N, each lane
+    loading vec_elems consecutive elements and atomic-adding them into
+    out[ind, :].
+
+    fp16/bf16 use paired x2 atomics (``red.global.add.noftz.{f16x2,bf16x2}``)
+    to match the instruction count aten gets with ``atomicAdd(__half2*, ...)``.
+    fp32 uses scalar ``atomicAdd``.
+    """
+    is_half = dtype is Float16 or dtype is BFloat16
+
+    @cute.kernel
+    def _kernel(
+        mSrc: cute.Tensor,
+        mIndex: cute.Tensor,
+        mOut: cute.Tensor,
+        num_entries: Int32,
+        D: Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        gdim, _, _ = cute.arch.grid_dim()
+
+        warp_in_block = tidx // Int32(32)
+        lane = tidx - warp_in_block * Int32(32)
+
+        entries_per_block = Int32(_WARPS_PER_BLOCK)
+        base = bidx * entries_per_block
+        while base < num_entries:
+            entry_id = base + warp_in_block
+            if entry_id < num_entries:
+                idx_t = cute.make_tensor(
+                    mIndex.iterator + Int64(entry_id) * Int64(mIndex.stride[0]),
+                    cute.make_layout(1),
+                )
+                r = Int64(idx_t[0])
+
+                lane_offset = lane * Int32(vec_elems)
+                stride_elems = Int32(32 * vec_elems)
+
+                off = lane_offset
+                while off < D:
+                    src_off = Int64(entry_id) * Int64(D) + Int64(off)
+                    dst_off = r * Int64(D) + Int64(off)
+
+                    if const_expr(is_half):
+                        # Paired atomics: one x2 atomic per 2 elements.
+                        # vec_elems is even for halves (8 for f16/bf16 at
+                        # 16 bytes), so vec_elems // 2 is exact.
+                        for p in cutlass.range_constexpr(vec_elems // 2):
+                            v0 = 2 * p
+                            v1 = 2 * p + 1
+                            src_a = cute.make_tensor(
+                                mSrc.iterator + (src_off + Int64(v0)),
+                                cute.make_layout(1),
+                            )
+                            src_b = cute.make_tensor(
+                                mSrc.iterator + (src_off + Int64(v1)),
+                                cute.make_layout(1),
+                            )
+                            dst_ptr = mOut.iterator + (dst_off + Int64(v0))
+                            if const_expr(dtype is Float16):
+                                _atomic_add_f16x2(dst_ptr, src_a[0], src_b[0])
+                            else:
+                                _atomic_add_bf16x2(dst_ptr, src_a[0], src_b[0])
+                    else:
+                        for v in cutlass.range_constexpr(vec_elems):
+                            src_t = cute.make_tensor(
+                                mSrc.iterator + (src_off + Int64(v)),
+                                cute.make_layout(1),
+                            )
+                            dst_ptr_v = mOut.iterator + (dst_off + Int64(v))
+                            cute.arch.atomic_add(dst_ptr_v, src_t[0])
+
+                    off = off + stride_elems
+
+            base = base + gdim * entries_per_block
+
+    @cute.jit
+    def _launch(
+        mSrc: cute.Tensor,
+        mIndex: cute.Tensor,
+        mOut: cute.Tensor,
+        stream: cuda.CUstream,
+        num_entries: Int32,
+        D: Int32,
+        grid_x: Int32,
+    ):
+        _kernel(mSrc, mIndex, mOut, num_entries, D).launch(
+            grid=[grid_x, 1, 1],
+            block=[_THREADS_PER_BLOCK, 1, 1],
+            stream=stream,
+        )
+
+    return _launch
+
+
+@jit_cache
+def _compile_vec_scatter(torch_dtype: torch.dtype, N: int):
+    dtype = _TORCH_TO_CUTE[torch_dtype]
+    elem_bytes = dtype.width // 8
+    vec_elems = _VEC_BYTES // elem_bytes
+    launcher = _make_kernel(dtype, elem_bytes, vec_elems)
+
+    mSrc_fake = cute.runtime.make_fake_tensor(
+        dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
+    )
+    mIndex_fake = cute.runtime.make_fake_tensor(
+        Int64, (cute.sym_int(),), stride=(cute.sym_int64(),)
+    )
+    mOut_fake = cute.runtime.make_fake_tensor(
+        dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
+    )
+    return cute.compile(
+        launcher,
+        mSrc_fake,
+        mIndex_fake,
+        mOut_fake,
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        Int32(0),
+        Int32(0),
+        Int32(0),
+        options="--enable-tvm-ffi",
+    )
+
+
+def vec_elems_for(dtype: torch.dtype) -> int:
+    """Elements per lane per step (16-byte vector gather)."""
+    return _VEC_BYTES // torch.tensor([], dtype=dtype).element_size()
+
+
+def vec_scatter_add_into(
+    out: torch.Tensor,
+    index_1d: torch.Tensor,
+    src: torch.Tensor,
+) -> None:
+    """In-place: ``out[index_1d[i], :] += src[i, :]`` for every i.
+
+    Requires N divisible by ``vec_elems_for(src.dtype)`` (the cond enforces
+    this). When N < 32 * vec_elems the loop has fewer active lanes per
+    warp; lanes whose starting offset is >= N simply skip.
+    """
+    M, N = src.shape
+    compiled = _compile_vec_scatter(src.dtype, N)
+    sm = torch.cuda.get_device_properties(out.device).multi_processor_count
+    grid = min((M + _WARPS_PER_BLOCK - 1) // _WARPS_PER_BLOCK, sm * 8)
+    compiled(src, index_1d, out, M, N, grid)

--- a/torch/_native/ops/scatter_add/vec_scatter_kernel.py
+++ b/torch/_native/ops/scatter_add/vec_scatter_kernel.py
@@ -17,6 +17,7 @@ per lane per step) and issue atomics into ``out[ind, :]``:
 import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]
 import cutlass
 import cutlass.cute as cute
+import cutlass.cute.testing as cute_testing
 from cutlass import BFloat16, const_expr, Float16, Float32, Int32, Int64
 from cutlass._mlir import ir
 from cutlass._mlir.dialects import llvm, vector as mlir_vector
@@ -114,6 +115,12 @@ def _make_kernel(dtype, elem_bytes: int, vec_elems: int, contig: bool):
             entry_id = base + warp_in_block
             if entry_id < num_entries:
                 r = Int64(mIndex[entry_id])
+                # Bounds check: out-of-range ``r`` would make the
+                # atomicAdd below corrupt unrelated memory. Compiling
+                # with ``--enable-assertions`` turns this into a
+                # device-side trap; otherwise it folds away.
+                cute_testing.assert_(r >= Int64(0))
+                cute_testing.assert_(r < Int64(mOut.shape[0]))
 
                 lane_offset = lane * Int32(vec_elems)
                 stride_elems = Int32(32 * vec_elems)
@@ -210,7 +217,12 @@ def _compile_vec_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
         Int32(0),
         Int64(0),
         Int64(0),
-        options="--enable-tvm-ffi",
+        # ``--enable-assertions`` keeps the ``cute_testing.assert_``
+        # bounds checks on ``r`` live in production. Cost is roughly
+        # +1-10% (geomean +7.7%) on most shapes; the safety net is
+        # worth it because an OOB ``r`` would otherwise silently
+        # corrupt unrelated gmem via the per-element ``atomicAdd``.
+        options="--enable-tvm-ffi --enable-assertions",
     )
 
 

--- a/torch/_native/ops/scatter_add/vec_scatter_kernel.py
+++ b/torch/_native/ops/scatter_add/vec_scatter_kernel.py
@@ -72,12 +72,13 @@ def _atomic_add_bf16x2(ptr, val_a: BFloat16, val_b: BFloat16, *, loc=None, ip=No
     _packed_atomic_add_bf16x2(gmem_ptr_i64, packed, loc=loc, ip=ip)
 
 
-def _make_kernel(dtype, elem_bytes: int, vec_elems: int):
+def _make_kernel(dtype, elem_bytes: int, vec_elems: int, contig: bool):
     """Build a dtype-specialized vectorized scatter-add kernel.
 
     Each warp handles one source row. 32 lanes chunk through N, each lane
-    loading vec_elems consecutive elements and atomic-adding them into
-    out[ind, :].
+    issuing a single vectorized LDG.128 (via ``cute.autovec_copy``) for
+    ``vec_elems`` consecutive elements and atomic-adding them into
+    ``out[ind, :]``.
 
     fp16/bf16 use paired x2 atomics (``red.global.add.noftz.{f16x2,bf16x2}``)
     to match the instruction count aten gets with ``atomicAdd(__half2*, ...)``.
@@ -92,61 +93,62 @@ def _make_kernel(dtype, elem_bytes: int, vec_elems: int):
         mOut: cute.Tensor,
         num_entries: Int32,
         D: Int32,
+        src_row_stride: Int64,
+        out_row_stride: Int64,
     ):
         tidx, _, _ = cute.arch.thread_idx()
         bidx, _, _ = cute.arch.block_idx()
         gdim, _, _ = cute.arch.grid_dim()
 
         warp_in_block = tidx // Int32(32)
-        lane = tidx - warp_in_block * Int32(32)
+        lane = tidx % Int32(32)
+
+        # Contiguous fast path: row stride is D at compile time.
+        if const_expr(contig):
+            src_row_stride = Int64(D)
+            out_row_stride = Int64(D)
 
         entries_per_block = Int32(_WARPS_PER_BLOCK)
         base = bidx * entries_per_block
         while base < num_entries:
             entry_id = base + warp_in_block
             if entry_id < num_entries:
-                idx_t = cute.make_tensor(
-                    mIndex.iterator + Int64(entry_id) * Int64(mIndex.stride[0]),
-                    cute.make_layout(1),
-                )
-                r = Int64(idx_t[0])
+                r = Int64(mIndex[entry_id])
 
                 lane_offset = lane * Int32(vec_elems)
                 stride_elems = Int32(32 * vec_elems)
 
                 off = lane_offset
                 while off < D:
-                    src_off = Int64(entry_id) * Int64(D) + Int64(off)
-                    dst_off = r * Int64(D) + Int64(off)
+                    src_off = Int64(entry_id) * src_row_stride + Int64(off)
+                    dst_off = r * out_row_stride + Int64(off)
+
+                    # Vectorized gmem -> register load. ``autovec_copy``
+                    # picks the widest safe instruction given the static
+                    # shape (vec_elems x elem_bytes == 16 bytes, so this
+                    # becomes a single LDG.128).
+                    gsrc = cute.make_tensor(
+                        mSrc.iterator + src_off,
+                        cute.make_layout(vec_elems),
+                    )
+                    rvals = cute.make_rmem_tensor(vec_elems, dtype)
+                    cute.autovec_copy(gsrc, rvals)
 
                     if const_expr(is_half):
                         # Paired atomics: one x2 atomic per 2 elements.
-                        # vec_elems is even for halves (8 for f16/bf16 at
-                        # 16 bytes), so vec_elems // 2 is exact.
+                        # vec_elems is even for halves (8 at 16 bytes),
+                        # so vec_elems // 2 is exact.
                         for p in cutlass.range_constexpr(vec_elems // 2):
                             v0 = 2 * p
-                            v1 = 2 * p + 1
-                            src_a = cute.make_tensor(
-                                mSrc.iterator + (src_off + Int64(v0)),
-                                cute.make_layout(1),
-                            )
-                            src_b = cute.make_tensor(
-                                mSrc.iterator + (src_off + Int64(v1)),
-                                cute.make_layout(1),
-                            )
                             dst_ptr = mOut.iterator + (dst_off + Int64(v0))
                             if const_expr(dtype is Float16):
-                                _atomic_add_f16x2(dst_ptr, src_a[0], src_b[0])
+                                _atomic_add_f16x2(dst_ptr, rvals[v0], rvals[v0 + 1])
                             else:
-                                _atomic_add_bf16x2(dst_ptr, src_a[0], src_b[0])
+                                _atomic_add_bf16x2(dst_ptr, rvals[v0], rvals[v0 + 1])
                     else:
                         for v in cutlass.range_constexpr(vec_elems):
-                            src_t = cute.make_tensor(
-                                mSrc.iterator + (src_off + Int64(v)),
-                                cute.make_layout(1),
-                            )
                             dst_ptr_v = mOut.iterator + (dst_off + Int64(v))
-                            cute.arch.atomic_add(dst_ptr_v, src_t[0])
+                            cute.arch.atomic_add(dst_ptr_v, rvals[v])
 
                     off = off + stride_elems
 
@@ -161,8 +163,18 @@ def _make_kernel(dtype, elem_bytes: int, vec_elems: int):
         num_entries: Int32,
         D: Int32,
         grid_x: Int32,
+        src_row_stride: Int64,
+        out_row_stride: Int64,
     ):
-        _kernel(mSrc, mIndex, mOut, num_entries, D).launch(
+        _kernel(
+            mSrc,
+            mIndex,
+            mOut,
+            num_entries,
+            D,
+            src_row_stride,
+            out_row_stride,
+        ).launch(
             grid=[grid_x, 1, 1],
             block=[_THREADS_PER_BLOCK, 1, 1],
             stream=stream,
@@ -172,18 +184,18 @@ def _make_kernel(dtype, elem_bytes: int, vec_elems: int):
 
 
 @jit_cache
-def _compile_vec_scatter(torch_dtype: torch.dtype, N: int):
+def _compile_vec_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
     dtype = _TORCH_TO_CUTE[torch_dtype]
     elem_bytes = dtype.width // 8
     vec_elems = _VEC_BYTES // elem_bytes
-    launcher = _make_kernel(dtype, elem_bytes, vec_elems)
+    launcher = _make_kernel(dtype, elem_bytes, vec_elems, contig)
 
     mSrc_fake = cute.runtime.make_fake_tensor(
         dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
     )
-    mIndex_fake = cute.runtime.make_fake_tensor(
-        Int64, (cute.sym_int(),), stride=(cute.sym_int64(),)
-    )
+    # Index is contiguous (see _flatten_for_expanded_1d); fix stride=1
+    # so `mIndex[i]` doesn't emit a runtime stride multiply.
+    mIndex_fake = cute.runtime.make_fake_tensor(Int64, (cute.sym_int(),), stride=(1,))
     mOut_fake = cute.runtime.make_fake_tensor(
         dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
     )
@@ -196,6 +208,8 @@ def _compile_vec_scatter(torch_dtype: torch.dtype, N: int):
         Int32(0),
         Int32(0),
         Int32(0),
+        Int64(0),
+        Int64(0),
         options="--enable-tvm-ffi",
     )
 
@@ -212,12 +226,14 @@ def vec_scatter_add_into(
 ) -> None:
     """In-place: ``out[index_1d[i], :] += src[i, :]`` for every i.
 
-    Requires N divisible by ``vec_elems_for(src.dtype)`` (the cond enforces
-    this). When N < 32 * vec_elems the loop has fewer active lanes per
-    warp; lanes whose starting offset is >= N simply skip.
+    ``out`` / ``src`` are 2D with inner-dim stride 1; outer row stride
+    can differ from N. Requires N divisible by ``vec_elems_for(src.dtype)``
+    (the cond enforces this). When N < 32 * vec_elems the loop has fewer
+    active lanes per warp; lanes whose starting offset is >= N skip.
     """
     M, N = src.shape
-    compiled = _compile_vec_scatter(src.dtype, N)
+    contig = src.stride(0) == N and out.stride(0) == N
+    compiled = _compile_vec_scatter(src.dtype, N, contig)
     sm = torch.cuda.get_device_properties(out.device).multi_processor_count
     grid = min((M + _WARPS_PER_BLOCK - 1) // _WARPS_PER_BLOCK, sm * 8)
-    compiled(src, index_1d, out, M, N, grid)
+    compiled(src, index_1d, out, M, N, grid, src.stride(0), out.stride(0))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #182854
* __->__ #182818

Add cuteDSL kernel overrides to aten::scatter_add for specialized cases
with fp16/bf16/fp32 inputs.

Use either TMA loads + TMA reduction, or vectorized LDG/atomicAdd
depending on case. Use 2d-tiled TMA with OOB support to handle
non-multiple-of-TMA-load-width cases.

Non-supported cases (non-expanded index, dim != 0, non-inner-contiguous
inputs, deterministic mode, unsupported dtypes, row_bytes not
16-aligned) fall through to aten.

Performance on B200, via ``torch.utils.benchmark.blocked_autorange`` at
median. ``cute`` runs ``scatter_add_(0, idx.unsqueeze(-1).expand(-1, D),
src)`` with the override registered; ``aten`` runs the semantically
equivalent ``index_add_(0, idx, src)`` on the same shapes with the
override deregistered.

high_cont (outrows=1.72M, src=7.77M, 50% collide on row 0):

| D    | dtype |    cute |    aten | speedup |
| ---- | ----- | ------: | ------: | ------: |
|  128 | fp32  | 18.48ms | 19.83ms |    1.1x |
|  128 | bf16  | 17.37ms | 42.45ms |    2.4x |
|  256 | fp32  | 34.31ms | 36.83ms |    1.1x |
|  256 | bf16  | 18.47ms | 48.41ms |    2.6x |
|  512 | fp32  | 35.97ms | 46.01ms |    1.3x |
|  512 | bf16  | 34.32ms | 83.58ms |    2.4x |
| 1024 | fp32  | 39.45ms | 98.87ms |    2.5x |
| 1024 | bf16  | 35.98ms |106.09ms |    2.9x |

uniform (outrows=100K, src=500K):

| D    | dtype |    cute |    aten | speedup |
| ---- | ----- | ------: | ------: | ------: |
|  128 | fp32  |   98us  |  492us  |    5.0x |
|  128 | bf16  |   87us  |  545us  |    6.3x |
|  256 | fp32  |  193us  |  973us  |    5.0x |
|  256 | bf16  |   97us  | 1052us  |   10.8x |
|  512 | fp32  |  422us  | 1959us  |    4.6x |
|  512 | bf16  |  193us  | 2066us  |   10.7x |
| 1024 | fp32  |  919us  | 3945us  |    4.3x |
| 1024 | bf16  |  420us  | 4183us  |   10.0x |

few_idx (outrows=50, D large, small N_src, exercises 2D grid y-axis):

| shape         |   cute |   aten | speedup |
| ------------- | -----: | -----: | ------: |
| D=64K  N=1000 |  107us |  393us |    3.7x |
| D=640K N=100  |  154us |  406us |    2.6x |

Test Plan:

Two-step testing:
- Test that conditionals for overrides fire as expected
- Test those test cases knowing that the appropriate overrides will run.

| suite                                          | result                  |
| ---------------------------------------------- | ----------------------- |
| test/test_scatter_gather_ops.py                | 197 passed,  7 skipped  |
| test/test_torch.py -k scatter                  | 127 passed,  3 skipped  |
| test/test_ops.py -k scatter_add                |  60 passed, 10 skipped  |
| test/test_ops_gradients.py -k scatter_add      |  20 passed,  4 skipped  |
| test/test_ops_fwd_gradients.py -k scatter_add  |  12 passed              |
| test/test_proxy_tensor.py -k scatter_add       |   5 passed,  1 xfail    |

Authored by Claude.

@diff-train-skip-merge