### PR TITLE
[ROCm][CD] Bump default ROCm binary-test timeout from 240 to 420 minutes

### DIFF
--- a/.github/workflows/_binary-test-rocm-linux.yml
+++ b/.github/workflows/_binary-test-rocm-linux.yml
@@ -42,7 +42,7 @@ on:
       timeout-minutes:
         required: false
         type: number
-        default: 240
+        default: 420
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary

Aligns the default `timeout-minutes` on `.github/workflows/_binary-test-rocm-linux.yml` with the 420-minute build-side ROCm timeout already set in `linux_binary_build_workflow.yml.j2` (#179596).

Authored with Claude.

## Test plan

- [ ] Confirm ROCm test jobs in nightly use a 420-minute timeout.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang