### PR TITLE
adds missing vector header in Handlers.hpp

### DIFF
--- a/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
+++ b/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <c10/macros/Export.h>
 


### PR DESCRIPTION
This change adds  `vector` to `Handlers.hpp` to fix this compilation error with `clang`:
```
ERROR: third_party/py/torch/BUILD:934:11: Compiling third_party/py/torch/torch/csrc/distributed/c10d/control_plane/PythonHandlers.cpp failed: (Exit 1) wrapped_clang failed: error executing CppCompile command (from cc_library rule target //third_party/py/torch:torch_python) third_party/crosstool/v18/stable/toolchain/bin/wrapped_clang '-frandom-seed=blaze-out/k8-opt-cuda/bin/third_party/py/torch/_objs/torch_python/PythonHandlers.pic.o' ... (remaining 934 arguments skipped).  [forge_remote_host=jqded6]
In file included from third_party/py/torch/torch/csrc/distributed/c10d/control_plane/PythonHandlers.cpp:1:
third_party/py/torch/torch/csrc/distributed/c10d/control_plane/Handlers.hpp:61:16: error: no template named 'vector' in namespace 'std'
   61 | TORCH_API std::vector<std::string> getHandlerNames();
      |           ~~~~~^
1 error generated.
```