### PR TITLE
[inductor] Add CPU provenance tracing test; ignore carets when checking stack traces

### DIFF
--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -551,9 +551,66 @@ class TestProvenanceTracingStackTraces(TestCase):
         finally:
             trace_log.removeHandler(payload_handler)
 
-    def extract_code_line(self, s, i=-2):
-        # Extract ith line
-        return s.split("\n")[i].strip()
+    def extract_code_line(self, s):
+        # Extract the source code line from a stack trace entry.
+        # Filter out empty lines, "File ..." lines, and caret annotation
+        # lines (e.g. "~~^~~~~~") added in Python 3.13+.
+        lines = s.split("\n")
+        for line in reversed(lines):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped.startswith("File "):
+                continue
+            if all(c in " ~^" for c in stripped):
+                continue
+            return stripped
+        return lines[-2].strip()
+
+    @torch._inductor.config.patch({"trace.provenance_tracking_level": 2})
+    def test_tlparse_kernel_stack_traces_cpu(self):
+        model = Model4()
+        example_inputs = (
+            torch.randn(8, 10),
+            torch.randn(10, 20),
+            torch.randn(20, 30),
+            torch.randn(10, 30),
+        )
+
+        expected = {
+            "cpp_fused_mul_relu_sigmoid_threshold_backward_0:2": [
+                "d = a * 3.14",
+                "x = self.relu(x)",
+                "x = self.sigmoid(x)",
+            ],
+            "cpp_fused_gelu_1:4": [
+                "z = torch.nn.functional.gelu(y)",
+            ],
+            "extern_kernels.addmm:1": [
+                "x = self.fc1(x)",
+            ],
+            "extern_kernels.addmm:3": [
+                "y = torch.addmm(c, d, b)",
+            ],
+        }
+
+        compiled = torch.compile(model)
+        for _ in range(2):
+            torch._dynamo.reset()
+            reset_inductor_kernel_provenance_debug_handle()
+            with self._setup_provenance_capture() as payload_buffer:
+                compiled = torch.compile(model)
+                compiled(*example_inputs)
+                payload_content = payload_buffer.getvalue().strip()
+                data = json.loads(payload_content)
+                self.assertEqual(set(data.keys()), set(expected.keys()))
+                for key, expected_lines in expected.items():
+                    actual_lines = [self.extract_code_line(s) for s in data[key]]
+                    self.assertEqual(
+                        sorted(actual_lines),
+                        sorted(expected_lines),
+                        f"Mismatch for key: {key}",
+                    )
 
     @torch._inductor.config.patch({"trace.provenance_tracking_level": 2})
     @requires_gpu_and_triton


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182931



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo