### PR TITLE
Fix UAF in CUDAStream/Event `tp_dealloc` overrides

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: dynamo"]
+import gc
 import re
 import unittest
 import weakref
@@ -8,6 +9,8 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.graph_bytecode_inputs import (
+    CURRENT_STREAM_INDEX,
+    index_to_external_object_weakref,
     reset_user_object_tracking,
     store_user_object_weakrefs,
 )
@@ -41,6 +44,95 @@ class TestStreams(torch._dynamo.test_case.TestCase):
     def test_event_weakref(self):
         e = torch.Event()
         weakref.ref(e)
+
+    def _assert_weakref_callback_fires(self, factory):
+        """Backend Stream/Event tp_dealloc overrides must call
+        PyObject_ClearWeakRefs so that weakrefs to destroyed instances
+        are properly cleared.  Without it, the weakref's wr_object is
+        left dangling and any later access (e.g. the dynamo external-
+        object registry being cleared at interpreter finalization)
+        hits a use-after-free.
+
+        The callback firing is the only reliable Python-level signal —
+        `weakref.ref(s)() is None` can return True even with the bug
+        present, because other CPython paths may null wr_object
+        without invoking callbacks (Objects/weakrefobject.c).
+        """
+        called = []
+        obj = factory()
+        # `_weakref_keepalive` must outlive `del obj` so the callback
+        # has a chance to fire; the binding is load-bearing.
+        _weakref_keepalive = weakref.ref(obj, lambda _ref: called.append(True))
+        del obj
+        gc.collect()
+        self.assertEqual(called, [True])
+        del _weakref_keepalive
+
+    @requires_cuda
+    def test_cuda_stream_event_weakref_callback(self):
+        self._assert_weakref_callback_fires(torch.cuda.Stream)
+        self._assert_weakref_callback_fires(torch.cuda.Event)
+
+    @unittest.skipUnless(TEST_XPU, "xpu only")
+    def test_xpu_stream_event_weakref_callback(self):
+        self._assert_weakref_callback_fires(torch.xpu.Stream)
+        self._assert_weakref_callback_fires(torch.xpu.Event)
+
+    @requires_cuda
+    def test_dynamo_registry_no_dangling_weakref(self):
+        """Natural repro of the original UAF pattern.
+
+        `torch.compile(fn, backend="eager")` with `fn` referencing
+        `torch.cuda.current_stream()` causes dynamo to register a
+        weakref to the captured stream in
+        `index_to_external_object_weakref` (via
+        `store_user_object_weakrefs`, which does NOT pin via
+        `keep_alive`).  As soon as `fn` returns, the captured wrapper
+        has no strong references and is freed via `THCPStream_dealloc`.
+
+        At that point the patched tp_dealloc must call
+        `PyObject_ClearWeakRefs`, otherwise the registry now holds a
+        weakref whose `wr_object` is a dangling pointer to freed
+        memory.  Later, when `_PyModule_ClearDict` tears down the
+        registry at interpreter finalization, dereferencing that
+        dangling pointer to clear the weakref hits a use-after-free.
+        """
+        # Start from a known-clean registry so the assertion below is
+        # a statement about what happened in *this* test, not residue
+        # from earlier tests in the same process.
+        reset_user_object_tracking()
+
+        def fn(x):
+            return torch.cuda.current_stream().cuda_stream
+
+        x = torch.zeros(1, device="cuda")
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        compiled(x)
+        del compiled
+        gc.collect()
+
+        # Tripwire: torch.compile of a function referencing
+        # current_stream() must still register under
+        # CURRENT_STREAM_INDEX.  If this fails, the production code
+        # path that originally surfaced the UAF has moved and this
+        # regression test no longer covers it.
+        self.assertIn(
+            CURRENT_STREAM_INDEX,
+            index_to_external_object_weakref,
+            "torch.compile of a function referencing current_stream() must "
+            "register a weakref under CURRENT_STREAM_INDEX",
+        )
+
+        # The captured stream wrapper was freed when fn returned.  The
+        # patched tp_dealloc must have cleared the registry's weakref;
+        # dereferencing it now must return None rather than a dangling
+        # pointer into freed memory.
+        self.assertIsNone(
+            index_to_external_object_weakref[CURRENT_STREAM_INDEX](),
+            "dynamo registry holds a weakref to a Stream wrapper that has "
+            "been freed; tp_dealloc must call PyObject_ClearWeakRefs to "
+            "clear it, otherwise the registry retains a dangling pointer",
+        )
 
     @requires_cuda
     def test_stream_enter_exit(self):

--- a/torch/csrc/Event.cpp
+++ b/torch/csrc/Event.cpp
@@ -75,13 +75,17 @@ PyObject* THPEvent_new(c10::DeviceType device_type, c10::EventFlag flag) {
   return self.release();
 }
 
+void THPEvent_dealloc_common(THPEvent* self) {
+  PyObject_ClearWeakRefs((PyObject*)self);
+  Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
+}
+
 static void THPEvent_dealloc(THPEvent* self) {
   {
     pybind11::gil_scoped_release no_gil{};
     self->event.~Event();
   }
-  PyObject_ClearWeakRefs((PyObject*)self);
-  Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
+  THPEvent_dealloc_common(self);
 }
 
 static PyObject* THPEvent_get_device(THPEvent* self, void* unused) {

--- a/torch/csrc/Event.h
+++ b/torch/csrc/Event.h
@@ -13,6 +13,7 @@ TORCH_API extern PyTypeObject* THPEventClass;
 TORCH_API extern PyTypeObject THPEventType;
 
 TORCH_API void THPEvent_init(PyObject* module);
+TORCH_API void THPEvent_dealloc_common(THPEvent* self);
 TORCH_API PyObject* THPEvent_new(
     c10::DeviceType device_type,
     c10::EventFlag flag);

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -117,10 +117,14 @@ PyObject* THPStream_Wrap(const c10::Stream& stream) {
   END_HANDLE_TH_ERRORS
 }
 
-static void THPStream_dealloc(THPStream* self) {
+void THPStream_dealloc_common(THPStream* self) {
   PyObject_ClearWeakRefs((PyObject*)self);
   Py_CLEAR(self->context);
   Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
+}
+
+static void THPStream_dealloc(THPStream* self) {
+  THPStream_dealloc_common(self);
 }
 
 static PyObject* THPStream_get_device(THPStream* self, void* unused) {

--- a/torch/csrc/Stream.h
+++ b/torch/csrc/Stream.h
@@ -18,6 +18,7 @@ struct THPStream {
 extern TORCH_API PyTypeObject* THPStreamClass;
 
 void THPStream_init(PyObject* module);
+TORCH_API void THPStream_dealloc_common(THPStream* self);
 
 inline bool THPStream_Check(PyObject* obj) {
   return THPStreamClass && PyObject_IsInstance(obj, (PyObject*)THPStreamClass);

--- a/torch/csrc/cuda/Event.cpp
+++ b/torch/csrc/cuda/Event.cpp
@@ -105,6 +105,9 @@ static void THCPEvent_dealloc(THCPEvent* self) {
     pybind11::gil_scoped_release no_gil{};
     self->cuda_event.~CUDAEvent();
   }
+  // Mirror base THPEvent_dealloc: tear down native state under the GIL
+  // release, then clear weakrefs under the GIL before tp_free.
+  PyObject_ClearWeakRefs((PyObject*)self);
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -245,7 +248,7 @@ PyTypeObject THCPEventType = {
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
     nullptr, /* tp_richcompare */
-    0, /* tp_weaklistoffset */
+    offsetof(THPEvent, weakreflist), /* tp_weaklistoffset */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
     THCPEvent_methods, /* tp_methods */

--- a/torch/csrc/cuda/Event.cpp
+++ b/torch/csrc/cuda/Event.cpp
@@ -105,10 +105,7 @@ static void THCPEvent_dealloc(THCPEvent* self) {
     pybind11::gil_scoped_release no_gil{};
     self->cuda_event.~CUDAEvent();
   }
-  // Mirror base THPEvent_dealloc: tear down native state under the GIL
-  // release, then clear weakrefs under the GIL before tp_free.
-  PyObject_ClearWeakRefs((PyObject*)self);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  THPEvent_dealloc_common(reinterpret_cast<THPEvent*>(self));
 }
 
 static PyObject* THCPEvent_get_cuda_event(THCPEvent* self, void* unused) {

--- a/torch/csrc/cuda/Event.cpp
+++ b/torch/csrc/cuda/Event.cpp
@@ -245,7 +245,7 @@ PyTypeObject THCPEventType = {
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
     nullptr, /* tp_richcompare */
-    offsetof(THPEvent, weakreflist), /* tp_weaklistoffset */
+    0, /* tp_weaklistoffset (inherited from THPEventType via tp_base) */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
     THCPEvent_methods, /* tp_methods */

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -82,12 +82,7 @@ static PyObject* THCPStream_pynew(
 
 static void THCPStream_dealloc(THCPStream* self) {
   self->cuda_stream.~CUDAStream();
-  // Mirror base THPStream_dealloc: clear weakrefs (the subclass dealloc
-  // overrides the base, so it must perform the base's teardown too) and
-  // release the lazily-allocated stream context.
-  PyObject_ClearWeakRefs((PyObject*)self);
-  Py_CLEAR(self->context);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  THPStream_dealloc_common(reinterpret_cast<THPStream*>(self));
 }
 
 static PyObject* THCPStream_get_cuda_stream(THCPStream* self, void* unused) {

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -181,7 +181,7 @@ PyTypeObject THCPStreamType = {
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
     nullptr, /* tp_richcompare */
-    offsetof(THPStream, weakreflist), /* tp_weaklistoffset */
+    0, /* tp_weaklistoffset (inherited from THPStreamType via tp_base) */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
     THCPStream_methods, /* tp_methods */

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -82,6 +82,11 @@ static PyObject* THCPStream_pynew(
 
 static void THCPStream_dealloc(THCPStream* self) {
   self->cuda_stream.~CUDAStream();
+  // Mirror base THPStream_dealloc: clear weakrefs (the subclass dealloc
+  // overrides the base, so it must perform the base's teardown too) and
+  // release the lazily-allocated stream context.
+  PyObject_ClearWeakRefs((PyObject*)self);
+  Py_CLEAR(self->context);
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -181,7 +186,7 @@ PyTypeObject THCPStreamType = {
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
     nullptr, /* tp_richcompare */
-    0, /* tp_weaklistoffset */
+    offsetof(THPStream, weakreflist), /* tp_weaklistoffset */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
     THCPStream_methods, /* tp_methods */

--- a/torch/csrc/xpu/Event.cpp
+++ b/torch/csrc/xpu/Event.cpp
@@ -49,10 +49,7 @@ static void THXPEvent_dealloc(THXPEvent* self) {
     pybind11::gil_scoped_release no_gil{};
     self->xpu_event.~XPUEvent();
   }
-  // Mirror base THPEvent_dealloc: tear down native state under the GIL
-  // release, then clear weakrefs under the GIL before tp_free.
-  PyObject_ClearWeakRefs((PyObject*)self);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  THPEvent_dealloc_common(reinterpret_cast<THPEvent*>(self));
 }
 
 static PyObject* THXPEvent_get_sycl_event(THXPEvent* self, void* unused) {

--- a/torch/csrc/xpu/Event.cpp
+++ b/torch/csrc/xpu/Event.cpp
@@ -49,6 +49,9 @@ static void THXPEvent_dealloc(THXPEvent* self) {
     pybind11::gil_scoped_release no_gil{};
     self->xpu_event.~XPUEvent();
   }
+  // Mirror base THPEvent_dealloc: tear down native state under the GIL
+  // release, then clear weakrefs under the GIL before tp_free.
+  PyObject_ClearWeakRefs((PyObject*)self);
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -168,7 +171,7 @@ static PyTypeObject THXPEventType = {
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
     nullptr, /* tp_richcompare */
-    0, /* tp_weaklistoffset */
+    offsetof(THPEvent, weakreflist), /* tp_weaklistoffset */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
     THXPEvent_methods, /* tp_methods */

--- a/torch/csrc/xpu/Event.cpp
+++ b/torch/csrc/xpu/Event.cpp
@@ -168,7 +168,7 @@ static PyTypeObject THXPEventType = {
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
     nullptr, /* tp_richcompare */
-    offsetof(THPEvent, weakreflist), /* tp_weaklistoffset */
+    0, /* tp_weaklistoffset (inherited from THPEventType via tp_base) */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
     THXPEvent_methods, /* tp_methods */

--- a/torch/csrc/xpu/Stream.cpp
+++ b/torch/csrc/xpu/Stream.cpp
@@ -64,11 +64,7 @@ static PyObject* THXPStream_pynew(
 
 static void THXPStream_dealloc(THXPStream* self) {
   self->xpu_stream.~XPUStream();
-  // Mirror base THPStream_dealloc: clear weakrefs and release the
-  // lazily-allocated stream context.
-  PyObject_ClearWeakRefs((PyObject*)self);
-  Py_CLEAR(self->context);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  THPStream_dealloc_common(reinterpret_cast<THPStream*>(self));
 }
 
 static PyObject* THXPStream_get_sycl_queue(THXPStream* self, void* unused) {

--- a/torch/csrc/xpu/Stream.cpp
+++ b/torch/csrc/xpu/Stream.cpp
@@ -163,7 +163,7 @@ static PyTypeObject THXPStreamType = {
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
     nullptr, /* tp_richcompare */
-    offsetof(THPStream, weakreflist), /* tp_weaklistoffset */
+    0, /* tp_weaklistoffset (inherited from THPStreamType via tp_base) */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
     THXPStream_methods, /* tp_methods */

--- a/torch/csrc/xpu/Stream.cpp
+++ b/torch/csrc/xpu/Stream.cpp
@@ -64,6 +64,10 @@ static PyObject* THXPStream_pynew(
 
 static void THXPStream_dealloc(THXPStream* self) {
   self->xpu_stream.~XPUStream();
+  // Mirror base THPStream_dealloc: clear weakrefs and release the
+  // lazily-allocated stream context.
+  PyObject_ClearWeakRefs((PyObject*)self);
+  Py_CLEAR(self->context);
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -163,7 +167,7 @@ static PyTypeObject THXPStreamType = {
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
     nullptr, /* tp_richcompare */
-    0, /* tp_weaklistoffset */
+    offsetof(THPStream, weakreflist), /* tp_weaklistoffset */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
     THXPStream_methods, /* tp_methods */


### PR DESCRIPTION
The four backend `tp_dealloc` overrides for `torch.cuda.Stream`, `torch.cuda.Event`, `torch.xpu.Stream`, and `torch.xpu.Event` silently diverged from their base classes' deallocs (`THPStream_dealloc` in `torch/csrc/Stream.cpp` and `THPEvent_dealloc` in `torch/csrc/Event.cpp`) when those bases added weakref support in #164304 and #164522. 

Since CPython does not chain `tp_dealloc` automatically for static types, every freed `THCPStream` / `THCPEvent` / `THXPStream` / `THXPEvent` instance has been leaving:

- **dangling weakrefs** (no `PyObject_ClearWeakRefs(self)` call), and
- **a leaked lazy stream context** in the Stream subclasses (no `Py_CLEAR(self->context)` call).

The dangling weakrefs sat latent until #180497 made the dynamo external-object registry populate a `weakref.ref(torch.cuda.current_stream())` on every `torch.compile` invocation referencing `current_stream()`. 

From that point on, anything that triggered the dynamo registry plus a finalize-time GC pass would `_PyModule_ClearDict` walk the registry's now-dangling weakrefs at `Py_FinalizeEx` and SIGSEGV in `clear_weakref → _PyObject_GET_WEAKREFS_LISTPTR → PyType_Check(NULL)`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos