### PR TITLE
Fix torch.cuda.ExternalStream(0) to wrap the NULL stream

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1372,6 +1372,25 @@ print(t.is_pinned())
         self.assertEqual(external_result[0], 0)
         self.assertEqual(external_result[1], external_stream.cuda_stream)
 
+    def test_external_stream_wraps_null_handle(self):
+        # Regression for https://github.com/pytorch/pytorch/issues/182960
+        # ExternalStream(0) must wrap the NULL stream (handle 0x0), not return
+        # a pooled stream, and must behave identically to
+        # torch.cuda.get_stream_from_external(0).
+        device = torch.cuda.current_device()
+        external_stream = torch.cuda.ExternalStream(0, device=device)
+        from_get_stream_from_external = torch.cuda.get_stream_from_external(
+            0, device=device
+        )
+        default = torch.cuda.default_stream(device)
+
+        self.assertEqual(external_stream.cuda_stream, 0)
+        self.assertEqual(from_get_stream_from_external.cuda_stream, 0)
+        self.assertEqual(external_stream.cuda_stream, default.cuda_stream)
+
+        self.assertEqual(external_stream.device, from_get_stream_from_external.device)
+        self.assertEqual(external_stream.device, default.device)
+
     def test_events(self):
         stream = torch.cuda.current_stream()
         event = torch.cuda.Event(enable_timing=True)

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -25,7 +25,11 @@ static PyObject* THCPStream_pynew(
   int64_t stream_id = 0;
   int64_t device_index = 0;
   int64_t device_type = 0;
-  uint64_t stream_ptr = 0;
+  // stream_ptr is parsed as a Python object (default Py_None) rather than a
+  // raw uint64_t so we can distinguish "kwarg omitted" from "kwarg explicitly
+  // set to 0". The legacy "|iLLLK" format collapsed those two cases and
+  // caused ExternalStream(0) to land in getStreamFromPool.
+  PyObject* stream_ptr_obj = Py_None;
 
   // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
   constexpr const char* kwlist[] = {
@@ -38,15 +42,28 @@ static PyObject* THCPStream_pynew(
   if (!PyArg_ParseTupleAndKeywords(
           args,
           kwargs,
-          "|iLLLK",
+          "|iLLLO",
           // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
           const_cast<char**>(kwlist),
           &priority,
           &stream_id,
           &device_index,
           &device_type,
-          &stream_ptr)) {
+          &stream_ptr_obj)) {
     return nullptr;
+  }
+
+  const bool stream_ptr_provided = (stream_ptr_obj != Py_None);
+  uint64_t stream_ptr = 0;
+  if (stream_ptr_provided) {
+    TORCH_CHECK(
+        PyLong_Check(stream_ptr_obj),
+        "stream_ptr must be an int or None, got ",
+        Py_TYPE(stream_ptr_obj)->tp_name);
+    stream_ptr = PyLong_AsUnsignedLongLong(stream_ptr_obj);
+    if (PyErr_Occurred()) {
+      return nullptr;
+    }
   }
 
   THPObjectPtr ptr(type->tp_alloc(type, 0));
@@ -54,7 +71,7 @@ static PyObject* THCPStream_pynew(
     return nullptr;
   }
 
-  if (stream_ptr) {
+  if (stream_ptr_provided) {
     TORCH_CHECK(
         priority == 0, "Priority was explicitly set for an external stream")
   }
@@ -63,11 +80,11 @@ static PyObject* THCPStream_pynew(
             stream_id,
             static_cast<c10::DeviceIndex>(device_index),
             static_cast<c10::DeviceType>(device_type))
-      : stream_ptr ? at::cuda::getStreamFromExternal(
-                         // NOLINTNEXTLINE(performance-no-int-to-ptr)
-                         reinterpret_cast<cudaStream_t>(stream_ptr),
-                         current_device)
-                   : at::cuda::getStreamFromPool(priority);
+      : stream_ptr_provided ? at::cuda::getStreamFromExternal(
+                                  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+                                  reinterpret_cast<cudaStream_t>(stream_ptr),
+                                  current_device)
+                            : at::cuda::getStreamFromPool(priority);
 
   THCPStream* self = (THCPStream*)ptr.get();
   self->stream_id = static_cast<int64_t>(stream.id());

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -7,6 +7,8 @@ import ctypes
 import torch
 from torch._utils import _dummy_type
 
+from ._utils import _get_device_index
+
 
 if not hasattr(torch._C, "_CudaStreamBase"):
     # Define dummy base classes
@@ -153,7 +155,16 @@ class ExternalStream(Stream):
 
     def __new__(cls, stream_ptr, device=None, **kwargs):
         with torch.cuda.device(device):
-            return super().__new__(cls, stream_ptr=stream_ptr, **kwargs)
+            streamdata = torch._C._cuda_getStreamFromExternal(
+                stream_ptr, _get_device_index(device, optional=True)
+            )
+            return super().__new__(
+                cls,
+                stream_id=streamdata[0],
+                device_index=streamdata[1],
+                device_type=streamdata[2],
+                **kwargs,
+            )
 
 
 class Event(torch._C._CudaEventBase):

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -7,8 +7,6 @@ import ctypes
 import torch
 from torch._utils import _dummy_type
 
-from ._utils import _get_device_index
-
 
 if not hasattr(torch._C, "_CudaStreamBase"):
     # Define dummy base classes
@@ -155,16 +153,7 @@ class ExternalStream(Stream):
 
     def __new__(cls, stream_ptr, device=None, **kwargs):
         with torch.cuda.device(device):
-            streamdata = torch._C._cuda_getStreamFromExternal(
-                stream_ptr, _get_device_index(device, optional=True)
-            )
-            return super().__new__(
-                cls,
-                stream_id=streamdata[0],
-                device_index=streamdata[1],
-                device_type=streamdata[2],
-                **kwargs,
-            )
+            return super().__new__(cls, stream_ptr=stream_ptr, **kwargs)
 
 
 class Event(torch._C._CudaEventBase):


### PR DESCRIPTION
# Fix `torch.cuda.ExternalStream(0)` to wrap the NULL stream

Fixes #182960.

## Summary

- `torch.cuda.ExternalStream(0, device=...)` silently returned a freshly pooled stream (`cuda_stream != 0`, different on each call) instead of wrapping CUDA's NULL stream. The sibling `torch.cuda.get_stream_from_external(0)` was unaffected.
- Route `ExternalStream.__new__` through the existing `_cuda_getStreamFromExternal` binding so the C++ dispatch picks up `device_type=CUDA` (non-zero) and reaches the faithful `unpack3` branch.
- After this PR `ExternalStream(0)`, `get_stream_from_external(0)`, and `default_stream(device)` are behaviorally identical; non-zero handles are unaffected.

## Why this proposed solution

Taking into account the comments in https://github.com/pytorch/pytorch/issues/182960 and https://github.com/triton-lang/triton/pull/10186, I am proposing this solution because of the following considerations: 

1. **Matches `get_stream_from_external`.** With this fix `ExternalStream(0)` behaves identically to `torch.cuda.get_stream_from_external(0)`, which already wraps `0x0` correctly. Two doc-equivalent APIs disagreeing on `0` was the bug.

2. **I would argue that `0x0` can be considered an external stream.** strictly speaking, I would say the null stream is not a stream that PyTorch's pool produced, so in some sense it is external. Allowing `ExternalStream` to accept it and wrapping it as-is makes sense to me. I am happy to follow up with a docstring clarification of what *external* means in `ExternalStream` (e.g. "not allocated by PyTorch's internal pool"), and/or a deprecation discussion if a stricter policy is preferred? This is just my interpretation of the API. 

3. **Erroring out would be a user-side break.** @ngimel raised on the issue that erroring is a reasonable alternative because *"null stream is not external, it is an internal null stream used by pytorch"*. Rejecting `0` has real BC impact: `get_stream_from_external(0)` works today, and downstream code already passes raw `cudaStream_t` handles through this API, see [triton-lang/triton#10186](https://github.com/triton-lang/triton/pull/10186), which had to special-case `stream == 0` precisely because of this PyTorch bug. Erroring would force every such caller to gate their handles.
