### PR TITLE
[Docathon 2026] Convert `nn.functional.rst` to MyST Markdown

### DIFF
--- a/docs/source/nn.functional.md
+++ b/docs/source/nn.functional.md
@@ -1,14 +1,17 @@
+```{eval-rst}
 .. role:: hidden
     :class: hidden-section
+```
 
-torch.nn.functional
-===================
+# torch.nn.functional
 
+```{eval-rst}
 .. currentmodule:: torch.nn.functional
+```
 
-Convolution functions
-----------------------------------
+## Convolution functions
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -21,10 +24,11 @@ Convolution functions
     conv_transpose3d
     unfold
     fold
+```
 
-Pooling functions
-----------------------------------
+## Pooling functions
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -49,22 +53,24 @@ Pooling functions
     adaptive_avg_pool3d
     fractional_max_pool2d
     fractional_max_pool3d
+```
 
-Attention Mechanisms
--------------------------------
+## Attention Mechanisms
 
-The :mod:`torch.nn.attention.bias` module contains attention_biases that are designed to be used with
+The {mod}`torch.nn.attention.bias` module contains attention_biases that are designed to be used with
 scaled_dot_product_attention.
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     scaled_dot_product_attention
+```
 
-Non-linear activation functions
--------------------------------
+## Non-linear activation functions
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -113,20 +119,22 @@ Non-linear activation functions
 
 .. _Link 1: https://arxiv.org/abs/1611.00712
 .. _Link 2: https://arxiv.org/abs/1611.01144
+```
 
-Linear functions
-----------------
+## Linear functions
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     linear
     bilinear
+```
 
-Dropout functions
------------------
+## Dropout functions
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -137,10 +145,11 @@ Dropout functions
     dropout1d
     dropout2d
     dropout3d
+```
 
-Sparse functions
-----------------------------------
+## Sparse functions
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -148,10 +157,11 @@ Sparse functions
     embedding
     embedding_bag
     one_hot
+```
 
-Distance functions
-----------------------------------
+## Distance functions
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -159,11 +169,11 @@ Distance functions
     pairwise_distance
     cosine_similarity
     pdist
+```
 
+## Loss functions
 
-Loss functions
---------------
-
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -190,10 +200,11 @@ Loss functions
     soft_margin_loss
     triplet_margin_loss
     triplet_margin_with_distance_loss
+```
 
-Vision functions
-----------------
+## Vision functions
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -207,22 +218,23 @@ Vision functions
     upsample_bilinear
     grid_sample
     affine_grid
+```
 
-DataParallel functions (multi-GPU, distributed)
------------------------------------------------
+## DataParallel functions (multi-GPU, distributed)
 
-:hidden:`data_parallel`
-~~~~~~~~~~~~~~~~~~~~~~~
+### {hidden}`data_parallel`
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     torch.nn.parallel.data_parallel
+```
 
-Low-Precision functions
------------------------
+## Low-Precision functions
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -232,3 +244,4 @@ Low-Precision functions
     grouped_mm
     scaled_mm
     scaled_grouped_mm
+```


### PR DESCRIPTION
### Summary

Converts `docs/source/nn.functional.rst` from reStructuredText to MyST Markdown as part of the PyTorch Docathon 2026.

The file contains `autosummary` directive blocks which are kept inside `eval-rst` fences, matching the pattern used in the already-converted `nn.md`.

Fixes #182478

### Test plan

- [x] File renamed using `git mv` (preserves git history)
- [x] Content converted from rST to MyST Markdown syntax
- [x] `.. role::` directive wrapped in `eval-rst` (matches `nn.md` pattern)
- [x] `lintrunner --skip EXEC -m main` — no lint issues
- [x] `git diff --check` passes


cc @svekars @sekyondaMeta @AlannaBurke