### PR TITLE
[dynamo] Accept extra kwargs in CudagraphsBackend.__call__

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -386,6 +386,29 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
             )
             opt_fn(input)
 
+    def test_cudagraphs_backend_accepts_extra_kwargs(self):
+        # Issue #169939: torch.compile(backend="cudagraphs", options=...) used
+        # to raise TypeError because CudagraphsBackend.__call__ did not accept
+        # extra kwargs. The backend should ignore unknown kwargs with a warning,
+        # matching eager and other compiler-fn-style backends.
+        from torch._dynamo.backends.cudagraphs import CudagraphsBackend
+
+        backend = CudagraphsBackend()
+        gm = MagicMock()
+        sentinel = object()
+        with patch(
+            "torch._dynamo.backends.cudagraphs.cudagraphs", return_value=sentinel
+        ) as mock_cudagraphs:
+            with self.assertLogs(
+                "torch._dynamo.backends.cudagraphs", level="WARNING"
+            ) as cm:
+                result = backend(gm, [], options={"trace.enabled": True})
+
+        self.assertIs(result, sentinel)
+        # Extra kwargs are dropped, not forwarded to the inner compiler.
+        mock_cudagraphs.assert_called_once_with(gm, [])
+        self.assertTrue(any("ignoring extra kwargs" in m for m in cm.output))
+
     def test_backend_graph_freeze(self):
         from functorch.compile import make_boxed_func
         from torch._dynamo.backends.common import aot_autograd

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -22,6 +22,7 @@ Key components:
 """
 
 import functools
+import logging
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -49,6 +50,9 @@ from torch._inductor.utils import (
 from torch.multiprocessing.reductions import StorageWeakRef
 
 from .registry import register_backend
+
+
+log = logging.getLogger(__name__)
 
 
 def find_input_mutations(g: torch.fx.Graph) -> set[int]:
@@ -251,7 +255,11 @@ class CudagraphsBackend:
         reset_cudagraph_trees()
 
     @staticmethod
-    def __call__(model: torch.fx.GraphModule, inputs: Sequence[Any]) -> Any:
+    def __call__(
+        model: torch.fx.GraphModule, inputs: Sequence[Any], **kwargs: Any
+    ) -> Any:
+        if kwargs:
+            log.warning("cudagraphs backend ignoring extra kwargs %s", kwargs)
         return cudagraphs(model, inputs)
 
 


### PR DESCRIPTION
Fixes #169939

`torch.compile(fn, backend="cudagraphs", options={...})` raised `TypeError: CudagraphsBackend.__call__() got an unexpected keyword argument 'options'` because `CudagraphsBackend.__call__` did not accept `**kwargs`, while every other compiler-fn-style backend (`eager`, `eager_noexcept`, `pre_dispatch_eager`, `eager_debug`, `invoke_subgraph`, `aot_eager_decomp_partition`, `aot_autograd`) does. This makes `cudagraphs` follow the established pattern: accept any extra kwargs, log a warning that they are being ignored, and continue.

Repro from the issue now succeeds (with a warning):

```
W cudagraphs backend ignoring extra kwargs {'options': {'trace.enabled': True}}
```

Test added in `TestCustomBackendAPI`: directly invokes `CudagraphsBackend()` with `options=...` and asserts the inner `cudagraphs()` call still receives only `(model, inputs)` and that the warning is logged.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos