### PR TITLE
[AI Codemod][PerfAICT-VecRealloc] perf: reserve() upfront to avoid reallocation (#181786)

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
+++ b/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
@@ -85,6 +85,7 @@ inline AdvancedIndex make_info(Tensor self, IOptTensorListRef orig) {
         shapes_as_str(indices));
   }
   // add missing null Tensors so that it matches self.dim()
+  indices.reserve(self.dim());
   while (indices.size() < (size_t)self.dim()) {
     indices.emplace_back();
   }


### PR DESCRIPTION
Summary:

This diff pre-allocates capacity for the vector `indices` via `indices.reserve(self.dim())` before the while loop that calls `indices.emplace_back()`. The size `self.dim()` is the known final size of the vector after the loop completes, so this single reserve call eliminates all potential reallocations during the loop iterations. The vector is local to `make_info` and does not escape the function, so `reserve` (rather than `folly::grow_capacity_by`) is appropriate.

Reviewed By: lexprfuncall

Differential Revision: D102177228


