### PR TITLE
[custom-ops] Enable opcheck stride checking for CPU tensors

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -223,6 +223,21 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
         ):
             torch.library.opcheck(op, (x,), {})
 
+    # https://github.com/pytorch/pytorch/issues/149468
+    def test_opcheck_cpu_stride_mismatch(self, device):
+        @torch.library.custom_op("test::stride_mismatch", mutates_args=())
+        def stride_mismatch(x: torch.Tensor) -> torch.Tensor:
+            return x.clone().permute(2, 0, 1)
+
+        @stride_mismatch.register_fake
+        def _(x):
+            c, h, w = x.shape[2], x.shape[0], x.shape[1]
+            return x.new_empty(c, h, w)
+
+        x = torch.randn(4, 4, 3, device=device)
+        with self.assertRaisesRegex(optests.OpCheckError, "Stride mismatch"):
+            torch.library.opcheck(stride_mismatch, (x,))
+
     # https://github.com/pytorch/pytorch/issues/142410
     def test_opcheck_unbacked_stride(self, device):
         @torch.library.custom_op("test::f", mutates_args=[])

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -185,7 +185,7 @@ def compare_tensor_meta(
     # Stride checking is currently disabled, see https://github.com/pytorch/pytorch/issues/78050
     if check_strides:
         same_strides, idx = check_significant_strides(
-            a, b, allow_rhs_unbacked=allow_rhs_unbacked
+            a, b, only_cuda=False, allow_rhs_unbacked=allow_rhs_unbacked
         )
         if not same_strides:
             msg = f"Stride mismatch! Strides are {a.stride()} and {b.stride()} (mismatched at {idx})!"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183002

opcheck's stride validation was gated to CUDA-only tensors via the
`only_cuda=True` default in `check_significant_strides`. This meant a
custom op whose `register_fake` returned a tensor with incorrect strides
would pass all opcheck tests on CPU. Pass `only_cuda=False` from
`compare_tensor_meta` so stride mismatches are caught on all devices.

Fixes https://github.com/pytorch/pytorch/issues/149468

Authored with Claude.