### PR TITLE
[CUDA] Scope counter-based block ordering to NCCL MemPool only

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -167,11 +167,14 @@ struct Block;
 struct PrivatePool;
 typedef bool (*Comparison)(const Block*, const Block*);
 static bool BlockComparatorRegistrationCounter(const Block* a, const Block* b);
+static bool BlockComparatorSizeAddress(const Block* a, const Block* b);
 static bool BlockComparatorAddress(const Block* a, const Block* b);
 
 struct BlockPool {
   BlockPool(bool small, PrivatePool* private_pool = nullptr)
-      : blocks(BlockComparatorRegistrationCounter),
+      : blocks(
+            private_pool ? BlockComparatorRegistrationCounter
+                         : BlockComparatorSizeAddress),
         unmapped(BlockComparatorAddress),
         is_small(small),
         owner_PrivatePool(private_pool) {}
@@ -234,8 +237,11 @@ struct Block {
         requested_size(0),
         pool(pool),
         ptr(ptr) {
-    registration_counter =
-        registration_counter_global.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (pool && pool->owner_PrivatePool) {
+      registration_counter =
+          registration_counter_global.fetch_add(1, std::memory_order_relaxed) +
+          1;
+    }
   }
 
   // constructor for search key
@@ -1090,6 +1096,16 @@ bool BlockComparatorRegistrationCounter(const Block* a, const Block* b) {
     return a->size < b->size;
   }
   return a->registration_counter < b->registration_counter;
+}
+
+bool BlockComparatorSizeAddress(const Block* a, const Block* b) {
+  if (a->stream != b->stream) {
+    return (uintptr_t)a->stream < (uintptr_t)b->stream;
+  }
+  if (a->size != b->size) {
+    return a->size < b->size;
+  }
+  return (uintptr_t)a->ptr < (uintptr_t)b->ptr;
 }
 
 bool BlockComparatorAddress(const Block* a, const Block* b) {


### PR DESCRIPTION
Summary:
D100718946 (PyTorch upstream PR #178362) changed CUDACachingAllocator block ordering from memory-address-based to allocation-counter-based, and converted the registration counter from thread_local to std::atomic. While this fixed NCCL symmetric memory alignment for distributed training, it introduced a performance regression in inference workloads: the counter-based ordering degrades spatial locality of GPU memory accesses under multi-threaded inference, and the global atomic counter adds cross-thread cache-line contention on every allocation.

This forward fix scopes the counter-based ordering to NCCL MemPool (PrivatePool) only, restoring address-based ordering for default allocator pools used by inference:

- Adds BlockComparatorSizeAddress (stream, size, address) for default pools, matching pre-D100718946 behavior
- BlockPool constructor selects comparator based on whether it belongs to a PrivatePool
- Atomic counter increment is skipped for default pool blocks, eliminating unnecessary contention

The NCCL fix is preserved: PrivatePool-backed BlockPools (used by NCCL MemPool) continue to use counter-based ordering with the atomic counter.

Test Plan: Existing tests for NCCL MemPool (test_multi_threads_alloc_in_same_order, test_nccl_mem_alloc_addresses_in_random_order) should continue to pass since PrivatePool blocks still use counter-based ordering. Default pool behavior reverts to pre-D100718946 address-based ordering. Needs validation on GPU inference fleet to confirm performance regression is resolved.

Reviewed By: banitag1

Differential Revision: D104353509


