### PR TITLE
inductor: add dimension prefix to GEMM kernel profile names

### DIFF
--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -195,7 +195,7 @@ extern "C" {{export_declaration}}
 GEMM_TEMPLATE = r"""
 {{ template.codegen_gemm_stub_def() }}
 {
-    {{ kernel.maybe_codegen_profile() }}
+    {{ kernel.maybe_codegen_profile(template.get_kernel_prefix_name()) }}
     {{ template.codegen_blocks(
         num_threads, N, K, micro_gemm, is_dynamic_M, kernel, GemmOut, config, L1_cache_size, L2_cache_size, X, W
     ) }}
@@ -1633,6 +1633,9 @@ class CppGemmTemplate(CppTemplate):
             and X.get_dtype() is torch.bfloat16
             and W.get_dtype() is torch.int8
         )
+
+    def get_kernel_prefix_name(self) -> str:
+        return f"gemm_m{self.m}n{self.n}k{self.k}"
 
     def render(  # type: ignore[override, return]
         self,

--- a/torch/_inductor/codegen/cpp_grouped_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_grouped_gemm_template.py
@@ -42,7 +42,7 @@ GEMM_TEMPLATE = r"""
 extern "C" {{export_declaration}}
 {{kernel.def_kernel(inputs=kernel_args, outputs=Y_list, aliases=aliases)}}
 {
-    {{kernel.maybe_codegen_profile()}}
+    {{kernel.maybe_codegen_profile(template.get_kernel_prefix_name())}}
     {{ template.codegen_blocks(
         num_threads, N, K, micro_gemm, is_dynamic_M, kernel, GemmOuts[0], config, L1_cache_size, L2_cache_size, X_list[0], W_list[0]
     ) }}
@@ -358,6 +358,9 @@ class CppGroupedGemmTemplate(CppGemmTemplate):
         )
         template.maybe_append_choice(choices)
         return template
+
+    def get_kernel_prefix_name(self) -> str:
+        return f"grouped_gemm_g{self.gemm_grouped_num}m{self.m}n{self.n}k{self.k}"
 
     def render(  # type: ignore[override,return,no-untyped-def]
         self,

--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import itertools
 from collections.abc import Callable, Iterable
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import patch
 
 import sympy
@@ -186,10 +186,12 @@ class CppTemplateKernel(CppKernel):
         assert isinstance(permuted, ir.ReinterpretView)
         return permuted
 
-    def maybe_codegen_profile(self) -> str:
+    def maybe_codegen_profile(self, prefix_kernel_name: Optional[str] = None) -> str:
         if config.cpp.enable_kernel_profile:
             graph_id = V.graph.graph_id
             prefix = "graph_" + str(graph_id) + "_" if graph_id is not None else ""
+            if prefix and prefix_kernel_name:
+                prefix += prefix_kernel_name + "_"
             handle_str = (
                 "torch::aot_inductor::RAIIAtenRecordFunctionHandle "
                 f'record_{prefix}{self.kernel_name}_("{prefix}{self.kernel_name}", nullptr);'

--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import itertools
 from collections.abc import Callable, Iterable
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import patch
 
 import sympy
@@ -186,7 +186,7 @@ class CppTemplateKernel(CppKernel):
         assert isinstance(permuted, ir.ReinterpretView)
         return permuted
 
-    def maybe_codegen_profile(self, prefix_kernel_name: Optional[str] = None) -> str:
+    def maybe_codegen_profile(self, prefix_kernel_name: str | None = None) -> str:
         if config.cpp.enable_kernel_profile:
             graph_id = V.graph.graph_id
             prefix = "graph_" + str(graph_id) + "_" if graph_id is not None else ""


### PR DESCRIPTION
(Reopen of https://github.com/pytorch/pytorch/pull/161237)
Add `get_kernel_prefix_name()` to `CppGemmTemplate` and `CppGroupedGemmTemplate`, and pass it to `maybe_codegen_profile()` so the profiling record-function handle embeds GEMM dimensions:

  graph_<id>_gemm_m<M>n<N>k<K>_<kernel_name>
  graph_<id>_grouped_gemm_g<G>m<M>n<N>k<K>_<kernel_name>

This makes it possible to distinguish different template kernel instances in profiling traces.

Assisted by Copilot.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo