### PR TITLE
Add CUDAGraph.get_graph_data() for graph topology introspection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,11 @@ Follow these rules for all code changes in this repository:
 
 If uncertain, choose the simpler, more concise implementation.
 
+# cuda.bindings Error Checking
+
+Use `torch.cuda._utils._check_cuda_bindings` to error-check `cuda.bindings`
+runtime calls. Do not write inline error-checking helpers.
+
 # Dynamo Config
 
 Use `torch._dynamo.config.patch` for temporarily changing config. It can be used as a decorator on test methods or as a context manager:

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -1,6 +1,6 @@
 # Owner(s): ["module: cuda graphs"]
 
-"""Tests for CUDA graph kernel annotation via mark_kernels."""
+"""Tests for CUDA graph utilities: kernel annotations and graph introspection."""
 
 import unittest
 
@@ -393,6 +393,83 @@ class TestMarkKernels(TestCase):
 
         # Annotations should be empty because resolve was never called.
         self.assertEqual(len(get_kernel_annotations()), 0)
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA not available")
+@unittest.skipUnless(TEST_CUDA_BINDINGS, "cuda.bindings not available")
+@unittest.skipIf(
+    _is_tools_id_unavailable(),
+    "cudaGraphNodeGetToolsId not available (needs cuda-compat >= 13.1)",
+)
+class TestGetGraphData(TestCase):
+    def test_basic_structure(self):
+        g = torch.cuda.CUDAGraph(keep_graph=True)
+        x = torch.zeros([2000], device="cuda")
+        y = torch.ones([2000], device="cuda")
+        with torch.cuda.graph(g, capture_error_mode="relaxed"):
+            z = x + y
+            z = z.relu()
+
+        g.instantiate()
+        data = g.get_graph_data()
+
+        self.assertIn("exec_graph_id", data)
+        self.assertIn("nodes", data)
+        self.assertIsInstance(data["exec_graph_id"], int)
+        self.assertGreater(len(data["nodes"]), 0)
+
+        exec_graph_id = data["exec_graph_id"]
+        for node in data["nodes"]:
+            self.assertIn("index", node)
+            self.assertIn("node_type", node)
+            self.assertIn("tools_id", node)
+            self.assertIn("graph_id", node)
+            self.assertIn("node_id", node)
+            self.assertIn("kernel_name", node)
+            self.assertIn("dependencies", node)
+            self.assertIn("dependents", node)
+            self.assertEqual(node["graph_id"], exec_graph_id)
+            self.assertEqual(node["tools_id"], (exec_graph_id << 32) | node["node_id"])
+
+        kernel_nodes = [n for n in data["nodes"] if n["node_type"] == "kernel"]
+        self.assertGreater(len(kernel_nodes), 0)
+        for kn in kernel_nodes:
+            self.assertIsNotNone(kn["kernel_name"])
+            self.assertIsInstance(kn["kernel_name"], str)
+
+    def test_edges(self):
+        g = torch.cuda.CUDAGraph(keep_graph=True)
+        x = torch.zeros([2000], device="cuda")
+        y = torch.ones([2000], device="cuda")
+        with torch.cuda.graph(g, capture_error_mode="relaxed"):
+            z = x + y
+            z = z * 2
+            z = z.relu()
+
+        g.instantiate()
+        data = g.get_graph_data()
+        nodes = data["nodes"]
+
+        has_deps = any(len(n["dependencies"]) > 0 for n in nodes)
+        has_dependents = any(len(n["dependents"]) > 0 for n in nodes)
+        self.assertTrue(has_deps)
+        self.assertTrue(has_dependents)
+
+        for node in nodes:
+            for dep_idx in node["dependencies"]:
+                self.assertIn(node["index"], nodes[dep_idx]["dependents"])
+            for dep_idx in node["dependents"]:
+                self.assertIn(node["index"], nodes[dep_idx]["dependencies"])
+
+    def test_keep_graph_false_raises(self):
+        g = torch.cuda.CUDAGraph(keep_graph=False)
+        x = torch.zeros([2000], device="cuda")
+        y = torch.ones([2000], device="cuda")
+        with torch.cuda.graph(g, capture_error_mode="relaxed"):
+            _ = x + y
+
+        with self.assertRaises(RuntimeError):
+            g.get_graph_data()
 
 
 if __name__ == "__main__":

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -74,41 +74,40 @@ def disable_annotations() -> None:
     _annotations_enabled = False
 
 
+def _probe_tools_id() -> bool:
+    """Probe whether cudaGraphNodeGetToolsId is supported by the driver.
+
+    Calls with a null node: cudaErrorInvalidValue means the API exists
+    in the driver (good), cudaErrorCallRequiresNewerDriver means it
+    does not (bad).
+    """
+    if not hasattr(_cuda_runtime, "cudaGraphNodeGetToolsId"):
+        return False
+    err, *_ = _cuda_runtime.cudaGraphNodeGetToolsId(
+        0
+    )  # pyrefly: ignore[missing-attribute]
+    if (
+        err
+        == _cuda_runtime.cudaError_t.cudaErrorCallRequiresNewerDriver  # pyrefly: ignore[missing-attribute]
+    ):
+        logger.info(
+            "cudaGraphNodeGetToolsId requires a newer driver "
+            "(missing cuda-compat?); "
+            "CUDA graph kernel annotations will be disabled"
+        )
+        return False
+    return True
+
+
 def _is_tools_id_unavailable() -> bool:
-    """Return True if we already know cudaGraphNodeGetToolsId is missing."""
+    """Return True if cudaGraphNodeGetToolsId is not usable."""
+    global _tools_id_available
     if not _HAS_CUDA_BINDINGS:
         return True
-    if _tools_id_available is False:
-        return True
-    if not hasattr(_cuda_runtime, "cudaGraphNodeGetToolsId"):
-        return True
-    return False
-
-
-def _get_tools_id(node: Any) -> int | None:
-    """Return the toolsId for a graph node, or None if unavailable."""
-    global _tools_id_available
-    if _tools_id_available is None:
-        try:
-            tools_id = _check_cuda_bindings(
-                _cuda_runtime.cudaGraphNodeGetToolsId(  # pyrefly: ignore[missing-attribute]
-                    node
-                )
-            )
-        except Exception:
-            _tools_id_available = False
-            logger.info(
-                "cudaGraphNodeGetToolsId not available; "
-                "CUDA graph kernel annotations will be disabled"
-            )
-            return None
-        _tools_id_available = True
-        return tools_id
-    return _check_cuda_bindings(
-        _cuda_runtime.cudaGraphNodeGetToolsId(  # pyrefly: ignore[missing-attribute]
-            node
-        )
-    )
+    if _tools_id_available is not None:
+        return not _tools_id_available
+    _tools_id_available = _probe_tools_id()
+    return not _tools_id_available
 
 
 def _get_capture_graph(stream: Any) -> Any:
@@ -249,8 +248,12 @@ def resolve_pending_annotations() -> None:
         # Save capture graph ID for remap_to_exec_graph.
         global _last_capture_graph_id
         if num > 0:
-            first_tid = _get_tools_id(nodes[0])
-            _last_capture_graph_id = (first_tid >> 32) if first_tid else None
+            first_tid = _check_cuda_bindings(
+                _cuda_runtime.cudaGraphNodeGetToolsId(  # pyrefly: ignore[missing-attribute]
+                    nodes[0]
+                )
+            )
+            _last_capture_graph_id = first_tid >> 32
 
         annotatable = _get_annotatable_types()
 
@@ -294,14 +297,11 @@ def resolve_pending_annotations() -> None:
             if node_type not in annotatable:
                 continue
 
-            tools_id = _get_tools_id(node)
-            if tools_id is None:
-                logger.warning(
-                    "resolve_pending_annotations: toolsId unavailable, aborting"
+            tools_id = _check_cuda_bindings(
+                _cuda_runtime.cudaGraphNodeGetToolsId(  # pyrefly: ignore[missing-attribute]
+                    node
                 )
-                _pending_scopes.clear()
-                _capture_graph = None
-                return
+            )
 
             if len(active_stack) == 1:
                 _kernel_annotations[tools_id].append(active_stack[0][1])

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -9,6 +9,17 @@ from typing_extensions import ParamSpec, Self, TypeVar
 
 import torch
 from torch import Tensor
+from torch.cuda._utils import _check_cuda_bindings
+
+
+try:
+    from cuda.bindings import (  # pyrefly: ignore[missing-import]
+        driver as _cuda_driver,
+        runtime as _cuda_runtime,
+    )
+except ImportError:
+    _cuda_driver = None  # type: ignore[assignment]
+    _cuda_runtime = None  # type: ignore[assignment]
 
 
 if TYPE_CHECKING:
@@ -177,6 +188,139 @@ class CUDAGraph(_CUDAGraph):
         See the following for APIs for how to manipulate this object: `Graph Execution <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__GRAPH__EXEC.html>`_ and `cuda-python Graph Execution bindings <https://nvidia.github.io/cuda-python/cuda-bindings/latest/module/runtime.html#graph-execution>`_
         """
         return super().raw_cuda_graph_exec()
+
+    def get_graph_data(self) -> dict:
+        r"""Return a dictionary describing the graph's topology and node metadata.
+
+        ``keep_graph`` must be True.  The graph must have been instantiated
+        (via :meth:`instantiate`) before calling this method.
+        Requires the ``cuda.bindings`` package.
+
+        Returns a dictionary with structure::
+
+            {
+                "exec_graph_id": int,
+                "nodes": [
+                    {
+                        "index": int,
+                        "node_type": str,
+                        "tools_id": int,
+                        "graph_id": int,
+                        "node_id": int,
+                        "kernel_name": str or None,
+                        "dependencies": [int, ...],
+                        "dependents": [int, ...],
+                    },
+                    ...,
+                ],
+            }
+
+        Each node's ``graph_id`` is remapped to the exec graph id so that
+        ``tools_id`` values match those reported by CUPTI-based profilers.
+        ``dependencies`` and ``dependents`` are lists of node indices within
+        the ``nodes`` list.
+
+        This structure is useful for inspecting a profiler trace and
+        establishing whether a particular dependency observed in the profile
+        is a true dependency (encoded in the graph) or a fake dependency
+        caused by mapping of independent streams to the same hardware
+        channel.
+        """
+        from torch.cuda._graph_annotations import _is_tools_id_unavailable
+
+        if _cuda_runtime is None or _cuda_driver is None:
+            raise RuntimeError("get_graph_data requires the cuda.bindings package")
+
+        if _is_tools_id_unavailable():
+            raise RuntimeError(
+                "get_graph_data requires cudaGraphNodeGetToolsId which needs "
+                "cuda.bindings >= 13.1 and CUDA driver >= 13.1 "
+                "(or cuda-compat >= 13.1 in LD_LIBRARY_PATH)"
+            )
+
+        node_type_names = {
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeKernel: "kernel",
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeMemcpy: "memcpy",
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeMemset: "memset",
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeHost: "host",
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeGraph: "child_graph",
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeEmpty: "empty",
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeWaitEvent: "wait_event",
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeEventRecord: "event_record",
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeMemAlloc: "mem_alloc",
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeMemFree: "mem_free",
+        }
+
+        raw = self.raw_cuda_graph()
+
+        _, num = _check_cuda_bindings(_cuda_runtime.cudaGraphGetNodes(raw, numNodes=0))
+        nodes, num = _check_cuda_bindings(
+            _cuda_runtime.cudaGraphGetNodes(raw, numNodes=num)
+        )
+
+        handle_to_idx: dict[int, int] = {}
+        node_infos: list[dict] = []
+
+        for i in range(num):
+            node = nodes[i]
+            handle_to_idx[int(node)] = i
+
+            ntype = _check_cuda_bindings(_cuda_runtime.cudaGraphNodeGetType(node))
+            tools_id = _check_cuda_bindings(_cuda_runtime.cudaGraphNodeGetToolsId(node))
+            graph_id = tools_id >> 32
+            node_id = tools_id & 0xFFFFFFFF
+
+            kernel_name = None
+            if ntype == _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeKernel:
+                cu_node = _cuda_driver.CUgraphNode(init_value=int(node))
+                err, params = _cuda_driver.cuGraphKernelNodeGetParams(cu_node)
+                if err == _cuda_driver.CUresult.CUDA_SUCCESS and int(params.func):
+                    cu_func = _cuda_driver.CUfunction(init_value=int(params.func))
+                    err, name = _cuda_driver.cuFuncGetName(cu_func)
+                    if err == _cuda_driver.CUresult.CUDA_SUCCESS:
+                        kernel_name = name.decode() if isinstance(name, bytes) else name
+
+            node_infos.append(
+                {
+                    "index": i,
+                    "node_type": node_type_names.get(ntype, str(ntype)),
+                    "tools_id": tools_id,
+                    "graph_id": graph_id,
+                    "node_id": node_id,
+                    "kernel_name": kernel_name,
+                    "dependencies": [],
+                    "dependents": [],
+                }
+            )
+
+        _, _, _, num_edges = _check_cuda_bindings(
+            _cuda_runtime.cudaGraphGetEdges(raw, numEdges=0)
+        )
+        if num_edges > 0:
+            from_nodes, to_nodes, _edge_data, num_edges = _check_cuda_bindings(
+                _cuda_runtime.cudaGraphGetEdges(raw, numEdges=num_edges)
+            )
+            for i in range(num_edges):
+                src = handle_to_idx.get(int(from_nodes[i]))
+                dst = handle_to_idx.get(int(to_nodes[i]))
+                if src is not None and dst is not None:
+                    node_infos[src]["dependents"].append(dst)
+                    node_infos[dst]["dependencies"].append(src)
+
+        exec_handle = _cuda_runtime.cudaGraphExec_t(
+            init_value=self.raw_cuda_graph_exec()
+        )
+        exec_graph_id = _check_cuda_bindings(
+            _cuda_runtime.cudaGraphExecGetId(exec_handle)
+        )
+        for info in node_infos:
+            info["tools_id"] = (exec_graph_id << 32) | info["node_id"]
+            info["graph_id"] = exec_graph_id
+
+        return {
+            "exec_graph_id": exec_graph_id,
+            "nodes": node_infos,
+        }
 
 
 class graph:


### PR DESCRIPTION
Add a method to extract node topology, types, kernel names, and dependency edges from a captured CUDA graph. The tools_id and graph_id on each node are remapped to the exec graph id so they match CUPTI profiler output, making it possible to correlate graph structure with profiled kernel launches and distinguish true dependencies from fake ones caused by stream-to-channel mapping.

Also fix _is_tools_id_unavailable() in _graph_annotations.py to actually probe the driver instead of relying on hasattr, which always returns True since the Python binding attribute exists regardless of driver version.

Rename test_cuda_graph_annotations.py to test_cuda_graph_utils.py and add tests for get_graph_data there.

Authored with Claude.

cc @galv @yushangdi 