### PR TITLE
[dynamo] Handle member_descriptor in class-level attribute access

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -614,6 +614,18 @@ class UserDefinedClassVariable(UserDefinedVariable):
             )
             return variables.PropertyVariable(cls_attr, source=descriptor_source)
 
+        # member_get with obj=NULL returns self.
+        # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L162-L164
+        if isinstance(cls_attr, types.MemberDescriptorType):
+            descriptor_source = (
+                self.get_source_by_walking_mro(tx, name)
+                if self.source is not None
+                else None
+            )
+            return variables.MemberDescriptorVariable(
+                cls_attr, source=descriptor_source
+            )
+
         if isinstance(cls_attr, _collections._tuplegetter):
             descriptor_source = (
                 self.get_source_by_walking_mro(tx, name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182959
* #182742

When accessing a slot attribute on a class (e.g. `A.x` where `A` has
`__slots__`), the member_descriptor was falling through
resolve_cls_descriptor to the catch-all VariableTracker.build(), which
wrapped it as UserDefinedObjectVariable. This caused isinstance checks
against types.MemberDescriptorType to graph-break.

Add an explicit case for MemberDescriptorType in resolve_cls_descriptor,
matching the existing pattern for property and _tuplegetter. CPython's
member_get with obj=NULL returns the descriptor itself.

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98