### PR TITLE
Simplify Min/Max expressions using value range information

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1256,6 +1256,25 @@ def forward(self, x_1):
             )
         )
 
+    def test_min_simplify_with_upper_bound(self):
+        from torch.utils._sympy.functions import Min
+
+        shape_env = ShapeEnv()
+        u0 = shape_env.create_unbacked_symint()
+        torch._check(u0 <= 5)
+        torch._check(u0 >= 0)
+        sym = u0.node.expr
+        self.assertEqual(shape_env.simplify(Min(sym, 5)), sym)
+
+    def test_max_simplify_with_lower_bound(self):
+        from torch.utils._sympy.functions import Max
+
+        shape_env = ShapeEnv()
+        u0 = shape_env.create_unbacked_symint()
+        torch._check(u0 >= 10)
+        sym = u0.node.expr
+        self.assertEqual(shape_env.simplify(Max(sym, 10)), sym)
+
     def test_numpy_sym_max(self):
         self.assertEqual(torch.sym_max(np.int64(10), 12), 12)
         self.assertEqual(torch.sym_max(np.int64(12), 10), 12)
@@ -2208,6 +2227,20 @@ class TestDimConstraints(TestCase):
         # testing that this does not throw constraint violation error.
         self.assertEqual(func(x, 1), x * 400)
         self.assertEqual(func(x, 0), x * 400)
+
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
+    def test_min_max_simplify_e2e(self):
+        @torch.compile(fullgraph=True, backend="eager")
+        def f(x):
+            x0, x1 = x.tolist()
+            torch._check(x0 <= 5)
+            torch._check(x0 >= 0)
+            if torch.sym_min(x0, 5) == x0:
+                return torch.tensor(True)
+            else:
+                return torch.tensor(False)
+
+        self.assertEqual(f(torch.tensor([3, 5])), torch.tensor(True))
 
     def test_dim_constraints_reduce_congruences_simple(self):
         from sympy import Symbol

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -86,6 +86,7 @@ from torch.utils._sympy.functions import (
     IntTrueDiv,
     IsNonOverlappingAndDenseIndicator,
     Max,
+    Min,
     Mod,
     PythonMod,
     TruncToInt,
@@ -7151,21 +7152,17 @@ class ShapeEnv:
         expr = safe_expand(expr)
         expr = self.replace(expr)
 
-        # Simplify max(0/1, x) to x when x >= 0/1. max(1, x) is a commonly introduced
-        # expression when creating contiguous strides.
         if not size_oblivious:
             min_max_replacements: dict[sympy.Basic, sympy.Basic] = {}
-            for atom in expr.atoms(Max):  # type: ignore[has-type]
-                if len(atom.args) > 2:
+            for atom in expr.atoms(Min, Max):
+                if len(atom.args) != 2:
                     continue
                 a, b = atom.args
-                if b == 1 or b == 0:
-                    a, b = b, a
-
-                if a == 1 and self._maybe_evaluate_static(sympy.Ge(b, 1)):
-                    min_max_replacements[atom] = b
-                if a == 0 and self._maybe_evaluate_static(sympy.Ge(b, 0)):
-                    min_max_replacements[atom] = b
+                is_min = isinstance(atom, Min)
+                if self._maybe_evaluate_static(sympy.Le(a, b)) is sympy.true:
+                    min_max_replacements[atom] = a if is_min else b
+                elif self._maybe_evaluate_static(sympy.Le(b, a)) is sympy.true:
+                    min_max_replacements[atom] = b if is_min else a
             if min_max_replacements:
                 expr = expr.xreplace(min_max_replacements)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183004

Fixes #137096. Previously, `ShapeEnv.simplify` only handled two narrow
special cases: `Max(0, x)` and `Max(1, x)`. It didn't handle `Min` at
all, so `Min(u0, 5)` was never simplified even when `u0 <= 5` was known,
causing data-dependent expression errors in dynamo.

Generalize the simplification to handle both `Min` and `Max` with
arbitrary arguments by checking `Le(a, b)` via `_maybe_evaluate_static`,
which already has access to value range information. This subsumes the
old special cases.

Authored with Claude.