### PR TITLE
[dynamo] Get Dynamo CI green again

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -422,7 +422,9 @@ AOT_DISPATCH_TESTS = [
     test for test in TESTS if test.startswith("functorch/test_aotdispatch")
 ]
 FUNCTORCH_TESTS = [test for test in TESTS if test.startswith("functorch")]
-DYNAMO_CORE_TESTS = [test for test in TESTS if test.startswith("dynamo")]
+DYNAMO_CORE_TESTS = [
+    test for test in TESTS if test.startswith("dynamo") and "cpython" not in test
+]
 CPYTHON_TESTS = [test for test in TESTS if "cpython" in test]
 ONNX_TESTS = [test for test in TESTS if test.startswith("onnx")]
 QUANTIZATION_TESTS = [test for test in TESTS if test.startswith("test_quantization")]

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -404,7 +404,10 @@ def assert_sequence_equal(
     msg: str | None = None,
     seq_type: type[Any] | None = None,
 ) -> None:
-    return self_.assertTrue(seq1 == seq2, msg)
+    # list == tuple is False in Python even if elements match.
+    # Match unittest.TestCase.assertSequenceEqual behavior: when seq_type
+    # is None, compare element-by-element regardless of container type.
+    return self_.assertTrue(list(seq1) == list(seq2), msg)
 
 
 def getattr_and_trace(*args: Any, **kwargs: Any) -> Any:

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -404,10 +404,7 @@ def assert_sequence_equal(
     msg: str | None = None,
     seq_type: type[Any] | None = None,
 ) -> None:
-    # list == tuple is False in Python even if elements match.
-    # Match unittest.TestCase.assertSequenceEqual behavior: when seq_type
-    # is None, compare element-by-element regardless of container type.
-    return self_.assertTrue(list(seq1) == list(seq2), msg)
+    return self_.assertTrue(seq1 == seq2, msg)
 
 
 def getattr_and_trace(*args: Any, **kwargs: Any) -> Any:

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1692,7 +1692,7 @@ class BuiltinVariable(BaseBuiltinVariable):
                 return args[0].call_method(tx, name, args[1:], kwargs)
 
         if self.fn is str and len(args) >= 1:
-            resolved_fn = getattr(self.fn, name)
+            resolved_fn = getattr(self.fn, name, None)
             if resolved_fn in str_methods:
                 # Only delegate to ConstantVariable, not other types that happen to be constants
                 if isinstance(args[0], ConstantVariable):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #182885
* __->__ #182884

(test_namedtuple_default_values_Tensor_type) Fix getattr crash in BuiltinVariable.call_method when the method doesn't exist on str. The code unconditionally called `getattr(self.fn, name)` which raises AttributeError for methods like `__set_name__` that don't exist on str. The unsafe getattr was introduced in PR #146587; exposed by PR #181324 making Dynamo trace into typing.py.
    
(test_input_no_stdout_fileno) Skip cpython tests in dynamo-core (those should only be run on dynamo_wrapped).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98