### PR TITLE
[inductor] Add DualIndentedBuffer for dual-mode codegen

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1614,7 +1614,7 @@ class IndentedBuffer:
                 return
             other_code = other_code.rstrip()
             for s in other_code.split("\n"):
-                self.writeline(s)
+                IndentedBuffer.writeline(self, s)
 
     def map(self, func: Callable[[Any], Any]) -> IndentedBuffer:
         res = IndentedBuffer(initial_indent=self._indent)
@@ -1636,13 +1636,99 @@ class IndentedBuffer:
         return new_line in self._lines
 
 
+def is_dual_mode() -> bool:
+    """True when generating dual-mode C++ for both JIT and AOTI."""
+    from .virtualized import V
+
+    return V.graph.aot_mode and config.triton.autotune_at_compile_time is False
+
+
+class DualIndentedBuffer(IndentedBuffer):
+    """IndentedBuffer that simultaneously accumulates JIT and AOTI output.
+
+    The base class (self._lines) holds JIT content. self.aot holds AOTI content.
+    By default, writeline/splice write to both. Use _jit/_aot variants for
+    mode-specific writes.
+    """
+
+    def __init__(self, initial_indent: int = 0) -> None:
+        super().__init__(initial_indent)
+        self.aot = IndentedBuffer(initial_indent)
+
+    @property
+    def jit(self) -> IndentedBuffer:
+        """Read-only accessor for JIT buffer (for splicing into result).
+
+        WARNING: Do NOT use jit for writing — writes would go to both buffers
+        because self.writeline is overridden. Use writeline_jit/splice_jit instead.
+        """
+        return self  # type: ignore[return-value]
+
+    def writeline(self, line):  # type: ignore[override]
+        IndentedBuffer.writeline(self, line)
+        self.aot.writeline(line)
+
+    def writeline_jit(self, line) -> None:
+        IndentedBuffer.writeline(self, line)
+
+    def writeline_aot(self, line) -> None:
+        self.aot.writeline(line)
+
+    def writelines(self, lines):  # type: ignore[override]
+        for line in lines:
+            self.writeline(line)
+
+    def splice(self, other_code, strip: bool = False) -> None:  # type: ignore[override]
+        # Splice into each buffer independently. When other_code is itself a
+        # DualIndentedBuffer, each side reads from the matching side.
+        IndentedBuffer.splice(self, other_code, strip=strip)
+        aot_other = (
+            other_code.aot if isinstance(other_code, DualIndentedBuffer) else other_code
+        )
+        self.aot.splice(aot_other, strip=strip)
+
+    def splice_jit(self, other_code, strip: bool = False) -> None:
+        IndentedBuffer.splice(self, other_code, strip=strip)
+
+    def splice_aot(self, other_code, strip: bool = False) -> None:
+        aot_other = (
+            other_code.aot if isinstance(other_code, DualIndentedBuffer) else other_code
+        )
+        self.aot.splice(aot_other, strip=strip)
+
+    def indent(self, offset: int = 1):
+        @contextlib.contextmanager
+        def ctx():
+            self._indent += offset
+            self.aot._indent += offset
+            try:
+                yield
+            finally:
+                self._indent -= offset
+                self.aot._indent -= offset
+
+        return ctx()
+
+    def do_indent(self, offset: int = 1) -> None:
+        self._indent += offset
+        self.aot._indent += offset
+
+    def do_unindent(self, offset: int = 1) -> None:
+        self._indent -= offset
+        self.aot._indent -= offset
+
+    def clear(self) -> None:
+        super().clear()
+        self.aot.clear()
+
+
 class AotOnlyBuffer(IndentedBuffer):
     """IndentedBuffer for pure-AOTI codegen.
 
     Mirror of the base class's pure-JIT defaults: writeline_aot/splice_aot
     write to the buffer; writeline_jit/splice_jit are no-ops. Lets call
-    sites use writeline_jit/writeline_aot uniformly across pure-JIT and
-    pure-AOTI modes.
+    sites use writeline_jit/writeline_aot uniformly across pure-JIT,
+    pure-AOTI, and dual modes.
     """
 
     def writeline_jit(self, line) -> None:
@@ -1661,11 +1747,14 @@ class AotOnlyBuffer(IndentedBuffer):
 def make_codegen_buffer() -> IndentedBuffer:
     """Construct the IndentedBuffer subclass matching the current codegen mode.
 
+    Dual mode → DualIndentedBuffer (JIT and AOTI both active).
     Pure AOTI → AotOnlyBuffer (writeline_aot writes; writeline_jit drops).
     Pure JIT  → IndentedBuffer  (writeline_jit writes; writeline_aot drops).
     """
     from .virtualized import V
 
+    if is_dual_mode():
+        return DualIndentedBuffer()
     if V.graph.aot_mode:
         return AotOnlyBuffer()
     return IndentedBuffer()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #182914
* __->__ #182913
* #182912
* #182911

DualIndentedBuffer routes writeline_jit/splice_jit to the JIT buffer
and writeline_aot/splice_aot to the AOTI buffer; plain writeline/splice
write to both. is_dual_mode() identifies the AOTI lazy-autotune path,
and make_codegen_buffer() returns DualIndentedBuffer in that case.

No direct usage of DualIndentedBuffer in this PR. This is to prepare
for future PRs.

Authored with Claude