### PR TITLE
Avoid initializing CUDA in mem_get_info

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -200,6 +200,33 @@ class TestCuda(TestCase):
     def tearDown(self):
         super().tearDown()
 
+    def test_mem_get_info_does_not_initialize_cuda(self):
+        script = """
+import torch
+
+assert torch.cuda.is_available()
+assert not torch.cuda.is_initialized()
+assert torch.cuda.mem_get_info() == (0, 0)
+assert not torch.cuda.is_initialized()
+assert torch.cuda.mem_get_info(torch.device("cuda")) == (0, 0)
+assert not torch.cuda.is_initialized()
+assert torch.cuda.mem_get_info(0) == (0, 0)
+assert not torch.cuda.is_initialized()
+
+torch.empty(1, device="cuda:0")
+free, total = torch.cuda.mem_get_info(0)
+assert 0 <= free <= total
+assert total > 0
+assert torch.cuda.is_initialized()
+"""
+        subprocess.check_output(
+            [sys.executable, "-c", script],
+            stderr=subprocess.STDOUT,
+            # On Windows, opening the subprocess with the default CWD makes `import torch`
+            # fail, so just set CWD to this script's directory
+            cwd=os.path.dirname(os.path.realpath(__file__)),
+        )
+
     @property
     def expandable_segments(self):
         return EXPANDABLE_SEGMENTS

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -837,10 +837,27 @@ def mem_get_info(device: "Device" = None) -> tuple[int, int]:
             statistic for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default) or if the device index is not specified.
 
+    Returns:
+        tuple[int, int]: a tuple of two integers (free_memory, total_memory) in bytes.
+            Returns ``(0, 0)`` if CUDA has not been initialized.
+
     .. note::
         See :ref:`cuda-memory-management` for more
         details about GPU memory management.
     """
+    if not is_initialized():
+        if isinstance(device, str):
+            device = torch.device(device)
+        if (
+            isinstance(device, torch.device)
+            and device.type == "cuda"
+            and device.index is None
+        ):
+            return (0, 0)
+        if device is not None:
+            _get_device_index(device, optional=False)
+        return (0, 0)
+
     if device is None:
         device = torch.cuda.current_device()
     # optional=True allows `device = torch.device('cuda')` for which device.index is None


### PR DESCRIPTION
Fixes #103584

## Summary

- return `(0, 0)` from `torch.cuda.mem_get_info()` when CUDA has not been initialized
- avoid resolving the current CUDA device or calling `cudart()` on the uninitialized path
- add a subprocess regression test covering the uninitialized behavior and the initialized `cudaMemGetInfo` path