### PR TITLE
Add tests for OneCycleLR zero divisor initialization behavior

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -7,6 +7,7 @@ import tempfile
 import types
 import warnings
 from functools import partial
+from unittest import expectedFailure
 
 import torch
 import torch.nn.functional as F
@@ -2680,32 +2681,32 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
+    @expectedFailure
     def test_onecycle_lr_zero_div_factor(self):
-        # NOTE: This test documents the current behavior rather than defining
-        # intended API semantics.
-        #
+
         # `div_factor` is used to compute
         # `initial_lr = max_lr / div_factor` during initialization. When
         # `div_factor=0.0`, this currently falls through to a raw
         # ZeroDivisionError instead of being validated explicitly.
-        with self.assertRaises(ZeroDivisionError):
-            scheduler = OneCycleLR(
+        with self.assertRaisesRegex(ValueError, "Expected positive div_factor"):
+            OneCycleLR(
                 self.opt,
                 max_lr=1e-3,
                 total_steps=10,
                 div_factor=0.0,
             )
 
+    @expectedFailure
     def test_onecycle_lr_zero_final_div_factor(self):
-        # NOTE: This test documents the current behavior rather than defining
-        # intended API semantics.
-        #
+
         # `final_div_factor` is used to compute
         # `min_lr = initial_lr / final_div_factor` during initialization.
         # When `final_div_factor=0.0`, this currently falls through to a raw
         # ZeroDivisionError instead of being validated explicitly.
-        with self.assertRaises(ZeroDivisionError):
-            scheduler = OneCycleLR(
+        with self.assertRaisesRegex(
+            ValueError, "Expected positive final_div_factor"
+        ):
+            OneCycleLR(
                 self.opt,
                 max_lr=1e-3,
                 total_steps=10,

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2680,6 +2680,37 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
+    def test_onecycle_lr_zero_div_factor(self):
+        # NOTE: This test documents the current behavior rather than defining
+        # intended API semantics.
+        #
+        # `div_factor` is used to compute
+        # `initial_lr = max_lr / div_factor` during initialization. When
+        # `div_factor=0.0`, this currently falls through to a raw
+        # ZeroDivisionError instead of being validated explicitly.
+        with self.assertRaises(ZeroDivisionError):
+            scheduler = OneCycleLR(
+                self.opt,
+                max_lr=1e-3,
+                total_steps=10,
+                div_factor=0.0,
+            )
+
+    def test_onecycle_lr_zero_final_div_factor(self):
+        # NOTE: This test documents the current behavior rather than defining
+        # intended API semantics.
+        #
+        # `final_div_factor` is used to compute
+        # `min_lr = initial_lr / final_div_factor` during initialization.
+        # When `final_div_factor=0.0`, this currently falls through to a raw
+        # ZeroDivisionError instead of being validated explicitly.
+        with self.assertRaises(ZeroDivisionError):
+            scheduler = OneCycleLR(
+                self.opt,
+                max_lr=1e-3,
+                total_steps=10,
+                final_div_factor=0.0,
+            )
 
 instantiate_parametrized_tests(TestLRScheduler)
 


### PR DESCRIPTION
This PR adds tests documenting the current behavior of `OneCycleLR` when `div_factor=0.0` or `final_div_factor=0.0`.

Internally, these values are used during initialization to compute derived learning rates (`initial_lr = max_lr / div_factor` and `min_lr = initial_lr / final_div_factor`). When either value is zero, the scheduler currently falls through to a raw `ZeroDivisionError` during initialization instead of validating the inputs up front.

While investigating scheduler initialization and edge case handling, I noticed that `OneCycleLR` implicitly assumes both divisor values are non-zero, but this assumption is not currently enforced explicitly.

This PR is tests only. It documents the current behavior and makes these initialization failure modes explicit in the test suite. A follow up PR can introduce proper validation or define consistent handling for these invalid configurations (for example, by raising a clearer `ValueError` during construction).

Related discussion

This test is part of the broader scheduler cleanup work described in:

“RFC: Internal Unification of LRScheduler Semantics for Correct Resuming and Composition” #168044