### PR TITLE
[dynamo] Allow non-string assert messages in AssertionError

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1344,17 +1344,6 @@ class BuiltinVariable(BaseBuiltinVariable):
                 args: list[VariableTracker],
                 kwargs: dict[str, VariableTracker],
             ) -> VariableTracker:
-                if fn is AssertionError and not all(
-                    x.is_python_constant() and isinstance(x.as_python_constant(), str)
-                    for x in args
-                ):
-                    unimplemented(
-                        gb_type="assert with non-string message",
-                        context=str(args),
-                        explanation="Dynamo only supports asserts with string messages",
-                        hints=[*graph_break_hints.SUPPORTABLE],
-                    )
-
                 return variables.ExceptionVariable(fn, args, kwargs)
 
             return create_exception_class_object


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #183078
* #183077
* #183076
* #183075
* #183074
* #183073
* __->__ #183072
* #183071
* #183070

Remove the restriction that AssertionError args must be string
constants. ExceptionVariable already handles arbitrary VariableTracker
args correctly via codegen.foreach in reconstruct().

Removes 1 expected failure in test_raise (test_assert_with_tuple_arg).

Authored by Claude.