### PR TITLE
[Inductor] Fall back native_layer_norm; route var_mean through inductor lowering

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -6202,7 +6202,10 @@ class CPUReproTests(TestCase):
         with torch.no_grad():
             metrics.reset()
             torch.compile(model)(*example_batch)
-            check_metrics_vec_kernel_count(5)
+            # The original test checked for 5 vec kernels to verify add+layernorm
+            # fusion. native_layer_norm is now a fallback (extern kernel), so the
+            # remaining vec kernel count varies by ISA (1 on AVX2, 3 on AVX-512).
+            self.assertGreater(metrics.generated_cpp_vec_kernel_count, 0)
 
     def test_dropout(self):
         class Model(nn.Module):

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5000,8 +5000,10 @@ class CPUReproTests(TestCase):
             metrics.reset()
             _, code = run_and_get_cpp_code(opt_m, x)
             self.assertTrue(same(m(x), opt_m(x)))
-            # Two kernels: one for reduction, one pointwises
-            check_metrics_vec_kernel_count(4)
+            # Originally expected 4 vec kernels from LayerNorm decomposition.
+            # native_layer_norm is now a fallback (issue #168126); the remaining
+            # vec kernel count for the reshape/permute path is ISA-dependent.
+            self.assertGreater(metrics.generated_cpp_vec_kernel_count, 0)
             FileCheck().check_count(
                 "Vectorized<float>::loadu(tmpbuf.data())", 0, exactly=True
             ).run(code)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17903,6 +17903,10 @@ if RUN_GPU:
 
         def test_layer_norm_inplaces_after_matmul(self):
             # https://github.com/pytorch/pytorch/issues/132826
+            # Originally checked that the matmul output buffer is reused in-place
+            # by the LayerNorm Triton kernel. native_layer_norm is now a fallback
+            # (issue #168126), so there's no Triton kernel to do that reuse.
+            # Just keep the correctness check.
             batch_size = 32
             seq_length = 50
             hidden_size = 768
@@ -17919,8 +17923,6 @@ if RUN_GPU:
                 torch.randn(hidden_size, hidden_size, device=GPU_TYPE),
             ]
             fn_opt = torch.compile(fn)
-            code = run_and_get_triton_code(fn_opt, *inps)
-            self.assertTrue(len(re.findall(r"in_out_ptr\d+", code)) > 0)
             self.assertEqual(fn_opt(*inps), fn(*inps))
 
         @torch._functorch.config.patch("donated_buffer", True)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6404,6 +6404,23 @@ class CommonTemplate:
 
         self.common(foo, (inp, weight), check_lowp=False)
 
+    def test_layer_norm_numerics_under_autocast(self):
+        # https://github.com/pytorch/pytorch/issues/168126
+        norm = torch.nn.LayerNorm(128, eps=1e-5, device=self.device)
+        linear = torch.nn.Linear(128, 128, bias=False, device=self.device)
+
+        def f(x):
+            return linear(norm(x))
+
+        compiled_f = torch.compile(f, fullgraph=True)
+
+        with torch.autocast(device_type=self.device, dtype=torch.bfloat16):
+            torch.manual_seed(42)
+            x = torch.randn(4, 32, 32, 128, device=self.device)
+            out_eager = f(x)
+            out_compiled = compiled_f(x)
+            torch.testing.assert_close(out_eager, out_compiled)
+
     def test_transpose_add(self):
         def fn(a, b):
             return a.t() + b

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17630,7 +17630,7 @@ if RUN_GPU:
                 ),
                 (
                     fn3,
-                    "triton_poi_fused_native_layer_norm_relu",
+                    "triton_poi_fused_relu",
                     (torch.randn(4, 4, device=GPU_TYPE),),
                 ),
             ]
@@ -17643,7 +17643,7 @@ if RUN_GPU:
                 ),
                 (
                     fn3,
-                    "triton_poi_fused_LayerNorm_ReLU",
+                    "triton_poi_fused_ReLU",
                     (torch.randn(4, 4, device=GPU_TYPE),),
                 ),
             ]

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -35,7 +35,6 @@ from torch._prims_common import (
     suggest_memory_format,
     type_to_dtype,
 )
-from torch._refs import native_layer_norm as decomp_native_layer_norm
 from torch.fx.experimental.symbolic_shapes import guard_or_false, statically_known_true
 
 from . import config, inductor_prims
@@ -87,7 +86,6 @@ inductor_decompositions = get_decompositions(
         aten.batch_norm_backward,
         aten.native_batch_norm,
         aten.native_group_norm,
-        aten.native_layer_norm,
         aten.nll_loss2d_backward,
         aten.permute_copy,
         aten.rrelu_with_noise_backward,
@@ -118,7 +116,7 @@ decomps_to_exclude: list[torch._ops.OpOverload | torch._ops.OpOverloadPacket] = 
     aten.clamp_max,
     aten.clamp_min,
     aten.embedding_dense_backward,  # we fall back on xpu
-    aten.native_layer_norm,  # we fall back on mtia
+    aten.native_layer_norm,  # inductor uses make_fallback
     aten.index_add,  # we conditionally call this decomp
     aten.glu,  # inductor lowers this directly
     aten.select_scatter,  # need to be in the ATen graph in order for it to work with the re-inplacing pass
@@ -202,20 +200,6 @@ def _embedding_dense_backward(
     return decomp_embedding_dense_backward(
         grad_output, indices, num_weights, padding_idx, scale_grad_by_freq
     )
-
-
-@register_decomposition(aten.native_layer_norm)
-def _native_layer_norm(
-    input: torch.Tensor,
-    normalized_shape: utils.ShapeType,
-    weight: torch.Tensor | None,
-    bias: torch.Tensor | None,
-    eps: float,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    if input.is_mtia:
-        return NotImplemented
-    # We can write a util function to update decomp table if we have more ops to fallback.
-    return decomp_native_layer_norm(input, normalized_shape, weight, bias, eps)
 
 
 @register_decomposition([aten.sym_constrain_range_for_size.default])

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -116,7 +116,7 @@ decomps_to_exclude: list[torch._ops.OpOverload | torch._ops.OpOverloadPacket] = 
     aten.clamp_max,
     aten.clamp_min,
     aten.embedding_dense_backward,  # we fall back on xpu
-    aten.native_layer_norm,  # inductor uses make_fallback
+    aten.native_layer_norm,  # inductor uses make_fallback (issue #168126)
     aten.index_add,  # we conditionally call this decomp
     aten.glu,  # inductor lowers this directly
     aten.select_scatter,  # need to be in the ATen graph in order for it to work with the re-inplacing pass
@@ -126,6 +126,7 @@ decomps_to_exclude: list[torch._ops.OpOverload | torch._ops.OpOverloadPacket] = 
     aten.squeeze,  # inductor lowers this directly
     aten.sum,  # inductor lowers this directly
     aten.unbind,  # inductor lowers this directly
+    aten.var_mean,  # routes through inductor's coherent var_mean lowering (issue #168126)
     aten.baddbmm,  # upcasts to fp32, perf issue
     # FMA ops - we have lowerings that use FMA to match eager CUDA behavior
     aten.addcmul,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3379,10 +3379,7 @@ if torch.xpu._is_compiled():
         aten.embedding_dense_backward, warn=False
     )  # (XPU-only and faster than decomp)
 
-if torch.mtia._is_compiled():
-    make_fallback(
-        aten.native_layer_norm, warn=False
-    )  # (MTIA-only and faster than decomp)
+make_fallback(aten.native_layer_norm, warn=False)
 
 # 1.5) Easy or Impossible
 make_fallback(aten._cdist_forward)  # p=2 should be feasible


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183009

Under bf16 autocast, the native_layer_norm decomposition produces
slightly different fp32 results than the native kernel (~7e-7 max diff
from different reduction algorithms). The subsequent matmul rounds to
bf16, and values near bf16 rounding boundaries tip differently --
producing 1 ULP differences that compound through downstream operations
(einsum, etc.) into large numerical divergence (99.4% mismatch, max
rtol ~224,000x in the model from issue #168126).

There are two layered fixes here:

1. Make native_layer_norm a fallback unconditionally. The reference
   decomposition (torch/_refs/__init__.py) reads var and mean from
   separate reductions whose orders differ from the native Welford
   kernel; we can't close that gap without re-implementing the kernel.
   The native CUDA (cuDNN) and CPU (MKLDNN/native) implementations are
   well-optimized and memory-bound, so the loss of fusion opportunity is
   negligible. MTIA already did this; now it applies for all devices.

2. Exclude aten.var_mean from inductor's decomposition table so it
   reaches inductor's existing var_mean lowering at
   torch/_inductor/lowering.py:6938. Previously, _refs.var_mean split
   it into separate var() and mean() calls; var() lowered through
   var_mean_helper_ which internally computed a mean and discarded it,
   while mean() lowered to a separate sum/N reduction. _normalize then
   used these two different means in the same formula -- a latent
   internal-inconsistency bug. The new path returns coherent (var,
   mean) from a single computation. This benefits all callers of
   var_mean (BatchNorm, GroupNorm, std, std_mean, etc.) regardless of
   the LayerNorm fallback.

Updates four tests that were validating decomposition-induced fusion
behaviors no longer present with the fallback:
- test_kernel_names_descriptive: update expected kernel names
- test_add_layernorm: relax exact vec kernel count (ISA-dependent now)
- test_layer_norm_inplaces_after_matmul: drop in_out_ptr assertion
- test_vec_contiguous_ModularIndexing: relax exact vec kernel count

Fixes https://github.com/pytorch/pytorch/issues/168126

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo