### PR TITLE
[CI] Fix docker builds: pin miniforge, use --extra-index-url

### DIFF
--- a/.ci/docker/common/cache_vision_models.sh
+++ b/.ci/docker/common/cache_vision_models.sh
@@ -8,7 +8,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/common_utils.sh"
 IMPORT_SCRIPT_FILENAME="/tmp/torchvision_import_script.py"
 as_jenkins echo 'import torchvision; torchvision.models.mobilenet_v2(pretrained=True); torchvision.models.mobilenet_v3_large(pretrained=True);' > "${IMPORT_SCRIPT_FILENAME}"
 
-pip_install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
+pip_install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 # Very weird quoting behavior here https://github.com/conda/conda/issues/10972,
 # so echo the command to a file and run the file instead
 conda_run python "${IMPORT_SCRIPT_FILENAME}"

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -4,7 +4,10 @@ set -ex
 
 # Optionally install conda
 if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
-  BASE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"  # @lint-ignore
+  # Pin miniforge to avoid regressions from conda/pip version changes.
+  # Miniforge 26.3.2-0 (2026-05-02) ships conda 26.3.2 + pip 26.1.1 which
+  # break pip-installed packages when later pip commands use --index-url.
+  BASE_URL="https://github.com/conda-forge/miniforge/releases/download/26.1.1-3"  # @lint-ignore
   CONDA_FILE="Miniforge3-Linux-$(uname -m).sh"
 
   MAJOR_PYTHON_VERSION=$(echo "$ANACONDA_PYTHON_VERSION" | cut -d . -f 1)

--- a/.ci/docker/common/install_inductor_benchmark_deps.sh
+++ b/.ci/docker/common/install_inductor_benchmark_deps.sh
@@ -44,8 +44,11 @@ else
   echo "DESIRED_CUDA=${DESIRED_CUDA}, using cu128 wheels"
 fi
 
-# Stable packages are ok here, just to satisfy TorchBench check
-pip_install torch torchvision torchaudio --index-url "${CUDA_INDEX_URL}"
+# Stable packages are ok here, just to satisfy TorchBench check.
+# Use --extra-index-url (not --index-url) so PyPI remains available for
+# transitive dependencies like numpy/pillow that the PyTorch wheel index
+# may carry at stale versions.
+pip_install torch torchvision torchaudio --extra-index-url "${CUDA_INDEX_URL}"
 
 # Pin setuptools<82 to avoid breaking visdom install (setuptools 82 removed
 # pkg_resources which visdom's setup.py depends on)

--- a/.ci/docker/common/install_onnx.sh
+++ b/.ci/docker/common/install_onnx.sh
@@ -22,8 +22,10 @@ pip_install \
 IMPORT_SCRIPT_FILENAME="/tmp/onnx_import_script.py"
 as_jenkins echo 'import transformers; transformers.GPTJForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gptj");' > "${IMPORT_SCRIPT_FILENAME}"
 
-# Need a PyTorch version for transformers to work
-pip_install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+# Need a PyTorch version for transformers to work.
+# Use --extra-index-url so previously pip-installed packages (e.g.
+# transformers) remain resolvable from PyPI during dependency resolution.
+pip_install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 # Very weird quoting behavior here https://github.com/conda/conda/issues/10972,
 # so echo the command to a file and run the file instead
 conda_run python "${IMPORT_SCRIPT_FILENAME}"


### PR DESCRIPTION
Docker image builds are broken because `pip install --index-url <pytorch-wheel-index>` replaces PyPI as the sole package source. When pip's resolver re-evaluates the dependency graph, previously pip-installed packages (numpy, transformers, etc.) can be removed because the PyTorch wheel index carries stale or incompatible copies of those packages. This was exposed by miniforge 26.3.2-0 (2026-05-02) shipping conda 26.3.2 and pip 26.1.1 from conda-forge, which changed resolver/activation behavior.

Two fixes:
- Pin miniforge to 26.1.1-3 (last known-good) so the latest conda/pip regressions do not affect builds.
- Switch from `--index-url` to `--extra-index-url` in the three scripts that install torch from PyTorch wheel indexes. This keeps PyPI as the primary index so transitive dependencies resolve correctly, while still pulling torch/torchvision/torchaudio from the CUDA or nightly index.

Authored with Claude.