### PR TITLE
test: skip some test_non_standard_bool_values test cases

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15028,6 +15028,9 @@ op_db: list[OpInfo] = [
                # Compiler issue on ROCm. Regression started in ROCm 6.4.
                DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
+               # CUB produces incorrect boolean truth values whith non-standard bool values.
+               DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
+                            dtypes=[torch.bool], device_type='cuda'),
                # Exception: RuntimeError not raised : inplace variant either incorrectly allowed resizing
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager', device_type='mps'),
                # Exception: "masked_scatter_ only supports boolean masks" does not match
@@ -16800,6 +16803,9 @@ op_db: list[OpInfo] = [
                # Compiler issue on ROCm. Regression started in ROCm 6.4.
                DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
+               # CUB produces incorrect boolean truth values whith non-standard bool values.
+               DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
+                            dtypes=[torch.bool], device_type='cuda'),
                # RuntimeError: Failed to create function state object for: col2im_kernel_float2
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
                DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64,)),
@@ -20104,6 +20110,9 @@ op_db: list[OpInfo] = [
                # Compiler issue on ROCm. Regression started in ROCm 6.4.
                DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
+               # CUB produces incorrect boolean truth values whith non-standard bool values.
+               DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
+                            dtypes=[torch.bool], device_type='cuda'),
            )),
     UnaryUfuncInfo(
         'bfloat16',
@@ -20917,6 +20926,9 @@ op_db: list[OpInfo] = [
                # Compiler issue on ROCm. Regression started in ROCm 6.4.
                DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
+               # CUB produces incorrect boolean truth values whith non-standard bool values.
+               DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
+                            dtypes=[torch.bool], device_type='cuda'),
            )),
     OpInfo('stack',
            dtypes=all_types_and_complex_and(torch.complex32, torch.bool, torch.float16, torch.bfloat16),
@@ -21138,7 +21150,12 @@ op_db: list[OpInfo] = [
            check_batched_gradgrad=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           sample_inputs_func=sample_inputs_msort),
+           sample_inputs_func=sample_inputs_msort,
+           skips=(
+                # CUB produces incorrect boolean truth values whith non-standard bool values.
+                DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
+                            dtypes=[torch.bool], device_type='cuda'),
+           )),
     OpInfo('movedim',
            aliases=('moveaxis',),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16, torch.chalf),
@@ -21518,6 +21535,9 @@ op_db: list[OpInfo] = [
                # Compiler issue on ROCm. Regression started in ROCm 6.4.
                DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
+               # CUB produces incorrect boolean truth values whith non-standard bool values.
+               DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
+                            dtypes=[torch.bool], device_type='cuda'),
            )),
     OpInfo('triu',
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16, torch.chalf),
@@ -21529,6 +21549,9 @@ op_db: list[OpInfo] = [
                # Compiler issue on ROCm. Regression started in ROCm 6.4.
                DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
+               # CUB produces incorrect boolean truth values whith non-standard bool values.
+               DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
+                            dtypes=[torch.bool], device_type='cuda'),
            )),
     OpInfo('triu_indices',
            dtypes=_dispatch_dtypes((torch.int32, torch.int64)),
@@ -21909,6 +21932,9 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestVmapOperatorsOpInfo', 'test_op_has_batch_rule'),
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
+               # CUB produces incorrect boolean truth values whith non-standard bool values.
+               DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
+                            dtypes=[torch.bool], device_type='cuda'),
            )),
     # Following tests are for jiterator's python interface
     # Jiterator can be used to author elementwise CUDA kernel
@@ -23344,6 +23370,9 @@ op_db: list[OpInfo] = [
             # Compiler issue on ROCm. Regression started in ROCm 6.4.
             DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
                          dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
+            # CUB produces incorrect boolean truth values whith non-standard bool values.
+            DecorateInfo(unittest.skip('Skipped!'), 'TestCommon', 'test_non_standard_bool_values',
+                        dtypes=[torch.bool], device_type='cuda'),
         ),
     ),
     OpInfo(


### PR DESCRIPTION
Skip `test_non_standard_bool_values` cases with `cuda` for:
- `masked_scatter`
- `msort`
- `nn_functional_unfold`
- `nonzero_static`
- `scatter` / `scatter_add` / `scatter_reduce_sum`
- `tril` / `triu`

CUB produces incorrect boolean truth values whith non-standard bool values as shown in the logs.

<details>
  <summary>Logs</summary>

  ```python
FAILED test/test_ops.py::TestCommonCUDA::test_non_standard_bool_values_masked_scatter_cuda_bool - Exception: Tensor-likes are not equal!

Mismatched elements: 3 / 25 (12.0%)
Greatest absolute difference: 1 at index (1, 0)
Greatest relative difference: inf at index (1, 0)

Caused by sample input at index 0: SampleInput(input=Tensor[size=(5, 5), device="cuda:0", dtype=torch.bool], args=TensorList[Tensor[size=(5, 5), device="cuda:0", dtype=torch.bool], Tensor[size=(5, 5), device="cuda:0", dtype=torch.bool]], kwargs={}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python [test/test_ops](http://test/test_ops).py TestCommonCUDA.test_non_standard_bool_values_masked_scatter_cuda_bool

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED test/test_ops.py::TestCommonCUDA::test_non_standard_bool_values_msort_cuda_bool - Exception: Tensor-likes are not equal!

Mismatched elements: 64 / 250 (25.6%)
Greatest absolute difference: 1 at index (0, 1, 0)
Greatest relative difference: inf at index (0, 1, 0)

Caused by sample input at index 1: SampleInput(input=Tensor[size=(5, 10, 5), device="cuda:0", dtype=torch.bool], args=(), kwargs={}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=1 PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python [test/test_ops](http://test/test_ops).py TestCommonCUDA.test_non_standard_bool_values_msort_cuda_bool

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED test/test_ops.py::TestCommonCUDA::test_non_standard_bool_values_nn_functional_unfold_cuda_bool - Exception: Tensor-likes are not equal!

Mismatched elements: 110 / 384 (28.6%)
Greatest absolute difference: 1 at index (0, 0, 5)
Greatest relative difference: inf at index (0, 0, 5)

Caused by sample input at index 81: SampleInput(input=Tensor[size=(2, 3, 5, 5), device="cuda:0", dtype=torch.bool], args=(2,1,0,1), kwargs={}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=81 PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python [test/test_ops](http://test/test_ops).py TestCommonCUDA.test_non_standard_bool_values_nn_functional_unfold_cuda_bool

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED test/test_ops.py::TestCommonCUDA::test_non_standard_bool_values_nonzero_static_cuda_bool - Exception: Tensor-likes are not equal!

Mismatched elements: 2 / 5 (40.0%)
Greatest absolute difference: 72058693549555714 at index (3, 0)
Greatest relative difference: 1.0 at index (3, 0)

Caused by sample input at index 18: SampleInput(input=Tensor[size=(5,), device="cuda:0", dtype=torch.bool], args=(), kwargs={'size': '5'}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=18 PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python test/test_ops.py TestCommonCUDA.test_non_standard_bool_values_nonzero_static_cuda_bool

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED test/test_ops.py::TestCommonCUDA::test_non_standard_bool_values_scatter_add_cuda_bool - Exception: Tensor-likes are not equal!

Mismatched elements: 1 / 50 (2.0%)
Greatest absolute difference: 1 at index (4, 1)
Greatest relative difference: inf at index (4, 1)

Caused by sample input at index 0: SampleInput(input=Tensor[size=(10, 5), device="cuda:0", dtype=torch.bool], args=(0,Tensor[size=(5, 5), device="cuda:0", dtype=torch.int64],Tensor[size=(5, 5), device="cuda:0", dtype=torch.bool]), kwargs={}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python test/test_ops.py TestCommonCUDA.test_non_standard_bool_values_scatter_add_cuda_bool

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED [test/test_ops](http://test/test_ops).py::TestCommonCUDA::test_non_standard_bool_values_scatter_cuda_bool - Exception: Tensor-likes are not equal!

Mismatched elements: 3 / 50 (6.0%)
Greatest absolute difference: 1 at index (1, 3)
Greatest relative difference: inf at index (1, 3)

Caused by sample input at index 1: SampleInput(input=Tensor[size=(10, 5), device="cuda:0", dtype=torch.bool], args=(0,Tensor[size=(5, 5), device="cuda:0", dtype=torch.int64],Tensor[size=(5, 5), device="cuda:0", dtype=torch.bool]), kwargs={'reduce': "'add'"}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=1 PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python test/test_ops.py TestCommonCUDA.test_non_standard_bool_values_scatter_cuda_bool

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED test/test_ops.py::TestCommonCUDA::test_non_standard_bool_values_scatter_reduce_sum_cuda_bool - Exception: Tensor-likes are not equal!

Mismatched elements: 3 / 50 (6.0%)
Greatest absolute difference: 1 at index (2, 4)
Greatest relative difference: inf at index (2, 4)

Caused by sample input at index 0: SampleInput(input=Tensor[size=(10, 5), device="cuda:0", dtype=torch.bool], args=(0,Tensor[size=(5, 5), device="cuda:0", dtype=torch.int64],Tensor[size=(5, 5), device="cuda:0", dtype=torch.bool],'sum'), kwargs={'include_self': 'False'}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python test/test_ops.py TestCommonCUDA.test_non_standard_bool_values_scatter_reduce_sum_cuda_bool

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED test/test_ops.py::TestCommonCUDA::test_non_standard_bool_values_tril_cuda_bool - Exception: Tensor-likes are not equal!

Mismatched elements: 18 / 100 (18.0%)
Greatest absolute difference: 1 at index (1, 0)
Greatest relative difference: inf at index (1, 0)

Caused by sample input at index 0: SampleInput(input=Tensor[size=(10, 10), device="cuda:0", dtype=torch.bool], args=(), kwargs={}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python [test/test_ops](http://test/test_ops).py TestCommonCUDA.test_non_standard_bool_values_tril_cuda_bool

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
FAILED test/test_ops.py::TestCommonCUDA::test_non_standard_bool_values_triu_cuda_bool - Exception: Tensor-likes are not equal!

Mismatched elements: 15 / 100 (15.0%)
Greatest absolute difference: 1 at index (0, 6)
Greatest relative difference: inf at index (0, 6)

Caused by sample input at index 0: SampleInput(input=Tensor[size=(10, 10), device="cuda:0", dtype=torch.bool], args=(), kwargs={}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 PYTORCH_TEST_WITH_ASAN=1 PYTORCH_TEST_WITH_UBSAN=1 python test/test_ops.py TestCommonCUDA.test_non_standard_bool_values_triu_cuda_bool

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
= 9 failed, 326 passed, 11 skipped, 68055 deselected, 2 xfailed, 2 warnings in 88.39s (0:01:28) =
  ```
</details>