### PR TITLE
[DTensor] Switch test_math_ops and test_matrix_ops to DTensorOpTestBase

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1064,8 +1064,7 @@ class DistMathOpsTest(DTensorOpTestBase):
     def test_cumsum(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
-        torch.manual_seed(42)
-        inp = torch.rand(3, 5, device=self.device_type)
+        inp = torch.arange(15, dtype=torch.float, device=self.device_type).reshape(3, 5)
 
         shard_dim = 0
         input_dtensor = distribute_tensor(
@@ -1093,8 +1092,7 @@ class DistMathOpsTest(DTensorOpTestBase):
     def test_scan_ops(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
-        torch.manual_seed(42)
-        inp = torch.rand(3, 5, device=self.device_type)
+        inp = torch.arange(1, 16, dtype=torch.float, device=self.device_type).reshape(3, 5)
 
         shard_dim = 0
         input_dtensor = distribute_tensor(
@@ -1116,8 +1114,7 @@ class DistMathOpsTest(DTensorOpTestBase):
     def test_scan_ops_with_indices(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
-        torch.manual_seed(42)
-        inp = torch.rand(12, 8, device=self.device_type)
+        inp = torch.arange(96, dtype=torch.float, device=self.device_type).reshape(12, 8)
 
         shard_dim = 0
         input_dtensor = distribute_tensor(
@@ -1281,8 +1278,7 @@ class DistMathOpsTest(DTensorOpTestBase):
     def test_logsumexp(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
-        torch.manual_seed(42)
-        inp = torch.rand(3, 5, device=self.device_type)
+        inp = torch.arange(15, dtype=torch.float, device=self.device_type).reshape(3, 5)
 
         shard_dim = 0
         input_dtensor = distribute_tensor(

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -30,7 +30,8 @@ from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import run_tests, skipIfRocm
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
-    DTensorTestBase,
+    DTensorOpTestBase,
+    LocalDTensorOpTestBase,
     map_local_for_rank,
     skip_unless_torch_gpu,
     with_comms,
@@ -40,7 +41,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 funcol = torch.ops.c10d_functional
 
 
-class DistMathOpsTest(DTensorTestBase):
+class DistMathOpsTest(DTensorOpTestBase):
     def _check_module(self, m1, m2, check_grad=False):
         named_parameters = dict(m1.named_parameters())
         for name, param_m2 in m2.named_parameters():
@@ -1063,6 +1064,7 @@ class DistMathOpsTest(DTensorTestBase):
     def test_cumsum(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
+        torch.manual_seed(42)
         inp = torch.rand(3, 5, device=self.device_type)
 
         shard_dim = 0
@@ -1091,6 +1093,7 @@ class DistMathOpsTest(DTensorTestBase):
     def test_scan_ops(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
+        torch.manual_seed(42)
         inp = torch.rand(3, 5, device=self.device_type)
 
         shard_dim = 0
@@ -1113,6 +1116,7 @@ class DistMathOpsTest(DTensorTestBase):
     def test_scan_ops_with_indices(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
+        torch.manual_seed(42)
         inp = torch.rand(12, 8, device=self.device_type)
 
         shard_dim = 0
@@ -1277,6 +1281,7 @@ class DistMathOpsTest(DTensorTestBase):
     def test_logsumexp(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
+        torch.manual_seed(42)
         inp = torch.rand(3, 5, device=self.device_type)
 
         shard_dim = 0
@@ -1830,7 +1835,7 @@ class DistMathOpsTest(DTensorTestBase):
 
 
 DistMathOpsTestWithLocalTensor = create_local_tensor_test_class(
-    DistMathOpsTest,
+    DistMathOpsTest, base_class=LocalDTensorOpTestBase
 )
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1092,7 +1092,9 @@ class DistMathOpsTest(DTensorOpTestBase):
     def test_scan_ops(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
-        inp = torch.arange(1, 16, dtype=torch.float, device=self.device_type).reshape(3, 5)
+        inp = torch.arange(
+            1, 16, dtype=torch.float, device=self.device_type
+        ).reshape(3, 5)
 
         shard_dim = 0
         input_dtensor = distribute_tensor(
@@ -1114,7 +1116,9 @@ class DistMathOpsTest(DTensorOpTestBase):
     def test_scan_ops_with_indices(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
-        inp = torch.arange(96, dtype=torch.float, device=self.device_type).reshape(12, 8)
+        inp = torch.arange(
+            96, dtype=torch.float, device=self.device_type
+        ).reshape(12, 8)
 
         shard_dim = 0
         input_dtensor = distribute_tensor(

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1153,7 +1153,11 @@ class DistMathOpsTest(DTensorOpTestBase):
     @with_comms
     def test_dim_reductions_with_indices(self):
         device_mesh = self.build_device_mesh()
-        tensor = torch.randn(12, 8, device=self.device_type)
+        # Use a deterministic tensor so all threads see the same data
+        # (torch.randn gives independent values per thread under MultiThreadedTestCase).
+        tensor = torch.arange(
+            96, dtype=torch.float, device=self.device_type
+        ).reshape(12, 8)
         shard_dim = 0
         dtensor = distribute_tensor(tensor, device_mesh, [Shard(shard_dim)])
 

--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -38,7 +38,8 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
-    DTensorTestBase,
+    DTensorOpTestBase,
+    LocalDTensorOpTestBase,
     skip_unless_torch_gpu,
     with_comms,
 )
@@ -61,7 +62,7 @@ def scale_for_fp8(
     return t_fp8.flatten(end_dim=1).flatten(start_dim=-2), scale.view(scale_shape)
 
 
-class DistMatrixOpsTest(DTensorTestBase):
+class DistMatrixOpsTest(DTensorOpTestBase):
     @with_comms
     def test_addmm(self):
         """
@@ -1136,7 +1137,7 @@ class DistMatrixOpsTest(DTensorTestBase):
 instantiate_parametrized_tests(DistMatrixOpsTest)
 
 DistMatrixOpsTestWithLocalTensor = create_local_tensor_test_class(
-    DistMatrixOpsTest,
+    DistMatrixOpsTest, base_class=LocalDTensorOpTestBase
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Converts `DistMathOpsTest` and `DistMatrixOpsTest` from `DTensorTestBase` (`MultiProcessTestCase`) to `DTensorOpTestBase` (`MultiThreadedTestCase`), following the pattern established in `test_pointwise_ops.py`.

- `test/distributed/tensor/test_math_ops.py`: `DistMathOpsTest` → `DTensorOpTestBase`
- `test/distributed/tensor/test_matrix_ops.py`: `DistMatrixOpsTest` → `DTensorOpTestBase`
- Both `create_local_tensor_test_class` calls updated to use `LocalDTensorOpTestBase`

The `self.rank` usages in `test_math_ops.py` (used with `map_local_for_rank`) are compatible with `MultiThreadedTestCase` since it sets `self.rank` per thread.

This is part of #108744. See also #183269 for `test_embedding_ops.py`.