### PR TITLE
[not for land]  Apply fusions.diff: fusion regions cleanup and overlap scheduling updates

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -964,63 +964,6 @@ class TestOverlapPreservingBucketing(InductorTestCase):
         f.check("pre_bucket_all_gather").check("all_gather_into_tensor_out")
         f.run(graph_str)
 
-    def test_dead_fusible_code_no_crash(self):
-        """
-        Test that dead fusible code (fusion regions with no external outputs)
-        does not crash collapse_fusion_regions, and that collapse/expand
-        round-trips preserve the graph.
-
-        Regression test for the bug where dead code created a fusion region
-        with no external outputs, causing fuse_by_partitions to crash with
-        "AssertionError: last_output_node is None".
-        """
-
-        def func_with_dead_fusible_code(x, y):
-            group_name = "0"
-            group_size = 1
-
-            ag = torch.ops._c10d_functional.all_gather_into_tensor(
-                x, group_size, group_name
-            )
-
-            # Dead fusible chain - not consumed by output
-            dead1 = x + 1.0
-            dead2 = dead1 * 2.0
-            dead3 = dead2 + dead1  # noqa: F841
-
-            # Live fusible chain
-            live1 = y + 1.0
-            live2 = live1 * 2.0
-
-            mm_result = torch.mm(y, y)
-            live3 = mm_result + 1.0
-
-            ag_out = torch.ops._c10d_functional.wait_tensor(ag)
-
-            return (live2 + live3 + ag_out).sum()
-
-        from torch._inductor.fx_passes.fusion_regions import (
-            build_fusion_regions,
-            collapse_fusion_regions,
-            expand_fusion_regions,
-        )
-
-        with FakeTensorMode():
-            x = torch.randn(16, 16)
-            y = torch.randn(16, 16)
-            gm = make_fx(func_with_dead_fusible_code)(x, y)
-
-        graph_str_before = gm.print_readable(print_output=False)
-
-        region_of = build_fusion_regions(gm)
-        new_region_of = collapse_fusion_regions(gm, region_of)
-
-        # Expand back and verify graph is preserved
-        expand_fusion_regions(gm, new_region_of)
-        gm.recompile()
-        graph_str_after = gm.print_readable(print_output=False)
-        self.assertEqual(graph_str_before, graph_str_after)
-
     @torch._inductor.config.patch(deterministic=True)
     def test_deterministic_mode_no_benchmark_error(self):
         """
@@ -1430,13 +1373,11 @@ class TestFusibleNodeOverlap(InductorTestCase):
             OverlapScheduler,
         )
 
-        estimations, fusion_region_of = gather_node_runtime_estimations(
+        estimations = gather_node_runtime_estimations(
             traced,
             collective_estimator="analytical",
             enable_fusion_regions=enable_fusion_regions,
         )
-        for node in fusion_region_of:
-            self.assertIn(node, estimations)
 
         scheduler = OverlapScheduler(
             traced,
@@ -1559,19 +1500,7 @@ class TestOverlapSchedulingFixes(InductorTestCase):
         result.graph.lint()
 
     def test_no_cycle_with_fusion_regions_and_bucketing(self):
-        """
-        Test that fusion regions + bucketing doesn't create cycles.
-
-        This tests multiple fixes:
-        1. Self-dependency prevention (augmented_graph_helper.py)
-        2. Track erased getitem nodes (const_fold.py, fusion_regions.py)
-        3. Skip DCE during expansion (const_fold.py, fusion_regions.py)
-
-        The scenario: Fusion regions collapse fusible ops into call_module nodes.
-        When bucketing merges collectives, getitem nodes from fusion outputs
-        get erased. Without proper tracking and DCE skip, this causes cycles
-        or assertion failures.
-        """
+        """Test that fusion regions + bucketing doesn't create cycles."""
 
         def func(a, b, c, d):
             group_name = dist.distributed_c10d._get_default_group().group_name
@@ -1639,7 +1568,7 @@ class TestOverlapSchedulingFixes(InductorTestCase):
             max_coll_distance=200,
             custom_runtime_estimation=None,
             collective_estimator="analytical",
-            enable_fusion_regions=True,  # Enable fusion regions
+            enable_fusion_regions=True,
         )
         # This should complete without errors
         result = scheduler.run()
@@ -2124,7 +2053,7 @@ class TestCoalescedCollectiveOverlap(InductorTestCase):
                 return 5.0
             return None
 
-        estimations, _ = gather_node_runtime_estimations(
+        estimations = gather_node_runtime_estimations(
             traced,
             custom_runtime_estimation=custom_runtime,
             collective_estimator="analytical",

--- a/test/inductor/test_fusion_regions.py
+++ b/test/inductor/test_fusion_regions.py
@@ -9,7 +9,6 @@ from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.ops import aten
-from torch.testing._internal.common_utils import xfailIfNoAcceleratorTriton
 
 
 HAS_GPU = torch.cuda.is_available()
@@ -104,17 +103,18 @@ class TestFusionRegionDetection(InductorTestCase):
             "Ops before and after mm should not be in the same fusion region",
         )
 
-    @xfailIfNoAcceleratorTriton
-    def test_collapse_and_expand_fusion_regions(self):
-        """Test collapse creates call_module nodes and expand restores graph."""
+    def test_estimate_fused_node_costs(self):
+        """Test that fused costs correctly exclude internal I/O."""
         from torch._inductor.fx_passes.fusion_regions import (
             build_fusion_regions,
-            collapse_fusion_regions,
-            expand_fusion_regions,
+            estimate_fused_node_costs,
         )
 
         def model(a, b):
-            x = (a + 1) * 2  # region 1
+            # region 1: 3-node chain, middle node has only internal I/O
+            x = a + 1  # reads a (ext), writes to neg (int)
+            x = -x  # reads add (int), writes to mul (int) -> cost=0
+            x = x * 2  # reads neg (int), writes to mm (ext)
             x = torch.mm(x, a)  # mm boundary
             x = (x - 1) / 2  # region 2
             y = (b + 3) * 4  # region 3 (independent)
@@ -126,25 +126,29 @@ class TestFusionRegionDetection(InductorTestCase):
             traced = make_fx(model)(a, b)
 
         region_of = build_fusion_regions(traced)
-        new_region_of = collapse_fusion_regions(traced, region_of)
+        fused_costs = estimate_fused_node_costs(region_of)
 
-        # Should have 3 fusion regions
-        self.assertEqual(len(new_region_of), 3)
-        call_modules = list(traced.graph.find_nodes(op="call_module"))
-        self.assertEqual(len(call_modules), 3)
+        # All region nodes should have a fused cost entry
+        for node in region_of:
+            self.assertIn(node, fused_costs)
 
-        # Verify metas and bytes on each region
-        tensor_bytes = 64 * 64 * 4  # 64x64 float32
-        for module_node in call_modules:
-            self.assertIn("val", module_node.meta)
-            region = new_region_of[module_node]
-            # Each region has 1 input + 1 output = 2 tensors
-            self.assertEqual(region.total_bytes, 2 * tensor_bytes)
-            self.assertGreater(region.cost_ms, 0)
-
-        # Expand back
-        expand_fusion_regions(traced, new_region_of)
+        # Graph should NOT be mutated (no call_module nodes)
         self.assertEqual(len(list(traced.graph.find_nodes(op="call_module"))), 0)
+
+        # Nodes with only internal I/O should have cost 0
+        zero_cost_nodes = [n for n, c in fused_costs.items() if c == 0.0]
+        nonzero_cost_nodes = [n for n, c in fused_costs.items() if c > 0.0]
+        self.assertGreater(len(zero_cost_nodes), 0, "Should have internal-only nodes")
+        self.assertGreater(len(nonzero_cost_nodes), 0, "Should have external I/O nodes")
+
+        # Total fused cost should be less than sum of individual roofline estimates
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            estimate_roofline_runtime_ms,
+        )
+
+        individual_total = sum(estimate_roofline_runtime_ms(n) for n in region_of)
+        fused_total = sum(fused_costs.values())
+        self.assertLessEqual(fused_total, individual_total)
 
     def test_is_fusible_node(self):
         """Test is_fusible_node correctly classifies ops."""
@@ -175,89 +179,79 @@ class TestFusionRegionDetection(InductorTestCase):
         self.assertIsNotNone(qr_node)
         self.assertFalse(is_fusible_node(qr_node))
 
-    @xfailIfNoAcceleratorTriton
-    def test_collapse_expand_preserves_correctness(self):
-        """Test that collapse and expand preserve numerical correctness.
-
-        Run the module before collapse, after collapse, and after expand,
-        verifying all produce the same results. Also verify the graph string
-        is identical before and after the round-trip.
-        """
+    def test_fused_costs_does_not_mutate_graph(self):
+        """estimate_fused_node_costs must not mutate the graph."""
         from torch._inductor.fx_passes.fusion_regions import (
             build_fusion_regions,
-            collapse_fusion_regions,
-            expand_fusion_regions,
+            estimate_fused_node_costs,
         )
 
         def model(a, b):
-            # Group 1: before mm
             x = a + 1
             x = x * 2
-
-            # mm boundary
             x = torch.mm(x, a)
-
-            # Group 2: after mm
             x = x - 1
             x = x / 2
-
-            # Group 3: separate chain with multi-output
             y = b + 3
             z = y * 4
-
             return x, y, z
 
-        # Use real tensors for numerical correctness check
-        torch.manual_seed(42)
-        a = torch.randn(64, 64, device=self.device)
-        b = torch.randn(64, 64, device=self.device)
-
-        # Get expected results from eager execution
-        expected = model(a, b)
-
-        # Trace with FakeTensorMode, then run with real tensors
         with FakeTensorMode():
-            a_fake = torch.ones(64, 64, device=self.device)
-            b_fake = torch.ones(64, 64, device=self.device)
-            traced = make_fx(model)(a_fake, b_fake)
+            a = torch.ones(64, 64, device=self.device)
+            b = torch.ones(64, 64, device=self.device)
+            traced = make_fx(model)(a, b)
 
-        # Capture graph string before any transformation
         graph_str_before = traced.print_readable(print_output=False)
 
-        # Run traced module before any transformation
-        result_before = traced(a, b)
-        for i, (exp, res) in enumerate(zip(expected, result_before)):
-            self.assertEqual(exp, res, f"Output {i} mismatch before collapse")
-
-        # Build and collapse fusion regions
         region_of = build_fusion_regions(traced)
-        new_region_of = collapse_fusion_regions(traced, region_of)
+        estimate_fused_node_costs(region_of)
 
-        # Run traced module after collapse (with call_module nodes)
-        traced.recompile()
-        result_after_collapse = traced(a, b)
-        for i, (exp, res) in enumerate(zip(expected, result_after_collapse)):
-            self.assertEqual(exp, res, f"Output {i} mismatch after collapse")
-
-        # Expand (inline) the fusion regions back
-        expand_fusion_regions(traced, new_region_of)
-
-        # Run traced module after expand
-        traced.recompile()
-        result_after_expand = traced(a, b)
-        for i, (exp, res) in enumerate(zip(expected, result_after_expand)):
-            self.assertEqual(exp, res, f"Output {i} mismatch after expand")
-
-        # Verify graph string is identical after round-trip
-        # Note: Multi-output regions may add getitem nodes, so we run DCE first
-        traced.graph.eliminate_dead_code()
-        traced.recompile()
         graph_str_after = traced.print_readable(print_output=False)
         self.assertEqual(
             graph_str_before,
             graph_str_after,
-            "Graph string should be identical after collapse/expand round-trip",
+            "Graph must not be mutated by estimate_fused_node_costs",
         )
+
+    def test_fused_costs_handles_forced_bad_region(self):
+        """estimate_fused_node_costs works for any region_of mapping."""
+        from torch._inductor.fx_passes.fusion_regions import estimate_fused_node_costs
+
+        with FakeTensorMode():
+            t = torch.randn(64, 64, device=self.device)
+
+            def fn(x):
+                a = x.neg()
+                b = a.relu()
+                mm_out = torch.mm(b, x)
+                v = mm_out.view(64, 64)
+                c = v.neg()
+                d = c.abs()
+                return b + d
+
+            traced = make_fx(fn)(t)
+
+        fusible_nodes = [
+            n
+            for n in traced.graph.nodes
+            if n.op == "call_function"
+            and n.target
+            in (
+                aten.neg.default,
+                aten.relu.default,
+                aten.abs.default,
+            )
+        ]
+
+        self.assertGreaterEqual(len(fusible_nodes), 4)
+        from torch.utils._ordered_set import OrderedSet
+
+        bad_group = OrderedSet(fusible_nodes)
+        region_of = dict.fromkeys(fusible_nodes, bad_group)
+
+        costs = estimate_fused_node_costs(region_of)
+        self.assertEqual(len(costs), len(fusible_nodes))
+        self.assertTrue(all(c >= 0.0 for c in costs.values()))
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1236,9 +1236,9 @@ class aten_distributed_optimizations:
     bucket_only_internode_comms: bool = False
 
     # Enable fusion region detection for overlap scheduling cost estimation.
-    # When enabled, groups of fusible ops (pointwise, reduction, etc.) are treated
-    # as atomic units with memory-bound runtime estimates.
-    enable_fusion_regions: bool | None = None
+    # When enabled, groups of fusible ops (pointwise, reduction, etc.) have their
+    # I/O costs corrected to exclude intermediates that inductor will not materialize.
+    enable_fusion_regions: bool = True
 
     # Post-scheduling foreach_mm: after overlap scheduling, unwrap
     # control_deps(mm) that don't depend on collectives, then batch

--- a/torch/_inductor/fx_passes/fusion_regions.py
+++ b/torch/_inductor/fx_passes/fusion_regions.py
@@ -1,50 +1,8 @@
 """Detect fusion regions for overlap scheduling."""
 
-import operator
-from dataclasses import dataclass, field
-
 import torch
 import torch.fx as fx
-from torch._logging import trace_structured
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._runtime_estimation import get_num_bytes
-
-
-@dataclass
-class FusionRegion:
-    """Represents a connected set of fusible operations that will fuse together."""
-
-    subgraph_node: fx.Node  # The call_module node for this fusion
-    subgraph_module: fx.GraphModule  # The subgraph module
-    total_bytes: int = field(default=0, init=False)  # Total input + output bytes
-    cost_ms: float = field(default=0.0, init=False)  # Estimated cost in milliseconds
-
-    def __post_init__(self) -> None:
-        """Compute cost based on subgraph's placeholder inputs and output node."""
-        self.total_bytes, self.cost_ms = self._compute_cost()
-
-    def _compute_cost(self) -> tuple[int, float]:
-        from torch.utils._pytree import tree_flatten
-        from torch.utils._runtime_estimation import get_transfer_time
-
-        subgraph = self.subgraph_module
-        input_vals = [
-            n.meta.get("val") for n in subgraph.graph.find_nodes(op="placeholder")
-        ]
-        output_vals = [
-            n.meta.get("val")
-            for n in torch._inductor.utils.output_node(subgraph).all_input_nodes
-        ]
-        flat_inputs, _ = tree_flatten(input_vals)
-        flat_outputs, _ = tree_flatten(output_vals)
-
-        transfer_time_ns = get_transfer_time(flat_inputs, flat_outputs)
-        total_bytes = sum(
-            get_num_bytes(t)
-            for t in flat_inputs + flat_outputs
-            if isinstance(t, torch.Tensor)
-        )
-        return total_bytes, transfer_time_ns / 1e6
 
 
 def is_view_node(n: fx.Node) -> bool:
@@ -208,133 +166,52 @@ def build_fusion_regions(
     return region_of
 
 
-def collapse_fusion_regions(
-    gm: fx.GraphModule,
+def estimate_fused_node_costs(
     region_of: dict[fx.Node, OrderedSet[fx.Node]],
-) -> dict[fx.Node, FusionRegion]:
-    """
-    Collapse fusion regions into call_module nodes using fuse_by_partitions.
-    Returns new_region_of mapping module nodes to FusionRegions.
-    """
-    from torch.fx.passes.utils.fuser_utils import fuse_by_partitions
+) -> dict[fx.Node, float]:
+    """Estimate per-node costs accounting for fusion (no graph collapse).
 
-    if not region_of:
-        return {}
+    For each node in a fusion region, only count I/O that crosses the
+    region boundary (external reads/writes). Internal intermediates
+    won't be materialized by inductor, so they shouldn't count.
 
-    # Get unique node sets (regions with <2 nodes already filtered in build_fusion_regions)
-    unique_regions: list[tuple[OrderedSet[fx.Node], int]] = []
-    seen_region_ids: OrderedSet[int] = OrderedSet()
+    Nodes with only internal I/O get cost 0. Nodes with external I/O
+    get the bandwidth cost of just those external tensors.
+    """
+    from torch.utils._pytree import tree_flatten
+    from torch.utils._runtime_estimation import get_transfer_time
+
+    costs: dict[fx.Node, float] = {}
+    seen: OrderedSet[int] = OrderedSet()
+
     for node_set in region_of.values():
-        region_id = id(node_set)
-        if region_id not in seen_region_ids:
-            seen_region_ids.add(region_id)
-            unique_regions.append((node_set, region_id))
-
-    if not unique_regions:
-        return {}
-
-    # Log graph before fusion
-    trace_structured(
-        "artifact",
-        metadata_fn=lambda: {
-            "name": "fusion_regions_before",
-            "encoding": "string",
-        },
-        payload_fn=lambda: gm.print_readable(print_output=False),
-    )
-
-    # Build partitions list for fuse_by_partitions
-    partitions = [dict.fromkeys(nodes) for nodes, _ in unique_regions]
-
-    # Fuse all partitions at once
-    fuse_by_partitions(gm, partitions, prefix="_fusion_region_")
-
-    # Log graph after fusion
-    trace_structured(
-        "artifact",
-        metadata_fn=lambda: {
-            "name": "fusion_regions_after",
-            "encoding": "string",
-        },
-        payload_fn=lambda: gm.print_readable(print_output=False),
-    )
-
-    # Build new_region_of by finding the call_module nodes
-    new_region_of: dict[fx.Node, FusionRegion] = {}
-
-    for region_idx in range(len(unique_regions)):
-        subgraph_name = f"_fusion_region_{region_idx}"
-
-        # Find the call_module node
-        module_nodes = list(gm.graph.find_nodes(op="call_module", target=subgraph_name))
-        assert len(module_nodes) == 1, (
-            f"Expected 1 call_module for {subgraph_name}, got {len(module_nodes)}"
-        )
-        module_node = module_nodes[0]
-
-        subgraph_module = getattr(gm, subgraph_name)
-
-        # Create FusionRegion with all required info
-        region = FusionRegion(
-            subgraph_node=module_node,
-            subgraph_module=subgraph_module,
-        )
-
-        new_region_of[module_node] = region
-
-    return new_region_of
-
-
-def expand_fusion_regions(
-    gm: fx.GraphModule,
-    region_of: dict[fx.Node, FusionRegion],
-) -> dict[fx.Node, fx.Node | None]:
-    """
-    Expand call_module nodes back to their original nodes using _inline_module.
-
-    Returns a mapping from erased module nodes to their replacement (last inlined node).
-    This is used with transfer_erased_node_deps to update dependencies.
-    """
-    from torch.fx.experimental.const_fold import _inline_module
-
-    result: dict[fx.Node, fx.Node | None] = {}
-
-    if not region_of:
-        return result
-
-    for module_node, region in list(region_of.items()):
-        if module_node.op != "call_module":
+        rid = id(node_set)
+        if rid in seen:
             continue
+        seen.add(rid)
 
-        subgraph_name = module_node.target
-        assert isinstance(subgraph_name, str)
-        assert hasattr(gm, subgraph_name), (
-            f"Expected submodule {subgraph_name} to exist"
-        )
+        for n in node_set:
+            # External inputs: values from nodes outside this region
+            ext_inputs = []
+            for inp in n.all_input_nodes:
+                if inp not in node_set:
+                    val = inp.meta.get("val")
+                    if val is not None:
+                        ext_inputs.append(val)
 
-        # Users of module_node are get_items that will be removed from the graph
-        for user in module_node.users:
-            if user.op == "call_function" and user.target == operator.getitem:
-                result[user] = None
+            # External outputs: this node's value is used outside the region
+            ext_outputs = []
+            has_external_user = any(u not in node_set for u in n.users)
+            if has_external_user:
+                val = n.meta.get("val")
+                if val is not None:
+                    ext_outputs.append(val)
 
-        # Get the output arg from the subgraph to determine what will replace module_node
-        output_arg = torch._inductor.utils.output_node(region.subgraph_module).args[0]
+            if not ext_inputs and not ext_outputs:
+                costs[n] = 0.0
+            else:
+                flat_in, _ = tree_flatten(ext_inputs)
+                flat_out, _ = tree_flatten(ext_outputs)
+                costs[n] = get_transfer_time(flat_in, flat_out) / 1e6
 
-        # Inline the module and get the mapping from subgraph nodes to new nodes.
-        # Skip DCE since the graph may not be in a topo ordered state
-        subgraph_to_new = _inline_module(gm, subgraph_name, run_dce=False)
-
-        # Map module_node to the replacement for the output arg
-        # For multi-output (tuple), use the last element (latest in topo order)
-        # so dependencies are only satisfied after all outputs are computed
-        if isinstance(output_arg, (list, tuple)):
-            if output_arg:
-                last_arg = output_arg[-1]
-                assert isinstance(last_arg, fx.Node)
-                result[module_node] = subgraph_to_new[last_arg]
-        elif isinstance(output_arg, fx.Node) and output_arg in subgraph_to_new:
-            result[module_node] = subgraph_to_new[output_arg]
-
-        delattr(gm, subgraph_name)
-
-    return result
+    return costs

--- a/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
+++ b/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
@@ -143,7 +143,6 @@ class OverlapPreservingBucketer:
         collective_bucketing: bool = True,
         bucket_mode: BucketMode | None = None,
         bucket_exposed_first: bool | None = None,
-        region_of: dict[fx.Node, Any] | None = None,
         bucket_only_internode_comms: bool = False,
     ):
         self.graph = graph
@@ -157,7 +156,6 @@ class OverlapPreservingBucketer:
         self.bucket_only_internode_comms = bucket_only_internode_comms
         self.bucket_mode = bucket_mode or _default_bucket_mode()
         self.collective_bucketing = collective_bucketing
-        self.region_of: dict[fx.Node, Any] = region_of or {}
         self.node_to_event: dict[fx.Node, PGEvent] = {}
         self.all_hiding_nodes: OrderedSet[fx.Node] = OrderedSet()
 
@@ -374,37 +372,13 @@ class OverlapPreservingBucketer:
                 preserve_node_ordering(self.graph, filtered_deps)
 
     def bucket_collectives(self) -> None:
-        """Run the full bucketing and dep application flow.
-
-        Order is important:
-        1. Bucketing - merge collectives into buckets
-        2. Inline fusions - expand call_module back to original nodes
-        3. Transfer deps - move deps from erased nodes to their replacements
-        4. Add control deps - apply effect tokens and topo sort
-
-        Steps 2-3 MUST happen before step 4, because control deps need to
-        reference the final inlined nodes, not the erased fusion modules.
-        """
+        """Run the full bucketing and dep application flow."""
         # Step 1: Bucket collectives
         all_buckets: list[CollBucket] | None = None
         if self.collective_bucketing:
             all_buckets = self._bucket_collectives_impl()
 
-        # Step 2: Inline fusion regions (expand call_module -> original nodes)
-        replaced: dict[fx.Node, fx.Node | None] = {}
-        if self.region_of:
-            from torch._inductor.fx_passes.fusion_regions import expand_fusion_regions
-
-            gm = self.graph.owning_module
-            if gm is None:
-                raise AssertionError("graph.owning_module must not be None")
-            replaced = expand_fusion_regions(gm, self.region_of)
-
-        # Step 3: Transfer deps from erased fusion modules to inlined nodes
-        if replaced:
-            self.aug_graph.transfer_erased_node_deps(replaced)
-
-        # Step 4: Add control deps (MUST be after inline + transfer)
+        # Step 2: Add control deps
         self._apply_deps_and_effect_tokens()
         self.graph.lint()
 
@@ -1079,19 +1053,16 @@ def finalize_overlap_scheduling(
     insert_overlap_deps: bool = False,
     max_bucket_memory_gb: float = 2.0,
     max_coll_distance: int = 1000,
-    region_of: dict[fx.Node, Any] | None = None,
     bucket_exposed_first: bool | None = None,
     bucket_only_internode_comms: bool = False,
     bucket_mode: BucketMode | None = None,
 ) -> None:
     """
-    Finalize overlap scheduling by applying deps, inlining fusions, and optionally bucketing.
+    Finalize overlap scheduling by applying deps and optionally bucketing.
 
     This is the main entry point for post-scheduling graph transformations:
     1. Bucket collectives (if collective_bucketing=True)
-    2. Inline fusion regions back to original nodes
-    3. Transfer deps from erased nodes to replacements
-    4. Apply topological sort and effect tokens
+    2. Apply topological sort and effect tokens
 
     Args:
         gm: The graph module to modify
@@ -1101,7 +1072,6 @@ def finalize_overlap_scheduling(
         insert_overlap_deps: Whether to insert effect tokens for overlap deps
         max_bucket_memory_gb: Maximum memory for a bucket in GB
         max_coll_distance: Maximum distance for bucketing candidates
-        region_of: Optional dict mapping module nodes to FusionRegions
     """
     bucketer = OverlapPreservingBucketer(
         graph=gm.graph,
@@ -1113,7 +1083,6 @@ def finalize_overlap_scheduling(
         collective_bucketing=collective_bucketing,
         bucket_exposed_first=bucket_exposed_first,
         bucket_only_internode_comms=bucket_only_internode_comms,
-        region_of=region_of,
         bucket_mode=bucket_mode,
     )
     bucketer.bucket_collectives()

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -469,19 +469,15 @@ class OverlapScheduler:
                 num_device_put_converted,
             )
 
-        # Build fusion regions (mutates gm.graph) and compute initial node runtime
-        # estimates. Compute nodes use roofline model here; the alignment step in
-        # run() replaces them with benchmarked + cross-rank-aligned values.
-        self.node_estimations, self.region_of = gather_node_runtime_estimations(
+        # Compute initial node runtime estimates. Compute nodes use roofline model
+        # here; the alignment step in run() replaces them with benchmarked +
+        # cross-rank-aligned values.
+        self.node_estimations = gather_node_runtime_estimations(
             gm,
             custom_runtime_estimation,
             enable_fusion_regions=enable_fusion_regions,
             log_estimations=True,
         )
-        if self.region_of:
-            # fuse_by_partitions replaces gm.graph, so we need to update our reference
-            self.graph = gm.graph
-
         # Build structures
         stable_topological_sort(self.graph)
         self.nodes = list(self.graph.nodes)
@@ -1027,7 +1023,7 @@ class OverlapScheduler:
 
         self._reorder_graph()
 
-        # Finalize: bucket collectives (if enabled), inline fusions, apply deps
+        # Finalize: bucket collectives (if enabled), apply deps
         from torch._inductor.fx_passes.overlap_preserving_bucketer import (
             finalize_overlap_scheduling,
         )
@@ -1040,7 +1036,6 @@ class OverlapScheduler:
             insert_overlap_deps=self.insert_overlap_deps,
             max_bucket_memory_gb=2.0,
             max_coll_distance=self.max_node_distance,
-            region_of=self.region_of,
             bucket_exposed_first=self.bucket_exposed_first,
             bucket_only_internode_comms=self.bucket_only_internode_comms,
             bucket_mode=self.bucket_mode,
@@ -1101,6 +1096,9 @@ class OverlapScheduler:
         # using these nodes for overlap prevents bucketing. potentially if chain time < latency
         if runtime_estimate is None:
             assert not is_compute_node(node), "should have estimate for compute nodes"
+            self._schedule(node)
+            return
+        if runtime_estimate == 0 and not is_compute_node(node):
             self._schedule(node)
             return
 
@@ -1632,16 +1630,16 @@ def gather_node_runtime_estimations(
     collective_estimator: Literal["analytical", "benchmark"] = "analytical",
     enable_fusion_regions: bool = False,
     log_estimations: bool = False,
-) -> tuple[dict[fx.Node, float], dict[fx.Node, Any]]:
+) -> dict[fx.Node, float]:
     """Gather initial runtime estimations for all nodes without scheduling.
 
-    Uses analytical models (roofline) for compute nodes — the alignment step
+    Uses analytical models (roofline) for compute nodes -- the alignment step
     in OverlapScheduler.run() replaces these with benchmarked + cross-rank-aligned
     values. Collectives use bandwidth formulas or CUDA events depending on
     collective_estimator.
 
-    When enable_fusion_regions is True, builds and collapses fusion regions
-    (mutating gm's graph), then includes their costs in the estimations.
+    When enable_fusion_regions is True, builds fusion regions and corrects
+    per-node I/O costs to account for fusion (no graph mutation).
 
     Args:
         collective_estimator: "analytical" uses bandwidth formulas,
@@ -1649,21 +1647,18 @@ def gather_node_runtime_estimations(
         log_estimations: When True, log compute and collective estimations
             via trace_structured for tlparse.
 
-    Returns (estimations, fusion_region_of) where estimations maps fx.Node to
-    runtime in ms, and fusion_region_of maps call_module nodes to FusionRegion
-    objects (empty dict if fusion regions are disabled).
+    Returns estimations mapping fx.Node to runtime in ms.
     """
-    # Build and collapse fusion regions first (mutates gm)
-    fusion_region_of: dict[fx.Node, Any] = {}
+    fused_costs: dict[fx.Node, float] = {}
     if enable_fusion_regions:
         from torch._inductor.fx_passes.fusion_regions import (
             build_fusion_regions,
-            collapse_fusion_regions,
+            estimate_fused_node_costs,
         )
 
-        fusion_region_of = build_fusion_regions(gm)
-        if fusion_region_of:
-            fusion_region_of = collapse_fusion_regions(gm, fusion_region_of)
+        raw_regions = build_fusion_regions(gm)
+        if raw_regions:
+            fused_costs = estimate_fused_node_costs(raw_regions)
 
     estimations: dict[fx.Node, float] = {}
     nodes = list(gm.graph.nodes)
@@ -1708,9 +1703,8 @@ def gather_node_runtime_estimations(
                 if est > 0:
                     estimations[node] = est
 
-    # Fusion region costs (call_module nodes from collapse_fusion_regions)
-    for node, region in fusion_region_of.items():
-        estimations[node] = region.cost_ms  # pyrefly: ignore[missing-attribute]
+    # Apply fused costs: replace individual I/O estimates with fusion-aware ones
+    estimations.update(fused_costs)
 
     # Logging
     if log_estimations and compute_nodes:
@@ -1738,7 +1732,7 @@ def gather_node_runtime_estimations(
             artifact_name="fx_collectives_analytical_estimation",
         )
 
-    return estimations, fusion_region_of
+    return estimations
 
 
 def align_estimations_across_ranks(

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -382,16 +382,12 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         )
 
         overlap_deps = config.aten_distributed_optimizations.insert_overlap_deps
-        fusion_regions = config.aten_distributed_optimizations.enable_fusion_regions
 
-        # by default, insert overlap deps and enable fusion regions within inductor
+        # by default, insert overlap deps within inductor
         with config.patch(
             {
                 "aten_distributed_optimizations.insert_overlap_deps": (
                     True if overlap_deps is None else overlap_deps
-                ),
-                "aten_distributed_optimizations.enable_fusion_regions": (
-                    True if fusion_regions is None else fusion_regions
                 ),
             }
         ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #183271
* #183270
* #182631

Cherry-picked from fusions.diff on top of foreach_mm commit.
Authored by Claude.