### PR TITLE
[dynamo] Fix #182594: Avoid value-specialization guards on unused constant kwargs in HOPs

### DIFF
--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -539,6 +539,116 @@ class LazyConstantVariableTests(TestCase):
         self.assertEqual(eager6[2], compiled6[2])
         self.assertEqual(counter_multi.frame_count, 1)
 
+    def test_hop_unused_constant_kwargs_no_recompile(self):
+        """Unused constant kwargs in higher-order ops should not cause recompiles.
+
+        When constant kwargs are passed through a HOP (e.g. torch.cond) but never
+        read by the body function, changing their values should not invalidate the
+        compiled graph. Only TYPE_MATCH guards should be installed, not
+        CONSTANT_MATCH / FALSE_MATCH / NONE_MATCH.
+        """
+
+        def true_fn(x, unused_flag, unused_none):
+            return x.sin() * 2
+
+        def false_fn(x, unused_flag, unused_none):
+            return x.cos() * 2
+
+        def fn(x, pred, unused_flag, unused_none):
+            return torch.cond(pred, true_fn, false_fn, (x, unused_flag, unused_none))
+
+        counter = CompileCounter()
+        opt_fn = torch.compile(fn, backend=counter)
+        x = torch.randn(4)
+        pred = torch.tensor(True)
+
+        opt_fn(x, pred, False, None)
+        self.assertEqual(counter.frame_count, 1)
+
+        opt_fn(x, pred, True, None)
+        self.assertEqual(counter.frame_count, 1)
+
+        opt_fn(x, pred, False, None)
+        self.assertEqual(counter.frame_count, 1)
+
+    def test_hop_used_constant_kwargs_do_recompile(self):
+        """Constants that ARE read by the HOP body should still cause recompiles."""
+
+        def true_fn(x, flag):
+            if flag:
+                return x.sin() * 2
+            return x.sin()
+
+        def false_fn(x, flag):
+            if flag:
+                return x.cos() * 2
+            return x.cos()
+
+        def fn(x, pred, flag):
+            return torch.cond(pred, true_fn, false_fn, (x, flag))
+
+        counter = CompileCounter()
+        opt_fn = torch.compile(fn, backend=counter)
+        x = torch.randn(4)
+        pred = torch.tensor(True)
+
+        opt_fn(x, pred, False)
+        self.assertEqual(counter.frame_count, 1)
+
+        opt_fn(x, pred, True)
+        self.assertEqual(counter.frame_count, 2)
+
+    def test_hop_none_to_supported_type_does_recompile(self):
+        """Changing from None to a supported LazyConstantVariable type should
+        trigger recompile since the TYPE changes."""
+
+        def true_fn(x, val):
+            return x.sin() * 2
+
+        def false_fn(x, val):
+            return x.cos() * 2
+
+        def fn(x, pred, val):
+            return torch.cond(pred, true_fn, false_fn, (x, val))
+
+        counter = CompileCounter()
+        opt_fn = torch.compile(fn, backend=counter)
+        x = torch.randn(4)
+        pred = torch.tensor(True)
+
+        opt_fn(x, pred, None)
+        self.assertEqual(counter.frame_count, 1)
+
+        opt_fn(x, pred, "hello")
+        self.assertEqual(counter.frame_count, 2)
+
+    def test_speculate_subgraph_unused_constant_no_recompile(self):
+        """speculate_subgraph's realize_all should not install value guards
+        on unused lazy constants."""
+
+        def true_fn(x, unused_str):
+            return x.sin()
+
+        def false_fn(x, unused_str):
+            return x.cos()
+
+        def fn(x, pred, tag):
+            return torch.cond(pred, true_fn, false_fn, (x, tag))
+
+        counter = CompileCounter()
+        opt_fn = torch.compile(fn, backend=counter)
+        x = torch.randn(4)
+        pred = torch.tensor(True)
+
+        opt_fn(x, pred, "alpha")
+        self.assertEqual(counter.frame_count, 1)
+
+        opt_fn(x, pred, "beta")
+        self.assertEqual(counter.frame_count, 1)
+
+        opt_fn(x, pred, "gamma")
+        self.assertEqual(counter.frame_count, 1)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -62,7 +62,7 @@ from ..source import AttrSource, DictGetItemSource
 from ..utils import proxy_args_kwargs, set_example_value
 from .base import VariableTracker
 from .dicts import ConstDictVariable
