### PR TITLE
[inductor] Roll back failed vertical reindexing

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1548,6 +1548,7 @@ class SchedulerNode(BaseSchedulerNode):
         node: ir.ComputedBuffer | ir.TemplateBuffer,
     ) -> None:
         super().__init__(scheduler)
+        self._loop_mutation_listener: Callable[[SchedulerNode], None] | None = None
         self._init_from_node(node)
         self._compute_attrs()
 
@@ -1657,7 +1658,12 @@ class SchedulerNode(BaseSchedulerNode):
         self.pointwise_read_writes.clear_cache(self)
         SIMDScheduling.candidate_tilings.cache_clear()
 
+    def _before_loop_state_mutation(self) -> None:
+        if self._loop_mutation_listener is not None:
+            self._loop_mutation_listener(self)
+
     def apply_new_loop_order(self, new_order: Sequence[int]) -> None:
+        self._before_loop_state_mutation()
         self._body = self._body.reorder_iter_loops(
             new_order,
         )
@@ -1668,6 +1674,7 @@ class SchedulerNode(BaseSchedulerNode):
     def apply_loop_reindexing(self, new_iter_sizes: Sequence[sympy.Expr]) -> None:
         assert isinstance(self.node, (ir.ComputedBuffer, ir.TemplateBuffer))
 
+        self._before_loop_state_mutation()
         self._body = self._body.reindex_iter_loops(new_iter_sizes)
         self._sizes = self._body.sizes
 
@@ -3101,6 +3108,115 @@ def is_template_fusion(node1: BaseSchedulerNode, node2: BaseSchedulerNode):
 
 def template_fusion_pw_node(node1: BaseSchedulerNode, node2: BaseSchedulerNode):
     return node2 if is_epilogue_fusion(node1, node2) else node1
+
+
+@dataclasses.dataclass
+class _LoopStateSnapshot:
+    """Captured loop state for a set of scheduler nodes, restorable on rollback.
+
+    Stores both SchedulerNode loop state (body, sizes, deps) and
+    FusedSchedulerNode group assignments, since the latter is reassigned
+    directly after child reindexing and has no mutation listener.
+    """
+
+    scheduler_node_states: dict[SchedulerNode, tuple[Any, ...]] = dataclasses.field(
+        default_factory=dict
+    )
+    fused_node_groups: dict[FusedSchedulerNode, Any] = dataclasses.field(
+        default_factory=dict
+    )
+
+    @classmethod
+    def create(cls, nodes: tuple[BaseSchedulerNode, ...]) -> _LoopStateSnapshot:
+        """Capture scheduler-node boundaries and their mutable leaf loop state."""
+        snapshot = cls()
+        for node in nodes:
+            snapshot.snapshot_node(node)
+        return snapshot
+
+    def _snapshot_scheduler_node(self, sn: SchedulerNode) -> None:
+        """Capture one leaf scheduler node before its first loop mutation."""
+        assert sn not in self.scheduler_node_states
+        self.scheduler_node_states[sn] = sn.snapshot_loop_state()
+
+    def _snapshot_fused_node(self, node: FusedSchedulerNode) -> None:
+        """Capture fused-node group metadata changed outside leaf listeners."""
+        assert node not in self.fused_node_groups
+        self.fused_node_groups[node] = node.group
+
+    def snapshot_node(self, node: BaseSchedulerNode) -> None:
+        """Capture a scheduler node boundary and all mutable leaf loop state."""
+        if isinstance(node, FusedSchedulerNode):
+            self._snapshot_fused_node(node)
+        for sn in node.get_nodes():
+            if isinstance(sn, SchedulerNode):
+                self._snapshot_scheduler_node(sn)
+
+    def restore(self) -> None:
+        """Restore all captured loop state and fused-node group metadata."""
+        for sn, state in self.scheduler_node_states.items():
+            sn.restore_loop_state(state)
+        for node, group in self.fused_node_groups.items():
+            node.group = group
+            refresh_group_node_dependencies(node)
+
+
+@dataclasses.dataclass
+class _LoopMutationTracker:
+    """Rollback scope for speculative loop mutations during can_fuse().
+
+    can_fuse() may speculatively reorder or reindex loops while evaluating
+    whether a fusion is legal. If the final decision rejects the fusion,
+    this tracker restores the original loop structure so later fusion
+    candidates do not inherit a speculative layout chosen for a fusion
+    that did not happen.
+
+    Usage: call finish(commit=True) to keep mutations, or finish(commit=False)
+    to restore the original state. If no mutation occurred, finish() is a no-op.
+    """
+
+    nodes: tuple[BaseSchedulerNode, ...]
+    watched_nodes: OrderedSet[SchedulerNode] = dataclasses.field(
+        default_factory=OrderedSet
+    )
+    state: _LoopStateSnapshot | None = None
+
+    @classmethod
+    def create(cls, nodes: tuple[BaseSchedulerNode, ...]) -> _LoopMutationTracker:
+        """Create a rollback scope and watch mutable leaf scheduler nodes."""
+        seen = OrderedSet(nodes)
+        tracker = cls(nodes=tuple(seen))
+        for node in seen:
+            for sn in node.get_nodes():
+                if isinstance(sn, SchedulerNode):
+                    tracker.watch(sn)
+        return tracker
+
+    def watch(self, sn: SchedulerNode) -> None:
+        """Install this scope as the mutation listener for a leaf node."""
+        if sn._loop_mutation_listener is not None:
+            return
+        self.watched_nodes.add(sn)
+        sn._loop_mutation_listener = self.track
+
+    def track(self, sn: SchedulerNode) -> None:
+        """Lazily snapshot candidate roots when the first mutation occurs."""
+        assert sn in self.watched_nodes
+        if self.state is not None:
+            return
+
+        # The listener tells us a child loop mutated. Snapshot the original
+        # candidate roots here so we also capture fused-node group state,
+        # which is reassigned directly and has no listener of its own.
+        self.state = _LoopStateSnapshot.create(self.nodes)
+
+    def finish(self, *, rollback: bool) -> None:
+        """Detach listeners and restore captured state if rolling back."""
+        for sn in self.watched_nodes:
+            sn._loop_mutation_listener = None
+        if not rollback or self.state is None:
+            return
+        self.state.restore()
 
 
 class Scheduler:
