### PR TITLE
[inductor] Fix torch.compile bypassing device mismatch in index_add/copy/reduce

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -413,6 +413,16 @@ static void index_func_meta_impl(
       self.sizes(),
       " source.shape = ",
       source.sizes());
+  TORCH_CHECK(
+      self.device() == source.device() && self.device() == index.device(),
+      func,
+      "_(): self, index and source expected to be in the same device, "
+      "but got (self) ",
+      self.device(),
+      ", (index) ",
+      index.device(),
+      ", and (source) ",
+      source.device());
 
   auto& result = meta.maybe_get_output(0);
   bool is_defined = result.defined();

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -14256,6 +14256,24 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertEqual(ref, actual)
         self.assertTrue(called)
 
+    @requires_gpu()
+    def test_index_add_device_mismatch(self):
+        if self.device == "cpu":
+            raise unittest.SkipTest("requires GPU for device mismatch test")
+
+        def fn(x, source):
+            index = torch.randperm(x.size(0))
+            return torch.index_add(x, 0, index, source)
+
+        x = torch.randn(10, 3, device=self.device)
+        source = torch.randn(10, 3, device=self.device)
+
+        with self.assertRaises(RuntimeError):
+            fn(x, source)
+
+        with self.assertRaises(RuntimeError):
+            torch.compile(fn)(x, source)
+
     @skip_if_gpu_halide  # cuda error
     def test_mutations_loop_fusion(self):
         def fn(tensor, index, source):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -14257,12 +14257,17 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertTrue(called)
 
     @requires_gpu()
-    def test_index_add_device_mismatch(self):
+    @parametrize("inplace", [False, True])
+    def test_index_add_device_mismatch(self, inplace):
         if self.device == "cpu":
             raise unittest.SkipTest("requires GPU for device mismatch test")
 
         def fn(x, source):
             index = torch.randperm(x.size(0))
+            if inplace:
+                x = x.clone()
+                x.index_add_(0, index, source)
+                return x
             return torch.index_add(x, 0, index, source)
 
         x = torch.randn(10, 3, device=self.device)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3089,17 +3089,11 @@ def _index_add(
 ):
     dim = utils.canonicalize_dims(x.ndim, dim)
     torch._check(
-        x.device == index.device,
+        x.device == index.device and x.device == tensor.device,
         lambda: (
-            f"index_add(): Expected all tensors to be on the same device, "
-            f"but got index on {index.device} and self on {x.device}"
-        ),
-    )
-    torch._check(
-        x.device == tensor.device,
-        lambda: (
-            f"index_add(): Expected all tensors to be on the same device, "
-            f"but got source on {tensor.device} and self on {x.device}"
+            f"index_add(): self, index and source expected to be in the same device, "
+            f"but got (self) {x.device}, (index) {index.device}, "
+            f"and (source) {tensor.device}"
         ),
     )
     torch._check(
@@ -3184,6 +3178,14 @@ def _index_copy(
     x: TensorLike, dim: int, index: TensorLike, tensor: TensorLike, *, inplace: bool
 ):
     dim = utils.canonicalize_dims(x.ndim, dim)
+    torch._check(
+        x.device == index.device and x.device == tensor.device,
+        lambda: (
+            f"index_copy(): self, index and source expected to be in the same device, "
+            f"but got (self) {x.device}, (index) {index.device}, "
+            f"and (source) {tensor.device}"
+        ),
+    )
     torch._check(
         index.ndim <= 1,
         lambda: f"Index should have dimension 1 or 0 (got {index.ndim})",

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3089,6 +3089,20 @@ def _index_add(
 ):
     dim = utils.canonicalize_dims(x.ndim, dim)
     torch._check(
+        x.device == index.device,
+        lambda: (
+            f"index_add(): Expected all tensors to be on the same device, "
+            f"but got index on {index.device} and self on {x.device}"
+        ),
+    )
+    torch._check(
+        x.device == tensor.device,
+        lambda: (
+            f"index_add(): Expected all tensors to be on the same device, "
+            f"but got source on {tensor.device} and self on {x.device}"
+        ),
+    )
+    torch._check(
         index.ndim <= 1,
         lambda: f"Index should have dimension 1 or 0 (got {index.ndim})",
     )

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -1065,6 +1065,14 @@ def index_reduce(
     *,
     include_self: bool = True,
 ) -> torch.Tensor:
+    torch._check(
+        self.device == index.device and self.device == src.device,
+        lambda: (
+            f"index_reduce(): self, index and source expected to be in the same device, "
+            f"but got (self) {self.device}, (index) {index.device}, "
+            f"and (source) {src.device}"
+        ),
+    )
     if reduction_type == "mean" and not needs_fallback_due_to_atomic_add_limitations(
         self.dtype
     ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183007

torch.compile silently succeeded when index_add/index_copy/index_reduce
received a CPU index tensor with CUDA data tensors. Eager mode correctly
raises RuntimeError.

The root cause: during AOT autograd, these ops decompose into index_put,
which legitimately allows CPU indices with CUDA tensors. The
ConstructorMoverPass then moves randperm from CPU to CUDA as an
optimization, completely masking the device mismatch.

The fix adds device consistency checks to the _index_add and _index_copy
decompositions in torch/_decomp/decompositions.py and to the index_reduce
decomposition in torch/_inductor/decomposition.py, so the error is raised
during tracing before index_put or ConstructorMoverPass run. Also adds the
same check to the C++ meta function index_func_meta_impl (shared by
index_add and index_reduce) for consistency with the existing index_copy
meta check.

Fixes #172184

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo