### PR TITLE
docs(optim): use Adam in Optimizer.load_state_dict example

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -903,7 +903,7 @@ class Optimizer:
         Example:
             >>> # xdoctest: +SKIP
             >>> model = torch.nn.Linear(10, 10)
-            >>> optim = torch.optim.SGD(model.parameters(), lr=3e-4)
+            >>> optim = torch.optim.Adam(model.parameters(), lr=3e-4)
             >>> scheduler1 = torch.optim.lr_scheduler.LinearLR(
             ...     optim,
             ...     start_factor=0.1,


### PR DESCRIPTION
## Summary

Fixes #183036

The `load_state_dict` docstring in the base `Optimizer` class had an example using `torch.optim.SGD`. Because every optimizer inherits this docstring, the generated docs for **every optimizer** — including `Adadelta`, `RMSprop`, `Adagrad`, etc. — displayed an SGD example. This was confusing to users reading the docs for a different optimizer.

Changed the example from `SGD` to `Adam`. The `lr=3e-4` value is already a well-known default for Adam (Karpathy's constant), so the example is now self-consistent.

## Before / After

```python
# Before — confusing when shown on Adadelta/RMSprop/etc. docs pages
>>> optim = torch.optim.SGD(model.parameters(), lr=3e-4)

# After
>>> optim = torch.optim.Adam(model.parameters(), lr=3e-4)
```

## Test plan
- [ ] This is a one-line docstring change with no behavioral impact — no test changes needed.
- [ ] Verified the root cause: `torch/optim/optimizer.py` `Optimizer.load_state_dict` example, line 906.