### PR TITLE
[c10d] Remove false-positive DeviceMesh pickle warning in async checkpoint

### DIFF
--- a/test/distributed/test_serialization.py
+++ b/test/distributed/test_serialization.py
@@ -125,6 +125,26 @@ class TestSerialization(TestCase):
         torch.testing.assert_close(result.to_local(), state_dict.to_local())
         self.assertEqual(result._spec, state_dict._spec)
 
+    def test_dtensor_unpickle_without_pgs(self) -> None:
+        # Regression test for #182102: unpickling a DTensor in a process
+        # where the original PGs don't exist (e.g., the async checkpoint
+        # subprocess) must not emit warnings.
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="gloo", rank=0, world_size=1, store=dist.HashStore()
+            )
+
+        device_mesh = DeviceMesh("cpu", 1)
+        dtensor = distribute_tensor(torch.randn(4, 4), device_mesh, [])
+        file = BytesIO()
+        _streaming_save(dtensor, file)
+        file.seek(0)
+        dist.destroy_process_group()
+
+        with self.assertNoLogs("torch.distributed.device_mesh", level="WARNING"):
+            result = cast(DTensor, _streaming_load(file))
+        self.assertEqual(result.device_mesh._pg_registry, {})
+
     def test_python_object(self) -> None:
         state_dict = {
             "obj": MyClass(42),

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -419,11 +419,11 @@ else:
 
         def __setstate__(self, state: dict) -> None:
             self.__dict__.update(state)
-            # Reconstruct _pg_registry from _dim_group_names.
-            # PGs may not exist when unpickling in a different process (e.g.,
-            # async checkpoint subprocess). That's fine -- _get_pg_from_name
-            # falls back to _resolve_process_group outside torch.compile and
-            # raises a clear error if a PG is genuinely missing during compile.
+            # Reconstruct _pg_registry from _dim_group_names. PGs may not
+            # exist when unpickling in a different process (e.g., async
+            # checkpoint subprocess); in that case the registry stays empty
+            # and _get_pg_from_name raises a clear error if the mesh is
+            # actually used under torch.compile.
             self._pg_registry = {}
             if hasattr(self, "_dim_group_names"):
                 for name in self._dim_group_names:
@@ -432,7 +432,13 @@ else:
                         if pg is not None:
                             self._pg_registry[name] = pg
                     except RuntimeError:
-                        pass
+                        # Debug, not warning: expected and benign in processes
+                        # that never created the PGs (see #182102).
+                        logger.debug(
+                            "Process group %s could not be resolved while "
+                            "unpickling DeviceMesh; skipping registry entry",
+                            name,
+                        )
 
         @property
         def device_type(self) -> str:

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -419,7 +419,11 @@ else:
 
         def __setstate__(self, state: dict) -> None:
             self.__dict__.update(state)
-            # Reconstruct _pg_registry from _dim_group_names
+            # Reconstruct _pg_registry from _dim_group_names.
+            # PGs may not exist when unpickling in a different process (e.g.,
+            # async checkpoint subprocess). That's fine -- _get_pg_from_name
+            # falls back to _resolve_process_group outside torch.compile and
+            # raises a clear error if a PG is genuinely missing during compile.
             self._pg_registry = {}
             if hasattr(self, "_dim_group_names"):
                 for name in self._dim_group_names:
@@ -428,12 +432,7 @@ else:
                         if pg is not None:
                             self._pg_registry[name] = pg
                     except RuntimeError:
-                        # Note: process groups may not exist if loading in a different process
-                        logger.warning(
-                            "It seems like pickling/unpickling of the DeviceMesh "
-                            "occurred before the PGs were created. This will cause PG "
-                            "lookup to fail when torch.compile is enabled"
-                        )
+                        pass
 
         @property
         def device_type(self) -> str:


### PR DESCRIPTION
When using `dcp.async_save` with `AsyncCheckpointerType.PROCESS`, DTensors are pickled and sent to a checkpoint subprocess. On unpickle, `DeviceMesh.__setstate__` tries to resolve the original process groups which don't exist in the subprocess, emitting a spurious warning per PG per DTensor.

Fixes #182102