### PR TITLE
Order void-op deps in control_deps_op_lowering.

### DIFF
--- a/test/inductor/test_control_deps.py
+++ b/test/inductor/test_control_deps.py
@@ -257,6 +257,78 @@ class TestControlDeps(InductorTestCase):
             expected = fn(x, y)
             torch.testing.assert_close(result, expected)
 
+    @requires_gpu()
+    def test_control_deps_orders_void_op_across_nested_calls(self):
+        """record_event's void op must be named as an additional_buffer_dep
+        of the subsequent wait_event's operations after Inductor lowering.
+
+        record_event lowers to a NoneLayout (void) op and the overall
+        control_deps call around it returns a tuple/None.  When a later
+        control_deps call (around wait_event) lists the record's control_deps
+        node as an additional dep, the lowered value fails the
+        ``isinstance(dep, IRNode)`` check.  Before the fix, the void op was
+        silently dropped and never referenced in the wait's
+        additional_buffer_deps, so Inductor's cudagraph partitioning and
+        other consumers of additional_buffer_deps could reorder the wait
+        before the record.
+        """
+        from unittest.mock import patch
+
+        from torch._inductor import ir, scheduler
+        from torch._inductor.virtualized import V
+
+        def fn(x):
+            s1 = torch.Stream(device=GPU_TYPE)
+            s2 = torch.Stream(device=GPU_TYPE)
+            e = torch.Event()
+            with s1:
+                y = x + 1
+                e.record()
+            with s2:
+                a = x * 3
+                e.wait()
+                z = y * a
+            return z
+
+        captured: list[dict] = []
+        orig_init = scheduler.Scheduler._init
+
+        def capture_init(self, nodes):
+            void_names = {
+                op.get_name()
+                for op in V.graph.operations
+                if hasattr(op, "layout") and isinstance(op.layout, ir.NoneLayout)
+            }
+            referenced: set[str] = set()
+            for deps in V.graph.additional_buffer_deps.values():
+                referenced.update(deps)
+            captured.append({"void_names": void_names, "referenced": referenced})
+            return orig_init(self, nodes)
+
+        torch._dynamo.reset()
+        with patch.object(scheduler.Scheduler, "_init", capture_init):
+            x = torch.ones(2, 2, device=GPU_TYPE)
+            torch.compile(fn)(x)
+
+        self.assertTrue(captured, "expected at least one Inductor compile")
+
+        void_names: set[str] = set()
+        referenced: set[str] = set()
+        for state in captured:
+            void_names |= state["void_names"]
+            referenced |= state["referenced"]
+
+        self.assertGreater(
+            len(void_names),
+            0,
+            "expected record_event/wait_event to lower to NoneLayout ops",
+        )
+        self.assertTrue(
+            void_names & referenced,
+            "no record_event void op appears as an additional_buffer_dep; "
+            f"void_names={void_names}, referenced={referenced}",
+        )
+
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_GPU_AND_TRITON:

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -427,6 +427,10 @@ class GraphLowering(torch.fx.Interpreter):
             OrderedSet
         )
         self.additional_star_deps: dict[str, OrderedSet[str]] = defaultdict(OrderedSet)
+        # Maps control_deps FX node to operation names created when lowering it,
+        # for void ops (e.g. record_event) that return None and therefore cannot
+        # be referenced by name in subsequent control_deps ordering constraints.
+        self._void_ctrl_dep_op_names: dict[torch.fx.Node, list[str]] = {}
 
         # Inplace padding may require Inductor to allocate slightly larger
         # tensor for padding.

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8350,14 +8350,22 @@ def control_deps_op_lowering(additional_deps, subgraph_fn, *args):
     2. Execute the target operation normally
     3. Track the dependencies for the scheduler
     """
-    # Realize all additional dependencies
-    dep_names = []
-    for dep in additional_deps:
-        if not isinstance(dep, IRNode):
-            continue
+    # Pair lowered deps with their original FX nodes so we can handle void ops
+    # (e.g. record_event) that lower to None but still create operations that
+    # subsequent control_deps nodes (e.g. wait_event) must be ordered after.
+    original_dep_nodes = V.graph.current_node.args[0]
+    assert isinstance(original_dep_nodes, tuple)
 
-        dep.realize()
-        dep_names.append(dep.get_name())
+    dep_names = []
+    for dep, orig_node in zip(additional_deps, original_dep_nodes):
+        if isinstance(dep, IRNode):
+            dep.realize()
+            dep_names.append(dep.get_name())
+        elif isinstance(orig_node, torch.fx.Node):
+            # Void op (e.g. record_event returns None): look up the buffer
+            # names stored when it was previously lowered.
+            found = V.graph._void_ctrl_dep_op_names.get(orig_node, [])
+            dep_names.extend(found)
 
     original_args = V.graph.current_node.args
     arg_offset = 2  # first two args (additional_deps, subgraph)
@@ -8371,6 +8379,22 @@ def control_deps_op_lowering(additional_deps, subgraph_fn, *args):
 
     assert additional_deps
 
+    new_ops = V.graph.operations[operation_len:]
+
+    # Store buffer names of void ops (e.g. record_event has NoneLayout) so that
+    # subsequent control_deps nodes (e.g. wait_event) can depend on them even
+    # though void ops don't produce a usable tensor value.  We detect void ops
+    # by NoneLayout rather than checking `output is None`, because the overall
+    # control_deps output may be a passthrough tuple (not None) even when the
+    # subgraph contains a void op.
+    void_names = [
+        op.get_name()
+        for op in new_ops
+        if isinstance(op, ir.Buffer) and isinstance(op.layout, ir.NoneLayout)
+    ]
+    if void_names:
+        V.graph._void_ctrl_dep_op_names[V.graph.current_node] = void_names
+
     # some operators, like wait_tensor, just return their input,
     # so its more robust to add dep to the operation itself,
     # otherwise you can have a cycle of
@@ -8378,7 +8402,7 @@ def control_deps_op_lowering(additional_deps, subgraph_fn, *args):
     # b = control_deps(a, mm, ...)
     # c = control_deps(b, wait, ...)
     # if c == a, then you have a cycle.
-    for op in V.graph.operations[operation_len:]:
+    for op in new_ops:
         for dep_name in dep_names:
             op_name = op.operation_name
             assert op_name is not None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #183340
* __->__ #183339

control_deps_op_lowering iterates additional_deps, realises each
IRNode dep, and adds its buffer name to additional_buffer_deps of the
current operations so the scheduler sees an explicit ordering
constraint.  Deps that are not IRNode values were silently dropped by
the old ``if not isinstance(dep, IRNode): continue``.

That hole bites record_event / wait_event pairs wrapped by
_aot_autograd/streams.py::wrap_all_sync_nodes_with_control_deps.
record_event lowers to a NoneLayout void op: the overall control_deps
call around the record returns None, so when a later control_deps
call (around the wait_event) names the record's control_deps node as
an additional dep, ``dep`` is None, is not an IRNode, and gets
skipped.  The wait's new operations pick up no additional_buffer_deps
entry on the record's void buffer.  FX topological order still keeps
the wait after the record via the passthrough getitem, but anything
that consumes additional_buffer_deps directly does not see the
ordering -- most visibly Inductor's cudagraph partitioning, which can
then place the record and wait in ways that invalidate capture.

Pair each lowered dep with its original FX node so we can recognise
the void-op case.  When the FX node corresponds to a prior
control_deps call whose subgraph produced a NoneLayout op, pick the
stored void op buffer name out of the new
GraphLowering._void_ctrl_dep_op_names map and add it to dep_names.
Populate that map at the end of every control_deps lowering by
scanning the newly-appended V.graph.operations for NoneLayout ops;
detection is by layout rather than ``output is None`` because the
overall control_deps call can still return a passthrough tuple when
its subgraph contains a void side-effecting op.

Authored with Claude.