### PR TITLE
[inductor] preserve scan carry strides with shape padding

### DIFF
--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -2010,7 +2010,6 @@ class ScanTests(TestCase):
     @parametrize("reverse", [True, False])
     @parametrize("dim", [0, 1, 2])
     @parametrize("autograd", [True, False])
-    @torch._inductor.config.patch(shape_padding=False)
     @torch._dynamo.config.patch("capture_scalar_outputs", True)
     def test_scan_pytree_in_out(self, device, dynamic, reverse, dim, autograd):
         self._run_test(
@@ -2023,6 +2022,22 @@ class ScanTests(TestCase):
             device=device,
             dynamic=dynamic,
             autograd=autograd,
+        )
+
+    @requires_gpu
+    @torch._inductor.config.patch(shape_padding=True, force_shape_pad=True)
+    @torch._dynamo.config.patch("capture_scalar_outputs", True)
+    def test_scan_pytree_in_out_shape_padding(self):
+        self._run_test(
+            model=ScanModels.SimpleWithPytreeInOuts(reverse=False, dim=0),
+            inputs=(
+                torch.ones(2, 2, 2),
+                torch.ones(2, 2),
+                torch.ones(2),
+            ),
+            device=GPU_TYPE,
+            dynamic=False,
+            autograd=True,
         )
 
     @requires_gpu

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -22,7 +22,7 @@ from torch._prims_common import is_boolean_dtype, is_expandable_to, is_integer_d
 from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
 from torch.utils._ordered_set import OrderedSet
 
-from .. import config, ir, pattern_matcher  # noqa: F401
+from .. import config, inductor_prims, ir, pattern_matcher  # noqa: F401
 from ..codegen.common import custom_backend_passes
 from ..fx_utils import FakeTensorUpdater, get_fake_args_kwargs, get_node_storage
 from ..lowering import lowerings as L
@@ -743,20 +743,10 @@ def decompose_scan_to_while_loop(gm: torch.fx.GraphModule):
                     sub_gm(*(list(carry) + sub_xs + list(additional_inputs))),
                     num_init_leaves,
                 )
-                # Shape padding can produce same-sized carry values with padded strides.
-                # while_loop requires loop-carried metadata to remain stable.
                 next_carry = [
-                    (
-                        next_carry_elem
-                        if next_carry_elem.stride() == carry_elem.stride()
-                        else torch.empty_strided(
-                            next_carry_elem.size(),
-                            carry_elem.stride(),
-                            device=next_carry_elem.device,
-                            dtype=next_carry_elem.dtype,
-                            layout=next_carry_elem.layout,
-                            requires_grad=next_carry_elem.requires_grad,
-                        ).copy_(next_carry_elem)
+                    inductor_prims.force_exact_strides(
+                        next_carry_elem,
+                        carry_elem.stride(),
                     )
                     for next_carry_elem, carry_elem in zip(next_carry, carry)
                 ]

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -743,6 +743,23 @@ def decompose_scan_to_while_loop(gm: torch.fx.GraphModule):
                     sub_gm(*(list(carry) + sub_xs + list(additional_inputs))),
                     num_init_leaves,
                 )
+                # Shape padding can produce same-sized carry values with padded strides.
+                # while_loop requires loop-carried metadata to remain stable.
+                next_carry = [
+                    (
+                        next_carry_elem
+                        if next_carry_elem.stride() == carry_elem.stride()
+                        else torch.empty_strided(
+                            next_carry_elem.size(),
+                            carry_elem.stride(),
+                            device=next_carry_elem.device,
+                            dtype=next_carry_elem.dtype,
+                            layout=next_carry_elem.layout,
+                            requires_grad=next_carry_elem.requires_grad,
+                        ).copy_(next_carry_elem)
+                    )
+                    for next_carry_elem, carry_elem in zip(next_carry, carry)
+                ]
                 for y, y_out in zip(ys, ys_outs):
                     y_out_slice = torch.ops.aten.select.int(y_out, 0, idx_int)
                     y_out_slice.copy_(y)

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -56,6 +56,18 @@ def eager_force_stride(input_tensor: Tensor, stride) -> Tensor:
     return new_tensor
 
 
+def eager_force_exact_strides(input_tensor: Tensor, stride) -> Tensor:
+    if input_tensor.stride() == tuple(stride):
+        return input_tensor
+    return torch.empty_strided(
+        input_tensor.shape,
+        stride,
+        device=input_tensor.device,
+        dtype=input_tensor.dtype,
+        layout=input_tensor.layout,
+    ).copy_(input_tensor)
+
+
 def eager_prepare_softmax(x: Tensor, dim: int) -> tuple[Tensor, Tensor]:
     amax = torch.amax(x, dim, keepdim=True)
     return amax, torch.sum(torch.exp(x - amax), dim, keepdim=True)
@@ -196,6 +208,14 @@ force_stride_order = make_prim(
     "inductor_force_stride_order(Tensor input, SymInt[] stride) -> Tensor",
     eager_force_stride,
     doc="Force the stride order for input tensor. No-op if the input tensor already has the stride. Do a copy otherwise",
+)
+force_exact_strides = make_prim(
+    "inductor_force_exact_strides(Tensor input, SymInt[] stride) -> Tensor",
+    eager_force_exact_strides,
+    doc=(
+        "Force exact strides for input tensor. No-op if the input tensor already "
+        "has the stride. Do a copy otherwise"
+    ),
 )
 _unsafe_index_put_ = make_prim(
     "_unsafe_index_put_(Tensor(a!) self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor(a!)",

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2776,6 +2776,11 @@ def inductor_force_stride_order(input_tensor, stride):
     return ir.ExternKernel.require_stride_order(input_tensor, stride_order)
 
 
+@register_lowering(inductor_prims.force_exact_strides, type_promotion_kind=None)
+def inductor_force_exact_strides(input_tensor, stride):
+    return ir.ExternKernel.require_exact_strides(input_tensor, stride)
+
+
 @register_lowering(inductor_prims.seed, type_promotion_kind=None)
 def inductor_seed(device: torch.device):
     raise AssertionError("should be handled in fuse_seed_creation_pass()")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183384
* #183383

Scan lowering decomposes scan into while_loop, whose carried values must preserve metadata across iterations. Shape padding can return same-sized matmul results with padded strides, so normalize next_carry back to the incoming carry stride and cover the forced-padding regression.

Authored with Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo