### PR TITLE
[inductor] Wire up AOTI lazy compile in codegen_with_cpp_wrapper

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -9006,6 +9006,40 @@ copy_tests(
 )
 
 
+# Lazy-autotune-mode-specific failures go here. Inherits regular GPU failures.
+GPU_LAZY_AUTOTUNE_TEST_FAILURES = {
+    **GPU_TEST_FAILURES,
+}
+
+
+@unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")
+class AOTInductorTestABICompatibleGpuLazyAutotune(TestCase):
+    """Run AOTInductor tests with autotune_at_compile_time=False, exercising
+    the lazy Triton compile + dual-wrapper-mode codegen path."""
+
+    device = GPU_TYPE
+    device_type = GPU_TYPE
+    check_model = check_model
+    check_model_with_multiple_inputs = check_model_with_multiple_inputs
+    code_check_count = code_check_count
+    allow_stack_allocation = False
+    use_minimal_arrayref_interface = False
+
+    def setUp(self):
+        super().setUp()
+        ctx = torch._inductor.config.patch("triton.autotune_at_compile_time", False)
+        ctx.__enter__()
+        self.addCleanup(ctx.__exit__, None, None, None)
+
+
+copy_tests(
+    AOTInductorTestsTemplate,
+    AOTInductorTestABICompatibleGpuLazyAutotune,
+    GPU_TYPE,
+    GPU_LAZY_AUTOTUNE_TEST_FAILURES,
+)
+
+
 @unittest.skipIf(not torch.backends.mps.is_available(), "No MPS backend available")
 class AOTInductorTestABICompatibleMps(TestCase):
     device = "mps"

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -60,6 +60,97 @@ def cpp_string_literal(s: str) -> str:
     return f'"{escaped}"'
 
 
+def generate_aoti_kernel_config_header(kernel_names: list[str]) -> str:
+    """Generate a C header defining macros for each lazy-compiled kernel.
+
+    Called after the JIT first-pass runs and populates CudaKernelParamCache.
+    The AOTI compilation includes this header so that LazyKernelCompileResult
+    structs get compile-time-initialized with the autotuned values.
+    """
+
+    def braced(values: list[int]) -> str:
+        return "{" + ", ".join(str(v) for v in values) + "}"
+
+    buf = IndentedBuffer()
+    buf.splice("""
+        #pragma once
+        // Auto-generated kernel configurations for AOTInductor lazy compile.
+    """)
+
+    for kernel_name in kernel_names:
+        params = CudaKernelParamCache.get(kernel_name)
+        assert params is not None, (
+            f"CudaKernelParamCache not populated for {kernel_name} "
+            "after first-pass execution"
+        )
+
+        macro_prefix = kernel_name.upper()
+        cubin_path = cpp_string_literal(params[get_cpp_wrapper_cubin_path_name()])
+        mangled_name = cpp_string_literal(params["mangled_name"])
+        num_warps = params["num_warps"]
+        shared_mem = params["shared_mem"]
+
+        # params["config"] is already a dict (from config_to_dict in CachingAutotuner)
+        config_dict = params.get("config") or {}
+
+        # For combo/foreach kernels, merge default_config
+        inductor_meta = params.get("inductor_meta") or {}
+        combo_grid_meta = inductor_meta.get("combo_grid_meta")
+        default_config = (
+            combo_grid_meta.get("default_config") if combo_grid_meta else None
+        )
+        if default_config:
+            config_dict = {**default_config, **config_dict}
+
+        config_index: int | None = None
+        grid_type = inductor_meta.get("grid_type")
+        if grid_type == "PrecomputedGrid":
+            precomputed_grids = inductor_meta.get("precomputed_grids", [])
+            for idx, entry in enumerate(precomputed_grids):
+                entry_config = entry.get("config", {})
+                if all(config_dict.get(k) == v for k, v in entry_config.items()):
+                    config_index = idx
+                    break
+
+        # Per-subkernel block sizes for combo kernels, or single-element lists.
+        num_kernels = combo_grid_meta.get("num_kernels", 1) if combo_grid_meta else 1
+        if num_kernels > 1 and "XBLOCK_0" in config_dict:
+            xblocks = [config_dict.get(f"XBLOCK_{i}", 128) for i in range(num_kernels)]
+            yblocks = [config_dict.get(f"YBLOCK_{i}", 1) for i in range(num_kernels)]
+            zblocks = [config_dict.get(f"ZBLOCK_{i}", 1) for i in range(num_kernels)]
+            r0blocks = [config_dict.get(f"R0_BLOCK_{i}", 1) for i in range(num_kernels)]
+        else:
+            xblocks = [config_dict.get("XBLOCK", 128)]
+            yblocks = [config_dict.get("YBLOCK", 1)]
+            zblocks = [config_dict.get("ZBLOCK", 1)]
+            r0blocks = [config_dict.get("R0_BLOCK", 1)]
+        rsplit = config_dict.get("RSPLIT", 1)
+        rsplit_size = config_dict.get("RSPLIT_SIZE", 1)
+        ci = config_index if config_index is not None else -1
+        gs = params.get("global_scratch", -1) or -1
+        ps = params.get("profile_scratch", -1) or -1
+
+        buf.writeline("")
+        buf.splice(f"""
+            // Kernel: {kernel_name}
+            #define {macro_prefix}_CUBIN_PATH {cubin_path}
+            #define {macro_prefix}_MANGLED_NAME {mangled_name}
+            #define {macro_prefix}_NUM_WARPS {num_warps}
+            #define {macro_prefix}_SHARED_MEM {shared_mem}
+            #define {macro_prefix}_XBLOCKS {braced(xblocks)}
+            #define {macro_prefix}_YBLOCKS {braced(yblocks)}
+            #define {macro_prefix}_ZBLOCKS {braced(zblocks)}
+            #define {macro_prefix}_R0BLOCKS {braced(r0blocks)}
+            #define {macro_prefix}_RSPLIT {rsplit}
+            #define {macro_prefix}_RSPLIT_SIZE {rsplit_size}
+            #define {macro_prefix}_CONFIG_INDEX {ci}
+            #define {macro_prefix}_GLOBAL_SCRATCH {gs}
+            #define {macro_prefix}_PROFILE_SCRATCH {ps}
+        """)
+
+    return buf.getvalue()
+
+
 TRITON_SIGNATURE_TO_CPP = {
     "i32": "int32_t",
     "i64": "int64_t",
@@ -493,17 +584,26 @@ class DeferredTritonCallWrapper:
         # kernel_args_ is consumed by both JIT and AOT launchKernel calls.
         prefix.writeline(f"void* kernel_args_[] = {{{call_args_str}}};")
         prefix.writeline_jit(f"launchKernel({kernel_name}, {common_launch_args});")
+        prefix.writeline_aot(
+            f"launchKernel(kernels_.{kernel_name}, {common_launch_args});"
+        )
 
     def generate_lazy(self, wrapper: CppWrapperGpu):
         """
-        Generate C++ code that embeds Triton source and compiles it at runtime.
+        Generate dual-wrapper-mode C++ code for lazy Triton kernel compilation.
 
-        Writes JIT-side content via writeline_jit/splice_jit; on a plain
-        IndentedBuffer those are equivalent to writeline/splice. AOTI-side
-        emission for dual-wrapper mode is added later in the stack.
+        DualIndentedBuffer routes lines into separate JIT and AOTI sources:
+        - JIT side: embeds Triton source, compiles at runtime, autotunes
+          with real inputs.
+        - AOTI side: uses a compile-time-initialized LazyKernelCompileResult
+          from a config header generated after the JIT first-pass.
+
+        Grid computation and kernel launch are shared between both sides
+        via the LazyKernelCompileResult struct.
         """
         prefix = wrapper.prefix
         kernel_name = self.kernel_name
+        macro_prefix = kernel_name.upper()
 
         # Track kernel names for parallel initialization (JIT only)
         wrapper._lazy_kernel_names.append(kernel_name)
@@ -525,11 +625,34 @@ class DeferredTritonCallWrapper:
             f"static const char* {kernel_name}_source = {kernel_body};"
         )
 
+        # LazyKernelCompileResult: JIT fills at runtime; AOTI uses compile-time
+        # init from the config header generated after the first pass.
         prefix.writeline_jit(f"static LazyKernelCompileResult {kernel_name}_result;")
+        prefix.splice_aot(
+            f"""\
+            static LazyKernelCompileResult {kernel_name}_result = {{
+                {macro_prefix}_CUBIN_PATH,
+                {macro_prefix}_MANGLED_NAME,
+                {macro_prefix}_NUM_WARPS,
+                {macro_prefix}_SHARED_MEM,
+                {macro_prefix}_XBLOCKS,
+                {macro_prefix}_YBLOCKS,
+                {macro_prefix}_ZBLOCKS,
+                {macro_prefix}_R0BLOCKS,
+                {macro_prefix}_RSPLIT,
+                {macro_prefix}_RSPLIT_SIZE,
+                {macro_prefix}_CONFIG_INDEX,
+                {macro_prefix}_GLOBAL_SCRATCH,
+                {macro_prefix}_PROFILE_SCRATCH,
+            }};
+            """
+        )
 
         wrapper_arg_names, kernel_arg_names = self._resolve_lazy_arg_names()
         signature = (self.triton_meta or {}).get("signature", {})
 
+        # kernels_type_/kernels_ are routed to the AOTI buffer; if prefix is a
+        # plain IndentedBuffer (pure JIT lazy compile) those writes are dropped.
         self._write_wrapper_signature(
             prefix,
             wrapper,
@@ -559,9 +682,11 @@ class DeferredTritonCallWrapper:
                 autotune_arg_list.append(name)
         autotune_args = ", ".join(autotune_arg_list)
 
-        # Lazy compile with autotuning on first invocation.
-        # Build into temp buffer to avoid DualIndentedBuffer dispatch.
         with prefix.indent():
+            # First-call initialization: JIT lazy compiles, AOTI loads cubin
+
+            # JIT: lazy compile with autotuning on first invocation.
+            # Build into temp buffer to avoid DualIndentedBuffer dispatch.
             jit_init = IndentedBuffer(initial_indent=prefix._indent)
             jit_init.writeline(f"if ({kernel_name} == nullptr) {{")
             with jit_init.indent():
@@ -586,6 +711,23 @@ class DeferredTritonCallWrapper:
             jit_init.writeline("}")
             prefix.splice_jit(jit_init)
 
+            # AOTI: load precompiled cubin from compile-time-initialized result.
+            aoti_init = IndentedBuffer(initial_indent=prefix._indent)
+            aoti_init.writeline(f"if (kernels_.{kernel_name} == nullptr) {{")
+            with aoti_init.indent():
+                aoti_init.splice(
+                    f"""\
+                    kernels_.{kernel_name} = loadKernel(
+                        {kernel_name}_result.cubin_path,
+                        {kernel_name}_result.mangled_name,
+                        {kernel_name}_result.shared_mem,
+                        cubin_dir_);
+                    """
+                )
+            aoti_init.writeline("}")
+            prefix.splice_aot(aoti_init)
+
+            # Shared: grid computation and launch using result struct
             self._generate_lazy_grid(prefix)
             self._generate_lazy_launch(
                 prefix,

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -55,7 +55,7 @@ from torch.utils._mode_utils import no_dispatch
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.numbers import int_oo
 
-from . import config, ir, metrics
+from . import config, ir
 from .codegen.common import (
     BackendFeature,
     DeviceOpOverrides,
@@ -362,6 +362,16 @@ def is_mkldnn_conv(node: Node) -> bool:
 
 
 class GraphLowering(torch.fx.Interpreter):
+    """Lowers an FX graph to Inductor IR and drives backend code generation.
+
+    Walks the FX graph node-by-node, materializing inputs/outputs and
+    constants, dispatching each call to an Inductor lowering, and accumulating
+    the resulting IR nodes. Holds graph-wide state needed by lowerings and
+    codegen (sizevars, scheduler inputs, device/dtype tracking, wrapper code,
+    etc.) and orchestrates the call into `codegen()` to produce a wrapper +
+    kernel module via the configured backend (Python/C++ wrappers, AOTI).
+    """
+
     graph_outputs: list[ir.IRNode]
 
     def __init__(
@@ -2540,31 +2550,112 @@ class GraphLowering(torch.fx.Interpreter):
             else:
                 if not self.aot_mode:
                     # Lazy kernel compilation does not require two passes
-                    # TODO: need to consolidate the logic between AOT and JIT
                     return self.codegen()
 
-                # first pass
-                self.cpp_wrapper = False
-                compiled = self.compile_to_module().call
+                # AOTI with lazy compile: single codegen pass producing
+                # two separate C++ files — JIT (for autotuning) and AOTI
+                # (for packaging) — via DualIndentedBuffer.
 
-                real_inputs = extract_real_inputs()
-                with torch.utils._python_dispatch._disable_current_modes():
-                    compiled(real_inputs)
-                del real_inputs
+                wrapper_code, kernel_code = self.codegen()
+                # wrapper_code is the JIT variant (default assembly
+                # reads the JIT side of DualIndentedBuffers).
+                # AOTI variant is in self.wrapper_code._aot_output.
 
-                # second pass
-                self.cpp_wrapper = True
-                self.removed_buffers.clear()
-                self.removed_operations.clear()
-                self.inplaced_to_remove.clear()
-                V.graph.sizevars.precomputed_replacements.clear()
-                V.graph.sizevars.inv_precomputed_replacements.clear()
-                metrics.reset()
-                with config.patch({"triton.autotune_at_compile_time": False}):
-                    return self.codegen()
+                lazy_kernel_names = list(
+                    self.wrapper_code._lazy_kernel_names  # type: ignore[attr-defined]
+                )
+                self._run_jit_variant_for_autotune(
+                    wrapper_code,
+                    kernel_code,
+                    extract_real_inputs,
+                    lazy_kernel_names,
+                )
+
+                # Prepend config header with kernel compile results
+                # to the AOTI source for packaging.
+                from .codegen.cpp_wrapper_gpu import generate_aoti_kernel_config_header
+
+                config_header = generate_aoti_kernel_config_header(lazy_kernel_names)
+                aoti_wrapper = ValueWithLineMap(
+                    config_header + "\n" + self.wrapper_code._aot_output,  # type: ignore[attr-defined]
+                    wrapper_code.line_map,
+                )
+
+                return aoti_wrapper, kernel_code
         else:
             # cpu
             return self.codegen()
+
+    def _run_jit_variant_for_autotune(
+        self,
+        wrapper_code,
+        kernel_code,
+        extract_real_inputs,
+        kernel_names: list[str],
+    ) -> None:
+        """Compile dual-wrapper-mode C++ as JIT variant and run to autotune kernels.
+
+        Compiles the dual-wrapper-mode C++ source without -DAOT_INDUCTOR, which
+        activates the JIT path (inductor_entry_impl). Running this with
+        real inputs triggers lazy Triton compilation and autotuning,
+        populating CudaKernelParamCache for the AOTI packaging step.
+        """
+        from .codecache import (
+            CppWrapperCodeCache,
+            CudaKernelParamCache,
+            get_cpp_wrapper_cubin_path_name,
+            output_code_log,
+        )
+
+        cpp_source = wrapper_code.value
+        kernel_source = kernel_code.value if kernel_code else None
+
+        output_code_log.debug("AOTI lazy compile JIT wrapper code: \n%s", cpp_source)
+
+        # Prefer the GPU device for the JIT compile: the wrapper includes
+        # cpp_wrapper/<gpu>.h which transitively pulls in cuda_runtime.h.
+        # A "cpu" device would precompile cpp_wrapper/cpu.h, which does not
+        # include the CUDA headers needed to compile the kernel call sites.
+        device_type = next(
+            (d for d in self.device_types if d in ("cuda", "xpu")),
+            next((d for d in self.device_types if d != "meta"), "cpu"),
+        )
+
+        compiled_fn = CppWrapperCodeCache.load_pybinding(
+            argtypes=["std::vector<AtenTensorHandle>"],
+            main_code=cpp_source,
+            device_type=device_type,
+            num_outputs=len(self.graph_outputs),
+            kernel_code=kernel_source,
+        )
+
+        real_inputs = extract_real_inputs()
+        # Non-tensor scalars become 0-d CPU tensors; None and ints/floats
+        # that the graph specialized away aren't part of the C++ wrapper
+        # signature and must be skipped.
+        input_tensors: list[torch.Tensor] = []
+        for arg in real_inputs:
+            if arg is None:
+                continue
+            if isinstance(arg, torch.Tensor):
+                input_tensors.append(arg)
+            else:
+                input_tensors.append(torch.tensor(arg, device="cpu"))
+        if self.constants:
+            input_tensors.extend(self.constants.values())
+        input_handles = torch._C._aoti.unsafe_alloc_void_ptrs_from_tensors(
+            input_tensors
+        )
+        del real_inputs, input_tensors
+
+        compiled_fn(input_handles)
+
+        # Collect cubin files produced by lazy compilation for AOTI packaging
+        cubin_path_name = get_cpp_wrapper_cubin_path_name()
+        for name in kernel_names:
+            params = CudaKernelParamCache.get(name)
+            if params and cubin_path_name in params:
+                self.wrapper_code.additional_files.append(params[cubin_path_name])
 
     def _update_scheduler(self) -> None:
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183441
* #183059
* #182953
* #182917
* #182983
* #182911
* #182982

Implement the end-to-end flow for autotune_at_compile_time=False
in AOTI mode:

1. codegen() with dual-wrapper-mode produces JIT file + AOTI file
2. _run_jit_variant_for_autotune: compile JIT file, run with real
   inputs, trigger lazy compilation, populate CudaKernelParamCache
3. generate_aoti_kernel_config_header builds a header from
   CudaKernelParamCache; prepend to AOTI file and return for packaging

Also adds the AOTI-side emission in DeferredTritonCallWrapper.generate_lazy
that consumes the result: compile-time-initialized LazyKernelCompileResult
from config header macros, AOTI loadKernel block, and AOTI launchKernel
using the kernels_ struct.

Authored-with: Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo