### PR TITLE
docs: document 5 functions in torch.utils submodules

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -959,9 +959,6 @@ coverage_ignore_functions = [
     "hann",
     "kaiser",
     "nuttall",
-    # torch.utils.backend_registration
-    "generate_methods_for_privateuse1_backend",
-    "rename_privateuse1_backend",
     # torch.utils.benchmark.examples.op_benchmark
     # torch.utils.benchmark.op_fuzzers.spectral
     "power_range",
@@ -994,8 +991,6 @@ coverage_ignore_functions = [
     "detach_variable",
     "get_device_states",
     "noop_context_fn",
-    # torch.utils.cpp_backtrace
-    "get_cpp_backtrace",
     # torch.utils.cpp_extension
     "check_compiler_is_gcc",
     "check_compiler_ok_for_platform",
@@ -1050,7 +1045,6 @@ coverage_ignore_functions = [
     "apply_shuffle_settings",
     "get_all_graph_pipes",
     # torch.utils.hooks
-    "unserializable_hook",
     "warn_if_has_hooks",
     # torch.utils.jit.log_extract
     "extract_ir",
@@ -1084,8 +1078,6 @@ coverage_ignore_functions = [
     "tensor_proto",
     "text",
     "video",
-    # torch.utils.throughput_benchmark
-    "format_time",
 ]
 
 coverage_ignore_classes = [

--- a/docs/source/utils.md
+++ b/docs/source/utils.md
@@ -19,6 +19,50 @@
     swap_tensors
 ```
 
+# torch.utils.backend_registration
+
+```{eval-rst}
+.. currentmodule:: torch.utils.backend_registration
+```
+
+```{eval-rst}
+.. autofunction:: generate_methods_for_privateuse1_backend
+```
+
+```{eval-rst}
+.. autofunction:: rename_privateuse1_backend
+```
+
+# torch.utils.cpp_backtrace
+
+```{eval-rst}
+.. currentmodule:: torch.utils.cpp_backtrace
+```
+
+```{eval-rst}
+.. autofunction:: get_cpp_backtrace
+```
+
+# torch.utils.hooks
+
+```{eval-rst}
+.. currentmodule:: torch.utils.hooks
+```
+
+```{eval-rst}
+.. autofunction:: unserializable_hook
+```
+
+# torch.utils.throughput_benchmark
+
+```{eval-rst}
+.. currentmodule:: torch.utils.throughput_benchmark
+```
+
+```{eval-rst}
+.. autofunction:: format_time
+```
+
 # torch.utils.collect_env
 ```{eval-rst}
 .. automodule:: torch.utils.collect_env

--- a/docs/source/utils.md
+++ b/docs/source/utils.md
@@ -12,35 +12,23 @@
     :toctree: generated
     :nosignatures:
 
-    rename_privateuse1_backend
-    generate_methods_for_privateuse1_backend
     get_cpp_backtrace
     set_module
     swap_tensors
 ```
 
 # torch.utils.backend_registration
-
 ```{eval-rst}
 .. currentmodule:: torch.utils.backend_registration
 ```
 
 ```{eval-rst}
-.. autofunction:: generate_methods_for_privateuse1_backend
-```
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
 
-```{eval-rst}
-.. autofunction:: rename_privateuse1_backend
-```
-
-# torch.utils.cpp_backtrace
-
-```{eval-rst}
-.. currentmodule:: torch.utils.cpp_backtrace
-```
-
-```{eval-rst}
-.. autofunction:: get_cpp_backtrace
+    generate_methods_for_privateuse1_backend
+    rename_privateuse1_backend
 ```
 
 # torch.utils.hooks


### PR DESCRIPTION
Fixes #182832 

## Summary
Document 5 functions in `torch.utils` submodules.

## Changes
- Removed entries from `coverage_ignore_functions` in `docs/source/conf.py`:
  - `torch.utils.backend_registration`: `generate_methods_for_privateuse1_backend`, `rename_privateuse1_backend`
  - `torch.utils.cpp_backtrace`: `get_cpp_backtrace`
  - `torch.utils.hooks`: `unserializable_hook`
  - `torch.utils.throughput_benchmark`: `format_time`
- Added 4 new sections to `docs/source/utils.md` with `currentmodule` + `autofunction` directives.

## Verification
- `make coverage` no longer reports these 5 functions as undocumented
- `make html` renders all 5 with correct namespaces

<img width="3022" height="1632" alt="image" src="https://github.com/user-attachments/assets/9c932677-ad94-4ad3-b1b5-184c393fcffd" />

<img width="2970" height="2034" alt="image" src="https://github.com/user-attachments/assets/8da9fc0e-c00a-43aa-b395-aec544bf8187" />

<img width="1470" height="820" alt="image" src="https://github.com/user-attachments/assets/4e705c0b-1050-4d78-ad25-efefbacdf2b5" />


cc @svekars @sekyondaMeta @AlannaBurke