### PR TITLE
[CI] No-op docker change to test current build state

### DIFF
--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -2,6 +2,7 @@ ARG UBUNTU_VERSION
 
 FROM ubuntu:${UBUNTU_VERSION} as base
 
+# No-op change to trigger docker-builds CI and verify current state.
 ARG UBUNTU_VERSION
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Adding a comment to trigger docker-builds CI and confirm whether the builds fail in their current state (before any fixes).

Authored with Claude.