### PR TITLE
[Docathon]: documented quantization-support backend_config and qconfig fucntions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -552,6 +552,7 @@ coverage_ignore_functions = [
     "get_remote_module_template",
     # torch.distributed.optim.utils
     "as_functional_optim",
+    "register_functional_optim",
     # torch.distributed.rendezvous
     "rendezvous",
     # torch.distributed.rpc.api

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -342,17 +342,11 @@ coverage_ignore_functions = [
     "module_contains_param",
     "module_to_fqn",
     "swap_module",
-    # torch.ao.quantization.backend_config.executorch
-    "get_executorch_backend_config",
-    # torch.ao.quantization.backend_config.fbgemm
-    "get_fbgemm_backend_config",
     # torch.ao.quantization.backend_config.native
     "get_native_backend_config",
     "get_native_backend_config_dict",
     "get_test_only_legacy_native_backend_config",
     "get_test_only_legacy_native_backend_config_dict",
-    # torch.ao.quantization.backend_config.onednn
-    "get_onednn_backend_config",
     # torch.ao.quantization.backend_config.qnnpack
     "get_qnnpack_backend_config",
     # torch.ao.quantization.backend_config.tensorrt
@@ -400,16 +394,10 @@ coverage_ignore_functions = [
     "fold_bn_weights_into_conv_node",
     "remove_tensor_overload_for_qdq_ops",
     # torch.ao.quantization.qconfig
-    "get_default_qat_qconfig",
     "get_default_qat_qconfig_dict",
-    "get_default_qconfig",
     "get_default_qconfig_dict",
-    "qconfig_equals",
     # torch.ao.quantization.quantize
     "get_default_custom_config_dict",
-    # torch.ao.quantization.quantize_fx
-    "attach_preserved_attrs_to_model",
-    "convert_to_reference_fx",
     # torch.ao.quantization.quantize_jit
     "convert_dynamic_jit",
     "convert_jit",
@@ -564,7 +552,6 @@ coverage_ignore_functions = [
     "get_remote_module_template",
     # torch.distributed.optim.utils
     "as_functional_optim",
-    "register_functional_optim",
     # torch.distributed.rendezvous
     "rendezvous",
     # torch.distributed.rpc.api

--- a/docs/source/quantization-support.md
+++ b/docs/source/quantization-support.md
@@ -88,6 +88,8 @@ This module contains FX graph mode quantization APIs (prototype).
 
 ```{eval-rst}
 .. currentmodule:: torch.ao.quantization.quantize_fx
+.. autofunction:: attach_preserved_attrs_to_model
+.. autofunction:: convert_to_reference_fx
 ```
 
 ```{eval-rst}
@@ -129,19 +131,22 @@ Quantization to work with this as well.
 
 ```{eval-rst}
 .. currentmodule:: torch.ao.quantization.backend_config
-```
 
-```{eval-rst}
-.. autosummary::
-    :toctree: generated
-    :nosignatures:
-    :template: classtemplate.rst
+.. currentmodule:: torch.ao.quantization.backend_config.executorch
+.. autofunction:: get_executorch_backend_config
 
-    BackendConfig
-    BackendPatternConfig
-    DTypeConfig
-    DTypeWithConstraints
-    ObservationType
+.. currentmodule:: torch.ao.quantization.backend_config.fbgemm
+.. autofunction:: get_fbgemm_backend_config
+
+.. currentmodule:: torch.ao.quantization.backend_config.onednn
+.. autofunction:: get_onednn_backend_config
+
+.. currentmodule:: torch.ao.quantization.backend_config
+.. autoclass:: BackendConfig
+.. autoclass:: BackendPatternConfig
+.. autoclass:: DTypeConfig
+.. autoclass:: DTypeWithConstraints
+.. autoclass:: ObservationType
 ```
 
 ## torch.ao.quantization.backend_config.utils
@@ -402,6 +407,9 @@ to configure quantization settings for individual ops.
 
 ```{eval-rst}
 .. currentmodule:: torch.ao.quantization.qconfig
+.. autofunction:: get_default_qat_qconfig
+.. autofunction:: get_default_qconfig
+.. autofunction:: qconfig_equals
 ```
 
 ```{eval-rst}

--- a/docs/source/quantization-support.md
+++ b/docs/source/quantization-support.md
@@ -132,6 +132,17 @@ Quantization to work with this as well.
 ```{eval-rst}
 .. currentmodule:: torch.ao.quantization.backend_config
 
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: classtemplate.rst
+
+    BackendConfig
+    BackendPatternConfig
+    DTypeConfig
+    DTypeWithConstraints
+    ObservationType
+
 .. currentmodule:: torch.ao.quantization.backend_config.executorch
 .. autofunction:: get_executorch_backend_config
 
@@ -141,12 +152,6 @@ Quantization to work with this as well.
 .. currentmodule:: torch.ao.quantization.backend_config.onednn
 .. autofunction:: get_onednn_backend_config
 
-.. currentmodule:: torch.ao.quantization.backend_config
-.. autoclass:: BackendConfig
-.. autoclass:: BackendPatternConfig
-.. autoclass:: DTypeConfig
-.. autoclass:: DTypeWithConstraints
-.. autoclass:: ObservationType
 ```
 
 ## torch.ao.quantization.backend_config.utils


### PR DESCRIPTION
Fixes: #182829

Removed function from ignore coverage:

- attach_preserved_attrs_to_model
- convert_to_reference_fx
- get_default_qat_qconfig
- get_default_qconfig
- qconfig_equals
- get_executorch_backend_config
- get_fbgemm_backend_config
- get_onednn_backend_config

cc @svekars @sekyondaMeta @AlannaBurke