### PR TITLE
Port D104346887/PR 182675 for index large select (#183455)

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1176,6 +1176,32 @@ void index_add_cuda_impl(const Tensor& self, int64_t dim, const Tensor& index, c
 
   const int mpc = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
 
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+  // Fast path: index_add_(0, idx, src) with alpha == 1 is equivalent to
+  // self.scatter_add_(0, idx.view({n, 1, ...}).expand_as(src), src). Delegate
+  // so scatter_add's own TMA/vectorized eligibility check + dispatch is the
+  // single source of truth (see PR #182675). Pattern from
+  // pytorch/pytorch#180430.
+  // Gated on CUDA >= 12.8: pre-12.8 builds compile out the TMA branch in
+  // scatter_add and fall back to its vectorized atomicAdd path, which
+  // regresses skewed/high-contention workloads vs indexFunc{Small,Large}Index
+  // (warp-per-entry scheduling concentrates atomic contention on hot rows).
+  // Older builds therefore stay on the existing indexFunc dispatch.
+  // index_add supports {complex64, complex128, ComplexHalf, Bool} that
+  // scatter_add does not, so exclude those and let them use indexFunc.
+  const auto stype = self_.scalar_type();
+  const bool dtype_supported_by_scatter_add =
+      !c10::isComplexType(stype) && stype != at::kBool;
+  if (dim == 0 && alpha.toDouble() == 1.0 && numIndex > 0 &&
+      dtype_supported_by_scatter_add &&
+      index.dim() <= 1 && indContig) {
+    std::vector<int64_t> idx_shape(source_.dim(), 1);
+    idx_shape[0] = static_cast<int64_t>(numIndex);
+    self_.scatter_add_(0, index.view(idx_shape).expand_as(source_), source_);
+    return;
+  }
+#endif
+
 #define SMALL_INDEX(TENSOR_TYPE, INDICES_TYPE, TYPE, SELF_DIM, SOURCE_DIM, IDX_DIM)     \
   indexFuncSmallIndex<TENSOR_TYPE, INDICES_TYPE, TYPE, SELF_DIM, SOURCE_DIM, IDX_DIM>   \
     <<<smallIndexGrid, smallIndexBlock, 0, stream>>>(                                   \

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -21,10 +21,13 @@ from torch.testing._internal.common_device_type import (
     expectedFailureMPS,
     instantiate_device_type_tests,
     onlyCPU,
+    onlyCUDA,
     onlyNativeDeviceTypes,
     onlyOn,
     skipXLA,
     skipXPUIf,
+    tol,
+    toleranceOverride,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,
@@ -2041,6 +2044,106 @@ class TestIndexing(TestCase):
                 for _ in range(3):
                     y_nd = torch.index_add(x, dim, index, src, alpha=alpha)
                     self.assertEqual(y_nd, y0, atol=1e-3, rtol=1e-5)
+
+    @serialTest()
+    @onlyCUDA
+    @toleranceOverride(
+        {
+            torch.float32: tol(atol=1e-5, rtol=1e-3),
+            torch.float64: tol(atol=1e-5, rtol=1e-3),
+            torch.half: tol(atol=5e-2, rtol=5e-2),
+            torch.bfloat16: tol(atol=0.5, rtol=0.5),
+        }
+    )
+    @dtypes(torch.float32, torch.float64, torch.half, torch.bfloat16)
+    def test_index_add_fast_path(self, device, dtype):
+        # Coverage for the index_add_ TMA fast path: one eligible case + five
+        # fallback predicates per shape, asserted against a CPU reference.
+        # Shapes keep n/m <= 1 so atomicAdd-order noise on bf16/half stays
+        # within tolerance; (4096, 1024, 1024) crosses the TMA chunk_elems
+        # boundary (D > one chunk).
+        def check(out, dim, idx, src, alpha=1.0):
+            expected = (
+                out.cpu().clone().index_add_(dim, idx.cpu(), src.cpu(), alpha=alpha)
+            )
+            out.index_add_(dim, idx, src, alpha=alpha)
+            self.assertEqual(out.cpu(), expected)
+
+        for m, n, D in [(1024, 512, 128), (4096, 3072, 128), (4096, 1024, 1024)]:
+            torch.cuda.empty_cache()
+            for idx_dtype in (torch.int32, torch.int64):
+                src = make_tensor((n, D), device=device, dtype=dtype)
+                idx = torch.randint(m, (n,), device=device, dtype=idx_dtype)
+
+                # 1) Eligible -> fast path.
+                check(torch.zeros(m, D, device=device, dtype=dtype), 0, idx, src)
+                # 2) alpha != 1 -> fallback.
+                check(
+                    torch.zeros(m, D, device=device, dtype=dtype),
+                    0,
+                    idx,
+                    src,
+                    alpha=2.5,
+                )
+                # 3) Discontiguous src -> fallback.
+                src_strided = torch.empty(n, 2 * D, device=device, dtype=dtype)[
+                    :, ::2
+                ].copy_(src)
+                check(
+                    torch.zeros(m, D, device=device, dtype=dtype), 0, idx, src_strided
+                )
+                # 4) Misaligned self (one-element pointer offset) -> fallback.
+                self_mis = (
+                    torch.empty(m * D + 1, device=device, dtype=dtype)[1:]
+                    .view(m, D)
+                    .zero_()
+                )
+                check(self_mis, 0, idx, src)
+                # 5) dim != 0 -> fallback.
+                check(
+                    torch.zeros(D, m, device=device, dtype=dtype),
+                    1,
+                    idx,
+                    make_tensor((D, n), device=device, dtype=dtype),
+                )
+                # 6) Sliced inner dim (not is_contiguous) -> fallback.
+                sl = slice(64, 192)
+                check(
+                    torch.zeros(m, 256, device=device, dtype=dtype)[:, sl],
+                    0,
+                    idx,
+                    make_tensor((n, 256), device=device, dtype=dtype)[:, sl],
+                )
+
+        # 7) Empty index is a no-op.
+        out = torch.randn(8, 128, device=device, dtype=dtype)
+        expected = out.clone()
+        out.index_add_(
+            0,
+            torch.empty(0, device=device, dtype=torch.int64),
+            torch.empty(0, 128, device=device, dtype=dtype),
+        )
+        self.assertEqual(out, expected)
+
+    @serialTest()
+    @onlyCUDA
+    @dtypes(torch.complex64, torch.complex128, torch.bool)
+    def test_index_add_excluded_dtypes(self, device, dtype):
+        # scatter_add_'s CUDA dispatch covers neither complex nor bool, so the
+        # fast-path delegation in index_add_cuda_impl excludes these dtypes
+        # and lets them fall through to indexFunc{Small,Large}Index. Regression
+        # test that an eligible-shape (dim=0, alpha=1, contiguous, aligned)
+        # call still produces correct results for these dtypes.
+        m, n, D = 1024, 512, 128
+        if dtype == torch.bool:
+            src = torch.randint(0, 2, (n, D), device=device, dtype=dtype)
+        else:
+            src = make_tensor((n, D), device=device, dtype=dtype)
+        out = torch.zeros(m, D, device=device, dtype=dtype)
+        idx = torch.randint(m, (n,), device=device, dtype=torch.int64)
+        expected = out.cpu().clone().index_add_(0, idx.cpu(), src.cpu())
+        out.index_add_(0, idx, src)
+        self.assertEqual(out.cpu(), expected)
 
     @onlyNativeDeviceTypes
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/1973")


### PR DESCRIPTION
Summary:

Adopts the vectorized scatter_add(dim=0) kernel from D104346887 / PR #182675 as a fast path for `index_add_` on CUDA. `index_add_(0, idx, src)` is mathematically equivalent to `self.scatter_add_(0, idx.unsqueeze(-1).expand_as(src), src)` when `alpha == 1`, so we can call `tma_scatter_add_kernel_launch` directly.

Eligibility (all required to enter the fast path):
- `dim == 0`
- `alpha == 1`
- dtype in `{float, double, half, bfloat16}`
- `self_` and `source_` contiguous, `index` 1-D contiguous, `numIndex > 0`
- 16-byte alignment of self/src ptrs, slice size, and row strides
- sm_90+ at runtime
- CUDA 12.8+ at compile time

Outside the eligible regime, falls through to the existing `indexFunc{Small,Large}Index` dispatch (untouched). The block is preprocessed out entirely on CUDA < 12.8, since the upstream vectorized fallback contains an int32 stride overflow that triggers `cudaErrorIllegalAddress` on the production workloads we're targeting; pre-Hopper builds therefore stay on the existing baseline rather than picking up the broken vectorized fallback.

## Benchmarks

Bench script: `caffe2/benchmarks/operator_benchmark/pt/bench_index_add_large.py` (in parent commit). Baseline = parent commit; fast path = this commit. Each was a fresh `buck2 run mode/opt` build with the same CUDA toolchain. Per-call timing via CUDA events.

### B200 (sm_100, CUDA 12.8, TMA path)

Real workloads:

| Workload | Baseline (us) | Fast path (us) | Speedup |
|---|---:|---:|---:|
| REAL bf16 [4036236,128] dim=0 nIdx=4036236 (H100 shape) | 4388 | 971 | **4.52x** |
| REAL fp32 [1722482,128] dim=0 nIdx=7773925 (B200 shape) | 6968 | 2542 | **2.74x** |

bf16 sweep (dim=0):

| Shape | Baseline (us) | Fast path (us) | Speedup |
|---|---:|---:|---:|
| 1M x 128 | 1076 | 280 | 3.85x |
| 4M x 128 | 4349 | 1001 | 4.34x |
| 4M x 256 | 8335 | 1309 | 6.36x |
| 4M x 512 | 16612 | 2244 | **7.40x** |

fp32 distribution sweep (dst=[1.7M, 128], nIdx=7.77M):

| Distribution | Baseline (us) | Fast path (us) | Speedup |
|---|---:|---:|---:|
| uniform | 6837 | 2518 | 2.72x |
| zipf s=1.0 | 17740 | 16659 | 1.06x |
| zipf s=1.5 | 22465 | 21280 | 1.06x |
| skewed 80/20 | 6614 | 2119 | 3.12x |
| skewed hot=100 | 6584 | 2307 | 2.85x |

bf16 distribution sweep:

| Distribution | Baseline (us) | Fast path (us) | Speedup |
|---|---:|---:|---:|
| uniform | 8074 | 1940 | 4.16x |
| zipf s=1.0 | 37692 | 16495 | 2.29x |
| zipf s=1.5 | 47448 | 20843 | 2.28x |
| skewed 80/20 | 7934 | 1724 | 4.60x |
| skewed hot=100 | 7923 | 1736 | 4.56x |

### H100 (sm_90, CUDA 12.8, TMA path)

Real workloads:

| Workload | Baseline (us) | Fast path (us) | Speedup |
|---|---:|---:|---:|
| REAL bf16 [4036236,128] dim=0 nIdx=4036236 (H100 shape) | 4859 | 1636 | **2.97x** |
| REAL fp32 [1722482,128] dim=0 nIdx=7773925 (B200 shape) | 8537 | 6001 | **1.42x** |

fp32 distribution sweep:

| Distribution | Baseline (us) | Fast path (us) | Speedup |
|---|---:|---:|---:|
| uniform | 8349 | 5985 | 1.39x |
| zipf s=1.0 | 19768 | 19751 | neutral |
| zipf s=1.5 | 24052 | 24196 | neutral |
| skewed 80/20 | 7641 | 3240 | 2.36x |
| skewed hot=100 | 7354 | 4183 | 1.76x |

bf16 distribution sweep:

| Distribution | Baseline (us) | Fast path (us) | Speedup |
|---|---:|---:|---:|
| uniform | 9182 | 3088 | 2.97x |
| zipf s=1.0 | 41165 | 18610 | 2.21x |
| zipf s=1.5 | 53089 | 23986 | 2.21x |
| skewed 80/20 | 8622 | 2409 | 3.58x |
| skewed hot=100 | 8541 | 2692 | 3.17x |

### Cross-arch observations

- bf16 wins are large on both arches because the dominant cost in baseline is scalar bf16 atomicAdd (CAS-loop). The TMA kernel's `cp.reduce.async.bulk.add.bf16` replaces that with hardware-supported reduction.
- B200 wins are larger than H100 on non-contention workloads — Blackwell's TMA throughput is meaningfully higher than Hopper's.
- bf16 zipf high-contention is arch-invariant (2.21x H100 vs 2.28-2.29x B200) — that workload is bottlenecked on atomic contention into the same hot rows, so neither generation can pull ahead.
- fp32 zipf high-contention is neutral on H100 and only ~1.06x on B200 — same reason: contention dominates.

### CUDA 12.4 build verification

A separate run with `-c fbcode.platform010_cuda_version=12.4` confirms the gate works: `strings Indexing.cu.o | grep -c index_add_fast` returns 0, the fast-path block is preprocessed out, and the bench runs against the existing baseline path with no crash and no regression. Pre-Hopper / older-CUDA users land safely on the existing kernel path.

Test Plan:
Added `test_index_add_fast_path` in `caffe2/test/test_indexing.py`. Parametrized over `dtypes(float32, float64, half, bfloat16)` across 3 shapes × 2 index dtypes (int32/int64), with 7 sub-cases per (shape, idx_dtype):

1. Fast path: `dim=0 + alpha=1 + contig + 16B aligned` -> hits TMA kernel
2. Fallback: `alpha != 1` (alpha=2.5)
3. Fallback: discontiguous src (strided slice)
4. Fallback: misaligned self (one-element pointer offset)
5. Fallback: `dim != 0` (dim=1)
6. Fallback: sliced inner-dim (not `is_contiguous()`)
7. Edge case: empty index (no-op)

All sub-cases assert correctness against a CPU reference. Tolerances bound the CPU-vs-CUDA atomicAdd-order noise (`fp32/fp64: 1e-5/1e-3`, `half: 5e-2/5e-2`, `bf16: 0.5/0.5`); shapes keep `n/m <= ~1` to bound the per-row sum noise.

Test results on B200 (CUDA 12.8):

```
$ buck2 test fbcode//mode/opt -c fbcode.enable_gpu_sections=true \
    -c fbcode.platform010_cuda_version=12.8 -c fbcode.nvcc_arch=b200a \
    fbcode//caffe2/test:test_others_cuda -- --regex 'test_index_add_fast_path'
Pass 5. Fail 0.

$ buck2 test ... fbcode//caffe2/test:test_torch_cuda -- --regex 'test_index_add'
Pass 7. Fail 0. Skip 1 (pre-existing, unrelated).
```

No regressions in existing index_add tests.

Build verification on CUDA 12.4 (gate behavior): `strings Indexing.cu.pic.o | grep -c index_add_fast` returns 0, confirming the fast-path block is preprocessed out cleanly when CUDA < 12.8. Bench run with CUDA 12.4 + a100 confirms no crash and no behavioral change vs baseline (numbers are neutral, as expected since the fast path is gated out).

See diff Summary for full B200 + H100 benchmark numbers.


https://www.internalfb.com/mlhub/pipelines/runs/mast/fire-albertchen-f1081016863?job_attempt=0&version=0&tab=summary

 {F1989741342} 

vs prod

https://www.internalfb.com/mlhub/pipelines/runs/mast/mvai-training-online-2134319967?job_attempt=7&version=37&tab=summary
 {F1989741358}


Skew workload

https://www.internalfb.com/mast/job/fire-yujiah-20260512-1008-9a6ab7ff

trace: https://www.internalfb.com/intern/kernelhub/perfetto/?bucket=mvai_gpu_traces&trace_path=tree%2Ftraces%2Fdynocli%2Ffire-yujiah-20260512-1008-9a6ab7ff%2F0%2Frank-0.May_12_11_00_53.4196.pt.trace.json.gz 

{F1989752493}

baseline: https://www.internalfb.com/mast/job/fire-yujiah-20260512-1000-8f514189

trace: https://www.internalfb.com/intern/kernelhub/perfetto/?bucket=mvai_gpu_traces&trace_path=tree%2Ftraces%2Fdynocli%2Ffire-yujiah-20260512-1000-8f514189%2F0%2Frank-0.May_12_10_40_33.4216.pt.trace.json.gz 

 {F1989752599}

Reviewed By: drisspg

Differential Revision: D104669063


