### PR TITLE
[inductor] Fix backslash escaping order in user-defined Triton kernel…

### DIFF
--- a/tools/linter/adapters/docstring_linter-grandfather.json
+++ b/tools/linter/adapters/docstring_linter-grandfather.json
@@ -116,7 +116,7 @@
   },
   "torch/_inductor/codegen/wrapper.py": {
     "def PythonWrapperCodegen.benchmark_compiled_module()": 96,
-    "def PythonWrapperCodegen.define_user_defined_triton_kernel()": 269,
+    "def PythonWrapperCodegen.define_user_defined_triton_kernel()": 297,
     "def PythonWrapperCodegen.generate_example_arg_value()": 84,
     "def user_defined_kernel_grid_fn_code()": 108
   },

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3066,10 +3066,13 @@ class PythonWrapperCodegen(CodeGen):
         if config.triton.unique_user_kernel_names:
             # We replace the original_name with the unique name.
             kernel_src = kernel_src.replace(f"def {original_name}(", f"def {name}(")
+        # Double all backslashes FIRST so that the escaping steps below don't
+        # accidentally double-escape backslashes they themselves introduce.
+        kernel_src = kernel_src.replace("\\", "\\\\")
         if config.cpp_wrapper:
             # With cpp_wrapper + autotune_at_compile_time=False, the source is
             # further embedded in a C++ raw string inside a Python r"""...""" wrapper.
-            # So we need to add backslash here.
+            # So we need to escape triple double-quotes here.
             kernel_src = kernel_src.replace('"""', '\\"\\"\\"')
         kernel_src = kernel_src.replace("'''", "\\'\\'\\'")
         compile_wrapper.splice(kernel_src)


### PR DESCRIPTION
… embedding

As seen on mikekg:fix-inductor-userdef-triton-backslash (PR #183421).

define_user_defined_triton_kernel embeds kernel source in a triple-quoted string in the generated AOT module. Backslashes must be doubled BEFORE the triple-quote escaping steps, otherwise:
- (original bug #183420) \n in a tl.constexpr default is converted to a real newline by Python's parser, causing SyntaxError in the second-stage file.
- (regression) when cpp_wrapper=True, the backslashes introduced by the triple-double-quote escaping step are immediately re-doubled, corrupting kernel docstrings.

Fix: move replace("\\", "\\\\") before the if config.cpp_wrapper block.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo