### PR TITLE
Fix tensor subclass construction under torch.compile

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -8148,6 +8148,28 @@ SavedForBackwardsAOTOutput(idx=5)""",
         compiled_zero = cf(size, torch.empty([0]))
         self.assertEqual(compiled_zero.shape, torch.Size([2, 3]))
 
+    def test_basic_tensor_subclass_constructor(self):
+        # Tests that basic Tensor subclass construction works with torch.compile
+        # Regression test for LazyVariableTracker not being realized before
+        # accessing __dict__ in TensorWithTFOverrideVariable.from_tensor_var
+        class MyTensor(torch.Tensor):
+            pass
+
+        def f(x):
+            y = MyTensor(x)
+            return torch.abs(y)
+
+        x = torch.randn(4)
+        eager_out = f(x)
+        compiled_f = torch.compile(f, backend="eager", fullgraph=True, dynamic=True)
+        compiled_out = compiled_f(x)
+
+        torch.testing.assert_close(
+            torch.as_tensor(eager_out),
+            torch.as_tensor(compiled_out),
+        )
+        self.assertIsInstance(compiled_out, MyTensor)
+
 
 class ReproTestsDevice(torch._dynamo.test_case.TestCase):
     def test_sub_alpha_scalar_repro(self, device):

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2006,6 +2006,28 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertFalse(y.requires_grad)
         self.assertFalse(z.requires_grad)
 
+    def test_basic_tensor_subclass_constructor(self):
+        # Tests that basic Tensor subclass construction works with torch.compile
+        # Regression test for LazyVariableTracker not being realized before
+        # accessing __dict__ in TensorWithTFOverrideVariable.from_tensor_var
+        class MyTensor(torch.Tensor):
+            pass
+
+        def f(x):
+            y = MyTensor(x)
+            return torch.abs(y)
+
+        x = torch.randn(4)
+        eager_out = f(x)
+        compiled_f = torch.compile(f, backend="eager", fullgraph=True, dynamic=True)
+        compiled_out = compiled_f(x)
+
+        torch.testing.assert_close(
+            torch.as_tensor(eager_out),
+            torch.as_tensor(compiled_out),
+        )
+        self.assertIsInstance(compiled_out, MyTensor)
+
     def test_locals_traced_correctly_under_compile(self):
         def fn(x):
             if x.dim() > 2:
@@ -8147,28 +8169,6 @@ SavedForBackwardsAOTOutput(idx=5)""",
         # Zero-element out should be resized
         compiled_zero = cf(size, torch.empty([0]))
         self.assertEqual(compiled_zero.shape, torch.Size([2, 3]))
-
-    def test_basic_tensor_subclass_constructor(self):
-        # Tests that basic Tensor subclass construction works with torch.compile
-        # Regression test for LazyVariableTracker not being realized before
-        # accessing __dict__ in TensorWithTFOverrideVariable.from_tensor_var
-        class MyTensor(torch.Tensor):
-            pass
-
-        def f(x):
-            y = MyTensor(x)
-            return torch.abs(y)
-
-        x = torch.randn(4)
-        eager_out = f(x)
-        compiled_f = torch.compile(f, backend="eager", fullgraph=True, dynamic=True)
-        compiled_out = compiled_f(x)
-
-        torch.testing.assert_close(
-            torch.as_tensor(eager_out),
-            torch.as_tensor(compiled_out),
-        )
-        self.assertIsInstance(compiled_out, MyTensor)
 
 
 class ReproTestsDevice(torch._dynamo.test_case.TestCase):

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -604,8 +604,7 @@ class TensorWithTFOverrideVariable(TensorVariable):
         # TensorWithTFOverrideVariable. In eager, this is just a type change.
         import torch
 
-        tensor_var = tensor_var.unwrap()
-
+        tensor_var = tensor_var.realize()
         # This simulates shallow-copying the tensor object.
         kwargs = dict(tensor_var.__dict__)
         input_tensor_type = kwargs.pop("class_type")

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -604,6 +604,8 @@ class TensorWithTFOverrideVariable(TensorVariable):
         # TensorWithTFOverrideVariable. In eager, this is just a type change.
         import torch
 
+        tensor_var = tensor_var.unwrap()
+
         # This simulates shallow-copying the tensor object.
         kwargs = dict(tensor_var.__dict__)
         input_tensor_type = kwargs.pop("class_type")


### PR DESCRIPTION
Fixes #183261 
Fixes InternalDynamoError when compiling tensor subclass constructors by unwrapping LazyVariableTracker before accessing class_type in from_tensor_var

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos