### PR TITLE
[Docathon] Convert elastic/subprocess_handler.rst to MyST Markdown

### DIFF
--- a/docs/source/elastic/subprocess_handler.md
+++ b/docs/source/elastic/subprocess_handler.md
@@ -1,20 +1,22 @@
-.. _elastic_subprocess_handler-api:
+(elastic_subprocess_handler-api)=
+# Subprocess Handling
 
-Subprocess Handling
-======================
-
+```{eval-rst}
 .. automodule:: torch.distributed.elastic.multiprocessing.subprocess_handler
 .. automodule:: torch.distributed.elastic.multiprocessing.subprocess_handler.subprocess_handler
 .. automodule:: torch.distributed.elastic.multiprocessing.subprocess_handler.handlers
+```
 
-Retrieve SubprocessHandler
----------------------------
+## Retrieve SubprocessHandler
 
+```{eval-rst}
 .. autofunction:: torch.distributed.elastic.multiprocessing.subprocess_handler.handlers.get_subprocess_handler
+```
 
-SubprocessHandler
----------------------
+## SubprocessHandler
 
+```{eval-rst}
 .. currentmodule:: torch.distributed.elastic.multiprocessing.subprocess_handler.subprocess_handler
 
 .. autoclass:: SubprocessHandler
+```


### PR DESCRIPTION
 Converts docs/source/elastic/subprocess_handler.rst to MyST Markdown as part of Docathon 2026.
 Closes #182473

cc @svekars @sekyondaMeta @AlannaBurke