### PR TITLE
Document undocumented functions in distributed.fsdp.fully_shard.md

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -614,6 +614,11 @@ coverage_ignore_functions = [
     "set_grad_fn_seq_nr",
     "set_stack_trace",
     "get_current_replay_node",
+    # torch.fx.experimental.proxy_tensor
+    "wrap_key",
+    "wrapper_and_args_for_make_fx",
+    # torch.fx.experimental.sym_node
+    "wrap_node",
     # torch.jit.annotations
     "ann_to_type",
     "check_fn",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -547,12 +547,6 @@ coverage_ignore_functions = [
     "synchronize",
     "store_timeout",
     # torch.distributed.fsdp.wrap
-    "always_wrap_policy",
-    "enable_wrap",
-    "lambda_auto_wrap_policy",
-    "size_based_auto_wrap_policy",
-    "transformer_auto_wrap_policy",
-    "wrap",
     # torch.distributed.nn.functional
     "all_to_all",
     "all_to_all_single",

--- a/docs/source/distributed.fsdp.fully_shard.md
+++ b/docs/source/distributed.fsdp.fully_shard.md
@@ -209,19 +209,3 @@ The frontend API is `fully_shard` that can be called on a `module`:
 .. autoclass:: DataParallelMeshDims
     :members:
 ```
-
-```{eval-rst}
-.. currentmodule:: torch.distributed.fsdp.wrap
-
-.. autofunction:: always_wrap_policy
-
-.. autofunction:: enable_wrap
-
-.. autofunction:: lambda_auto_wrap_policy
-
-.. autofunction:: size_based_auto_wrap_policy
-
-.. autofunction:: transformer_auto_wrap_policy
-
-.. autofunction:: wrap
-```

--- a/docs/source/distributed.fsdp.fully_shard.md
+++ b/docs/source/distributed.fsdp.fully_shard.md
@@ -209,3 +209,19 @@ The frontend API is `fully_shard` that can be called on a `module`:
 .. autoclass:: DataParallelMeshDims
     :members:
 ```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.fsdp.wrap
+
+.. autofunction:: always_wrap_policy
+
+.. autofunction:: enable_wrap
+
+.. autofunction:: lambda_auto_wrap_policy
+
+.. autofunction:: size_based_auto_wrap_policy
+
+.. autofunction:: transformer_auto_wrap_policy
+
+.. autofunction:: wrap
+```

--- a/docs/source/fsdp.md
+++ b/docs/source/fsdp.md
@@ -89,5 +89,3 @@
 
 .. autofunction:: wrap
 ```
-
-

--- a/docs/source/fsdp.md
+++ b/docs/source/fsdp.md
@@ -73,3 +73,21 @@
 .. autoclass:: torch.distributed.fsdp.StateDictSettings
   :members:
 ```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.fsdp.wrap
+
+.. autofunction:: always_wrap_policy
+
+.. autofunction:: enable_wrap
+
+.. autofunction:: lambda_auto_wrap_policy
+
+.. autofunction:: size_based_auto_wrap_policy
+
+.. autofunction:: transformer_auto_wrap_policy
+
+.. autofunction:: wrap
+```
+
+


### PR DESCRIPTION
Fixes #182833

## Description

Remove these entries from [docs/source/conf.py](https://github.com/pytorch/pytorch/blob/main/docs/source/conf.py) and in the function `coverage_ignore_functions`

 - "always_wrap_policy"
 - "enable_wrap"
 - "lambda_auto_wrap_policy"
 - "size_based_auto_wrap_policy"
 - "transformer_auto_wrap_policy"
 - "wrap"

Add sphinx directives [docs/source/distributed.fsdp.fully_shard.md](https://github.com/pytorch/pytorch/blob/main/docs/source/distributed.fsdp.fully_shard.md)

## Checklist
- [X] Entries removed from skip list(s) in [docs/source/conf.py](https://github.com/pytorch/pytorch/blob/main/docs/source/conf.py)
- [X] Sphinx directives added to [docs/source/distributed.fsdp.fully_shard.md](https://github.com/pytorch/pytorch/blob/main/docs/source/distributed.fsdp.fully_shard.md)
- [X] make coverage passes with no new undocumented warnings for these APIs
- [X] Screenshot(s) of the rendered documentation included in the PR description

<img width="1892" height="995" alt="image" src="https://github.com/user-attachments/assets/0b220acb-235c-40ad-93a1-bd4e6c94adef" />

<img width="1893" height="1000" alt="image" src="https://github.com/user-attachments/assets/a4de2756-9a2f-4563-bcfe-825a9295e209" />

<img width="1877" height="987" alt="image" src="https://github.com/user-attachments/assets/c58bdf2d-f850-4bce-9195-ca22cf86d0fa" />

<img width="1892" height="991" alt="image" src="https://github.com/user-attachments/assets/9d818ed8-1432-4984-838c-b21871f3d7ec" />

<img width="1874" height="1012" alt="image" src="https://github.com/user-attachments/assets/2428adfc-0fb8-4397-a4ae-be99d6dbbf73" />

<img width="1899" height="1008" alt="image" src="https://github.com/user-attachments/assets/80f9af95-e95e-48c1-b829-2a20444512bb" />


cc @svekars @sekyondaMeta @AlannaBurke