### PR TITLE
[dynamo] Fix list.__init__() to clear items when called with no args

### DIFF
--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1190,11 +1190,12 @@ class ListVariable(CommonListMethodsVariable):
         if name == "__init__" and self.is_mutable():
             if kwargs:
                 raise_args_mismatch(tx, name, "0 kwargs", f"{len(kwargs)} kwargs")
+            tx.output.side_effects.mutation(self)
             if len(args) == 0:
+                self.items.clear()
                 return ConstantVariable.create(None)
             elif len(args) == 1 and args[0].has_force_unpack_var_sequence(tx):
                 (arg,) = args
-                tx.output.side_effects.mutation(self)
                 self.items[:] = arg.force_unpack_var_sequence(tx)
                 return ConstantVariable.create(None)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183078
* #183077
* #183076
* #183075
* #183074
* #183073
* #183072
* #183071
* #183070

list.__init__() should clear the list, but the handler returned None
without clearing self.items. Also hoist mutation tracking to cover
both the no-args (clear) and one-arg (replace) branches.

Removes 1 expected failure (test_init in test_list).

Authored by Claude.