### PR TITLE
[OSDC] Migrate quantization-periodic.yml to OSDC (ARC) 

### DIFF
--- a/.github/workflows/quantization-periodic.yml
+++ b/.github/workflows/quantization-periodic.yml
@@ -28,7 +28,7 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
-      opt_out_experiments: lf
+      check_experiments: arc,lf
 
   periodic-quantization-build:
     name: periodic-quantization-build
@@ -43,13 +43,23 @@ jobs:
         { include: [
           { config: "quantization", shard: 1, num_shards: 1, runner: "${{ needs.get-default-label-prefix.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
         ]}
+      use-arc: ${{ needs.get-default-label-prefix.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
   periodic-test-quantization:
     name: periodic-test-quantization
     uses: ./.github/workflows/_linux-test.yml
-    needs: periodic-quantization-build
+    needs:
+      - periodic-quantization-build
+      - get-default-label-prefix
     with:
       build-environment: ${{ needs.periodic-quantization-build.outputs.build-environment }}
       docker-image: ${{ needs.periodic-quantization-build.outputs.docker-image }}
       test-matrix: ${{ needs.periodic-quantization-build.outputs.test-matrix }}
+      use-arc: ${{ needs.get-default-label-prefix.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit


### PR DESCRIPTION
## Summary

Migrate `quantization-periodic.yml` to OSDC (ARC) via the dial-up pattern.

- Add `check_experiments: arc,lf` to the runner-determinator so it considers the ARC experiment
- Plumb `use-arc`, `python-version`, `compiler`, `cuda-version` into both build and test jobs
- Add `get-default-label-prefix` to the test job's `needs` so it can read determinator outputs
- Values derived from Docker image `pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11` (Python 3.10 / GCC11 / CUDA 13.0)

Behavior is unchanged by default (EC2 path). When the ARC experiment is enabled, `build-osdc`/`test-osdc` jobs activate instead.

## Test plan

- Default path (no experiment flag): existing EC2 `build`/`test` jobs run as before
- With ARC experiment enabled: `build-osdc`/`test-osdc` jobs should run on OSDC runners
