### PR TITLE
[caffe2] Fix identity check bug in as_record(): use isinstance(f, tuple) instead of f is tuple (#183382)

### DIFF
--- a/test/test_schema_as_record.py
+++ b/test/test_schema_as_record.py
@@ -1,0 +1,50 @@
+# Owner(s): ["module: tests"]
+
+# pyre-unsafe
+import unittest
+
+import numpy as np
+
+from caffe2.python.schema import as_record, Scalar, Struct
+from torch.testing._internal.common_utils import run_tests
+
+
+class TestAsRecord(unittest.TestCase):
+    def test_named_tuple_list_returns_struct(self):
+        result = as_record([("field1", np.float32), ("field2", np.int32)])
+        self.assertIsInstance(result, Struct)
+
+    def test_named_tuple_returns_correct_field_names(self):
+        result = as_record([("a", np.float32), ("b", np.int32)])
+        self.assertEqual(
+            sorted(result.field_names()),
+            sorted(["a", "b"]),
+        )
+
+    def test_single_named_tuple_returns_struct(self):
+        result = as_record([("only_field", np.float64)])
+        self.assertIsInstance(result, Struct)
+
+    def test_dict_returns_struct(self):
+        result = as_record({"x": np.float32, "y": np.int32})
+        self.assertIsInstance(result, Struct)
+
+    def test_scalar_passthrough(self):
+        s = Scalar(dtype=np.float32)
+        result = as_record(s)
+        self.assertIs(result, s)
+
+    def test_nested_named_tuples(self):
+        result = as_record([("outer", [("inner", np.float32)])])
+        self.assertIsInstance(result, Struct)
+        inner = result["outer"]
+        self.assertIsInstance(inner, Struct)
+
+    def test_named_fields_with_scalar_values(self):
+        s = Scalar(dtype=np.float32)
+        result = as_record([("my_scalar", s)])
+        self.assertIsInstance(result, Struct)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Summary:

**Context**: `as_record()` in `schema.py` converts raw Python values into caffe2 schema `Field` objects. When given a list of 2-tuples like `[("name", field)]`, it should detect this as a named field list and construct a `Struct`. The detection logic uses `f is tuple` to check if each element is a tuple.

**This diff**: Fixes `f is tuple` to `isinstance(f, tuple)`. The `is` operator checks object identity — whether `f` is literally the `tuple` class object itself — not whether `f` is an instance of `tuple`. For actual tuple values like `("name", field)`, `f is tuple` is always `False`, making the Struct construction path dead code. All list/tuple inputs incorrectly fall through to the unnamed `Tuple(*)` path instead.

Also adds unit tests for `as_record()` covering the Struct path (named tuple lists), Scalar passthrough, dict input, and nested named tuples.

Test Plan:
Added `test_schema_as_record` with 7 test cases covering `as_record()`.

**Without the fix** (`f is tuple`): 5 tests fail — all Struct-path tests return `Tuple` instead of `Struct`.
**With the fix** (`isinstance(f, tuple)`): all 7 tests pass.

```
$ buck2 test fbcode//caffe2/test:test_schema_as_record
Tests finished: Pass 7. Fail 0.
```

Differential Revision: D104619129


