### PR TITLE
[DO NOT MERGE][TEST ONLY] Test file descriptor exhaustion during Inductor UT

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -149,6 +149,10 @@ if [[ "${PYTORCH_TEST_RERUN_DISABLED_TESTS}" == "1" ]] || [[ "${CONTINUE_THROUGH
   # certain threshold. However, this is not supported inside Docker container atm
 fi
 
+echo "Current file descriptor limit: $(ulimit -n)"
+ulimit -n 1024
+echo "Updated file descriptor limit: $(ulimit -n)"
+
 # Get fully qualified path using realpath
 CUSTOM_TEST_ARTIFACT_BUILD_DIR=$(realpath "${CUSTOM_TEST_ARTIFACT_BUILD_DIR:-"build/custom_test_artifacts"}")
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -99,17 +99,7 @@ jobs:
       cuda-arch-list: '7.5 8.9'
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
-          { config: "default", shard: 2, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
-          { config: "default", shard: 3, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
-          { config: "default", shard: 4, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
-          { config: "default", shard: 5, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g4dn.12xlarge.nvidia.gpu" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g4dn.12xlarge.nvidia.gpu" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g4dn.12xlarge.nvidia.gpu" },
-          { config: "pr_time_benchmarks", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g4dn.metal.nvidia.gpu" },
-          # Test cross-compiled models with Windows libs extracted from wheel (CUDA 13.0)
-          { config: "aoti_cross_compile_for_windows", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu", win_torch_wheel_artifact: "win-vs2022-cuda13.0-py3" },
+          { config: "default", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu" },
         ]}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -132,7 +122,7 @@ jobs:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.test-matrix }}
-      tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
+      tests-to-include: inductor/test_torchinductor_opinfo_properties
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -269,20 +259,7 @@ jobs:
       # sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 2, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 3, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 4, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 5, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 6, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 7, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 8, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 9, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 10, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "distributed", shard: 1, num_shards: 4, runner: "linux.rocm.gpu.gfx950.2" },
-          { config: "distributed", shard: 2, num_shards: 4, runner: "linux.rocm.gpu.gfx950.2" },
-          { config: "distributed", shard: 3, num_shards: 4, runner: "linux.rocm.gpu.gfx950.2" },
-          { config: "distributed", shard: 4, num_shards: 4, runner: "linux.rocm.gpu.gfx950.2" },
+          { config: "default", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx950.1" },
         ]}
       use-arc: false
       python-version: "3.10"
@@ -299,7 +276,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
-      tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
+      tests-to-include: inductor/test_torchinductor_opinfo_properties
     secrets: inherit
 
   inductor-build:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1940,7 +1940,13 @@ def load_test_times_from_file(file: str) -> dict[str, Any]:
 def load_test_file_times(
     file: str = ADDITIONAL_CI_FILES_FOLDER / TEST_TIMES_FILE,
 ) -> dict[str, float]:
-    return cast(dict[str, float], load_test_times_from_file(file))
+    times = cast(dict[str, float], load_test_times_from_file(file))
+    times["inductor/test_torchinductor_opinfo_properties"] = 10.0
+    print_to_stderr(
+        "::warning:: Forcing inductor/test_torchinductor_opinfo_properties "
+        "test time to 10.0s to keep pytest sharding to one shard."
+    )
+    return times
 
 
 def load_test_class_times(


### PR DESCRIPTION
## Summary
- Test file descriptor exhaustion during Inductor UT execution: ROCm vs CUDA.
- Limit trunk CUDA and ROCm to the opinfo properties suite in one shard.
- Log and set the CI test file descriptor limit to 1024, and force the opinfo properties timing estimate low enough to avoid pytest-level sharding.

## Test plan
- python3 -m py_compile test/run_test.py
- bash -n .ci/pytorch/test.sh
- YAML parse validation for .github/workflows/trunk.yml


Made with [Cursor](https://cursor.com)