### PR TITLE
[AI Codemod][ClaudeCodeFbandroidWarningsAsErrors] [3] Bulk run of CodemodConfigClaudeCodeFbandroidWarningsAsErrors (10 units) (#183306)

### DIFF
--- a/android/pytorch_android/src/main/java/org/pytorch/IValue.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/IValue.java
@@ -315,12 +315,14 @@ public class IValue {
   }
 
   @DoNotStrip
+  @SuppressWarnings("unchecked")
   public Map<String, IValue> toDictStringKey() {
     preconditionType(TYPE_CODE_DICT_STRING_KEY, mTypeCode);
     return (Map<String, IValue>) mData;
   }
 
   @DoNotStrip
+  @SuppressWarnings("unchecked")
   public Map<Long, IValue> toDictLongKey() {
     preconditionType(TYPE_CODE_DICT_LONG_KEY, mTypeCode);
     return (Map<Long, IValue>) mData;

--- a/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
@@ -392,7 +392,7 @@ public abstract class Tensor {
   /** Calculates the number of elements in a tensor with the specified shape. */
   public static long numel(long[] shape) {
     checkShape(shape);
-    int result = 1;
+    long result = 1;
     for (long s : shape) {
       result *= s;
     }


### PR DESCRIPTION
Summary:

This diff enables `warnings_as_errors = True` for the Buck target and fixes any compilation warnings that arise.

Reviewed By: drhill-meta

Differential Revision: D104108992


