### PR TITLE
Fix torch.norm(dim=-1) shape for size-1 dimensions under torch.compile

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -6317,6 +6317,13 @@ class CPUReproTests(TestCase):
         res = compiled_vector_norm(x, ord=2, dim=[], keepdim=False, dtype=None)
         self.assertEqual(ref, res)
 
+    def test_vector_norm_negative_dim_size_one(self):
+        def fn(x):
+            return x.norm(dim=-1)
+
+        x = torch.rand(5, 7, 1)
+        self.common(fn, [x])
+
     def test_fractional_max_pool2d_3d_input(self):
         """Test for https://github.com/pytorch/pytorch/issues/156682 - 3D input causing assertion error"""
 

--- a/torch/_refs/linalg/__init__.py
+++ b/torch/_refs/linalg/__init__.py
@@ -185,7 +185,8 @@ def vector_norm(
             elif dim is None:
                 return to_result_dtype(x).flatten()[0]
             else:
-                new_shape = [s for d, s in enumerate(x.shape) if d not in dim]
+                canon_dim = {d % x.ndim for d in dim}
+                new_shape = [s for d, s in enumerate(x.shape) if d not in canon_dim]
                 return to_result_dtype(x.view(new_shape)).contiguous()
 
         if not (is_ord_even and utils.is_float_dtype(x.dtype)):


### PR DESCRIPTION
Summary:
`torch.norm(dim=-1)` returns an incorrect output shape when the reduced last dimension has size 1 and the model is compiled with the Inductor backend. Eager execution correctly removes the reduced dimension (e.g., `(5, 7, 1)` -> `(5, 7)`), while the compiled function retains it (`(5, 7, 1)`).

The bug is in `vector_norm`'s size-1 dimension optimization path in `torch/_refs/linalg/__init__.py`. When building the output shape, the code filters dimensions using `d not in dim` where `d` comes from `enumerate` (always non-negative: 0, 1, 2, ...) but `dim` can contain negative values (e.g., `[-1]`). So `2 not in [-1]` evaluates to `True` and the dimension is incorrectly kept.

The fix canonicalizes negative dim values to non-negative using modulo before the set membership check.

Closes gh-183121 Issue: https://github.com/pytorch/pytorch/issues/183121

Test Plan:
buck2 test fbcode//caffe2/test/inductor:cpu_repro_cpu -- test_vector_norm_compile test_vector_norm_negative_dim_size_one
Result: Pass 2. Fail 0.

Both `test_vector_norm_compile` (existing) and `test_vector_norm_negative_dim_size_one` (new regression test) passed.

Differential Revision: D104615065




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo