### PR TITLE
[ROCm][inductor] Force XBLOCK=1 in reduction contiguous_config when xnumel <= 64 on HIP

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4329,7 +4329,8 @@ def _reduction_configs(
         # Default XBLOCK=2 launches too few programs to fill
         # the device. Prefer XBLOCK=1 so the autotuner has a candidate
         # that can saturate all CUs.
-        1 if (torch.version.hip and size_hints.get("x", 0) <= 64)
+        1
+        if (torch.version.hip and size_hints.get("x", 0) <= 64)
         else (2 if rnumel <= 2048 else 1),  # 1024 or less is persistent
         min(rnumel, MAX_R0_BLOCK),
         register_intensive=register_intensive,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4326,7 +4326,12 @@ def _reduction_configs(
         )
 
     contiguous_config = make_config(
-        2 if rnumel <= 2048 else 1,  # 1024 or less is persistent
+        # On HIP, when xnumel is small relative to the CU count (256+ on
+        # MI300/MI350), default XBLOCK=2 launches too few programs to fill
+        # the device. Prefer XBLOCK=1 so the autotuner has a candidate
+        # that can saturate all CUs.
+        1 if (torch.version.hip and size_hints.get("x", 0) <= 64)
+        else (2 if rnumel <= 2048 else 1),  # 1024 or less is persistent
         min(rnumel, MAX_R0_BLOCK),
         register_intensive=register_intensive,
     )

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4326,8 +4326,7 @@ def _reduction_configs(
         )
 
     contiguous_config = make_config(
-        # On HIP, when xnumel is small relative to the CU count (256+ on
-        # MI300/MI350), default XBLOCK=2 launches too few programs to fill
+        # Default XBLOCK=2 launches too few programs to fill
         # the device. Prefer XBLOCK=1 so the autotuner has a candidate
         # that can saturate all CUs.
         1 if (torch.version.hip and size_hints.get("x", 0) <= 64)


### PR DESCRIPTION
- Default XBLOCK=2 launches too few programs to fill CUs for tiny-x reductions, 
- and ** under reduction_hint=INNER ** is the only candidate returned. 
- Force XBLOCK=1 on HIP when xnumel <= 64 so the autotuner has a candidate that can saturate the device. 
- CUDA path unchanged.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben