### PR TITLE
[sparse] check_invariants does not silence warning for torch.sparse_csr_tensor

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -7,12 +7,13 @@ import functools
 import operator
 import random
 import unittest
+import warnings
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import TestCase, run_tests, do_test_dtypes, \
     load_tests, TEST_NUMPY, TEST_SCIPY, IS_WINDOWS, gradcheck, coalescedonoff, \
     DeterministicGuard, first_sample, TEST_WITH_CROSSREF, TEST_WITH_ROCM, skipIfTorchDynamo, \
     parametrize, subtest, is_coalesced_indices, suppress_warnings, instantiate_parametrized_tests, \
-    skipIfCrossRef
+    skipIfCrossRef, set_warn_always_context
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_mps import mps_ops_modifier
 from numbers import Number
@@ -466,6 +467,66 @@ class TestSparse(TestSparseBase):
             msg = "Sparse invariant checks are implicitly disabled."
             with self.assertWarnsRegex(UserWarning, msg):
                 x = torch.sparse_coo_tensor(indices, values, shape)
+
+    @dtypes(torch.float32)
+    @expectedFailureMPS
+    @skipIfCrossRef
+    def test_no_warn_when_check_invariants_is_explicit(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/178274
+        def assert_invariant_warning(fn, check):
+            with torch.sparse.check_sparse_tensor_invariants(None), \
+                    set_warn_always_context(True):
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    fn()
+                    invariant_warnings = [
+                        x for x in w if "implicitly disabled" in str(x.message)
+                    ]
+                    if check is None:
+                        self.assertNotEqual(len(invariant_warnings), 0)
+                    else:
+                        self.assertEqual(len(invariant_warnings), 0)
+
+        for check in [True, False, None]:
+            assert_invariant_warning(
+                lambda: torch.sparse_coo_tensor(
+                    torch.tensor([[0, 1], [2, 0]], device=device),
+                    torch.tensor([1, 2], dtype=dtype, device=device),
+                    check_invariants=check,
+                ), check
+            )
+            assert_invariant_warning(
+                lambda: torch.sparse_coo_tensor(
+                    torch.tensor([[0, 1], [2, 0]], device=device),
+                    torch.tensor([1, 2], dtype=dtype, device=device),
+                    (3, 3),
+                    check_invariants=check,
+                ), check
+            )
+            assert_invariant_warning(
+                lambda: torch.sparse_coo_tensor(
+                    (3, 3),
+                    device=device,
+                    check_invariants=check,
+                ), check
+            )
+            assert_invariant_warning(
+                lambda: torch.sparse_csr_tensor(
+                    torch.tensor([0, 2, 4], dtype=torch.int64, device=device),
+                    torch.tensor([0, 1, 0, 1], dtype=torch.int64, device=device),
+                    torch.tensor([1, 2, 3, 4], dtype=dtype, device=device),
+                    (2, 2),
+                    check_invariants=check,
+                ), check
+            )
+            assert_invariant_warning(
+                lambda: torch.sparse_csc_tensor(
+                    torch.tensor([0, 2, 4], dtype=torch.int64, device=device),
+                    torch.tensor([0, 1, 0, 1], dtype=torch.int64, device=device),
+                    torch.tensor([1, 2, 3, 4], dtype=dtype, device=device),
+                    check_invariants=check,
+                ), check
+            )
 
     @dtypes(torch.double)
     @dtypesIfMPS(torch.float32)

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -876,9 +876,14 @@ Tensor indexing_tensor_from_data(
 
 class CheckSparseTensorInvariantsContext {
  public:
-  CheckSparseTensorInvariantsContext()
+  explicit CheckSparseTensorInvariantsContext(
+      std::optional<bool> check_invariants_arg = std::nullopt)
       : state{at::globalContext().checkSparseTensorInvariants(
-            /*warn_when_uninitialized=*/true)} {}
+            /*warn_when_uninitialized=*/!check_invariants_arg.has_value())} {
+    if (check_invariants_arg.has_value()) {
+      at::globalContext().setCheckSparseTensorInvariants(check_invariants_arg);
+    }
+  }
   ~CheckSparseTensorInvariantsContext() {
     at::globalContext().setCheckSparseTensorInvariants(state);
   }
@@ -954,7 +959,9 @@ static Tensor sparse_compressed_tensor_ctor_worker(
       ? reinterpret_cast<THPDtype*>(plain_indices_dtype_attr.get())->scalar_type
       : kInt;
   CheckSparseTensorInvariantsContext
-      restores_check_sparse_tensor_invariants_global_state{};
+      restores_check_sparse_tensor_invariants_global_state{
+          (r.idx == 0) ? r.toBoolOptional(ARG_CHECK_INVARIANTS)
+                       : r.toBoolOptional(ARG_CHECK_INVARIANTS1)};
 
   if (r.idx == 0) {
     const bool pin_memory = r.toBool(ARG_PIN_MEMORY);
@@ -965,12 +972,6 @@ static Tensor sparse_compressed_tensor_ctor_worker(
         r.scalartypeWithDefault(ARG_TYPE, scalar_type);
     auto deviceOptional = r.deviceOptional(ARG_DEVICE);
     at::OptionalDeviceGuard device_guard(deviceOptional);
-    // the global state of invariants check flag will be restored via
-    // CheckSparseTensorInvariantsContext destructor
-    if (auto check_invariants = r.toBoolOptional(ARG_CHECK_INVARIANTS);
-        check_invariants.has_value()) {
-      at::globalContext().setCheckSparseTensorInvariants(check_invariants);
-    }
     Tensor values = internal_new_from_data(
         inferred_options,
         inferred_scalar_type,
@@ -1024,12 +1025,6 @@ static Tensor sparse_compressed_tensor_ctor_worker(
     auto deviceOptional = r.deviceOptional(ARG_DEVICE1);
     at::OptionalDeviceGuard device_guard(deviceOptional);
     const bool pin_memory = r.toBool(ARG_PIN_MEMORY1);
-    // the global state of invariants check flag will be restored via
-    // CheckSparseTensorInvariantsContext destructor
-    if (auto check_invariants = r.toBoolOptional(ARG_CHECK_INVARIANTS1);
-        check_invariants.has_value()) {
-      at::globalContext().setCheckSparseTensorInvariants(check_invariants);
-    }
     Tensor values = internal_new_from_data(
         inferred_options,
         inferred_scalar_type,
@@ -1186,7 +1181,10 @@ Tensor sparse_coo_tensor_ctor(
   };
 
   CheckSparseTensorInvariantsContext
-      restores_check_sparse_tensor_invariants_global_state{};
+      restores_check_sparse_tensor_invariants_global_state{
+          (r.idx == 0)       ? r.toBoolOptional(ARG_CHECK_INVARIANTS)
+              : (r.idx == 1) ? r.toBoolOptional(ARG_CHECK_INVARIANTS1)
+                             : r.toBoolOptional(ARG_CHECK_INVARIANTS2)};
   if (r.idx == 0) {
     bool pin_memory = r.toBool(ARG_PIN_MEMORY);
     bool type_inference = r.isNone(ARG_TYPE);
@@ -1196,10 +1194,6 @@ Tensor sparse_coo_tensor_ctor(
         r.scalartypeWithDefault(ARG_TYPE, scalar_type);
     auto deviceOptional = r.deviceOptional(ARG_DEVICE);
     at::OptionalDeviceGuard device_guard(deviceOptional);
-    if (auto check_invariants = r.toBoolOptional(ARG_CHECK_INVARIANTS);
-        check_invariants.has_value()) {
-      at::globalContext().setCheckSparseTensorInvariants(check_invariants);
-    }
 
     // if no dtype provided, infer type based on value type.
     Tensor values = internal_new_from_data(
@@ -1234,10 +1228,6 @@ Tensor sparse_coo_tensor_ctor(
         r.scalartypeWithDefault(ARG_TYPE1, scalar_type);
     auto deviceOptional = r.deviceOptional(ARG_DEVICE1);
     at::OptionalDeviceGuard device_guard(deviceOptional);
-    if (auto check_invariants = r.toBoolOptional(ARG_CHECK_INVARIANTS1);
-        check_invariants.has_value()) {
-      at::globalContext().setCheckSparseTensorInvariants(check_invariants);
-    }
 
     Tensor values = internal_new_from_data(
         inferred_options,
@@ -1269,10 +1259,6 @@ Tensor sparse_coo_tensor_ctor(
     const auto inferred_scalar_type =
         r.scalartypeWithDefault(ARG_TYPE2, scalar_type);
     at::OptionalDeviceGuard device_guard(r.deviceOptional(ARG_DEVICE2));
-    if (auto check_invariants = r.toBoolOptional(ARG_CHECK_INVARIANTS2);
-        check_invariants.has_value()) {
-      at::globalContext().setCheckSparseTensorInvariants(check_invariants);
-    }
     return at::sparse_coo_tensor(
                r.intlist(ARG_SIZE2),
                inferred_options.dtype(inferred_scalar_type).layout(at::kSparse))


### PR DESCRIPTION

When passing `check_invariants=True/False` to **sparse tensor factory functions (sparse_csr_tensor, sparse_coo_tensor, etc.),** the `"Sparse invariant checks are implicitly disabled" `UserWarning still fired. This happened because the `CheckSparseTensorInvariantsContext`
RAII guard queried and warned about the global state before the user's `check_invariants` argument was applied.
  
Fix: Accept the user's check_invariants value in the RAII constructor — skip the warning when the user explicitly opted in/out, and apply the value to global state before tensor creation. The destructor still restores the original global state. This also deduplicates 5 identical `check_invariants ` handling blocks across constructor branches.

Test: Added `test_no_warn_when_check_invariants_is_explicit `covering all factory overloads (COO r.idx 0/1/2, compressed r.idx 0/1) with both True and False, on CPU and CUDA. Uses `set_warn_always_context(True)` to bypass `TORCH_WARN_ONCE` static semantics.

Fixes #178274