### PR TITLE
Add RISC-V native fp16 conversion paths

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_half.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_half.h
@@ -6,6 +6,13 @@
 #include <ATen/cpu/vec/vec256/vec256_16bit_float.h>
 #include <c10/util/irange.h>
 
+#if defined(__riscv) && defined(__riscv_v_intrinsic) &&              \
+    (defined(__riscv_zvfh) || defined(__riscv_zvfhmin)) &&           \
+    defined(__riscv_zve32f) && defined(__FLT16_MANT_DIG__)
+#define ATEN_RISCV_VECTOR_F16 1
+#include <riscv_vector.h>
+#endif
+
 namespace at::vec {
 // See Note [CPU_CAPABILITY namespace]
 inline namespace CPU_CAPABILITY {
@@ -221,10 +228,55 @@ LOAD_FP32_VECTORIZED_INIT(Half, fp16)
 
 #else // defined(CPU_CAPABILITY_AVX2)
 
+#if defined(ATEN_RISCV_VECTOR_F16)
+template <>
+inline void convert(const float* src, Half* dst, int64_t n) {
+  auto* rvv_dst = reinterpret_cast<_Float16*>(dst);
+  int64_t i = 0;
+  while (i < n) {
+    const auto vl = __riscv_vsetvl_e32m2(static_cast<size_t>(n - i));
+    auto values = __riscv_vle32_v_f32m2(src + i, vl);
+    auto half_values = __riscv_vfncvt_f_f_w_f16m1(values, vl);
+    __riscv_vse16_v_f16m1(rvv_dst + i, half_values, vl);
+    i += static_cast<int64_t>(vl);
+  }
+}
+
+template <>
+inline void convert(const Half* src, float* dst, int64_t n) {
+  auto* rvv_src = reinterpret_cast<const _Float16*>(src);
+  int64_t i = 0;
+  while (i < n) {
+    const auto vl = __riscv_vsetvl_e16m1(static_cast<size_t>(n - i));
+    auto half_values = __riscv_vle16_v_f16m1(rvv_src + i, vl);
+    auto values = __riscv_vfwcvt_f_f_v_f32m2(half_values, vl);
+    __riscv_vse32_v_f32m2(dst + i, values, vl);
+    i += static_cast<int64_t>(vl);
+  }
+}
+#endif
+
 #if !(defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__) && !defined(CPU_CAPABILITY_SVE256))
 CONVERT_NON_VECTORIZED_INIT(Half, half)
 #endif
 
+#if defined(ATEN_RISCV_VECTOR_F16)
+inline void load_fp32_from_fp16(const Half* data, Vectorized<float>& out) {
+  __at_align__ float values[Vectorized<float>::size()];
+  convert(data, values, Vectorized<float>::size());
+  out = Vectorized<float>::loadu(values);
+}
+
+inline void load_fp32_from_fp16(
+    const Half* data,
+    Vectorized<float>& out1,
+    Vectorized<float>& out2) {
+  load_fp32_from_fp16(data, out1);
+  data += Vectorized<float>::size();
+  load_fp32_from_fp16(data, out2);
+}
+#else
 LOAD_FP32_NON_VECTORIZED_INIT(Half, fp16)
+#endif
 #endif // defined(CPU_CAPABILITY_AVX2)
 }} // namsepace at::vec::CPU_CAPABILITY

--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -49,6 +49,8 @@ inline C10_HOST_DEVICE Half::Half(float value)
 #elif (defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)) && \
     !defined(__APPLE__)
       x(at::vec::float2half_scalar(value))
+#elif defined(C10_RISCV_F16)
+      x(detail::native_fp16_from_fp32_value(value))
 #else
       x(detail::fp16_ieee_from_fp32_value(value))
 #endif
@@ -66,6 +68,8 @@ inline C10_HOST_DEVICE Half::operator float() const {
     !defined(__APPLE__)
   return at::vec::half2float_scalar(x);
 #elif defined(__aarch64__) && !defined(__CUDACC__)
+  return detail::native_fp16_to_fp32_value(x);
+#elif defined(C10_RISCV_F16)
   return detail::native_fp16_to_fp32_value(x);
 #else
   return detail::fp16_ieee_to_fp32_value(x);

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -62,6 +62,15 @@
 #endif // __x86_64__ || _M_X64 || __i386 || _M_IX86
 #endif // __GNUC__ || __clang__
 
+#if defined(__riscv) &&                                      \
+    (defined(__riscv_zfh) || defined(__riscv_zfhmin)) &&     \
+    defined(__FLT16_MANT_DIG__) &&                           \
+    !(defined(__CUDA_ARCH__) || defined(__CUDACC__) ||       \
+      defined(__HIP_DEVICE_COMPILE__) ||                     \
+      defined(__SYCL_DEVICE_ONLY__))
+#define C10_RISCV_F16 1
+#endif
+
 namespace c10 {
 
 namespace detail {
@@ -375,6 +384,22 @@ inline float native_fp16_to_fp32_value(uint16_t h) {
 
 inline uint16_t native_fp16_from_fp32_value(float f) {
   return fp16_to_bits(static_cast<float16_t>(f));
+}
+#elif defined(C10_RISCV_F16)
+inline _Float16 fp16_from_bits(uint16_t h) {
+  return c10::bit_cast<_Float16>(h);
+}
+
+inline uint16_t fp16_to_bits(_Float16 f) {
+  return c10::bit_cast<uint16_t>(f);
+}
+
+inline float native_fp16_to_fp32_value(uint16_t h) {
+  return static_cast<float>(fp16_from_bits(h));
+}
+
+inline uint16_t native_fp16_from_fp32_value(float f) {
+  return fp16_to_bits(static_cast<_Float16>(f));
 }
 #endif
 


### PR DESCRIPTION
  ## Summary

  This PR adds RISC-V native fp16 conversion support for `c10::Half`.

  - Use native `_Float16` conversion for scalar `Half <-> float` on RISC-V targets with `zfh`/`zfhmin`.
  - Add RVV bulk `float <-> Half` conversion when `v + zve32f + zvfh/zvfhmin` are available.
  - Keep existing x86, AArch64, and generic fallback paths unchanged.

  ## Motivation

  RISC-V currently falls back to software fp32/fp16 conversion in these paths, which is expensive for tensor initialization and conversion-heavy workloads. The new paths allow the compiler to emit native scalar fp16 conversion and RVV narrowing/widening conversion instructions.

  ## Test Plan
  - Ran correctness test with `qemu-riscv64 10.1`: `PASS`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01