### PR TITLE
Fix/signbit cuda half nan

### DIFF
--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -81,8 +81,20 @@ void signbit_kernel_cuda(TensorIteratorBase& iter){
     });
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cuda", [&]() {
-      using opmath_t = at::opmath_type<scalar_t>;
-      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return signbit(opmath_t{a}); });
+      if constexpr (std::is_same_v<scalar_t, at::Half> || std::is_same_v<scalar_t, at::BFloat16>) {
+        // FIX: For half-precision types, extract the sign bit directly from
+        // the raw 16-bit representation instead of promoting to float first.
+        // Promoting to float32 can canonicalize NaN values on CUDA, which
+        // strips the sign bit from negative NaNs (e.g. 0xFE00 becomes the
+        // canonical positive NaN 0x7FC00000).
+        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool {
+          const uint16_t bits = c10::bit_cast<uint16_t>(a);
+          return (bits >> 15) & 1;
+        });
+      } else {
+        using opmath_t = at::opmath_type<scalar_t>;
+        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return signbit(opmath_t{a}); });
+      }
     });
   }
 }

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -1969,6 +1969,35 @@ class TestUnaryUfuncs(TestCase):
         self.assertEqual(got, ref)
 
 
+    @onlyCUDA
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_signbit_negative_nan_half(self, device, dtype):
+        # https://github.com/pytorch/pytorch/issues/181806
+        # CUDA was losing the sign bit of negative NaN during half→float promotion
+        if dtype == torch.float16:
+            neg_nan = torch.from_numpy(
+                np.array([0xFE00, 0xFE00, 0xFE00], dtype=np.uint16).view(np.float16)
+            )
+        else:
+            neg_nan = torch.tensor(float("nan"), dtype=dtype).neg().expand(3).contiguous()
+
+        cpu_result = torch.signbit(neg_nan)
+        cuda_result = torch.signbit(neg_nan.to(device)).cpu()
+        self.assertEqual(cpu_result, cuda_result)
+        self.assertTrue(cuda_result.all())
+
+    @onlyCUDA
+    @dtypes(torch.float16)
+    def test_signbit_positive_nan_half(self, device, dtype):
+        pos_nan = torch.from_numpy(
+            np.array([0x7E00, 0x7E00, 0x7E00], dtype=np.uint16).view(np.float16)
+        )
+        cpu_result = torch.signbit(pos_nan)
+        cuda_result = torch.signbit(pos_nan.to(device)).cpu()
+        self.assertEqual(cpu_result, cuda_result)
+        self.assertFalse(cuda_result.any())
+
+
 instantiate_device_type_tests(TestUnaryUfuncs, globals())
 
 if __name__ == "__main__":

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -1971,31 +1971,46 @@ class TestUnaryUfuncs(TestCase):
 
     @onlyCUDA
     @dtypes(torch.float16, torch.bfloat16)
-    def test_signbit_negative_nan_half(self, device, dtype):
+    def test_signbit_nan_half(self, device, dtype):
         # https://github.com/pytorch/pytorch/issues/181806
         # CUDA was losing the sign bit of negative NaN during half→float promotion
         if dtype == torch.float16:
+            # 0xFE00 = negative NaN in fp16, 0x7E00 = positive NaN in fp16
             neg_nan = torch.from_numpy(
                 np.array([0xFE00, 0xFE00, 0xFE00], dtype=np.uint16).view(np.float16)
             )
+            pos_nan = torch.from_numpy(
+                np.array([0x7E00, 0x7E00, 0x7E00], dtype=np.uint16).view(np.float16)
+            )
         else:
-            neg_nan = torch.tensor(float("nan"), dtype=dtype).neg().expand(3).contiguous()
+            # 0xFFC0 = negative NaN in bf16, 0x7FC0 = positive NaN in bf16
+            neg_bits = torch.tensor([0xFFC0, 0xFFC0, 0xFFC0], dtype=torch.uint16)
+            neg_nan = neg_bits.view(torch.bfloat16)
+            pos_bits = torch.tensor([0x7FC0, 0x7FC0, 0x7FC0], dtype=torch.uint16)
+            pos_nan = pos_bits.view(torch.bfloat16)
 
+        # Negative NaN should have signbit=True
         cpu_result = torch.signbit(neg_nan)
         cuda_result = torch.signbit(neg_nan.to(device)).cpu()
         self.assertEqual(cpu_result, cuda_result)
         self.assertTrue(cuda_result.all())
 
-    @onlyCUDA
-    @dtypes(torch.float16)
-    def test_signbit_positive_nan_half(self, device, dtype):
-        pos_nan = torch.from_numpy(
-            np.array([0x7E00, 0x7E00, 0x7E00], dtype=np.uint16).view(np.float16)
-        )
+        # Positive NaN should have signbit=False
         cpu_result = torch.signbit(pos_nan)
         cuda_result = torch.signbit(pos_nan.to(device)).cpu()
         self.assertEqual(cpu_result, cuda_result)
         self.assertFalse(cuda_result.any())
+
+    @onlyCUDA
+    @dtypes(torch.float16, torch.bfloat16)
+    def test_signbit_half_basic(self, device, dtype):
+        # Regression test: ensure signbit works for normal values, zeros, and infs
+        vals = torch.tensor([-1.0, -0.5, 0.0, 0.5, 1.0, float('inf'), float('-inf')], dtype=dtype)
+        cpu_result = torch.signbit(vals)
+        cuda_result = torch.signbit(vals.to(device)).cpu()
+        self.assertEqual(cpu_result, cuda_result)
+        expected = torch.tensor([True, True, False, False, False, False, True])
+        self.assertEqual(cuda_result, expected)
 
 
 instantiate_device_type_tests(TestUnaryUfuncs, globals())


### PR DESCRIPTION
## Summary

Fixes #181806

`torch.signbit` on CUDA was returning incorrect results for negative
`float16` NaN values. CPU correctly returns `True`, but CUDA was
returning `False`.

The issue was caused by `signbit_kernel_cuda` promoting `Half` and
`BFloat16` values to `float` before calling `signbit()`. During this
conversion, CUDA canonicalizes NaN values and drops the original sign
bit, so negative NaNs become positive NaNs.

This change avoids the float promotion for `Half` and `BFloat16` and
instead reads the sign bit directly from the underlying `uint16_t`
representation. `float` and `double` behavior is unchanged.

## Reproduction

```python
import numpy as np
import torch

src = torch.from_numpy(
    np.array([0xfe00, 0xfe00, 0xfe00], dtype=np.uint16).view(np.float16)
)

cpu = torch.signbit(src)
print(cpu)
# tensor([True, True, True])

cuda = torch.signbit(src.cuda()).cpu()
print(cuda)
# tensor([False, False, False])
```
