### PR TITLE
Auto-label .ci/docker changes with no-runner-experiments

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -189,6 +189,9 @@
 - test/distributed/**/*mem*
 - test/distributed/**/*mem*/**
 
+"no-runner-experiments":
+- .ci/docker/**
+
 "ciflow/torchtitan":
 # torchtitan commit pin updates
 - .github/ci_commit_pins/torchtitan.txt


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #183243
* __->__ #183244

The Docker build workflows have not been migrated to OSDC yet. The resulting
images are pushed to a private ECR registry that OSDC runners cannot access
(unlike the ghcr.io mirror used for OSDC). Until the Docker build pipeline
is migrated, PRs that touch .ci/docker/ should opt out of the runner
experiments so OSDC shadow jobs do not try to pull from ECR and fail.

Authored by Claude.