### PR TITLE
[CI] Disable NCCL NVLS on H100 distributed CI job

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -459,6 +459,9 @@ test_dtensor() {
 
 test_h100_distributed() {
   # Distributed tests at H100
+  # Disable NVLS: AWS H100 instances lack the IMEX channel device
+  # needed for NCCL NVLS multicast
+  export NCCL_NVLS_ENABLE=0
   time python test/run_test.py --include distributed/_composable/test_composability/test_pp_composability.py  $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   # This test requires multicast support
   time python test/run_test.py --include distributed/_composable/fsdp/test_fully_shard_comm.py -k TestFullyShardAllocFromPG $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182888

The h100_distributed CI job has a 100% failure rate because NCCL tries
to use NVLS multicast on the AWS H100 instances, but the IMEX channel
device is not available. Set NCCL_NVLS_ENABLE=0 to fall back to
non-NVLS algorithms, matching what h100-symm-mem already does.

Authored with Claude.