### PR TITLE
[Docathon] Document undocumented functions in distributed.tensor.parallel.md (3 functions) 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -571,12 +571,6 @@ coverage_ignore_functions = [
     # torch.distributed.rpc.internal
     "deserialize",
     "serialize",
-    # torch.distributed.tensor.parallel.api
-    "parallelize_module",
-    # torch.distributed.tensor.parallel.input_reshard
-    "input_reshard",
-    # torch.distributed.tensor.parallel.loss
-    "loss_parallel",
     # torch.distributed.tensor.parallel.style
     "make_sharded_output_tensor",
     # torch.fx.passes.dialect.common.cse_pass

--- a/docs/source/distributed.tensor.parallel.md
+++ b/docs/source/distributed.tensor.parallel.md
@@ -26,6 +26,11 @@ The entrypoint to parallelize your `nn.Module` using Tensor Parallelism is:
 .. autofunction::  parallelize_module
 ```
 
+```{eval-rst}
+.. currentmodule:: torch.distributed.tensor.parallel.api
+.. autofunction:: parallelize_module
+```
+
 Tensor Parallelism supports the following parallel styles:
 
 ```{eval-rst}
@@ -90,3 +95,13 @@ Parallelized cross-entropy loss computation (loss parallelism), is supported via
 :::{warning}
     The loss_parallel API is experimental and subject to change.
 :::
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.tensor.parallel.loss
+.. autofunction:: loss_parallel
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.tensor.parallel.input_reshard
+.. autofunction:: input_reshard
+```


### PR DESCRIPTION
Fixes #182834

## Description

Documents three public Tensor Parallel APIs by adding Sphinx autodoc directives to `docs/source/distributed.tensor.parallel.md` and removing the corresponding entries from `coverage_ignore_functions` in `docs/source/conf.py`.

Documented APIs:
- `torch.distributed.tensor.parallel.api.parallelize_module`
- `torch.distributed.tensor.parallel.input_reshard.input_reshard`
- `torch.distributed.tensor.parallel.loss.loss_parallel`

## Verification

- `make coverage` passes with no undocumented warnings for these APIs.
- Targeted `make html` / Sphinx HTML build passes.
- Rendered documentation was checked in `docs/build/html/distributed.tensor.parallel.html`.

## Screenshots

Attach the rendered screenshots for:
- `torch.distributed.tensor.parallel.api.parallelize_module` :
<img width="1009" height="499" alt="Screenshot 2026-05-08 at 1 09 49 AM" src="https://github.com/user-attachments/assets/3e565627-fb21-4ae7-936e-55ba8ed91f72" />

- `torch.distributed.tensor.parallel.input_reshard.input_reshard` :
<img width="1031" height="485" alt="Screenshot 2026-05-08 at 1 09 11 AM" src="https://github.com/user-attachments/assets/52e76a51-a4b6-4f87-9ca1-8e97bfa90ecd" />


- `torch.distributed.tensor.parallel.loss.loss_parallel`:
<img width="1042" height="480" alt="Screenshot 2026-05-08 at 1 09 26 AM" src="https://github.com/user-attachments/assets/3daefd2f-a7d4-4b6d-847c-40b100a88baf" />


## Checklist

<!-- Make sure to add `x` to all items in the following checklist: -->
- [x] Entries removed from skip list(s) in `docs/source/conf.py`
- [x] Sphinx directives added to `docs/source/distributed.tensor.parallel.md`
- [x] `make coverage` passes with no new undocumented warnings for these APIs
- [x] Screenshot(s) of the rendered documentation included in the PR description

cc: @sekyondaMeta @svekars 


cc @svekars @sekyondaMeta @AlannaBurke