### PR TITLE
docs: convert nn.init to markdown

### DIFF
--- a/docs/source/nn.init.md
+++ b/docs/source/nn.init.md
@@ -1,17 +1,21 @@
+```{eval-rst}
 .. role:: hidden
     :class: hidden-section
+```
 
-.. _nn-init-doc:
+(nn-init-doc)=
 
-torch.nn.init
-=============
+# torch.nn.init
 
-.. warning::
-    All the functions in this module are intended to be used to initialize neural network
-    parameters, so they all run in :func:`torch.no_grad` mode and will not be taken into
-    account by autograd.
+```{warning}
+All the functions in this module are intended to be used to initialize neural
+network parameters, so they all run in {func}`torch.no_grad` mode and will not
+be taken into account by autograd.
+```
 
+```{eval-rst}
 .. currentmodule:: torch.nn.init
+
 .. autofunction:: calculate_gain
 .. autofunction:: uniform_
 .. autofunction:: normal_
@@ -27,3 +31,4 @@ torch.nn.init
 .. autofunction:: trunc_normal_
 .. autofunction:: orthogonal_
 .. autofunction:: sparse_
+```

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -190,7 +190,8 @@ def calculate_gain(
     ================= ====================================================
 
     .. warning::
-        In order to implement `Self-Normalizing Neural Networks`_ ,
+        In order to implement `Self-Normalizing Neural Networks
+        <https://papers.nips.cc/paper/2017/hash/5d44ee6f2c3f71b73125876103c8f6c4-Abstract.html>`__,
         you should use ``nonlinearity='linear'`` instead of ``nonlinearity='selu'``.
         This gives the initial weights a variance of ``1 / N``,
         which is necessary to induce a stable fixed point in the forward pass.
@@ -206,7 +207,6 @@ def calculate_gain(
         ...     "leaky_relu", 0.2
         ... )  # leaky_relu with negative_slope=0.2
 
-    .. _Self-Normalizing Neural Networks: https://papers.nips.cc/paper/2017/hash/5d44ee6f2c3f71b73125876103c8f6c4-Abstract.html
     """
     linear_fns = [
         "linear",


### PR DESCRIPTION
Fixes #182479

Converts `docs/source/nn.init.rst` to MyST Markdown.

Notes:
- Renamed the page from `.rst` to `.md`.
- Preserved the `nn-init-doc` anchor, hidden role directive, warning text, `torch.no_grad` reference, currentmodule directive, and all existing autofunction directives.
- Did not update `docs/source/redirects.py` for the `.rst` to `.md` migration.

Test plan:
- `git diff --check origin/main..HEAD`
- `bash .github/scripts/pr-sanity-check.sh` (PR SIZE is 0)
- `source /home/tihor/pytorchdocathon/.venv/bin/activate && lintrunner -m origin/main`
- Isolated Sphinx page build without `-W` for `nn.init.md`

Labels requested: `docathon-2026`, `module: docs`

cc @svekars @sekyondaMeta @AlannaBurke
