### PR TITLE
[xpu][feature] Add torch.xpu.utilization to query GPU engine utilization

### DIFF
--- a/docs/source/xpu.md
+++ b/docs/source/xpu.md
@@ -36,6 +36,7 @@
     stream
     synchronize
     temperature
+    utilization
 ```
 
 ## Random Number Generator

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -292,6 +292,8 @@ if __name__ == "__main__":
                 torch.xpu.clock_rate()
             with self.assertRaisesRegex(ImportError, "pyzes is required"):
                 torch.xpu.power_draw()
+            with self.assertRaisesRegex(ImportError, "pyzes is required"):
+                torch.xpu.utilization()
 
     def test_temperature_returns_float(self):
         try:
@@ -346,6 +348,24 @@ if __name__ == "__main__":
         # Sanity check: GPU power draw should be non-negative and within a plausible range (0–1000 W)
         self.assertGreaterEqual(power, 0.0)
         self.assertLess(power, 1000.0)
+
+    def test_utilization_returns_float(self):
+        try:
+            import pyzes  # noqa: F401
+        except ImportError:
+            self.skipTest("pyzes is required for this test")
+
+        try:
+            util = torch.xpu.utilization()
+        except RuntimeError as e:
+            if "elevated privileges" in str(e):
+                self.skipTest("Reading GPU utilization requires elevated privileges")
+            raise
+
+        self.assertIsInstance(util, float)
+        # Sanity check: GPU utilization should be between 0 and 100 percent
+        self.assertGreaterEqual(util, 0.0)
+        self.assertLessEqual(util, 100.0)
 
     def test_device_count_respects_affinity_mask(self):
         try:

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -831,11 +831,9 @@ def _get_zes_temperature_handle(device: Device = None) -> c_void_p:
         "Can't get Level Zero Sysman temperature sensor handles.",
     )
 
-    # Select the GPU temperature sensor matching this device:
-    #   - Tiled dGPU (subdevice_id set): use the per-tile GPU sensor
-    #     whose subdeviceId matches.
-    #   - Non-tiled: use the root-level (non-subdevice) GPU sensor.
-    # Raises RuntimeError if no matching sensor is found.
+    # Note [telemetry handle selection]:
+    # For tiled dGPUs, pick the handle whose subdeviceId matches.
+    # For non-tiled devices, pick the root-level (non-subdevice) handle.
     temperature_handle = None
     for temp_handle in temp_handles:
         temp_props = pyzes.zes_temp_properties_t()
@@ -847,12 +845,10 @@ def _get_zes_temperature_handle(device: Device = None) -> c_void_p:
         if temp_props.type != pyzes.ZES_TEMP_SENSORS_GPU:
             continue
         if subdevice_id is not None:
-            # Tiled dGPU: match the per-tile sensor for this sub-device.
             if temp_props.onSubdevice and temp_props.subdeviceId == subdevice_id:
                 temperature_handle = temp_handle
                 break
         else:
-            # Non-tiled or root device: pick the root-level GPU sensor.
             if not temp_props.onSubdevice:
                 temperature_handle = temp_handle
                 break
@@ -1109,11 +1105,7 @@ def _get_zes_engine_handle(device: Device = None) -> c_void_p:
         "Can't get Level Zero Sysman engine group handles.",
     )
 
-    # Select the GPU engine group matching this device:
-    #   - Tiled dGPU (subdevice_id set): use the per-tile engine group
-    #     whose subdeviceId matches.
-    #   - Non-tiled: use the root-level (non-subdevice) engine group.
-    # Raises RuntimeError if no matching engine group is found.
+    # See Note [telemetry handle selection]
     engine_handle = None
     for eng_handle in engine_handles:
         eng_props = pyzes.zes_engine_properties_t()
@@ -1125,12 +1117,10 @@ def _get_zes_engine_handle(device: Device = None) -> c_void_p:
         if eng_props.type != pyzes.ZES_ENGINE_GROUP_ALL:
             continue
         if subdevice_id is not None:
-            # Tiled dGPU: match the per-tile engine group for this sub-device.
             if eng_props.onSubdevice and eng_props.subdeviceId == subdevice_id:
                 engine_handle = eng_handle
                 break
         else:
-            # Non-tiled or root device: pick the root-level engine group.
             if not eng_props.onSubdevice:
                 engine_handle = eng_handle
                 break

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -1123,7 +1123,7 @@ def _get_zes_engine_handle(device: Device = None) -> c_void_p:
 
 
 def utilization(device: Device = None) -> float:
-    r"""Return the GPU utilization as a percentage.
+    r"""Return the GPU engine utilization as a percentage.
 
     Args:
         device (torch.device, str or int, optional): selected device. Uses the

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -1081,7 +1081,9 @@ def _get_zes_engine_handle(device: Device = None) -> c_void_p:
         "Can't get Level Zero Sysman engine group count.",
     )
     if engine_count.value == 0:
-        raise RuntimeError("No Level Zero Sysman engine groups found.")
+        raise RuntimeError(
+            "No Level Zero Sysman engine groups found. The GPU may not support engine monitoring, or try running with elevated privileges (e.g. sudo)."
+        )
     engine_handles = (pyzes.zes_engine_handle_t * engine_count.value)()
     _zes_check(
         pyzes.zesDeviceEnumEngineGroups(

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -59,6 +59,7 @@ class _ZesDeviceInfo:
     temperature_handle: c_void_p | None = None
     frequency_handle: c_void_p | None = None
     power_handle: c_void_p | None = None
+    engine_handle: c_void_p | None = None
 
 
 _cached_zes_device_infos: list[_ZesDeviceInfo] = []
@@ -1052,6 +1053,121 @@ def power_draw(device: Device = None) -> float:
     return (power_energy.energy - energy_start) / dt
 
 
+def _get_zes_engine_handle(device: Device = None) -> c_void_p:
+    r"""Return the Level Zero Sysman GPU engine group handle for the specified device.
+
+    The result is cached in ``_ZesDeviceInfo.engine_handle`` so that
+    repeated calls skip group enumeration.  ``_cached_zes_device_infos``
+    is lazily populated on the first call.
+
+    Args:
+        device (torch.device, str or int, optional): target device. Uses the
+            current device, given by :func:`~torch.xpu.current_device`,
+            if ``None`` (default).
+    """
+    try:
+        import pyzes  # type: ignore[import]
+    except ImportError:
+        raise ImportError(
+            "pyzes is required; install it with 'pip install pyzes'"
+        ) from None
+
+    device = _get_device_index(device, optional=True)
+    _zes_ensure_device_infos(device)
+
+    info = _cached_zes_device_infos[device]
+    if info.engine_handle is not None:
+        return info.engine_handle
+
+    device_handle = info.device_handle
+    subdevice_id = info.subdevice_id
+
+    # Enumerate all engine groups under this device handle.
+    # For tiled dGPUs each sub-device's group are under the root handle.
+    engine_count = c_uint32(0)
+    _zes_check(
+        pyzes.zesDeviceEnumEngineGroups(device_handle, byref(engine_count), None),
+        "Can't get Level Zero Sysman engine group count.",
+    )
+    if engine_count.value == 0:
+        raise RuntimeError("No Level Zero Sysman engine groups found.")
+    engine_handles = (pyzes.zes_engine_handle_t * engine_count.value)()
+    _zes_check(
+        pyzes.zesDeviceEnumEngineGroups(
+            device_handle, byref(engine_count), engine_handles
+        ),
+        "Can't get Level Zero Sysman engine group handles.",
+    )
+
+    # Select the GPU engine group matching this device:
+    #   - Tiled dGPU (subdevice_id set): use the per-tile engine group
+    #     whose subdeviceId matches.
+    #   - Non-tiled: use the root-level (non-subdevice) engine group.
+    # Raises RuntimeError if no matching engine group is found.
+    engine_handle = None
+    for eng_handle in engine_handles:
+        eng_props = pyzes.zes_engine_properties_t()
+        eng_props.stype = pyzes.ZES_STRUCTURE_TYPE_ENGINE_PROPERTIES
+        _zes_check(
+            pyzes.zesEngineGetProperties(eng_handle, byref(eng_props)),
+            "Can't get Level Zero Sysman engine properties.",
+        )
+        if eng_props.type != pyzes.ZES_ENGINE_GROUP_ALL:
+            continue
+        if subdevice_id is not None:
+            # Tiled dGPU: match the per-tile engine group for this sub-device.
+            if eng_props.onSubdevice and eng_props.subdeviceId == subdevice_id:
+                engine_handle = eng_handle
+                break
+        else:
+            # Non-tiled or root device: pick the root-level engine group.
+            if not eng_props.onSubdevice:
+                engine_handle = eng_handle
+                break
+
+    if engine_handle is None:
+        raise RuntimeError("No Level Zero Sysman GPU engine handle found.")
+    info.engine_handle = engine_handle
+    return engine_handle
+
+
+def utilization(device: Device = None) -> float:
+    r"""Return the GPU utilization as a percentage.
+
+    Args:
+        device (torch.device, str or int, optional): selected device. Uses the
+            current device, given by :func:`~torch.xpu.current_device`,
+            if ``None`` (default).
+
+    .. note:: This API may require elevated privileges (e.g. ``sudo``) to access GPU utilization information.
+    """
+    engine_handle = _get_zes_engine_handle(device)
+
+    import pyzes  # type: ignore[import]
+
+    engine_stats = pyzes.zes_engine_stats_t()
+    rc = pyzes.zesEngineGetActivity(engine_handle, byref(engine_stats))
+    if rc == pyzes.ZE_RESULT_ERROR_NOT_AVAILABLE:
+        raise RuntimeError(
+            "GPU utilization querying is not available. Try running with elevated privileges (e.g. sudo)."
+        )
+    if rc != pyzes.ZE_RESULT_SUCCESS:
+        raise RuntimeError(
+            f"Can't get Level Zero Sysman GPU engine activity (rc={rc})."
+        )
+    active_start = engine_stats.activeTime
+    timestamp_start = engine_stats.timestamp
+    _zes_check(
+        pyzes.zesEngineGetActivity(engine_handle, byref(engine_stats)),
+        "Can't get Level Zero Sysman GPU engine activity.",
+    )
+    # activeTime and timestamp are monotonic counters in microseconds.
+    dt = engine_stats.timestamp - timestamp_start
+    if dt == 0:
+        return 0.0
+    return (engine_stats.activeTime - active_start) / dt * 100
+
+
 # import here to avoid circular import
 from .memory import (
     change_current_allocator,
@@ -1147,4 +1263,5 @@ __all__ = [
     "streams",
     "synchronize",
     "temperature",
+    "utilization",
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #183431
* #183430
* __->__ #183429
* #183428
* #183427

# Motivation
This PR adds `torch.xpu.utilization` using the Level Zero Sysman engine activity API (`zesEngineGetActivity`).
`torch.xpu.utilization` takes two snapshots `_zes_sample_interval_ms` (150ms) apart and computes delta_activeTime / delta_timestamp * 100. The 150ms interval is chosen well above the driver team's recommended hardware counter update granularity of 100ms.

# Additional Context
- Add `_get_zes_engine_handle()` with handle caching. Unlike the frequency and power handle getters, this one does filter by `zesEngineGetProperties` — it selects the `ZES_ENGINE_GROUP_ALL` handle matching the target subdevice (for tiled dGPUs) or the root-level handle (for non-tiled devices).

Known limitation: This API blocks for ~150ms per call. Some drivers may not expose engine groups at all (engine_count=0), in which case a `RuntimeError` is raised with guidance to check privileges.
