### PR TITLE
Fix typos in distributed and data loading modules

### DIFF
--- a/torch/distributed/elastic/rendezvous/api.py
+++ b/torch/distributed/elastic/rendezvous/api.py
@@ -53,7 +53,7 @@ class RendezvousStateError(RendezvousError):
 
 
 class RendezvousGracefulExitError(RendezvousError):
-    """Raised when node wasn't not included in rendezvous and gracefully exits.
+    """Raised when node wasn't included in rendezvous and gracefully exits.
 
     Exception is a mechanism to exit the stack, however does not mean a failure.
     """

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -329,8 +329,8 @@ def _remove_participant_epilogue(
     else:
         if len(state.participants) < settings.min_nodes:
             msg = (
-                f"Number of participants {len(state.participants)}) less than"
-                f"min_nodes {settings.min_nodes}, clearning deadline in state"
+                f"Number of participants {len(state.participants)} less than "
+                f"min_nodes {settings.min_nodes}, clearing deadline in state"
             )
             logger.debug(msg)
             state.deadline = None

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -191,7 +191,7 @@ class _PeriodicTimer:
             The function to run.
     """
 
-    # The state of the timer is hold in a separate context object to avoid a
+    # The state of the timer is held in a separate context object to avoid a
     # reference cycle between the timer and the background thread.
     class _Context:
         interval: float

--- a/torch/distributed/elastic/timer/api.py
+++ b/torch/distributed/elastic/timer/api.py
@@ -137,7 +137,7 @@ class TimerServer(abc.ABC):
     def register_timers(self, timer_requests: list[TimerRequest]) -> None:
         """
         Processes the incoming timer requests and registers them with the server.
-        The timer request can either be a acquire-timer or release-timer request.
+        The timer request can either be an acquire-timer or release-timer request.
         Timer requests with a negative expiration_time should be interpreted
         as a release-timer request.
         """

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -91,7 +91,7 @@ class SymmMemAllocMixin:
         # Force initialization of communicator; otherwise, the rendezvous may
         # see empty communicator.
         # TODO: Remove this, maybe by warning user to perform eager dist init.
-        # For now, it is okay since it isjust a one-time cost at init.
+        # For now, it is okay since it is just a one-time cost at init.
         dist.barrier(group=group)
 
     def allocate(

--- a/torch/utils/data/_utils/__init__.py
+++ b/torch/utils/data/_utils/__init__.py
@@ -1,4 +1,4 @@
-r"""Utility classes & functions for data loading. Code in this folder is mostly used by ../dataloder.py.
+r"""Utility classes & functions for data loading. Code in this folder is mostly used by ../dataloader.py.
 
 A lot of multiprocessing is used in data loading, which only supports running
 functions defined in global environment (py2 can't serialize static methods).


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183326

Fix a double negative ("wasn't not included"), a mismatched parenthesis
and misspelling ("clearning" → "clearing") in dynamic rendezvous, a
grammar error ("hold" → "held"), an incorrect article ("a acquire" →
"an acquire"), a missing space ("isjust"), and a filename typo
("dataloder" → "dataloader").

Authored with Claude (typo_terminator2).