### PR TITLE
[Docathon] Added undocumented functions in ddp_comm_hooks.md

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -463,14 +463,6 @@ coverage_ignore_functions = [
     "unique_id",
     # torch.cuda.profiler
     "init",
-    # torch.distributed.algorithms.ddp_comm_hooks.ddp_zero_hook
-    "hook_with_zero_step",
-    "hook_with_zero_step_interleaved",
-    # torch.distributed.algorithms.ddp_comm_hooks.post_localSGD_hook
-    "post_localSGD_hook",
-    # torch.distributed.algorithms.ddp_comm_hooks.quantization_hooks
-    "quantization_perchannel_hook",
-    "quantization_pertensor_hook",
     # torch.distributed.checkpoint.default_planner
     "create_default_global_load_plan",
     "create_default_global_save_plan",

--- a/docs/source/ddp_comm_hooks.md
+++ b/docs/source/ddp_comm_hooks.md
@@ -40,6 +40,22 @@ Particularly, {class}`torch.distributed.GradBucket` represents a bucket of gradi
 .. autofunction:: register_ddp_comm_hook
 ```
 
+```{eval-rst}
+.. currentmodule:: torch.distributed.algorithms.ddp_comm_hooks.post_localSGD_hook
+.. autofunction:: post_localSGD_hook
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.algorithms.ddp_comm_hooks.ddp_zero_hook
+.. autofunction:: hook_with_zero_step
+.. autofunction:: hook_with_zero_step_interleaved
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.algorithms.ddp_comm_hooks.quantization_hooks
+.. autofunction:: quantization_perchannel_hook
+.. autofunction:: quantization_pertensor_hook
+```
 ## Default Communication Hooks
 
 Default communication hooks are simple **stateless** hooks, so the input state


### PR DESCRIPTION
Description
This PR addresses issue #182519 by documenting 5 previously undocumented functions in the torch.distributed.algorithms.ddp_comm_hooks module. By adding these to the official documentation, we ensure better visibility and usability for users working with DDP communication hooks.

Changes
- Removed the functions from ignore list in conf.py
- Added directives into ddp_comm_hooks.md

Verification 
- [x] make coverage found no issue
- [x] Visual verification using make html and make serve showed that it was added properly
<img width="1633" height="1165" alt="image" src="https://github.com/user-attachments/assets/90c77992-910b-4956-9788-1852f9b0fa63" />
<img width="1623" height="1203" alt="image" src="https://github.com/user-attachments/assets/6315c74d-83e5-43ea-96cc-332ea892d4e2" />
<img width="1603" height="1192" alt="image" src="https://github.com/user-attachments/assets/58803150-dfe6-4934-91a1-1226ecd685c3" />
<img width="1603" height="1090" alt="image" src="https://github.com/user-attachments/assets/31e5883d-3648-443c-8f6a-436e068fe9d7" />
<img width="1622" height="1096" alt="image" src="https://github.com/user-attachments/assets/3c65cdcd-467e-465e-a152-35106c1e9a14" />


cc @svekars @sekyondaMeta @AlannaBurke