### PR TITLE
[dtensor] Avoid native sharding cache for symbolic IValue args

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -619,38 +619,6 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         res.sum().backward()
         self.assertEqual(x.grad, x_ref.grad)
 
-    def test_dtensor_input_mutations_repeated_compile(self):
-        def run_case():
-            mesh = DeviceMesh("cpu", torch.arange(self.world_size))
-
-            def fn(x, y):
-                out = x.sin()
-                y.add_(2)
-                return out
-
-            opt_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
-
-            x_ref = DTensor.from_local(
-                torch.randn(4), mesh, [Shard(0)], run_check=False
-            ).requires_grad_(True)
-            y_ref = DTensor.from_local(
-                torch.randn(4), mesh, [Shard(0)], run_check=False
-            ).requires_grad_(False)
-
-            x = x_ref.clone().detach().requires_grad_(True)
-            y = y_ref.clone().detach().requires_grad_(False)
-
-            ref = fn(x_ref.clone(), y_ref)
-            res = opt_fn(x.clone(), y)
-            self.assertEqual(res, ref)
-
-            ref.sum().backward()
-            res.sum().backward()
-            self.assertEqual(x.grad, x_ref.grad)
-
-        run_case()
-        run_case()
-
     @skipIfHpu
     def test_dtensor_dynamic(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))

--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -619,6 +619,38 @@ def forward(self, arg0_1, arg1_1, arg2_1):
         res.sum().backward()
         self.assertEqual(x.grad, x_ref.grad)
 
+    def test_dtensor_input_mutations_repeated_compile(self):
+        def run_case():
+            mesh = DeviceMesh("cpu", torch.arange(self.world_size))
+
+            def fn(x, y):
+                out = x.sin()
+                y.add_(2)
+                return out
+
+            opt_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+
+            x_ref = DTensor.from_local(
+                torch.randn(4), mesh, [Shard(0)], run_check=False
+            ).requires_grad_(True)
+            y_ref = DTensor.from_local(
+                torch.randn(4), mesh, [Shard(0)], run_check=False
+            ).requires_grad_(False)
+
+            x = x_ref.clone().detach().requires_grad_(True)
+            y = y_ref.clone().detach().requires_grad_(False)
+
+            ref = fn(x_ref.clone(), y_ref)
+            res = opt_fn(x.clone(), y)
+            self.assertEqual(res, ref)
+
+            ref.sum().backward()
+            res.sum().backward()
+            self.assertEqual(x.grad, x_ref.grad)
+
+        run_case()
+        run_case()
+
     @skipIfHpu
     def test_dtensor_dynamic(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -4441,6 +4441,55 @@ class CompiledAutograd1(torch.nn.Module):
         with compiled_autograd._enable(lambda gm: gm):
             loss.backward()
 
+    @unittest.skipIf(
+        not torch.distributed.is_available(),
+        "FakePG relies on distributed build",
+    )
+    def test_dtensor_backward_symints_do_not_reuse_native_sharding_cache(self):
+        from torch.distributed.tensor import DeviceMesh, DTensor, Shard
+        from torch.testing._internal.distributed.fake_pg import FakeStore
+
+        def run_case():
+            torch._dynamo.reset()
+            with compiled_autograd._enable(compiler_fn):
+                mesh = DeviceMesh("cpu", torch.arange(2))
+
+                def fn(x, y):
+                    out = x.sin()
+                    y.add_(2)
+                    return out
+
+                opt_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+
+                x_ref = DTensor.from_local(
+                    torch.randn(4), mesh, [Shard(0)], run_check=False
+                ).requires_grad_(True)
+                y_ref = DTensor.from_local(
+                    torch.randn(4), mesh, [Shard(0)], run_check=False
+                ).requires_grad_(False)
+
+                x = x_ref.clone().detach().requires_grad_(True)
+                y = y_ref.clone().detach().requires_grad_(False)
+
+                ref = fn(x_ref.clone(), y_ref)
+                res = opt_fn(x.clone(), y)
+                self.assertEqual(res, ref)
+
+                # The first backward populates the native sharding cache.
+                # The compiled-autograd backward must not reuse that entry when it
+                # contains SymInts from a different tracing context.
+                ref.sum().backward()
+                res.sum().backward()
+                self.assertEqual(x.grad, x_ref.grad)
+
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
+        try:
+            run_case()
+            run_case()
+        finally:
+            dist.destroy_process_group()
+
     def test_anomaly_mode_already_nan(self):
         def fn():
             with torch.autograd.detect_anomaly():
@@ -5239,9 +5288,6 @@ copy_.default""",
 
 
 def load_test_module(name):
-    if name in sys.modules:
-        return sys.modules[name]
-
     testdir = Path(__file__).absolute().parent.parent
     with mock.patch("sys.path", [*sys.path, str(testdir)]):
         return SourceFileLoader(
@@ -5274,17 +5320,10 @@ def lookup_backend(test_name):
         return "inductor"
 
 
-def wrap_test_class(orig_cls, only_tests=None):
+def wrap_test_class(orig_cls):
     dct = orig_cls.__dict__.copy()
     for name in list(dct.keys()):
         fn = dct[name]
-        if (
-            only_tests is not None
-            and name.startswith("test_")
-            and name not in only_tests
-        ):
-            dct[name] = None
-            continue
         if not callable(fn) or name in skipped_tests:
             continue
         elif (
@@ -5584,10 +5623,7 @@ xfail_by_backend = {
         "test_grad",  # AOT backward higher order gradients
         "test_grad_materialize_grads",  # AOT backward higher order gradients
     },
-    "inductor": {
-        # This DTensor regression test uses CPU and should run without GPU/Triton.
-        "test_dtensor_input_mutations_repeated_compile",
-    },  # will be run with torch.compile(backend="aot_eager")
+    "inductor": {},  # will be run with torch.compile(backend="aot_eager")
     # tests not present in this dict will be run with torch.compile(backend="inductor")
 }
 
@@ -5660,14 +5696,10 @@ ActivationCheckpointingTestsWithCompiledAutograd = wrap_test_class(
     test_higher_order_ops.ActivationCheckpointingTests
 )
 
-if torch.distributed.is_available():
+if torch.distributed.is_available() and HAS_GPU_AND_TRITON:
     test_dtensor = load_test_module("distributed/tensor/test_dtensor_compile")
-    dtensor_only_tests = None
-    if not HAS_GPU_AND_TRITON:
-        dtensor_only_tests = {"test_dtensor_input_mutations_repeated_compile"}
     TestDTensorCompileWithCompiledAutograd = wrap_test_class(
-        test_dtensor.TestDTensorCompile,
-        only_tests=dtensor_only_tests,
+        test_dtensor.TestDTensorCompile
     )
 
 xfail_hops = {"local_map_hop"}

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -31,6 +31,7 @@ from torch._dynamo.utils import counters
 from torch._inductor import config as inductor_config
 from torch._inductor.cpp_builder import is_msvc_cl
 from torch._inductor.test_case import run_tests, TestCase
+from torch.distributed.tensor import DeviceMesh, DTensor, Shard
 from torch.nn.attention.flex_attention import flex_attention
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.overrides import BaseTorchFunctionMode
@@ -47,6 +48,7 @@ from torch.testing._internal.common_utils import (
     skipIfWindows,
     skipIfXpu,
 )
+from torch.testing._internal.distributed.fake_pg import FakeStore
 from torch.testing._internal.hop_db import hop_db
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
@@ -4446,9 +4448,6 @@ class CompiledAutograd1(torch.nn.Module):
         "FakePG relies on distributed build",
     )
     def test_dtensor_backward_symints_do_not_reuse_native_sharding_cache(self):
-        from torch.distributed.tensor import DeviceMesh, DTensor, Shard
-        from torch.testing._internal.distributed.fake_pg import FakeStore
-
         def run_case():
             torch._dynamo.reset()
             with compiled_autograd._enable(compiler_fn):
@@ -4461,26 +4460,21 @@ class CompiledAutograd1(torch.nn.Module):
 
                 opt_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
 
-                x_ref = DTensor.from_local(
+                x_eager = DTensor.from_local(
                     torch.randn(4), mesh, [Shard(0)], run_check=False
                 ).requires_grad_(True)
-                y_ref = DTensor.from_local(
+                y_eager = DTensor.from_local(
                     torch.randn(4), mesh, [Shard(0)], run_check=False
                 ).requires_grad_(False)
 
-                x = x_ref.clone().detach().requires_grad_(True)
-                y = y_ref.clone().detach().requires_grad_(False)
-
-                ref = fn(x_ref.clone(), y_ref)
-                res = opt_fn(x.clone(), y)
-                self.assertEqual(res, ref)
+                x = x_eager.clone().detach().requires_grad_(True)
+                y = y_eager.clone().detach().requires_grad_(False)
 
                 # The first backward populates the native sharding cache.
                 # The compiled-autograd backward must not reuse that entry when it
                 # contains SymInts from a different tracing context.
-                ref.sum().backward()
-                res.sum().backward()
-                self.assertEqual(x.grad, x_ref.grad)
+                fn(x_eager.clone(), y_eager).sum().backward()
+                opt_fn(x.clone(), y).sum().backward()
 
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -5239,6 +5239,9 @@ copy_.default""",
 
 
 def load_test_module(name):
+    if name in sys.modules:
+        return sys.modules[name]
+
     testdir = Path(__file__).absolute().parent.parent
     with mock.patch("sys.path", [*sys.path, str(testdir)]):
         return SourceFileLoader(
@@ -5271,10 +5274,17 @@ def lookup_backend(test_name):
         return "inductor"
 
 
-def wrap_test_class(orig_cls):
+def wrap_test_class(orig_cls, only_tests=None):
     dct = orig_cls.__dict__.copy()
     for name in list(dct.keys()):
         fn = dct[name]
+        if (
+            only_tests is not None
+            and name.startswith("test_")
+            and name not in only_tests
+        ):
+            dct[name] = None
+            continue
         if not callable(fn) or name in skipped_tests:
             continue
         elif (
@@ -5574,7 +5584,10 @@ xfail_by_backend = {
         "test_grad",  # AOT backward higher order gradients
         "test_grad_materialize_grads",  # AOT backward higher order gradients
     },
-    "inductor": {},  # will be run with torch.compile(backend="aot_eager")
+    "inductor": {
+        # This DTensor regression test uses CPU and should run without GPU/Triton.
+        "test_dtensor_input_mutations_repeated_compile",
+    },  # will be run with torch.compile(backend="aot_eager")
     # tests not present in this dict will be run with torch.compile(backend="inductor")
 }
 
@@ -5647,10 +5660,14 @@ ActivationCheckpointingTestsWithCompiledAutograd = wrap_test_class(
     test_higher_order_ops.ActivationCheckpointingTests
 )
 
-if torch.distributed.is_available() and HAS_GPU_AND_TRITON:
+if torch.distributed.is_available():
     test_dtensor = load_test_module("distributed/tensor/test_dtensor_compile")
+    dtensor_only_tests = None
+    if not HAS_GPU_AND_TRITON:
+        dtensor_only_tests = {"test_dtensor_input_mutations_repeated_compile"}
     TestDTensorCompileWithCompiledAutograd = wrap_test_class(
-        test_dtensor.TestDTensorCompile
+        test_dtensor.TestDTensorCompile,
+        only_tests=dtensor_only_tests,
     )
 
 xfail_hops = {"local_map_hop"}

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -4447,6 +4447,10 @@ class CompiledAutograd1(torch.nn.Module):
         not torch.distributed.is_available(),
         "FakePG relies on distributed build",
     )
+    @unittest.skipIf(
+        sys.platform == "darwin",
+        "FakePG DTensor test is not supported on macOS",
+    )
     def test_dtensor_backward_symints_do_not_reuse_native_sharding_cache(self):
         def run_case():
             torch._dynamo.reset()

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -31,7 +31,6 @@ from torch._dynamo.utils import counters
 from torch._inductor import config as inductor_config
 from torch._inductor.cpp_builder import is_msvc_cl
 from torch._inductor.test_case import run_tests, TestCase
-from torch.distributed.tensor import DeviceMesh, DTensor, Shard
 from torch.nn.attention.flex_attention import flex_attention
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.overrides import BaseTorchFunctionMode
@@ -48,7 +47,6 @@ from torch.testing._internal.common_utils import (
     skipIfWindows,
     skipIfXpu,
 )
-from torch.testing._internal.distributed.fake_pg import FakeStore
 from torch.testing._internal.hop_db import hop_db
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
@@ -63,6 +61,15 @@ from torch.testing._internal.triton_utils import (
     requires_gpu_and_triton,
 )
 from torch.utils._python_dispatch import TorchDispatchMode
+
+
+try:
+    from torch.distributed.tensor import DeviceMesh, DTensor, Shard
+    from torch.testing._internal.distributed.fake_pg import FakeStore
+
+    HAS_DTENSOR = True
+except ImportError:
+    HAS_DTENSOR = False
 
 
 # note: these tests are not run on windows due to inductor_utils.HAS_CPU
@@ -4444,12 +4451,8 @@ class CompiledAutograd1(torch.nn.Module):
             loss.backward()
 
     @unittest.skipIf(
-        not torch.distributed.is_available(),
-        "FakePG relies on distributed build",
-    )
-    @unittest.skipIf(
-        sys.platform == "darwin",
-        "FakePG DTensor test is not supported on macOS",
+        not HAS_DTENSOR,
+        "DTensor/FakePG requires distributed build",
     )
     def test_dtensor_backward_symints_do_not_reuse_native_sharding_cache(self):
         def run_case():

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -2259,37 +2259,6 @@ static bool contains_any_symint(const py::tuple& tup) {
   return false;
 }
 
-static bool ivalue_has_symbolic_symint(const c10::IValue& value) {
-  if (value.isSymInt()) {
-    return value.toSymInt().is_symbolic();
-  }
-  if (value.isSymIntList()) {
-    const auto symints = value.toSymIntList();
-    for (const auto idx : c10::irange(symints.size())) {
-      if (symints.get(idx).is_symbolic()) {
-        return true;
-      }
-    }
-    return false;
-  }
-  if (value.isTuple()) {
-    for (const auto& item : value.toTupleRef().elements()) {
-      if (ivalue_has_symbolic_symint(item)) {
-        return true;
-      }
-    }
-    return false;
-  }
-  if (value.isList()) {
-    for (const auto& item : value.toList()) {
-      if (ivalue_has_symbolic_symint(item)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 static bool dtensor_spec_has_symints(py::handle spec) {
   const auto tensor_meta = spec.attr(dtensor_interned_strings.tensor_meta);
   if (tensor_meta.is_none()) {
@@ -2340,10 +2309,18 @@ create_native_op_schema(
     bool is_none_or_undefined =
         arg.isNone() || (arg.isTensor() && !arg.toTensor().defined());
     if (idx >= native_info.static_argnum || is_none_or_undefined) {
-      if (ivalue_has_symbolic_symint(arg)) {
+      if (arg.isSymInt() && arg.toSymInt().is_symbolic()) {
         // Symbolic SymInts are scoped to a single tracing/capture context,
         // so cached sharding results containing them cannot be reused.
         return true;
+      }
+      if (arg.isSymIntList()) {
+        const auto symints = arg.toSymIntList();
+        for (const auto sym_idx : c10::irange(symints.size())) {
+          if (symints.get(sym_idx).is_symbolic()) {
+            return true;
+          }
+        }
       }
       if (arg.isList()) {
         const auto& list = arg.toList();
@@ -2383,10 +2360,18 @@ create_native_op_schema(
     // We coerce undefined Tensor to None, just as we do when
     // converting IValues to PyObject. (same behaviour as
     // handle_non_dtensor_arg)
-    if (ivalue_has_symbolic_symint(arg)) {
+    if (arg.isSymInt() && arg.toSymInt().is_symbolic()) {
       // Symbolic SymInts are scoped to a single tracing/capture context,
       // so cached sharding results containing them cannot be reused.
       return true;
+    }
+    if (arg.isSymIntList()) {
+      const auto symints = arg.toSymIntList();
+      for (const auto sym_idx : c10::irange(symints.size())) {
+        if (symints.get(sym_idx).is_symbolic()) {
+          return true;
+        }
+      }
     }
     if (arg.isTensor() && !arg.toTensor().defined()) {
       arg = c10::IValue();

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -2336,33 +2336,39 @@ create_native_op_schema(
 
   const auto handle_non_dtensor_arg =
       [&comparison_key, &comparison_key_hash, &native_info](
-          size_t idx, c10::IValue arg) {
-        bool is_none_or_undefined =
-            arg.isNone() || (arg.isTensor() && !arg.toTensor().defined());
-        if (idx >= native_info.static_argnum || is_none_or_undefined) {
-          if (arg.isList()) {
-            const auto& list = arg.toList();
-            if (list.empty()) {
-              arg = c10::ivalue::Tuple::create({});
-            } else {
-              // WARNING: here we rely on c10::List being represented
-              // by a contiguous array of IValue for efficiency!
-              arg = c10::ivalue::Tuple::create(c10::ArrayRef<c10::IValue>(
-                  &(*list.begin()).get(), list.size()));
-            }
-          } else if (arg.isTensor() && !arg.toTensor().defined()) {
-            // Coerce undefined Tensor to None, just as we do when
-            // converting IValues to PyObject. Otherwise comparison
-            // doesn't work. (undefined Tensors can get here because
-            // check_for_dtensor_or_tensor calls them non-Tensors, but
-            // doesn't have a way to do the coercion for us.)
-            arg = c10::IValue();
-          }
-          comparison_key_hash =
-              c10::hash_combine(comparison_key_hash, c10::IValue::hash(arg));
-          comparison_key.emplace_back(std::move(arg));
+          size_t idx, c10::IValue arg) -> bool {
+    bool is_none_or_undefined =
+        arg.isNone() || (arg.isTensor() && !arg.toTensor().defined());
+    if (idx >= native_info.static_argnum || is_none_or_undefined) {
+      if (ivalue_has_symbolic_symint(arg)) {
+        // Symbolic SymInts are scoped to a single tracing/capture context,
+        // so cached sharding results containing them cannot be reused.
+        return true;
+      }
+      if (arg.isList()) {
+        const auto& list = arg.toList();
+        if (list.empty()) {
+          arg = c10::ivalue::Tuple::create({});
+        } else {
+          // WARNING: here we rely on c10::List being represented
+          // by a contiguous array of IValue for efficiency!
+          arg = c10::ivalue::Tuple::create(
+              c10::ArrayRef<c10::IValue>(&(*list.begin()).get(), list.size()));
         }
-      };
+      } else if (arg.isTensor() && !arg.toTensor().defined()) {
+        // Coerce undefined Tensor to None, just as we do when
+        // converting IValues to PyObject. Otherwise comparison
+        // doesn't work. (undefined Tensors can get here because
+        // check_for_dtensor_or_tensor calls them non-Tensors, but
+        // doesn't have a way to do the coercion for us.)
+        arg = c10::IValue();
+      }
+      comparison_key_hash =
+          c10::hash_combine(comparison_key_hash, c10::IValue::hash(arg));
+      comparison_key.emplace_back(std::move(arg));
+    }
+    return false;
+  };
   const auto handle_dtensor_arg = [&comparison_key,
                                    &comparison_key_hash](py::object arg) {
     comparison_key_hash = c10::hash_combine(
@@ -2371,19 +2377,25 @@ create_native_op_schema(
   };
 
   const auto handle_non_tensor_or_undefined =
-      [&comparison_key, &comparison_key_hash](c10::IValue arg) {
-        // We reach here when arg is TensorFlavor::NON_TENSOR
-        // (not a Tensor at all or undefined Tensor)
-        // We coerce undefined Tensor to None, just as we do when
-        // converting IValues to PyObject. (same behaviour as
-        // handle_non_dtensor_arg)
-        if (arg.isTensor() && !arg.toTensor().defined()) {
-          arg = c10::IValue();
-        }
-        comparison_key_hash =
-            c10::hash_combine(comparison_key_hash, c10::IValue::hash(arg));
-        comparison_key.emplace_back(std::move(arg));
-      };
+      [&comparison_key, &comparison_key_hash](c10::IValue arg) -> bool {
+    // We reach here when arg is TensorFlavor::NON_TENSOR
+    // (not a Tensor at all or undefined Tensor)
+    // We coerce undefined Tensor to None, just as we do when
+    // converting IValues to PyObject. (same behaviour as
+    // handle_non_dtensor_arg)
+    if (ivalue_has_symbolic_symint(arg)) {
+      // Symbolic SymInts are scoped to a single tracing/capture context,
+      // so cached sharding results containing them cannot be reused.
+      return true;
+    }
+    if (arg.isTensor() && !arg.toTensor().defined()) {
+      arg = c10::IValue();
+    }
+    comparison_key_hash =
+        c10::hash_combine(comparison_key_hash, c10::IValue::hash(arg));
+    comparison_key.emplace_back(std::move(arg));
+    return false;
+  };
 
   const bool allow_implicit_replication =
       at::get_dtensor_allow_implicit_replication();
@@ -2434,11 +2446,6 @@ create_native_op_schema(
         break;
       }
       case TensorFlavor::NON_TENSOR: {
-        if (ivalue_has_symbolic_symint(arg)) {
-          // Symbolic SymInts are scoped to a single tracing/capture context,
-          // so cached sharding results containing them cannot be reused.
-          return std::nullopt;
-        }
         // Check if this is a list/tuple that might contain DTensors (e.g.,
         // torch.cat)
         if (arg.isList()) {
@@ -2466,13 +2473,17 @@ create_native_op_schema(
               // if the list's argument index is >= static_argnum.
               // Otherwise, step-varying scalars (like AdamW bias
               // corrections) cause unbounded cache growth.
-              handle_non_dtensor_arg(idx, item);
+              if (handle_non_dtensor_arg(idx, item)) {
+                return std::nullopt;
+              }
             }
           }
         } else {
           // non DTensor/Tensor args (i.e. int/float/bool), just add to
           // local_args
-          handle_non_dtensor_arg(idx, arg);
+          if (handle_non_dtensor_arg(idx, arg)) {
+            return std::nullopt;
+          }
         }
         break;
       }
@@ -2557,11 +2568,6 @@ create_native_op_schema(
           break;
         }
         case TensorFlavor::NON_TENSOR: {
-          if (ivalue_has_symbolic_symint(*argument_it)) {
-            // Symbolic SymInts are scoped to a single tracing/capture context,
-            // so cached sharding results containing them cannot be reused.
-            return std::nullopt;
-          }
           if (argument_it->isList()) {
             const auto list = argument_it->toList();
             comparison_key_hash =
@@ -2581,11 +2587,16 @@ create_native_op_schema(
                   item_flavor == TensorFlavor::NON_DTENSOR_TENSOR_SUBCLASS) {
                 handle_exactly_tensor(item_py_tensor);
               } else { // non-tensor
-                handle_non_tensor_or_undefined(item);
+                if (handle_non_tensor_or_undefined(item)) {
+                  return std::nullopt;
+                }
               }
             }
           } else {
-            handle_non_dtensor_arg(native_info.static_argnum, *argument_it);
+            if (handle_non_dtensor_arg(
+                    native_info.static_argnum, *argument_it)) {
+              return std::nullopt;
+            }
           }
           break;
         }

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -2259,6 +2259,37 @@ static bool contains_any_symint(const py::tuple& tup) {
   return false;
 }
 
+static bool ivalue_has_symbolic_symint(const c10::IValue& value) {
+  if (value.isSymInt()) {
+    return value.toSymInt().is_symbolic();
+  }
+  if (value.isSymIntList()) {
+    const auto symints = value.toSymIntList();
+    for (const auto idx : c10::irange(symints.size())) {
+      if (symints.get(idx).is_symbolic()) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (value.isTuple()) {
+    for (const auto& item : value.toTupleRef().elements()) {
+      if (ivalue_has_symbolic_symint(item)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (value.isList()) {
+    for (const auto& item : value.toList()) {
+      if (ivalue_has_symbolic_symint(item)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 static bool dtensor_spec_has_symints(py::handle spec) {
   const auto tensor_meta = spec.attr(dtensor_interned_strings.tensor_meta);
   if (tensor_meta.is_none()) {
@@ -2403,6 +2434,11 @@ create_native_op_schema(
         break;
       }
       case TensorFlavor::NON_TENSOR: {
+        if (ivalue_has_symbolic_symint(arg)) {
+          // Symbolic SymInts are scoped to a single tracing/capture context,
+          // so cached sharding results containing them cannot be reused.
+          return std::nullopt;
+        }
         // Check if this is a list/tuple that might contain DTensors (e.g.,
         // torch.cat)
         if (arg.isList()) {
@@ -2521,6 +2557,11 @@ create_native_op_schema(
           break;
         }
         case TensorFlavor::NON_TENSOR: {
+          if (ivalue_has_symbolic_symint(*argument_it)) {
+            // Symbolic SymInts are scoped to a single tracing/capture context,
+            // so cached sharding results containing them cannot be reused.
+            return std::nullopt;
+          }
           if (argument_it->isList()) {
             const auto list = argument_it->toList();
             comparison_key_hash =


### PR DESCRIPTION
[dtensor] Avoid native sharding cache for symbolic IValue args

DTensor native sharding propagation skips cache usage on the Python path while tracing, because SymInts are scoped to a particular ShapeEnv. The C++ fast path already avoided caching DTensorSpecs whose tensor_meta
contains SymInts, but it did not check non-tensor schema arguments.

This can make shape-sensitive ops such as aten.expand.default cache an OutputSharding containing a symbolic size from one compiled-autograd capture, then reuse that stale symbol in a later capture where the same symbol name refers to a different size. In particular, SumBackward0 can pass a symbolic DTensor global size through expand's sizes argument, causing the cached output sharding to confuse the global DTensor shape
with the local shard shape.

Detect symbolic SymInts inside IValue non-tensor arguments and fall back to the Python sharding propagation path instead of constructing a native cache key. This keeps the native cache from storing OutputSharding values
that contain tracing-scoped symbols.

Fixes #183021

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo