### PR TITLE
[CPU Kernel Fusion Framework] Expose overlapsWithUsedNodes and getVmap from SubgraphRewriter (#183333)

### DIFF
--- a/torch/nativert/graph/passes/SubgraphRewriter.cpp
+++ b/torch/nativert/graph/passes/SubgraphRewriter.cpp
@@ -252,6 +252,31 @@ bool SubgraphMatcher::tryMatchValue(
 // SubgraphRewriter
 //-------------------------
 
+c10::FastMap<std::string, const Value*> SubgraphRewriter::
+    computePatternValueMap(const Graph& pattern) {
+  c10::FastMap<std::string, const Value*> vmap;
+  for (const auto& v : pattern.inputs()) {
+    vmap[std::string(v->name())] = v;
+  }
+  for (const auto& n : pattern.nodes()) {
+    for (const Value* v : n.outputs()) {
+      vmap[std::string(v->name())] = v;
+    }
+  }
+  return vmap;
+}
+
+bool SubgraphRewriter::overlapsWithUsedNodes(
+    const Match& match,
+    const std::unordered_set<Node*>& usedNodes) {
+  for (const auto& kv : match.node_map) {
+    if (usedNodes.find(kv.second) != usedNodes.end()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void SubgraphRewriter::registerRewritePattern(
     const std::string& pattern,
     const std::string& replacement) {
@@ -282,9 +307,10 @@ bool SubgraphRewriter::runForPattern(
   VLOG(1) << "[GraphPasses] Found " << matches.size()
           << " matches for : " << name_;
 
+  const auto vmap = computePatternValueMap(pattern);
   for (auto& m : matches) {
     if (!std::all_of(filters.begin(), filters.end(), [&](const MatchFilter& f) {
-          return f(m, getVmap(pattern));
+          return f(m, vmap);
         })) {
       continue;
     }
@@ -320,20 +346,6 @@ bool SubgraphRewriter::runForPattern(
   graph->lint();
 
   return mutated;
-}
-
-bool SubgraphRewriter::overlapsWithUsedNodes(
-    const Match& match,
-    const std::unordered_set<Node*>& usedNodes) {
-  // If any node or value used by this match is already in usedNodes/usedValues,
-  // then this match overlaps with a previously selected match.
-  for (auto& kv : match.node_map) {
-    Node* target_node = kv.second;
-    if (usedNodes.find(target_node) != usedNodes.end()) {
-      return true;
-    }
-  }
-  return false;
 }
 
 void SubgraphRewriter::rewriteMatch(
@@ -436,17 +448,4 @@ void SubgraphRewriter::rewriteMatch(
   }
 }
 
-c10::FastMap<std::string, const Value*> SubgraphRewriter::getVmap(
-    const Graph& pattern) {
-  c10::FastMap<std::string, const Value*> vmap;
-  for (const auto& v : pattern.inputs()) {
-    vmap[std::string(v->name())] = v;
-  }
-  for (const auto& n : pattern.nodes()) {
-    for (const Value* v : n.outputs()) {
-      vmap[std::string(v->name())] = v;
-    }
-  }
-  return vmap;
-}
 } // namespace torch::nativert

--- a/torch/nativert/graph/passes/SubgraphRewriter.h
+++ b/torch/nativert/graph/passes/SubgraphRewriter.h
@@ -178,23 +178,37 @@ class SubgraphRewriter {
       Graph* graph,
       const std::vector<MatchFilter>& filters);
 
+  /**
+   * Returns a map from every value name in `pattern` (graph inputs and node
+   * outputs) to its corresponding Value* in the pattern graph. Useful when a
+   * MatchFilter or a custom match-driven pass needs to look up matched target
+   * Value*s by their pattern variable name via match.value_map.
+   */
+  static c10::FastMap<std::string, const Value*> computePatternValueMap(
+      const Graph& pattern);
+
+  /**
+   * Returns true if any target node in `match` is already present in
+   * `usedNodes`. Intended for callers that drive their own match loop and need
+   * to skip matches whose nodes have already been consumed by a previously
+   * accepted match in the same pass.
+   */
+  static bool overlapsWithUsedNodes(
+      const Match& match,
+      const std::unordered_set<Node*>& usedNodes);
+
  private:
   std::string name_;
-  std::vector<RewriteRule> patterns_; // The subgraph pattern to match
-  std::unordered_set<Node*> replacedNodes_;
-  std::vector<Value*> valuesToRewrite_;
-  std::unordered_map<const Value*, Value*> valueRewrites_;
+  std::vector<RewriteRule> patterns_{}; // The subgraph pattern to match
+  std::unordered_set<Node*> replacedNodes_{};
+  std::vector<Value*> valuesToRewrite_{};
+  std::unordered_map<const Value*, Value*> valueRewrites_{};
 
   // Helper methods
-  bool overlapsWithUsedNodes(
-      const Match& match,
-      const std::unordered_set<Node*>& replacedNodes);
   void rewriteMatch(
       Graph* graph,
       const Match& match,
       const Graph& pattern,
       const Graph& replacement);
-
-  c10::FastMap<std::string, const Value*> getVmap(const Graph& pattern);
 };
 } // namespace torch::nativert


### PR DESCRIPTION
Summary:

Exposing overlapsWithUsedNodes and getVmap. No behavior changed

Reviewed By: jijunyan

Differential Revision: D101720006


