### PR TITLE
[Avocado][MI350X] Non-overlay compatibility for new AITER/CK overlays (#183418)

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
@@ -3,6 +3,7 @@
  ******************************************************************************/
 
 #include <ATen/native/transformers/hip/flash_attn/flash_common_hip.hpp>
+#ifndef CK_FMHA_BWD_DISABLED
 #include <mha_bwd.h>
 #include <fmha_bwd.hpp>
 #include <mask.hpp>
@@ -453,3 +454,17 @@ mha_bwd_ck(const at::Tensor &dout,                   // batch_size x seqlen_q x 
     return { dq, dk, dv, softmax_d, dbias };
 }
 } // namespace pytorch_flash
+#else
+// Stub when backward FMHA is disabled (inference-only CK build)
+#include <ATen/native/transformers/hip/flash_attn/flash_api.h>
+namespace pytorch_flash {
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd_ck(
+    const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&,
+    const at::Tensor&, const at::Tensor&, std::optional<at::Tensor>&,
+    std::optional<at::Tensor>&, std::optional<at::Tensor>&, std::optional<at::Tensor>&,
+    bool, std::optional<at::Tensor>&, float, float, bool, int, int, bool,
+    const at::Tensor, const at::Tensor) {
+    TORCH_CHECK(false, "CK FMHA backward is not available in this build");
+}
+} // namespace pytorch_flash
+#endif // CK_FMHA_BWD_DISABLED

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
@@ -3,6 +3,7 @@
  ******************************************************************************/
 
 #include <ATen/native/transformers/hip/flash_attn/flash_common_hip.hpp>
+#ifndef CK_FMHA_BWD_DISABLED
 #include <fmha_bwd.hpp>
 #include <mask.hpp>
 
@@ -477,3 +478,17 @@ mha_varlen_bwd_ck(const at::Tensor &dout,                   // total_q x num_hea
     return { dq, dk, dv, softmax_d, dbias };
 }
 } // namespace pytorch_flash
+#else
+#include <ATen/native/transformers/hip/flash_attn/flash_api.h>
+namespace pytorch_flash {
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_varlen_bwd_ck(
+    const at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Tensor&,
+    const at::Tensor&, const at::Tensor&, std::optional<at::Tensor>&,
+    std::optional<at::Tensor>&, std::optional<at::Tensor>&,
+    const at::Tensor&, const at::Tensor&, std::optional<at::Tensor>&,
+    bool, std::optional<at::Tensor>&, int, int, float, float, bool, bool, int, int, bool,
+    const at::Tensor, const at::Tensor) {
+    TORCH_CHECK(false, "CK FMHA backward is not available in this build");
+}
+} // namespace pytorch_flash
+#endif // CK_FMHA_BWD_DISABLED


### PR DESCRIPTION
Summary:

Adds select()-guarded compatibility changes to shared paths (caffe2, xplat, flash_attention_v2, third-party/aiter) needed by the new AITER dde1703 + CK v1.2.0 overlays.

All changes are guarded by select({"fbcode//ck:avocado_prod": [...], "DEFAULT": []}) or #ifndef guards, so they are no-ops without the avocado_prod modifier. The third-party/aiter changes are additive (new functions only).

Changes:
- caffe2/TARGETS, xplat/caffe2/TARGETS: select() to disable CK FMHA BWD with avocado_prod
- caffe2/aten/.../codegen/: Add #ifndef CK_FMHA_BWD_DISABLED guards, new CK v1.2.0 includes
- flash_attention_v2/BUCK: select() to disable flash_attn CK with avocado_prod
- flash_attention_v2/*.hip: #ifndef FLASH_ATTN_CK_DISABLED guards, new CK v1.2.0 includes
- third-party/aiter/: Add fused_allreduce_rmsnorm_quant and custom_all_reduce updates (additive)
- gen_ai/llm_inference/BUCK: Use //aiter:aiter modifier path (default target points to third-party)

Test Plan:
- Non-avocado builds unaffected (all select() defaults are empty, all #ifndef guards are inactive)
- Combined with D1, buck2 build succeeds for avocado_prod

Differential Revision: D103771416


