### PR TITLE
[xpu][feature] Add torch.xpu.power_draw to query GPU card power

### DIFF
--- a/docs/source/xpu.md
+++ b/docs/source/xpu.md
@@ -30,6 +30,7 @@
     is_bf16_supported
     is_initialized
     is_tf32_supported
+    power_draw
     set_device
     set_stream
     stream

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -290,6 +290,8 @@ if __name__ == "__main__":
                 torch.xpu.temperature()
             with self.assertRaisesRegex(ImportError, "pyzes is required"):
                 torch.xpu.clock_rate()
+            with self.assertRaisesRegex(ImportError, "pyzes is required"):
+                torch.xpu.power_draw()
 
     def test_temperature_returns_float(self):
         try:
@@ -326,6 +328,24 @@ if __name__ == "__main__":
         # Sanity check: GPU clock rate should be in a plausible range (0–5000 MHz)
         self.assertGreaterEqual(rate, 0.0)
         self.assertLess(rate, 5000.0)
+
+    def test_power_draw_returns_float(self):
+        try:
+            import pyzes  # noqa: F401
+        except ImportError:
+            self.skipTest("pyzes is required for this test")
+
+        try:
+            power = torch.xpu.power_draw()
+        except RuntimeError as e:
+            if "elevated privileges" in str(e):
+                self.skipTest("Reading GPU power draw requires elevated privileges")
+            raise
+
+        self.assertIsInstance(power, float)
+        # Sanity check: GPU power draw should be non-negative and within a plausible range (0–1000 W)
+        self.assertGreaterEqual(power, 0.0)
+        self.assertLess(power, 1000.0)
 
     def test_device_count_respects_affinity_mask(self):
         try:

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -62,6 +62,8 @@ class _ZesDeviceInfo:
 
 
 _cached_zes_device_infos: list[_ZesDeviceInfo] = []
+# Interval between two HW counter reads; must be >=100ms for fresh data.
+_zes_sample_interval_ms = 150
 
 
 def _is_compiled() -> bool:
@@ -1041,8 +1043,7 @@ def power_draw(device: Device = None) -> float:
 
     import time
 
-    # 100ms is well above the hardware energy-counter update granularity.
-    time.sleep(0.1)
+    time.sleep(_zes_sample_interval_ms / 1000.0)
 
     counter_end = pyzes.zes_power_energy_counter_t()
     _zes_check(

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -1011,12 +1011,18 @@ def _get_zes_power_handle(device: Device = None) -> c_void_p:
 
 
 def power_draw(device: Device = None) -> float:
-    r"""Return the GPU power draw in watts.
+    r"""Return the GPU card power draw in watts.
+
+    The value is computed by dividing the energy delta by the time delta between
+    two energy-counter reads separated by a 100ms sampling interval.
 
     Args:
         device (torch.device, str or int, optional): selected device. Uses the
             current device, given by :func:`~torch.xpu.current_device`,
             if ``None`` (default).
+
+    .. note:: This function blocks for approximately 100ms per call due to the
+        sampling interval required to compute an accurate power reading.
 
     .. note:: This API may require elevated privileges (e.g. ``sudo``) to access GPU power information.
     """
@@ -1032,6 +1038,12 @@ def power_draw(device: Device = None) -> float:
         )
     if rc != pyzes.ZE_RESULT_SUCCESS:
         raise RuntimeError(f"Can't get Level Zero Sysman GPU power draw (rc={rc}).")
+
+    import time
+
+    # 100ms is well above the hardware energy-counter update granularity.
+    time.sleep(0.1)
+
     counter_end = pyzes.zes_power_energy_counter_t()
     _zes_check(
         pyzes.zesPowerGetEnergyCounter(power_handle, byref(counter_end)),

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -58,6 +58,7 @@ class _ZesDeviceInfo:
     is_integrated: bool = False
     temperature_handle: c_void_p | None = None
     frequency_handle: c_void_p | None = None
+    power_handle: c_void_p | None = None
 
 
 _cached_zes_device_infos: list[_ZesDeviceInfo] = []
@@ -962,6 +963,95 @@ def clock_rate(device: Device = None) -> float:
     return freq_state.actual
 
 
+def _get_zes_power_handle(device: Device = None) -> c_void_p:
+    r"""Return the Level Zero Sysman GPU power domain handle for the specified device.
+
+    The result is cached in ``_ZesDeviceInfo.power_handle`` so that
+    repeated calls skip domain enumeration.  ``_cached_zes_device_infos``
+    is lazily populated on the first call.
+
+    Args:
+        device (torch.device, str or int, optional): target device. Uses the
+            current device, given by :func:`~torch.xpu.current_device`,
+            if ``None`` (default).
+    """
+    try:
+        import pyzes  # type: ignore[import]
+    except ImportError:
+        raise ImportError(
+            "pyzes is required; install it with 'pip install pyzes'"
+        ) from None
+
+    device = _get_device_index(device, optional=True)
+    _zes_ensure_device_infos(device)
+
+    info = _cached_zes_device_infos[device]
+    if info.power_handle is not None:
+        return info.power_handle
+
+    device_handle = info.device_handle
+
+    # Enumerate all power domains under this device handle.
+    # For tiled dGPUs each sub-device's domains are under the root handle.
+    power_count = c_uint32(0)
+    _zes_check(
+        pyzes.zesDeviceEnumPowerDomains(device_handle, byref(power_count), None),
+        "Can't get Level Zero Sysman power domains count.",
+    )
+    if power_count.value == 0:
+        raise RuntimeError("No Level Zero Sysman power domains found.")
+    power_handles = (pyzes.zes_pwr_handle_t * power_count.value)()
+    _zes_check(
+        pyzes.zesDeviceEnumPowerDomains(
+            device_handle, byref(power_count), power_handles
+        ),
+        "Can't get Level Zero Sysman power domain handles.",
+    )
+
+    # TODO: pyzes lacks zesPowerGetProperties, so we cannot filter by
+    # subdevice or domain type. We assume index 0 (ZES_POWER_DOMAIN_CARD)
+    # is the GPU card power domain.
+    power_handle = power_handles[0]
+    info.power_handle = power_handle
+    return power_handle
+
+
+def power_draw(device: Device = None) -> float:
+    r"""Return the GPU power draw in watts.
+
+    Args:
+        device (torch.device, str or int, optional): selected device. Uses the
+            current device, given by :func:`~torch.xpu.current_device`,
+            if ``None`` (default).
+
+    .. note:: This API may require elevated privileges (e.g. ``sudo``) to access GPU power information.
+    """
+    power_handle = _get_zes_power_handle(device)
+
+    import pyzes  # type: ignore[import]
+
+    power_energy = pyzes.zes_power_energy_counter_t()
+    rc = pyzes.zesPowerGetEnergyCounter(power_handle, byref(power_energy))
+    if rc == pyzes.ZE_RESULT_ERROR_NOT_AVAILABLE:
+        raise RuntimeError(
+            "GPU power draw querying is not available. Try running with elevated privileges (e.g. sudo)."
+        )
+    if rc != pyzes.ZE_RESULT_SUCCESS:
+        raise RuntimeError(f"Can't get Level Zero Sysman GPU power draw (rc={rc}).")
+    timestamp_start = power_energy.timestamp
+    energy_start = power_energy.energy
+    _zes_check(
+        pyzes.zesPowerGetEnergyCounter(power_handle, byref(power_energy)),
+        "Can't get Level Zero Sysman GPU power energy counter.",
+    )
+    # energy is in microjoules, timestamp is in microseconds (per L0 Sysman spec).
+    # microjoules / microseconds = watts, so the micro factors cancel.
+    dt = power_energy.timestamp - timestamp_start
+    if dt == 0:
+        return 0.0
+    return (power_energy.energy - energy_start) / dt
+
+
 # import here to avoid circular import
 from .memory import (
     change_current_allocator,
@@ -1042,6 +1132,7 @@ __all__ = [
     "memory_stats",
     "memory_stats_as_nested_dict",
     "MemPool",
+    "power_draw",
     "use_mem_pool",
     "reset_accumulated_memory_stats",
     "reset_peak_memory_stats",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #183431
* #183430
* #183429
* __->__ #183428
* #183427

# Motivation
This PR adds `torch.xpu.power_draw` to report GPU card power draw in watts, using the Level Zero Sysman energy counter API (`zesPowerGetEnergyCounter`).
`torch.xpu.power_draw` takes two snapshots `_zes_sample_interval_ms` (150ms) apart and computes average power as delta_energy / delta_time. The 150ms interval is well above the driver team's recommended hardware counter update granularity of 100ms. The return unit is watts (microjoules / microseconds cancel out).

# Additional Context
- Add `_get_zes_power_handle()` with handle caching, following the same pattern as temperature and frequency handle getters.

Known limitation: pyzes currently lacks `zesPowerGetProperties`, so `_get_zes_power_handle` cannot filter by subdevice. It assumes index 0 is the card-level power domain. This API blocks for ~150ms per call. The docstring documents this behavior.