### PR TITLE
[Docathon] Convert cpu.rst to MyST Markdown

### DIFF
--- a/docs/source/cpu.md
+++ b/docs/source/cpu.md
@@ -1,8 +1,14 @@
-torch.cpu
-===================================
-.. automodule:: torch.cpu
-.. currentmodule:: torch.cpu
+# torch.cpu
 
+```{eval-rst}
+.. automodule:: torch.cpu
+```
+
+```{eval-rst}
+.. currentmodule:: torch.cpu
+```
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -17,11 +23,14 @@ torch.cpu
     set_device
     device_count
     StreamContext
+```
 
-Streams and events
-------------------
+## Streams and events
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     Stream
+```


### PR DESCRIPTION
### Summary

Converts `docs/source/cpu.rst` to MyST Markdown as part of the PyTorch Docathon h1-2025 track.

Fixes #182459

### Conversions

- `===` heading underline → `# torch.cpu`
- `---` heading underline → `## Streams and events`
- `.. automodule:: torch.cpu`, `.. currentmodule:: torch.cpu`, and the two `.. autosummary::` blocks are each wrapped in a MyST `` ```{eval-rst} `` fenced block, matching the established pattern used by `docs/source/cuda.md` and other peer device-API pages.

### Mechanics

- File renamed with `git mv` to preserve `git log --follow` history (rendered as a 76% rename).
- No content was added or removed beyond the rST → MyST syntactic transformation; the autosummary entries are byte-for-byte the same set in the same order.
- The toctree entry in `docs/source/pytorch-api.md` is the extension-less name `cpu`, so it resolves to the renamed file without further change.
- No Python source under `torch/` references `cpu.rst` (verified by grep), so there were no `.. include::` paths to inline.

### Verification

- Visual side-by-side comparison of structure and directive options against `docs/source/cuda.md` (peer page).
- The rendered Markdown should produce the same Sphinx pages as the original rST. Doc CI build and `linux-jammy-py3.9-gcc11 / test (docs_test, …)` will validate that the generated HTML matches.


cc @svekars @sekyondaMeta @AlannaBurke