### PR TITLE
Fix #182318: _EnableTorchFunction destructor leaks torch function TLS state

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -626,6 +626,20 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
             # verify it carries correct metadata.
             self.assertEqual(convert_nodes[0].meta["val"].dtype, torch.float64)
 
+    def test_enable_torch_function_no_tls_leak(self):
+        @torch.compile(backend="eager")
+        def fn():
+            with torch._C.DisableTorchFunctionSubclass():
+                g = torch._C._EnableTorchFunction()
+                del g
+
+        fn()
+        self.assertTrue(torch._C._is_torch_function_enabled())
+        self.assertEqual(
+            torch._C._get_torch_function_state(),
+            torch._C._TorchFunctionState.ENABLED,
+        )
+
     def test_torch_function_state_graph_break(self):
         @torch.compile(backend="eager")
         def fn(x):

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -1805,18 +1805,14 @@ class TestTorchFunctionMode(TestCase):
 
         self.assertFalse(called)
 
-    @unittest.skipIf(TEST_WITH_TORCHDYNAMO, "https://github.com/pytorch/pytorch/issues/182318")
     def test_disable_enable_subclass(self):
         class A(torch.Tensor):
             pass
 
         x = A(torch.randn(5))
         with torch._C.DisableTorchFunctionSubclass():
-            g = torch._C._EnableTorchFunction()
-            try:
+            with torch._C._EnableTorchFunction():
                 self.assertIsInstance(torch.sum(x), A)
-            finally:
-                del g
 
     def test_disable_enable_torch_function_ctx(self):
         class A(torch.Tensor):

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -619,8 +619,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
 
   py_context_manager_DEPRECATED<torch::DisableTorchDispatch>(
       _C_m, "_DisableTorchDispatch");
-  py_context_manager_DEPRECATED<EnableTorchFunction>(
-      _C_m, "_EnableTorchFunction");
+  py_context_manager<EnableTorchFunction>(_C_m, "_EnableTorchFunction");
   py_context_manager_DEPRECATED<EnablePythonDispatcher>(
       _C_m, "_EnablePythonDispatcher");
   py_context_manager<c10::impl::DisablePythonDispatcher>(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #183066

Root cause: _EnableTorchFunction was registered with py_context_manager_DEPRECATED,
which acquires the resource (saves + modifies TLS) in the C++ constructor and
releases it in the destructor. When dynamo hits a graph break on
_EnableTorchFunction(), the modified outer-function bytecode re-enters
DisableTorchFunctionSubclass, executes the CALL (creating an instance whose
constructor snapshots TLS = SUBCLASSES_DISABLED), then exits the context and
passes the instance to the resume function. The instance survives on the outer
frame until RETURN_VALUE triggers frame cleanup -- at which point the C++
destructor fires and clobbers TLS back to SUBCLASSES_DISABLED, long after the
context manager already restored it to ENABLED.

Fix: switch _EnableTorchFunction from py_context_manager_DEPRECATED to
py_context_manager. The non-deprecated variant stores constructor args but
defers the actual C++ guard construction to __enter__, so creating a Python
instance is side-effect-free. The destructor is also harmless because the
guard is held in a std::optional that __exit__ already cleared. This means
stray instances created during codegen no longer corrupt TLS on destruction.
The one existing RAII-style usage (create instance, rely on destructor to
restore state) in test_overrides.py is updated to use the `with` pattern.

The companion FX pass usage in _tensorify_python_scalars.py already used
`with torch._C._EnableTorchFunction()`, so it works without changes.

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98