### PR TITLE
Optimize for layernorm + sigmoid epilogue by prodiving ideal input shape to layernorm after sparse matmul (#183472)

### DIFF
--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1514,6 +1514,62 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         torch.testing.assert_close(sparse_result, dense_result, rtol=1e-3, atol=1e-3)
 
     @unittest.skipIf(TEST_WITH_ROCM, "Not supported on ROCm")
+    @dtypes(torch.float16, torch.bfloat16)
+    @parametrize("dense_input_shape", [(128, 1), (128, 3)])
+    def test_mm_padded_output_shape(self, dtype, dense_input_shape, device):
+        """Explicitly verify the padded path in cusparselt_mm trims output to the correct shape.
+
+        Shapes like (128, 1) and (128, 3) have n % dense_min_cols != 0 (dense_min_cols=8),
+        triggering the need_pad branch and the narrow(0, 0, out_cols) dim slicing.
+        """
+        A = rand_sparse_semi_structured_mask(256, 128, dtype=dtype)
+        A_sparse = to_sparse_semi_structured(A)
+        B = torch.rand(dense_input_shape, device=device).to(dtype)
+
+        dense_result = torch.mm(A, B)
+        sparse_result = torch.mm(A_sparse, B)
+
+        self.assertEqual(sparse_result.shape, dense_result.shape)
+
+    @unittest.skipIf(TEST_WITH_ROCM, "Not supported on ROCm")
+    @dtypes(torch.float16, torch.bfloat16)
+    @parametrize("dense_input_shape", [(1, 128), (3, 128)])
+    def test_mm_padded_output_shape_sparse_second(self, dtype, dense_input_shape, device):
+        """Verify cusparselt_mm trims output correctly for dense @ sparse.t() (Branch B).
+
+        Shapes like (1, 128) and (3, 128) have m % dense_min_rows != 0 (dense_min_rows=8),
+        triggering need_pad with should_transpose_dense=True. The narrow(0, 0, out_rows)
+        path must correctly return shape (m, n_out) without a trailing .t().
+        """
+        B = rand_sparse_semi_structured_mask(256, 128, dtype=dtype)
+        B_sparse = to_sparse_semi_structured(B)
+        A = torch.rand(dense_input_shape, device=device).to(dtype)
+
+        dense_result = torch.mm(A, B.t())
+        sparse_result = torch.mm(A, B_sparse.t())
+
+        self.assertEqual(sparse_result.shape, dense_result.shape)
+
+    @unittest.skipIf(TEST_WITH_ROCM, "Not supported on ROCm")
+    @dtypes(torch.float16, torch.bfloat16)
+    @parametrize("dense_input_shape", [(1, 128), (3, 128)])
+    def test_addmm_padded_output_shape_sparse_second(self, dtype, dense_input_shape, device):
+        """Verify cusparselt_mm trims output correctly for addmm with dense @ sparse.t() (Branch B + bias).
+
+        Covers the semi_sparse_addmm path (used by nn.Linear) with should_transpose_dense=True
+        and padding-triggering input shapes.
+        """
+        B = rand_sparse_semi_structured_mask(256, 128, dtype=dtype)
+        B_sparse = to_sparse_semi_structured(B)
+        A = torch.rand(dense_input_shape, device=device).to(dtype)
+        bias = torch.rand(256, device=device).to(dtype)
+
+        dense_result = torch.addmm(bias, A, B.t())
+        sparse_result = torch.addmm(bias, A, B_sparse.t())
+
+        self.assertEqual(sparse_result.shape, dense_result.shape)
+
+    @unittest.skipIf(TEST_WITH_ROCM, "Not supported on ROCm")
     def test_cusparselt_backend(self):
         if not torch.backends.cusparselt.is_available():
             raise AssertionError("cusparselt backend should be available")
@@ -1606,7 +1662,7 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         A = rand_sparse_semi_structured_mask(256, 128, dtype=torch.float16).cuda()
         A_compressed = torch._cslt_compress(A)
         B = torch.ones((128, 128), device=device).to(torch.float16)
-        alg_id = torch._cslt_sparse_mm_search(A_compressed, B.t())
+        alg_id = torch._cslt_sparse_mm_search(A_compressed, B)
         A_sparse = to_sparse_semi_structured(A, alg_id=alg_id)
         self.assertEqual(A_sparse.alg_id_cusparselt, alg_id)
         dense_result = torch.mm(A, B).to(torch.float16)

--- a/torch/sparse/_semi_structured_ops.py
+++ b/torch/sparse/_semi_structured_ops.py
@@ -146,7 +146,7 @@ def semi_sparse_mm(func, types, args=(), kwargs=None) -> torch.Tensor:
             raise AssertionError(
                 f"expected SparseSemiStructuredTensor, got {type(B_t).__name__}"
             )
-        return B_t._mm(A, should_transpose_dense=True).t()
+        return B_t._mm(A, should_transpose_dense=True)
 
 
 def semi_sparse_addmm(func, types, args=(), kwargs=None) -> torch.Tensor:
@@ -171,7 +171,7 @@ def semi_sparse_addmm(func, types, args=(), kwargs=None) -> torch.Tensor:
             f"expected SparseSemiStructuredTensor, got {type(B_t).__name__}"
         )
     row, _col = A.shape
-    return B_t._mm(A, bias=bias, should_transpose_dense=True).t()
+    return B_t._mm(A, bias=bias, should_transpose_dense=True)
 
 
 def semi_sparse_linear(func, types, args=(), kwargs=None) -> torch.Tensor:

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -699,7 +699,7 @@ class SparseSemiStructuredTensorCUSPARSELT(SparseSemiStructuredTensor):
                 self.shape[0],
                 constraints.dense_min_rows,
                 constraints.dense_min_cols,
-                self.fuse_transpose_cusparselt,
+                should_transpose_dense,
                 self.alg_id_cusparselt,
                 should_transpose_dense,
             )
@@ -746,12 +746,9 @@ def _ensure_cutlass_mm_registered():
             res = torch._sparse_semi_structured_addmm(bias, packed, meta, mm_input)
         if need_pad:
             out_cols = m if should_transpose_dense else n
-            return (
-                res[:out_features]
-                .narrow(1, 0, out_cols)
-                .clone(memory_format=torch.contiguous_format)
-            )
-        return res.contiguous()
+            res = res[:out_features].narrow(1, 0, out_cols)
+            return res.t().contiguous() if should_transpose_dense else res.contiguous()
+        return res.t().contiguous() if should_transpose_dense else res
 
     @cutlass_mm.register_fake
     def _cutlass_mm_fake(
@@ -765,9 +762,11 @@ def _ensure_cutlass_mm_registered():
         transpose_dense: bool,
     ) -> torch.Tensor:
         out_cols = dense.shape[0] if transpose_dense else dense.shape[1]
+        output_shape = (
+            (out_cols, out_features) if transpose_dense else (out_features, out_cols)
+        )
         return torch.empty(
-            out_features,
-            out_cols,
+            output_shape,
             dtype=dense.dtype,
             device=dense.device,
         )
@@ -812,14 +811,13 @@ def _ensure_cusparselt_mm_registered():
             transpose_result=fuse_transpose,
             alg_id=alg_id,
         )
-        if fuse_transpose:
-            res = res.t()
         if need_pad:
             out_cols = m if should_transpose_dense else n
-            return res.narrow(1, 0, out_cols).clone(
-                memory_format=torch.contiguous_format
-            )
-        return res.contiguous()
+            if fuse_transpose:
+                return res.narrow(0, 0, out_cols).contiguous()
+            else:
+                return res.narrow(1, 0, out_cols).contiguous()
+        return res
 
     @cusparselt_mm.register_fake
     def _cusparselt_mm_fake(
@@ -834,9 +832,11 @@ def _ensure_cusparselt_mm_registered():
         should_transpose_dense: bool,
     ) -> torch.Tensor:
         out_cols = dense.shape[0] if should_transpose_dense else dense.shape[1]
+        output_shape = (
+            (out_cols, out_features) if fuse_transpose else (out_features, out_cols)
+        )
         return torch.empty(
-            out_features,
-            out_cols,
+            output_shape,
             dtype=dense.dtype,
             device=dense.device,
         )


### PR DESCRIPTION
Summary:

We noticed that laynorm + sigmoid has less latency in dense version compared to sparse matmul + laynorm + sigmoid.

Diving into it, it was because the laynorm + sigmoid will be fused together in dense version but not sparse version. I believe this is because we did not provide an ideal input form for layernorm -- continuous memory layout at the last dimension. 

I believe this makes sense to always provide a continuous memory layout to subsequent kernels in order to avoid unexpected performance issue. Therefore, I'd like to change the default behavior of semi-tensor addmm/mm, to always return a continuous layout output.


A bench mark result as follow: 
Focus on 4 columns
EpiDc:  (dense) LayerNorm + sigmoid (continuous input)
EpiDNc: (dense) LayerNorm + sigmoid (non-continuous input)
EpiSpNc: (sparse) LayerNorm + sigmoid (non-continuous input)
EpiSpC: (sparse) LayerNorm + sigmoid (continuous input)

     M        N        K |     EpiDc   EpiDNc   EpiSpNc   EpiSpC

     8     6144   141312 |     39.2     55.8     50.1     31.3
    32     6144   141312 |     46.2     62.0     52.3     36.9
   128     6144   141312 |     36.6     51.3     51.9     37.9
   256     6144   141312 |     35.9     50.0     50.2     35.9
   512     6144   141312 |     35.4     50.7     50.7     35.5
  1024     6144   141312 |     35.6     51.0     52.2     36.4
  2048     6144   141312 |     52.8     76.4     77.5     53.3

     8    32768     6144 |     40.1     46.2     45.2     40.0
    32    32768     6144 |     41.2     49.1     49.4     41.3
   128    32768     6144 |     44.2     73.4     73.1     43.9
   256    32768     6144 |     76.3    120.6    120.9     76.6
   512    32768     6144 |    111.9    213.8    219.1    112.2
  1024    32768     6144 |    184.1    392.5    390.7    183.0
  2048    32768     6144 |    329.3    752.7    739.0    326.4

     8   141312     1024 |    152.9    164.5    164.6    153.2
    32   141312     1024 |    166.4    184.4    184.3    166.4
   128   141312     1024 |    325.9    451.9    451.8    325.1
   256   141312     1024 |    384.2    637.1    635.9    384.1
   512   141312     1024 |    488.7   1006.2   1007.5    486.5
  1024   141312     1024 |    758.5   1826.1   1820.3    762.7
  2048   141312     1024 |   1400.5   3579.2   3614.3   1402.2

     8     1024   141312 |     26.9     32.4     33.8     26.7
    32     1024   141312 |     26.9     33.0     33.8     27.1
   128     1024   141312 |     27.1     32.3     32.2     30.1
   256     1024   141312 |     27.1     32.8     32.1     27.2
   512     1024   141312 |     27.2     32.6     32.3     27.0
  1024     1024   141312 |     30.0     32.8     34.0     27.5
  2048     1024   141312 |     27.1     32.7     34.7     27.6

     8   136192     1024 |    148.6    159.1    159.0    147.8
    32   136192     1024 |    161.2    177.9    177.3    154.4
   128   136192     1024 |    313.8    432.9    432.2    312.6
   256   136192     1024 |    370.2    613.7    613.4    370.5
   512   136192     1024 |    469.2    968.9    978.8    466.3
  1024   136192     1024 |    729.7   1735.3   1736.7    734.3
  2048   136192     1024 |   1350.1   3449.1   3419.6   1352.3

Test Plan:
OSS CI

[zihaoliu@devgpu073.odn1 ~/local/fbsource/fbcode (aec6bb875c)]$ buck2 test //caffe2/test:test_sparse_cuda \
  mode/opt \
  mode/inplace \
  -c fbcode.platform010_cuda_version=12.8 \
  -c fbcode.nvcc_arch=h100a \
  -c fbcode.enable_gpu_sections=true \
  -m fbcode//caffe2:enable_cusparselt \
  -- test_mm_padded_output_shape_sparse_second \
  -- test_addmm_padded_output_shape_sparse_second \
  -- test_mm_padded_output_shape -v
Buck UI: https://www.internalfb.com/buck2/e873b43b-681a-4903-869d-69217d480b8b
Test UI: https://www.internalfb.com/intern/testinfra/testrun/28710447634418653
Network: Up: 0B  Down: 0B
Command: test.                                                                                                                                                                                                           
Time elapsed: 13.4s
Tests finished: Pass 13. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0

Reviewed By: RandySheriff

Differential Revision: D104880058


