### PR TITLE
Document 5 public APIs in docs/source/utils.md

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -971,9 +971,6 @@ coverage_ignore_functions = [
     "hann",
     "kaiser",
     "nuttall",
-    # torch.utils.backend_registration
-    "generate_methods_for_privateuse1_backend",
-    "rename_privateuse1_backend",
     # torch.utils.benchmark.examples.op_benchmark
     # torch.utils.benchmark.op_fuzzers.spectral
     "power_range",
@@ -1006,8 +1003,6 @@ coverage_ignore_functions = [
     "detach_variable",
     "get_device_states",
     "noop_context_fn",
-    # torch.utils.cpp_backtrace
-    "get_cpp_backtrace",
     # torch.utils.cpp_extension
     "check_compiler_is_gcc",
     "check_compiler_ok_for_platform",
@@ -1062,7 +1057,6 @@ coverage_ignore_functions = [
     "apply_shuffle_settings",
     "get_all_graph_pipes",
     # torch.utils.hooks
-    "unserializable_hook",
     "warn_if_has_hooks",
     # torch.utils.jit.log_extract
     "extract_ir",
@@ -1096,8 +1090,6 @@ coverage_ignore_functions = [
     "tensor_proto",
     "text",
     "video",
-    # torch.utils.throughput_benchmark
-    "format_time",
 ]
 
 coverage_ignore_classes = [

--- a/docs/source/utils.md
+++ b/docs/source/utils.md
@@ -19,6 +19,42 @@
     swap_tensors
 ```
 
+```{eval-rst}
+.. currentmodule:: torch.utils.backend_registration
+```
+
+```{eval-rst}
+.. autofunction:: generate_methods_for_privateuse1_backend
+```
+
+```{eval-rst}
+.. autofunction:: rename_privateuse1_backend
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.cpp_backtrace
+```
+
+```{eval-rst}
+.. autofunction:: get_cpp_backtrace
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.hooks
+```
+
+```{eval-rst}
+.. autofunction:: unserializable_hook
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.throughput_benchmark
+```
+
+```{eval-rst}
+.. autofunction:: format_time
+```
+
 # torch.utils.collect_env
 ```{eval-rst}
 .. automodule:: torch.utils.collect_env


### PR DESCRIPTION
Add documentation for 5 undocumented public APIs in `docs/source/utils.md`:

- `torch.utils.backend_registration.generate_methods_for_privateuse1_backend`
- `torch.utils.backend_registration.rename_privateuse1_backend`
- `torch.utils.cpp_backtrace.get_cpp_backtrace`
- `torch.utils.hooks.unserializable_hook`
- `torch.utils.throughput_benchmark.format_time`

### Changes Made

1. **`docs/source/utils.md`**: Added `currentmodule` and `autofunction` directives for each function, placed after the main `torch.utils` autosummary section.

2. **`docs/source/conf.py`**: Removed the 5 functions from `coverage_ignore_functions` so they are tracked by doc coverage.

### Related Issue

Tracking meta-issue: https://github.com/pytorch/pytorch/issues/64185

cc @svekars @AlannaBurke
