### PR TITLE
Do not mirror Bazel files

### DIFF
--- a/cmake/FileMirroring.cmake
+++ b/cmake/FileMirroring.cmake
@@ -29,6 +29,8 @@ install(DIRECTORY
 install(DIRECTORY
   "${PROJECT_SOURCE_DIR}/tools/autograd/"
   DESTINATION "${SKBUILD_PLATLIB_DIR}/torchgen/packaged/autograd"
+  PATTERN "BUILD.bazel" EXCLUDE
+  PATTERN "*.bzl" EXCLUDE
 )
 
 # --- mirror_inductor_external_kernels ---


### PR DESCRIPTION
If downstream Bazel build includes built PyTorch installation, BUILD.bazel file creates an unwanted package boundary.

Fixes #182722.