### PR TITLE
Fix arange int64 fractional-step zero handling on CPU and CUDA.

### DIFF
--- a/aten/src/ATen/native/RangeUtils.h
+++ b/aten/src/ATen/native/RangeUtils.h
@@ -41,9 +41,12 @@ int64_t compute_arange_size(const Scalar& start, const Scalar& end, const Scalar
   double size_d;
   if constexpr (std::is_same_v<scalar_t, int64_t>) {
     using accscalar_t = at::acc_type<scalar_t, false>;
+    auto dstep = step.to<double>();
+    TORCH_CHECK(dstep <= -1.0 || dstep >= 1.0, "step must be nonzero");
     auto xstart = start.to<accscalar_t>();
     auto xend = end.to<accscalar_t>();
     auto xstep = step.to<accscalar_t>();
+    TORCH_CHECK(xstep != 0, "step must be nonzero");
     int64_t sgn = (xstep > 0) - (xstep < 0);
     size_d = std::ceil((xend - xstart + xstep - sgn) / xstep);
   } else {

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -225,6 +225,9 @@ Tensor& arange_cuda_out(const Scalar& start, const Scalar& end, const Scalar& st
     // the corner-case we do want to take into account is int64_t, which has higher precision than double
     double size_d;
     if constexpr (std::is_same_v<scalar_t, int64_t>) {
+      auto dstep = step.to<double>();
+      TORCH_CHECK(dstep <= -1.0 || dstep >= 1.0, "step must be nonzero");
+      TORCH_CHECK(xstep != 0, "step must be nonzero");
       int64_t sgn = (xstep > 0) - (xstep < 0);
       size_d = std::ceil((xend - xstart + xstep - sgn) / xstep);
     } else {

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2562,6 +2562,9 @@ class TestTensorCreation(TestCase):
         self.assertRaisesRegex(RuntimeError, msg, lambda: torch.arange(float('nan'), 10, device=device))
         self.assertRaisesRegex(RuntimeError, msg, lambda: torch.arange(float('inf'), device=device))
         self.assertRaisesRegex(RuntimeError, msg, lambda: torch.arange(float('nan'), device=device))
+        self.assertRaisesRegex(
+            RuntimeError, "step must be nonzero",
+            lambda: torch.arange(0, 5, 0.5, dtype=torch.int64, device=device))
 
         self.assertRaisesRegex(
             RuntimeError, "overflow",


### PR DESCRIPTION
Prevent divide-by-zero crashes when a fractional step is used with int64 dtype by validating step magnitude before integer conversion in both CPU and CUDA arange paths, and add regression coverage in tensor creation tests.