### PR TITLE
[Docathon] Document undocumented functions in backends.md

### DIFF
--- a/docs/source/backends.md
+++ b/docs/source/backends.md
@@ -557,4 +557,6 @@ Each DSL controller provides the following methods:
 
 ```{eval-rst}
 .. py:module:: torch.backends.xeon.run_cpu
+
+.. autofunction:: torch.backends.xeon.run_cpu.create_args
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -435,8 +435,6 @@ coverage_ignore_functions = [
     # torch.backends.cudnn.rnn
     "get_cudnn_mode",
     "init_dropout_state",
-    # torch.backends.xeon.run_cpu
-    "create_args",
     # torch.cuda.amp.autocast_mode
     "custom_bwd",
     "custom_fwd",


### PR DESCRIPTION
Fixes: #182514 

Add documentation for public function `torch.backends.xeon.run_cpu.create_args`

<img width="1800" height="950" alt="Screenshot 2026-05-10 at 11 32 49 AM" src="https://github.com/user-attachments/assets/69e23137-3295-48e6-ae58-f09fa3b9ad91" />


cc @svekars @sekyondaMeta @AlannaBurke