### PR TITLE
[c10d][symm_mem] Coalesce NCCL buffer + signal pad into a single allocation

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -441,10 +441,6 @@ ncclWindow_t NCCLSymmetricMemory::get_window() {
   return pai_->combined_win_;
 }
 
-ncclWindow_t NCCLSymmetricMemory::get_signal_pad_handle() {
-  return pai_->combined_win_;
-}
-
 size_t NCCLSymmetricMemory::get_offset() {
   return offset_;
 }

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -139,16 +139,25 @@ NCCLAllocMap::iterator find_allocation_covering(
 // Before NCCL 2.29, we can use device-side APIs to get peer pointers.
 #if NCCL_VERSION_CODE < NCCL_VERSION(2, 29, 0)
 #ifdef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+// Fill both peer pointer arrays in a single kernel launch. For each peer,
+// the buffer pointer comes from NCCL and the signal pad pointer is derived
+// as `buffer + round_up(buffer_size, 16)`, mirroring the host-side layout.
 static __global__ void build_ptr_dev(
   ncclWindow_t  handle,
-  size_t  offset,  // byte offset inside the window
-  void**  buffer,  // symmetric memory buffer
+  size_t  buffer_size,    // user buffer size; the kernel rounds it up to 16
+  void**  buffers,        // out: peer buffer pointers
+  void**  signal_pads,    // out: peer signal pad pointers
   int  world_size)
 {
+  const size_t aligned_buffer_size = (buffer_size + 15UL) & ~15UL;
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int stride = blockDim.x * gridDim.x;
   for (int peer = tid; peer < world_size; peer += stride) {
-      buffer[peer] = ncclGetLsaPointer(handle, offset, peer);
+      void* buf = ncclGetLsaPointer(handle, 0, peer);
+      buffers[peer] = buf;
+      signal_pads[peer] = buf == nullptr
+          ? nullptr
+          : static_cast<char*>(buf) + aligned_buffer_size;
   }
 }
 #endif // NCCL_HAS_SYMMEM_DEVICE_SUPPORT
@@ -200,32 +209,31 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     manager.register_comm(group_name_, comm_);
 
     // Starting from NCCL 2.28, we can get peer pointers.
-    // Allocate a single device buffer for both peer arrays and split it:
-    //   [0, arr_size)            - buffers_dev_
-    //   [arr_size, 2 * arr_size) - signal_pads_dev_
     const size_t arr_size = sizeof(void*) * world_size_;
     buffers_dev_ = reinterpret_cast<void**>(
-        c10::cuda::CUDACachingAllocator::raw_alloc(arr_size * 2));
+        c10::cuda::CUDACachingAllocator::raw_alloc(arr_size));
     signal_pads_dev_ = reinterpret_cast<void**>(
-        reinterpret_cast<char*>(buffers_dev_) + arr_size);
+        c10::cuda::CUDACachingAllocator::raw_alloc(arr_size));
     buffers_.resize(world_size_);
     signal_pads_.resize(world_size_);
 
-    // Fill out the peer pointer array. We only fetch the buffer pointers
-    // for each peer; signal pad pointers are derived from them as
-    // buffer + aligned_buffer_size, since every rank sees the same
-    // symmetric-memory layout.
 #if NCCL_VERSION_CODE < NCCL_VERSION(2, 29, 0)
-    // Lack of host-side API to get peer pointers, so we get them inside a
-    // kernel and copy the result to host.
+    // Lack of host-side API to get peer pointers, so a kernel writes both
+    // peer arrays at once and copies the results to host.
     int threads = std::min(128, world_size_);
     auto stream = at::cuda::getCurrentCUDAStream();
-    build_ptr_dev<<<1, threads, 0, stream>>>(combined_win_, 0, buffers_dev_, world_size_);
+    build_ptr_dev<<<1, threads, 0, stream>>>(
+        combined_win_, buffer_size_, buffers_dev_, signal_pads_dev_, world_size_);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
     C10_CUDA_CHECK(cudaStreamSynchronize(stream));
     C10_CUDA_CHECK(cudaMemcpy(
       buffers_.data(),  // dst (host)
       buffers_dev_,  // src (device)
+      arr_size,
+      cudaMemcpyDeviceToHost));
+    C10_CUDA_CHECK(cudaMemcpy(
+      signal_pads_.data(),  // dst (host)
+      signal_pads_dev_,  // src (device)
       arr_size,
       cudaMemcpyDeviceToHost));
 #else
@@ -244,6 +252,20 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     arr_size,
     cudaMemcpyHostToDevice));
 
+  // Derive each peer's signal pad pointer from its buffer pointer; all
+  // ranks share the same aligned_buffer_size so we don't need to ask NCCL
+  // for the signal pad pointers separately.
+  for (int i = 0; i < world_size_; i++) {
+    signal_pads_[i] = buffers_[i] == nullptr
+        ? nullptr
+        : static_cast<char*>(buffers_[i]) + aligned_buffer_size;
+  }
+  C10_CUDA_CHECK(cudaMemcpy(
+      signal_pads_dev_,  // dst (device)
+      signal_pads_.data(),  // src (host)
+      arr_size,
+      cudaMemcpyHostToDevice));
+
   // Starting from NCCL 2.29, we can use `ncclGetLsaMultimemDevicePointer`
   // to get multicast address.
   void* mc_addr = nullptr;
@@ -253,20 +275,6 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     mc_addr_ = mc_addr;
   }
 #endif // NCCL_VERSION_CODE < NCCL_VERSION(2, 29, 0)
-
-    // Derive each peer's signal pad pointer from its buffer pointer; all
-    // ranks share the same aligned_buffer_size so we don't have to ask
-    // NCCL for the signal pad pointers separately.
-    for (int i = 0; i < world_size_; i++) {
-      signal_pads_[i] = buffers_[i] == nullptr
-          ? nullptr
-          : static_cast<char*>(buffers_[i]) + aligned_buffer_size;
-    }
-    C10_CUDA_CHECK(cudaMemcpy(
-        signal_pads_dev_,  // dst (device)
-        signal_pads_.data(),  // src (host)
-        arr_size,
-        cudaMemcpyHostToDevice));
 #endif // NCCL_HAS_SYMMEM_DEVICE_SUPPORT
   }
 
@@ -290,10 +298,11 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     }
     // signal_pad_ptr_ is part of the owning NCCLAllocation's combined
     // ncclMemAlloc region; freeing the buffer there releases it too.
-    // buffers_dev_ owns the combined allocation that also backs
-    // signal_pads_dev_; a single raw_delete frees both halves.
     if (buffers_dev_ != nullptr) {
       c10::cuda::CUDACachingAllocator::raw_delete(buffers_dev_);
+    }
+    if (signal_pads_dev_ != nullptr) {
+      c10::cuda::CUDACachingAllocator::raw_delete(signal_pads_dev_);
     }
   }
 
@@ -304,9 +313,6 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
   int world_size_;
   std::vector<void*> buffers_;
   std::vector<void*> signal_pads_;
-  // buffers_dev_ owns a single CUDACachingAllocator allocation of
-  // 2 * arr_size bytes. The first half holds the peer buffer pointers;
-  // signal_pads_dev_ points at the second half (offset arr_size).
   void** buffers_dev_{nullptr};
   void** signal_pads_dev_{nullptr};
   std::string group_name_;

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -36,12 +36,14 @@ static StoreExchange storeExchange = StoreExchange("NCCLAllocation");
 
 struct NCCLAllocation {
   // Combined ncclMemAlloc region. Layout:
-  //   [0, buffer_size)                            - user buffer
-  //   [buffer_size, buffer_size + signal_pad_size) - signal pad
-  // Total allocation size is round_up(buffer_size + signal_pad_size, 16).
+  //   [0, buffer_size)                                       - user buffer
+  //   [aligned_buffer_size, aligned_buffer_size + get_signal_pad_size()) - signal pad
+  // aligned_buffer_size is buffer_size rounded up to 16 bytes so the signal
+  // pad start is 16-byte aligned. Total allocation size is
+  // aligned_buffer_size + get_signal_pad_size().
   void* ptr;
   size_t buffer_size;
-  size_t signal_pad_size;
+  size_t aligned_buffer_size;
   int device_idx;
   std::mutex mutex;
   // Map of group name to peer alloc info
@@ -51,11 +53,11 @@ struct NCCLAllocation {
   NCCLAllocation(
       void* ptr,
       size_t buffer_size,
-      size_t signal_pad_size,
+      size_t aligned_buffer_size,
       int device_idx)
       : ptr(ptr),
         buffer_size(buffer_size),
-        signal_pad_size(signal_pad_size),
+        aligned_buffer_size(aligned_buffer_size),
         device_idx(device_idx) {}
 
   ~NCCLAllocation() {
@@ -180,9 +182,11 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
           rank_));
 
     // Signal pad lives in the same ncclMemAlloc region as the buffer,
-    // starting immediately after it; no additional ncclMemAlloc is needed.
-    signal_pad_ptr_ = static_cast<char*>(allocation->ptr) + buffer_size_;
-    const size_t signal_pad_size = allocation->signal_pad_size;
+    // starting at aligned_buffer_size (buffer_size rounded up to 16 bytes for
+    // alignment); no additional ncclMemAlloc is needed.
+    signal_pad_ptr_ = static_cast<char*>(allocation->ptr) +
+        allocation->aligned_buffer_size;
+    const size_t signal_pad_size = get_signal_pad_size();
     C10D_NCCL_CHECK(
     ncclCommWindowRegister(comm_, signal_pad_ptr_, signal_pad_size, &signal_handle_, NCCL_WIN_COLL_SYMMETRIC),
     c10::str(
@@ -204,11 +208,10 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     //   [0, arr_size)            - buffers_dev_
     //   [arr_size, 2 * arr_size) - signal_pads_dev_
     const size_t arr_size = sizeof(void*) * world_size_;
-    peer_ptrs_dev_ = reinterpret_cast<void**>(
+    buffers_dev_ = reinterpret_cast<void**>(
         c10::cuda::CUDACachingAllocator::raw_alloc(arr_size * 2));
-    buffers_dev_ = peer_ptrs_dev_;
     signal_pads_dev_ = reinterpret_cast<void**>(
-        reinterpret_cast<char*>(peer_ptrs_dev_) + arr_size);
+        reinterpret_cast<char*>(buffers_dev_) + arr_size);
     buffers_.resize(world_size_);
     signal_pads_.resize(world_size_);
 
@@ -296,8 +299,10 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     }
     // signal_pad_ptr_ is part of the owning NCCLAllocation's combined
     // ncclMemAlloc region; freeing the buffer there releases it too.
-    if (peer_ptrs_dev_ != nullptr) {
-      c10::cuda::CUDACachingAllocator::raw_delete(peer_ptrs_dev_);
+    // buffers_dev_ owns the combined allocation that also backs
+    // signal_pads_dev_; a single raw_delete frees both halves.
+    if (buffers_dev_ != nullptr) {
+      c10::cuda::CUDACachingAllocator::raw_delete(buffers_dev_);
     }
   }
 
@@ -308,10 +313,9 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
   int world_size_;
   std::vector<void*> buffers_;
   std::vector<void*> signal_pads_;
-  // Single CUDACachingAllocator allocation that backs both buffers_dev_ and
-  // signal_pads_dev_. buffers_dev_ aliases peer_ptrs_dev_; signal_pads_dev_
-  // is offset arr_size into the same buffer.
-  void** peer_ptrs_dev_{nullptr};
+  // buffers_dev_ owns a single CUDACachingAllocator allocation of
+  // 2 * arr_size bytes. The first half holds the peer buffer pointers;
+  // signal_pads_dev_ points at the second half (offset arr_size).
   void** buffers_dev_{nullptr};
   void** signal_pads_dev_{nullptr};
   std::string group_name_;
@@ -465,10 +469,26 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
 
     c10::cuda::CUDAGuard guard(device_idx);
     // Allocate buffer + signal pad together in a single ncclMemAlloc call.
-    // Buffer occupies [0, size); signal pad starts at offset `size`; the
-    // total allocation is rounded up to 16 bytes for alignment.
-    const size_t signal_pad_size = get_signal_pad_size();
-    const size_t total_size = at::round_up(size + signal_pad_size, 16UL);
+    // Buffer occupies [0, size); signal pad starts at aligned_buffer_size.
+    // The signal pad start must be aligned to NCCL's window registration
+    // granularity (the CUDA VMM allocation granularity, typically 2MB on
+    // Hopper) — `ncclCommWindowRegister` rejects sub-allocation addresses
+    // that aren't aligned to that granularity.
+    size_t window_alignment = 16UL;
+#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+    {
+      CUmemAllocationProp prop = {};
+      prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+      prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+      // NOLINTNEXTLINE(bugprone-signed-char-misuse)
+      prop.location.id = device_idx;
+      auto driver_api = c10::cuda::DriverAPI::get();
+      C10_CUDA_DRIVER_CHECK(driver_api->cuMemGetAllocationGranularity_(
+          &window_alignment, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
+    }
+#endif
+    const size_t aligned_buffer_size = at::round_up(size, window_alignment);
+    const size_t total_size = aligned_buffer_size + get_signal_pad_size();
     void* ptr;
     C10D_NCCL_CHECK(ncclMemAlloc(&ptr, total_size), "ncclMemAlloc");
     {
@@ -476,7 +496,7 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       allocations_.emplace(
           ptr,
           std::make_unique<NCCLAllocation>(
-              ptr, size, signal_pad_size, device_idx));
+              ptr, size, aligned_buffer_size, device_idx));
     }
     return ptr;
   }

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -36,14 +36,15 @@ static StoreExchange storeExchange = StoreExchange("NCCLAllocation");
 
 struct NCCLAllocation {
   // Combined ncclMemAlloc region. Layout:
-  //   [0, buffer_size)                                       - user buffer
-  //   [aligned_buffer_size, aligned_buffer_size + get_signal_pad_size()) - signal pad
-  // aligned_buffer_size is buffer_size rounded up to 16 bytes so the signal
-  // pad start is 16-byte aligned. Total allocation size is
-  // aligned_buffer_size + get_signal_pad_size().
+  //   [0, buffer_size)                                          - user data buffer
+  //   [round_up(buffer_size, 16), round_up(buffer_size, 16) + signal_pad_size)
+  //                                                             - signal pad
+  // Total allocation size is round_up(buffer_size, 16) + signal_pad_size.
   void* ptr;
+  // Size of the user-visible data buffer in bytes, as requested by the
+  // caller of `alloc()`.
   size_t buffer_size;
-  size_t aligned_buffer_size;
+  size_t signal_pad_size;
   int device_idx;
   std::mutex mutex;
   // Map of group name to peer alloc info
@@ -53,11 +54,11 @@ struct NCCLAllocation {
   NCCLAllocation(
       void* ptr,
       size_t buffer_size,
-      size_t aligned_buffer_size,
+      size_t signal_pad_size,
       int device_idx)
       : ptr(ptr),
         buffer_size(buffer_size),
-        aligned_buffer_size(aligned_buffer_size),
+        signal_pad_size(signal_pad_size),
         device_idx(device_idx) {}
 
   ~NCCLAllocation() {
@@ -171,31 +172,26 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     TORCH_CHECK(ncclPg != nullptr, "backend must be a NCCL process group");
     comm_ = reinterpret_cast<ncclComm_t>(ncclPg->getCommPtr());
 
+    // Register a single window over the combined buffer + signal pad region.
+    // Layout inside the registration:
+    //   [0, aligned_buffer_size)            - user data buffer
+    //   [aligned_buffer_size, total_size)   - signal pad
+    // The single registration sidesteps NCCL's window-alignment requirement
+    // for the signal-pad sub-region: only the base pointer (returned by
+    // ncclMemAlloc, already granularity-aligned) is registered.
+    const size_t aligned_buffer_size = at::round_up(buffer_size_, 16UL);
+    const size_t signal_pad_size = allocation->signal_pad_size;
+    const size_t total_size = aligned_buffer_size + signal_pad_size;
     C10D_NCCL_CHECK(
-      ncclCommWindowRegister(comm_, allocation->ptr, buffer_size_, &buffer_win_, NCCL_WIN_COLL_SYMMETRIC),
+      ncclCommWindowRegister(comm_, allocation->ptr, total_size, &combined_win_, NCCL_WIN_COLL_SYMMETRIC),
       c10::str(
           "Failed to window register segment with ptr ",
           allocation->ptr,
           ", size ",
-          buffer_size_,
+          total_size,
           " on rank ",
           rank_));
-
-    // Signal pad lives in the same ncclMemAlloc region as the buffer,
-    // starting at aligned_buffer_size (buffer_size rounded up to 16 bytes for
-    // alignment); no additional ncclMemAlloc is needed.
-    signal_pad_ptr_ = static_cast<char*>(allocation->ptr) +
-        allocation->aligned_buffer_size;
-    const size_t signal_pad_size = get_signal_pad_size();
-    C10D_NCCL_CHECK(
-    ncclCommWindowRegister(comm_, signal_pad_ptr_, signal_pad_size, &signal_handle_, NCCL_WIN_COLL_SYMMETRIC),
-    c10::str(
-        "Failed to window register segment with ptr ",
-        signal_pad_ptr_,
-        ", size ",
-        signal_pad_size,
-        " on rank ",
-        rank_));
+    signal_pad_ptr_ = static_cast<char*>(allocation->ptr) + aligned_buffer_size;
 
 #ifdef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
     // Register the host-side communicator for device communicator management.
@@ -215,25 +211,21 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     buffers_.resize(world_size_);
     signal_pads_.resize(world_size_);
 
-    // Fill out the peer pointer array
+    // Fill out the peer pointer array. We only fetch the buffer pointers
+    // for each peer; signal pad pointers are derived from them as
+    // buffer + aligned_buffer_size, since every rank sees the same
+    // symmetric-memory layout.
 #if NCCL_VERSION_CODE < NCCL_VERSION(2, 29, 0)
     // Lack of host-side API to get peer pointers, so we get them inside a
     // kernel and copy the result to host.
     int threads = std::min(128, world_size_);
     auto stream = at::cuda::getCurrentCUDAStream();
-    build_ptr_dev<<<1, threads, 0, stream>>>(buffer_win_, 0, buffers_dev_, world_size_);
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-    build_ptr_dev<<<1, threads, 0, stream>>>(signal_handle_, 0, signal_pads_dev_, world_size_);
+    build_ptr_dev<<<1, threads, 0, stream>>>(combined_win_, 0, buffers_dev_, world_size_);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
     C10_CUDA_CHECK(cudaStreamSynchronize(stream));
     C10_CUDA_CHECK(cudaMemcpy(
       buffers_.data(),  // dst (host)
       buffers_dev_,  // src (device)
-      arr_size,
-      cudaMemcpyDeviceToHost));
-    C10_CUDA_CHECK(cudaMemcpy(
-      signal_pads_.data(),  // dst (host)
-      signal_pads_dev_,  // src (device)
       arr_size,
       cudaMemcpyDeviceToHost));
 #else
@@ -242,21 +234,13 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     // If peer is not accessible within LSA domain, `ncclGetPeerDevicePointer`
     // returns nullptr.
     C10D_NCCL_CHECK(
-      ncclGetPeerDevicePointer(buffer_win_, 0, i, &buffers_[i]),
-      "ncclGetPeerDevicePointer failed");
-    C10D_NCCL_CHECK(
-      ncclGetPeerDevicePointer(signal_handle_, 0, i, &signal_pads_[i]),
+      ncclGetPeerDevicePointer(combined_win_, 0, i, &buffers_[i]),
       "ncclGetPeerDevicePointer failed");
   }
-  // Copy the peer access pointers to device arrays.
+  // Copy the peer buffer pointers to the device-side buffers array.
   C10_CUDA_CHECK(cudaMemcpy(
     buffers_dev_,  // dst (device)
     buffers_.data(),  // src (host)
-    arr_size,
-    cudaMemcpyHostToDevice));
-  C10_CUDA_CHECK(cudaMemcpy(
-    signal_pads_dev_,  // dst (device)
-    signal_pads_.data(),  // src (host)
     arr_size,
     cudaMemcpyHostToDevice));
 
@@ -265,10 +249,24 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
   void* mc_addr = nullptr;
   // Skip CHECK on purpose to improve fault tolerance since some machine's
   // Fabric Manager may be in bad NVLink Sharp state.
-  if (ncclGetLsaMultimemDevicePointer(buffer_win_, 0, &mc_addr) == ncclSuccess) {
+  if (ncclGetLsaMultimemDevicePointer(combined_win_, 0, &mc_addr) == ncclSuccess) {
     mc_addr_ = mc_addr;
   }
 #endif // NCCL_VERSION_CODE < NCCL_VERSION(2, 29, 0)
+
+    // Derive each peer's signal pad pointer from its buffer pointer; all
+    // ranks share the same aligned_buffer_size so we don't have to ask
+    // NCCL for the signal pad pointers separately.
+    for (int i = 0; i < world_size_; i++) {
+      signal_pads_[i] = buffers_[i] == nullptr
+          ? nullptr
+          : static_cast<char*>(buffers_[i]) + aligned_buffer_size;
+    }
+    C10_CUDA_CHECK(cudaMemcpy(
+        signal_pads_dev_,  // dst (device)
+        signal_pads_.data(),  // src (host)
+        arr_size,
+        cudaMemcpyHostToDevice));
 #endif // NCCL_HAS_SYMMEM_DEVICE_SUPPORT
   }
 
@@ -283,17 +281,10 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
       return;
     }
     c10::cuda::CUDAGuard guard(device_idx_);
-    if (buffer_win_ != nullptr) {
-      auto res = ncclCommWindowDeregister(comm_, buffer_win_);
+    if (combined_win_ != nullptr) {
+      auto res = ncclCommWindowDeregister(comm_, combined_win_);
       if (res != ncclSuccess) {
-        LOG(WARNING) << "ncclCommWindowDeregister failed for buffer_win: "
-                     << ncclGetErrorString(res);
-      }
-    }
-    if (signal_handle_ != nullptr) {
-      auto res = ncclCommWindowDeregister(comm_, signal_handle_);
-      if (res != ncclSuccess) {
-        LOG(WARNING) << "ncclCommWindowDeregister failed for signal_handle: "
+        LOG(WARNING) << "ncclCommWindowDeregister failed: "
                      << ncclGetErrorString(res);
       }
     }
@@ -319,8 +310,8 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
   void** buffers_dev_{nullptr};
   void** signal_pads_dev_{nullptr};
   std::string group_name_;
-  ncclWindow_t buffer_win_{nullptr};
-  ncclWindow_t signal_handle_{nullptr};
+  // Single NCCL window covering both the user data buffer and the signal pad.
+  ncclWindow_t combined_win_{nullptr};
   void* signal_pad_ptr_{nullptr};
   // Multicast address
   void* mc_addr_{nullptr};
@@ -441,11 +432,11 @@ c10::Device NCCLSymmetricMemory::get_device() {
 }
 
 ncclWindow_t NCCLSymmetricMemory::get_window() {
-  return pai_->buffer_win_;
+  return pai_->combined_win_;
 }
 
 ncclWindow_t NCCLSymmetricMemory::get_signal_pad_handle() {
-  return pai_->signal_handle_;
+  return pai_->combined_win_;
 }
 
 size_t NCCLSymmetricMemory::get_offset() {
@@ -469,26 +460,12 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
 
     c10::cuda::CUDAGuard guard(device_idx);
     // Allocate buffer + signal pad together in a single ncclMemAlloc call.
-    // Buffer occupies [0, size); signal pad starts at aligned_buffer_size.
-    // The signal pad start must be aligned to NCCL's window registration
-    // granularity (the CUDA VMM allocation granularity, typically 2MB on
-    // Hopper) — `ncclCommWindowRegister` rejects sub-allocation addresses
-    // that aren't aligned to that granularity.
-    size_t window_alignment = 16UL;
-#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
-    {
-      CUmemAllocationProp prop = {};
-      prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-      prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-      // NOLINTNEXTLINE(bugprone-signed-char-misuse)
-      prop.location.id = device_idx;
-      auto driver_api = c10::cuda::DriverAPI::get();
-      C10_CUDA_DRIVER_CHECK(driver_api->cuMemGetAllocationGranularity_(
-          &window_alignment, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
-    }
-#endif
-    const size_t aligned_buffer_size = at::round_up(size, window_alignment);
-    const size_t total_size = aligned_buffer_size + get_signal_pad_size();
+    // Buffer occupies [0, size); signal pad starts at round_up(size, 16).
+    // A single window is registered over the whole region at rendezvous
+    // time, so only the base pointer (already granularity-aligned by
+    // ncclMemAlloc) needs to satisfy NCCL's window-alignment requirement.
+    const size_t signal_pad_size = get_signal_pad_size();
+    const size_t total_size = at::round_up(size, 16UL) + signal_pad_size;
     void* ptr;
     C10D_NCCL_CHECK(ncclMemAlloc(&ptr, total_size), "ncclMemAlloc");
     {
@@ -496,7 +473,7 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       allocations_.emplace(
           ptr,
           std::make_unique<NCCLAllocation>(
-              ptr, size, aligned_buffer_size, device_idx));
+              ptr, size, signal_pad_size, device_idx));
     }
     return ptr;
   }

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -35,16 +35,28 @@ namespace symmetric_memory {
 static StoreExchange storeExchange = StoreExchange("NCCLAllocation");
 
 struct NCCLAllocation {
+  // Combined ncclMemAlloc region. Layout:
+  //   [0, buffer_size)                            - user buffer
+  //   [buffer_size, buffer_size + signal_pad_size) - signal pad
+  // Total allocation size is round_up(buffer_size + signal_pad_size, 16).
   void* ptr;
   size_t buffer_size;
+  size_t signal_pad_size;
   int device_idx;
   std::mutex mutex;
   // Map of group name to peer alloc info
   ska::flat_hash_map<std::string, c10::intrusive_ptr<NCCLPeerAllocInfo>>
       peer_alloc_infos_;
 
-  NCCLAllocation(void* ptr, size_t buffer_size, int device_idx)
-      : ptr(ptr), buffer_size(buffer_size), device_idx(device_idx) {}
+  NCCLAllocation(
+      void* ptr,
+      size_t buffer_size,
+      size_t signal_pad_size,
+      int device_idx)
+      : ptr(ptr),
+        buffer_size(buffer_size),
+        signal_pad_size(signal_pad_size),
+        device_idx(device_idx) {}
 
   ~NCCLAllocation() {
     // Avoid calling CUDA functions after driver shutting down
@@ -52,6 +64,7 @@ struct NCCLAllocation {
       return;
     }
     c10::cuda::CUDAGuard guard(device_idx);
+    // Single free for the combined buffer + signal pad region.
     ncclResult_t res = ncclMemFree(ptr);
     if (res != ncclSuccess) {
         LOG(WARNING) << "ncclMemFree failed in NCCLAllocation dtor: "
@@ -166,9 +179,10 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
           " on rank ",
           rank_));
 
-    const size_t signal_pad_size = get_signal_pad_size();
-    C10D_NCCL_CHECK(
-        ncclMemAlloc(&signal_pad_ptr_, signal_pad_size), "ncclMemAlloc failed");
+    // Signal pad lives in the same ncclMemAlloc region as the buffer,
+    // starting immediately after it; no additional ncclMemAlloc is needed.
+    signal_pad_ptr_ = static_cast<char*>(allocation->ptr) + buffer_size_;
+    const size_t signal_pad_size = allocation->signal_pad_size;
     C10D_NCCL_CHECK(
     ncclCommWindowRegister(comm_, signal_pad_ptr_, signal_pad_size, &signal_handle_, NCCL_WIN_COLL_SYMMETRIC),
     c10::str(
@@ -186,11 +200,15 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     manager.register_comm(group_name_, comm_);
 
     // Starting from NCCL 2.28, we can get peer pointers.
+    // Allocate a single device buffer for both peer arrays and split it:
+    //   [0, arr_size)            - buffers_dev_
+    //   [arr_size, 2 * arr_size) - signal_pads_dev_
     const size_t arr_size = sizeof(void*) * world_size_;
-    buffers_dev_ = reinterpret_cast<void**>(
-        c10::cuda::CUDACachingAllocator::raw_alloc(arr_size));
+    peer_ptrs_dev_ = reinterpret_cast<void**>(
+        c10::cuda::CUDACachingAllocator::raw_alloc(arr_size * 2));
+    buffers_dev_ = peer_ptrs_dev_;
     signal_pads_dev_ = reinterpret_cast<void**>(
-        c10::cuda::CUDACachingAllocator::raw_alloc(arr_size));
+        reinterpret_cast<char*>(peer_ptrs_dev_) + arr_size);
     buffers_.resize(world_size_);
     signal_pads_.resize(world_size_);
 
@@ -276,18 +294,10 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
                      << ncclGetErrorString(res);
       }
     }
-    if (signal_pad_ptr_ != nullptr) {
-      auto res = ncclMemFree(signal_pad_ptr_);
-      if (res != ncclSuccess) {
-        LOG(WARNING) << "ncclMemFree failed for signal_pad: "
-                     << ncclGetErrorString(res);
-      }
-    }
-    if (buffers_dev_ != nullptr) {
-      c10::cuda::CUDACachingAllocator::raw_delete(buffers_dev_);
-    }
-    if (signal_pads_dev_ != nullptr) {
-      c10::cuda::CUDACachingAllocator::raw_delete(signal_pads_dev_);
+    // signal_pad_ptr_ is part of the owning NCCLAllocation's combined
+    // ncclMemAlloc region; freeing the buffer there releases it too.
+    if (peer_ptrs_dev_ != nullptr) {
+      c10::cuda::CUDACachingAllocator::raw_delete(peer_ptrs_dev_);
     }
   }
 
@@ -298,6 +308,10 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
   int world_size_;
   std::vector<void*> buffers_;
   std::vector<void*> signal_pads_;
+  // Single CUDACachingAllocator allocation that backs both buffers_dev_ and
+  // signal_pads_dev_. buffers_dev_ aliases peer_ptrs_dev_; signal_pads_dev_
+  // is offset arr_size into the same buffer.
+  void** peer_ptrs_dev_{nullptr};
   void** buffers_dev_{nullptr};
   void** signal_pads_dev_{nullptr};
   std::string group_name_;
@@ -450,13 +464,19 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
         "must not be called with a group_name");
 
     c10::cuda::CUDAGuard guard(device_idx);
-    // TODO: we might need to use a roundup or mempool for mem allocation.
+    // Allocate buffer + signal pad together in a single ncclMemAlloc call.
+    // Buffer occupies [0, size); signal pad starts at offset `size`; the
+    // total allocation is rounded up to 16 bytes for alignment.
+    const size_t signal_pad_size = get_signal_pad_size();
+    const size_t total_size = at::round_up(size + signal_pad_size, 16UL);
     void* ptr;
-    C10D_NCCL_CHECK(ncclMemAlloc(&ptr, size), "ncclMemAlloc");
+    C10D_NCCL_CHECK(ncclMemAlloc(&ptr, total_size), "ncclMemAlloc");
     {
       std::lock_guard<std::mutex> lock(mutex_);
       allocations_.emplace(
-          ptr, std::make_unique<NCCLAllocation>(ptr, size, device_idx));
+          ptr,
+          std::make_unique<NCCLAllocation>(
+              ptr, size, signal_pad_size, device_idx));
     }
     return ptr;
   }

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp
@@ -45,8 +45,6 @@ class NCCLSymmetricMemory : public SymmetricMemory {
 
   ncclWindow_t get_window();
 
-  ncclWindow_t get_signal_pad_handle();
-
   size_t get_offset() override;
 
  private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183344

When we first onboard NCCL backend for symmetric memory, we use two separate ptr for data buffer and signal pad. This is not efficient, so we want to consolidate them all together so that we only call window registration once.

We combine the signal pad lives immediately after the data buffer in the same region. And we align the size of data buffer to 16 bytes before appending signal pad. The signal pad is already 16 byte aligned.

Authored by Claude and manually polished again.