### PR TITLE
[8.2A/11][aoti] Add C-ABI-safe UpdateConstantBufferPairs (#183031)

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -247,6 +247,25 @@ AOTIRuntimeError AOTInductorModelContainerExtractConstantsMap(
     })
 }
 
+AOTIRuntimeError AOTInductorModelContainerExtractConstantsMapEntries(
+    AOTInductorModelContainerHandle container_handle,
+    const AOTInductorConstantMapEntry** entries,
+    size_t* num_entries,
+    bool use_inactive) {
+  if (!entries || !num_entries) {
+    return AOTI_RUNTIME_FAILURE;
+  }
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+    const auto& extracted =
+        container->extract_constants_map_entries(use_inactive);
+    *entries = extracted.empty() ? nullptr : extracted.data();
+    *num_entries = extracted.size();
+  })
+}
+
 AOTIRuntimeError AOTInductorModelContainerUpdateUserManagedConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // Stores the last error message from a failed AOTI runtime call so that
@@ -57,6 +58,21 @@ struct AOTINoGradGuard {
   AOTINoGradGuard& operator=(AOTINoGradGuard&&) noexcept = delete;
   bool prev_mode{aoti_torch_grad_mode_is_enabled()};
 };
+
+namespace {
+
+std::unordered_map<std::string, AtenTensorHandle> constant_map_from_pairs(
+    const AOTInductorConstantMapEntry* pairs,
+    size_t num_pairs) {
+  std::unordered_map<std::string, AtenTensorHandle> input_map;
+  input_map.reserve(num_pairs);
+  for (size_t i = 0; i < num_pairs; ++i) {
+    input_map.emplace(pairs[i].name, pairs[i].handle);
+  }
+  return input_map;
+}
+
+} // namespace
 
 extern "C" {
 
@@ -313,6 +329,22 @@ AOTIRuntimeError AOTInductorModelContainerUpdateConstantBuffer(
   CONVERT_EXCEPTION_TO_ERROR_CODE({
     container->update_constant_buffer(
         *input_map, use_inactive, validate_full_update);
+  })
+}
+
+AOTIRuntimeError AOTInductorModelContainerUpdateConstantBufferPairs(
+    AOTInductorModelContainerHandle container_handle,
+    const AOTInductorConstantMapEntry* pairs,
+    size_t num_pairs,
+    bool use_inactive,
+    bool validate_full_update) {
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  auto input_map = constant_map_from_pairs(pairs, num_pairs);
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+    container->update_constant_buffer(
+        input_map, use_inactive, validate_full_update);
   })
 }
 

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -188,9 +188,23 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerGetConstantDataSize(
     size_t* data_size);
 
 // Extract the constants that is being used in the container.
+//
+// DEPRECATED: V1 API; see AOTInductorModelContainerExtractConstantsMapEntries.
 AOTI_API AOTIRuntimeError AOTInductorModelContainerExtractConstantsMap(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
+    bool use_inactive);
+
+// C-ABI-safe variant of AOTInductorModelContainerExtractConstantsMap.
+// On success, `entries` points to `num_entries` container-owned entries.
+// The returned array and each `entries[i].name` are valid until the next
+// AOTInductorModelContainerExtractConstantsMapEntries call on the same
+// container, until the container's constants are mutated, or until the
+// container is deleted. Callers that need to retain names should copy them.
+AOTI_API AOTIRuntimeError AOTInductorModelContainerExtractConstantsMapEntries(
+    AOTInductorModelContainerHandle container_handle,
+    const AOTInductorConstantMapEntry** entries,
+    size_t* num_entries,
     bool use_inactive);
 
 // Setup the constant buffer in model container with provided ConstantMap.

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -229,9 +229,19 @@ AOTInductorModelContainerUpdateUserManagedConstantBufferPairs(
 // Setup the constant buffer in model container with provided ConstantMap
 // use_inactive should be set as true if the inactive buffer is to be updated.
 // validate_full_update checks if all constants are included in the ConstantMap
+//
+// DEPRECATED: V1 API; see AOTInductorModelContainerUpdateConstantBufferPairs.
 AOTI_API AOTIRuntimeError AOTInductorModelContainerUpdateConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
+    bool use_inactive,
+    bool validate_full_update);
+
+// C-ABI-safe variant of AOTInductorModelContainerUpdateConstantBuffer.
+AOTI_API AOTIRuntimeError AOTInductorModelContainerUpdateConstantBufferPairs(
+    AOTInductorModelContainerHandle container_handle,
+    const AOTInductorConstantMapEntry* pairs,
+    size_t num_pairs,
     bool use_inactive,
     bool validate_full_update);
 

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -11,6 +11,7 @@
 // in model.so, and should not refer to any aten/c10 headers except the stable
 // C ABI defined in torch/csrc/inductor/aoti_torch/c/shim.h. The same rule
 // applies to other files under torch/csrc/inductor/aoti_runtime/.
+#include <torch/csrc/inductor/aoti_runtime/interface.h>
 #include <torch/csrc/inductor/aoti_runtime/model.h>
 
 namespace torch::aot_inductor {
@@ -264,6 +265,32 @@ class AOTInductorModelContainer {
     }
 
     return ret;
+  }
+
+  const std::vector<AOTInductorConstantMapEntry>& extract_constants_map_entries(
+      bool use_inactive) {
+    size_t n_consts = this->num_constants();
+    extracted_constant_map_entry_names_.clear();
+    extracted_constant_map_entries_.clear();
+    extracted_constant_map_entry_names_.reserve(n_consts);
+    extracted_constant_map_entries_.reserve(n_consts);
+
+    const auto& extract_map = use_inactive ? inactive().map : active().map;
+    for (size_t idx = 0; idx < n_consts; idx++) {
+      if (this->constant_from_folded(idx)) {
+        continue;
+      }
+
+      auto it = extract_map->find(this->constant_name(idx));
+      if (it != extract_map->end()) {
+        extracted_constant_map_entry_names_.emplace_back(
+            this->constant_original_fqn(idx));
+        extracted_constant_map_entries_.push_back(
+            {extracted_constant_map_entry_names_.back().c_str(), it->second});
+      }
+    }
+
+    return extracted_constant_map_entries_;
   }
 
   size_t num_constants() const {
@@ -768,6 +795,9 @@ class AOTInductorModelContainer {
 
   // Notified whenever a model is placed onto pending_models_.
   std::condition_variable pending_models_available_;
+
+  std::vector<std::string> extracted_constant_map_entry_names_;
+  std::vector<AOTInductorConstantMapEntry> extracted_constant_map_entries_;
 
   ConstantBufferSet& active() {
     return buffers_[active_idx_];


### PR DESCRIPTION
Summary:

Add AOTInductorModelContainerUpdateConstantBufferPairs, a C-ABI-safe replacement for AOTInductorModelContainerUpdateConstantBuffer.

The legacy API receives constants via AOTInductorConstantMapHandle, which is a host-owned std::unordered_map<std::string, AtenTensorHandle>* crossing the model DSO boundary. The new API accepts a flat AOTInductorConstantMapEntry[] and constructs the std::unordered_map inside the DSO.

This is additive; the V1 symbol remains exported for existing callers.

Test Plan:
buck build fbcode//mode/opt fbcode//caffe2:torch-cpp-cpu fbcode//caffe2/test/inductor/fb:test_aot_inductor_model_runner_pybind fbcode//sigmoid/core/executor:aoti_model_impl_cpu

arc lint fbcode/caffe2/torch/csrc/inductor/aoti_runtime/interface.h xplat/caffe2/torch/csrc/inductor/aoti_runtime/interface.h fbcode/caffe2/torch/_inductor/codegen/aoti_runtime/interface.cpp xplat/caffe2/torch/_inductor/codegen/aoti_runtime/interface.cpp

Reviewed By: desertfire

Differential Revision: D104312404




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo