### PR TITLE
[inductor] Fix block descriptor final shape expansion

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1415,6 +1415,7 @@ class CommonTemplate:
             a,
             b,
             table,
+            atol=3e-5,
             config_patches={
                 "triton.persistent_reductions": False,
                 "triton.max_tiles": 2,

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1419,7 +1419,7 @@ class CommonTemplate:
                 "triton.persistent_reductions": False,
                 "triton.max_tiles": 2,
             },
-            expected_num_triton_kernels=2
+            expected_num_triton_kernels=2,
         )
 
     def test_mul_broadcast_multi_output(self):

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1419,6 +1419,7 @@ class CommonTemplate:
                 "triton.persistent_reductions": False,
                 "triton.max_tiles": 2,
             },
+            expected_num_triton_kernels=2
         )
 
     def test_mul_broadcast_multi_output(self):

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1385,6 +1385,42 @@ class CommonTemplate:
         num_broadcasts = triton_code.count("tl.broadcast_to")
         self.assertEqual(num_broadcasts, 1)
 
+    def test_reduction_fused_with_as_strided_scatter_broadcast_error(self):
+        # Regression test for a fused pointwise+reduction kernel where the side
+        # output is materialized through as_strided_scatter. The pointwise load
+        # is rank-expanded to match the reduction loop, and the immediate store
+        # must preserve that singleton reduction dimension instead of lowering a
+        # [XBLOCK, 1] temporary to a [XBLOCK] store.
+        def fn(a, b, table):
+            dst = torch.zeros(
+                (a.shape[0], a.shape[1], a.shape[2] + 1),
+                dtype=a.dtype,
+                device=a.device,
+            )
+            side = torch.as_strided_scatter(
+                dst, a, list(a.shape), list(dst.stride()), 1
+            )
+            gathered = torch.embedding(table, a)
+            reduced = (b + gathered.unsqueeze(0)).sum(-1)
+            return side, reduced
+
+        device = torch.device(self.device)
+        base = torch.randint(0, 1024, (4, 64, 1), dtype=torch.int64, device=device)
+        a = base.expand(4, 64, 32)
+        b = torch.randn((4, 64, 32, 128), dtype=torch.float32, device=device)
+        table = torch.randn((1024, 128), dtype=torch.float32, device=device)
+
+        self._run_and_compare(
+            fn,
+            a,
+            b,
+            table,
+            config_patches={
+                "triton.persistent_reductions": False,
+                "triton.max_tiles": 2,
+            },
+        )
+
     def test_mul_broadcast_multi_output(self):
         def foo(x, y, z):
             a = x * y

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -77,6 +77,7 @@ from ..utils import (
     is_welford_reduction,
     Placeholder,
     prefix_is_reduction,
+    prefix_is_pointwise,
     sympy_dot,
     sympy_product,
     sympy_subs,
@@ -446,6 +447,35 @@ class BlockDescriptorOptions:
         # Drop singleton dimensions from the block descriptor.
         params = params.remove_dims(singleton_dims)
 
+        # Compute the final shape, adjusting for special kernel types.
+        final_shape = [TritonSymbols.get_block_size(tree) for tree in range_trees]
+        if V.kernel.no_x_dim:
+            assert range_trees[0].prefix == "x"
+            final_shape.pop(0)
+
+        # Check to see which of the final shape dimensions are included in this parameter
+        # e.g. if block shape is [XBLOCK // 2, XBLOCK % 2], but the kernel shape
+        # is [XBLOCK, R0_BLOCK], we need to expand the final shape to add reduction dims.
+        # We do this before broadcasting dimensions are removed so that the check
+        # below that compares the number of included dimensions to the kernel numels
+        # is correct
+        included_final_shape_dims = set()
+        for expr in params.block_shape:
+            if isinstance(expr, sympy.Expr):
+                for sym in expr.free_symbols:
+                    sym_str = str(sym).lower()
+                    if prefix_is_reduction(sym_str) or prefix_is_pointwise(sym_str):
+                        included_final_shape_dims.add(sym)
+
+        reduction_ndim = V.kernel.num_reduction_dims
+        if (
+            not V.kernel.inside_reduction
+            and len(included_final_shape_dims) == len(V.kernel.numels) - reduction_ndim
+            and V.kernel.features.is_reduction()
+        ):
+            # Need to expand rank to match the rank used inside the reduction loop
+            final_shape += [sympy.S.One] * reduction_ndim
+
         # Maybe reorder dimensions based on strides
         # with tl.trans applied at load / store time
         params, stride_sorter = params.maybe_sort_with_stride_order(
@@ -465,20 +495,6 @@ class BlockDescriptorOptions:
 
         # Drop broadcasting dims from the block descriptor.
         params = params.remove_dims(broadcasting_dims)
-
-        # Compute the final shape, adjusting for special kernel types.
-        final_shape = [TritonSymbols.get_block_size(tree) for tree in range_trees]
-        if V.kernel.no_x_dim:
-            assert range_trees[0].prefix == "x"
-            final_shape.pop(0)
-
-        reduction_ndim = V.kernel.num_reduction_dims
-        if (
-            not V.kernel.inside_reduction
-            and V.kernel.features.is_reduction()
-        ):
-            # Need to expand rank to match the rank used inside the reduction loop
-            final_shape += [sympy.S.One] * reduction_ndim
 
         try:
             # Get permutation to sort strides in ascending order.

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -475,7 +475,6 @@ class BlockDescriptorOptions:
         reduction_ndim = V.kernel.num_reduction_dims
         if (
             not V.kernel.inside_reduction
-            and len(params.strides) == len(V.kernel.numels) - reduction_ndim
             and V.kernel.features.is_reduction()
         ):
             # Need to expand rank to match the rank used inside the reduction loop

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -76,8 +76,8 @@ from ..utils import (
     get_kernel_metadata,
     is_welford_reduction,
     Placeholder,
-    prefix_is_reduction,
     prefix_is_pointwise,
+    prefix_is_reduction,
     sympy_dot,
     sympy_product,
     sympy_subs,
@@ -459,7 +459,7 @@ class BlockDescriptorOptions:
         # We do this before broadcasting dimensions are removed so that the check
         # below that compares the number of included dimensions to the kernel numels
         # is correct
-        included_final_shape_dims = set()
+        included_final_shape_dims = OrderedSet()
         for expr in params.block_shape:
             if isinstance(expr, sympy.Expr):
                 for sym in expr.free_symbols:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1149,6 +1149,8 @@ def get_bounds_index_expr(index: sympy.Expr) -> ValueRanges[Any]:
 def prefix_is_reduction(prefix: str) -> bool:
     return prefix[0] == "r"
 
+def prefix_is_pointwise(prefix: str) -> bool:
+    return prefix[0] in ("x", "y", "z")
 
 def sympy_index_symbol_with_prefix(prefix: SymT, idx: int) -> sympy.Symbol:
     """

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1149,8 +1149,10 @@ def get_bounds_index_expr(index: sympy.Expr) -> ValueRanges[Any]:
 def prefix_is_reduction(prefix: str) -> bool:
     return prefix[0] == "r"
 
+
 def prefix_is_pointwise(prefix: str) -> bool:
     return prefix[0] in ("x", "y", "z")
+
 
 def sympy_index_symbol_with_prefix(prefix: SymT, idx: int) -> sympy.Symbol:
     """


### PR DESCRIPTION
For fused pointwise & reduction kernels the pointwise operations need to be rank expanded to match [pointwise_numel, reduction_numel]. For block descriptor based load / store, currently this only applies if the number of dimensions matches the number of range trees minus the reduction trees. However this fails when there is discontiguity in the load / store.

For example:
range_trees = {x: ..., r0: ...}
block descriptor shape = [XBLOCK // 2, XBLOCK % 2]
num_reduction_dims = 1

so here the number of block descriptor dimensions won't be equal to (len(range_trees) - num_reduction_dims) (2 range trees, 1 reduction dim). and the determined final shape for this example will be [XBLOCK], instead of [XBLOCK, 1] (with the added reduction dim). This PR makes the check more robust by accounting for discontiguity.

Added a unit test for this fix. based on a compilation failure from GPT2 and Stable Diffusion XL torch compile run. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo