### PR TITLE
[inductor][rocm] Skip TestFastCudaLauncher on ROCm

### DIFF
--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -21,7 +21,7 @@ from torch._inductor.runtime.triton_compat import (
 )
 from torch._inductor.runtime.triton_helpers import libdevice
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import IS_WINDOWS, skipIfXpu
+from torch.testing._internal.common_utils import IS_WINDOWS, skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_XPU_AND_TRITON
 from torch.testing._internal.triton_utils import requires_gpu_and_triton
 
@@ -537,6 +537,8 @@ class TestStaticTritonCompileResult(TestCase):
 
 
 @requires_gpu_and_triton
+# _FastCudaLauncher hipModuleLaunchKernel path segfaults on ROCm
+@skipIfRocm
 @skipIfXpu
 class TestFastCudaLauncher(TestCase):
     """Tests for _FastCudaLauncher vectorcall C extension."""
@@ -678,6 +680,7 @@ class TestFastCudaLauncher(TestCase):
         "use_fast_triton_launcher": True,
     }
 )
+@skipIfRocm  # see TestFastCudaLauncher
 class TestFastCudaLauncherCompileResult(TestCase):
     """E2E tests verifying _FastCudaLauncher is actually used by torch.compile.
 


### PR DESCRIPTION
TestFastCudaLauncher and TestFastCudaLauncherCompileResult were silently dropped from discovery on every platform by the buggy class-level @skipIfXpu shim. Once #182295 and #182439 fixed that, the classes started running on ROCm, where _FastCudaLauncher's hipModuleLaunchKernel path segfaults at the first launch. Skip both classes on ROCm pending a fix to torch/csrc/inductor/static_launcher/cuda.cpp.

Authored by Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben