### PR TITLE
[inductor][cpp_wrapper] Scale lazy TMA scratch by grid (#182825)

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 from typing import NamedTuple
 
 import torch
@@ -20,9 +21,11 @@ from torch.testing._internal.common_utils import (
     slowTest,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, RUN_GPU
+from torch.utils._triton import has_triton_tensor_descriptor_host_tma
 
 
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+
 
 try:
     try:
@@ -413,6 +416,148 @@ class TestCppWrapperStaticInitDeadlock(InductorTestCase):
             r.returncode,
             0,
             f"Subprocess failed:\nstderr:\n{r.stderr[-2000:]}\nstdout:\n{r.stdout[-2000:]}",
+        )
+
+
+# Helper script for test_lazy_tma_global_scratch_scales_with_launch_grid
+# Run this repro in a subprocess because the regression can poison the CUDA context.
+_LAZY_TMA_GLOBAL_SCRATCH_SCRIPT = """\
+import torch
+import triton
+import triton.language as tl
+
+from torch._library import capture_triton
+
+
+M = 1048576
+N = 16
+BLOCK_M = 16
+BLOCK_N = 16
+
+
+def _alloc_scratch(size, alignment, stream):
+    return torch.empty(size, device="cuda", dtype=torch.uint8)
+
+
+triton.set_allocator(_alloc_scratch)
+
+
+@triton.jit
+def _tma_copy_kernel(
+    in_ptr,
+    out_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+
+    # Each CTA builds a different descriptor so one shared scratch slot is corrupt.
+    in_desc = tl.make_tensor_descriptor(
+        in_ptr + pid * BLOCK_M * N,
+        shape=[BLOCK_M, N],
+        strides=[N, 1],
+        block_shape=[BLOCK_M, BLOCK_N],
+    )
+    tile = in_desc.load([0, 0])
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    tl.store(out_ptr + offs_m[:, None] * N + offs_n[None, :], tile)
+
+
+@torch.library.triton_op("test_inductor::lazy_tma_scratch_copy", mutates_args={})
+def _tma_copy(x: torch.Tensor) -> torch.Tensor:
+    y = torch.empty_like(x)
+    grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N),)
+    capture_triton(_tma_copy_kernel)[grid](
+        x,
+        y,
+        M,
+        N,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=4,
+    )
+    return y
+
+
+def run():
+    x = (torch.arange(M * N, device="cuda", dtype=torch.float32) % 100).to(
+        torch.float16
+    )
+    x = x.reshape(M, N)
+
+    def fn(x):
+        return _tma_copy(x)
+
+    eager = fn(x)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(eager, x)
+
+    compiled = torch.compile(
+        fn,
+        fullgraph=True,
+        options={
+            "cpp_wrapper": True,
+            "triton.autotune_at_compile_time": False,
+        },
+    )
+    warmup = compiled(x)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(warmup, x)
+    # The warmup lazy-compiles through Python; the second call uses the cached C++ launch.
+    out = compiled(x)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, x)
+
+
+run()
+"""
+
+
+class TestLazyTmaGlobalScratch(InductorTestCase):
+    device = GPU_TYPE
+
+    def test_lazy_tma_global_scratch_scales_with_launch_grid(self):
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+        if GPU_TYPE != "cuda" or torch.version.hip:
+            self.skipTest("requires CUDA")
+        if torch.cuda.get_device_capability()[0] < 9:
+            self.skipTest("requires Hopper or newer for TMA")
+        if not has_triton_tensor_descriptor_host_tma():
+            self.skipTest("requires Triton TensorDescriptor TMA support")
+
+        with tempfile.TemporaryDirectory() as cache_dir:
+            script_path = Path(cache_dir) / "lazy_tma_global_scratch_repro.py"
+            script_path.write_text(_LAZY_TMA_GLOBAL_SCRATCH_SCRIPT, encoding="utf-8")
+            env = {
+                **os.environ,
+                "CUDA_LAUNCH_BLOCKING": "1",
+                "TORCHINDUCTOR_CACHE_DIR": cache_dir,
+            }
+            result = subprocess.run(
+                [sys.executable, str(script_path)],
+                capture_output=True,
+                cwd=cache_dir,
+                text=True,
+                env=env,
+                timeout=180,
+            )
+
+        stderr_tail = "\n".join(result.stderr.splitlines()[-80:])
+        self.assertEqual(
+            result.returncode,
+            0,
+            "lazy TMA scratch regression subprocess failed:\n"
+            f"returncode: {result.returncode}\n"
+            f"stderr tail:\n{stderr_tail}",
         )
 
 

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -411,6 +411,10 @@ class DeferredTritonCallWrapper:
             ", "
         )
         device_ptr_type = wrapper.device_codegen.cpp_device_ptr()
+        # Triton reports per-CTA scratch via kernel.metadata.global_scratch_size;
+        # the kernel writes its slot at offset (pid * scratch_size). Scale by the
+        # full launch grid so concurrent CTAs don't collide.
+        grid_extent = "static_cast<int64_t>(grid_0) * grid_1 * grid_2"
         for scratch_name in ("global_scratch", "profile_scratch"):
             size_expr = f"{kernel_name}_result.{scratch_name}"
             var = f"{scratch_name}_ptr"
@@ -420,7 +424,7 @@ class DeferredTritonCallWrapper:
                 {device_ptr_type} {var} = 0;
                 RAIIAtenTensorHandle {var}_tensor;
                 if ({size_expr} > 0) {{
-                    int64_t {var}_size[] = {{{size_expr}}};
+                    int64_t {var}_size[] = {{{size_expr} * {grid_extent}}};
                     int64_t {var}_stride[] = {{1}};
                     AtenTensorHandle {var}_handle;
                     AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_empty_strided(


### PR DESCRIPTION
Summary:

Triton reports device-side TMA global scratch per CTA, but the lazy cpp_wrapper cached launch allocated only one CTA's scratch. Scale global and profile scratch allocations by the runtime launch grid before passing them to the cached kernel.

Add a subprocess regression test that builds per-CTA TMA descriptors, verifies eager and lazy warmup behavior, then exercises the cached C++ launch that fails without the grid scaling.

Reviewed By: sevenEng

Differential Revision: D104241670




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo