### PR TITLE
[DO NOT MERGE][TESTING ONLY] Set MI300 ROCm build arch to SPIR-V

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -29,6 +29,12 @@ on:
         default: "7.5"
         description: |
           List of CUDA architectures CI build should target.
+      pytorch-rocm-arch:
+        required: false
+        type: string
+        default: ""
+        description: |
+          List of ROCm architectures CI build should target.
       runner_prefix:
         required: false
         default: ""
@@ -261,6 +267,7 @@ jobs:
           OUR_GITHUB_JOB_ID: ${{ steps.setup-linux.outputs.job-id }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           BUILD_ADDITIONAL_PACKAGES: ${{ inputs.build-additional-packages }}
+          PYTORCH_ROCM_ARCH: ${{ inputs.pytorch-rocm-arch }}
           RUNNER: ${{ inputs.runner }}
         run: |
           START_TIME=$(date +%s)
@@ -332,6 +339,7 @@ jobs:
             -e OUR_GITHUB_JOB_ID \
             -e HUGGING_FACE_HUB_TOKEN \
             -e BUILD_ADDITIONAL_PACKAGES \
+            -e PYTORCH_ROCM_ARCH \
             -e RUNNER \
             --memory="${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}g" \
             --memory-swap="${TOTAL_MEMORY_WITH_SWAP}g" \
@@ -548,6 +556,7 @@ jobs:
           OUR_GITHUB_JOB_ID: ${{ steps.setup-linux.outputs.job-id }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           BUILD_ADDITIONAL_PACKAGES: ${{ inputs.build-additional-packages }}
+          PYTORCH_ROCM_ARCH: ${{ inputs.pytorch-rocm-arch }}
           RUNNER: ${{ inputs.runner }}
           SKIP_SCCACHE_INITIALIZATION: 1
         shell: bash

--- a/.github/workflows/rocm-mi300.yml
+++ b/.github/workflows/rocm-mi300.yml
@@ -44,6 +44,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-noble-rocm-py3.12-mi300
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
+      pytorch-rocm-arch: amdgcnspirv
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx942.1" },


### PR DESCRIPTION
## Summary
- Add an optional `pytorch-rocm-arch` input to the reusable Linux build workflow.
- Pass `PYTORCH_ROCM_ARCH` into the build environment for both Linux build paths.
- Set `PYTORCH_ROCM_ARCH=amdgcnspirv` only for the regular ROCm MI300 workflow.

## Test plan
- Parsed `.github/workflows/_linux-build.yml` and `.github/workflows/rocm-mi300.yml` as YAML.
- Verified only `.github/workflows/rocm-mi300.yml` sets `pytorch-rocm-arch: amdgcnspirv`.
- Verified `_linux-build.yml` wires `PYTORCH_ROCM_ARCH` through both build paths.


Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang