### PR TITLE
stub: declare _CudaEventBase as a subclass of torch._C.Event

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -2402,8 +2402,11 @@ class _CudaStreamBase(Stream):
     def synchronize(self) -> None: ...
     def priority_range(self) -> tuple[_int, _int]: ...
 
-# Defined in torch/csrc/cuda/Event.cpp
-class _CudaEventBase:
+# Defined in torch/csrc/cuda/Event.cpp.  At the Python C-API level
+# ``THCPEventType.tp_base = THPEventClass`` (see Event.cpp), so this
+# binding really does inherit from ``torch._C.Event``.  Declaring the
+# base here lets static checkers (pyrefly, mypy) see the relationship.
+class _CudaEventBase(torch._C.Event):
     device: _device
     cuda_event: _int
 


### PR DESCRIPTION
``torch/_C/__init__.pyi.in`` declares ``class _CudaEventBase:`` with no base, which doesn't reflect the actual Python C-API hierarchy: ``torch/csrc/cuda/Event.cpp`` sets

    THCPEventType.tp_base = THPEventClass;

so at runtime ``issubclass(torch.cuda.Event, torch._C.Event)`` is ``True`` (through ``_CudaEventBase``).  Static checkers walking the stubs don't see the relationship and reject any call that expects a ``torch._C.Event`` (= ``torch.Event``) but receives a ``torch.cuda.Event`` -- for example pyrefly flagging ``maybe_emit_streams_op_proxy(self, ...)`` inside
``torch/cuda/streams.py``.

Declare the base explicitly.  The matching ``_CudaStreamBase(Stream)`` declaration a few lines above is the analogous case for streams and already follows this pattern.