### PR TITLE
[ROCm][Windows] Fix Windows DLL linkage for c10::cuda stream helper declarations

### DIFF
--- a/c10/cuda/CUDAStream.h
+++ b/c10/cuda/CUDAStream.h
@@ -199,10 +199,10 @@ class C10_CUDA_API CUDAStream {
  * isHighPriority to true, or a stream for a specific device by setting device
  * (defaulting to the current CUDA stream.)
  */
-C10_API CUDAStream
+C10_CUDA_API CUDAStream
 getStreamFromPool(const bool isHighPriority = false, DeviceIndex device = -1);
 // no default priority to disambiguate overloads
-C10_API CUDAStream
+C10_CUDA_API CUDAStream
 getStreamFromPool(const int priority, DeviceIndex device = -1);
 
 /**
@@ -212,7 +212,7 @@ getStreamFromPool(const int priority, DeviceIndex device = -1);
  * want to operate on a non-torch allocated stream for data exchange or similar
  * purposes
  */
-C10_API CUDAStream
+C10_CUDA_API CUDAStream
 getStreamFromExternal(cudaStream_t ext_stream, DeviceIndex device_index);
 
 /**
@@ -221,7 +221,7 @@ getStreamFromExternal(cudaStream_t ext_stream, DeviceIndex device_index);
  * where most computation occurs when you aren't explicitly using
  * streams.
  */
-C10_API CUDAStream getDefaultCUDAStream(DeviceIndex device_index = -1);
+C10_CUDA_API CUDAStream getDefaultCUDAStream(DeviceIndex device_index = -1);
 
 /**
  * Get the current CUDA stream, for the passed CUDA device, or for the
@@ -230,7 +230,7 @@ C10_API CUDAStream getDefaultCUDAStream(DeviceIndex device_index = -1);
  * be different if someone called 'setCurrentCUDAStream' or used 'StreamGuard'
  * or 'CUDAStreamGuard'.
  */
-C10_API CUDAStream getCurrentCUDAStream(DeviceIndex device_index = -1);
+C10_CUDA_API CUDAStream getCurrentCUDAStream(DeviceIndex device_index = -1);
 
 /**
  * Set the current stream on the device of the passed in stream to be
@@ -242,9 +242,9 @@ C10_API CUDAStream getCurrentCUDAStream(DeviceIndex device_index = -1);
  * (which will switch both your current device and current stream in the way you
  * expect, and reset it back to its original state afterwards).
  */
-C10_API void setCurrentCUDAStream(CUDAStream stream);
+C10_CUDA_API void setCurrentCUDAStream(CUDAStream stream);
 
-C10_API std::ostream& operator<<(std::ostream& stream, const CUDAStream& s);
+C10_CUDA_API std::ostream& operator<<(std::ostream& stream, const CUDAStream& s);
 
 } // namespace c10::cuda
 

--- a/c10/cuda/CUDAStream.h
+++ b/c10/cuda/CUDAStream.h
@@ -244,7 +244,9 @@ C10_CUDA_API CUDAStream getCurrentCUDAStream(DeviceIndex device_index = -1);
  */
 C10_CUDA_API void setCurrentCUDAStream(CUDAStream stream);
 
-C10_CUDA_API std::ostream& operator<<(std::ostream& stream, const CUDAStream& s);
+C10_CUDA_API std::ostream& operator<<(
+    std::ostream& stream,
+    const CUDAStream& s);
 
 } // namespace c10::cuda
 


### PR DESCRIPTION
Fix for `-Winconsistent-dllimport` warning on Windows:

```
'c10::cuda::getStreamFromPool' redeclared without 'dllimport' attribute:
'dllexport' attribute added [-Winconsistent-dllimport]
```

(and similarly for `getStreamFromExternal`, `getDefaultCUDAStream`, `getCurrentCUDAStream`, `setCurrentCUDAStream`, `operator<<`).

**Solution:**
The implementations of these helpers live in the CUDA/HIP runtime translation units (e.g. `c10/cuda/CUDAStream.cpp` / `c10/hip/HIPStream.cpp`) and are exported from the `c10_cuda` / `c10_hip` (ROCm) DLL with dllexport. The header previously declared the same symbols with `C10_API`, which ties them to `libc10` on Windows and makes the compiler treat them as `dllimport` from the wrong binary.

This change updates `c10/cuda/CUDAStream.h`: each affected function declaration in namespace `c10::cuda` now uses `C10_CUDA_API` instead of `C10_API`:

- getStreamFromPool (both overloads)
- getStreamFromExternal
- getDefaultCUDAStream
- getCurrentCUDAStream
- setCurrentCUDAStream
- operator<<(std::ostream&, const CUDAStream&)

Aligning the declarations with `C10_CUDA_API` matches the DLL that actually defines these symbols and removes `[-Winconsistent-dllimport]` for those APIs on Windows.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang