### PR TITLE
[MTIA][PyTorch] Map MTIA device type to kDLExtDev for DLPack interop (#182981)

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -109,7 +109,8 @@ DLDataType getDLDataType(const Tensor& t) {
 DLDevice torchDeviceToDLDevice(at::Device device) {
   DLDevice ctx;
 
-  ctx.device_id = (device.is_cuda() || device.is_privateuseone())
+  ctx.device_id =
+      (device.is_cuda() || device.is_privateuseone() || device.is_mtia())
       ? static_cast<int32_t>(static_cast<unsigned char>(device.index()))
       : 0;
 
@@ -140,6 +141,9 @@ DLDevice torchDeviceToDLDevice(at::Device device) {
       ctx.device_type = DLDeviceType::kDLMAIA;
       break;
     case DeviceType::PrivateUse1:
+      ctx.device_type = DLDeviceType::kDLExtDev;
+      break;
+    case DeviceType::MTIA:
       ctx.device_type = DLDeviceType::kDLExtDev;
       break;
     case DeviceType::MPS:


### PR DESCRIPTION
Summary:

Adds a `case DeviceType::MTIA:` arm to ATen's DLConvertor so torch tensors on the MTIA device can produce a DLPack capsule instead of being rejected by the case-default.

MTIA tensors map to `kDLExtDev` (DLPack's "external device" tag) -- the same code already used for `DeviceType::PrivateUse1`, since DLPack does not have a dedicated MTIA device id.

Test Plan:
```
buck2 build fbcode//caffe2:torch fbcode//mode/dev-nosan
```
Build succeeded.

Followed by exercising the path from the dependent stack: `from_dlpack(torch.zeros(..., device="mtia"))` no longer gives following error:

```
======================================================================
ERROR: test_tensor_arg_forwarded_to_kernel (mtia.cutedsl.tests.python.test_tensor_arg_forwarding.TensorArgForwardingTest)
cute.jit accepts a tensor arg and forwards it to cute.kernel.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/re_cwd/buck-out/v2/art/fbcode/d28e1aa8ac03f5ae/mtia/cutedsl/tests/python/__test_tensor_arg_forwarding__/test_tensor_arg_forwarding#link-tree/mtia/cutedsl/tests/python/test_tensor_arg_forwarding.py", line 44, in test_tensor_arg_forwarded_to_kernel
    host(from_dlpack(a))
         ^^^^^^^^^^^^^^
  File "/re_cwd/buck-out/v2/art/fbcode/d28e1aa8ac03f5ae/mtia/cutedsl/tests/python/__test_tensor_arg_forwarding__/test_tensor_arg_forwarding#link-tree/cutlass/_impl/runtime.py", line 110, in from_dlpack
    capsule = tensor.__dlpack__(stream=-1)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/re_cwd/buck-out/v2/art/fbcode/d28e1aa8ac03f5ae/mtia/cutedsl/tests/python/__test_tensor_arg_forwarding__/test_tensor_arg_forwarding#link-tree/torch/_tensor.py", line 1834, in __dlpack__
    return _C._to_dlpack(self, dl_device=dl_device, copy=copy)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
BufferError: Cannot pack tensors on mtia:0
```

Reviewed By: malfet

Differential Revision: D103458176


