### PR TITLE
[Docathon] Document undocumented functions in rpc.md (#182830)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -531,6 +531,10 @@ coverage_ignore_functions = [
     # torch.distributed.rpc.api
     "method_factory",
     "new_method",
+    "remote",
+    "rpc_async",
+    "rpc_sync",
+    "shutdown",
     # torch.distributed.rpc.backend_registry
     "construct_rpc_backend_options",
     "init_backend",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -529,18 +529,18 @@ coverage_ignore_functions = [
     # torch.distributed.rendezvous
     "rendezvous",
     # torch.distributed.rpc.api
-    "get_worker_info",
+    # "get_worker_info",
     "method_factory",
     "new_method",
-    "remote",
-    "rpc_async",
-    "rpc_sync",
-    "shutdown",
+    # "remote",
+    # "rpc_async",
+    # "rpc_sync",
+    # "shutdown",
     # torch.distributed.rpc.backend_registry
-    "backend_registered",
+    # "backend_registered",
     "construct_rpc_backend_options",
     "init_backend",
-    "register_backend",
+    # "register_backend",
     # torch.distributed.rpc.internal
     "deserialize",
     "serialize",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -529,18 +529,11 @@ coverage_ignore_functions = [
     # torch.distributed.rendezvous
     "rendezvous",
     # torch.distributed.rpc.api
-    # "get_worker_info",
     "method_factory",
     "new_method",
-    # "remote",
-    # "rpc_async",
-    # "rpc_sync",
-    # "shutdown",
     # torch.distributed.rpc.backend_registry
-    # "backend_registered",
     "construct_rpc_backend_options",
     "init_backend",
-    # "register_backend",
     # torch.distributed.rpc.internal
     "deserialize",
     "serialize",

--- a/docs/source/rpc.md
+++ b/docs/source/rpc.md
@@ -118,6 +118,19 @@ how a given function should be treated on the callee side.
 .. autofunction:: torch.distributed.rpc.functions.async_execution
 ```
 
+```{eval-rst}
+.. automodule:: torch.distributed.rpc.backend_registry
+
+.. currentmodule:: torch.distributed.rpc.backend_registry
+
+.. autofunction:: backend_registered
+.. autofunction:: register_backend
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.rpc
+```
+
 (rpc-backends)=
 ### Backends
 

--- a/docs/source/rpc.md
+++ b/docs/source/rpc.md
@@ -119,8 +119,6 @@ how a given function should be treated on the callee side.
 ```
 
 ```{eval-rst}
-.. automodule:: torch.distributed.rpc.backend_registry
-
 .. currentmodule:: torch.distributed.rpc.backend_registry
 
 .. autofunction:: backend_registered

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -73,7 +73,7 @@ def register_backend(
             ``rpc_backend.construct_rpc_backend_options(**dict)`` is called.
         init_backend_handler (function): Handler that is invoked when the
             `_init_rpc_backend()` function is called with a backend.
-             This returns the agent.
+            This returns the agent.
     """
     global BackendType
     if backend_registered(backend_name):

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -70,7 +70,7 @@ def register_backend(
         backend_name (str): backend string to identify the handler.
         construct_rpc_backend_options_handler (function):
             Handler that is invoked when
-            rpc_backend.construct_rpc_backend_options(**dict) is called.
+            ``rpc_backend.construct_rpc_backend_options(**dict)`` is called.
         init_backend_handler (function): Handler that is invoked when the
             `_init_rpc_backend()` function is called with a backend.
              This returns the agent.


### PR DESCRIPTION
Fixes #182830

## Description

Documents 2 public APIs in `torch.distributed.rpc.backend_registry` and removes 7 entries from `coverage_ignore_functions` in `conf.py`.

**Documented APIs:**
- `torch.distributed.rpc.backend_registry.backend_registered`
- `torch.distributed.rpc.backend_registry.register_backend`

The other 5 functions from the issue (`get_worker_info`, `remote`, `rpc_async`, `rpc_sync`, `shutdown`) are already documented at the package level in `rpc.md` via the existing `automodule:: torch.distributed.rpc` block. Adding duplicate directives under `torch.distributed.rpc.api` would render them twice on the page, same situation as in #182876 (cc @svekars @sekyondaMeta @AlannaBurke). Following that resolution, this PR only removes them from `conf.py` without adding new directives.

As a result, `torch.distributed.rpc.api` shows 0% / 4 undocumented in `python.txt`. Overall coverage is 99.69%.

## Verification

- `make coverage` passes for `torch.distributed.rpc.backend_registry`.
- Rendered HTML `docs/build/html/rpc.html`.

<img width="678" height="381" alt="image" src="https://github.com/user-attachments/assets/e6abfa0e-fa97-4c5c-ae26-bd0772cd7183" />


## Checklist

- [x] Entries removed from skip list in `docs/source/conf.py`
- [x] Sphinx directives added to `docs/source/rpc.md`
- [x] `make coverage` passes with no new undocumented warnings for these APIs
- [x] Screenshot of the rendered documentation included in the PR description

cc @svekars @sekyondaMeta @AlannaBurke @albanD