### PR TITLE
[CI] Pin miniforge to 26.1.1-3 to fix docker builds

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -4,7 +4,12 @@ set -ex
 
 # Optionally install conda
 if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
-  BASE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"  # @lint-ignore
+  # Pin miniforge to avoid regressions from conda/pip version changes.
+  # Miniforge 26.3.2-0 (2026-05-02) ships conda 26.3.2 which changed how
+  # pip-installed packages are tracked in the environment model, causing
+  # packages like numpy and transformers to go missing during later
+  # conda install / conda run operations.
+  BASE_URL="https://github.com/conda-forge/miniforge/releases/download/26.1.1-3"  # @lint-ignore
   CONDA_FILE="Miniforge3-Linux-$(uname -m).sh"
 
   MAJOR_PYTHON_VERSION=$(echo "$ANACONDA_PYTHON_VERSION" | cut -d . -f 1)


### PR DESCRIPTION
Miniforge 26.3.2-0 (released 2026-05-02) ships conda 26.3.2 which changed how pip-installed packages are tracked in the environment model ("Do not include pip-installed packages in the list of explicit packages"). This causes pip-installed packages (numpy, transformers, etc.) to go missing during subsequent conda install or conda run operations, breaking docker image builds for inductor benchmarks and ONNX.

Pin to 26.1.1-3, the last release before the conda 26.3.x changes.

Authored with Claude.