### PR TITLE
Fix for #183002

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -388,6 +388,17 @@ class FakeTensorTest(TestCase):
                     torch._C._dispatch_key_set(y)
                 )
 
+    def test_compare_tensor_meta_unbacked_numel(self):
+        from torch.fx.experimental.symbolic_shapes import _constrain_range_for_size
+
+        shape_env = ShapeEnv()
+        with FakeTensorMode(shape_env=shape_env):
+            u0 = shape_env.create_unbacked_symint()
+            _constrain_range_for_size(u0, min=0)
+            a = torch.empty(u0, 16, device="cpu")
+            b = torch.empty(u0, 16, device="cpu")
+        prims.utils.compare_tensor_meta(a, b, check_strides=True)
+
     def test_batch_tensor(self):
         x = torch.rand((3, 4, 5))
         b = _add_batch_dim(x, 0, 0)

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -215,13 +215,16 @@ def _check_strides_helper(
     significant_only=True,
     allow_rhs_unbacked=False,
 ) -> tuple[bool, int | None]:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
     # NOTE: only on CUDA because CPU elementwise strides are incorrect in PyTorch
     # See https://github.com/pytorch/pytorch/issues/77553
     # Only compares strides that are "meaningful" -- strides for dimensions with length > 1
-    # and for tensors with more than one element
+    # and for tensors with more than one element. Use guard_or_false on the
+    # numel gate so unbacked shapes don't trigger a data-dependent guard.
     if (
         not only_cuda or a.device.type == "cuda" or b.device.type == "cuda"
-    ) and a.numel() > 0:
+    ) and guard_or_false(a.numel() > 0):
         for idx in range(a.ndim):
             check = not significant_only or a.shape[idx] > 1
             # TODO: Check the symbols are consistent with each other


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183353

#183002 enabled opcheck stride checking for CPU tensors by passing
only_cuda=False through compare_tensor_meta. That regressed callers
with unbacked symbolic shapes: _check_strides_helper guarded
a.numel() > 0 directly, which raises GuardOnDataDependentSymNode when
numel is an unbacked symint.

Wrap the numel gate in guard_or_false so unbacked numels skip stride
checking instead of crashing. Skipping is safe: the loop body already
treats unbacked strides on b as untestable, and a tensor whose numel is
unknown is the same kind of "untestable" case.

Authored with Claude.