### PR TITLE
[inductor][cpp_wrapper] Defer Triton compile kickoff out of static init (#182824)

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -339,6 +339,7 @@ class TestLazyCompileKernelCollision(InductorTestCase):
             r1 = subprocess.run(
                 [sys.executable, "-c", _LAZY_COMPILE_COLLISION_SCRIPT],
                 capture_output=True,
+                cwd=cache_dir,
                 text=True,
                 env=env,
             )
@@ -347,10 +348,72 @@ class TestLazyCompileKernelCollision(InductorTestCase):
             r2 = subprocess.run(
                 [sys.executable, "-c", _LAZY_COMPILE_COLLISION_SCRIPT],
                 capture_output=True,
+                cwd=cache_dir,
                 text=True,
                 env=env,
             )
             self.assertEqual(r2.returncode, 0, f"Warm run failed:\n{r2.stderr[-2000:]}")
+
+
+# Helper script for test_static_init_dlopen_does_not_deadlock
+_STATIC_INIT_DEADLOCK_SCRIPT = """\
+import torch
+from torch.testing._internal.inductor_utils import GPU_TYPE
+
+from torch._inductor import config
+
+config.compile_threads = 1
+config.cpp_wrapper = True
+config.triton.autotune_at_compile_time = False
+
+
+def fn(x):
+    return (x * 2 + 1).sum()
+
+
+compiled = torch.compile(fn)
+x = torch.randn(128, device=GPU_TYPE)
+compiled(x)
+"""
+
+
+class TestCppWrapperStaticInitDeadlock(InductorTestCase):
+    device = GPU_TYPE
+
+    def test_static_init_dlopen_does_not_deadlock(self):
+        """The cpp_wrapper-generated .so must not trigger Triton kernel
+        compilation from a static initializer (dlopen-time): doing so
+        runs Triton -> mlir::verify -> llvm::StdThreadPool, whose workers
+        contend for the dynamic linker's global init lock and deadlock
+        the main thread inside dlopen.
+        """
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+
+        with tempfile.TemporaryDirectory() as cache_dir:
+            env = {
+                **os.environ,
+                "TORCHINDUCTOR_CACHE_DIR": cache_dir,
+            }
+            try:
+                r = subprocess.run(
+                    [sys.executable, "-c", _STATIC_INIT_DEADLOCK_SCRIPT],
+                    capture_output=True,
+                    cwd=cache_dir,
+                    text=True,
+                    env=env,
+                    timeout=60,
+                )
+            except subprocess.TimeoutExpired:
+                self.fail(
+                    "cpp_wrapper subprocess timed out after 60s -- likely "
+                    "deadlocked in dlopen / static-init Triton kernel compile."
+                )
+        self.assertEqual(
+            r.returncode,
+            0,
+            f"Subprocess failed:\nstderr:\n{r.stderr[-2000:]}\nstdout:\n{r.stdout[-2000:]}",
+        )
 
 
 class DynamicShapesGpuWrapperGpuTests(InductorTestCase):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -288,10 +288,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         # For GEMM kernels that must be initialized and are resolved at linking.
         self.initialized_kernels: dict[str, Kernel] = {}
         self.device_codegen = get_device_op_overrides(self.device)
-        # only need to include each header once
-        self.include_extra_header = functools.lru_cache(None)(  # type: ignore[method-assign]
-            self._include_extra_header
-        )
+        self._included_extra_headers: OrderedSet[str] = OrderedSet()
         self.codegen_int_array_var_cache = {}
 
     @staticmethod
@@ -511,8 +508,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 """
             )
 
-    def _include_extra_header(self, header: str):
+    def include_extra_header(self, header: str):
         # This is needed for cpp to python dtype conversion
+        if header in self._included_extra_headers:
+            return
+        self._included_extra_headers.add(header)
         self.header.splice(f"#include <{header}>")
 
     def mark_output_type(self):
@@ -943,6 +943,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def write_wrapper_decl(self):
         self._write_entry_point_signature()
         with self.prefix.indent():
+            self._codegen_entry_impl_prologue()
             self._write_input_preamble()
             self._write_input_unpacking()
             self._write_constants_unpacking()
@@ -1500,6 +1501,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
             if output not in output2idx:
                 output2idx[output] = idx
+
+    def _codegen_entry_impl_prologue(self):
+        """Hook for subclasses to emit code at the top of inductor_entry_impl,
+        before the GIL is released. Default no-op."""
 
     def generate_before_suffix(self, result):
         if not V.graph.is_const_graph:
@@ -2983,13 +2988,17 @@ if (!custom_op_wrapper) {
                 # torch/_prims_common/__init__.py
                 return handle_scalar(raw_arg)
             elif isinstance(raw_arg, torch.device):
+                self.include_extra_header("torch/csrc/Device.h")
                 device_str, device_index = self.codegen_device(raw_arg).split(", ")
                 return f"THPDevice_New(c10::Device(static_cast<c10::DeviceType>({device_str}), {device_index}))"
             elif isinstance(raw_arg, torch.dtype):
+                self.include_extra_header("torch/csrc/DynamicTypes.h")
                 return f"Py_NewRef(torch::getTHPDtype(static_cast<c10::ScalarType>({self.codegen_dtype(raw_arg)})))"
             elif isinstance(raw_arg, torch.layout):
+                self.include_extra_header("torch/csrc/DynamicTypes.h")
                 return f"Py_NewRef(torch::getTHPLayout(static_cast<c10::Layout>({self.codegen_layout(raw_arg)})))"
             elif isinstance(raw_arg, torch.memory_format):
+                self.include_extra_header("torch/csrc/utils/tensor_memoryformats.h")
                 return (
                     "Py_NewRef(torch::utils::getTHPMemoryFormat(static_cast<c10::MemoryFormat>("
                     f"{self.codegen_memory_format(raw_arg)})))"

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -26,6 +26,7 @@ from ..ir import (
 )
 from ..utils import (
     cache_on_self,
+    DeferredLineBase,
     get_gpu_type,
     GPU_ALIGN_BYTES,
     IndentedBuffer,
@@ -93,6 +94,18 @@ def _unpack_tma_descriptor_args(var_name: str, sig_type: str) -> list[str]:
     for i in range(ndim):
         result.append(f"&{var_name}.strides[{i}]")
     return result
+
+
+class _LazyTritonCompileKickoffLine(DeferredLineBase):
+    def __init__(self, lazy_kernel_names: list[str], line: str):
+        super().__init__(line)
+        self.lazy_kernel_names = lazy_kernel_names
+
+    def __call__(self) -> str | None:
+        return self.line if self.lazy_kernel_names else None
+
+    def _new_line(self, line: str) -> Self:
+        return _LazyTritonCompileKickoffLine(self.lazy_kernel_names, line)
 
 
 @dataclasses.dataclass
@@ -919,6 +932,13 @@ class CppWrapperGpu(CppWrapperCpu):
         with dynamo_timed("CppWrapperGpu.generate", log_pt2_compile_event=True):
             return super().generate(is_inference)
 
+    def _codegen_entry_impl_prologue(self):
+        self.prefix.writeline(
+            _LazyTritonCompileKickoffLine(
+                self._lazy_kernel_names, "ensure_triton_kernel_compiles_started();"
+            )
+        )
+
     def finalize_prefix(self):
         """Define the triton kernels now that autotuning is finished"""
         old_prefix = self.prefix  # new content should go at start of prefix
@@ -931,28 +951,33 @@ class CppWrapperGpu(CppWrapperCpu):
             self.prefix.writeline("\n")
             kernel.generate(self)
 
-        # Generate parallel kernel compilation initialization function
         if self._lazy_kernel_names:
-            start_compile_calls = "\n    ".join(
-                f'startKernelCompile(_module_pending_kernels, "{name}", {name}_source);'
-                for name in self._lazy_kernel_names
+            start_compile_body = (
+                "loadLazyCompileFuncs();\n"
+                "    _module_pending_kernels = PyDict_New();\n"
+                '    AOTI_TORCH_CHECK(_module_pending_kernels, "Failed to create pending kernels dict");\n'
+                "    "
+                + "\n    ".join(
+                    f'startKernelCompile(_module_pending_kernels, "{name}", {name}_source);'
+                    for name in self._lazy_kernel_names
+                )
             )
+            self.include_extra_header("mutex")
             self.prefix.splice(
                 f"""\
-// Start parallel compilation of all Triton kernels
+// Start parallel compilation of all Triton kernels.
 static inline void start_all_triton_kernel_compiles() {{
-    loadLazyCompileFuncs();
-    _module_pending_kernels = PyDict_New();
-    AOTI_TORCH_CHECK(_module_pending_kernels, "Failed to create pending kernels dict");
-    {start_compile_calls}
+    {start_compile_body}
 }}
 
-// Static initializer to start kernel compilation on module load
-static struct TritonKernelCompileInit {{
-    TritonKernelCompileInit() {{
+// inductor_entry_impl calls this on every forward;
+// std::call_once makes the first call do the work.
+static std::once_flag _triton_kernel_compile_init_flag;
+static inline void ensure_triton_kernel_compiles_started() {{
+    std::call_once(_triton_kernel_compile_init_flag, [] {{
         start_all_triton_kernel_compiles();
-    }}
-}} __triton_kernel_compile_init;
+    }});
+}}
 """
             )
 


### PR DESCRIPTION
Summary:

Move lazy Triton kernel-compile kickoff out of the cpp_wrapper static initializer and into a `std::call_once` helper invoked from the entry prologue. This avoids dlopen-time deadlocks when Triton/MLIR starts worker threads while the dynamic linker init lock is held.

Test Plan: buck2 test fbcode//mode/dev-nosan //caffe2/test/inductor:gpu_cpp_wrapper -- test_static_init_dlopen_does_not_deadlock

Reviewed By: leitian

Differential Revision: D104155507




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo