### PR TITLE
AArch64 inductor benchmark: revert benchmarking on 16 cores

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1368,10 +1368,6 @@ test_inductor_set_cpu_affinity(){
   thread_per_core=$(lscpu | grep 'Thread(s) per core:' | awk '{print $4}')
   cores=$((cpus / thread_per_core))
 
-  # Set number of cores to 16 on aarch64 for performance runs
-  if [[ "$(uname -m)" == "aarch64" && $cores -gt 16 ]]; then
-    cores=16
-  fi
   export OMP_NUM_THREADS=$cores
 
   # Handle cgroups slice start and end CPU


### PR DESCRIPTION
Update to use all the cores of metal instance when running `Compiler inductor benchmark` for AArch64 runs, since the thread scaling issues are addressed in recent versions of oneDNN and updating to latest  version of libgomp.

[TorchInductor HUD Dashboard](https://hud.pytorch.org/benchmark/compilers_regression?renderGroupId=main&time.start=2026-05-05T00%3A00%3A00.000Z&time.end=2026-05-12T23%3A59%3A59.999Z&filters.repo=pytorch%2Fpytorch&filters.benchmarkName=compiler&filters.backend=&filters.mode=inference&filters.dtype=bfloat16&filters.deviceName=cpu+%28aarch64%29&filters.device=cpu&filters.arch=aarch64&lbranch=main&rbranch=adi%2Finductor&rcommit.workflow_id=25677437216&rcommit.label=25677437216&rcommit.commit=0b0589d6527f3821bb2fe9eea69db21a2f53872e&rcommit.branch=adi%2Finductor&rcommit.date=2026-05-11T15%3A00%3A00Z&lcommit.commit=9b611591067e98455f24c027938cde6fcdb70496&lcommit.workflow_id=25721494095&lcommit.date=2026-05-12T08%3A00%3A00Z&lcommit.branch=main&maxSampling=110)

<img width="525" height="294" alt="Screenshot 2026-05-12 at 20 35 06" src="https://github.com/user-attachments/assets/6c35e870-e640-43e2-a923-26f953a1d18c" />
