### PR TITLE
[HOP] Implementation of torch.switch (1/N)

### DIFF
--- a/docs/source/higher_order_ops/index.md
+++ b/docs/source/higher_order_ops/index.md
@@ -54,6 +54,7 @@ Control flow operators solve these problems by representing control flow as expl
 :maxdepth: 1
 
 cond
+switch
 while_loop
 scan
 associative_scan
@@ -65,6 +66,7 @@ map
 | Operator | Use Case | Example |
 |----------|----------|---------|
 | [cond](cond.md) | If `pred` is True, returns `true_fn(*operands)`, otherwise returns `false_fn(*operands)`. | `cond(pred, true_fn, false_fn, operands)` |
+| [switch](switch.md) | N-way branching: returns `branches[index](*operands)` with `index` clamped into `[0, len(branches)-1]`. | `switch(index, branches, operands)` |
 | [while_loop](while_loop.md) | While `cond_fn(*operands)` is True, executes `body_fn(*operands)`, which returns the operands for the next iteration. | `while_loop(cond_fn, body_fn, operands)` |
 | [scan](scan.md) | Applies cumulative operations to `xs` with carried state | `scan(combine_fn, init, xs)` |
 | [associative_scan](associative_scan.md) | Similar to `scan`, but requiring an associative `combine_fn` to allow for more optimizations. | `associative_scan(add, xs, dim=0)` |

--- a/docs/source/higher_order_ops/switch.md
+++ b/docs/source/higher_order_ops/switch.md
@@ -1,0 +1,156 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+mystnb:
+  execution_timeout: 30
+  execution_show_tb: True
+  merge_streams: True
+---
+
+(switch)=
+
+# Control Flow - Switch
+
+`torch.switch` is a structured control flow operator for multi-way branching. It can be used to specify
+switch-case like control flow and can logically be seen as implemented as follows:
+
+```python
+def switch(
+    index: Union[int, torch.Tensor],
+    branches: Tuple[Callable, ...],
+    operands: Tuple[torch.Tensor]
+):
+    return branches[index](*operands)
+```
+
+Its unique power lies in its ability to express **data-dependent multi-way control flow**: it lowers to a
+switch operator (`torch.ops.higher_order.switch`), which preserves the index, all branch functions, and operands.
+This enables efficient compilation and deployment of models with N-way branching based on the **value** or
+**shape** of inputs or intermediate outputs.
+
+```{warning}
+`torch.switch` is a prototype feature in PyTorch. It has limited support for input and output types.
+Please look forward to a more stable implementation in a future version of PyTorch.
+Read more about feature classification at: https://pytorch.org/blog/pytorch-feature-classification-changes/#prototype
+```
+
+## Examples
+
+Below is an example that uses switch to select between multiple operations based on an input index:
+
+```{code-cell}
+import torch
+from torch._higher_order_ops.switch import switch
+
+def branch0(x: torch.Tensor):
+    return x.cos()
+
+def branch1(x: torch.Tensor):
+    return x.sin()
+
+def branch2(x: torch.Tensor):
+    return x.tan()
+
+class BasicSwitch(torch.nn.Module):
+    """
+    A basic usage of switch with multiple branches.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, index: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        return switch(index, [branch0, branch1, branch2], (x,))
+
+switch_mod = BasicSwitch()
+```
+
+We can eagerly run the model and expect the results vary based on the index:
+
+```{code-cell}
+x = torch.randn(3)
+idx0 = torch.tensor(0)
+idx1 = torch.tensor(1)
+idx2 = torch.tensor(2)
+print(switch_mod(idx0, x), branch0(x))
+print(switch_mod(idx1, x), branch1(x))
+print(switch_mod(idx2, x), branch2(x))
+```
+
+We can export the model for further transformations and deployment:
+
+```{code-cell}
+x = torch.randn(4, 3)
+idx = torch.tensor(1)
+ep = torch.export.export(
+    BasicSwitch(),
+    (idx, x),
+    dynamic_shapes={"index": None, "x": {0: torch.export.Dim.DYNAMIC}}
+)
+print(ep)
+```
+
+Notice that `torch.switch` is lowered to `torch.ops.higher_order.switch`, and branch functions become
+sub-graph attributes of the top level graph module.
+
+Here is another example showcasing switch with data-dependent index:
+
+```{code-cell}
+def branch0(x: torch.Tensor):
+    return x * 2
+
+def branch1(x: torch.Tensor):
+    return x + 10
+
+def branch2(x: torch.Tensor):
+    return x ** 2
+
+class DataDependentSwitch(torch.nn.Module):
+    """
+    A usage of switch with data-dependent index.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Select branch based on the sign of the sum
+        index = torch.clamp((x.sum() > 0).long() + (x.sum() > 5).long(), 0, 2)
+        return switch(index, [branch0, branch1, branch2], (x,))
+
+x = torch.randn(4, 3)
+ep = torch.export.export(
+    DataDependentSwitch(),
+    (x,),
+    dynamic_shapes={"x": {0: torch.export.Dim.DYNAMIC}}
+)
+print(ep)
+```
+
+## Invariants of torch.ops.higher_order.switch
+
+There are several useful invariants for `torch.ops.higher_order.switch`:
+
+- For index:
+    - If the index is a constant (e.g. a Python int), the operator may specialize to a single branch
+    - If the index is a tensor, it must be a single-element tensor
+    - Out-of-range indices are clamped to [0, len(branches)-1]
+
+- For branches:
+    - All branches must have the same input and output signature
+    - The input and output signature will be a flattened tuple
+    - They are `torch.fx.GraphModule`
+    - Closures in original functions become explicit inputs. No closures.
+    - No mutations on inputs or globals are allowed
+    - Branch outputs must be tensors or possibly nested tuples/lists/dicts of tensors. Non-tensor leaves must be `int` or `None`. Diverging `int` values across branches are merged into a SymInt for dynamic shapes; `None` must match positionally across every branch.
+
+- For operands:
+    - It will be a flat tuple of tensors
+
+- Nesting of `torch.switch` in user program becomes nested graph modules
+
+## API Reference
+
+```{eval-rst}
+.. autofunction:: torch._higher_order_ops.switch.switch
+```

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -7277,6 +7277,7 @@ xfail_hops_compile = {
     # inductor
     "while_loop",  # LoweringException: AssertionError
     "flex_attention",  # LoweringException: AssertionError
+    "switch",  # no inductor lowering registered
 }
 
 

--- a/test/export/test_hop.py
+++ b/test/export/test_hop.py
@@ -137,7 +137,11 @@ class TestHOP(TestCase):
         torchdynamo._reset_guarded_backend_cache()
 
     @ops(hop_tests, allowed_dtypes=(torch.float,))
-    @skipOps(hop_export_failures | inline_asm_rocm_serialize_skips)
+    @skipOps(
+        hop_export_failures
+        | inline_asm_rocm_serialize_skips
+        | {xfail("switch", "simple")}
+    )
     def test_serialize_export(self, device, dtype, op):
         class Foo(torch.nn.Module):
             def forward(self, *args):

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -23,6 +23,7 @@ from torch._higher_order_ops.cudagraph_conditional_nodes import (
 from torch._higher_order_ops.map import _fake_map
 from torch._higher_order_ops.scan import _fake_scan, scan
 from torch._higher_order_ops.schema import HopSchemaGenerator
+from torch._higher_order_ops.switch import switch
 from torch._higher_order_ops.while_loop import while_loop
 from torch._subclasses.functional_tensor import (
     CppFunctionalizeAPI,
@@ -1436,6 +1437,508 @@ def forward(self, pred_1, x_1):
         cond_outputs, cond_inputs = self._test_cond_autograd(
             cond_fct, pred_fn, true_fn, false_fn, operands
         )
+
+    def test_switch_basic(self):
+        x = torch.tensor([0, 1, 2])
+        branches = (
+            lambda inp_x: torch.zeros_like(inp_x),
+            lambda inp_x: torch.ones_like(inp_x),
+            lambda inp_x: 2 * torch.ones_like(inp_x),
+        )
+
+        # integer indices (including clamped out-of-range)
+        result = switch(-1, branches, (x,))
+        self.assertEqual(result, torch.zeros_like(x))
+
+        result = switch(0, branches, (x,))
+        self.assertEqual(result, torch.zeros_like(x))
+
+        result = switch(1, branches, (x,))
+        self.assertEqual(result, torch.ones_like(x))
+
+        result = switch(2, branches, (x,))
+        self.assertEqual(result, 2 * torch.ones_like(x))
+
+        result = switch(3, branches, (x,))
+        self.assertEqual(result, 2 * torch.ones_like(x))
+
+        # tensor indices
+        result = switch(torch.tensor([-1]), branches, (x,))
+        self.assertEqual(result, torch.zeros_like(x))
+
+        result = switch(torch.tensor([0]), branches, (x,))
+        self.assertEqual(result, torch.zeros_like(x))
+
+        result = switch(torch.tensor([1]), branches, (x,))
+        self.assertEqual(result, torch.ones_like(x))
+
+        result = switch(torch.tensor([2]), branches, (x,))
+        self.assertEqual(result, 2 * torch.ones_like(x))
+
+        result = switch(torch.tensor([3]), branches, (x,))
+        self.assertEqual(result, 2 * torch.ones_like(x))
+
+    def test_switch_zero_args(self):
+        branches = (
+            lambda: torch.zeros(3),
+            lambda: torch.ones(3),
+            lambda: 2.0 * torch.ones(3),
+        )
+
+        for i in range(3):
+            self.assertEqual(switch(i, branches, []), branches[i]())
+
+    def test_switch_multiple_args(self):
+        x = torch.ones(3)
+        y = torch.tensor([1.0, 2.0, 3.0])
+        branches = (
+            lambda inp_x, inp_y: inp_x + inp_y,
+            lambda inp_x, inp_y: inp_x * inp_y,
+            lambda inp_x, inp_y: inp_x - 0.5 * inp_y,
+        )
+
+        for i in range(3):
+            self.assertEqual(switch(i, branches, (x, y)), branches[i](x, y))
+
+    def test_switch_invalid_index(self):
+        x = torch.ones(3)
+        branches = (torch.sin, torch.cos)
+
+        with self.assertRaisesRegex(RuntimeError, "Expected index to be"):
+            switch([0, 1], branches, (x,))
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Expected index to be int or single-element tensor"
+        ):
+            switch(torch.tensor([0, 1]), branches, (x,))
+
+    def test_switch_zero_branch(self):
+        x = torch.ones(3)
+
+        # Empty-branch rejection happens unconditionally at the top of
+        # torch.switch, matching jax.lax.switch — both int and tensor
+        # indices surface the same RuntimeError.
+        idx = 0
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Expected branches to be a non-empty tuple or list of callables",
+        ):
+            switch(idx, [], (x,))
+
+    def test_switch_single_branch_shortcut(self):
+        # A single-branch switch degenerates to a plain call regardless of
+        # index value (matches jax.lax.switch). The index is ignored since
+        # it clamps to 0.
+        def only_branch(inp_x):
+            return inp_x.sin()
+
+        x = torch.randn(4)
+        self.assertEqual(switch(0, (only_branch,), (x,)), x.sin())
+        self.assertEqual(switch(5, (only_branch,), (x,)), x.sin())
+        self.assertEqual(switch(torch.tensor([0]), (only_branch,), (x,)), x.sin())
+        self.assertEqual(switch(torch.tensor([7]), (only_branch,), (x,)), x.sin())
+
+    def test_switch_different_output_shapes(self):
+        x = (torch.pi / 2) * torch.ones(2)
+        branches = (torch.sin, torch.sum)
+
+        result = switch(0, branches, (x,))
+        self.assertEqual(result, torch.ones_like(x))
+
+        result = switch(1, branches, (x,))
+        self.assertEqual(result.item(), torch.pi)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
+    def test_switch_gpu(self):
+        def branch0(inp_x):
+            return inp_x.sin()
+
+        def branch1(inp_x):
+            return inp_x.cos()
+
+        x = torch.randn(4, device="cuda")
+        index = torch.tensor(1, device="cuda")
+        result = switch(index, (branch0, branch1), (x,))
+        self.assertEqual(result, torch.cos(x))
+
+    def test_switch_no_trace(self):
+        # Smoke-test eager execution with 2 branches (cond is a special case of switch).
+        def branch0(inp_x):
+            return inp_x.cos()
+
+        def branch1(inp_x):
+            return inp_x.sin()
+
+        x = torch.randn(4)
+        self.assertEqual(switch(0, (branch0, branch1), (x,)), x.cos())
+        self.assertEqual(switch(1, (branch0, branch1), (x,)), x.sin())
+        # tensor index
+        self.assertEqual(switch(torch.tensor([0]), (branch0, branch1), (x,)), x.cos())
+        self.assertEqual(switch(torch.tensor([1]), (branch0, branch1), (x,)), x.sin())
+
+    def test_switch_cond_equivalence(self):
+        # switch(int(pred), [false_fn, true_fn], ops) must equal cond(pred, true_fn, false_fn, ops).
+        def true_fn(inp_x):
+            return inp_x.sin()
+
+        def false_fn(inp_x):
+            return inp_x.cos()
+
+        x = torch.randn(4)
+        for pred_val in [True, False]:
+            pred = torch.tensor(pred_val)
+            cond_result = cond(pred, true_fn, false_fn, (x,))
+            idx = torch.tensor([1 if pred_val else 0])
+            switch_result = switch(idx, (false_fn, true_fn), (x,))
+            self.assertEqual(cond_result, switch_result)
+
+    def test_switch_functionalized(self):
+        def branch0(inp_x):
+            y = inp_x.sin()
+            y.add_(4)
+            return y.sum()
+
+        def branch1(inp_x):
+            return inp_x.cos().sum()
+
+        def branch2(inp_x):
+            return inp_x.abs().sum()
+
+        def f(idx, inp_x):
+            return switch(idx, (branch0, branch1, branch2), (inp_x,))
+
+        x = torch.ones(4, 5)
+        functional_f = torch.func.functionalize(f)
+        for i in range(3):
+            idx = torch.tensor([i])
+            self.assertEqual(functional_f(idx, x), f(idx, x))
+
+    def test_switch_functionalized_input_mutation(self):
+        def branch_mutating(inp_x):
+            view_x = inp_x.view(inp_x.shape)
+            view_x.add_(1)
+            return view_x.sin().sum()
+
+        def branch_clean(inp_x):
+            return inp_x.cos().sum()
+
+        def f(idx, inp_x):
+            return switch(idx, (branch_mutating, branch_clean), (inp_x,))
+
+        x = torch.ones(4, 5)
+        # Tensor index -> tracing mode -> mutation check fires in switch_func.
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.TorchRuntimeError,
+            "switch_branch0",
+        ):
+            make_fx(torch.func.functionalize(f), tracing_mode="symbolic")(
+                torch.tensor([0]), x
+            )
+
+    def test_switch_with_tensor_closure(self):
+        a = torch.ones(2, 3)
+        b = torch.ones(2, 3) + 1
+        c = torch.ones(2, 3) * 2
+
+        def branch0(inp_x):
+            return inp_x + a
+
+        def branch1(inp_x):
+            return inp_x + b
+
+        def branch2(inp_x):
+            return inp_x + c
+
+        def foo(idx, inp_x):
+            return switch(idx, (branch0, branch1, branch2), (inp_x,))
+
+        inp = torch.randn(2, 3)
+        for i, closure_val in enumerate((a, b, c)):
+            idx = torch.tensor([i])
+            self.assertEqual(foo(idx, inp), inp + closure_val)
+
+        # Closed-over tensors must be lifted as extra inputs in the traced
+        # graph. This exercises _merge_graph_inputs, which unions
+        # free variables across all branches into a shared placeholder
+        # signature.
+        gm = make_fx(foo)(torch.tensor([0]), inp)
+        self.assertEqual(gm(torch.tensor([0]), inp), inp + a)
+        # After mutating the closure, the traced graph should reflect the new value.
+        a.add_(-1)
+        self.assertEqual(gm(torch.tensor([0]), inp), inp + a)
+
+    def test_switch_branch_returns_none(self):
+        # None is allowed as a branch output leaf when every branch returns
+        # None in that position. cond._merge_output already handles None;
+        # the dynamo-side gate was over-rejecting it, now fixed.
+        def branch0(inp_x):
+            return inp_x.sin(), None
+
+        def branch1(inp_x):
+            return inp_x.cos(), None
+
+        def f(idx, inp_x):
+            return switch(idx, (branch0, branch1), (inp_x,))
+
+        x = torch.randn(4)
+        for i, fn in enumerate((branch0, branch1)):
+            idx = torch.tensor([i])
+            t, n = f(idx, x)
+            self.assertEqual(t, fn(x)[0])
+            self.assertIsNone(n)
+
+    def test_switch_three_branches_divergent_int_leaves(self):
+        def branch0(inp_x):
+            return inp_x.sin(), 0
+
+        def branch1(inp_x):
+            return inp_x.cos(), 1
+
+        def branch2(inp_x):
+            return inp_x.abs(), 2
+
+        def f(idx, inp_x):
+            return switch(idx, (branch0, branch1, branch2), (inp_x,))
+
+        x = torch.randn(4)
+        graph = make_fx(f, tracing_mode="symbolic")(torch.tensor([0]), x)
+        for i, fn in enumerate((branch0, branch1, branch2)):
+            t, n = graph(torch.tensor([i]), x)
+            self.assertEqual(t, fn(x)[0])
+            self.assertEqual(n, fn(x)[1])
+
+        def branch0_eq(inp_x):
+            return inp_x.sin(), 7
+
+        def branch1_eq(inp_x):
+            return inp_x.cos(), 7
+
+        def branch2_eq(inp_x):
+            return inp_x.abs(), 7
+
+        def g(idx, inp_x):
+            return switch(idx, (branch0_eq, branch1_eq, branch2_eq), (inp_x,))
+
+        graph_eq = make_fx(g, tracing_mode="symbolic")(torch.tensor([0]), x)
+        for i, fn in enumerate((branch0_eq, branch1_eq, branch2_eq)):
+            t, n = graph_eq(torch.tensor([i]), x)
+            self.assertEqual(t, fn(x)[0])
+            self.assertEqual(n, 7)
+
+    def test_switch_branch_returns_float_rejected(self):
+        # Python float leaves are blocked by the shared HOP output gate.
+        # Captures the current behavior so a future relaxation of
+        # validate_subgraph_output_types must update this test.
+        def branch0(inp_x):
+            return inp_x.sin(), 3.14
+
+        def branch1(inp_x):
+            return inp_x.cos(), 3.14
+
+        def f(idx, inp_x):
+            return switch(idx, (branch0, branch1), (inp_x,))
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.UncapturedHigherOrderOpError,
+            "HigherOrderOperator body's output must consist of tensors",
+        ):
+            f(torch.tensor([0]), torch.randn(4))
+
+    def test_switch_mismatched_output_arity(self):
+        # Branch 0 returns one tensor, branch 1 returns a tuple of two
+        # tensors — different number of outputs.
+        def branch0(inp_x):
+            return inp_x.sin()
+
+        def branch1(inp_x):
+            return inp_x.cos(), inp_x.abs()
+
+        def f(idx, inp_x):
+            return switch(idx, (branch0, branch1), (inp_x,))
+
+        with self.assertRaisesRegex(
+            (RuntimeError, torch._dynamo.exc.TorchRuntimeError),
+            r"(differing branch outputs|Unmatched output spec from torch\.switch branches)",
+        ):
+            f(torch.tensor([0]), torch.randn(4))
+
+    def test_switch_mismatched_output_structure(self):
+        # Branch 0 returns a tuple; branch 1 returns a dict. Two tensor
+        # leaves each, but the tree specs disagree.
+        def branch0(inp_x):
+            return (inp_x.sin(), inp_x.cos())
+
+        def branch1(inp_x):
+            return {"a": inp_x.sin(), "b": inp_x.cos()}
+
+        def f(idx, inp_x):
+            return switch(idx, (branch0, branch1), (inp_x,))
+
+        with self.assertRaisesRegex(
+            (RuntimeError, torch._dynamo.exc.TorchRuntimeError),
+            r"(differing branch outputs|Unmatched output spec from torch\.switch branches)",
+        ):
+            f(torch.tensor([0]), torch.randn(4))
+
+    def test_switch_mismatched_output_structure_three_branches(self):
+        # Three-branch mismatch: branches 0 and 1 agree on a single-tensor
+        # return; branch 2 diverges by returning a two-tensor tuple.
+        def branch0(inp_x):
+            return inp_x.sin()
+
+        def branch1(inp_x):
+            return inp_x.cos()
+
+        def branch2(inp_x):
+            return inp_x.abs(), inp_x.sum()
+
+        def f(idx, inp_x):
+            return switch(idx, (branch0, branch1, branch2), (inp_x,))
+
+        with self.assertRaisesRegex(
+            (RuntimeError, torch._dynamo.exc.TorchRuntimeError),
+            r"(differing branch outputs|Unmatched output spec from torch\.switch branches)",
+        ):
+            f(torch.tensor([0]), torch.randn(4))
+
+    def test_switch_constant_index_specialization(self):
+        # When the index is a Python constant, dynamo specializes to that
+        # specific branch — the switch HOP never enters the graph.
+        # backend="eager" is used because PR 1 has no inductor lowering;
+        # specialization is a dynamo-level concern.
+        def branch0(inp_x):
+            return inp_x.sin()
+
+        def branch1(inp_x):
+            return inp_x.cos()
+
+        def branch2(inp_x):
+            return inp_x.abs()
+
+        branches = (branch0, branch1, branch2)
+
+        # Each compiled wrapper has its index baked in as a literal so
+        # dynamo definitely sees a ConstantVariable (sidestepping any
+        # scalar-argument promotion to SymInt).
+        @torch.compile(backend="eager", fullgraph=True)
+        def f0(inp_x):
+            return switch(0, branches, (inp_x,))
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f1(inp_x):
+            return switch(1, branches, (inp_x,))
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f2(inp_x):
+            return switch(2, branches, (inp_x,))
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f_neg(inp_x):
+            return switch(-5, branches, (inp_x,))
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f_huge(inp_x):
+            return switch(99, branches, (inp_x,))
+
+        x = torch.randn(4)
+        self.assertEqual(f0(x), branch0(x))
+        self.assertEqual(f1(x), branch1(x))
+        self.assertEqual(f2(x), branch2(x))
+        # Clamped negative index picks branch 0.
+        self.assertEqual(f_neg(x), branch0(x))
+        # Clamped above-range index picks branch N-1.
+        self.assertEqual(f_huge(x), branch2(x))
+
+    def test_switch_nn_module_branches(self):
+        # Each branch is a different nn.Module whose parameters are
+        # captured as free variables. Dynamo must lift the parameters of
+        # all branches into the HOP's operand tuple and rewrite every
+        # branch graph's signature to match.
+        linear0 = torch.nn.Linear(4, 3)
+        linear1 = torch.nn.Linear(4, 3)
+
+        def f(idx, inp_x):
+            return switch(idx, (linear0, linear1), (inp_x,))
+
+        x = torch.randn(2, 4)
+        self.assertEqual(f(torch.tensor([0]), x), linear0(x))
+        self.assertEqual(f(torch.tensor([1]), x), linear1(x))
+
+    def test_switch_complex_nn_module_branches(self):
+        # Complex modules: each branch is a different multi-layer MLP with
+        # different hidden dimensions. As long as the final output shape
+        # matches across branches, dynamo captures and lifts all module
+        # parameters correctly.
+        class MLP(torch.nn.Module):
+            def __init__(self, in_dim, hidden, out_dim):
+                super().__init__()
+                self.fc1 = torch.nn.Linear(in_dim, hidden)
+                self.fc2 = torch.nn.Linear(hidden, out_dim)
+
+            def forward(self, inp_x):
+                return self.fc2(torch.relu(self.fc1(inp_x)))
+
+        mlp_small = MLP(4, 8, 2)
+        mlp_large = MLP(4, 16, 2)
+        mlp_tiny = MLP(4, 3, 2)
+
+        def f(idx, inp_x):
+            return switch(idx, (mlp_small, mlp_large, mlp_tiny), (inp_x,))
+
+        x = torch.randn(5, 4)
+        for i, mlp in enumerate((mlp_small, mlp_large, mlp_tiny)):
+            self.assertEqual(f(torch.tensor([i]), x), mlp(x))
+
+    def test_switch_heterogeneous_lifted_args(self):
+        # Branches with different combinations of lifted free variables:
+        # branch0 captures one tensor, branch1 captures two tensors,
+        # branch2 captures an nn.Module. dynamo unions all lifted
+        # freevars across branches and every branch graph receives the
+        # same placeholder signature.
+        bias = torch.ones(3)
+        offset = torch.tensor([0.5, 0.5, 0.5])
+        linear = torch.nn.Linear(4, 3)
+
+        def branch0(inp_x):
+            return torch.nn.functional.linear(inp_x, torch.eye(4, 3).t()) + bias
+
+        def branch1(inp_x):
+            return (
+                torch.nn.functional.linear(inp_x, torch.eye(4, 3).t()) + bias + offset
+            )
+
+        def branch2(inp_x):
+            return linear(inp_x)
+
+        def f(idx, inp_x):
+            return switch(idx, (branch0, branch1, branch2), (inp_x,))
+
+        x = torch.randn(2, 4)
+        self.assertEqual(f(torch.tensor([0]), x), branch0(x))
+        self.assertEqual(f(torch.tensor([1]), x), branch1(x))
+        self.assertEqual(f(torch.tensor([2]), x), branch2(x))
+
+    def test_switch_pytree_operands(self):
+        # Test that switch supports pytree operands (nested dict/list/tuple of tensors)
+        def branch0(inp_x):
+            return inp_x["t"][0] + inp_x["t"][1]["b"] * inp_x["t"][2][0]
+
+        def branch1(inp_x):
+            return inp_x["t"][0] * (inp_x["t"][2][0] / inp_x["t"][1]["b"])
+
+        def branch2(inp_x):
+            return inp_x["t"][0] - inp_x["t"][1]["b"] + inp_x["t"][2][0]
+
+        a = torch.randn(4)
+        b = torch.randn(4)
+        c = torch.randn(4)
+        operands = ({"t": [a, {"b": b}, (c,)]},)
+
+        # Test each branch
+        for idx, fn in enumerate([branch0, branch1, branch2]):
+            result = switch(torch.tensor(idx), [branch0, branch1, branch2], operands)
+            expected = fn(operands[0])
+            self.assertEqual(result, expected)
 
     @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
     def test_map_gpu(self):
@@ -5531,6 +6034,362 @@ class TestControlFlowTraced(TestCase):
 
         graph = make_fx(f, tracing_mode="symbolic")(x, torch.tensor(False))
         self.assertEqual(graph(x, torch.tensor(True)), f(x, torch.tensor(True)))
+
+    def test_switch_traced_mismatched_output_structure(self):
+        from torch._higher_order_ops.switch import switch_op
+
+        def branch0(inp_x):
+            return (inp_x.sin(), inp_x.cos())
+
+        def branch1(inp_x):
+            return {"a": inp_x.sin(), "b": inp_x.cos()}
+
+        def f(idx, inp_x):
+            return switch_op(idx, (branch0, branch1), (inp_x,))
+
+        x = torch.randn(4)
+        with self.assertRaisesRegex(
+            RuntimeError, "Unmatched output spec from torch.switch branches"
+        ):
+            make_fx(f)(torch.tensor([0]), x)
+
+    def test_switch_traced_not_nested(self):
+        def branch0(inp_x):
+            return inp_x.sin()
+
+        def branch1(inp_x):
+            return inp_x.cos()
+
+        def branch2(inp_x):
+            return inp_x.abs()
+
+        def f(idx, inp_x):
+            return switch(idx, (branch0, branch1, branch2), (inp_x,))
+
+        x = torch.randn(4)
+        graph = make_fx(f)(torch.tensor([0]), x)
+        # The traced graph must dispatch to each branch when fed the
+        # corresponding index at runtime, and each case must match eager.
+        self.assertEqual(graph(torch.tensor([0]), x), branch0(x))
+        self.assertEqual(graph(torch.tensor([1]), x), branch1(x))
+        self.assertEqual(graph(torch.tensor([2]), x), branch2(x))
+        # Clamped indices must match the first/last branch.
+        self.assertEqual(graph(torch.tensor([-1]), x), branch0(x))
+        self.assertEqual(graph(torch.tensor([99]), x), branch2(x))
+
+        # And the same under symbolic tracing.
+        graph = make_fx(f, tracing_mode="symbolic")(torch.tensor([0]), x)
+        for i, fn in enumerate((branch0, branch1, branch2)):
+            self.assertEqual(graph(torch.tensor([i]), x), fn(x))
+
+    def test_switch_tracing_all_modes(self):
+        def branch0(inp_x):
+            return inp_x.sin()
+
+        def branch1(inp_x):
+            return inp_x.cos()
+
+        def branch2(inp_x):
+            return inp_x.abs()
+
+        def f(idx, inp_x):
+            return switch(idx, (branch0, branch1, branch2), (inp_x,))
+
+        # Exercise the helper, which round-trips through symbolic / real /
+        # fake and asserts graph(*args) == eager for each.
+        self._check_tracing(f, (torch.tensor([1]), torch.randn(4)))
+
+    @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
+    @skipIfCrossRef  # Arg order changes with crossref
+    def test_switch_simple_capture_check_graph(self):
+        def f(idx, inp_x):
+            branches = (
+                lambda inp_x: inp_x.sin(),
+                lambda inp_x: inp_x.cos(),
+                lambda inp_x: inp_x.abs(),
+            )
+            return switch(idx, branches, (inp_x,))
+
+        x = torch.randn(4)
+
+        backend = EagerAndRecordGraphs()
+        torch.compile(f, backend=backend)(torch.tensor([1]), x)
+        self.assertEqual(len(backend.graphs), 1)
+        gm = backend.graphs[0]
+
+        # Pin down the outer graph: each branch is installed as a submodule
+        # named switch_branch{i}_0 and the HOP is called with the full list.
+        self.assertExpectedInline(
+            gm.code.strip(),
+            """\
+def forward(self, L_inp_x_ : torch.Tensor, L_idx_ : torch.Tensor):
+    l_inp_x_ = L_inp_x_
+    l_idx_ = L_idx_
+    switch_branch0_0 = self.switch_branch0_0
+    switch_branch1_0 = self.switch_branch1_0
+    switch_branch2_0 = self.switch_branch2_0
+    switch = torch.ops.higher_order.switch(l_idx_, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_,));  l_idx_ = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = None
+    getitem = switch[0];  switch = None
+    return (getitem,)""",
+        )
+        # Each branch is a single op applied to the lifted input.
+        self.assertExpectedInline(
+            gm.switch_branch0_0.code.strip(),
+            """\
+def forward(self, l_inp_x_):
+    l_inp_x__1 = l_inp_x_
+    sin = l_inp_x__1.sin();  l_inp_x__1 = None
+    return (sin,)""",
+        )
+        self.assertExpectedInline(
+            gm.switch_branch1_0.code.strip(),
+            """\
+def forward(self, l_inp_x_):
+    l_inp_x__1 = l_inp_x_
+    cos = l_inp_x__1.cos();  l_inp_x__1 = None
+    return (cos,)""",
+        )
+        self.assertExpectedInline(
+            gm.switch_branch2_0.code.strip(),
+            """\
+def forward(self, l_inp_x_):
+    l_inp_x__1 = l_inp_x_
+    abs_1 = l_inp_x__1.abs();  l_inp_x__1 = None
+    return (abs_1,)""",
+        )
+
+    @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
+    @skipIfCrossRef  # Arg order changes with crossref
+    def test_switch_lifted_args_check_graph(self):
+        # When different branches close over different tensors, dynamo must
+        # union the free variables across branches so every branch graph
+        # shares the same placeholder signature and the HOP receives the
+        # full union as operands. This pins down _merge_graph_inputs.
+        a = torch.ones(2, 3)
+        b = torch.ones(2, 3) + 1
+        c = torch.ones(2, 3) * 2
+
+        def branch0(inp_x):
+            return inp_x + a
+
+        def branch1(inp_x):
+            return inp_x + b
+
+        def branch2(inp_x):
+            return inp_x + c
+
+        def f(idx, inp_x):
+            return switch(idx, (branch0, branch1, branch2), (inp_x,))
+
+        backend = EagerAndRecordGraphs()
+        torch.compile(f, backend=backend)(torch.tensor([1]), torch.randn(2, 3))
+        self.assertEqual(len(backend.graphs), 1)
+        gm = backend.graphs[0]
+
+        # The outer graph lifts all three closure cells and passes the full
+        # union as switch operands (cells first, then the explicit operand x).
+        self.assertExpectedInline(
+            gm.code.strip(),
+            """\
+def forward(self, L_inp_x_ : torch.Tensor, L_idx_ : torch.Tensor, L_branch0_closure_0_cell_contents : torch.Tensor, L_branch1_closure_0_cell_contents : torch.Tensor, L_branch2_closure_0_cell_contents : torch.Tensor):
+    l_inp_x_ = L_inp_x_
+    l_idx_ = L_idx_
+    l_branch0_closure_0_cell_contents = L_branch0_closure_0_cell_contents
+    l_branch1_closure_0_cell_contents = L_branch1_closure_0_cell_contents
+    l_branch2_closure_0_cell_contents = L_branch2_closure_0_cell_contents
+    switch_branch0_0 = self.switch_branch0_0
+    switch_branch1_0 = self.switch_branch1_0
+    switch_branch2_0 = self.switch_branch2_0
+    switch = torch.ops.higher_order.switch(l_idx_, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_, l_branch0_closure_0_cell_contents, l_branch1_closure_0_cell_contents, l_branch2_closure_0_cell_contents));  l_idx_ = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = l_branch0_closure_0_cell_contents = l_branch1_closure_0_cell_contents = l_branch2_closure_0_cell_contents = None
+    getitem = switch[0];  switch = None
+    return (getitem,)""",
+        )
+        # Every branch submodule exposes the same placeholder signature —
+        # the union of all closures plus the operand — even though each
+        # branch only reads one of the closure cells.
+        self.assertExpectedInline(
+            gm.switch_branch0_0.code.strip(),
+            """\
+def forward(self, l_inp_x_, l_branch0_closure_0_cell_contents_branch0, l_branch1_closure_0_cell_contents_branch1, l_branch2_closure_0_cell_contents_branch2):
+    l_inp_x__1 = l_inp_x_
+    add = l_inp_x__1 + l_branch0_closure_0_cell_contents_branch0;  l_inp_x__1 = l_branch0_closure_0_cell_contents_branch0 = None
+    return (add,)""",
+        )
+        self.assertExpectedInline(
+            gm.switch_branch1_0.code.strip(),
+            """\
+def forward(self, l_inp_x_, l_branch0_closure_0_cell_contents_branch0, l_branch1_closure_0_cell_contents_branch1, l_branch2_closure_0_cell_contents_branch2):
+    l_inp_x__1 = l_inp_x_
+    add = l_inp_x__1 + l_branch1_closure_0_cell_contents_branch1;  l_inp_x__1 = l_branch1_closure_0_cell_contents_branch1 = None
+    return (add,)""",
+        )
+        self.assertExpectedInline(
+            gm.switch_branch2_0.code.strip(),
+            """\
+def forward(self, l_inp_x_, l_branch0_closure_0_cell_contents_branch0, l_branch1_closure_0_cell_contents_branch1, l_branch2_closure_0_cell_contents_branch2):
+    l_inp_x__1 = l_inp_x_
+    add = l_inp_x__1 + l_branch2_closure_0_cell_contents_branch2;  l_inp_x__1 = l_branch2_closure_0_cell_contents_branch2 = None
+    return (add,)""",
+        )
+
+    @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
+    @skipIfCrossRef  # Arg order changes with crossref
+    def test_switch_constant_index_specialization_check_graph(self):
+        # When the index is a Python constant, dynamo specializes into the
+        # selected branch and the switch HOP is not emitted at all. The
+        # captured graph contains only the ops of branches[idx].
+        def branch0(inp_x):
+            return inp_x.sin()
+
+        def branch1(inp_x):
+            return inp_x.cos()
+
+        def branch2(inp_x):
+            return inp_x.abs()
+
+        branches = (branch0, branch1, branch2)
+
+        backend = EagerAndRecordGraphs()
+        torch.compile(
+            lambda inp_x: switch(1, branches, (inp_x,)),
+            backend=backend,
+            fullgraph=True,
+        )(torch.randn(4))
+
+        self.assertEqual(len(backend.graphs), 1)
+        gm = backend.graphs[0]
+        # No switch HOP in the graph — only branch1's cos op survives.
+        self.assertExpectedInline(
+            gm.code.strip(),
+            """\
+def forward(self, L_inp_x_ : torch.Tensor):
+    l_inp_x_ = L_inp_x_
+    cos = l_inp_x_.cos();  l_inp_x_ = None
+    return (cos,)""",
+        )
+        # And no branch submodules were installed because the HOP never ran.
+        self.assertEqual(list(dict(gm.named_children()).keys()), [])
+
+    @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
+    @skipIfCrossRef  # Arg order changes with crossref
+    def test_switch_index_type_specialization_check_graph(self):
+        # Pin down dynamo's specialization behavior by index type.
+        # Python int -> specialize: HOP is not emitted, only branches[idx]'s ops survive.
+        # SymInt or Tensor -> no specialize: HOP is emitted with all branches as submodules.
+        def branch0(inp_x):
+            return inp_x.sin()
+
+        def branch1(inp_x):
+            return inp_x.cos()
+
+        def branch2(inp_x):
+            return inp_x.abs()
+
+        branches = (branch0, branch1, branch2)
+
+        def fn(idx, inp_x):
+            return switch(idx, branches, (inp_x,))
+
+        x = torch.randn(4)
+
+        # 1. Python int: dynamo specializes into branch1; HOP is not emitted.
+        torch._dynamo.reset()
+        backend = EagerAndRecordGraphs()
+        torch.compile(fn, backend=backend, fullgraph=True)(1, x)
+        self.assertEqual(len(backend.graphs), 1)
+        gm = backend.graphs[0]
+        self.assertNotIn("higher_order.switch", gm.code)
+        self.assertEqual(list(dict(gm.named_children()).keys()), [])
+
+        # 2. SymInt: derive the index from a dynamically-shaped tensor's
+        # `.shape` so it is genuinely symbolic at trace time. No specialization;
+        # HOP captures all branches.
+        def fn_symint(idx_carrier, inp_x):
+            idx = idx_carrier.shape[0] - 1
+            return switch(idx, branches, (inp_x,))
+
+        idx_carrier = torch.zeros(2)  # shape[0]-1 == 1 -> branch1 at runtime
+        torch._dynamo.mark_dynamic(idx_carrier, 0)
+
+        torch._dynamo.reset()
+        backend = EagerAndRecordGraphs()
+        torch.compile(fn_symint, backend=backend, fullgraph=True)(idx_carrier, x)
+        self.assertEqual(len(backend.graphs), 1)
+        gm = backend.graphs[0]
+        self.assertIn("higher_order.switch", gm.code)
+        self.assertEqual(
+            sorted(dict(gm.named_children()).keys()),
+            ["switch_branch0_0", "switch_branch1_0", "switch_branch2_0"],
+        )
+
+        # 3. Tensor: no specialization; HOP captures all branches.
+        torch._dynamo.reset()
+        backend = EagerAndRecordGraphs()
+        torch.compile(fn, backend=backend, fullgraph=True)(torch.tensor([1]), x)
+        self.assertEqual(len(backend.graphs), 1)
+        gm = backend.graphs[0]
+        self.assertIn("higher_order.switch", gm.code)
+        self.assertEqual(
+            sorted(dict(gm.named_children()).keys()),
+            ["switch_branch0_0", "switch_branch1_0", "switch_branch2_0"],
+        )
+
+    @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
+    @skipIfCrossRef  # Arg order changes with crossref
+    def test_switch_nn_module_lifted_check_graph(self):
+        # nn.Module branches: every parameter of every branch's module is
+        # lifted into the HOP operand tuple, and each branch's submodule
+        # signature accepts the full union. Reads of foreign parameters
+        # are present in the signature but unused inside the branch body.
+        linear0 = torch.nn.Linear(4, 3)
+        linear1 = torch.nn.Linear(4, 3)
+
+        backend = EagerAndRecordGraphs()
+        torch.compile(
+            lambda idx, inp_x: switch(idx, (linear0, linear1), (inp_x,)),
+            backend=backend,
+            fullgraph=True,
+        )(torch.tensor([1]), torch.randn(2, 4))
+
+        self.assertEqual(len(backend.graphs), 1)
+        gm = backend.graphs[0]
+
+        # Both modules' weights AND biases are lifted into the HOP operand
+        # tuple, in sorted order of their placeholder names.
+        self.assertExpectedInline(
+            gm.code.strip(),
+            """\
+def forward(self, L_inp_x_ : torch.Tensor, L_idx_ : torch.Tensor, L_linear0_parameters_weight_ : torch.nn.parameter.Parameter, L_linear0_parameters_bias_ : torch.nn.parameter.Parameter, L_linear1_parameters_weight_ : torch.nn.parameter.Parameter, L_linear1_parameters_bias_ : torch.nn.parameter.Parameter):
+    l_inp_x_ = L_inp_x_
+    l_idx_ = L_idx_
+    l_linear0_parameters_weight_ = L_linear0_parameters_weight_
+    l_linear0_parameters_bias_ = L_linear0_parameters_bias_
+    l_linear1_parameters_weight_ = L_linear1_parameters_weight_
+    l_linear1_parameters_bias_ = L_linear1_parameters_bias_
+    switch_branch0_0 = self.switch_branch0_0
+    switch_branch1_0 = self.switch_branch1_0
+    switch = torch.ops.higher_order.switch(l_idx_, [switch_branch0_0, switch_branch1_0], (l_inp_x_, l_linear0_parameters_bias_, l_linear0_parameters_weight_, l_linear1_parameters_bias_, l_linear1_parameters_weight_));  l_idx_ = switch_branch0_0 = switch_branch1_0 = l_inp_x_ = l_linear0_parameters_bias_ = l_linear0_parameters_weight_ = l_linear1_parameters_bias_ = l_linear1_parameters_weight_ = None
+    getitem = switch[0];  switch = None
+    return (getitem,)""",
+        )
+        # Each branch submodule receives the full union but only reads its
+        # own module's parameters.
+        self.assertExpectedInline(
+            gm.switch_branch0_0.code.strip(),
+            """\
+def forward(self, l_inp_x_, l_linear0_parameters_bias__branch0, l_linear0_parameters_weight__branch0, l_linear1_parameters_bias__branch1, l_linear1_parameters_weight__branch1):
+    l_inp_x__1 = l_inp_x_
+    linear = torch._C._nn.linear(l_inp_x__1, l_linear0_parameters_weight__branch0, l_linear0_parameters_bias__branch0);  l_inp_x__1 = l_linear0_parameters_weight__branch0 = l_linear0_parameters_bias__branch0 = None
+    return (linear,)""",
+        )
+        self.assertExpectedInline(
+            gm.switch_branch1_0.code.strip(),
+            """\
+def forward(self, l_inp_x_, l_linear0_parameters_bias__branch0, l_linear0_parameters_weight__branch0, l_linear1_parameters_bias__branch1, l_linear1_parameters_weight__branch1):
+    l_inp_x__1 = l_inp_x_
+    linear = torch._C._nn.linear(l_inp_x__1, l_linear1_parameters_weight__branch1, l_linear1_parameters_bias__branch1);  l_inp_x__1 = l_linear1_parameters_weight__branch1 = l_linear1_parameters_bias__branch1 = None
+    return (linear,)""",
+        )
 
     @torch._dynamo.config.patch(trace_autograd_ops=True)
     @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2446,6 +2446,16 @@
       ]
     }
   ],
+  "GB7694": [
+    {
+      "Gb_type": "torch.switch: unsupported branch return type (constant)",
+      "Context": "str(ret_val)",
+      "Explanation": "Constants returned from branches must be int or None.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    }
+  ],
   "GB0169": [
     {
       "Gb_type": "Write to immutable cell",
@@ -3323,6 +3333,16 @@
       "Hints": [
         "Remove param warn_only in function call torch.use_deterministic_algorithms.",
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
+  "GB9760": [
+    {
+      "Gb_type": "torch.switch: improper operands contents",
+      "Context": "str(operands)",
+      "Explanation": "Expected `operands` to be a list/tuple of pytrees that only consists of tensor leaves.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
       ]
     }
   ],
@@ -5038,6 +5058,66 @@
       "Hints": []
     }
   ],
+  "GB8165": [
+    {
+      "Gb_type": "torch.switch: improper args/kwargs",
+      "Context": "args: {args}, kwargs: {kwargs}",
+      "Explanation": "torch.switch expects 3 positional arguments (got {len(args)}) and no keyword arguments (got {len(kwargs)}) Usage: switch(index, branches, operands)",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    }
+  ],
+  "GB9509": [
+    {
+      "Gb_type": "torch.switch: improper index",
+      "Context": "str(index)",
+      "Explanation": "Expected index to be an int or a tensor with a single item but got {str(type(index))} with original python type {str(index.python_type())}.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    }
+  ],
+  "GB8206": [
+    {
+      "Gb_type": "torch.switch: improper operands",
+      "Context": "str(operands)",
+      "Explanation": "Expected operands to be a list/tuple but got {operands.python_type()}.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    }
+  ],
+  "GB5884": [
+    {
+      "Gb_type": "torch.switch: improper branches",
+      "Context": "str(branches)",
+      "Explanation": "Expected branches to be a list/tuple of callables.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    }
+  ],
+  "GB4307": [
+    {
+      "Gb_type": "torch.switch: empty branches",
+      "Context": "str(branches)",
+      "Explanation": "Expected at least one branch.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    }
+  ],
+  "GB9203": [
+    {
+      "Gb_type": "torch.switch: differing branch outputs",
+      "Context": "branch{i}: {spec_a.treespec}, branch{i + 1}: {spec_b.treespec}, same_spec: {same_spec}",
+      "Explanation": "Expected branches to return the same pytree structure.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    }
+  ],
   "GB0333": [
     {
       "Gb_type": "wrap_with_autocast: unexpected kwargs",
@@ -5101,6 +5181,16 @@
       "Gb_type": "torch.while_loop: infinite loop detected",
       "Context": "str(cond_r)",
       "Explanation": "Infinite loop detected because while_loop's cond_fn always returns the same value {pred}.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    }
+  ],
+  "GB1824": [
+    {
+      "Gb_type": "torch.switch: unsupported branch return type",
+      "Context": "str(ret_val)",
+      "Explanation": "Expected branches to return a possibly nested pytree of tensor or constant int/None leaves.",
       "Hints": [
         "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
       ]

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -26,6 +26,7 @@ import logging
 import traceback
 import types
 import warnings
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast, Literal, Optional, TYPE_CHECKING, Union
@@ -959,25 +960,13 @@ def _call_while_loop(
         include_contiguity=False,
     )
 
-    (
-        cond_graph,
-        body_graph,
-        cond_shared,
-        _body_shared,
-        cond_unique,
-        body_unique,
-    ) = _merge_graph_inputs(
-        cond_graph,
-        cond_lifted_freevars,
-        "cond_fn",
-        body_graph,
-        body_lifted_freevars,
-        "body_fn",
+    shared, (cond_unique, body_unique) = _merge_graph_inputs(
+        [cond_graph, body_graph],
+        [cond_lifted_freevars, body_lifted_freevars],
+        ["cond_fn", "body_fn"],
     )
 
-    # Note: cond_shared and body_shared refer to the same proxy in parent graph
-    # so using either of them is OK. Use cond_shared as it doesn't matter.
-    additional_lifted_inputs = cond_shared + cond_unique + body_unique
+    additional_lifted_inputs = shared + cond_unique + body_unique
     all_while_loop_inputs: list[VariableTracker | Proxy] = (
         list(operands_seq)
         + list(additional_inputs_seq)
@@ -1276,108 +1265,104 @@ def validate_args_and_maybe_create_graph_inputs(
         return args
 
 
-# This helper function is used to make sure two graphs share the same input signature. For example,
-# in torch.cond, two branches might lift different set of tensors as inputs. This function helps to
-# dedup the inputs and modify the graphs to take the same set of inputs.
+# N-branch generalization of former _merge_graph_inputs. Used by torch.cond (2 branches)
+# and torch.switch (N branches): both must produce subgraphs with a unified
+# placeholder signature so the higher order op can pass a single operand list.
+#
+# Returns (shared, unique_per_branch):
+#   * shared: proxies present in every branch's lifted freevars. For plain
+#     proxies, "present" means by identity. For get_attr proxies, "present"
+#     means by node target (branches in separate tracing contexts can produce
+#     distinct proxies for the same nn module attr); the proxy from the first
+#     branch is chosen as the canonical representative.
+#   * unique_per_branch[i]: proxies lifted by branch i but not shared.
+# Each block is sorted by node name for determinism.
+#
+# Side effect: each graph is rewritten in-place so its placeholders follow the
+# 1 + N block layout: shared block (no suffix), then one block per branch
+# (suffixed with "_<branch_name>") holding that branch's unique freevars. Only
+# the originating branch's unique placeholders are wired to the inner uses;
+# the other branches' unique blocks become unused placeholders for signature
+# alignment.
 def _merge_graph_inputs(
-    l_graph: torch.fx.Graph,
-    l_lifted_freevars: dict[Proxy, Proxy],
-    l_name: str,
-    r_graph: torch.fx.Graph,
-    r_lifted_freevars: dict[Proxy, Proxy],
-    r_name: str,
-) -> tuple[
-    torch.fx.Graph, torch.fx.Graph, list[Proxy], list[Proxy], list[Proxy], list[Proxy]
-]:
-    def dedup_and_sort_lifted_freevars(
-        l_lifted_freevars: dict[Proxy, Proxy], r_lifted_freevars: dict[Proxy, Proxy]
-    ) -> tuple[list[Proxy], list[Proxy], list[Proxy], list[Proxy]]:
-        # The nn module attributes are guaranteed to be registered into the top-level graph module during
-        # higher order op speculation. Therefore, get_attr nodes in two branches with the same
-        # target refer to the same attribute and we can safely deduplicate them with their target.
-        #
-        # Note: ideally, dynamo should just create a single proxy for the same attribute of a nn module. But
-        # true_branch and false_branch belong to two separate tracing contexts, they may register the same
-        # attribute to top level separately. This creates two get_attr proxies for the same attribute
-        # that have different meta data such as stack_trace (one stack trace for the true_branch,
-        # and the other for false_branch). It seems better to discard the proxy explicitly in cond
-        # than make dynamo create a single proxy for the same get_attr target.
-        def shared_getattrs(
-            l_lifted_proxies: Sequence[Proxy], r_lifted_proxies: Sequence[Proxy]
-        ) -> tuple[dict[Proxy, Proxy], dict[Proxy, Proxy]]:
-            true_targets = {
-                proxy.node.target: proxy
-                for proxy in l_lifted_proxies
-                if proxy.node.op == "get_attr"
-            }
-            l_shared_getattrs = {}
-            r_shared_getattrs = {}
-
-            for false_proxy in r_lifted_proxies:
-                if (
-                    false_proxy.node.op == "get_attr"
-                    and false_proxy.node.target in true_targets
-                ):
-                    true_proxy = true_targets[false_proxy.node.target]
-                    l_shared_getattrs[true_proxy] = true_proxy
-                    r_shared_getattrs[false_proxy] = true_proxy
-            return l_shared_getattrs, r_shared_getattrs
-
-        l_shared_getattrs, r_shared_getattrs = shared_getattrs(
-            l_lifted_freevars.keys(),  # type: ignore[arg-type]
-            r_lifted_freevars.keys(),  # type: ignore[arg-type]
+    graphs: list[torch.fx.Graph],
+    lifted_freevars: list[dict[Proxy, Proxy]],
+    names: list[str],
+) -> tuple[list[Proxy], list[list[Proxy]]]:
+    n = len(graphs)
+    if n != len(lifted_freevars) or n != len(names):
+        raise AssertionError(
+            "Expected graphs, lifted_freevars and names to have the same length"
         )
+    if n == 0:
+        raise AssertionError("Expected at least one graph")
 
-        l_shared_freevars = (l_lifted_freevars.keys() & r_lifted_freevars.keys()).union(
-            l_shared_getattrs.keys()
+    # Step 1: pick a canonical proxy for every distinct outer freevar across
+    # branches, deduplicating get_attrs that share a target. A canonical proxy
+    # is shared iff every branch contributed to it.
+    get_attr_canonical: dict[Any, Proxy] = {}
+    per_branch_outer_to_canonical: list[dict[Proxy, Proxy]] = []
+    canonical_branch_count: Counter[Proxy] = Counter()
+    for branch_lifted in lifted_freevars:
+        outer_to_canonical: dict[Proxy, Proxy] = {}
+        for outer in branch_lifted:
+            canonical = outer
+            if outer.node.op == "get_attr":
+                target = outer.node.target
+                canonical = get_attr_canonical.setdefault(target, outer)
+            outer_to_canonical[outer] = canonical
+        per_branch_outer_to_canonical.append(outer_to_canonical)
+        canonical_branch_count.update(set(outer_to_canonical.values()))
+
+    shared_canonical = {c for c, count in canonical_branch_count.items() if count == n}
+
+    # Step 2: derive the shared block and the per-branch unique blocks. Plain
+    # proxies are the same object across branches, so a single canonical entry
+    # covers all of them; for shared get_attrs the canonical is the branch-0
+    # proxy.
+    def _sort_by_name(vars: Iterable[Proxy]) -> list[Proxy]:
+        return sorted(vars, key=lambda var: var.node.name)
+
+    shared = _sort_by_name(shared_canonical)
+    unique_per_branch = [
+        _sort_by_name(
+            outer
+            for outer, canonical in outer_to_canonical.items()
+            if canonical not in shared_canonical
         )
-        r_shared_freevars = (l_lifted_freevars.keys() & r_lifted_freevars.keys()).union(
-            r_shared_getattrs.keys()
-        )
-        unique_l_freevars = l_lifted_freevars.keys() - l_shared_freevars
-        unique_r_freevars = r_lifted_freevars.keys() - r_shared_freevars
+        for outer_to_canonical in per_branch_outer_to_canonical
+    ]
 
-        def _sort_by_name(vars: list[Proxy]) -> list[Proxy]:
-            return sorted(vars, key=lambda var: var.node.name)
-
-        return (
-            list(_sort_by_name(list(l_shared_freevars))),
-            list(_sort_by_name(list(r_shared_freevars))),
-            list(_sort_by_name(list(unique_l_freevars))),
-            list(_sort_by_name(list(unique_r_freevars))),
-        )
-
-    (l_shared, r_shared, unique_l, unique_r) = dedup_and_sort_lifted_freevars(
-        l_lifted_freevars, r_lifted_freevars
-    )
-
-    # Let's say we capture cond(pred, true_fn, false_fn, (x,))
+    # Let's say we capture cond(pred, true_fn, false_fn, (x,)).
     # With set_graph_input set to automatic,
-    # true_fn has lifted variables x, a, b, c
-    # false_fn has lifted variables x, a, b, d
-    # Then fixup_branch_inps make sure both branches have the same signature, i.e.:
-    # - true_fn(x, a, b, c_true_branch, d_false_branch)
-    # - false_fn(x, a, b, c_true_branch, d_false_branch)
+    #   true_fn has lifted variables x, a, b, c
+    #   false_fn has lifted variables x, a, b, d
+    # Then fixup_branch_inps makes sure both branches have the same signature, i.e.:
+    #   true_fn(x, a, b, c_true_branch, d_false_branch)
+    #   false_fn(x, a, b, c_true_branch, d_false_branch)
     #
-    # More formally, the signature has three parts in the following order:
-    # 1. used in both branches: x, a, b
-    # 2. only used in true branches: c, suffixed with _true_branch
-    # 3. only used in false branches: d, suffixed with _false_branch
-    # Within each part, we re-order the nodes by name to have a derterministic ordering for testing.
+    # For N branches the merged signature has 1 + N blocks: shared (no suffix)
+    # then one suffixed block per branch. Within each block proxies are
+    # ordered by node name for determinism.
     def fixup_branch_inps(
         graph: torch.fx.Graph,
-        lifted_freevars: dict[Proxy, Proxy],
-        shared: Sequence[Proxy],
-        unique_l: Sequence[Proxy],
-        unique_r: Sequence[Proxy],
+        branch_lifted: dict[Proxy, Proxy],
+        outer_to_canonical: dict[Proxy, Proxy],
     ) -> None:
+        # Reverse-map canonical -> this branch's outer proxy so we can find the
+        # old placeholder to replace when emitting the shared block.
+        canonical_to_branch_outer = {c: o for o, c in outer_to_canonical.items()}
+
         def _insert_or_replace_phs(new_args: Sequence[Proxy], name_suffix: str) -> None:
             for arg in new_args:
                 new_ph = graph.placeholder(arg.node.name + name_suffix)
                 new_ph.meta = arg.node.meta
-                # Override with new_ph if there exists a old placeholder.
-                if arg in lifted_freevars:
-                    old_ph = lifted_freevars[arg].node
+                # If this branch lifted `arg` (directly or via a shared
+                # get_attr target), wire the new placeholder to the existing
+                # uses and erase the old placeholder.
+                local_outer = canonical_to_branch_outer.get(arg, arg)
+                if local_outer in branch_lifted:
+                    old_ph = branch_lifted[local_outer].node
                     old_ph.replace_all_uses_with(new_ph)
                     # replace_all_uses_with doesn't clean users. Clean it manually so that we could erase it.
                     old_ph.users = {}
@@ -1388,12 +1373,15 @@ def _merge_graph_inputs(
         )
         with graph.inserting_before(first_not_ph_node):
             _insert_or_replace_phs(shared, "")
-            _insert_or_replace_phs(unique_l, "_" + l_name)
-            _insert_or_replace_phs(unique_r, "_" + r_name)
+            for other_name, other_unique in zip(names, unique_per_branch):
+                _insert_or_replace_phs(other_unique, "_" + other_name)
 
-    fixup_branch_inps(l_graph, l_lifted_freevars, l_shared, unique_l, unique_r)
-    fixup_branch_inps(r_graph, r_lifted_freevars, r_shared, unique_l, unique_r)
-    return l_graph, r_graph, l_shared, r_shared, unique_l, unique_r
+    for graph, branch_lifted, outer_to_canonical in zip(
+        graphs, lifted_freevars, per_branch_outer_to_canonical
+    ):
+        fixup_branch_inps(graph, branch_lifted, outer_to_canonical)
+
+    return shared, unique_per_branch
 
 
 # NOTE: [HigherOrderOperator subgraph input ordering]
@@ -2578,20 +2566,10 @@ class CondHigherOrderVariable(TorchHigherOrderOperatorVariable):
                 ],
             )
 
-        (
-            true_graph,
-            false_graph,
-            true_shared,
-            _false_shared,
-            unique_true,
-            unique_false,
-        ) = _merge_graph_inputs(
-            true_graph,
-            true_lifted_freevars,
-            "true_branch",
-            false_graph,
-            false_lifted_freevars,
-            "false_branch",
+        shared, (unique_true, unique_false) = _merge_graph_inputs(
+            [true_graph, false_graph],
+            [true_lifted_freevars, false_lifted_freevars],
+            ["true_branch", "false_branch"],
         )
 
         true_name = tx.output.install_subgraph(
@@ -2610,8 +2588,7 @@ class CondHigherOrderVariable(TorchHigherOrderOperatorVariable):
             pred.as_proxy(),
             true_node,
             false_node,
-            # We pick true_shared but it shouldn't matter
-            tuple(true_shared + unique_true + unique_false),
+            tuple(shared + unique_true + unique_false),
         )
 
         return _call_function_and_unflatten_output(
@@ -2622,6 +2599,230 @@ class CondHigherOrderVariable(TorchHigherOrderOperatorVariable):
             None,
             true_spec,
             true_r,
+        )
+
+
+class SwitchHigherOrderVariable(TorchHigherOrderOperatorVariable):
+    _HOP_NAME = "torch.switch"
+    _ALLOW_FALLBACK_TO_EAGER = False
+    supports_input_mutation = False
+    supports_aliasing = False
+
+    def _call_function(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        from . import ListVariable
+
+        args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
+
+        for i, k in enumerate(["index", "branches", "operands"]):
+            if v := kwargs.pop(k, None):
+                if i != len(args):
+                    raise AssertionError(
+                        "did not provide the right number of non-keyword args"
+                    )
+                args.append(v)
+
+        if len(args) != 3 or kwargs:
+            unimplemented(
+                gb_type="torch.switch: improper args/kwargs",
+                context=f"args: {args}, kwargs: {kwargs}",
+                explanation=f"torch.switch expects 3 positional arguments (got {len(args)}) "
+                f"and no keyword arguments (got {len(kwargs)}) "
+                "Usage: switch(index, branches, operands)",
+                hints=[*graph_break_hints.USER_ERROR],
+            )
+
+        index, branches, operands = args
+        if type(index) is ConstantVariable:
+            # Specialize into one of the branches since index is constant.
+            warnings.warn(
+                "Index is a Python constant. When used with torch.switch, it specializes on one of the branches."
+                " If you want torch.switch to preserve the branches, please make the index a tensor or SymInt.",
+                UserWarning,
+            )
+            idx = index.as_python_constant()
+            branch_fns = branches.unpack_var_sequence(tx)
+            clamped = min(max(0, idx), len(branch_fns) - 1)
+            return branch_fns[clamped].call_function(
+                tx, operands.unpack_var_sequence(tx), {}
+            )
+
+        # index
+        if type(index.realize()) not in (
+            ConstantVariable,
+            TensorVariable,
+            SymNodeVariable,
+        ):
+            unimplemented(
+                gb_type="torch.switch: improper index",
+                context=str(index),
+                explanation="Expected index to be an int or a tensor with a single item "
+                f"but got {str(type(index))} with original python type {str(index.python_type())}.",
+                hints=[*graph_break_hints.USER_ERROR],
+            )
+
+        # operands
+        if not isinstance(operands, (ListVariable, TupleVariable)):
+            unimplemented(
+                gb_type="torch.switch: improper operands",
+                context=str(operands),
+                explanation=f"Expected operands to be a list/tuple "
+                f"but got {operands.python_type()}.",
+                hints=[*graph_break_hints.USER_ERROR],
+            )
+
+        operands_seq = operands.unpack_var_sequence(tx)
+        if not only_consist_of(
+            operands, (TensorVariable, ConstantVariable, SymNodeVariable)
+        ):
+            unimplemented(
+                gb_type="torch.switch: improper operands contents",
+                context=str(operands),
+                explanation="Expected `operands` to be a list/tuple of pytrees that only consists of tensor leaves.",
+                hints=[*graph_break_hints.USER_ERROR],
+            )
+
+        # branches
+        if not isinstance(branches, (ListVariable, TupleVariable)):
+            unimplemented(
+                gb_type="torch.switch: improper branches",
+                context=str(branches),
+                explanation="Expected branches to be a list/tuple of callables.",
+                hints=[*graph_break_hints.USER_ERROR],
+            )
+
+        branch_fns = branches.unpack_var_sequence(tx)
+        if len(branch_fns) == 0:
+            unimplemented(
+                gb_type="torch.switch: empty branches",
+                context=str(branches),
+                explanation="Expected at least one branch.",
+                hints=[*graph_break_hints.USER_ERROR],
+            )
+
+        for i, branch_fn in enumerate(branch_fns):
+            _check_supported_callable_arg(tx, branch_fn, f"branch{i}")
+
+        # Our strategy for tracing the branches of switch mirrors cond: each
+        # branch is speculated in isolation and the resulting graphs are
+        # merged, asserting the output specs agree. Side effects are not
+        # permitted inside branches because of the path-explosion problem.
+        def speculate_branch(
+            func,
+        ) -> tuple[VariableTracker, OutputSpec, torch.fx.Graph, dict[Proxy, Proxy]]:
+            if self._HOP_NAME is None:
+                raise AssertionError("_HOP_NAME must be set")
+            (
+                (ret_val, ret_spec),
+                ret_graph,
+                ret_lifted_freevars,
+            ) = speculate_subgraph(
+                tx,
+                func,
+                operands_seq,
+                {},
+                self._HOP_NAME,
+                source_target=self.value,
+                should_flatten_outputs=True,
+                remove_consts_from_outputs=False,
+                supports_input_mutation=self.supports_input_mutation,
+                supports_aliasing=self.supports_aliasing,
+            )
+
+            # need to ensure we increase epoch so we don't memoize unbacked bindings
+            # across different subgraphs which can interfere with runtime assertion
+            # generation.
+            if tx.fake_mode is None:
+                raise AssertionError("tx.fake_mode must not be None")
+            tx.fake_mode.epoch += 1
+
+            if not only_consist_of(
+                ret_val, (TensorVariable, ConstantVariable), allow_none=True
+            ):
+                unimplemented(
+                    gb_type="torch.switch: unsupported branch return type",
+                    context=str(ret_val),
+                    explanation="Expected branches to return a possibly nested pytree of tensor or constant int/None leaves.",
+                    hints=[*graph_break_hints.USER_ERROR],
+                )
+            for ret in ret_val.unpack_var_sequence(tx):
+                if ret.is_python_constant():
+                    const = ret.as_python_constant()
+                    # Python floats in branch outputs are blocked upstream by
+                    # validate_subgraph_output_types (shared HOP gate); we
+                    # mirror the whitelist here to keep the error specific to
+                    # torch.switch. bool is implicitly accepted via the int check.
+                    if not (isinstance(const, int) or const is None):
+                        unimplemented(
+                            gb_type="torch.switch: unsupported branch return type (constant)",
+                            context=str(ret_val),
+                            explanation="Constants returned from branches must be int or None.",
+                            hints=[*graph_break_hints.USER_ERROR],
+                        )
+            return ret_val, ret_spec, ret_graph, ret_lifted_freevars
+
+        branch_states: list[Any] = []
+        branch_nn_modules: list[Any] = []
+        for f in branch_fns:
+            branch_states.append(speculate_branch(f))
+            branch_nn_modules.append(dict(tx.output.nn_modules))
+        branch_rets, branch_specs, branch_graphs, branch_lifted_freevars = zip(
+            *branch_states
+        )
+
+        for i, (spec_a, spec_b) in enumerate(itertools.pairwise(branch_specs)):
+            same_spec = _make_inlined(tx, pytree.TreeSpec.__eq__)(
+                spec_a.treespec, spec_b.treespec
+            ).as_python_constant()
+            # 3.14: NotImplemented cannot be converted to bool
+            if same_spec is not NotImplemented and not same_spec:
+                unimplemented(
+                    gb_type="torch.switch: differing branch outputs",
+                    context=f"branch{i}: {spec_a.treespec}, branch{i + 1}: {spec_b.treespec}, same_spec: {same_spec}",
+                    explanation="Expected branches to return the same pytree structure.",
+                    hints=[*graph_break_hints.USER_ERROR],
+                )
+
+        # Merge lifted freevars across all branches so they all share the same
+        # placeholder signature. Branches may capture different free variables
+        # (e.g. different nn module attrs), so we union them and add missing
+        # placeholders to any branch graph that lacks them.
+        branch_names_for_merge = [f"branch{i}" for i in range(len(branch_fns))]
+        shared, unique_per_branch = _merge_graph_inputs(
+            list(branch_graphs),
+            list(branch_lifted_freevars),
+            branch_names_for_merge,
+        )
+        all_lifted = shared + [u for branch in unique_per_branch for u in branch]
+
+        branch_names = [
+            tx.output.install_subgraph(
+                f"switch_branch{i}",
+                GraphModule(branch_nn_modules[i], graph),
+            )
+            for i, graph in enumerate(branch_graphs)
+        ]
+
+        branch_nodes = [make_attr(tx, name) for name in branch_names]
+
+        p_args = (
+            index.as_proxy(),
+            branch_nodes,
+            tuple(all_lifted),
+        )
+
+        return _call_function_and_unflatten_output(
+            tx,
+            torch.ops.higher_order.switch,
+            p_args,
+            {},
+            None,
+            branch_specs[0],
+            branch_rets[0],
         )
 
 
@@ -6131,6 +6332,7 @@ from .invoke_subgraph import InvokeSubgraphHigherOrderVariable
 # Map operator names to their corresponding variable for fast TorchHigherOrderOperatorVariable.make()
 _hop_name_to_variable_class = {
     "cond": CondHigherOrderVariable,
+    "switch": SwitchHigherOrderVariable,
     "while_loop": WhileLoopHigherOrderVariable,
     "while_loop_stack_output": WhileLoopStackOutputHigherOrderVariable,
     "map_impl": MapHigherOrderVariable,

--- a/torch/_higher_order_ops/__init__.py
+++ b/torch/_higher_order_ops/__init__.py
@@ -31,6 +31,7 @@ from torch._higher_order_ops.print import print
 from torch._higher_order_ops.run_const_graph import run_const_graph
 from torch._higher_order_ops.scan import scan
 from torch._higher_order_ops.strict_mode import strict_mode
+from torch._higher_order_ops.switch import switch
 from torch._higher_order_ops.torchbind import call_torchbind
 from torch._higher_order_ops.while_loop import (
     while_loop,
@@ -48,6 +49,7 @@ from torch._higher_order_ops.wrap import (
 
 __all__ = [
     "cond",
+    "switch",
     "while_loop",
     "invoke_subgraph",
     "scan",

--- a/torch/_higher_order_ops/switch.py
+++ b/torch/_higher_order_ops/switch.py
@@ -74,7 +74,9 @@ def switch(
 
     Restrictions:
         - Each branch must have the same signature as operands and return the same
-          output structure (shape, dtype, etc.).
+          output structure (shape, dtype, etc.). Constant ``int`` and ``None`` leaves
+          are also permitted in branch outputs and are merged across branches (an
+          unbacked SymInt is introduced when ``int`` leaves differ between branches).
         - Branches cannot have in-place mutations on inputs or global variables.
         - Autograd is not supported in this prototype: the autograd dispatch
           key is a no-op that redispatches below autograd, so gradients will

--- a/torch/_higher_order_ops/switch.py
+++ b/torch/_higher_order_ops/switch.py
@@ -1,0 +1,296 @@
+import contextlib
+import functools
+import logging
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.utils._pytree as pytree
+from torch._C import DispatchKey
+from torch._functorch.utils import exposed_in
+from torch._higher_order_ops.utils import (
+    _maybe_compile_and_run_fn,
+    _maybe_run_with_interpreter,
+    reenter_make_fx,
+    unique_graph_id,
+    validate_subgraph_args_types,
+)
+from torch._ops import HigherOrderOperator
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
+from torch.utils._python_dispatch import _get_current_dispatch_mode
+
+
+log = logging.getLogger(__name__)
+
+
+class SwitchOp(HigherOrderOperator):
+    def __init__(self):
+        super().__init__("switch")
+
+    def __call__(self, index, branches, operands):
+        validate_subgraph_args_types(operands)
+        # pyrefly: ignore [missing-attribute]
+        return super().__call__(index, branches, operands)
+
+
+switch_op = SwitchOp()
+
+
+def wrap_branch_fn_flat(*args, branch_fn, spec_operands):
+    operands = pytree.tree_unflatten(args, spec_operands)
+    return branch_fn(*operands)
+
+
+@exposed_in("torch")
+def switch(
+    index: int | torch.Tensor,
+    branches: tuple[Callable, ...] | list[Callable],
+    operands: tuple | list = (),
+) -> Any:
+    r"""
+    Selects and runs one of N branch functions by index.
+
+    .. warning::
+
+        `torch.switch` is a prototype feature in PyTorch. It has limited support for input and
+        output types. Please look forward to a more stable implementation in a future version of
+        PyTorch. Read more about feature classification at:
+        https://pytorch.org/blog/pytorch-feature-classification-changes/#prototype
+
+    Equivalent to: ``branches[index](*operands)`` with index in ``[0, len(branches))``.
+
+    Args:
+        index (Union[int, torch.Tensor]): An int or single-element integer tensor
+          indicating which branch to run. Out-of-range values are clamped into
+          ``[0, len(branches))``.
+
+        branches (Union[tuple[Callable, ...], list[Callable]]): Non-empty sequence of
+          callables. Each must accept operands and return the same structure of outputs.
+
+        operands (Tuple of possibly nested dict/list/tuple of torch.Tensor): Inputs to
+          the branch functions. Defaults to ().
+
+    Restrictions:
+        - Each branch must have the same signature as operands and return the same
+          output structure (shape, dtype, etc.).
+        - Branches cannot have in-place mutations on inputs or global variables.
+        - Autograd is not supported in this prototype: the autograd dispatch
+          key is a no-op that redispatches below autograd, so gradients will
+          not flow through ``torch.switch``. Full autograd support is planned
+          for a future release.
+    """
+
+    # Flatten operands so the HOP only sees a flat list of tensors.
+    # Each branch is wrapped to unflatten the leaves
+    # back to the user-facing pytree before invocation.
+    leaves_operands, spec_operands = pytree.tree_flatten(operands)
+
+    def _validate_input(index, branches, operands):
+        if not isinstance(index, (int, torch.SymInt, torch.Tensor)):
+            raise RuntimeError(
+                f"Expected index to be int or single-element tensor, but got {index}."
+            )
+
+        if isinstance(index, torch.Tensor) and index.numel() != 1:
+            raise RuntimeError(
+                f"Expected index to be int or single-element tensor, but got {index}."
+            )
+
+        if not isinstance(branches, (tuple, list)) or len(branches) == 0:
+            raise RuntimeError(
+                "Expected branches to be a non-empty tuple or list of callables."
+            )
+
+        for i, branch in enumerate(branches):
+            if not callable(branch):
+                raise RuntimeError(
+                    f"Expected all branches to be callable. branch{i} is not callable."
+                )
+
+        for x in operands:
+            if not isinstance(x, torch.Tensor):
+                raise RuntimeError(f"All operand leaves must be a Tensor but got {x}")
+
+    _validate_input(index, branches, leaves_operands)
+
+    wrapped_branches = tuple(
+        functools.partial(
+            wrap_branch_fn_flat,
+            branch_fn=branch_fn,
+            spec_operands=spec_operands,
+        )
+        for branch_fn in branches
+    )
+
+    # Early shortcut: single-branch switch degenerates to a plain call
+    if len(wrapped_branches) == 1:
+        return wrapped_branches[0](*leaves_operands)
+
+    # Constant index shortcut for eager mode.
+    if not torch.compiler.is_dynamo_compiling() and isinstance(index, int):
+        # This is the non-strict export case. Strict export and torch.compile are
+        # handled below via _maybe_compile_and_run_fn.
+        if torch.compiler.is_compiling():
+            warnings.warn(
+                "Index is a Python constant. When used with torch.switch, it specializes on one of the branches."
+                " If you want torch.switch to preserve the branches, please make the index an int tensor or a SymInt.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        # Clamp out-of-range indices rather than raising for consistency with compiled behavior.
+        clamped_index = min(max(0, index), len(wrapped_branches) - 1)
+        return wrapped_branches[clamped_index](*leaves_operands)
+
+    # Use _maybe_compile_and_run_fn pattern from scan/associative_scan
+    def run_switch(index, wrapped_branches, leaves_operands):
+        return switch_op(index, wrapped_branches, leaves_operands)
+
+    return _maybe_compile_and_run_fn(
+        run_switch, index, wrapped_branches, leaves_operands
+    )
+
+
+def trace_switch(proxy_mode, func_overload, index, branches, operands):
+    if not isinstance(operands, (list, tuple)):
+        raise AssertionError(
+            f"Switch operands must be a list or tuple of tensors and SymInts {operands}"
+        )
+    if not isinstance(branches, (list, tuple)) or len(branches) == 0:
+        raise AssertionError(
+            "Switch branches must be a non-empty list or tuple of callables"
+        )
+
+    branch_graphs = [reenter_make_fx(branch)(*operands) for branch in branches]
+
+    branch_outs = [list() for _ in branches]
+    for i, branch_graph in enumerate(branch_graphs):
+        for node in branch_graph.graph.nodes:
+            if node.op == "output":
+                branch_outs[i].extend(node.args)
+
+    branch_out_spec = [pytree.tree_flatten(outs)[1] for outs in branch_outs]
+    for i, spec in enumerate(branch_out_spec):
+        if branch_out_spec[0] != spec:
+            raise RuntimeError(
+                "Unmatched output spec from torch.switch branches: "
+                f"branch0 tree_spec {branch_out_spec[0]} vs branch{i} tree_spec {spec}"
+            )
+
+    uid, _ = unique_graph_id(proxy_mode, prefix="branch0_graph")
+    for i, branch_graph in enumerate(branch_graphs):
+        proxy_mode.tracer.root.register_module(f"branch{i}_graph_{uid}", branch_graph)
+
+    args = (index, branch_graphs, operands)
+
+    proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
+
+    out_proxy = proxy_mode.tracer.create_proxy(
+        "call_function", func_overload, proxy_args, {}
+    )
+
+    out = func_overload(index, branch_graphs, operands)
+
+    return track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
+
+
+@switch_op.py_impl(DispatchKey.CompositeExplicitAutograd)
+def switch_op_dense(index, branches, operands):
+    if not all(isinstance(o, (torch.Tensor, int)) for o in operands):
+        raise RuntimeError(
+            f"Dense implementation operands must be a list of tensors and ints {operands}"
+        )
+    mode = _get_current_dispatch_mode()
+    if mode is not None:
+        raise AssertionError("Mode should never be enabled for CPU/CUDA key")
+    idx: int = int(index.item()) if isinstance(index, torch.Tensor) else int(index)
+    # Clamp out-of-range indices rather than raising for consistency with compiled behavior.
+    clamped_idx = min(max(0, idx), len(branches) - 1)
+    return branches[clamped_idx](*operands)
+
+
+@switch_op.py_autograd_impl
+def switch_autograd(index, branches, operands):
+    with torch._C._AutoDispatchBelowAutograd():
+        return switch_op(index, branches, operands)
+
+
+@switch_op.py_impl(ProxyTorchDispatchMode)
+def inner(mode, index, branches, operands):
+    return trace_switch(mode, switch_op, index, branches, operands)
+
+
+@switch_op.py_impl(FakeTensorMode)
+def switch_fake_tensor_mode(mode, index, branches, operands):
+    # Ignore here, because if you've gotten here but you're not manually
+    # tracing the inner graphs, that means that you intend to reuse the graph
+    # directly.  Which means the old unbacked symbol bindings are appropriate.
+    # This strategy will not work if unbacked symbols can escape.
+    ignore_fresh_unbacked = contextlib.nullcontext()
+    if mode.shape_env:
+        ignore_fresh_unbacked = mode.shape_env.ignore_fresh_unbacked_symbols()
+
+    with mode, ignore_fresh_unbacked:
+        flat_branch_outs, branch_out_spec = zip(
+            *[pytree.tree_flatten(branch(*operands)) for branch in branches]
+        )
+        for i, spec in enumerate(branch_out_spec):
+            if branch_out_spec[0] != spec:
+                raise RuntimeError(
+                    "Unmatched output spec from torch.switch branches: "
+                    f"branch0 tree_spec {branch_out_spec[0]} vs branch{i} tree_spec {spec}"
+                )
+
+    merged_outs = []
+    for branches_out in zip(*flat_branch_outs):
+        merged_outs.append(_merge_output(branches_out, mode))
+    return pytree.tree_unflatten(merged_outs, branch_out_spec[0])
+
+
+def _merge_output(xs: tuple[torch.Tensor | int | None, ...], mode: FakeTensorMode):
+    from torch._higher_order_ops.cond import _merge_output as cond_merge_output
+
+    # Shortcut if a branch produces None outputs; then all branches need to produce None
+    if any(x is None for x in xs):
+        if not all(x is None for x in xs):
+            raise AssertionError(f"expected all leaves to be None, got {xs}")
+        return None
+
+    # In case all branches return an int, use an unbacked symbol as the merge result
+    if all(type(x) is int for x in xs):
+        if all(x == xs[0] for x in xs):
+            return xs[0]
+        if mode.shape_env is None:
+            raise AssertionError("mode.shape_env is None")
+        merged_out = mode.shape_env.create_unbacked_symint()
+        mode.shape_env.constrain_symbol_range(
+            merged_out.node.expr,
+            min(xs),  # type: ignore[type-var]
+            max(xs),  # type: ignore[type-var]
+        )
+        return merged_out
+
+    return functools.reduce(lambda a, b: cond_merge_output(a, b, mode), xs)
+
+
+@switch_op.py_functionalize_impl
+def switch_func(ctx, index, branches, inputs):
+    from torch._higher_order_ops.utils import _check_alias_and_mutation
+
+    unwrapped_inputs = ctx.unwrap_tensors(inputs)
+    unwrapped_index = ctx.unwrap_tensors(index)
+    with ctx.redispatch_to_next():
+        functional_branches = [
+            ctx.functionalize(_maybe_run_with_interpreter(fn)) for fn in branches
+        ]
+        pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
+        for i, branch in enumerate(branches):
+            _check_alias_and_mutation(
+                branch, unwrapped_inputs, f"switch_branch{i}", pre_dispatch
+            )
+        switch_return = switch_op(
+            unwrapped_index, functional_branches, unwrapped_inputs
+        )
+        return ctx.wrap_tensors(switch_return)

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -169,6 +169,26 @@ def simple_cond(x):
     return torch.cond(x.sum() > 2, lambda x: (x.cos(),), lambda x: (x.sin(),), [x])
 
 
+def sample_inputs_switch(opinfo, device, dtype, requires_grad, **kwargs):
+    make_arg = functools.partial(
+        make_tensor, device=device, dtype=dtype, requires_grad=requires_grad
+    )
+    yield SampleInput(make_arg(2, 2, 2, low=0.1, high=2))
+
+
+def simple_switch(x):
+    # Tensor index so the HOP is actually captured (Python-constant indices
+    # would specialize away in dynamo).
+    from torch._higher_order_ops.switch import switch
+
+    idx = (x.sum() > 2).long()
+    return switch(
+        idx,
+        (lambda x: (x.cos(),), lambda x: (x.sin(),), lambda x: (x.abs(),)),
+        [x],
+    )
+
+
 def sample_inputs_invoke_subgraph(opinfo, device, dtype, requires_grad, **kwargs):
     make_arg = functools.partial(
         make_tensor, device=device, dtype=dtype, requires_grad=requires_grad
@@ -531,6 +551,22 @@ hop_db = [
         supports_autograd=True,
         # "torch.compile with aot_autograd does not currently support double backward."
         supports_gradgrad=False,
+    ),
+    OpInfo(
+        name="switch",
+        variant_test_name="simple",
+        op=simple_switch,
+        sample_inputs_func=sample_inputs_switch,
+        dtypes=all_types_and(torch.bool, torch.half),
+        supports_out=False,
+        check_batched_grad=False,
+        check_batched_gradgrad=False,
+        check_batched_forward_grad=False,
+        check_inplace_batched_forward_grad=False,
+        # The full SwitchAutogradOp lands in PR 3. PR 1 ships only a
+        # passthrough autograd stub (CompositeExplicitAutograd-style) that
+        # is not sufficient for HOP-level backward tests.
+        supports_autograd=False,
     ),
     OpInfo(
         name="invoke_quant",


### PR DESCRIPTION
This is the first PR of a series of PRs to add the `torch.switch` functionality, which shares an equivalent API as the JAX implementation under https://docs.jax.dev/en/latest/_autosummary/jax.lax.switch.html. 
In this PR, we add the initial skeleton of switch with the dense implementation only, along with various tests. In follow-up PRs, we will add _inductor support, Autograd, gen_schema, etc.

This PR is related to https://github.com/pytorch/pytorch/issues/175891

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @lakshayg @ydwu4 @ezyang