### PR TITLE
[dynamo] Implement the nb_absolute slot

### DIFF
--- a/test/dynamo/test_nb_unary.py
+++ b/test/dynamo/test_nb_unary.py
@@ -1,5 +1,5 @@
 # Owner(s): ["module: dynamo"]
-"""Tests for nb_negative / nb_positive: unary ops via PyNumber_Negative/Positive."""
+"""Tests for nb unary: unary ops via PyNumber_slot."""
 
 import operator
 import sys
@@ -686,7 +686,7 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(result, fn(x))
 
-    # --- op specific tests ---    
+    # --- op specific tests ---
 
     # --- complex abs overflow (OverflowError from _Py_c_abs) ---
     # CPython's complex_abs calls _Py_c_abs which sets errno=ERANGE when
@@ -699,10 +699,11 @@ class NbUnaryTests(TestCase):
             except OverflowError as e:
                 return str(e)
 
+        eager_result = fn(0)
         result = torch.compile(fn, backend="eager", fullgraph=True)(
             torch.tensor(0)
         )
-        self.assertEqual(result, "absolute value too large")
+        self.assertEqual(result, eager_result)
 
 
 instantiate_parametrized_tests(NbUnaryTests)

--- a/test/dynamo/test_nb_unary.py
+++ b/test/dynamo/test_nb_unary.py
@@ -2,6 +2,7 @@
 """Tests for nb_negative / nb_positive: unary ops via PyNumber_Negative/Positive."""
 
 import operator
+import sys
 
 import torch
 import torch._dynamo.testing
