### PR TITLE
Fix VecMask mask materialization aliasing

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_mask.h
+++ b/aten/src/ATen/cpu/vec/vec_mask.h
@@ -124,6 +124,16 @@ class VecMask {
  private:
   VectorizedN<T, N> mask_;
 
+  template <typename U>
+  static T value_to_mask(U b) {
+    if constexpr (std::is_same_v<T, bool>) {
+      return static_cast<bool>(b);
+    } else {
+      using int_t = int_same_size_t<T>;
+      return b ? c10::bit_cast<T>(~(int_t)0) : static_cast<T>(0);
+    }
+  }
+
  public:
   VecMask() : mask_(static_cast<T>(0)) {}
   VecMask(const VectorizedN<T, N>& mask) : mask_(mask) {}
@@ -147,33 +157,29 @@ class VecMask {
 
   template <typename U>
   static VecMask<T, N> from(U b) {
-    using int_t = int_same_size_t<T>;
-    T mask = b ? c10::bit_cast<T>((int_t)(~(int_t)0)) : (T)0;
-    return VectorizedN<T, N>(mask);
+    return VectorizedN<T, N>(value_to_mask(b));
   }
 
   template <typename U>
   static VecMask<T, N> from(U* b) {
-    using int_t = int_same_size_t<T>;
     __at_align__ T mask[size()];
 #ifndef __msvc_cl__
 #pragma unroll
 #endif
     for (int i = 0; i < size(); i++) {
-      *(int_t*)(mask + i) = b[i] ? ~(int_t)0 : (int_t)0;
+      mask[i] = value_to_mask(b[i]);
     }
     return VectorizedN<T, N>(VectorizedN<T, N>::loadu(mask));
   }
 
   template <typename U>
   static VecMask<T, N> from(U* b, int count) {
-    using int_t = int_same_size_t<T>;
     __at_align__ T mask[size()];
 #ifndef __msvc_cl__
 #pragma unroll
 #endif
     for (int i = 0; i < count; i++) {
-      *(int_t*)(mask + i) = b[i] ? ~(int_t)0 : (int_t)0;
+      mask[i] = value_to_mask(b[i]);
     }
     return VectorizedN<T, N>(VectorizedN<T, N>::loadu(mask, count));
   }

--- a/aten/src/ATen/cpu/vec/vec_mask.h
+++ b/aten/src/ATen/cpu/vec/vec_mask.h
@@ -130,7 +130,7 @@ class VecMask {
       return static_cast<bool>(b);
     } else {
       using int_t = int_same_size_t<T>;
-      return b ? c10::bit_cast<T>(~(int_t)0) : static_cast<T>(0);
+      return b ? c10::bit_cast<T>(static_cast<int_t>(-1)) : static_cast<T>(0);
     }
   }
 

--- a/aten/src/ATen/cpu/vec/vec_mask.h
+++ b/aten/src/ATen/cpu/vec/vec_mask.h
@@ -125,7 +125,7 @@ class VecMask {
   VectorizedN<T, N> mask_;
 
   template <typename U>
-  static T value_to_mask(U b) {
+  constexpr static T value_to_mask(U b) {
     if constexpr (std::is_same_v<T, bool>) {
       return static_cast<bool>(b);
     } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182974

Avoid writing integer mask bits into a T buffer through an incompatible int pointer in `VecMask::from`. Use `c10::bit_cast` for non-bool mask storage types so floating-point masks still receive the intended all-ones bit pattern without strict-aliasing UB.

Keep bool masks as normal boolean values, since bit_cast from an integer mask is not valid for bool-sized storage.

This keeps the existing mask representation unchanged while making the materialization legal C++. The previous pointer cast could be optimized under strict-aliasing assumptions because the destination object has type T, not int_t.

Validated with a CPU-only AArch64/SVE build using GCC 13.4.0, plus focused VecMask<float, 1>::from(bool*) roundtrip checks including a forced SVE256 case covering 8 float lanes.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01