### PR TITLE
Fix OOM error suggesting expandable_segments when already enabled

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1838,6 +1838,17 @@ class DeviceCachingAllocator {
 
       lock.unlock();
 
+      std::string expandable_segments_suggestion;
+
+      if (!c10::CachingAllocator::AcceleratorAllocatorConfig::
+              use_expandable_segments()) {
+        expandable_segments_suggestion =
+            " If reserved but unallocated memory is large try setting"
+            " PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid"
+            " fragmentation.  See documentation for Memory Management "
+            " (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)";
+      }
+
       for (const auto& obs : observers_local) {
         obs(device_id,
             alloc_size,
@@ -1885,10 +1896,7 @@ class DeviceCachingAllocator {
           format_size(
               reserved_bytes - allocated_bytes - allocated_in_private_pools),
           " is reserved by PyTorch but unallocated.",
-          " If reserved but unallocated memory is large try setting",
-          " PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid"
-          " fragmentation.  See documentation for Memory Management "
-          " (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)");
+          expandable_segments_suggestion);
     }
 
     bool split_remainder = should_split(

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5467,6 +5467,42 @@ print(value, end="")
         with self.assertRaises(torch.cuda.OutOfMemoryError):
             torch.empty(1024 * 1024 * 1024 * 1024, device="cuda")
 
+    @serialTest()
+    @unittest.skipIf(TEST_CUDAMALLOCASYNC, "setAllocatorSettings not supported")
+    def test_oom_message_expandable_segments_suggestion(self):
+        """When expandable_segments is already enabled, the OOM error
+        should not suggest enabling it again."""
+        for expandable in (False, True):
+            torch.cuda.memory.empty_cache()
+            torch.cuda.memory._set_allocator_settings(
+                f"expandable_segments:{expandable}"
+            )
+            try:
+                torch.empty(1024 * 1024 * 1024 * 1024, device="cuda")
+            except torch.cuda.OutOfMemoryError as e:
+                msg = str(e)
+                if expandable:
+                    self.assertNotIn(
+                        "expandable_segments:True",
+                        msg,
+                        "OOM message should not suggest expandable_segments "
+                        "when it is already enabled",
+                    )
+                else:
+                    self.assertIn(
+                        "expandable_segments:True",
+                        msg,
+                        "OOM message should suggest expandable_segments "
+                        "when it is not enabled",
+                    )
+            else:
+                self.fail("Expected OutOfMemoryError")
+
+        # Restore suite baseline
+        torch.cuda.memory._set_allocator_settings(
+            f"expandable_segments:{EXPANDABLE_SEGMENTS}"
+        )
+
     @unittest.skipIf(
         not ((IS_X86 or IS_ARM64) and IS_LINUX), "cpp traces are linux x86/aarch64 only"
     )


### PR DESCRIPTION
Fixes #173049

## Summary

When a CUDA OOM occurs and `expandable_segments` is already enabled via `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`, the error message still tells the user to try setting it. This is confusing — they already did.

The fix checks `AcceleratorAllocatorConfig::use_expandable_segments()` before including the suggestion. If expandable segments are already on, the suggestion is omitted.

## Test Plan

Verified by reading the code path in `CUDACachingAllocator.cpp` — the `expandable_segments_suggestion` string is now conditionally populated only when `use_expandable_segments()` returns false.

Authored with Claude.