### PR TITLE
fix: compilation issues in mem_eff_attention with clang

### DIFF
--- a/aten/src/ATen/cuda/PhiloxUtils.cuh
+++ b/aten/src/ATen/cuda/PhiloxUtils.cuh
@@ -1,4 +1,5 @@
 #pragma once
 
+#include <tuple>
 #include <ATen/cuda/PhiloxCudaState.h>
 #include <ATen/cuda/detail/UnpackRaw.cuh>

--- a/aten/src/ATen/cuda/detail/UnpackRaw.cuh
+++ b/aten/src/ATen/cuda/detail/UnpackRaw.cuh
@@ -1,6 +1,7 @@
 // No "#pragma once" because this is a raw definition that can be copied by jit codegen.
 // Eager mode clients should not include this file directly, instead,
 // they should #include <ATen/cuda/PhiloxUtils.cuh>, which has a #pragma once.
+#include <tuple>
 
 namespace at::cuda::philox {
 

--- a/aten/src/ATen/cuda/detail/UnpackRaw.cuh
+++ b/aten/src/ATen/cuda/detail/UnpackRaw.cuh
@@ -1,7 +1,6 @@
 // No "#pragma once" because this is a raw definition that can be copied by jit codegen.
 // Eager mode clients should not include this file directly, instead,
 // they should #include <ATen/cuda/PhiloxUtils.cuh>, which has a #pragma once.
-#include <tuple>
 
 namespace at::cuda::philox {
 

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
@@ -2401,7 +2401,7 @@ struct AttentionBackwardKernel {
         thread_id,
         cutlass::MatrixCoord{0, 0});
 
-    MatmulQK::Mma::prologue<kReloadK, true>(
+    MatmulQK::Mma::template prologue<kReloadK, true>(
         shared_storage.mm_qk_k(),
         shared_storage.mm_qk_q(),
         iterator_A,

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
@@ -7,7 +7,6 @@
  */
 #pragma once
 
-#include <tuple>
 #include <ATen/cuda/PhiloxUtils.cuh>
 #include <c10/util/Exception.h>
 

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <tuple>
 #include <ATen/cuda/PhiloxUtils.cuh>
 #include <c10/util/Exception.h>
 
@@ -716,7 +717,7 @@ struct AttentionKernel {
 
       auto prologueV = [&](int blockN) {
         typename MM1::Mma::IteratorB iterator_V(
-            typename MM1::IteratorB::Params{MM1::LayoutB(p.v_strideM)},
+            typename MM1::IteratorB::Params{typename MM1::LayoutB(p.v_strideM)},
             const_cast<scalar_t*>(p.value_ptr + iter_key_start * p.v_strideM),
             {problem_size_1_k, problem_size_1_n},
             thread_id(),
@@ -1010,7 +1011,7 @@ struct AttentionKernel {
         }
 
         typename MM1::Mma::IteratorB iterator_V(
-            typename MM1::IteratorB::Params{MM1::LayoutB(p.v_strideM)},
+            typename MM1::IteratorB::Params{typename MM1::LayoutB(p.v_strideM)},
             const_cast<scalar_t*>(p.value_ptr + iter_key_start * p.v_strideM),
             {problem_size_1_k, problem_size_1_n},
             thread_id(),


### PR DESCRIPTION
This change fixes a few issues when compiling `mem_eff_attention` with `clang`:

Missing `tuple` header:
```console
In file included from third_party/py/torch/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h:10:
In file included from third_party/py/torch/aten/src/ATen/cuda/PhiloxUtils.cuh:4:
third_party/py/torch/aten/src/ATen/cuda/detail/UnpackRaw.cuh:17:1: error: implicit instantiation of undefined template 'std::tuple<unsigned long, unsigned long>'
   17 | unpack(at::PhiloxCudaState arg) {
      | ^
third_party/crosstool/v18/stable/src/libcxx/include/__fwd/tuple.h:30:7: note: template is declared here
   30 | class tuple;
      |       ^
```

Missing `typename`:
```console
third_party/py/torch/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h:719:45: error: missing 'typename' prior to dependent type name 'MM1::LayoutB' (aka 'cutlass::layout::RowMajor')
  719 |             typename MM1::IteratorB::Params{MM1::LayoutB(p.v_strideM)},
      |                                             ^~~~~~~~~~~~
third_party/py/torch/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h:1013:45: error: missing 'typename' prior to dependent type name 'MM1::LayoutB' (aka 'cutlass::layout::RowMajor')
 1013 |             typename MM1::IteratorB::Params{MM1::LayoutB(p.v_strideM)},
      |                                             ^~~~~~~~~~~~
```

`clang` is not able to disambiguate and resolve correctly:
```console
third_party/py/torch/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h:2404:5: error: reference to overloaded function could not be resolved; did you mean to call it?
 2404 |     MatmulQK::Mma::prologue(
      |     ^~~~~~~~~~~~~~~~~~~~~~~
```