### PR TITLE
[MPS] enable gqa in sdpa metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -59,11 +59,11 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
   auto key = key_;
   auto value = value_;
   if (key_.size(1) != query.size(1)) {
-    int64_t q_heads = query.size(1);
-    int64_t k_heads = key_.size(1);
+    auto q_heads = query.size(1);
+    auto k_heads = key_.size(1);
     TORCH_CHECK(
         q_heads % k_heads == 0, "For GQA, q_heads (", q_heads, ") must be divisible by k_heads (", k_heads, ")");
-    int64_t repeat_factor = q_heads / k_heads;
+    auto repeat_factor = q_heads / k_heads;
     key = key_.repeat_interleave(repeat_factor, /*dim=*/-3);
     value = value_.repeat_interleave(repeat_factor, /*dim=*/-3);
   }

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -41,8 +41,8 @@ static inline std::tuple<Tensor, bool> ensure_4d(const Tensor& x) {
 
 // general version
 static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
-                                                   const Tensor& key,
-                                                   const Tensor& value,
+                                                   const Tensor& key_,
+                                                   const Tensor& value_,
                                                    const std::optional<Tensor>& attn_mask,
                                                    double dropout_p,
                                                    bool is_causal,
@@ -54,6 +54,19 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
   // MPSGraph fallback path doesn't combine causal + attn_mask correctly
   TORCH_CHECK(!(is_causal && attn_mask.has_value()),
               "_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True");
+
+  // MPSGraph matmul requires matched head counts, broadcast K/V here for GQA
+  auto key = key_;
+  auto value = value_;
+  if (key_.size(1) != query.size(1)) {
+    int64_t q_heads = query.size(1);
+    int64_t k_heads = key_.size(1);
+    TORCH_CHECK(
+        q_heads % k_heads == 0, "For GQA, q_heads (", q_heads, ") must be divisible by k_heads (", k_heads, ")");
+    int64_t repeat_factor = q_heads / k_heads;
+    key = key_.repeat_interleave(repeat_factor, /*dim=*/-3);
+    value = value_.repeat_interleave(repeat_factor, /*dim=*/-3);
+  }
   struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* qTensor = nil;
@@ -197,6 +210,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
   uint maxSeqLength = k_.size(2);
   uint N = k_.size(2);
   uint B = q_.size(0) * q_.size(1);
+  uint gqa_factor = q_.size(1) / k_.size(1);
   uint q_batch_stride = q_.stride(0);
   uint q_head_stride = q_.stride(1);
   uint q_seq_stride = q_.stride(2);
@@ -227,7 +241,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
                   k_,
                   v_,
                   out,
-                  1,
+                  gqa_factor,
                   N,
                   std::array<uint32_t, 3>{q_head_stride, k_head_stride, v_head_stride},
                   std::array<uint32_t, 3>{q_seq_stride, k_seq_stride, v_seq_stride},
@@ -675,30 +689,26 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
   const auto any_nested = query.is_nested() || key_.is_nested() || value_.is_nested();
   const auto all_contiguous =
       query.is_contiguous_or_false() && key_.is_contiguous_or_false() && value_.is_contiguous_or_false();
-  auto key = key_;
-  auto value = value_;
+  // The kernel paths (vector fast / 2pass / prefill) all broadcast K/V across
+  // GQA groups internally via their gqa_factor parameter, so we leave K/V at
+  // their original [B, H_kv, L, D] shape here. sdpa_general_mps expands K/V
+  // itself when it falls back to MPSGraph matmul.
   if (enable_gqa) {
     int64_t q_heads = query.size(-3);
     int64_t k_heads = key_.size(-3);
-    int64_t repeat_factor = q_heads / k_heads;
-
-    if (repeat_factor > 1) {
-      TORCH_CHECK(q_heads % k_heads == 0,
-                  "For GQA, the query tensor's head dimension (" + std::to_string(q_heads) +
-                      ") must be divisible by the key tensor's head dimension (" + std::to_string(k_heads) + ").");
-      key = key_.repeat_interleave(repeat_factor, /*dim=*/-3);
-      value = value_.repeat_interleave(repeat_factor, /*dim=*/-3);
-    }
+    TORCH_CHECK(q_heads % k_heads == 0,
+                "For GQA, the query tensor's head dimension (" + std::to_string(q_heads) +
+                    ") must be divisible by the key tensor's head dimension (" + std::to_string(k_heads) + ").");
   }
 
   auto query_tuple = ensure_4d(query);
   Tensor q_ = std::get<0>(query_tuple);
   bool unsqueezed = std::get<1>(query_tuple);
 
-  auto key_tuple = ensure_4d(key);
+  auto key_tuple = ensure_4d(key_);
   Tensor k_ = std::get<0>(key_tuple);
 
-  auto value_tuple = ensure_4d(value);
+  auto value_tuple = ensure_4d(value_);
   Tensor v_ = std::get<0>(value_tuple);
 
   std::optional<Tensor> mask_;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10373,9 +10373,13 @@ class TestSDPA(TestCaseMPS):
 
     @parametrize("dtype", [torch.float16, torch.float32])
     @parametrize("is_causal", [True, False])
-    def test_sdpa_enable_gqa(self, dtype, is_causal):
-        q_heads = 32
-        key_heads = 16
+    @parametrize("gqa_factor", [2, 4, 8])
+    def test_sdpa_enable_gqa(self, dtype, is_causal, gqa_factor):
+        # HS=23 keeps the dispatch on the MPSGraph general path (not in the
+        # set of kernel-supported head dims), so this exercises sdpa_general_mps
+        # with KV expansion happening inside the helper
+        key_heads = 4
+        q_heads = key_heads * gqa_factor
         L = 7
         S = 17
         HS = 23
@@ -10497,7 +10501,7 @@ class TestSDPA(TestCaseMPS):
     @parametrize("head_dim", [64, 96, 128, 256])  # supported by the fast kernel
     @parametrize("with_mask", [True, False])
     @parametrize("is_causal", [False, True])
-    @parametrize("gqa_factor", [1, 4])  # 1 = no GQA; >1 exercises kernel-native GQA
+    @parametrize("gqa_factor", [1, 4])
     def test_fast_vector_attention(
         self, dtype: torch.dtype, layout: str, head_dim: int, with_mask: bool, is_causal: bool, gqa_factor: int
     ):
@@ -10517,17 +10521,19 @@ class TestSDPA(TestCaseMPS):
     @parametrize("head_dim", [64, 96, 128, 256])  # supported by the fast kernel
     @parametrize("with_mask", [True, False])
     @parametrize("is_causal", [False, True])
+    @parametrize("gqa_factor", [1, 4])
     def test_fast_vector_attention_2pass(
-        self, dtype: torch.dtype, layout: str, head_dim: int, with_mask: bool, is_causal: bool
+        self, dtype: torch.dtype, layout: str, head_dim: int, with_mask: bool, is_causal: bool, gqa_factor: int
     ):
         if is_causal and with_mask:
             self.skipTest("PyTorch SDPA disallows attn_mask together with is_causal")
         torch.manual_seed(1729)
         batch = 1
-        NH = 32
+        NH_kv = 8
+        NH_q = NH_kv * gqa_factor
         q_len = 8
         s_len = 1024  # large enough to trigger the two–pass path
-        q, k, v = self.generate_qkv(batch, NH, q_len, s_len, head_dim, layout, dtype)
+        q, k, v = self.generate_qkv(batch, NH_q, q_len, s_len, head_dim, layout, dtype, NH_kv=NH_kv)
         self.run_fast_attention_test(q, k, v, with_mask, is_causal=is_causal)
 
     def test_fast_vector_permuted_inputs_regression(self):
@@ -10660,19 +10666,21 @@ class TestSDPA(TestCaseMPS):
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
     @parametrize("head_dim", [32, 64, 72, 80, 96, 128, 256])
     @parametrize("variant", ["plain", "causal", "bool_mask", "float_mask"])
-    def test_prefill_attention_correctness_sweep(self, dtype, head_dim, variant):
+    @parametrize("gqa_factor", [1, 4])
+    def test_prefill_attention_correctness_sweep(self, dtype, head_dim, variant, gqa_factor):
         torch.manual_seed(1729)
-        B, NH, qL, kL = 2, 4, 16, 32
-        q, k, v = self._prefill_qkv(B, NH, NH, qL, kL, head_dim, "contiguous", dtype)
+        B, NH_kv, qL, kL = 2, 4, 16, 32
+        NH_q = NH_kv * gqa_factor
+        q, k, v = self._prefill_qkv(B, NH_q, NH_kv, qL, kL, head_dim, "contiguous", dtype)
         is_causal = False
         attn_mask = None
         if variant == "causal":
             is_causal = True
         elif variant == "bool_mask":
-            attn_mask = torch.ones(B, NH, qL, kL, dtype=torch.bool, device="mps")
+            attn_mask = torch.ones(B, NH_q, qL, kL, dtype=torch.bool, device="mps")
             attn_mask[..., kL // 2:] = False
         elif variant == "float_mask":
-            attn_mask = torch.zeros(B, NH, qL, kL, dtype=dtype, device="mps")
+            attn_mask = torch.zeros(B, NH_q, qL, kL, dtype=dtype, device="mps")
             attn_mask[..., kL // 2:] = -1e4
         self._run_prefill_test(q, k, v, attn_mask=attn_mask, is_causal=is_causal)
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10496,7 +10496,7 @@ class TestSDPA(TestCaseMPS):
             )
         self._compare_tensors(y.cpu(), y_ref)
 
-    @parametrize("dtype", [torch.float16, torch.float32])
+    @parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
     @parametrize("layout", ["contiguous", "mT", "transpose_seq_head", "permute"])
     @parametrize("head_dim", [64, 96, 128, 256])  # supported by the fast kernel
     @parametrize("with_mask", [True, False])

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10414,26 +10414,29 @@ class TestSDPA(TestCaseMPS):
         # 1 kB different maximum allowed value
         torch.testing.assert_close(memory_footprints[-1], memory_footprints[0], atol=1e-3, rtol=1e-3)
 
-    def generate_qkv(self, batch: int, NH: int, q_len: int, s_len: int, head_dim: int, layout: str, dtype: torch.dtype):
+    def generate_qkv(self, batch: int, NH: int, q_len: int, s_len: int, head_dim: int, layout: str,
+                     dtype: torch.dtype, NH_kv: int | None = None):
+        if NH_kv is None:
+            NH_kv = NH
         if layout == "contiguous":
             q = torch.randn(batch, NH, q_len, head_dim, dtype=dtype, device="mps")
-            k = torch.randn(batch, NH, s_len, head_dim, dtype=dtype, device="mps")
+            k = torch.randn(batch, NH_kv, s_len, head_dim, dtype=dtype, device="mps")
         elif layout == "mT":
             # Transpose head dimension and length
             q = torch.randn(batch, NH, head_dim, q_len, dtype=dtype, device="mps").mT
-            k = torch.randn(batch, NH, head_dim, s_len, dtype=dtype, device="mps").mT
+            k = torch.randn(batch, NH_kv, head_dim, s_len, dtype=dtype, device="mps").mT
         elif layout == "transpose_seq_head":
             # Transpose length and number of heads
             q = torch.randn(batch, q_len, NH, head_dim, dtype=dtype, device="mps").transpose(1, 2)
-            k = torch.randn(batch, s_len, NH, head_dim, dtype=dtype, device="mps").transpose(1, 2)
+            k = torch.randn(batch, s_len, NH_kv, head_dim, dtype=dtype, device="mps").transpose(1, 2)
         elif layout == "permute":
             # Permute head dimension and length
             q = torch.randn(batch, head_dim, NH, q_len, dtype=dtype, device="mps").permute(0, 2, 3, 1)
-            k = torch.randn(batch, head_dim, NH, s_len, dtype=dtype, device="mps").permute(0, 2, 3, 1)
+            k = torch.randn(batch, head_dim, NH_kv, s_len, dtype=dtype, device="mps").permute(0, 2, 3, 1)
         else:
             raise ValueError(f"Unknown layout: {layout}")
 
-        v = torch.randn(batch, NH, s_len, head_dim, dtype=dtype, device="mps")
+        v = torch.randn(batch, NH_kv, s_len, head_dim, dtype=dtype, device="mps")
         return q, k, v
 
     def run_fast_attention_test(
@@ -10447,6 +10450,7 @@ class TestSDPA(TestCaseMPS):
     ):
         q_len = q.shape[2]
         s_len = k.shape[2]
+        enable_gqa = q.shape[1] != k.shape[1]
 
         if with_mask:
             attn_mask = torch.zeros(q.shape[0], q.shape[1], q_len, s_len,
@@ -10459,6 +10463,7 @@ class TestSDPA(TestCaseMPS):
                     attn_mask=attn_mask,
                     dropout_p=dropout_p,
                     is_causal=is_causal,
+                    enable_gqa=enable_gqa,
                 )
             y_ref = F.scaled_dot_product_attention(
                 q.cpu(),
@@ -10467,6 +10472,7 @@ class TestSDPA(TestCaseMPS):
                 attn_mask=attn_mask.cpu(),
                 dropout_p=dropout_p,
                 is_causal=is_causal,
+                enable_gqa=enable_gqa,
             )
         else:
             with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
@@ -10474,6 +10480,7 @@ class TestSDPA(TestCaseMPS):
                     q, k, v,
                     dropout_p=dropout_p,
                     is_causal=is_causal,
+                    enable_gqa=enable_gqa,
                 )
             y_ref = F.scaled_dot_product_attention(
                 q.cpu(),
@@ -10481,6 +10488,7 @@ class TestSDPA(TestCaseMPS):
                 v.cpu(),
                 dropout_p=dropout_p,
                 is_causal=is_causal,
+                enable_gqa=enable_gqa,
             )
         self._compare_tensors(y.cpu(), y_ref)
 
@@ -10489,17 +10497,19 @@ class TestSDPA(TestCaseMPS):
     @parametrize("head_dim", [64, 96, 128, 256])  # supported by the fast kernel
     @parametrize("with_mask", [True, False])
     @parametrize("is_causal", [False, True])
+    @parametrize("gqa_factor", [1, 4])  # 1 = no GQA; >1 exercises kernel-native GQA
     def test_fast_vector_attention(
-        self, dtype: torch.dtype, layout: str, head_dim: int, with_mask: bool, is_causal: bool
+        self, dtype: torch.dtype, layout: str, head_dim: int, with_mask: bool, is_causal: bool, gqa_factor: int
     ):
         if is_causal and with_mask:
             self.skipTest("PyTorch SDPA disallows attn_mask together with is_causal")
         torch.manual_seed(1729)
         batch = 1
-        NH = 2
+        NH_kv = 2
+        NH_q = NH_kv * gqa_factor
         q_len = 4  # <8 so that vector fast is eligible
         s_len = 16  # smaller than 1024 so that we use the one–pass variant
-        q, k, v = self.generate_qkv(batch, NH, q_len, s_len, head_dim, layout, dtype)
+        q, k, v = self.generate_qkv(batch, NH_q, q_len, s_len, head_dim, layout, dtype, NH_kv=NH_kv)
         self.run_fast_attention_test(q, k, v, with_mask, is_causal=is_causal)
 
     @parametrize("dtype", [torch.float32])  # float16 underflows sometimes, which leads to flaky tests


### PR DESCRIPTION
Metal kernels already support gqa but we were materializing the KV tensor due to mps graph not supporting strided KV. This fixes it for those kernels while leaving the original implementation for general mps graph path