### PR TITLE
[Docathon]: removed torch.signal.windows functions from coverage ignore

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -915,18 +915,9 @@ coverage_ignore_functions = [
     "storage_to_tensor_type",
     "validate_cuda_device",
     "validate_hpu_device",
-    # torch.signal.windows.windows
-    "bartlett",
-    "blackman",
-    "cosine",
-    "exponential",
-    "gaussian",
-    "general_cosine",
-    "general_hamming",
-    "hamming",
-    "hann",
-    "kaiser",
-    "nuttall",
+    # torch.utils.backend_registration
+    "generate_methods_for_privateuse1_backend",
+    "rename_privateuse1_backend",
     # torch.utils.benchmark.examples.op_benchmark
     # torch.utils.benchmark.op_fuzzers.spectral
     "power_range",

--- a/docs/source/signal.md
+++ b/docs/source/signal.md
@@ -16,6 +16,7 @@ The `torch.signal` module, modeled after SciPy's [signal](https://docs.scipy.org
 ```{eval-rst}
 .. automodule:: torch.signal.windows
 .. currentmodule:: torch.signal.windows
+.. currentmodule:: torch.signal.windows.windows
 ```
 
 ```{eval-rst}


### PR DESCRIPTION
Fixes: #182831

Functions removed:
- bartlett
- blackman
- cosine
- exponential
- gaussian
- general_cosine
- general_hamming
- hamming
- hann
- kaiser
- nuttall

cc @svekars @sekyondaMeta @AlannaBurke