### PR TITLE
Replace __args__ with typing.get_args() and TensorType.dims

### DIFF
--- a/test/fx/test_gradual_type.py
+++ b/test/fx/test_gradual_type.py
@@ -526,10 +526,10 @@ class TypeCheckerTest(TestCase):
                 if n.type != t:
                     raise AssertionError(f"Expected n.type == {t}, got {n.type}")
             if n.op == "output":
-                if torch.Size(n.type.__args__) != b.shape:
+                if torch.Size(n.type.dims) != b.shape:
                     raise AssertionError(
-                        f"Expected torch.Size(n.type.__args__) == {b.shape}, "
-                        f"got {torch.Size(n.type.__args__)}"
+                        f"Expected torch.Size(n.type.dims) == {b.shape}, "
+                        f"got {torch.Size(n.type.dims)}"
                     )
             if n.op == "call_module":
                 if n.type != t:
@@ -764,10 +764,10 @@ class TypeCheckerTest(TestCase):
                         f"Expected n.type to be TensorType, got {type(n.type)}"
                     )
                 expected_size = B.forward(torch.rand(2, 2, 4, 5)).size()
-                if torch.Size(n.type.__args__) != expected_size:
+                if torch.Size(n.type.dims) != expected_size:
                     raise AssertionError(
-                        f"Expected torch.Size(n.type.__args__) == {expected_size}, "
-                        f"got {torch.Size(n.type.__args__)}"
+                        f"Expected torch.Size(n.type.dims) == {expected_size}, "
+                        f"got {torch.Size(n.type.dims)}"
                     )
 
     def test_type_check_conv2D_maxpool2d_flatten(self):
@@ -1136,7 +1136,7 @@ class TypeCheckerTest(TestCase):
                 raise AssertionError(
                     f"Expected n.type to be TensorType, got {type(n.type)}"
                 )
-            batch_sizes.add(n.type.__args__[0])
+            batch_sizes.add(n.type.dims[0])
         if len(batch_sizes) != 1:
             raise AssertionError(
                 f"Expected len(batch_sizes) == 1, got {len(batch_sizes)}"
@@ -1264,15 +1264,15 @@ class TypeCheckerTest(TestCase):
 
         for n in traced.graph.nodes:
             if n.op == "call_module":
-                if not isinstance(n.type.__args__[2], sympy.floor):
+                if not isinstance(n.type.dims[2], sympy.floor):
                     raise AssertionError(
-                        f"Expected n.type.__args__[2] to be sympy.floor, "
-                        f"got {type(n.type.__args__[2])}"
+                        f"Expected n.type.dims[2] to be sympy.floor, "
+                        f"got {type(n.type.dims[2])}"
                     )
-                if not isinstance(n.type.__args__[3], sympy.floor):
+                if not isinstance(n.type.dims[3], sympy.floor):
                     raise AssertionError(
-                        f"Expected n.type.__args__[3] to be sympy.floor, "
-                        f"got {type(n.type.__args__[3])}"
+                        f"Expected n.type.dims[3] to be sympy.floor, "
+                        f"got {type(n.type.dims[3])}"
                     )
 
     def test_type_check_symbolic_inferenceconv2D_maxpool2d_flatten(self):

--- a/test/inductor/test_cache.py
+++ b/test/inductor/test_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import pickle
+import typing
 from concurrent.futures import ThreadPoolExecutor
 from inspect import isclass
 from os import environ
@@ -80,7 +81,7 @@ class TestMixin:
         if len(cache_type.__orig_bases__) != 1:
             raise AssertionError
         generic_base = cache_type.__orig_bases__[0]
-        _key_type, _value_type = generic_base.__args__
+        _key_type, _value_type = typing.get_args(generic_base)
         if ((_key_type != icache.Key) and (_key_type != key_type)) or (
             (_value_type != icache.Value) and (_value_type != value_type)
         ):

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import inspect
+import typing
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from functools import lru_cache, partial, wraps
@@ -123,7 +124,7 @@ def _convert_out_params(f):
                 default=None,
                 annotation=t,
             )
-            for o, t in zip(out_names, out_annotation.__args__)
+            for o, t in zip(out_names, typing.get_args(out_annotation))
         ]
         # Drop the out parameter and concatenate the new kwargs in the signature
         params = chain((v for k, v in sig.parameters.items() if k != "out"), out_params)

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -2437,7 +2437,7 @@ class BuiltinVariable(BaseBuiltinVariable):
         ):
             isinstance_type_tuple = (isinstance_type,)
         elif isinstance(isinstance_type, types.UnionType):
-            isinstance_type_tuple = isinstance_type.__args__
+            isinstance_type_tuple = typing.get_args(isinstance_type)
         elif isinstance(isinstance_type, tuple) and all(
             isinstance(tp, type) or callable(getattr(tp, "__instancecheck__", None))
             for tp in isinstance_type

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -34,6 +34,7 @@ import re
 import sys
 import traceback
 import types
+import typing
 from collections import namedtuple
 from collections.abc import Callable, Sequence
 from types import CellType, FunctionType
@@ -1000,7 +1001,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         union_type = getattr(types, "UnionType", None)
         if union_type is not None and isinstance(value, union_type):
             collected = []
-            for entry in value.__args__:
+            for entry in typing.get_args(value):
                 flat = self._flatten_type_spec(entry)
                 if flat is None:
                     return None

--- a/torch/_inductor/fuzzer.py
+++ b/torch/_inductor/fuzzer.py
@@ -235,10 +235,9 @@ class SamplingMethod(Enum):
                 random.choice(characters) for _ in range(random.randint(1, 20))
             )
         elif is_type(type_hint, list):
-            elem_type = getattr(
-                type_hint,
-                "__args__",
-                [type(default[0])] if default and len(default) else [type(None)],
+            elem_type = (
+                get_args(type_hint)
+                or ([type(default[0])] if default and len(default) else [type(None)])
             )[0]
             new_default = default[0] if default and len(default) > 0 else None
             return [
@@ -249,10 +248,9 @@ class SamplingMethod(Enum):
             ]
         elif is_type(type_hint, set):  # noqa: set_linter
             indexable = list(default)
-            elem_type = getattr(
-                type_hint,
-                "__args__",
-                [type(indexable[0])] if default and len(default) else [type(None)],
+            elem_type = (
+                get_args(type_hint)
+                or ([type(indexable[0])] if default and len(default) else [type(None)])
             )[0]
             new_default = indexable[0] if default and len(default) > 0 else None
             return {  # noqa: set_linter
@@ -263,10 +261,9 @@ class SamplingMethod(Enum):
             }
         elif is_type(type_hint, OrderedSet):
             indexable = list(default)
-            elem_type = getattr(
-                type_hint,
-                "__args__",
-                [type(indexable[0])] if default and len(default) else [type(None)],
+            elem_type = (
+                get_args(type_hint)
+                or ([type(indexable[0])] if default and len(default) else [type(None)])
             )[0]
             new_default = indexable[0] if default and len(default) > 0 else None
             return OrderedSet(
@@ -278,12 +275,10 @@ class SamplingMethod(Enum):
                 ]
             )
         elif is_type(type_hint, dict):
-            key_type, value_type = getattr(
-                type_hint,
-                "__args__",
-                map(type, next(iter(default.items())))
+            key_type, value_type = get_args(type_hint) or (
+                tuple(map(type, next(iter(default.items()))))
                 if (default is not None and len(default))
-                else (type(None), type(None)),
+                else (type(None), type(None))
             )
             if default is not None and len(default.items()) > 0:
                 default_key, default_val = next(iter(default.items()))
@@ -299,15 +294,14 @@ class SamplingMethod(Enum):
             }
         elif is_type(type_hint, Union) or is_type(type_hint, types.UnionType):
             # do whatever is not the type of default
-            try:
-                assert len(type_hint.__args__) > 1
-            except AttributeError as err:
-                raise ValueError("Union type with no args") from err
+            union_args = get_args(type_hint)
+            if len(union_args) <= 1:
+                raise ValueError("Union type with no args")
             if random_sample:
-                new_type = random.choice(type_hint.__args__)
+                new_type = random.choice(union_args)
             else:
                 new_type = random.choice(
-                    [t for t in type_hint.__args__ if t is not type(default)]
+                    [t for t in union_args if t is not type(default)]
                 )
             try:
                 new_default = new_type()
@@ -319,11 +313,7 @@ class SamplingMethod(Enum):
                 random_sample, field_name, new_type, new_default
             )
         elif is_type(type_hint, tuple):
-            args = getattr(
-                type_hint,
-                "__args__",
-                tuple(map(type, default)),
-            )
+            args = get_args(type_hint) or tuple(map(type, default))
             zipped = zip(args, default)
             return tuple(
                 map(  # noqa: C417
@@ -334,22 +324,22 @@ class SamplingMethod(Enum):
                 )
             )
         elif is_type(type_hint, Literal):
-            try:
-                if random_sample:
-                    return random.choice(type_hint.__args__)
+            literal_args = get_args(type_hint)
+            if not literal_args:
+                raise ValueError("Literal type with no args")
+            if random_sample:
+                return random.choice(literal_args)
+            else:
+                choices = [t for t in literal_args if t != default]
+                if choices:
+                    return random.choice(choices)
                 else:
-                    choices = [t for t in type_hint.__args__ if t != default]
-                    if choices:
-                        return random.choice(choices)
-                    else:
-                        return default
-            except AttributeError as err:
-                raise ValueError("Literal type with no args") from err
+                    return default
         elif is_optional_type(type_hint):
-            try:
-                elem_type = type_hint.__args__[0]
-            except AttributeError as err:
-                raise ValueError("Optional type with no args") from err
+            optional_args = get_args(type_hint)
+            if not optional_args:
+                raise ValueError("Optional type with no args")
+            elem_type = optional_args[0]
             if random_sample:
                 return random.choice(
                     [
@@ -369,10 +359,10 @@ class SamplingMethod(Enum):
         elif type_hint is type(None):
             return None
         elif is_callable_type(type_hint):
-            try:
-                return_type = list(type_hint.__args__)[-1]
-            except AttributeError as err:
-                raise ValueError("Callable type with no args") from err
+            callable_args = get_args(type_hint)
+            if not callable_args:
+                raise ValueError("Callable type with no args")
+            return_type = callable_args[-1]
 
             @wraps(lambda *args, **kwargs: None)
             def dummy_function(*args, **kwargs):  # type: ignore[no-untyped-def]

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -347,14 +347,11 @@ def tuple_to_list(tuple_type: type[tuple]) -> type[list]:
     """
     Convert `tuple_type` into a list type with the same type arguments. Assumes that `tuple_type` is typing.Tuple type.
     """
-    type_args = getattr(tuple_type, "__args__", None)
-    # Account for different python versions, e.g. python 3.8 would give ()
-    # but python 3.12 would give None.
+    type_args = typing.get_args(tuple_type)
     if (
         tuple_type is typing.Tuple  # noqa: UP006
         or tuple_type is tuple
-        or type_args == ()
-        or type_args is None
+        or not type_args
     ):
         # Handle the case of an empty tuple type
         return list

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import inspect
 import types
+import typing
 import warnings
 from collections.abc import Callable, Sequence
 from functools import wraps
@@ -83,12 +84,9 @@ def _maybe_convert_to_type(a: NumberType, typ: type) -> NumberType:
 
 
 def _annotation_has_type(*, typ, annotation):
-    if hasattr(annotation, "__args__"):
-        for a in annotation.__args__:
-            if _annotation_has_type(typ=typ, annotation=a):
-                return True
-        return False
-
+    args = typing.get_args(annotation)
+    if args:
+        return any(_annotation_has_type(typ=typ, annotation=a) for a in args)
     return typ is annotation
 
 

--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -71,9 +71,9 @@ def expand_to_tensor_dim(t: Any, n: int) -> TensorType:
         dims = [Dyn] * n
         return TensorType(tuple(dims))
     elif isinstance(t, TensorType):
-        if len(t.__args__) != n:
+        if len(t.dims) != n:
             raise TypeError(
-                f"Cannot extend tensor. Tensor {t} has rank {len(t.__args__)}. It should have rank {n}"
+                f"Cannot extend tensor. Tensor {t} has rank {len(t.dims)}. It should have rank {n}"
             )
         return t
     else:
@@ -92,11 +92,11 @@ def broadcast_types(t1: Any, t2: Any) -> tuple[Any, Any]:
         return t1, t2
 
     if isinstance(t1, TensorType) and isinstance(t2, TensorType):
-        s1 = len(t1.__args__)
-        s2 = len(t2.__args__)
+        s1 = len(t1.dims)
+        s2 = len(t2.dims)
 
-        new_t1 = list(t1.__args__)
-        new_t2 = list(t2.__args__)
+        new_t1 = list(t1.dims)
+        new_t2 = list(t2.dims)
 
         # We make the types the same length which is the first requirement
         # for consistency
@@ -268,8 +268,8 @@ def transpose_inference_rule(n: Node) -> Any:
             return n.type
 
         elif isinstance(t, TensorType):
-            if 0 <= dim1 < len(t.__args__) and 0 <= dim2 < len(t.__args__):
-                new_type = list(t.__args__)
+            if 0 <= dim1 < len(t.dims) and 0 <= dim2 < len(t.dims):
+                new_type = list(t.dims)
                 new_type[dim1], new_type[dim2] = new_type[dim2], new_type[dim1]
                 final = TensorType(new_type)
                 n.type = get_greatest_upper_bound(n.type, final)
@@ -315,7 +315,7 @@ def reshape_inference_rule(n: Node) -> TensorType:
     elif isinstance(t1, TensorType):
         if not isinstance(t1, TensorType):
             raise AssertionError(f"Expected TensorType, got {type(t1)}")
-        a = [e if e != Dyn else 1 for e in t1.__args__]
+        a = [e if e != Dyn else 1 for e in t1.dims]
         p1 = reduce(operator.mul, a)
         p2 = reduce(operator.mul, t2)
         if p1 % p2 == 0 or p2 % p1 == 0:
@@ -348,8 +348,8 @@ def bn2d_inference_rule(n: Node, module_instance: Any) -> Any:
     # and any existing annotation
     # we also check for consistency between both annotations
     if (
-        is_consistent(arg_type.__args__[1], module_instance.num_features)
-        and is_consistent(n.type.__args__[1], module_instance.num_features)
+        is_consistent(arg_type.dims[1], module_instance.num_features)
+        and is_consistent(n.type.dims[1], module_instance.num_features)
         and is_consistent(arg_type, n.type)
     ):
         # we choose the more precise type
@@ -419,7 +419,7 @@ def get_greatest_upper_bound(type1: Any, type2: Any) -> Any:
             raise TypeError(f"Inconsistent types {type1}, {type2}")
         gub = [
             t1 if is_more_precise(t1, t2) else t2
-            for (t1, t2) in zip(type1.__args__, type2.__args__)
+            for (t1, t2) in zip(type1.dims, type2.dims)
         ]
         return TensorType(tuple(gub))
 
@@ -440,13 +440,13 @@ def conv2d_inference_rule(n: Node, module_instance: Any) -> Any:
     arg_type = n.args[0].type
     curr_node_type = expand_to_tensor_dim(n.type, 4)
 
-    if is_consistent(arg_type.__args__[1], module_instance.in_channels):
-        w_in = arg_type.__args__[3]
-        h_in = arg_type.__args__[2]
+    if is_consistent(arg_type.dims[1], module_instance.in_channels):
+        w_in = arg_type.dims[3]
+        h_in = arg_type.dims[2]
         h_out = calculate_out_dimension(h_in, module_instance, 0)
         w_out = calculate_out_dimension(w_in, module_instance, 1)
         new_type = TensorType(
-            (arg_type.__args__[0], module_instance.out_channels, h_out, w_out)
+            (arg_type.dims[0], module_instance.out_channels, h_out, w_out)
         )
         gub = get_greatest_upper_bound(new_type, curr_node_type)
         n.type = gub
@@ -466,7 +466,7 @@ def relu_inference_rule(n: Node, module_instance: Any) -> Any:
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
     if n.args[0].type == Dyn and isinstance(n.type, TensorType):
-        n.args[0].type = expand_to_tensor_dim(n.args[0].type, len(n.type.__args__))
+        n.args[0].type = expand_to_tensor_dim(n.args[0].type, len(n.type.dims))
 
     if isinstance(n.args[0].type, TensorType):
         n.type = get_greatest_upper_bound(n.args[0].type, n.type)
@@ -478,7 +478,7 @@ def maxpool2d_check(typ: Any, module_instance: Any) -> TensorType:
     Applies the maxpool2d shape information to the input
     this affects the last two dimensions
     """
-    new_type_list = list(typ.__args__)
+    new_type_list = list(typ.dims)
     if len(new_type_list) == 4 or len(new_type_list) == 3:
         w_in = new_type_list[-1]
         h_in = new_type_list[-2]
@@ -510,7 +510,7 @@ def maxpool2d_inference_rule(n: Node, module_instance: Any) -> Any:
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
     if n.args[0].type == Dyn and isinstance(n.type, TensorType):
-        n.args[0].type = expand_to_tensor_dim(n.args[0].type, len(n.type.__args__))
+        n.args[0].type = expand_to_tensor_dim(n.args[0].type, len(n.type.dims))
     if isinstance(n.args[0].type, TensorType):
         output = maxpool2d_check(n.args[0].type, module_instance)
         n.type = get_greatest_upper_bound(output, n.type)
@@ -522,14 +522,14 @@ def linear_check(tensor_type: Any, module_instance: Any) -> TensorType:
     Checks that an input tensor type satisfies the conditions for linear operation
     and returns the output type based on in and out features given by module_instance
     """
-    if len(tensor_type.__args__) >= 2:
-        if is_consistent(module_instance.in_features, tensor_type.__args__[-1]):
-            new_type_args = list(tensor_type.__args__)
+    if len(tensor_type.dims) >= 2:
+        if is_consistent(module_instance.in_features, tensor_type.dims[-1]):
+            new_type_args = list(tensor_type.dims)
             new_type_args[-1] = module_instance.out_features
             return TensorType(tuple(new_type_args))
         else:
             raise TypeError(
-                f"Inconsistent {module_instance.in_features} and {tensor_type.__args__[-1]} in {module_instance}"
+                f"Inconsistent {module_instance.in_features} and {tensor_type.dims[-1]} in {module_instance}"
             )
     else:
         raise TypeError(f"Type {tensor_type} must have rank 2 or more.")
@@ -544,7 +544,7 @@ def linear_inference_rule(n: Node, module_instance: Any) -> Any:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     if n.args[0].type == Dyn and isinstance(n.type, TensorType):
-        n.args[0].type = expand_to_tensor_dim(n.args[0].type, len(n.type.__args__))
+        n.args[0].type = expand_to_tensor_dim(n.args[0].type, len(n.type.dims))
     if isinstance(n.args[0].type, TensorType):
         output_type = linear_check(n.args[0].type, module_instance)
         n.type = get_greatest_upper_bound(output_type, n.type)
@@ -562,9 +562,9 @@ def adaptiveavgpool2d_check(tensor_type: Any, module_instance: Any) -> TensorTyp
         if output_size[1] is None:
             output_size[1] = output_size[0]
 
-    new_type_list = list(tensor_type.__args__)
+    new_type_list = list(tensor_type.dims)
 
-    if len(tensor_type.__args__) == 4 or len(tensor_type.__args__) == 3:
+    if len(tensor_type.dims) == 4 or len(tensor_type.dims) == 3:
         new_type_list[-1] = output_size[1]
         new_type_list[-2] = output_size[0]
 
@@ -583,7 +583,7 @@ def adaptiveavgpool2d_inference_rule(n: Node, module_instance: Any) -> Any:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     if n.args[0].type == Dyn and isinstance(n.type, TensorType):
-        n.args[0].type = expand_to_tensor_dim(n.args[0].type, len(n.type.__args__))
+        n.args[0].type = expand_to_tensor_dim(n.args[0].type, len(n.type.dims))
     if isinstance(n.args[0].type, TensorType):
         output_type = adaptiveavgpool2d_check(n.args[0].type, module_instance)
         n.type = get_greatest_upper_bound(n.type, output_type)
@@ -591,13 +591,13 @@ def adaptiveavgpool2d_inference_rule(n: Node, module_instance: Any) -> Any:
 
 
 def flatten_check(tensor_type: Any, start_dim: int, end_dim: int) -> TensorType:
-    l = len(tensor_type.__args__)
+    l = len(tensor_type.dims)
 
     start_dim = l if start_dim == -1 else abs(start_dim)
     end_dim = l + end_dim + 1 if end_dim < 0 else end_dim + 1
 
     if 0 <= start_dim <= (l - 1) and 0 <= end_dim <= l and start_dim < end_dim:
-        my_args = list(tensor_type.__args__)
+        my_args = list(tensor_type.dims)
         lhs = my_args[0:start_dim]
         rhs = my_args[end_dim:]
         mid = my_args[start_dim:end_dim]
@@ -637,7 +637,7 @@ def flatten_inference_rule(n: Node) -> Any:
         end_dim = n.args[2]
 
     if n.args[0].type == Dyn and isinstance(n.type, TensorType):
-        n.args[0].type = expand_to_tensor_dim(n.args[0].type, len(n.type.__args__))
+        n.args[0].type = expand_to_tensor_dim(n.args[0].type, len(n.type.dims))
 
     if isinstance(n.args[0].type, TensorType):
         output_type = flatten_check(n.args[0].type, start_dim, end_dim)
@@ -738,7 +738,7 @@ def conv_refinement_rule(n: Node) -> list[Any] | None:
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     arg_type = n.args[0].type
     if isinstance(arg_type, TensorType) and isinstance(n.type, TensorType):
-        res = [Equality(arg_type.__args__[0], n.type.__args__[0])]
+        res = [Equality(arg_type.dims[0], n.type.dims[0])]
         return res
 
 
@@ -753,7 +753,7 @@ def linear_refinement_rule(n: Node) -> list[Any]:
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     arg_type = n.args[0].type
     if isinstance(arg_type, TensorType) and isinstance(n.type, TensorType):
-        res = [Equality(arg_type.__args__[0], n.type.__args__[0])]
+        res = [Equality(arg_type.dims[0], n.type.dims[0])]
     return res
 
 
@@ -768,8 +768,8 @@ def all_eq(n: Node) -> list[Any]:
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     arg_type = n.args[0].type
     if isinstance(arg_type, TensorType) and isinstance(n.type, TensorType):
-        args1 = arg_type.__args__
-        args2 = n.type.__args__
+        args1 = arg_type.dims
+        args2 = n.type.dims
         res = [Equality(args1[i], args2[i]) for i in range(len(args1))]
     return res
 
@@ -786,8 +786,8 @@ def first_two_eq(n: Node) -> list[Any]:
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     arg_type = n.args[0].type
     if isinstance(arg_type, TensorType) and isinstance(n.type, TensorType):
-        args1 = arg_type.__args__
-        args2 = n.type.__args__
+        args1 = arg_type.dims
+        args2 = n.type.dims
         res = [Equality(args1[0], args2[0]), Equality(args1[1], args2[1])]
     return res
 
@@ -820,9 +820,9 @@ def element_wise_eq(n: Node) -> list[Any]:
         ):
             args1, args2 = broadcast_types(arg_type1, arg_type2)
             # by this point, we know that args1 and args2 are the same size.
-            a1 = args1.__args__
-            a2 = args2.__args__
-            a3 = n.type.__args__
+            a1 = args1.dims
+            a2 = args2.dims
+            a3 = n.type.dims
 
             # we would be here in the second iteration where we establish equality
             # between operand type dimensions and the resulting type dimensions
@@ -859,15 +859,15 @@ def flatten_refinement_rule(n: Node) -> list[Any]:
         end_dim = n.args[2]
 
     if isinstance(n.type, TensorType) and isinstance(n.args[0].type, TensorType):
-        l = len(n.type.__args__)
+        l = len(n.type.dims)
         arg_type = n.args[0].type
         start_dim = l if start_dim == -1 else start_dim
         end_dim = l + end_dim + 1 if end_dim < 0 else end_dim + 1
 
-        for t1, t2 in zip(n.type.__args__[0:start_dim], arg_type.__args__[0:start_dim]):
+        for t1, t2 in zip(n.type.dims[0:start_dim], arg_type.dims[0:start_dim]):
             eq_const.append(Equality(t1, t2))
 
-        for t1, t2 in zip(n.type.__args__[end_dim:], arg_type.__args__[end_dim:]):
+        for t1, t2 in zip(n.type.dims[end_dim:], arg_type.dims[end_dim:]):
             eq_const.append(Equality(t1, t2))
     return eq_const
 
@@ -882,11 +882,11 @@ def conv_rule(n: Node, module_instance: Any) -> TensorType | None:
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     arg_type = n.args[0].type
     if isinstance(arg_type, TensorType) and isinstance(n.type, TensorType):
-        w_in = arg_type.__args__[3]
-        h_in = arg_type.__args__[2]
+        w_in = arg_type.dims[3]
+        h_in = arg_type.dims[2]
         h_out = calculate_out_dimension(h_in, module_instance, 0)
         w_out = calculate_out_dimension(w_in, module_instance, 1)
-        new_type = TensorType((n.type.__args__[0], n.type.__args__[1], h_out, w_out))
+        new_type = TensorType((n.type.dims[0], n.type.dims[1], h_out, w_out))
         n.type = new_type
         return new_type
 
@@ -931,7 +931,7 @@ class Refine:
             new_symbol = Var(next(self.symbol_iter))
             return new_symbol
         elif isinstance(typ, TensorType):
-            new_args = [self.replace_dyn_with_fresh_var(a) for a in typ.__args__]
+            new_args = [self.replace_dyn_with_fresh_var(a) for a in typ.dims]
             return TensorType(tuple(new_args))
         elif isinstance(typ, list):
             return [self.replace_dyn_with_fresh_var(t) for t in typ]
@@ -947,7 +947,7 @@ class Refine:
         if isinstance(typ, Var):
             return sympy.symbols(str(typ))
         elif isinstance(typ, TensorType):
-            new_args = [self.convert_to_sympy_symbols(a) for a in typ.__args__]
+            new_args = [self.convert_to_sympy_symbols(a) for a in typ.dims]
             return TensorType(tuple(new_args))
         elif isinstance(typ, list):
             return [self.convert_to_sympy_symbols(t) for t in typ]

--- a/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
@@ -317,20 +317,20 @@ def generate_binconstraint_t(
         if constraint.lhs == Dyn:
             return T(), counter
         elif isinstance(constraint.lhs, TensorType):
-            is_fully_static = all(d != Dyn for d in constraint.lhs.__args__)
+            is_fully_static = all(d != Dyn for d in constraint.lhs.dims)
             if is_fully_static:
                 return BinConstraintT(constraint.lhs, constraint.rhs, op_eq), counter
             else:
                 new_dims = []
 
-                for _ in range(len(constraint.lhs.__args__)):
+                for _ in range(len(constraint.lhs.dims)):
                     dim, counter = gen_dvar(counter)
                     new_dims.append(dim)
 
                 new_dim_constraints = (
                     [
                         BinConstraintD(old_dim, new_dim, op_precision)
-                        for new_dim, old_dim in zip(new_dims, constraint.lhs.__args__)
+                        for new_dim, old_dim in zip(new_dims, constraint.lhs.dims)
                     ]
                     + [BinConstraintT(constraint.rhs, TensorType(new_dims), op_eq)]
                     + [BinConstraintD(1, new_dim, op_leq) for new_dim in new_dims]
@@ -343,10 +343,10 @@ def generate_binconstraint_t(
     elif constraint.op == op_matching:
         if not isinstance(constraint.rhs, TensorType):
             raise AssertionError(f"Expected TensorType, got {type(constraint.rhs)}")
-        d1 = constraint.rhs.__args__[0]
-        d2 = constraint.rhs.__args__[1]
-        d3 = constraint.rhs.__args__[2]
-        d4 = constraint.rhs.__args__[3]
+        d1 = constraint.rhs.dims[0]
+        d2 = constraint.rhs.dims[1]
+        d3 = constraint.rhs.dims[2]
+        d4 = constraint.rhs.dims[3]
 
         conj = [
             BinConstraintT(constraint.lhs, Dyn, op_eq),
@@ -670,7 +670,7 @@ def generate_reshape(constraint: Constraint, counter: int) -> tuple[Constraint, 
     d3 = d[2]
     d4 = d[3]
 
-    target = constraint.target.__args__
+    target = constraint.target.dims
 
     is_fully_static = all(d != Dyn for d in target)
 
@@ -1345,14 +1345,12 @@ def gen_greatest_upper_bound(
             BinConstraintT(constraint.res, c3tensor, op_eq),
         ] + gen_nat_constraints(dims1 + dims2 + dims3)
 
-        if not (
-            len(c3tensor.__args__) == len(c1tensor.__args__) == len(c2tensor.__args__)
-        ):
+        if not (len(c3tensor.dims) == len(c1tensor.dims) == len(c2tensor.dims)):
             raise AssertionError("Tensor args lengths must be equal")
-        for i in range(len(c3tensor.__args__)):
+        for i in range(len(c3tensor.dims)):
             c.append(
                 DGreatestUpperBound(
-                    c3tensor.__args__[i], c1tensor.__args__[i], c2tensor.__args__[i]
+                    c3tensor.dims[i], c1tensor.dims[i], c2tensor.dims[i]
                 )
             )
 

--- a/torch/fx/experimental/migrate_gradual_types/transform_to_z3.py
+++ b/torch/fx/experimental/migrate_gradual_types/transform_to_z3.py
@@ -280,23 +280,23 @@ try:
         """
         if isinstance(tensor, TensorType):
             res: list[_Z3Expr] = []
-            for t in tensor.__args__:
+            for t in tensor.dims:
                 transformed, counter = transform_dimension(t, counter, dimension_dict)
                 res.append(transformed)
 
             if len(res) > 4:
                 raise AssertionError(f"Expected res length <= 4, got {len(res)}")
-            if len(tensor.__args__) == 1:
+            if len(tensor.dims) == 1:
                 return tensor_type.tensor1(res[0]), counter
-            elif len(tensor.__args__) == 2:
+            elif len(tensor.dims) == 2:
                 return tensor_type.tensor2(res[0], res[1]), counter
-            elif len(tensor.__args__) == 3:
+            elif len(tensor.dims) == 3:
                 return tensor_type.tensor3(res[0], res[1], res[2]), counter
-            elif len(tensor.__args__) == 4:
+            elif len(tensor.dims) == 4:
                 return tensor_type.tensor4(res[0], res[1], res[2], res[3]), counter
             else:
                 raise AssertionError(
-                    f"Unexpected tensor args length: {len(tensor.__args__)}"
+                    f"Unexpected tensor args length: {len(tensor.dims)}"
                 )
 
         elif tensor == Dyn:

--- a/torch/fx/experimental/unify_refinements.py
+++ b/torch/fx/experimental/unify_refinements.py
@@ -83,7 +83,7 @@ def substitute_solution_one_type(mapping: dict[object, object], t: object) -> An
 
     elif isinstance(t, TensorType):
         new_type = []
-        for typ in t.__args__:
+        for typ in t.dims:
             if typ in mapping:
                 new_type.append(mapping[typ])
             else:

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -31,6 +31,7 @@ from . import _pytree as fx_pytree
 from ._compatibility import compatibility
 from .immutable_collections import immutable_dict
 from .node import _get_qualified_name, _type_repr, Argument, Node, Target
+from .tensor_type import TensorType
 
 
 log = logging.getLogger(__name__)
@@ -555,7 +556,7 @@ class CodeGen:
             typename = _type_repr(o)
             if isinstance(o, types.UnionType) and "|" in typename:
                 # str | int
-                args = [type_repr(arg) for arg in o.__args__]
+                args = [type_repr(arg) for arg in typing.get_args(o)]
                 return "|".join(args)
 
             if origin_type := getattr(o, "__origin__", None):
@@ -567,8 +568,12 @@ class CodeGen:
 
                 origin_typename = add_global(_type_repr(origin_type), origin_type)
 
-                if hasattr(o, "__args__") and o.__args__:
-                    args = [type_repr(arg) for arg in o.__args__]
+                if isinstance(o, TensorType):
+                    type_args = o.dims
+                else:
+                    type_args = typing.get_args(o)
+                if type_args:
+                    args = [type_repr(arg) for arg in type_args]
                     return f"{origin_typename}[{','.join(args)}]"
                 else:
                     return origin_typename

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -319,11 +319,11 @@ def type_matches(signature_type: Any, argument_type: Any) -> bool:
     # Union types in signature. Given type needs to match one of the
     # contained types in the Union
     if sig_origin_type is typing.Union and signature_type != argument_type:
-        sig_contained = signature_type.__args__
+        sig_contained = typing.get_args(signature_type)
         return any(type_matches(c, argument_type) for c in sig_contained)
 
     if getattr(signature_type, "__origin__", None) is list:
-        sig_el_type = signature_type.__args__[0]
+        sig_el_type = typing.get_args(signature_type)[0]
 
         # int can be promoted to list[int]
         if argument_type is int and sig_el_type is int:
@@ -335,7 +335,7 @@ def type_matches(signature_type: Any, argument_type: Any) -> bool:
             )
             return False
         if getattr(argument_type, "__origin__", None) is list:
-            return issubclass(argument_type.__args__[0], sig_el_type)
+            return issubclass(typing.get_args(argument_type)[0], sig_el_type)
 
         def is_homogeneous_tuple(t: object) -> bool:
             if typing.get_origin(t) is not tuple:

--- a/torch/fx/passes/annotate_getitem_nodes.py
+++ b/torch/fx/passes/annotate_getitem_nodes.py
@@ -1,4 +1,5 @@
 import operator
+import typing
 
 import torch
 
@@ -22,7 +23,7 @@ def annotate_getitem_nodes(graph: torch.fx.Graph) -> None:
                 continue
             # container types
             if hasattr(sequence_node.type, "_name"):
-                parameterized_types = sequence_node.type.__args__
+                parameterized_types = typing.get_args(sequence_node.type)
                 if sequence_node.type._name == "Tuple":
                     if len(parameterized_types) == 2 and isinstance(
                         parameterized_types[1], type(...)
@@ -44,7 +45,7 @@ def annotate_getitem_nodes(graph: torch.fx.Graph) -> None:
                     node.type = parameterized_types[0]
             # Generic Alias Type
             elif hasattr(sequence_node.type, "__origin__"):
-                parameterized_types = sequence_node.type.__args__
+                parameterized_types = typing.get_args(sequence_node.type)
                 if sequence_node.type.__origin__ is tuple:
                     if len(parameterized_types) == 2 and isinstance(
                         parameterized_types[1], type(...)

--- a/torch/fx/tensor_type.py
+++ b/torch/fx/tensor_type.py
@@ -26,18 +26,20 @@ class TensorType:
                 return torch.add(x, y)
     """
 
-    __args__: Sequence[DVar | int | _DynType]
-
     def __init__(self, dim: Sequence[Any]) -> None:
         self.__origin__ = TensorType
         self.__args__ = dim
 
+    @property
+    def dims(self) -> Sequence[DVar | int | _DynType]:
+        return self.__args__
+
     def __repr__(self) -> str:
-        return f"TensorType[{self.__args__}]"
+        return f"TensorType[{self.dims}]"
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, self.__class__):
-            return list(self.__args__) == list(other.__args__)
+            return list(self.dims) == list(other.dims)
         else:
             return False
 
@@ -89,9 +91,8 @@ def is_consistent(t1: object, t2: object) -> bool:
         return True
 
     if isinstance(t1, TensorType) and isinstance(t2, TensorType):
-        return len(t1.__args__) == len(t2.__args__) and all(
-            is_consistent(elem1, elem2)
-            for elem1, elem2 in zip(t1.__args__, t2.__args__)
+        return len(t1.dims) == len(t2.dims) and all(
+            is_consistent(elem1, elem2) for elem1, elem2 in zip(t1.dims, t2.dims)
         )
     else:
         return False
@@ -116,9 +117,8 @@ def is_more_precise(t1: object, t2: object) -> bool:
         return True
 
     if isinstance(t1, TensorType) and isinstance(t2, TensorType):
-        return len(t1.__args__) == len(t2.__args__) and all(
-            is_more_precise(elem1, elem2)
-            for elem1, elem2 in zip(t1.__args__, t2.__args__)
+        return len(t1.dims) == len(t2.dims) and all(
+            is_more_precise(elem1, elem2) for elem1, elem2 in zip(t1.dims, t2.dims)
         )
 
     else:

--- a/torch/utils/data/datapipes/_typing.py
+++ b/torch/utils/data/datapipes/_typing.py
@@ -23,6 +23,7 @@ from typing import (
     Any,
     ForwardRef,
     Generic,
+    get_args,
     get_type_hints,
     TypeVar,
     Union,
@@ -111,7 +112,7 @@ def _decompose_type(t, to_list=True):
             # For T_co, __constraints__ is ()
             ts = list(t.__constraints__)
     elif hasattr(t, "__origin__") and t.__origin__ == Union:
-        ts = t.__args__
+        ts = get_args(t)
     else:
         if not to_list:
             return None
@@ -153,8 +154,7 @@ def _issubtype_with_constraints(variant, constraints, recursive=True):
     # Variant is not TypeVar or Union
     if hasattr(variant, "__origin__") and variant.__origin__ is not None:
         v_origin = variant.__origin__
-        # In Python-3.9 typing library untyped generics do not have args
-        v_args = getattr(variant, "__args__", None)
+        v_args = get_args(variant) or None
     else:
         v_origin = variant
         v_args = None
@@ -175,8 +175,7 @@ def _issubtype_with_constraints(variant, constraints, recursive=True):
                 if v_origin == c_origin:
                     if not recursive:
                         return True
-                    # In Python-3.9 typing library untyped generics do not have args
-                    c_args = getattr(constraint, "__args__", None)
+                    c_args = get_args(constraint) or None
                     if c_args is None or len(c_args) == 0:
                         return True
                     if (
@@ -200,8 +199,7 @@ def issubinstance(data, data_type):
     if not issubtype(type(data), data_type, recursive=False):
         return False
 
-    # In Python-3.9 typing library __args__ attribute is not defined for untyped generics
-    dt_args = getattr(data_type, "__args__", None)
+    dt_args = get_args(data_type) or None
     if isinstance(data, tuple):
         if dt_args is None or len(dt_args) == 0:
             return True
@@ -455,7 +453,7 @@ def _dp_init_subclass(sub_cls, *args, **kwargs) -> None:
                         sub_cls.__name__, _type_repr(hints["return"])
                     )
                 )
-            data_type = return_hint.__args__[0]
+            data_type = get_args(return_hint)[0]
             if not issubtype(data_type, sub_cls.type.param):
                 raise TypeError(
                     f"Expected return type of '__iter__' as a subtype of {sub_cls.type},"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183006

Addresses #169073. Two changes:

1. TensorType (torch/fx/tensor_type.py) was using __args__ and __origin__
   to mimic a typing generic, but it's actually a domain type representing
   tensor dimensions. Added a `dims` property and migrated all internal
   usages from `.__args__` to `.dims` (the backing `__args__` attribute
   is kept for backward compat). This removes the confusion about whether
   TensorType should be accessed via typing.get_args().

2. Replaced all remaining `.__args__` accesses on standard typing generics
   (Union, List, Tuple, etc.) with `typing.get_args()`, the recommended
   public API. Covers operator_schemas, graph codegen, dynamo variables,
   inductor fuzzer, datapipes typing, and several other modules.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98