### PR TITLE
[Distributed] Add `ranks_only` to `StateDictOptions` for controlling which ranks receive the full state dict

### DIFF
--- a/test/distributed/checkpoint/fsdp/test_fsdp_dsd.py
+++ b/test/distributed/checkpoint/fsdp/test_fsdp_dsd.py
@@ -601,6 +601,73 @@ class TestFullyShardWithDistributedStateDict(FSDPTest):
                 self.assertEqual(fsdp2_tp_full_msd, tp_full_msd)
                 self.assertEqual(fsdp2_tp_full_osd, tp_full_osd)
 
+    @skip_if_lt_x_gpu(2)
+    def test_fsdp2_ranks_only(self):
+        self.run_subtests(
+            {
+                "ranks_only": [(0,), (), (1,), (0, 1), None],
+                "cpu_offload": [True, False],
+            },
+            self._test_fsdp2_ranks_only,
+        )
+
+    def _test_fsdp2_ranks_only(self, ranks_only, cpu_offload):
+        """
+        Test ranks_only behavior for FSDP2 state_dict.
+        """
+        orig_model = self._get_base_model()
+        fsdp_model = copy.deepcopy(orig_model)
+        for module in fsdp_model:
+            fully_shard(module)
+        fully_shard(fsdp_model)
+
+        optim = torch.optim.AdamW(fsdp_model.parameters(), lr=1e-4)
+
+        # Run one training step to populate optimizer state
+        inp = torch.randn((2, 2), device="cuda")
+        fsdp_model(inp).sum().backward()
+        optim.step()
+
+        options = StateDictOptions(
+            full_state_dict=True, cpu_offload=cpu_offload, ranks_only=ranks_only
+        )
+        dsd = get_model_state_dict(fsdp_model, options=options)
+        osd = get_optimizer_state_dict(fsdp_model, optim, options=options)
+
+        # Determine expected ranks that should receive the state dict
+        if ranks_only is not None:
+            expected_ranks = ranks_only if ranks_only else tuple(range(self.world_size))
+        else:
+            expected_ranks = (0,) if cpu_offload else tuple(range(self.world_size))
+
+        if self.rank in expected_ranks:
+            self.assertTrue(len(dsd) > 0)
+            self.assertTrue(len(osd) > 0)
+
+            if cpu_offload:
+                cpu_device = torch.device("cpu")
+                self.assertTrue(
+                    tree_all_only(
+                        (torch.Tensor, DTensor),
+                        lambda v: v.device == cpu_device,
+                        dsd,
+                    )
+                )
+            else:
+                self.assertTrue(
+                    tree_all_only(
+                        (torch.Tensor, DTensor),
+                        lambda v: v.device.type == "cuda",
+                        dsd,
+                    )
+                )
+
+            orig_sd = orig_model.state_dict()
+            self.assertEqual(set(orig_sd.keys()), set(dsd.keys()))
+        else:
+            self.assertEqual(dsd, {})
+            self.assertEqual(osd, {})
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -498,6 +498,31 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
             self._test_cpu_offload_full_state_dict,
         )
 
+    def test_ranks_only_requires_full_state_dict(self) -> None:
+        """Test that ranks_only raises ValueError when full_state_dict is False."""
+        model = nn.Linear(2, 2)
+
+        # ranks_only is not None but full_state_dict=False should raise ValueError
+        with self.assertRaises(ValueError):
+            get_model_state_dict(
+                model,
+                options=StateDictOptions(full_state_dict=False, ranks_only=(0,)),
+            )
+
+        # ranks_only=() with full_state_dict=False should also raise ValueError
+        with self.assertRaises(ValueError):
+            get_model_state_dict(
+                model,
+                options=StateDictOptions(full_state_dict=False, ranks_only=()),
+            )
+
+        # ranks_only=None with full_state_dict=False should not raise (default behavior)
+        msd = get_model_state_dict(
+            model,
+            options=StateDictOptions(full_state_dict=False),
+        )
+        self.assertEqual(msd, model.state_dict())
+
     @with_comms
     @skip_if_lt_x_gpu(1)
     def test_activation_ckpt_fqns_ddp(self) -> None:

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -6,7 +6,7 @@ import warnings
 from collections.abc import Callable, Generator, Iterable
 from dataclasses import asdict, dataclass, field
 from itertools import chain
-from typing import Any, cast, no_type_check
+from typing import Any, cast, no_type_check, Optional
 
 import torch
 import torch.distributed as dist
@@ -98,9 +98,21 @@ class StateDictOptions:
       returned state_dict will be gathered. No ShardedTensor and DTensor
       will be in the returned state_dict.
 
+    - ``ranks_only``: a tuple of **global ranks** that should receive the full
+       state_dict when ``full_state_dict`` is True. All other ranks will get
+       empty state_dicts.
+       - If ``None`` (default), the behavior is determined by ``cpu_offload``.
+       - If ``()`` (empty tuple), all ranks will receive the full state_dict.
+       - If ``(rank, ...)`` (non-empty tuple), only the specified global ranks
+         will receive the full state_dict.
+       This option is useful in Pipeline Parallel scenarios where each stage
+       needs a representative rank (not necessarily global rank 0) to hold the
+       stage's full state_dict for export.
+
     - ``cpu_offload``: offload all the tensors to cpu. To prevent CPU OOM, if
-      ``full_state_dict`` is also true, then only the rank0 will get the
-      state_dict and all other ranks will get empty state_dict.
+      ``full_state_dict`` is also true and ``ranks_only`` is not specified,
+      then only the rank0 will get the state_dict and all other ranks will get
+      empty state_dict.
 
     - ``ignore_frozen_params``: if the value is True, the returned state_dict
       won't contain any frozen parameters -- the ``requires_grad`` is False.
@@ -128,6 +140,7 @@ class StateDictOptions:
     """
 
     full_state_dict: bool = False
+    ranks_only: Optional[tuple[int, ...]] = None
     cpu_offload: bool = False
     ignore_frozen_params: bool = False
     keep_submodule_prefixes: bool = True
@@ -334,6 +347,11 @@ def _verify_options(
         raise ValueError(
             "full_state_dict must be True when broadcast_from_rank0 is True."
         )
+    if options.ranks_only is not None and not options.full_state_dict:
+        raise ValueError(
+            "full_state_dict must be True when ranks_only is specified."
+        )
+
     fsdp_modules = FSDP.fsdp_modules(model)
     state_dict_config: StateDictConfig
     optim_state_dict_config: OptimStateDictConfig
@@ -417,6 +435,7 @@ def _verify_state_dict(
         and not info.submodule_prefixes
         and not info.ignore_frozen_params
         and not (info.cpu_offload and info.full_state_dict)
+        and not (info.full_state_dict and info.ranks_only is not None)
         and info.strict
         and not info.broadcast_from_rank0
     ):
@@ -430,6 +449,7 @@ def _verify_state_dict(
         if (
             not optim_state_dict
             and not (info.cpu_offload and info.full_state_dict)
+            and not (info.full_state_dict and info.ranks_only is not None)
             and (not info.broadcast_from_rank0)
         ):
             raise RuntimeError(
@@ -456,11 +476,13 @@ def _maybe_full_or_cpu_state_dict(
     state_dict: dict[str, Any], info: _StateDictInfo
 ) -> dict[str, Any]:
     if info.full_state_dict:
-        ranks_only = (
-            ()
-            if (not info.cpu_offload or not torch.distributed.is_initialized())
-            else (0,)
-        )
+        if info.ranks_only is not None:
+            ranks_only = info.ranks_only
+        elif not info.cpu_offload or not torch.distributed.is_initialized():
+            ranks_only = ()
+        else:
+            ranks_only = (0,)
+
         return _gather_state_dict(
             state_dict, cpu_offload=info.cpu_offload, ranks_only=ranks_only
         )


### PR DESCRIPTION
### Background / Motivation

When exporting a model trained with Pipeline Parallelism (PP) + FSDP/TP for inference, users typically need to:

1. Call `get_model_state_dict(stage_module, options=StateDictOptions(full_state_dict=True))` on each PP stage to gather the full (unsharded) parameters.
2. Collect the per-stage state dicts to a single rank (e.g., rank 0) for final export.

Currently, the `ranks_only` behavior in `_maybe_full_or_cpu_state_dict` is implicitly controlled by `cpu_offload`:

```python
ranks_only = (
    ()       # cpu_offload=False → ALL ranks get the full state dict
    if (not info.cpu_offload or not torch.distributed.is_initialized())
    else (0,)  # cpu_offload=True → only global rank 0 gets it
)
```

This creates a dilemma for PP export scenarios:

- **`cpu_offload=False`**: Every rank in the stage holds a full copy of the stage's parameters in GPU memory — wasteful when only one representative rank per stage needs the data.
- **`cpu_offload=True`**: Only **global rank 0** receives the state dict. But in PP, global rank 0 belongs to only one stage (stage 0). Representative ranks of other stages (e.g., rank 8 for stage 1) get empty dicts, making cross-stage collection impossible through the public API.

Users are forced to either:
- Waste memory (all ranks hold full copies), or
- Call the **private** `_gather_state_dict` API directly with a custom `ranks_only` tuple — which is fragile and not guaranteed across versions.

### Solution

Add a public `ranks_only` field to `StateDictOptions`, allowing users to explicitly specify which global ranks should receive the full state dict when `full_state_dict=True`.

### Changes

1. **`StateDictOptions`**: New field `ranks_only: Optional[tuple[int, ...]] = None`.
   - `None` (default): behavior determined by `cpu_offload` (backward compatible).
   - `()` (empty tuple): ALL ranks receive the full state dict.
   - `(0, 4)` (non-empty): only specified ranks receive the full state dict.

2. **`_verify_options`**: Raises `ValueError` when `ranks_only is not None` and `full_state_dict=False`.

3. **`_maybe_full_or_cpu_state_dict`**: Priority logic:
   - If `ranks_only is not None` → use it directly (empty tuple = all ranks).
   - Else if `cpu_offload=True` → default to `(0,)` (existing behavior).
   - Else → `()` (all ranks, existing behavior).

4. **`_verify_state_dict`**: Skip empty state_dict validation for both model and optimizer
   when `full_state_dict=True` and `ranks_only is not None`, since non-target ranks
   legitimately return empty dicts.

### Usage Example

```python
from torch.distributed.checkpoint.state_dict import get_model_state_dict, StateDictOptions

# PP export: only the representative rank of each stage gets the full state dict
stage_first_rank = mesh_3d.mesh[pp_rank, 0, 0].item()

options = StateDictOptions(
    full_state_dict=True,
    ranks_only=(stage_first_rank,),
    cpu_offload=True,
)
state_dict = get_model_state_dict(stage_module, options=options)
# Stage's first rank: holds full CPU state dict
# Other ranks: empty dict {}
```

### Design Points

| Aspect | Detail |
|--------|--------|
| **Backward compatible** | Default `ranks_only=None` preserves existing behavior exactly |
| **Clear priority** | Explicit `ranks_only` overrides the implicit `cpu_offload`-based logic |
| **Minimal change** | Reuses the existing `ranks_only` parameter already supported by `_gather_state_dict` / `_iterate_state_dict` — no changes needed in `_state_dict_utils.py` |
| **DTensor compatible** | DTensor's all-gather still uses its own DeviceMesh (all ranks participate in communication as required by collectives); `ranks_only` only controls which ranks **retain** the result |
| **Validation** | `ranks_only` without `full_state_dict=True` raises `ValueError` to prevent nonsensical combinations |

### Note on Communication

Setting `ranks_only` does **not** skip the collective communication — all ranks in the DTensor's DeviceMesh still participate in the all-gather (this is a fundamental requirement of collective operations). The optimization is that non-target ranks **discard the result immediately** after the collective completes, avoiding:
- Sustained CPU memory usage on non-target ranks
- The need for users to manually `del` large state dicts

### Test

- Existing tests pass (no behavior change with default `ranks_only=None`).
- New unit test: verify that with `ranks_only=(0,)`, only rank 0 gets a non-empty state dict while other ranks get `{}`.
- New unit test: verify `ValueError` when `ranks_only` is set without `full_state_dict=True`.
