### PR TITLE
Fix SAC FIFO mismatch for inductor_compiled_code HOP

### DIFF
--- a/test/dynamo/test_wrap_inductor_compiled_regions.py
+++ b/test/dynamo/test_wrap_inductor_compiled_regions.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
 import functools
+import unittest
 
 import torch
 import torch._dynamo.test_case
@@ -1218,6 +1219,79 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         result = traced(inp)
         expected = inp + 1
         torch.testing.assert_close(result, expected)
+
+    @unittest.skipIf(not torch.distributed.is_available(), "requires torch.distributed")
+    def test_sac_cached_value_fifo_mismatch(self):
+        """
+        Regression test for https://github.com/pytorch/pytorch/issues/175258
+
+        When SAC is used with wrap_inductor_compiled_regions=True and a global
+        cache causes different op sequences between forward and recompute, the
+        SAC FIFO queue should not return the wrong cached value.
+
+        The bug: all inductor_compiled_code HOP calls share one FIFO queue keyed
+        by func identity. If a compiled region is skipped during recompute
+        (because its result was cached in a global dict during forward), the queue
+        returns the wrong entry, causing DTensor.__tensor_unflatten__ to receive
+        int tensors when it expects float tensors.
+        """
+        import torch.distributed as dist
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.tensor import DTensor, Replicate
+        from torch.testing._internal.distributed.fake_pg import FakeStore
+
+        fake_store = FakeStore()
+        dist.init_process_group(backend="fake", store=fake_store, rank=0, world_size=1)
+
+        try:
+            mesh = init_device_mesh("cpu", mesh_shape=(1,), mesh_dim_names=("dp",))
+
+            @torch.compile(dynamic=False, fullgraph=True)
+            def compute_int_stuff(n):
+                return torch.arange(n, dtype=torch.int32)
+
+            @torch.compile(dynamic=False, fullgraph=True)
+            def compute_float(q, cached_ints):
+                ql = q.to_local()
+                out = ql * cached_ints.float().sum()
+                return DTensor.from_local(
+                    out, device_mesh=q.device_mesh, placements=q.placements
+                )
+
+            _cache: dict = {}
+
+            def outer_fn(x):
+                # Forward: cache miss, compute_int_stuff runs as inductor_compiled_code.
+                # Recompute: cache hit, compute_int_stuff is skipped; only compute_float
+                # runs. With a single shared FIFO queue this would pop the int-tensor
+                # entry and feed it to compute_float.
+                if "data" not in _cache:
+                    _cache["data"] = compute_int_stuff(x.shape[-1])
+                return compute_float(x, _cache["data"])
+
+            def policy_fn(ctx, op, *args, **kwargs):
+                if isinstance(op, torch._ops.HigherOrderOperator):
+                    if op.name() == "inductor_compiled_code":
+                        return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
+
+            context_fn = functools.partial(
+                create_selective_checkpoint_contexts, policy_fn
+            )
+
+            x = DTensor.from_local(
+                torch.randn(4, 4, dtype=torch.float32, requires_grad=True),
+                mesh,
+                (Replicate(),),
+            )
+
+            with inductor_config.patch({"wrap_inductor_compiled_regions": True}):
+                out = checkpoint(
+                    outer_fn, x, use_reentrant=False, context_fn=context_fn
+                )
+                out.sum().backward()
+        finally:
+            dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1319,6 +1319,23 @@ SAC_IGNORED_OPS = {
 } | set(torch._subclasses.functional_tensor.FunctionalTensor.metadata_fns)  # type: ignore[has-type]
 
 
+def _sac_storage_key(func, args):
+    """Compute the SAC storage key for a given op.
+
+    For inductor_compiled_code, each compiled region gets its own FIFO queue
+    keyed by the callable's unique idx.  Without this, all compiled regions
+    share one queue and a cache-hit that skips a region during recompute
+    causes the queue to return the wrong entry (see gh-175258).
+    """
+    from torch._higher_order_ops.wrap import (
+        _resolve_inductor_callable,
+        inductor_compiled_code as _inductor_compiled_code,
+    )
+    if func is _inductor_compiled_code and args:
+        return (func, _resolve_inductor_callable(args[0]).idx)
+    return func
+
+
 class _CachingTorchDispatchMode(TorchDispatchMode):
     @classmethod
     def ignore_compile_internals(cls):
@@ -1352,8 +1369,9 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
 
         out = func(*args, **kwargs)
 
-        idx = self.func_counter[func]
-        self.func_counter[func] += 1
+        key = _sac_storage_key(func, args)
+        idx = self.func_counter[key]
+        self.func_counter[key] += 1
 
         policy = self.policy_fn(SelectiveCheckpointContext(is_recompute=False, op_output=out),
                                 func, *args, **kwargs)
@@ -1368,9 +1386,9 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
                     node.meta["recompute"] = policy
 
         if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
-            self.storage[func][idx] = tree_map(lambda x: _VersionWrapper(_detach_helper(x)), out)
+            self.storage[key][idx] = tree_map(lambda x: _VersionWrapper(_detach_helper(x)), out)
         else:
-            self.storage[func][idx] = _RECOMPUTE
+            self.storage[key][idx] = _RECOMPUTE
         return out
 
 _RECOMPUTE = object()
@@ -1404,10 +1422,11 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
         if func in SAC_IGNORED_OPS:
             return func(*args, **kwargs)
 
-        idx = self.func_counter[func]
-        self.func_counter[func] += 1
+        key = _sac_storage_key(func, args)
+        idx = self.func_counter[key]
+        self.func_counter[key] += 1
 
-        func_storage = self.storage.get(func)
+        func_storage = self.storage.get(key)
         if func_storage is None:
             raise RuntimeError(
                 f"{func} encountered during backward but not found in "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183080

Each compiled region now gets its own FIFO storage in the SAC dispatch modes,
keyed by the InductorCompiledCallable's unique idx. Previously all
inductor_compiled_code calls shared one queue keyed by the HOP, so a region
skipped during recompute (cache hit) would cause the queue to return the
wrong entry. The key resolves through _resolve_inductor_callable so both
the eager (callable-arg) and FX-replay (int-arg) forms are covered.

The regression test reproduces the mismatch on CPU using a fake process
group, so it runs in standard dynamo test jobs without requiring CUDA.

Authored with Claude.

Fixes #175258

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98