### PR TITLE
[Docathon] Convert elastic/multiprocessing.rst from rST to MyST Markdown #182469

### DIFF
--- a/docs/source/elastic/multiprocessing.md
+++ b/docs/source/elastic/multiprocessing.md
@@ -1,18 +1,18 @@
-:github_url: https://github.com/pytorch/elastic
+# Multiprocessing
 
-Multiprocessing
-================
-
+```{eval-rst}
 .. automodule:: torch.distributed.elastic.multiprocessing
+```
 
-Starting Multiple Workers
----------------------------
+## Starting Multiple Workers
 
+```{eval-rst}
 .. autofunction:: torch.distributed.elastic.multiprocessing.start_processes
+```
 
-Process Context
-----------------
+## Process Context
 
+```{eval-rst}
 .. currentmodule:: torch.distributed.elastic.multiprocessing.api
 
 .. autoclass:: PContext
@@ -24,9 +24,10 @@ Process Context
 .. autoclass:: RunProcsResult
 
 .. autoclass:: DefaultLogsSpecs
-    :members:
+   :members:
 
 .. autoclass:: LogsDest
 
 .. autoclass:: LogsSpecs
-    :members:
+   :members:
+```


### PR DESCRIPTION
Closes: https://github.com/pytorch/pytorch/issues/182469
- Renamed `docs/source/elastic/multiprocessing.rst` → `docs/source/elastic/multiprocessing.md` using `git mv` to preserve file history
- Converted RST underline-style headings (`===`, `---`) to MyST Markdown headings (`#`, `##`)
- Wrapped Sphinx autodoc directives (`automodule`, `autofunction`, `autoclass`, `currentmodule`) inside `eval-rst` blocks
- Removed the unused `:github_url:` metadata field
- No toctree or cross-reference updates were required since the parent toctree uses extension-less paths
- No tabs or trailing whitespace
- Proper trailing newline added

`docathon-h1-2025`
 `module: docs`
 `topic: not user facing`
 `topic: docs`

cc **@pytorch/docs**
@pytorchbot 
#label 
#"docathon-h1-2025" "module: docs" "topic: docs"


cc @svekars @sekyondaMeta @AlannaBurke