### PR TITLE
[ATen][FakeTensor] Handle unbacked dims in folded matmul

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -22,6 +22,7 @@
 #include <ATen/native/mkldnn/Utils.h>
 #include <ATen/cpu/Utils.h>
 #include <c10/core/GradMode.h>
+#include <c10/core/SymBool.h>
 #include <c10/util/accumulate.h>
 #include <c10/util/env.h>
 #include <c10/util/irange.h>
@@ -138,6 +139,7 @@
 #include <ATen/ops/prod.h>
 #include <ATen/ops/real.h>
 #include <ATen/ops/relu.h>
+#include <ATen/ops/reshape.h>
 #include <ATen/ops/slogdet_native.h>
 #include <ATen/ops/sort.h>
 #include <ATen/ops/sqrt.h>
@@ -1979,16 +1981,17 @@ static bool should_fold(const Tensor& tensor1, const Tensor& tensor2, bool has_o
 
   // Can always fold if the tensor is empty
   // This serves as a precondition for the code below
-  if (t1->numel() == 0) {
+  if (TORCH_GUARD_OR_FALSE(t1->sym_numel().sym_eq(0))) {
     return true;
   }
 
   // t1->view(-1, t1->size(-1)) does not copy only when the first n-1 dimensions are contiguous
   // in the sense that t1_stride[i] = t1_stride[i+1]*t1_shape[i+1]
-  const auto t1_shape = t1->sizes();
-  const auto t1_strides = t1->strides();
+  const auto t1_shape = t1->sym_sizes();
+  const auto t1_strides = t1->sym_strides();
   for (auto i = int64_t{0}; i < dim_t1 - int64_t{2}; ++i) {
-    if (t1_strides[i] != t1_strides[i+1] * t1_shape[i+1]) {
+    if (TORCH_GUARD_OR_TRUE(
+            t1_strides[i].sym_ne(t1_strides[i + 1] * t1_shape[i + 1]))) {
       return false;
     }
   }
@@ -2065,40 +2068,43 @@ static Tensor _matmul_impl(
     // Why not t1->view(-1, sizes_1.back())?
     // If the last dim is 0, then view(-1, 0) won't work because the -1 becomes ambiguous.
     // This can happen in e.g. [3, 5, 0] @ [0, 0].
-    const auto sizes_1 = t1->sizes();
-    auto output_shape = DimVector(sizes_1.begin(), sizes_1.end() - 1);
+    const auto sizes_1 = t1->sym_sizes();
+    auto output_shape = c10::SymDimVector(sizes_1.begin(), sizes_1.end() - 1);
     const auto folded_dim1 = c10::multiply_integers(output_shape);
 
     // Readjust output_shape if we are multiplying by a matrix
     const auto t2_is_matrix = t2->dim() == 2;
     if (t2_is_matrix) {
-      output_shape.push_back(t2->sizes()[1]);
+      output_shape.push_back(t2->sym_sizes()[1]);
     }
     // This will almost always be a view.
     // It may not be a view if t2->requires_grad(). See should_fold for an explanation
-    const auto t1_folded = t1->reshape({folded_dim1, sizes_1.back()});
+    const c10::SymDimVector t1_folded_shape{folded_dim1, sizes_1.back()};
+    const auto t1_folded = at::reshape_symint(*t1, t1_folded_shape);
     if (!has_out) {
       if (t2_is_matrix) {
-        const auto output = at::_unsafe_view(t1_folded.mm(*t2), output_shape);
+        const auto output = at::_unsafe_view_symint(t1_folded.mm(*t2), output_shape);
         // This copies if we perform a 2D @ 3D and the first tensor requires_grad
         // See should_fold for why.
         // If mm_out were differentiable, we could use it here, and pass a result with the
         // correct strides to avoid this unnecessary copy.
         return transpose ? output.mT().contiguous() : output;
       } else {
-        return at::_unsafe_view(t1_folded.mv(*t2), output_shape);
+        return at::_unsafe_view_symint(t1_folded.mv(*t2), output_shape);
       }
     } else {
       // See the !has_out branch for an explanation
       TORCH_INTERNAL_ASSERT(!(transpose && t2_is_matrix));
 
       // Resize output into the correct shape
-      at::native::resize_output(out, output_shape);
+      at::native::resize_output_symint(out, output_shape);
 
       // We then reshape the output to the expected shape and call mm/mv
       // and transpose back if necessary
-      auto reshaped_out = t2_is_matrix ? out.reshape({folded_dim1, t2->sizes().back()})
-                                       : out.reshape({folded_dim1});
+      auto reshaped_out = t2_is_matrix
+          ? at::reshape_symint(
+                out, c10::SymDimVector{folded_dim1, t2->sym_sizes().back()})
+          : at::reshape_symint(out, c10::SymDimVector{folded_dim1});
       if (t2_is_matrix) {
         at::mm_out(reshaped_out, t1_folded, *t2);
       } else {

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -45,6 +45,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import (
     DimDynamic,
     free_symbols,
+    free_unbacked_symbols,
     ShapeEnv,
     ShapeEnvSettings,
     StatelessSymbolicContext,
@@ -901,6 +902,62 @@ class FakeTensorTest(TestCase):
         self.assertIs(t2.fake_mode, mode2)
         self.assertIs(t2.size(0).node.shape_env, t1.size(0).node.shape_env)
         self.assertEqual(str(t2.size(0)), str(t1.size(0)))
+
+    def test_linear_rank3_unbacked_batch_dim(self):
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=shape_env)
+        fake_x = fake_mode.from_tensor(
+            torch.randn(4, 16, 256),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[
+                    DimDynamic.UNBACKED,
+                    DimDynamic.STATIC,
+                    DimDynamic.STATIC,
+                ],
+                constraint_sizes=[None, None, None],
+            ),
+        )
+        fake_weight = fake_mode.from_tensor(torch.randn(3072, 256), static_shapes=True)
+
+        def f(x):
+            return torch.nn.functional.linear(x, fake_weight)
+
+        self.assertTrue(free_unbacked_symbols(fake_x.shape[0]))
+        with fake_mode:
+            out = f(fake_x)
+
+        self.assertEqual(out.shape[1:], (16, 3072))
+        self.assertTrue(free_unbacked_symbols(out.shape[0]))
+
+        x = torch.randn(4, 16, 256)
+        weight = torch.randn(3072, 256)
+        torch._dynamo.decorators.mark_unbacked(
+            x, 0, min=2, max=8, hint_override=x.shape[0]
+        )
+
+        def trace_f(x, weight):
+            return torch.nn.functional.linear(x, weight)
+
+        gm = make_fx(trace_f, tracing_mode="symbolic")(x, weight)
+        replay_out = gm(torch.randn(5, 16, 256), weight)
+        self.assertEqual(replay_out.shape, (5, 16, 3072))
+
+    def test_view_unbacked_contiguous_relation_from_hints(self):
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=shape_env)
+        with fake_mode:
+            seq = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(seq, 16)
+            base = torch.empty(4, seq, 256)
+            chunked = torch.as_strided(
+                base,
+                (4, 2 * (seq // 2), 256),
+                (256 * seq, 256, 1),
+            )
+            out = chunked.view(4 * 2 * (seq // 2), 256)
+
+        self.assertEqual(out.shape, (4 * 2 * (seq // 2), 256))
+        self.assertTrue(free_unbacked_symbols(out.shape[0]))
 
     # TODO: Support NJT.  There's also some funny business with dynamic shapes
     # which would need to be dealt with as well

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1442,8 +1442,8 @@ def forward(self, crop_camera_1, mask_1):
     view_1 = torch.ops.aten.view.default(expand_1, [sym_size_int, sym_size_int_1, sym_size_int_2]);  expand_1 = sym_size_int_1 = sym_size_int_2 = None
     bmm = torch.ops.aten.bmm.default(view, view_1);  view = view_1 = None
     view_2 = torch.ops.aten.view.default(bmm, [sym_size_int, 3, 3]);  bmm = None
-    mul_9 = sym_size_int * 3
-    view_3 = torch.ops.aten.view.default(view_2, [mul_9, 3]);  view_2 = mul_9 = None
+    mul_11 = sym_size_int * 3
+    view_3 = torch.ops.aten.view.default(view_2, [mul_11, 3]);  view_2 = mul_11 = None
     mm = torch.ops.aten.mm.default(view_3, eye);  view_3 = eye = None
     _unsafe_view = torch.ops.aten._unsafe_view.default(mm, [sym_size_int, 3, 3]);  mm = sym_size_int = None
     index_put_ = torch.ops.aten.index_put_.default(crop_camera_1, [mask_1], _unsafe_view);  crop_camera_1 = mask_1 = _unsafe_view = index_put_ = None

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4888,7 +4888,7 @@ def should_fold(tensor1: torch.Tensor, tensor2: torch.Tensor, is_out: bool) -> b
         return True
     if tensor1.ndim == 2:
         return False
-    if guard_or_false(t1.numel() == 0):
+    if guard_or_false(sym_numel(t1) == 0):
         return True
 
     t1_shape = t1.shape

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -642,6 +642,69 @@ def _compute_stride(
     return new_stride
 
 
+def _optimization_hint_or_none(value: Any) -> int | None:
+    if type(value) is int:
+        return value
+    if isinstance(value, torch.SymInt):
+        from torch.fx.experimental.symbolic_shapes import optimization_hint
+
+        return optimization_hint(value, fallback=None)
+    return None
+
+
+def _hinted_eq(lhs: Any, rhs: Any) -> bool:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    if guard_or_false(lhs == rhs):
+        return True
+
+    lhs_hint = _optimization_hint_or_none(lhs)
+    rhs_hint = _optimization_hint_or_none(rhs)
+    if lhs_hint is None or rhs_hint is None or lhs_hint != rhs_hint:
+        return False
+
+    # Hints are not shape semantics. They only show that the equality is true
+    # for the traced example, so record the symbolic equality required for the
+    # view rather than specializing either side to a concrete value.
+    torch._check(lhs == rhs)
+    return True
+
+
+def _is_contiguous_with_hinted_checks(a: torch.Tensor) -> bool:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false, is_nested_int
+
+    if guard_or_false(a.numel() < 2):
+        return True
+
+    numel_hint = _optimization_hint_or_none(a.numel())
+    if numel_hint is None:
+        return False
+    if numel_hint < 2:
+        torch._check(a.numel() < 2)
+        return True
+
+    expected_stride = 1
+    expected_stride_max = 1
+    for size, stride in reversed(tuple(zip(a.shape, a.stride()))):
+        if guard_or_false(size == 1):
+            continue
+
+        size_hint = _optimization_hint_or_none(size)
+        if size_hint == 1:
+            torch._check(size == 1)
+            continue
+
+        if not _hinted_eq(stride, expected_stride) and not _hinted_eq(
+            stride, expected_stride_max
+        ):
+            return False
+
+        expected_stride_max *= size if is_nested_int(size) else torch.sym_max(size, 1)
+        expected_stride *= size
+
+    return True
+
+
 def _view_has_unbacked_input(
     a: torch.Tensor, shape: ShapeType | tuple[ShapeType]
 ) -> bool:
@@ -833,6 +896,10 @@ def _view_unbacked_meta(
                 allow_copy=allow_copy,
                 tried_duck_specialize=True,
             )
+
+        if _is_contiguous_with_hinted_checks(a):
+            strides = make_contiguous_strides_for(shape)
+            return a.as_strided(shape, strides)  # type: ignore[return-value]
 
         return _view_unbacked_meta(
             a, shape, size_oblivious_enabled=False, allow_copy=allow_copy


### PR DESCRIPTION
Stacked PRs:
 * #183545
 * #183544
 * #183495
 * #183398
 * __->__#183397


--- --- ---

### [ATen][FakeTensor] Handle unbacked dims in folded matmul


The folded matmul path used for ND @ 1D/2D tensors was still forcing concrete sizes in two places: the empty-tensor check used numel(), and the fold/view path built concrete DimVector shapes from sizes(). With unbacked input dimensions, both paths can require specializing a data-dependent symbol even though the operation can be represented symbolically.

Keep the folded path symbolic by using sym_numel(), sym_sizes(), sym_strides(), reshape_symint(), _unsafe_view_symint(), and symbolic output resize. The contiguity predicate now uses symbolic equality guarded through TORCH_GUARD_OR_FALSE instead of forcing concrete stride/shape integers.

Also let fake view metadata recover from hinted unbacked contiguity relations by emitting symbolic equality checks for stride relations that are true at the traced hint. This handles shapes such as 2 * (u0 // 2) with a stride expressed through u0 without specializing u0 to a concrete value.

Add fake tensor regression tests for rank-3 linear with an unbacked batch dimension and hinted unbacked view contiguity.

Test Plan:

python test/test_fake_tensor.py FakeTensorTest.test_linear_rank3_unbacked_batch_dim FakeTensorTest.test_view_unbacked_contiguous_relation_from_hints -v

lintrunner --config=.lintrunner.toml aten/src/ATen/native/LinearAlgebra.cpp torch/_decomp/decompositions.py torch/_subclasses/fake_impls.py test/test_fake_tensor.py

Fixes pytorch/torchtitan#3322
