### PR TITLE
[MPS] Add fused cross-entropy Metal kernel

### DIFF
--- a/aten/src/ATen/native/mps/kernels/CrossEntropyKernel.h
+++ b/aten/src/ATen/native/mps/kernels/CrossEntropyKernel.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <c10/metal/common.h>
+
+struct CrossEntropyParams {
+  uint32_t vocab_size;
+  uint32_t batch_size;
+  int32_t ignore_index;
+  float label_smoothing;
+};

--- a/aten/src/ATen/native/mps/kernels/CrossEntropyKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/CrossEntropyKernel.metal
@@ -1,0 +1,294 @@
+#include <ATen/native/mps/kernels/CrossEntropyKernel.h>
+#include <metal_simdgroup>
+#include <metal_stdlib>
+using namespace metal;
+using c10::metal::simdgroup_size;
+
+static inline float4 ce_load_vec4(device const float* p) {
+  return *reinterpret_cast<device const packed_float4*>(p);
+}
+static inline float4 ce_load_vec4(device const half* p) {
+  return float4(*reinterpret_cast<device const packed_half4*>(p));
+}
+static inline float4 ce_load_vec4(device const bfloat* p) {
+  return float4(float(p[0]), float(p[1]), float(p[2]), float(p[3]));
+}
+
+static inline void ce_store_vec4(device float* p, float4 v) {
+  *reinterpret_cast<device packed_float4*>(p) = v;
+}
+static inline void ce_store_vec4(device half* p, float4 v) {
+  *reinterpret_cast<device packed_half4*>(p) = half4(v);
+}
+static inline void ce_store_vec4(device bfloat* p, float4 v) {
+  p[0] = static_cast<bfloat>(v[0]);
+  p[1] = static_cast<bfloat>(v[1]);
+  p[2] = static_cast<bfloat>(v[2]);
+  p[3] = static_cast<bfloat>(v[3]);
+}
+
+// Forward: compute cross-entropy loss per sample.
+// One threadgroup per batch row. Loops over vocab with online log-sum-exp.
+// Outputs: loss[B] (unreduced), lse[B] (for backward recomputation).
+template <typename T>
+kernel void cross_entropy_forward(
+    device const T* logits [[buffer(0)]],
+    device const int64_t* target [[buffer(1)]],
+    device float* loss [[buffer(2)]],
+    device float* lse [[buffer(3)]],
+    constant CrossEntropyParams& params [[buffer(4)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint V = params.vocab_size;
+  int32_t ignore_idx = params.ignore_index;
+  float smoothing = params.label_smoothing;
+
+  int64_t tgt = target[tg_id];
+  device const T* row = logits + uint64_t(tg_id) * V;
+
+  // Check ignore_index
+  if (tgt == int64_t(ignore_idx)) {
+    if (tid == 0) {
+      loss[tg_id] = 0.0f;
+      lse[tg_id] = 0.0f;
+    }
+    return;
+  }
+
+  // Pass 1: online log-sum-exp + find target logit + sum of all logits (for
+  // label smoothing)
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  float local_logit_sum = 0.0f;
+  float target_logit = 0.0f;
+  bool found_target = false;
+
+  for (uint r = 0; r < V; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= V) {
+      float4 v = ce_load_vec4(row + base);
+      float chunk_max = fmax(fmax(v.x, v.y), fmax(v.z, v.w));
+      float new_max = fmax(local_max, chunk_max);
+      local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+          metal::precise::exp(v.x - new_max) +
+          metal::precise::exp(v.y - new_max) +
+          metal::precise::exp(v.z - new_max) +
+          metal::precise::exp(v.w - new_max);
+      local_max = new_max;
+      local_logit_sum += v.x + v.y + v.z + v.w;
+
+      // Check if target falls in this chunk
+      for (int i = 0; i < N_READS; i++) {
+        if (int64_t(base + i) == tgt) {
+          target_logit = v[i];
+          found_target = true;
+        }
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), V); i++) {
+        float val = float(row[i]);
+        float new_max = fmax(local_max, val);
+        local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+            metal::precise::exp(val - new_max);
+        local_max = new_max;
+        local_logit_sum += val;
+        if (int64_t(i) == tgt) {
+          target_logit = val;
+          found_target = true;
+        }
+      }
+    }
+  }
+
+  // Reduce max across threadgroup.
+  // Guard: when all threads in a simdgroup are idle, local_max and sg_max
+  // are both -inf. exp(-inf - (-inf)) = exp(NaN) = NaN, which poisons the
+  // sum. Use factor=0 when sg_max is -inf (no valid data in this simdgroup).
+  float sg_max = simd_max(local_max);
+  float rescale = (sg_max == -INFINITY) ? 0.0f
+      : metal::precise::exp(local_max - sg_max);
+  local_sum *= rescale;
+
+  float sg_sum = simd_sum(local_sum);
+  float sg_logit_sum = simd_sum(local_logit_sum);
+
+  threadgroup float shared_max[simdgroup_size];
+  threadgroup float shared_sum[simdgroup_size];
+  threadgroup float shared_logit_sum[simdgroup_size];
+  threadgroup float tg_result[4]; // max, sum, target_logit, logit_sum
+
+  if (simd_lane_id == 0) {
+    shared_max[simdgroup_id] = sg_max;
+    shared_sum[simdgroup_id] = sg_sum;
+    shared_logit_sum[simdgroup_id] = sg_logit_sum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (simdgroup_id == 0) {
+    float m = (simd_lane_id < lsize / simdgroup_size)
+        ? shared_max[simd_lane_id]
+        : -INFINITY;
+    float global_max = simd_max(m);
+    float s = (simd_lane_id < lsize / simdgroup_size)
+        ? shared_sum[simd_lane_id] * metal::precise::exp(m - global_max)
+        : 0.0f;
+    float global_sum = simd_sum(s);
+    float ls = (simd_lane_id < lsize / simdgroup_size)
+        ? shared_logit_sum[simd_lane_id]
+        : 0.0f;
+    float global_logit_sum = simd_sum(ls);
+    if (simd_lane_id == 0) {
+      tg_result[0] = global_max;
+      tg_result[1] = global_sum;
+      tg_result[3] = global_logit_sum;
+    }
+  }
+
+  // Broadcast target_logit: exactly one thread found it
+  threadgroup float shared_target[1];
+  if (found_target) {
+    shared_target[0] = target_logit;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    float row_max = tg_result[0];
+    float total_sum = tg_result[1];
+    float logit_sum = tg_result[3];
+    float tgt_logit = shared_target[0];
+
+    float log_sum_exp = row_max + metal::precise::log(total_sum);
+    lse[tg_id] = log_sum_exp;
+
+    // NLL component: -log_softmax(target)
+    float nll = -(tgt_logit - log_sum_exp);
+
+    if (smoothing > 0.0f) {
+      // Label smoothing: (1-eps)*nll + eps*(lse - mean_logit)
+      float smooth_loss = log_sum_exp - logit_sum / float(V);
+      loss[tg_id] = (1.0f - smoothing) * nll + smoothing * smooth_loss;
+    } else {
+      loss[tg_id] = nll;
+    }
+  }
+}
+
+// Backward: compute gradient of cross-entropy w.r.t. logits.
+// grad_input[b,c] = grad_out[b] * (softmax(logit[b,c]) - (c == target[b]))
+// Recomputes softmax on-the-fly from saved lse.
+template <typename T>
+kernel void cross_entropy_backward(
+    device const float* grad_output [[buffer(0)]],
+    device const T* logits [[buffer(1)]],
+    device const int64_t* target [[buffer(2)]],
+    device const float* lse [[buffer(3)]],
+    device T* grad_input [[buffer(4)]],
+    constant CrossEntropyParams& params [[buffer(5)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint V = params.vocab_size;
+  int32_t ignore_idx = params.ignore_index;
+  float smoothing = params.label_smoothing;
+
+  int64_t tgt = target[tg_id];
+  float grad_out = grad_output[tg_id];
+  device const T* row_in = logits + uint64_t(tg_id) * V;
+  device T* row_out = grad_input + uint64_t(tg_id) * V;
+
+  // If ignored, zero the gradient
+  if (tgt == int64_t(ignore_idx)) {
+    for (uint r = 0; r < V; r += lsize * N_READS) {
+      uint base = r + tid * N_READS;
+      if (base + N_READS <= V) {
+        ce_store_vec4(row_out + base, float4(0.0f));
+      } else {
+        for (uint i = base; i < min(base + uint(N_READS), V); i++) {
+          row_out[i] = static_cast<T>(0.0f);
+        }
+      }
+    }
+    return;
+  }
+
+  float row_lse = lse[tg_id];
+  float inv_V = 1.0f / float(V);
+
+  for (uint r = 0; r < V; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= V) {
+      float4 v = ce_load_vec4(row_in + base);
+      float4 sm = float4(
+          metal::precise::exp(v.x - row_lse),
+          metal::precise::exp(v.y - row_lse),
+          metal::precise::exp(v.z - row_lse),
+          metal::precise::exp(v.w - row_lse));
+
+      float4 grad;
+      if (smoothing > 0.0f) {
+        // d/dx of (1-eps)*nll + eps*smooth_loss
+        // = (1-eps)*(sm - one_hot) + eps*(sm - 1/V)
+        // = sm - (1-eps)*one_hot - eps/V
+        for (int i = 0; i < N_READS; i++) {
+          float indicator = (int64_t(base + i) == tgt) ? 1.0f : 0.0f;
+          grad[i] =
+              grad_out * (sm[i] - (1.0f - smoothing) * indicator - smoothing * inv_V);
+        }
+      } else {
+        for (int i = 0; i < N_READS; i++) {
+          float indicator = (int64_t(base + i) == tgt) ? 1.0f : 0.0f;
+          grad[i] = grad_out * (sm[i] - indicator);
+        }
+      }
+      ce_store_vec4(row_out + base, grad);
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), V); i++) {
+        float val = float(row_in[i]);
+        float sm = metal::precise::exp(val - row_lse);
+        float indicator = (int64_t(i) == tgt) ? 1.0f : 0.0f;
+        float g;
+        if (smoothing > 0.0f) {
+          g = grad_out * (sm - (1.0f - smoothing) * indicator - smoothing * inv_V);
+        } else {
+          g = grad_out * (sm - indicator);
+        }
+        row_out[i] = static_cast<T>(g);
+      }
+    }
+  }
+}
+
+#define INSTANTIATE_CE(DTYPE)                                                  \
+  template [[host_name("cross_entropy_forward_" #DTYPE)]] kernel void         \
+  cross_entropy_forward<DTYPE>(                                               \
+      device const DTYPE* logits [[buffer(0)]],                               \
+      device const int64_t* target [[buffer(1)]],                             \
+      device float* loss [[buffer(2)]],                                       \
+      device float* lse [[buffer(3)]],                                        \
+      constant CrossEntropyParams& params [[buffer(4)]],                      \
+      uint tg_id [[threadgroup_position_in_grid]],                            \
+      uint tid [[thread_position_in_threadgroup]],                            \
+      uint lsize [[threads_per_threadgroup]],                                 \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                        \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);                   \
+                                                                              \
+  template [[host_name("cross_entropy_backward_" #DTYPE)]] kernel void        \
+  cross_entropy_backward<DTYPE>(                                              \
+      device const float* grad_output [[buffer(0)]],                          \
+      device const DTYPE* logits [[buffer(1)]],                               \
+      device const int64_t* target [[buffer(2)]],                             \
+      device const float* lse [[buffer(3)]],                                  \
+      device DTYPE* grad_input [[buffer(4)]],                                 \
+      constant CrossEntropyParams& params [[buffer(5)]],                      \
+      uint tg_id [[threadgroup_position_in_grid]],                            \
+      uint tid [[thread_position_in_threadgroup]],                            \
+      uint lsize [[threads_per_threadgroup]]);
+
+INSTANTIATE_CE(float)
+INSTANTIATE_CE(half)
+INSTANTIATE_CE(bfloat)

--- a/aten/src/ATen/native/mps/operations/CrossEntropy.mm
+++ b/aten/src/ATen/native/mps/operations/CrossEntropy.mm
@@ -1,0 +1,139 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/CrossEntropyKernel.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_mps_fused_cross_entropy_backward_native.h>
+#include <ATen/ops/_mps_fused_cross_entropy_forward_native.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/empty_like.h>
+#endif
+
+namespace at::native {
+
+namespace mps {
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& ce_lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/CrossEntropyKernel_metallib.h>
+static auto& ce_lib = lib;
+#endif
+
+} // namespace mps
+
+std::tuple<Tensor, Tensor> _mps_fused_cross_entropy_forward(
+    const Tensor& logits,
+    const Tensor& target,
+    int64_t ignore_index,
+    double label_smoothing) {
+  using namespace mps;
+  TORCH_CHECK(
+      logits.dim() == 2,
+      "fused cross entropy expects 2D logits, got ",
+      logits.dim(),
+      "D");
+  TORCH_CHECK(
+      logits.is_contiguous(),
+      "fused cross entropy expects contiguous logits");
+  TORCH_CHECK(
+      logits.scalar_type() == kFloat || logits.scalar_type() == kHalf ||
+          logits.scalar_type() == kBFloat16,
+      "fused cross entropy supports float32/float16/bfloat16, got ",
+      logits.scalar_type());
+
+  int64_t B = logits.size(0);
+  int64_t V = logits.size(1);
+
+  auto loss = at::empty({B}, logits.options().dtype(kFloat));
+  auto lse = at::empty({B}, logits.options().dtype(kFloat));
+
+  Tensor target_i64 = target.to(kLong);
+
+  CrossEntropyParams params = {};
+  params.vocab_size = static_cast<uint32_t>(V);
+  params.batch_size = static_cast<uint32_t>(B);
+  params.ignore_index = static_cast<int32_t>(ignore_index);
+  params.label_smoothing = static_cast<float>(label_smoothing);
+
+  std::string kname = fmt::format(
+      "cross_entropy_forward_{}", scalarToMetalTypeString(logits));
+
+  MPSStream* mpsStream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      auto computeEncoder = mpsStream->commandEncoder();
+      auto pso = ce_lib.getPipelineStateForFunc(kname);
+      [computeEncoder setComputePipelineState:pso];
+      mtl_setArgs(computeEncoder, logits, target_i64, loss, lse, params);
+
+      uint32_t tg_size = 1024;
+      tg_size = std::min(
+          tg_size,
+          static_cast<uint32_t>([pso maxTotalThreadsPerThreadgroup]));
+      tg_size = (tg_size / [pso threadExecutionWidth]) *
+          [pso threadExecutionWidth];
+
+      [computeEncoder
+          dispatchThreadgroups:MTLSizeMake(B, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(tg_size, 1, 1)];
+    }
+  });
+
+  return {loss, lse};
+}
+
+Tensor _mps_fused_cross_entropy_backward(
+    const Tensor& grad_output,
+    const Tensor& logits,
+    const Tensor& target,
+    const Tensor& lse,
+    int64_t ignore_index,
+    double label_smoothing) {
+  using namespace mps;
+
+  int64_t B = logits.size(0);
+  int64_t V = logits.size(1);
+
+  auto grad_input = at::empty_like(logits);
+  Tensor target_i64 = target.to(kLong);
+
+  CrossEntropyParams params = {};
+  params.vocab_size = static_cast<uint32_t>(V);
+  params.batch_size = static_cast<uint32_t>(B);
+  params.ignore_index = static_cast<int32_t>(ignore_index);
+  params.label_smoothing = static_cast<float>(label_smoothing);
+
+  std::string kname = fmt::format(
+      "cross_entropy_backward_{}", scalarToMetalTypeString(logits));
+
+  MPSStream* mpsStream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      auto computeEncoder = mpsStream->commandEncoder();
+      auto pso = ce_lib.getPipelineStateForFunc(kname);
+      [computeEncoder setComputePipelineState:pso];
+      mtl_setArgs(
+          computeEncoder, grad_output, logits, target_i64, lse, grad_input,
+          params);
+
+      uint32_t tg_size = 1024;
+      tg_size = std::min(
+          tg_size,
+          static_cast<uint32_t>([pso maxTotalThreadsPerThreadgroup]));
+      tg_size = (tg_size / [pso threadExecutionWidth]) *
+          [pso threadExecutionWidth];
+
+      [computeEncoder
+          dispatchThreadgroups:MTLSizeMake(B, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(tg_size, 1, 1)];
+    }
+  });
+
+  return grad_input;
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/CrossEntropy.mm
+++ b/aten/src/ATen/native/mps/operations/CrossEntropy.mm
@@ -98,6 +98,7 @@ Tensor _mps_fused_cross_entropy_backward(
   int64_t B = logits.size(0);
   int64_t V = logits.size(1);
 
+  Tensor grad_out_c = grad_output.contiguous();
   auto grad_input = at::empty_like(logits);
   Tensor target_i64 = target.to(kLong);
 
@@ -117,7 +118,7 @@ Tensor _mps_fused_cross_entropy_backward(
       auto pso = ce_lib.getPipelineStateForFunc(kname);
       [computeEncoder setComputePipelineState:pso];
       mtl_setArgs(
-          computeEncoder, grad_output, logits, target_i64, lse, grad_input,
+          computeEncoder, grad_out_c, logits, target_i64, lse, grad_input,
           params);
 
       uint32_t tg_size = 1024;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -15273,6 +15273,14 @@
     MPS: _scaled_dot_product_attention_math_mps
   tags: nondeterministic_seeded
 
+- func: _mps_fused_cross_entropy_forward(Tensor logits, Tensor target, int ignore_index=-100, float label_smoothing=0.0) -> (Tensor, Tensor)
+  dispatch:
+    MPS: _mps_fused_cross_entropy_forward
+
+- func: _mps_fused_cross_entropy_backward(Tensor grad_output, Tensor logits, Tensor target, Tensor lse, int ignore_index=-100, float label_smoothing=0.0) -> Tensor
+  dispatch:
+    MPS: _mps_fused_cross_entropy_backward
+
 - func: _scaled_dot_product_flash_attention(Tensor query, Tensor key, Tensor value, float dropout_p=0.0, bool is_causal=False, bool return_debug_mask=False, *, float? scale=None) -> (Tensor output, Tensor logsumexp, Tensor cum_seq_q, Tensor cum_seq_k, SymInt max_q, SymInt max_k, Tensor rng_state, Tensor unused, Tensor debug_attn_mask)
   dispatch:
     CUDA: _scaled_dot_product_flash_attention_cuda

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3510,6 +3510,21 @@ def cross_entropy(
         )
     if size_average is not None or reduce is not None:
         reduction = _Reduction.legacy_get_string(size_average, reduce)
+    # Fused cross-entropy for MPS: single Metal kernel replaces
+    # log_softmax + nll_loss, eliminating the [B, V] intermediate tensor.
+    if (
+        input.device.type == "mps"
+        and input.dim() == 2
+        and input.is_contiguous()
+        and target.dim() == 1
+        and target.dtype in (torch.int32, torch.int64)
+        and weight is None
+        and (input.dtype in (torch.float32, torch.float16, torch.bfloat16))
+    ):
+        return _mps_fused_cross_entropy(
+            input, target, ignore_index, label_smoothing, reduction
+        )
+
     return torch._C._nn.cross_entropy_loss(
         input,
         target,
@@ -3519,6 +3534,38 @@ def cross_entropy(
         ignore_index,
         label_smoothing,
     )
+
+
+def _mps_fused_cross_entropy(input, target, ignore_index, label_smoothing, reduction):
+    class _Fn(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, logits, target, ignore_index, label_smoothing):  # type: ignore[override]
+            loss, lse = torch.ops.aten._mps_fused_cross_entropy_forward(
+                logits, target, ignore_index, label_smoothing
+            )
+            ctx.save_for_backward(logits, target, lse)
+            ctx.ignore_index = ignore_index
+            ctx.label_smoothing = label_smoothing
+            return loss
+
+        @staticmethod
+        def backward(ctx, grad_output):  # type: ignore[override]
+            logits, target, lse = ctx.saved_tensors
+            grad_output = grad_output.contiguous()
+            grad_input = torch.ops.aten._mps_fused_cross_entropy_backward(
+                grad_output, logits, target, lse,
+                ctx.ignore_index, ctx.label_smoothing
+            )
+            return grad_input, None, None, None
+
+    loss = _Fn.apply(input, target, ignore_index, label_smoothing)
+    if reduction == "none":
+        return loss
+    elif reduction == "sum":
+        return loss.sum()
+    else:  # "mean"
+        count = (target != ignore_index).sum()
+        return loss.sum() / count.clamp(min=1)
 
 
 def binary_cross_entropy(


### PR DESCRIPTION
## Summary

Adds a fused cross-entropy loss Metal kernel for MPS that replaces the current log_softmax -> nll_loss decomposition with a single compute pass. This eliminates the [B, V] intermediate tensor that log_softmax materializes and NLL loss reads exactly one element of per row.

**Forward kernel**: Single-pass online log-sum-exp with vec4 loads, finding the target logit and accumulating the log-sum-exp in registers. One threadgroup per batch row, 1024 threads, looped over vocab. Outputs per-sample loss and saved LSE for backward recomputation.

**Backward kernel**: Recomputes softmax = exp(logit - lse) on-the-fly from saved LSE, writes grad_out * (softmax - indicator) directly. No intermediate softmax tensor stored.

**Python routing**: F.cross_entropy dispatches to the fused kernel when: device is MPS, logits are 2D contiguous, targets are integer, no per-class weights, supported dtype (float32/float16/bfloat16).

Falls back to decomposed path when conditions are not met (per-class weights, non-2D input, soft targets, etc.).

### Features
- ignore_index support (zero loss + zero gradient for ignored samples)
- label_smoothing support (combined NLL + uniform smooth loss in single pass)
- All three reduction modes: none, mean, sum
- float32, float16, bfloat16

### Bug fixes during development
- **NaN for small vocab**: When idle simdgroups have all threads with local_max = -inf, exp(-inf - (-inf)) = NaN poisons the reduction. Guarded with (sg_max == -INFINITY) ? 0.0f : exp(...).
- **Non-contiguous grad_output**: Autograd backward through .sum() creates grad_output by expanding a scalar (stride=0, storage_size=1). The Metal kernel indexes by grad_output[tg_id], reading out-of-bounds for tg_id > 0. Fixed by calling .contiguous() in both the .mm dispatch and the Python autograd.Function.

## Benchmarks

M4 Pro, mean of 5 runs (warmup=30, iters=100):

| Shape | Forward | Fwd+Bwd |
|-------|---------|---------|
| (1, 128256) | 1.17x | 1.16x |
| (8, 128256) | 1.47x | 1.73x |
| (32, 32000) | 1.50x | 1.99x |
| (256, 1000) | 1.32x | 1.70x |
| (8, 128256) label_smoothing=0.1 | **7.93x** | **5.95x** |

Memory: eliminates the [B, V] float32 intermediate (e.g., 3.9 MB for [8, 128256]).

## Test plan

- [x] Correctness vs CPU F.cross_entropy for shapes (1,100), (1,128256), (8,128256), (32,32000), (256,1000)
- [x] All three reductions (none, mean, sum) x all shapes
- [x] ignore_index with 2/8 samples masked
- [x] label_smoothing=0.1 x all reductions
- [x] Forward + backward gradient matching (max_diff < 1e-4 in all cases, typically < 1e-8)
- [x] Direct kernel call correctness (28 tests)
- [x] End-to-end through F.cross_entropy autograd chain
- [ ] CI: test_mps.py cross-entropy tests

cc @malfet @kulinseth
