### PR TITLE
[HOP] Adding input mutation support for associative_scan (1/N)

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -10447,6 +10447,52 @@ class TestHopSchema(TestCase):
             """associative_scan(Any combine_fn, Tensor xs0, Tensor xs1) -> (Tensor, Tensor)""",
         )
 
+    def test_associative_scan_gen_schema_with_additional_input_mutation(self):
+        def combine_fn(x, y, buf):
+            buf.add_(x)
+            return x * y
+
+        schema = torch.ops.higher_order.associative_scan.gen_schema(
+            combine_fn,
+            (torch.randn(5, 3, 4),),
+            (torch.randn(3, 4),),
+        )
+        self.assertExpectedInline(
+            str(schema),
+            """associative_scan(Any combine_fn, Tensor xs0, Tensor(a2!) additional_input0) -> ((Tensor))""",
+        )
+
+    def test_associative_scan_gen_schema_with_multiple_additional_input_mutation(self):
+        def combine_fn(x1, x2, y1, y2, buf1, buf2):
+            buf1.add_(x1)
+            buf2.sub_(x2)
+            return x1 + y1, x2 * y2
+
+        schema = torch.ops.higher_order.associative_scan.gen_schema(
+            combine_fn,
+            (torch.randn(5, 3, 4), torch.randn(5, 2, 3)),
+            (torch.randn(3, 4), torch.randn(2, 3)),
+        )
+        self.assertExpectedInline(
+            str(schema),
+            """associative_scan(Any combine_fn, Tensor xs0, Tensor xs1, Tensor(a3!) additional_input0, Tensor(a4!) additional_input1) -> (Tensor, Tensor)""",
+        )
+
+    def test_associative_scan_gen_schema_xs_mutation_raises(self):
+        def combine_fn(x, y):
+            x.add_(1)
+            return x + y
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "For associative_scan, combine_fn cannot mutate xs inputs",
+        ):
+            torch.ops.higher_order.associative_scan.gen_schema(
+                combine_fn,
+                (torch.randn(5, 3, 4),),
+                (),
+            )
+
     def test_while_loop_gen_schema_with_int_carries(self):
         def cond_fn(x, y, z, c):
             return x < y

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -120,10 +120,18 @@ class AssociativeScanOp(HigherOrderOperator):
             outputs,
         ) = check_input_alias_and_mutation_return_outputs(combine_gm)
 
-        # Mutation is only allowed on loop-invariant inputs (additional_inputs).
-        # xs slots (both left and right operands of combine_fn) are fed with
-        # per-step tensors that appear in multiple combine calls across the
-        # O(T log T) reduction, so mutating them is unsafe.
+        # Mutation semantics for associative_scan:
+        # - additional_inputs is mutable: loop-invariant tensor identity
+        #   across the O(T log T) reduction, same semantics as while_loop's
+        #   additional_inputs (CUDA-graph-friendly lifted / pre-allocated
+        #   buffers).
+        # - xs is NOT mutable: associative_scan's combine_fn runs
+        #   O(T log T) times over overlapping pairs, so the same xs element
+        #   identity feeds multiple combine calls (once as the left operand,
+        #   later as the right operand of another pair). Any mutation on
+        #   either xs slot would change the inputs to subsequent combine
+        #   invocations, corrupting the reduction semantics. Users wanting
+        #   per-step in-place writes over a sequence should use scan or map.
         n_xs = len(xs)
         xs_mutated = [i for i in mutated_inputs if i < 2 * n_xs]
         if xs_mutated:

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -119,11 +119,19 @@ class AssociativeScanOp(HigherOrderOperator):
             mutated_inputs,
             outputs,
         ) = check_input_alias_and_mutation_return_outputs(combine_gm)
-        if len(mutated_inputs) > 0:
+
+        # Mutation is only allowed on loop-invariant inputs (additional_inputs).
+        # xs slots (both left and right operands of combine_fn) are fed with
+        # per-step tensors that appear in multiple combine calls across the
+        # O(T log T) reduction, so mutating them is unsafe.
+        n_xs = len(xs)
+        xs_mutated = [i for i in mutated_inputs if i < 2 * n_xs]
+        if xs_mutated:
             raise RuntimeError(
-                "For associative_scan, combine_fn cannot have in-place mutations but found "
-                f"{mutated_inputs}-th inputs are mutated."
+                "For associative_scan, combine_fn cannot mutate xs inputs but found "
+                f"{[i % n_xs for i in xs_mutated]}-th xs inputs are mutated."
             )
+        mutated_set = set(mutated_inputs)
 
         schema_gen = HopSchemaGenerator(self)
         schema_gen.add_arg("combine_fn", combine_gm)
@@ -135,6 +143,7 @@ class AssociativeScanOp(HigherOrderOperator):
             schema_gen.add_arg(
                 f"additional_input{idx}",
                 arg,
+                is_mutated=(2 * n_xs + idx) in mutated_set,
             )
 
         for out in outputs:


### PR DESCRIPTION
This PR is the first of a series to add input mutation support for `associative_scan`.
In this first PR, we add the `gen_schema` function, marking the allowed variables for input mutations. 

cc @ydwu4