### PR TITLE
[CUDA] Fix reentrant deadlock in torch.cuda._lazy_call

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1196,6 +1196,32 @@ print(t.is_pinned())
             self.assertEqual(a, b)
             self.assertEqual(torch.cuda.initial_seed(), 2)
 
+    def test_lazy_call_reentrant_set_rng_state_does_not_deadlock(self):
+        code = r"""
+import torch
+
+torch.cuda.init()
+state = torch.cuda.get_rng_state()
+
+def cb():
+    torch.cuda.set_rng_state(state)
+
+torch.cuda._lazy_call(cb)
+print("done")
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=20,
+        )
+        if proc.returncode != 0:
+            self.fail(
+                f"subprocess failed rc={proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+            )
+        self.assertIn("done", proc.stdout)
+
     def test_specify_improper_device_name(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             fname = os.path.join(tmpdir, "tempfile.pt")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1197,28 +1197,34 @@ print(t.is_pinned())
             self.assertEqual(torch.cuda.initial_seed(), 2)
 
     def test_lazy_call_reentrant_set_rng_state_does_not_deadlock(self):
-        code = r"""
-import torch
-
-torch.cuda.init()
-state = torch.cuda.get_rng_state()
-
-def cb():
-    torch.cuda.set_rng_state(state)
-
-torch.cuda._lazy_call(cb)
-print("done")
-"""
-        proc = subprocess.run(
-            [sys.executable, "-c", code],
-            capture_output=True,
-            text=True,
-            timeout=20,
+        # Separate process: a regression deadlocks the interpreter (non-reentrant lock).
+        # Happy path is usually a few seconds; allow margin for slow CI / CUDA init.
+        timeout_sec = 15
+        script = (
+            "import torch; "
+            "torch.cuda.init(); "
+            "state = torch.cuda.get_rng_state(); "
+            "torch.cuda._lazy_call(lambda: torch.cuda.set_rng_state(state)); "
+            "print('done')"
         )
-        if proc.returncode != 0:
-            self.fail(
-                f"subprocess failed rc={proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
             )
+        except subprocess.TimeoutExpired as e:
+            self.fail(
+                f"lazy_call reentrancy subprocess did not finish within {timeout_sec}s "
+                "(likely deadlock in torch.cuda._lazy_call); "
+                f"cmd={e.cmd!r}"
+            )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}",
+        )
         self.assertIn("done", proc.stdout)
 
     def test_specify_improper_device_name(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1211,8 +1211,7 @@ print("done")
 """
         proc = subprocess.run(
             [sys.executable, "-c", code],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
             timeout=20,
         )

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1403,6 +1403,32 @@ print(t.is_pinned())
             self.assertEqual(a, b)
             self.assertEqual(torch.cuda.initial_seed(), 2)
 
+    def test_lazy_call_reentrant_set_rng_state_does_not_deadlock(self):
+        code = r"""
+import torch
+
+torch.cuda.init()
+state = torch.cuda.get_rng_state()
+
+def cb():
+    torch.cuda.set_rng_state(state)
+
+torch.cuda._lazy_call(cb)
+print("done")
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=20,
+        )
+        if proc.returncode != 0:
+            self.fail(
+                f"subprocess failed rc={proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+            )
+        self.assertIn("done", proc.stdout)
+
     def test_specify_improper_device_name(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             fname = os.path.join(tmpdir, "tempfile.pt")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1404,28 +1404,34 @@ print(t.is_pinned())
             self.assertEqual(torch.cuda.initial_seed(), 2)
 
     def test_lazy_call_reentrant_set_rng_state_does_not_deadlock(self):
-        code = r"""
-import torch
-
-torch.cuda.init()
-state = torch.cuda.get_rng_state()
-
-def cb():
-    torch.cuda.set_rng_state(state)
-
-torch.cuda._lazy_call(cb)
-print("done")
-"""
-        proc = subprocess.run(
-            [sys.executable, "-c", code],
-            capture_output=True,
-            text=True,
-            timeout=20,
+        # Separate process: a regression deadlocks the interpreter (non-reentrant lock).
+        # Happy path is usually a few seconds; allow margin for slow CI / CUDA init.
+        timeout_sec = 15
+        script = (
+            "import torch; "
+            "torch.cuda.init(); "
+            "state = torch.cuda.get_rng_state(); "
+            "torch.cuda._lazy_call(lambda: torch.cuda.set_rng_state(state)); "
+            "print('done')"
         )
-        if proc.returncode != 0:
-            self.fail(
-                f"subprocess failed rc={proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
             )
+        except subprocess.TimeoutExpired as e:
+            self.fail(
+                f"lazy_call reentrancy subprocess did not finish within {timeout_sec}s "
+                "(likely deadlock in torch.cuda._lazy_call); "
+                f"cmd={e.cmd!r}"
+            )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}",
+        )
         self.assertIn("done", proc.stdout)
 
     def test_specify_improper_device_name(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1403,17 +1403,11 @@ print(t.is_pinned())
             self.assertEqual(a, b)
             self.assertEqual(torch.cuda.initial_seed(), 2)
 
-    def test_lazy_call_reentrant_set_rng_state_does_not_deadlock(self):
+    def _check_lazy_call_reentrant_no_deadlock(self, script):
         # Separate process: a regression deadlocks the interpreter (non-reentrant lock).
-        # Happy path is usually a few seconds; allow margin for slow CI / CUDA init.
-        timeout_sec = 15
-        script = (
-            "import torch; "
-            "torch.cuda.init(); "
-            "state = torch.cuda.get_rng_state(); "
-            "torch.cuda._lazy_call(lambda: torch.cuda.set_rng_state(state)); "
-            "print('done')"
-        )
+        # The pass path exits quickly regardless of the limit; the timeout only
+        # bounds failure detection, so keep it generous for slow CI.
+        timeout_sec = 60
         try:
             proc = subprocess.run(
                 [sys.executable, "-c", script],
@@ -1433,6 +1427,28 @@ print(t.is_pinned())
             msg=f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}",
         )
         self.assertIn("done", proc.stdout)
+
+    def test_lazy_call_reentrant_set_rng_state_does_not_deadlock(self):
+        # Reentrant _lazy_call after CUDA is initialized.
+        script = (
+            "import torch; "
+            "torch.cuda.init(); "
+            "state = torch.cuda.get_rng_state(); "
+            "torch.cuda._lazy_call(lambda: torch.cuda.set_rng_state(state)); "
+            "print('done')"
+        )
+        self._check_lazy_call_reentrant_no_deadlock(script)
+
+    def test_lazy_call_reentrant_queued_does_not_deadlock(self):
+        # Reentrant _lazy_call from a queued callback while _lazy_init drains
+        # _queued_calls with _initialization_lock held.
+        script = (
+            "import torch; "
+            "torch.cuda._lazy_call(lambda: torch.cuda.manual_seed(42)); "
+            "torch.cuda.init(); "
+            "print('done')"
+        )
+        self._check_lazy_call_reentrant_no_deadlock(script)
 
     def test_specify_improper_device_name(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1418,8 +1418,7 @@ print("done")
 """
         proc = subprocess.run(
             [sys.executable, "-c", code],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
             timeout=20,
         )

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -451,9 +451,14 @@ def is_initialized():
 
 
 def _lazy_call(callable, **kwargs):
+    if is_initialized():
+        callable()
+        return
+
+    run_now = False
     with _initialization_lock:
         if is_initialized():
-            callable()
+            run_now = True
         else:
             # TODO(torch_deploy): this accesses linecache, which attempts to read the
             # file system to get traceback info. Patch linecache or do something
@@ -466,6 +471,9 @@ def _lazy_call(callable, **kwargs):
             else:
                 # Don't store the actual traceback to avoid memory cycle
                 _queued_calls.append((callable, traceback.format_stack()))
+
+    if run_now:
+        callable()
 
 
 _lazy_call(_check_capability)

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -451,6 +451,8 @@ def is_initialized():
 
 
 def _lazy_call(callable, **kwargs):
+    # Do not invoke user callbacks while holding _initialization_lock
+    # they may call back into _lazy_call.
     if is_initialized():
         callable()
         return

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -517,9 +517,11 @@ def is_initialized():
 
 
 def _lazy_call(callable, **kwargs):
-    # Do not invoke user callbacks while holding _initialization_lock
-    # they may call back into _lazy_call.
-    if is_initialized():
+    # Do not invoke user callbacks while holding _initialization_lock;
+    # they may call back into _lazy_call. The is_initializing check
+    # mirrors _lazy_init: while it drains _queued_calls this thread
+    # already holds the lock, so run reentrant callbacks immediately.
+    if is_initialized() or hasattr(_tls, "is_initializing"):
         callable()
         return
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -517,9 +517,14 @@ def is_initialized():
 
 
 def _lazy_call(callable, **kwargs):
+    if is_initialized():
+        callable()
+        return
+
+    run_now = False
     with _initialization_lock:
         if is_initialized():
-            callable()
+            run_now = True
         else:
             # TODO(torch_deploy): this accesses linecache, which attempts to read the
             # file system to get traceback info. Patch linecache or do something
@@ -532,6 +537,9 @@ def _lazy_call(callable, **kwargs):
             else:
                 # Don't store the actual traceback to avoid memory cycle
                 _queued_calls.append((callable, traceback.format_stack()))
+
+    if run_now:
+        callable()
 
 
 _lazy_call(_check_capability)

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -517,6 +517,8 @@ def is_initialized():
 
 
 def _lazy_call(callable, **kwargs):
+    # Do not invoke user callbacks while holding _initialization_lock
+    # they may call back into _lazy_call.
     if is_initialized():
         callable()
         return


### PR DESCRIPTION
Fixes a deadlock where a callback passed to `torch.cuda._lazy_call` re-enters `_lazy_call`, e.g. via `torch.cuda.set_rng_state` or `torch.cuda.manual_seed`. `_initialization_lock` is a non-reentrant `threading.Lock`, so the nested acquisition blocks forever. Originally encountered on ROCm while running larger models under `torch.compile`.

There are two reentrancy paths, both fixed here:

1. **Already initialized**: callbacks used to run while holding `_initialization_lock`, so a nested `_lazy_call` deadlocked. Callbacks now run outside the lock: a fast path runs them immediately when CUDA is initialized, and otherwise the lock is held only for the queue-or-run decision, with the callback invoked after release if initialization won the race.
2. **Queued callback during initialization**: `_lazy_init` drains `_queued_calls` while holding the lock and with `_initialized` still `False`, so a queued callback that re-enters `_lazy_call` deadlocked on its own thread's lock. `_lazy_call` now mirrors `_lazy_init`'s reentrancy guard and runs the callback immediately when `_tls.is_initializing` is set; `torch._C._cuda_init()` has already completed at that point, so this is safe.

Regression tests `test_lazy_call_reentrant_set_rng_state_does_not_deadlock` and `test_lazy_call_reentrant_queued_does_not_deadlock` run each scenario in a subprocess with a generous timeout. Both fail with a deadlock timeout before the fix and pass after (verified on a ROCm gfx90a host).

`torch/mtia/__init__.py` and `torch/xpu/__init__.py` have the same callback-under-lock pattern and would need the same treatment in a follow-up.

*Parts of this PR (the queued-path fix, second regression test, and this description) were drafted with the assistance of Claude Code and reviewed by a human.*
