### PR TITLE
Fix formatting in extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,6 @@
         "meta.pyrefly",
         "ms-vscode.cmake-tools",
         "EditorConfig.EditorConfig",
-        "streetsidesoftware.code-spell-checker",
+        "streetsidesoftware.code-spell-checker"
     ]
 }


### PR DESCRIPTION
## Description
Fixes invalid JSON syntax in `.vscode/extensions.json` by removing a trailing comma 
from the recommendations array.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] JSON syntax is now valid
- [x] VSCode extensions configuration will load correctly