### PR TITLE
[MPS] Fix Metal unary operators behavior on large strided tensors

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -670,11 +670,8 @@ void MetalShaderLibrary::exec_unary_kernel_with_params(TensorIteratorBase& iter,
       [computeEncoder setComputePipelineState:cplState];
       bind_iter_tensors(computeEncoder, iter);
       if (!iter.is_contiguous()) {
-        mtl_setArgs<2>(computeEncoder,
-                       outputTensor.sizes(),
-                       inputTensor.strides(),
-                       outputTensor.strides(),
-                       inputTensor.ndimension());
+        mtl_setArgs<2>(
+            computeEncoder, iter.shape(), iter.strides(1), iter.strides(0), static_cast<uint32_t>(iter.ndim()));
       }
       detail::mtl_setArg(computeEncoder, params, iter.is_contiguous() ? 2 : 6);
       mtl_dispatch1DJob(computeEncoder, cplState, length);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1058,11 +1058,8 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
             computeEncoder, cplState, (length + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD);
       } else {
         if (!is_contiguous) {
-          mtl_setArgs<2>(computeEncoder,
-                         outputTensor.sizes(),
-                         inputTensor.strides(),
-                         outputTensor.strides(),
-                         inputTensor.ndimension());
+          mtl_setArgs<2>(
+              computeEncoder, iter.shape(), iter.strides(1), iter.strides(0), static_cast<uint32_t>(iter.ndim()));
         }
         if (alpha) {
           mtl_setBytes(computeEncoder, getMPSScalar(*alpha, alpha_type), is_contiguous ? 2 : 6);

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -44,6 +44,22 @@ inline long offset_from_thread_index(
   return offset_from_coord(pos, strides, ndim);
 }
 
+template <typename T>
+inline T val_at_offs(constant void* ptr, long offs) {
+  return *reinterpret_cast<constant T*>(
+      static_cast<constant char*>(ptr) + offs);
+}
+
+template <typename T>
+inline T val_at_offs(device void* ptr, long offs) {
+  return *reinterpret_cast<device T*>(static_cast<device char*>(ptr) + offs);
+}
+
+template <typename T>
+inline device T& ref_at_offs(device void* ptr, long offs) {
+  return *reinterpret_cast<device T*>(static_cast<device char*>(ptr) + offs);
+}
+
 // One thread per element. Used for small dense tensors where the ILP variant's
 // per-thread overhead isn't amortized (see ILP_DISPATCH_THRESHOLD on the host).
 template <typename T, typename F>
@@ -90,19 +106,21 @@ kernel void unary_dense(
 
 template <typename T, typename F>
 kernel void unary_strided(
-    device result_of<F, T>* output [[buffer(0)]],
-    constant T* input [[buffer(1)]],
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
     constant long* sizes [[buffer(2)]],
     constant long* input_strides [[buffer(3)]],
     constant long* output_strides [[buffer(4)]],
     constant uint& ndim [[buffer(5)]],
     uint index [[thread_position_in_grid]]) {
   F f;
+  using res_t = result_of<F, T>;
   int pos[max_ndim];
   pos_from_thread_index(int(index), pos, sizes, ndim);
   const auto input_offs = offset_from_coord(pos, input_strides, ndim);
   const auto output_offs = offset_from_coord(pos, output_strides, ndim);
-  output[output_offs] = f(input[input_offs]);
+  ref_at_offs<res_t>(output, output_offs) =
+      f(val_at_offs<T>(input, input_offs));
 }
 
 #define REGISTER_UNARY_OP(NAME, DTYPE0, DTYPE1)                                \
@@ -124,8 +142,8 @@ kernel void unary_strided(
               uint index);                                                     \
   template [[host_name(#NAME "_strided_" #DTYPE1 "_" #DTYPE0)]] kernel void :: \
       c10::metal::unary_strided<DTYPE0, NAME##_functor>(                       \
-          device ::c10::metal::result_of<NAME##_functor, DTYPE0> * output,     \
-          constant DTYPE0 * input,                                             \
+          device void* output,                                                 \
+          constant void* input,                                                \
           constant long* sizes,                                                \
           constant long* input_strides,                                        \
           constant long* output_strides,                                       \
@@ -166,8 +184,8 @@ kernel void unary_alpha_dense(
 
 template <typename T, typename T2, typename F>
 kernel void unary_alpha_strided(
-    device result_of<F, T, T2>* output [[buffer(0)]],
-    constant T* input [[buffer(1)]],
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
     constant long* sizes [[buffer(2)]],
     constant long* input_strides [[buffer(3)]],
     constant long* output_strides [[buffer(4)]],
@@ -175,11 +193,13 @@ kernel void unary_alpha_strided(
     constant T2& alpha [[buffer(6)]],
     uint index [[thread_position_in_grid]]) {
   F f;
+  using res_t = result_of<F, T, T2>;
   int pos[max_ndim];
   pos_from_thread_index(int(index), pos, sizes, ndim);
   const auto input_offs = offset_from_coord(pos, input_strides, ndim);
   const auto output_offs = offset_from_coord(pos, output_strides, ndim);
-  output[output_offs] = f(input[input_offs], alpha);
+  ref_at_offs<res_t>(output, output_offs) =
+      f(val_at_offs<T>(input, input_offs), alpha);
 }
 
 #define REGISTER_UNARY_ALPHA_OP(NAME, DTYPEI, DTYPEA, DTYPEO)              \
@@ -199,9 +219,8 @@ kernel void unary_alpha_strided(
   template [[host_name(#NAME "_strided_" #DTYPEO "_" #DTYPEI               \
                              "_" #DTYPEA)]] kernel void ::c10::metal::     \
       unary_alpha_strided<DTYPEI, DTYPEA, NAME##_functor>(                 \
-          device ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEA> * \
-              output,                                                      \
-          constant DTYPEI * input,                                         \
+          device void* output,                                             \
+          constant void* input,                                            \
           constant long* sizes,                                            \
           constant long* input_strides,                                    \
           constant long* output_strides,                                   \
@@ -209,18 +228,7 @@ kernel void unary_alpha_strided(
           constant DTYPEA& alpha,                                          \
           uint index)
 
-template <typename T>
-inline T val_at_offs(constant void* ptr, long offs) {
-  return *reinterpret_cast<constant T*>(
-      static_cast<constant char*>(ptr) + offs);
-}
-
 // Value at offset with dynamic cast from provided type
-template <typename T>
-inline T val_at_offs(device void* ptr, long offs) {
-  return *reinterpret_cast<device T*>(static_cast<device char*>(ptr) + offs);
-}
-
 template <typename T, typename P>
 inline T val_at_offs(P ptr, long offs, ScalarType type) {
   switch (type) {
@@ -230,11 +238,6 @@ inline T val_at_offs(P ptr, long offs, ScalarType type) {
     C10_METAL_ALL_TYPES_FUNCTOR(_CASE_)
 #undef _CASE_
   }
-}
-
-template <typename T>
-inline device T& ref_at_offs(device void* ptr, long offs) {
-  return *reinterpret_cast<device T*>(static_cast<device char*>(ptr) + offs);
 }
 
 // Store with dynamic cast to provided type. Mirrors val_at_offs's runtime

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9327,6 +9327,16 @@ class TestLargeTensors(TestCaseMPS):
         self.assertGreater(tail.unique().numel(), 50)
         del x
 
+    @serialTest()
+    def test_64bit_strided_unary(self):
+        # https://github.com/pytorch/pytorch/issues/183419: slice's byte-stride
+        # extent > INT32_MAX forces TensorIterator to split the iter
+        if torch.mps.recommended_max_memory() < 8_000_000_000:
+            raise unittest.SkipTest("Needs at least 8Gb of RAM")
+        sl = torch.randn(1_200_000, 464, dtype=torch.float32, device='mps')[:, 4:50]
+        assert (sl.size(0) - 1) * sl.stride(0) * sl.element_size() > (1 << 31) - 1
+        self.assertEqual(sl.neg().cpu(), sl.cpu().neg())
+
 
 class TestLogical(TestCaseMPS):
     def _wrap_tensor(self, x, device="cpu", dtype=None, requires_grad=False):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9334,7 +9334,7 @@ class TestLargeTensors(TestCaseMPS):
         if torch.mps.recommended_max_memory() < 8_000_000_000:
             raise unittest.SkipTest("Needs at least 8Gb of RAM")
         sl = torch.randn(1_200_000, 464, dtype=torch.float32, device='mps')[:, 4:50]
-        assert (sl.size(0) - 1) * sl.stride(0) * sl.element_size() > (1 << 31) - 1
+        self.assertGreater((sl.size(0) - 1) * sl.stride(0) * sl.element_size(), (1 << 31) - 1)
         self.assertEqual(sl.neg().cpu(), sl.cpu().neg())
 
 


### PR DESCRIPTION
Use `iter` shape and stride rather than tensor ones attached to it
Also switch unary_strided to byte offsets like binary_strided as TensorIterator strides are in bytes
Fixes #183419
