### PR TITLE
add _cdist_backward MPS kernel

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Cdist.metal
+++ b/aten/src/ATen/native/mps/kernels/Cdist.metal
@@ -1,0 +1,133 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+// Layout must match `CdistBwdParams` in operations/Distance.mm.
+struct CdistBwdParams {
+  long B;
+  long P;
+  long R;
+  long D;
+  float p_minus_1;
+};
+
+// P_KIND: 0 = p==1, 1 = p==inf, 2 = generic. The TG precomputes
+// `grad / cdist^(p-1)` per (b, i, j) into `s_reducer`, shared across c-threads.
+template <typename T, int P_KIND, uint TG_C>
+kernel void cdist_backward(
+    constant T* x1 [[buffer(0)]],
+    constant T* x2 [[buffer(1)]],
+    constant T* grad [[buffer(2)]],
+    constant float* cdist [[buffer(3)]],
+    device T* out [[buffer(4)]],
+    constant CdistBwdParams& params [[buffer(5)]],
+    uint3 tid [[thread_position_in_grid]],
+    uint3 ltid3 [[thread_position_in_threadgroup]]) {
+  const uint ltid = ltid3.x;
+
+  const long D = params.D;
+  const long P = params.P;
+  const long R = params.R;
+  const float pm1 = params.p_minus_1;
+
+  const long c = static_cast<long>(tid.x);
+  const long i = static_cast<long>(tid.y);
+  const long b = static_cast<long>(tid.z);
+  // Padding threads (c >= D) still participate in the cooperative load.
+  const bool active = c < D;
+
+  threadgroup float s_reducer[TG_C];
+  // Only the p == inf exact-match test needs cdist in TG memory.
+  threadgroup float s_cdist[(P_KIND == 1) ? TG_C : 1];
+
+  const ulong x1_off =
+      static_cast<ulong>(b) * static_cast<ulong>(P) * static_cast<ulong>(D) +
+      static_cast<ulong>(i) * static_cast<ulong>(D) + static_cast<ulong>(c);
+  const ulong x2_row =
+      static_cast<ulong>(b) * static_cast<ulong>(R) * static_cast<ulong>(D);
+  const ulong gr_row =
+      static_cast<ulong>(b) * static_cast<ulong>(P) * static_cast<ulong>(R) +
+      static_cast<ulong>(i) * static_cast<ulong>(R);
+
+  const float x1ic = active ? static_cast<float>(x1[x1_off]) : 0.0f;
+  float acc = 0.0f;
+
+  for (long j_base = 0; j_base < R; j_base += TG_C) {
+    const long tile_size = min(static_cast<long>(TG_C), R - j_base);
+
+    // Tile size = TG_C: each thread loads at most one j per tile.
+    const long t = static_cast<long>(ltid);
+    if (t < tile_size) {
+      const ulong g_idx = gr_row + static_cast<ulong>(j_base + t);
+      const float g_val = static_cast<float>(grad[g_idx]);
+      if constexpr (P_KIND == 0) {
+        s_reducer[t] = g_val;
+      } else if constexpr (P_KIND == 1) {
+        s_reducer[t] = g_val;
+        s_cdist[t] = cdist[g_idx];
+      } else {
+        const float c_val = cdist[g_idx];
+        s_reducer[t] =
+            (c_val == 0.0f) ? 0.0f : g_val / ::metal::precise::pow(c_val, pm1);
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (active) {
+      const ulong x2_off = x2_row +
+          static_cast<ulong>(j_base) * static_cast<ulong>(D) +
+          static_cast<ulong>(c);
+      for (long t_off = 0; t_off < tile_size; ++t_off) {
+        const float x2jc = static_cast<float>(
+            x2[x2_off + static_cast<ulong>(t_off) * static_cast<ulong>(D)]);
+        const float dij = x1ic - x2jc;
+        // dij == 0 contributes 0 (sign(0) = 0); also dodges pow(0, neg) when
+        // p<1.
+        if (dij == 0.0f) {
+          continue;
+        }
+        const float sij = (dij > 0.0f) ? 1.0f : -1.0f;
+        const float r = s_reducer[t_off];
+        if constexpr (P_KIND == 0) {
+          acc += r * sij;
+        } else if constexpr (P_KIND == 1) {
+          if (::metal::precise::abs(dij) == s_cdist[t_off]) {
+            acc += r * sij;
+          }
+        } else {
+          acc +=
+              r * sij * ::metal::precise::pow(::metal::precise::abs(dij), pm1);
+        }
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (active) {
+    out[x1_off] = static_cast<T>(acc);
+  }
+}
+
+#define REGISTER_CDIST_BACKWARD(T, P_KIND, TG_C)                        \
+  template [[host_name("cdist_backward_" #T "_p" #P_KIND "_tg" #TG_C)]] \
+  kernel void cdist_backward<T, P_KIND, TG_C>(                          \
+      constant T * x1 [[buffer(0)]],                                    \
+      constant T * x2 [[buffer(1)]],                                    \
+      constant T * grad [[buffer(2)]],                                  \
+      constant float* cdist [[buffer(3)]],                              \
+      device T* out [[buffer(4)]],                                      \
+      constant CdistBwdParams& params [[buffer(5)]],                    \
+      uint3 tid [[thread_position_in_grid]],                            \
+      uint3 ltid3 [[thread_position_in_threadgroup]]);
+
+#define REGISTER_CDIST_BACKWARD_FOR_TYPE(T) \
+  REGISTER_CDIST_BACKWARD(T, 0, 32)         \
+  REGISTER_CDIST_BACKWARD(T, 0, 128)        \
+  REGISTER_CDIST_BACKWARD(T, 1, 32)         \
+  REGISTER_CDIST_BACKWARD(T, 1, 128)        \
+  REGISTER_CDIST_BACKWARD(T, 2, 32)         \
+  REGISTER_CDIST_BACKWARD(T, 2, 128)
+
+REGISTER_CDIST_BACKWARD_FOR_TYPE(float)
+REGISTER_CDIST_BACKWARD_FOR_TYPE(half)
+REGISTER_CDIST_BACKWARD_FOR_TYPE(bfloat)

--- a/aten/src/ATen/native/mps/operations/Distance.mm
+++ b/aten/src/ATen/native/mps/operations/Distance.mm
@@ -1,0 +1,155 @@
+//  Copyright © 2026 Apple Inc.
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/ExpandUtils.h>
+#include <ATen/native/mps/OperationUtils.h>
+#include <c10/metal/common.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_cdist_backward_native.h>
+#include <ATen/ops/_cdist_forward_native.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/linalg_vector_norm.h>
+#include <ATen/ops/where.h>
+#include <ATen/ops/zeros.h>
+#endif
+
+#include <cmath>
+
+namespace at::native {
+using namespace mps;
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Cdist_metallib.h>
+#endif
+
+// Layout must match `CdistBwdParams` in kernels/Cdist.metal.
+struct CdistBwdParams {
+  int64_t B;
+  int64_t P;
+  int64_t R;
+  int64_t D;
+  float p_minus_1;
+};
+static_assert(offsetof(CdistBwdParams, p_minus_1) == 32, "Metal struct layout mismatch");
+static_assert(sizeof(CdistBwdParams) == 40, "Metal struct size mismatch");
+
+Tensor _cdist_forward_mps(const Tensor& x1, const Tensor& x2, const double p, std::optional<int64_t> compute_mode) {
+  TORCH_CHECK(x1.dim() >= 2, "cdist only supports at least 2D tensors, X1 got: ", x1.dim(), "D");
+  TORCH_CHECK(x2.dim() >= 2, "cdist only supports at least 2D tensors, X2 got: ", x2.dim(), "D");
+  TORCH_CHECK(x1.size(-1) == x2.size(-1),
+              "X1 and X2 must have the same number of columns. X1: ",
+              x1.size(-1),
+              " X2: ",
+              x2.size(-1));
+  TORCH_CHECK(
+      at::isFloatingType(x1.scalar_type()), "cdist only supports floating-point dtypes, X1 got: ", x1.scalar_type());
+  TORCH_CHECK(
+      at::isFloatingType(x2.scalar_type()), "cdist only supports floating-point dtypes, X2 got: ", x2.scalar_type());
+  TORCH_CHECK(p >= 0, "cdist only supports non-negative p values");
+
+  const int64_t mode = compute_mode.value_or(0);
+  TORCH_CHECK(mode >= 0 && mode <= 2, "possible modes: 0, 1, 2, but was: ", mode);
+
+  // Promote fp16/bf16 to fp32 internally so the max-norm argmax selection
+  // matches what the CPU reference does (which falls back to fp32 for
+  // these dtypes anyway).
+  const auto out_dtype = x1.scalar_type();
+  const bool promote = at::isReducedFloatingType(out_dtype);
+  const auto compute_dtype = promote ? at::kFloat : out_dtype;
+  auto diff = x1.to(compute_dtype).unsqueeze(-2).sub(x2.to(compute_dtype).unsqueeze(-3));
+  auto result = at::linalg_vector_norm(diff, p, makeArrayRef<int64_t>(-1), /*keepdim=*/false, /*dtype=*/std::nullopt);
+  return promote ? result.to(out_dtype) : result;
+}
+
+Tensor _cdist_backward_mps(const Tensor& grad,
+                           const Tensor& x1,
+                           const Tensor& x2,
+                           const double p,
+                           const Tensor& cdist) {
+  const int64_t r1 = x1.size(-2);
+  const int64_t r2 = x2.size(-2);
+  const int64_t c = x1.size(-1);
+  const std::vector<int64_t> expand_batch =
+      infer_size(x1.sizes().slice(0, x1.dim() - 2), x2.sizes().slice(0, x2.dim() - 2));
+  std::vector<int64_t> out_size(expand_batch);
+  out_size.insert(out_size.end(), {r1, c});
+
+  const int64_t batch_product = c10::multiply_integers(expand_batch);
+  if (r1 == 0 || r2 == 0 || c == 0 || batch_product == 0 || p == 0.0) {
+    return at::zeros(out_size, x1.options());
+  }
+
+  // p == 2: Euclidean identity, no kernel needed.
+  if (p == 2.0) {
+    Tensor coeff = at::where(cdist.eq(0), 0, grad.div(cdist));
+    return x1.mul(coeff.sum(-1, /*keepdim=*/true)).sub(coeff.matmul(x2));
+  }
+
+  std::vector<int64_t> x2_expand_size(expand_batch);
+  x2_expand_size.insert(x2_expand_size.end(), {r2, c});
+  std::vector<int64_t> dist_expand_size(expand_batch);
+  dist_expand_size.insert(dist_expand_size.end(), {r1, r2});
+
+  const Tensor x1c = x1.expand(out_size).contiguous();
+  const Tensor x2c = x2.expand(x2_expand_size).contiguous();
+  const Tensor gradc = grad.expand(dist_expand_size).contiguous();
+  // Kernel reads cdist as fp32. For p == inf with reduced precision the
+  // fp16-rounded saved cdist would miss the argmax-c match, so recompute.
+  const bool reduced = at::isReducedFloatingType(x1c.scalar_type());
+  const Tensor cdistc = (std::isinf(p) && reduced)
+      ? at::linalg_vector_norm(x1c.to(at::kFloat).unsqueeze(-2).sub(x2c.to(at::kFloat).unsqueeze(-3)),
+                               p,
+                               makeArrayRef<int64_t>(-1),
+                               /*keepdim=*/false,
+                               /*dtype=*/std::nullopt)
+            .contiguous()
+      : cdist.expand(dist_expand_size).to(at::kFloat).contiguous();
+  const Tensor out = at::empty(out_size, x1.options());
+
+  const CdistBwdParams params{
+      .B = batch_product,
+      .P = r1,
+      .R = r2,
+      .D = c,
+      .p_minus_1 = static_cast<float>(p - 1.0),
+  };
+
+  // Values must match `P_KIND` in kernels/Cdist.metal.
+  const int p_kind = std::isinf(p) ? 1 : (p == 1.0 ? 0 : 2);
+  // TG_C choices must match REGISTER_CDIST_BACKWARD_FOR_TYPE in Cdist.metal.
+  constexpr uint32_t kSmallTG = c10::metal::simdgroup_size;
+  constexpr uint32_t kLargeTG = 4 * c10::metal::simdgroup_size;
+  const uint32_t tg_c = (c >= 2 * kSmallTG) ? kLargeTG : kSmallTG;
+  const auto D_padded = c10::metal::ceil_div(static_cast<uint32_t>(c), tg_c) * tg_c;
+
+  auto stream = getCurrentMPSStream();
+  @autoreleasepool {
+    auto pso = lib.getPipelineStateForFunc(
+        fmt::format("cdist_backward_{}_p{}_tg{}", scalarToMetalTypeString(x1c), p_kind, tg_c));
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto compute_encoder = stream->commandEncoder();
+        [compute_encoder setComputePipelineState:pso];
+        mtl_setArgs(compute_encoder,
+                    x1c.view({batch_product, r1, c}),
+                    x2c.view({batch_product, r2, c}),
+                    gradc.view({batch_product, r1, r2}),
+                    cdistc.view({batch_product, r1, r2}),
+                    out.view({batch_product, r1, c}),
+                    params);
+        const MTLSize grid = MTLSizeMake(D_padded, static_cast<NSUInteger>(r1), static_cast<NSUInteger>(batch_product));
+        const MTLSize tg = MTLSizeMake(tg_c, 1, 1);
+        [compute_encoder dispatchThreads:grid threadsPerThreadgroup:tg];
+      }
+    });
+  }
+
+  return out;
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -13,7 +13,6 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
-#include <ATen/ops/_cdist_forward_native.h>
 #include <ATen/ops/all_native.h>
 #include <ATen/ops/amax_native.h>
 #include <ATen/ops/amin_native.h>
@@ -22,7 +21,6 @@
 #include <ATen/ops/argmax_native.h>
 #include <ATen/ops/argmin_native.h>
 #include <ATen/ops/count_nonzero_native.h>
-#include <ATen/ops/linalg_vector_norm.h>
 #include <ATen/ops/max_native.h>
 #include <ATen/ops/mean_native.h>
 #include <ATen/ops/median.h>
@@ -1178,33 +1176,6 @@ Tensor count_nonzero_mps(const Tensor& self, IntArrayRef dims) {
   auto iter =
       make_reduction("count_nonzero_mps", result, self, dims, /*keepdim=*/false, self.scalar_type(), ScalarType::Long);
   count_nonzero_kernel_mps(iter);
-  return result;
-}
-
-Tensor _cdist_forward_mps(const Tensor& x1, const Tensor& x2, const double p, std::optional<int64_t> compute_mode) {
-  TORCH_CHECK(x1.dim() >= 2, "cdist only supports at least 2D tensors, X1 got: ", x1.dim(), "D");
-  TORCH_CHECK(x2.dim() >= 2, "cdist only supports at least 2D tensors, X2 got: ", x2.dim(), "D");
-  TORCH_CHECK(x1.size(-1) == x2.size(-1),
-              "X1 and X2 must have the same number of columns. X1: ",
-              x1.size(-1),
-              " X2: ",
-              x2.size(-1));
-  TORCH_CHECK(
-      at::isFloatingType(x1.scalar_type()), "cdist only supports floating-point dtypes, X1 got: ", x1.scalar_type());
-  TORCH_CHECK(
-      at::isFloatingType(x2.scalar_type()), "cdist only supports floating-point dtypes, X2 got: ", x2.scalar_type());
-  TORCH_CHECK(p >= 0, "cdist only supports non-negative p values");
-
-  int64_t mode = compute_mode.value_or(0);
-  TORCH_CHECK(mode >= 0 && mode <= 2, "possible modes: 0, 1, 2, but was: ", mode);
-
-  Tensor x1_ = x1.unsqueeze(-2);
-  Tensor x2_ = x2.unsqueeze(-3);
-  Tensor diff = x1_.sub(x2_);
-  IntArrayRef output_shape(diff.sizes().data(), diff.dim() - 1);
-  Tensor result = at::empty(output_shape, x1.options());
-  linalg_vector_norm_out(result, diff, p, makeArrayRef<int64_t>(-1), /*keepdim=*/false, /*dtype=*/std::nullopt);
-
   return result;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4652,6 +4652,7 @@
 - func: _cdist_backward(Tensor grad, Tensor x1, Tensor x2, float p, Tensor cdist) -> Tensor
   dispatch:
     CPU, CUDA: _cdist_backward
+    MPS: _cdist_backward_mps
   autogen: _cdist_backward.out
 
 - func: pdist(Tensor self, float p=2) -> Tensor

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -112,6 +112,11 @@ def _build_test(
                     keep_config = False
                     break
 
+            if "mps" in attr.values():
+                if not torch.backends.mps.is_available():
+                    keep_config = False
+                    break
+
             test_attrs.update(attr)
 
         if not keep_config:
@@ -417,14 +422,16 @@ class BenchmarkRunner:
             device_module = torch.get_device_module(device.type)
         # TODO: add support for cpu memory measurement
         while True:
-            if hasattr(device_module, "reset_peak_memory_stats"):
-                device_module.reset_peak_memory_stats(device)
+            if device_module is not None:
+                if hasattr(device_module, "reset_peak_memory_stats"):
+                    device_module.reset_peak_memory_stats(device)
             run_time_sec = launch_test(test_case, iters, print_per_iter)
-            if hasattr(device_module, "synchronize"):
-                device_module.synchronize(device)
+            if device_module is not None:
+                device_module.synchronize()
             # Memory measurement process
-            if hasattr(device_module, "max_memory_allocated"):
-                peak_memory = device_module.max_memory_allocated(device)
+            if device_module is not None:
+                if hasattr(device_module, "max_memory_allocated"):
+                    peak_memory = device_module.max_memory_allocated(device)
             curr_test_total_time += run_time_sec
             # Analyze time after each run to decide if the result is stable
             results_are_significant = self._iteration_result_is_significant(

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -14,7 +14,7 @@ This module contains utilities for writing microbenchmark tests.
 
 # Here are the reserved keywords in the benchmark suite
 _reserved_keywords = {"probs", "total_samples", "tags"}
-_supported_devices = {"cpu", "cuda"}
+_supported_devices = {"cpu", "cuda", "mps"}
 
 
 def shape_to_string(shape):

--- a/benchmarks/operator_benchmark/pt/cdist_test.py
+++ b/benchmarks/operator_benchmark/pt/cdist_test.py
@@ -1,0 +1,45 @@
+import operator_benchmark as op_bench
+
+import torch
+
+
+"""Microbenchmarks for torch.cdist (pairwise distances)."""
+
+
+cdist_configs = op_bench.cross_product_configs(
+    B=[1, 8],
+    P=[64, 512],
+    R=[64, 512],
+    M=[16, 64],
+    p=[1.0, 2.0, 3.0, 4.0],
+    device=["cpu", "cuda", "mps"],
+    tags=["long"],
+)
+
+
+class CdistBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, device, B, P, R, M, p):
+        self.inputs = {
+            "x1": torch.rand(B, P, M, device=device, requires_grad=self.auto_set()),
+            "x2": torch.rand(B, R, M, device=device, requires_grad=self.auto_set()),
+            "p": p,
+        }
+        self.set_module_name("cdist")
+
+    def forward(self, x1, x2, p):
+        return torch.cdist(x1, x2, p=p)
+
+
+op_bench.generate_pt_test(
+    cdist_configs,
+    CdistBenchmark,
+)
+
+op_bench.generate_pt_gradient_test(
+    cdist_configs,
+    CdistBenchmark,
+)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1107,9 +1107,8 @@ class TestMPS(TestCaseMPS):
             x = torch.randn(sizex, device=device, dtype=torch.float)
             dist_grad = torch.randn((1, 27, 27), device=device, dtype=torch.float)
             y = x.clone()
-            eps = 1e-6
             x.requires_grad = True
-            d = torch.cdist(x, y)
+            d = torch.cdist(x, y, p=p)
             d.backward(dist_grad)
             # Check that the backward pass does not contain invalid
             # values such as nan or inf

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
@@ -13,6 +13,7 @@ extern "C" {
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__adaptive_avg_pool2d(AtenTensorHandle self, const int64_t* output_size, int64_t output_size_len_, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__adaptive_avg_pool2d_backward(AtenTensorHandle grad_output, AtenTensorHandle self, AtenTensorHandle* ret0);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__cdist_backward(AtenTensorHandle grad, AtenTensorHandle x1, AtenTensorHandle x2, double p, AtenTensorHandle cdist, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__cdist_forward(AtenTensorHandle x1, AtenTensorHandle x2, double p, int64_t* compute_mode, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__efficientzerotensor(const int64_t* size, int64_t size_len_, int32_t* dtype, int32_t* layout, int32_t* device, int32_t device_index_, int32_t* pin_memory, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__embedding_bag(AtenTensorHandle weight, AtenTensorHandle indices, AtenTensorHandle offsets, int32_t scale_grad_by_freq, int64_t mode, int32_t sparse, AtenTensorHandle* per_sample_weights, int32_t include_last_offset, int64_t padding_idx, AtenTensorHandle* ret0, AtenTensorHandle* ret1, AtenTensorHandle* ret2, AtenTensorHandle* ret3);

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13478,9 +13478,6 @@ op_db: list[OpInfo] = [
            assert_autodiffed=False,
            sample_inputs_func=sample_inputs_cdist,
            skips=(
-               # NotImplementedError: The operator 'aten::_cdist_backward' is not currently implemented for the MPS device
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples', device_type='mps'),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager', device_type='mps'),
                DecorateInfo(toleranceOverride(
                    {
                        torch.float16: tol(atol=1e-3, rtol=2e-2),

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -901,7 +901,6 @@ if torch.backends.mps.is_available():
             "linalg.householder_product": None,
             "unique_consecutive": [torch.float16, torch.float32],
             "scalar_tensor": [torch.float16, torch.float32],
-            "cdist": None,
             "masked.scatter": [torch.float16, torch.float32],
             "igamma": None,  # currently not supported for any device
             "igammac": None,  # currently not supported for any device


### PR DESCRIPTION
This PR adds _cdist_backward MPS kernel and fixes unused `p` in test_cdist_same_inputs. Helped by Claude Code.