### PR TITLE
[xpu] Add more device_id that recognized as Intel BMG.

### DIFF
--- a/torch/testing/_internal/common_xpu.py
+++ b/torch/testing/_internal/common_xpu.py
@@ -39,6 +39,7 @@ _DEVICE_ID_TO_CODENAME = {
     0xE20C: XPUCodename.BMG,
     0xE20D: XPUCodename.BMG,
     0xE210: XPUCodename.BMG,
+    0xE211: XPUCodename.BMG,
     0xE212: XPUCodename.BMG,
     0xE215: XPUCodename.BMG,
     0xE216: XPUCodename.BMG,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #183414

## Motivation

Currently our BMG CI machine's device id is `0xE211`, which is mapped to `unknow`, and then the flag `Xe20_Or_Later` failed, which caused all the test cases decorated with it skipped in the CI machine.

## Solution

Add the device_id into the map `_DEVICE_ID_TO_CODENAME `