### PR TITLE
Fix torch.compile(torch.func.grad(model)) with 3D+ input to nn.Linear

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -5423,14 +5423,19 @@ class TestCompileTransforms(TestCase):
         self.assertEqual(result, expected)
 
     @parametrize("backend", ["eager", "aot_eager", "inductor"])
-    def test_compile_grad_linear_nd_input(self, device, backend):
+    @parametrize(
+        "input_shape",
+        [(16, 3, 6), (2, 4, 3, 6)],
+        name_fn=lambda s: f"{len(s)}d",
+    )
+    def test_compile_grad_linear_nd_input(self, device, backend, input_shape):
         # Regression test for https://github.com/pytorch/pytorch/issues/181304
         linear = nn.Linear(6, 52).to(device)
 
         def model(x):
             return torch.abs(linear(x)).mean()
 
-        x = torch.randn(16, 3, 6, device=device)
+        x = torch.randn(*input_shape, device=device)
         expected = grad(model)(x)
 
         torch._dynamo.reset()

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -5422,6 +5422,22 @@ class TestCompileTransforms(TestCase):
         result = compiled(x)
         self.assertEqual(result, expected)
 
+    @parametrize("backend", ["eager", "aot_eager", "inductor"])
+    def test_compile_grad_linear_nd_input(self, device, backend):
+        # Regression test for https://github.com/pytorch/pytorch/issues/181304
+        linear = nn.Linear(6, 52).to(device)
+
+        def model(x):
+            return torch.abs(linear(x)).mean()
+
+        x = torch.randn(16, 3, 6, device=device)
+        expected = grad(model)(x)
+
+        torch._dynamo.reset()
+        compiled = torch.compile(grad(model), backend=backend)
+        result = compiled(x)
+        self.assertEqual(result, expected)
+
     # torch.compile is not supported on Windows
     @torch._dynamo.config.patch(suppress_errors=False)
     def test_grad_deprecated_api(self, device):

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -3431,16 +3431,6 @@ def _device_handler(args: Sequence[object]) -> torch.device:
         return args[0].fake_device
 
 
-# [subclass inputs]
-# Suppose we enable fake tensor mode.  This means that fake tensor
-# mode will run first.  But what if we do an operation that
-# involves a tensor subclass that will desugar into normal tensor
-# operations?  Without returning NotImplemented, fake tensor mode will run first,
-# decide that a conversion was made (since there was a non fake
-# tensor argument), and report an error that converting non
-# fake tensor is not supported.  What we actually wanted to happen
-# was to give the subclass a chance to figure out what it wants to
-# before erroring out. Returning NotImplemented here allows this.
 def _maybe_extract_fake_view(x: Tensor, fake_mode: FakeTensorMode) -> FakeTensor | None:
     """If *x* is a plain-Tensor view of a FunctionalTensor whose innermost
     storage is a FakeTensor belonging to *fake_mode*, return the
@@ -3468,6 +3458,16 @@ def _maybe_extract_fake_view(x: Tensor, fake_mode: FakeTensorMode) -> FakeTensor
     return out  # pyrefly: ignore[bad-return]
 
 
+# [subclass inputs]
+# Suppose we enable fake tensor mode.  This means that fake tensor
+# mode will run first.  But what if we do an operation that
+# involves a tensor subclass that will desugar into normal tensor
+# operations?  Without returning NotImplemented, fake tensor mode will run first,
+# decide that a conversion was made (since there was a non fake
+# tensor argument), and report an error that converting non
+# fake tensor is not supported.  What we actually wanted to happen
+# was to give the subclass a chance to figure out what it wants to
+# before erroring out. Returning NotImplemented here allows this.
 def _check_for_subclass(flat_args: Sequence[object]) -> bool:
     return any(_check_for_subclass_arg(x) for x in flat_args)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -3028,6 +3028,17 @@ class FakeTensorMode(TorchDispatchMode):
                     else fake_tensor_tls.allow_non_fake_inputs_override
                 )
                 if not allow_non_fake_inputs:
+                    # During joint graph tracing, the C++ autograd engine
+                    # can produce plain-Tensor views of FunctionalTensors
+                    # that wrap FakeTensors (e.g. when a backward function
+                    # reshapes a saved FunctionalTensor). Recover the
+                    # underlying FakeTensor view instead of raising.
+                    fake_view = _maybe_extract_fake_view(x, self)
+                    if fake_view is not None:
+                        out = fake_view
+                        flat_arg_fake_tensors.append(out)
+                        return out
+
                     if isinstance(x, FakeTensor) and x.fake_mode is not self:
                         raise AssertionError(
                             f"Mixing fake modes NYI x.fake_mode={x.fake_mode} vs self={self}"
@@ -3430,6 +3441,33 @@ def _device_handler(args: Sequence[object]) -> torch.device:
 # fake tensor is not supported.  What we actually wanted to happen
 # was to give the subclass a chance to figure out what it wants to
 # before erroring out. Returning NotImplemented here allows this.
+def _maybe_extract_fake_view(x: Tensor, fake_mode: FakeTensorMode) -> FakeTensor | None:
+    """If *x* is a plain-Tensor view of a FunctionalTensor whose innermost
+    storage is a FakeTensor belonging to *fake_mode*, return the
+    corresponding FakeTensor view.  Otherwise return ``None``.
+
+    During joint-graph tracing the C++ autograd engine can produce
+    plain-Tensor views of FunctionalTensors (e.g. when a backward
+    function reshapes a saved FunctionalTensor at the C++ level).
+    These views bypass FunctionalTensorMode wrapping, so they arrive
+    at FakeTensorMode as non-fake tensors.  Rather than raising, we
+    recover the underlying FakeTensor and re-apply the view."""
+    from torch._subclasses.functional_tensor import FunctionalTensor
+
+    base = x._base
+    if base is None or not isinstance(base, FunctionalTensor):
+        return None
+    if not torch._is_functional_tensor(base.elem):
+        return None
+    inner_fake = torch._from_functional_tensor(base.elem)
+    if not fake_mode.is_our_fake(inner_fake):
+        return None
+    # as_strided on a FakeTensor produces a FakeTensor; the cast is
+    # only needed to satisfy the static type checker.
+    out = inner_fake.as_strided(x.shape, x.stride(), x.storage_offset())
+    return out  # pyrefly: ignore[bad-return]
+
+
 def _check_for_subclass(flat_args: Sequence[object]) -> bool:
     return any(_check_for_subclass_arg(x) for x in flat_args)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183051

Fix #181304

When `torch.compile` wraps `torch.func.grad(model)` and the model
contains `nn.Linear` with a 3D+ input, the backward of `F.linear`
decomposes through `view -> addmm -> view`, which introduces
reshape operations in the autograd graph. During AOTAutograd's joint
forward+backward tracing (`create_joint`), the C++ autograd engine runs
backward functions that produce plain-Tensor views of FunctionalTensors
(e.g., when `ViewBackward0` reshapes a saved FunctionalTensor gradient
at the C++ level). These views bypass `FunctionalTensorMode` wrapping
and arrive at `FakeTensorMode` as non-fake tensors, triggering the
assertion "Please convert all Tensors to FakeTensors first."

The fix adds `_maybe_extract_fake_view` to `FakeTensorMode`: when a
non-fake tensor is encountered and it turns out to be a view of a
`FunctionalTensor` whose inner storage is a `FakeTensor`, we recover the
underlying `FakeTensor` and re-apply the view via `as_strided` instead
of raising. This lets the joint-graph tracing proceed normally.

With 2D inputs the issue never manifested because `F.linear` uses
`addmm` directly (no reshaping), so the backward path never creates
these intermediate views. The bug bites exclusively for 3D+ inputs
where the decomposition introduces `view` ops whose backward creates
the problematic plain-Tensor views.

Verified by running `torch.compile(torch.func.grad(model))(x)` for 2D,
3D, and 4D inputs with eager, aot_eager, and inductor backends --
all produce correct gradients matching the eager reference.

Authored by Claude.