-from .lazy import LazyVariableTracker
+from .lazy import LazyConstantVariable, LazyVariableTracker
 from .lists import ListVariable, TupleVariable
 from .sets import SetVariable
 
@@ -688,7 +688,9 @@ def _call_while_loop(
 ) -> VariableTracker:
     from torch._higher_order_ops.while_loop import _create_unbacked_symint
 
-    args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
+    args, kwargs = LazyVariableTracker.realize_all(
+        (args, kwargs), allow_lazy_constant=True
+    )
     cond_fn, body_fn, operands, additional_inputs = args
 
     # Input checks
@@ -1179,7 +1181,20 @@ def validate_args_and_maybe_create_graph_inputs(
                 args.append(a)
                 continue
 
-            if a.is_python_constant():
+            if isinstance(a, LazyConstantVariable) and not a.is_realized():
+                # LazyConstantVariable wraps a primitive constant (bool, str,
+                # None, etc.) that hasn't been read yet. Use python_type()
+                # (which installs only TYPE_MATCH) and peek_value() (no value
+                # guard) so that changing the value without changing the type
+                # does not trigger a recompile.
+                arg_name = (
+                    "const_unused"
+                    if sub_args_names is None
+                    else f"const_unused_{sub_args_names[idx]}"
+                )
+                tracer.create_graph_input(arg_name, a.python_type(), a.peek_value())
+                new_arg = a
+            elif a.is_python_constant():
                 # This arg is not used in the body of the higher order op.
                 # Currently, this new input is added to make the calls
                 # happy, which expect a fixed number of arguments. In
@@ -2043,6 +2058,7 @@ def speculate_subgraph(
         # ensure guards on args get installed in parent subgraph
         f, sub_args, sub_kwargs = LazyVariableTracker.realize_all(
             (f, sub_args, sub_kwargs),
+            allow_lazy_constant=True,
         )
 
         with tx.output.subtracer(source_target, tracer, description) as subtracer:
@@ -2364,7 +2380,9 @@ class CondHigherOrderVariable(TorchHigherOrderOperatorVariable):
         self.supports_input_mutation = not torch.is_grad_enabled()
         self.supports_aliasing = not torch.is_grad_enabled()
 
-        args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
+        args, kwargs = LazyVariableTracker.realize_all(
+            (args, kwargs), allow_lazy_constant=True
+        )
 
         for i, k in enumerate(["pred", "true_fn", "false_fn", "operands"]):
             if v := kwargs.pop(k, None):
@@ -2390,7 +2408,7 @@ class CondHigherOrderVariable(TorchHigherOrderOperatorVariable):
 
         # Specialize into one of the branches since pred is constant
         pred, true_fn, false_fn, operands = args
-        if type(args[0]) is ConstantVariable:
+        if isinstance(args[0], ConstantVariable):
             warnings.warn(
                 "Pred is a Python constant. When used with torch.cond, it specializes on one of the branches."
                 " If you want torch.cond to preserve two branches, please make the predicate a boolean tensor or a SymBool.",
@@ -2609,7 +2627,9 @@ class CallTorchbindHigherOrderVariable(TorchHigherOrderOperatorVariable):
     ) -> VariableTracker:
         from .builder import wrap_fx_proxy
 
-        args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
+        args, kwargs = LazyVariableTracker.realize_all(
+            (args, kwargs), allow_lazy_constant=True
+        )
 
         args_proxy = [arg.as_proxy() for arg in args]
         kwargs_proxy = {k: v.as_proxy() for k, v in kwargs.items()}
@@ -2711,7 +2731,9 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
     ) -> VariableTracker:
         from torch._higher_order_ops.utils import first_slice_copy
 
-        args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
+        args, kwargs = LazyVariableTracker.realize_all(
+            (args, kwargs), allow_lazy_constant=True
+        )
 
         def arg_extractor(
             combine_fn: VariableTracker,
@@ -2955,7 +2977,9 @@ class ScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
         from torch._higher_order_ops.scan import _extract_carry_and_out
         from torch._higher_order_ops.utils import first_slice_copy
 
-        args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
+        args, kwargs = LazyVariableTracker.realize_all(
+            (args, kwargs), allow_lazy_constant=True
+        )
 
         # combine_fn input check
         def _check_combine_fn_is_normalized(combine_fn_var: VariableTracker) -> bool:
@@ -3199,7 +3223,9 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         args: Sequence[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
+        args, kwargs = LazyVariableTracker.realize_all(
+            (args, kwargs), allow_lazy_constant=True
+        )
 
         if len(kwargs) > 0:
             unimplemented(
@@ -3316,7 +3342,9 @@ class PrintHigherOrderVariable(TorchHigherOrderOperatorVariable):
     ) -> VariableTracker:
         from .builder import wrap_fx_proxy
 
-        args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
+        args, kwargs = LazyVariableTracker.realize_all(
+            (args, kwargs), allow_lazy_constant=True
+        )
 
         args_proxy = [arg.as_proxy() for arg in args]
         kwargs_proxy = {k: v.as_proxy() for k, v in kwargs.items()}
@@ -3600,7 +3628,9 @@ class WrapWithSetGradEnabledHigherOrderVariable(TorchHigherOrderOperatorVariable
         args: Sequence[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
+        args, kwargs = LazyVariableTracker.realize_all(
+            (args, kwargs), allow_lazy_constant=True
+        )
 
         if kwargs:
             unimplemented(
@@ -3691,7 +3721,9 @@ class WrapWithAutocastHigherOrderVariable(TorchHigherOrderOperatorVariable):
         args: Sequence[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
+        args, kwargs = LazyVariableTracker.realize_all(
+            (args, kwargs), allow_lazy_constant=True
+        )
 
         if kwargs:
             unimplemented(

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -310,7 +310,7 @@ class LazyConstantVariable(LazyVariableTracker):
       flow or math), which subsumes any TYPE_MATCH guard
     """
 
-    supported_types = (int, float, bool, str)
+    supported_types = (int, float, bool, str, type(None))
     _nonvar_fields = {
         "_type_guard_installed",
         "_type_guard_ref",
@@ -405,7 +405,9 @@ class LazyConstantVariable(LazyVariableTracker):
 
     def is_constant_none(self) -> bool:
         self._ensure_type_guard()
-        return False
+        if not self.is_realized():
+            return self.peek_type() is type(None)
+        return self.realize().is_constant_none()
 
     def _maybe_realize_for_type(self) -> type | None:
         """Check if we need to realize to determine the VariableTracker type.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #183050

Higher-order operators (cond, while_loop, scan, etc.) were eagerly
realizing all LazyVariableTracker instances via `realize_all` in their
`_call_function` methods and in `speculate_subgraph`. This installed
CONSTANT_MATCH guards (FALSE_MATCH, NONE_MATCH, EQUALS_MATCH) on every
constant argument -- even ones the body function never reads. The result:
changing an unused kwarg's value (same type!) between calls would
needlessly invalidate the compiled graph and trigger a recompile. Not
great when your users are innocently threading **kwargs through a wrapper.

Root cause, in three acts:

1. `realize_all` was called with `allow_lazy_constant=False` (the
   default), which forces LazyConstantVariable instances to realize and
   install full value guards.

2. The `flatten_manual` path in `validate_args_and_maybe_create_graph_inputs`
   called `is_python_constant()` and `as_python_constant()` on each arg,
   which triggered realization even for args the body never touches. The
   comment right there literally says "This arg is not used in the body"
   -- the irony was not lost on us.

3. `None` values weren't covered by LazyConstantVariable (supported_types
   was just int/float/bool/str), so they always got eagerly realized with
   NONE_MATCH guards.

The fix, also in three acts:

1. Pass `allow_lazy_constant=True` to every `realize_all` call in HOP
   `_call_function` methods and in `speculate_subgraph`. This lets
   LazyConstantVariables stay lazy, deferring guard installation.

2. Add a fast path in `validate_args_and_maybe_create_graph_inputs` for
   unrealized LazyConstantVariables: use `python_type()` (TYPE_MATCH
   only) and `peek_value()` (no value guard) instead of triggering full
   realization.

3. Add `type(None)` to `LazyConstantVariable.supported_types` and fix
   `is_constant_none()` to handle it correctly.

Also fixed `CondHigherOrderVariable` to use `isinstance(pred,
ConstantVariable)` instead of `type(pred) is ConstantVariable`, so that
LazyConstantVariable wrapping a bool pred still triggers the
constant-pred specialization path.

Authored by Claude.

Fix #182594

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98