### PR TITLE
[inductor] extract _emit_triton_kernel_compile_metric helper

### DIFF
--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -143,6 +143,27 @@ def _add_triton_kernel_info(kernel_name: str, info: dict[str, Any]):
         _triton_kernel_metrics[kernel_name] = info
 
 
+def _emit_triton_kernel_compile_metric(
+    kernel: CachingAutotuner,
+    kernel_name: str,
+    elapsed_us: int,
+) -> None:
+    """Emit per-kernel ``compile_time_us`` to both the dynamo
+    ``_triton_kernel_metrics`` map and the ``MetricsContext`` top-N.
+
+    Note: ``kernel.autotune_cache_info`` is only mutated in place when
+    non-empty; when ``None`` or ``{}`` the metric still reaches
+    ``_triton_kernel_metrics`` via a throwaway dict, but the kernel
+    attribute stays untouched.
+    """
+    info = kernel.autotune_cache_info or {}
+    info["compile_time_us"] = elapsed_us
+    _add_triton_kernel_info(kernel_name, info)
+    get_metrics_context().add_top_n(
+        "triton_kernel_compile_times_us", kernel_name, elapsed_us
+    )
+
+
 _IS_WINDOWS = sys.platform == "win32"
 
 log = logging.getLogger(__name__)
@@ -468,12 +489,7 @@ class AsyncCompile:
                     reload_kernel=reload_kernel_in_parent,
                     static_triton_bundle_key=CompiledTritonKernels.key(source_code),
                 )
-                info = kernel.autotune_cache_info or {}
-                info["compile_time_us"] = elapsed_us
-                _add_triton_kernel_info(kernel_name, info)
-                get_metrics_context().add_top_n(
-                    "triton_kernel_compile_times_us", kernel_name, elapsed_us
-                )
+                _emit_triton_kernel_compile_metric(kernel, kernel_name, elapsed_us)
                 return kernel
 
             future = LambdaFuture(get_result, future=task)
@@ -499,12 +515,7 @@ class AsyncCompile:
                         static_triton_bundle_key=CompiledTritonKernels.key(source_code),
                     )
                     elapsed_us = (time_ns() - start_ns) // 1000
-                    get_metrics_context().add_top_n(
-                        "triton_kernel_compile_times_us", kernel_name, elapsed_us
-                    )
-                    info = kernel.autotune_cache_info or {}
-                    info["compile_time_us"] = elapsed_us
-                    _add_triton_kernel_info(kernel_name, info)
+                    _emit_triton_kernel_compile_metric(kernel, kernel_name, elapsed_us)
                     return kernel
                 except Exception as e:
                     fail = str(e)


### PR DESCRIPTION
Summary:
Pulls the per-kernel `compile_time_us` emission boilerplate (build dict -> `_add_triton_kernel_info` + `MetricsContext.add_top_n`) out of `AsyncCompile.triton`'s two callsites (parallel-compile `get_result` and synchronous fallback) into a standalone helper. Pure refactor; behavior at the existing callsites is unchanged.

The helper docstring also calls out a small pre-existing quirk left intact: when `kernel.autotune_cache_info` is `None` or `{}`, the metric still reaches `_triton_kernel_metrics`, but the kernel attribute itself is not updated (only the truthy case mutates in place via the `or {}` reference).

Authored by Claude.

Test Plan: buck test fbcode//mode/opt fbcode//caffe2/test/inductor:async_compile

Differential Revision: D104186703




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo