### PR TITLE
[ROCm] Revert #178310 to fix cmake error

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -202,15 +202,9 @@ file(GLOB native_flash_attn_api_cpp CONFIGURE_DEPENDS "native/transformers/cuda/
 file(GLOB flash_attention_hip_hip CONFIGURE_DEPENDS "native/transformers/hip/flash_attn/*.hip")
 # if USE_FLASH_ATTENTION is set, ensure CK instances get generated
 if(USE_FLASH_ATTENTION)
-  # Now building CK by default
-  if(USE_ROCM)
-    if(DEFINED ENV{USE_ROCM_CK_SDPA})
-        if(ENV{USE_ROCM_CK_SDPA} EQUAL 1)
-          caffe2_update_option(USE_ROCM_CK_SDPA ON)
-        endif()
-    else()
-      caffe2_update_option(USE_ROCM_CK_SDPA ON)
-    endif()
+  if("$ENV{USE_CK_FLASH_ATTENTION}" STREQUAL "1")
+    message(STATUS "USE_CK_FLASH_ATTENTION is being deprecated. Please use USE_ROCM_CK_SDPA instead")
+    caffe2_update_option(USE_ROCM_CK_SDPA ON)
   endif()
   if(USE_ROCM AND USE_ROCM_CK_SDPA)
     if(DEFINED ENV{PYTORCH_ROCM_ARCH})

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/CMakeLists.txt
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/CMakeLists.txt
@@ -1,7 +1,7 @@
 # generate a list of kernels, but not actually emit files at config stage
 execute_process(
-  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --optdim=32,64,128,256
-  --api fwd --receipt 4 --filter "*_lse*ntrload*nsink*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_blob_list.txt
+  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
+  --api fwd --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_blob_list.txt
   RESULT_VARIABLE ret
 )
 
@@ -10,8 +10,8 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 execute_process(
-  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --optdim=32,64,128,256
-  --api fwd_splitkv --receipt 4 --filter "*psdv*_lse*_nsquant*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_splitkv_blob_list.txt
+  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
+  --api fwd_splitkv --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_splitkv_blob_list.txt
   RESULT_VARIABLE ret
 )
 
@@ -20,8 +20,8 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 execute_process(
-  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --optdim=32,64,128,256
-  --api fwd_appendkv --receipt 4 --filter "*psskddv_*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_appendkv_blob_list.txt
+  COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
+  --api fwd_appendkv --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/fwd_appendkv_blob_list.txt
   RESULT_VARIABLE ret
 )
 
@@ -31,7 +31,7 @@ endif()
 
 execute_process(
   COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py
-  --api bwd --optdim=32,64,128,256 --receipt 4 --filter "*psdv*@*psd*@*_pd1dv1*_ntrload*" --list_blobs ${CMAKE_CURRENT_LIST_DIR}/bwd_blob_list.txt
+  --api bwd --receipt 4 --list_blobs ${CMAKE_CURRENT_LIST_DIR}/bwd_blob_list.txt
   RESULT_VARIABLE ret
 )
 
@@ -40,28 +40,28 @@ if(ret AND NOT ret EQUAL 0)
 endif()
 
 # Generate the files for both fwd, fwd_splitkv, fwd_appendkv, and bwd
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd  --optdim=32,64,128,256 --receipt 4 --filter "*_lse*ntrload*nsink*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
   message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD kernels.")
 endif()
 
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd_splitkv --optdim=32,64,128,256 --receipt 4 --filter "*psdv*_lse*_nsquant*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd_splitkv --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
     message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD_SPLITKV kernels.")
 endif()
 
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd_appendkv --optdim=32,64,128,256 --receipt 4 --filter "*psskddv_*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api fwd_appendkv --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
 )
 
 if(ret AND NOT ret EQUAL 0)
     message( FATAL_ERROR "CK Tile FMHA FAILED to generate FWD_APPENDKV kernels.")
 endif()
 
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api bwd --optdim=32,64,128,256 --receipt 4 --filter "*psdv*@*psd*@*_pd1dv1*_ntrload*" --output_dir ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/third_party/composable_kernel/example/ck_tile/01_fmha/generate.py --api bwd --receipt 4 --output_dir ${CMAKE_CURRENT_LIST_DIR}
   RESULT_VARIABLE ret
 )
 

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/fav_v3/CMakeLists.txt
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/fav_v3/CMakeLists.txt
@@ -1,38 +1,14 @@
 include(CMakePrintHelpers)
 
-# Create an isolated venv for codegen.py which requires pandas>=2.1.0 (for
-# the "future.no_silent_downcasting" option).  This avoids polluting the CI /
-# host Python environment while still satisfying the dependency.
-set(CODEGEN_VENV_DIR "${CMAKE_CURRENT_BINARY_DIR}/_codegen_venv")
-
-if(NOT EXISTS "${CODEGEN_VENV_DIR}/bin/python3")
-    message(STATUS "Creating isolated codegen venv at ${CODEGEN_VENV_DIR}")
-    execute_process(
-        COMMAND python3 -m venv "${CODEGEN_VENV_DIR}"
-        RESULT_VARIABLE ret
-    )
-    if(ret AND NOT ret EQUAL 0)
-        message(FATAL_ERROR "Failed to create codegen venv")
-    endif()
-
-    execute_process(
-        COMMAND "${CODEGEN_VENV_DIR}/bin/pip" install --quiet "pandas>=2.1.0,<=2.3.3" numpy
-        RESULT_VARIABLE ret
-    )
-    if(ret AND NOT ret EQUAL 0)
-        message(FATAL_ERROR "Failed to install pandas/numpy into codegen venv")
-    endif()
-endif()
-
-# Generate AITER/CK Asm code (using the venv python so pandas is new enough)
+# Generate AITER/CK Asm code
 execute_process(
     COMMAND ${CMAKE_COMMAND} -E env "AITER_GPU_ARCHS=gfx942;gfx950"
-            "${CODEGEN_VENV_DIR}/bin/python3" ${CMAKE_SOURCE_DIR}/third_party/aiter/hsa/codegen.py -m fmha_v3_bwd --output_dir ${CMAKE_CURRENT_LIST_DIR}
+            python3 ${CMAKE_SOURCE_DIR}/third_party/aiter/hsa/codegen.py -m fmha_v3_bwd --output_dir ${CMAKE_CURRENT_LIST_DIR}
     RESULT_VARIABLE ret
 )
 
 if(ret AND NOT ret EQUAL 0)
-    message(FATAL_ERROR "Failed to generate FAv3 CK Kernels")
+    message( FATAL_ERROR "Failed to generate FAv3 CK Kernels")
 endif()
 
 execute_process(COMMAND bash -c "cp ${CMAKE_SOURCE_DIR}/third_party/aiter/csrc/cpp_itfs/mha_bwd.cu ${CMAKE_CURRENT_LIST_DIR}/mha_bwd.hip")

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -6,100 +6,9 @@
 #include <fmha_fwd.hpp>
 #include <mask.hpp>
 
-#include <cstdio>
-
-namespace {
-/* Debug traces. Comment in to aid in debug of 'Invalid argument to fmha_fwd' error
-const char* mask_enum_str(mask_enum m) {
-    switch (m) {
-        case mask_enum::no_mask:          return "no_mask";
-        case mask_enum::mask_top_left:    return "mask_top_left";
-        case mask_enum::mask_bottom_right:return "mask_bottom_right";
-        case mask_enum::window_generic:   return "window_generic";
-        default:                          return "unknown";
-    }
-}
-
-const char* bias_enum_str(bias_enum b) {
-    switch (b) {
-        case bias_enum::no_bias:          return "no_bias";
-        case bias_enum::elementwise_bias: return "elementwise_bias";
-        case bias_enum::alibi:            return "alibi";
-        default:                          return "unknown";
-    }
-}
-
-const char* qscale_enum_str(quant_scale_enum q) {
-    switch (q) {
-        case quant_scale_enum::no_scale:      return "no_scale";
-        case quant_scale_enum::pertensor:      return "pertensor";
-        case quant_scale_enum::blockscale:     return "blockscale";
-        case quant_scale_enum::kv_blockscale:  return "kv_blockscale";
-        default:                               return "unknown";
-    }
-}
-
-void dump_fmha_fwd_kernel_selection_params(const fmha_fwd_traits& t,
-                                           const fmha_fwd_args& a) {
-    std::printf("=== fmha_fwd kernel selection params ===\n");
-    std::printf("--- traits ---\n");
-    std::printf("  data_type          : %s\n",  t.data_type.c_str());
-    std::printf("  hdim_q             : %d\n",  t.hdim_q);
-    std::printf("  hdim_v             : %d\n",  t.hdim_v);
-    std::printf("  is_group_mode      : %s\n",  t.is_group_mode      ? "true" : "false");
-    std::printf("  is_v_rowmajor      : %s\n",  t.is_v_rowmajor      ? "true" : "false");
-    std::printf("  has_logits_soft_cap: %s\n",  t.has_logits_soft_cap ? "true" : "false");
-    std::printf("  mask_type          : %s (%d)\n", mask_enum_str(t.mask_type),
-                static_cast<int>(t.mask_type));
-    std::printf("  bias_type          : %s (%d)\n", bias_enum_str(t.bias_type),
-                static_cast<int>(t.bias_type));
-    std::printf("  has_lse            : %s\n",  t.has_lse             ? "true" : "false");
-    std::printf("  has_dropout        : %s\n",  t.has_dropout         ? "true" : "false");
-    std::printf("  qscale_type        : %s (%d)\n", qscale_enum_str(t.qscale_type),
-                static_cast<int>(t.qscale_type));
-    std::printf("  skip_min_seqlen_q  : %s\n",  t.skip_min_seqlen_q  ? "true" : "false");
-    std::printf("  has_sink           : %s\n",  t.has_sink            ? "true" : "false");
-    std::printf("--- args ---\n");
-    std::printf("  hdim_q             : %d\n",  static_cast<int>(a.hdim_q));
-    std::printf("  hdim_v             : %d\n",  static_cast<int>(a.hdim_v));
-    std::printf("  seqlen_k           : %d\n",  static_cast<int>(a.seqlen_k));
-    std::printf("  cu_seqlen_k_ptr    : %p\n",  a.cu_seqlen_k_ptr);
-    std::printf("  batch              : %d\n",  static_cast<int>(a.batch));
-    std::printf("  nhead_q            : %d\n",  static_cast<int>(a.nhead_q));
-    std::printf("  max_seqlen_q       : %d\n",  static_cast<int>(a.max_seqlen_q));
-    std::printf("========================================\n");
-    std::fflush(stdout);
-}
-*/
-} // anonymous namespace
 
 namespace pytorch_flash {
 
-// SFINAE trait to detect block-scale quantization fields in fmha_fwd_args.
-// Newer versions of composable_kernel add these fields; older versions don't.
-// This lets the PyTorch integration layer work with either version.
-template <typename T, typename = void>
-struct has_fmha_block_scale_fields : std::false_type {};
-
-template <typename T>
-struct has_fmha_block_scale_fields<T,
-    std::void_t<decltype(std::declval<T&>().block_scale_size_q)>> : std::true_type {};
-
-template <typename Args>
-void set_fmha_fwd_block_scale_fields([[maybe_unused]] Args& args) {
-    if constexpr (has_fmha_block_scale_fields<Args>::value) {
-        args.block_scale_seqstart_q_ptr = nullptr;
-        args.block_scale_seqstart_k_ptr = nullptr;
-        args.nhead_stride_q_descale = 0;
-        args.nhead_stride_k_descale = 0;
-        args.nhead_stride_v_descale = 0;
-        args.batch_stride_q_descale = 0;
-        args.batch_stride_k_descale = 0;
-        args.batch_stride_v_descale = 0;
-        args.block_scale_size_q = 0;
-        args.block_scale_size_kv = 0;
-    }
-}
 
 fmha_fwd_traits get_ck_fmha_fwd_traits(const mask_info &mask,
                                        std::string dtype,
@@ -187,58 +96,61 @@ fmha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
         nhead_stride_bias = a_b.stride(1);
         batch_stride_bias = a_b.stride(0);
     }
-    fmha_fwd_args args{};
-    args.q_ptr = q.data_ptr();
-    args.k_ptr = k.data_ptr();
-    args.v_ptr = v.data_ptr();
-    args.bias_ptr = attn_bias_ptr;
-    args.q_descale_ptr = nullptr;
-    args.k_descale_ptr = nullptr;
-    args.v_descale_ptr = nullptr;
-    args.rand_val_ptr = has_dropout_randval ? dropout_randval.data_ptr() : nullptr;
-    args.lse_ptr = has_lse ? softmax_lse.data_ptr() : nullptr;
-    args.o_ptr = out.data_ptr();
-    args.sink_ptr = nullptr;
-    args.seqlen_q = seqlen_q;
-    args.seqlen_k = seqlen_k;
-    args.batch = b;
-    args.max_seqlen_q = seqlen_q;
-    args.hdim_q = d;
-    args.hdim_v = d;
-    args.nhead_q = h;
-    args.nhead_k = h_k;
-    args.scale_s = softmax_scale;
-    args.logits_soft_cap = 0.0f;
-    args.stride_q = stride_q;
-    args.stride_k = stride_k;
-    args.stride_v = stride_v;
-    args.stride_bias = stride_attn_bias;
-    args.stride_randval = stride_randval;
-    args.stride_o = stride_o;
-    args.nhead_stride_q = nhead_stride_q;
-    args.nhead_stride_k = nhead_stride_k;
-    args.nhead_stride_v = nhead_stride_v;
-    args.nhead_stride_bias = nhead_stride_bias;
-    args.nhead_stride_randval = nhead_stride_randval;
-    args.nhead_stride_lse = nhead_stride_lse;
-    args.nhead_stride_o = nhead_stride_o;
-    args.batch_stride_q = batch_stride_q;
-    args.batch_stride_k = batch_stride_k;
-    args.batch_stride_v = batch_stride_v;
-    args.batch_stride_bias = batch_stride_bias;
-    args.batch_stride_randval = batch_stride_randval;
-    args.batch_stride_lse = batch_stride_lse;
-    args.batch_stride_o = batch_stride_o;
-    args.window_size_left = mask.left;
-    args.window_size_right = mask.right;
-    args.sink_size = 0;
-    args.mask_type = static_cast<ck_tile::index_t>(mask.type);
-    args.min_seqlen_q = -1;
-    args.p_drop = p_dropout;
-    args.s_randval = has_dropout_randval;
-    args.drop_seed_offset = drop_seed_offset;
-    set_fmha_fwd_block_scale_fields(args);
-    return args;
+    return fmha_fwd_args{q.data_ptr(),
+                         k.data_ptr(),
+                         v.data_ptr(),
+                         attn_bias_ptr, // bias
+                         nullptr, // q_descale_ptr
+                         nullptr, // k_descale_ptr
+                         nullptr, // v_descale_ptr
+                         has_dropout_randval ? dropout_randval.data_ptr() : nullptr,
+                         has_lse ? softmax_lse.data_ptr() : nullptr,
+                         out.data_ptr(),
+                         nullptr, // seqstart_q
+                         nullptr, // seqstart_k
+                         nullptr, // seqlen_q_ptr
+                         nullptr, // seqlen_k_ptr
+                         nullptr, // cu_seqlen_q_ptr
+                         nullptr, // cu_seqlen_k_ptr
+                         nullptr, // sink_ptr
+                         seqlen_q,
+                         seqlen_k,
+                         b,
+                         seqlen_q,                          // max_seqlen_q
+                         d,                                 // hdim_q
+                         d,                                 // hdim_v
+                         h,                                 // nhead
+                         h_k,                               // nhead_k
+                         softmax_scale,                     // scale_s
+                         0.0f,                              // logits_soft_cap
+                         stride_q,
+                         stride_k,
+                         stride_v,
+                         stride_attn_bias,
+                         stride_randval,
+                         stride_o,
+                         nhead_stride_q,
+                         nhead_stride_k,
+                         nhead_stride_v,
+                         nhead_stride_bias,                 // nhead_stride_bias
+                         nhead_stride_randval,
+                         nhead_stride_lse,
+                         nhead_stride_o,
+                         batch_stride_q,
+                         batch_stride_k,
+                         batch_stride_v,
+                         batch_stride_bias,                 // batch_stride_bias
+                         batch_stride_randval,
+                         batch_stride_lse,
+                         batch_stride_o,
+                         mask.left,
+                         mask.right,
+                         0,                                 // sink_size
+                         static_cast<ck_tile::index_t>(mask.type),
+                         -1,                                // min_seqlen_q
+                         p_dropout,
+                         has_dropout_randval,
+                         drop_seed_offset};
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
@@ -8,32 +8,6 @@
 
 namespace pytorch_flash {
 
-// SFINAE trait to detect block-scale quantization fields in fmha_fwd_args.
-// Newer versions of composable_kernel add these fields; older versions don't.
-// This lets the PyTorch integration layer work with either version.
-template <typename T, typename = void>
-struct has_fmha_block_scale_fields : std::false_type {};
-
-template <typename T>
-struct has_fmha_block_scale_fields<T,
-    std::void_t<decltype(std::declval<T&>().block_scale_size_q)>> : std::true_type {};
-
-template <typename Args>
-void set_fmha_fwd_block_scale_fields([[maybe_unused]] Args& args) {
-    if constexpr (has_fmha_block_scale_fields<Args>::value) {
-        args.block_scale_seqstart_q_ptr = nullptr;
-        args.block_scale_seqstart_k_ptr = nullptr;
-        args.nhead_stride_q_descale = 0;
-        args.nhead_stride_k_descale = 0;
-        args.nhead_stride_v_descale = 0;
-        args.batch_stride_q_descale = 0;
-        args.batch_stride_k_descale = 0;
-        args.batch_stride_v_descale = 0;
-        args.block_scale_size_q = 0;
-        args.block_scale_size_kv = 0;
-    }
-}
-
 fmha_fwd_traits get_ck_fmha_varlen_fwd_traits(const mask_info &mask,
                                               std::string dtype,
                                               int head_size,
@@ -123,60 +97,61 @@ fmha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
         stride_attn_bias = a_b.stride(0);
     }
 
-    fmha_fwd_args args{};
-    args.q_ptr = q.data_ptr();
-    args.k_ptr = k.data_ptr();
-    args.v_ptr = v.data_ptr();
-    args.bias_ptr = attn_bias_ptr;
-    args.q_descale_ptr = nullptr;
-    args.k_descale_ptr = nullptr;
-    args.v_descale_ptr = nullptr;
-    args.rand_val_ptr = has_dropout_randval ? dropout_randval.data_ptr() : nullptr;
-    args.lse_ptr = has_lse ? softmax_lse.data_ptr() : nullptr;
-    args.o_ptr = out.data_ptr();
-    args.seqstart_q_ptr = seqlens_q.data_ptr();
-    args.seqstart_k_ptr = seqlens_k.data_ptr();
-    args.sink_ptr = nullptr;
-    args.seqlen_q = total_q;
-    args.seqlen_k = total_k;
-    args.batch = b;
-    args.max_seqlen_q = max_seqlen_q;
-    args.hdim_q = d;
-    args.hdim_v = d;
-    args.nhead_q = h;
-    args.nhead_k = h_k;
-    args.scale_s = softmax_scale;
-    args.logits_soft_cap = 0.0f;
-    args.stride_q = stride_q;
-    args.stride_k = stride_k;
-    args.stride_v = stride_v;
-    args.stride_bias = stride_attn_bias;
-    args.stride_randval = stride_randval;
-    args.stride_o = stride_o;
-    args.nhead_stride_q = nhead_stride_q;
-    args.nhead_stride_k = nhead_stride_k;
-    args.nhead_stride_v = nhead_stride_v;
-    args.nhead_stride_bias = 0;
-    args.nhead_stride_randval = nhead_stride_randval;
-    args.nhead_stride_lse = nhead_stride_lse;
-    args.nhead_stride_o = nhead_stride_o;
-    args.batch_stride_q = batch_stride_q;
-    args.batch_stride_k = batch_stride_k;
-    args.batch_stride_v = batch_stride_v;
-    args.batch_stride_bias = 0;
-    args.batch_stride_randval = batch_stride_randval;
-    args.batch_stride_lse = batch_stride_lse;
-    args.batch_stride_o = batch_stride_o;
-    args.window_size_left = mask.left;
-    args.window_size_right = mask.right;
-    args.sink_size = 0;
-    args.mask_type = static_cast<ck_tile::index_t>(mask.type);
-    args.min_seqlen_q = -1;
-    args.p_drop = p_dropout;
-    args.s_randval = has_dropout_randval;
-    args.drop_seed_offset = drop_seed_offset;
-    set_fmha_fwd_block_scale_fields(args);
-    return args;
+    return fmha_fwd_args{q.data_ptr(),
+                         k.data_ptr(),
+                         v.data_ptr(),
+                         attn_bias_ptr, // bias
+                         nullptr, // q_descale_ptr
+                         nullptr, // k_descale_ptr
+                         nullptr, // v_descale_ptr
+                         has_dropout_randval ? dropout_randval.data_ptr() : nullptr,
+                         has_lse ? softmax_lse.data_ptr() : nullptr,
+                         out.data_ptr(),
+                         seqlens_q.data_ptr(), // seqstart_q
+                         seqlens_k.data_ptr(), // seqstart_k
+                         nullptr, // seqlen_q_ptr
+                         nullptr, // seqlen_k_ptr
+                         nullptr, // cu_seqlen_q_ptr
+                         nullptr, // cu_seqlen_k_ptr
+                         nullptr, // sink_ptr
+                         total_q,
+                         total_k,
+                         b,
+                         max_seqlen_q,
+                         d,             // hdim_q
+                         d,             // hdim_v
+                         h,             // nhead
+                         h_k,           // nhead_k
+                         softmax_scale, // scale_s
+                         0.0f,          // logits_soft_cap
+                         stride_q,
+                         stride_k,
+                         stride_v,
+                         stride_attn_bias,
+                         stride_randval,
+                         stride_o,
+                         nhead_stride_q,
+                         nhead_stride_k,
+                         nhead_stride_v,
+                         0, // nhead_stride_bias, FA without bias
+                         nhead_stride_randval,
+                         nhead_stride_lse,
+                         nhead_stride_o,
+                         batch_stride_q,
+                         batch_stride_k,
+                         batch_stride_v,
+                         0, // batch_stride_bias, FA without bias
+                         batch_stride_randval,
+                         batch_stride_lse,
+                         batch_stride_o,
+                         mask.left,
+                         mask.right,
+                         0,             // sink_size
+                         static_cast<ck_tile::index_t>(mask.type),
+                         -1,                                // min_seqlen_q
+                         p_dropout,
+                         has_dropout_randval,
+                         drop_seed_offset};
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>


### PR DESCRIPTION
#178310 causes the following cmake error when building with TheRock.
```
Optional package hipsparselt not found
ROCm is enabled.
CMake Error at cmake/public/utils.cmake:123 (set):
  set given invalid arguments: FORCE specified without CACHE
Call Stack (most recent call first):
  aten/src/ATen/CMakeLists.txt:212 (caffe2_update_option)
```

Additionally, I really hope CK isn't going to replace triton for the default SDPA. The performance of CK is **absolutely horrible** for RDNA3.5.

Take this with a grain of salt though since the performance of CK you see here is shown through flash-attention. However, I can assure you that CK convolution doesn't do any better.

The `PyTorch SDPA` seen below is from a few months ago and is using aotriton with `AOTRITON_INSTALL_FROM_SOURCE=ON` using `triton-windows` as the local triton wheel. I have beef with the false errors in the pytorch aotriton.cmake claiming that noimage must be ON for windows builds, but that is a problem for another day. For now I just patch it out.


```
SeqLen     | Method                   | Latency      | TFLOPS     | vs SDPA
------------------------------------------------------------------------------
4096       | PyTorch SDPA             |    14.71 ms |     9.34 | 1.00x (ref)
           | SageAttn V1              |    15.35 ms |     8.95 |  0.96x
           | FA2 Triton               |    18.75 ms |     7.33 |  0.78x
           | FA2 CK                   |    40.88 ms |     3.36 |  0.36x
------------------------------------------------------------------------------
8192       | PyTorch SDPA             |    59.21 ms |     9.29 | 1.00x (ref)
           | SageAttn V1              |    47.96 ms |    11.46 |  1.23x
           | FA2 Triton               |    68.31 ms |     8.05 |  0.87x
           | FA2 CK                   |   162.09 ms |     3.39 |  0.37x
------------------------------------------------------------------------------
16384      | PyTorch SDPA             |   214.76 ms |    10.24 | 1.00x (ref)
           | SageAttn V1              |   191.69 ms |    11.47 |  1.12x
           | FA2 Triton               |   276.85 ms |     7.94 |  0.78x
           | FA2 CK                   |   650.47 ms |     3.38 |  0.33x
------------------------------------------------------------------------------
32768      | PyTorch SDPA             |   863.99 ms |    10.18 | 1.00x (ref)
           | SageAttn V1              |  1261.91 ms |     6.97 |  0.68x
           | FA2 Triton               |  1131.45 ms |     7.77 |  0.76x
           | FA2 CK                   |  2533.70 ms |     3.47 |  0.34x
------------------------------------------------------------------------------
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang