### PR TITLE
[RFC][distributed] Add parallel_map with collective operation interception…

### DIFF
--- a/test/distributed/test_parallel_mapper.py
+++ b/test/distributed/test_parallel_mapper.py
@@ -1,0 +1,411 @@
+# Owner(s): ["oncall: distributed"]
+
+"""Tests for torch.distributed.parallel and _collective_interceptor."""
+
+import os
+import threading
+
+import torch
+import torch.distributed as dist
+import torch.distributed.parallel._parallel_mapper as pm
+from torch.distributed.parallel import (
+    parallel_map,
+    parallel_multi_apply,
+    parallel_starmap,
+    sync_wrap,
+)
+from torch.distributed._collective_interceptor import (
+    call_collective_interceptor,
+    clear_worker_id,
+    get_collective_interceptor,
+    get_worker_id,
+    set_collective_interceptor,
+    set_worker_id,
+)
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    requires_nccl,
+    skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+def _make_mock_collective():
+    """Return (mock_op, call_order) where mock_op honours the interceptor."""
+    call_order: list = []
+    lock = threading.Lock()
+
+    def _impl(tensor):
+        with lock:
+            call_order.append(tensor)
+        return tensor
+
+    def mock_op(tensor):
+        interceptor = get_collective_interceptor()
+        if interceptor is not None:
+            return interceptor("mock_op", _impl, tensor)
+        return _impl(tensor)
+
+    return mock_op, call_order
+
+
+class TestCollectiveInterceptor(TestCase):
+    """Thread-local interceptor primitives."""
+
+    def tearDown(self):
+        set_collective_interceptor(None)
+        clear_worker_id()
+        super().tearDown()
+
+    def test_set_get_clear(self):
+        self.assertIsNone(get_collective_interceptor())
+        fn = lambda *a, **kw: None  # noqa: E731
+        set_collective_interceptor(fn)
+        self.assertIs(get_collective_interceptor(), fn)
+        set_collective_interceptor(None)
+        self.assertIsNone(get_collective_interceptor())
+
+    def test_thread_isolation(self):
+        set_collective_interceptor(lambda *a, **kw: None)
+        set_worker_id(7)
+        seen = {}
+
+        def probe():
+            seen["interceptor"] = get_collective_interceptor()
+            seen["worker_id"] = get_worker_id()
+
+        t = threading.Thread(target=probe)
+        t.start()
+        t.join()
+        self.assertIsNone(seen["interceptor"])
+        self.assertIsNone(seen["worker_id"])
+
+    def test_reentrant_guard(self):
+        inner_value = []
+
+        def interceptor(op_name, fn, *args, **kwargs):
+            inner_value.append(get_collective_interceptor())
+            return fn(*args, **kwargs)
+
+        set_collective_interceptor(interceptor)
+        call_collective_interceptor(interceptor, "op", lambda: 42)
+        self.assertIsNone(inner_value[0])
+        self.assertIsNotNone(get_collective_interceptor())
+
+
+class TestParallelMap(TestCase):
+    """Core parallel_map / starmap / multi_apply behaviour."""
+
+    def test_map_basic(self):
+        self.assertEqual(
+            parallel_map(lambda x: x * 2, [1, 2, 3, 4, 5], max_workers=3),
+            [2, 4, 6, 8, 10],
+        )
+
+    def test_starmap_basic(self):
+        self.assertEqual(
+            parallel_starmap(lambda a, b: a + b, [(1, 10), (2, 20)], max_workers=2),
+            [11, 22],
+        )
+
+    def test_multi_apply_basic(self):
+        sums, prods = parallel_multi_apply(
+            lambda a, b: (a + b, a * b), [1, 2, 3], [10, 20, 30], max_workers=3
+        )
+        self.assertEqual(sums, [11, 22, 33])
+        self.assertEqual(prods, [10, 40, 90])
+
+    def test_multi_apply_with_kwargs(self):
+        def fn(a, scale=1):
+            return a * scale, a + scale
+
+        scaled, added = parallel_multi_apply(fn, [1, 2, 3], max_workers=3, scale=10)
+        self.assertEqual(scaled, [10, 20, 30])
+        self.assertEqual(added, [11, 12, 13])
+
+    def test_multi_apply_fewer_workers_than_items(self):
+        """multi_apply batches correctly when max_workers < len(items)."""
+        mock_op, order = _make_mock_collective()
+
+        def fn(a, b):
+            mock_op(a)
+            return a + b, a * b
+
+        sums, prods = parallel_multi_apply(
+            fn, [1, 2, 3, 4, 5, 6], [10, 20, 30, 40, 50, 60], max_workers=2
+        )
+        self.assertEqual(sums, [11, 22, 33, 44, 55, 66])
+        self.assertEqual(prods, [10, 40, 90, 160, 250, 360])
+        self.assertEqual(order, [1, 2, 3, 4, 5, 6])
+
+    def test_empty_and_single(self):
+        self.assertEqual(parallel_map(lambda x: x, [], max_workers=4), [])
+        self.assertEqual(parallel_map(lambda x: x * 3, [7], max_workers=4), [21])
+
+    def test_batching(self):
+        results = parallel_map(lambda x: x + 1, list(range(10)), max_workers=3)
+        self.assertEqual(results, list(range(1, 11)))
+
+    def test_return_order_matches_input(self):
+        def slow_first(x):
+            if x == 0:
+                s = 0
+                for i in range(200_000):
+                    s += i
+            return x
+
+        self.assertEqual(
+            parallel_map(slow_first, [0, 1, 2, 3], max_workers=4), [0, 1, 2, 3]
+        )
+
+
+class TestOrdering(TestCase):
+    """Collective ops are serialized in strict worker_id order."""
+
+    def test_single_round(self):
+        mock_op, order = _make_mock_collective()
+
+        results = parallel_map(
+            lambda item: (mock_op(item * 10), item * 10)[1],
+            [0, 1, 2, 3],
+            max_workers=4,
+        )
+        self.assertEqual(results, [0, 10, 20, 30])
+        self.assertEqual(order, [0, 10, 20, 30])
+
+    def test_multiple_rounds(self):
+        mock_op, order = _make_mock_collective()
+
+        def fn(item):
+            mock_op(f"r1_w{item}")
+            mock_op(f"r2_w{item}")
+            return item
+
+        parallel_map(fn, [0, 1, 2], max_workers=3)
+        self.assertEqual(
+            order, ["r1_w0", "r1_w1", "r1_w2", "r2_w0", "r2_w1", "r2_w2"]
+        )
+
+    def test_computation_between_syncs(self):
+        mock_op, order = _make_mock_collective()
+
+        def fn(item):
+            s = 0
+            for i in range(item * 50_000):
+                s += i
+            mock_op(f"w{item}")
+            return item
+
+        parallel_map(fn, [0, 1, 2, 3], max_workers=4)
+        self.assertEqual(order, ["w0", "w1", "w2", "w3"])
+
+    def test_fewer_workers_than_items_with_sync(self):
+        """Ordering stays correct across batches when max_workers < len(items)."""
+        mock_op, order = _make_mock_collective()
+
+        def fn(item):
+            mock_op(item)
+            return item
+
+        # 6 items, 2 workers => 3 batches
+        results = parallel_map(fn, [0, 1, 2, 3, 4, 5], max_workers=2)
+        self.assertEqual(results, [0, 1, 2, 3, 4, 5])
+        self.assertEqual(order, [0, 1, 2, 3, 4, 5])
+
+
+class TestSyncWrap(TestCase):
+
+    def test_ordering_and_passthrough(self):
+        order: list = []
+        lock = threading.Lock()
+
+        def custom_sync(data):
+            with lock:
+                order.append(data)
+            return data
+
+        wrapped = sync_wrap(custom_sync)
+
+        # Inside parallel_map: serialized in worker_id order
+        def fn(item):
+            wrapped(f"w{item}")
+            return item
+
+        parallel_map(fn, [0, 1, 2], max_workers=3)
+        self.assertEqual(order, ["w0", "w1", "w2"])
+
+        # Outside parallel_map: passthrough
+        order.clear()
+        self.assertEqual(wrapped(42), 42)
+        self.assertEqual(order, [42])
+
+    def test_preserves_name(self):
+        def my_function(x):
+            return x
+
+        wrapped = sync_wrap(my_function)
+        self.assertEqual(wrapped.__name__, "my_function")
+        self.assertIs(wrapped.__wrapped__, my_function)
+
+
+class TestErrorHandling(TestCase):
+
+    def test_exception_propagation(self):
+        def fn(item):
+            if item == 2:
+                raise ValueError("boom")
+            return item
+
+        with self.assertRaisesRegex(ValueError, "boom"):
+            parallel_map(fn, [0, 1, 2, 3], max_workers=4)
+
+    def test_exception_before_sync_no_deadlock(self):
+        mock_op, _ = _make_mock_collective()
+
+        def fn(item):
+            if item == 1:
+                raise RuntimeError("early fail")
+            mock_op(item)
+            return item
+
+        with self.assertRaisesRegex(RuntimeError, "early fail"):
+            parallel_map(fn, [0, 1, 2], max_workers=3)
+
+    def test_pool_recovers_after_error(self):
+        with self.assertRaises(ZeroDivisionError):
+            parallel_map(lambda x: 1 // 0 if x == 1 else x, [0, 1, 2], max_workers=3)
+
+        self.assertEqual(
+            parallel_map(lambda x: x * 2, [1, 2, 3], max_workers=3), [2, 4, 6]
+        )
+
+
+class TestWorkerId(TestCase):
+
+    def test_worker_id_in_fn_and_cleared_after(self):
+        def fn(item):
+            return (item, get_worker_id())
+
+        results = parallel_map(fn, [10, 20, 30], max_workers=3)
+        self.assertEqual([r[0] for r in results], [10, 20, 30])
+        self.assertEqual(set(r[1] for r in results), {0, 1, 2})
+        self.assertIsNone(get_worker_id())
+
+
+class TestTimeout(TestCase):
+
+    def test_inconsistent_sync_triggers_timeout(self):
+        mock_op, _ = _make_mock_collective()
+        old_timeout = pm._SYNC_TIMEOUT
+        pm._SYNC_TIMEOUT = 1.0
+        try:
+            def fn(item):
+                if item == 1:
+                    mock_op(item)
+                return item
+
+            with self.assertRaises(TimeoutError):
+                parallel_map(fn, [0, 1], max_workers=2)
+        finally:
+            pm._SYNC_TIMEOUT = old_timeout
+
+
+class TestStress(TestCase):
+
+    def test_repeated_calls_with_sync(self):
+        mock_op, order = _make_mock_collective()
+        for _ in range(50):
+            order.clear()
+            results = parallel_map(
+                lambda item: (mock_op(item), item)[1], [0, 1, 2, 3], max_workers=4
+            )
+            self.assertEqual(results, [0, 1, 2, 3])
+            self.assertEqual(order, [0, 1, 2, 3])
+
+
+class TestParallelMapNCCL(MultiProcessTestCase):
+    """Multi-GPU tests with real NCCL collective operations."""
+
+    @property
+    def world_size(self):
+        return 2
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self):
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    def _init_pg(self):
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            "nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        torch.cuda.set_device(self.rank)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_all_reduce_in_parallel_map(self):
+        """parallel_map correctly serializes real dist.all_reduce calls."""
+        self._init_pg()
+        device = f"cuda:{self.rank}"
+
+        def fn(item):
+            t = torch.tensor([item + self.rank], dtype=torch.float32, device=device)
+            dist.all_reduce(t)
+            return t.item()
+
+        results = parallel_map(fn, [10.0, 20.0, 30.0], max_workers=3)
+        # world_size=2, so all_reduce sums rank 0 and rank 1 values
+        # For item=10: rank0 has 10+0=10, rank1 has 10+1=11, sum=21
+        # For item=20: 20+21=41, For item=30: 30+31=61
+        expected = [
+            (item + 0) + (item + 1) for item in [10.0, 20.0, 30.0]
+        ]
+        self.assertEqual(results, expected)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_broadcast_in_parallel_map(self):
+        """parallel_map correctly serializes real dist.broadcast calls."""
+        self._init_pg()
+        device = f"cuda:{self.rank}"
+
+        def fn(item):
+            t = torch.tensor([item * (self.rank + 1)], dtype=torch.float32, device=device)
+            dist.broadcast(t, src=0)
+            return t.item()
+
+        results = parallel_map(fn, [1.0, 2.0, 3.0], max_workers=3)
+        # broadcast from rank 0: rank 0 has item*1, after broadcast all ranks have rank 0's value
+        expected = [1.0, 2.0, 3.0]
+        self.assertEqual(results, expected)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_multiple_collectives_in_parallel_map(self):
+        """Multiple real collective ops per worker stay correctly ordered."""
+        self._init_pg()
+        device = f"cuda:{self.rank}"
+
+        def fn(item):
+            t = torch.full((4,), float(item), device=device)
+            dist.all_reduce(t)  # sum across ranks: item * world_size
+            dist.broadcast(t, src=0)  # both ranks get rank 0's result
+            return t[0].item()
+
+        results = parallel_map(fn, [1.0, 2.0, 3.0, 4.0], max_workers=4)
+        expected = [item * self.world_size for item in [1.0, 2.0, 3.0, 4.0]]
+        self.assertEqual(results, expected)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/_collective_interceptor.py
+++ b/torch/distributed/_collective_interceptor.py
@@ -1,0 +1,76 @@
+"""Thread-local collective operation interceptor for parallel execution.
+
+This module provides the interceptor primitives used by:
+- torch/distributed/distributed_c10d.py: checks interceptor at collective op entry
+- torch/distributed/parallel/: sets interceptor in worker threads
+
+When a thread-local interceptor is set, collective operations (all_reduce, etc.)
+are redirected through it instead of executing directly. This enables the
+parallel mapper to serialize collective ops on the main thread while allowing
+Python-side computation to run concurrently in worker threads.
+"""
+
+import threading
+from typing import Any, Callable, Optional
+
+_thread_local = threading.local()
+
+
+def set_collective_interceptor(fn: Optional[Callable]) -> None:
+    """Set the collective operation interceptor for the current thread.
+
+    Args:
+        fn: Interceptor callback with signature
+            fn(op_name: str, original_fn: Callable, *args, **kwargs) -> Any
+            Set to None to clear the interceptor.
+    """
+    _thread_local.interceptor = fn
+
+
+def get_collective_interceptor() -> Optional[Callable]:
+    """Get the collective operation interceptor for the current thread.
+
+    Returns None if no interceptor is set (the common case),
+    or if we are already inside an interceptor call (re-entrancy guard).
+    """
+    if getattr(_thread_local, "_in_interceptor", False):
+        return None
+    return getattr(_thread_local, "interceptor", None)
+
+
+def call_collective_interceptor(
+    interceptor: Callable,
+    op_name: str,
+    fn: Callable,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Call the interceptor with re-entrancy protection.
+
+    Sets a thread-local flag so that if the interceptor calls back into a
+    collective op on the same thread, the interceptor check is skipped and
+    the op executes directly. This prevents infinite recursion.
+    """
+    _thread_local._in_interceptor = True
+    try:
+        return interceptor(op_name, fn, *args, **kwargs)
+    finally:
+        _thread_local._in_interceptor = False
+
+
+def set_worker_id(worker_id: int) -> None:
+    """Set the parallel mapper worker id for the current thread."""
+    _thread_local.worker_id = worker_id
+
+
+def get_worker_id() -> Optional[int]:
+    """Get the parallel mapper worker id for the current thread.
+
+    Returns None if not running inside a parallel_map worker.
+    """
+    return getattr(_thread_local, "worker_id", None)
+
+
+def clear_worker_id() -> None:
+    """Clear the parallel mapper worker id for the current thread."""
+    _thread_local.worker_id = None

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -55,6 +55,8 @@ from . import config as dist_config
 from .c10d_logger import _exception_logger, _time_logger
 from .constants import default_pg_nccl_timeout, default_pg_timeout
 from .rendezvous import register_rendezvous_handler, rendezvous  # noqa: F401
+from ._collective_interceptor import get_collective_interceptor as _get_collective_interceptor
+from ._collective_interceptor import call_collective_interceptor as _call_collective_interceptor
 
 
 __all__ = [
@@ -2561,6 +2563,9 @@ def isend(
         None, if not part of the group
 
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "isend", isend, tensor, dst=dst, group=group, tag=tag, group_dst=group_dst)
     relevant_args = (tensor,)
     if has_torch_function(relevant_args):
         return handle_torch_function(
@@ -2615,6 +2620,9 @@ def irecv(
         None, if not part of the group
 
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "irecv", irecv, tensor, src=src, group=group, tag=tag, group_src=group_src)
     relevant_args = (tensor,)
     if has_torch_function(relevant_args):
         return handle_torch_function(
@@ -2667,6 +2675,9 @@ def send(
         group_dst (int, optional): Destination rank on ``group``.  Invalid to specify both ``dst`` and ``group_dst``.
 
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "send", send, tensor, dst=dst, group=group, tag=tag, group_dst=group_dst)
     relevant_args = (tensor,)
     if has_torch_function(relevant_args):
         return handle_torch_function(
@@ -2715,6 +2726,9 @@ def recv(
         -1, if not part of the group
 
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "recv", recv, tensor, src=src, group=group, tag=tag, group_src=group_src)
     relevant_args = (tensor,)
     if has_torch_function(relevant_args):
         return handle_torch_function(
@@ -2965,6 +2979,10 @@ def batch_isend_irecv(p2p_op_list: list[P2POp]) -> list[Work]:
         not the first collective call in the ``group``, batched P2P operations
         involving only a subset of ranks of the ``group`` are allowed.
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "batch_isend_irecv", batch_isend_irecv, p2p_op_list)
+
     _check_p2p_op_list(p2p_op_list)
     group = p2p_op_list[0].group
     if group is None:
@@ -3040,6 +3058,9 @@ def broadcast(
         None, if not async_op or if not part of the group
 
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "broadcast", broadcast, tensor, src=src, group=group, async_op=async_op, group_src=group_src)
     relevant_args = (tensor,)
     if has_torch_function(relevant_args):
         return handle_torch_function(
@@ -3146,6 +3167,10 @@ def all_reduce(tensor, op=ReduceOp.SUM, group=None, async_op: bool = False):
             async_op=async_op,
         )
 
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "all_reduce", all_reduce, tensor, op=op, group=group, async_op=async_op)
+
     _check_single_tensor(tensor, "tensor")
     if _rank_not_in_group(group):
         _warn_not_in_group("all_reduce")
@@ -3223,6 +3248,10 @@ def all_reduce_coalesced(tensors, op=ReduceOp.SUM, group=None, async_op: bool = 
         None, if not async_op or if not part of the group.
 
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "all_reduce_coalesced", all_reduce_coalesced, tensors, op=op, group=group, async_op=async_op)
+
     if isinstance(tensors, torch.Tensor):
         tensors = [tensors]
     relevant_args = tuple(tensors) if isinstance(tensors, (list, tuple)) else (tensors,)
@@ -3294,6 +3323,9 @@ def reduce(
         None, if not async_op or if not part of the group
 
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "reduce", reduce, tensor, dst=dst, op=op, group=group, async_op=async_op, group_dst=group_dst)
     relevant_args = (tensor,)
     if has_torch_function(relevant_args):
         return handle_torch_function(
@@ -4191,6 +4223,10 @@ def all_gather(tensor_list, tensor, group=None, async_op=False):
             async_op=async_op,
         )
 
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "all_gather", all_gather, tensor_list, tensor, group=group, async_op=async_op)
+
     _check_tensor_list(tensor_list, "tensor_list")
     _check_single_tensor(tensor, "tensor")
     _ensure_all_tensors_same_dtype(tensor_list, tensor)
@@ -4281,6 +4317,10 @@ def all_gather_into_tensor(output_tensor, input_tensor, group=None, async_op=Fal
             group=group,
             async_op=async_op,
         )
+
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "all_gather_into_tensor", all_gather_into_tensor, output_tensor, input_tensor, group=group, async_op=async_op)
 
     _check_single_tensor(input_tensor, "input_tensor")
     _check_single_tensor(output_tensor, "output_tensor")
@@ -4524,6 +4564,9 @@ def gather(
         None                                                                   # Rank 1
 
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "gather", gather, tensor, gather_list=gather_list, dst=dst, group=group, async_op=async_op, group_dst=group_dst)
     relevant_args = (tensor,)
     if has_torch_function(relevant_args):
         return handle_torch_function(
@@ -4627,6 +4670,9 @@ def scatter(
         tensor([5., 5.], device='cuda:1') # Rank 1
 
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "scatter", scatter, tensor, scatter_list=scatter_list, src=src, group=group, async_op=async_op, group_src=group_src)
     relevant_args = (tensor,)
     if has_torch_function(relevant_args):
         return handle_torch_function(
@@ -4711,6 +4757,9 @@ def reduce_scatter(
         None, if not async_op or if not part of the group.
 
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "reduce_scatter", reduce_scatter, output, input_list, op=op, group=group, async_op=async_op)
     relevant_args = (output,)
     if has_torch_function(relevant_args):
         return handle_torch_function(
@@ -4812,6 +4861,10 @@ def reduce_scatter_tensor(output, input, op=ReduceOp.SUM, group=None, async_op=F
             group=group,
             async_op=async_op,
         )
+
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "reduce_scatter_tensor", reduce_scatter_tensor, output, input, op=op, group=group, async_op=async_op)
 
     _check_single_tensor(output, "output")
     _check_single_tensor(input, "input")
@@ -4994,6 +5047,10 @@ def all_to_all_single(
             async_op=async_op,
         )
 
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "all_to_all_single", all_to_all_single, output, input, output_split_sizes=output_split_sizes, input_split_sizes=input_split_sizes, group=group, async_op=async_op)
+
     if _rank_not_in_group(group):
         _warn_not_in_group("all_to_all_single")
         return
@@ -5121,6 +5178,9 @@ def all_to_all(
         [tensor([4+4j]), tensor([8+8j]), tensor([12+12j]), tensor([16+16j])]        # Rank 3
 
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "all_to_all", all_to_all, output_tensor_list, input_tensor_list, group=group, async_op=async_op)
     relevant_args = (
         tuple(input_tensor_list)
         if isinstance(input_tensor_list, (list, tuple))
@@ -5197,6 +5257,10 @@ def barrier(
        that was first used with this process group, if another collective with tensor inputs has been performed, (4)
        the device index indicated by the global rank mod local device count.
     """
+    _interceptor = _get_collective_interceptor()
+    if _interceptor is not None:
+        return _call_collective_interceptor(_interceptor, "barrier", barrier, group=group, async_op=async_op, device_ids=device_ids)
+
     group = group or _get_default_group()
 
     if _rank_not_in_group(group):

--- a/torch/distributed/parallel/__init__.py
+++ b/torch/distributed/parallel/__init__.py
@@ -1,0 +1,21 @@
+"""Parallel execution utilities for torch.distributed.
+
+Provides multi-threaded parallel map that serializes collective operations
+(all_reduce, broadcast, etc.) on the main thread while running Python-side
+computation concurrently in worker threads. Requires nogil Python (3.14t+)
+for true parallelism.
+"""
+
+from ._parallel_mapper import (
+    parallel_map,
+    parallel_multi_apply,
+    parallel_starmap,
+    sync_wrap,
+)
+
+__all__ = [
+    "parallel_map",
+    "parallel_starmap",
+    "parallel_multi_apply",
+    "sync_wrap",
+]

--- a/torch/distributed/parallel/_parallel_mapper.py
+++ b/torch/distributed/parallel/_parallel_mapper.py
@@ -1,0 +1,425 @@
+"""Parallel mapper for multi-threaded execution with collective operation serialization.
+
+Enables parallel Python-side computation in separate threads while serializing
+torch.distributed collective operations (all_reduce, etc.) on the main thread.
+"""
+
+import os
+import threading
+from typing import Any, Callable, List, Optional, TypeVar
+
+from torch.distributed._collective_interceptor import (
+    set_collective_interceptor,
+    get_collective_interceptor,
+    set_worker_id,
+    get_worker_id,
+    clear_worker_id,
+)
+
+R = TypeVar('R')
+
+_thread_local = threading.local()
+
+# Sync timeout (seconds). 0 or unset means no timeout.
+# Used to detect deadlocks caused by precondition violations.
+_SYNC_TIMEOUT: Optional[float] = None
+_timeout_env = os.environ.get("PARALLEL_MAPPER_TIMEOUT", "")
+if _timeout_env:
+    _SYNC_TIMEOUT = float(_timeout_env)
+
+
+# ============ sync_wrap ============
+
+def sync_wrap(func: Callable) -> Callable:
+    """Wrap a function to execute synchronously on the main thread.
+
+    When called inside a parallel_map worker thread, the wrapped function
+    will be submitted to the main thread for serialized execution.
+    When called outside a worker thread, the original function runs directly.
+
+    Usage:
+        my_queue_put = sync_wrap(my_queue.put)
+        my_custom_op = sync_wrap(some_module.sync_operation)
+    """
+    def _wrapper(*args, **kwargs):
+        worker_id = get_worker_id()
+        coordinator = getattr(_thread_local, '_coordinator', None)
+        if worker_id is not None and coordinator is not None:
+            return coordinator.submit(worker_id, func, *args, **kwargs)
+        return func(*args, **kwargs)
+    _wrapper.__wrapped__ = func
+    _wrapper.__name__ = getattr(func, '__name__', str(func))
+    return _wrapper
+
+
+# ============ Exception propagation ============
+
+class _PropagatedError(BaseException):
+    """Internal exception: propagated to waiting workers when another worker fails.
+    Inherits from BaseException to prevent being caught by user code's
+    except Exception handlers."""
+    def __init__(self, original: BaseException):
+        self.original = original
+
+
+# ============ Sync coordinator ============
+
+class _SyncRequest:
+    __slots__ = ['worker_id', 'func', 'args', 'kwargs', 'event', 'result', 'error']
+
+    def __init__(
+        self,
+        worker_id: int,
+        func: Callable,
+        args: tuple,
+        kwargs: dict,
+        event: threading.Event,
+    ):
+        self.worker_id = worker_id
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+        self.event = event
+        self.result: Any = None
+        self.error: Any = None
+
+
+class _SyncCoordinator:
+    """Waits for sync requests in worker_id order and dispatches execution.
+
+    Worker 0's request executes immediately when it arrives without waiting
+    for other workers. Supports exception propagation and timeout detection.
+    """
+
+    def __init__(self, num_workers: int):
+        self.num_workers = num_workers
+        self._cond = threading.Condition()
+        self._pending: List[Optional[_SyncRequest]] = [None] * num_workers
+        self._events = [threading.Event() for _ in range(num_workers)]
+        self._next_id = 0
+        self._done_count = 0
+        self._error: Optional[BaseException] = None
+
+    def submit(self, worker_id: int, func: Callable, *args, **kwargs) -> Any:
+        event = self._events[worker_id]
+        event.clear()
+        req = _SyncRequest(worker_id, func, args, kwargs, event)
+        with self._cond:
+            if self._error is not None:
+                raise _PropagatedError(self._error)
+            self._pending[worker_id] = req
+            self._cond.notify()
+        event.wait()
+        if req.error is not None:
+            raise _PropagatedError(req.error)
+        return req.result
+
+    def notify_error(self, exc: BaseException):
+        """Called when a worker errors out.
+
+        Sets error flag and wakes the main thread.
+        """
+        with self._cond:
+            if self._error is None:
+                self._error = exc
+            self._cond.notify()
+
+    def notify_worker_done(self):
+        with self._cond:
+            self._done_count += 1
+            self._cond.notify()
+
+    def _release_all_pending(self, exc: BaseException):
+        """Release all submitted but still waiting requests.
+
+        Caller must hold _cond lock.
+        """
+        for i, req in enumerate(self._pending):
+            if req is not None:
+                req.error = exc
+                req.event.set()
+                self._pending[i] = None
+
+    def get_next_request(self) -> Optional[_SyncRequest]:
+        """Wait for the next sync request in worker_id order.
+        Returns None when all workers are done or a worker has errored."""
+        with self._cond:
+            while True:
+                if self._error is not None:
+                    self._release_all_pending(self._error)
+                    return None
+                if self._pending[self._next_id] is not None:
+                    req = self._pending[self._next_id]
+                    self._pending[self._next_id] = None
+                    self._next_id = (self._next_id + 1) % self.num_workers
+                    return req
+                if self._done_count == self.num_workers:
+                    return None
+                if not self._cond.wait(timeout=_SYNC_TIMEOUT):
+                    submitted = [
+                        i for i, r in enumerate(self._pending)
+                        if r is not None
+                    ]
+                    raise TimeoutError(
+                        f"parallel_mapper: sync timeout ({_SYNC_TIMEOUT}s). "
+                        f"Waiting for worker {self._next_id}, "
+                        f"submitted: {submitted}, "
+                        f"done: {self._done_count}/{self.num_workers}. "
+                        f"Likely cause: workers have inconsistent sync call patterns."
+                    )
+
+
+# ============ Worker thread ============
+
+class _WorkerThread(threading.Thread):
+    """Persistent worker thread.
+
+    Receives tasks via task_event, signals completion via done_event.
+    """
+
+    def __init__(self, worker_id: int):
+        super().__init__(daemon=True)
+        self.worker_id = worker_id
+        self._task_event = threading.Event()
+        self._done_event = threading.Event()
+        self._func: Optional[Callable] = None
+        self._arg: Any = None
+        self._result: Any = None
+        self._exception: Optional[BaseException] = None
+        self._coordinator: Optional[_SyncCoordinator] = None
+        self.start()
+
+    def assign(
+        self,
+        func: Callable,
+        arg: Any,
+        coordinator: _SyncCoordinator,
+        cuda_device: Optional[int] = None,
+    ):
+        self._func = func
+        self._arg = arg
+        self._result = None
+        self._exception = None
+        self._coordinator = coordinator
+        self._cuda_device = cuda_device
+        self._done_event.clear()
+        self._task_event.set()
+
+    def wait_done(self):
+        self._done_event.wait()
+        return self._result
+
+    def run(self):
+        while True:
+            self._task_event.wait()
+            self._task_event.clear()
+
+            # Propagate CUDA device from the main thread
+            if self._cuda_device is not None:
+                import torch
+                torch.cuda.set_device(self._cuda_device)
+
+            coordinator = self._coordinator
+            set_worker_id(self.worker_id)
+            _thread_local._coordinator = coordinator
+
+            # Set PyTorch interceptor: collective ops are submitted to the coordinator
+            set_collective_interceptor(
+                lambda op_name, original_fn, *args,
+                       _coord=coordinator, _wid=self.worker_id, **kwargs:
+                    _coord.submit(_wid, original_fn, *args, **kwargs)
+            )
+
+            try:
+                self._result = self._func(*self._arg)
+            except _PropagatedError:
+                # Exception propagated from another worker, no need to record
+                pass
+            except BaseException as e:
+                self._exception = e
+                if coordinator is not None:
+                    coordinator.notify_error(e)
+            finally:
+                set_collective_interceptor(None)
+                _thread_local._coordinator = None
+                clear_worker_id()
+                self._done_event.set()
+                if coordinator is not None:
+                    coordinator.notify_worker_done()
+                    self._coordinator = None
+
+
+# ============ Parallel pool ============
+
+class _ParallelPool:
+    """Parallel map thread pool with main thread coordinating sync operations.
+
+    Only one _run_batch executes at a time to prevent worker state conflicts
+    from concurrent calls.
+    """
+
+    def __init__(self, max_workers: int = 0):
+        self._max_workers = max_workers
+        self._workers: List[_WorkerThread] = []
+        self._lock = threading.Lock()
+
+    def _ensure_workers(self, n: int):
+        while len(self._workers) < n:
+            self._workers.append(_WorkerThread(len(self._workers)))
+
+    def _run_batch(self, func: Callable, batch_args: List[Any]):
+        num = len(batch_args)
+        with self._lock:
+            self._ensure_workers(num)
+            coordinator = _SyncCoordinator(num)
+
+            # Capture current CUDA device to propagate to worker threads
+            cuda_device = None
+            try:
+                import torch
+                if (
+                    torch.cuda.is_available()
+                    and torch.cuda.current_device() is not None
+                ):
+                    cuda_device = torch.cuda.current_device()
+            except Exception:
+                pass
+
+            for i, arg in enumerate(batch_args):
+                self._workers[i].assign(func, arg, coordinator, cuda_device)
+
+            # Main thread: wait for, execute, and release requests in worker_id order
+            req = None
+            try:
+                while True:
+                    req = coordinator.get_next_request()
+                    if req is None:
+                        break
+                    req.result = req.func(*req.args, **req.kwargs)
+                    req.event.set()
+                    req = None
+            except BaseException as e:
+                # Main thread exception during sync op (e.g. NCCL error, timeout).
+                # Must release all waiting workers to prevent deadlock.
+                coordinator.notify_error(e)
+                if req is not None and not req.event.is_set():
+                    req.error = e
+                    req.event.set()
+                # get_next_request detects _error, releases
+                # remaining pending, returns None
+                coordinator.get_next_request()
+
+            # Wait for all workers, collect results
+            results = []
+            first_error = coordinator._error
+            for i in range(num):
+                self._workers[i].wait_done()
+                exc = self._workers[i]._exception
+                if exc is not None and first_error is None:
+                    first_error = exc
+                results.append(self._workers[i]._result)
+
+            if first_error is not None:
+                raise first_error
+
+            return results
+
+    def run(self, func: Callable, args: Optional[List[Any]] = None,
+            max_workers: Optional[int] = None) -> List[Any]:
+        # When args is None, invoke func with empty args
+        # based on max_workers/_max_workers count
+        if args is None:
+            n = max_workers if max_workers is not None else self._max_workers
+            if not n:
+                raise ValueError("max_workers must be specified when args is None")
+            args = [() for _ in range(n)]
+
+        # Determine max concurrency for this run
+        max_w = max_workers if max_workers is not None else (
+            self._max_workers or len(args)
+        )
+        max_w = min(max_w, len(args))
+
+        if max_w <= 1:
+            return [func(*a) for a in args]
+
+        results = []
+        # Execute in batches, each batch has at most max_w workers
+        for i in range(0, len(args), max_w):
+            batch = args[i:i + max_w]
+            results.extend(self._run_batch(func, batch))
+        return results
+
+
+# Global singleton
+_pool = _ParallelPool()
+
+
+# ============ Public API ============
+
+def parallel_starmap(fn: Callable[..., R], args: Optional[List[Any]] = None,
+                     max_workers: Optional[int] = None) -> List[R]:
+    """Parallel starmap, analogous to itertools.starmap.
+
+    Each element in args is a tuple that gets unpacked and passed to fn.
+
+    Args:
+        fn: The mapping function.
+        args: List of argument tuples, e.g. [(a1, b1), (a2, b2)].
+              Each tuple is unpacked: fn(*tuple). If None, fn is called
+              max_workers times with no arguments.
+        max_workers: Maximum concurrent threads. Excess items are batched.
+
+    Returns:
+        List of results.
+
+    Example:
+        parallel_starmap(fn, [(1, 'a'), (2, 'b')])  # fn(1,'a'), fn(2,'b')
+    """
+    return _pool.run(fn, args, max_workers)
+
+
+def parallel_map(fn: Callable[[Any], R], iterable, max_workers: Optional[int] = None) -> List[R]:
+    """Parallel map, analogous to builtin map(fn, iterable).
+
+    Each element in iterable is passed as a single argument to fn.
+
+    Args:
+        fn: The mapping function.
+        iterable: Input sequence. Each element is the sole argument to fn.
+        max_workers: Maximum concurrent threads. Excess items are batched.
+
+    Returns:
+        List of results.
+
+    Example:
+        parallel_map(fn, [1, 2, 3])  # fn(1), fn(2), fn(3)
+    """
+    args = [(x,) for x in iterable]
+    return _pool.run(fn, args, max_workers)
+
+
+def parallel_multi_apply(func, *args, max_workers: Optional[int] = None, **kwargs):
+    """Parallel version of multi_apply, interface compatible with mmdet.core.multi_apply.
+
+    Args:
+        func: The function to apply.
+        *args: Multiple equal-length lists, zipped and passed element-wise to func.
+        max_workers: Maximum concurrent threads.
+        **kwargs: Extra keyword arguments bound to func via functools.partial.
+
+    Returns:
+        tuple: Tuple of result lists, one per return value position.
+
+    Example:
+        parallel_multi_apply(fn, [a1, a2], [b1, b2])
+        # Equivalent to fn(a1, b1), fn(a2, b2), returns ([r1, r2], [s1, s2])
+    """
+    from functools import partial
+    pfunc = partial(func, **kwargs) if kwargs else func
+    num_args = len(args[0]) if args else 0
+    if num_args == 0:
+        return tuple()
+    packed_args = [tuple(arg[i] for arg in args) for i in range(num_args)]
+    map_results = _pool.run(pfunc, packed_args, max_workers)
+    return tuple(map(list, zip(*map_results)))


### PR DESCRIPTION
Relates to https://github.com/pytorch/pytorch/issues/180550

## Motivation

Under free-threaded Python (nogil), user code that runs independent iterations in parallel threads can easily hit collective ordering issues — when multiple threads call `dist.all_reduce` (or other collectives) concurrently, cross-rank pairing becomes non-deterministic, leading to silent data corruption or hangs.

Users could in principle restructure their code to move collective calls out of the parallel region, but this becomes impractical when collectives are buried deep inside third-party libraries or framework internals that the user cannot easily access or modify. This PR provides a framework-level solution that minimizes user-side changes: just replace the for-loop with `parallel_map`, and the user function itself does not need to change at all.

The primary use case is parallelizing serial for-loops in training (e.g., per-decoder-layer loss computation) where each iteration contains both CPU-side Python logic and GPU/distributed ops. See `test/distributed/test_parallel_mapper.py` for detailed usage examples.

## Summary

Implements `parallel_map` / `parallel_starmap` / `parallel_multi_apply` APIs that enable multi-threaded parallel execution under free-threaded Python, with automatic serialization of `torch.distributed` collective operations.

```python
# Before
results = [work(x) for x in inputs]

# After
from torch.distributed.parallel import parallel_map
results = parallel_map(work, inputs)
```

## Design

The key idea is intercepting collective operations at the Python API level in `distributed_c10d.py`. When a worker thread calls `dist.all_reduce` (or any collective), the call is redirected to the main thread and executed in strict worker-id order, ensuring cross-rank correctness.

```
Workers (parallel):  [compute] → [collective intercepted] → [compute]
Main thread:                      serializes in order 0, 1, 2, ...
```

The interceptor check is a lightweight thread-local attribute lookup (`getattr(thread_local, ..., None)`), so there is effectively zero overhead when `parallel_map` is not in use.

Components added:
- `torch/distributed/_collective_interceptor.py` — thread-local interceptor primitives with re-entrancy guard
- `torch/distributed/parallel/_parallel_mapper.py` — `_SyncCoordinator`, `_WorkerThread`, `_ParallelPool`
- `torch/distributed/parallel/__init__.py` — public API (`parallel_map`, `parallel_starmap`, `parallel_multi_apply`, `sync_wrap`)
- `test/distributed/test_parallel_mapper.py` — test suite
- `torch/distributed/distributed_c10d.py` — interceptor checks at ~18 collective entry points

## This is a preliminary implementation

We're sharing this early implementation to **get feedback on the design approach**:

- Is intercepting collectives at the Python API level the right place, or should this be done at a lower layer (ProcessGroup / C++)?
- Does the main-thread serialization model make sense?
- What should the public API look like?

If the overall direction is well-received, we'll follow up with API refinement, additional tests, and documentation based on community feedback.
