### PR TITLE
[FSDP] Support replicated shard placement params

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -33,11 +33,12 @@ from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
     foreach_reduce,
 )
 from torch.distributed.fsdp._fully_shard._fsdp_common import (
+    DDPMeshInfo,
     FSDPMeshInfo,
     HSDPMeshInfo,
     ShardPlacementResult,
 )
-from torch.distributed.tensor import DTensor, init_device_mesh, Shard
+from torch.distributed.tensor import DTensor, init_device_mesh, Replicate, Shard
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
@@ -1426,6 +1427,59 @@ class TestFullyShardShardPlacementFnMultiProcess(FSDPTest):
         for param, ref_param in zip(model.parameters(), ref_model.parameters()):
             full_param = param.full_tensor()
             self.assertEqual(full_param, ref_param)
+
+    @skip_if_lt_x_gpu(2, allow_cpu=True)
+    def test_shard_placement_fn_replicated_param(self):
+        self._test_shard_placement_fn_replicated_param(use_explicit_ddp_mesh=False)
+
+    @skip_if_lt_x_gpu(2, allow_cpu=True)
+    def test_shard_placement_fn_replicated_param_explicit_mesh_info(self):
+        self._test_shard_placement_fn_replicated_param(use_explicit_ddp_mesh=True)
+
+    def _test_shard_placement_fn_replicated_param(self, use_explicit_ddp_mesh: bool):
+        torch.manual_seed(42)
+        model = nn.Linear(4, 4, device=device_type)
+        ref_model = copy.deepcopy(model)
+        mesh = init_device_mesh(device_type.type, (self.world_size,))
+        ddp_mesh_info = DDPMeshInfo(mesh, replicate_mesh_dim=0)
+        replicated_params = {model.bias}
+
+        def shard_placement_fn(
+            param: nn.Parameter,
+        ) -> Shard | Replicate | ShardPlacementResult | None:
+            if param in replicated_params:
+                if use_explicit_ddp_mesh:
+                    return ShardPlacementResult(Replicate(), ddp_mesh_info)
+                return Replicate()
+            return Shard(0)
+
+        fully_shard(model, mesh=mesh, shard_placement_fn=shard_placement_fn)
+        self.assertIsInstance(model.weight, DTensor)
+        self.assertIsInstance(model.bias, DTensor)
+        self.assertEqual(model.bias.placements, (Replicate(),))
+
+        optim = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9, foreach=True)
+        ref_optim = torch.optim.SGD(
+            ref_model.parameters(), lr=0.1, momentum=0.9, foreach=True
+        )
+
+        torch.manual_seed(42 + self.rank + 1)
+        inp = torch.randn((2, 4), device=device_type.type)
+        ref_loss = ref_model(inp).pow(2).sum()
+        loss = model(inp).pow(2).sum()
+        self.assertEqual(loss, ref_loss)
+
+        ref_loss.backward()
+        loss.backward()
+        for param in ref_model.parameters():
+            if param.grad is not None:
+                dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
+
+        self.assertEqual(model.bias.grad.to_local(), ref_model.bias.grad)
+        optim.step()
+        ref_optim.step()
+        self.assertEqual(model.weight.full_tensor(), ref_model.weight)
+        self.assertEqual(model.bias.full_tensor(), ref_model.bias)
 
 
 class TestFullyShardShardPlacementFnMultiThread(FSDPTestMultiThread):

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
@@ -10,7 +10,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed._composable.contract import _get_registry
-from torch.distributed.tensor import DeviceMesh, DTensor, Shard
+from torch.distributed.tensor import DeviceMesh, DTensor, Replicate, Shard
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 
 from ._fsdp_api import DataParallelMeshDims
@@ -173,23 +173,26 @@ def is_bw() -> bool:
 
 @dataclass
 class ShardPlacementResult:
-    placement: Shard | None
-    mesh_info: FSDPMeshInfo
+    placement: Shard | Replicate | None
+    mesh_info: DataParallelMeshInfo
 
 
-ShardPlacementFnResult = Shard | ShardPlacementResult | None
+ShardPlacementFnResult = Shard | Replicate | ShardPlacementResult | None
 
 
 def resolve_shard_placement(
     result: ShardPlacementFnResult,
-    default_mesh_info: FSDPMeshInfo,
+    default_mesh_info: DataParallelMeshInfo,
 ) -> ShardPlacementResult:
     """Resolve the shard_placement_fn result to a ShardPlacementResult.
 
     Handles different input types and applies defaults:
     - None: Use default sharding (Shard(0)) on default mesh
     - Shard: Use specified shard dimension on default mesh
-    - ShardPlacementResult: Use as-is
+    - Replicate: Use a replicated DDPMeshInfo on the default 1D mesh
+    - ShardPlacementResult: Use as-is. Its mesh_info may be FSDPMeshInfo,
+      HSDPMeshInfo, or DDPMeshInfo. For DDPMeshInfo, placement may be
+      Replicate() or None.
 
     Args:
         result: The return value from shard_placement_fn, or None if no fn provided.
@@ -202,6 +205,45 @@ def resolve_shard_placement(
         return ShardPlacementResult(placement=None, mesh_info=default_mesh_info)
     if isinstance(result, Shard):
         return ShardPlacementResult(placement=result, mesh_info=default_mesh_info)
+    if isinstance(result, Replicate):
+        if isinstance(default_mesh_info, DDPMeshInfo) and not isinstance(
+            default_mesh_info, FSDPMeshInfo
+        ):
+            return ShardPlacementResult(placement=None, mesh_info=default_mesh_info)
+        if default_mesh_info.mesh.ndim != 1:
+            raise ValueError(
+                "Returning Replicate() directly from shard_placement_fn is only "
+                "supported with a 1D mesh. For multi-dimensional meshes, return "
+                "ShardPlacementResult(Replicate(), DDPMeshInfo(...)) to specify "
+                "the replicate group explicitly."
+            )
+        return ShardPlacementResult(
+            placement=None,
+            mesh_info=DDPMeshInfo(default_mesh_info.mesh, replicate_mesh_dim=0),
+        )
     if isinstance(result, ShardPlacementResult):
+        if not isinstance(result.mesh_info, (FSDPMeshInfo, DDPMeshInfo)):
+            raise ValueError(
+                "ShardPlacementResult mesh_info must be FSDPMeshInfo, "
+                "HSDPMeshInfo, or DDPMeshInfo"
+            )
+        if isinstance(result.mesh_info, DDPMeshInfo) and not isinstance(
+            result.mesh_info, FSDPMeshInfo
+        ):
+            if result.placement is None or isinstance(result.placement, Replicate):
+                return ShardPlacementResult(
+                    placement=None,
+                    mesh_info=result.mesh_info,
+                )
+            raise ValueError(
+                "ShardPlacementResult with DDPMeshInfo must use placement=None "
+                "or Replicate() since DDPMeshInfo represents replicated/all-reduce "
+                "parameters"
+            )
+        if isinstance(result.placement, Replicate):
+            raise ValueError(
+                "ShardPlacementResult with FSDPMeshInfo or HSDPMeshInfo must use "
+                "a Shard placement or None"
+            )
         return result
     raise ValueError(f"Invalid shard_placement_fn result: {result}")

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_init.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_init.py
@@ -7,7 +7,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch._logging import warning_once
 from torch.distributed.device_mesh import _get_device_handle
-from torch.distributed.tensor import DeviceMesh, DTensor, init_device_mesh
+from torch.distributed.tensor import DeviceMesh, DTensor, init_device_mesh, Replicate
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 from ._fsdp_common import (
@@ -451,7 +451,7 @@ def _init_param_group(
     params, this creates a single group.
     """
     # Import here to avoid circular imports
-    from ._fsdp_common import FSDPMeshInfo, resolve_shard_placement
+    from ._fsdp_common import DDPMeshInfo, FSDPMeshInfo, resolve_shard_placement
     from ._fsdp_param_group import FSDPParamGroup
 
     if not params:
@@ -475,28 +475,46 @@ def _init_param_group(
         )
         return
 
-    # Group params by their process group to support per-param mesh,
+    # Group params by their process groups to support per-param mesh,
     # e.g., expert params using ep_mesh vs regular params using dp_mesh.
-    # For HSDP, also key by replicate_process_group to avoid grouping
-    # FSDPMeshInfo params with HSDPMeshInfo params that share the same
-    # shard_process_group but require different gradient reduction behavior.
+    # For HSDP/DDP, also key by replicate_process_group to avoid grouping
+    # params that require different gradient reduction behavior.
     if not isinstance(mesh_info, FSDPMeshInfo):
         raise ValueError(
             "Per-param mesh via shard_placement_fn is not supported with "
             f"{type(mesh_info).__name__}; it requires FSDPMeshInfo (or subclass)"
         )
     pg_to_group: dict[
-        tuple[dist.ProcessGroup, dist.ProcessGroup | None],
-        tuple[FSDPMeshInfo, list[nn.Parameter]],
+        tuple[dist.ProcessGroup | None, dist.ProcessGroup | None],
+        tuple[DataParallelMeshInfo, list[nn.Parameter]],
     ] = {}
+    default_ddp_mesh_info: DDPMeshInfo | None = None
     for param in params:
-        param_mesh_info = resolve_shard_placement(
-            shard_placement_fn(param),
-            mesh_info,
-        ).mesh_info
-        shard_pg = param_mesh_info.shard_process_group
+        placement_result = shard_placement_fn(param)
+        if isinstance(placement_result, Replicate):
+            if default_ddp_mesh_info is None:
+                if mesh_info.mesh.ndim != 1:
+                    raise ValueError(
+                        "Returning Replicate() directly from shard_placement_fn is "
+                        "only supported with a 1D mesh. For multi-dimensional "
+                        "meshes, return ShardPlacementResult(Replicate(), "
+                        "DDPMeshInfo(...)) to specify the replicate group explicitly."
+                    )
+                default_ddp_mesh_info = DDPMeshInfo(
+                    mesh_info.mesh,
+                    replicate_mesh_dim=0,
+                )
+            param_mesh_info = default_ddp_mesh_info
+        else:
+            param_mesh_info = resolve_shard_placement(
+                placement_result,
+                mesh_info,
+            ).mesh_info
+        shard_pg: dist.ProcessGroup | None = None
+        if isinstance(param_mesh_info, FSDPMeshInfo):
+            shard_pg = param_mesh_info.shard_process_group
         replicate_pg: dist.ProcessGroup | None = None
-        if isinstance(param_mesh_info, HSDPMeshInfo):
+        if isinstance(param_mesh_info, DDPMeshInfo):
             replicate_pg = param_mesh_info.replicate_process_group
         key = (shard_pg, replicate_pg)
         if key not in pg_to_group:
@@ -506,19 +524,24 @@ def _init_param_group(
             if existing_mesh_info is not param_mesh_info:
                 raise ValueError(
                     f"Params sharing the same process group must use the same "
-                    f"FSDPMeshInfo object, but got different objects: "
+                    f"DataParallelMeshInfo object, but got different objects: "
                     f"{existing_mesh_info} vs {param_mesh_info}"
                 )
             pg_to_group[key][1].append(param)
 
     # Create a FSDPParamGroup per process group
     for group_mesh_info, group_params in pg_to_group.values():
-        if group_mesh_info is not mesh_info:
+        if (
+            isinstance(group_mesh_info, FSDPMeshInfo)
+            and group_mesh_info is not mesh_info
+        ):
             group_post_forward = _get_post_forward_mesh_info(
                 reshard_after_forward, group_mesh_info
             )
-        else:
+        elif group_mesh_info is mesh_info:
             group_post_forward = post_forward_mesh_info
+        else:
+            group_post_forward = None
         state._fsdp_param_groups.append(
             FSDPParamGroup(
                 group_params,

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -231,7 +231,7 @@ class FSDPParam:
         if callable(shard_placement_fn):
             shard_result = resolve_shard_placement(
                 shard_placement_fn(param),
-                cast(FSDPMeshInfo, mesh_info),
+                mesh_info,
             )
             self.mesh_info = shard_result.mesh_info
             fsdp_placement = shard_result.placement
@@ -246,6 +246,10 @@ class FSDPParam:
         if not param.is_contiguous():
             raise NotImplementedError(
                 f"FSDP does not support non-contiguous parameters yet: {param.shape=} {param.stride()=}"
+            )
+        if isinstance(fsdp_placement, Replicate):
+            raise AssertionError(
+                f"Expected Shard or None, got {type(fsdp_placement)}: {fsdp_placement}"
             )
         if fsdp_placement is None:
             fsdp_placement = Shard(0)

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -209,11 +209,15 @@ def fully_shard(
               ``fully_shard``.
             - :class:`Shard`: Shard the parameter on the specified dimension
               using the mesh passed to ``fully_shard``.
+            - :class:`Replicate`: Replicate and all-reduce the parameter on the
+              1D mesh passed to ``fully_shard``.
             - :class:`ShardPlacementResult`: Specify both the shard placement
-              and a custom :class:`FSDPMeshInfo`. This allows different
-              parameters to be sharded across different process groups, enabling
-              use cases like Mixture of Experts where expert params use a
-              different mesh than regular params.
+              and a custom data parallel mesh info. This allows different
+              parameters to use different process groups or data parallel
+              policies, enabling use cases like Mixture of Experts where expert
+              params use a different mesh than regular params. Returning a
+              ``DDPMeshInfo`` with ``placement=None`` or ``Replicate()`` makes
+              that parameter replicated and all-reduced instead of sharded.
 
             If sharding on a nonzero dim, we currently require even sharding,
             i.e. the tensor dim size on that dim must be divisible by the FSDP


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #183366

Allow fully_shard shard_placement_fn to return Replicate() for 1D meshes, mapping those parameters to a DDP-style all-reduce param group while keeping Shard placements on the FSDP reduce-scatter path.

Add coverage for both direct Replicate() and explicit ShardPlacementResult(Replicate(), DDPMeshInfo(...)) forms on stock nn.Linear, including foreach optimizer behavior.

Fixes #183207

Test Plan:

lintrunner torch/distributed/fsdp/_fully_shard/_fsdp_common.py torch/distributed/fsdp/_fully_shard/_fsdp_init.py torch/distributed/fsdp/_fully_shard/_fsdp_param.py torch/distributed/fsdp/_fully_shard/_fully_shard.py test/distributed/_composable/fsdp/test_fully_shard_training.py

python -m py_compile torch/distributed/fsdp/_fully_shard/_fsdp_common.py torch/distributed/fsdp/_fully_shard/_fsdp_init.py torch/distributed/fsdp/_fully_shard/_fsdp_param.py torch/distributed/fsdp/_fully_shard/_fully_shard.py test/distributed/_composable/fsdp/test_fully_shard_training.py

python test/distributed/_composable/fsdp/test_fully_shard_training.py -k 'TestFullyShardShardPlacementFnMultiProcess.test_shard_placement_fn_replicated_param'