### PR TITLE
[Docathon] Document undocumented functions in profiler.md (3 functions)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -958,10 +958,6 @@ coverage_ignore_functions = [
     "verify_aten_graph",
     # torch.overrides
     "enable_reentrant_dispatch",
-    # torch.profiler.profiler
-    "schedule",
-    "supported_activities",
-    "tensorboard_trace_handler",
     # torch.return_types
     "pytree_register_structseq",
     # torch.serialization

--- a/docs/source/profiler.md
+++ b/docs/source/profiler.md
@@ -9,6 +9,16 @@
 .. automodule:: torch.profiler
 ```
 
+```{eval-rst}
+.. currentmodule:: torch.profiler.profiler
+
+.. autofunction:: schedule
+
+.. autofunction:: supported_activities
+
+.. autofunction:: tensorboard_trace_handler
+```
+
 ## API Reference
 ```{eval-rst}
 
@@ -21,12 +31,6 @@
 
 .. autoclass:: torch.profiler.ProfilerActivity
   :members:
-
-.. autofunction:: torch.profiler.schedule
-
-.. autofunction:: torch.profiler.tensorboard_trace_handler
-
-.. autofunction:: torch.profiler.supported_activities
 ```
 
 ## Intel Instrumentation and Tracing Technology APIs


### PR DESCRIPTION
Entries removed from skip list(s) in [docs/source/conf.py](https://github.com/pytorch/pytorch/blob/main/docs/source/conf.py).

Sphinx directives added to [docs/source/profiler.md](https://github.com/pytorch/pytorch/blob/main/docs/source/profiler.md).

`make coverage` passes with no new undocumented warnings for these APIs. `torch.profiler.profiler` reports `100.00%` coverage with `0` undocumented entries.

Screenshot of the rendered documentation:

<img width="1726" height="796" alt="Screenshot 2026-05-08 at 12 50 19" src="https://github.com/user-attachments/assets/3cca8e25-aaa9-42b8-9a61-b7d213e3e1ae" />

Related to #182828


cc @svekars @sekyondaMeta @AlannaBurke