### PR TITLE
lint: ignore B904 for vendored code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,8 +180,6 @@ ignore = [
     "PERF203",
     "PERF401",
     # these ignores are from PYI; please fix!
-    "PYI024",
-    "PYI036",
     "PYI041",
     "PYI056",
     "SIM102", "SIM103", "SIM112", # flake8-simplify code styles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,8 @@ ignore = [
     "PERF203",
     "PERF401",
     # these ignores are from PYI; please fix!
+    "PYI024",
+    "PYI036",
     "PYI041",
     "PYI056",
     "SIM102", "SIM103", "SIM112", # flake8-simplify code styles
@@ -341,6 +343,7 @@ select = [
     "UP", # collect_env.py needs to work with older versions of Python
 ]
 "torch/_vendor/**" = [
+    "B904", # Fix in upstream projects, then revendor instead of editing _vendor
     "UP", # No need to mess with _vendor
 ]
 "tools/linter/**" = [

--- a/torch/_vendor/quack/cute_dsl_elf_fix.py
+++ b/torch/_vendor/quack/cute_dsl_elf_fix.py
@@ -74,7 +74,7 @@ def patch() -> None:
                 with open(file_path, "rb") as f:
                     object_file_content = f.read()
             except Exception as e:
-                raise DSLRuntimeError(f"Failed to read object file {file_path}: {e}")
+                raise DSLRuntimeError(f"Failed to read object file {file_path}: {e}") from e
 
         useJitLink = not enable_tvm_ffi
         if not useJitLink and object_file_content:

--- a/torch/_vendor/quack/cute_dsl_elf_fix.py
+++ b/torch/_vendor/quack/cute_dsl_elf_fix.py
@@ -74,7 +74,7 @@ def patch() -> None:
                 with open(file_path, "rb") as f:
                     object_file_content = f.read()
             except Exception as e:
-                raise DSLRuntimeError(f"Failed to read object file {file_path}: {e}") from e
+                raise DSLRuntimeError(f"Failed to read object file {file_path}: {e}")
 
         useJitLink = not enable_tvm_ffi
         if not useJitLink and object_file_content:


### PR DESCRIPTION
## Summary

Follow-up to reviewer feedback that PyTorch should not hand-edit vendored quack code.

- Added a `B904` per-file ignore for `torch/_vendor/**`, alongside the existing vendored-code lint exception.
- Restored the vendored quack file to match the recorded upstream snapshot.
- Opened the upstream quack fix at https://github.com/Dao-AILab/quack/pull/137 so a future revendor can pick up the actual exception chaining change.

## Test

- `ruff check --select B904 .`
- `ruff check --select RUF200 pyproject.toml`
- `git diff --check`

## BC-breaking?

No.