### PR TITLE
[PyTorch] Add _ccode methods to FloorToInt, TruncToInt, and ToFloat sympy functions

### DIFF
--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -1080,6 +1080,55 @@ class TestTypedExpr(TestCase):
         self.assertEqual(typed_I.expr, 1)
 
 
+class TestCCodePrinting(TestCase):
+    """Test _ccode methods on sympy function classes."""
+
+    def test_floor_to_int_ccode(self):
+        from torch.utils._sympy.functions import FloorToInt
+
+        x = sympy.Symbol("x")
+        expr = FloorToInt(x)
+        self.assertEqual(sympy.ccode(expr), "(int64_t)(floor(x))")
+
+    def test_floor_to_int_ccode_compound(self):
+        from torch.utils._sympy.functions import FloorToInt
+
+        x, y = sympy.symbols("x y")
+        expr = FloorToInt(x + y)
+        self.assertEqual(sympy.ccode(expr), "(int64_t)(floor(x + y))")
+
+    def test_ceil_to_int_ccode(self):
+        from torch.utils._sympy.functions import CeilToInt
+
+        x = sympy.Symbol("x")
+        expr = CeilToInt(x)
+        self.assertEqual(sympy.ccode(expr), "(int64_t)(ceil(x))")
+
+    def test_trunc_to_int_ccode(self):
+        from torch.utils._sympy.functions import TruncToInt
+
+        x = sympy.Symbol("x")
+        expr = TruncToInt(x)
+        self.assertEqual(sympy.ccode(expr), "(int64_t)(trunc(x))")
+
+    def test_to_float_ccode(self):
+        from torch.utils._sympy.functions import ToFloat
+
+        x = sympy.Symbol("x", integer=True)
+        expr = ToFloat(x)
+        self.assertEqual(sympy.ccode(expr), "(double)(x)")
+
+    def test_ccode_in_compound_expr(self):
+        from torch.utils._sympy.functions import FloorToInt, ToFloat
+
+        x = sympy.Symbol("x")
+        expr = FloorToInt(ToFloat(x) + 1)
+        result = sympy.ccode(expr)
+        self.assertIn("int64_t", result)
+        self.assertIn("floor", result)
+        self.assertIn("double", result)
+
+
 instantiate_parametrized_tests(TestValueRanges)
 instantiate_parametrized_tests(TestSympyInterp)
 instantiate_parametrized_tests(TestSympySolve)

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -571,8 +571,8 @@ class CeilToInt(sympy.Function):
             return sympy.Integer(math.ceil(float(number)))
 
     def _ccode(self, printer) -> str:
-        number = printer.parenthesize(self.args[0], self.args[0].precedence - 0.5)
-        return f"ceil({number})"
+        number = printer._print(self.args[0])
+        return f"(int64_t)(ceil({number}))"
 
 
 class FloorToInt(sympy.Function):
@@ -582,12 +582,16 @@ class FloorToInt(sympy.Function):
     def eval(cls, number):
         if number in (sympy.oo, int_oo):
             return int_oo
-        if number in (-sympy.oo, int_oo):
+        if number in (-sympy.oo, -int_oo):
             return -int_oo
         if isinstance(number, sympy.Integer):
             return number
         if isinstance(number, sympy.Number):
             return sympy.Integer(math.floor(float(number)))
+
+    def _ccode(self, printer) -> str:
+        number = printer._print(self.args[0])
+        return f"(int64_t)(floor({number}))"
 
 
 class CeilDiv(sympy.Function):
@@ -1264,6 +1268,10 @@ class TruncToInt(sympy.Function):
         if isinstance(number, sympy.Number):
             return sympy.Integer(math.trunc(float(number)))
 
+    def _ccode(self, printer) -> str:
+        number = printer._print(self.args[0])
+        return f"(int64_t)(trunc({number}))"
+
 
 # This is float -> int
 class RoundToInt(sympy.Function):
@@ -1321,6 +1329,10 @@ class ToFloat(sympy.Function):
             return sympy.oo
         if number is -int_oo:
             return -sympy.oo
+
+    def _ccode(self, printer) -> str:
+        number = printer._print(self.args[0])
+        return f"(double)({number})"
 
 
 class Identity(sympy.Function):


### PR DESCRIPTION
Summary:
Add C code generation support to `FloorToInt`, `TruncToInt`, and `ToFloat` sympy function classes, and fix the pre-existing `CeilToInt._ccode` implementation. This allows `sympy.ccode()` to natively print these functions without requiring `user_functions` overrides.

Changes:
- `FloorToInt._ccode`: emits `(int64_t)(floor(...))`
- `TruncToInt._ccode`: emits `(int64_t)(trunc(...))`
- `ToFloat._ccode`: emits `(double)(...)`
- `CeilToInt._ccode`: adds `(int64_t)` cast (was missing), and fixes `printer.parenthesize` crash

All `_ccode` methods now use `printer._print()` instead of `printer.parenthesize()` with `self.args[0].precedence`. The old pattern crashed on compound expressions like `FloorToInt(ToFloat(x) + 1)` because sympy `Add` objects do not have a `.precedence` attribute (it is a module-level function in `sympy.printing.precedence`, not an instance attribute). Since the printed result is always wrapped in function-call parens (`floor(...)`) or cast parens (`(double)(...)`), parenthesization was unnecessary anyway.

Also fixes a pre-existing typo in `FloorToInt.eval`: the negative-infinity check was `(-sympy.oo, int_oo)` (positive `int_oo`) instead of `(-sympy.oo, -int_oo)`. This meant `FloorToInt(-int_oo)` would not simplify to `-int_oo`.

Test Plan:
Unit tests added in `TestCCodePrinting` class in `test_sympy_utils.py`:
- `test_floor_to_int_ccode`: FloorToInt(x) -> "floor(x)"
- `test_floor_to_int_ccode_compound`: FloorToInt(x+y) -> "floor(x + y)"
- `test_ceil_to_int_ccode`: CeilToInt(x) -> "ceil(x)"
- `test_trunc_to_int_ccode`: TruncToInt(x) -> "trunc(x)"
- `test_to_float_ccode`: ToFloat(x) -> "(double)(x)"
- `test_ccode_in_compound_expr`: FloorToInt(ToFloat(x) + 1) contains both floor and double

E2E validation:
- `buck run fbcode//mtia/host_runtime/afg/tests/dynamic_shapes:test_dynamic_shapes_basic_ops_bin -- -k test_op_floordiv` — PASSED (exercises ccode_printer through FBA shape calculator)

Reviewed By: kalpit-meta-1

Differential Revision: D104852318




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01