### PR TITLE
[ci] Fix torchtitan test flake from ciflow tag collision

### DIFF
--- a/.ci/lumen_cli/cli/lib/common/git_helper.py
+++ b/.ci/lumen_cli/cli/lib/common/git_helper.py
@@ -41,7 +41,7 @@ def clone_external_repo(target: str, repo: str, dst: str = "", update_submodules
         # Clone and fetch
         remove_dir(dst)
         r = Repo.clone_from(repo, dst, progress=PrintProgress())
-        r.git.fetch("--all", "--tags")
+        r.git.fetch("--all", "--tags", "--force")
 
         # Checkout pinned commit
         commit = get_post_build_pinned_commit(target)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182875

Use `--force` with `git fetch --tags` so that force-updated ephemeral ciflow tags on the torchtitan repo don't cause the fetch to fail when they collide with stale cached tags.

Authored by Claude.