### PR TITLE
[TMA]: Fix TMA config lowering block sizes below heuristic choice

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1665,7 +1665,7 @@ class TritonTensorDescriptorTestCUDA(BlockDescriptorTestBase):
         def fn(a):
             return a + 4
 
-        t = torch.zeros(2**30 + 1, dtype=torch.int8, device='cuda')
+        t = torch.zeros(2**30 + 1, dtype=torch.int8, device=GPU_TYPE)
         compiled_fn = torch.compile(fn)
         actual = compiled_fn(t)
         self.assertTrue((actual == 4).all())

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -21,6 +21,7 @@ from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
 from torch._inductor.virtualized import V
 from torch.testing._internal.common_cuda import SM100OrLater
+from torch.testing._internal.common_device_type import largeTensorTest
 from torch.testing._internal.common_utils import (
     decorateIf,
     instantiate_parametrized_tests,
@@ -1658,6 +1659,16 @@ class TritonTensorDescriptorTestCUDA(BlockDescriptorTestBase):
         loss.backward()
         self.assertIsNotNone(x.grad)
         self.assertIsNotNone(w.grad)
+
+    @largeTensorTest("1GB", inductor=True)
+    def test_large_tensor_pointwise(self):
+        def fn(a):
+            return a + 4
+
+        t = torch.zeros(2**30 + 1, dtype=torch.int8, device='cuda')
+        compiled_fn = torch.compile(fn)
+        actual = compiled_fn(t)
+        self.assertTrue((actual == 4).all())
 
 
 test_torchinductor.copy_tests(

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3601,7 +3601,9 @@ def _maybe_filter_configs_for_tma_restrictions(inductor_meta, configs: list[Conf
         # Add a config that is guaranteed to compile
         example_config = configs[0]
         config_block_sizes = {**example_config.kwargs}
-        config_block_sizes.update(tma_min_block_sizes)
+        for block_type, min_block_value in tma_min_block_sizes.items():
+            existing = config_block_sizes.get(block_type, 1)
+            config_block_sizes[block_type] = max(existing, min_block_value)
         new_configs = [
             Config(
                 config_block_sizes,


### PR DESCRIPTION
Fixes #183325 

### Root cause

For dtypes with small TMA minimums (e.g. XBLOCK=8 for bf16), this massively inflates the grid, causing Triton's per-program global scratch offset to overflow i32 and trigger cudaErrorIllegalAddress on large tensors.


### The fix
Use per-key max instead so it never lowers a block size below what the heuristic already chose.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos