### PR TITLE
docs: convert elastic rendezvous to markdown

### DIFF
--- a/docs/source/elastic/rendezvous.md
+++ b/docs/source/elastic/rendezvous.md
@@ -1,17 +1,18 @@
-.. _rendezvous-api:
+(rendezvous-api)=
 
-Rendezvous
-==========
+# Rendezvous
 
+```{eval-rst}
 .. automodule:: torch.distributed.elastic.rendezvous
+```
 
 Below is a state diagram describing how rendezvous works.
 
-.. image:: etcd_rdzv_diagram.png
+![Rendezvous state diagram](etcd_rdzv_diagram.png)
 
-Registry
---------
+## Registry
 
+```{eval-rst}
 .. autoclass:: RendezvousParameters
    :members:
 
@@ -20,17 +21,20 @@ Registry
 .. automodule:: torch.distributed.elastic.rendezvous.registry
 
 .. autofunction:: torch.distributed.elastic.rendezvous.registry.get_rendezvous_handler
+```
 
-Handler
--------
+## Handler
 
+```{eval-rst}
 .. currentmodule:: torch.distributed.elastic.rendezvous
 
 .. autoclass:: RendezvousHandler
    :members:
+```
 
-Dataclasses
------------
+## Dataclasses
+
+```{eval-rst}
 .. autoclass:: RendezvousInfo
 
 .. currentmodule:: torch.distributed.elastic.rendezvous.api
@@ -38,22 +42,24 @@ Dataclasses
 .. autoclass:: RendezvousStoreInfo
 
    .. automethod:: build(rank, store)
+```
 
-Exceptions
-----------
+## Exceptions
+
+```{eval-rst}
 .. autoclass:: RendezvousError
 .. autoclass:: RendezvousClosedError
 .. autoclass:: RendezvousTimeoutError
 .. autoclass:: RendezvousConnectionError
 .. autoclass:: RendezvousStateError
 .. autoclass:: RendezvousGracefulExitError
+```
 
-Implementations
----------------
+## Implementations
 
-Dynamic Rendezvous
-******************
+### Dynamic Rendezvous
 
+```{eval-rst}
 .. currentmodule:: torch.distributed.elastic.rendezvous.dynamic_rendezvous
 
 .. autofunction:: create_handler
@@ -66,62 +72,71 @@ Dynamic Rendezvous
 
 .. autoclass:: RendezvousTimeout
    :members:
+```
 
-C10d Backend
-^^^^^^^^^^^^
+#### C10d Backend
 
+```{eval-rst}
 .. currentmodule:: torch.distributed.elastic.rendezvous.c10d_rendezvous_backend
 
 .. autofunction:: create_backend
 
 .. autoclass:: C10dRendezvousBackend
    :members:
+```
 
-Etcd Backend
-^^^^^^^^^^^^
+#### Etcd Backend
 
+```{eval-rst}
 .. currentmodule:: torch.distributed.elastic.rendezvous.etcd_rendezvous_backend
 
 .. autofunction:: create_backend
 
 .. autoclass:: EtcdRendezvousBackend
    :members:
+```
 
-Etcd Rendezvous (Legacy)
-************************
+### Etcd Rendezvous (Legacy)
 
-.. warning::
-    The ``DynamicRendezvousHandler`` class supersedes the ``EtcdRendezvousHandler``
-    class, and is recommended for most users. ``EtcdRendezvousHandler`` is in
-    maintenance mode and will be deprecated in the future.
+```{warning}
+The `DynamicRendezvousHandler` class supersedes the `EtcdRendezvousHandler`
+class, and is recommended for most users. `EtcdRendezvousHandler` is in
+maintenance mode and will be deprecated in the future.
+```
 
+```{eval-rst}
 .. currentmodule:: torch.distributed.elastic.rendezvous.etcd_rendezvous
 
 .. autoclass:: EtcdRendezvousHandler
+```
 
-Etcd Store
-**********
+### Etcd Store
 
-The ``EtcdStore`` is the C10d ``Store`` instance type returned by
-``next_rendezvous()`` when etcd is used as the rendezvous backend.
+The `EtcdStore` is the C10d `Store` instance type returned by
+`next_rendezvous()` when etcd is used as the rendezvous backend.
 
+```{eval-rst}
 .. currentmodule:: torch.distributed.elastic.rendezvous.etcd_store
 
 .. autoclass:: EtcdStore
    :members:
+```
 
-Etcd Server
-***********
+### Etcd Server
 
-The ``EtcdServer`` is a convenience class that makes it easy for you to
+The `EtcdServer` is a convenience class that makes it easy for you to
 start and stop an etcd server on a subprocess. This is useful for testing
 or single-node (multi-worker) deployments where manually setting up an
 etcd server on the side is cumbersome.
 
-.. warning:: For production and multi-node deployments please consider
-             properly deploying a highly available etcd server as this is
-             the single point of failure for your distributed jobs.
+```{warning}
+For production and multi-node deployments please consider properly deploying
+a highly available etcd server as this is the single point of failure for your
+distributed jobs.
+```
 
+```{eval-rst}
 .. currentmodule:: torch.distributed.elastic.rendezvous.etcd_server
 
 .. autoclass:: EtcdServer
+```


### PR DESCRIPTION
Fixes #182471

Converts `docs/source/elastic/rendezvous.rst` to MyST Markdown.

Notes:
- Renamed the page from `.rst` to `.md`.
- Preserved the `rendezvous-api` anchor, state diagram image, warnings, heading hierarchy, and existing autodoc/currentmodule directives via `eval-rst` blocks.
- Did not update `docs/source/redirects.py` for the `.rst` to `.md` migration.

Test plan:
- `git diff --check origin/main..HEAD`
- `bash .github/scripts/pr-sanity-check.sh` (PR SIZE is 0)
- `source /home/tihor/pytorchdocathon/.venv/bin/activate && lintrunner -m origin/main`
- Isolated Sphinx page build without `-W` for `elastic/rendezvous.md`

Labels requested: `docathon-2026`, `module: docs`

cc @svekars @sekyondaMeta @AlannaBurke
