### PR TITLE
[xpu][feature] Add torch.xpu.device_memory_used to query GPU used device global memory

### DIFF
--- a/docs/source/xpu.md
+++ b/docs/source/xpu.md
@@ -19,6 +19,7 @@
     device
     device_count
     device_of
+    device_memory_used
     get_arch_list
     get_device_capability
     get_device_name

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -296,6 +296,8 @@ if __name__ == "__main__":
                 torch.xpu.utilization()
             with self.assertRaisesRegex(ImportError, "pyzes is required"):
                 torch.xpu.memory_usage()
+            with self.assertRaisesRegex(ImportError, "pyzes is required"):
+                torch.xpu.device_memory_used()
 
     def test_temperature_returns_float(self):
         try:
@@ -386,6 +388,25 @@ if __name__ == "__main__":
         # Sanity check: GPU memory bandwidth usage should be between 0 and 100 percent
         self.assertGreaterEqual(mem_usage, 0.0)
         self.assertLessEqual(mem_usage, 100.0)
+
+    def test_device_memory_used_returns_int(self):
+        try:
+            import pyzes  # noqa: F401
+        except ImportError:
+            self.skipTest("pyzes is required for this test")
+
+        try:
+            mem_used = torch.xpu.device_memory_used()
+        except RuntimeError as e:
+            if "elevated privileges" in str(e):
+                self.skipTest("Reading GPU memory usage requires elevated privileges")
+            raise
+
+        self.assertIsInstance(mem_used, int)
+        # Sanity check: Memory used should be non-negative and less than total memory
+        total_memory = torch.xpu.get_device_properties().total_memory
+        self.assertGreaterEqual(mem_used, 0)
+        self.assertLessEqual(mem_used, total_memory)
 
     def test_device_count_respects_affinity_mask(self):
         try:

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -1339,7 +1339,10 @@ def device_memory_used(device: Device = None) -> int:
         pyzes.zesMemoryGetProperties(memory_handle, byref(mem_props)),
         "Can't get Level Zero Sysman memory properties.",
     )
-    return mem_props.physicalSize - mem_state.free
+    # TODO: Some drivers report physicalSize as 0 on client GPUs; fall back to
+    # the allocatable size as an approximation in that case.
+    total = mem_props.physicalSize if mem_props.physicalSize != 0 else mem_state.size
+    return total - mem_state.free
 
 
 # import here to avoid circular import

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -1291,6 +1291,31 @@ def memory_usage(device: Device = None) -> float:
     return 1e6 * bytes_transferred / (mem_bandwidth.maxBandwidth * dt)
 
 
+def device_memory_used(device: Device = None) -> int:
+    r"""Return the current GPU used global (device) memory in bytes.
+
+    Args:
+        device (torch.device, str or int, optional): selected device. Uses the
+            current device, given by :func:`~torch.xpu.current_device`,
+            if ``None`` (default).
+
+    .. note:: This API may require elevated privileges (e.g. ``sudo``) to access GPU memory usage information.
+    """
+    memory_handle = _zes_get_memory_handle(device)
+
+    import pyzes  # type: ignore[import]
+
+    mem_state = pyzes.zes_mem_state_t()
+    rc = pyzes.zesMemoryGetState(memory_handle, byref(mem_state))
+    if rc == pyzes.ZE_RESULT_ERROR_NOT_AVAILABLE:
+        raise RuntimeError(
+            "GPU memory usage querying is not available. Try running with elevated privileges (e.g. sudo)."
+        )
+    if rc != pyzes.ZE_RESULT_SUCCESS:
+        raise RuntimeError(f"Can't get Level Zero Sysman GPU memory state (rc={rc}).")
+    return mem_state.size - mem_state.free
+
+
 # import here to avoid circular import
 from .memory import (
     change_current_allocator,
@@ -1340,6 +1365,7 @@ __all__ = [
     "device",
     "device_of",
     "device_count",
+    "device_memory_used",
     "empty_cache",
     "get_arch_list",
     "get_device_capability",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183431
* #183430
* #183429
* #183428
* #183427

# Motivation
This PR adds `torch.xpu.device_memory_used` using the Level Zero Sysman memory state API (`zesMemoryGetState`).

# Additional Context
- reuse `_zes_get_memory_handle()`

Known limitation: This API blocks for ~150ms per call. The 150ms sampling interval is well above the driver team's recommended hardware counter update granularity of 100ms. Some drivers report `physicalSize` as 0 on client GPUs; fall back to the allocatable `size` as an approximation in that case. Already fixed in the new driver. On older Xe GPUs (pre-PVC), pyzes initialization can fail if the SYCL runtime has already been initialized. This happens because the L0 adapter initializes Level Zero with `zeInit` and sets `ZES_ENABLE_SYSMAN=1`, which conflicts with pyzes calling `zesInit`. Setting `UR_L0_ENABLE_SYSMAN_ENV_DEFAULT=0` avoids the issue on these older platforms, while newer GPUs do not require any additional configuration.
