### PR TITLE
[inductor][symm_mem] Add low-contention allgather variants

### DIFF
--- a/benchmarks/distributed/symm_mem_all_gather_variants.py
+++ b/benchmarks/distributed/symm_mem_all_gather_variants.py
@@ -2,20 +2,20 @@
 """
 Benchmark for low-contention all-gather variants in torch.ops.symm_mem.
 
-Compares v1 (baseline), v2 (stream_wait_value32), v3 (P2P push/put),
-v4 (NVLS multicast + CE), and v5 (in-kernel multimem.st) across
-a sweep of shard sizes at a fixed world size. v4 and v5 require multicast
-support (NVSwitch / NVLink SHARP) and are skipped automatically on systems
-without it.
+Compares nccl (production baseline), v1 (barrier kernel + CE pull), v2
+(stream_wait_value32), v3 (P2P push/put), v4 (NVLS multicast + CE), and v5
+(in-kernel multimem.st) across a sweep of shard sizes at a fixed world size.
+v4 and v5 require multicast support (NVSwitch / NVLink SHARP) and are skipped
+automatically on systems without it.
 
 Launch with torchrun on a single node:
 
     torchrun --nproc_per_node=8 \
         benchmarks/distributed/symm_mem_all_gather_variants.py
 
-The script prints a markdown table of per-variant TPS (GB/s) for each
-shard size. All numbers are the mean over ``--iters`` runs after
-``--warmup`` warmup iterations.
+The script prints a markdown table of per-variant TPS (GB/s) for AG-only mode,
+or timing/exposed-communication tables for AG+matmul overlap mode. All numbers
+are the mean over ``--iters`` runs after ``--warmup`` warmup iterations.
 """
 
 from __future__ import annotations
@@ -77,6 +77,16 @@ def _build_variant(
             device=torch.device("cuda", rank),
         )
 
+    if op_name == "nccl":
+
+        def run_nccl() -> torch.Tensor:
+            res = torch.ops._c10d_functional.all_gather_into_tensor(
+                t, world_size, group_name
+            )
+            return torch.ops._c10d_functional.wait_tensor(res)
+
+        return run_nccl
+
     op = getattr(torch.ops.symm_mem, op_name)
 
     def run() -> torch.Tensor:
@@ -84,6 +94,43 @@ def _build_variant(
         return torch.ops._c10d_functional.wait_tensor(res)
 
     return run
+
+
+def _get_variant_op(op_name: str) -> Optional[Callable[..., torch.Tensor]]:
+    if op_name == "nccl":
+        return torch.ops._c10d_functional.all_gather_into_tensor
+    if op_name in (
+        "_low_contention_all_gather_v4",
+        "_low_contention_all_gather_v5",
+    ):
+        if not _SymmetricMemory.has_multicast_support(
+            DeviceType.CUDA, torch.cuda.current_device()
+        ):
+            return None
+    return getattr(torch.ops.symm_mem, op_name)
+
+
+def _make_input(
+    rank: int,
+    dtype: torch.dtype,
+    shard_numel: int,
+    group_name: str,
+    symm_mem_input: bool,
+) -> torch.Tensor:
+    if symm_mem_input:
+        return _SymmetricMemory.empty_strided_p2p(
+            size=(shard_numel,),
+            stride=(1,),
+            dtype=dtype,
+            device=torch.device("cuda", rank),
+            group_name=group_name,
+        ).fill_(rank)
+    return torch.full(
+        (shard_numel,),
+        rank,
+        dtype=dtype,
+        device=torch.device("cuda", rank),
+    )
 
 
 def _bench(
@@ -106,49 +153,15 @@ def _bench(
     return statistics.mean(times_s), statistics.stdev(times_s) if iters > 1 else 0.0
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--warmup", type=int, default=10)
-    parser.add_argument("--iters", type=int, default=100)
-    parser.add_argument("--dtype", type=str, default="bfloat16")
-    parser.add_argument(
-        "--shard-bytes",
-        type=int,
-        nargs="+",
-        default=list(DEFAULT_SHARD_BYTES),
-        help="Per-rank shard sizes in bytes to benchmark.",
-    )
-    parser.add_argument(
-        "--variants",
-        type=str,
-        nargs="+",
-        default=["v1", "v2", "v3", "v4", "v5"],
-        choices=["v1", "v2", "v3", "v4", "v5"],
-    )
-    parser.add_argument(
-        "--symm-mem-input",
-        action="store_true",
-        help="Allocate the input tensor via empty_strided_p2p().",
-    )
-    args = parser.parse_args()
-
-    rank = int(os.environ["RANK"])
-    world_size = int(os.environ["WORLD_SIZE"])
-    torch.cuda.set_device(rank)
-    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
-    group_name = dist.group.WORLD.group_name
-
-    dtype = getattr(torch, args.dtype)
-    element_size = torch.tensor([], dtype=dtype).element_size()
-
-    op_map = {
-        "v1": "_low_contention_all_gather",
-        "v2": "_low_contention_all_gather_v2",
-        "v3": "_low_contention_all_gather_v3",
-        "v4": "_low_contention_all_gather_v4",
-        "v5": "_low_contention_all_gather_v5",
-    }
-
+def _run_ag_only(
+    args: argparse.Namespace,
+    op_map: dict[str, str],
+    rank: int,
+    world_size: int,
+    dtype: torch.dtype,
+    element_size: int,
+    group_name: str,
+) -> None:
     rows: list[tuple[int, dict[str, float]]] = []
     for shard_bytes in args.shard_bytes:
         shard_numel = shard_bytes // element_size
@@ -187,6 +200,144 @@ def main() -> None:
                 for v in args.variants
             ]
             print("| " + " | ".join(cells) + " |")
+
+
+def _run_overlap(
+    args: argparse.Namespace,
+    op_map: dict[str, str],
+    rank: int,
+    world_size: int,
+    dtype: torch.dtype,
+    element_size: int,
+    group_name: str,
+) -> None:
+    a = torch.randn((args.matmul_m, args.matmul_k), dtype=dtype, device="cuda")
+    b = torch.randn((args.matmul_k, args.matmul_n), dtype=dtype, device="cuda")
+    mm_out = torch.empty((args.matmul_m, args.matmul_n), dtype=dtype, device="cuda")
+
+    def run_mm() -> None:
+        torch.mm(a, b, out=mm_out)
+
+    mm_s, _ = _bench(run_mm, args.warmup, args.iters)
+    rows: list[tuple[int, list[tuple[str, float, float, float, float]]]] = []
+    for shard_bytes in args.shard_bytes:
+        shard_numel = shard_bytes // element_size
+        ag_input = _make_input(
+            rank, dtype, shard_numel, group_name, args.symm_mem_input
+        )
+        per_variant: list[tuple[str, float, float, float, float]] = []
+        for v in args.variants:
+            op = _get_variant_op(op_map[v])
+            if op is None:
+                per_variant.append(
+                    (v, float("nan"), float("nan"), float("nan"), float("nan"))
+                )
+                continue
+
+            def run_ag() -> None:
+                if v == "nccl":
+                    y = op(ag_input, world_size, group_name)
+                else:
+                    y = op(ag_input, group_name)
+                torch.ops._c10d_functional.wait_tensor(y)
+
+            def run_overlap() -> None:
+                if v == "nccl":
+                    y = op(ag_input, world_size, group_name)
+                else:
+                    y = op(ag_input, group_name)
+                torch.mm(a, b, out=mm_out)
+                torch.ops._c10d_functional.wait_tensor(y)
+
+            ag_s, _ = _bench(run_ag, args.warmup, args.iters)
+            overlap_s, _ = _bench(run_overlap, args.warmup, args.iters)
+            ideal_s = max(mm_s, ag_s)
+            exposed_s = max(0.0, overlap_s - mm_s)
+            per_variant.append(
+                (
+                    v,
+                    ag_s * 1000.0,
+                    overlap_s * 1000.0,
+                    ideal_s * 1000.0,
+                    exposed_s * 1000.0,
+                )
+            )
+        rows.append((shard_bytes, per_variant))
+
+    if rank == 0:
+        print(
+            f"\n# AG + matmul overlap, world_size={world_size}, "
+            f"dtype={args.dtype}, symm_mem_input={args.symm_mem_input}, "
+            f"matmul={args.matmul_m}x{args.matmul_k}x{args.matmul_n}"
+        )
+        print(f"matmul_only_ms: {mm_s * 1000.0:.3f}")
+        print("| shard_bytes | variant | ag_only_ms | overlap_ms | ideal_ms | exposed_ag_ms |")
+        print("|---:|---|---:|---:|---:|---:|")
+        for shard_bytes, per_variant in rows:
+            for variant, ag_ms, overlap_ms, ideal_ms, exposed_ms in per_variant:
+                if ag_ms != ag_ms:
+                    print(f"| {shard_bytes} | {variant} | n/a | n/a | n/a | n/a |")
+                else:
+                    print(
+                        f"| {shard_bytes} | {variant} | {ag_ms:.3f} | "
+                        f"{overlap_ms:.3f} | {ideal_ms:.3f} | {exposed_ms:.3f} |"
+                    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--dtype", type=str, default="bfloat16")
+    parser.add_argument("--mode", choices=["ag-only", "overlap"], default="ag-only")
+    parser.add_argument(
+        "--shard-bytes",
+        type=int,
+        nargs="+",
+        default=list(DEFAULT_SHARD_BYTES),
+        help="Per-rank shard sizes in bytes to benchmark.",
+    )
+    parser.add_argument(
+        "--variants",
+        type=str,
+        nargs="+",
+        default=["nccl", "v1", "v2", "v3", "v4", "v5"],
+        choices=["nccl", "v1", "v2", "v3", "v4", "v5"],
+    )
+    parser.add_argument(
+        "--symm-mem-input",
+        action="store_true",
+        help="Allocate the input tensor via empty_strided_p2p().",
+    )
+    parser.add_argument("--matmul-m", type=int, default=8192)
+    parser.add_argument("--matmul-k", type=int, default=8192)
+    parser.add_argument("--matmul-n", type=int, default=8192)
+    args = parser.parse_args()
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(rank)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    group_name = dist.group.WORLD.group_name
+
+    dtype = getattr(torch, args.dtype)
+    element_size = torch.tensor([], dtype=dtype).element_size()
+
+    op_map = {
+        "nccl": "nccl",
+        "v1": "_low_contention_all_gather",
+        "v2": "_low_contention_all_gather_v2",
+        "v3": "_low_contention_all_gather_v3",
+        "v4": "_low_contention_all_gather_v4",
+        "v5": "_low_contention_all_gather_v5",
+    }
+
+    if args.mode == "ag-only":
+        _run_ag_only(args, op_map, rank, world_size, dtype, element_size, group_name)
+    elif args.mode == "overlap":
+        _run_overlap(args, op_map, rank, world_size, dtype, element_size, group_name)
+    else:
+        raise AssertionError(f"unknown benchmark mode: {args.mode}")
 
     dist.destroy_process_group()
 

--- a/benchmarks/distributed/symm_mem_all_gather_variants.py
+++ b/benchmarks/distributed/symm_mem_all_gather_variants.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Benchmark for low-contention all-gather variants in torch.ops.symm_mem.
+
+Compares v1 (baseline), v2 (stream_wait_value32), v3 (P2P push/put),
+v4 (NVLS multicast + CE), and v5 (in-kernel multimem.st) across
+a sweep of shard sizes at a fixed world size. v4 and v5 require multicast
+support (NVSwitch / NVLink SHARP) and are skipped automatically on systems
+without it.
+
+Launch with torchrun on a single node:
+
+    torchrun --nproc_per_node=8 \
+        benchmarks/distributed/symm_mem_all_gather_variants.py
+
+The script prints a markdown table of per-variant TPS (GB/s) for each
+shard size. All numbers are the mean over ``--iters`` runs after
+``--warmup`` warmup iterations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+from typing import Callable, Optional
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch._C._autograd import DeviceType
+from torch._C._distributed_c10d import _SymmetricMemory
+
+
+DEFAULT_SHARD_BYTES = (
+    64 * 1024,
+    1 * 1024 * 1024,
+    16 * 1024 * 1024,
+    256 * 1024 * 1024,
+)
+
+
+def _build_variant(
+    op_name: str,
+    rank: int,
+    world_size: int,
+    dtype: torch.dtype,
+    shard_numel: int,
+    group_name: str,
+    symm_mem_input: bool,
+) -> Optional[Callable[[], torch.Tensor]]:
+    """Return a zero-arg callable that runs the given AG variant, or None if
+    the variant is not applicable on this device.
+    """
+    if op_name in (
+        "_low_contention_all_gather_v4",
+        "_low_contention_all_gather_v5",
+    ):
+        if not _SymmetricMemory.has_multicast_support(
+            DeviceType.CUDA, torch.cuda.current_device()
+        ):
+            return None
+
+    if symm_mem_input:
+        t = _SymmetricMemory.empty_strided_p2p(
+            size=(shard_numel,),
+            stride=(1,),
+            dtype=dtype,
+            device=torch.device("cuda", rank),
+            group_name=group_name,
+        ).fill_(rank)
+    else:
+        t = torch.full(
+            (shard_numel,),
+            rank,
+            dtype=dtype,
+            device=torch.device("cuda", rank),
+        )
+
+    op = getattr(torch.ops.symm_mem, op_name)
+
+    def run() -> torch.Tensor:
+        res = op(t, group_name)
+        return torch.ops._c10d_functional.wait_tensor(res)
+
+    return run
+
+
+def _bench(
+    fn: Callable[[], torch.Tensor], warmup: int, iters: int
+) -> tuple[float, float]:
+    """Return (mean_seconds, stdev_seconds) averaged over ``iters`` runs."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    dist.barrier()
+
+    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    for i in range(iters):
+        start_events[i].record()
+        fn()
+        end_events[i].record()
+    torch.cuda.synchronize()
+    times_s = [s.elapsed_time(e) / 1000.0 for s, e in zip(start_events, end_events)]
+    return statistics.mean(times_s), statistics.stdev(times_s) if iters > 1 else 0.0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--dtype", type=str, default="bfloat16")
+    parser.add_argument(
+        "--shard-bytes",
+        type=int,
+        nargs="+",
+        default=list(DEFAULT_SHARD_BYTES),
+        help="Per-rank shard sizes in bytes to benchmark.",
+    )
+    parser.add_argument(
+        "--variants",
+        type=str,
+        nargs="+",
+        default=["v1", "v2", "v3", "v4", "v5"],
+        choices=["v1", "v2", "v3", "v4", "v5"],
+    )
+    parser.add_argument(
+        "--symm-mem-input",
+        action="store_true",
+        help="Allocate the input tensor via empty_strided_p2p().",
+    )
+    args = parser.parse_args()
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(rank)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    group_name = dist.group.WORLD.group_name
+
+    dtype = getattr(torch, args.dtype)
+    element_size = torch.tensor([], dtype=dtype).element_size()
+
+    op_map = {
+        "v1": "_low_contention_all_gather",
+        "v2": "_low_contention_all_gather_v2",
+        "v3": "_low_contention_all_gather_v3",
+        "v4": "_low_contention_all_gather_v4",
+        "v5": "_low_contention_all_gather_v5",
+    }
+
+    rows: list[tuple[int, dict[str, float]]] = []
+    for shard_bytes in args.shard_bytes:
+        shard_numel = shard_bytes // element_size
+        per_variant: dict[str, float] = {}
+        for v in args.variants:
+            fn = _build_variant(
+                op_map[v],
+                rank,
+                world_size,
+                dtype,
+                shard_numel,
+                group_name,
+                args.symm_mem_input,
+            )
+            if fn is None:
+                per_variant[v] = float("nan")
+                continue
+            mean_s, _stdev = _bench(fn, args.warmup, args.iters)
+            # Algorithm bandwidth: per-rank output bytes / time. AG output is
+            # world_size * shard_bytes; the per-rank useful bandwidth is
+            # reported as total output bytes / time (algo bw).
+            per_variant[v] = (world_size * shard_bytes) / mean_s / 1e9
+        rows.append((shard_bytes, per_variant))
+
+    if rank == 0:
+        print(
+            f"\n# symm_mem all-gather variants, world_size={world_size}, "
+            f"dtype={args.dtype}, symm_mem_input={args.symm_mem_input}"
+        )
+        header = ["shard_bytes", *args.variants]
+        print("| " + " | ".join(header) + " |")
+        print("|" + "|".join("---" for _ in header) + "|")
+        for shard_bytes, per_variant in rows:
+            cells = [f"{shard_bytes}"] + [
+                "n/a" if per_variant[v] != per_variant[v] else f"{per_variant[v]:.1f}"
+                for v in args.variants
+            ]
+            print("| " + " | ".join(cells) + " |")
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -85,6 +85,7 @@
   _(cuMemsetD32Async, 12000)                       \
   _(cuStreamWriteValue32, 12000)                   \
   _(cuStreamWaitValue32, 12000)                    \
+  _(cuStreamBatchMemOp, 12000)                     \
   _(cuGetErrorString, 12000)
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12080)

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -340,11 +340,53 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(2)
     @requires_multicast_support()
+    def test_low_contention_all_gather_v4_out(self) -> None:
+        self._run_lc_ag_variant_out_correctness(
+            "_low_contention_all_gather_v4_out"
+        )
+
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    @requires_multicast_support()
     @parametrize("symm_mem_input", [True, False])
     def test_low_contention_all_gather_v5(self, symm_mem_input: bool) -> None:
         self._run_lc_ag_variant_correctness(
             "_low_contention_all_gather_v5", symm_mem_input
         )
+
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    @requires_multicast_support()
+    def test_low_contention_all_gather_v5_out(self) -> None:
+        self._run_lc_ag_variant_out_correctness(
+            "_low_contention_all_gather_v5_out"
+        )
+
+    def _run_lc_ag_variant_out_correctness(self, op_name: str) -> None:
+        self._init_process()
+
+        t = torch.full((64, 64), self.rank, dtype=torch.float32, device=self.device)
+        out = _SymmetricMemory.empty_strided_p2p(
+            size=(64 * self.world_size, 64),
+            stride=(64, 1),
+            dtype=torch.float32,
+            device=self.device,
+            group_name="0",
+        )
+
+        op = getattr(torch.ops.symm_mem, op_name)
+        res = op(t, "0", out)
+        self.assertEqual(res.data_ptr(), out.data_ptr())
+        res = torch.ops._c10d_functional.wait_tensor(res)
+        self.assertEqual(res.shape, (64 * self.world_size, 64))
+
+        chunks = res.chunk(self.world_size)
+        for r in range(self.world_size):
+            self.assertTrue(chunks[r].eq(r).all())
 
     def _run_lc_ag_variant_cuda_graph(self, op_name: str) -> None:
         """Capture an AG into a CUDA graph and replay it multiple times.
@@ -1632,6 +1674,152 @@ class LoweringTest(MultiProcContinuousTest):
             ", out=",
             code,
             "one_shot_all_reduce_copy_out should have out= parameter.",
+        )
+
+    @skip_if_rocm_multiprocess  # requires registered-buffer support
+    @skip_if_lt_x_gpu(2)
+    @fresh_inductor_cache()
+    @parametrize("variant", ["v4", "v5"])
+    def test_low_contention_all_gather_planned_output_codegen(
+        self, variant: str
+    ):
+        self._init_process()
+        old_disable_multicast = os.environ.pop(
+            "TORCH_SYMM_MEM_DISABLE_MULTICAST", None
+        )
+        try:
+            if not _SymmetricMemory.has_multicast_support(DeviceType.CUDA, 0):
+                self.skipTest("multicast support is not available")
+
+            op = getattr(torch.ops.symm_mem, f"_low_contention_all_gather_{variant}")
+
+            def func(x):
+                return torch.ops._c10d_functional.wait_tensor(op(x, "0"))
+
+            x = torch.full((8, 8), self.rank, dtype=torch.float32, device=self.device)
+            compiled = torch.compile(func, fullgraph=True)
+            code = run_and_get_triton_code(compiled, x)
+
+            FileCheck().check("empty_strided_p2p").check(
+                "alloc_id="
+            ).check(
+                f"_low_contention_all_gather_{variant}_out"
+            ).check(", out=").check_not("_ag_output_cache").run(
+                code
+            )
+
+            res = compiled(x)
+            self.assertEqual(res.shape, (8 * self.world_size, 8))
+            chunks = res.chunk(self.world_size)
+            for r in range(self.world_size):
+                self.assertTrue(chunks[r].eq(r).all())
+        finally:
+            if old_disable_multicast is not None:
+                os.environ["TORCH_SYMM_MEM_DISABLE_MULTICAST"] = (
+                    old_disable_multicast
+                )
+
+    def _make_lc_ag_out_graph(self, num_collectives: int) -> torch.fx.Graph:
+        graph = torch.fx.Graph()
+        waits = []
+        for i in range(num_collectives):
+            x = graph.placeholder(f"x{i}")
+            x.meta["val"] = torch.empty(8, 8, device=self.device)
+            out = graph.placeholder(f"out{i}")
+            out.meta["val"] = torch.empty(
+                8 * self.world_size, 8, device=self.device
+            )
+            ag = graph.call_function(
+                torch.ops._c10d_functional.all_gather_into_tensor_out.default,
+                args=(x, self.world_size, "0"),
+                kwargs={"out": out},
+            )
+            ag.meta["val"] = out.meta["val"]
+            mm = graph.call_function(torch.ops.aten.mm.default, args=(x, x))
+            mm.meta["val"] = torch.empty(8, 8, device=self.device)
+            wait = graph.call_function(
+                torch.ops._c10d_functional.wait_tensor.default,
+                args=(out,),
+            )
+            wait.meta["val"] = out.meta["val"]
+            waits.append(wait)
+        graph.output(tuple(waits))
+        return graph
+
+    def _run_lc_ag_pass_test(self, graph: torch.fx.Graph, variant: str) -> None:
+        from torch._inductor.fx_passes import low_contention_collectives as lc
+
+        old_enable_symm_mem = lc._enable_symm_mem
+        old_has_multicast_support = lc._has_multicast_support
+        try:
+            lc._enable_symm_mem = lambda group_name: True
+            lc._has_multicast_support = lambda device_index: True
+            use_v4 = variant == "v4"
+            use_v5 = variant == "v5"
+            config_patches = {
+                "aten_distributed_optimizations.low_contention_min_bytes_per_rank": 0,
+                "aten_distributed_optimizations.low_contention_max_replacements": -1,
+                "aten_distributed_optimizations.low_contention_all_gather_v2": False,
+                "aten_distributed_optimizations.low_contention_all_gather_v3": False,
+                "aten_distributed_optimizations.low_contention_all_gather_v4": use_v4,
+                "aten_distributed_optimizations.low_contention_all_gather_v5": use_v5,
+            }
+            with torch._inductor.config.patch(config_patches):
+                lc.replace_collectives_with_low_contention(graph)
+        finally:
+            lc._enable_symm_mem = old_enable_symm_mem
+            lc._has_multicast_support = old_has_multicast_support
+
+    @skip_if_rocm_multiprocess
+    @skip_if_lt_x_gpu(2)
+    @parametrize("variant", ["v4", "v5"])
+    def test_low_contention_all_gather_out_rewrite_preserves_out(
+        self, variant: str
+    ) -> None:
+        self._init_process()
+
+        graph = self._make_lc_ag_out_graph(num_collectives=1)
+        original_out = next(n for n in graph.nodes if n.name == "out0")
+        self._run_lc_ag_pass_test(graph, variant)
+
+        target = getattr(
+            torch.ops.symm_mem, f"_low_contention_all_gather_{variant}_out"
+        ).default
+        replacement = next(n for n in graph.nodes if n.target is target)
+        self.assertIs(replacement.args[2], original_out)
+        self.assertFalse(
+            any(
+                n.target
+                is torch.ops._c10d_functional.all_gather_into_tensor_out.default
+                for n in graph.nodes
+            )
+        )
+
+    @skip_if_rocm_multiprocess
+    @skip_if_lt_x_gpu(2)
+    def test_low_contention_all_gather_output_budget(self) -> None:
+        self._init_process()
+
+        graph = self._make_lc_ag_out_graph(num_collectives=2)
+        first_out = next(n for n in graph.nodes if n.name == "out0")
+        first_out_val = first_out.meta["val"]
+        first_out_bytes = first_out_val.numel() * first_out_val.element_size()
+        config_patches = {
+            "aten_distributed_optimizations."
+            "low_contention_max_output_bytes_per_graph": first_out_bytes
+        }
+        with torch._inductor.config.patch(config_patches):
+            self._run_lc_ag_pass_test(graph, "v5")
+
+        symm_target = torch.ops.symm_mem._low_contention_all_gather_v5_out.default
+        c10d_target = torch.ops._c10d_functional.all_gather_into_tensor_out.default
+        self.assertEqual(
+            sum(1 for n in graph.nodes if n.target is symm_target),
+            1,
+        )
+        self.assertEqual(
+            sum(1 for n in graph.nodes if n.target is c10d_target),
+            1,
         )
 
     @skip_if_rocm_multiprocess  # test requires support for registered buffers

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -286,6 +286,114 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         for r in range(self.world_size):
             self.assertTrue(chunks[r].eq(r).all())
 
+    def _run_lc_ag_variant_correctness(
+        self, op_name: str, symm_mem_input: bool
+    ) -> None:
+        """Shared body for v3/v4/v5 correctness tests."""
+        self._init_process()
+
+        if symm_mem_input:
+            t = _SymmetricMemory.empty_strided_p2p(
+                size=(64, 64),
+                stride=(64, 1),
+                dtype=torch.float32,
+                device=self.device,
+                group_name="0",
+            ).fill_(self.rank)
+        else:
+            t = torch.full(
+                (64, 64), self.rank, dtype=torch.float32, device=self.device
+            )
+
+        op = getattr(torch.ops.symm_mem, op_name)
+        res = op(t, "0")
+        res = torch.ops._c10d_functional.wait_tensor(res)
+        self.assertEqual(res.shape, (64 * self.world_size, 64))
+
+        chunks = res.chunk(self.world_size)
+        for r in range(self.world_size):
+            self.assertTrue(chunks[r].eq(r).all())
+
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    @parametrize("symm_mem_input", [True, False])
+    def test_low_contention_all_gather_v3(self, symm_mem_input: bool) -> None:
+        self._run_lc_ag_variant_correctness(
+            "_low_contention_all_gather_v3", symm_mem_input
+        )
+
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    @requires_multicast_support()
+    @parametrize("symm_mem_input", [True, False])
+    def test_low_contention_all_gather_v4(self, symm_mem_input: bool) -> None:
+        self._run_lc_ag_variant_correctness(
+            "_low_contention_all_gather_v4", symm_mem_input
+        )
+
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    @requires_multicast_support()
+    @parametrize("symm_mem_input", [True, False])
+    def test_low_contention_all_gather_v5(self, symm_mem_input: bool) -> None:
+        self._run_lc_ag_variant_correctness(
+            "_low_contention_all_gather_v5", symm_mem_input
+        )
+
+    def _run_lc_ag_variant_cuda_graph(self, op_name: str) -> None:
+        """Capture an AG into a CUDA graph and replay it multiple times.
+
+        This is only valid for AG variants whose synchronization protocol does
+        not depend on host-side counters captured as constants.
+        """
+        self._init_process()
+
+        inp = torch.full(
+            (64, 64), self.rank, dtype=torch.float32, device=self.device
+        )
+        op = getattr(torch.ops.symm_mem, op_name)
+
+        # Warmup on a side stream so capture sees steady state.
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            _ = op(inp, "0")
+            torch.cuda.synchronize()
+        torch.cuda.current_stream().wait_stream(s)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            res = op(inp, "0")
+            res = torch.ops._c10d_functional.wait_tensor(res)
+
+        for _ in range(4):
+            graph.replay()
+            torch.cuda.synchronize()
+            chunks = res.chunk(self.world_size)
+            for r in range(self.world_size):
+                self.assertTrue(
+                    chunks[r].eq(r).all(),
+                    f"CUDA graph replay mismatch for rank {r}",
+                )
+
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    @skip("v4 CE barriers use host-side counters; graph-safe sync is a follow-up")
+    def test_low_contention_all_gather_v4_cuda_graph(self) -> None:
+        self._run_lc_ag_variant_cuda_graph("_low_contention_all_gather_v4")
+
+    # NOTE: v3/v4/v5 use cached symmetric outputs and host-side signal
+    # counters in eager mode. A graph-safe implementation needs planned output
+    # slots plus a capture-safe synchronization protocol.
+
     @skipIf(
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
@@ -1626,6 +1734,62 @@ class SymmMemSingleProcTest(TestCase):
 
         with self.assertRaises(RuntimeError):
             _SymmetricMemory.stream_write_value32(tensor, offset=0, val=4294967296)
+
+    @requires_cuda
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    def test_stream_batch_mem_op_writes(self):
+        # Exercise stream_batch_mem_op in the write-only case. A batched
+        # write to all slots should produce the same end state as the
+        # per-slot stream_write_value32 path.
+        tensor = torch.zeros(8, dtype=torch.uint32, device="cuda")
+
+        _SymmetricMemory.stream_batch_mem_op(
+            pads=[tensor] * 4,
+            offsets=[0, 2, 4, 6],
+            vals=[10, 20, 30, 40],
+            op_types=[0, 0, 0, 0],
+            flags=[0, 0, 0, 0],
+        )
+        torch.cuda.synchronize()
+        expected = torch.tensor(
+            [10, 0, 20, 0, 30, 0, 40, 0], dtype=torch.uint32, device="cuda"
+        )
+        torch.testing.assert_close(tensor, expected)
+
+    @requires_cuda
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    def test_stream_batch_mem_op_argchecks(self):
+        tensor = torch.zeros(4, dtype=torch.uint32, device="cuda")
+        with self.assertRaisesRegex(
+            RuntimeError, "parallel-array arguments must have the same length"
+        ):
+            _SymmetricMemory.stream_batch_mem_op(
+                pads=[tensor, tensor],
+                offsets=[0],
+                vals=[1, 2],
+                op_types=[0, 0],
+                flags=[0, 0],
+            )
+        with self.assertRaisesRegex(RuntimeError, "must be 0 .write. or 1 .wait."):
+            _SymmetricMemory.stream_batch_mem_op(
+                pads=[tensor],
+                offsets=[0],
+                vals=[1],
+                op_types=[9],
+                flags=[0],
+            )
+        with self.assertRaisesRegex(RuntimeError, "offset out of range"):
+            _SymmetricMemory.stream_batch_mem_op(
+                pads=[tensor],
+                offsets=[100],
+                vals=[1],
+                op_types=[0],
+                flags=[0],
+            )
 
     @skipIf(
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"

--- a/torch/_inductor/comm_lowering.py
+++ b/torch/_inductor/comm_lowering.py
@@ -545,6 +545,34 @@ def register_symm_mem_lowerings():
                 group_name,  # type: ignore[arg-type]
             )
 
+    def _create_low_contention_ag_out(
+        kernel: torch._ops.OpOverload,
+        inp: ir.TensorBox,
+        group_name: str,
+    ) -> ir.TensorBox:
+        from torch.distributed import distributed_c10d as c10d
+
+        inp.realize()
+        group_size = c10d._get_group_size_by_name(group_name)
+        out_size = [inp.get_size()[0] * group_size, *inp.get_size()[1:]]
+        layout = ir.CommBufferLayout(
+            ir.FixedLayout(
+                device=inp.get_device_or_error(),
+                dtype=inp.get_dtype(),
+                size=out_size,
+            ),
+            ir.CommBufferType.SYMM_MEM,
+            group_name,
+        )
+        return ir.TensorBox.create(
+            ir.ExternKernelOut(
+                layout=layout,
+                inputs=[inp],
+                constant_args=(group_name,),
+                op_overload=kernel,
+            )
+        )
+
     @register_lowering(symm_mem.one_shot_all_reduce)
     def _symm_mem_one_shot_all_reduce(
         inp: ir.TensorBox,
@@ -920,13 +948,33 @@ def register_symm_mem_lowerings():
         inp: ir.TensorBox,
         group_name: str,
     ):
+        return _create_low_contention_ag_out(
+            symm_mem._low_contention_all_gather_v4_out.default,
+            inp,
+            group_name,
+        )
+
+    @register_lowering(symm_mem._low_contention_all_gather_v4_out)
+    def _symm_mem_low_contention_all_gather_v4_out(
+        inp: ir.TensorBox,
+        group_name: str,
+        out: ir.TensorBox,
+    ):
         inp.realize()
+        if can_realize_as_comm_buffer(out, ir.CommBufferType.SYMM_MEM):
+            realize_as_comm_buffer(out, ir.CommBufferType.SYMM_MEM, group_name)
+        else:
+            raise AssertionError(
+                "_low_contention_all_gather_v4_out requires an Inductor-owned "
+                "output buffer that can be realized as symmetric memory."
+            )
         return pytree.tree_map(
             ir.TensorBox.create,
             ir.FallbackKernel.create(
-                symm_mem._low_contention_all_gather_v4.default,
+                symm_mem._low_contention_all_gather_v4_out.default,
                 inp,
                 group_name,
+                out,
             ),
         )
 
@@ -935,13 +983,33 @@ def register_symm_mem_lowerings():
         inp: ir.TensorBox,
         group_name: str,
     ):
+        return _create_low_contention_ag_out(
+            symm_mem._low_contention_all_gather_v5_out.default,
+            inp,
+            group_name,
+        )
+
+    @register_lowering(symm_mem._low_contention_all_gather_v5_out)
+    def _symm_mem_low_contention_all_gather_v5_out(
+        inp: ir.TensorBox,
+        group_name: str,
+        out: ir.TensorBox,
+    ):
         inp.realize()
+        if can_realize_as_comm_buffer(out, ir.CommBufferType.SYMM_MEM):
+            realize_as_comm_buffer(out, ir.CommBufferType.SYMM_MEM, group_name)
+        else:
+            raise AssertionError(
+                "_low_contention_all_gather_v5_out requires an Inductor-owned "
+                "output buffer that can be realized as symmetric memory."
+            )
         return pytree.tree_map(
             ir.TensorBox.create,
             ir.FallbackKernel.create(
-                symm_mem._low_contention_all_gather_v5.default,
+                symm_mem._low_contention_all_gather_v5_out.default,
                 inp,
                 group_name,
+                out,
             ),
         )
 

--- a/torch/_inductor/comm_lowering.py
+++ b/torch/_inductor/comm_lowering.py
@@ -900,18 +900,65 @@ def register_symm_mem_lowerings():
             ),
         )
 
-    @register_lowering(symm_mem._nccl_ce_all_gather)
-    def _symm_mem_nccl_ce_all_gather(
+    @register_lowering(symm_mem._low_contention_all_gather_v3)
+    def _symm_mem_low_contention_all_gather_v3(
         inp: ir.TensorBox,
         group_name: str,
-        buffer_id: int = 0,
     ):
-        return _create_out_of_place(
-            symm_mem._nccl_ce_all_gather.default,
-            inp,
-            group_name,
-            buffer_id,
+        inp.realize()
+        return pytree.tree_map(
+            ir.TensorBox.create,
+            ir.FallbackKernel.create(
+                symm_mem._low_contention_all_gather_v3.default,
+                inp,
+                group_name,
+            ),
         )
+
+    @register_lowering(symm_mem._low_contention_all_gather_v4)
+    def _symm_mem_low_contention_all_gather_v4(
+        inp: ir.TensorBox,
+        group_name: str,
+    ):
+        inp.realize()
+        return pytree.tree_map(
+            ir.TensorBox.create,
+            ir.FallbackKernel.create(
+                symm_mem._low_contention_all_gather_v4.default,
+                inp,
+                group_name,
+            ),
+        )
+
+    @register_lowering(symm_mem._low_contention_all_gather_v5)
+    def _symm_mem_low_contention_all_gather_v5(
+        inp: ir.TensorBox,
+        group_name: str,
+    ):
+        inp.realize()
+        return pytree.tree_map(
+            ir.TensorBox.create,
+            ir.FallbackKernel.create(
+                symm_mem._low_contention_all_gather_v5.default,
+                inp,
+                group_name,
+            ),
+        )
+
+    if hasattr(symm_mem, "_nccl_ce_all_gather"):
+
+        @register_lowering(symm_mem._nccl_ce_all_gather)
+        def _symm_mem_nccl_ce_all_gather(
+            inp: ir.TensorBox,
+            group_name: str,
+            buffer_id: int = 0,
+        ):
+            return _create_out_of_place(
+                symm_mem._nccl_ce_all_gather.default,
+                inp,
+                group_name,
+                buffer_id,
+            )
 
     @register_lowering(symm_mem._low_contention_reduce_scatter)
     def _symm_mem_low_contention_reduce_scatter(
@@ -932,15 +979,17 @@ def register_symm_mem_lowerings():
             ),
         )
 
-    @register_lowering(symm_mem._nccl_efficiency_reduce_scatter)
-    def _symm_mem_nccl_efficiency_reduce_scatter(
-        inp: ir.TensorBox,
-        reduce_op: str,
-        group_name: str,
-    ):
-        return _create_out_of_place(
-            symm_mem._nccl_efficiency_reduce_scatter.default,
-            inp,
-            reduce_op,
-            group_name,
-        )
+    if hasattr(symm_mem, "_nccl_efficiency_reduce_scatter"):
+
+        @register_lowering(symm_mem._nccl_efficiency_reduce_scatter)
+        def _symm_mem_nccl_efficiency_reduce_scatter(
+            inp: ir.TensorBox,
+            reduce_op: str,
+            group_name: str,
+        ):
+            return _create_out_of_place(
+                symm_mem._nccl_efficiency_reduce_scatter.default,
+                inp,
+                reduce_op,
+                group_name,
+            )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1234,6 +1234,14 @@ class aten_distributed_optimizations:
     # overhead exceeds the benefit. Set to 0 to disable.
     low_contention_min_bytes_per_rank: int = 16 * 1024 * 1024
 
+    # Optional cap on the number of collectives replaced by the LC pass.
+    # A negative value means no cap.
+    low_contention_max_replacements: int = -1
+
+    # Optional per-FX-graph cap on estimated planned output bytes for v4/v5
+    # all-gather replacements. A negative value means no cap.
+    low_contention_max_output_bytes_per_graph: int = -1
+
     # Use v2 all-gather (stream_write/wait_value32 instead of barrier kernels).
     low_contention_all_gather_v2: bool = False
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1237,6 +1237,17 @@ class aten_distributed_optimizations:
     # Use v2 all-gather (stream_write/wait_value32 instead of barrier kernels).
     low_contention_all_gather_v2: bool = False
 
+    # Direct-input P2P push/put variant. No multicast requirement.
+    low_contention_all_gather_v3: bool = False
+
+    # Direct-input NVLS multicast + Copy Engine variant. Requires NVSwitch /
+    # NVLink SHARP and uses cudaMemcpyAsync to the multicast pointer.
+    low_contention_all_gather_v4: bool = False
+
+    # Direct-input multimem.st variant. Single CUDA kernel launch per AG:
+    # GPU-initiated multicast writes + system-scope atomic barrier.
+    low_contention_all_gather_v5: bool = False
+
 
 def parallel_compile_enabled_internally() -> bool:
     """

--- a/torch/_inductor/fx_passes/low_contention_collectives.py
+++ b/torch/_inductor/fx_passes/low_contention_collectives.py
@@ -61,6 +61,8 @@ def replace_collectives_with_low_contention(
 
     cfg = config.aten_distributed_optimizations
     min_bytes = cfg.low_contention_min_bytes_per_rank
+    max_replacements = cfg.low_contention_max_replacements
+    max_output_bytes = cfg.low_contention_max_output_bytes_per_graph
     use_ag_v2 = cfg.low_contention_all_gather_v2
     use_ag_v3 = cfg.low_contention_all_gather_v3
     use_ag_v4 = cfg.low_contention_all_gather_v4
@@ -90,8 +92,13 @@ def replace_collectives_with_low_contention(
     skipped_small = 0
     skipped_no_overlap = 0
     skipped_nvlink_contention = 0
+    skipped_budget = 0
+    selected_output_bytes = 0
     for node, is_ag, group_name in collectives:
         coll_type = "AG" if is_ag else "RS"
+
+        if max_replacements >= 0 and replacements >= max_replacements:
+            break
 
         # Size filter: LC barrier overhead dominates for small messages
         if min_bytes > 0:
@@ -123,29 +130,64 @@ def replace_collectives_with_low_contention(
             )
             continue
 
+        target = None
+        if is_ag:
+            target = _select_low_contention_all_gather_target(
+                symm_mem,
+                input_node=node.args[0],
+                use_ag_v2=use_ag_v2,
+                use_ag_v3=use_ag_v3,
+                use_ag_v4=use_ag_v4,
+                use_ag_v5=use_ag_v5,
+            )
+            if max_output_bytes >= 0 and _is_budgeted_all_gather_target(
+                target, symm_mem
+            ):
+                output_bytes = _get_ag_output_bytes(node, group_name)
+                if (
+                    output_bytes is None
+                    or selected_output_bytes + output_bytes > max_output_bytes
+                ):
+                    skipped_budget += 1
+                    log.debug(
+                        "LC skip %s %s: output budget exceeded "
+                        "(estimated_output_bytes=%s, selected_output_bytes=%d, "
+                        "max_output_bytes_per_graph=%d)",
+                        coll_type,
+                        node.name,
+                        output_bytes,
+                        selected_output_bytes,
+                        max_output_bytes,
+                    )
+                    continue
+                selected_output_bytes += output_bytes
+
         _replace_collective(
             node,
             graph,
             symm_mem,
             is_ag,
             group_name,
-            use_ag_v2=use_ag_v2,
-            use_ag_v3=use_ag_v3,
-            use_ag_v4=use_ag_v4,
-            use_ag_v5=use_ag_v5,
+            target=target,
         )
         replacements += 1
 
     log.info(
         "Replaced %d/%d FSDP collectives "
         "(skipped_small=%d, skipped_no_overlap=%d, "
-        "skipped_nvlink_contention=%d, min_bytes=%d)",
+        "skipped_nvlink_contention=%d, skipped_budget=%d, min_bytes=%d, "
+        "max_replacements=%d, max_output_bytes_per_graph=%d, "
+        "selected_output_bytes=%d)",
         replacements,
         len(collectives),
         skipped_small,
         skipped_no_overlap,
         skipped_nvlink_contention,
+        skipped_budget,
         min_bytes,
+        max_replacements,
+        max_output_bytes,
+        selected_output_bytes,
     )
 
 
@@ -195,63 +237,84 @@ def _has_multicast_support(device_index: int) -> bool:
     return result
 
 
+def _select_low_contention_all_gather_target(
+    symm_mem,
+    input_node,
+    use_ag_v2=False,
+    use_ag_v3=False,
+    use_ag_v4=False,
+    use_ag_v5=False,
+):
+    # Selection order: v5 > v4 > v3 > v2 > v1. v4 and v5 require
+    # multicast support; if absent we fall through to v3/v2/v1 as appropriate.
+    device_index = None
+    input_val = input_node.meta.get("val")
+    if isinstance(input_val, torch.Tensor) and input_val.device.type == "cuda":
+        device_index = input_val.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+
+    if use_ag_v5 and _has_multicast_support(device_index):
+        return symm_mem._low_contention_all_gather_v5.default
+    if use_ag_v5:
+        log.info(
+            "low_contention_all_gather_v5 requested but multicast is not "
+            "supported on device %d; falling through.",
+            device_index,
+        )
+
+    if use_ag_v4 and _has_multicast_support(device_index):
+        return symm_mem._low_contention_all_gather_v4.default
+    if use_ag_v4:
+        log.info(
+            "low_contention_all_gather_v4 requested but multicast is not "
+            "supported on device %d; falling through.",
+            device_index,
+        )
+
+    if use_ag_v3:
+        return symm_mem._low_contention_all_gather_v3.default
+    if use_ag_v2:
+        return symm_mem._low_contention_all_gather_v2.default
+    return symm_mem._low_contention_all_gather.default
+
+
+def _is_budgeted_all_gather_target(target, symm_mem) -> bool:
+    return target in (
+        symm_mem._low_contention_all_gather_v4.default,
+        symm_mem._low_contention_all_gather_v5.default,
+    )
+
+
 def _replace_collective(
     node,
     graph,
     symm_mem,
     is_ag,
     group_name,
-    use_ag_v2=False,
-    use_ag_v3=False,
-    use_ag_v4=False,
-    use_ag_v5=False,
+    target=None,
 ):
     input_node = node.args[0]
     if is_ag:
-        # Selection order: v5 > v4 > v3 > v2 > v1. v4 and v5 require
-        # multicast support; if absent we fall through to v3/v2/v1 as
-        # appropriate. The device index is derived from the input tensor's
-        # meta val so the decision is graph-local (important for graphs
-        # that span multiple devices in the future).
-        device_index = None
-        input_val = input_node.meta.get("val")
-        if isinstance(input_val, torch.Tensor) and input_val.device.type == "cuda":
-            device_index = input_val.device.index
-        if device_index is None:
-            device_index = torch.cuda.current_device()
+        assert target is not None
 
-        if use_ag_v5 and _has_multicast_support(device_index):
-            target = symm_mem._low_contention_all_gather_v5.default
-        elif use_ag_v5 and not _has_multicast_support(device_index):
-            log.info(
-                "low_contention_all_gather_v5 requested but multicast is not "
-                "supported on device %d; falling through.",
-                device_index,
+        if node.target is torch.ops._c10d_functional.all_gather_into_tensor_out.default:
+            out = node.kwargs["out"]
+            if target is symm_mem._low_contention_all_gather_v5.default:
+                target = symm_mem._low_contention_all_gather_v5_out.default
+            elif target is symm_mem._low_contention_all_gather_v4.default:
+                target = symm_mem._low_contention_all_gather_v4_out.default
+            else:
+                # v1/v2/v3 do not have out variants.
+                out = None
+
+            args = (
+                (input_node, group_name, out)
+                if out is not None
+                else (input_node, group_name)
             )
-            target = None
         else:
-            target = None
-
-        if target is None:
-            if use_ag_v4 and _has_multicast_support(device_index):
-                target = symm_mem._low_contention_all_gather_v4.default
-            elif use_ag_v4 and not _has_multicast_support(device_index):
-                log.info(
-                    "low_contention_all_gather_v4 requested but multicast is "
-                    "not supported on device %d; falling through.",
-                    device_index,
-                )
-
-        if target is None and use_ag_v3:
-            target = symm_mem._low_contention_all_gather_v3.default
-
-        if target is None and use_ag_v2:
-            target = symm_mem._low_contention_all_gather_v2.default
-
-        if target is None:
-            target = symm_mem._low_contention_all_gather.default
-
-        args = (input_node, group_name)
+            args = (input_node, group_name)
     else:
         reduce_op = node.args[1]
         target = symm_mem._low_contention_reduce_scatter.default
@@ -262,6 +325,45 @@ def _replace_collective(
     new_node.meta.update(node.meta)
     node.replace_all_uses_with(new_node)
     graph.erase_node(node)
+
+
+def _get_tensor_nbytes(tensor: torch.Tensor) -> int | None:
+    numel = 1
+    for dim in tensor.shape:
+        if not isinstance(dim, int):
+            return None
+        numel *= dim
+    return numel * tensor.element_size()
+
+
+def _get_group_size(node, group_name) -> int | None:
+    if len(node.args) > 1 and isinstance(node.args[1], int):
+        return node.args[1]
+    try:
+        from torch.distributed import distributed_c10d as c10d
+
+        return c10d._get_group_size_by_name(group_name)
+    except Exception:
+        return None
+
+
+def _get_ag_output_bytes(node, group_name) -> int | None:
+    """Return estimated all-gather output bytes for budget accounting."""
+    if node.target is torch.ops._c10d_functional.all_gather_into_tensor_out.default:
+        out = node.kwargs.get("out")
+        if isinstance(out, torch.fx.Node):
+            out_val = out.meta.get("val")
+            if isinstance(out_val, torch.Tensor):
+                return _get_tensor_nbytes(out_val)
+
+    input_val = node.args[0].meta.get("val") if node.args else None
+    if not isinstance(input_val, torch.Tensor):
+        return None
+    input_bytes = _get_tensor_nbytes(input_val)
+    group_size = _get_group_size(node, group_name)
+    if input_bytes is None or group_size is None:
+        return None
+    return input_bytes * group_size
 
 
 def _get_per_rank_bytes(node, is_ag):

--- a/torch/_inductor/fx_passes/low_contention_collectives.py
+++ b/torch/_inductor/fx_passes/low_contention_collectives.py
@@ -59,8 +59,30 @@ def replace_collectives_with_low_contention(
 
     from torch._inductor import config
 
-    min_bytes = config.aten_distributed_optimizations.low_contention_min_bytes_per_rank
-    use_ag_v2 = config.aten_distributed_optimizations.low_contention_all_gather_v2
+    cfg = config.aten_distributed_optimizations
+    min_bytes = cfg.low_contention_min_bytes_per_rank
+    use_ag_v2 = cfg.low_contention_all_gather_v2
+    use_ag_v3 = cfg.low_contention_all_gather_v3
+    use_ag_v4 = cfg.low_contention_all_gather_v4
+    use_ag_v5 = cfg.low_contention_all_gather_v5
+
+    enabled_ag_flags = [
+        name
+        for name, val in (
+            ("v2", use_ag_v2),
+            ("v3", use_ag_v3),
+            ("v4", use_ag_v4),
+            ("v5", use_ag_v5),
+        )
+        if val
+    ]
+    if len(enabled_ag_flags) > 1:
+        log.warning(
+            "Multiple low_contention_all_gather_v{2,3,4,5} flags are enabled "
+            "(%s). Selecting the most aggressive applicable variant per op "
+            "(v5 > v4 > v3 > v2).",
+            ", ".join(enabled_ag_flags),
+        )
 
     node_positions = {n: i for i, n in enumerate(graph.nodes)}
 
@@ -101,7 +123,17 @@ def replace_collectives_with_low_contention(
             )
             continue
 
-        _replace_collective(node, graph, symm_mem, is_ag, group_name, use_ag_v2)
+        _replace_collective(
+            node,
+            graph,
+            symm_mem,
+            is_ag,
+            group_name,
+            use_ag_v2=use_ag_v2,
+            use_ag_v3=use_ag_v3,
+            use_ag_v4=use_ag_v4,
+            use_ag_v5=use_ag_v5,
+        )
         replacements += 1
 
     log.info(
@@ -136,15 +168,90 @@ def _enable_symm_mem(group_name):
         return False
 
 
-def _replace_collective(node, graph, symm_mem, is_ag, group_name, use_ag_v2=False):
+_has_multicast_cached: dict[int, bool] = {}
+
+
+def _has_multicast_support(device_index: int) -> bool:
+    """Return True iff the current CUDA device supports NVLink multicast.
+
+    Cached per-device so we don't call into the driver every lowering.
+    """
+    cached = _has_multicast_cached.get(device_index)
+    if cached is not None:
+        return cached
+    try:
+        from torch._C._autograd import DeviceType
+        from torch._C._distributed_c10d import _SymmetricMemory
+    except ImportError:
+        _has_multicast_cached[device_index] = False
+        return False
+    try:
+        result = bool(
+            _SymmetricMemory.has_multicast_support(DeviceType.CUDA, device_index)
+        )
+    except Exception:
+        result = False
+    _has_multicast_cached[device_index] = result
+    return result
+
+
+def _replace_collective(
+    node,
+    graph,
+    symm_mem,
+    is_ag,
+    group_name,
+    use_ag_v2=False,
+    use_ag_v3=False,
+    use_ag_v4=False,
+    use_ag_v5=False,
+):
     input_node = node.args[0]
     if is_ag:
-        if use_ag_v2:
-            target = symm_mem._low_contention_all_gather_v2.default
-            args = (input_node, group_name)
+        # Selection order: v5 > v4 > v3 > v2 > v1. v4 and v5 require
+        # multicast support; if absent we fall through to v3/v2/v1 as
+        # appropriate. The device index is derived from the input tensor's
+        # meta val so the decision is graph-local (important for graphs
+        # that span multiple devices in the future).
+        device_index = None
+        input_val = input_node.meta.get("val")
+        if isinstance(input_val, torch.Tensor) and input_val.device.type == "cuda":
+            device_index = input_val.device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+
+        if use_ag_v5 and _has_multicast_support(device_index):
+            target = symm_mem._low_contention_all_gather_v5.default
+        elif use_ag_v5 and not _has_multicast_support(device_index):
+            log.info(
+                "low_contention_all_gather_v5 requested but multicast is not "
+                "supported on device %d; falling through.",
+                device_index,
+            )
+            target = None
         else:
+            target = None
+
+        if target is None:
+            if use_ag_v4 and _has_multicast_support(device_index):
+                target = symm_mem._low_contention_all_gather_v4.default
+            elif use_ag_v4 and not _has_multicast_support(device_index):
+                log.info(
+                    "low_contention_all_gather_v4 requested but multicast is "
+                    "not supported on device %d; falling through.",
+                    device_index,
+                )
+
+        if target is None and use_ag_v3:
+            target = symm_mem._low_contention_all_gather_v3.default
+
+        if target is None and use_ag_v2:
+            target = symm_mem._low_contention_all_gather_v2.default
+
+        if target is None:
             target = symm_mem._low_contention_all_gather.default
-            args = (input_node, group_name)
+
+        args = (input_node, group_name)
     else:
         reduce_op = node.args[1]
         target = symm_mem._low_contention_reduce_scatter.default
@@ -184,7 +291,9 @@ def _has_compute_bound_overlap(start_node, graph, node_positions):
     wait_pos = node_positions[wait_node]
 
     for node in graph.nodes:
-        pos = node_positions[node]
+        pos = node_positions.get(node)
+        if pos is None:
+            continue
         if pos <= start_pos or pos >= wait_pos:
             continue
         if is_compute_node(node):
@@ -202,7 +311,9 @@ def _has_other_group_collectives(start_node, group_name, graph, node_positions):
     wait_pos = node_positions[wait_node]
 
     for node in graph.nodes:
-        pos = node_positions[node]
+        pos = node_positions.get(node)
+        if pos is None:
+            continue
         if pos <= start_pos or pos >= wait_pos:
             continue
         info = _get_collective_info(node)

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1302,6 +1302,33 @@ Example:
           py::arg("val"),
           py::arg("flags") = 0)
       .def_static(
+          "stream_batch_mem_op",
+          [](const std::vector<at::Tensor>& pads,
+             const std::vector<int64_t>& offsets,
+             const std::vector<int64_t>& vals,
+             const std::vector<int64_t>& op_types,
+             const std::vector<int64_t>& flags) {
+            auto op = c10::Dispatcher::singleton()
+                          .findSchemaOrThrow("symm_mem::stream_batch_mem_op", "")
+                          .typed<void(
+                              at::TensorList,
+                              at::IntArrayRef,
+                              at::IntArrayRef,
+                              at::IntArrayRef,
+                              at::IntArrayRef)>();
+            op.call(
+                at::TensorList(pads),
+                at::IntArrayRef(offsets),
+                at::IntArrayRef(vals),
+                at::IntArrayRef(op_types),
+                at::IntArrayRef(flags));
+          },
+          py::arg("pads"),
+          py::arg("offsets"),
+          py::arg("vals"),
+          py::arg("op_types"),
+          py::arg("flags"))
+      .def_static(
           "memset32",
           [](at::Tensor& input, int64_t offset, int64_t val, int64_t count) {
             // The range of `val` is checked inside the op

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryOps.cu
@@ -469,6 +469,141 @@ at::Tensor multimem_all_gather_out(
   return out;
 }
 
+// Copy a source tensor's bytes into a symm_mem allocation's multicast address
+// at a given byte offset, using the CUDA Copy Engine (cudaMemcpyAsync).
+//
+// Writing to the multicast pointer causes the NVSwitch to broadcast the write
+// to all peers' backing memory. Used by _low_contention_all_gather_v3: each
+// rank's shard crosses NVLink exactly once, giving bandwidth-optimal AG
+// without consuming SMs.
+//
+// Precondition: `symm_mem_out` is a tensor whose storage was allocated via
+// empty_strided_p2p() and the underlying SymmetricMemory handle has multicast
+// support. `byte_offset` is in bytes and is relative to the base of the
+// multicast region (not the tensor's storage_offset).
+at::Tensor memcpy_async_to_multicast(
+    at::Tensor& symm_mem_out,
+    const at::Tensor& src,
+    int64_t byte_offset,
+    std::string group_name) {
+  TORCH_CHECK(
+      src.is_contiguous(),
+      "symm_mem::memcpy_async_to_multicast: src must be contiguous.");
+  TORCH_CHECK(
+      src.device().is_cuda() && symm_mem_out.device().is_cuda(),
+      "symm_mem::memcpy_async_to_multicast: src and dst must be CUDA tensors.");
+  TORCH_CHECK(
+      byte_offset >= 0,
+      "symm_mem::memcpy_async_to_multicast: byte_offset must be >= 0 (got ",
+      byte_offset,
+      ").");
+
+  auto symm_mem = c10d::symmetric_memory::rendezvous(symm_mem_out, group_name);
+  TORCH_CHECK(
+      symm_mem != nullptr,
+      "symm_mem::memcpy_async_to_multicast: dst must be allocated with "
+      "empty_strided_p2p().");
+  TORCH_CHECK(
+      symm_mem->has_multicast_support(),
+      "symm_mem::memcpy_async_to_multicast: dst must have multicast support.");
+
+  const size_t bytes = src.numel() * src.element_size();
+  const size_t buffer_bytes = symm_mem->get_buffer_size();
+  TORCH_CHECK(
+      static_cast<size_t>(byte_offset) + bytes <= buffer_bytes,
+      "symm_mem::memcpy_async_to_multicast: byte_offset (",
+      byte_offset,
+      ") + src bytes (",
+      bytes,
+      ") exceeds dst buffer size (",
+      buffer_bytes,
+      ").");
+
+  c10::cuda::CUDAGuard guard(symm_mem_out.device());
+  auto* dst_ptr =
+      reinterpret_cast<char*>(symm_mem->get_multicast_ptr()) + byte_offset;
+  C10_CUDA_CHECK(cudaMemcpyAsync(
+      dst_ptr,
+      src.data_ptr(),
+      bytes,
+      cudaMemcpyDeviceToDevice,
+      at::cuda::getCurrentCUDAStream()));
+  return symm_mem_out;
+}
+
+void memcpy_batch_async(at::TensorList dsts, at::TensorList srcs) {
+  const size_t count = dsts.size();
+  TORCH_CHECK(
+      count == srcs.size(),
+      "symm_mem::memcpy_batch_async: dsts and srcs must have the same length "
+      "(got dsts=",
+      count,
+      ", srcs=",
+      srcs.size(),
+      ").");
+  if (count == 0) {
+    return;
+  }
+
+#if !defined(USE_ROCM) && CUDART_VERSION >= 12080
+  c10::Device device = dsts[0].device();
+  std::vector<void*> dst_ptrs;
+  std::vector<const void*> src_ptrs;
+  std::vector<size_t> sizes;
+  dst_ptrs.reserve(count);
+  src_ptrs.reserve(count);
+  sizes.reserve(count);
+
+  for (size_t i = 0; i < count; ++i) {
+    const auto& dst = dsts[i];
+    const auto& src = srcs[i];
+    TORCH_CHECK(
+        dst.device().is_cuda() && src.device().is_cuda(),
+        "symm_mem::memcpy_batch_async: all tensors must be CUDA tensors.");
+    TORCH_CHECK(
+        dst.device() == device && src.device() == device,
+        "symm_mem::memcpy_batch_async: all tensors must be on the same "
+        "device as dsts[0] (got dst=",
+        dst.device(),
+        ", src=",
+        src.device(),
+        ", expected=",
+        device,
+        ").");
+    TORCH_CHECK(
+        dst.is_contiguous() && src.is_contiguous(),
+        "symm_mem::memcpy_batch_async: all tensors must be contiguous.");
+    TORCH_CHECK(
+        dst.numel() == src.numel() && dst.element_size() == src.element_size(),
+        "symm_mem::memcpy_batch_async: dst and src at index ",
+        i,
+        " must have the same byte size.");
+    dst_ptrs.push_back(dst.data_ptr());
+    src_ptrs.push_back(src.data_ptr());
+    sizes.push_back(src.numel() * src.element_size());
+  }
+
+  cudaMemcpyAttributes attrs{};
+  attrs.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+  size_t attrs_idx = 0;
+
+  c10::cuda::CUDAGuard guard(device);
+  C10_CUDA_CHECK(cudaMemcpyBatchAsync(
+      dst_ptrs.data(),
+      src_ptrs.data(),
+      sizes.data(),
+      count,
+      &attrs,
+      &attrs_idx,
+      1,
+      at::cuda::getCurrentCUDAStream()));
+#else
+  TORCH_CHECK(
+      false,
+      "memcpy_batch_async: requires CUDA 12.8+ and is not supported on ROCm.");
+#endif
+}
+
 #endif //no multi-cast support on ROCm
 
 // One-shot all-reduce is register-intensive because it stages values loaded
@@ -1112,6 +1247,19 @@ at::Tensor multimem_all_gather_out(
   return out;
 }
 
+at::Tensor memcpy_async_to_multicast(
+    at::Tensor& symm_mem_out,
+    const at::Tensor& src,
+    int64_t byte_offset,
+    std::string group_name) {
+  TORCH_CHECK(false, "memcpy_async_to_multicast: requires CUDA 12.3+.");
+  return symm_mem_out;
+}
+
+void memcpy_batch_async(at::TensorList dsts, at::TensorList srcs) {
+  TORCH_CHECK(false, "memcpy_batch_async: requires CUDA 12.8+.");
+}
+
 at::Tensor one_shot_all_reduce_out(
     const at::Tensor& input,
     std::string reduce_op,
@@ -1358,6 +1506,149 @@ void stream_wait_value32(
 #endif
 }
 
+// Submit a batch of cuStreamWriteValue32 / cuStreamWaitValue32 operations as a
+// single driver call via cuStreamBatchMemOp.
+//
+// Each entry (i) of the parallel-array arguments describes one op:
+//   pads[i]     : uint32, flat, contiguous tensor holding the target slot
+//   offsets[i]  : element offset into pads[i]
+//   vals[i]     : value to write (for write ops) or to compare against (waits)
+//   op_types[i] : 0 = write, 1 = wait
+//   flags[i]    : write ops: 0 = default
+//                 wait  ops: 0 = GEQ, 1 = EQ, 2 = AND, 3 = NOR
+//
+// Used by the v3 and v4 low-contention all-gather variants to replace O(N)
+// sequential driver calls per barrier with a single batched call, matching the
+// nvFuser cuda_p2p.cpp reference implementation.
+//
+// Capture-safe: `cuStreamBatchMemOp` is supported under CUDA graph capture on
+// all CUDA 12.x drivers. The caller is responsible for ensuring the target
+// pads are legal symmetric-memory signal pads.
+void stream_batch_mem_op(
+    at::TensorList pads,
+    at::IntArrayRef offsets,
+    at::IntArrayRef vals,
+    at::IntArrayRef op_types,
+    at::IntArrayRef flags) {
+  const int64_t count = static_cast<int64_t>(pads.size());
+  TORCH_CHECK(
+      offsets.size() == static_cast<size_t>(count) &&
+          vals.size() == static_cast<size_t>(count) &&
+          op_types.size() == static_cast<size_t>(count) &&
+          flags.size() == static_cast<size_t>(count),
+      "symm_mem::stream_batch_mem_op: parallel-array arguments must have the "
+      "same length (got pads=",
+      count,
+      ", offsets=",
+      offsets.size(),
+      ", vals=",
+      vals.size(),
+      ", op_types=",
+      op_types.size(),
+      ", flags=",
+      flags.size(),
+      ").");
+  if (count == 0) {
+    return;
+  }
+
+#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+  std::vector<CUstreamBatchMemOpParams> params(count);
+  c10::Device device = pads[0].device();
+  for (int64_t i = 0; i < count; ++i) {
+    const auto& pad = pads[i];
+    TORCH_CHECK(
+        pad.dim() == 1 && pad.is_contiguous() &&
+            pad.scalar_type() == c10::ScalarType::UInt32,
+        "symm_mem::stream_batch_mem_op: every pad must be a flat, contiguous "
+        "uint32 tensor (index ",
+        i,
+        ").");
+    TORCH_CHECK(
+        pad.device() == device,
+        "symm_mem::stream_batch_mem_op: all pads must be on the same device "
+        "(got ",
+        pad.device(),
+        " at index ",
+        i,
+        " but expected ",
+        device,
+        ").");
+    TORCH_CHECK(
+        offsets[i] >= 0 && offsets[i] < pad.numel(),
+        "symm_mem::stream_batch_mem_op: offset out of range at index ",
+        i,
+        " (got ",
+        offsets[i],
+        ", pad.numel() = ",
+        pad.numel(),
+        ").");
+    TORCH_CHECK(
+        vals[i] >= 0 &&
+            static_cast<uint64_t>(vals[i]) <=
+                std::numeric_limits<uint32_t>::max(),
+        "symm_mem::stream_batch_mem_op: val must fit in uint32 at index ",
+        i,
+        " (got ",
+        vals[i],
+        ").");
+
+    auto addr = reinterpret_cast<CUdeviceptr>(
+        reinterpret_cast<uint32_t*>(pad.data_ptr()) + offsets[i]);
+    auto& p = params[i];
+    std::memset(&p, 0, sizeof(p));
+
+    if (op_types[i] == 0) {
+      TORCH_CHECK(
+          flags[i] == 0,
+          "symm_mem::stream_batch_mem_op: write-op flags must be 0 at index ",
+          i,
+          " (got ",
+          flags[i],
+          ").");
+      p.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+      p.writeValue.address = addr;
+      p.writeValue.value = static_cast<cuuint32_t>(vals[i]);
+      p.writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
+    } else if (op_types[i] == 1) {
+      TORCH_CHECK(
+          flags[i] >= 0 && flags[i] <= 3,
+          "symm_mem::stream_batch_mem_op: wait-op flags must be 0..3 (GEQ, EQ,"
+          " AND, NOR) at index ",
+          i,
+          " (got ",
+          flags[i],
+          ").");
+      p.operation = CU_STREAM_MEM_OP_WAIT_VALUE_32;
+      p.waitValue.address = addr;
+      p.waitValue.value = static_cast<cuuint32_t>(vals[i]);
+      p.waitValue.flags = static_cast<unsigned int>(flags[i]);
+    } else {
+      TORCH_CHECK(
+          false,
+          "symm_mem::stream_batch_mem_op: op_types[",
+          i,
+          "] must be 0 (write) or 1 (wait), got ",
+          op_types[i],
+          ".");
+    }
+  }
+
+  c10::cuda::CUDAGuard guard(device);
+  auto driver_api = c10::cuda::DriverAPI::get();
+  C10_CUDA_DRIVER_CHECK(driver_api->cuStreamBatchMemOp_(
+      at::cuda::getCurrentCUDAStream(),
+      static_cast<unsigned int>(count),
+      params.data(),
+      0));
+#else
+  TORCH_CHECK(
+      false,
+      "symm_mem::stream_batch_mem_op requires a non-ROCm build with "
+      "PYTORCH_C10_DRIVER_API_SUPPORTED.");
+#endif
+}
+
 } // namespace
 
 TORCH_LIBRARY_IMPL(symm_mem, CUDA, m) {
@@ -1388,8 +1679,11 @@ TORCH_LIBRARY_IMPL(symm_mem, CUDA, m) {
   m.impl(
       "multimem_one_shot_reduce_out", ::multimem_one_shot_reduce_out);
   m.impl("multimem_all_gather_out", ::multimem_all_gather_out);
+  m.impl("memcpy_async_to_multicast", ::memcpy_async_to_multicast);
+  m.impl("memcpy_batch_async", ::memcpy_batch_async);
 #endif
   m.impl("stream_write_value32_", ::stream_write_value32_);
   m.impl("stream_wait_value32", ::stream_wait_value32);
+  m.impl("stream_batch_mem_op", ::stream_batch_mem_op);
   m.impl("memset32_", ::memset32_);
 }

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -548,7 +548,12 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
   m.def(
       "stream_wait_value32(Tensor input, int offset, int val, int flags=0) -> ()");
   m.def(
+      "stream_batch_mem_op(Tensor[] pads, int[] offsets, int[] vals, int[] op_types, int[] flags) -> ()");
+  m.def(
       "memset32_(Tensor(a!) input, int offset, int val, int count) -> Tensor(a!)");
+  m.def(
+      "memcpy_async_to_multicast(Tensor(a!) symm_mem_out, Tensor src, int byte_offset, str group_name) -> Tensor(a!)");
+  m.def("memcpy_batch_async(Tensor(a!)[] dsts, Tensor[] srcs) -> ()");
 
   m.def("nvshmem_put(Tensor(a!) tensor, int peer) -> ()");
   m.def("nvshmem_get(Tensor(a!) tensor, int peer) -> ()");

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1888,7 +1888,7 @@ def _low_contention_all_gather_v2(
 #
 #   slots [0 .. ws)           barrier() channel 0 + multimem sync_remote_blocks
 #   slots [ws .. 3*ws)        v2 two barriers (unchanged)
-#   slots [3*ws .. 5*ws)      v3 batched ready/done barriers
+#   slots [3*ws .. 5*ws)      v3 per-peer ready/done signals
 #   slots [5*ws .. 7*ws)      v4 CE->multicast barriers
 #
 # v5 reuses the existing multimem kernel synchronization slots.
@@ -2007,7 +2007,7 @@ def _low_contention_all_gather_v3(
     tensor: torch.Tensor,
     group_name: c10d.GroupName,
 ) -> torch.Tensor:
-    """Direct-input P2P push all-gather using one batched memcpy call."""
+    """Direct-input P2P push all-gather with per-peer Lamport signals."""
     world_size = c10d._get_group_size_by_name(group_name)
     device_index = (
         tensor.device.index
@@ -2030,24 +2030,45 @@ def _low_contention_all_gather_v3(
     backend_stream.wait_stream(torch.cuda.current_stream())
     with backend_stream:
         ag_input = _direct_ag_input(tensor, backend_stream)
-        _batched_counter_barrier(
-            symm_mem, rank, world_size, ready_base, counter
-        )
-
-        dsts = [
-            symm_mem.get_buffer(
-                dst_rank,
-                tensor.shape,
-                tensor.dtype,
-                storage_offset=rank * tensor.numel(),
+        local_pad = symm_mem.get_signal_pad(rank)
+        for sender in range(world_size):
+            _SymmetricMemory.stream_write_value32(
+                local_pad, ready_base + sender, counter
             )
-            for dst_rank in range(world_size)
-        ]
-        torch.ops.symm_mem.memcpy_batch_async(
-            dsts, [ag_input for _ in range(world_size)]
-        )
-        _batched_counter_barrier(
-            symm_mem, rank, world_size, done_base, counter
+
+        peer_streams: list[torch.cuda.Stream] = []
+        for step in range(1, world_size):
+            dst_rank = (rank + step) % world_size
+            peer_stream = _get_peer_stream(device_index, dst_rank)
+            peer_stream.wait_stream(backend_stream)
+            with peer_stream:
+                ag_input.record_stream(peer_stream)
+                torch.ops.symm_mem.stream_wait_value32(
+                    symm_mem.get_signal_pad(dst_rank), ready_base + rank, counter
+                )
+                dst = symm_mem.get_buffer(
+                    dst_rank,
+                    tensor.shape,
+                    tensor.dtype,
+                    storage_offset=rank * tensor.numel(),
+                )
+                dst.copy_(ag_input)
+                _SymmetricMemory.stream_write_value32(
+                    symm_mem.get_signal_pad(dst_rank), done_base + rank, counter
+                )
+            peer_streams.append(peer_stream)
+
+        output.chunk(world_size)[rank].copy_(ag_input)
+        _SymmetricMemory.stream_write_value32(local_pad, done_base + rank, counter)
+
+        for peer_stream in peer_streams:
+            backend_stream.wait_stream(peer_stream)
+        torch.ops.symm_mem.stream_batch_mem_op(
+            [local_pad for _ in range(world_size)],
+            [done_base + sender for sender in range(world_size)],
+            [counter for _ in range(world_size)],
+            [_LC_OP_WAIT for _ in range(world_size)],
+            [_LC_WAIT_GEQ for _ in range(world_size)],
         )
         output.record_stream(backend_stream)
         torch._C._distributed_c10d._register_work(output, Work())

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -524,7 +524,15 @@ lib.define(
     "_low_contention_all_gather_v4(Tensor tensor, str group_name) -> Tensor"
 )
 lib.define(
+    "_low_contention_all_gather_v4_out("
+    "Tensor tensor, str group_name, Tensor(a!) out) -> Tensor(a!)"
+)
+lib.define(
     "_low_contention_all_gather_v5(Tensor tensor, str group_name) -> Tensor"
+)
+lib.define(
+    "_low_contention_all_gather_v5_out("
+    "Tensor tensor, str group_name, Tensor(a!) out) -> Tensor(a!)"
 )
 
 lib.define("get_remote_tensors(Tensor x, str group_name) -> Tensor[]")
@@ -1912,6 +1920,30 @@ def _require_multicast(device_index: int, op_name: str) -> None:
         raise RuntimeError(f"{op_name} requires multicast support (NVSwitch / NVLS).")
 
 
+def _check_lc_ag_out(
+    tensor: torch.Tensor,
+    output: torch.Tensor,
+    world_size: int,
+    op_name: str,
+) -> None:
+    expected_shape = (tensor.shape[0] * world_size, *tensor.shape[1:])
+    if tuple(output.shape) != expected_shape:
+        raise RuntimeError(
+            f"{op_name}: expected out shape {expected_shape}, "
+            f"but got {tuple(output.shape)}."
+        )
+    if output.dtype != tensor.dtype:
+        raise RuntimeError(
+            f"{op_name}: expected out dtype {tensor.dtype}, but got {output.dtype}."
+        )
+    if output.device != tensor.device:
+        raise RuntimeError(
+            f"{op_name}: expected out device {tensor.device}, but got {output.device}."
+        )
+    if not output.is_contiguous():
+        raise RuntimeError(f"{op_name}: out must be contiguous.")
+
+
 def _check_lc_signal_pad_capacity(symm_mem: _SymmetricMemory) -> None:
     required_bytes = 7 * symm_mem.world_size * 4
     actual_bytes = _SymmetricMemory.signal_pad_size
@@ -2046,9 +2078,45 @@ def _low_contention_all_gather_v4(
     world_size = c10d._get_group_size_by_name(group_name)
     out_shape = (tensor.shape[0] * world_size, *tensor.shape[1:])
     output = _get_ag_output("v4", group_name, device_index, tensor.dtype, out_shape)
+    return _low_contention_all_gather_v4_impl(tensor, group_name, output)
+
+
+@torch.library.impl(lib, "_low_contention_all_gather_v4_out", "Meta")
+def _low_contention_all_gather_v4_out_meta(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    return out
+
+
+@torch.library.impl(lib, "_low_contention_all_gather_v4_out", "CUDA")
+def _low_contention_all_gather_v4_out(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    """Direct-input copy-engine multicast all-gather into caller-provided output."""
+    world_size = c10d._get_group_size_by_name(group_name)
+    _check_lc_ag_out(tensor, out, world_size, "_low_contention_all_gather_v4")
+    return _low_contention_all_gather_v4_impl(tensor, group_name, out)
+
+
+def _low_contention_all_gather_v4_impl(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    device_index = (
+        output.device.index
+        if output.device.index is not None
+        else torch.cuda.current_device()
+    )
+    _require_multicast(device_index, "_low_contention_all_gather_v4")
     symm_mem = rendezvous(output, group_name)
     if symm_mem is None:
         raise RuntimeError("v4 output must be allocated from symmetric memory")
+    world_size = symm_mem.world_size
     _check_lc_signal_pad_capacity(symm_mem)
 
     rank = symm_mem.rank
@@ -2095,6 +2163,44 @@ def _low_contention_all_gather_v5(
     world_size = c10d._get_group_size_by_name(group_name)
     out_shape = (tensor.shape[0] * world_size, *tensor.shape[1:])
     output = _get_ag_output("v5", group_name, device_index, tensor.dtype, out_shape)
+    return _low_contention_all_gather_v5_impl(tensor, group_name, output)
+
+
+@torch.library.impl(lib, "_low_contention_all_gather_v5_out", "Meta")
+def _low_contention_all_gather_v5_out_meta(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    return out
+
+
+@torch.library.impl(lib, "_low_contention_all_gather_v5_out", "CUDA")
+def _low_contention_all_gather_v5_out(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    """Direct-input multimem kernel all-gather into caller-provided output."""
+    world_size = c10d._get_group_size_by_name(group_name)
+    _check_lc_ag_out(tensor, out, world_size, "_low_contention_all_gather_v5")
+    return _low_contention_all_gather_v5_impl(tensor, group_name, out)
+
+
+def _low_contention_all_gather_v5_impl(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    device_index = (
+        output.device.index
+        if output.device.index is not None
+        else torch.cuda.current_device()
+    )
+    _require_multicast(device_index, "_low_contention_all_gather_v5")
+    symm_mem = rendezvous(output, group_name)
+    if symm_mem is None:
+        raise RuntimeError("v5 output must be allocated from symmetric memory")
 
     backend_stream = _get_backend_stream()
     backend_stream.wait_stream(torch.cuda.current_stream())

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -143,6 +143,46 @@ def _get_backend_stream(priority: int = 0) -> torch.cuda.Stream:
     return _backend_streams[priority]
 
 
+# Cached CUDA streams for low-contention collectives that need work to run
+# off the backend stream. v4 currently uses a single peer stream per device.
+_peer_streams: dict[tuple[int, int], torch.cuda.Stream] = {}
+
+
+def _get_peer_stream(device_index: int, peer: int) -> torch.cuda.Stream:
+    key = (device_index, peer)
+    stream = _peer_streams.get(key)
+    if stream is None:
+        stream = torch.cuda.Stream(device=device_index, priority=0)
+        _peer_streams[key] = stream
+    return stream
+
+
+_ag_output_cache: dict[
+    tuple[str, c10d.GroupName, int, torch.dtype, tuple[int, ...]], torch.Tensor
+] = {}
+
+
+def _get_ag_output(
+    variant: str,
+    group_name: c10d.GroupName,
+    device_index: int,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+) -> torch.Tensor:
+    key = (variant, group_name, device_index, dtype, shape)
+    output = _ag_output_cache.get(key)
+    if output is None:
+        output = _SymmetricMemory.empty_strided_p2p(
+            size=shape,
+            stride=torch.empty(shape, dtype=dtype).stride(),
+            dtype=dtype,
+            device=torch.device("cuda", device_index),
+            group_name=group_name,
+        )
+        _ag_output_cache[key] = output
+    return output
+
+
 def _pipelined_multi_all_gather_and_consume(
     shard: list[torch.Tensor],
     shard_consumer: Callable[[list[torch.Tensor], int], None],
@@ -476,6 +516,15 @@ lib.define(
 )
 lib.define(
     "_low_contention_all_gather_v2(Tensor tensor, str group_name) -> Tensor"
+)
+lib.define(
+    "_low_contention_all_gather_v3(Tensor tensor, str group_name) -> Tensor"
+)
+lib.define(
+    "_low_contention_all_gather_v4(Tensor tensor, str group_name) -> Tensor"
+)
+lib.define(
+    "_low_contention_all_gather_v5(Tensor tensor, str group_name) -> Tensor"
 )
 
 lib.define("get_remote_tensors(Tensor x, str group_name) -> Tensor[]")
@@ -1823,6 +1872,236 @@ def _low_contention_all_gather_v2(
                     local_signal_pad, b2_base + peer, counter
                 )
 
+        torch._C._distributed_c10d._register_work(output, Work())
+        return output
+
+
+# Signal-pad layout for direct-input all-gather experiments:
+#
+#   slots [0 .. ws)           barrier() channel 0 + multimem sync_remote_blocks
+#   slots [ws .. 3*ws)        v2 two barriers (unchanged)
+#   slots [3*ws .. 5*ws)      v3 batched ready/done barriers
+#   slots [5*ws .. 7*ws)      v4 CE->multicast barriers
+#
+# v5 reuses the existing multimem kernel synchronization slots.
+_LC_OP_WRITE = 0
+_LC_OP_WAIT = 1
+_LC_WAIT_GEQ = 0
+
+_lc_ag_counter: dict[c10d.GroupName, int] = {}
+
+
+def _next_lc_ag_counter(group_name: c10d.GroupName) -> int:
+    counter = _lc_ag_counter.get(group_name, 0) + 1
+    if counter > 0xFFFFFFFF:
+        raise RuntimeError("low_contention all-gather signal counter overflowed")
+    _lc_ag_counter[group_name] = counter
+    return counter
+
+
+def _direct_ag_input(
+    tensor: torch.Tensor, stream: torch.cuda.Stream
+) -> torch.Tensor:
+    ag_input = tensor if tensor.is_contiguous() else tensor.contiguous()
+    ag_input.record_stream(stream)
+    return ag_input
+
+
+def _require_multicast(device_index: int, op_name: str) -> None:
+    if not _SymmetricMemory.has_multicast_support(DeviceType.CUDA, device_index):
+        raise RuntimeError(f"{op_name} requires multicast support (NVSwitch / NVLS).")
+
+
+def _check_lc_signal_pad_capacity(symm_mem: _SymmetricMemory) -> None:
+    required_bytes = 7 * symm_mem.world_size * 4
+    actual_bytes = _SymmetricMemory.signal_pad_size
+    if actual_bytes < required_bytes:
+        raise RuntimeError(
+            f"low_contention all-gather requires signal_pad_size >= "
+            f"{required_bytes} bytes for world_size={symm_mem.world_size}, but "
+            f"the current size is {actual_bytes} bytes."
+        )
+
+
+def _batched_counter_barrier(
+    symm_mem: _SymmetricMemory,
+    rank: int,
+    world_size: int,
+    base_slot: int,
+    counter: int,
+) -> None:
+    if world_size <= 1:
+        return
+
+    pads: list[torch.Tensor] = []
+    offsets: list[int] = []
+    vals: list[int] = []
+    op_types: list[int] = []
+    flags: list[int] = []
+
+    for peer in range(world_size):
+        if peer == rank:
+            continue
+        pads.append(symm_mem.get_signal_pad(peer))
+        offsets.append(base_slot + rank)
+        vals.append(counter)
+        op_types.append(_LC_OP_WRITE)
+        flags.append(0)
+
+    local_pad = symm_mem.get_signal_pad(rank)
+    for peer in range(world_size):
+        if peer == rank:
+            continue
+        pads.append(local_pad)
+        offsets.append(base_slot + peer)
+        vals.append(counter)
+        op_types.append(_LC_OP_WAIT)
+        flags.append(_LC_WAIT_GEQ)
+
+    _SymmetricMemory.stream_batch_mem_op(pads, offsets, vals, op_types, flags)
+
+
+@torch.library.impl(lib, "_low_contention_all_gather_v3", "Meta")
+def _low_contention_all_gather_v3_meta(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+) -> torch.Tensor:
+    world_size = c10d._get_group_size_by_name(group_name)
+    return tensor.new_empty(tensor.shape[0] * world_size, *tensor.shape[1:])
+
+
+@torch.library.impl(lib, "_low_contention_all_gather_v3", "CUDA")
+def _low_contention_all_gather_v3(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+) -> torch.Tensor:
+    """Direct-input P2P push all-gather using one batched memcpy call."""
+    world_size = c10d._get_group_size_by_name(group_name)
+    device_index = (
+        tensor.device.index
+        if tensor.device.index is not None
+        else torch.cuda.current_device()
+    )
+    out_shape = (tensor.shape[0] * world_size, *tensor.shape[1:])
+    output = _get_ag_output("v3", group_name, device_index, tensor.dtype, out_shape)
+    symm_mem = rendezvous(output, group_name)
+    if symm_mem is None:
+        raise RuntimeError("v3 output must be allocated from symmetric memory")
+    _check_lc_signal_pad_capacity(symm_mem)
+
+    rank = symm_mem.rank
+    ready_base = 3 * world_size
+    done_base = 4 * world_size
+    counter = _next_lc_ag_counter(group_name)
+
+    backend_stream = _get_backend_stream()
+    backend_stream.wait_stream(torch.cuda.current_stream())
+    with backend_stream:
+        ag_input = _direct_ag_input(tensor, backend_stream)
+        _batched_counter_barrier(
+            symm_mem, rank, world_size, ready_base, counter
+        )
+
+        dsts = [
+            symm_mem.get_buffer(
+                dst_rank,
+                tensor.shape,
+                tensor.dtype,
+                storage_offset=rank * tensor.numel(),
+            )
+            for dst_rank in range(world_size)
+        ]
+        torch.ops.symm_mem.memcpy_batch_async(
+            dsts, [ag_input for _ in range(world_size)]
+        )
+        _batched_counter_barrier(
+            symm_mem, rank, world_size, done_base, counter
+        )
+        output.record_stream(backend_stream)
+        torch._C._distributed_c10d._register_work(output, Work())
+        return output
+
+
+@torch.library.impl(lib, "_low_contention_all_gather_v4", "Meta")
+def _low_contention_all_gather_v4_meta(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+) -> torch.Tensor:
+    world_size = c10d._get_group_size_by_name(group_name)
+    return tensor.new_empty(tensor.shape[0] * world_size, *tensor.shape[1:])
+
+
+@torch.library.impl(lib, "_low_contention_all_gather_v4", "CUDA")
+def _low_contention_all_gather_v4(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+) -> torch.Tensor:
+    """Direct-input copy-engine multicast all-gather into cached output."""
+    device_index = (
+        tensor.device.index
+        if tensor.device.index is not None
+        else torch.cuda.current_device()
+    )
+    _require_multicast(device_index, "_low_contention_all_gather_v4")
+    world_size = c10d._get_group_size_by_name(group_name)
+    out_shape = (tensor.shape[0] * world_size, *tensor.shape[1:])
+    output = _get_ag_output("v4", group_name, device_index, tensor.dtype, out_shape)
+    symm_mem = rendezvous(output, group_name)
+    if symm_mem is None:
+        raise RuntimeError("v4 output must be allocated from symmetric memory")
+    _check_lc_signal_pad_capacity(symm_mem)
+
+    rank = symm_mem.rank
+    shard_bytes = tensor.numel() * tensor.element_size()
+    counter = _next_lc_ag_counter(group_name)
+    b1_slot = 5 * world_size
+    b2_slot = 6 * world_size
+
+    backend_stream = _get_backend_stream()
+    backend_stream.wait_stream(torch.cuda.current_stream())
+    with backend_stream:
+        ag_input = _direct_ag_input(tensor, backend_stream)
+        _batched_counter_barrier(symm_mem, rank, world_size, b1_slot, counter)
+        torch.ops.symm_mem.memcpy_async_to_multicast(
+            output, ag_input, rank * shard_bytes, group_name
+        )
+        _batched_counter_barrier(symm_mem, rank, world_size, b2_slot, counter)
+        output.record_stream(backend_stream)
+        torch._C._distributed_c10d._register_work(output, Work())
+        return output
+
+
+@torch.library.impl(lib, "_low_contention_all_gather_v5", "Meta")
+def _low_contention_all_gather_v5_meta(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+) -> torch.Tensor:
+    world_size = c10d._get_group_size_by_name(group_name)
+    return tensor.new_empty(tensor.shape[0] * world_size, *tensor.shape[1:])
+
+
+@torch.library.impl(lib, "_low_contention_all_gather_v5", "CUDA")
+def _low_contention_all_gather_v5(
+    tensor: torch.Tensor,
+    group_name: c10d.GroupName,
+) -> torch.Tensor:
+    """Direct-input multimem kernel all-gather into cached multicast output."""
+    device_index = (
+        tensor.device.index
+        if tensor.device.index is not None
+        else torch.cuda.current_device()
+    )
+    _require_multicast(device_index, "_low_contention_all_gather_v5")
+    world_size = c10d._get_group_size_by_name(group_name)
+    out_shape = (tensor.shape[0] * world_size, *tensor.shape[1:])
+    output = _get_ag_output("v5", group_name, device_index, tensor.dtype, out_shape)
+
+    backend_stream = _get_backend_stream()
+    backend_stream.wait_stream(torch.cuda.current_stream())
+    with backend_stream:
+        ag_input = _direct_ag_input(tensor, backend_stream)
+        torch.ops.symm_mem.multimem_all_gather_out(ag_input, group_name, output)
+        output.record_stream(backend_stream)
         torch._C._distributed_c10d._register_work(output, Work())
         return output
 


### PR DESCRIPTION
## Summary

This PR adds other POC variants implementations of low-contention allgather, featuring direct-input and cached-output, for comparing non-multicast P2P, NVLS copy-engine multicast, and multimem kernel approaches.

Variants:
- `v3`: closest continuation of existing `v2`; non-multicast P2P path using direct input, cached symmetric outputs, ~~batched ready/done barriers, and `cudaMemcpyBatchAsync`~~ (`cudaMemcpyBatchAsync` is not cuda graph capturable) stream parallelized p2p push transfer with Lamport style synchronization.
- `v4`: copy-engine `cudaMemcpyAsync` into cached NVLS multicast output. This is the main low-contention candidate: multicast bandwidth with no SM usage on the copy path.
- `v5`: single multimem kernel into cached multicast output. Fastest standalone path for small/medium AG, but uses SMs.

Interesting bits are in `torch/distributed/_symmetric_memory/__init__.py`, other files are mostly testing and scaffholding.









## Perf Results


### Allgather only

Testing on single node 8*H100 nvLink

AG-only, WS=8 bf16, GB/s, (**higher is better**):

| shard | nccl | v1 | v2 | v3 | v4 | v5 |
|---:|---:|---:|---:|---:|---:|---:|
| 1 MiB | 12.4 | 6.3 | 4.3 | 3.5 | 9.4 | 19.0 |
| 4 MiB | 57.2 | 25.2 | 17.2 | 13.6 | 37.7 | 75.7 |
| 16 MiB | 229.4 | 99.4 | 69.1 | 56.6 | 149.1 | 244.8 |
| 64 MiB | 382.7 | 375.6 | 270.8 | 212.1 | 383.9 | 369.0 |

### AG + matmul overlap

AG + 8192³ bf16 matmul overlap, exposed AG ms (`= overlap_ms - matmul_only_ms`)(**lower is better**):

| shard | nccl | v1 | v2 | v3 | v4 | v5 |
|---:|---:|---:|---:|---:|---:|---:|
| 1 MiB | 0.147 | 0.177 | 0.702 | 1.260 | 0.046 | 0.081 |
| 4 MiB | 0.226 | 0.190 | 0.703 | 1.244 | 0.066 | 0.094 |
| 16 MiB | 0.420 | 0.416 | 0.796 | 1.221 | 0.070 | 0.337 |
| 64 MiB | 1.462 | 1.484 | 1.517 | 1.233 | 0.145 | 1.354 |


### Interpretation:
- `v5` is best for standalone AG throughput in the 1-16 MiB range, but it uses SMs, so it is not truly low-contention against compute.
- `v4` is the best overlap candidate: NVLS multicast plus copy engines gives low exposed communication under matmul overlap.
- `v3` improves on `v2` for overlap scenarios with large message size.

Detailed overlap data, in milliseconds.

| shard | variant | ag_only_ms | overlap_ms | ideal_ms | exposed_ag_ms |
|---:|---|---:|---:|---:|---:|
| 1 MiB | nccl | 0.575 | 1.556 | 1.409 | 0.147 |
| 1 MiB | v1 | 1.333 | 1.586 | 1.409 | 0.177 |
| 1 MiB | v2 | 1.934 | 2.111 | 1.934 | 0.702 |
| 1 MiB | v3 | 2.409 | 2.670 | 2.409 | 1.260 |
| 1 MiB | v4 | 0.899 | 1.455 | 1.409 | 0.046 |
| 1 MiB | v5 | 0.456 | 1.489 | 1.409 | 0.081 |
| 4 MiB | nccl | 0.569 | 1.634 | 1.409 | 0.226 |
| 4 MiB | v1 | 1.328 | 1.598 | 1.409 | 0.190 |
| 4 MiB | v2 | 1.917 | 2.111 | 1.917 | 0.703 |
| 4 MiB | v3 | 2.436 | 2.657 | 2.436 | 1.244 |
| 4 MiB | v4 | 1.057 | 1.475 | 1.409 | 0.066 |
| 4 MiB | v5 | 0.451 | 1.503 | 1.409 | 0.094 |
| 16 MiB | nccl | 0.599 | 1.828 | 1.409 | 0.420 |
| 16 MiB | v1 | 1.348 | 1.824 | 1.409 | 0.416 |
| 16 MiB | v2 | 1.926 | 2.205 | 1.926 | 0.796 |
| 16 MiB | v3 | 2.392 | 2.630 | 2.392 | 1.221 |
| 16 MiB | v4 | 0.908 | 1.478 | 1.409 | 0.070 |
| 16 MiB | v5 | 0.464 | 1.745 | 1.409 | 0.337 |
| 64 MiB | nccl | 1.460 | 2.870 | 1.460 | 1.462 |
| 64 MiB | v1 | 1.458 | 2.893 | 1.458 | 1.484 |
| 64 MiB | v2 | 1.988 | 2.926 | 1.988 | 1.517 |
| 64 MiB | v3 | 2.458 | 2.644 | 2.458 | 1.233 |
| 64 MiB | v4 | 1.420 | 1.553 | 1.420 | 0.145 |
| 64 MiB | v5 | 1.470 | 2.763 | 1.470 | 1.354 |


## Caveat

The eager variants currently use a cached output allocation keyed by `(variant, group, device, dtype, shape)`. This is suitable for performance exploration, but not production-safe for graphs with multiple live all-gather outputs sharing the same cache key.

We also provide `_low_contention_all_gather_v{4,5}` "`_out`" variants and a way for Inductor to lower to it and write into planner-owned `CommBufferLayout(SYMM_MEM)` buffers (`empty_strided_p2p(..., alloc_id=...)`).

This mitigates memory footprint. A good (maybe preferable) alternative would be to use symmetric-memory `MemPool`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo