### PR TITLE
Convert docs/source/elastic/events.rst to MyST Markdown

### DIFF
--- a/docs/source/elastic/events.md
+++ b/docs/source/elastic/events.md
@@ -1,30 +1,47 @@
-.. _events-api:
+(events-api)=
 
-Events
-============================
+# Events
 
+```{eval-rst}
 .. automodule:: torch.distributed.elastic.events
+```
 
-API Methods
-------------
+## API Methods
 
+```{eval-rst}
 .. autofunction:: torch.distributed.elastic.events.record
+```
 
+```{eval-rst}
 .. autofunction:: torch.distributed.elastic.events.construct_and_record_rdzv_event
+```
 
+```{eval-rst}
 .. autofunction:: torch.distributed.elastic.events.get_logging_handler
+```
 
+```{eval-rst}
 .. autofunction:: torch.distributed.elastic.events.record_rdzv_event
+```
 
-Event Objects
------------------
+## Event Objects
 
+```{eval-rst}
 .. currentmodule:: torch.distributed.elastic.events.api
+```
 
+```{eval-rst}
 .. autoclass:: torch.distributed.elastic.events.api.Event
+```
 
+```{eval-rst}
 .. autoclass:: torch.distributed.elastic.events.api.EventSource
+```
 
+```{eval-rst}
 .. autoclass:: torch.distributed.elastic.events.api.EventMetadataValue
+```
 
+```{eval-rst}
 .. autoclass:: torch.distributed.elastic.events.api.NodeState
+```

--- a/docs/source/redirects.py
+++ b/docs/source/redirects.py
@@ -159,4 +159,6 @@ redirects = {
         "user_guide/torch_compiler/compile/"
         "programming_model.where_to_apply_compile.html"
     ),
+    # Auto-generated redirects for moved files
+    "elastic/events": "elastic/events.html",
 }

--- a/docs/source/redirects.py
+++ b/docs/source/redirects.py
@@ -159,6 +159,4 @@ redirects = {
         "user_guide/torch_compiler/compile/"
         "programming_model.where_to_apply_compile.html"
     ),
-    # Auto-generated redirects for moved files
-    "elastic/events": "elastic/events.html",
 }


### PR DESCRIPTION
 Converts `docs/source/elastic/events.rst` in rST format to `docs/source/elastic/events.md` MyST Markdown format.
 Closes #182467
 Part of PyTorch Docathon 2026.

cc @svekars @sekyondaMeta @AlannaBurke 