### PR TITLE
[amp] Add __all__ to torch.amp

### DIFF
--- a/torch/amp/__init__.py
+++ b/torch/amp/__init__.py
@@ -8,6 +8,7 @@ from .autocast_mode import (
 )
 from .grad_scaler import GradScaler
 
+
 __all__ = [
     "autocast",
     "custom_bwd",

--- a/torch/amp/__init__.py
+++ b/torch/amp/__init__.py
@@ -7,3 +7,11 @@ from .autocast_mode import (
     is_autocast_available,
 )
 from .grad_scaler import GradScaler
+
+__all__ = [
+    "autocast",
+    "custom_bwd",
+    "custom_fwd",
+    "is_autocast_available",
+    "GradScaler",
+]


### PR DESCRIPTION
## Summary

Adds an explicit `__all__` to `torch/amp/__init__.py`. Without it, static type checkers (Pylance, Pyright) flag exports like `GradScaler` and `autocast` as unconfirmed re-exports.

Follows the same pattern as `torch/cuda/amp/__init__.py`. Private names `_enter_autocast` and `_exit_autocast` are intentionally excluded from `__all__`.

Fixes #181654

## Test plan
- [ ] `python -c "import torch.amp; print(torch.amp.__all__)"` outputs the expected list
- [ ] No regressions in existing amp tests

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5