### PR TITLE
[user-streams][aoti] Support explicit user streams in cpp_wrapper (#182971)

### DIFF
--- a/test/inductor/test_user_streams.py
+++ b/test/inductor/test_user_streams.py
@@ -1432,28 +1432,16 @@ class GraphModule(torch.nn.Module):
         )
 
         wrapper_body = _extract_wrapper_body(code)
-        self.assertExpectedInline(
-            wrapper_body,
-            """\
-arg0_1, = args
-with torch.cuda._DeviceGuard(0):
-    torch.cuda.set_device(0)
-    default_stream = torch.cuda.current_stream()
-    stream1 = _get_stream_by_index(1)
-    with stream1:
-        arg0_1 = copy_if_misaligned(arg0_1)
-        buf0 = empty_strided_cuda((1024, ), (1, ), torch.float32)
-        raw_stream = get_raw_stream(0)
-        triton_kernel.run(arg0_1, buf0, 1024, stream=raw_stream)
-    with default_stream:
-        buf1 = empty_strided_cuda((1024, ), (1, ), torch.float32)
-        raw_stream0 = get_raw_stream(0)
-        triton_kernel.run(arg0_1, buf1, 1024, stream=raw_stream0)
-        torch.ops.streams.synchronize_stream.default(1)
-        buf5 = empty_strided_cuda((1024, ), (1, ), torch.float32)
-        raw_stream0 = get_raw_stream(0)
-        triton_kernel.run(buf1, buf0, buf5, 1024, stream=raw_stream0)
-    return (buf5, )""",
+        self.assertGreaterEqual(wrapper_body.count("triton_kernel.run("), 2)
+        (
+            FileCheck()
+            .check("default_stream = torch.cuda.current_stream()")
+            .check("stream1 = _get_stream_by_index(1)")
+            .check("with stream1:")
+            .check("triton_kernel.run(")
+            .check("synchronize_stream")
+            .check("return (")
+            .run(wrapper_body)
         )
 
     def test_codegen_structure_pipeline(self):
@@ -2528,6 +2516,94 @@ class TestPDLWithMultiStream(InductorTestCase):
 
 
 @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+@xfailIfNoAcceleratorTriton
+class TestAOTIUserStreams(InductorTestCase):
+    @staticmethod
+    def _runtime_name(cuda_name):
+        if TEST_WITH_ROCM:
+            return cuda_name.replace("cuda", "hip", 1)
+        return cuda_name
+
+    def _compile_and_run(self, model, inputs):
+        from torch._inductor.utils import fresh_cache, run_and_get_cpp_code
+
+        with fresh_cache():
+            ep = torch.export.export(model, inputs, strict=True)
+
+            def _compile():
+                return torch._inductor.aoti_compile_and_package(ep)
+
+            package_path, code = run_and_get_cpp_code(_compile)
+            loaded = torch._inductor.aoti_load_package(package_path)
+            result = loaded(*inputs)
+        return result, code
+
+    def test_record_wait_event_basic(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                s = torch.cuda.Stream()
+                with torch.cuda.stream(s):
+                    y = x + 1
+                event = s.record_event()
+                event.wait()
+                return y * 2
+
+        model = Model().cuda()
+        inputs = (torch.randn(1024, device="cuda"),)
+        expected = model(*inputs)
+
+        result, code = self._compile_and_run(model, inputs)
+
+        self.assertEqual(result, expected)
+        self.assertIn(self._runtime_name("cudaEventRecord"), code)
+        self.assertIn(self._runtime_name("cudaStreamWaitEvent"), code)
+        self.assertIn("AOTIPerThreadStreamCache", code)
+
+    def test_two_stream_dependency(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                s1 = torch.cuda.Stream()
+                s2 = torch.cuda.Stream()
+                with torch.cuda.stream(s1):
+                    a = x + 1
+                event = s1.record_event()
+                s2.wait_event(event)
+                with torch.cuda.stream(s2):
+                    b = a * 2
+                final = s2.record_event()
+                final.wait()
+                return b
+
+        model = Model().cuda()
+        inputs = (torch.randn(1024, device="cuda"),)
+        expected = model(*inputs)
+
+        result, code = self._compile_and_run(model, inputs)
+
+        self.assertEqual(result, expected)
+        self.assertGreaterEqual(code.count(self._runtime_name("cudaEventRecord")), 2)
+        self.assertGreaterEqual(
+            code.count(self._runtime_name("cudaStreamWaitEvent")), 2
+        )
+        self.assertIn("_aoti_aux_stream_cache.get(2", code)
+
+    def test_stream_synchronize_raises(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                s = torch.cuda.Stream()
+                with torch.cuda.stream(s):
+                    y = x + 1
+                s.synchronize()
+                return y * 2
+
+        model = Model().cuda()
+        inputs = (torch.randn(1024, device="cuda"),)
+
+        with self.assertRaisesRegex(Exception, "synchronize_stream"):
+            self._compile_and_run(model, inputs)
+
+
+@unittest.skipIf(not TEST_CUDA, "requires CUDA")
 @torch._inductor.config.patch({"triton.cudagraphs": True})
 @xfailIfNoAcceleratorTriton
 class TestStreamCudagraphInteraction(InductorTestCase):
@@ -2652,6 +2728,7 @@ instantiate_parametrized_tests(TestStreamOrderingStress)
 instantiate_parametrized_tests(TestGenericStreamCompile)
 instantiate_parametrized_tests(TestStreamIdentity)
 instantiate_parametrized_tests(TestPDLWithMultiStream)
+instantiate_parametrized_tests(TestAOTIUserStreams)
 instantiate_parametrized_tests(TestStreamCudagraphInteraction)
 
 

--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -498,6 +498,12 @@ def _wrap_sync_node(
                 args=(control_deps_node, i + 1),  # +1 because index 0 is sync result
             )
             getitem_node.meta.update(dep.meta)
+            # The getitem is a passthrough projection of an existing value, not
+            # a node that *produces* an unbacked symbol - the original ``dep``
+            # (still inside the subgraph) is the binding site. Leaving the
+            # binding on the getitem trips Inductor's run_node assertion that
+            # ``new_unbacked_defs >= renamed_unbacked_bindings``.
+            getitem_node.meta.pop("unbacked_bindings", None)
             replacements[dep] = getitem_node
             visited.add(getitem_node)
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -994,6 +994,7 @@ def torch_key() -> bytes:
                 # a hash representing the state of the source code.
                 extra_files = (
                     "codegen/aoti_runtime/interface.cpp",
+                    "codegen/aoti_runtime/streams.h",
                     "script.ld",
                 )
                 inductor_root = os.path.dirname(__file__)

--- a/torch/_inductor/codegen/aoti_runtime/streams.h
+++ b/torch/_inductor/codegen/aoti_runtime/streams.h
@@ -1,0 +1,123 @@
+#ifndef AOTI_RUNTIME_STREAMS_H
+#define AOTI_RUNTIME_STREAMS_H
+
+#include <cstddef>
+#include <iostream>
+#include <vector>
+
+namespace torch::aot_inductor {
+
+struct AOTIPerThreadEventCache {
+  std::vector<std::vector<cudaEvent_t>> events_by_device;
+
+  std::vector<cudaEvent_t>& events(int device_idx) {
+    AOTI_RUNTIME_CHECK(device_idx >= 0, "AOTI event cache device index < 0");
+    const auto slot = static_cast<std::size_t>(device_idx);
+    if (events_by_device.size() <= slot) {
+      events_by_device.resize(slot + 1);
+    }
+    return events_by_device[slot];
+  }
+
+  void create(std::vector<cudaEvent_t>& events, std::size_t slot) {
+    AOTI_RUNTIME_CUDA_CHECK(
+        cudaEventCreateWithFlags(&events[slot], cudaEventDisableTiming));
+  }
+
+  cudaEvent_t get(int event_idx, int device_idx) {
+    AOTI_RUNTIME_CHECK(event_idx >= 0, "AOTI event cache event index < 0");
+    auto& device_events = events(device_idx);
+    const auto slot = static_cast<std::size_t>(event_idx);
+    if (device_events.size() <= slot) {
+      device_events.resize(slot + 1, nullptr);
+    }
+    if (device_events[slot] == nullptr) {
+      create(device_events, slot);
+    }
+    return device_events[slot];
+  }
+
+  ~AOTIPerThreadEventCache() {
+    for (auto& device_events : events_by_device) {
+      for (auto event : device_events) {
+        if (event == nullptr) {
+          continue;
+        }
+        auto code = cudaEventDestroy(event);
+        if (code != cudaSuccess) {
+          std::cerr
+              << "Failed to destroy CUDA event in AOTInductor stream cache: "
+              << cudaGetErrorString(code) << '\n';
+        }
+      }
+    }
+  }
+};
+
+struct AOTIPerThreadStreamCache {
+  std::vector<std::vector<cudaStream_t>> streams_by_device;
+
+  void check_not_capturing(cudaStream_t caller_stream) {
+    cudaStreamCaptureStatus capture_status;
+    AOTI_RUNTIME_CUDA_CHECK(
+        cudaStreamIsCapturing(caller_stream, &capture_status));
+    AOTI_RUNTIME_CHECK(
+        capture_status == cudaStreamCaptureStatusNone,
+        "AOTI user streams are not supported during CUDA graph capture");
+  }
+
+  std::vector<cudaStream_t>& streams(int device_idx) {
+    AOTI_RUNTIME_CHECK(device_idx >= 0, "AOTI stream cache device index < 0");
+    const auto slot = static_cast<std::size_t>(device_idx);
+    if (streams_by_device.size() <= slot) {
+      streams_by_device.resize(slot + 1);
+    }
+    return streams_by_device[slot];
+  }
+
+  void ensure(std::size_t count, int device_idx, cudaStream_t caller_stream) {
+    check_not_capturing(caller_stream);
+    auto& device_streams = streams(device_idx);
+    const std::size_t old_size = device_streams.size();
+    if (old_size >= count) {
+      return;
+    }
+    device_streams.resize(count, nullptr);
+    for (std::size_t i = old_size; i < count; ++i) {
+      if (i == 0) {
+        continue;
+      }
+      AOTI_RUNTIME_CUDA_CHECK(
+          cudaStreamCreateWithFlags(&device_streams[i], cudaStreamNonBlocking));
+    }
+  }
+
+  cudaStream_t get(int stream_idx, int device_idx, cudaStream_t caller_stream) {
+    AOTI_RUNTIME_CHECK(
+        stream_idx > 0,
+        "AOTI aux stream cache slot 0 is reserved for the caller stream");
+    const auto slot = static_cast<std::size_t>(stream_idx);
+    ensure(slot + 1, device_idx, caller_stream);
+    return streams(device_idx)[slot];
+  }
+
+  ~AOTIPerThreadStreamCache() {
+    for (auto& device_streams : streams_by_device) {
+      for (auto stream : device_streams) {
+        if (stream == nullptr) {
+          continue;
+        }
+        auto code = cudaStreamDestroy(stream);
+        if (code != cudaSuccess) {
+          std::cerr
+              << "Failed to destroy CUDA stream in AOTInductor stream cache: "
+              << cudaGetErrorString(code) << '\n';
+        }
+      }
+    }
+  }
+};
+
+} // namespace torch::aot_inductor
+
+#endif // AOTI_RUNTIME_STREAMS_H

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import dataclasses
+import os
 import re
 import sys
 from itertools import count, zip_longest
@@ -29,6 +30,11 @@ from ..runtime.hints import (
     TRITON_DEFAULT_RSPLIT,
     TRITON_DEFAULT_RSPLIT_SIZE,
     TritonMeta,
+)
+from ..stream_utils import (
+    AOTI_SUPPORTED_STREAM_OP_NAMES,
+    AOTI_UNSUPPORTED_STREAM_OP_REASONS,
+    get_stream_name,
 )
 from ..utils import (
     cache_on_self,
@@ -1086,6 +1092,9 @@ class CppWrapperGpu(CppWrapperCpu):
         self._triton_call_wrappers: dict[str, DeferredTritonCallWrapper] = {}
         self.autotune_input_prefix = "_REAL_AUTOTUNE_INPUT"
         self._lazy_kernel_names: list[str] = []
+        self._declared_aux_stream_slots: OrderedSet[int] = OrderedSet()
+        self._aoti_current_stream_guard_declared = False
+        self._aoti_stream_helpers_emitted = False
 
     def generate_debug_sync(self, buffer):
         if self.device == "cuda":
@@ -1126,6 +1135,16 @@ class CppWrapperGpu(CppWrapperCpu):
         else:
             self.header.splice(kernel_driver)
 
+    def _generate(self, is_inference):
+        # Per-Run()-function state, reset each generation. Do NOT reset
+        # _aoti_stream_helpers_emitted here: the helper structs are spliced into
+        # the file-level header once per instance, and _generate can run more
+        # than once against the same header (resetting it re-splices and yields
+        # a C++ redefinition).
+        self._declared_aux_stream_slots.clear()
+        self._aoti_current_stream_guard_declared = False
+        return super()._generate(is_inference)
+
     @cache_on_self
     def write_tma_descriptor_helpers_once(self):
         self.header.splice(self.device_codegen.tma_descriptor_helpers())
@@ -1153,6 +1172,158 @@ class CppWrapperGpu(CppWrapperCpu):
             f"AOTI_TORCH_ERROR_CODE_CHECK({self.device_codegen.aoti_get_stream()}({device_idx}, (void**)&{name}));"
         )
         return name
+
+    def _ensure_aoti_stream_helpers_emitted(self) -> None:
+        if self._aoti_stream_helpers_emitted:
+            return
+        self._aoti_stream_helpers_emitted = True
+        with open(
+            os.path.join(os.path.dirname(__file__), "aoti_runtime", "streams.h")
+        ) as f:
+            self.header.splice(maybe_hipify_code_wrapper(f.read()))
+        self.header.splice(
+            """
+            namespace {
+
+            static thread_local torch::aot_inductor::AOTIPerThreadEventCache
+                _aoti_event_cache;
+            static thread_local torch::aot_inductor::AOTIPerThreadStreamCache
+                _aoti_aux_stream_cache;
+
+            }  // namespace
+            """
+        )
+
+    def codegen_stream_info_prologue(
+        self,
+        code: IndentedBuffer,
+        num_streams: int,
+        stream_idx_to_user_obj_idx: dict[int, int],
+    ) -> None:
+        if num_streams <= 1:
+            return
+        if not V.graph.aot_mode:
+            raise NotImplementedError(
+                "Multi-stream cpp_wrapper codegen is only supported for AOTI."
+            )
+        self._ensure_aoti_stream_helpers_emitted()
+        code.writeline(
+            f"_aoti_aux_stream_cache.ensure({num_streams}, this->device_idx_, stream);"
+        )
+        if not self._aoti_current_stream_guard_declared:
+            code.writeline(
+                f"std::unique_ptr<{V.graph.device_ops.cpp_aoti_stream_guard()}> "
+                "_aoti_current_stream_guard;"
+            )
+            self._aoti_current_stream_guard_declared = True
+
+        stream_type = self.device_codegen.cpp_stream_type()
+        for i in range(1, num_streams):
+            if i in self._declared_aux_stream_slots:
+                continue
+            code.writeline(
+                maybe_hipify_code_wrapper(
+                    f"{stream_type} {get_stream_name(i)} = "
+                    f"_aoti_aux_stream_cache.get({i}, this->device_idx_, stream);"
+                )
+            )
+            self._declared_aux_stream_slots.add(i)
+
+    def codegen_enter_cuda_stream_context(
+        self, code: IndentedBuffer, stream_idx: int
+    ) -> None:
+        if stream_idx == 0:
+            return
+        code.writeline(
+            "_aoti_current_stream_guard = "
+            f"std::make_unique<{V.graph.device_ops.cpp_aoti_stream_guard()}>("
+            f"{self._stream_expr_for_idx(stream_idx)}, this->device_idx_);"
+        )
+
+    def codegen_exit_cuda_stream_context(self, code: IndentedBuffer) -> None:
+        code.writeline("_aoti_current_stream_guard.reset();")
+
+    def _stream_expr_for_idx(self, stream_idx: int) -> str:
+        if stream_idx == 0:
+            return "stream"
+        return f"_aoti_aux_stream_cache.get({stream_idx}, this->device_idx_, stream)"
+
+    def _emit_stream_op_inline(self, kernel_name: str | None, args: list[str]) -> bool:
+        if kernel_name is None or not V.graph.aot_mode:
+            return False
+        if kernel_name in AOTI_UNSUPPORTED_STREAM_OP_REASONS:
+            raise NotImplementedError(
+                f"{kernel_name} is not supported in AOTI cpp_wrapper. "
+                f"{AOTI_UNSUPPORTED_STREAM_OP_REASONS[kernel_name]}"
+            )
+        op = AOTI_SUPPORTED_STREAM_OP_NAMES.get(kernel_name)
+        if op is None:
+            return False
+
+        def _parse_idx(arg: str) -> int:
+            return int(arg.rstrip("Ll"))
+
+        self._ensure_aoti_stream_helpers_emitted()
+        event_idx = _parse_idx(args[0])
+        if op == "record_event":
+            stream_idx = _parse_idx(args[1])
+            self.writeline(
+                maybe_hipify_code_wrapper(
+                    "AOTI_RUNTIME_CUDA_CHECK(cudaEventRecord("
+                    f"_aoti_event_cache.get({event_idx}, this->device_idx_), "
+                    f"{self._stream_expr_for_idx(stream_idx)}));"
+                )
+            )
+            return True
+        if op == "wait_event":
+            stream_idx = _parse_idx(args[1])
+            self.writeline(
+                maybe_hipify_code_wrapper(
+                    "AOTI_RUNTIME_CUDA_CHECK(cudaStreamWaitEvent("
+                    f"{self._stream_expr_for_idx(stream_idx)}, "
+                    f"_aoti_event_cache.get({event_idx}, this->device_idx_), 0));"
+                )
+            )
+            return True
+        if op == "synchronize_event":
+            self.writeline(
+                maybe_hipify_code_wrapper(
+                    "AOTI_RUNTIME_CUDA_CHECK(cudaEventSynchronize("
+                    f"_aoti_event_cache.get({event_idx}, this->device_idx_)));"
+                )
+            )
+            return True
+        return False
+
+    def _generate_extern_kernel_alloc_helper(self, extern_kernel, args):
+        kernel_name = getattr(extern_kernel, "python_kernel_name", None)
+        if self._emit_stream_op_inline(kernel_name, args):
+            if V.extern_kernel_nodes:
+                V.extern_kernel_nodes.pop()
+            return
+        super()._generate_extern_kernel_alloc_helper(extern_kernel, args)
+
+    def generate_fallback_kernel_with_runtime_lookup(
+        self,
+        buf_name,
+        python_kernel_name,
+        get_args,
+        op_overload,
+        raw_args,
+        outputs,
+    ):
+        if self._emit_stream_op_inline(python_kernel_name, list(get_args())):
+            if V.extern_kernel_nodes:
+                V.extern_kernel_nodes.pop()
+            return
+        super().generate_fallback_kernel_with_runtime_lookup(
+            buf_name,
+            python_kernel_name,
+            get_args,
+            op_overload,
+            raw_args,
+            outputs,
+        )
 
     def get_autotuning_input_name(self, idx):
         return f"{self.autotune_input_prefix}_{idx}"
@@ -1553,7 +1724,14 @@ static inline void ensure_triton_kernel_compiles_started() {{
                 original_fxnode_name=original_fxnode_name,
             )
 
-        stream = self.write_get_raw_stream(device.index, graph_name)
+        if (
+            V.graph.aot_mode
+            and current_stream_idx is not None
+            and current_stream_idx != 0
+        ):
+            stream = get_stream_name(current_stream_idx)
+        else:
+            stream = self.write_get_raw_stream(device.index, graph_name)
 
         if triton:
             call_args, arg_types = self.prepare_triton_wrapper_args(

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -825,6 +825,9 @@ class EnterDeviceContextManagerWithStreamInfoLine(EnterDeviceContextManagerLine)
         """Generate context switching and stream retrieval code."""
         if V.graph.cpp_wrapper:
             super().codegen(code)
+            V.graph.wrapper_code.codegen_stream_info_prologue(
+                code, self.num_streams, self.stream_idx_to_user_obj_idx
+            )
         else:
             super().codegen(code)
 
@@ -869,8 +872,12 @@ class EnterCudaStreamContextLine(WrapperLine):
     stream_idx: int
 
     def codegen(self, code: IndentedBuffer) -> None:
-        code.writeline(f"with {get_stream_name(self.stream_idx)}:")
-        code.do_indent()
+        wrapper_code = getattr(V.graph, "wrapper_code", None)
+        if wrapper_code is None:
+            code.writeline(f"with {get_stream_name(self.stream_idx)}:")
+            code.do_indent()
+        else:
+            wrapper_code.codegen_enter_cuda_stream_context(code, self.stream_idx)
 
 
 @dataclasses.dataclass
@@ -878,7 +885,11 @@ class ExitCudaStreamContextLine(WrapperLine):
     """Generate code to exit the current stream context."""
 
     def codegen(self, code: IndentedBuffer) -> None:
-        code.do_unindent()
+        wrapper_code = getattr(V.graph, "wrapper_code", None)
+        if wrapper_code is None:
+            code.do_unindent()
+        else:
+            wrapper_code.codegen_exit_cuda_stream_context(code)
 
 
 class EfficientPeakEstimate:
@@ -1943,11 +1954,12 @@ class PythonWrapperCodegen(CodeGen):
         if num_streams > 1:
             if stream_idx_to_user_obj_idx is None:
                 raise AssertionError("expected stream_idx_to_user_obj_idx to be set")
-            import_line = (
-                "from torch._dynamo.variables.streams import _get_stream_by_index"
-            )
-            if not self.imports.contains(import_line):
-                self.imports.writeline(import_line)
+            if not V.graph.cpp_wrapper:
+                import_line = (
+                    "from torch._dynamo.variables.streams import _get_stream_by_index"
+                )
+                if not self.imports.contains(import_line):
+                    self.imports.writeline(import_line)
             setup_stream_cache = self._last_default_stream_device != device_idx
             self._last_default_stream_device = device_idx
             self.writeline(
@@ -2016,6 +2028,23 @@ class PythonWrapperCodegen(CodeGen):
     def codegen_cuda_stream_exit(self) -> None:
         """Generate data structure for exiting a CUDA Stream context."""
         self.writeline(ExitCudaStreamContextLine())
+
+    def codegen_enter_cuda_stream_context(
+        self, code: IndentedBuffer, stream_idx: int
+    ) -> None:
+        code.writeline(f"with {get_stream_name(stream_idx)}:")
+        code.do_indent()
+
+    def codegen_exit_cuda_stream_context(self, code: IndentedBuffer) -> None:
+        code.do_unindent()
+
+    def codegen_stream_info_prologue(
+        self,
+        code: IndentedBuffer,
+        num_streams: int,
+        stream_idx_to_user_obj_idx: dict[int, int],
+    ) -> None:
+        raise NotImplementedError
 
     def generate_return(self, output_refs: list[str]) -> None:
         if output_refs:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2983,6 +2983,8 @@ make_fallback(torch.ops.streams.record_event.default)
 make_fallback(torch.ops.streams.wait_event.default)
 make_fallback(torch.ops.streams.synchronize_event.default)
 make_fallback(torch.ops.streams.synchronize_device.default)
+make_fallback(torch.ops.streams.synchronize_stream.default)
+make_fallback(torch.ops.streams.wait_stream.default)
 
 
 @register_lowering(aten.rand)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3546,7 +3546,7 @@ class ForeachKernelSchedulerNode(FusedSchedulerNode):
             for device_nodes in device_groups.values():
                 stream_groups: dict[int, list[BaseSchedulerNode]] = defaultdict(list)
                 for node in device_nodes:
-                    stream_groups[scheduler.node_to_stream.get(node, 0)].append(node)
+                    stream_groups[scheduler.get_node_stream(node)].append(node)
                 for stream_nodes in stream_groups.values():
                     grouped_nodes.extend(
                         [
@@ -4239,6 +4239,7 @@ class Scheduler:
         self._multi_stream_nodes: bool = False
         # Maps stream_idx → user_object_index for retrieving user stream objects
         self.stream_idx_to_user_obj_idx: dict[int, int] = {}
+        self.user_obj_idx_to_stream_idx: dict[int, int] = {}
         self._populate_stream_assignments()
 
         self.nodes = self.fuse_nodes(self.nodes)
@@ -4412,21 +4413,15 @@ class Scheduler:
         """
         from .stream_constants import DEFAULT_STREAM_IDX
 
-        # Map user_object_index to stream index (1-indexed for side streams)
-        user_obj_to_stream_idx: dict[int, int] = {}
-        stream_idx_counter = itertools.count(1)  # 0 is reserved for default stream
-
         for node in self.nodes:
             stream_idx = DEFAULT_STREAM_IDX
 
             if node.node is not None:
                 user_obj_idx = node.node.get_stream_idx()
                 if user_obj_idx is not None:
-                    if user_obj_idx not in user_obj_to_stream_idx:
-                        new_stream_idx = next(stream_idx_counter)
-                        user_obj_to_stream_idx[user_obj_idx] = new_stream_idx
-                        self.stream_idx_to_user_obj_idx[new_stream_idx] = user_obj_idx
-                    stream_idx = user_obj_to_stream_idx[user_obj_idx]
+                    stream_idx = self._get_or_create_stream_idx_for_user_obj(
+                        user_obj_idx
+                    )
 
             self.node_to_stream[node] = stream_idx
 
@@ -4459,6 +4454,60 @@ class Scheduler:
             for stream_idx in self.node_to_stream.values()
         )
 
+    def _get_or_create_stream_idx_for_user_obj(self, user_obj_idx: int) -> int:
+        stream_idx = self.user_obj_idx_to_stream_idx.get(user_obj_idx)
+        if stream_idx is None:
+            # 0 is reserved for the default stream.
+            stream_idx = len(self.user_obj_idx_to_stream_idx) + 1
+            self.user_obj_idx_to_stream_idx[user_obj_idx] = stream_idx
+            self.stream_idx_to_user_obj_idx[stream_idx] = user_obj_idx
+        return stream_idx
+
+    def get_node_stream(self, node: BaseSchedulerNode) -> int:
+        from .stream_constants import DEFAULT_STREAM_IDX
+
+        if node in self.node_to_stream:
+            return self.node_to_stream[node]
+
+        child_streams = OrderedSet(
+            self.get_node_stream(child)
+            for child in node.get_nodes()
+            if child is not node
+        )
+        if len(child_streams) == 1:
+            stream_idx = next(iter(child_streams))
+        elif len(child_streams) > 1:
+            raise AssertionError(
+                f"Scheduler node {node.get_name()} combines multiple streams: "
+                f"{list(child_streams)}"
+            )
+        elif (
+            node.node is not None
+            and (user_obj_idx := node.node.get_stream_idx()) is not None
+        ):
+            stream_idx = self._get_or_create_stream_idx_for_user_obj(user_obj_idx)
+        else:
+            buffer_streams = OrderedSet(
+                self.buff_to_stream[buf_name]
+                for buf_name in node.get_buffer_names()
+                if buf_name in self.buff_to_stream
+            )
+            if len(buffer_streams) > 1:
+                raise AssertionError(
+                    f"Scheduler node {node.get_name()} has outputs on multiple "
+                    f"streams: {list(buffer_streams)}"
+                )
+            stream_idx = (
+                next(iter(buffer_streams)) if buffer_streams else DEFAULT_STREAM_IDX
+            )
+
+        self.node_to_stream[node] = stream_idx
+        if stream_idx != DEFAULT_STREAM_IDX:
+            self._multi_stream_nodes = True
+        for buf_name in node.get_buffer_names():
+            self.buff_to_stream.setdefault(buf_name, stream_idx)
+        return stream_idx
+
     def _has_multi_stream_nodes(self) -> bool:
         """Check if any nodes are assigned to non-default streams."""
         return self._multi_stream_nodes
@@ -4476,7 +4525,7 @@ class Scheduler:
         """
         if not self._has_multi_stream_nodes():
             return False
-        return self.get_buf_stream(buf_name) != self.node_to_stream.get(node, 0)
+        return self.get_buf_stream(buf_name) != self.get_node_stream(node)
 
     @property
     def current_device(self) -> torch.device | None:
@@ -6001,9 +6050,7 @@ class Scheduler:
 
         # Propagate stream assignment to the fused node so that subsequent
         # fusion rounds still respect stream boundaries.
-        stream1 = self.node_to_stream.get(node1)
-        if stream1 is not None:
-            self.node_to_stream[node3] = stream1
+        self.node_to_stream[node3] = self.get_node_stream(node1)
 
         return node3
 
@@ -6383,9 +6430,12 @@ class Scheduler:
             self.name_to_fused_node.update(
                 {n.get_name(): combo_node for n in combo_node.get_nodes()}
             )
-            stream = self.node_to_stream.get(accepted[0])
-            if stream is not None:
-                self.node_to_stream[combo_node] = stream
+            accepted_streams = OrderedSet(self.get_node_stream(n) for n in accepted)
+            if len(accepted_streams) != 1:
+                raise AssertionError(
+                    f"Combo kernel combines multiple streams: {list(accepted_streams)}"
+                )
+            self.node_to_stream[combo_node] = next(iter(accepted_streams))
 
         for num, node_list in enumerate(
             ForeachKernelSchedulerNode.group_nodes_for_combo_kernels(self)
@@ -7650,9 +7700,9 @@ class Scheduler:
 
         # Prevent fusion across stream boundaries
         if self._has_multi_stream_nodes():
-            stream1 = self.node_to_stream.get(node1)
-            stream2 = self.node_to_stream.get(node2)
-            if stream1 is not None and stream2 is not None and stream1 != stream2:
+            stream1 = self.get_node_stream(node1)
+            stream2 = self.get_node_stream(node2)
+            if stream1 != stream2:
                 return False
 
         if isinstance(node1, FusedNestedReductions):
@@ -9768,7 +9818,9 @@ class Scheduler:
                         num_streams = 1
                         if self._has_multi_stream_nodes():
                             # Count unique streams (excluding default stream 0)
-                            unique_streams = OrderedSet(self.node_to_stream.values())
+                            unique_streams = OrderedSet(
+                                self.get_node_stream(n) for n in self.nodes
+                            )
                             num_streams = (
                                 max(unique_streams) + 1 if unique_streams else 1
                             )
@@ -10011,7 +10063,7 @@ class Scheduler:
         """Code-gen to enter the Stream context assigned to node."""
         if isinstance(node, NopKernelSchedulerNode):
             raise AssertionError("expected node to not be a NopKernelSchedulerNode")
-        node_stream = self.node_to_stream[node]
+        node_stream = self.get_node_stream(node)
         self._current_stream_ctx = V.graph.wrapper_code.codegen_cuda_stream_enter(
             stream_idx=node_stream,
         )
@@ -10030,12 +10082,10 @@ class Scheduler:
         the previous node's stream. NopKernelSchedulerNodes have stream=None and inherit the
         enclosing stream context (or do nothing if no context is active yet).
         """
-        if node not in self.node_to_stream:
-            raise AssertionError("expected node to be in node_to_stream")
         stream = (
             None
             if isinstance(node, NopKernelSchedulerNode)
-            else self.node_to_stream[node]
+            else self.get_node_stream(node)
         )
         if self.current_stream_idx == stream:
             # Covers: same stream as current (no switch needed), and both None

--- a/torch/_inductor/stream_utils.py
+++ b/torch/_inductor/stream_utils.py
@@ -12,12 +12,39 @@ from torch._inductor.stream_constants import (
 
 
 __all__ = [
+    "AOTI_SUPPORTED_STREAM_OP_NAMES",
+    "AOTI_UNSUPPORTED_STREAM_OP_REASONS",
     "DEFAULT_STREAM",
     "DEFAULT_STREAM_IDX",
     "STREAM_NAME_TEMPLATE",
     "get_raw_stream_name",
     "get_stream_name",
 ]
+
+
+AOTI_SUPPORTED_STREAM_OP_NAMES: dict[str, str] = {
+    "torch.ops.streams.record_event.default": "record_event",
+    "torch.ops.streams.wait_event.default": "wait_event",
+    # A targeted single-event host wait (cudaEventSynchronize); required by e.g.
+    # pinned non-blocking copies. Unlike synchronize_stream/device, it does not
+    # block the whole stream/device, so it is safe to emit inside an AOTI Run().
+    "torch.ops.streams.synchronize_event.default": "synchronize_event",
+}
+
+
+AOTI_UNSUPPORTED_STREAM_OP_REASONS: dict[str, str] = {
+    "torch.ops.streams.synchronize_stream.default": (
+        "Host-blocking sync ops are not supported inside an AOTI Run(). "
+        "Use record_event + wait_event for device-side ordering instead."
+    ),
+    "torch.ops.streams.synchronize_device.default": (
+        "Host-blocking device synchronization is not supported inside an AOTI Run()."
+    ),
+    "torch.ops.streams.wait_stream.default": (
+        "wait_stream is not supported in AOTI cpp_wrapper. Use explicit "
+        "record_event on the waited-on stream + wait_event on the waiting stream."
+    ),
+}
 
 
 @functools.lru_cache


### PR DESCRIPTION
Summary:

Extending user-streams to AOT inductor. This mechanism will also be later leveraged for compiler created multi-streams (profile guided parallelism).

Leverages thread local storage without freeing for stream and event creation. Later PRs will include mechanisms to change the stream priority at creation.

**NOTE**: Internally at Meta we tightly control the host threads that run AOTI models making it favorable to have a TLS mechanism.

Authored with Claude.

Test Plan:
Lint/format: `arc lint -a` on all touched `caffe2` files -> No lint issues. OSS `lintrunner` (noclang linter set) run locally -> clean.

Exercised end-to-end on an A100, rebased on `master`.

Full user-streams suite (JIT `torch.compile` + AOTI paths), including the new `TestAOTIUserStreams` (inline `cudaEventRecord` / `cudaStreamWaitEvent`, per-thread `AOTIPerThreadStreamCache` / `AOTIPerThreadEventCache`, loud rejection of `synchronize_stream`) and the JIT cross-stream strided-copy regression:

```
buck2 test mode/opt-split-dwarf -c fbcode.use_link_groups=True -c fbcode.fbgemm_codegen_inference_mode=true -c fbcode.dwp=true -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=a100 -c fbcode.platform=platform010 -c fbcode.split-dwarf=true fbcode//caffe2/test/inductor:user_streams
```
Result: `Tests finished: Pass 71. Fail 0. Skip 7.`

AOTI pinned non-blocking copy, which lowers to `torch.ops.streams.synchronize_event` (this diff emits it inline as `cudaEventSynchronize`):

```
buck2 test mode/opt-split-dwarf -c fbcode.use_link_groups=True -c fbcode.fbgemm_codegen_inference_mode=true -c fbcode.dwp=true -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=a100 -c fbcode.platform=platform010 -c fbcode.split-dwarf=true fbcode//caffe2/test/inductor:test_aot_inductor -- test_copy_non_blocking_is_pinned_cuda
```
Result: `Tests finished: Pass 3. Fail 0.`

Reviewed By: mlazos, desertfire

Differential Revision: D104403189


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo