### PR TITLE
[ROCm][Windows] Align TORCH_API on ATen native declarations (fix -Winconsistent-dllimport)

### DIFF
--- a/aten/src/ATen/native/mkldnn/Conv.h
+++ b/aten/src/ATen/native/mkldnn/Conv.h
@@ -7,7 +7,7 @@
 
 namespace at {
 namespace native {
-C10_API Tensor mkldnn_convolution_pointwise(
+TORCH_API Tensor mkldnn_convolution_pointwise(
     const Tensor& input_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
@@ -19,7 +19,7 @@ C10_API Tensor mkldnn_convolution_pointwise(
     torch::List<std::optional<at::Scalar>> scalars,
     std::optional<std::string_view> algorithm);
 
-C10_API Tensor mkldnn_convolution_pointwise_binary(
+TORCH_API Tensor mkldnn_convolution_pointwise_binary(
     const Tensor& input_t,
     const Tensor& other_t,
     const Tensor& weight_t,
@@ -34,7 +34,7 @@ C10_API Tensor mkldnn_convolution_pointwise_binary(
     torch::List<std::optional<at::Scalar>> unary_scalars,
     std::optional<std::string_view> unary_algorithm);
 
-C10_API Tensor& mkldnn_convolution_pointwise_binary_(
+TORCH_API Tensor& mkldnn_convolution_pointwise_binary_(
     Tensor& other_t,
     const Tensor& input_t,
     const Tensor& weight_t,

--- a/aten/src/ATen/native/mkldnn/Linear.h
+++ b/aten/src/ATen/native/mkldnn/Linear.h
@@ -6,7 +6,7 @@
 #if AT_MKLDNN_ENABLED()
 
 namespace at::native {
-C10_API Tensor mkldnn_linear_pointwise(
+TORCH_API Tensor mkldnn_linear_pointwise(
     const Tensor& input_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
@@ -14,7 +14,7 @@ C10_API Tensor mkldnn_linear_pointwise(
     c10::List<std::optional<at::Scalar>> scalars,
     std::optional<std::string_view> algorithm);
 
-C10_API Tensor mkldnn_linear_pointwise_binary(
+TORCH_API Tensor mkldnn_linear_pointwise_binary(
     const Tensor& input_t,
     const Tensor& other_t,
     const Tensor& weight_t,

--- a/aten/src/ATen/native/mkldnn/Linear.h
+++ b/aten/src/ATen/native/mkldnn/Linear.h
@@ -23,7 +23,7 @@ TORCH_API Tensor mkldnn_linear_pointwise_binary(
 
 #if AT_MKL_ENABLED()
 
-C10_API Tensor mkl_linear(
+TORCH_API Tensor mkl_linear(
     const Tensor& self,
     const Tensor& mkl_weight_t,
     const Tensor& origin_weight_t,

--- a/aten/src/ATen/native/quantized/cpu/qconv.h
+++ b/aten/src/ATen/native/quantized/cpu/qconv.h
@@ -8,7 +8,7 @@ namespace native {
 class QConvoneDNN final {
  public:
 
-  C10_API static at::Tensor run_pointwise(
+  TORCH_API static at::Tensor run_pointwise(
       at::Tensor act, // contains quantized values but not QTensor
       double act_scale,
       int64_t act_zero_point,
@@ -27,7 +27,7 @@ class QConvoneDNN final {
       torch::List<std::optional<at::Scalar>> scalars,
       std::optional<std::string_view> algorithm);
 
-  C10_API static at::Tensor run_pointwise_tensor(
+  TORCH_API static at::Tensor run_pointwise_tensor(
       at::Tensor act, // contains quantized values but not QTensor
       at::Tensor act_scale,
       at::Tensor act_zero_point,
@@ -46,7 +46,7 @@ class QConvoneDNN final {
       torch::List<std::optional<at::Scalar>> scalars,
       std::optional<std::string_view> algorithm);
 
-  C10_API static at::Tensor run_pointwise_binary(
+  TORCH_API static at::Tensor run_pointwise_binary(
       at::Tensor act, // contains quantized values but not QTensor
       double act_scale,
       int64_t act_zero_point,
@@ -70,7 +70,7 @@ class QConvoneDNN final {
       torch::List<std::optional<at::Scalar>> unary_scalars,
       std::optional<std::string_view> unary_algorithm);
 
-  C10_API static at::Tensor run_pointwise_binary_tensor(
+  TORCH_API static at::Tensor run_pointwise_binary_tensor(
       at::Tensor act, // contains quantized values but not QTensor
       at::Tensor act_scale,
       at::Tensor act_zero_point,

--- a/aten/src/ATen/native/quantized/cpu/qlinear.h
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.h
@@ -6,7 +6,7 @@ namespace at::native {
 
 class QLinearOnednn final {
  public:
-  C10_API static Tensor run_pointwise_tensor(
+  TORCH_API static Tensor run_pointwise_tensor(
       Tensor act, // int8 CPU tensor, not QTensor
       Tensor act_scale,
       Tensor act_zero_point,
@@ -21,7 +21,7 @@ class QLinearOnednn final {
       c10::List<std::optional<at::Scalar>> post_op_args,
       std::string_view post_op_algorithm);
 
-C10_API static Tensor run_pointwise_binary_tensor(
+  TORCH_API static Tensor run_pointwise_binary_tensor(
       Tensor act, // int8 CPU tensor, not QTensor
       Tensor act_scale,
       Tensor act_zero_point,
@@ -42,7 +42,7 @@ C10_API static Tensor run_pointwise_binary_tensor(
       std::string_view unary_post_op_algorithm);
 };
 
-C10_API Tensor _weight_int4pack_mm_cpu_tensor(
+TORCH_API Tensor _weight_int4pack_mm_cpu_tensor(
     const Tensor& A,
     const Tensor& B,
     const Tensor& qGroupSize,


### PR DESCRIPTION
Several forward declarations used `C10_API` while the definitions live in `.cpp` files linked into `torch_cpu`. The compiler then sees a `c10 import` on the declaration and a `torch_cpu export` on the definition, which triggers `[-Winconsistent-dllimport]`.

## Solution

Replace `C10_API` with `TORCH_API` on those declarations. The implementations are not in libc10; they are built into torch_cpu, so the declaration must use the same export macro as that DLL. `TORCH_API` on the header removes the mismatch.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01