### PR TITLE
prefer duck specialization over 0/1 in unbacked meta fallback for gso

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -438,6 +438,47 @@ graph():
         }
         ep = export(MyModel(), inps, dynamic_shapes=spec)
 
+    @torch.fx.experimental._config.patch(backed_size_oblivious=True)
+    def test_view_unify_cross_symbols(self):
+        """
+        Cross-symbol view triggers `Eq(s, 1)` specialization in
+        `_view_unbacked_meta` because `is_contiguous_or_false` returns False
+        on the non-contiguous slice from `cat → split`, and the recursive
+        non-size-oblivious branch uses `eval_eager` to specialize.
+
+        - With `unify_view_symbols_unbacked_meta=False` (default): export
+          fails with ConstraintViolationError ("specialized value of 1").
+        - With `unify_view_symbols_unbacked_meta=True`: `_view_unbacked_meta`
+          discovers the cross-symbol equality automatically, unifies the
+          symbols, and export succeeds without specialization.
+        """
+
+        class M(torch.nn.Module):
+            def forward(self, getattr_1, values_1):
+                wide = torch.cat([values_1] * 9, dim=1)
+                a, _ = torch.split(wide, [33536, 3328], dim=1)
+                x = a.view(getattr_1.size(0), -1, 256)
+                return x.sum() + getattr_1.sum()
+
+        getattr_1 = torch.randn(1, 8)
+        values_1 = torch.randn(1, 4096)
+        B = Dim("B", min=0, max=1024)
+        ds = {"getattr_1": {0: B}, "values_1": {0: B}}
+
+        # Without the flag → must FAIL with ConstraintViolationError.
+        with torch.fx.experimental._config.patch(
+            unify_view_symbols_unbacked_meta=False
+        ):
+            with self.assertRaises(
+                torch._dynamo.exc.UserError,
+            ):
+                export(M(), (getattr_1, values_1), dynamic_shapes=ds, strict=False)
+
+        # With the flag → must SUCCEED.
+        with torch.fx.experimental._config.patch(unify_view_symbols_unbacked_meta=True):
+            ep = export(M(), (getattr_1, values_1), dynamic_shapes=ds, strict=False)
+            self.assertIsNotNone(ep)
+
     def test_export_constraints_error(self):
         class ConflictingConstraints(torch.nn.Module):
             def forward(self, x):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -446,9 +446,9 @@ graph():
         on the non-contiguous slice from `cat → split`, and the recursive
         non-size-oblivious branch uses `eval_eager` to specialize.
 
-        - With `unify_view_symbols_unbacked_meta=False` (default): export
+        - With `unify_view_symbols_bso_meta=False` (default): export
           fails with ConstraintViolationError ("specialized value of 1").
-        - With `unify_view_symbols_unbacked_meta=True`: `_view_unbacked_meta`
+        - With `unify_view_symbols_bso_meta=True`: `_view_unbacked_meta`
           discovers the cross-symbol equality automatically, unifies the
           symbols, and export succeeds without specialization.
         """
@@ -466,16 +466,14 @@ graph():
         ds = {"getattr_1": {0: B}, "values_1": {0: B}}
 
         # Without the flag → must FAIL with ConstraintViolationError.
-        with torch.fx.experimental._config.patch(
-            unify_view_symbols_unbacked_meta=False
-        ):
+        with torch.fx.experimental._config.patch(unify_view_symbols_bso_meta=False):
             with self.assertRaises(
                 torch._dynamo.exc.UserError,
             ):
                 export(M(), (getattr_1, values_1), dynamic_shapes=ds, strict=False)
 
         # With the flag → must SUCCEED.
-        with torch.fx.experimental._config.patch(unify_view_symbols_unbacked_meta=True):
+        with torch.fx.experimental._config.patch(unify_view_symbols_bso_meta=True):
             ep = export(M(), (getattr_1, values_1), dynamic_shapes=ds, strict=False)
             self.assertIsNotNone(ep)
 

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -656,11 +656,96 @@ def _view_has_unbacked_input(
     )
 
 
+def try_duck_specialization_first(a: torch.Tensor, shape) -> bool:
+    """
+    Smarter heuristic: collect candidate (x, y) pairs whose runtime hints
+    match (so they *could* be equal), then test whether substituting them
+    into the view's numel equation makes the equation symbolically zero.
+    Only commit the equalities (adds the real Eq guards via bool(x == y)
+    which triggers set_replacement) if the substitution actually solves
+    the view validity check.
+
+    This avoids polluting the shape env with spurious guards from probing.
+
+    Returns True if at least one equality was committed.
+
+    Conservative: only considers SymInts that appear as a top-level dim of
+    the input or target (skipping the -1 marker), and skips already-equal
+    pairs, and skips unbacked symbols.
+    """
+    import operator
+    from functools import reduce
+
+    from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
+
+    def _atomic_syms(dims) -> list[torch.SymInt]:
+        """Keep only SymInts whose expr is a single bare *backed* symbol."""
+        out: list[torch.SymInt] = []
+        for s in dims:
+            if not isinstance(s, torch.SymInt):
+                continue
+            expr = s.node.expr
+            free = expr.free_symbols
+            if len(free) != 1 or expr not in free:
+                continue
+            if free_unbacked_symbols(expr):
+                continue
+            out.append(s)
+        return out
+
+    import sympy
+
+    a_syms = _atomic_syms(a.size())
+    target_syms = _atomic_syms(shape)
+    if not a_syms or not target_syms:
+        return False
+
+    # 1) Collect candidate equalities: (x, y) pairs whose hints match.
+    #    Build a sympy substitution map.
+    subs: dict[sympy.Expr, sympy.Expr] = {}
+    candidates: list[tuple[torch.SymInt, torch.SymInt]] = []
+    for x in a_syms:
+        for y in target_syms:
+            x_expr = x.node.expr
+            y_expr = y.node.expr
+            if x_expr == y_expr:
+                continue  # already same symbol
+            if x.node.hint != y.node.hint:
+                continue  # hints disagree, not a candidate
+            # Substitute y -> x (canonicalise on the input-side symbol).
+            if y_expr in subs and subs[y_expr] == x_expr:
+                continue
+            subs[y_expr] = x_expr
+            candidates.append((x, y))
+
+    if not subs:
+        return False
+
+    # 2) Symbolic test: does the substitution make the view's numel match?
+    def _expr_of(s):
+        return s.node.expr if isinstance(s, torch.SymInt) else s
+
+    try:
+        a_numel = reduce(operator.mul, (_expr_of(s) for s in a.size()), 1)
+        shape_numel = reduce(operator.mul, (_expr_of(s) for s in shape), 1)
+        diff = sympy.simplify((a_numel - shape_numel).subs(subs))
+        if diff != 0:
+            return False
+    except Exception:
+        return False
+
+    # 3) Commit the equalities for real (adds Eq guards, triggers set_replacement).
+    for x, y in candidates:
+        torch._check(x == y)
+    return True
+
+
 def _view_unbacked_meta(
     a: torch.Tensor,
     shape: ShapeType | tuple[ShapeType],
     size_oblivious_enabled: bool = True,
     allow_copy: bool = False,
+    tried_duck_specialize: bool = False,
 ) -> torch.Tensor:
     from torch._prims import view_of
     from torch.fx.experimental.symbolic_shapes import guard_or_false, sym_eq
@@ -724,6 +809,26 @@ def _view_unbacked_meta(
         torch.fx.experimental._config.backed_size_oblivious
         or _view_has_unbacked_input(a, shape)
     ):
+        # Heuristic: before falling through to the specializing recursion
+        # (which often emits Eq(s, 1) via eval_eager), try to discover
+        # cross-symbol equalities between input and target shape symbols.
+        # If a pair (x, y) is True at the runtime hint, the shape env will
+        # record Eq(x, y) and set_replacement unifies them — letting the
+        # size-oblivious view path succeed without specialization on x==1.
+        # But with potential duck specializations which are more general.
+        if (
+            torch.fx.experimental._config.unify_view_symbols_unbacked_meta
+            and not tried_duck_specialize
+            and try_duck_specialization_first(a, shape)
+        ):
+            return _view_unbacked_meta(
+                a,
+                shape,
+                size_oblivious_enabled=True,
+                allow_copy=allow_copy,
+                tried_duck_specialize=True,
+            )
+
         return _view_unbacked_meta(
             a, shape, size_oblivious_enabled=False, allow_copy=allow_copy
         )

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -658,9 +658,9 @@ def _view_has_unbacked_input(
 
 def try_duck_specialization_first(a: torch.Tensor, shape) -> bool:
     """
-    Smarter heuristic: collect candidate (x, y) pairs whose runtime hints
-    match (so they *could* be equal), then test whether substituting them
-    into the view's numel equation makes the equation symbolically zero.
+    Collect candidate (x, y) pairs whose runtime hints match (so they
+    *could* be equal), then test whether substituting them into the
+    view's numel equation makes the equation symbolically zero.
     Only commit the equalities (adds the real Eq guards via bool(x == y)
     which triggers set_replacement) if the substitution actually solves
     the view validity check.
@@ -817,7 +817,7 @@ def _view_unbacked_meta(
         # size-oblivious view path succeed without specialization on x==1.
         # But with potential duck specializations which are more general.
         if (
-            torch.fx.experimental._config.unify_view_symbols_unbacked_meta
+            torch.fx.experimental._config.unify_view_symbols_bso_meta
             and not tried_duck_specialize
             and try_duck_specialization_first(a, shape)
         ):

--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -99,14 +99,12 @@ meta_nonzero_assume_all_nonzero = False
 # Currently an experimental option for export.
 backed_size_oblivious = False
 
-# When True, _view_unbacked_meta will try to discover and add cross-symbol
-# equalities (Eq(x, y)) before falling through to the specializing recursion
-# that emits Eq(s, 1) via eval_eager. Useful for two-export pipelines where
-# the equality info from a torch._check in the source model is consumed by
-# set_replacement during the first export and lost from the resulting
-# GraphModule, so the second export needs a way to rediscover the equality
-# automatically. Defaults to False (current behavior).
-unify_view_symbols_unbacked_meta = False
+# When True, the size-oblivious fallback in `_view_unbacked_meta` (used when
+# `backed_size_oblivious=True`) will, before falling through to the specializing
+# recursion that emits Eq(s, 1) via eval_eager, try to discover and commit
+# cross-symbol equalities (Eq(x, y)) that satisfy the view's numel constraint.
+# Only applies when `backed_size_oblivious=True`. Defaults to False.
+unify_view_symbols_bso_meta = False
 
 # Skip dtype check in meta registrations. Only used for systems that does its own dtype checking.
 skip_dtype_check_in_meta_registrations = False

--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -99,6 +99,15 @@ meta_nonzero_assume_all_nonzero = False
 # Currently an experimental option for export.
 backed_size_oblivious = False
 
+# When True, _view_unbacked_meta will try to discover and add cross-symbol
+# equalities (Eq(x, y)) before falling through to the specializing recursion
+# that emits Eq(s, 1) via eval_eager. Useful for two-export pipelines where
+# the equality info from a torch._check in the source model is consumed by
+# set_replacement during the first export and lost from the resulting
+# GraphModule, so the second export needs a way to rediscover the equality
+# automatically. Defaults to False (current behavior).
+unify_view_symbols_unbacked_meta = False
+
 # Skip dtype check in meta registrations. Only used for systems that does its own dtype checking.
 skip_dtype_check_in_meta_registrations = False
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183322

Squash of:
- prefer duck specialization over 0/1 in unbacked meta fallback for gso (PR #183166)
- add speculative lookahead before commiting duck spesalizations (PR #183176)