### PR TITLE
[MPS] Migrate replication pad to metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ReplicationPad.metal
+++ b/aten/src/ATen/native/mps/kernels/ReplicationPad.metal
@@ -1,0 +1,136 @@
+#include <c10/metal/utils.h>
+#include <metal_stdlib>
+
+using namespace metal;
+using namespace c10::metal;
+
+// 1D replication padding (a.k.a. clamp-to-edge). Mirrors the algorithm used by
+// the CUDA kernels in aten/src/ATen/native/cuda/ReplicationPadding.cu so that
+// negative paddings (which crop the input) match across devices.
+//
+// Forward: w_in = clip(w_out, padL, input_W + padL - 1) + (iStart - oStart)
+// where iStart = max(0, -padL), oStart = max(0, padL). The (iStart - oStart)
+// term equals -padL for both positive and negative padL, so this simplifies to
+//   w_in = clip(w_out - padL, 0, input_W - 1)
+// when w_out is also clamped to [0, output_W - 1] (which it always is).
+
+template <typename T>
+kernel void replication_pad1d_forward(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant int4& sizes_pad [[buffer(2)]], // (input_W, output_W, padL, padR)
+    uint3 tid [[thread_position_in_grid]],
+    uint3 grid [[threads_per_grid]]) {
+  const int input_W = sizes_pad.x;
+  const int output_W = sizes_pad.y;
+  const int padL = sizes_pad.z;
+
+  const int w_out = static_cast<int>(tid.x);
+  const uint c = tid.y;
+  const uint n = tid.z;
+  const uint nplane = grid.y;
+
+  const int iStart = max(0, -padL);
+  const int oStart = max(0, padL);
+  const int w_in =
+      min(max(padL, w_out), input_W + padL - 1) - oStart + iStart;
+
+  const ulong in_base =
+      (static_cast<ulong>(n) * nplane + c) * static_cast<ulong>(input_W);
+  const ulong out_base =
+      (static_cast<ulong>(n) * nplane + c) * static_cast<ulong>(output_W);
+  output[out_base + static_cast<ulong>(w_out)] =
+      input[in_base + static_cast<ulong>(w_in)];
+}
+
+// Backward uses a gather (one thread per input position sums over the small
+// range of output positions whose forward-mapped w_in equals this thread's
+// w_in). This avoids atomics entirely and is naturally deterministic, unlike
+// the CUDA path which scatters with atomicAdd.
+template <typename T>
+kernel void replication_pad1d_backward(
+    constant T* grad_output [[buffer(0)]],
+    device T* grad_input [[buffer(1)]],
+    constant int4& sizes_pad [[buffer(2)]], // (input_W, output_W, padL, padR)
+    uint3 tid [[thread_position_in_grid]],
+    uint3 grid [[threads_per_grid]]) {
+  const int input_W = sizes_pad.x;
+  const int output_W = sizes_pad.y;
+  const int padL = sizes_pad.z;
+
+  const int w_in = static_cast<int>(tid.x);
+  const uint c = tid.y;
+  const uint n = tid.z;
+  const uint nplane = grid.y;
+
+  // Determine the inclusive range [wo_lo, wo_hi] of output positions that map
+  // to this w_in under the forward rule. wo_hi < wo_lo encodes "empty range",
+  // which can happen with negative padding.
+  int wo_lo = 0;
+  int wo_hi = -1;
+  if (input_W == 1) {
+    wo_lo = 0;
+    wo_hi = output_W - 1;
+  } else if (w_in == 0) {
+    wo_lo = 0;
+    wo_hi = min(padL, output_W - 1);
+  } else if (w_in == input_W - 1) {
+    wo_lo = max(0, input_W + padL - 1);
+    wo_hi = output_W - 1;
+  } else {
+    const int wo = w_in + padL;
+    if (wo >= 0 && wo < output_W) {
+      wo_lo = wo;
+      wo_hi = wo;
+    }
+  }
+
+  const ulong in_base =
+      (static_cast<ulong>(n) * nplane + c) * static_cast<ulong>(input_W);
+  const ulong out_base =
+      (static_cast<ulong>(n) * nplane + c) * static_cast<ulong>(output_W);
+
+  opmath_t<T> sum = 0;
+  for (int wo = wo_lo; wo <= wo_hi; ++wo) {
+    sum += static_cast<opmath_t<T>>(
+        grad_output[out_base + static_cast<ulong>(wo)]);
+  }
+  grad_input[in_base + static_cast<ulong>(w_in)] = static_cast<T>(sum);
+}
+
+#define INSTANTIATE_REPLICATION_PAD1D_FWD(DTYPE)         \
+  template [[host_name("replication_pad1d_forward_" #DTYPE)]] \
+  kernel void replication_pad1d_forward<DTYPE>(          \
+      constant DTYPE * input [[buffer(0)]],              \
+      device DTYPE * output [[buffer(1)]],               \
+      constant int4 & sizes_pad [[buffer(2)]],           \
+      uint3 tid [[thread_position_in_grid]],             \
+      uint3 grid [[threads_per_grid]])
+
+#define INSTANTIATE_REPLICATION_PAD1D_BWD(DTYPE)          \
+  template [[host_name("replication_pad1d_backward_" #DTYPE)]] \
+  kernel void replication_pad1d_backward<DTYPE>(          \
+      constant DTYPE * grad_output [[buffer(0)]],         \
+      device DTYPE * grad_input [[buffer(1)]],            \
+      constant int4 & sizes_pad [[buffer(2)]],            \
+      uint3 tid [[thread_position_in_grid]],              \
+      uint3 grid [[threads_per_grid]])
+
+INSTANTIATE_REPLICATION_PAD1D_FWD(float);
+INSTANTIATE_REPLICATION_PAD1D_FWD(half);
+INSTANTIATE_REPLICATION_PAD1D_FWD(bfloat);
+INSTANTIATE_REPLICATION_PAD1D_FWD(float2);
+INSTANTIATE_REPLICATION_PAD1D_FWD(half2);
+INSTANTIATE_REPLICATION_PAD1D_FWD(long);
+INSTANTIATE_REPLICATION_PAD1D_FWD(int);
+INSTANTIATE_REPLICATION_PAD1D_FWD(short);
+INSTANTIATE_REPLICATION_PAD1D_FWD(char);
+INSTANTIATE_REPLICATION_PAD1D_FWD(uchar);
+INSTANTIATE_REPLICATION_PAD1D_FWD(bool);
+
+// Backward only registered for the dtypes CUDA registers (floating + complex).
+INSTANTIATE_REPLICATION_PAD1D_BWD(float);
+INSTANTIATE_REPLICATION_PAD1D_BWD(half);
+INSTANTIATE_REPLICATION_PAD1D_BWD(bfloat);
+INSTANTIATE_REPLICATION_PAD1D_BWD(float2);
+INSTANTIATE_REPLICATION_PAD1D_BWD(half2);

--- a/aten/src/ATen/native/mps/kernels/ReplicationPad.metal
+++ b/aten/src/ATen/native/mps/kernels/ReplicationPad.metal
@@ -4,16 +4,6 @@
 using namespace metal;
 using namespace c10::metal;
 
-// 1D replication padding (a.k.a. clamp-to-edge). Mirrors the algorithm used by
-// the CUDA kernels in aten/src/ATen/native/cuda/ReplicationPadding.cu so that
-// negative paddings (which crop the input) match across devices.
-//
-// Forward: w_in = clip(w_out, padL, input_W + padL - 1) + (iStart - oStart)
-// where iStart = max(0, -padL), oStart = max(0, padL). The (iStart - oStart)
-// term equals -padL for both positive and negative padL, so this simplifies to
-//   w_in = clip(w_out - padL, 0, input_W - 1)
-// when w_out is also clamped to [0, output_W - 1] (which it always is).
-
 template <typename T>
 kernel void replication_pad1d_forward(
     constant T* input [[buffer(0)]],
@@ -32,8 +22,7 @@ kernel void replication_pad1d_forward(
 
   const int iStart = max(0, -padL);
   const int oStart = max(0, padL);
-  const int w_in =
-      min(max(padL, w_out), input_W + padL - 1) - oStart + iStart;
+  const int w_in = min(max(padL, w_out), input_W + padL - 1) - oStart + iStart;
 
   const ulong in_base =
       (static_cast<ulong>(n) * nplane + c) * static_cast<ulong>(input_W);
@@ -43,10 +32,6 @@ kernel void replication_pad1d_forward(
       input[in_base + static_cast<ulong>(w_in)];
 }
 
-// Backward uses a gather (one thread per input position sums over the small
-// range of output positions whose forward-mapped w_in equals this thread's
-// w_in). This avoids atomics entirely and is naturally deterministic, unlike
-// the CUDA path which scatters with atomicAdd.
 template <typename T>
 kernel void replication_pad1d_backward(
     constant T* grad_output [[buffer(0)]],
@@ -63,9 +48,6 @@ kernel void replication_pad1d_backward(
   const uint n = tid.z;
   const uint nplane = grid.y;
 
-  // Determine the inclusive range [wo_lo, wo_hi] of output positions that map
-  // to this w_in under the forward rule. wo_hi < wo_lo encodes "empty range",
-  // which can happen with negative padding.
   int wo_lo = 0;
   int wo_hi = -1;
   if (input_W == 1) {
@@ -98,22 +80,22 @@ kernel void replication_pad1d_backward(
   grad_input[in_base + static_cast<ulong>(w_in)] = static_cast<T>(sum);
 }
 
-#define INSTANTIATE_REPLICATION_PAD1D_FWD(DTYPE)         \
+#define INSTANTIATE_REPLICATION_PAD1D_FWD(DTYPE)              \
   template [[host_name("replication_pad1d_forward_" #DTYPE)]] \
-  kernel void replication_pad1d_forward<DTYPE>(          \
-      constant DTYPE * input [[buffer(0)]],              \
-      device DTYPE * output [[buffer(1)]],               \
-      constant int4 & sizes_pad [[buffer(2)]],           \
-      uint3 tid [[thread_position_in_grid]],             \
+  kernel void replication_pad1d_forward<DTYPE>(               \
+      constant DTYPE * input [[buffer(0)]],                   \
+      device DTYPE * output [[buffer(1)]],                    \
+      constant int4 & sizes_pad [[buffer(2)]],                \
+      uint3 tid [[thread_position_in_grid]],                  \
       uint3 grid [[threads_per_grid]])
 
-#define INSTANTIATE_REPLICATION_PAD1D_BWD(DTYPE)          \
+#define INSTANTIATE_REPLICATION_PAD1D_BWD(DTYPE)               \
   template [[host_name("replication_pad1d_backward_" #DTYPE)]] \
-  kernel void replication_pad1d_backward<DTYPE>(          \
-      constant DTYPE * grad_output [[buffer(0)]],         \
-      device DTYPE * grad_input [[buffer(1)]],            \
-      constant int4 & sizes_pad [[buffer(2)]],            \
-      uint3 tid [[thread_position_in_grid]],              \
+  kernel void replication_pad1d_backward<DTYPE>(               \
+      constant DTYPE * grad_output [[buffer(0)]],              \
+      device DTYPE * grad_input [[buffer(1)]],                 \
+      constant int4 & sizes_pad [[buffer(2)]],                 \
+      uint3 tid [[thread_position_in_grid]],                   \
       uint3 grid [[threads_per_grid]])
 
 INSTANTIATE_REPLICATION_PAD1D_FWD(float);
@@ -128,7 +110,6 @@ INSTANTIATE_REPLICATION_PAD1D_FWD(char);
 INSTANTIATE_REPLICATION_PAD1D_FWD(uchar);
 INSTANTIATE_REPLICATION_PAD1D_FWD(bool);
 
-// Backward only registered for the dtypes CUDA registers (floating + complex).
 INSTANTIATE_REPLICATION_PAD1D_BWD(float);
 INSTANTIATE_REPLICATION_PAD1D_BWD(half);
 INSTANTIATE_REPLICATION_PAD1D_BWD(bfloat);

--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -39,12 +39,12 @@ NSArray<NSNumber*>* IntArrayToNSArray(IntArrayRef arr) {
 } // anonymous namespace
 
 Tensor _fft_c2r_mps(const Tensor& self, IntArrayRef dim, int64_t normalization, int64_t last_dim_size) {
-  auto out = at::empty({}, self.options().dtype(c10::toRealValueType(self.scalar_type())));
+  auto out = at::empty({0}, self.options().dtype(c10::toRealValueType(self.scalar_type())));
   return _fft_c2r_mps_out(self, dim, normalization, last_dim_size, out);
 }
 
 Tensor _fft_r2c_mps(const Tensor& self, IntArrayRef dim, int64_t normalization, bool onesided) {
-  auto out = at::empty({}, self.options().dtype(c10::toComplexType(self.scalar_type())));
+  auto out = at::empty({0}, self.options().dtype(c10::toComplexType(self.scalar_type())));
   return _fft_r2c_mps_out(self, dim, normalization, onesided, out);
 }
 

--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -39,12 +39,12 @@ NSArray<NSNumber*>* IntArrayToNSArray(IntArrayRef arr) {
 } // anonymous namespace
 
 Tensor _fft_c2r_mps(const Tensor& self, IntArrayRef dim, int64_t normalization, int64_t last_dim_size) {
-  auto out = at::empty({0}, self.options().dtype(c10::toRealValueType(self.scalar_type())));
+  auto out = at::empty({}, self.options().dtype(c10::toRealValueType(self.scalar_type())));
   return _fft_c2r_mps_out(self, dim, normalization, last_dim_size, out);
 }
 
 Tensor _fft_r2c_mps(const Tensor& self, IntArrayRef dim, int64_t normalization, bool onesided) {
-  auto out = at::empty({0}, self.options().dtype(c10::toComplexType(self.scalar_type())));
+  auto out = at::empty({}, self.options().dtype(c10::toComplexType(self.scalar_type())));
   return _fft_r2c_mps_out(self, dim, normalization, onesided, out);
 }
 

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -357,10 +357,10 @@ static void replication_pad1d_kernel_mps(const Tensor& input_, IntArrayRef paddi
   const auto nplane = input.size(1);
   const auto input_W = input.size(2);
   const auto output_W = output_c.size(2);
-  const std::array<auto, 4> sizes_pad = {static_cast<int32_t>(input_W),
-                                         static_cast<int32_t>(output_W),
-                                         static_cast<int32_t>(padding[0]),
-                                         static_cast<int32_t>(padding[1])};
+  const std::array<int32_t, 4> sizes_pad = {static_cast<int32_t>(input_W),
+                                            static_cast<int32_t>(output_W),
+                                            static_cast<int32_t>(padding[0]),
+                                            static_cast<int32_t>(padding[1])};
 
   auto pso = replication_pad_lib.getPipelineStateForFunc("replication_pad1d_forward_" + scalarToMetalTypeString(input));
   auto stream = getCurrentMPSStream();
@@ -396,10 +396,10 @@ static void replication_pad1d_backward_kernel_mps(const Tensor& grad_output_,
   const auto nplane = grad_input_c.size(1);
   const auto input_W = grad_input_c.size(2);
   const auto output_W = grad_output.size(2);
-  const std::array<auto, 4> sizes_pad = {static_cast<int32_t>(input_W),
-                                         static_cast<int32_t>(output_W),
-                                         static_cast<int32_t>(padding[0]),
-                                         static_cast<int32_t>(padding[1])};
+  const std::array<int32_t, 4> sizes_pad = {static_cast<int32_t>(input_W),
+                                            static_cast<int32_t>(output_W),
+                                            static_cast<int32_t>(padding[0]),
+                                            static_cast<int32_t>(padding[1])};
 
   auto pso = replication_pad_lib.getPipelineStateForFunc("replication_pad1d_backward_" +
                                                          scalarToMetalTypeString(grad_input_c));

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -25,6 +25,12 @@
 namespace at::native {
 namespace mps {
 
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& replication_pad_lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/ReplicationPad_metallib.h>
+#endif
+
 // Pad operations (1D/2D/3D forward and backward)
 static Tensor& pad_out_template(Tensor& output,
                                 const Tensor& input_,
@@ -324,15 +330,18 @@ static Tensor& pad_out_template(Tensor& output,
   return output;
 }
 
-#ifndef PYTORCH_JIT_COMPILE_SHADERS
-static auto& replication_pad_lib = MetalShaderLibrary::getBundledLibrary();
-#else
-#include <ATen/native/mps/ReplicationPad_metallib.h>
-#endif
+static MTLSize replication_pad1d_threadgroup(id<MTLComputePipelineState> pso,
+                                             NSUInteger gx,
+                                             NSUInteger gy,
+                                             NSUInteger gz) {
+  const auto maxTPG = [pso maxTotalThreadsPerThreadgroup];
+  const auto tg_x = std::min<NSUInteger>(maxTPG, gx);
+  const auto tg_y = std::min<NSUInteger>(maxTPG / tg_x, gy);
+  const auto tg_z = std::min<NSUInteger>(maxTPG / (tg_x * tg_y), gz);
+  return MTLSizeMake(tg_x, tg_y, tg_z);
+}
 
-static void replication_pad1d_kernel_mps(const Tensor& input_,
-                                         IntArrayRef padding,
-                                         const Tensor& output) {
+static void replication_pad1d_kernel_mps(const Tensor& input_, IntArrayRef padding, const Tensor& output) {
   if (output.numel() == 0 || input_.numel() == 0) {
     return;
   }
@@ -353,8 +362,7 @@ static void replication_pad1d_kernel_mps(const Tensor& input_,
                                             static_cast<int32_t>(padding[0]),
                                             static_cast<int32_t>(padding[1])};
 
-  auto pso = replication_pad_lib.getPipelineStateForFunc("replication_pad1d_forward_" +
-                                                         scalarToMetalTypeString(input));
+  auto pso = replication_pad_lib.getPipelineStateForFunc("replication_pad1d_forward_" + scalarToMetalTypeString(input));
   auto stream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
@@ -362,10 +370,8 @@ static void replication_pad1d_kernel_mps(const Tensor& input_,
       auto encoder = stream->commandEncoder();
       [encoder setComputePipelineState:pso];
       mtl_setArgs(encoder, input, output_c, sizes_pad);
-      const NSUInteger maxTPG = [pso maxTotalThreadsPerThreadgroup];
-      const NSUInteger tg_x = std::min(maxTPG, static_cast<NSUInteger>(output_W));
       [encoder dispatchThreads:MTLSizeMake(output_W, nplane, nbatch)
-          threadsPerThreadgroup:MTLSizeMake(tg_x, 1, 1)];
+          threadsPerThreadgroup:replication_pad1d_threadgroup(pso, output_W, nplane, nbatch)];
       getMPSProfiler().endProfileKernel(pso);
     }
   });
@@ -404,10 +410,8 @@ static void replication_pad1d_backward_kernel_mps(const Tensor& grad_output_,
       auto encoder = stream->commandEncoder();
       [encoder setComputePipelineState:pso];
       mtl_setArgs(encoder, grad_output, grad_input_c, sizes_pad);
-      const NSUInteger maxTPG = [pso maxTotalThreadsPerThreadgroup];
-      const NSUInteger tg_x = std::min(maxTPG, static_cast<NSUInteger>(input_W));
       [encoder dispatchThreads:MTLSizeMake(input_W, nplane, nbatch)
-          threadsPerThreadgroup:MTLSizeMake(tg_x, 1, 1)];
+          threadsPerThreadgroup:replication_pad1d_threadgroup(pso, input_W, nplane, nbatch)];
       getMPSProfiler().endProfileKernel(pso);
     }
   });

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -346,21 +346,23 @@ static void replication_pad1d_kernel_mps(const Tensor& input_, IntArrayRef paddi
     return;
   }
   auto input = input_.contiguous();
-  auto output_c = output;
+  const bool output_needs_copy = !output.is_contiguous();
+  auto output_buf = output_needs_copy ? at::empty(output.sizes(), output.options()) : output;
+  auto output_c = output_buf;
   if (input.dim() == 2) {
     input = input.unsqueeze(0);
     output_c = output_c.unsqueeze(0);
   }
   TORCH_INTERNAL_ASSERT(input.dim() == 3 && output_c.dim() == 3);
 
-  const auto nbatch = input.size(0);
-  const auto nplane = input.size(1);
-  const auto input_W = input.size(2);
-  const auto output_W = output_c.size(2);
-  const std::array<int32_t, 4> sizes_pad = {static_cast<int32_t>(input_W),
-                                            static_cast<int32_t>(output_W),
-                                            static_cast<int32_t>(padding[0]),
-                                            static_cast<int32_t>(padding[1])};
+  const auto nbatch = c10::checked_convert<int32_t>(input.size(0), "int32_t");
+  const auto nplane = c10::checked_convert<int32_t>(input.size(1), "int32_t");
+  const auto input_W = c10::checked_convert<int32_t>(input.size(2), "int32_t");
+  const auto output_W = c10::checked_convert<int32_t>(output_c.size(2), "int32_t");
+  const std::array<int32_t, 4> sizes_pad = {input_W,
+                                            output_W,
+                                            c10::checked_convert<int32_t>(padding[0], "int32_t"),
+                                            c10::checked_convert<int32_t>(padding[1], "int32_t")};
 
   auto pso = lib.getPipelineStateForFunc("replication_pad1d_forward_" + scalarToMetalTypeString(input));
   auto stream = getCurrentMPSStream();
@@ -375,6 +377,9 @@ static void replication_pad1d_kernel_mps(const Tensor& input_, IntArrayRef paddi
       getMPSProfiler().endProfileKernel(pso);
     }
   });
+  if (output_needs_copy) {
+    output.copy_(output_buf);
+  }
 }
 
 static void replication_pad1d_backward_kernel_mps(const Tensor& grad_output_,
@@ -385,21 +390,23 @@ static void replication_pad1d_backward_kernel_mps(const Tensor& grad_output_,
     return;
   }
   auto grad_output = grad_output_.contiguous();
-  auto grad_input_c = grad_input;
+  const bool grad_input_needs_copy = !grad_input.is_contiguous();
+  auto grad_input_buf = grad_input_needs_copy ? at::empty(grad_input.sizes(), grad_input.options()) : grad_input;
+  auto grad_input_c = grad_input_buf;
   if (input.dim() == 2) {
     grad_output = grad_output.unsqueeze(0);
     grad_input_c = grad_input_c.unsqueeze(0);
   }
   TORCH_INTERNAL_ASSERT(grad_output.dim() == 3 && grad_input_c.dim() == 3);
 
-  const auto nbatch = grad_input_c.size(0);
-  const auto nplane = grad_input_c.size(1);
-  const auto input_W = grad_input_c.size(2);
-  const auto output_W = grad_output.size(2);
-  const std::array<int32_t, 4> sizes_pad = {static_cast<int32_t>(input_W),
-                                            static_cast<int32_t>(output_W),
-                                            static_cast<int32_t>(padding[0]),
-                                            static_cast<int32_t>(padding[1])};
+  const auto nbatch = c10::checked_convert<int32_t>(grad_input_c.size(0), "int32_t");
+  const auto nplane = c10::checked_convert<int32_t>(grad_input_c.size(1), "int32_t");
+  const auto input_W = c10::checked_convert<int32_t>(grad_input_c.size(2), "int32_t");
+  const auto output_W = c10::checked_convert<int32_t>(grad_output.size(2), "int32_t");
+  const std::array<int32_t, 4> sizes_pad = {input_W,
+                                            output_W,
+                                            c10::checked_convert<int32_t>(padding[0], "int32_t"),
+                                            c10::checked_convert<int32_t>(padding[1], "int32_t")};
 
   auto pso = lib.getPipelineStateForFunc("replication_pad1d_backward_" + scalarToMetalTypeString(grad_input_c));
   auto stream = getCurrentMPSStream();
@@ -414,6 +421,9 @@ static void replication_pad1d_backward_kernel_mps(const Tensor& grad_output_,
       getMPSProfiler().endProfileKernel(pso);
     }
   });
+  if (grad_input_needs_copy) {
+    grad_input.copy_(grad_input_buf);
+  }
 }
 
 } // namespace mps

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -26,7 +26,7 @@ namespace at::native {
 namespace mps {
 
 #ifndef PYTORCH_JIT_COMPILE_SHADERS
-static auto& replication_pad_lib = MetalShaderLibrary::getBundledLibrary();
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #else
 #include <ATen/native/mps/ReplicationPad_metallib.h>
 #endif
@@ -362,7 +362,7 @@ static void replication_pad1d_kernel_mps(const Tensor& input_, IntArrayRef paddi
                                             static_cast<int32_t>(padding[0]),
                                             static_cast<int32_t>(padding[1])};
 
-  auto pso = replication_pad_lib.getPipelineStateForFunc("replication_pad1d_forward_" + scalarToMetalTypeString(input));
+  auto pso = lib.getPipelineStateForFunc("replication_pad1d_forward_" + scalarToMetalTypeString(input));
   auto stream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
@@ -401,8 +401,7 @@ static void replication_pad1d_backward_kernel_mps(const Tensor& grad_output_,
                                             static_cast<int32_t>(padding[0]),
                                             static_cast<int32_t>(padding[1])};
 
-  auto pso = replication_pad_lib.getPipelineStateForFunc("replication_pad1d_backward_" +
-                                                         scalarToMetalTypeString(grad_input_c));
+  auto pso = lib.getPipelineStateForFunc("replication_pad1d_backward_" + scalarToMetalTypeString(grad_input_c));
   auto stream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -345,22 +345,22 @@ static void replication_pad1d_kernel_mps(const Tensor& input_, IntArrayRef paddi
   if (output.numel() == 0 || input_.numel() == 0) {
     return;
   }
-  Tensor input = input_.contiguous();
-  Tensor output_c = output;
+  auto input = input_.contiguous();
+  auto output_c = output;
   if (input.dim() == 2) {
     input = input.unsqueeze(0);
     output_c = output_c.unsqueeze(0);
   }
   TORCH_INTERNAL_ASSERT(input.dim() == 3 && output_c.dim() == 3);
 
-  const int64_t nbatch = input.size(0);
-  const int64_t nplane = input.size(1);
-  const int64_t input_W = input.size(2);
-  const int64_t output_W = output_c.size(2);
-  const std::array<int32_t, 4> sizes_pad = {static_cast<int32_t>(input_W),
-                                            static_cast<int32_t>(output_W),
-                                            static_cast<int32_t>(padding[0]),
-                                            static_cast<int32_t>(padding[1])};
+  const auto nbatch = input.size(0);
+  const auto nplane = input.size(1);
+  const auto input_W = input.size(2);
+  const auto output_W = output_c.size(2);
+  const std::array<auto, 4> sizes_pad = {static_cast<int32_t>(input_W),
+                                         static_cast<int32_t>(output_W),
+                                         static_cast<int32_t>(padding[0]),
+                                         static_cast<int32_t>(padding[1])};
 
   auto pso = replication_pad_lib.getPipelineStateForFunc("replication_pad1d_forward_" + scalarToMetalTypeString(input));
   auto stream = getCurrentMPSStream();
@@ -384,22 +384,22 @@ static void replication_pad1d_backward_kernel_mps(const Tensor& grad_output_,
   if (grad_input.numel() == 0 || grad_output_.numel() == 0) {
     return;
   }
-  Tensor grad_output = grad_output_.contiguous();
-  Tensor grad_input_c = grad_input;
+  auto grad_output = grad_output_.contiguous();
+  auto grad_input_c = grad_input;
   if (input.dim() == 2) {
     grad_output = grad_output.unsqueeze(0);
     grad_input_c = grad_input_c.unsqueeze(0);
   }
   TORCH_INTERNAL_ASSERT(grad_output.dim() == 3 && grad_input_c.dim() == 3);
 
-  const int64_t nbatch = grad_input_c.size(0);
-  const int64_t nplane = grad_input_c.size(1);
-  const int64_t input_W = grad_input_c.size(2);
-  const int64_t output_W = grad_output.size(2);
-  const std::array<int32_t, 4> sizes_pad = {static_cast<int32_t>(input_W),
-                                            static_cast<int32_t>(output_W),
-                                            static_cast<int32_t>(padding[0]),
-                                            static_cast<int32_t>(padding[1])};
+  const auto nbatch = grad_input_c.size(0);
+  const auto nplane = grad_input_c.size(1);
+  const auto input_W = grad_input_c.size(2);
+  const auto output_W = grad_output.size(2);
+  const std::array<auto, 4> sizes_pad = {static_cast<int32_t>(input_W),
+                                         static_cast<int32_t>(output_W),
+                                         static_cast<int32_t>(padding[0]),
+                                         static_cast<int32_t>(padding[1])};
 
   auto pso = replication_pad_lib.getPipelineStateForFunc("replication_pad1d_backward_" +
                                                          scalarToMetalTypeString(grad_input_c));

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -1,5 +1,6 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/OperationUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -322,6 +323,96 @@ static Tensor& pad_out_template(Tensor& output,
   }
   return output;
 }
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& replication_pad_lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/ReplicationPad_metallib.h>
+#endif
+
+static void replication_pad1d_kernel_mps(const Tensor& input_,
+                                         IntArrayRef padding,
+                                         const Tensor& output) {
+  if (output.numel() == 0 || input_.numel() == 0) {
+    return;
+  }
+  Tensor input = input_.contiguous();
+  Tensor output_c = output;
+  if (input.dim() == 2) {
+    input = input.unsqueeze(0);
+    output_c = output_c.unsqueeze(0);
+  }
+  TORCH_INTERNAL_ASSERT(input.dim() == 3 && output_c.dim() == 3);
+
+  const int64_t nbatch = input.size(0);
+  const int64_t nplane = input.size(1);
+  const int64_t input_W = input.size(2);
+  const int64_t output_W = output_c.size(2);
+  const std::array<int32_t, 4> sizes_pad = {static_cast<int32_t>(input_W),
+                                            static_cast<int32_t>(output_W),
+                                            static_cast<int32_t>(padding[0]),
+                                            static_cast<int32_t>(padding[1])};
+
+  auto pso = replication_pad_lib.getPipelineStateForFunc("replication_pad1d_forward_" +
+                                                         scalarToMetalTypeString(input));
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      getMPSProfiler().beginProfileKernel(pso, "replication_pad1d_forward", {input, output_c});
+      auto encoder = stream->commandEncoder();
+      [encoder setComputePipelineState:pso];
+      mtl_setArgs(encoder, input, output_c, sizes_pad);
+      const NSUInteger maxTPG = [pso maxTotalThreadsPerThreadgroup];
+      const NSUInteger tg_x = std::min(maxTPG, static_cast<NSUInteger>(output_W));
+      [encoder dispatchThreads:MTLSizeMake(output_W, nplane, nbatch)
+          threadsPerThreadgroup:MTLSizeMake(tg_x, 1, 1)];
+      getMPSProfiler().endProfileKernel(pso);
+    }
+  });
+}
+
+static void replication_pad1d_backward_kernel_mps(const Tensor& grad_output_,
+                                                  const Tensor& input,
+                                                  IntArrayRef padding,
+                                                  const Tensor& grad_input) {
+  if (grad_input.numel() == 0 || grad_output_.numel() == 0) {
+    return;
+  }
+  Tensor grad_output = grad_output_.contiguous();
+  Tensor grad_input_c = grad_input;
+  if (input.dim() == 2) {
+    grad_output = grad_output.unsqueeze(0);
+    grad_input_c = grad_input_c.unsqueeze(0);
+  }
+  TORCH_INTERNAL_ASSERT(grad_output.dim() == 3 && grad_input_c.dim() == 3);
+
+  const int64_t nbatch = grad_input_c.size(0);
+  const int64_t nplane = grad_input_c.size(1);
+  const int64_t input_W = grad_input_c.size(2);
+  const int64_t output_W = grad_output.size(2);
+  const std::array<int32_t, 4> sizes_pad = {static_cast<int32_t>(input_W),
+                                            static_cast<int32_t>(output_W),
+                                            static_cast<int32_t>(padding[0]),
+                                            static_cast<int32_t>(padding[1])};
+
+  auto pso = replication_pad_lib.getPipelineStateForFunc("replication_pad1d_backward_" +
+                                                         scalarToMetalTypeString(grad_input_c));
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      getMPSProfiler().beginProfileKernel(pso, "replication_pad1d_backward", {grad_output, grad_input_c});
+      auto encoder = stream->commandEncoder();
+      [encoder setComputePipelineState:pso];
+      mtl_setArgs(encoder, grad_output, grad_input_c, sizes_pad);
+      const NSUInteger maxTPG = [pso maxTotalThreadsPerThreadgroup];
+      const NSUInteger tg_x = std::min(maxTPG, static_cast<NSUInteger>(input_W));
+      [encoder dispatchThreads:MTLSizeMake(input_W, nplane, nbatch)
+          threadsPerThreadgroup:MTLSizeMake(tg_x, 1, 1)];
+      getMPSProfiler().endProfileKernel(pso);
+    }
+  });
+}
+
 } // namespace mps
 
 // 1D Reflection and Replication Padding
@@ -350,25 +441,12 @@ TORCH_IMPL_FUNC(reflection_pad1d_backward_out_mps)
 
 TORCH_IMPL_FUNC(replication_pad1d_out_mps)
 (const Tensor& input, IntArrayRef padding, const Tensor& output) {
-  mps::pad_out_template(const_cast<Tensor&>(output),
-                        input,
-                        padding,
-                        std::nullopt,
-                        MPSGraphPaddingModeClampToEdge,
-                        0.0,
-                        "replication_pad1d_out_mps");
+  mps::replication_pad1d_kernel_mps(input, padding, output);
 }
 
 TORCH_IMPL_FUNC(replication_pad1d_backward_out_mps)
 (const Tensor& grad_output, const Tensor& input, IntArrayRef padding, const Tensor& grad_input) {
-  grad_input.resize_as_(input).zero_();
-  mps::pad_out_template(const_cast<Tensor&>(grad_input),
-                        input,
-                        padding,
-                        grad_output,
-                        MPSGraphPaddingModeClampToEdge,
-                        0.0,
-                        "replication_pad1d_backward_out_mps");
+  mps::replication_pad1d_backward_kernel_mps(grad_output, input, padding, grad_input);
 }
 
 // 2D Reflection and Replication Padding

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8893,6 +8893,18 @@ class TestLargeTensors(TestCaseMPS):
         self.assertGreater(tail.unique().numel(), 50)
         del x
 
+    @serialTest()
+    def test_replication_pad1d_issue135442(self):
+        # backward(mpsgraph) used to hang the GPU
+        # https://github.com/pytorch/pytorch/issues/135442
+        x = torch.randn(65536, 2, 4, requires_grad=True)
+        x_mps = x.detach().to("mps").requires_grad_()
+        g = torch.randn(65536, 2, 11)
+        pad = torch.nn.ReplicationPad1d((3, 4))
+        pad(x).backward(g)
+        pad(x_mps).backward(g.to("mps"))
+        self.assertEqual(x_mps.grad.cpu(), x.grad)
+
 
 class TestLogical(TestCaseMPS):
     def _wrap_tensor(self, x, device="cpu", dtype=None, requires_grad=False):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8893,18 +8893,6 @@ class TestLargeTensors(TestCaseMPS):
         self.assertGreater(tail.unique().numel(), 50)
         del x
 
-    @serialTest()
-    def test_replication_pad1d_issue135442(self):
-        # backward(mpsgraph) used to hang the GPU
-        # https://github.com/pytorch/pytorch/issues/135442
-        x = torch.randn(65536, 2, 4, requires_grad=True)
-        x_mps = x.detach().to("mps").requires_grad_()
-        g = torch.randn(65536, 2, 11)
-        pad = torch.nn.ReplicationPad1d((3, 4))
-        pad(x).backward(g)
-        pad(x_mps).backward(g.to("mps"))
-        self.assertEqual(x_mps.grad.cpu(), x.grad)
-
 
 class TestLogical(TestCaseMPS):
     def _wrap_tensor(self, x, device="cpu", dtype=None, requires_grad=False):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9831,6 +9831,17 @@ class TestPad(TestCaseMPS):
         output_mps = torch.constant_pad_nd(input_mps, [])
         self.assertEqual(output_mps, input_mps)
 
+    def test_replication_pad1d_non_contig_out(self):
+        x = torch.randn(2, 3, 5, device="mps")
+        out = torch.empty(2, 7, 3, device="mps").transpose(1, 2)
+        torch.ops.aten.replication_pad1d.out(x, (1, 1), out=out)
+        self.assertEqual(out.cpu(), F.pad(x.cpu(), (1, 1), mode="replicate"))
+        go = torch.randn(2, 3, 7, device="mps")
+        gi = torch.empty(2, 5, 3, device="mps").transpose(1, 2)
+        torch.ops.aten.replication_pad1d_backward.grad_input(go, x, (1, 1), grad_input=gi)
+        gi_ref = torch.ops.aten.replication_pad1d_backward(go.cpu(), x.cpu(), (1, 1))
+        self.assertEqual(gi.cpu(), gi_ref)
+
 class TestLinalgMPS(TestCaseMPS):
     def _test_addmm_addmv(self, f, t, m, v, *, alpha=None, beta=None, transpose_out=False):
         dtype = t.dtype

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9657,7 +9657,6 @@ class TestNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, 'padding size is expected to be 6'):
             torch._C._nn.replication_pad3d(torch.randn([2]), padding=[])
 
-    @expectedFailureMPS  # Correctness issue https://github.com/pytorch/pytorch/issues/135447
     def test_ReplicationPad1d_large(self, device):
         shapes = ([2, 65736, 4], [65736, 2, 4])
         pl, pr = 3, 4


### PR DESCRIPTION
Migrates replication pad 1d to metal kernel which also fixes issue #135442

Longer term work would be to migrate all pad kernels and keep the template as it's done for MPS Graph ops

Perf:
Forward

| shape          | dtype | layout  | old (ms) | new (ms) | speedup    |
|---------------|-------|---------|---------:|---------:|-----------:|
| 16x32x64      | fp32  | contig  |   0.0124 |   0.0106 | 1.17x  |
| 16x32x64      | fp32  | strided |   0.0136 |   0.0075 | 1.81x  |
| 16x32x64      | bf16  | contig  |   0.0120 |   0.0056 | 2.14x  |
| 16x32x64      | bf16  | strided |   0.0136 |   0.0061 | 2.23x  |
| 32x64x256     | fp32  | contig  |   0.0224 |   0.0109 | 2.06x  |
| 32x64x256     | fp32  | strided |   0.0268 |   0.0262 | 1.02x  |
| 32x64x256     | bf16  | contig  |   0.0140 |   0.0092 | 1.52x  |
| 32x64x256     | bf16  | strided |   0.0256 |   0.0262 |     0.98x  |
| 4x16x4096     | fp32  | contig  |   0.0137 |   0.0057 | 2.40x  |
| 4x16x4096     | fp32  | strided |   0.0154 |   0.0156 |     0.99x  |
| 4x16x4096     | bf16  | contig  |   0.0137 |   0.0059 | 2.32x  |
| 4x16x4096     | bf16  | strided |   0.0151 |   0.0148 | 1.02x  |
| 8192x4x32     | fp32  | contig  |   0.0272 |   0.0207 | 1.31x  |
| 8192x4x32     | fp32  | strided |   0.0576 |   0.0515 | 1.12x  |
| 8192x4x32     | bf16  | contig  |   0.0273 |   0.0168 | 1.63x  |
| 8192x4x32     | bf16  | strided |   0.0558 |   0.0480 | 1.16x  |
| 65535x2x4     | fp32  | contig  |   0.0238 |   0.0190 | 1.25x  |
| 65535x2x4     | fp32  | strided |   0.0422 |   0.0367 | 1.15x  |
| 65535x2x4     | bf16  | contig  |   0.0231 |   0.0184 | 1.26x  |
| 65535x2x4     | bf16  | strided |   0.0380 |   0.0356 | 1.07x  |
| 65536x2x4     | fp32  | contig  |  hung    |   0.0188 | hung   |
| 65536x2x4     | fp32  | strided |  hung    |   0.0373 | hung   |
| 65536x2x4     | bf16  | contig  |  hung    |   0.0186 | hung   |
| 65536x2x4     | bf16  | strided |  hung    |   0.0352 | hung   |
| 1024x16x1024  | fp32  | contig  |   0.6918 |   0.5626 | 1.23x  |
| 1024x16x1024  | fp32  | strided |   1.4546 |   1.3426 | 1.08x  |
| 1024x16x1024  | bf16  | contig  |   0.3284 |   0.3071 | 1.07x  |
| 1024x16x1024  | bf16  | strided |   0.7300 |   0.7439 |     0.98x  |

Forward + backward

| shape          | dtype | layout  | old (ms) | new (ms) | speedup    |
|---------------|-------|---------|---------:|---------:|-----------:|
| 16x32x64      | fp32  | contig  |   0.0460 |   0.0220 | 2.09x  |
| 16x32x64      | fp32  | strided |   0.0501 |   0.0305 | 1.64x  |
| 16x32x64      | bf16  | contig  |   0.0466 |   0.0171 | 2.73x  |
| 16x32x64      | bf16  | strided |   0.0498 |   0.0219 | 2.27x  |
| 32x64x256     | fp32  | contig  |   0.0473 |   0.0332 | 1.42x  |
| 32x64x256     | fp32  | strided |   0.0532 |   0.0500 | 1.06x  |
| 32x64x256     | bf16  | contig  |   0.0484 |   0.0315 | 1.54x  |
| 32x64x256     | bf16  | strided |   0.0537 |   0.0487 | 1.10x  |
| 4x16x4096     | fp32  | contig  |   0.0491 |   0.0240 | 2.05x  |
| 4x16x4096     | fp32  | strided |   0.0530 |   0.0335 | 1.58x  |
| 4x16x4096     | bf16  | contig  |   0.0483 |   0.0233 | 2.07x  |
| 4x16x4096     | bf16  | strided |   0.0526 |   0.0336 | 1.57x  |
| 8192x4x32     | fp32  | contig  |   0.0943 |   0.0635 | 1.49x  |
| 8192x4x32     | fp32  | strided |   0.1258 |   0.0978 | 1.29x  |
| 8192x4x32     | bf16  | contig  |   0.0953 |   0.0606 | 1.57x  |
| 8192x4x32     | bf16  | strided |   0.1236 |   0.0917 | 1.35x  |
| 65535x2x4     | fp32  | contig  |   0.1375 |   0.0512 | 2.69x  |
| 65535x2x4     | fp32  | strided |   0.1543 |   0.0689 | 2.24x  |
| 65535x2x4     | bf16  | contig  |   0.1390 |   0.0476 | 2.92x  |
| 65535x2x4     | bf16  | strided |   0.1541 |   0.0642 | 2.40x  |
| 65536x2x4     | fp32  | contig  |  hung    |   0.0521 | hung   |
| 65536x2x4     | fp32  | strided |  hung    |   0.0689 | hung   |
| 65536x2x4     | bf16  | contig  |  hung    |   0.0480 | hung   |
| 65536x2x4     | bf16  | strided |  hung    |   0.0645 | hung   |
| 1024x16x1024  | fp32  | contig  |   1.4450 |   1.1157 | 1.30x  |
| 1024x16x1024  | fp32  | strided |   2.3538 |   1.8775 | 1.25x  |
| 1024x16x1024  | bf16  | contig  |   1.0344 |   0.5867 | 1.76x  |
| 1024x16x1024  | bf16  | strided |   1.5062 |   1.0347 | 1.46x  |