### PR TITLE
[Docathon] Document undocumented functions in distributed.checkpoint.md (7 functions)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -461,18 +461,7 @@ coverage_ignore_functions = [
     "quantization_perchannel_hook",
     "quantization_pertensor_hook",
     # torch.distributed.checkpoint.default_planner
-    "create_default_global_load_plan",
-    "create_default_global_save_plan",
     "create_default_local_load_plan",
-    "create_default_local_save_plan",
-    # torch.distributed.checkpoint.optimizer
-    "load_sharded_optimizer_state_dict",
-    # torch.distributed.checkpoint.planner_helpers
-    "create_read_items_for_chunk_list",
-    # torch.distributed.checkpoint.state_dict_loader
-    "load_state_dict",
-    # torch.distributed.checkpoint.state_dict_saver
-    "save_state_dict",
     # torch.distributed.checkpoint.utils
     "find_state_dict_object",
     "find_tensor_shard",

--- a/docs/source/distributed.checkpoint.md
+++ b/docs/source/distributed.checkpoint.md
@@ -27,6 +27,38 @@ The entrypoints to load and save a checkpoint are the following:
 ```
 
 ```{eval-rst}
+.. currentmodule:: torch.distributed.checkpoint.optimizer
+```
+
+```{eval-rst}
+.. autofunction:: load_sharded_optimizer_state_dict
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.checkpoint.planner_helpers
+```
+
+```{eval-rst}
+.. autofunction:: create_read_items_for_chunk_list
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.checkpoint.default_planner
+```
+
+```{eval-rst}
+.. autofunction:: create_default_global_load_plan
+```
+
+```{eval-rst}
+.. autofunction:: create_default_global_save_plan
+```
+
+```{eval-rst}
+.. autofunction:: create_default_local_save_plan
+```
+
+```{eval-rst}
 .. currentmodule:: torch.distributed.checkpoint.state_dict_saver
 ```
 
@@ -49,7 +81,7 @@ The entrypoints to load and save a checkpoint are the following:
 ```
 
 ```{eval-rst}
-.. autofunction::  save_state_dict
+.. autofunction:: save_state_dict
 ```
 
 ```{eval-rst}
@@ -61,7 +93,7 @@ The entrypoints to load and save a checkpoint are the following:
 ```
 
 ```{eval-rst}
-.. autofunction::  load_state_dict
+.. autofunction:: load_state_dict
 ```
 
 The following module is also useful for additional customization of the staging mechanisms used for asynchronous checkpointing (`torch.distributed.checkpoint.async_save`):

--- a/torch/distributed/checkpoint/optimizer.py
+++ b/torch/distributed/checkpoint/optimizer.py
@@ -225,6 +225,9 @@ def load_sharded_optimizer_state_dict(
     Load a state_dict in conjunction with FSDP sharded optimizer state.
 
     This is the current recommended way to checkpoint FSDP.
+
+    Examples::
+
     >>> # xdoctest: +SKIP
     >>> import torch.distributed.checkpoint as dist_cp
     >>> # Save


### PR DESCRIPTION
Fixes #182826

## Description

Documents public Distributed Checkpoint APIs by adding Sphinx autodoc directives to `docs/source/distributed.checkpoint.md` and removing the corresponding entries from `coverage_ignore_functions` in `docs/source/conf.py`.

Documented APIs:
- `torch.distributed.checkpoint.state_dict_loader.load_state_dict`
- `torch.distributed.checkpoint.state_dict_saver.save_state_dict`
- `torch.distributed.checkpoint.optimizer.load_sharded_optimizer_state_dict`
- `torch.distributed.checkpoint.planner_helpers.create_read_items_for_chunk_list`
- `torch.distributed.checkpoint.default_planner.create_default_global_load_plan`
- `torch.distributed.checkpoint.default_planner.create_default_global_save_plan`
- `torch.distributed.checkpoint.default_planner.create_default_local_save_plan`

Also fixes the rendered example for `load_sharded_optimizer_state_dict` so Sphinx renders it as a code block instead of paragraph text.

## Verification

- `make coverage` passes with no undocumented warnings for these APIs.
- Rendered documentation was checked in `docs/build/html/distributed.checkpoint.html`.

## Screenshots

<img width="1028" height="550" alt="Screenshot 2026-05-08 at 2 01 26 AM" src="https://github.com/user-attachments/assets/2b17cb5c-63ba-4c59-aca7-678b5658896e" />
<img width="1022" height="442" alt="Screenshot 2026-05-08 at 2 01 44 AM" src="https://github.com/user-attachments/assets/0004c654-cba5-4364-89e4-8b3d2f7c0dcf" />
<img width="1019" height="197" alt="Screenshot 2026-05-08 at 2 01 52 AM" src="https://github.com/user-attachments/assets/ee603aee-5b7b-4b32-ba65-24164d41d5eb" />
<img width="1019" height="289" alt="Screenshot 2026-05-08 at 2 01 59 AM" src="https://github.com/user-attachments/assets/d85aecb1-f6a6-42d1-a793-6acf8dc79824" />
<img width="1015" height="256" alt="Screenshot 2026-05-08 at 2 02 09 AM" src="https://github.com/user-attachments/assets/80035bce-b54d-41cd-8b01-43a14574b42d" />
<img width="1012" height="128" alt="Screenshot 2026-05-08 at 2 02 18 AM" src="https://github.com/user-attachments/assets/3ca39abb-8603-473b-a7db-1701bbc5e296" />
<img width="1013" height="188" alt="Screenshot 2026-05-08 at 2 02 25 AM" src="https://github.com/user-attachments/assets/df912f31-4375-4538-b2c3-1672171f4ba2" />


## Checklist

- [x] Entries removed from skip list(s) in `docs/source/conf.py`
- [x] Sphinx directives added to `docs/source/distributed.checkpoint.md`
- [x] `make coverage` passes with no new undocumented warnings for these APIs
- [x] Screenshot(s) of the rendered documentation included in the PR description

cc: @sekyondaMeta @svekars 

cc @svekars @sekyondaMeta @AlannaBurke