### PR TITLE
[ATen] SM carveout for cublas (#183330)

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -175,6 +175,43 @@ void _cublasAdjustLdLevel3(
   }
 }
 
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+class CuBlasSMCarveoutGuard {
+ public:
+  explicit CuBlasSMCarveoutGuard(cublasHandle_t handle) : handle_(handle) {
+    const auto smCarveout = at::globalContext()._SMCarveout_EXPERIMENTAL();
+    if (smCarveout.has_value()) {
+      const int smCount =
+          at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+      const int carveout = smCarveout.value();
+      TORCH_CHECK(
+          carveout >= 0 && carveout < smCount,
+          "SM carveout must be between 0 and ",
+          smCount - 1,
+          " (num_sms-1), got ",
+          carveout);
+      TORCH_CUDABLAS_CHECK(
+          cublasSetSmCountTarget(handle_, smCount - carveout));
+      enabled_ = true;
+    }
+  }
+  ~CuBlasSMCarveoutGuard() {
+    if (enabled_) {
+      cublasSetSmCountTarget(handle_, 0);
+    }
+  }
+  CuBlasSMCarveoutGuard(const CuBlasSMCarveoutGuard&) = delete;
+  CuBlasSMCarveoutGuard& operator=(const CuBlasSMCarveoutGuard&) = delete;
+
+ private:
+  cublasHandle_t handle_;
+  bool enabled_ = false;
+};
+#define CUBLAS_SM_CARVEOUT_GUARD(handle) CuBlasSMCarveoutGuard smCarveoutGuard(handle)
+#else
+#define CUBLAS_SM_CARVEOUT_GUARD(handle)
+#endif
+
 #ifndef USE_ROCM
 uint32_t _getAlignment(uintptr_t address) {
   // alignment are in bytes
@@ -613,6 +650,7 @@ inline void bgemm_internal_cublas(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_D
 template <>
 void bgemm_internal_cublas<double>(CUDABLAS_BGEMM_ARGTYPES(double)) {
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -624,6 +662,7 @@ void bgemm_internal_cublas<double>(CUDABLAS_BGEMM_ARGTYPES(double)) {
 template <>
 void bgemm_internal_cublas<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -635,6 +674,7 @@ void bgemm_internal_cublas<float>(CUDABLAS_BGEMM_ARGTYPES(float)) {
 template <>
 void bgemm_internal_cublas<c10::complex<double>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<double>)) {
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -648,6 +688,7 @@ void bgemm_internal_cublas<c10::complex<double>>(CUDABLAS_BGEMM_ARGTYPES(c10::co
 template <>
 void bgemm_internal_cublas<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<float>)) {
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -661,6 +702,7 @@ void bgemm_internal_cublas<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::com
 template <typename C_Dtype>
 inline void bgemm_internal_cublas_half_helper(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(at::Half, C_Dtype)) {
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -733,6 +775,7 @@ template <typename C_Dtype>
 inline void bgemm_internal_cublas_bfloat16_helper(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(at::BFloat16, C_Dtype)) {
   BGEMM_CHECK_ARGVALUES(at::BFloat16);
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   const float falpha = alpha;
@@ -1055,6 +1098,7 @@ inline void gemm_internal_cublas(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dty
 template <>
 void gemm_internal_cublas<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -1066,6 +1110,7 @@ void gemm_internal_cublas<double>(CUDABLAS_GEMM_ARGTYPES(double)) {
 template <>
 void gemm_internal_cublas<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -1077,6 +1122,7 @@ void gemm_internal_cublas<float>(CUDABLAS_GEMM_ARGTYPES(float)) {
 template <>
 void gemm_internal_cublas<c10::complex<double>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<double>)) {
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -1090,6 +1136,7 @@ void gemm_internal_cublas<c10::complex<double>>(CUDABLAS_GEMM_ARGTYPES(c10::comp
 template <>
 void gemm_internal_cublas<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<float>)) {
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   _cublasAdjustLdLevel3(transa, transb, m, n, k, &lda, &ldb, &ldc);
@@ -1103,6 +1150,7 @@ void gemm_internal_cublas<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::compl
 template <typename C_Dtype>
 inline void gemm_internal_cublas_half_helper(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(at::Half, C_Dtype)) {
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   float falpha = alpha;
@@ -1218,6 +1266,7 @@ inline void gemm_internal_cublas_half_helper(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(
 template <typename C_Dtype>
 inline void gemm_internal_cublas_bfloat16_helper(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(at::BFloat16, C_Dtype)) {
   cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CUBLAS_SM_CARVEOUT_GUARD(handle);
   cublasOperation_t opa = _cublasOpFromChar(transa);
   cublasOperation_t opb = _cublasOpFromChar(transb);
   float falpha = alpha;

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: linear algebra"]
 
 import contextlib
+import json
+import math
 import os
 import unittest
 from itertools import product
@@ -51,6 +53,7 @@ from torch.testing._internal.common_utils import (
     TEST_CUDA,
     TEST_WITH_ROCM,
     TestCase,
+    TemporaryFileName,
     decorateIf,
 )
 
@@ -94,6 +97,16 @@ def rocm_group_gemm_ck_env(value):
         else:
             os.environ[var] = old
 
+
+@contextlib.contextmanager
+def sm_carveout(value: int | None):
+    torch._C._set_sm_carveout_experimental(value)
+    try:
+        yield
+    finally:
+        torch._C._set_sm_carveout_experimental(None)
+
+
 class TestMatmulCuda(InductorTestCase):
     def setUp(self):
         super().setUp()
@@ -102,6 +115,82 @@ class TestMatmulCuda(InductorTestCase):
     def tearDown(self):
         torch.backends.cuda.matmul.allow_tf32 = True
         super().tearDown()
+
+    @unittest.skipIf(not SM90OrLater, "sm89 kernel isn't opted into carveout yet")
+    def test_legacy_cublas_honors_sm_carveout(self, device):
+        if torch.version.cuda is None or int(torch.version.cuda.split(".")[0]) < 12:
+            raise unittest.SkipTest("cublasSetSmCountTarget requires CUDA 12+")
+
+        torch._C._set_sm_carveout_experimental(None)
+        dtype = torch.float16
+        sm_count = torch.cuda.get_device_properties().multi_processor_count
+        carveout = max(1, sm_count // 2)
+        a = torch.empty(8192, 8192, device=device, dtype=dtype)
+        b = torch.empty(8192, 8192, device=device, dtype=dtype)
+
+        def mm_grid_size(carveout_value: int | None) -> int:
+            with sm_carveout(carveout_value), TemporaryFileName(mode="w+") as fname:
+                with profile(activities=[ProfilerActivity.CUDA]) as prof:
+                    torch.mm(a, b)
+                prof.export_chrome_trace(fname)
+                with open(fname) as trace_file:
+                    total_grid_size = 0
+                    kernel_count = 0
+                    for evt in json.load(trace_file)["traceEvents"]:
+                        grid = evt.get("args", {}).get("grid")
+                        if evt.get("cat", "") == "kernel" and grid:
+                            total_grid_size += math.prod(grid)
+                            kernel_count += 1
+
+            self.assertNotEqual(0, kernel_count)
+            return total_grid_size
+
+        with blas_library_context("cublas"):
+            torch.mm(a, b)
+            torch.cuda.synchronize()
+
+            no_carveout = mm_grid_size(None)
+            carveout_0 = mm_grid_size(0)
+            carved_out = mm_grid_size(carveout)
+            no_carveout_again = mm_grid_size(None)
+
+        self.assertEqual(no_carveout, carveout_0)
+        self.assertNotEqual(no_carveout, carved_out)
+        self.assertEqual(no_carveout, no_carveout_again)
+
+    @unittest.skipIf(not SM90OrLater, "sm89 kernel isn't opted into carveout yet")
+    def test_sm_carveout_invalid_value_throws(self, device):
+        sm_count = torch.cuda.get_device_properties().multi_processor_count
+        a = torch.empty(64, 64, device=device, dtype=torch.float16)
+        b = torch.empty(64, 64, device=device, dtype=torch.float16)
+
+        with blas_library_context("cublas"):
+            with sm_carveout(sm_count):
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    r"SM carveout must be between 0 and \d+",
+                    torch.mm,
+                    a,
+                    b,
+                )
+
+            with sm_carveout(sm_count + 1):
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    r"SM carveout must be between 0 and \d+",
+                    torch.mm,
+                    a,
+                    b,
+                )
+
+            with sm_carveout(-1):
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    r"SM carveout must be between 0 and \d+",
+                    torch.mm,
+                    a,
+                    b,
+                )
 
     def cublas_addmm(
         self,


### PR DESCRIPTION
Summary:

The `torch._C._get_sm_carveout_experimental()` currently does not affect the standard cublas path, only cublaslt. This PR adds support for default cublas as well.

Test Plan: `test_legacy_cublas_honors_sm_carveout`

Reviewed By: jananisriram

