### PR TITLE
[AI Codemod][PerfAICT-ObjCpy] perf: Avoid unnecessary std::string construction (#183011)

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -19,6 +19,7 @@
 #include <ostream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -1702,7 +1703,8 @@ static const std::vector<OperatorGeneratorArgs> stringOpGenArgs{
         TORCH_SELECTIVE_SCHEMA(
             "aten::strip(str self, str chars=' \\n\\t\\f\\v') -> str"),
         [](Stack& stack) {
-          std::string chars = pop(stack).toStringRef();
+          auto charsIValue = pop(stack);
+          std::string_view chars = charsIValue.toStringRef();
           std::string string = pop(stack).toStringRef();
           auto rindex = string.find_last_not_of(chars);
           if (rindex != std::string::npos) {
@@ -1716,7 +1718,7 @@ static const std::vector<OperatorGeneratorArgs> stringOpGenArgs{
           } else {
             string = "";
           }
-          push(stack, string);
+          push(stack, std::move(string));
         },
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(


### PR DESCRIPTION
Summary:

This change was generated by pointing an AI agent at hot functions showing up in our internal profiles. It was then reviewed by a human:

Optimized `torch::jit::$_225::operator()` in `fbcode/caffe2/torch/csrc/jit/runtime/register_prim_ops.cpp` by eliminating an unnecessary string copy at line 1705. The original code `std::string chars = pop(stack).toStringRef()` copied the string from the popped IValue into a local variable, even though `chars` is only used as a read-only argument to `find_last_not_of` and `find_first_not_of`. The fix keeps the IValue alive in a local variable (`charsIValue`) and takes a `const std::string&` reference to its internal string, avoiding the heap allocation and copy of the string data.

Reviewed By: IosifSpulber

Differential Revision: D104067900


