### PR TITLE
[inductor][mtia] Skip matvec bmm/addmm decomposition on MTIA; add MTIA matvec bmm lowering (#182857)

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -358,7 +358,11 @@ def bmm(
 
     # TODO: Re-enable for mps once our reductions are performant enough
     # (https://github.com/pytorch/pytorch/issues/150121)
-    if config.coordinate_descent_tuning and self.device.type not in ["cpu", "mps"]:
+    if config.coordinate_descent_tuning and self.device.type not in [
+        "cpu",
+        "mps",
+        "mtia",
+    ]:
         if statically_known_true(self.shape[1] == 1) or statically_known_true(
             batch2.shape[2] == 1
         ):
@@ -385,7 +389,7 @@ def addmm(
     beta: torch.types.Number = 1,
     alpha: torch.types.Number = 1,
 ) -> torch.Tensor:
-    if mat1.device.type not in ["cpu", "mps"]:
+    if mat1.device.type not in ["cpu", "mps", "mtia"]:
         if (
             statically_known_true(mat1.size(-1) == 1)
             and statically_known_true(mat1.size(0) != 1)


### PR DESCRIPTION
Summary:

Two-part change so MTIA emits a real matmul for matvec torch.bmm (M=1 or N=1), instead of running the broadcast-mul-sum decomposition.

Part 1 -- Inductor decomposition (PyTorch side):
Add "mtia" to the device-type exclusion list in decomp_bmm and decomp_addmm so the coordinate_descent_tuning matvec rewrite is skipped for MTIA tensors. Upstream rewrites matvec mm/bmm into unsqueeze + broadcast mul + sum to help GPU autotuners; on MTIA we keep the bmm/mm op so the backend can route it to a real matmul kernel.

Part 2 -- MTIA matvec bmm lowering (MTIA Inductor backend):
New matvec_bmm.py overrides the aten.bmm Inductor lowering on MTIA. Matvec inputs (today: M=1 only -- see below) go through a local Triton template with explicit block sizes and per-arch compile options. Non-matvec bmm continues to fall through to the upstream tuned_bmm, which lands on the ATen extern kernel since the MTIA environment pins max_autotune_gemm_backends="ATEN".

Notes:
- The local jinja template is a fork of the upstream triton_bmm.py.jinja that renames the kernel args to in_ptr0 / in_ptr1; MTIA's Inductor glue only recognises those names and otherwise raises "Unrecognized kernel arg".
- N=1 (mat2 = [B, K, 1]) is excluded today due to a layout/padding interaction on MTIA: the size-1 N dim is virtually padded to padding_alignment_bytes (1 -> 32), the runtime layout transform inflates storage to match, and the resulting kernel reads off-allocation values. Masked loads with other=0.0 do not rescue the result. Until that interaction is fixed, N=1 falls through to the ATen extern bmm.

Test Plan: https://www.internalfb.com/intern/testinfra/testconsole/testrun/32651097305717237/

Differential Revision: D104267626




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo