### PR TITLE
[dynamo, CI] Remove CI references to ciflow/dynamo

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -8,7 +8,6 @@ ciflow_push_tags:
 - ciflow/binaries_libtorch
 - ciflow/binaries_wheel
 - ciflow/dtensor
-- ciflow/dynamo
 - ciflow/h100
 - ciflow/h100-cutlass-backend
 - ciflow/h100-distributed

--- a/.github/workflows/dynamo-unittest.yml
+++ b/.github/workflows/dynamo-unittest.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - main
       - release/*
-    tags:
-      - ciflow/dynamo/*
   workflow_call:
 
 concurrency:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182885
* #182884

https://github.com/pytorch/pytorch/pull/182674 causes dynamo-unittest to
run on every PR, so we shouldn't need to look for ciflow/dynamo anymore.