### PR TITLE
fix: safely handle non-standard boolean values in the CUDA kernel

### DIFF
--- a/aten/src/ATen/native/cuda/Nonzero.cu
+++ b/aten/src/ATen/native/cuda/Nonzero.cu
@@ -26,6 +26,14 @@ struct NonZeroOp {
   }
 };
 
+
+template <>
+struct NonZeroOp<bool> {
+  __host__ __device__ __forceinline__ bool operator()(const bool& a) const {
+    return (*reinterpret_cast<const unsigned char*>(&a) != 0);
+  }
+};
+
 // TODO: actually support int64_t index_t
 template <typename index_t>
 struct TensorDims {


### PR DESCRIPTION
I got the following error executing `TestCommonCUDA.test_non_standard_bool_values`:
```
File "/third_party/py/torch/test/test_ops.py", line 1604, in test_non_standard_bool_values
    actual = op(transformed.input, *transformed.args, **transformed.kwargs)
  File "/third_party/py/torch/testing/_internal/opinfo/core.py", line 1237, in __call__
    return self.op(*args, **kwargs)
           ~~~~~~~^^^^^^^^^^^^^^^^^
  File "/third_party/py/torch/testing/_internal/common_methods_invocations.py", line 21441, in <lambda>
    op=lambda x, *args: x.to_sparse(*args),
                        ~~~~~~~~~~~^^^^^^^
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
Search for `cudaErrorIllegalAddress' in [https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html](https://www.google.com/url?q=https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html&sa=D) for more information.
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Device-side assertion tracking was not enabled by user.
Exception raised from memcpy_and_sync at third_party/py/torch/c10/cuda/CUDAFunctions.h:105
```

Since the C++ standard dictates that valid bool values are only `0` or `1`, the compiler or the CUB library routines (`cub::DeviceSelect::Flagged`) optimized based on this assumption. When passed a reference to a byte containing a value like `2`, this caused undefined behavior, manifesting as an asynchronous illegal memory access on the GPU.

This fix guarantees that any non-zero byte is correctly treated as true regardless of standard compliance, preventing illegal memory access.