### PR TITLE
[ROCm][Inductor] Make missing GPU warp-size metadata explicit

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -189,7 +189,18 @@ class TestMaxAutotune(TestCase):
         Verify that `max_autotune` includes all pointwise configs from
         `max_autotune_pointwise` for 1D, 2D, and 3D pointwise kernels.
         """
-        triton_meta = {"device": DeviceProperties.create(torch.device(GPU_TYPE, 0))}
+        # Fake device properties for this unit test; no CUDA state is needed.
+        triton_meta = {
+            "device": DeviceProperties(
+                type="cuda",
+                index=0,
+                multi_processor_count=1,
+                cc=80,
+                major=8,
+                max_threads_per_block=1024,
+                warp_size=32,
+            )
+        }
         inductor_meta_common = {"autotune_pointwise": False}
 
         for size_hints in (

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2330,10 +2330,11 @@ class CommonTemplate:
         triton reduction configs for large size hints. #128826 introduced a scaling XBLOCK
         feature to resolve the issue in reduction configs which may exceed the maxGridSize
         """
+        from torch._inductor.runtime.hints import get_warp_size
         from torch._inductor.runtime.runtime_utils import next_power_of_2
         from torch._inductor.runtime.triton_heuristics import triton_config_reduction
 
-        warp_size = 64 if torch.version.hip else 32
+        warp_size = get_warp_size(torch.device(self.device))
         size_hints = {"x": 67108864, "r0_": 8192}
         for _ in range(4):
             size_hints["x"] = next_power_of_2(size_hints["x"])

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2333,10 +2333,11 @@ class CommonTemplate:
         from torch._inductor.runtime.runtime_utils import next_power_of_2
         from torch._inductor.runtime.triton_heuristics import triton_config_reduction
 
+        warp_size = 64 if torch.version.hip else 32
         size_hints = {"x": 67108864, "r0_": 8192}
         for _ in range(4):
             size_hints["x"] = next_power_of_2(size_hints["x"])
-            triton_config_reduction(size_hints, 1, 2048, 1, 8)
+            triton_config_reduction(size_hints, 1, 2048, 1, 8, warp_size=warp_size)
 
     def test_prod(self):
         def fn(a):

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -90,7 +90,6 @@ def get_autotuned_amd_sqr_kernel():
         key=[],
     )(amd_sqr_kernel)
 
-
 @instantiate_parametrized_tests
 class TestTritonHeuristics(TestCase):
     device_type = GPU_TYPE
@@ -1116,7 +1115,9 @@ class TestFastLauncherDeviceSupport(TestCase):
         return CachingAutotuner(
             fn=triton_,
             triton_meta=triton_meta,
-            configs=[triton_config({"x": 1}, 1)],
+            configs=[
+                triton_config({"x": 1}, 1, warp_size=device.warp_size_or_default)
+            ],
             save_cache_hook=False,
             mutated_arg_names=[],
             reset_to_zero_arg_names=[],
@@ -1427,7 +1428,15 @@ class TestWarpSizeUnification(TestCase):
         none_props = DeviceProperties(
             type="cuda", index=0, multi_processor_count=80, cc=80, warp_size=None
         )
-        self.assertEqual(none_props.warp_size_or_default, 32)
+        with self.assertRaisesRegex(
+            RuntimeError, "cuda device properties must report warp_size"
+        ):
+            none_props.warp_size_or_default
+
+        cpu_props = DeviceProperties(
+            type="cpu", index=0, multi_processor_count=80, cc=80, warp_size=None
+        )
+        self.assertEqual(cpu_props.warp_size_or_default, 32)
 
         w32 = DeviceProperties(
             type="cuda", index=0, multi_processor_count=80, cc=80, warp_size=32

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -90,6 +90,7 @@ def get_autotuned_amd_sqr_kernel():
         key=[],
     )(amd_sqr_kernel)
 
+
 @instantiate_parametrized_tests
 class TestTritonHeuristics(TestCase):
     device_type = GPU_TYPE
@@ -1115,9 +1116,7 @@ class TestFastLauncherDeviceSupport(TestCase):
         return CachingAutotuner(
             fn=triton_,
             triton_meta=triton_meta,
-            configs=[
-                triton_config({"x": 1}, 1, warp_size=device.warp_size_or_default)
-            ],
+            configs=[triton_config({"x": 1}, 1, warp_size=device.warp_size_or_default)],
             save_cache_hook=False,
             mutated_arg_names=[],
             reset_to_zero_arg_names=[],

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -481,9 +481,7 @@ class InductorChoices:
         so we will do the reduction in two phases."""
         props = DeviceProperties.create(device)
         num_sm = props.multi_processor_count
-        warp_size = props.warp_size
-        if warp_size is None:
-            return 1
+        warp_size = props.warp_size_or_default
         max_threads_per_sm = (
             props.max_threads_per_multi_processor
             if props.max_threads_per_multi_processor is not None

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -481,7 +481,9 @@ class InductorChoices:
         so we will do the reduction in two phases."""
         props = DeviceProperties.create(device)
         num_sm = props.multi_processor_count
-        warp_size = props.warp_size_or_default
+        warp_size = props.warp_size
+        if warp_size is None:
+            return 1
         max_threads_per_sm = (
             props.max_threads_per_multi_processor
             if props.max_threads_per_multi_processor is not None

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -56,6 +56,8 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
     def kernel_driver(self) -> str:
         """Return C++ host-side helpers (loadKernel, launchKernel, CUDA_DRIVER_CHECK)
         embedded in AOTI-generated wrapper code."""
+        # NVIDIA devices have a warp size of 32, while AMD devices can have a
+        # warp size of 32 or 64 depending on the architecture.
         source_codes = """
             #define CUDA_DRIVER_CHECK(EXPR)                    \\
             do {                                               \\
@@ -135,16 +137,16 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                     void* args[],
                     cudaStream_t stream) {
                 CUDA_DRIVER_CHECK(cuLaunchKernel(
-                    func, gridX, gridY, gridZ, 32*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
+                    func, gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
                 ));
             }
         """
-        if torch.version.hip is not None:
-            # Adjusting the warp size to GPU supported wavefront size on AMD GPU
+        if torch.version.hip is not None and torch.cuda.is_available():
             device = torch.device("cuda", torch.cuda.current_device())
             warp_size = get_warp_size(device)
-            source_codes = source_codes.replace("32*numWarps", f"{warp_size}*numWarps")
-        return source_codes
+        else:
+            warp_size = 32
+        return source_codes.replace("__WARP_SIZE__", str(warp_size))
 
     def tma_descriptor_helpers(self) -> str:
         """

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -180,7 +180,11 @@ class DeviceProperties(typing.NamedTuple):
 
     @property
     def warp_size_or_default(self) -> int:
-        return self.warp_size if self.warp_size is not None else 32
+        if self.warp_size is not None:
+            return self.warp_size
+        if self.type in ("cuda", "hip"):
+            raise RuntimeError(f"{self.type} device properties must report warp_size")
+        return 32
 
     @classmethod
     @functools.cache
@@ -215,17 +219,17 @@ class DeviceProperties(typing.NamedTuple):
                 props, "max_threads_per_multi_processor", None
             ),
             max_threads_per_block=getattr(props, "max_threads_per_block", 1024),
-            warp_size=getattr(props, "warp_size", 32 if device_type != "cpu" else None),
+            warp_size=getattr(props, "warp_size", None),
         )
 
 
 def get_warp_size(device) -> int:
     """Return the wave/warp size in threads for the given device.
 
-    Reads from torch.cuda.get_device_properties(device).warp_size via the
-    cached DeviceProperties.create(). Correct on both AMD (64 for CDNA/gfx9,
-    32 for RDNA/gfx10+) and NVIDIA (always 32). Falls back to 32 only when
-    the field is unavailable.
+    Reads from torch.cuda.get_device_properties(device).warp_size via the cached
+    DeviceProperties.create(). Correct on both AMD (64 for CDNA/gfx9, 32 for
+    RDNA/gfx10+) and NVIDIA (always 32). Missing cuda/hip warp_size metadata is
+    treated as an error rather than silently falling back.
     """
     return DeviceProperties.create(device).warp_size_or_default
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3445,7 +3445,6 @@ def triton_config(
     xnumel = size_hints["x"]
     ynumel = size_hints.get("y")
     znumel = size_hints.get("z")
-    warp_size = device_props.warp_size_or_default()
 
     # Increase x to satisfy min_elem_per_thread requirements.
     block_size = max(

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4201,7 +4201,6 @@ def _reduction_configs(
     num_dynamic=0,
 ) -> list[Config]:
     reduction_hint = inductor_meta.get("reduction_hint")
-    device_props = triton_meta["device"]
 
     # Convert reductions to 1D, to simplify heuristics.
     rnumel = get_total_reduction_numel(size_hints)
@@ -4784,7 +4783,6 @@ def _persistent_reduction_configs(
     max_autotune_enabled = inductor_meta.get("max_autotune") or inductor_meta.get(
         "max_autotune_pointwise"
     )
-    device_props = triton_meta["device"]
 
     if torch.version.hip:
         xblock_vals = [1, 4, 8, 16, 32, 64, 128, 256]

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -196,6 +196,13 @@ def autotune_hints_to_configs(
     configs: list[Config] = []
     for hint in hints:
         if hint == AutotuneHint.ONE_ELEMENT_PER_THREAD:
+            if device_props.warp_size is None:
+                log.debug(
+                    "Skipping %s autotune hint because device %s does not report warp_size",
+                    AutotuneHint.ONE_ELEMENT_PER_THREAD,
+                    device_props.type,
+                )
+                continue
             if len(size_hints) == 1:
                 xyz_options = ((block_size // 4, None, None),)
             elif len(size_hints) == 2:
@@ -715,6 +722,7 @@ class CachingAutotuner(KernelInterface):
             and bool(device_prop.major)
             and (device_prop.major >= 8 or torch.version.hip)
             and device_prop.regs_per_multiprocessor is not None
+            and device_prop.warp_size is not None
         )
 
     def _iter_rblock_scale_candidates(self):
@@ -733,8 +741,10 @@ class CachingAutotuner(KernelInterface):
             )
         if not device_prop.multi_processor_count:
             raise AssertionError("device_prop.multi_processor_count is not set")
+        if device_prop.warp_size is None:
+            raise AssertionError("device_prop.warp_size is not set")
         seen_config_hashes: OrderedSet[Hashable] | None = None
-        warp_size = device_prop.warp_size_or_default
+        warp_size = device_prop.warp_size
         for result in self.compile_results:
             triton_config = result.config
             compiled_binary = result.kernel
@@ -776,14 +786,14 @@ class CachingAutotuner(KernelInterface):
             nreg_per_warp = nreg * warp_size
             nreg_per_block = nreg_per_warp * triton_config.num_warps
 
-            # Previously we set max_blocks_per_sm to 'max_threads_per_multi_processo / (32 * num_warps)'
+            # Previously we set max_blocks_per_sm to 'max_threads_per_multi_processor / (warp_size * num_warps)'
             # The formula below is a tighter upper bound since we have the assumption that
             #   nreg > device_prop.regs_per_multiprocessor // device_prop.max_threads_per_multi_processor
             # due to the if condition above and:
             #   regs_per_multiprocessor / nreg_per_block
-            #   = regs_per_multiprocessor / (nreg * 32 * num_warps)
-            #   < regs_per_multiprocessor / ((regs_per_multiprocessor / max_threads_per_multi_processor) * 32 * num_warps)
-            #   = max_threads_per_multi_processor / (32 * num_warps)
+            #   = regs_per_multiprocessor / (nreg * warp_size * num_warps)
+            #   < regs_per_multiprocessor / ((regs_per_multiprocessor / max_threads_per_multi_processor) * warp_size * num_warps)
+            #   = max_threads_per_multi_processor / (warp_size * num_warps)
             # Using a tighter upper bound can reveal more optimization opportunities.
             max_blocks_per_sm = max(
                 device_prop.regs_per_multiprocessor // nreg_per_block, 1
@@ -3435,6 +3445,7 @@ def triton_config(
     xnumel = size_hints["x"]
     ynumel = size_hints.get("y")
     znumel = size_hints.get("z")
+    warp_size = device_props.warp_size_or_default()
 
     # Increase x to satisfy min_elem_per_thread requirements.
     block_size = max(
@@ -4191,6 +4202,7 @@ def _reduction_configs(
     num_dynamic=0,
 ) -> list[Config]:
     reduction_hint = inductor_meta.get("reduction_hint")
+    device_props = triton_meta["device"]
 
     # Convert reductions to 1D, to simplify heuristics.
     rnumel = get_total_reduction_numel(size_hints)
@@ -4773,6 +4785,7 @@ def _persistent_reduction_configs(
     max_autotune_enabled = inductor_meta.get("max_autotune") or inductor_meta.get(
         "max_autotune_pointwise"
     )
+    device_props = triton_meta["device"]
 
     if torch.version.hip:
         xblock_vals = [1, 4, 8, 16, 32, 64, 128, 256]

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3808,12 +3808,13 @@ def _occupancy_before_and_after_fusion(
 
     # # Need device info to calculate occupancy
     regs_per_sm = device_props.regs_per_multiprocessor
-    if regs_per_sm is None:
+    warp_size = device_props.warp_size
+    if regs_per_sm is None or warp_size is None:
         return 1, 1  # Can't calculate, allow fusion
 
     if not num_warps:
         raise AssertionError("expected num_warps to be truthy")
-    threads_per_block = num_warps * device_props.warp_size_or_default
+    threads_per_block = num_warps * warp_size
 
     regs_per_block_unfused = unfused_n_regs * threads_per_block
     regs_per_block_fused = fused_n_regs * threads_per_block

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1074,11 +1074,22 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         self,
         configs: list[BaseConfig],
     ) -> list[BaseConfig]:
+        try:
+            device = torch.cuda.current_device()
+            props = torch.cuda.get_device_properties(device)
+            warp_size = props.warp_size
+        except (RuntimeError, AttributeError, AssertionError):
+            return configs
+
         pruned_configs = []
+        # NVIDIA-oriented approximation for the per-thread register limit.
+        # TODO: generalize this threshold for ROCm devices.
+        NUM_REG = 255
         for gemm_config in configs:
-            NUM_REG = 255
             acc_regs = math.ceil(
-                gemm_config.block_m * gemm_config.block_n / (gemm_config.num_warps * 32)
+                gemm_config.block_m
+                * gemm_config.block_n
+                / (gemm_config.num_warps * warp_size)
             )
             # Lower bound for register spillage, if exceeds the kernel will certainly spill
             if acc_regs > NUM_REG:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3233,11 +3233,10 @@ def get_max_numwarps() -> int:
         max_threads_per_block = props.max_threads_per_block
         if max_threads_per_block is None:
             raise AssertionError("expected max_threads_per_block to be set")
-    else:
-        # Defaults
-        warp_size = 32
-        max_threads_per_block = 1024
-    return max_threads_per_block // warp_size
+        return max_threads_per_block // warp_size
+
+    log.debug("CUDA is not available; defaulting max num warps to 32")
+    return 32
 
 
 def is_welford_reduction(reduction_type: str) -> bool:


### PR DESCRIPTION
Upstream PR #181112 (`[inductor] Unify threads-per-wave (warp_size) extraction`) has now landed and did much of the original broad warp-size plumbing for this PR: it centralized `DeviceProperties.warp_size`, threaded `warp_size` through Inductor's Triton config helpers, and made HIP wave32 devices follow the non-wave64 path.

After rebasing on top of that work, this PR is now focused on the remaining stricter ROCm-safe behavior:

- Preserve missing `DeviceProperties.warp_size` as `None` instead of synthesizing `32` for CUDA/HIP devices.
- Make `DeviceProperties.warp_size_or_default` raise for missing CUDA/HIP warp-size metadata, while preserving the explicit non-GPU fallback.
- Skip optional autotune/rblock/fusion/split-reduction heuristics when required warp-size metadata is unavailable instead of guessing.
- Keep CUDA launcher generation on the fast `32` path, but use the device warp size for HIP launcher block dimensions.
- Use queried device warp size in template register-spill pruning, with graceful fallback on non-CUDA/XPU builds.
- Update the relevant Inductor tests for the stricter missing CUDA/HIP metadata behavior.

### Validation

- Rebased cleaned stack onto `upstream/main` at `19791183fec`.
- Rebuilt PyTorch from scratch with `/home/niromero/docker_workspace/framework_scripts/pytorch/build.sh`.
- Ran impacted UTs:
  - `python test/inductor/test_triton_heuristics.py TestWarpSizeUnification TestTritonHeuristics.test_autotune_hints_to_configs TestFastLauncherDeviceSupport`
  - `python test/inductor/test_max_autotune.py TestMaxAutotune.test_max_autotune_includes_max_autotune_pointwise_configs`
  - `python test/inductor/test_torchinductor_dynamic_shapes.py -k test_embedding_backward_dynamic_shapes_large_grid`
  - `python test/inductor/test_torchinductor.py -k test_reduction_config_limit`

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos