### PR TITLE
[xpu][feature] Add torch.xpu.clock_rate to query GPU frequency

### DIFF
--- a/docs/source/xpu.md
+++ b/docs/source/xpu.md
@@ -13,6 +13,7 @@
 
     StreamContext
     can_device_access_peer
+    clock_rate
     current_device
     current_stream
     device

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -288,6 +288,8 @@ if __name__ == "__main__":
         with unittest.mock.patch.dict("sys.modules", {"pyzes": None}):
             with self.assertRaisesRegex(ImportError, "pyzes is required"):
                 torch.xpu.temperature()
+            with self.assertRaisesRegex(ImportError, "pyzes is required"):
+                torch.xpu.clock_rate()
 
     def test_temperature_returns_float(self):
         try:
@@ -306,6 +308,24 @@ if __name__ == "__main__":
         # Sanity check: GPU temperature should be in a plausible range (0–150 °C)
         self.assertGreaterEqual(temp, 0.0)
         self.assertLess(temp, 150.0)
+
+    def test_clock_rate_returns_float(self):
+        try:
+            import pyzes  # noqa: F401
+        except ImportError:
+            self.skipTest("pyzes is required for this test")
+
+        try:
+            rate = torch.xpu.clock_rate()
+        except RuntimeError as e:
+            if "elevated privileges" in str(e):
+                self.skipTest("Reading GPU clock rate requires elevated privileges")
+            raise
+
+        self.assertIsInstance(rate, float)
+        # Sanity check: GPU clock rate should be in a plausible range (0–5000 MHz)
+        self.assertGreaterEqual(rate, 0.0)
+        self.assertLess(rate, 5000.0)
 
     def test_device_count_respects_affinity_mask(self):
         try:

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -913,7 +913,6 @@ def _get_zes_frequency_handle(device: Device = None) -> c_void_p:
     device_handle = info.device_handle
 
     # Enumerate all frequency domains under this device handle.
-    # For tiled dGPUs each sub-device's domains are under the root handle.
     freq_count = c_uint32(0)
     _zes_check(
         pyzes.zesDeviceEnumFrequencyDomains(device_handle, byref(freq_count), None),

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -944,8 +944,6 @@ def clock_rate(device: Device = None) -> float:
         device (torch.device, str or int, optional): selected device. Uses the
             current device, given by :func:`~torch.xpu.current_device`,
             if ``None`` (default).
-
-    .. note:: This API may require elevated privileges (e.g. ``sudo``) to access GPU clock information.
     """
     frequency_handle = _get_zes_frequency_handle(device)
 
@@ -953,10 +951,6 @@ def clock_rate(device: Device = None) -> float:
 
     freq_state = pyzes.zes_freq_state_t()
     rc = pyzes.zesFrequencyGetState(frequency_handle, byref(freq_state))
-    if rc == pyzes.ZE_RESULT_ERROR_NOT_AVAILABLE:
-        raise RuntimeError(
-            "GPU clock rate querying is not available. Try running with elevated privileges (e.g. sudo)."
-        )
     if rc != pyzes.ZE_RESULT_SUCCESS:
         raise RuntimeError(f"Can't get Level Zero Sysman GPU clock rate (rc={rc}).")
     return freq_state.actual

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -57,6 +57,7 @@ class _ZesDeviceInfo:
     subdevice_id: int | None = None
     is_integrated: bool = False
     temperature_handle: c_void_p | None = None
+    frequency_handle: c_void_p | None = None
 
 
 _cached_zes_device_infos: list[_ZesDeviceInfo] = []
@@ -767,6 +768,19 @@ def _zes_check(rc: int, msg: str) -> None:
         raise RuntimeError(f"{msg} (rc={rc})")
 
 
+def _zes_ensure_device_infos(device: int):
+    """Ensure the ZES device info cache is populated and validate the device index."""
+    if not _cached_zes_device_infos:
+        if _enum_zes_device_infos(_parse_visible_devices(strict=True)) < 0:
+            raise RuntimeError("Failed to enumerate devices via Level Zero Sysman.")
+
+    total_devices = len(_cached_zes_device_infos)
+    if device >= total_devices:
+        raise RuntimeError(
+            f"The device {device} is out of range for Level Zero Sysman. It must be in the range [0, {total_devices})."
+        )
+
+
 def _get_zes_temperature_handle(device: Device = None) -> c_void_p:
     r"""Return the Level Zero Sysman GPU temperature sensor handle for the specified device.
 
@@ -787,16 +801,7 @@ def _get_zes_temperature_handle(device: Device = None) -> c_void_p:
         ) from None
 
     device = _get_device_index(device, optional=True)
-    global _cached_zes_device_infos
-    if not _cached_zes_device_infos:
-        if _enum_zes_device_infos(_parse_visible_devices(strict=True)) < 0:
-            raise RuntimeError("Failed to enumerate devices via Level Zero Sysman.")
-
-    total_devices = len(_cached_zes_device_infos)
-    if device >= total_devices:
-        raise RuntimeError(
-            f"The device {device} is out of range for Level Zero Sysman. It must be in the range [0, {total_devices})."
-        )
+    _zes_ensure_device_infos(device)
 
     info = _cached_zes_device_infos[device]
     if info.temperature_handle is not None:
@@ -879,6 +884,84 @@ def temperature(device: Device = None) -> float:
     return temp.value
 
 
+def _get_zes_frequency_handle(device: Device = None) -> c_void_p:
+    r"""Return the Level Zero Sysman GPU frequency domain handle for the specified device.
+
+    The result is cached in ``_ZesDeviceInfo.frequency_handle`` so that
+    repeated calls skip domain enumeration.  ``_cached_zes_device_infos``
+    is lazily populated on the first call.
+
+    Args:
+        device (torch.device, str or int, optional): target device. Uses the
+            current device, given by :func:`~torch.xpu.current_device`,
+            if ``None`` (default).
+    """
+    try:
+        import pyzes  # type: ignore[import]
+    except ImportError:
+        raise ImportError(
+            "pyzes is required; install it with 'pip install pyzes'"
+        ) from None
+
+    device = _get_device_index(device, optional=True)
+    _zes_ensure_device_infos(device)
+
+    info = _cached_zes_device_infos[device]
+    if info.frequency_handle is not None:
+        return info.frequency_handle
+
+    device_handle = info.device_handle
+
+    # Enumerate all frequency domains under this device handle.
+    # For tiled dGPUs each sub-device's domains are under the root handle.
+    freq_count = c_uint32(0)
+    _zes_check(
+        pyzes.zesDeviceEnumFrequencyDomains(device_handle, byref(freq_count), None),
+        "Can't get Level Zero Sysman frequency domains count.",
+    )
+    if freq_count.value == 0:
+        raise RuntimeError("No Level Zero Sysman frequency domains found.")
+    freq_handles = (pyzes.zes_freq_handle_t * freq_count.value)()
+    _zes_check(
+        pyzes.zesDeviceEnumFrequencyDomains(
+            device_handle, byref(freq_count), freq_handles
+        ),
+        "Can't get Level Zero Sysman frequency domain handles.",
+    )
+
+    # TODO: pyzes lacks zesFrequencyGetProperties, so we cannot filter by
+    # subdevice or domain type. We assume index 0 (ZES_FREQ_DOMAIN_GPU)
+    # is the GPU frequency domain.
+    frequency_handle = freq_handles[0]
+    info.frequency_handle = frequency_handle
+    return frequency_handle
+
+
+def clock_rate(device: Device = None) -> float:
+    r"""Return the GPU clock rate in MHz.
+
+    Args:
+        device (torch.device, str or int, optional): selected device. Uses the
+            current device, given by :func:`~torch.xpu.current_device`,
+            if ``None`` (default).
+
+    .. note:: This API may require elevated privileges (e.g. ``sudo``) to access GPU clock information.
+    """
+    frequency_handle = _get_zes_frequency_handle(device)
+
+    import pyzes  # type: ignore[import]
+
+    freq_state = pyzes.zes_freq_state_t()
+    rc = pyzes.zesFrequencyGetState(frequency_handle, byref(freq_state))
+    if rc == pyzes.ZE_RESULT_ERROR_NOT_AVAILABLE:
+        raise RuntimeError(
+            "GPU clock rate querying is not available. Try running with elevated privileges (e.g. sudo)."
+        )
+    if rc != pyzes.ZE_RESULT_SUCCESS:
+        raise RuntimeError(f"Can't get Level Zero Sysman GPU clock rate (rc={rc}).")
+    return freq_state.actual
+
+
 # import here to avoid circular import
 from .memory import (
     change_current_allocator,
@@ -921,6 +1004,7 @@ __all__ = [
     "XPUGraph",
     "can_device_access_peer",
     "change_current_allocator",
+    "clock_rate",
     "current_device",
     "current_stream",
     "default_generators",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #183431
* #183430
* #183429
* #183428
* __->__ #183427

# Motivation
`torch.xpu` would like to exposes several device telemetry APIs (`temperature`, `clock_rate`, `power_draw`, `utilization`, `memory_usage`, `device_memory_used`) via pyzes, giving users visibility into GPU state for profiling and monitoring. `torch.xpu` currently only has temperature. This PR adds `torch.xpu.clock_rate` to bring XPU closer to parity with CUDA's telemetry surface.
The implementation queries GPU frequency through Intel's Level Zero Sysman API (`zesFrequencyGetState`), using the existing pyzes Python bindings.

# Additional Context
- Add _`zes_ensure_device_infos()` to deduplicate the device cache init / bounds-check logic previously inlined in `_get_zes_temperature_handle`, and reuse it for the new frequency handle getter.
- Add `_get_zes_frequency_handle()` with handle caching, mirroring the existing `_get_zes_temperature_handle` pattern.

Known limitation: pyzes currently lacks `zesFrequencyGetProperties`, so `_get_zes_frequency_handle` cannot filter by frequency domain type or subdevice ID. It assumes index 0 is `ZES_FREQ_DOMAIN_GPU` (in most situations). This will be addressed once pyzes adds the binding.
