### PR TITLE
[Inductor] Expose config for sm carveout of templates (#182984)

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1045,7 +1045,10 @@ class TestMaxAutotune(TestCase):
     )
     @parametrize("carveout", (None, 0, 27))
     @parametrize("op", ("mm", "scaled_mm"))
-    def test_honor_sm_carveout_with_triton_tma(self, carveout, op: str):
+    @parametrize("use_inductor_config", (False, True))
+    def test_honor_sm_carveout_with_triton_tma(
+        self, carveout, op: str, use_inductor_config: bool
+    ):
         def mm_func(a, b):
             return torch.mm(a, b)
 
@@ -1076,22 +1079,25 @@ class TestMaxAutotune(TestCase):
         )
         func = scaled_mm if op == "scaled_mm" else mm_func
 
-        # Set the specified carveout value
-        torch._C._set_sm_carveout_experimental(carveout)
-        if carveout is None:
-            self.assertIsNone(torch._C._get_sm_carveout_experimental())
-        else:
-            self.assertEqual(torch._C._get_sm_carveout_experimental(), carveout)
+        config_patch = {
+            "max_autotune": True,
+            "triton.enable_persistent_tma_matmul": True,
+            "triton.native_matmul": False,
+            "max_autotune_gemm_backends": "TRITON",
+            "test_configs.autotune_choice_name_regex": "tma",
+        }
 
-        with config.patch(
-            {
-                "max_autotune": True,
-                "triton.enable_persistent_tma_matmul": True,
-                "triton.native_matmul": False,
-                "max_autotune_gemm_backends": "TRITON",
-                "test_configs.autotune_choice_name_regex": "tma",
-            }
-        ):
+        if use_inductor_config:
+            config_patch["triton.persistent_matmul_sm_carveout"] = carveout
+        else:
+            # Set the specified carveout value via global API
+            torch._C._set_sm_carveout_experimental(carveout)
+            if carveout is None:
+                self.assertIsNone(torch._C._get_sm_carveout_experimental())
+            else:
+                self.assertEqual(torch._C._get_sm_carveout_experimental(), carveout)
+
+        with config.patch(config_patch):
             compiled_mm = torch.compile(func, mode="max-autotune-no-cudagraphs")
             compiled_mm(*args)  # Warm-up compilation
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2027,6 +2027,18 @@ class triton:
     # Should TMA store be enable from templates. TODO: Remove once we
     # can autotune over the result.
     enable_template_tma_store = os.environ.get("ENABLE_TEMPLATE_TMA_STORE", "0") == "1"
+
+    # Number of SMs to carve out from persistent matmul kernels.
+    # Allows persistent kernels to coexist with background ops (e.g., NCCL)
+    # that occupy some SMs, avoiding wave quantization issues.
+    # If None, falls back to torch._C._get_sm_carveout_experimental().
+    persistent_matmul_sm_carveout: int | None = (
+        int(v)
+        if (v := os.environ.get("TORCHINDUCTOR_PERSISTENT_MATMUL_SM_CARVEOUT"))
+        is not None
+        else None
+    )
+
     # Skip L1 cache for buffers that are used only once.  Disabled by default
     skip_l1_cache = os.environ.get("TORCHINDUCTOR_SKIP_L1", "0") == "1"
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1790,11 +1790,18 @@ def using_b200() -> bool:
 
 def get_num_sms() -> int:
     """Handle experimental carveout if set otherwise return hardware SM count"""
+    from torch._inductor import config
+
     # TODO we need to properly guard on this global
     if torch.xpu.is_available():
         return get_max_num_sms()
-    carveout = torch._C._get_sm_carveout_experimental()
-    return get_max_num_sms() - (carveout if carveout is not None else 0)
+
+    # Use inductor config if set, otherwise fall back to global setting
+    carveout = config.triton.persistent_matmul_sm_carveout
+    if carveout is None:
+        carveout = torch._C._get_sm_carveout_experimental() or 0
+
+    return get_max_num_sms() - carveout
 
 
 def get_tma_workspace_arg(


### PR DESCRIPTION
Summary:

Expose SM carveout for persistent templates as a configuration option.

Test Plan: `test_honor_sm_carveout_with_triton_tma`

Differential Revision: D104442040




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo