### PR TITLE
Fixes DefaultStager crash when reused

### DIFF
--- a/test/distributed/checkpoint/test_state_dict_stager.py
+++ b/test/distributed/checkpoint/test_state_dict_stager.py
@@ -19,7 +19,11 @@ from torch.distributed._shard.sharded_tensor import (
 from torch.distributed._tensor import DTensor
 from torch.distributed._tensor.placement_types import Replicate, Shard
 from torch.distributed.checkpoint._state_dict_stager import StateDictStager
-from torch.distributed.checkpoint.staging import _ReplicationStager
+from torch.distributed.checkpoint.staging import (
+    _ReplicationStager,
+    DefaultStager,
+    StagingOptions,
+)
 from torch.distributed.checkpoint.state_dict_saver import async_save
 from torch.distributed.tensor import DeviceMesh, distribute_tensor
 from torch.testing._internal.common_distributed import (
@@ -838,6 +842,33 @@ class TestStateDictStager(TestCase):
                         cpu_tensor2.storage().is_shared(),
                         "When share_memory=False, tensor storage should not be shared",
                     )
+
+    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
+    def test_async_save_can_reuse_default_stager(self):
+        state_dict = {
+            "weight": torch.randn(4, 4, device=device_type),
+            "step": 42,
+        }
+        stager = DefaultStager(
+            StagingOptions(
+                use_pinned_memory=False,
+                use_shared_memory=False,
+                use_async_staging=False,
+                use_non_blocking_copy=False,
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for step in range(2):
+                metadata = async_save(
+                    state_dict,
+                    checkpoint_id=os.path.join(temp_dir, f"step_{step}"),
+                    async_stager=stager,
+                    no_dist=True,
+                ).result()
+                self.assertIsNotNone(metadata)
+
+        stager.close()
 
 
 class TestDTensorStateDictStager(DTensorTestBase):

--- a/torch/distributed/checkpoint/staging.py
+++ b/torch/distributed/checkpoint/staging.py
@@ -154,11 +154,6 @@ class DefaultStager(AsyncStager):
         staged_dict = future.result()
         stager.close()
 
-        # Context manager pattern (recommended)
-        stager = DefaultStager(config)
-        with stager:
-        result = stager.stage(state_dict)
-
     Performance Considerations:
         - Async staging provides best performance when model computation
           can overlap with staging operations
@@ -245,10 +240,6 @@ class DefaultStager(AsyncStager):
             self._staging_stream.synchronize() if self._staging_stream else torch.accelerator.synchronize()
         else:
             state_dict = self._state_dict_stager.stage(state_dict, non_blocking=False)
-
-        # release reference cycle to prevent memory leaks in async_save
-        # created by _deepcopy_dispatch that capture self
-        self._state_dict_stager.close()
 
         return state_dict
 

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
+import contextlib
 import inspect
 import os
 import warnings
@@ -234,7 +235,9 @@ def async_save(
 
     .. warning::
         This feature is experimental and subject to change.
-        MUST CALL CLOSE AFTER LAST CHECKPOINT IS SAVED
+        If you provide an ``async_stager``, call ``close()`` after the last
+        checkpoint is saved. Internally created default stagers are closed
+        automatically.
 
     Args:
         state_dict (Dict[str, Any]): The state_dict to save.
@@ -258,8 +261,10 @@ def async_save(
             whether to do checkpoint in separate thread or process
             (Default: ``AsyncCheckpointerType.THREAD``)
         async_stager (AsyncStager):
-            provides staging implementation. If storage_writer implements AsyncStager
-            and async_stager is provided, async_stager will be used for staging
+            provides staging implementation. If ``storage_writer`` implements
+            ``AsyncStager`` and ``async_stager`` is not provided, ``storage_writer``
+            will be used for staging. User-provided stagers remain owned by the
+            caller and should be closed after the last checkpoint is saved.
         no_dist (bool):
             If ``True``, this function will assume the intent is to save
             a checkpoint on a single rank/process.
@@ -299,6 +304,7 @@ def async_save(
                 "A CPU backend must be enabled for async save; try initializing process group with 'cpu:gloo,cuda:nccl'"
             )
 
+    owned_async_stager: AsyncStager | None = None
     if async_stager is None:
         if storage_writer is not None and isinstance(storage_writer, AsyncStager):
             # bwc with old storage_writers
@@ -312,30 +318,48 @@ def async_save(
                     False,
                 )
             )
+            owned_async_stager = async_stager
 
     state_dict = _stateful_to_state_dict(state_dict)
+
+    owned_async_stager_closed = False
+
+    def maybe_close_owned_async_stager() -> None:
+        nonlocal owned_async_stager_closed
+        if owned_async_stager is not None and not owned_async_stager_closed:
+            owned_async_stager_closed = True
+            owned_async_stager.close()
 
     @_dcp_method_logger(log_exceptions=True)
     def stage_state_dict() -> Future[STATE_DICT_TYPE] | STATE_DICT_TYPE:
         return async_stager.stage(state_dict)
 
-    staging_future_or_state_dict = stage_state_dict()
+    with contextlib.ExitStack() as stack:
+        if owned_async_stager is not None:
+            stack.callback(maybe_close_owned_async_stager)
 
-    upload_executor: _AsyncCheckpointExecutor = (
-        _ProcessBasedAsyncCheckpointExecutor()
-        if async_checkpointer_type == AsyncCheckpointerType.PROCESS
-        else _ThreadBasedAsyncCheckpointExecutor()
-    )
+        staging_future_or_state_dict = stage_state_dict()
 
-    upload_future: Future = upload_executor.execute_save(
-        staging_future_or_state_dict,
-        checkpoint_id=checkpoint_id,
-        storage_writer=storage_writer,
-        planner=planner,
-        process_group=process_group,
-        no_dist=no_dist,
-        use_collectives=use_collectives,
-    )
+        upload_executor: _AsyncCheckpointExecutor = (
+            _ProcessBasedAsyncCheckpointExecutor()
+            if async_checkpointer_type == AsyncCheckpointerType.PROCESS
+            else _ThreadBasedAsyncCheckpointExecutor()
+        )
+
+        upload_future: Future = upload_executor.execute_save(
+            staging_future_or_state_dict,
+            checkpoint_id=checkpoint_id,
+            storage_writer=storage_writer,
+            planner=planner,
+            process_group=process_group,
+            no_dist=no_dist,
+            use_collectives=use_collectives,
+        )
+
+        if owned_async_stager is not None:
+            upload_future.add_done_callback(lambda _: maybe_close_owned_async_stager())
+            # in the success path transfer cleanup ownership to the upload future
+            stack.pop_all()
 
     if isinstance(staging_future_or_state_dict, Future):
         staging_future = staging_future_or_state_dict


### PR DESCRIPTION
Fixes #183413 

DefaultStager stopped being reusable because DefaultStager._stage() closed its internal StateDictStager after every stage, because of my earlier pr [#170431](https://github.com/pytorch/pytorch/pull/170431) that fixed issue #170163 

This fixes that by keeping user provided stagers alive across saves and moving cleanup of internally created default stagers into `async_save()`.  Added test to verify re-usability of `DefaultStager` and verified to regression.