@@ -5723,8 +5839,6 @@ class Scheduler:
         self,
         node1: BaseSchedulerNode,
         node2: BaseSchedulerNode,
-        *,
-        rollback_if_vertical_fusion_fails: bool = False,
     ) -> bool:
         """
         Reindex a pointwise's iteration loops to match a reduction's
@@ -5732,10 +5846,13 @@ class Scheduler:
         expressions, enabling the codegen to CSE loads.
 
         Returns True if reindexing was applied.
-        If rollback_if_vertical_fusion_fails is true, roll back unless the
-        reindexed nodes also pass can_fuse_vertical().
         """
         from .codegen.simd import SIMDKernel
+
+        # Keep this consistent with shared_data_after_reordering_loop(): CPU
+        # reindexing is not validated yet.
+        if node1.is_cpu() or node2.is_cpu():
+            return False
 
         if node1.is_reduction() and not node2.is_reduction():
             reduction_node, pw_node = node1, node2
@@ -5774,20 +5891,11 @@ class Scheduler:
         if all(tuple(sn._sizes[0]) == target_iter_sizes for sn in snodes):
             return False
 
-        # Snapshot state before mutation so we can rollback if the
-        # reindexed deps don't actually improve the fusion score.
-        snapshots = [(sn, sn.snapshot_loop_state()) for sn in snodes]
-        old_pw_group = (
-            pw_node.group if isinstance(pw_node, FusedSchedulerNode) else None
-        )
-
-        def restore_state() -> None:
-            for sn, state in snapshots:
-                sn.restore_loop_state(state)
-            if isinstance(pw_node, FusedSchedulerNode):
-                assert old_pw_group is not None
-                pw_node.group = old_pw_group
-                refresh_group_node_dependencies(pw_node)
+        # Local rollback is still needed even with _LoopMutationTracker: this
+        # helper is also used by shared_data_after_reordering_loop(), where a
+        # failed reindex attempt returns -1 and the caller may keep evaluating
+        # fusion within the same can_fuse() call.
+        rollback_snapshot = _LoopStateSnapshot.create((pw_node,))
 
         for sn in snodes:
             sn.apply_loop_reindexing([red_numel, red_rnumel])
@@ -5807,7 +5915,7 @@ class Scheduler:
             for name in common_names
         )
         if not has_benefit:
-            restore_state()
+            rollback_snapshot.restore()
             return False
 
         # When loop ordering is disabled, re-extract deps with
@@ -5820,12 +5928,6 @@ class Scheduler:
                 sn.refresh_dependencies(normalize=True, need_clear_tiling_cache=False)
             if isinstance(pw_node, FusedSchedulerNode):
                 refresh_group_node_dependencies(pw_node)
-
-        if rollback_if_vertical_fusion_fails and not self.can_fuse_vertical(
-            node1, node2
-        ):
-            restore_state()
-            return False
 
         return True
 
@@ -6005,6 +6107,28 @@ class Scheduler:
             return None
 
     def can_fuse(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        can_reorder: bool = False,
+        allow_mix_order_reduction: bool = True,
+    ) -> bool:
+        """Determine if node1 and node2 can be combined into a single fused node.
+
+        Speculative loop mutations (reordering, reindexing) are automatically
+        rolled back if the fusion decision ultimately fails.
+        """
+        tracker = _LoopMutationTracker.create((node1, node2))
+        can_fuse = self._can_fuse_impl(
+            node1,
+            node2,
+            can_reorder=can_reorder,
+            allow_mix_order_reduction=allow_mix_order_reduction,
+        )
+        tracker.finish(rollback=not can_fuse)
+        return can_fuse
+
+    def _can_fuse_impl(
         self,
         node1: BaseSchedulerNode,
         node2: BaseSchedulerNode,
@@ -6248,23 +6372,8 @@ class Scheduler:
 
         if node1.get_operation_names() & node2.ancestors:
             # node2 depends on node1 outputs
-            can_fuse_vertical = self.can_fuse_vertical(node1, node2)
-            if (
-                not can_fuse_vertical
-                and can_reorder
-                and config.loop_reindexing_after_fusion
-                and self._try_reindex_pointwise_for_reduction(
-                    node1,
-                    node2,
-                    rollback_if_vertical_fusion_fails=True,
-                )
-            ):
-                shared_data_score = self.score_fusion_memory(node1, node2)
-                assert isinstance(shared_data_score, int)
-                can_fuse_vertical = True
-
             return (
-                can_fuse_vertical
+                self.can_fuse_vertical(node1, node2)
                 and V.choices.can_fuse_vertical(self, node1, node2, shared_data_score)
                 and self.get_backend(device).can_fuse_vertical(node1, node2)
             )

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3171,6 +3171,11 @@ class _LoopMutationTracker:
     candidates do not inherit a speculative layout chosen for a fusion
     that did not happen.
 
+    The first active tracker for a SchedulerNode leaf owns that leaf's
+    listener. Recursive can_fuse() calls reuse the outer listener instead of
+    installing nested listeners, so the captured state is the original state at
+    the outermost decision boundary.
+
     Usage: call finish(commit=True) to keep mutations, or finish(commit=False)
     to restore the original state. If no mutation occurred, finish() is a no-op.
     """
@@ -3195,6 +3200,7 @@ class _LoopMutationTracker:
     def watch(self, sn: SchedulerNode) -> None:
         """Install this scope as the mutation listener for a leaf node."""
         if sn._loop_mutation_listener is not None:
+            # A recursive can_fuse() is already covered by an outer scope.
             return
         self.watched_nodes.add(sn)
         sn._loop_mutation_listener = self.track
@@ -3203,6 +3209,7 @@ class _LoopMutationTracker:
         """Lazily snapshot candidate roots when the first mutation occurs."""
         assert sn in self.watched_nodes
         if self.state is not None:
+            # Keep the original pre-mutation snapshot for the whole scope.
             return
 
         # The listener tells us a child loop mutated. Snapshot the original

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -5723,6 +5723,8 @@ class Scheduler:
         self,
         node1: BaseSchedulerNode,
         node2: BaseSchedulerNode,
+        *,
+        rollback_if_vertical_fusion_fails: bool = False,
     ) -> bool:
         """
         Reindex a pointwise's iteration loops to match a reduction's
@@ -5730,6 +5732,8 @@ class Scheduler:
         expressions, enabling the codegen to CSE loads.
 
         Returns True if reindexing was applied.
+        If rollback_if_vertical_fusion_fails is true, roll back unless the
+        reindexed nodes also pass can_fuse_vertical().
         """
         from .codegen.simd import SIMDKernel
 
@@ -5765,12 +5769,25 @@ class Scheduler:
         ):
             return False
 
+        # Nothing to reindex if the pointwise already uses the reduction split.
+        target_iter_sizes = (red_numel, red_rnumel)
+        if all(tuple(sn._sizes[0]) == target_iter_sizes for sn in snodes):
+            return False
+
         # Snapshot state before mutation so we can rollback if the
         # reindexed deps don't actually improve the fusion score.
         snapshots = [(sn, sn.snapshot_loop_state()) for sn in snodes]
         old_pw_group = (
             pw_node.group if isinstance(pw_node, FusedSchedulerNode) else None
         )
+
+        def restore_state() -> None:
+            for sn, state in snapshots:
+                sn.restore_loop_state(state)
+            if isinstance(pw_node, FusedSchedulerNode):
+                assert old_pw_group is not None
+                pw_node.group = old_pw_group
+                refresh_group_node_dependencies(pw_node)
 
         for sn in snodes:
             sn.apply_loop_reindexing([red_numel, red_rnumel])
@@ -5790,12 +5807,7 @@ class Scheduler:
             for name in common_names
         )
         if not has_benefit:
-            for sn, state in snapshots:
-                sn.restore_loop_state(state)
-            if isinstance(pw_node, FusedSchedulerNode):
-                assert old_pw_group is not None
-                pw_node.group = old_pw_group
-                refresh_group_node_dependencies(pw_node)
+            restore_state()
             return False
 
         # When loop ordering is disabled, re-extract deps with
@@ -5808,6 +5820,12 @@ class Scheduler:
                 sn.refresh_dependencies(normalize=True, need_clear_tiling_cache=False)
             if isinstance(pw_node, FusedSchedulerNode):
                 refresh_group_node_dependencies(pw_node)
+
+        if rollback_if_vertical_fusion_fails and not self.can_fuse_vertical(
+            node1, node2
+        ):
+            restore_state()
+            return False
 
         return True
 
@@ -6230,8 +6248,23 @@ class Scheduler:
 
         if node1.get_operation_names() & node2.ancestors:
             # node2 depends on node1 outputs
+            can_fuse_vertical = self.can_fuse_vertical(node1, node2)
+            if (
+                not can_fuse_vertical
+                and can_reorder
+                and config.loop_reindexing_after_fusion
+                and self._try_reindex_pointwise_for_reduction(
+                    node1,
+                    node2,
+                    rollback_if_vertical_fusion_fails=True,
+                )
+            ):
+                shared_data_score = self.score_fusion_memory(node1, node2)
+                assert isinstance(shared_data_score, int)
+                can_fuse_vertical = True
+
             return (
-                self.can_fuse_vertical(node1, node2)
+                can_fuse_vertical
                 and V.choices.can_fuse_vertical(self, node1, node2, shared_data_score)
                 and self.get_backend(device).can_fuse_vertical(node1, node2)
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #182898
* #182897
* #182896
* #182895
* #182893
* #182892
* #182891
* __->__ #182890

Wrap can_fuse() in a _LoopMutationTracker that lazily snapshots loop state before the first     
speculative mutation (reordering or reindexing) and restores it if fusion is rejected. Replaces
the rollback_if_vertical_fusion_fails flag previously threaded into                             
_try_reindex_pointwise_for_reduction.                           

Later commits in this stack use the same mechanism for recursive can_fuse() calls during nested 
reduction fusion.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo