### PR TITLE
[BE] Fix B018 useless-expression violations in package_importer and _pattern_matcher

### DIFF
--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -484,10 +484,7 @@ class PackageImporter(Importer):
                 return self.modules[name]
             parent_module = self.modules[parent]
 
-            try:
-                parent_module.__path__  # type: ignore[attr-defined]
-
-            except AttributeError:
+            if not hasattr(parent_module, "__path__"):
                 # when we attempt to import a package only containing pybinded files,
                 # the parent directory isn't always a package as defined by python,
                 # so we search if the package is actually there or not before calling the error.

--- a/torch/profiler/_pattern_matcher.py
+++ b/torch/profiler/_pattern_matcher.py
@@ -428,7 +428,7 @@ class SynchronizedDataLoaderPattern(Pattern):
         # actually point to an already freed string when the even is a PyCall.
         # Just silently skip this to unblock testing.
         try:
-            event.name
+            _ = event.name
         except UnicodeDecodeError:
             return False
 


### PR DESCRIPTION
## Summary

Fixes two ruff B018 (`useless-expression`) violations. Part of #106571.

**`torch/package/package_importer.py`**: replace `try: parent_module.__path__ except AttributeError` with `if not hasattr(parent_module, "__path__")` — semantically identical, idiomatic Python.

**`torch/profiler/_pattern_matcher.py`**: assign `_ = event.name` so the expression is not useless; the `try/except UnicodeDecodeError` guard is intentional per the existing comment.

## Test plan
- `python -m ruff check --select=B018 torch/package/package_importer.py torch/profiler/_pattern_matcher.py` — passes clean
- No behavior change in either file