### PR TITLE
[CI] Match MI355 ROCm shards with trunk

### DIFF
--- a/.github/workflows/periodic-rocm-mi355.yml
+++ b/.github/workflows/periodic-rocm-mi355.yml
@@ -51,9 +51,10 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 1, num_shards: 4, runner: "linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 2, num_shards: 4, runner: "linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 3, num_shards: 4, runner: "linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 4, num_shards: 4, runner: "linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
         ]}
     secrets: inherit
 

--- a/.github/workflows/rocm-mi355.yml
+++ b/.github/workflows/rocm-mi355.yml
@@ -44,12 +44,16 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 1, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 2, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 3, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 4, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 5, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 6, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 7, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 8, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 9, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 10, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
## Summary
- Increase `rocm-mi355` default test shards from 6 to 10.
- Increase `periodic-rocm-mi355` distributed test shards from 3 to 4.

## Why
The MI355 trunk workflow is already producing artifacts with 10 default shards and 4 distributed shards. Aligning the dedicated `rocm-mi355` and `periodic-rocm-mi355` workflows with those shard totals keeps artifact names consistent across workflows and prevents downstream parity/reporting jobs from looking for stale shard layouts.

Made with cursor
cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang