### PR TITLE
Make docs preview upload faster

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -342,6 +342,10 @@ jobs:
           pip install $(echo dist/*.whl)[opt-einsum]
           ./.ci/pytorch/${DOCS_TYPE}_doc_push_script.sh
 
+      - name: Install AWS CLI
+        if: ${{ steps.aws-creds.outcome == 'success' && steps.build-docs.outcome == 'success' }}
+        run: pip install awscli==1.29.40
+
       - name: Upload Python Docs Preview
         if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}
         run: |
@@ -390,7 +394,7 @@ jobs:
         if: ${{ steps.aws-creds.outcome == 'success' && !inputs.push && github.event_name != 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
         run: |
           # Unlike EC2 runners, the OSDC container doesn't have aws CLI pre-installed
-          pip install awscli==1.45.6==1.29.40
+          pip install awscli==1.29.40
           aws s3 cp cppdocs/ s3://doc-previews/pytorch/pytorch/nightly-${{ github.sha }}/cppdocs --recursive --quiet
           echo "C++ docs preview available at:"
           echo "https://docs-preview.pytorch.org/pytorch/pytorch/nightly-${{ github.sha }}/cppdocs/index.html"

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -207,7 +207,7 @@ jobs:
 
       - name: Install awscli
         if: ${{ github.event_name == 'pull_request' && steps.build-docs.outcome == 'success' }}
-        run: pip install awscli
+        run: pip install awscli==1.45.6
 
       - name: Upload Python Docs Preview
         if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}
@@ -348,7 +348,7 @@ jobs:
 
       - name: Install awscli
         if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && steps.build-docs.outcome == 'success' }}
-        run: pip install awscli
+        run: pip install awscli==1.45.6
 
       - name: Upload Python Docs Preview
         if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}
@@ -398,7 +398,7 @@ jobs:
         if: ${{ steps.aws-creds.outcome == 'success' && !inputs.push && github.event_name != 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
         run: |
           # Unlike EC2 runners, the OSDC container doesn't have aws CLI pre-installed
-          pip install awscli==1.29.40
+          pip install awscli==1.45.6==1.29.40
           aws s3 cp cppdocs/ s3://doc-previews/pytorch/pytorch/nightly-${{ github.sha }}/cppdocs --recursive --quiet
           echo "C++ docs preview available at:"
           echo "https://docs-preview.pytorch.org/pytorch/pytorch/nightly-${{ github.sha }}/cppdocs/index.html"

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -205,6 +205,10 @@ jobs:
           role-session-name: gha-linux-test
           aws-region: us-east-1
 
+      - name: Install awscli
+        if: ${{ github.event_name == 'pull_request' && steps.build-docs.outcome == 'success' }}
+        run: pip install awscli
+
       - name: Upload Python Docs Preview
         if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}
         run: |
@@ -341,6 +345,10 @@ jobs:
           export DOCS_VERSION="${target}"
           pip install $(echo dist/*.whl)[opt-einsum]
           ./.ci/pytorch/${DOCS_TYPE}_doc_push_script.sh
+
+      - name: Install awscli
+        if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && steps.build-docs.outcome == 'success' }}
+        run: pip install awscli
 
       - name: Upload Python Docs Preview
         if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -206,24 +206,14 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload Python Docs Preview
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
         if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}
-        with:
-          retention-days: 14
-          s3-bucket: doc-previews
-          if-no-files-found: error
-          path: pytorch_docs/main/
-          s3-prefix: pytorch/pytorch/${{ github.event.pull_request.number }}
+        run: |
+          aws s3 sync pytorch_docs/main/ s3://doc-previews/pytorch/pytorch/${{ github.event.pull_request.number }} --delete --quiet
 
       - name: Upload C++ Docs Preview
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
         if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
-        with:
-          retention-days: 14
-          if-no-files-found: error
-          s3-bucket: doc-previews
-          path: cppdocs/
-          s3-prefix: pytorch/pytorch/${{ github.event.pull_request.number }}/cppdocs
+        run: |
+          aws s3 sync cppdocs/ s3://doc-previews/pytorch/pytorch/${{ github.event.pull_request.number }}/cppdocs --delete --quiet
 
       - name: Post C++ Docs Coverage Comment
         if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
@@ -353,24 +343,14 @@ jobs:
           ./.ci/pytorch/${DOCS_TYPE}_doc_push_script.sh
 
       - name: Upload Python Docs Preview
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
         if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}
-        with:
-          retention-days: 14
-          s3-bucket: doc-previews
-          if-no-files-found: error
-          path: pytorch_docs/main/
-          s3-prefix: pytorch/pytorch/${{ github.event.pull_request.number }}
+        run: |
+          aws s3 sync pytorch_docs/main/ s3://doc-previews/pytorch/pytorch/${{ github.event.pull_request.number }} --delete --quiet
 
       - name: Upload C++ Docs Preview
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
         if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
-        with:
-          retention-days: 14
-          if-no-files-found: error
-          s3-bucket: doc-previews
-          path: cppdocs/
-          s3-prefix: pytorch/pytorch/${{ github.event.pull_request.number }}/cppdocs
+        run: |
+          aws s3 sync cppdocs/ s3://doc-previews/pytorch/pytorch/${{ github.event.pull_request.number }}/cppdocs --delete --quiet
 
       - name: Post C++ Docs Coverage Comment
         if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -205,10 +205,6 @@ jobs:
           role-session-name: gha-linux-test
           aws-region: us-east-1
 
-      - name: Install awscli
-        if: ${{ github.event_name == 'pull_request' && steps.build-docs.outcome == 'success' }}
-        run: pip install awscli==1.45.6
-
       - name: Upload Python Docs Preview
         if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}
         run: |
@@ -345,10 +341,6 @@ jobs:
           export DOCS_VERSION="${target}"
           pip install $(echo dist/*.whl)[opt-einsum]
           ./.ci/pytorch/${DOCS_TYPE}_doc_push_script.sh
-
-      - name: Install awscli
-        if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && steps.build-docs.outcome == 'success' }}
-        run: pip install awscli==1.45.6
 
       - name: Upload Python Docs Preview
         if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}


### PR DESCRIPTION
Replace the seemethere/upload-artifact-s3 GitHub Action with aws s3 sync --delete for doc preview uploads. The action uploads files sequentially (one s3.upload() call per file in a for await loop), which takes ~15 minutes for the Python docs. aws s3 sync does parallel transfers, only uploads changed files, and cleans up stale files with --delete. The nightly C++ dry-run path already uses this approach.

The `seemethere` action set per-object Expires headers for 14-day retention for the HTTP header that didn't actually trigger deletion — the real cleanup was always this 90-day lifecycle rule.