### PR TITLE
[donotrvw][broken][WIP] spmd_types + PP: _SpmdTypesMeta and nullcontext decorator fix

### DIFF
--- a/test/distributed/pipelining/test_spmd_types_pp_integration.py
+++ b/test/distributed/pipelining/test_spmd_types_pp_integration.py
@@ -1,0 +1,603 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# Owner(s): ["oncall: distributed"]
+
+from __future__ import annotations
+
+import copy
+import functools
+import types
+from typing import TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+from torch.distributed.fsdp import DataParallelMeshDims, fully_shard
+from torch.distributed.pipelining.schedules import Schedule1F1B
+from torch.distributed.pipelining.stage import PipelineStage
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
+    requires_accelerator_dist_backend,
+)
+from torch.testing._internal.common_utils import (
+    run_tests,
+    skip_but_pass_in_sandcastle_if,
+    TEST_MULTIACCELERATOR,
+)
+
+
+if dist._is_spmd_types_available():
+    import spmd_types as spmd
+    import spmd_types._checker
+    import spmd_types._type_attr
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+d_hid = 256
+batch_size = 64
+n_microbatches = 4
+
+MODEL_SEED = 0
+INPUT_SEED = 42
+TARGET_SEED = 123
+
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+backend = dist.get_default_backend_for_device(device_type)
+
+
+class NormMLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.norm = nn.RMSNorm(dim)
+        self.fc1 = nn.Linear(dim, 4 * dim, bias=False)
+        self.act = nn.GELU()
+        self.fc2 = nn.Linear(4 * dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.act(self.fc1(self.norm(x))))
+
+
+class NormMLPStack(nn.Module):
+    def __init__(self, dim: int, n_layers: int):
+        super().__init__()
+        self.layers = nn.ModuleList([NormMLP(dim) for _ in range(n_layers)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+def _apply_spmd_tp(block: NormMLP, tp_pg: dist.ProcessGroup) -> None:
+    """Shard weights for column/row parallel TP using spmd_types collectives."""
+    from spmd_types import all_reduce, convert
+
+    tp_rank = tp_pg.rank()
+    tp_size = tp_pg.size()
+
+    with torch.no_grad():
+        # Column-parallel: shard fc1 weight on dim 0
+        block.fc1.weight = nn.Parameter(
+            block.fc1.weight.chunk(tp_size, dim=0)[tp_rank].contiguous()
+        )
+        # Row-parallel: shard fc2 weight on dim 1
+        block.fc2.weight = nn.Parameter(
+            block.fc2.weight.chunk(tp_size, dim=1)[tp_rank].contiguous()
+        )
+
+    def _tp_forward(self, x):
+        # Input arrives as Invariant, broadcast to Replicate for matmul
+        x = convert(x, tp_pg, src=spmd.I, dst=spmd.R)
+        z = self.fc1(self.norm(x))
+        z = self.act(z)
+        z = self.fc2(z)
+        # All-reduce to go back to Invariant
+        z = all_reduce(z, tp_pg, dst=spmd.I)
+        return z
+
+    block.forward = types.MethodType(_tp_forward, block)
+
+
+def _annotate_replicate(model: nn.Module, tp_mesh: DeviceMesh) -> None:
+    """Annotate all parameters as Replicate on the TP axis."""
+    tp_axis = spmd.MeshAxis.of(tp_mesh.get_group())
+    for param in model.parameters():
+        spmd._type_attr.set_local_type(param, {tp_axis: spmd.R})
+
+
+def _wrap_with_typecheck(model: NormMLPStack, mesh: DeviceMesh) -> None:
+    """Wrap each NormMLP layer's forward to run under spmd_types typecheck."""
+    mesh_axes = frozenset(
+        spmd.MeshAxis.of(mesh.get_group(name))
+        for name in mesh.mesh_dim_names
+    )
+
+    for layer in model.layers:
+        orig_fwd = layer.forward
+
+        def _make_typechecked(fwd):
+            def _typechecked_fwd(*args, **kwargs):
+                with (
+                    spmd.set_current_mesh(mesh_axes),
+                    spmd._checker.typecheck(strict_mode="strict"),
+                ):
+                    return fwd(*args, **kwargs)
+            return _typechecked_fwd
+
+        layer.forward = _make_typechecked(orig_fwd)
+
+
+def _loss_fn(output: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    return (output - target).pow(2).mean()
+
+
+def _requires_multi_gpu(func):
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 4+ GPUs"
+    )
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@skip_but_pass_in_sandcastle_if(
+    not dist._is_spmd_types_available(), "requires spmd_types"
+)
+class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
+    world_size = 4
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return backend
+
+    @classmethod
+    def device_type(cls) -> str:
+        return device_type
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(device_type, self.rank)
+
+    def init_pg(self) -> None:
+        if device_type == "cuda":
+            torch.cuda.set_device(self.device)
+        from spmd_types._mesh_axis import _reset
+
+        _reset()
+
+    def _make_mesh(self) -> DeviceMesh:
+        return init_device_mesh(device_type, (2, 2), mesh_dim_names=("pp", "tp"))
+
+    # ------------------------------------------------------------------
+    # Reference model: run all layers serially with microbatched fwd/bwd
+    # ------------------------------------------------------------------
+
+    def _run_reference_microbatched(
+        self,
+        ref_model: NormMLPStack,
+        input_tensor: torch.Tensor,
+        target_tensor: torch.Tensor,
+        tp_mesh: DeviceMesh,
+    ) -> tuple[
+        dict[str, torch.Tensor | None], dict[int, tuple[torch.Tensor, torch.Tensor]]
+    ]:
+        """Run the reference model microbatched, capturing per-stage I/O shapes.
+
+        Returns:
+            ref_grads: {param_fqn: grad_tensor}
+            static_stage_io: {stage_idx: (input_like, output_like)} for static metadata
+        """
+        ref_model.zero_grad(set_to_none=True)
+
+        input_chunks = torch.tensor_split(input_tensor, n_microbatches)
+        target_chunks = torch.tensor_split(target_tensor, n_microbatches)
+
+        # Re-annotate chunks (tensor_split doesn't preserve spmd_types)
+        if spmd._checker.has_local_type(input_tensor):
+            lt = spmd.get_local_type(input_tensor)
+            for chunk in input_chunks:
+                spmd.assert_type(chunk, lt)
+
+        # Capture first-microbatch I/O shapes per stage
+        captured_io: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+        hooks: list[torch.utils.hooks.RemovableHandle] = []
+
+        for stage_idx, stage_mod in enumerate(ref_model.layers):
+
+            def _capture_io(
+                _module: nn.Module,
+                args: tuple[torch.Tensor, ...],
+                output: torch.Tensor,
+                *,
+                idx: int = stage_idx,
+            ) -> None:
+                captured_io[idx] = (args[0], output)
+
+            hooks.append(stage_mod.register_forward_hook(_capture_io))
+
+        for mb_idx, (inp_chunk, tgt_chunk) in enumerate(
+            zip(input_chunks, target_chunks)
+        ):
+            output = ref_model(inp_chunk)
+            loss = _loss_fn(output, tgt_chunk)
+            loss.backward()
+
+            if mb_idx == 0:
+                # Capture shapes from first microbatch, then remove hooks
+                static_stage_io: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+                for si in range(len(ref_model.layers)):
+                    stage_in, stage_out = captured_io[si]
+                    static_stage_io[si] = (
+                        torch.empty_like(stage_in),
+                        torch.empty_like(stage_out),
+                    )
+                for h in hooks:
+                    h.remove()
+                hooks = []
+
+        # Average gradients across microbatches
+        for param in ref_model.parameters():
+            if param.grad is not None:
+                param.grad.div_(n_microbatches)
+
+        ref_grads = {
+            name: param.grad.clone() if param.grad is not None else None
+            for name, param in ref_model.named_parameters()
+        }
+        return ref_grads, static_stage_io
+
+    # ------------------------------------------------------------------
+    # PP stage construction
+    # ------------------------------------------------------------------
+
+    def _make_stage(
+        self,
+        pp_model: NormMLPStack,
+        stage_index: int,
+        num_stages: int,
+        pp_group: dist.ProcessGroup,
+        tp_mesh: DeviceMesh,
+    ) -> PipelineStage:
+        stage_module = pp_model.get_submodule(f"layers.{stage_index}")
+        return PipelineStage(
+            submodule=stage_module,
+            stage_index=stage_index,
+            num_stages=num_stages,
+            device=self.device,
+            group=pp_group,
+            device_mesh=tp_mesh,
+        )
+
+    # ------------------------------------------------------------------
+    # Core test: training correctness
+    # ------------------------------------------------------------------
+
+    def _run_training_correctness(
+        self,
+        apply_parallelism: Callable[[NormMLP, dist.ProcessGroup], None],
+        annotate_fn: Callable[[nn.Module, DeviceMesh], None],
+    ) -> None:
+        self.init_pg()
+
+        mesh = self._make_mesh()
+        tp_mesh = mesh["tp"]
+        pp_mesh = mesh["pp"]
+        pp_group = pp_mesh.get_group()
+        pp_rank = pp_mesh.get_local_rank()
+        tp_pg = tp_mesh.get_group()
+
+        n_layers = 2  # 1 stage per PP rank
+
+        # Build two identical models
+        torch.manual_seed(MODEL_SEED)
+        with torch.device(self.device):
+            ref_model = NormMLPStack(d_hid, n_layers)
+        pp_model = copy.deepcopy(ref_model)
+
+        # Apply TP parallelism to both
+        for layer in ref_model.layers:
+            apply_parallelism(layer, tp_pg)
+        for layer in pp_model.layers:
+            apply_parallelism(layer, tp_pg)
+
+        # Annotate with spmd_types and wrap forward with typecheck
+        annotate_fn(ref_model, tp_mesh)
+        annotate_fn(pp_model, tp_mesh)
+        _wrap_with_typecheck(ref_model, tp_mesh)
+        _wrap_with_typecheck(pp_model, tp_mesh)
+
+        # Create inputs (same on all ranks for Replicate; per-rank shard for TP)
+        torch.manual_seed(INPUT_SEED)
+        input_full = torch.randn(batch_size, d_hid, device=self.device)
+        torch.manual_seed(TARGET_SEED)
+        target_full = torch.randn(batch_size, d_hid, device=self.device)
+
+        # Annotate inputs
+        tp_axis = spmd.MeshAxis.of(tp_pg)
+
+        # Reference: microbatched serial execution
+        ref_input = input_full.clone().requires_grad_(True)
+        spmd.assert_type(ref_input, {tp_axis: spmd.R})
+        ref_target = target_full.clone()
+        ref_grads, _ = self._run_reference_microbatched(
+            ref_model, ref_input, ref_target, tp_mesh
+        )
+
+        # PP execution (dynamic metadata inference)
+        stage = self._make_stage(
+            pp_model=pp_model,
+            stage_index=pp_rank,
+            num_stages=n_layers,
+            pp_group=pp_group,
+            tp_mesh=tp_mesh,
+        )
+        stage.submod.zero_grad(set_to_none=True)
+
+        pp_input = input_full.clone().requires_grad_(True)
+        spmd.assert_type(pp_input, {tp_axis: spmd.R})
+        pp_target = target_full.clone()
+
+        schedule = Schedule1F1B(
+            stage,
+            n_microbatches=n_microbatches,
+            loss_fn=_loss_fn,
+        )
+
+        if stage.is_first and stage.is_last:
+            losses: list[torch.Tensor] = []
+            schedule.step(pp_input, target=pp_target, losses=losses)
+        elif stage.is_first:
+            schedule.step(pp_input)
+        elif stage.is_last:
+            losses = []
+            schedule.step(target=pp_target, losses=losses)
+        else:
+            schedule.step()
+
+        # Compare gradients
+        stage_module = pp_model.get_submodule(f"layers.{pp_rank}")
+        for name, param in stage_module.named_parameters():
+            param_fqn = f"layers.{pp_rank}.{name}"
+            self.assertIsNotNone(param.grad, f"Missing PP grad for {param_fqn}")
+            ref_grad = ref_grads[param_fqn]
+            self.assertIsNotNone(ref_grad, f"Missing ref grad for {param_fqn}")
+            torch.testing.assert_close(
+                param.grad,
+                ref_grad,
+                msg=f"Gradient mismatch for {param_fqn}",
+            )
+
+    # ------------------------------------------------------------------
+    # Annotation verification: check annotations survive PP forward recv
+    # ------------------------------------------------------------------
+
+    def _run_annotation_check(
+        self,
+        apply_parallelism: Callable[[NormMLP, dist.ProcessGroup], None],
+        annotate_fn: Callable[[nn.Module, DeviceMesh], None],
+        expected_activation_types: dict[str, object],
+    ) -> None:
+        """Verify that spmd_types annotations on activations survive PP recv.
+
+        Registers a forward pre-hook on stage 1 to check that the activation
+        received from stage 0 carries the expected per-axis spmd type.
+
+        Args:
+            expected_activation_types: {mesh_dim_name: expected_type}, e.g.
+                {"tp": spmd.R}.
+        """
+        self.init_pg()
+
+        mesh = self._make_mesh()
+        tp_mesh = mesh["tp"]
+        pp_mesh = mesh["pp"]
+        pp_group = pp_mesh.get_group()
+        pp_rank = pp_mesh.get_local_rank()
+        tp_pg = tp_mesh.get_group()
+
+        torch.manual_seed(MODEL_SEED)
+        with torch.device(self.device):
+            model = NormMLPStack(d_hid, 2)
+
+        for layer in model.layers:
+            apply_parallelism(layer, tp_pg)
+        annotate_fn(model, tp_mesh)
+
+        # Register hook on stage 1 to check forward input annotations
+        annotation_results: list[dict] = []
+
+        def check_fwd_annotation(module, args):
+            inp = args[0]
+            result = {"has_type": spmd._checker.has_local_type(inp)}
+            if result["has_type"]:
+                lt = spmd.get_local_type(inp)
+                result["local_type"] = {
+                    name: lt.get(spmd.MeshAxis.of(tp_mesh.get_group(name)))
+                    for name in tp_mesh.mesh_dim_names
+                }
+            annotation_results.append(result)
+
+        model.layers[1].register_forward_pre_hook(check_fwd_annotation)
+
+        torch.manual_seed(INPUT_SEED)
+        input_full = torch.randn(batch_size, d_hid, device=self.device)
+        torch.manual_seed(TARGET_SEED)
+        target_full = torch.randn(batch_size, d_hid, device=self.device)
+
+        stage = self._make_stage(
+            pp_model=model,
+            stage_index=pp_rank,
+            num_stages=2,
+            pp_group=pp_group,
+            tp_mesh=tp_mesh,
+        )
+
+        schedule = Schedule1F1B(
+            stage,
+            n_microbatches=n_microbatches,
+            loss_fn=_loss_fn,
+        )
+
+        if stage.is_first:
+            schedule.step(input_full)
+        elif stage.is_last:
+            losses = []
+            schedule.step(target=target_full, losses=losses)
+
+        # Only pp_rank=1 (stage 1) runs the hook
+        if pp_rank == 1:
+            self.assertGreater(
+                len(annotation_results),
+                0,
+                "Forward pre-hook was not called on stage 1",
+            )
+            first = annotation_results[0]
+            self.assertTrue(
+                first["has_type"],
+                "Activation received by stage 1 has no spmd_types annotation",
+            )
+            for dim_name, expected_type in expected_activation_types.items():
+                actual = first["local_type"].get(dim_name)
+                self.assertEqual(
+                    actual,
+                    expected_type,
+                    f"Activation type on '{dim_name}': expected {expected_type}, got {actual}",
+                )
+
+    # ------------------------------------------------------------------
+    # Test methods
+    # ------------------------------------------------------------------
+
+    @_requires_multi_gpu
+    def test_replicate(self):
+        """PP + spmd_types with all-Replicate annotations."""
+
+        def _no_tp(block, tp_pg):
+            pass
+
+        self._run_training_correctness(
+            _no_tp,
+            _annotate_replicate,
+        )
+
+    @_requires_multi_gpu
+    def test_tp(self):
+        """PP + TP with spmd_types annotations."""
+        self._run_training_correctness(
+            _apply_spmd_tp,
+            _annotate_replicate,
+        )
+
+    # ------------------------------------------------------------------
+    # FSDP + PP test
+    # ------------------------------------------------------------------
+
+    def _run_fsdp_pp_correctness(self) -> None:
+        """FSDP + PP: params annotated as Replicate on FSDP axis, then fully_shard'd."""
+        self.init_pg()
+
+        mesh = init_device_mesh(device_type, (2, 2), mesh_dim_names=("pp", "fsdp"))
+        fsdp_mesh = mesh["fsdp"]
+        pp_mesh = mesh["pp"]
+        pp_group = pp_mesh.get_group()
+        pp_rank = pp_mesh.get_local_rank()
+        fsdp_axis = spmd.MeshAxis.of(fsdp_mesh.get_group())
+
+        n_layers = 2
+
+        torch.manual_seed(MODEL_SEED)
+        with torch.device(self.device):
+            ref_model = NormMLPStack(d_hid, n_layers)
+        pp_model = copy.deepcopy(ref_model)
+
+        # Annotate params as Replicate on FSDP axis, then apply fully_shard
+        for param in pp_model.parameters():
+            spmd._type_attr.set_local_type(param, {fsdp_axis: spmd.R})
+        _wrap_with_typecheck(pp_model, fsdp_mesh)
+
+        for layer in pp_model.layers:
+            fully_shard(
+                layer,
+                mesh=fsdp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(shard="fsdp"),
+            )
+        fully_shard(
+            pp_model,
+            mesh=fsdp_mesh,
+            dp_mesh_dims=DataParallelMeshDims(shard="fsdp"),
+        )
+
+        # Reference: replicate on all ranks (no FSDP), microbatched
+        from torch.distributed._composable import replicate
+
+        _wrap_with_typecheck(ref_model, fsdp_mesh)
+        replicate(ref_model, device_ids=[self.rank])
+
+        torch.manual_seed(INPUT_SEED)
+        input_full = torch.randn(batch_size, d_hid, device=self.device)
+        torch.manual_seed(TARGET_SEED)
+        target_full = torch.randn(batch_size, d_hid, device=self.device)
+
+        ref_input = input_full.clone().requires_grad_(True)
+        ref_target = target_full.clone()
+        ref_grads, _ = self._run_reference_microbatched(
+            ref_model, ref_input, ref_target, fsdp_mesh
+        )
+
+        stage = self._make_stage(
+            pp_model=pp_model,
+            stage_index=pp_rank,
+            num_stages=n_layers,
+            pp_group=pp_group,
+            tp_mesh=fsdp_mesh,
+        )
+        stage.submod.zero_grad(set_to_none=True)
+
+        pp_input = input_full.clone().requires_grad_(True)
+        pp_target = target_full.clone()
+
+        schedule = Schedule1F1B(
+            stage,
+            n_microbatches=n_microbatches,
+            loss_fn=_loss_fn,
+        )
+
+        if stage.is_first and stage.is_last:
+            losses: list[torch.Tensor] = []
+            schedule.step(pp_input, target=pp_target, losses=losses)
+        elif stage.is_first:
+            schedule.step(pp_input)
+        elif stage.is_last:
+            losses = []
+            schedule.step(target=pp_target, losses=losses)
+        else:
+            schedule.step()
+
+        # Compare gradients (FSDP grads are DTensors, compare full tensors)
+        stage_module = pp_model.get_submodule(f"layers.{pp_rank}")
+        for name, param in stage_module.named_parameters():
+            param_fqn = f"layers.{pp_rank}.{name}"
+            self.assertIsNotNone(param.grad, f"Missing PP grad for {param_fqn}")
+            ref_grad = ref_grads[param_fqn]
+            self.assertIsNotNone(ref_grad, f"Missing ref grad for {param_fqn}")
+            pp_grad = param.grad
+            if hasattr(pp_grad, "full_tensor"):
+                pp_grad = pp_grad.full_tensor()
+            torch.testing.assert_close(
+                pp_grad,
+                ref_grad,
+                msg=f"Gradient mismatch for {param_fqn}",
+            )
+
+    @_requires_multi_gpu
+    def test_fsdp_pp(self):
+        """FSDP + PP with spmd_types annotations."""
+        self._run_fsdp_pp_correctness()
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/pipelining/test_spmd_types_pp_integration.py
+++ b/test/distributed/pipelining/test_spmd_types_pp_integration.py
@@ -3,16 +3,12 @@
 
 from __future__ import annotations
 
-import copy
 import functools
-import types
-from typing import TYPE_CHECKING
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
-from torch.distributed.fsdp import DataParallelMeshDims, fully_shard
+from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.pipelining.schedules import Schedule1F1B
 from torch.distributed.pipelining.stage import PipelineStage
 from torch.testing._internal.common_distributed import (
@@ -31,17 +27,9 @@ if dist._is_spmd_types_available():
     import spmd_types._checker
     import spmd_types._type_attr
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-
 d_hid = 256
 batch_size = 64
 n_microbatches = 4
-
-MODEL_SEED = 0
-INPUT_SEED = 42
-TARGET_SEED = 123
 
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 backend = dist.get_default_backend_for_device(device_type)
@@ -70,65 +58,6 @@ class NormMLPStack(nn.Module):
         return x
 
 
-def _apply_spmd_tp(block: NormMLP, tp_pg: dist.ProcessGroup) -> None:
-    """Shard weights for column/row parallel TP using spmd_types collectives."""
-    from spmd_types import all_reduce, convert
-
-    tp_rank = tp_pg.rank()
-    tp_size = tp_pg.size()
-
-    with torch.no_grad():
-        # Column-parallel: shard fc1 weight on dim 0
-        block.fc1.weight = nn.Parameter(
-            block.fc1.weight.chunk(tp_size, dim=0)[tp_rank].contiguous()
-        )
-        # Row-parallel: shard fc2 weight on dim 1
-        block.fc2.weight = nn.Parameter(
-            block.fc2.weight.chunk(tp_size, dim=1)[tp_rank].contiguous()
-        )
-
-    def _tp_forward(self, x):
-        # Input arrives as Invariant, broadcast to Replicate for matmul
-        x = convert(x, tp_pg, src=spmd.I, dst=spmd.R)
-        z = self.fc1(self.norm(x))
-        z = self.act(z)
-        z = self.fc2(z)
-        # All-reduce to go back to Invariant
-        z = all_reduce(z, tp_pg, dst=spmd.I)
-        return z
-
-    block.forward = types.MethodType(_tp_forward, block)
-
-
-def _annotate_replicate(model: nn.Module, tp_mesh: DeviceMesh) -> None:
-    """Annotate all parameters as Replicate on the TP axis."""
-    tp_axis = spmd.MeshAxis.of(tp_mesh.get_group())
-    for param in model.parameters():
-        spmd._type_attr.set_local_type(param, {tp_axis: spmd.R})
-
-
-def _wrap_with_typecheck(model: NormMLPStack, mesh: DeviceMesh) -> None:
-    """Wrap each NormMLP layer's forward to run under spmd_types typecheck."""
-    mesh_axes = frozenset(
-        spmd.MeshAxis.of(mesh.get_group(name)) for name in mesh.mesh_dim_names
-    )
-
-    for layer in model.layers:
-        orig_fwd = layer.forward
-
-        def _make_typechecked(fwd):
-            def _typechecked_fwd(*args, **kwargs):
-                with (
-                    spmd.set_current_mesh(mesh_axes),
-                    spmd._checker.typecheck(strict_mode="strict"),
-                ):
-                    return fwd(*args, **kwargs)
-
-            return _typechecked_fwd
-
-        layer.forward = _make_typechecked(orig_fwd)
-
-
 def _loss_fn(output: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
     return (output - target).pow(2).mean()
 
@@ -149,6 +78,8 @@ def _requires_multi_gpu(func):
     not dist._is_spmd_types_available(), "requires spmd_types"
 )
 class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
+    """Verify that PP recv preserves spmd_types annotations on activations."""
+
     world_size = 4
 
     @classmethod
@@ -170,435 +101,90 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
 
         _reset()
 
-    def _make_mesh(self) -> DeviceMesh:
-        return init_device_mesh(device_type, (2, 2), mesh_dim_names=("pp", "tp"))
+    @_requires_multi_gpu
+    def test_annotations_survive_pp_recv(self):
+        """Stage 0 output carries Replicate annotation; stage 1 should receive it."""
+        self.init_pg()
 
-    # ------------------------------------------------------------------
-    # Reference model: run all layers serially with microbatched fwd/bwd
-    # ------------------------------------------------------------------
+        mesh = init_device_mesh(device_type, (2, 2), mesh_dim_names=("pp", "tp"))
+        tp_mesh = mesh["tp"]
+        pp_mesh = mesh["pp"]
+        pp_group = pp_mesh.get_group()
+        pp_rank = pp_mesh.get_local_rank()
+        tp_axis = spmd.MeshAxis.of(tp_mesh.get_group())
 
-    def _run_reference_microbatched(
-        self,
-        ref_model: NormMLPStack,
-        input_tensor: torch.Tensor,
-        target_tensor: torch.Tensor,
-    ) -> tuple[
-        dict[str, torch.Tensor | None], dict[int, tuple[torch.Tensor, torch.Tensor]]
-    ]:
-        """Run the reference model microbatched, capturing per-stage I/O shapes.
+        torch.manual_seed(0)
+        with torch.device(self.device):
+            model = NormMLPStack(d_hid, 2)
 
-        Returns:
-            ref_grads: {param_fqn: grad_tensor}
-            static_stage_io: {stage_idx: (input_like, output_like)} for static metadata
-        """
-        ref_model.zero_grad(set_to_none=True)
+        # Annotate all params as Replicate on TP axis
+        for param in model.parameters():
+            spmd._type_attr.set_local_type(param, {tp_axis: spmd.R})
 
-        input_chunks = torch.tensor_split(input_tensor, n_microbatches)
-        target_chunks = torch.tensor_split(target_tensor, n_microbatches)
+        # Enable typechecking so forward outputs carry annotations
+        mesh_axes = frozenset({tp_axis})
+        for layer in model.layers:
+            orig_fwd = layer.forward
 
-        # Re-annotate chunks (tensor_split doesn't preserve spmd_types attrs)
-        if spmd._checker.has_local_type(input_tensor):
-            lt = spmd._type_attr.get_local_type(input_tensor)
-            for chunk in input_chunks:
-                spmd._type_attr.set_local_type(chunk, lt)
+            def _make_typechecked(fwd):
+                def _typechecked_fwd(*args, **kwargs):
+                    with (
+                        spmd.set_current_mesh(mesh_axes),
+                        spmd._checker.typecheck(strict_mode="strict"),
+                    ):
+                        return fwd(*args, **kwargs)
 
-        # Capture first-microbatch I/O shapes per stage
-        captured_io: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
-        hooks: list[torch.utils.hooks.RemovableHandle] = []
+                return _typechecked_fwd
 
-        for stage_idx, stage_mod in enumerate(ref_model.layers):
+            layer.forward = _make_typechecked(orig_fwd)
 
-            def _capture_io(
-                _module: nn.Module,
-                args: tuple[torch.Tensor, ...],
-                output: torch.Tensor,
-                *,
-                idx: int = stage_idx,
-            ) -> None:
-                captured_io[idx] = (args[0], output)
+        # Hook stage 1 to capture annotation on received activation
+        received_types: list[dict | None] = []
 
-            hooks.append(stage_mod.register_forward_hook(_capture_io))
+        def _capture_annotation(module, args):
+            inp = args[0]
+            if spmd._checker.has_local_type(inp):
+                lt = spmd._type_attr.get_local_type(inp)
+                received_types.append(
+                    {
+                        name: lt.get(spmd.MeshAxis.of(tp_mesh.get_group(name)))
+                        for name in tp_mesh.mesh_dim_names
+                    }
+                )
+            else:
+                received_types.append(None)
 
-        for mb_idx, (inp_chunk, tgt_chunk) in enumerate(
-            zip(input_chunks, target_chunks)
-        ):
-            output = ref_model(inp_chunk)
-            loss = _loss_fn(output, tgt_chunk)
-            loss.backward()
+        model.layers[1].register_forward_pre_hook(_capture_annotation)
 
-            if mb_idx == 0:
-                # Capture shapes from first microbatch, then remove hooks
-                static_stage_io: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
-                for si in range(len(ref_model.layers)):
-                    stage_in, stage_out = captured_io[si]
-                    static_stage_io[si] = (
-                        torch.empty_like(stage_in),
-                        torch.empty_like(stage_out),
-                    )
-                for h in hooks:
-                    h.remove()
-                hooks = []
-
-        # Average gradients across microbatches
-        for param in ref_model.parameters():
-            if param.grad is not None:
-                param.grad.div_(n_microbatches)
-
-        ref_grads = {
-            name: param.grad.clone() if param.grad is not None else None
-            for name, param in ref_model.named_parameters()
-        }
-        return ref_grads, static_stage_io
-
-    # ------------------------------------------------------------------
-    # PP stage construction
-    # ------------------------------------------------------------------
-
-    def _make_stage(
-        self,
-        pp_model: NormMLPStack,
-        stage_index: int,
-        num_stages: int,
-        pp_group: dist.ProcessGroup,
-        tp_mesh: DeviceMesh,
-    ) -> PipelineStage:
-        stage_module = pp_model.get_submodule(f"layers.{stage_index}")
-        return PipelineStage(
-            submodule=stage_module,
-            stage_index=stage_index,
-            num_stages=num_stages,
+        stage = PipelineStage(
+            submodule=model.get_submodule(f"layers.{pp_rank}"),
+            stage_index=pp_rank,
+            num_stages=2,
             device=self.device,
             group=pp_group,
             device_mesh=tp_mesh,
         )
 
-    # ------------------------------------------------------------------
-    # Core test: training correctness
-    # ------------------------------------------------------------------
+        torch.manual_seed(42)
+        input_tensor = torch.randn(batch_size, d_hid, device=self.device)
+        spmd._type_attr.set_local_type(input_tensor, {tp_axis: spmd.R})
+        target_tensor = torch.randn(batch_size, d_hid, device=self.device)
 
-    def _run_training_correctness(
-        self,
-        apply_parallelism: Callable[[NormMLP, dist.ProcessGroup], None],
-        annotate_fn: Callable[[nn.Module, DeviceMesh], None],
-        input_spmd_type: object | None = None,
-        typecheck: bool = False,
-    ) -> None:
-        self.init_pg()
-
-        mesh = self._make_mesh()
-        tp_mesh = mesh["tp"]
-        pp_mesh = mesh["pp"]
-        pp_group = pp_mesh.get_group()
-        pp_rank = pp_mesh.get_local_rank()
-        tp_pg = tp_mesh.get_group()
-
-        n_layers = 2  # 1 stage per PP rank
-
-        # Build two identical models
-        torch.manual_seed(MODEL_SEED)
-        with torch.device(self.device):
-            ref_model = NormMLPStack(d_hid, n_layers)
-        pp_model = copy.deepcopy(ref_model)
-
-        # Apply TP parallelism to both
-        for layer in ref_model.layers:
-            apply_parallelism(layer, tp_pg)
-        for layer in pp_model.layers:
-            apply_parallelism(layer, tp_pg)
-
-        # Annotate with spmd_types
-        annotate_fn(ref_model, tp_mesh)
-        annotate_fn(pp_model, tp_mesh)
-        if typecheck:
-            _wrap_with_typecheck(ref_model, tp_mesh)
-            _wrap_with_typecheck(pp_model, tp_mesh)
-
-        # Create inputs (same on all ranks for Replicate; per-rank shard for TP)
-        tp_axis = spmd.MeshAxis.of(tp_pg)
-        torch.manual_seed(INPUT_SEED)
-        input_full = torch.randn(batch_size, d_hid, device=self.device)
-        torch.manual_seed(TARGET_SEED)
-        target_full = torch.randn(batch_size, d_hid, device=self.device)
-
-        # Reference: microbatched serial execution
-        ref_input = input_full.clone().requires_grad_(True)
-        if input_spmd_type is not None:
-            spmd._type_attr.set_local_type(ref_input, {tp_axis: input_spmd_type})
-        ref_target = target_full.clone()
-        ref_grads, _ = self._run_reference_microbatched(
-            ref_model, ref_input, ref_target
-        )
-
-        # PP execution (dynamic metadata inference)
-        stage = self._make_stage(
-            pp_model=pp_model,
-            stage_index=pp_rank,
-            num_stages=n_layers,
-            pp_group=pp_group,
-            tp_mesh=tp_mesh,
-        )
-        stage.submod.zero_grad(set_to_none=True)
-
-        pp_input = input_full.clone().requires_grad_(True)
-        if input_spmd_type is not None:
-            spmd._type_attr.set_local_type(pp_input, {tp_axis: input_spmd_type})
-        pp_target = target_full.clone()
-
-        schedule = Schedule1F1B(
-            stage,
-            n_microbatches=n_microbatches,
-            loss_fn=_loss_fn,
-        )
-
-        if stage.is_first and stage.is_last:
-            losses: list[torch.Tensor] = []
-            schedule.step(pp_input, target=pp_target, losses=losses)
-        elif stage.is_first:
-            schedule.step(pp_input)
-        elif stage.is_last:
-            losses = []
-            schedule.step(target=pp_target, losses=losses)
-        else:
-            schedule.step()
-
-        # Compare gradients
-        stage_module = pp_model.get_submodule(f"layers.{pp_rank}")
-        for name, param in stage_module.named_parameters():
-            param_fqn = f"layers.{pp_rank}.{name}"
-            self.assertIsNotNone(param.grad, f"Missing PP grad for {param_fqn}")
-            ref_grad = ref_grads[param_fqn]
-            self.assertIsNotNone(ref_grad, f"Missing ref grad for {param_fqn}")
-            torch.testing.assert_close(
-                param.grad,
-                ref_grad,
-                msg=f"Gradient mismatch for {param_fqn}",
-            )
-
-    # ------------------------------------------------------------------
-    # Annotation verification: check annotations survive PP forward recv
-    # ------------------------------------------------------------------
-
-    def _run_annotation_check(
-        self,
-        apply_parallelism: Callable[[NormMLP, dist.ProcessGroup], None],
-        annotate_fn: Callable[[nn.Module, DeviceMesh], None],
-        expected_activation_types: dict[str, object],
-    ) -> None:
-        """Verify that spmd_types annotations on activations survive PP recv.
-
-        Registers a forward pre-hook on stage 1 to check that the activation
-        received from stage 0 carries the expected per-axis spmd type.
-
-        Args:
-            expected_activation_types: {mesh_dim_name: expected_type}, e.g.
-                {"tp": spmd.R}.
-        """
-        self.init_pg()
-
-        mesh = self._make_mesh()
-        tp_mesh = mesh["tp"]
-        pp_mesh = mesh["pp"]
-        pp_group = pp_mesh.get_group()
-        pp_rank = pp_mesh.get_local_rank()
-        tp_pg = tp_mesh.get_group()
-
-        torch.manual_seed(MODEL_SEED)
-        with torch.device(self.device):
-            model = NormMLPStack(d_hid, 2)
-
-        for layer in model.layers:
-            apply_parallelism(layer, tp_pg)
-        annotate_fn(model, tp_mesh)
-
-        # Register hook on stage 1 to check forward input annotations
-        annotation_results: list[dict] = []
-
-        def check_fwd_annotation(module, args):
-            inp = args[0]
-            result = {"has_type": spmd._checker.has_local_type(inp)}
-            if result["has_type"]:
-                lt = spmd.get_local_type(inp)
-                result["local_type"] = {
-                    name: lt.get(spmd.MeshAxis.of(tp_mesh.get_group(name)))
-                    for name in tp_mesh.mesh_dim_names
-                }
-            annotation_results.append(result)
-
-        model.layers[1].register_forward_pre_hook(check_fwd_annotation)
-
-        torch.manual_seed(INPUT_SEED)
-        input_full = torch.randn(batch_size, d_hid, device=self.device)
-        torch.manual_seed(TARGET_SEED)
-        target_full = torch.randn(batch_size, d_hid, device=self.device)
-
-        stage = self._make_stage(
-            pp_model=model,
-            stage_index=pp_rank,
-            num_stages=2,
-            pp_group=pp_group,
-            tp_mesh=tp_mesh,
-        )
-
-        schedule = Schedule1F1B(
-            stage,
-            n_microbatches=n_microbatches,
-            loss_fn=_loss_fn,
-        )
+        schedule = Schedule1F1B(stage, n_microbatches=n_microbatches, loss_fn=_loss_fn)
 
         if stage.is_first:
-            schedule.step(input_full)
-        elif stage.is_last:
-            losses = []
-            schedule.step(target=target_full, losses=losses)
-
-        # Only pp_rank=1 (stage 1) runs the hook
-        if pp_rank == 1:
-            self.assertGreater(
-                len(annotation_results),
-                0,
-                "Forward pre-hook was not called on stage 1",
-            )
-            first = annotation_results[0]
-            self.assertTrue(
-                first["has_type"],
-                "Activation received by stage 1 has no spmd_types annotation",
-            )
-            for dim_name, expected_type in expected_activation_types.items():
-                actual = first["local_type"].get(dim_name)
-                self.assertEqual(
-                    actual,
-                    expected_type,
-                    f"Activation type on '{dim_name}': expected {expected_type}, got {actual}",
-                )
-
-    # ------------------------------------------------------------------
-    # Test methods
-    # ------------------------------------------------------------------
-
-    @_requires_multi_gpu
-    def test_replicate(self):
-        """PP + spmd_types with all-Replicate annotations and typecheck."""
-
-        def _no_tp(block, tp_pg):
-            pass
-
-        self._run_training_correctness(
-            _no_tp,
-            _annotate_replicate,
-            input_spmd_type=spmd.R,
-            typecheck=True,
-        )
-
-    @_requires_multi_gpu
-    def test_tp(self):
-        """PP + TP with spmd_types annotations."""
-        self._run_training_correctness(
-            _apply_spmd_tp,
-            _annotate_replicate,
-        )
-
-    # ------------------------------------------------------------------
-    # FSDP + PP test
-    # ------------------------------------------------------------------
-
-    def _run_fsdp_pp_correctness(self) -> None:
-        """FSDP + PP: params annotated as Replicate on FSDP axis, then fully_shard'd."""
-        self.init_pg()
-
-        mesh = init_device_mesh(device_type, (2, 2), mesh_dim_names=("pp", "fsdp"))
-        fsdp_mesh = mesh["fsdp"]
-        pp_mesh = mesh["pp"]
-        pp_group = pp_mesh.get_group()
-        pp_rank = pp_mesh.get_local_rank()
-        fsdp_axis = spmd.MeshAxis.of(fsdp_mesh.get_group())
-
-        n_layers = 2
-
-        torch.manual_seed(MODEL_SEED)
-        with torch.device(self.device):
-            ref_model = NormMLPStack(d_hid, n_layers)
-        pp_model = copy.deepcopy(ref_model)
-
-        # Annotate params as Replicate on FSDP axis, then apply fully_shard
-        for param in pp_model.parameters():
-            spmd._type_attr.set_local_type(param, {fsdp_axis: spmd.R})
-        for layer in pp_model.layers:
-            fully_shard(
-                layer,
-                mesh=fsdp_mesh,
-                dp_mesh_dims=DataParallelMeshDims(shard="fsdp"),
-            )
-        fully_shard(
-            pp_model,
-            mesh=fsdp_mesh,
-            dp_mesh_dims=DataParallelMeshDims(shard="fsdp"),
-        )
-
-        # Reference: replicate on all ranks (no FSDP), microbatched
-        from torch.distributed._composable import replicate
-
-        replicate(ref_model, device_ids=[self.rank])
-
-        torch.manual_seed(INPUT_SEED)
-        input_full = torch.randn(batch_size, d_hid, device=self.device)
-        torch.manual_seed(TARGET_SEED)
-        target_full = torch.randn(batch_size, d_hid, device=self.device)
-
-        ref_input = input_full.clone().requires_grad_(True)
-        ref_target = target_full.clone()
-        ref_grads, _ = self._run_reference_microbatched(
-            ref_model, ref_input, ref_target
-        )
-
-        stage = self._make_stage(
-            pp_model=pp_model,
-            stage_index=pp_rank,
-            num_stages=n_layers,
-            pp_group=pp_group,
-            tp_mesh=fsdp_mesh,
-        )
-        stage.submod.zero_grad(set_to_none=True)
-
-        pp_input = input_full.clone().requires_grad_(True)
-        pp_target = target_full.clone()
-
-        schedule = Schedule1F1B(
-            stage,
-            n_microbatches=n_microbatches,
-            loss_fn=_loss_fn,
-        )
-
-        if stage.is_first and stage.is_last:
-            losses: list[torch.Tensor] = []
-            schedule.step(pp_input, target=pp_target, losses=losses)
-        elif stage.is_first:
-            schedule.step(pp_input)
-        elif stage.is_last:
-            losses = []
-            schedule.step(target=pp_target, losses=losses)
+            schedule.step(input_tensor)
         else:
-            schedule.step()
+            schedule.step(target=target_tensor, losses=[])
 
-        # Compare gradients (FSDP grads are DTensors, compare full tensors)
-        stage_module = pp_model.get_submodule(f"layers.{pp_rank}")
-        for name, param in stage_module.named_parameters():
-            param_fqn = f"layers.{pp_rank}.{name}"
-            self.assertIsNotNone(param.grad, f"Missing PP grad for {param_fqn}")
-            ref_grad = ref_grads[param_fqn]
-            self.assertIsNotNone(ref_grad, f"Missing ref grad for {param_fqn}")
-            pp_grad = param.grad
-            if hasattr(pp_grad, "full_tensor"):
-                pp_grad = pp_grad.full_tensor()
-            torch.testing.assert_close(
-                pp_grad,
-                ref_grad,
-                msg=f"Gradient mismatch for {param_fqn}",
+        # Only stage 1 (pp_rank=1) runs the hook
+        if pp_rank == 1:
+            self.assertGreater(len(received_types), 0, "Hook was not called on stage 1")
+            first = received_types[0]
+            self.assertIsNotNone(first, "Activation has no spmd_types annotation")
+            self.assertEqual(
+                first["tp"], spmd.R, f"Expected Replicate, got {first['tp']}"
             )
-
-    @_requires_multi_gpu
-    def test_fsdp_pp(self):
-        """FSDP + PP with spmd_types annotations."""
-        self._run_fsdp_pp_correctness()
 
 
 if __name__ == "__main__":

--- a/test/distributed/pipelining/test_spmd_types_pp_integration.py
+++ b/test/distributed/pipelining/test_spmd_types_pp_integration.py
@@ -110,8 +110,7 @@ def _annotate_replicate(model: nn.Module, tp_mesh: DeviceMesh) -> None:
 def _wrap_with_typecheck(model: NormMLPStack, mesh: DeviceMesh) -> None:
     """Wrap each NormMLP layer's forward to run under spmd_types typecheck."""
     mesh_axes = frozenset(
-        spmd.MeshAxis.of(mesh.get_group(name))
-        for name in mesh.mesh_dim_names
+        spmd.MeshAxis.of(mesh.get_group(name)) for name in mesh.mesh_dim_names
     )
 
     for layer in model.layers:
@@ -124,6 +123,7 @@ def _wrap_with_typecheck(model: NormMLPStack, mesh: DeviceMesh) -> None:
                     spmd._checker.typecheck(strict_mode="strict"),
                 ):
                     return fwd(*args, **kwargs)
+
             return _typechecked_fwd
 
         layer.forward = _make_typechecked(orig_fwd)
@@ -182,7 +182,6 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
         ref_model: NormMLPStack,
         input_tensor: torch.Tensor,
         target_tensor: torch.Tensor,
-        tp_mesh: DeviceMesh,
     ) -> tuple[
         dict[str, torch.Tensor | None], dict[int, tuple[torch.Tensor, torch.Tensor]]
     ]:
@@ -197,11 +196,11 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
         input_chunks = torch.tensor_split(input_tensor, n_microbatches)
         target_chunks = torch.tensor_split(target_tensor, n_microbatches)
 
-        # Re-annotate chunks (tensor_split doesn't preserve spmd_types)
+        # Re-annotate chunks (tensor_split doesn't preserve spmd_types attrs)
         if spmd._checker.has_local_type(input_tensor):
-            lt = spmd.get_local_type(input_tensor)
+            lt = spmd._type_attr.get_local_type(input_tensor)
             for chunk in input_chunks:
-                spmd.assert_type(chunk, lt)
+                spmd._type_attr.set_local_type(chunk, lt)
 
         # Capture first-microbatch I/O shapes per stage
         captured_io: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
@@ -281,6 +280,8 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
         self,
         apply_parallelism: Callable[[NormMLP, dist.ProcessGroup], None],
         annotate_fn: Callable[[nn.Module, DeviceMesh], None],
+        input_spmd_type: object | None = None,
+        typecheck: bool = False,
     ) -> None:
         self.init_pg()
 
@@ -305,27 +306,27 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
         for layer in pp_model.layers:
             apply_parallelism(layer, tp_pg)
 
-        # Annotate with spmd_types and wrap forward with typecheck
+        # Annotate with spmd_types
         annotate_fn(ref_model, tp_mesh)
         annotate_fn(pp_model, tp_mesh)
-        _wrap_with_typecheck(ref_model, tp_mesh)
-        _wrap_with_typecheck(pp_model, tp_mesh)
+        if typecheck:
+            _wrap_with_typecheck(ref_model, tp_mesh)
+            _wrap_with_typecheck(pp_model, tp_mesh)
 
         # Create inputs (same on all ranks for Replicate; per-rank shard for TP)
+        tp_axis = spmd.MeshAxis.of(tp_pg)
         torch.manual_seed(INPUT_SEED)
         input_full = torch.randn(batch_size, d_hid, device=self.device)
         torch.manual_seed(TARGET_SEED)
         target_full = torch.randn(batch_size, d_hid, device=self.device)
 
-        # Annotate inputs
-        tp_axis = spmd.MeshAxis.of(tp_pg)
-
         # Reference: microbatched serial execution
         ref_input = input_full.clone().requires_grad_(True)
-        spmd.assert_type(ref_input, {tp_axis: spmd.R})
+        if input_spmd_type is not None:
+            spmd._type_attr.set_local_type(ref_input, {tp_axis: input_spmd_type})
         ref_target = target_full.clone()
         ref_grads, _ = self._run_reference_microbatched(
-            ref_model, ref_input, ref_target, tp_mesh
+            ref_model, ref_input, ref_target
         )
 
         # PP execution (dynamic metadata inference)
@@ -339,7 +340,8 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
         stage.submod.zero_grad(set_to_none=True)
 
         pp_input = input_full.clone().requires_grad_(True)
-        spmd.assert_type(pp_input, {tp_axis: spmd.R})
+        if input_spmd_type is not None:
+            spmd._type_attr.set_local_type(pp_input, {tp_axis: input_spmd_type})
         pp_target = target_full.clone()
 
         schedule = Schedule1F1B(
@@ -475,7 +477,7 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
 
     @_requires_multi_gpu
     def test_replicate(self):
-        """PP + spmd_types with all-Replicate annotations."""
+        """PP + spmd_types with all-Replicate annotations and typecheck."""
 
         def _no_tp(block, tp_pg):
             pass
@@ -483,6 +485,8 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
         self._run_training_correctness(
             _no_tp,
             _annotate_replicate,
+            input_spmd_type=spmd.R,
+            typecheck=True,
         )
 
     @_requires_multi_gpu
@@ -518,8 +522,6 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
         # Annotate params as Replicate on FSDP axis, then apply fully_shard
         for param in pp_model.parameters():
             spmd._type_attr.set_local_type(param, {fsdp_axis: spmd.R})
-        _wrap_with_typecheck(pp_model, fsdp_mesh)
-
         for layer in pp_model.layers:
             fully_shard(
                 layer,
@@ -535,7 +537,6 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
         # Reference: replicate on all ranks (no FSDP), microbatched
         from torch.distributed._composable import replicate
 
-        _wrap_with_typecheck(ref_model, fsdp_mesh)
         replicate(ref_model, device_ids=[self.rank])
 
         torch.manual_seed(INPUT_SEED)
@@ -546,7 +547,7 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
         ref_input = input_full.clone().requires_grad_(True)
         ref_target = target_full.clone()
         ref_grads, _ = self._run_reference_microbatched(
-            ref_model, ref_input, ref_target, fsdp_mesh
+            ref_model, ref_input, ref_target
         )
 
         stage = self._make_stage(
@@ -598,6 +599,7 @@ class TestSpmdTypesPPIntegration(MultiProcContinuousTest):
     def test_fsdp_pp(self):
         """FSDP + PP with spmd_types annotations."""
         self._run_fsdp_pp_correctness()
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/pipelining/_utils.py
+++ b/torch/distributed/pipelining/_utils.py
@@ -252,8 +252,89 @@ class _DTensorMeta(_TensorMeta):
         return diffs
 
 
+@dataclass(frozen=True, slots=True)
+class _SpmdTypesMeta(_TensorMeta):
+    """Metadata for spmd_types-annotated plain tensors.
+
+    Inherited fields (shape, stride, dtype, requires_grad) are the plain
+    tensor's attributes. Additional fields capture per-mesh-axis type
+    annotations needed to restore spmd_types info after P2P communication.
+
+    The DeviceMesh is not stored; it is looked up from _MeshCache using
+    (mesh_dim_names, mesh_layout) as the key.
+    """
+
+    # Per-dim-name spmd type values: {"tp": R, "dp": S(0), ...}
+    spmd_types_by_dim_name: dict[str, object] = field(default_factory=dict)
+
+    # Mesh identification (same pattern as _DTensorMeta)
+    mesh_dim_names: tuple[str, ...] = field(default=())
+    mesh_layout: _MeshLayout | None = field(default=None)
+
+    @staticmethod
+    def from_spmd_tensor(
+        tensor: torch.Tensor, device_mesh: DeviceMesh
+    ) -> _SpmdTypesMeta:
+        import spmd_types as spmd
+
+        local_type = spmd.get_local_type(tensor)
+        spmd_types_by_dim_name: dict[str, object] = {}
+        dim_names = device_mesh.mesh_dim_names or ()
+        for axis, axis_type in local_type.items():
+            for name in dim_names:
+                if spmd.MeshAxis.of(device_mesh.get_group(name)) == axis:
+                    spmd_types_by_dim_name[name] = axis_type
+                    break
+
+        return _SpmdTypesMeta(
+            shape=tensor.shape,
+            stride=tensor.stride(),
+            dtype=tensor.dtype,
+            requires_grad=tensor.requires_grad,
+            spmd_types_by_dim_name=spmd_types_by_dim_name,
+            mesh_dim_names=(
+                tuple(device_mesh.mesh_dim_names) if device_mesh.mesh_dim_names else ()
+            ),
+            mesh_layout=device_mesh._layout,
+        )
+
+    @property
+    def mesh_cache_key(self) -> MeshCacheKey:
+        return (self.mesh_dim_names, self.mesh_layout)
+
+    def reannotate(self, tensor: torch.Tensor, mesh: DeviceMesh) -> torch.Tensor:
+        """Restore spmd_types annotations on a plain tensor after recv."""
+        import spmd_types as spmd
+
+        local_type = {}
+        for name, axis_type in self.spmd_types_by_dim_name.items():
+            axis = spmd.MeshAxis.of(mesh.get_group(name))
+            local_type[axis] = axis_type
+        spmd.assert_type(tensor, local_type)
+        return tensor
+
+    def get_diff(self, other: _TensorMeta) -> list[str]:
+        if self == other:
+            return []
+        diffs = _TensorMeta.get_diff(self, other)
+        if isinstance(other, _SpmdTypesMeta):
+            if self.spmd_types_by_dim_name != other.spmd_types_by_dim_name:
+                diffs.append(
+                    f"spmd_types mismatch: {self.spmd_types_by_dim_name} "
+                    f"vs {other.spmd_types_by_dim_name}"
+                )
+            if self.mesh_dim_names != other.mesh_dim_names:
+                diffs.append(
+                    f"mesh_dim_names mismatch: {self.mesh_dim_names} "
+                    f"vs {other.mesh_dim_names}"
+                )
+        else:
+            diffs.append("type: _SpmdTypesMeta vs _TensorMeta")
+        return diffs
+
+
 # Type alias for union of tensor metadata types
-TensorMeta: TypeAlias = _TensorMeta | _DTensorMeta
+TensorMeta: TypeAlias = _TensorMeta | _DTensorMeta | _SpmdTypesMeta
 
 
 # Not frozen: fields are populated incrementally during forward and
@@ -278,6 +359,13 @@ class _StageMeta:
         """Check if any input/output metadata is DTensor type."""
         for metas in [self.inputs, self.outputs]:
             if metas and any(isinstance(m, _DTensorMeta) for m in metas if m):
+                return True
+        return False
+
+    def has_spmd_types(self) -> bool:
+        """Check if any input/output metadata is spmd_types type."""
+        for metas in [self.inputs, self.outputs]:
+            if metas and any(isinstance(m, _SpmdTypesMeta) for m in metas if m):
                 return True
         return False
 
@@ -449,8 +537,8 @@ class InferenceMode(Enum):
         if not meta.is_complete_for_forward():
             return True
 
-        # Case 2: No DTensors → STATIC is fine (bwd metadata derivable from fwd metadata)
-        if not meta.has_dtensors():
+        # Case 2: No distributed tensors → STATIC is fine (bwd metadata derivable)
+        if not meta.has_dtensors() and not meta.has_spmd_types():
             return False
 
         # Case 3: No backward needed → STATIC is fine (don't need grad metadata)
@@ -579,22 +667,36 @@ class PipeInfo:
 # ============================================================================
 
 
-def extract_tensor_meta(tensor: torch.Tensor) -> TensorMeta:
+def _has_spmd_local_type(tensor: torch.Tensor) -> bool:
+    """Check if a tensor has spmd_types annotations."""
+    try:
+        import spmd_types._checker
+
+        return spmd_types._checker.has_local_type(tensor)
+    except ImportError:
+        return False
+
+
+def extract_tensor_meta(
+    tensor: torch.Tensor,
+    device_mesh: DeviceMesh | None = None,
+) -> TensorMeta:
     """Extract metadata from a tensor.
 
-    Handles both plain Tensor and DTensor correctly: DTensors are
-    dispatched to ``_DTensorMeta.from_dtensor`` which captures local
-    shard attributes plus global shape/placement info, while plain
-    tensors use ``_TensorMeta.from_tensor``.
+    Handles DTensor, spmd_types-annotated tensors, and plain tensors.
 
     Args:
-        tensor: A plain tensor or DTensor.
+        tensor: A plain tensor, DTensor, or spmd_types-annotated tensor.
+        device_mesh: Required for spmd_types tensors (they don't carry
+            their mesh internally unlike DTensors).
 
     Returns:
-        ``_TensorMeta`` for plain tensors, ``_DTensorMeta`` for DTensors.
+        ``_DTensorMeta``, ``_SpmdTypesMeta``, or ``_TensorMeta``.
     """
     if isinstance(tensor, DTensor):
         return _DTensorMeta.from_dtensor(tensor)
+    elif device_mesh is not None and _has_spmd_local_type(tensor):
+        return _SpmdTypesMeta.from_spmd_tensor(tensor, device_mesh)
     else:
         return _TensorMeta.from_tensor(tensor)
 
@@ -604,6 +706,7 @@ def extract_tensor_metas(
     tensors: tuple[torch.Tensor, ...] | None,
     *,
     allow_none: Literal[False] = ...,
+    device_mesh: DeviceMesh | None = ...,
 ) -> tuple[TensorMeta, ...] | None: ...
 
 
@@ -612,6 +715,7 @@ def extract_tensor_metas(
     tensors: tuple[torch.Tensor | None, ...] | None,
     *,
     allow_none: Literal[True],
+    device_mesh: DeviceMesh | None = ...,
 ) -> tuple[TensorMeta | None, ...] | None: ...
 
 
@@ -619,12 +723,14 @@ def extract_tensor_metas(
     tensors: tuple[torch.Tensor | None, ...] | tuple[torch.Tensor, ...] | None,
     *,
     allow_none: bool = False,
+    device_mesh: DeviceMesh | None = None,
 ) -> tuple[TensorMeta | None, ...] | None:
     """Extract metadata from a tuple of tensors.
 
     Args:
         tensors: Tuple of tensors (may include ``None`` when ``allow_none=True``).
         allow_none: If ``True``, preserve ``None`` elements (for gradients).
+        device_mesh: Passed through to ``extract_tensor_meta`` for spmd_types.
 
     Returns:
         Tuple of ``TensorMeta``, or ``None`` if ``tensors`` is ``None``.
@@ -639,7 +745,7 @@ def extract_tensor_metas(
     has_none = False
     for t in tensors:
         if isinstance(t, torch.Tensor):
-            metas_with_none.append(extract_tensor_meta(t))
+            metas_with_none.append(extract_tensor_meta(t, device_mesh=device_mesh))
         else:
             has_none = True
             metas_with_none.append(None)

--- a/torch/distributed/pipelining/microbatch.py
+++ b/torch/distributed/pipelining/microbatch.py
@@ -184,6 +184,27 @@ def _split_block_mask(
     return chunk_block_masks
 
 
+def _reannotate_spmd_chunks(
+    original: torch.Tensor, chunks: Sequence[torch.Tensor]
+) -> None:
+    """Re-apply spmd_types annotations from *original* to each chunk.
+
+    ``tensor_split`` returns views that don't inherit spmd_types tensor
+    attributes.  This copies them so that downstream typechecked forwards
+    see the correct per-axis types.
+    """
+    try:
+        import spmd_types._checker
+        import spmd_types._type_attr
+    except ImportError:
+        return
+    if not spmd_types._checker.has_local_type(original):
+        return
+    lt = spmd_types._type_attr.get_local_type(original)
+    for chunk in chunks:
+        spmd_types._type_attr.set_local_type(chunk, lt)
+
+
 def _split_tensor(
     tensor: torch.Tensor,
     spec: TensorChunkSpec,
@@ -221,6 +242,8 @@ def _split_tensor(
         chunk_tensors: Sequence[torch.Tensor] = split_fn(tensor)  # type: ignore[assignment]
     else:
         chunk_tensors = torch.tensor_split(tensor, num_chunks, spec.split_dim)
+        # tensor_split doesn't preserve spmd_types annotations; re-apply them
+        _reannotate_spmd_chunks(tensor, chunk_tensors)
 
     # tensor_split on a leaf tensor produces non-leaf views that won't
     # accumulate .grad during torch.autograd.backward().  Call retain_grad()

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -1815,7 +1815,16 @@ class PipelineStage(_PipelineStageBase):
         TensorMeta is materialized as an empty tensor (or DTensor via mesh cache).
         """
         if isinstance(arg, torch.Tensor):
-            return arg.detach().requires_grad_(arg.requires_grad)
+            result = arg.detach().requires_grad_(arg.requires_grad)
+            # detach() strips spmd_types annotations; re-apply them
+            from torch.distributed.pipelining._utils import _has_spmd_local_type
+
+            if _has_spmd_local_type(arg):
+                import spmd_types._type_attr
+
+                lt = spmd_types._type_attr.get_local_type(arg)
+                spmd_types._type_attr.set_local_type(result, lt)
+            return result
         elif isinstance(arg, TensorMeta):
             if isinstance(arg, _DTensorMeta):
                 mesh = self._mesh_cache.get_mesh(arg.mesh_cache_key)

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -19,6 +19,7 @@ from torch.distributed.pipelining._utils import (
     _DTensorMeta,
     _make_tensor_from_meta,
     _MeshCache,
+    _SpmdTypesMeta,
     _StageBackwardMeta,
     _StageForwardMeta,
     _StageMeta,
@@ -629,6 +630,10 @@ class _PipelineStageBase(ABC):
                         stride=info.tensor_meta.global_stride,
                         run_check=False,
                     ).requires_grad_(effective_requires_grad)
+                elif isinstance(info.tensor_meta, _SpmdTypesMeta):
+                    mesh = self._mesh_cache.get_mesh(info.tensor_meta.mesh_cache_key)
+                    info.tensor_meta.reannotate(info.buffer, mesh)
+                    activation = info.buffer.requires_grad_(effective_requires_grad)
                 else:
                     activation = info.buffer.requires_grad_(effective_requires_grad)
                 # Activation must be a leaf so backward terminates here.
@@ -690,6 +695,10 @@ class _PipelineStageBase(ABC):
                         stride=info.tensor_meta.global_stride,
                         run_check=False,
                     )
+                elif isinstance(info.tensor_meta, _SpmdTypesMeta):
+                    mesh = self._mesh_cache.get_mesh(info.tensor_meta.mesh_cache_key)
+                    info.tensor_meta.reannotate(info.buffer, mesh)
+                    grad = info.buffer
                 else:
                     grad = info.buffer
                 grads.append(grad)
@@ -1624,14 +1633,23 @@ class PipelineStage(_PipelineStageBase):
         group: dist.ProcessGroup | None = None,
         dw_builder: Callable[[], Callable[..., None]] | None = None,
         get_mesh: GetMeshCallback | None = None,
+        device_mesh: torch.distributed.device_mesh.DeviceMesh | None = None,
     ):
         super().__init__(submodule, stage_index, num_stages, device, group, dw_builder)
 
         self._mesh_cache = _MeshCache(get_mesh_cb=get_mesh)
+        self._spmd_device_mesh = device_mesh
         self._inference_mode: InferenceMode | None = None
         self._fwd_outputs_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
         self._fwd_inputs_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
         self._fwd_kwargs_tensors_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
+
+        # Pre-populate mesh cache from device_mesh if provided
+        if device_mesh is not None:
+            dim_names = (
+                tuple(device_mesh.mesh_dim_names) if device_mesh.mesh_dim_names else ()
+            )
+            self._mesh_cache.put((dim_names, device_mesh._layout), device_mesh)
 
         # Validate and normalize args to tuples
         inputs = validate_and_normalize_to_tuple(input_args)
@@ -1640,10 +1658,14 @@ class PipelineStage(_PipelineStageBase):
         out_grads = validate_and_normalize_to_tuple(output_grads, allow_none=True)
 
         self._user_meta = _StageMeta(
-            inputs=extract_tensor_metas(inputs),
-            outputs=extract_tensor_metas(outputs),
-            input_grads=extract_tensor_metas(in_grads, allow_none=True),
-            output_grads=extract_tensor_metas(out_grads, allow_none=True),
+            inputs=extract_tensor_metas(inputs, device_mesh=device_mesh),
+            outputs=extract_tensor_metas(outputs, device_mesh=device_mesh),
+            input_grads=extract_tensor_metas(
+                in_grads, allow_none=True, device_mesh=device_mesh
+            ),
+            output_grads=extract_tensor_metas(
+                out_grads, allow_none=True, device_mesh=device_mesh
+            ),
         )
 
         # Cache meshes from user-provided DTensors
@@ -1798,6 +1820,11 @@ class PipelineStage(_PipelineStageBase):
             if isinstance(arg, _DTensorMeta):
                 mesh = self._mesh_cache.get_mesh(arg.mesh_cache_key)
                 return arg.to_dtensor(self.device, mesh)
+            elif isinstance(arg, _SpmdTypesMeta):
+                t = arg.to_tensor(self.device)
+                mesh = self._mesh_cache.get_mesh(arg.mesh_cache_key)
+                arg.reannotate(t, mesh)
+                return t
             else:
                 return arg.to_tensor(self.device)
         else:
@@ -1822,6 +1849,9 @@ class PipelineStage(_PipelineStageBase):
                 stride=meta.global_stride,
                 run_check=False,
             )
+        if isinstance(meta, _SpmdTypesMeta):
+            mesh = self._mesh_cache.get_mesh(meta.mesh_cache_key)
+            meta.reannotate(local_ones, mesh)
         return local_ones
 
     def _forward_metadata_inference(
@@ -1853,7 +1883,9 @@ class PipelineStage(_PipelineStageBase):
                 )
             tensor_args = validate_and_normalize_to_tuple(args)
             assert tensor_args is not None  # noqa: S101
-            self._stage_meta.inputs = extract_tensor_metas(tensor_args)
+            self._stage_meta.inputs = extract_tensor_metas(
+                tensor_args, device_mesh=self._spmd_device_mesh
+            )
             inference_args = tuple(self._to_tensor(a) for a in tensor_args)
         elif self._is_same_rank(self.stage_index - 1):
             # Same-rank: _StageForwardMeta passed via argument
@@ -1892,7 +1924,9 @@ class PipelineStage(_PipelineStageBase):
         # Normalize outputs to tuple
         outputs = validate_and_normalize_to_tuple(outputs)
 
-        self._stage_meta.outputs = extract_tensor_metas(outputs)
+        self._stage_meta.outputs = extract_tensor_metas(
+            outputs, device_mesh=self._spmd_device_mesh
+        )
 
         # Store for backward metadata inference (always, even during eval)
         fwd_kwargs_tensors = tuple(
@@ -2030,7 +2064,9 @@ class PipelineStage(_PipelineStageBase):
 
         input_grads = all_input_grads[: len(fwd_inputs)]
         self._stage_meta.input_grads = tuple(
-            extract_tensor_meta(g) if isinstance(g, torch.Tensor) else None
+            extract_tensor_meta(g, device_mesh=self._spmd_device_mesh)
+            if isinstance(g, torch.Tensor)
+            else None
             for g in input_grads
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #182864
* #181519
* #181398
* #180880

----

- Add _SpmdTypesMeta(_TensorMeta) to pipelining/_utils.py for preserving
  spmd_types annotations across PP stage boundaries
- Update extract_tensor_meta/extract_tensor_metas with optional device_mesh
- Update PipelineStage.__init__ with device_mesh parameter
- Update _retrieve_recv_activations/_retrieve_recv_grads for _SpmdTypesMeta
- Update _to_tensor, _ones_from_metadata for _SpmdTypesMeta
- Fix spmd_no_typecheck() returning non-callable nullcontext (CI fix)
- Add test_spmd_types_pp_integration.py (test_replicate, test_tp, test_fsdp_pp)

Authored by Claude.