### PR TITLE
[DOCS][CUDA] Document `allow_splitk` flag in more places

### DIFF
--- a/docs/source/backends.md
+++ b/docs/source/backends.md
@@ -63,20 +63,17 @@ These backends include:
 
     A :class:`bool` that controls whether reduced precision reductions (e.g.,
     with fp16 accumulation type) are allowed with fp16 GEMMs.
-    Assigning a :class:`bool` sets this value and sets ``allow_splitk`` to
-    ``True``. Assigning a tuple ``(allow_reduced_precision, allow_splitk)`` lets
-    you also toggle whether split-k reductions may be used when dispatching to
-    cuBLASLt. ``allow_splitk`` defaults to ``True`` and can only be disabled
-    when ``allow_reduced_precision`` is ``False``.
+    For tuple assignment and split-k behavior, see
+    :ref:`Reduced Precision Reduction in FP16 GEMMs <fp16reducedprecision>`.
 ```
 
 ```{eval-rst}
 .. attribute::  allow_fp16_reduced_precision_reduction_split_k
 
     A readonly :class:`bool` that reports whether split-K heuristics may be used
-    for fp16 GEMMs when dispatching to cuBLASLt. Set this through
-    :attr:`allow_fp16_reduced_precision_reduction` by assigning
-    ``(allow_reduced_precision, allow_splitk)``.
+    for fp16 GEMMs when dispatching to cuBLASLt. For how this value is
+    controlled, see
+    :ref:`Reduced Precision Reduction in FP16 GEMMs <fp16reducedprecision>`.
 ```
 
 ```{eval-rst}
@@ -84,20 +81,17 @@ These backends include:
 
     A :class:`bool` that controls whether reduced precision reductions are
     allowed with bf16 GEMMs.
-    Assigning a :class:`bool` sets this value and sets ``allow_splitk`` to
-    ``True``. Assigning a tuple ``(allow_reduced_precision, allow_splitk)`` lets
-    you also toggle whether split-k reductions may be used when dispatching to
-    cuBLASLt. ``allow_splitk`` defaults to ``True`` and can only be disabled
-    when ``allow_reduced_precision`` is ``False``.
+    For tuple assignment and split-k behavior, see
+    :ref:`Reduced Precision Reduction in BF16 GEMMs <bf16reducedprecision>`.
 ```
 
 ```{eval-rst}
 .. attribute::  allow_bf16_reduced_precision_reduction_split_k
 
     A readonly :class:`bool` that reports whether split-K heuristics may be used
-    for bf16 GEMMs when dispatching to cuBLASLt. Set this through
-    :attr:`allow_bf16_reduced_precision_reduction` by assigning
-    ``(allow_reduced_precision, allow_splitk)``.
+    for bf16 GEMMs when dispatching to cuBLASLt. For how this value is
+    controlled, see
+    :ref:`Reduced Precision Reduction in BF16 GEMMs <bf16reducedprecision>`.
 ```
 
 ```{eval-rst}

--- a/docs/source/backends.md
+++ b/docs/source/backends.md
@@ -61,17 +61,43 @@ These backends include:
 ```{eval-rst}
 .. attribute::  allow_fp16_reduced_precision_reduction
 
-    A :class:`bool` that controls whether reduced precision reductions (e.g., with fp16 accumulation type) are allowed with fp16 GEMMs.
-    Assigning a tuple ``(allow_reduced_precision, allow_splitk)`` lets you also toggle whether
-    split-K heuristics may be used when dispatching to cuBLASLt. ``allow_splitk`` defaults to ``True``.
+    A :class:`bool` that controls whether reduced precision reductions (e.g.,
+    with fp16 accumulation type) are allowed with fp16 GEMMs.
+    Assigning a :class:`bool` sets this value and sets ``allow_splitk`` to
+    ``True``. Assigning a tuple ``(allow_reduced_precision, allow_splitk)`` lets
+    you also toggle whether split-k reductions may be used when dispatching to
+    cuBLASLt. ``allow_splitk`` defaults to ``True`` and can only be disabled
+    when ``allow_reduced_precision`` is ``False``.
+```
+
+```{eval-rst}
+.. attribute::  allow_fp16_reduced_precision_reduction_split_k
+
+    A readonly :class:`bool` that reports whether split-K heuristics may be used
+    for fp16 GEMMs when dispatching to cuBLASLt. Set this through
+    :attr:`allow_fp16_reduced_precision_reduction` by assigning
+    ``(allow_reduced_precision, allow_splitk)``.
 ```
 
 ```{eval-rst}
 .. attribute::  allow_bf16_reduced_precision_reduction
 
-    A :class:`bool` that controls whether reduced precision reductions are allowed with bf16 GEMMs.
-    Assigning a tuple ``(allow_reduced_precision, allow_splitk)`` lets you also toggle whether
-    split-K heuristics may be used when dispatching to cuBLASLt. ``allow_splitk`` defaults to ``True``.
+    A :class:`bool` that controls whether reduced precision reductions are
+    allowed with bf16 GEMMs.
+    Assigning a :class:`bool` sets this value and sets ``allow_splitk`` to
+    ``True``. Assigning a tuple ``(allow_reduced_precision, allow_splitk)`` lets
+    you also toggle whether split-k reductions may be used when dispatching to
+    cuBLASLt. ``allow_splitk`` defaults to ``True`` and can only be disabled
+    when ``allow_reduced_precision`` is ``False``.
+```
+
+```{eval-rst}
+.. attribute::  allow_bf16_reduced_precision_reduction_split_k
+
+    A readonly :class:`bool` that reports whether split-K heuristics may be used
+    for bf16 GEMMs when dispatching to cuBLASLt. Set this through
+    :attr:`allow_bf16_reduced_precision_reduction` by assigning
+    ``(allow_reduced_precision, allow_splitk)``.
 ```
 
 ```{eval-rst}

--- a/docs/source/notes/cuda.md
+++ b/docs/source/notes/cuda.md
@@ -224,11 +224,27 @@ If full precision reductions are needed, users can disable reduced precision red
 torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
 ```
 
+Assigning a boolean is equivalent to assigning
+`(allow_reduced_precision, True)` and sets `allow_splitk` to `True`. To
+disable both reduced precision reductions and split-k reductions, assign
+`(allow_reduced_precision, allow_splitk)` explicitly:
+
+```python
+torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (False, False)
+```
+
+The current split-k setting can be queried with
+`torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction_split_k`.
+The combination `(True, False)` is not supported because reduced precision
+reductions require split-k.
+
 To toggle the reduced precision reduction flags in C++, one can do
 
 ```cpp
-at::globalContext().setAllowFP16ReductionCuBLAS(false);
+at::globalContext().setAllowFP16ReductionCuBLAS(false, false);
 ```
+
+The second argument is `allow_splitk` and defaults to `true` when omitted.
 
 (bf16reducedprecision)=
 
@@ -245,11 +261,27 @@ precision reductions in bf16 GEMMs with:
 torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
 ```
 
+Assigning a boolean is equivalent to assigning
+`(allow_reduced_precision, True)` and sets `allow_splitk` to `True`. To
+disable both reduced precision reductions and split-k reductions, assign
+`(allow_reduced_precision, allow_splitk)` explicitly:
+
+```python
+torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (False, False)
+```
+
+The current split-K setting can be queried with
+`torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction_split_k`.
+The combination `(True, False)` is not supported because reduced precision
+reductions require split-K.
+
 To toggle the reduced precision reduction flags in C++, one can do
 
 ```cpp
-at::globalContext().setAllowBF16ReductionCuBLAS(true);
+at::globalContext().setAllowBF16ReductionCuBLAS(false, false);
 ```
+
+The second argument is `allow_splitk` and defaults to `true` when omitted.
 
 (fp16accumulation)=
 

--- a/docs/source/notes/numerical_accuracy.md
+++ b/docs/source/notes/numerical_accuracy.md
@@ -141,10 +141,16 @@ unexpected results (e.g., `inf` values when the final result should be represent
 half-precision).
 If reduced-precision reductions are problematic, they can be turned off with
 `torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False`.
+This sets `allow_splitk` to `True`. To disable both reduced-precision reductions
+and split-k reductions, use
+`torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (False, False)`.
 
 A similar flag exists for BF16 GEMM operations and is turned on by default. If BF16
 reduced-precision reductions are problematic, they can be turned off with
 `torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False`.
+This sets `allow_splitk` to `True`. To disable both reduced-precision reductions
+and split-k reductions, use
+`torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (False, False)`.
 
 For more information see {ref}`allow_fp16_reduced_precision_reduction <fp16reducedprecision>`
 and {ref}`allow_bf16_reduced_precision_reduction <bf16reducedprecision>`.


### PR DESCRIPTION
I think #164766 only changed one of the main places `allow_[bf|fp]16_reduced_precision_reduction` but there are a few other places

authored with codex

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia