### PR TITLE
Fix nightly docs push by giving OSDC job access to pytorchbot-env

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -278,6 +278,7 @@ jobs:
       contents: read
       actions: read
     runs-on: ${{ matrix.runner }}
+    environment: ${{ (github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) && 'pytorchbot-env' || '' }}
     container:
       image: ${{ inputs.docker-image }}
     strategy:


### PR DESCRIPTION
The OSDC docs build path added in #181802 didn't declare the `pytorchbot-env` GitHub Environment, so `secrets.GH_PYTORCHBOT_TOKEN` resolved to empty and the `.netrc`-based push to pytorchbot/temp-branch-py failed with "could not read Username for 'https://github.com'". Mirror the same conditional environment line that the legacy build-docs job uses.

Authored by Claude.