### PR TITLE
docs: document consume_prefix_in_state_dict_if_present in nn.aliases

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -731,8 +731,6 @@ coverage_ignore_functions = [
     "xavier_uniform",  # deprecated
     # torch.nn.modules.rnn
     "apply_permutation",  # deprecated
-    # torch.nn.modules.utils
-    "consume_prefix_in_state_dict_if_present",
     # torch.nn.parallel.comm
     "broadcast",
     "broadcast_coalesced",

--- a/docs/source/nn.aliases.md
+++ b/docs/source/nn.aliases.md
@@ -334,6 +334,16 @@ The following are aliases to their counterparts in ``torch.nn`` in the ``torch.n
 
 ```
 
+## torch.nn.modules.utils
+
+```{eval-rst}
+.. currentmodule:: torch.nn.modules.utils
+```
+
+```{eval-rst}
+.. autofunction:: consume_prefix_in_state_dict_if_present
+```
+
 ## torch.nn.utils
 
 The following are aliases to their counterparts in ``torch.nn.utils`` in nested namespaces.


### PR DESCRIPTION
Fixes #182827

## Summary
Document `consume_prefix_in_state_dict_if_present` from `torch.nn.modules.utils` 
in `docs/source/nn.aliases.md`.

## Changes
- Removed `consume_prefix_in_state_dict_if_present` from 
  `coverage_ignore_functions` in `docs/source/conf.py`.
- Added a new `## torch.nn.modules.utils` section to `docs/source/nn.aliases.md` 
  with `currentmodule` and `autofunction` directives.

## Verification
- `make coverage` no longer reports `consume_prefix_in_state_dict_if_present` as undocumented.
- `make html` renders the function correctly with its docstring.

## Screenshot

<img width="1242" height="720" alt="image" src="https://github.com/user-attachments/assets/fa5912b3-13aa-416d-8b49-918ac836aa61" />


cc @svekars @sekyondaMeta @AlannaBurke