### PR TITLE
[TEST][CUTLASS] Fix some skips in `test_cutlass_evt.py`

### DIFF
--- a/test/inductor/test_cutlass_evt.py
+++ b/test/inductor/test_cutlass_evt.py
@@ -13,11 +13,7 @@ from torch._inductor.codegen.cutlass.utils import (
 from torch._inductor.ir import ComputedBuffer, FixedLayout, PermuteView, Pointwise
 from torch._inductor.scheduler import BaseSchedulerNode
 from torch._inductor.utils import OrderedSet
-from torch.testing._internal.common_cuda import (
-    IS_SM10X,
-    IS_SM90,
-    SM90OrLater,
-)
+from torch.testing._internal.common_cuda import IS_SM10X, IS_SM90, SM90OrLater
 from torch.testing._internal.common_device_type import skipCUDAIf, skipXPUIf
 from torch.testing._internal.common_xpu import Xe2_Or_Later
 from torch.testing._internal.inductor_utils import (
@@ -33,11 +29,7 @@ def _is_cuda_sm90_or_sm10x():
 
 
 def _expect_cuda_evt_key_error():
-    return (
-        GPU_TYPE == "cuda"
-        and bool(IS_SM10X)
-        and int(cutlass_arch(GPU_TYPE)) > 100
-    )
+    return GPU_TYPE == "cuda" and bool(IS_SM10X) and int(cutlass_arch(GPU_TYPE)) > 100
 
 
 if try_import_cutlass():

--- a/test/inductor/test_cutlass_evt.py
+++ b/test/inductor/test_cutlass_evt.py
@@ -6,6 +6,7 @@ import sympy
 import torch
 from torch._dynamo.test_case import TestCase
 from torch._inductor.codegen.cutlass.utils import (
+    cutlass_arch,
     torch_dtype_to_cutlass_type,
     try_import_cutlass,
 )
@@ -13,9 +14,8 @@ from torch._inductor.ir import ComputedBuffer, FixedLayout, PermuteView, Pointwi
 from torch._inductor.scheduler import BaseSchedulerNode
 from torch._inductor.utils import OrderedSet
 from torch.testing._internal.common_cuda import (
-    IS_SM100,
+    IS_SM10X,
     IS_SM90,
-    SM120OrLater,
     SM90OrLater,
 )
 from torch.testing._internal.common_device_type import skipCUDAIf, skipXPUIf
@@ -26,6 +26,18 @@ from torch.testing._internal.inductor_utils import (
     HAS_GPU_AND_TRITON,
     MockGraphHandler,
 )
+
+
+def _is_cuda_sm90_or_sm10x():
+    return bool(IS_SM90) or bool(IS_SM10X)
+
+
+def _expect_cuda_evt_key_error():
+    return (
+        GPU_TYPE == "cuda"
+        and bool(IS_SM10X)
+        and int(cutlass_arch(GPU_TYPE)) > 100
+    )
 
 
 if try_import_cutlass():
@@ -382,18 +394,25 @@ return tmp_1, D""",
             )
 
     @skipXPUIf(not Xe2_Or_Later, "Unsupported platform")
-    @skipCUDAIf(not (IS_SM90 or IS_SM100), "need sm_90 or sm_100")
+    @skipCUDAIf(not _is_cuda_sm90_or_sm10x(), "need sm_90 or sm_10x")
     @unittest.skipIf(not try_import_cutlass(), "requires cutlass")
     def test_evt_argument_codegen(self):
-        from torch._inductor.codegen.cutlass.utils import cutlass_arch
-
         arch = int(cutlass_arch(GPU_TYPE))
-        epilogue_functor = _trace(BIAS_CODE, EXAMPLE_TENSORS, arch)
-        code = _render_argument_type(
-            epilogue_functor,
-            _create_mock_buffer_name_map(EXAMPLE_TENSORS),
-            lambda x: int(x),
-        )[0]
+
+        def render_code():
+            epilogue_functor = _trace(BIAS_CODE, EXAMPLE_TENSORS, arch)
+            return _render_argument_type(
+                epilogue_functor,
+                _create_mock_buffer_name_map(EXAMPLE_TENSORS),
+                lambda x: int(x),
+            )[0]
+
+        if _expect_cuda_evt_key_error():
+            with self.assertRaises(KeyError):
+                render_code()
+            return
+
+        code = render_code()
         if GPU_TYPE == "xpu":
             self.assertExpectedInline(
                 code,
@@ -444,11 +463,9 @@ return tmp_1, D""",
             )
 
     @skipXPUIf(not Xe2_Or_Later, "Unsupported platform")
-    @skipCUDAIf(not (IS_SM90 or IS_SM100), "need sm_90 or sm_100")
+    @skipCUDAIf(not _is_cuda_sm90_or_sm10x(), "need sm_90 or sm_10x")
     @unittest.skipIf(not try_import_cutlass(), "requires cutlass")
     def test_evt_argument_codegen_return_accumulator(self):
-        from torch._inductor.codegen.cutlass.utils import cutlass_arch
-
         arch = int(cutlass_arch(GPU_TYPE))
 
         code = """
@@ -472,12 +489,20 @@ def fn(accum, bias):
             ),
         }
 
-        epilogue_functor = _trace(code, example_tensors, arch)
-        code = _render_argument_type(
-            epilogue_functor,
-            _create_mock_buffer_name_map(example_tensors),
-            lambda x: int(x),
-        )[0]
+        def render_code():
+            epilogue_functor = _trace(code, example_tensors, arch)
+            return _render_argument_type(
+                epilogue_functor,
+                _create_mock_buffer_name_map(example_tensors),
+                lambda x: int(x),
+            )[0]
+
+        if _expect_cuda_evt_key_error():
+            with self.assertRaises(KeyError):
+                render_code()
+            return
+
+        code = render_code()
 
         if GPU_TYPE == "xpu":
             self.assertExpectedInline(
@@ -509,20 +534,28 @@ def fn(accum, bias):
             )
 
     @skipXPUIf(not Xe2_Or_Later, "Unsupported platform")
-    @skipCUDAIf(not (IS_SM90 or IS_SM100), "need sm_90 or sm_100")
+    @skipCUDAIf(not _is_cuda_sm90_or_sm10x(), "need sm_90 or sm_10x")
     @unittest.skipIf(not try_import_cutlass(), "requires cutlass")
     def test_evt_codegen(self):
-        _, _, code, _ = trace(
-            BIAS_CODE,
-            EXAMPLE_TENSORS,
-            DataType.f32,
-            DataType.f32,
-            MockTileDescription(),
-            EpilogueScheduleType.ScheduleAuto,
-            _create_mock_buffer_name_map(EXAMPLE_TENSORS),
-            lambda x: x,  # static shapes
-            device_type=GPU_TYPE,
-        )
+        def render_code():
+            return trace(
+                BIAS_CODE,
+                EXAMPLE_TENSORS,
+                DataType.f32,
+                DataType.f32,
+                MockTileDescription(),
+                EpilogueScheduleType.ScheduleAuto,
+                _create_mock_buffer_name_map(EXAMPLE_TENSORS),
+                lambda x: x,  # static shapes
+                device_type=GPU_TYPE,
+            )[2]
+
+        if _expect_cuda_evt_key_error():
+            with self.assertRaises(KeyError):
+                render_code()
+            return
+
+        code = render_code()
         if IS_SM90:
             self.assertExpectedInline(
                 code,
@@ -626,7 +659,7 @@ using StrideD = cute::Stride<int64_t, cute::Int<1>, cute::Int<0>>;
 """,
             )
 
-        if IS_SM100:
+        if IS_SM10X:
             self.assertExpectedInline(
                 code,
                 """\

--- a/test/inductor/test_cutlass_evt.py
+++ b/test/inductor/test_cutlass_evt.py
@@ -382,7 +382,7 @@ return tmp_1, D""",
             )
 
     @skipXPUIf(not Xe2_Or_Later, "Unsupported platform")
-    @skipCUDAIf(not SM90OrLater or SM120OrLater, "need sm_90 or sm_100")
+    @skipCUDAIf(not (IS_SM90 or IS_SM100), "need sm_90 or sm_100")
     @unittest.skipIf(not try_import_cutlass(), "requires cutlass")
     def test_evt_argument_codegen(self):
         from torch._inductor.codegen.cutlass.utils import cutlass_arch
@@ -444,7 +444,7 @@ return tmp_1, D""",
             )
 
     @skipXPUIf(not Xe2_Or_Later, "Unsupported platform")
-    @skipCUDAIf(not SM90OrLater or SM120OrLater, "need sm_90 or sm_100")
+    @skipCUDAIf(not (IS_SM90 or IS_SM100), "need sm_90 or sm_100")
     @unittest.skipIf(not try_import_cutlass(), "requires cutlass")
     def test_evt_argument_codegen_return_accumulator(self):
         from torch._inductor.codegen.cutlass.utils import cutlass_arch
@@ -509,7 +509,7 @@ def fn(accum, bias):
             )
 
     @skipXPUIf(not Xe2_Or_Later, "Unsupported platform")
-    @skipCUDAIf(not SM90OrLater or SM120OrLater, "need sm_90 or sm_100")
+    @skipCUDAIf(not (IS_SM90 or IS_SM100), "need sm_90 or sm_100")
     @unittest.skipIf(not try_import_cutlass(), "requires cutlass")
     def test_evt_codegen(self):
         _, _, code, _ = trace(

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -43,6 +43,7 @@ IS_JETSON = LazyVal(lambda: torch.cuda.is_available() and (torch.cuda.get_device
 IS_SM89 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (8, 9))
 IS_SM90 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (9, 0))
 IS_SM100 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0))
+IS_SM10X = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10)
 IS_SM12X = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12)
 
 @contextlib.contextmanager


### PR DESCRIPTION
I think https://github.com/pytorch/pytorch/pull/180817 had the right idea but was off-by-one in the decorator (e.g., SM120 would try to run the test while the message would expect it to fail)

authored manually

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo