### PR TITLE
[CI] Upgrade ninja to version 1.13.0

### DIFF
--- a/.ci/docker/common/install_triton.sh
+++ b/.ci/docker/common/install_triton.sh
@@ -17,6 +17,8 @@ get_pip_version() {
 if [ -n "${XPU_VERSION}" ]; then
   TRITON_REPO="https://github.com/intel/intel-xpu-backend-for-triton"
   TRITON_TEXT_FILE="triton-xpu"
+  # XPU believes new ninja is bad, see https://github.com/intel/intel-xpu-backend-for-triton/commit/fe21682167b831e48bba2544712012abe2f74bb1
+  pip_install ninja==1.11.1.4
 elif [ -n "${TRITON_CPU}" ]; then
   TRITON_REPO="https://github.com/triton-lang/triton-cpu"
   TRITON_TEXT_FILE="triton-cpu"

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -111,10 +111,10 @@ networkx==2.8.8
 #Pinned versions: 2.8.8
 #test that import: functorch
 
-ninja==1.11.1.4
+ninja==1.13.0
 #Description: build system. Used in some tests. Used in build to generate build
 #time tracing information
-#Pinned versions: 1.11.1.4
+#Pinned versions: 1.13.0
 #test that import: run_test.py, test_cpp_extensions_aot.py,test_determination.py
 
 numba==0.57.1 ; python_version == "3.10" and platform_machine != "s390x"


### PR DESCRIPTION
Not sure what's the point of sticking to older ninja
Though XPU folks believe there is https://github.com/intel/intel-xpu-backend-for-triton/commit/fe21682167b831e48bba2544712012abe2f74bb1