### PR TITLE
[CD] Trim build_env_setup.py OS-package install to zip+openssl

### DIFF
--- a/.ci/manywheel/build_env_setup.py
+++ b/.ci/manywheel/build_env_setup.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
 """GPU/toolchain environment setup (runs once before any wheel is built).
 
-When running on a standard manylinux container (no pre-installed GPU
-toolkits), installs CUDA, cuDNN, NCCL, MAGMA, cuSPARSELt, etc. via the
-.ci/docker/common/install_*.sh scripts.
+The manywheel builder image (.ci/docker/manywheel/Dockerfile_2_28) is
+expected to ship the heavy build dependencies (CUDA, cuDNN, NCCL, MAGMA,
+cuSPARSELt, MKL, plus the standard OS package set). This script:
+
+  * Installs the two packages historically added at wheel-build time
+    (zip, openssl) to match the legacy build_common.sh contract.
+  * Falls back to running install_cuda.sh / install_magma.sh if CUDA or
+    MAGMA is missing, so the script remains usable on a lean manylinux
+    base.
+  * Hard-fails if MKL is missing (expected to be baked into the image).
+  * Wires the symlinks/env to target the requested CUDA version.
 
 Build-flag exports (USE_CUDA, TH_BINARY_BUILD, ...) are written to the file
 given by --env-out; the caller (build.sh) sources it so the values reach
@@ -147,53 +155,19 @@ def os_name() -> str:
 
 
 def install_os_packages() -> None:
+    # Everything else the build needs is baked into the manywheel image
+    # (.ci/docker/manywheel/Dockerfile_2_28). Only zip + openssl are not,
+    # matching the legacy build_common.sh contract.
     name = os_name()
     if any(distro in name for distro in ("AlmaLinux", "CentOS", "Red Hat")):
         subprocess.run(
-            [
-                "yum",
-                "install",
-                "-q",
-                "-y",
-                "zip",
-                "openssl",
-                "openssl-devel",
-                "sudo",
-                "wget",
-                "curl",
-                "perl",
-                "util-linux",
-                "xz",
-                "bzip2",
-                "git",
-                "patch",
-                "which",
-                "zlib-devel",
-            ],
+            ["yum", "install", "-q", "-y", "zip", "openssl"],
             check=True,
         )
     elif "Ubuntu" in name:
-        # Disable nvidia apt repos that may 404 on plain Ubuntu images
-        for entry in Path("/etc/apt").rglob("*.list"):
-            text = entry.read_text()
-            new = "\n".join(
-                f"# {line}" if "nvidia" in line else line for line in text.splitlines()
-            )
-            if new != text:
-                entry.write_text(new + ("\n" if text.endswith("\n") else ""))
         subprocess.run(["apt-get", "update", "-qq"], check=True)
         subprocess.run(
-            [
-                "apt-get",
-                "-y",
-                "-qq",
-                "install",
-                "zip",
-                "openssl",
-                "wget",
-                "curl",
-                "git",
-            ],
+            ["apt-get", "-y", "-qq", "install", "zip", "openssl"],
             check=True,
         )
 
@@ -368,12 +342,11 @@ def main() -> None:
 
     ensure_pip_on_path()
 
-    # MKL: x86_64 only; aarch64 uses OpenBLAS/ACL from the builder image.
     if arch == "x86_64" and not Path("/opt/intel/lib").is_dir():
-        print("MKL not found, installing...")
-        subprocess.run(
-            ["bash", str(repo_root() / ".ci/docker/common/install_mkl.sh")],
-            check=True,
+        sys.exit(
+            "MKL not found at /opt/intel/lib. The manywheel builder image is "
+            "expected to ship MKL; rebuild .ci/docker/manywheel/Dockerfile_2_28 "
+            "if it is missing."
         )
 
     if gpu_arch_type in ("cuda", "cuda-aarch64"):


### PR DESCRIPTION
## Summary

Follow-up to #182409, addressing the review observation that the new `build_env_setup.py` duplicated the OS-package list already baked into the manywheel builder image (`.ci/docker/manywheel/Dockerfile_2_28`), with no CI use case for the duplication. The drift risk between the Dockerfile and the Python script and the broadened wheel-build-time supply-chain surface (fresh yum/apt fetches vs. the image's frozen baseline) provide no benefit on the standard CI path.

This PR restores the legacy "trust the image" contract for the OS-package list:

- `install_os_packages` now installs only `zip` + `openssl` on RHEL/Ubuntu (the original `build_common.sh` set). All other yum/apt packages come from `Dockerfile_2_28` at image-build time.
- The nvidia-apt list mangling on Ubuntu is removed (no longer needed once the install set is trimmed).
- The MKL fallback in `main()` becomes a hard exit pointing at the Dockerfile (MKL is expected to be baked into the image).

The CUDA + MAGMA bootstrap path (`install_cuda_toolkit` and the `install_magma.sh` fallback in `setup_cuda`) is kept so the script remains usable on a lean manylinux base when CUDA/MAGMA aren't already staged.

Net diff: 1 file, +20 / -47.

Authored with Claude.

## Test plan

- [ ] Nightly manywheel CUDA / CPU / aarch64 build jobs (Linux) succeed.
- [ ] No regressions from the trimmed OS-package install on Dockerfile_2_28.