### PR TITLE
[ROCm][CI] Unskip TestMatmulCuda.test_cublas_deterministic

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -373,7 +373,6 @@ class TestMatmulCuda(InductorTestCase):
         self.assertEqual(out1_gpu, out2_gpu[0])
 
     @onlyCUDA
-    @skipIfRocm
     @parametrize("shape", [2**i for i in range(5, 14)])
     @dtypes(torch.float, torch.half, torch.bfloat16)
     def test_cublas_deterministic(self, device, shape, dtype):


### PR DESCRIPTION
hipBLASLt multi-stream handle race that motivated the skip in #161749 was fixed in #179053. Test passes on MI200 with ROCm 7.2.1.

Fixes #168775.

Authored with assistance from Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @jerrymannil @xinyazhang