### PR TITLE
[CUDA] Expose cudaHostGetDevicePointer in cudart bindings

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -360,9 +360,16 @@ print(t.is_pinned())
         t = torch.ones(20)
         self.assertFalse(t.is_pinned())
         cudart = torch.cuda.cudart()
-        r = cudart.cudaHostRegister(t.data_ptr(), t.numel() * t.element_size(), 0)
+        cudaHostRegisterMapped = 2
+        r = cudart.cudaHostRegister(
+            t.data_ptr(), t.numel() * t.element_size(), cudaHostRegisterMapped
+        )
         self.assertEqual(r, 0)
         self.assertTrue(t.is_pinned())
+        r, device_ptr = cudart.cudaHostGetDevicePointer(t.data_ptr(), 0)
+        self.assertEqual(r, 0)
+        self.assertIsInstance(device_ptr, int)
+        self.assertNotEqual(device_ptr, 0)
         r = cudart.cudaHostUnregister(t.data_ptr())
         self.assertEqual(r, 0)
         self.assertFalse(t.is_pinned())

--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -75,6 +75,19 @@ void initCudartBindings(PyObject* module) {
       });
   cudart.def(
       "cuda"
+      "HostGetDevicePointer",
+      [](uintptr_t ptr,
+         unsigned int flags) -> std::pair<cudaError_t, uintptr_t> {
+        void* device_ptr = nullptr;
+        py::gil_scoped_release no_gil;
+        const auto error = C10_CUDA_ERROR_HANDLED(
+            // NOLINTNEXTLINE(performance-no-int-to-ptr)
+            cudaHostGetDevicePointer(&device_ptr, (void*)ptr, flags));
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        return {error, (uintptr_t)device_ptr};
+      });
+  cudart.def(
+      "cuda"
       "StreamCreate",
       [](uintptr_t ptr) -> cudaError_t {
         py::gil_scoped_release no_gil;


### PR DESCRIPTION
Summary:
- expose cudaHostGetDevicePointer through torch.cuda.cudart()
- return both the cudaError_t status and CUDA-visible device pointer
- extend the existing cudart host registration test to register mapped host memory and retrieve the device pointer

Example:

```python
import torch
from torch.cuda import check_error, cudart

t = torch.ones(20)
flags = 2  # cudaHostRegisterMapped
check_error(cudart().cudaHostRegister(t.data_ptr(), t.numel() * t.element_size(), flags))
try:
    err, device_ptr = cudart().cudaHostGetDevicePointer(t.data_ptr(), 0)
    check_error(err)
    # device_ptr can be passed to a custom extension that needs the CUDA-visible
    # pointer for mapped host memory.
finally:
    check_error(cudart().cudaHostUnregister(t.data_ptr()))
```

