### PR TITLE
[inductor] Canonicalize view bias before freezing conv layout

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1046,6 +1046,19 @@ class CPUReproTests(TestCase):
                 (x,),
             )
 
+    def test_conv2d_view_bias_torch_compile(self):
+        def fn(x):
+            b = x.to(torch.bool).float()
+            return F.conv2d(b, b, b.flatten(), stride=1, padding=0)
+
+        x = torch.full((1, 1, 1, 1), 3.5)
+        eager = fn(x)
+
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=True)
+        actual = compiled(x)
+
+        torch.testing.assert_close(actual, eager)
+
     def test_acosh_with_negative_large_input(self):
         # https://github.com/pytorch/pytorch/issues/118267.
 

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -8,6 +8,7 @@ import torch
 from torch._inductor.codegen.rocm.ck_conv_template import CKGroupedConvFwdTemplate
 
 from .. import config, ir
+from ..ir import TensorBox
 from ..lowering import (
     add_layout_constraint,
     constrain_to_fx_strides,
@@ -35,8 +36,6 @@ from .mm_common import load_kernel_template
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-    from ..ir import TensorBox
 
 log = logging.getLogger(__name__)
 
@@ -598,6 +597,13 @@ def convolution(
     else:
         bias = ir.ExternKernel.realize_input(bias)  # type: ignore[assignment]
         assert bias is not None
+
+        # Generic views need a layout-backed buffer before freeze_layout().
+        if isinstance(bias.data, ir.BaseView) and not isinstance(
+            bias.data, ir.ReinterpretView
+        ):
+            bias = TensorBox(ir.ExternKernel.require_contiguous(bias))
+
         args = [x, weight, bias]
         bias.freeze_layout()
         V.graph.sizevars.guard_int_seq(bias.get_size())


### PR DESCRIPTION
## Summary
Fixes  #183372
Fix an Inductor lowering failure when `torch.compile` sees a `conv2d` bias that is a view, such as `flatten()`.

The CPU conv lowering path assumes `bias` supports `freeze_layout()`, but a repro like:

```python
import torch
import torch.nn.functional as F

def fn(x):
    b = x.to(torch.bool).float()
    return F.conv2d(b, b, b.flatten(), stride=1, padding=0)
```

passes a view-derived bias into `aten.convolution`. This causes lowering to fail when Inductor tries to freeze the bias layout.

This change canonicalizes view-like bias tensors to a layout-backed contiguous tensor before calling `freeze_layout()`.

## Repro

```python
import torch
import torch.nn as nn
import torch.nn.functional as F

class M(nn.Module):
    def forward(self, x):
        b = x.to(torch.bool).float()
        return F.conv2d(b, b, b.flatten(), stride=1, padding=0)

m = M()
x = torch.full((1, 1, 1, 1), 3.5)

print("eager:", m(x.clone()))
print("compiled:", torch.compile(m)(x.clone()))
```

Before this change, compile fails with an error like:

```text
LoweringException: AttributeError: 'View' object has no attribute 'freeze_layout'
```

## Root Cause

`flatten()` lowers to an Inductor `View`, and the conv lowering path later does:

- `bias.realize()`
- `bias.freeze_layout()`

for the bias passed to backend conv lowering.

Generic `View` inputs do not satisfy that assumption. Converting the bias to a layout-backed contiguous tensor first avoids the failure and keeps the fix local to conv lowering.

## Fix

When `bias.data` is a generic `ir.BaseView` but not already a `ReinterpretView`, call `ir.ExternKernel.require_contiguous(bias)` before freezing layout.

This is intentionally a narrow conv-specific fix rather than a global change to `View` layout semantics.

## Testing

Added a regression test covering `conv2d(..., bias=b.flatten())`.

Local validation was done by patching an installed PyTorch environment and rerunning the repro:

- before: compile failed with `View` / `freeze_layout` lowering error
- after: eager and compiled both produced `tensor([[[[2.]]]])`

I was not able to run the in-tree test locally, so I am relying on CI for repo-side verification.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos