### PR TITLE
Add dtype equality check to mm/bmm meta functions

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -291,7 +291,7 @@ template <typename Meta>
 static void common_checks_baddbmm_bmm(Meta& meta, const Tensor& batch1, const Tensor& batch2, const Scalar& beta, const Scalar& alpha, bool is_bmm, const std::optional<Tensor>& self_baddbmm = std::nullopt) {
   TORCH_CHECK(batch1.dim() == 3, "batch1 must be a 3D tensor");
   TORCH_CHECK(batch2.dim() == 3, "batch2 must be a 3D tensor");
-  TORCH_CHECK(batch1.scalar_type() == batch2.scalar_type(), "batch1 and batch2 must have the same dtype, but got ", batch1.scalar_type(), " and ", batch2.scalar_type());
+  TORCH_CHECK(batch1.scalar_type() == batch2.scalar_type(), "expected scalar type ", batch1.scalar_type(), " but found ", batch2.scalar_type());
 
   const auto batch1_sizes = batch1.sizes();
   const auto batch2_sizes = batch2.sizes();

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -200,6 +200,7 @@ TORCH_META_FUNC(_addmm_activation)(const Tensor& self, const Tensor& mat1, const
 }
 
 TORCH_META_FUNC(mm)(const Tensor & self, const Tensor & mat2) {
+  TORCH_CHECK(self.scalar_type() == mat2.scalar_type(), "self and mat2 must have the same dtype, but got ", self.scalar_type(), " and ", mat2.scalar_type());
   TORCH_CHECK(self.dim() == 2, "self must be a matrix");
   TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix");
   TORCH_CHECK(
@@ -290,6 +291,7 @@ template <typename Meta>
 static void common_checks_baddbmm_bmm(Meta& meta, const Tensor& batch1, const Tensor& batch2, const Scalar& beta, const Scalar& alpha, bool is_bmm, const std::optional<Tensor>& self_baddbmm = std::nullopt) {
   TORCH_CHECK(batch1.dim() == 3, "batch1 must be a 3D tensor");
   TORCH_CHECK(batch2.dim() == 3, "batch2 must be a 3D tensor");
+  TORCH_CHECK(batch1.scalar_type() == batch2.scalar_type(), "batch1 and batch2 must have the same dtype, but got ", batch1.scalar_type(), " and ", batch2.scalar_type());
 
   const auto batch1_sizes = batch1.sizes();
   const auto batch2_sizes = batch2.sizes();

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10738,6 +10738,24 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         with self.assertRaisesRegex(RuntimeError, "expected scalar type .* but found"):
             torch.compile(lambda x, y: torch.matmul(x, y), fullgraph=True)(a, b)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_mm_matmul_2d_mixed_dtype_error(self):
+        a = torch.randn(8, 8, device="cuda", dtype=torch.float16)
+        b = torch.randn(8, 64, device="cuda", dtype=torch.float32)
+        err = "same dtype|expected scalar type"
+
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.mm(a, b)
+
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.compile(lambda x, y: torch.mm(x, y), fullgraph=True)(a, b)
+
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.matmul(a, b)
+
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.compile(lambda x, y: torch.matmul(x, y), fullgraph=True)(a, b)
+
     def test_conj_neg_tolist(self):
         x = torch.randn(2, dtype=torch.cfloat)
         y1 = x.conj()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10738,11 +10738,10 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         with self.assertRaisesRegex(RuntimeError, "expected scalar type .* but found"):
             torch.compile(lambda x, y: torch.matmul(x, y), fullgraph=True)(a, b)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_mm_matmul_2d_mixed_dtype_error(self):
-        a = torch.randn(8, 8, device="cuda", dtype=torch.float16)
-        b = torch.randn(8, 64, device="cuda", dtype=torch.float32)
-        err = "same dtype|expected scalar type"
+        a = torch.randn(8, 8, dtype=torch.float16)
+        b = torch.randn(8, 64, dtype=torch.float32)
+        err = "same dtype"
 
         with self.assertRaisesRegex(RuntimeError, err):
             torch.mm(a, b)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2465,6 +2465,10 @@ def meta__fused_moving_avg_obs_fq_helper(
 def meta_mm(a, b, out_dtype: torch.dtype | None = None):
     torch._check(a.dim() == 2, lambda: "a must be 2D")
     torch._check(b.dim() == 2, lambda: "b must be 2D")
+    torch._check(
+        a.dtype == b.dtype,
+        lambda: f"expected scalar type {a.dtype} but found {b.dtype}",
+    )
     N, M1 = a.shape
     M2, P = b.shape
     torch._check(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2465,10 +2465,11 @@ def meta__fused_moving_avg_obs_fq_helper(
 def meta_mm(a, b, out_dtype: torch.dtype | None = None):
     torch._check(a.dim() == 2, lambda: "a must be 2D")
     torch._check(b.dim() == 2, lambda: "b must be 2D")
-    torch._check(
-        a.dtype == b.dtype,
-        lambda: f"expected scalar type {a.dtype} but found {b.dtype}",
-    )
+    if not exp_config.skip_dtype_check_in_meta_registrations:
+        torch._check(
+            a.dtype == b.dtype,
+            lambda: f"self and mat2 must have the same dtype, but got {a.dtype} and {b.dtype}",
+        )
     N, M1 = a.shape
     M2, P = b.shape
     torch._check(
@@ -3827,6 +3828,11 @@ def meta_addbmm(self, batch1, batch2, *, beta=1, alpha=1):
     self = self.expand((dim1, dim2))
     torch._check(batch1.dim() == 3, lambda: "batch1 must be a 3D tensor")
     torch._check(batch2.dim() == 3, lambda: "batch2 must be a 3D tensor")
+    if not exp_config.skip_dtype_check_in_meta_registrations:
+        torch._check(
+            self.dtype == batch1.dtype == batch2.dtype,
+            lambda: f"Input dtypes must be the same, got: input: {self.dtype}, batch1: {batch1.dtype}, batch2: {batch2.dtype}",
+        )
     torch._check(
         batch1.size(0) == batch2.size(0),
         lambda: f"batch1 and batch2 must have same number of batches, got {batch1.size(0)} and {batch2.size(0)}",
@@ -4719,10 +4725,11 @@ def common_meta_baddbmm_bmm(batch1, batch2, is_bmm, self_baddbmm=None, out_dtype
 
     torch._check(batch1.dim() == 3, lambda: "batch1 must be a 3D tensor")
     torch._check(batch2.dim() == 3, lambda: "batch2 must be a 3D tensor")
-    torch._check(
-        batch1.dtype == batch2.dtype,
-        lambda: f"expected scalar type {batch1.dtype} but found {batch2.dtype}",
-    )
+    if not exp_config.skip_dtype_check_in_meta_registrations:
+        torch._check(
+            batch1.dtype == batch2.dtype,
+            lambda: f"expected scalar type {batch1.dtype} but found {batch2.dtype}",
+        )
 
     batch1_sizes = batch1.size()
     batch2_sizes = batch2.size()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183008

The meta functions for mm and bmm were missing dtype equality checks
that the actual CPU/CUDA kernels have. This meant FakeTensor tracing
during torch.compile would silently accept mismatched dtypes (e.g.
float16 @ float32) instead of raising an error like eager mode does.
This may surface latent bugs in user models that previously compiled
but produced wrong results in eager.

The primary fix is in meta_mm (Python), which is what FakeTensor
dispatch hits. meta_addbmm was also missing a dtype check entirely,
and common_meta_baddbmm_bmm's existing check was not gated on
skip_dtype_check_in_meta_registrations like meta_baddbmm's. Both are
now gated on that escape hatch for consistency. The C++ meta function
checks are defensive consistency to match what ADDMM_META() already
does.

Fixes #172183

Authored with Claude.