### PR TITLE
[MPS] Drop forward Python prim registration for native_group_norm

### DIFF
--- a/torch/backends/mps/__init__.py
+++ b/torch/backends/mps/__init__.py
@@ -64,15 +64,21 @@ _lib: _Library | None = None
 
 
 def _init() -> None:
-    r"""Register prims as implementation of var_mean and group_norm."""
+    r"""Register decomposition for native_group_norm_backward on MPS.
+
+    The forward path falls through to the ``CompositeExplicitAutograd``
+    ``math_group_norm`` registration, which is significantly faster on MPS
+    than the prim decomposition (it dispatches to the fused MPSGraph
+    normalization API via ``at::native_batch_norm``). Backward has no
+    composite or MPS native implementation, so it stays registered here
+    to avoid the regression in #88331.
+    """
     global _lib
 
     if _lib is not None or not is_built():
         return
 
     from torch._decomp.decompositions import native_group_norm_backward
-    from torch._refs import native_group_norm
 
     _lib = _Library("aten", "IMPL")
-    _lib.impl("native_group_norm", native_group_norm, "MPS")
     _lib.impl("native_group_norm_backward", native_group_norm_backward, "MPS")


### PR DESCRIPTION
## Issue

Part of #182805.

## Summary

The MPS dispatch for `aten::native_group_norm` was registered to a Python prim decomposition (`torch._refs.native_group_norm`) in `torch/backends/mps/__init__.py`.

That registration shadowed the yaml-level `CompositeExplicitAutograd:
math_group_norm`, which is much faster on MPS because it reshapes input to 3D and dispatches through `at::native_batch_norm` into the fused MPSGraph normalization API (already 5D-aware after #180335).

Removing the forward registration lets the existing composite take over.

The backward Python registration stays. `native_group_norm_backward` has no `CompositeExplicitAutograd` fallthrough and no MPS native implementation, so removing it would resurface #88331 (NaN gradients on MPS).

After this change:

```
aten::native_group_norm          (MPS) -> CompositeExplicitAutograd: math_group_norm
aten::native_group_norm_backward (MPS) -> torch/backends/mps/__init__.py
```

## Benchmarks

Single-process A/B on the same build, 5 trials of 50 iters each, 20 iters of
warmup per trial. Path A re-registers the prim impl at runtime; path B is the
math composite path enabled by this PR. Median of 5 trials. Numerics measured
against CPU at fp32.

| shape (N, C, ...) | G | fwd ms (before → after) | speedup | max\|diff\| |
|---|---:|---:|---:|---:|
| (8, 32, 1024)            | 4  | 0.21 → 0.14  | 1.56x | 1.4e-06 |
| (16, 64, 4096)           | 8  | 4.64 → 0.92  | 5.03x | 1.9e-06 |
| (32, 32, 64, 64)         | 4  | 4.60 → 0.94  | 4.92x | 1.9e-06 |
| (16, 128, 32, 32)        | 16 | 2.32 → 0.33  | 7.12x | 1.4e-06 |
| (8, 256, 28, 28)         | 32 | 1.45 → 0.22  | 6.73x | 2.9e-06 |
| (4, 512, 14, 14)         | 32 | 0.31 → 0.11  | 2.78x | 1.9e-06 |
| (16, 96, 56, 56)         | 12 | 5.21 → 1.04  | 5.03x | 1.9e-06 |
| **(4, 64, 64, 64, 64)**  | **8**  | **73.36 → 17.04** | **4.31x** | **1.9e-06** |
| (2, 128, 32, 32, 32)     | 16 | 9.08 → 2.29  | 3.97x | 1.9e-06 |
| (4, 32, 16, 64, 64)      | 4  | 9.75 → 1.75  | 5.56x | 2.9e-06 |
| (1, 256, 16, 16, 16)     | 32 | 0.69 → 0.13  | 5.31x | 1.4e-06 |
| (8, 64, 32, 32)          | 32 | 0.41 → 0.09  | 4.38x | 1.9e-06 |
| (8, 64, 32, 32)          | 1  | 0.42 → 0.10  | 4.15x | 1.4e-06 |

The bolded row is the issue's repro shape. 

Forward:  min 1.56x, **median 4.92x**, max 7.12x. 

`nn.GroupNorm` fwd+bwd: min 1.40x, median 1.59x, max 2.26x (backward unchanged). 

Numerics vs CPU at fp32, max across shapes: out 2.9e-06, mean 1.5e-08, rstd 1.8e-07. The (8, 256, 28, 28) row at 6.73x matches the speedup the issue reported on M4 Pro.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests: existing `test/test_mps.py` coverage for `nn.functional.group_norm` (TestConsistencyMPS, TestNNMPS) is sufficient; the #88331 anchor `test_group_norm_backward` is preserved.
- [ ] Updated documentation (if applicable): N/A.
- [x] Included benchmark results (for PRs impacting perf): see table above.

## BC-breaking?

No.
