### PR TITLE
[dynamo] Fix __contains__ and container equality to check identity first

### DIFF
--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -179,14 +179,15 @@ def impl_CONTAINS_OP_fallback(a: T, b: Iterable[T]) -> bool:
     # PyObject_GetIter itself falls back to PySequence_GetItem when tp_iter is NULL.
     if hasattr(b, "__iter__"):
         for x in b:
-            if x == a:
+            if x is a or x == a:
                 return True
         return False
     if hasattr(b, "__getitem__"):
         i = 0
         while True:
             try:
-                if b.__getitem__(i) == a:
+                item = b.__getitem__(i)
+                if item is a or item == a:
                     return True
                 i += 1
             except IndexError:
@@ -225,9 +226,12 @@ def list_cmp(
     if op is ne and left_len != right_len:
         return True
 
-    # Apply `op` to the first pair that differ
+    # Apply `op` to the first pair that differ.
+    # CPython's list_richcompare uses PyObject_RichCompareBool which checks
+    # identity before equality, so identical objects are always considered equal
+    # (e.g. NaN is NaN => True even though NaN == NaN => False).
     for a, b in zip(left, right):
-        if a != b:
+        if a is not b and a != b:
             return op(a, b)
 
     # No more pairs to compare, so compare sizes.
@@ -242,7 +246,8 @@ def dict___eq__(d: dict[T, U], other: dict[T, U]) -> bool:
         return list(d.items()) == list(other.items())
 
     for k, v in d.items():
-        if v != other[k]:
+        other_v = other[k]
+        if v is not other_v and v != other_v:
             return False
 
     return True

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3155,6 +3155,13 @@ def raise_args_mismatch(
     )
 
 
+def _richcompare_eq(a: Any, b: Any) -> bool:
+    """Mirrors CPython's PyObject_RichCompareBool for Py_EQ: identity first, then equality."""
+    if a is b:
+        return True
+    return a == b
+
+
 def iter_contains(
     items: Iterable[Any],
     search: Any,
@@ -3164,9 +3171,10 @@ def iter_contains(
     from .variables import ConstantVariable
 
     if search.is_python_constant():
+        search_val = search.as_python_constant()
         found_const = any(
             x.is_python_constant()
-            and x.as_python_constant() == search.as_python_constant()
+            and _richcompare_eq(x.as_python_constant(), search_val)
             for x in items
         )
         return ConstantVariable.create(found_const)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #183078
* #183077
* #183076
* #183075
* #183074
* __->__ #183073
* #183072
* #183071
* #183070

CPython's PyObject_RichCompareBool checks identity (is) before
equality (==). This means NAN in [NAN] returns True because
NAN is NAN, even though NAN == NAN is False. Dynamo's containment
and container equality only used ==, producing wrong results.

Add identity checks in iter_contains (utils.py), CONTAINS_OP
fallback, list_cmp, and dict___eq__ (polyfills).

Authored by Claude.