### PR TITLE
[Eager] [Bitwise-Equivalence] Implement an INNER_TREE sum reduction (#182986)

### DIFF
--- a/benchmarks/strict_numerics/sum_reduction.py
+++ b/benchmarks/strict_numerics/sum_reduction.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import argparse
+import os
+from itertools import cycle
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from triton.testing import do_bench, do_bench_cudagraph
+
+import torch
+import torch._inductor.config as inductor_config
+from torch._inductor.utils import fresh_inductor_cache
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+PROVIDERS = ["eager_aten", "eager_inner_tree", "inductor_default"]
+M_VALUES = [512, 1024, 2048, 4096, 8192, 16384]
+N_VALUES = [2**exponent for exponent in range(9, 18)]
+MEMORY_BUDGET = 40 * (1 << 30)
+CUDA_GRAPH_WORKING_SET_BYTES = 256 * (1 << 20)
+COLORS = {
+    "eager_aten": "C0",
+    "inductor_default": "C1",
+    "eager_inner_tree": "C2",
+}
+DTYPE = torch.float32
+
+
+def _gbps(m: int, n: int, milliseconds: float) -> float:
+    return m * n * DTYPE.itemsize / (milliseconds * 1e-3) / 1e9
+
+
+def _sum_rows(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.sum(1)
+
+
+def _circular_runner(
+    function: Callable[[torch.Tensor], torch.Tensor],
+    tensors: tuple[torch.Tensor, ...],
+) -> Callable[[], torch.Tensor]:
+    tensor_iterator = cycle(tensors)
+    return lambda: function(next(tensor_iterator))
+
+
+def measure(m: int, n: int, provider: str, cudagraph: bool) -> float:
+    tensor_bytes = m * n * DTYPE.itemsize
+    if tensor_bytes > MEMORY_BUDGET:
+        return float("nan")
+
+    torch.manual_seed(0)
+    input_count = (
+        max(
+            1,
+            (CUDA_GRAPH_WORKING_SET_BYTES + tensor_bytes - 1) // tensor_bytes,
+        )
+        if cudagraph
+        else 1
+    )
+    input_buffer = torch.randn(input_count, m, n, device="cuda", dtype=DTYPE)
+    tensors = input_buffer.unbind()
+    runner = _circular_runner(_sum_rows, tensors)
+    benchmark = do_bench_cudagraph if cudagraph else do_bench
+    inner_tree = provider == "eager_inner_tree"
+    try:
+        with patch.dict(
+            os.environ,
+            {"PYTORCH_SUM_INNER_TREE": "1" if inner_tree else "0"},
+        ):
+            if provider.startswith("eager"):
+                runner()
+                milliseconds = benchmark(runner)
+            else:
+                torch._dynamo.reset()
+                with fresh_inductor_cache():
+                    compiled = torch.compile(_sum_rows)
+                    runner = _circular_runner(compiled, tensors)
+                    runner()
+                    milliseconds = benchmark(runner)
+        return _gbps(m, n, milliseconds)
+    finally:
+        del runner
+        del tensors
+        del input_buffer
+        torch.cuda.empty_cache()
+
+
+def _assert_inner_tree_route() -> None:
+    tensor = torch.randn(1024, 300, device="cuda", dtype=DTYPE)
+    try:
+        with patch.dict(os.environ, {"PYTORCH_SUM_INNER_TREE": "1"}):
+            inner_tree = torch.sum(tensor, 1)
+        with patch.dict(os.environ, {"PYTORCH_SUM_INNER_TREE": "0"}):
+            aten = torch.sum(tensor, 1)
+        assert not torch.equal(inner_tree, aten), (  # noqa: S101
+            "eager_inner_tree did not route to CuTeDSL; refusing to label ATen "
+            "results as inner-tree results"
+        )
+    finally:
+        del tensor
+        torch.cuda.empty_cache()
+
+
+def _plot(data: dict[str, dict[int, list[float]]], cudagraph: bool) -> str:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    figure, axes = plt.subplots(3, 2, figsize=(12, 13))
+    flat_axes = axes.flatten()
+    for index, m in enumerate(M_VALUES):
+        axis = flat_axes[index]
+        for provider in PROVIDERS:
+            axis.plot(
+                N_VALUES,
+                data[provider][m],
+                marker="o",
+                label=provider,
+                color=COLORS[provider],
+            )
+        axis.set_xscale("log", base=2)
+        axis.set_title(f"M={m}")
+        axis.set_xlabel("N")
+        axis.set_ylabel("GB/s")
+        axis.legend(fontsize=8)
+        axis.grid(True, alpha=0.3)
+    mode = "CUDA Graph" if cudagraph else "standard"
+    figure.suptitle(f"Inner-tree SUM reduction {mode} GB/s vs N", y=1.0)
+    figure.tight_layout()
+    suffix = "_cudagraph" if cudagraph else ""
+    output_path = f"strict_numerics_row_reduction{suffix}_gbps_vs_n.png"
+    figure.savefig(output_path)
+    return output_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cudagraph", action="store_true")
+    args = parser.parse_args()
+
+    assert torch.cuda.is_available(), "needs CUDA"  # noqa: S101
+    _assert_inner_tree_route()
+    print("providers:", PROVIDERS)
+    measurement = (
+        "CUDA Graph replay with a "
+        f"{CUDA_GRAPH_WORKING_SET_BYTES // (1 << 20)} MiB circular input buffer"
+        if args.cudagraph
+        else "standard"
+    )
+    print("measurement:", measurement)
+
+    data = {provider: {m: [] for m in M_VALUES} for provider in PROVIDERS}
+    with inductor_config.patch({"force_disable_caches": True}):
+        for m in M_VALUES:
+            for n in N_VALUES:
+                for provider in PROVIDERS:
+                    data[provider][m].append(measure(m, n, provider, args.cudagraph))
+            row = "  ".join(
+                f"{provider}={data[provider][m][-1]:.0f}" for provider in PROVIDERS
+            )
+            print(f"M={m:>6} (N={N_VALUES[-1]}): {row}")
+
+    output_path = _plot(data, args.cudagraph)
+    print(f"saved plot to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python_native/test_sum_cutedsl.py
+++ b/test/python_native/test_sum_cutedsl.py
@@ -1,0 +1,348 @@
+# Owner(s): ["module: dsl-native-ops"]
+#
+# Correctness + bitwise-equivalence tests for the CuTeDSL ``aten::sum``
+# inner-tree override (``torch/_native/ops/sum``). The override is gated on
+# ``PYTORCH_SUM_INNER_TREE`` and registered for CUDA; these tests are gated on
+# CuTeDSL availability so the assertions exercise the CuTeDSL kernel.
+#
+# The bitwise tests pin the reduction output to precomputed SHA-256 hashes of
+# deterministic row sums. The hashes are the same ones the (now removed) ATen
+# CUDA inner-tree kernel produced -- the CuTeDSL kernel reproduces them
+# bit-for-bit, which is the contract for this op.
+
+import contextlib
+import os
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import (
+    PLATFORM_SUPPORTS_FP8,
+    SM100OrLater,
+    TEST_CUDA,
+)
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    skipIfNoCuteDSL,
+    skipIfRocm,
+    TestCase,
+)
+
+
+def _cutedsl_impl():
+    from torch._native.ops.sum import cutedsl_impl
+
+    return cutedsl_impl
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA required")
+@skipIfNoCuteDSL
+class TestSumCuteDSLOverride(TestCase):
+    """Tests for the CuTeDSL inner-tree reduction sum override."""
+
+    _ACC_DTYPES = {
+        torch.float8_e4m3fn: torch.float32,
+        torch.float16: torch.float32,
+        torch.float32: torch.float32,
+        torch.float64: torch.float64,
+    }
+
+    _SHAPES = [
+        (1, 32),
+        (1, 8192),
+        (1, 16384),
+        (128, 32),
+        (128, 8192),
+        (128, 16384),
+        (4096, 32),
+        (4096, 8192),
+        (4096, 16384),
+        (1, 27),
+        (1, 6561),
+        (1, 19683),
+        (128, 27),
+        (128, 6561),
+        (128, 19683),
+        (4096, 27),
+        (4096, 6561),
+        (4096, 19683),
+        (1, 36),
+        (1, 7776),
+        (1, 46656),
+        (128, 36),
+        (128, 7776),
+        (128, 46656),
+        (4096, 36),
+        (4096, 7776),
+        (4096, 46656),
+    ]
+
+    # fmt: off
+    _EXPECTED = {
+        ("float8_e4m3fn", 1, 32): "df3f619804a92fdb",
+        ("float8_e4m3fn", 1, 8192): "df3f619804a92fdb",
+        ("float8_e4m3fn", 1, 16384): "df3f619804a92fdb",
+        ("float8_e4m3fn", 128, 32): "f428ef9e3fbd9469",
+        ("float8_e4m3fn", 128, 8192): "4834001f0135cd23",
+        ("float8_e4m3fn", 128, 16384): "76e9b171932d1f9f",
+        ("float8_e4m3fn", 4096, 32): "a5c21039e21a5323",
+        ("float8_e4m3fn", 4096, 8192): "e34643d4c484ef9c",
+        ("float8_e4m3fn", 4096, 16384): "289c5f23e410c913",
+        ("float8_e4m3fn", 1, 27): "c68830a25204a09f",
+        ("float8_e4m3fn", 1, 6561): "c68830a25204a09f",
+        ("float8_e4m3fn", 1, 19683): "c68830a25204a09f",
+        ("float8_e4m3fn", 128, 27): "2252a0a2c19ada94",
+        ("float8_e4m3fn", 128, 6561): "6bf0fe73bdad39f5",
+        ("float8_e4m3fn", 128, 19683): "03b2636d8210d4d0",
+        ("float8_e4m3fn", 4096, 27): "41896635bfcb0c7c",
+        ("float8_e4m3fn", 4096, 6561): "990ad1490c767a17",
+        ("float8_e4m3fn", 4096, 19683): "c3cc65b050631480",
+        ("float8_e4m3fn", 1, 36): "df3f619804a92fdb",
+        ("float8_e4m3fn", 1, 7776): "df3f619804a92fdb",
+        ("float8_e4m3fn", 1, 46656): "df3f619804a92fdb",
+        ("float8_e4m3fn", 128, 36): "927688b93e357722",
+        ("float8_e4m3fn", 128, 7776): "e46696a8a4613062",
+        ("float8_e4m3fn", 128, 46656): "a10c4d305d19a761",
+        ("float8_e4m3fn", 4096, 36): "efe1cee0d5e0bf4e",
+        ("float8_e4m3fn", 4096, 7776): "d5588816762acbd4",
+        ("float8_e4m3fn", 4096, 46656): "27fc2749145207e3",
+        ("float16", 1, 32): "df3f619804a92fdb",
+        ("float16", 1, 8192): "df3f619804a92fdb",
+        ("float16", 1, 16384): "df3f619804a92fdb",
+        ("float16", 128, 32): "f428ef9e3fbd9469",
+        ("float16", 128, 8192): "4834001f0135cd23",
+        ("float16", 128, 16384): "76e9b171932d1f9f",
+        ("float16", 4096, 32): "a5c21039e21a5323",
+        ("float16", 4096, 8192): "e34643d4c484ef9c",
+        ("float16", 4096, 16384): "289c5f23e410c913",
+        ("float16", 1, 27): "c68830a25204a09f",
+        ("float16", 1, 6561): "c68830a25204a09f",
+        ("float16", 1, 19683): "c68830a25204a09f",
+        ("float16", 128, 27): "2252a0a2c19ada94",
+        ("float16", 128, 6561): "6bf0fe73bdad39f5",
+        ("float16", 128, 19683): "03b2636d8210d4d0",
+        ("float16", 4096, 27): "41896635bfcb0c7c",
+        ("float16", 4096, 6561): "990ad1490c767a17",
+        ("float16", 4096, 19683): "c3cc65b050631480",
+        ("float16", 1, 36): "df3f619804a92fdb",
+        ("float16", 1, 7776): "df3f619804a92fdb",
+        ("float16", 1, 46656): "df3f619804a92fdb",
+        ("float16", 128, 36): "927688b93e357722",
+        ("float16", 128, 7776): "e46696a8a4613062",
+        ("float16", 128, 46656): "a10c4d305d19a761",
+        ("float16", 4096, 36): "efe1cee0d5e0bf4e",
+        ("float16", 4096, 7776): "d5588816762acbd4",
+        ("float16", 4096, 46656): "27fc2749145207e3",
+        ("float32", 1, 32): "df3f619804a92fdb",
+        ("float32", 1, 8192): "df3f619804a92fdb",
+        ("float32", 1, 16384): "df3f619804a92fdb",
+        ("float32", 128, 32): "f428ef9e3fbd9469",
+        ("float32", 128, 8192): "4834001f0135cd23",
+        ("float32", 128, 16384): "76e9b171932d1f9f",
+        ("float32", 4096, 32): "a5c21039e21a5323",
+        ("float32", 4096, 8192): "e34643d4c484ef9c",
+        ("float32", 4096, 16384): "289c5f23e410c913",
+        ("float32", 1, 27): "c68830a25204a09f",
+        ("float32", 1, 6561): "c68830a25204a09f",
+        ("float32", 1, 19683): "c68830a25204a09f",
+        ("float32", 128, 27): "2252a0a2c19ada94",
+        ("float32", 128, 6561): "6bf0fe73bdad39f5",
+        ("float32", 128, 19683): "03b2636d8210d4d0",
+        ("float32", 4096, 27): "41896635bfcb0c7c",
+        ("float32", 4096, 6561): "990ad1490c767a17",
+        ("float32", 4096, 19683): "c3cc65b050631480",
+        ("float32", 1, 36): "df3f619804a92fdb",
+        ("float32", 1, 7776): "df3f619804a92fdb",
+        ("float32", 1, 46656): "df3f619804a92fdb",
+        ("float32", 128, 36): "927688b93e357722",
+        ("float32", 128, 7776): "e46696a8a4613062",
+        ("float32", 128, 46656): "a10c4d305d19a761",
+        ("float32", 4096, 36): "efe1cee0d5e0bf4e",
+        ("float32", 4096, 7776): "d5588816762acbd4",
+        ("float32", 4096, 46656): "27fc2749145207e3",
+        ("float64", 1, 32): "af5570f5a1810b7a",
+        ("float64", 1, 8192): "af5570f5a1810b7a",
+        ("float64", 1, 16384): "af5570f5a1810b7a",
+        ("float64", 128, 32): "35a0993dedd64659",
+        ("float64", 128, 8192): "05102af99bde7f20",
+        ("float64", 128, 16384): "c54af6a4a43a21d4",
+        ("float64", 4096, 32): "a5e02a44cc2dd361",
+        ("float64", 4096, 8192): "e9ba5b9f0409fec2",
+        ("float64", 4096, 16384): "6d8144f96bb8a210",
+        ("float64", 1, 27): "e77817b649821c63",
+        ("float64", 1, 6561): "e77817b649821c63",
+        ("float64", 1, 19683): "e77817b649821c63",
+        ("float64", 128, 27): "86e9b1f2d6fd4504",
+        ("float64", 128, 6561): "e761055386fc7295",
+        ("float64", 128, 19683): "3ce4cdd14e0b152f",
+        ("float64", 4096, 27): "4926c5d5541728d1",
+        ("float64", 4096, 6561): "417525b3b5d3de87",
+        ("float64", 4096, 19683): "cd8ef6c48ad2c67f",
+        ("float64", 1, 36): "af5570f5a1810b7a",
+        ("float64", 1, 7776): "af5570f5a1810b7a",
+        ("float64", 1, 46656): "af5570f5a1810b7a",
+        ("float64", 128, 36): "f00a064b84ba50b4",
+        ("float64", 128, 7776): "c227b341b6240d30",
+        ("float64", 128, 46656): "af1f2b32fdaf1f62",
+        ("float64", 4096, 36): "5cb245154bac020c",
+        ("float64", 4096, 7776): "751916d8d6b9dcba",
+        ("float64", 4096, 46656): "498bc246ba0b069a",
+    }
+    # fmt: on
+
+    _DTYPE_MAP = {
+        "float8_e4m3fn": torch.float8_e4m3fn,
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "float64": torch.float64,
+    }
+
+    @contextlib.contextmanager
+    def _inner_tree_flag(self):
+        old_value = os.environ.get("PYTORCH_SUM_INNER_TREE")
+        os.environ["PYTORCH_SUM_INNER_TREE"] = "1"
+        try:
+            yield
+        finally:
+            if old_value is None:
+                os.environ.pop("PYTORCH_SUM_INNER_TREE", None)
+            else:
+                os.environ["PYTORCH_SUM_INNER_TREE"] = old_value
+
+    def _make_input(self, m, n, dtype):
+        compute_dtype = torch.float64 if dtype == torch.float64 else torch.float32
+        cols = torch.arange(n, device="cuda", dtype=compute_dtype)
+        values = ((cols % 2) * 2 - 1).reshape(1, n)
+        if m > 1:
+            rows = torch.arange(m, device="cuda", dtype=compute_dtype).reshape(m, 1)
+            values = values + ((rows % 5) - 2) / 4
+        return values.to(dtype)
+
+    def _eager_sum(self, x):
+        acc_dtype = self._ACC_DTYPES[x.dtype]
+        if x.dtype == torch.float8_e4m3fn:
+            return x.to(torch.float32).sum(dim=1).to(acc_dtype)
+        return x.to(acc_dtype).sum(dim=1)
+
+    def _sha(self, t):
+        import hashlib
+
+        return hashlib.sha256(t.cpu().contiguous().numpy().tobytes()).hexdigest()[:16]
+
+    def _make_order_sensitive_input(self, m, n, dtype):
+        values = torch.arange(m * n, device="cuda", dtype=torch.float64).reshape(m, n)
+        return (((values % 29) - 14) / 29 + ((values % 7) - 3) / 13).to(dtype)
+
+    # --- predicate accept/reject ---
+
+    def test_cond_accepts_covered_shapes(self):
+        impl = _cutedsl_impl()
+        with self._inner_tree_flag():
+            for dtype in (torch.float32, torch.float64):
+                x = torch.randn(128, 8192, device="cuda", dtype=dtype)
+                self.assertTrue(impl._cond(x, [1]))
+                # Strided outer input (contiguous reduced dim) is still covered.
+                strided = torch.randn(256, 8192, device="cuda", dtype=dtype)[::2]
+                self.assertTrue(impl._cond(strided, [1]))
+
+    def test_cond_rejects_unsupported(self):
+        impl = _cutedsl_impl()
+        x = torch.randn(128, 8192, device="cuda", dtype=torch.float32)
+        # No flag -> reject.
+        self.assertFalse(impl._cond(x, [1]))
+        with self._inner_tree_flag():
+            # Multi-dim and full reductions are out of scope.
+            self.assertFalse(impl._cond(x, [0, 1]))
+            self.assertFalse(impl._cond(x, None))
+            # dtype-casting sum is out of scope.
+            self.assertFalse(impl._cond(x, [1], dtype=torch.float64))
+            # Non-contiguous reduced dim.
+            self.assertFalse(impl._cond(x[:, ::2], [1]))
+            # Integer / complex dtypes fall through to aten.
+            self.assertFalse(
+                impl._cond(torch.ones(17, 8192, device="cuda", dtype=torch.int64), [1])
+            )
+            self.assertFalse(
+                impl._cond(
+                    torch.ones(17, 8192, device="cuda", dtype=torch.complex64), [1]
+                )
+            )
+
+    # --- correctness ---
+
+    @parametrize("dtype", [torch.float32, torch.float64])
+    def test_override_matches_aten(self, dtype):
+        x = self._make_order_sensitive_input(128, 8192, dtype)
+        with torch.backends.python_native.cutedsl.disabled():
+            ref = x.sum(dim=1)
+        with self._inner_tree_flag():
+            got = x.sum(dim=1)
+        self.assertEqual(got, ref)
+
+    def test_override_out_variant(self):
+        x = self._make_order_sensitive_input(128, 8192, torch.float32)
+        with torch.backends.python_native.cutedsl.disabled():
+            ref = x.sum(dim=1)
+        out = torch.empty(128, device="cuda", dtype=torch.float32)
+        with self._inner_tree_flag():
+            torch.sum(x, dim=1, out=out)
+        self.assertEqual(out, ref)
+
+    def test_strided_outer_input(self):
+        base = torch.ones(256, 32, device="cuda", dtype=torch.float32)
+        base[1::2, :] = 5
+        x = base[::2, :]
+        with self._inner_tree_flag():
+            result = x.sum(dim=1)
+        self.assertEqual(result, torch.full((128,), 32, device="cuda", dtype=x.dtype))
+
+    def test_looped_kernel_partial_last_block(self):
+        x = torch.ones(129, 256, device="cuda", dtype=torch.float32)
+        with self._inner_tree_flag():
+            result = x.sum(dim=1)
+        self.assertEqual(result, torch.full((129,), 256, device="cuda", dtype=x.dtype))
+
+    @parametrize("dtype", [torch.int64, torch.complex64])
+    def test_integer_and_complex_fall_through(self, dtype):
+        # CuTeDSL declines integer/complex; the call must fall through to aten.
+        x = torch.ones(17, 8192, device="cuda", dtype=dtype)
+        with self._inner_tree_flag():
+            result = x.sum(dim=1)
+        self.assertEqual(result, torch.full((17,), 8192, device="cuda", dtype=dtype))
+
+    # --- bitwise equivalence ---
+
+    @skipIfRocm
+    @unittest.skipUnless(
+        SM100OrLater, "SM100 hash is generated on GB200 with CUDA 12.8"
+    )
+    def test_cross_warp_order_sensitive_hash_sm100(self):
+        x = self._make_order_sensitive_input(17, 8192, torch.float32)
+        with self._inner_tree_flag():
+            result = x.sum(dim=1)
+        self.assertEqual(self._sha(result), "75d8b1a702344e90")
+
+    @skipIfRocm
+    def test_bitwise(self):
+        for dtype_name, dtype in self._DTYPE_MAP.items():
+            if dtype == torch.float8_e4m3fn and not PLATFORM_SUPPORTS_FP8:
+                continue
+            for m, n in self._SHAPES:
+                with self.subTest(dtype_name=dtype_name, m=m, n=n):
+                    x = self._make_input(m, n, dtype)
+                    with self._inner_tree_flag():
+                        result = self._eager_sum(x)
+                    sha = self._sha(result)
+                    expected = self._EXPECTED[(dtype_name, m, n)]
+                    self.assertEqual(
+                        sha,
+                        expected,
+                        f"{dtype_name} m={m} n={n}: got {sha}, expected {expected}",
+                    )
+
+
+instantiate_parametrized_tests(TestSumCuteDSLOverride)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_sum_inner_tree_plan.py
+++ b/test/python_native/test_sum_inner_tree_plan.py
@@ -1,0 +1,54 @@
+# Owner(s): ["module: dsl-native-ops"]
+
+from __future__ import annotations
+
+import sys
+
+from torch._native.ops.sum.inner_tree_plan import (
+    compute_inner_tree_params,
+    InnerTreeParams,
+    vec_size,
+)
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
+class TestInnerTreePlan(TestCase):
+    @parametrize("itemsize, expected", [(2, 8), (4, 4), (8, 2)])
+    def test_vec_size(self, itemsize: int, expected: int) -> None:
+        self.assertEqual(vec_size(itemsize), expected)
+
+    @parametrize(
+        "inputs_per_output, num_outputs, vector_size, expected",
+        [
+            (512, 32, 4, InnerTreeParams(4, 512, 1, 1, 2, 1)),
+            (8192, 32, 4, InnerTreeParams(16, 8192, 1, 2, 1, 4)),
+            (8193, 32, 4, InnerTreeParams(8, 8192, 2, 3, 1, 8)),
+            (32769, 32, 4, InnerTreeParams(16, 8192, 5, 2, 1, 4)),
+        ],
+    )
+    def test_compute_inner_tree_params(
+        self,
+        inputs_per_output: int,
+        num_outputs: int,
+        vector_size: int,
+        expected: InnerTreeParams,
+    ) -> None:
+        self.assertEqual(
+            compute_inner_tree_params(inputs_per_output, num_outputs, vector_size),
+            expected,
+        )
+
+    def test_import_does_not_load_cutlass(self) -> None:
+        self.assertNotIn("cutlass", sys.modules)
+
+
+instantiate_parametrized_tests(TestInnerTreePlan)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -420,6 +420,7 @@ class TestPublicBindings(TestCase):
                 "torch._native.ops.foreach_mm.",
                 "torch._native.ops.polar.",
                 "torch._native.ops.scatter_add.",
+                "torch._native.ops.sum.inner_tree_kernel",
                 "torch._native.ops.topk.",
                 "torch._vendor.quack",
                 "torch.profiler._cupti.",

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2622,6 +2622,7 @@ class TestImports(TestCase):
                            "torch._native.ops.foreach_mm",  # depends on nvmath-python, cuda-python
                            "torch._native.ops.polar.nvmath_impl",  # depends on nvmath-python, cuda-python
                            "torch._native.ops.scatter_add",  # depends on cutlass
+                           "torch._native.ops.sum.inner_tree_kernel",  # depends on cutlass
                            "torch._native.ops.topk",  # depends on cutlass
                            "torch._inductor.codegen.cuda",  # depends on cutlass
                            "torch._inductor.codegen.cutedsl",  # depends on cutlass

--- a/torch/_native/ops/__init__.py
+++ b/torch/_native/ops/__init__.py
@@ -1,1 +1,1 @@
-from . import bmm_outer_product, foreach_mm, norm, polar, scatter_add, topk
+from . import bmm_outer_product, foreach_mm, norm, polar, scatter_add, sum, topk

--- a/torch/_native/ops/sum/__init__.py
+++ b/torch/_native/ops/sum/__init__.py
@@ -1,0 +1,4 @@
+from .cutedsl_impl import register_to_dispatch
+
+
+register_to_dispatch()

--- a/torch/_native/ops/sum/cutedsl_impl.py
+++ b/torch/_native/ops/sum/cutedsl_impl.py
@@ -1,0 +1,255 @@
+"""CuTeDSL override registrations for ``aten::sum`` (inner-tree reduction).
+
+CuTeDSL port of the Triton-style inner-tree reduction sum kernel that
+otherwise lives in ``aten/src/ATen/native/cuda/ReduceSumProdKernel.cu``
+(``try_inner_tree_reduction`` + the inner-tree kernels). This override
+runs only when ``PYTORCH_SUM_INNER_TREE`` is set to a truthy value, which
+is the feature-rollout gate for this operator -- it is *not* gated by the
+global ``TORCH_DISABLE_NATIVE_JIT`` kill switch alone (that is handled by
+``cutedsl_utils`` at registration time).
+
+We register two ATen dispatcher entries on ``CUDA``:
+
+* ``sum.dim_IntList`` -- functional/method ``x.sum(dim=...)``.
+* ``sum.IntList_out`` -- the structured ``.out`` target.
+
+``sum.dim_IntList`` is ``structured_delegate: sum.IntList_out``, so its
+delegation to the ``.out`` kernel happens *below* the dispatcher; overriding
+``.out`` alone would not intercept ``x.sum(dim=1)``. Both are separate
+dispatcher entries and are registered explicitly (the same reason
+``scatter_add_`` is registered separately from ``scatter_add.out``).
+
+Eligibility mirrors ``try_inner_tree_reduction`` (ReduceSumProdKernel.cu):
+build the reduction ``TensorIterator`` over ``(out, self)`` and accept only
+the coalesced geometry the kernels know how to run -- a single contiguous
+reduced (fastest) dimension whose non-reduced dims collapse to at most one
+outer-strided dimension. Anything else (multi-dim reduction, non-contiguous
+reduced dim, dtype-casting sum, integer/complex dtypes, non-collapsing outer
+layout) falls through to aten.
+
+Dispatch note: this CuTeDSL override is the only inner-tree path -- the ATen
+CUDA backend has no inner-tree kernel of its own. When this predicate accepts,
+the CuTeDSL kernel runs; when it rejects (or ``PYTORCH_SUM_INNER_TREE`` is
+unset), the call falls through to the unchanged ATen reduction.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+from torch._subclasses.fake_tensor import is_fake_tensor
+from torch._tensor_iterator import reduce_op, TensorIterator
+
+from ... import cutedsl_utils as cu
+
+
+# Reduction input dtypes the kernel handles. fp32/fp64 are the bitwise-
+# validated set (the inner-tree bitwise tests upcast fp16/bf16/fp8 data to
+# fp32 before summing, and fp64 sums in fp64). fp16/bf16 native reductions
+# (acc in fp32) are functionally supported but not part of the bitwise
+# contract.
+_SUPPORTED_DTYPES = frozenset(
+    {torch.float16, torch.bfloat16, torch.float32, torch.float64}
+)
+
+# The kernel indexes rows/elements and sizes the launch grid with Int32. Decline
+# reductions whose sizes would overflow that so we fall through to ATen rather
+# than silently wrap (mirrors the magnitude guard from the CUDA review).
+_INT32_MAX = 2**31 - 1
+
+
+def _int32_indexing_safe(self: torch.Tensor, d: int) -> bool:
+    """Decline giant reductions so the kernel's Int32 row/element indexing and
+    launch grid never wrap. The two-kernel grid is ``m * num_batches``;
+    ``num_batches`` is bounded above by ``ceil(n / (32 * vec_size))`` (the
+    smallest possible per-batch width), so this bound covers every path."""
+    n = self.shape[d]
+    if n == 0:
+        return True
+    m = self.numel() // n
+    vec_size = max(1, 16 // self.element_size())
+    num_batches_ub = -(-n // (32 * vec_size))
+    return n <= _INT32_MAX and m <= _INT32_MAX and m * num_batches_ub <= _INT32_MAX
+
+
+def _inner_tree_enabled() -> bool:
+    # The CUDA gate is `use_inner_tree_reduction()`; the CuTeDSL predicate
+    # requires the explicit feature flag (an empty/"0" value is off).
+    return os.getenv("PYTORCH_SUM_INNER_TREE", "") not in ("", "0")
+
+
+def _normalize_dim(dim: int, ndim: int) -> int:
+    return dim + ndim if dim < 0 else dim
+
+
+def _single_dim(dim, ndim: int) -> int | None:
+    """Return the one normalized reduced dim, or ``None`` if this is not a
+    single-dim reduction (matches ``num_reduce_dims == 1``)."""
+    if dim is None:
+        return None
+    if isinstance(dim, int):
+        dims = [dim]
+    else:
+        dims = list(dim)
+    if len(dims) != 1:
+        return None
+    return _normalize_dim(dims[0], ndim)
+
+
+def _keepdim_out_shape(self: torch.Tensor, d: int) -> list[int]:
+    shape = list(self.shape)
+    shape[d] = 1
+    return shape
+
+
+def _out_keepdim_view(
+    self: torch.Tensor, d: int, keepdim: bool, out: torch.Tensor
+) -> torch.Tensor | None:
+    """Return a keepdim-shaped ``(.., 1, ..)`` view of ``out`` so the kernel
+    writes ``out``'s storage directly. ``unsqueeze`` is always a view (unlike
+    ``reshape``, which may copy a non-contiguous ``out``). Returns ``None`` if
+    ``out`` is not the expected reduced shape."""
+    expected = _keepdim_out_shape(self, d)
+    try:
+        out_kd = out if keepdim else out.unsqueeze(d)
+    except IndexError:
+        return None
+    return out_kd if list(out_kd.shape) == expected else None
+
+
+def _eligibility(
+    self: torch.Tensor, d: int, out: torch.Tensor
+) -> TensorIterator | None:
+    """Return the reduction ``TensorIterator`` if ``(self, d, out)`` fits the
+    kernel's expected geometry, else ``None``. ``d`` is already normalized
+    and ``out`` is a keepdim-shaped output (broadcast-aligned with ``self``).
+
+    Mirrors ``try_inner_tree_reduction``: build the reduction iterator, then
+    require a single coalesced reduced (fastest) dimension with element
+    stride 1 on the input, and at most one non-reduced (outer) dimension so
+    the operands canonicalize to a single ``(M, N)`` view.
+    """
+    try:
+        it = reduce_op(out, self)
+    except RuntimeError:
+        return None
+
+    if it.numel == 0:
+        return None
+    if it.ndim == 0 or it.ndim > 2:
+        return None
+
+    input_index = it.ntensors - 1  # operands are (out, self); input is last
+    es_in = it.element_strides(input_index)
+    # Input must be contiguous on the reduced (fastest, dim-0) axis.
+    if es_in[0] != 1:
+        return None
+    # Reduction must be on the fastest dim: either the whole tensor is the
+    # reduction (ndim == 1) or the reduced-dim stride is the smallest.
+    if it.ndim == 2 and not (es_in[0] < es_in[1]):
+        return None
+    return it
+
+
+def _geometry(self: torch.Tensor, out: torch.Tensor, it: TensorIterator):
+    """Recover ``(M, N, in_row_stride, out_row_stride)`` (element units) from
+    the coalesced reduction iterator. ``M`` output rows, each a contiguous
+    ``N``-element reduction; ``in_row_stride`` / ``out_row_stride`` step
+    between rows of the canonical ``(M, N)`` / ``(M,)`` views."""
+    m = out.numel()
+    n = self.numel() // m if m else 0
+    if it.ndim == 2:
+        in_row_stride = it.element_strides(it.ntensors - 1)[1]
+        out_row_stride = it.element_strides(0)[1]
+    else:
+        in_row_stride = n
+        out_row_stride = 1
+    return m, n, in_row_stride, out_row_stride
+
+
+def _base_cond_ok(self: torch.Tensor, dim, dtype) -> int | None:
+    """Shared front gate. Returns the normalized reduced dim if the call is a
+    candidate, else ``None``."""
+    if not _inner_tree_enabled():
+        return None
+    if not self.is_cuda or is_fake_tensor(self):
+        return None
+    # dtype-casting sum (an explicit out/result dtype) is out of scope.
+    if dtype is not None:
+        return None
+    if self.dtype not in _SUPPORTED_DTYPES:
+        return None
+    d = _single_dim(dim, self.ndim)
+    if d is None or not (0 <= d < self.ndim):
+        return None
+    if not _int32_indexing_safe(self, d):
+        return None
+    return d
+
+
+def _cond(self, dim, keepdim=False, *, dtype=None) -> bool:
+    d = _base_cond_ok(self, dim, dtype)
+    if d is None:
+        return False
+    out = torch.empty(_keepdim_out_shape(self, d), dtype=self.dtype, device=self.device)
+    return _eligibility(self, d, out) is not None
+
+
+def _out_cond(self, dim, keepdim=False, *, dtype=None, out) -> bool:
+    d = _base_cond_ok(self, dim, dtype)
+    if d is None:
+        return False
+    if out.dtype != self.dtype or not out.is_cuda or is_fake_tensor(out):
+        return False
+    # The kernel writes ``out`` directly via a keepdim-aligned view; ``out``
+    # must already have the reduced shape. Reject mis-shaped ``out`` and let
+    # aten produce the proper error.
+    out_kd = _out_keepdim_view(self, d, keepdim, out)
+    if out_kd is None:
+        return False
+    return _eligibility(self, d, out_kd) is not None
+
+
+def _kernel():
+    from .inner_tree_kernel import inner_tree_sum_into
+
+    return inner_tree_sum_into
+
+
+def _run(self: torch.Tensor, d: int, out_kd: torch.Tensor) -> None:
+    """Run the kernel writing the reduction of ``self`` along ``d`` into the
+    keepdim-shaped ``out_kd``. Caller has validated eligibility."""
+    it = _eligibility(self, d, out_kd)
+    if it is None:
+        raise RuntimeError("sum cutedsl: cond approved but iter rebuild failed")
+    m, n, in_rs, out_rs = _geometry(self, out_kd, it)
+    if m == 0 or n == 0:
+        return
+    in_2d = self.as_strided((m, n), (in_rs, 1))
+    out_1d = out_kd.as_strided((m,), (out_rs,))
+    _kernel()(out_1d, in_2d)
+
+
+def _impl(self, dim, keepdim=False, *, dtype=None):
+    d = _normalize_dim(dim[0] if not isinstance(dim, int) else dim, self.ndim)
+    out_kd = torch.empty(
+        _keepdim_out_shape(self, d), dtype=self.dtype, device=self.device
+    )
+    _run(self, d, out_kd)
+    return out_kd if keepdim else out_kd.squeeze(d)
+
+
+def _out_impl(self, dim, keepdim=False, *, dtype=None, out):
+    d = _normalize_dim(dim[0] if not isinstance(dim, int) else dim, self.ndim)
+    out_kd = _out_keepdim_view(self, d, keepdim, out)
+    assert out_kd is not None  # noqa: S101  # _out_cond guarantees non-None
+    _run(self, d, out_kd)
+    return out
+
+
+def register_to_dispatch() -> None:
+    cu.register_op_override("aten", "sum.dim_IntList", "CUDA", cond=_cond, impl=_impl)
+    cu.register_op_override(
+        "aten", "sum.IntList_out", "CUDA", cond=_out_cond, impl=_out_impl
+    )

--- a/torch/_native/ops/sum/inner_tree_kernel.py
+++ b/torch/_native/ops/sum/inner_tree_kernel.py
@@ -1,0 +1,637 @@
+"""CuTeDSL inner-tree sum reduction kernels.
+
+Bitwise port of the inner-tree reduction kernels in
+``aten/src/ATen/native/cuda/ReduceSumProdKernel.cu`` (with helpers from
+``ReduceInnerTree.cuh`` / ``WarpReduce.cuh``). Each output element is the
+sum of ``N`` contiguous input elements; ``N`` is baked in at ``cute.compile``
+time so the per-row vector tree, streaming tree, and launch planning all
+unroll at trace time and the accumulation order matches the CUDA kernel
+exactly.
+
+Three execution shapes, selected on the host exactly as
+``try_inner_tree_reduction`` does:
+
+* Multirow (``inner_tree_reduction_multirow_kernel``): one thread per row,
+  used when ``N <= vec_size * kMultiRowMaxLoads``.
+* Looped (``inner_tree_reduction_looped_kernel``): warps cooperate per row,
+  batches accumulated inside the kernel; used when ``num_batches <= 3``.
+* Two-kernel (``inner_tree_reduction_kernel`` +
+  ``inner_tree_accumulate_multirow_kernel``): a partials kernel followed by a
+  linear per-row accumulate; used otherwise.
+
+Bitwise-critical ordering reproduced here:
+
+* ``vec_size = 16 / itemsize`` grouping; the in-vec tree order
+  (``inner_tree_reduce``) for vec_size >= 4, else linear. Zero-padded tails
+  are bitwise identical between tree and linear (``x + 0 == x``), so a single
+  uniform choice covers both the full and tail cases.
+* Warp butterfly with ASCENDING shuffle-XOR offsets ``1,2,4,...`` (matches
+  ``WarpReduceDirection::ASCENDING``); we hand-roll it because
+  ``cute.arch.warp_reduction`` uses descending offsets, which is a different
+  (and thus bitwise-different) order.
+* Streaming inner-tree carry across loads (``streaming_inner_tree_step``,
+  merge count = trailing-zero bits of ``load + 1``).
+* Accumulation dtype: fp32 for fp16/bf16/fp32, fp64 for fp64 -- matches
+  ``reduce_dispatch`` so rounding is identical. The inner-tree bitwise tests
+  only exercise fp32 and fp64 (they upcast narrower data first); fp16/bf16
+  native reductions are functionally supported but not bitwise-validated.
+
+Because ``N`` is compile-time, a warp/batch that owns fewer than the unrolled
+number of loads contributes zeros for the extra loads; zeros are additive
+identities, so this reproduces the ragged CUDA loop bit-for-bit.
+"""
+
+from __future__ import annotations
+
+import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]  # noqa: TC002
+
+import cutlass
+import cutlass.cute as cute
+
+# fp64 is part of the bitwise contract; import Float64 directly so an
+# unsupported runtime surfaces a clear error rather than silently dropping it.
+from cutlass import BFloat16, const_expr, Float16, Float32, Float64, Int32
+
+import torch
+from torch._native.instrumentation import instrumented_cutedsl_cache
+
+from .inner_tree_plan import (
+    _ceil_div,
+    _K_MULTIROW_MAX_LOADS,
+    _K_TWO_KERNEL_THRESHOLD,
+    _next_power_of_2,
+    _WARP_SIZE,
+    compute_inner_tree_params,
+    InnerTreeParams,
+    vec_size as _vec_size,
+)
+
+
+_MULTIROW_THREADS = 128
+_MULTIROW_MAX_DEPTH = 6  # kMaxDepth in the multirow kernel
+_ACCUM_THREADS = 128  # kAccumulateThreads
+
+_TORCH_TO_CUTE = {
+    torch.float16: Float16,
+    torch.bfloat16: BFloat16,
+    torch.float32: Float32,
+    torch.float64: Float64,
+}
+
+
+def _acc_for(in_dt):
+    return Float64 if in_dt is Float64 else Float32
+
+
+# Torch accumulator dtype for the two-kernel partials buffer (fp32 for
+# fp16/bf16/fp32, fp64 for fp64) -- keeps cross-batch accumulation in the
+# accumulator dtype, matching ATen.
+_ACC_TORCH_DTYPE = {
+    torch.float16: torch.float32,
+    torch.bfloat16: torch.float32,
+    torch.float32: torch.float32,
+    torch.float64: torch.float64,
+}
+
+
+# ---------------------------------------------------------------------------
+# Trace-time reduction helpers. These run during ``cute.compile`` tracing and
+# emit the exact add DAG; ``vals`` / ``tree`` are Python lists of cute
+# ``Numeric`` register values.
+# ---------------------------------------------------------------------------
+
+
+def _linear_reduce(vals):
+    acc = vals[0]
+    for i in range(1, len(vals)):
+        acc = acc + vals[i]
+    return acc
+
+
+def _inner_tree_reduce(vals):
+    v = list(vals)
+    n = len(v)
+    stride = 1
+    while stride < n:
+        i = 0
+        while i + stride < n:
+            v[i] = v[i] + v[i + stride]
+            i += stride * 2
+        stride *= 2
+    return v[0]
+
+
+def _reduce_vec(vals, vec_size: int):
+    return _inner_tree_reduce(vals) if vec_size >= 4 else _linear_reduce(vals)
+
+
+def _streaming_push(tree, val, load: int, max_depth: int) -> None:
+    """Port of ``streaming_inner_tree_step``: merge count is the number of
+    trailing zero bits of ``load + 1`` (``__ffs(load + 1) - 1``), capped at
+    ``max_depth``. ``carry = tree_accs[--top] + carry`` keeps the existing
+    accumulator on the left."""
+    trailing_zeros = ((load + 1) & -(load + 1)).bit_length() - 1
+    carry = val
+    for _ in range(min(trailing_zeros, max_depth)):
+        carry = tree.pop() + carry
+    tree.append(carry)
+
+
+def _warp_butterfly(val):
+    """Ascending-offset shuffle-XOR butterfly add reduce (matches the CUDA
+    ``warp_reduce`` ASCENDING direction)."""
+    offset = 1
+    while offset < _WARP_SIZE:
+        val = val + cute.arch.shuffle_sync_bfly(
+            val, offset=offset, mask_and_clamp=_WARP_SIZE - 1
+        )
+        offset <<= 1
+    return val
+
+
+def _load_vec_static(mIn, row, base: int, N: int, vec_size: int, acc, zero):
+    """Load + reduce one vector group with compile-time ``base`` (multirow)."""
+    vals = []
+    for i in range(vec_size):
+        off = base + i
+        vals.append(acc(mIn[row, off]) if off < N else zero)
+    return _reduce_vec(vals, vec_size)
+
+
+@cute.jit
+def _load_vec_dyn(
+    mIn,
+    row,
+    base,
+    N: cutlass.Constexpr,
+    vec_size: cutlass.Constexpr,
+    acc: cutlass.Constexpr,
+    zero,
+):
+    """Load + reduce one vector group with a runtime ``base`` (warp paths).
+
+    ``@cute.jit`` so the per-element bounds check is lowered by the DSL
+    instead of evaluated as a Python bool at trace time (the kernel body's
+    AST transform does not reach into plain helpers). Each element is guarded
+    against the row width so out-of-row reads never happen and tail elements
+    contribute zero.
+    """
+    vals = []
+    for i in cutlass.range_constexpr(vec_size):
+        off = base + Int32(i)
+        v = zero
+        if off < Int32(N):
+            v = acc(mIn[row, off])
+        vals.append(v)
+    return _reduce_vec(vals, vec_size)
+
+
+# ---------------------------------------------------------------------------
+# Kernel builders. Each returns a ``@cute.jit`` launcher specialized on the
+# compile-time parameters.
+# ---------------------------------------------------------------------------
+
+
+def _make_multirow(in_dt, acc, out_dt, N: int, vec_size: int):
+    num_loads = _next_power_of_2(_ceil_div(N, vec_size))
+
+    @cute.kernel
+    def _kernel(mIn: cute.Tensor, mOut: cute.Tensor, num_outputs: Int32):
+        tx, _, _ = cute.arch.thread_idx()
+        bx, _, _ = cute.arch.block_idx()
+        row = bx * Int32(_MULTIROW_THREADS) + tx
+        if row < num_outputs:
+            zero = acc(0.0)
+            tree = []
+            for load in cutlass.range_constexpr(num_loads):
+                val = _load_vec_static(
+                    mIn, row, load * vec_size, N, vec_size, acc, zero
+                )
+                _streaming_push(tree, val, load, _MULTIROW_MAX_DEPTH)
+            mOut[row] = out_dt(tree[0])
+
+    @cute.jit
+    def _launch(
+        mIn: cute.Tensor,
+        mOut: cute.Tensor,
+        stream: cuda.CUstream,
+        num_outputs: Int32,
+        grid: Int32,
+    ):
+        _kernel(mIn, mOut, num_outputs).launch(
+            grid=[grid, 1, 1], block=[_MULTIROW_THREADS, 1, 1], stream=stream
+        )
+
+    return _launch
+
+
+def _make_looped(in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreeParams):
+    wpr = p.num_warps  # warps_per_reduction == num_warps in launch_looped
+    rows_per_block = p.rows_per_block
+    total_warps = wpr * rows_per_block
+    wle = _WARP_SIZE * vec_size
+
+    # Per-batch geometry is fully compile-time (num_batches <= 3, fixed N).
+    batches = []
+    for b in range(p.num_batches):
+        batch_offset = b * p.batch_total_elements
+        remaining = min(p.batch_total_elements, N - batch_offset)
+        lpw = _ceil_div(remaining, wpr * wle)
+        if lpw > 1:
+            lpw = _next_power_of_2(lpw)
+        batches.append((batch_offset, remaining, lpw, lpw * wle))
+
+    @cute.kernel
+    def _kernel(mIn: cute.Tensor, mOut: cute.Tensor, num_outputs: Int32):
+        tx, ty, _ = cute.arch.thread_idx()
+        bx, _, _ = cute.arch.block_idx()
+        lane = tx
+        global_warp_id = ty
+        row_in_block = global_warp_id // Int32(wpr)
+        warp_id = global_warp_id % Int32(wpr)
+        row = bx * Int32(rows_per_block) + row_in_block
+        row_active = row < num_outputs
+
+        warp_writes = None  # bound for type checker; used only when wpr > 1
+        if const_expr(wpr > 1):
+            smem = cutlass.utils.SmemAllocator()
+            warp_writes = smem.allocate_tensor(
+                acc, cute.make_layout(total_warps), byte_alignment=8
+            )
+
+        zero = acc(0.0)
+        final_sum = zero
+        for b in cutlass.range_constexpr(p.num_batches):
+            batch_offset, remaining_c, lpw, warp_chunk = batches[b]
+            rem = Int32(0)
+            if row_active:
+                rem = Int32(remaining_c)
+            warp_off = warp_id * Int32(warp_chunk)
+            if warp_off > rem:
+                warp_off = rem
+            warp_start = Int32(batch_offset) + warp_off
+            this_warp_elements = Int32(warp_chunk)
+            tail = rem - warp_off
+            if this_warp_elements > tail:
+                this_warp_elements = tail
+            this_batch_loads = (this_warp_elements + Int32(wle - 1)) // Int32(wle)
+
+            tree = []
+            for load in cutlass.range_constexpr(lpw):
+                base = warp_start + Int32(load * wle) + lane * Int32(vec_size)
+                v = zero
+                if Int32(load) < this_batch_loads:
+                    v = _warp_butterfly(
+                        _load_vec_dyn(mIn, row, base, N, vec_size, acc, zero)
+                    )
+                _streaming_push(tree, v, load, p.depth)
+            warp_acc = tree[0]
+
+            if const_expr(wpr > 1):
+                assert warp_writes is not None  # noqa: S101
+                if lane == Int32(0):
+                    warp_writes[row_in_block * Int32(wpr) + warp_id] = warp_acc
+                cute.arch.barrier()
+                merged = zero
+                if lane < Int32(wpr):
+                    merged = warp_writes[row_in_block * Int32(wpr) + lane]
+                warp_acc = _warp_butterfly(merged)
+                if const_expr(b + 1 < p.num_batches):
+                    cute.arch.barrier()
+
+            final_sum = final_sum + warp_acc
+
+        if row_active:
+            if lane == Int32(0):
+                if warp_id == Int32(0):
+                    mOut[row] = out_dt(final_sum)
+
+    @cute.jit
+    def _launch(
+        mIn: cute.Tensor,
+        mOut: cute.Tensor,
+        stream: cuda.CUstream,
+        num_outputs: Int32,
+        grid: Int32,
+    ):
+        _kernel(mIn, mOut, num_outputs).launch(
+            grid=[grid, 1, 1], block=[_WARP_SIZE, total_warps, 1], stream=stream
+        )
+
+    return _launch
+
+
+def _make_two_partial(in_dt, acc, out_dt, N: int, vec_size: int, p: InnerTreeParams):
+    wpr = p.num_warps
+    num_batches = p.num_batches
+    wle = _WARP_SIZE * vec_size
+    eff = p.effective_loads
+
+    # Only two distinct per-batch widths: full batches and the (shorter) last
+    # batch. Precompute both; the kernel selects on ``batch_idx`` at runtime.
+    full_remaining = p.batch_total_elements
+    last_remaining = N - (num_batches - 1) * p.batch_total_elements
+    warp_chunk_full = eff * wle
+
+    def _lpw(remaining: int) -> int:
+        lpw = _ceil_div(remaining, wpr * wle)
+        return _next_power_of_2(lpw) if lpw > 1 else lpw
+
+    warp_chunk_last = _lpw(last_remaining) * wle
+
+    @cute.kernel
+    def _kernel(mIn: cute.Tensor, mPartials: cute.Tensor):
+        # Grid is exactly num_outputs * num_batches, so no row bounds check.
+        tx, ty, _ = cute.arch.thread_idx()
+        bx, _, _ = cute.arch.block_idx()
+        lane = tx
+        warp_id = ty
+        row = bx // Int32(num_batches)
+        batch_idx = bx % Int32(num_batches)
+
+        remaining = Int32(full_remaining)
+        warp_chunk = Int32(warp_chunk_full)
+        if batch_idx == Int32(num_batches - 1):
+            remaining = Int32(last_remaining)
+            warp_chunk = Int32(warp_chunk_last)
+        batch_offset = batch_idx * Int32(p.batch_total_elements)
+
+        warp_writes = None  # bound for type checker; used only when wpr > 1
+        if const_expr(wpr > 1):
+            smem = cutlass.utils.SmemAllocator()
+            warp_writes = smem.allocate_tensor(
+                acc, cute.make_layout(wpr), byte_alignment=8
+            )
+
+        warp_off = warp_id * warp_chunk
+        if warp_off > remaining:
+            warp_off = remaining
+        warp_start = batch_offset + warp_off
+        this_warp_elements = warp_chunk
+        tail = remaining - warp_off
+        if this_warp_elements > tail:
+            this_warp_elements = tail
+        this_batch_loads = (this_warp_elements + Int32(wle - 1)) // Int32(wle)
+
+        zero = acc(0.0)
+        tree = []
+        for load in cutlass.range_constexpr(eff):
+            base = warp_start + Int32(load * wle) + lane * Int32(vec_size)
+            v = zero
+            if Int32(load) < this_batch_loads:
+                v = _warp_butterfly(
+                    _load_vec_dyn(mIn, row, base, N, vec_size, acc, zero)
+                )
+            _streaming_push(tree, v, load, p.depth)
+        warp_acc = tree[0]
+
+        if const_expr(wpr > 1):
+            assert warp_writes is not None  # noqa: S101
+            if lane == Int32(0):
+                warp_writes[warp_id] = warp_acc
+            cute.arch.barrier()
+            merged = zero
+            if lane < Int32(wpr):
+                merged = warp_writes[lane]
+            warp_acc = _warp_butterfly(merged)
+
+        if lane == Int32(0):
+            if warp_id == Int32(0):
+                # Store partials in the accumulator dtype so the cross-batch
+                # sum stays in fp32 for fp16/bf16 (matches ATen's
+                # accumulate-in-fp32-round-once); downcast happens only in the
+                # accumulate kernel's final write.
+                mPartials[row * Int32(num_batches) + batch_idx] = acc(warp_acc)
+
+    @cute.jit
+    def _launch(
+        mIn: cute.Tensor,
+        mPartials: cute.Tensor,
+        stream: cuda.CUstream,
+        grid: Int32,
+    ):
+        _kernel(mIn, mPartials).launch(
+            grid=[grid, 1, 1], block=[_WARP_SIZE, wpr, 1], stream=stream
+        )
+
+    return _launch
+
+
+def _make_two_accum(acc, out_dt, num_batches: int):
+    @cute.kernel
+    def _kernel(mPartials: cute.Tensor, mOut: cute.Tensor, num_outputs: Int32):
+        tx, _, _ = cute.arch.thread_idx()
+        bx, _, _ = cute.arch.block_idx()
+        row = bx * Int32(_ACCUM_THREADS) + tx
+        if row < num_outputs:
+            base = row * Int32(num_batches)
+            # Partials are in the accumulator dtype; accumulate in that dtype
+            # and downcast to the output dtype only on the final store.
+            s = mPartials[base]
+            # Runtime loop, NOT range_constexpr: num_batches grows with N
+            # (thousands for very large reductions), so unrolling would make
+            # cute.compile blow up. Linear accumulation order matches the CUDA
+            # kernel regardless of unroll.
+            for b in cutlass.range(1, num_batches):
+                s = s + mPartials[base + b]
+            mOut[row] = out_dt(s)
+
+    @cute.jit
+    def _launch(
+        mPartials: cute.Tensor,
+        mOut: cute.Tensor,
+        stream: cuda.CUstream,
+        num_outputs: Int32,
+        grid: Int32,
+    ):
+        _kernel(mPartials, mOut, num_outputs).launch(
+            grid=[grid, 1, 1], block=[_ACCUM_THREADS, 1, 1], stream=stream
+        )
+
+    return _launch
+
+
+# ---------------------------------------------------------------------------
+# Compile cache + host dispatch.
+# ---------------------------------------------------------------------------
+
+
+def _fake_2d(dt, N: int):
+    return cute.runtime.make_fake_tensor(
+        dt, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
+    )
+
+
+def _fake_1d(dt):
+    return cute.runtime.make_fake_tensor(
+        dt, (cute.sym_int(),), stride=(cute.sym_int64(),)
+    )
+
+
+def _fake_1d_contig(dt):
+    return cute.runtime.make_fake_tensor(dt, (cute.sym_int(),), stride=(1,))
+
+
+@instrumented_cutedsl_cache(
+    "aten::sum",
+    key_fn=lambda torch_dtype, N: f"multirow {torch_dtype} N={N}",
+)
+def _compile_multirow(torch_dtype: torch.dtype, N: int):
+    in_dt = _TORCH_TO_CUTE[torch_dtype]
+    acc = _acc_for(in_dt)
+    launcher = _make_multirow(in_dt, acc, in_dt, N, _vec_size(torch_dtype.itemsize))
+    return cute.compile(
+        launcher,
+        _fake_2d(in_dt, N),
+        _fake_1d(in_dt),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        Int32(0),
+        Int32(0),
+        options="--enable-tvm-ffi",
+    )
+
+
+@instrumented_cutedsl_cache(
+    "aten::sum",
+    key_fn=lambda torch_dtype, N, num_warps, _bte, num_batches, *_rest: (
+        f"looped {torch_dtype} N={N} warps={num_warps} batches={num_batches}"
+    ),
+)
+def _compile_looped(
+    torch_dtype: torch.dtype,
+    N: int,
+    num_warps: int,
+    batch_total_elements: int,
+    num_batches: int,
+    depth: int,
+    rows_per_block: int,
+    effective_loads: int,
+):
+    in_dt = _TORCH_TO_CUTE[torch_dtype]
+    acc = _acc_for(in_dt)
+    p = InnerTreeParams(
+        num_warps,
+        batch_total_elements,
+        num_batches,
+        depth,
+        rows_per_block,
+        effective_loads,
+    )
+    launcher = _make_looped(in_dt, acc, in_dt, N, _vec_size(torch_dtype.itemsize), p)
+    return cute.compile(
+        launcher,
+        _fake_2d(in_dt, N),
+        _fake_1d(in_dt),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        Int32(0),
+        Int32(0),
+        options="--enable-tvm-ffi",
+    )
+
+
+@instrumented_cutedsl_cache(
+    "aten::sum",
+    key_fn=lambda torch_dtype, N, num_warps, _bte, num_batches, *_rest: (
+        f"two_partial {torch_dtype} N={N} warps={num_warps} batches={num_batches}"
+    ),
+)
+def _compile_two_partial(
+    torch_dtype: torch.dtype,
+    N: int,
+    num_warps: int,
+    batch_total_elements: int,
+    num_batches: int,
+    depth: int,
+    effective_loads: int,
+):
+    in_dt = _TORCH_TO_CUTE[torch_dtype]
+    acc = _acc_for(in_dt)
+    p = InnerTreeParams(
+        num_warps,
+        batch_total_elements,
+        num_batches,
+        depth,
+        1,
+        effective_loads,
+    )
+    launcher = _make_two_partial(in_dt, acc, acc, N, _vec_size(torch_dtype.itemsize), p)
+    return cute.compile(
+        launcher,
+        _fake_2d(in_dt, N),
+        _fake_1d_contig(acc),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        Int32(0),
+        options="--enable-tvm-ffi",
+    )
+
+
+@instrumented_cutedsl_cache(
+    "aten::sum",
+    key_fn=lambda torch_dtype, num_batches: (
+        f"two_accum {torch_dtype} batches={num_batches}"
+    ),
+)
+def _compile_two_accum(torch_dtype: torch.dtype, num_batches: int):
+    out_dt = _TORCH_TO_CUTE[torch_dtype]
+    acc = _acc_for(out_dt)
+    launcher = _make_two_accum(acc, out_dt, num_batches)
+    return cute.compile(
+        launcher,
+        _fake_1d_contig(acc),
+        _fake_1d(out_dt),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        Int32(0),
+        Int32(0),
+        options="--enable-tvm-ffi",
+    )
+
+
+def inner_tree_sum_into(out: torch.Tensor, src: torch.Tensor) -> None:
+    """Compute ``out[r] = sum(src[r, :])`` for every row ``r``.
+
+    ``src`` is a 2D ``(M, N)`` view with inner-dim stride 1 (outer row stride
+    may differ from N); ``out`` is a 1D ``(M,)`` view (its stride may differ
+    from 1). Both carry their strides into the kernel via the cute tensor, so
+    strided outer inputs and strided outputs are handled directly.
+    """
+    m, n = src.shape
+    dtype = src.dtype
+    vec_size = _vec_size(dtype.itemsize)
+
+    if n <= vec_size * _K_MULTIROW_MAX_LOADS:
+        compiled = _compile_multirow(dtype, n)
+        grid = _ceil_div(m, _MULTIROW_THREADS)
+        compiled(src, out, m, grid)
+        return
+
+    p = compute_inner_tree_params(n, m, vec_size)
+    if p.num_batches <= _K_TWO_KERNEL_THRESHOLD:
+        compiled = _compile_looped(
+            dtype,
+            n,
+            p.num_warps,
+            p.batch_total_elements,
+            p.num_batches,
+            p.depth,
+            p.rows_per_block,
+            p.effective_loads,
+        )
+        grid = _ceil_div(m, p.rows_per_block)
+        compiled(src, out, m, grid)
+        return
+
+    partials = torch.empty(
+        m * p.num_batches, dtype=_ACC_TORCH_DTYPE[dtype], device=src.device
+    )
+    c1 = _compile_two_partial(
+        dtype,
+        n,
+        p.num_warps,
+        p.batch_total_elements,
+        p.num_batches,
+        p.depth,
+        p.effective_loads,
+    )
+    c1(src, partials, m * p.num_batches)
+    c2 = _compile_two_accum(dtype, p.num_batches)
+    c2(partials, out, m, _ceil_div(m, _ACCUM_THREADS))

--- a/torch/_native/ops/sum/inner_tree_plan.py
+++ b/torch/_native/ops/sum/inner_tree_plan.py
@@ -1,0 +1,106 @@
+from typing import NamedTuple
+
+
+_WARP_SIZE = 32
+# Persistent/loop batch-size boundary (kInnerTreeThreshold).
+_K_INNER_TREE_THRESHOLD = 8192
+# Tiny-N multirow boundary (kMultiRowMaxLoads).
+_K_MULTIROW_MAX_LOADS = 8
+# Looped-vs-split boundary on num_batches (kTwoKernelThreshold).
+_K_TWO_KERNEL_THRESHOLD = 3
+_K_TARGET_WARPS_PER_BLOCK = 8  # kTargetWarpsPerBlock
+
+
+def _previous_power_of_2(n: int) -> int:
+    power = 1
+    while power * 2 <= n:
+        power <<= 1
+    return power
+
+
+def _next_power_of_2(n: int) -> int:
+    power = 1
+    while power < n:
+        power <<= 1
+    return power
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def vec_size(itemsize: int) -> int:
+    """16-byte vectorized loads: fp32->4, fp64->2, fp16/bf16->8."""
+    return max(1, 16 // max(1, itemsize))
+
+
+class InnerTreeParams(NamedTuple):
+    num_warps: int
+    batch_total_elements: int  # Inductor R0_BLOCK (the per-batch tile).
+    # Inductor split count: ceil(N / batch_total_elements).
+    num_batches: int
+    depth: int
+    rows_per_block: int
+    effective_loads: int
+
+
+def compute_inner_tree_params(
+    inputs_per_output: int, num_outputs: int, vec_size: int
+) -> InnerTreeParams:
+    """Plan the inner-tree reduction for one row of inputs.
+
+    ``vec_size`` is ``vec_size(itemsize)``. The result is the tiling used by
+    the eager kernel. Inductor consumes ``batch_total_elements`` (R0_BLOCK)
+    and ``num_batches`` (split count).
+    """
+    wle = _WARP_SIZE * vec_size
+    threshold = _K_INNER_TREE_THRESHOLD
+    n = inputs_per_output
+
+    if n > threshold:
+        num_batches_est = _ceil_div(n, threshold)
+        if num_batches_est <= _K_TWO_KERNEL_THRESHOLD:
+            total_ideal_warps = 0
+            for b in range(num_batches_est):
+                batch_start = b * threshold
+                batch_elements = min(threshold, n - batch_start)
+                total_ideal_warps += min(16, max(1, batch_elements // wle))
+            num_warps = max(1, total_ideal_warps // num_batches_est)
+        else:
+            num_warps = min(16, max(1, threshold // wle))
+    else:
+        num_warps = min(16, max(1, n // wle))
+    num_warps = _previous_power_of_2(num_warps)
+
+    loads_per_warp = _ceil_div(n, num_warps * wle)
+    if loads_per_warp > 1:
+        loads_per_warp = _next_power_of_2(loads_per_warp)
+
+    max_loads_per_batch = max(1, threshold // (wle * num_warps))
+    max_loads_per_batch = _previous_power_of_2(max_loads_per_batch)
+    effective_loads = min(loads_per_warp, max_loads_per_batch)
+
+    batch_total_elements = effective_loads * wle * num_warps
+    num_batches = _ceil_div(n, batch_total_elements)
+
+    if num_warps < _K_TARGET_WARPS_PER_BLOCK and num_batches <= _K_TWO_KERNEL_THRESHOLD:
+        rows_per_block = min(num_outputs, _K_TARGET_WARPS_PER_BLOCK // num_warps)
+    else:
+        rows_per_block = 1
+
+    depth = 0
+    nn = effective_loads + 1
+    while nn > 1:
+        depth += 1
+        nn >>= 1
+    if depth < 1:
+        depth = 1
+
+    return InnerTreeParams(
+        num_warps,
+        batch_total_elements,
+        num_batches,
+        depth,
+        rows_per_block,
+        effective_loads,
+    )


### PR DESCRIPTION
Summary:

Adds the triton-style inner tree reduction kernel for sum in the caffe2/ATen CUDA backend, including partitioned launch variants, tests, and the output/input offset handling from D104676317 so TensorIterator output strides and strided outer input rows are preserved.

Test Plan:
arc lint -a fbcode/caffe2/aten/src/ATen/native/cuda/ReduceSumProdKernel.cu xplat/caffe2/aten/src/ATen/native/cuda/ReduceSumProdKernel.cu fbcode/caffe2/test/test_reductions.py xplat/caffe2/test/test_reductions.py

buck2 test fbcode//caffe2/test:torch_cuda_cuda -- TestInnerTreeSum

Differential Revision: D100024904