@@ -15,48 +16,49 @@ from torch.testing._internal.common_utils import (
 
 
 UNARY_OPS = [
-    subtest((operator.neg, "-", "__neg__"), name="neg"),
-    subtest((operator.pos, "+", "__pos__"), name="pos"),
+    subtest((operator.neg, "__neg__"), name="neg"),
+    subtest((operator.pos, "__pos__"), name="pos"),
+    subtest((operator.abs, "__abs__"), name="abs"),
 ]
 
 
 class NbUnaryTests(TestCase):
     # --- int (ConstantVariable) ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_int(self, op, symbol, dunder):
+    def test_int(self, op, dunder):
         self.assertEqual(op(42), op(42))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_int_negative_value(self, op, symbol, dunder):
+    def test_int_negative_value(self, op, dunder):
         self.assertEqual(op(-7), op(-7))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_int_zero(self, op, symbol, dunder):
+    def test_int_zero(self, op, dunder):
         self.assertEqual(op(0), op(0))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_int_large(self, op, symbol, dunder):
+    def test_int_large(self, op, dunder):
         self.assertEqual(op(2**100), op(2**100))
 
     # --- float (ConstantVariable) ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_float(self, op, symbol, dunder):
+    def test_float(self, op, dunder):
         self.assertEqual(op(3.14), op(3.14))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_float_negative_value(self, op, symbol, dunder):
+    def test_float_negative_value(self, op, dunder):
         self.assertEqual(op(-2.5), op(-2.5))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_float_zero_copysign(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_float_zero_copysign(self, op, dunder):
         import math
 
         def fn(x):
@@ -66,8 +68,8 @@ class NbUnaryTests(TestCase):
         expected = op(0.0)
         self.assertEqual(math.copysign(1.0, result), math.copysign(1.0, expected))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_float_double_apply_zero(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_float_double_apply_zero(self, op, dunder):
         import math
 
         def fn(x):
@@ -77,22 +79,22 @@ class NbUnaryTests(TestCase):
         expected = op(op(0.0))
         self.assertEqual(math.copysign(1.0, result), math.copysign(1.0, expected))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_float_inf(self, op, symbol, dunder):
+    def test_float_inf(self, op, dunder):
         import math
 
         self.assertEqual(op(math.inf), op(math.inf))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_float_neg_inf(self, op, symbol, dunder):
+    def test_float_neg_inf(self, op, dunder):
         import math
 
         self.assertEqual(op(-math.inf), op(-math.inf))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_float_nan(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_float_nan(self, op, dunder):
         import math
 
         def fn(x):
@@ -103,40 +105,40 @@ class NbUnaryTests(TestCase):
 
     # --- complex (ConstantVariable) ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_complex(self, op, symbol, dunder):
+    def test_complex(self, op, dunder):
         self.assertEqual(op(3 + 4j), op(3 + 4j))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_complex_zero(self, op, symbol, dunder):
+    def test_complex_zero(self, op, dunder):
         self.assertEqual(op(0 + 0j), op(0 + 0j))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_complex_real_only(self, op, symbol, dunder):
+    def test_complex_real_only(self, op, dunder):
         self.assertEqual(op(5 + 0j), op(5 + 0j))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_complex_imag_only(self, op, symbol, dunder):
+    def test_complex_imag_only(self, op, dunder):
         self.assertEqual(op(0 + 3j), op(0 + 3j))
 
     # --- bool (ConstantVariable, inherits slot from int) ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_bool_true(self, op, symbol, dunder):
+    def test_bool_true(self, op, dunder):
         self.assertEqual(op(True), op(True))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_bool_false(self, op, symbol, dunder):
+    def test_bool_false(self, op, dunder):
         self.assertEqual(op(False), op(False))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_bool_result_type(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_bool_result_type(self, op, dunder):
         def fn(x):
             return op(True)
 
@@ -146,53 +148,53 @@ class NbUnaryTests(TestCase):
 
     # --- operator.X on constants ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_operator_int(self, op, symbol, dunder):
+    def test_operator_int(self, op, dunder):
         self.assertEqual(op(10), op(10))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_operator_float(self, op, symbol, dunder):
+    def test_operator_float(self, op, dunder):
         self.assertEqual(op(2.5), op(2.5))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_operator_bool(self, op, symbol, dunder):
+    def test_operator_bool(self, op, dunder):
         self.assertEqual(op(True), op(True))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_operator_complex(self, op, symbol, dunder):
+    def test_operator_complex(self, op, dunder):
         self.assertEqual(op(1 + 2j), op(1 + 2j))
 
     # --- dunder method on constants ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_dunder_int(self, op, symbol, dunder):
+    def test_dunder_int(self, op, dunder):
         self.assertEqual(getattr(42, dunder)(), op(42))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_dunder_float(self, op, symbol, dunder):
+    def test_dunder_float(self, op, dunder):
         self.assertEqual(getattr(3.14, dunder)(), op(3.14))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_dunder_bool(self, op, symbol, dunder):
+    def test_dunder_bool(self, op, dunder):
         self.assertEqual(getattr(True, dunder)(), op(True))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_dunder_complex(self, op, symbol, dunder):
+    def test_dunder_complex(self, op, dunder):
         self.assertEqual(getattr(1 + 2j, dunder)(), op(1 + 2j))
 
     # --- TypeError for types without the slot ---
     # CPython: "bad operand type for unary <symbol>: '<type>'"
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_str_raises(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_str_raises(self, op, dunder):
         def fn(x):
             try:
                 return op("hello")
@@ -203,8 +205,8 @@ class NbUnaryTests(TestCase):
         eager_result = fn(torch.tensor(0))
         self.assertEqual(result, eager_result)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_list_raises(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_list_raises(self, op, dunder):
         def fn(x):
             try:
                 return op([1, 2, 3])
@@ -215,8 +217,8 @@ class NbUnaryTests(TestCase):
         eager_result = fn(torch.tensor(0))
         self.assertEqual(result, eager_result)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_dict_raises(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_dict_raises(self, op, dunder):
         def fn(x):
             try:
                 return op({"a": 1})
@@ -227,8 +229,8 @@ class NbUnaryTests(TestCase):
         eager_result = fn(torch.tensor(0))
         self.assertEqual(result, eager_result)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_set_raises(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_set_raises(self, op, dunder):
         def fn(x):
             try:
                 return op({1, 2})
@@ -239,8 +241,8 @@ class NbUnaryTests(TestCase):
         eager_result = fn(torch.tensor(0))
         self.assertEqual(result, eager_result)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_tuple_raises(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_tuple_raises(self, op, dunder):
         def fn(x):
             try:
                 return op(())
@@ -251,8 +253,8 @@ class NbUnaryTests(TestCase):
         eager_result = fn(torch.tensor(0))
         self.assertEqual(result, eager_result)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_none_raises(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_none_raises(self, op, dunder):
         def fn(x):
             try:
                 return op(None)
@@ -263,8 +265,8 @@ class NbUnaryTests(TestCase):
         eager_result = fn(torch.tensor(0))
         self.assertEqual(result, eager_result)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_bytes_raises(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_bytes_raises(self, op, dunder):
         def fn(x):
             try:
                 return op(b"hello")
@@ -275,8 +277,8 @@ class NbUnaryTests(TestCase):
         eager_result = fn(torch.tensor(0))
         self.assertEqual(result, eager_result)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_operator_none_raises(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_operator_none_raises(self, op, dunder):
         def fn(x):
             try:
                 return op(None)
@@ -289,8 +291,8 @@ class NbUnaryTests(TestCase):
 
     # --- Tensor (TensorVariable, proxy-based) ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_tensor(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_tensor(self, op, dunder):
         def fn(x):
             return op(x)
 
@@ -298,8 +300,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(result, fn(x))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_tensor_integer_dtype(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_tensor_integer_dtype(self, op, dunder):
         def fn(x):
             return op(x)
 
@@ -307,8 +309,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(result, fn(x))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_tensor_complex_dtype(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_tensor_complex_dtype(self, op, dunder):
         def fn(x):
             return op(x)
 
@@ -316,8 +318,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(result, fn(x))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_tensor_creates_graph_node(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_tensor_creates_graph_node(self, op, dunder):
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
 
         @torch.compile(backend=backend, fullgraph=True)
@@ -329,8 +331,8 @@ class NbUnaryTests(TestCase):
         graph_str = backend.graphs[0].print_readable(False)
         self.assertIn(op.__name__, graph_str.lower())
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_tensor_operator(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_tensor_operator(self, op, dunder):
         def fn(x):
             return op(x)
 
@@ -338,8 +340,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(result, fn(x))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_tensor_dunder(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_tensor_dunder(self, op, dunder):
         def fn(x):
             return getattr(x, dunder)()
 
@@ -349,8 +351,8 @@ class NbUnaryTests(TestCase):
 
     # --- SymNodeVariable ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_symnode(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_symnode(self, op, dunder):
         def fn(x):
             s = x.size(0)
             return x[: op(s)]
@@ -359,8 +361,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(result, fn(x))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_symnode_operator(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_symnode_operator(self, op, dunder):
         def fn(x):
             s = x.size(0)
             return x[: op(s)]
@@ -369,8 +371,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(result, fn(x))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_symnode_dunder(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_symnode_dunder(self, op, dunder):
         def fn(x):
             s = x.size(0)
             return x[: getattr(s, dunder)()]
@@ -381,8 +383,8 @@ class NbUnaryTests(TestCase):
 
     # --- UserDefinedObjectVariable ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_user_defined(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_user_defined(self, op, dunder):
         class MyNum:
             def __init__(self, val):
                 self.val = val
@@ -396,8 +398,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, -10)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_user_defined_operator(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_user_defined_operator(self, op, dunder):
         class MyNum:
             def __init__(self, val):
                 self.val = val
@@ -411,8 +413,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, -7)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_user_defined_dunder(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_user_defined_dunder(self, op, dunder):
         class MyNum:
             def __init__(self, val):
                 self.val = val
@@ -426,8 +428,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, -3)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_user_defined_no_slot_raises(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_user_defined_no_slot_raises(self, op, dunder):
         class NoSlot:
             pass
 
@@ -443,8 +445,8 @@ class NbUnaryTests(TestCase):
         eager_result = fn(torch.tensor(0))
         self.assertEqual(result, eager_result)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_user_defined_returns_arbitrary_type(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_user_defined_returns_arbitrary_type(self, op, dunder):
         class Weird:
             pass
 
@@ -457,8 +459,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, "applied")
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_user_defined_raising_exception_propagates(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_user_defined_raising_exception_propagates(self, op, dunder):
         class Raising:
             pass
 
@@ -477,8 +479,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, "custom error")
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_user_defined_subclass(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_user_defined_subclass(self, op, dunder):
         class Base:
             def __init__(self, v):
                 self.v = v
@@ -498,8 +500,8 @@ class NbUnaryTests(TestCase):
 
     # --- nn.Module ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_nn_module(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_nn_module(self, op, dunder):
         class OpModule(torch.nn.Module):
             def forward(self, x):
                 return x
@@ -518,8 +520,8 @@ class NbUnaryTests(TestCase):
     # In CPython, op(SomeClass) calls type(SomeClass)->nb_slot,
     # i.e. the metaclass's dunder, not the class's.
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_metaclass(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_metaclass(self, op, dunder):
         class Meta(type):
             pass
 
@@ -534,8 +536,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, "applied A")
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_metaclass_no_slot_raises(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_metaclass_no_slot_raises(self, op, dunder):
         class Bar(type):
             pass
 
@@ -552,8 +554,8 @@ class NbUnaryTests(TestCase):
         eager_result = fn(torch.tensor(0))
         self.assertEqual(result, eager_result)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_metaclass_inherited(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_metaclass_inherited(self, op, dunder):
         class Meta(type):
             pass
 
@@ -571,8 +573,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, "applied D")
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_default_metaclass_raises(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_default_metaclass_raises(self, op, dunder):
         class Plain:
             pass
 
@@ -588,8 +590,8 @@ class NbUnaryTests(TestCase):
 
     # --- Unbound method calls: Type.dunder(instance) ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_unbound_user_defined(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_unbound_user_defined(self, op, dunder):
         class MyNum:
             def __init__(self, v):
                 self.v = v
@@ -603,8 +605,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, -5)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_unbound_parent_class(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_unbound_parent_class(self, op, dunder):
         class Base:
             def __init__(self, v):
                 self.v = v
@@ -622,40 +624,40 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, -10)
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_unbound_builtin_int(self, op, symbol, dunder):
+    def test_unbound_builtin_int(self, op, dunder):
         self.assertEqual(getattr(int, dunder)(42), op(42))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_unbound_builtin_float(self, op, symbol, dunder):
+    def test_unbound_builtin_float(self, op, dunder):
         self.assertEqual(getattr(float, dunder)(3.14), op(3.14))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_unbound_builtin_complex(self, op, symbol, dunder):
+    def test_unbound_builtin_complex(self, op, dunder):
         self.assertEqual(getattr(complex, dunder)(1 + 2j), op(1 + 2j))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_unbound_builtin_bool(self, op, symbol, dunder):
+    def test_unbound_builtin_bool(self, op, dunder):
         self.assertEqual(getattr(bool, dunder)(True), op(True))
 
     # --- Double application ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_double_apply_int(self, op, symbol, dunder):
+    def test_double_apply_int(self, op, dunder):
         self.assertEqual(op(op(42)), op(op(42)))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
+    @parametrize("op,dunder", UNARY_OPS)
     @make_dynamo_test
-    def test_double_apply_float(self, op, symbol, dunder):
+    def test_double_apply_float(self, op, dunder):
         self.assertEqual(op(op(3.14)), op(op(3.14)))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_double_apply_tensor(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_double_apply_tensor(self, op, dunder):
         def fn(x):
             return op(op(x))
 
@@ -665,8 +667,8 @@ class NbUnaryTests(TestCase):
 
     # --- Used in expressions ---
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_in_arithmetic(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_in_arithmetic(self, op, dunder):
         def fn(x):
             return x + op(x)
 
@@ -674,8 +676,8 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(result, fn(x))
 
-    @parametrize("op,symbol,dunder", UNARY_OPS)
-    def test_constant_in_tensor_op(self, op, symbol, dunder):
+    @parametrize("op,dunder", UNARY_OPS)
+    def test_constant_in_tensor_op(self, op, dunder):
         def fn(x):
             val = op(5)
             return x + val
@@ -683,6 +685,24 @@ class NbUnaryTests(TestCase):
         x = torch.ones(3)
         result = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(result, fn(x))
+
+    # --- op specific tests ---    
+
+    # --- complex abs overflow (OverflowError from _Py_c_abs) ---
+    # CPython's complex_abs calls _Py_c_abs which sets errno=ERANGE when
+    # hypot(real, imag) overflows a double, then raises OverflowError.
+
+    def test_complex_abs_overflow(self):
+        def fn(x):
+            try:
+                return abs(complex(sys.float_info.max, sys.float_info.max))
+            except OverflowError as e:
+                return str(e)
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)(
+            torch.tensor(0)
+        )
+        self.assertEqual(result, "absolute value too large")
 
 
 instantiate_parametrized_tests(NbUnaryTests)

--- a/test/dynamo/test_nb_unary.py
+++ b/test/dynamo/test_nb_unary.py
@@ -709,9 +709,9 @@ class NbUnaryTests(TestCase):
 
         real = torch.rand(1, dtype=torch.float32)
         imag = torch.rand(1, dtype=torch.float32)
-        complex = torch.complex(real, imag)
-        eager_result = fn(complex)
-        result = torch.compile(fn, backend="eager", fullgraph=True)(complex)
+        complex_val = torch.complex(real, imag)
+        eager_result = fn(complex_val)
+        result = torch.compile(fn, backend="eager", fullgraph=True)(complex_val)
         self.assertEqual(result.dtype, eager_result.dtype)
 
 

--- a/test/dynamo/test_nb_unary.py
+++ b/test/dynamo/test_nb_unary.py
@@ -703,6 +703,17 @@ class NbUnaryTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, eager_result)
 
+    def test_complex_abs_return_type(self):
+        def fn(x):
+            return abs(x)
+
+        real = torch.rand(1, dtype=torch.float32)
+        imag = torch.rand(1, dtype=torch.float32)
+        complex = torch.complex(real, imag)
+        eager_result = fn(complex)
+        result = torch.compile(fn, backend="eager", fullgraph=True)(complex)
+        self.assertEqual(result.dtype, eager_result.dtype)
+
 
 instantiate_parametrized_tests(NbUnaryTests)
 

--- a/test/dynamo/test_nb_unary.py
+++ b/test/dynamo/test_nb_unary.py
@@ -700,9 +700,7 @@ class NbUnaryTests(TestCase):
                 return str(e)
 
         eager_result = fn(0)
-        result = torch.compile(fn, backend="eager", fullgraph=True)(
-            torch.tensor(0)
-        )
+        result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, eager_result)
 
 

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -4661,6 +4661,16 @@
       ]
     }
   ],
+  "GB9548": [
+    {
+      "Gb_type": "nb_absolute_impl not implemented",
+      "Context": "{type(self).__name__} has nb_absolute slot but no nb_absolute_impl override",
+      "Explanation": "The type {self.python_type_name()} has an nb_absolute C slot but the corresponding VariableTracker doesn't implement nb_absolute_impl.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
   "GB0329": [
     {
       "Gb_type": "WrapHigherOrderVariable: kwargs unexpected",

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -820,6 +820,8 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             return self.nb_int_impl(tx)
         elif name == "__float__" and not args and not kwargs:
             return self.nb_float_impl(tx)
+        elif name == "__abs__" and not args and not kwargs:
+            return self.nb_absolute_impl(tx)
         elif name == "__get__" and len(args) in (1, 2) and not kwargs:
             # Route to tp_descr_get_impl if the VT implements it.
             # Mirrors slot_tp_descr_get which calls __get__(self, obj, type).
@@ -1370,6 +1372,23 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_subtract slot. Default: graph break."""
         return variables.ConstantVariable(NotImplemented)
+
+    def nb_absolute_impl(
+        self,
+        tx: Any,
+    ) -> VariableTracker:
+        """Mirrors CPython's tp_as_number->nb_absolute slot.
+
+        Called when type_implements_nb_absolute returns True for this type.
+        Subclasses override to provide the actual absolute value.
+        """
+        unimplemented(
+            gb_type="nb_absolute_impl not implemented",
+            context=f"{type(self).__name__} has nb_absolute slot but no nb_absolute_impl override",
+            explanation=f"The type {self.python_type_name()} has an nb_absolute C slot but "
+            "the corresponding VariableTracker doesn't implement nb_absolute_impl.",
+            hints=[*graph_break_hints.SUPPORTABLE],
+        )
 
     def __init__(
         self,

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -820,8 +820,6 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             return self.nb_int_impl(tx)
         elif name == "__float__" and not args and not kwargs:
             return self.nb_float_impl(tx)
-        elif name == "__abs__" and not args and not kwargs:
-            return self.nb_absolute_impl(tx)
         elif name == "__get__" and len(args) in (1, 2) and not kwargs:
             # Route to tp_descr_get_impl if the VT implements it.
             # Mirrors slot_tp_descr_get which calls __get__(self, obj, type).

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -109,6 +109,7 @@ from .misc import NullVariable, StringFormatVariable
 from .object_protocol import (
     binary_iop,
     binary_op,
+    generic_abs,
     generic_bool,
     generic_float,
     generic_getiter,
@@ -1723,6 +1724,11 @@ class BuiltinVariable(BaseBuiltinVariable):
             # e.g., int.__pos__(4) → pos(4)
             return generic_pos(tx, args[0])
 
+        if name == "__abs__" and len(args) == 1 and not kwargs:
+            # type.__abs__(instance) → abs(instance)
+            # e.g., int.__abs__(-4) → abs(-4)
+            return generic_abs(tx, args[0])
+
         return super().call_method(tx, name, args, kwargs)
 
     def call_int(
@@ -2042,13 +2048,7 @@ class BuiltinVariable(BaseBuiltinVariable):
     def call_abs(
         self, tx: "InstructionTranslator", arg: VariableTracker
     ) -> VariableTracker:
-        from .builder import SourcelessBuilder
-
-        # Call arg.__abs__()
-        abs_method = SourcelessBuilder.create(tx, getattr).call_function(
-            tx, [arg, VariableTracker.build(tx, "__abs__")], {}
-        )
-        return abs_method.call_function(tx, [], {})
+        return generic_abs(tx, arg)
 
     def call_pos(
         self, tx: "InstructionTranslator", arg: VariableTracker

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -548,6 +548,21 @@ class ConstantVariable(VariableTracker):
         except (TypeError, OverflowError) as e:
             raise_observed_exception(type(e), tx, args=list(e.args))
 
+    def nb_absolute_impl(
+        self,
+        tx: Any,
+    ) -> VariableTracker:
+        # int: https://github.com/python/cpython/blob/v3.13.0/Objects/longobject.c#L5184-L5190
+        # float: https://github.com/python/cpython/blob/v3.13.0/Objects/floatobject.c#L847-L850
+        # complex: https://github.com/python/cpython/blob/v3.13.0/Objects/complexobject.c#L588-L600
+        #   _Py_c_abs can set errno=ERANGE on overflow, which complex_abs
+        #   converts to OverflowError("absolute value too large").
+        # bool inherits nb_absolute from int via slot inheritance.
+        try:
+            return ConstantVariable.create(abs(self.value))
+        except OverflowError as e:
+            raise_observed_exception(OverflowError, tx, args=list(e.args))
+
 
 CONSTANT_VARIABLE_NONE = ConstantVariable(None)
 CONSTANT_VARIABLE_TRUE = ConstantVariable(True)

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -180,6 +180,12 @@ def type_implements_nb_positive(obj_type: type) -> bool:
     return has_slot(number_slots, PyNumberSlots.NB_POSITIVE)
 
 
+def type_implements_nb_absolute(obj_type: type) -> bool:
+    """Check whether obj_type implements the nb_absolute slot."""
+    _, _, number_slots, _ = _get_cached_slots(obj_type)
+    return has_slot(number_slots, PyNumberSlots.NB_ABSOLUTE)
+
+
 def type_implements_tp_iter(obj_type: type) -> bool:
     _, _, _, type_slot = _get_cached_slots(obj_type)
     return has_slot(type_slot, PyTypeSlots.TP_ITER)
@@ -529,6 +535,26 @@ def generic_pos(tx: "InstructionTranslator", obj: VariableTracker) -> VariableTr
     raise_type_error(
         tx,
         f"bad operand type for unary +: '{obj.python_type_name()}'",
+    )
+
+
+def generic_abs(tx: "InstructionTranslator", obj: VariableTracker) -> VariableTracker:
+    """Mirrors PyNumber_Absolute.
+
+    https://github.com/python/cpython/blob/v3.13.0/Objects/abstract.c#L1375-L1395
+
+    Algorithm:
+    1. If type has nb_absolute slot, call obj.nb_absolute_impl(tx)
+    2. Otherwise, raise TypeError
+    """
+    obj_type = maybe_get_python_type(obj)
+
+    if type_implements_nb_absolute(obj_type):
+        return obj.nb_absolute_impl(tx)
+
+    raise_type_error(
+        tx,
+        f"bad operand type for abs(): '{obj.python_type_name()}'",
     )
 
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1624,6 +1624,25 @@ class TensorVariable(VariableTracker):
     def method___pos__(self, tx: "InstructionTranslator") -> VariableTracker:
         return self.nb_positive_impl(tx)
 
+    def nb_absolute_impl(
+        self,
+        tx: "InstructionTranslator",
+    ) -> VariableTracker:
+        from .builder import wrap_fx_proxy
+
+        return wrap_fx_proxy(
+            tx,
+            tx.output.create_proxy(
+                "call_function",
+                operator.abs,
+                (self.as_proxy(),),
+                {},
+            ),
+        )
+
+    def method___abs__(self, tx: "InstructionTranslator") -> VariableTracker:
+        return self.nb_absolute_impl(tx)
+
     def method___getitem__(
         self,
         tx: "InstructionTranslator",
@@ -2489,6 +2508,21 @@ class SymNodeVariable(VariableTracker):
         self, tx: "InstructionTranslator", *args: Any, **kwargs: Any
     ) -> VariableTracker:
         return self.nb_positive_impl(tx)
+
+    def nb_absolute_impl(
+        self,
+        tx: "InstructionTranslator",
+    ) -> VariableTracker:
+        return SymNodeVariable.create(
+            tx,
+            operator.abs(self.as_proxy()),
+            sym_num=None,
+        )
+
+    def method___abs__(
+        self, tx: "InstructionTranslator", *args: Any, **kwargs: Any
+    ) -> VariableTracker:
+        return self.nb_absolute_impl(tx)
 
     def is_python_hashable(self) -> bool:
         return True

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -812,7 +812,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 m, self, source_fn=source
             ).call_function(tx, [], {})
         raise_type_error(
-            tx, f"object of type {self.python_type_name()} has no negative"
+            tx, f"bad operand type for unary -: '{self.python_type_name()}'"
         )
 
     def nb_positive_impl(self, tx: "InstructionTranslator") -> VariableTracker:
@@ -823,7 +823,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 m, self, source_fn=source
             ).call_function(tx, [], {})
         raise_type_error(
-            tx, f"object of type {self.python_type_name()} has no positive"
+            tx, f"bad operand type for unary +: '{self.python_type_name()}'"
         )
 
     def nb_absolute_impl(self, tx: "InstructionTranslator") -> VariableTracker:
@@ -1836,7 +1836,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         type_attr = self.lookup_class_mro_attr("__neg__")
         if type_attr is NO_SUCH_SUBOBJ:
             raise_type_error(
-                tx, f"object of type {self.python_type_name()} has no negative"
+                tx, f"bad operand type for unary -: '{self.python_type_name()}'"
             )
         if type_attr is None:
             raise_type_error(tx, "'NoneType' object is not callable")
@@ -1844,7 +1844,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         method = self._maybe_get_baseclass_method("__neg__")
         if method is None:
             raise_type_error(
-                tx, f"object of type {self.python_type_name()} has no negative"
+                tx, f"bad operand type for unary -: '{self.python_type_name()}'"
             )
 
         return self.call_method(tx, "__neg__", [], {})
@@ -1858,7 +1858,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         type_attr = self.lookup_class_mro_attr("__pos__")
         if type_attr is NO_SUCH_SUBOBJ:
             raise_type_error(
-                tx, f"object of type {self.python_type_name()} has no positive"
+                tx, f"bad operand type for unary +: '{self.python_type_name()}'"
             )
         if type_attr is None:
             raise_type_error(tx, "'NoneType' object is not callable")
@@ -1866,7 +1866,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         method = self._maybe_get_baseclass_method("__pos__")
         if method is None:
             raise_type_error(
-                tx, f"object of type {self.python_type_name()} has no positive"
+                tx, f"bad operand type for unary +: '{self.python_type_name()}'",
             )
 
         return self.call_method(tx, "__pos__", [], {})

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1866,7 +1866,8 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         method = self._maybe_get_baseclass_method("__pos__")
         if method is None:
             raise_type_error(
-                tx, f"bad operand type for unary +: '{self.python_type_name()}'",
+                tx,
+                f"bad operand type for unary +: '{self.python_type_name()}'",
             )
 
         return self.call_method(tx, "__pos__", [], {})

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -826,6 +826,18 @@ class UserDefinedClassVariable(UserDefinedVariable):
             tx, f"object of type {self.python_type_name()} has no positive"
         )
 
+    def nb_absolute_impl(self, tx: "InstructionTranslator") -> VariableTracker:
+        m = self._maybe_get_baseclass_method("__abs__")
+        if m:
+            source = self.source and AttrSource(self.source, "__abs__")
+            return variables.UserMethodVariable(
+                m, self, source_fn=source
+            ).call_function(tx, [], {})
+        raise_type_error(
+            tx,
+            f"bad operand type for abs(): '{self.python_type_name()}'",
+        )
+
     def _call_cross_entropy_loss(
         self,
         tx: "InstructionTranslator",
@@ -1858,6 +1870,30 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             )
 
         return self.call_method(tx, "__pos__", [], {})
+
+    def nb_absolute_impl(
+        self,
+        tx: "InstructionTranslator",
+    ) -> VariableTracker:
+        # CPython: slot_nb_absolute calls __abs__() via vectorcall_method.
+        # https://github.com/python/cpython/blob/v3.13.0/Objects/typeobject.c#L9406
+        type_attr = self.lookup_class_mro_attr("__abs__")
+        if type_attr is NO_SUCH_SUBOBJ:
+            raise_type_error(
+                tx,
+                f"bad operand type for abs(): '{self.python_type_name()}'",
+            )
+        if type_attr is None:
+            raise_type_error(tx, "'NoneType' object is not callable")
+
+        method = self._maybe_get_baseclass_method("__abs__")
+        if method is None:
+            raise_type_error(
+                tx,
+                f"bad operand type for abs(): '{self.python_type_name()}'",
+            )
+
+        return self.call_method(tx, "__abs__", [], {})
 
     def torch_function_check(self) -> None:
         if not has_torch_function(self):


### PR DESCRIPTION
Implement the nb_absolute slot to continue filling out the unary slot implementations.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98