### PR TITLE
Fix TD changed file detection for ghstack PRs

### DIFF
--- a/.github/workflows/target_determination.yml
+++ b/.github/workflows/target_determination.yml
@@ -50,7 +50,6 @@ jobs:
 
       - name: Do TD
         id: td
-        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/tools/test/heuristics/test_heuristics.py
+++ b/tools/test/heuristics/test_heuristics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -14,6 +15,9 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.append(str(REPO_ROOT))
 
 from tools.test.heuristics.test_interface import TestTD
+from tools.testing.target_determination.heuristics.edited_by_pr import (
+    _get_modified_tests,
+)
 from tools.testing.target_determination.heuristics.filepath import (
     file_matches_keyword,
     get_keywords,
@@ -25,12 +29,18 @@ from tools.testing.target_determination.heuristics.interface import TestPrioriti
 from tools.testing.target_determination.heuristics.previously_failed_in_pr import (
     get_previous_failures,
 )
+from tools.testing.target_determination.heuristics.utils import (
+    _get_pr_merge_base,
+    query_changed_files,
+)
 from tools.testing.test_run import TestRun
 
 
 sys.path.remove(str(REPO_ROOT))
 
 HEURISTIC_CLASS = "tools.testing.target_determination.heuristics.historical_class_failure_correlation."
+EDITED_BY_PR = "tools.testing.target_determination.heuristics.edited_by_pr."
+HEURISTIC_UTILS = "tools.testing.target_determination.heuristics.utils."
 
 
 def mocked_file(contents: dict[Any, Any]) -> io.IOBase:
@@ -113,6 +123,77 @@ class TestHistoricalClassFailureCorrelation(TestTD):
         self.assert_test_scores_almost_equal(
             test_prioritizations._test_scores, expected._test_scores
         )
+
+
+class TestChangedFiles(TestTD):
+    @mock.patch(EDITED_BY_PR + "query_changed_files", side_effect=RuntimeError)
+    def test_edited_by_pr_propagates_changed_files_errors(
+        self,
+        mock_query_changed_files: Any,
+    ) -> None:
+        with self.assertRaises(RuntimeError):
+            _get_modified_tests()
+
+        mock_query_changed_files.assert_called_once_with()
+
+    @mock.patch(
+        HEURISTIC_UTILS + "_git_merge_base",
+        side_effect=[
+            subprocess.CalledProcessError(128, ["git", "merge-base"]),
+            subprocess.CalledProcessError(128, ["git", "merge-base"]),
+        ],
+    )
+    @mock.patch(HEURISTIC_UTILS + "_git_head", return_value="head-sha")
+    @mock.patch(
+        HEURISTIC_UTILS + "_github_api_json",
+        return_value={"merge_base_commit": {"sha": "merge-base-sha"}},
+    )
+    def test_pr_merge_base_falls_back_to_github_compare(
+        self,
+        mock_github_api_json: Any,
+        mock_git_head: Any,
+        mock_git_merge_base: Any,
+    ) -> None:
+        pr_info: dict[str, object] = {
+            "base": {
+                "ref": "gh/bobrenjc93/893/base",
+                "sha": "base-sha",
+            }
+        }
+
+        self.assertEqual(_get_pr_merge_base(pr_info), "merge-base-sha")
+
+        mock_git_merge_base.assert_has_calls(
+            [
+                mock.call("origin/gh/bobrenjc93/893/base"),
+                mock.call("base-sha"),
+            ]
+        )
+        mock_git_head.assert_called_once_with()
+        mock_github_api_json.assert_called_once_with(
+            "compare/gh%2Fbobrenjc93%2F893%2Fbase...head-sha"
+        )
+
+    @mock.patch(HEURISTIC_UTILS + "get_pr_number", return_value=123)
+    @mock.patch(HEURISTIC_UTILS + "get_merge_base", side_effect=RuntimeError)
+    @mock.patch(
+        HEURISTIC_UTILS + "_query_changed_files_from_github",
+        return_value=["test/functorch/test_aotdispatch.py"],
+    )
+    def test_query_changed_files_falls_back_to_github_pr_files(
+        self,
+        mock_query_changed_files_from_github: Any,
+        mock_get_merge_base: Any,
+        mock_get_pr_number: Any,
+    ) -> None:
+        self.assertEqual(
+            query_changed_files(),
+            ["test/functorch/test_aotdispatch.py"],
+        )
+
+        mock_get_pr_number.assert_called_once_with()
+        mock_get_merge_base.assert_called_once_with()
+        mock_query_changed_files_from_github.assert_called_once_with(123)
 
 
 class TestParsePrevTests(TestTD):

--- a/tools/testing/target_determination/heuristics/edited_by_pr.py
+++ b/tools/testing/target_determination/heuristics/edited_by_pr.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from typing import Any
-from warnings import warn
 
 from tools.testing.target_determination.heuristics.interface import (
     HeuristicInterface,
@@ -39,18 +38,13 @@ class EditedByPR(HeuristicInterface):
 
 
 def _get_modified_tests() -> set[str]:
-    try:
-        changed_files = query_changed_files()
-        should_run = python_test_file_to_test_name(set(changed_files))
-        for test_file, regexes in ADDITIONAL_MAPPINGS.items():
-            if any(
-                re.search(regex, changed_file) is not None
-                for regex in regexes
-                for changed_file in changed_files
-            ):
-                should_run.add(test_file)
-        return should_run
-    except Exception as e:
-        warn(f"Can't query changed test files due to {e}")
-        # If unable to get changed files from git, quit without doing any sorting
-    return set()
+    changed_files = query_changed_files()
+    should_run = python_test_file_to_test_name(set(changed_files))
+    for test_file, regexes in ADDITIONAL_MAPPINGS.items():
+        if any(
+            re.search(regex, changed_file) is not None
+            for regex in regexes
+            for changed_file in changed_files
+        ):
+            should_run.add(test_file)
+    return should_run

--- a/tools/testing/target_determination/heuristics/filepath.py
+++ b/tools/testing/target_determination/heuristics/filepath.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
-from warnings import warn
 
 from tools.testing.target_determination.heuristics.interface import (
     HeuristicInterface,
@@ -115,11 +114,7 @@ class Filepath(HeuristicInterface):
         super().__init__(**kwargs)
 
     def get_prediction_confidence(self, tests: list[str]) -> TestPrioritizations:
-        try:
-            changed_files = query_changed_files()
-        except Exception as e:
-            warn(f"Can't query changed test files due to {e}")
-            changed_files = []
+        changed_files = query_changed_files()
 
         # If only documentation files (.rst, .md) were modified, skip all tests
         if is_docs_only_change(changed_files):

--- a/tools/testing/target_determination/heuristics/historical_class_failure_correlation.py
+++ b/tools/testing/target_determination/heuristics/historical_class_failure_correlation.py
@@ -4,7 +4,6 @@ import json
 import os
 from collections import defaultdict
 from typing import Any, cast
-from warnings import warn
 
 from tools.stats.import_test_stats import (
     ADDITIONAL_CI_FILES_FOLDER,
@@ -53,11 +52,7 @@ def _get_ratings_for_tests(
     tests_to_run: set[str],
 ) -> dict[str, float]:
     # Get the files edited
-    try:
-        changed_files = query_changed_files()
-    except Exception as e:
-        warn(f"Can't query changed test files due to {e}")
-        return {}
+    changed_files = query_changed_files()
 
     test_class_correlations = _get_historical_test_class_correlations()
     if not test_class_correlations:

--- a/tools/testing/target_determination/heuristics/public_bindings.py
+++ b/tools/testing/target_determination/heuristics/public_bindings.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any
-from warnings import warn
 
 from tools.testing.target_determination.heuristics.interface import (
     HeuristicInterface,
@@ -22,11 +21,7 @@ class PublicBindings(HeuristicInterface):
 
     def get_prediction_confidence(self, tests: list[str]) -> TestPrioritizations:
         test_ratings = {}
-        try:
-            changed_files = query_changed_files()
-        except Exception as e:
-            warn(f"Can't query changed test files due to {e}")
-            changed_files = []
+        changed_files = query_changed_files()
 
         if any(
             file.startswith("torch/") or file in self.additional_files

--- a/tools/testing/target_determination/heuristics/utils.py
+++ b/tools/testing/target_determination/heuristics/utils.py
@@ -8,8 +8,8 @@ from collections import defaultdict
 from functools import cache
 from pathlib import Path
 from typing import cast, TYPE_CHECKING
+from urllib.parse import quote
 from urllib.request import Request, urlopen
-from warnings import warn
 
 
 if TYPE_CHECKING:
@@ -17,6 +17,75 @@ if TYPE_CHECKING:
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _github_api_json(path: str) -> object:
+    github_repository = os.environ.get("GITHUB_REPOSITORY", "pytorch/pytorch")
+    github_token = os.environ.get("GITHUB_TOKEN")
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+    }
+    if github_token:
+        headers["Authorization"] = f"token {github_token}"
+    url = f"https://api.github.com/repos/{github_repository}/{path}"
+    with urlopen(Request(url, headers=headers)) as conn:
+        return json.loads(conn.read().decode())
+
+
+def _git_merge_base(base: str) -> str:
+    return subprocess.check_output(["git", "merge-base", base, "HEAD"]).decode().strip()
+
+
+def _git_head() -> str:
+    return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+
+
+def _get_pr_info(pr_number: int) -> dict[str, object]:
+    return cast(dict[str, object], _github_api_json(f"pulls/{pr_number}"))
+
+
+def _get_pr_merge_base(pr_info: dict[str, object]) -> str:
+    base_info = cast(dict[str, object], pr_info["base"])
+    base_ref = cast(str, base_info["ref"])
+    base_sha = cast(str | None, base_info.get("sha"))
+    last_error: Exception | None = None
+
+    for base in (f"origin/{base_ref}", base_sha):
+        if not base:
+            continue
+        try:
+            return _git_merge_base(base)
+        except subprocess.CalledProcessError as e:
+            last_error = e
+
+    head = _git_head()
+    compare = cast(
+        dict[str, object],
+        _github_api_json(f"compare/{quote(base_ref, safe='')}...{head}"),
+    )
+    merge_base_commit = cast(dict[str, object], compare.get("merge_base_commit", {}))
+    merge_base = cast(str | None, merge_base_commit.get("sha"))
+    if merge_base:
+        return merge_base
+    if base_sha:
+        return base_sha
+    if last_error:
+        raise last_error
+    raise RuntimeError(f"Unable to determine merge base for PR base {base_ref}")
+
+
+def _query_changed_files_from_github(pr_number: int) -> list[str]:
+    changed_files: list[str] = []
+    page = 1
+    while True:
+        files = cast(
+            list[dict[str, object]],
+            _github_api_json(f"pulls/{pr_number}/files?per_page=100&page={page}"),
+        )
+        changed_files.extend(cast(str, file["filename"]) for file in files)
+        if len(files) < 100:
+            return changed_files
+        page += 1
 
 
 def python_test_file_to_test_name(tests: set[str]) -> set[str]:
@@ -43,29 +112,11 @@ def get_pr_number() -> int | None:
 def get_merge_base() -> str:
     pr_number = get_pr_number()
     if pr_number is not None:
-        github_token = os.environ.get("GITHUB_TOKEN")
-        headers = {
-            "Accept": "application/vnd.github.v3+json",
-            "Authorization": f"token {github_token}",
-        }
-        url = f"https://api.github.com/repos/pytorch/pytorch/pulls/{pr_number}"
-        with urlopen(Request(url, headers=headers)) as conn:
-            pr_info = json.loads(conn.read().decode())
-            base = f"origin/{pr_info['base']['ref']}"
-        merge_base = (
-            subprocess.check_output(["git", "merge-base", base, "HEAD"])
-            .decode()
-            .strip()
-        )
-        return merge_base
+        return _get_pr_merge_base(_get_pr_info(pr_number))
     default_branch = f"origin/{os.environ.get('GIT_DEFAULT_BRANCH', 'main')}"
-    merge_base = (
-        subprocess.check_output(["git", "merge-base", default_branch, "HEAD"])
-        .decode()
-        .strip()
-    )
+    merge_base = _git_merge_base(default_branch)
 
-    head = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+    head = _git_head()
 
     if merge_base == head:
         # We are on the default branch, so check for changes since the last commit
@@ -74,17 +125,25 @@ def get_merge_base() -> str:
 
 
 def query_changed_files() -> list[str]:
-    base_commit = get_merge_base()
+    pr_number = get_pr_number()
+    try:
+        base_commit = get_merge_base()
 
-    proc = subprocess.run(
-        ["git", "diff", "--name-only", base_commit, "HEAD"],
-        capture_output=True,
-        check=False,
-    )
-    print(f"base_commit: {base_commit}")
+        proc = subprocess.run(
+            ["git", "diff", "--name-only", base_commit, "HEAD"],
+            capture_output=True,
+            check=False,
+        )
+        print(f"base_commit: {base_commit}")
 
-    if proc.returncode != 0:
-        raise RuntimeError("Unable to get changed files")
+        if proc.returncode != 0:
+            raise RuntimeError("Unable to get changed files")
+    except (subprocess.CalledProcessError, RuntimeError):
+        if pr_number is None:
+            raise
+        lines = _query_changed_files_from_github(pr_number)
+        print(f"Changed files from GitHub: {lines}")
+        return lines
 
     lines = proc.stdout.decode().strip().split("\n")
     lines = [line.strip() for line in lines]
@@ -176,11 +235,7 @@ def get_ratings_for_tests(file: str | Path) -> dict[str, float]:
         return {}
     with open(path) as f:
         test_file_ratings = cast(dict[str, dict[str, float]], json.load(f))
-    try:
-        changed_files = query_changed_files()
-    except Exception as e:
-        warn(f"Can't query changed test files due to {e}")
-        return {}
+    changed_files = query_changed_files()
     ratings: dict[str, float] = defaultdict(float)
     for file in changed_files:
         for test_file, score in test_file_ratings.get(file, {}).items():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182957

Target determination now falls back to GitHub PR metadata when local git cannot resolve a PR base ref, and changed-file lookup failures are no longer silently converted into empty heuristic results. The TD workflow now fails the job when TD fails.

Authored with Codex.