### PR TITLE
Fix to_dtype_preserve_strides for tensors with zero strides 

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -557,13 +557,28 @@ def check_model(
     actual_flat = pytree.tree_leaves(actual)
 
     def to_dtype_preserve_strides(src, dtype):
-        if any(s == 0 for s in src.stride()):
-            return src.to(dtype)
+        expanded_dims = []
+        src_slice = src
+
+        for dim in reversed(range(src.dim())):
+            if src.size(dim) > 1 and src.stride(dim) == 0:
+                expanded_dims.append(dim)
+                src_slice = src_slice.select(dim, 0)
+
         # Preserve strides when casting.
         result = torch.empty_strided(
-            src.size(), src.stride(), device=src.device, dtype=dtype
+            src_slice.size(),
+            src_slice.stride(),
+            device=src.device,
+            dtype=dtype,
         )
-        result.copy_(src)
+        result.copy_(src_slice)
+
+        for dim in reversed(expanded_dims):
+            result = result.unsqueeze(dim)
+
+        if expanded_dims:
+            return result.expand(src.size())
         return result
 
     def reference_to_expect(actual_flat, correct_flat):


### PR DESCRIPTION
`to_dtype_preserve_strides` does not preserve strides for broadcasted tensors, causing CPU tests computing a reference in float32 to fail when there are broadcast dimensions in the reference tensors:
- test_comprehensive_broadcast_to_cpu_float16 AssertionError: The values for attribute 'stride()' do not match: (1, 0, 0) != (25, 5, 1).
- test_comprehensive_meshgrid_variadic_tensors_cpu_float16 AssertionError: The values for attribute 'stride()' do not match: (1, 0) != (3, 1).

The approach in this PR is to identify the broadcasted slice of a tensor, create a new output using this slice (with the new dtype), and then expand the result to match the original broadcasted tensor.

Testing:

There are existing tests for this: TestTorchInductorOpinfoCPU, however these are currently disabled

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo