### PR TITLE
[Inductor] Filter triton configs by launch geometry in triton heuristics

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -56,6 +56,7 @@ from torch._inductor.runtime.triton_heuristics import (
     CachingAutotuner,
     CachingAutotunerPlugin,
     DEFER,
+    filter_configs_by_launch_geometry,
     make_matmul_triton_config,
     template,
     triton_config,
@@ -101,6 +102,223 @@ class TestTritonHeuristics(TestCase):
             if key not in cfg.kwargs:
                 continue
             self.assertTrue(cfg.kwargs[key] <= TRITON_MAX_BLOCK[label])
+
+    def test_filter_configs_by_launch_geometry_pointwise_1d(self):
+        triton_meta = {
+            "device": DeviceProperties(
+                type="xpu", index=0, multi_processor_count=80, cc=80
+            )
+        }
+        size_hints = {"x": 2**28}
+        inductor_meta = {
+            "filter_configs_by_launch_geometry": True,
+            "grid_type": "Grid1D",
+        }
+        configs = [
+            triton.Config({"XBLOCK": 1}, num_warps=1, num_stages=1),
+            triton.Config({"XBLOCK": 256}, num_warps=4, num_stages=1),
+        ]
+
+        filtered = filter_configs_by_launch_geometry(
+            size_hints=size_hints,
+            inductor_meta=inductor_meta,
+            triton_meta=triton_meta,
+            configs=configs,
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].kwargs["XBLOCK"], 256)
+
+    def test_filter_configs_by_launch_geometry_pointwise_2d(self):
+        triton_meta = {
+            "device": DeviceProperties(
+                type="xpu", index=0, multi_processor_count=80, cc=80
+            )
+        }
+        size_hints = {"x": 2**14, "y": 2**14}
+        inductor_meta = {
+            "filter_configs_by_launch_geometry": True,
+            "grid_type": "Grid2D",
+        }
+        configs = [
+            triton.Config({"XBLOCK": 1, "YBLOCK": 1}, num_warps=1, num_stages=1),
+            triton.Config({"XBLOCK": 256, "YBLOCK": 256}, num_warps=4, num_stages=1),
+        ]
+
+        filtered = filter_configs_by_launch_geometry(
+            size_hints=size_hints,
+            inductor_meta=inductor_meta,
+            triton_meta=triton_meta,
+            configs=configs,
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].kwargs["XBLOCK"], 256)
+        self.assertEqual(filtered[0].kwargs["YBLOCK"], 256)
+
+    def test_filter_configs_by_launch_geometry_reduction_1d(self):
+        triton_meta = {
+            "device": DeviceProperties(
+                type="xpu", index=0, multi_processor_count=80, cc=80
+            )
+        }
+        size_hints = {"x": 2**26, "r0_": 1024}
+        inductor_meta = {
+            "filter_configs_by_launch_geometry": True,
+            "grid_type": "Grid1D",
+        }
+        configs = [
+            triton.Config({"XBLOCK": 1, "R0_BLOCK": 4}, num_warps=1, num_stages=1),
+            triton.Config({"XBLOCK": 64, "R0_BLOCK": 64}, num_warps=4, num_stages=1),
+        ]
+
+        filtered = filter_configs_by_launch_geometry(
+            size_hints=size_hints,
+            inductor_meta=inductor_meta,
+            triton_meta=triton_meta,
+            configs=configs,
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].kwargs["XBLOCK"], 64)
+
+    def test_filter_configs_by_launch_geometry_mix_order_reduction(self):
+        triton_meta = {
+            "device": DeviceProperties(
+                type="xpu", index=0, multi_processor_count=80, cc=80
+            )
+        }
+        size_hints = {"x": 2**26, "r0_": 1024}
+        inductor_meta = {
+            "filter_configs_by_launch_geometry": True,
+            "grid_type": "MixOrderReductionGrid",
+        }
+        configs = [
+            # Must be kept when using MixOrderReductionGrid: low grid_ctas and high CTA work.
+            triton.Config(
+                {"XBLOCK": 1, "R0_BLOCK": 4, "RSPLIT_SIZE": 2**20},
+                num_warps=1,
+                num_stages=1,
+            ),
+            # Obvious bad config under mix-order semantics.
+            triton.Config(
+                {"XBLOCK": 1, "R0_BLOCK": 4, "RSPLIT_SIZE": 1},
+                num_warps=1,
+                num_stages=1,
+            ),
+            # Good due to high CTA work even with RSPLIT_SIZE=1.
+            triton.Config(
+                {"XBLOCK": 64, "R0_BLOCK": 64, "RSPLIT_SIZE": 1},
+                num_warps=4,
+                num_stages=1,
+            ),
+        ]
+
+        filtered = filter_configs_by_launch_geometry(
+            size_hints=size_hints,
+            inductor_meta=inductor_meta,
+            triton_meta=triton_meta,
+            configs=configs,
+        )
+
+        self.assertEqual(len(filtered), 2)
+        self.assertEqual(
+            sorted((c.kwargs["XBLOCK"], c.kwargs["RSPLIT_SIZE"]) for c in filtered),
+            [(1, 2**20), (64, 1)],
+        )
+
+    def test_filter_configs_by_launch_geometry_cooperative_reduction(self):
+        triton_meta = {
+            "device": DeviceProperties(
+                type="xpu", index=0, multi_processor_count=80, cc=80
+            )
+        }
+        size_hints = {"x": 2**14, "r0_": 2**20}
+        inductor_meta = {
+            "filter_configs_by_launch_geometry": True,
+            "grid_type": "CooperativeReductionGrid",
+        }
+        configs = [
+            # Bad: RSPLIT=256 splits reduction across too many CTAs with tiny per-CTA work.
+            triton.Config(
+                {"XBLOCK": 1, "R0_BLOCK": 4, "RSPLIT": 256},
+                num_warps=1,
+                num_stages=1,
+            ),
+            # Good: moderate RSPLIT keeps enough work per CTA.
+            triton.Config(
+                {"XBLOCK": 64, "R0_BLOCK": 1024, "RSPLIT": 4},
+                num_warps=4,
+                num_stages=1,
+            ),
+        ]
+
+        filtered = filter_configs_by_launch_geometry(
+            size_hints=size_hints,
+            inductor_meta=inductor_meta,
+            triton_meta=triton_meta,
+            configs=configs,
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].kwargs["XBLOCK"], 64)
+
+    def test_filter_configs_by_launch_geometry_split_scan(self):
+        triton_meta = {
+            "device": DeviceProperties(
+                type="xpu", index=0, multi_processor_count=80, cc=80
+            )
+        }
+        size_hints = {"x": 2**14, "r0_": 2**20}
+        inductor_meta = {
+            "filter_configs_by_launch_geometry": True,
+            "grid_type": "SplitScanGrid",
+        }
+        configs = [
+            # Bad: tiny R0_BLOCK produces a massive grid with almost no work per CTA.
+            triton.Config(
+                {"XBLOCK": 1, "R0_BLOCK": 1},
+                num_warps=1,
+                num_stages=1,
+            ),
+            # Good: large R0_BLOCK gives each CTA enough work.
+            triton.Config(
+                {"XBLOCK": 1, "R0_BLOCK": 1024},
+                num_warps=4,
+                num_stages=1,
+            ),
+        ]
+
+        filtered = filter_configs_by_launch_geometry(
+            size_hints=size_hints,
+            inductor_meta=inductor_meta,
+            triton_meta=triton_meta,
+            configs=configs,
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].kwargs["R0_BLOCK"], 1024)
+
+    def test_filter_configs_by_launch_geometry_keeps_smallest_grid(self):
+        triton_meta = {
+            "device": DeviceProperties(
+                type="xpu", index=0, multi_processor_count=1, cc=80
+            )
+        }
+        size_hints = {"x": 2**22}
+        inductor_meta = {
+            "filter_configs_by_launch_geometry": True,
+            "grid_type": "Grid1D",
+        }
+        configs = [
+            triton.Config({"XBLOCK": 1}, num_warps=1, num_stages=1),
+            triton.Config({"XBLOCK": 32}, num_warps=1, num_stages=1),
+        ]
+
+        filtered = filter_configs_by_launch_geometry(
+            size_hints=size_hints,
+            inductor_meta=inductor_meta,
+            triton_meta=triton_meta,
+            configs=configs,
+        )
+
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].kwargs["XBLOCK"], 32)
 
     def test_native_matmul_config_block_numel_limit(self):
         device = DeviceProperties(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5960,6 +5960,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             "deterministic": config.deterministic or config.batch_invariant,
             "batch_invariant": config.batch_invariant,
             "force_filter_reduction_configs": config.test_configs.force_filter_reduction_configs,
+            "filter_configs_by_launch_geometry": config.triton.filter_configs_by_launch_geometry,
             "mix_order_reduction_allow_multi_stages": config.triton.mix_order_reduction_allow_multi_stages,
             "dynamic_disable_pipelining": config.triton.dynamic_disable_pipelining,
         }

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1890,6 +1890,16 @@ class triton:
     # this should only be disabled for debugging/testing
     autotune_pointwise = True
 
+    # Filter out obviously poor autotune configs based on launch geometry
+    # vs device CTA count. This is independent of deterministic mode and
+    # intended to reduce futile benchmarking.
+    # Currently working only for XPUs, but can be extended to other devices
+    # by updating the device guard in implementation after testing on the device.
+    filter_configs_by_launch_geometry = (
+        os.environ.get("TORCHINDUCTOR_TRITON_FILTER_CONFIGS_BY_LAUNCH_GEOMETRY", "0")
+        == "1"
+    )
+
     # max autotune gemm with cublasLt
     autotune_cublasLt = True
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3870,6 +3870,12 @@ def pointwise(
         raise NotImplementedError(f"size_hints: {size_hints}")
 
     configs = _maybe_filter_configs_for_tma_restrictions(inductor_meta, configs)
+    configs = filter_configs_by_launch_geometry(
+        size_hints=size_hints,
+        inductor_meta=inductor_meta,
+        triton_meta=triton_meta,
+        configs=configs,
+    )
     if return_configs:
         return configs
 
@@ -4365,6 +4371,129 @@ def filter_reduction_configs_for_determinism(
     return configs
 
 
+def filter_configs_by_launch_geometry(
+    *,
+    size_hints: dict[str, int],
+    inductor_meta: dict[str, Any],
+    triton_meta: dict[str, Any],
+    configs: list[Config],
+) -> list[Config]:
+    """
+    Filter extremely poor launch configurations based on launch geometry and
+    device parallelism, while preserving at least one candidate.
+    """
+    device = triton_meta["device"]
+    if (
+        not inductor_meta.get("filter_configs_by_launch_geometry", False)
+        or device.type != "xpu"
+    ):
+        return configs
+    if len(configs) <= 1:
+        return configs
+
+    cta_count = getattr(device, "multi_processor_count", 0)
+    if not isinstance(cta_count, int) or cta_count <= 0:
+        return configs
+
+    def _size_hint_meta() -> dict[str, int]:
+        # GridExpr expects runtime numel names like xnumel/r0_numel.
+        return {f"{prefix}numel": numel for prefix, numel in size_hints.items()}
+
+    size_hint_meta = _size_hint_meta()
+
+    def _block(cfg: Config, name: str, default: int = 1) -> int:
+        value = cfg.kwargs.get(name, default)
+        return value if isinstance(value, int) and value > 0 else default
+
+    def _block_product(cfg: Config, keys: list[str]) -> int:
+        product = 1
+        for key in keys:
+            product *= _block(cfg, key)
+        return product
+
+    def _estimate_grid_ctas(cfg: Config) -> int:
+        grid_ctas = 1
+        if inductor_meta.get("grid_type"):
+            try:
+                grid = GridExpr.from_meta(inductor_meta, cfg)
+                x_grid, y_grid, z_grid = grid.eval_slow(size_hint_meta)
+                grid_ctas = (
+                    max(1, int(x_grid)) * max(1, int(y_grid)) * max(1, int(z_grid))
+                )
+            except Exception:
+                # Fall back to a generic estimate when grid metadata is incomplete.
+                grid_ctas = 1
+
+        if grid_ctas == 1:
+            for prefix, numel in size_hints.items():
+                if prefix_is_reduction(prefix):
+                    continue
+                block = cfg.kwargs.get(prefix.upper() + "BLOCK", 1)
+                if not isinstance(block, int) or block <= 0:
+                    block = 1
+                grid_ctas *= ceildiv(numel, block)
+
+        return grid_ctas
+
+    def _estimate_cta_work(cfg: Config, grid_ctas: int) -> int:
+        reduction_prefixes = [
+            prefix for prefix in size_hints if prefix_is_reduction(prefix)
+        ]
+        reduction_block_keys = [
+            f"{prefix.upper()}BLOCK" for prefix in reduction_prefixes
+        ]
+        pointwise_work = _block_product(cfg, ["XBLOCK", "YBLOCK", "ZBLOCK"])
+        reduction_work = _block_product(cfg, reduction_block_keys)
+
+        cta_work = pointwise_work * (reduction_work if reduction_prefixes else 1)
+        grid_type = inductor_meta.get("grid_type")
+        if grid_type == MixOrderReductionGrid.__name__:
+            cta_work = max(cta_work, _block(cfg, "XBLOCK") * _block(cfg, "RSPLIT_SIZE"))
+        elif grid_type == CooperativeReductionGrid.__name__ and reduction_prefixes:
+            # Cooperative reduction partitions the reduction dimension across RSPLIT CTAs.
+            cta_work = max(1, cta_work // _block(cfg, "RSPLIT"))
+        elif grid_type == SplitScanGrid.__name__:
+            cta_work = max(cta_work, _block(cfg, "R0_BLOCK"))
+
+        if cta_work <= 1 and grid_ctas > 0:
+            # Last-resort estimate when block metadata is sparse.
+            non_reduction_numel = math.prod(
+                numel
+                for prefix, numel in size_hints.items()
+                if not prefix_is_reduction(prefix)
+            )
+            cta_work = max(1, ceildiv(non_reduction_numel, grid_ctas))
+
+        return cta_work
+
+    def _config_stats(cfg: Config) -> tuple[int, int]:
+        grid_ctas = _estimate_grid_ctas(cfg)
+        return grid_ctas, _estimate_cta_work(cfg, grid_ctas)
+
+    def _is_extremely_bad(grid_ctas: int, cta_work: int) -> bool:
+        return (cta_work <= 32 and grid_ctas >= cta_count * 1024) or (
+            cta_work <= 64 and grid_ctas >= cta_count * 2048
+        )
+
+    config_stats = [(cfg, *_config_stats(cfg)) for cfg in configs]
+    filtered_configs = [
+        cfg
+        for cfg, grid_ctas, cta_work in config_stats
+        if not _is_extremely_bad(grid_ctas, cta_work)
+    ]
+    if len(filtered_configs) == 0:
+        # Keep one candidate with smallest grid_ctas when all configs are deemed poor.
+        return [min(config_stats, key=lambda stats: stats[1])[0]]
+
+    if len(filtered_configs) != len(configs) and log.isEnabledFor(logging.DEBUG):
+        log.debug(
+            "Filtered configs by device heuristics. Input size: %d. Output size: %d",
+            len(configs),
+            len(filtered_configs),
+        )
+    return filtered_configs
+
+
 def reduction(
     size_hints,
     reduction_hint=False,
@@ -4411,6 +4540,12 @@ def reduction(
     )
 
     configs = _maybe_filter_configs_for_tma_restrictions(inductor_meta, configs)
+    configs = filter_configs_by_launch_geometry(
+        size_hints=size_hints,
+        inductor_meta=inductor_meta,
+        triton_meta=triton_meta,
+        configs=configs,
+    )
     configs = filter_reduction_configs_for_determinism(inductor_meta, configs)
 
     if return_configs:
@@ -4469,6 +4604,12 @@ def cooperative_reduction(
     # TODO(jansel): add more configs in max_autotune
 
     configs = _maybe_filter_configs_for_tma_restrictions(inductor_meta, configs)
+    configs = filter_configs_by_launch_geometry(
+        size_hints=size_hints,
+        inductor_meta=inductor_meta,
+        triton_meta=triton_meta,
+        configs=configs,
+    )
     configs = filter_reduction_configs_for_determinism(inductor_meta, configs)
     return cached_autotune(
         size_hints,
@@ -4669,6 +4810,12 @@ def persistent_reduction(
     inductor_meta[persistent_reduction_key] = True
     configs = _maybe_filter_configs_for_tma_restrictions(inductor_meta, configs)
     inductor_meta.pop(persistent_reduction_key)
+    configs = filter_configs_by_launch_geometry(
+        size_hints=size_hints,
+        inductor_meta=inductor_meta,
+        triton_meta=triton_meta,
+        configs=configs,
+    )
 
     max_autotune_enabled = inductor_meta.get("max_autotune") or inductor_meta.get(
         "max_autotune_pointwise"
@@ -4776,6 +4923,12 @@ def split_scan(
                 cfg.kwargs[var] = min_rblock
 
     configs = _maybe_filter_configs_for_tma_restrictions(inductor_meta, configs)
+    configs = filter_configs_by_launch_geometry(
+        size_hints=size_hints,
+        inductor_meta=inductor_meta,
+        triton_meta=triton_meta,
+        configs=configs,
+    )
     configs = filter_reduction_configs_for_determinism(inductor_meta, configs)
     return cached_autotune(
         size_hints,


### PR DESCRIPTION
Implements the idea proposed in #182928:
1. Implement the function to filter out extremely bad configs based on the grid size, cta work and the number of ctas. Keep the smallest grid size if all the configs are filtered.
2. Use the function to filter configs at the end of pointwise, reduction, persistent_reduction, cooperative_reduction, split_scan.
3. Add a flag (torch._inductor.config.triton.filter_configs_by_launch_geometry or TORCHINDUCTOR_TRITON_FILTER_CONFIGS_BY_LAUNCH_GEOMETRY env) in the triton config to turn on or off the feature. By default turn off for now. 

Fixes #182928

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo