### PR TITLE
Always run EC2 route on pull requests in _linux-build/_linux-test

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -142,6 +142,12 @@ on:
       test-matrix:
         value: ${{ jobs.build.outputs.test-matrix || jobs.build-osdc.outputs.test-matrix }}
         description: An optional JSON description of what test configs to run later on.
+      # Separate output for the OSDC-remapped test matrix so shadow-mode test
+      # invocations (issue #183242) can route the OSDC test job to the right
+      # runners while the EC2 test job uses the prefix-stripped matrix above.
+      test-matrix-osdc:
+        value: ${{ jobs.build-osdc.outputs.test-matrix || jobs.build.outputs.test-matrix }}
+        description: An optional JSON description of what test configs to run on OSDC runners.
       build-environment:
         value: ${{ jobs.build.outputs.build-environment || jobs.build-osdc.outputs.build-environment }}
         description: Top-level label for what's being built/tested.
@@ -162,7 +168,7 @@ jobs:
     timeout-minutes: 480
     outputs:
       docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
-      test-matrix: ${{ steps.filter.outputs.test-matrix }}
+      test-matrix: ${{ steps.strip-runner-prefix.outputs.test-matrix }}
       build-environment: ${{ inputs.build-environment }}
     steps:
       - name: Setup SSH (Click me for login details)
@@ -233,6 +239,27 @@ jobs:
           test-matrix: ${{ inputs.test-matrix }}
           selected-test-configs: ${{ inputs.selected-test-configs }}
           job-name: ${{ steps.setup-linux.outputs.job-name }}
+
+      # Strip the runner_prefix (e.g. mt-) from runner labels in the test matrix
+      # so EC2 test jobs queue against linux.* labels rather than mt-linux.*.
+      # This is needed during the OSDC shadow-mode experiment (issue #183242)
+      # because callers set runner_prefix to the OSDC prefix even when EC2 also
+      # runs. Revert with the rest of the experiment changes.
+      - name: Strip runner prefix from EC2 test matrix
+        id: strip-runner-prefix
+        env:
+          FILTERED_TEST_MATRIX: ${{ steps.filter.outputs.test-matrix }}
+          RUNNER_PREFIX: ${{ inputs.runner_prefix }}
+        shell: bash
+        run: |
+          if [[ -z "${FILTERED_TEST_MATRIX}" || -z "${RUNNER_PREFIX}" ]]; then
+            echo "test-matrix=${FILTERED_TEST_MATRIX}" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          stripped=$(jq -c --arg p "${RUNNER_PREFIX}" '
+            if .include then .include |= map(.runner |= ltrimstr($p)) else . end
+          ' <<< "${FILTERED_TEST_MATRIX}")
+          echo "test-matrix=${stripped}" >> "${GITHUB_OUTPUT}"
 
       - name: Start monitoring script
         id: monitor-script

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -148,8 +148,12 @@ on:
 
 jobs:
   build:
-    # Don't run on forked repos
-    if: github.repository_owner == 'pytorch' && !inputs.use-arc
+    # Don't run on forked repos.
+    # Experiment (https://github.com/pytorch/pytorch/issues/183242): on
+    # pull_request events, always run the EC2 route so that callers passing
+    # use-arc=true execute OSDC in shadow mode alongside EC2. Pushed commits
+    # and scheduled workflows continue to honor use-arc as usual.
+    if: github.repository_owner == 'pytorch' && (!inputs.use-arc || github.event_name == 'pull_request')
     runs-on: ${{ inputs.runner_prefix }}${{ inputs.runner }}
     timeout-minutes: 480
     outputs:

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -123,8 +123,12 @@ env:
 
 jobs:
   test:
-    # Don't run on forked repos or empty test matrix
-    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix).include) != '[]' && !inputs.use-arc
+    # Don't run on forked repos or empty test matrix.
+    # Experiment (https://github.com/pytorch/pytorch/issues/183242): on
+    # pull_request events, always run the EC2 route so that callers passing
+    # use-arc=true execute OSDC in shadow mode alongside EC2. Pushed commits
+    # and scheduled workflows continue to honor use-arc as usual.
+    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix).include) != '[]' && (!inputs.use-arc || github.event_name == 'pull_request')
     strategy:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -11,6 +11,14 @@ on:
         required: true
         type: string
         description: JSON description of what test configs to run.
+      test-matrix-osdc:
+        required: false
+        type: string
+        default: ""
+        description: |
+          OSDC-remapped test matrix used by the test-osdc job during the
+          shadow-mode experiment (issue #183242). Falls back to test-matrix
+          when empty so OSDC-only callers keep working unchanged.
       docker-image:
         required: true
         type: string
@@ -614,10 +622,13 @@ jobs:
           docker kill -a || true
 
   test-osdc:
-    # Don't run on forked repos or empty test matrix
-    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix).include) != '[]' && inputs.use-arc
+    # Don't run on forked repos or empty test matrix.
+    # During the OSDC shadow-mode experiment (issue #183242) the build workflow
+    # emits a separate test-matrix-osdc with OSDC-remapped runners; fall back to
+    # test-matrix when callers haven't been updated yet.
+    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix-osdc != '' && inputs.test-matrix-osdc || inputs.test-matrix).include) != '[]' && inputs.use-arc
     strategy:
-      matrix: ${{ fromJSON(inputs.test-matrix) }}
+      matrix: ${{ fromJSON(inputs.test-matrix-osdc != '' && inputs.test-matrix-osdc || inputs.test-matrix) }}
       fail-fast: false
     environment: ${{ github.ref == 'refs/heads/main' && 'scribe-protected' || startsWith(github.ref, 'refs/heads/release/') && 'scribe-protected' || contains(github.event.pull_request.labels.*.name, 'ci-scribe') && 'scribe-pr' || '' }}
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -117,6 +117,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -164,6 +165,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -215,6 +217,7 @@ jobs:
       build-environment: linux-jammy-py3.14t-clang18
       docker-image: ${{ needs.linux-jammy-py3_14t-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_14t-clang18-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-py3_14t-clang18-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.14t"
       compiler: clang18
@@ -315,6 +318,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -373,6 +377,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -427,6 +432,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.14"
@@ -572,6 +578,7 @@ jobs:
       build-environment: linux-jammy-py3.13-clang18
       docker-image: ${{ needs.dynamo-cpython-build.outputs.docker-image }}
       test-matrix: ${{ needs.dynamo-cpython-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.dynamo-cpython-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.13"
       compiler: clang18


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #183243
* #183244

On pull_request events, the reusable Linux build and test workflows now
always execute the EC2 job regardless of the use-arc input. When a caller
passes use-arc=true on a PR, the OSDC job still runs alongside, giving us
shadow-mode data on OSDC without losing EC2 signal. Pushed commits and
scheduled workflows continue to honor use-arc as before, selecting exactly
one route. See https://github.com/pytorch/pytorch/issues/183242.

This change is to be reverted once https://github.com/pytorch/pytorch/issues/183242 concludes

### Testing

https://github.com/pytorch/pytorch/actions/runs/25651990199

Authored by Claude.