### PR TITLE
Extend test coverage for uint16/uint32/uint64 and complex32 dtypes

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -1861,7 +1861,8 @@ Tensor& index_select_out_cpu_(
           ScalarType::Half,
           ScalarType::Bool,
           ScalarType::BFloat16,
-          AT_EXPAND(AT_FLOAT8_TYPES));
+          AT_EXPAND(AT_FLOAT8_TYPES),
+          AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES));
     }
   }
 

--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -789,15 +789,23 @@ void flip_kernel(TensorIterator& iter, const bool quantized) {
       return;
     }
 
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, iter.dtype(), "flip_cpu",
-        [&iter] { cpu_kernel_vec(iter,
-          [](scalar_t a, scalar_t /*dummy input*/) -> scalar_t {
-            return a;
-        },
-          [](Vectorized<scalar_t> a, Vectorized<scalar_t> /*dummy input*/) -> Vectorized<scalar_t> {
-            return a;
-        });
-    });
+    AT_DISPATCH_V2(
+        iter.dtype(),
+        "flip_cpu",
+        AT_WRAP([&iter] {
+          cpu_kernel_vec(iter,
+            [](scalar_t a, scalar_t /*dummy input*/) -> scalar_t {
+              return a;
+            },
+            [](Vectorized<scalar_t> a, Vectorized<scalar_t> /*dummy input*/) -> Vectorized<scalar_t> {
+              return a;
+            });
+        }),
+        AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX),
+        AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES),
+        kBool,
+        kHalf,
+        kBFloat16);
   }
 }
 

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -6,6 +6,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/Config.h>
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/NumericUtils.h>
 #include <ATen/Parallel.h>
 #include <ATen/native/cpu/ReduceUtils.h>
@@ -205,9 +206,10 @@ struct cpu_scatter_gather_base_kernel {
     // to keep equal granularity in parallelism.
     int64_t grain_size = std::max((int64_t) 1, at::internal::GRAIN_SIZE / index_dim_size);
 
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
-      ScalarType::Bool, ScalarType::Half, ScalarType::BFloat16, self.scalar_type(),
-      "scatter_gather_scalar_cpu", [&] {
+    AT_DISPATCH_V2(
+      self.scalar_type(),
+      "scatter_gather_scalar_cpu",
+      AT_WRAP([&] {
         constexpr auto SELF_ITER_STRIDE_IDX = 0;
         constexpr auto INDEX_ITER_STRIDE_IDX = 1;
         using opmath_t = at::opmath_type<scalar_t>;
@@ -255,8 +257,10 @@ struct cpu_scatter_gather_base_kernel {
           }
         };
         iter.for_each(loop, grain_size);
-      }
-    );
+      }),
+      AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX),
+      AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES),
+      kBool, kHalf, kBFloat16);
     if (need_acc) {
       self.copy_(buffer);
     }
@@ -294,9 +298,10 @@ struct cpu_scatter_gather_base_kernel {
 
     int64_t grain_size = std::max((int64_t) 1, at::internal::GRAIN_SIZE / index_dim_size);
 
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
-      ScalarType::Bool, ScalarType::Half, ScalarType::BFloat16, iter.dtype(1),
-      "scatter_gather_tensor_cpu", [&] {
+    AT_DISPATCH_V2(
+      iter.dtype(1),
+      "scatter_gather_tensor_cpu",
+      AT_WRAP([&] {
         constexpr auto SELF_ITER_STRIDE_IDX = 0;
         constexpr auto INDEX_ITER_STRIDE_IDX = 2;
         constexpr auto SRC_ITER_STRIDE_IDX = 1;
@@ -352,8 +357,10 @@ struct cpu_scatter_gather_base_kernel {
           }
         };
         iter.for_each(loop, grain_size);
-      }
-    );
+      }),
+      AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX),
+      AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES),
+      kBool, kHalf, kBFloat16);
     if (need_acc) {
       self.copy_(buffer);
     }

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -2219,8 +2219,7 @@ class TestIndexing(TestCase):
 
     # The test fails for zero-dimensional tensors on XLA
     @onlyNativeDeviceTypes
-    @dtypes(*all_types_complex_float8_and(torch.half, torch.bool, torch.bfloat16))
-    @dtypesIfCUDA(
+    @dtypes(
         *all_types_complex_float8_and(
             torch.half,
             torch.bool,

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -2220,6 +2220,16 @@ class TestIndexing(TestCase):
     # The test fails for zero-dimensional tensors on XLA
     @onlyNativeDeviceTypes
     @dtypes(*all_types_complex_float8_and(torch.half, torch.bool, torch.bfloat16))
+    @dtypesIfCUDA(
+        *all_types_complex_float8_and(
+            torch.half,
+            torch.bool,
+            torch.bfloat16,
+            torch.uint16,
+            torch.uint32,
+            torch.uint64,
+        )
+    )
     @dtypesIfXPU(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     @dtypesIfMPS(*all_mps_types_and(torch.bool, torch.cfloat))
     def test_index_select(self, device, dtype):

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -14,7 +14,7 @@ from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, onlyCPU, onlyCUDA, dtypes, dtypesIfCUDA,
      toleranceOverride, tol,)
 from torch.testing._internal.common_dtype import \
-    (all_types_and_complex_and, get_all_dtypes,)
+    (all_passthru_types, all_passthru_types_and, get_all_dtypes,)
 
 from torch.testing._internal.common_cuda import CDNA3OrLater, SM90OrLater
 
@@ -40,10 +40,8 @@ class TestScatterGather(TestCase):
                     else:
                         idx[tuple(ii)] = torch.randint(dim_size, (elems_per_row,))
 
-    @dtypes(*all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16))
-    @dtypesIfCUDA(*all_types_and_complex_and(
-        torch.bool, torch.half, torch.bfloat16, torch.chalf,
-        torch.uint16, torch.uint32, torch.uint64))
+    @dtypes(*all_passthru_types())
+    @dtypesIfCUDA(*all_passthru_types_and(torch.chalf))
     def test_gather(self, device, dtype):
         m, n, o = random.randint(10, 20), random.randint(10, 20), random.randint(10, 20)
         elems_per_row = random.randint(1, 10)
@@ -66,7 +64,7 @@ class TestScatterGather(TestCase):
         self.assertEqual(actual, expected, atol=0, rtol=0)
 
         # Guarded because torch.max isn't defined for complex, bool, or
-        # barebones unsigned tensors on CUDA
+        # barebones unsigned tensors.
         max_unsupported = (
             dtype.is_complex
             or dtype is torch.bool

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -14,7 +14,7 @@ from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, onlyCPU, onlyCUDA, dtypes, dtypesIfCUDA,
      toleranceOverride, tol,)
 from torch.testing._internal.common_dtype import \
-    (get_all_dtypes,)
+    (all_types_and_complex_and, get_all_dtypes,)
 
 from torch.testing._internal.common_cuda import CDNA3OrLater, SM90OrLater
 
@@ -40,7 +40,10 @@ class TestScatterGather(TestCase):
                     else:
                         idx[tuple(ii)] = torch.randint(dim_size, (elems_per_row,))
 
-    @dtypes(torch.float32, torch.complex64)
+    @dtypes(*all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16))
+    @dtypesIfCUDA(*all_types_and_complex_and(
+        torch.bool, torch.half, torch.bfloat16, torch.chalf,
+        torch.uint16, torch.uint32, torch.uint64))
     def test_gather(self, device, dtype):
         m, n, o = random.randint(10, 20), random.randint(10, 20), random.randint(10, 20)
         elems_per_row = random.randint(1, 10)
@@ -62,8 +65,14 @@ class TestScatterGather(TestCase):
                     expected[i, j, k] = src[tuple(ii)]
         self.assertEqual(actual, expected, atol=0, rtol=0)
 
-        # Guarded because torch.max isn't defined for complex types
-        if not dtype.is_complex:
+        # Guarded because torch.max isn't defined for complex, bool, or
+        # barebones unsigned tensors on CUDA
+        max_unsupported = (
+            dtype.is_complex
+            or dtype is torch.bool
+            or dtype in (torch.uint16, torch.uint32, torch.uint64)
+        )
+        if not max_unsupported:
             src = make_tensor((3, 4, 5), device=device, dtype=dtype)
             expected, idx = src.max(2, True)
             actual = torch.gather(src, 2, idx)

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -63,11 +63,10 @@ class TestScatterGather(TestCase):
                     expected[i, j, k] = src[tuple(ii)]
         self.assertEqual(actual, expected, atol=0, rtol=0)
 
-        # Guarded because torch.max isn't defined for complex, bool, or
-        # barebones unsigned tensors.
+        # Guarded because torch.max isn't defined for complex or barebones
+        # unsigned tensors.
         max_unsupported = (
             dtype.is_complex
-            or dtype is torch.bool
             or dtype in (torch.uint16, torch.uint32, torch.uint64)
         )
         if not max_unsupported:

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -406,6 +406,17 @@ class TestShapeOps(TestCase):
             torch.clamp(X)
 
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
+    @dtypesIfCUDA(
+        *all_types_and_complex_and(
+            torch.half,
+            torch.bool,
+            torch.bfloat16,
+            torch.chalf,
+            torch.uint16,
+            torch.uint32,
+            torch.uint64,
+        )
+    )
     def test_flip(self, device, dtype):
         make_from_data = partial(torch.tensor, device=device, dtype=dtype)
         make_from_size = partial(make_tensor, device=device, dtype=dtype)

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -21,6 +21,8 @@ from torch.testing._internal.common_device_type import (
     onlyCPU,
 )
 from torch.testing._internal.common_dtype import (
+    all_passthru_types,
+    all_passthru_types_and,
     all_types,
     all_types_and,
     all_types_and_complex_and,
@@ -405,18 +407,8 @@ class TestShapeOps(TestCase):
         with self.assertRaisesRegex(RuntimeError, error_msg):
             torch.clamp(X)
 
-    @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
-    @dtypesIfCUDA(
-        *all_types_and_complex_and(
-            torch.half,
-            torch.bool,
-            torch.bfloat16,
-            torch.chalf,
-            torch.uint16,
-            torch.uint32,
-            torch.uint64,
-        )
-    )
+    @dtypes(*all_passthru_types())
+    @dtypesIfCUDA(*all_passthru_types_and(torch.chalf))
     def test_flip(self, device, dtype):
         make_from_data = partial(torch.tensor, device=device, dtype=dtype)
         make_from_size = partial(make_tensor, device=device, dtype=dtype)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6157,9 +6157,9 @@ class TestTorchDeviceType(TestCase):
     @onlyNativeDeviceTypes
     @dtypes(torch.uint16, torch.uint32, torch.uint64)
     def test_fill_barebones_unsigned(self, device, dtype):
-        # FillKernel.cu dispatches over barebones unsigned via
-        # AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES) but the fill OpInfo
-        # does not enumerate them. Cover that dispatch directly.
+        # Both FillKernel.cpp and FillKernel.cu dispatch over barebones
+        # unsigned via AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), but the fill
+        # OpInfo does not enumerate them. Cover that dispatch directly.
         for shape in ((5,), (4, 5), (2, 3, 4)):
             t = torch.empty(shape, dtype=dtype, device=device).fill_(7)
             self.assertEqual(t.cpu(), torch.full(shape, 7, dtype=dtype))
@@ -6210,11 +6210,10 @@ class TestTorchDeviceType(TestCase):
             a = make_tensor(shape, dtype=dtype, device=device)
             b = a.clone()
             # Differ exactly one element so eq/ne both have True and False
-            # to report. Compute the perturbed value on the CPU to avoid
-            # invoking integer arithmetic ufuncs on the barebones types.
+            # to report. XOR with 1 toggles the low bit, so the perturbed
+            # value is always in range and differs from old.
             old = int(a.view(-1)[0].item())
-            new = (old + 1) % torch.iinfo(dtype).max
-            b.view(-1)[0] = new
+            b.view(-1)[0] = old ^ 1
             self.assertEqual(torch.eq(a, b), (a.cpu() == b.cpu()).to(device))
             self.assertEqual(torch.ne(a, b), (a.cpu() != b.cpu()).to(device))
             self.assertEqual(torch.eq(a, a), torch.ones_like(a, dtype=torch.bool))
@@ -6301,17 +6300,17 @@ class TestTorchDeviceType(TestCase):
     @dtypes(*all_passthru_types_and(torch.chalf))
     def test_copy_(self, device, dtype):
         def can_cast(src_dtype, dst_dtype):
-            # torch.can_cast(torch.int16, torch.uint8) returns True
-            # which isn't actually safe-cast.
-            # This function returns False in this case. For unsigned
-            # destinations we require an unsigned source no wider than
-            # the destination so widening (uint8 -> uint16) round-trips
-            # losslessly but narrowing (uint16 -> uint8) is rejected.
+            # torch.can_cast(torch.int16, torch.uint8) returns True which
+            # isn't actually safe-cast. Override for unsigned destinations:
+            # only a bool source, or an unsigned source no wider than the
+            # destination, round-trips losslessly. Narrowing (uint16 ->
+            # uint8) is rejected.
             unsigned = {torch.uint8, torch.uint16, torch.uint32, torch.uint64}
 
             if dst_dtype in unsigned:
-                return (src_dtype in unsigned
-                        and src_dtype.itemsize <= dst_dtype.itemsize)
+                return (src_dtype is torch.bool
+                        or (src_dtype in unsigned
+                            and src_dtype.itemsize <= dst_dtype.itemsize))
             return torch.can_cast(src_dtype, dst_dtype)
 
         def make_tensor_wrapper(shape, dtype):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6154,6 +6154,86 @@ class TestTorchDeviceType(TestCase):
                         check_equal(torch.tensor(True), x, y)
                         check_equal(torch.tensor(True), y, x)
 
+    @onlyNativeDeviceTypes
+    @dtypes(torch.uint16, torch.uint32, torch.uint64)
+    def test_fill_barebones_unsigned(self, device, dtype):
+        # FillKernel.cu dispatches over barebones unsigned via
+        # AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES) but the fill OpInfo
+        # does not enumerate them. Cover that dispatch directly.
+        for shape in ((5,), (4, 5), (2, 3, 4)):
+            t = torch.empty(shape, dtype=dtype, device=device).fill_(7)
+            self.assertEqual(t.cpu(), torch.full(shape, 7, dtype=dtype))
+
+        # Non-contiguous tensor (every other row of a larger allocation).
+        big = torch.empty((8, 5), dtype=dtype, device=device)
+        nc = big[::2]
+        nc.fill_(11)
+        self.assertEqual(nc.cpu(), torch.full((4, 5), 11, dtype=dtype))
+
+        # Boundary fill value: max of each dtype.
+        max_val = torch.iinfo(dtype).max
+        t = torch.empty(8, dtype=dtype, device=device).fill_(max_val)
+        self.assertEqual(t.cpu().tolist(), [max_val] * 8)
+
+    @onlyNativeDeviceTypes
+    @dtypes(torch.uint16, torch.uint32, torch.uint64)
+    def test_where_barebones_unsigned(self, device, dtype):
+        # The barebones unsigned dtypes are excluded from the broader
+        # test_where_scalar_handcrafted_values because torch.result_type
+        # does not support promoting them. Cover the same-dtype path
+        # for where() against a CPU reference here.
+        for shape in ((5,), (1, 5), (4, 5)):
+            a = make_tensor(shape, dtype=dtype, device=device)
+            b = make_tensor(shape, dtype=dtype, device=device)
+            cond = torch.randint(0, 2, shape, dtype=torch.bool, device=device)
+            out = torch.where(cond, a, b)
+            expected = torch.where(cond.cpu(), a.cpu(), b.cpu()).to(device)
+            self.assertEqual(out, expected)
+
+        # Non-contiguous inputs.
+        big = make_tensor((8, 10), dtype=dtype, device=device)
+        a = big[::2]
+        b = big[1::2]
+        cond = torch.randint(0, 2, a.shape, dtype=torch.bool, device=device)
+        out = torch.where(cond, a, b)
+        expected = torch.where(cond.cpu(), a.cpu(), b.cpu()).to(device)
+        self.assertEqual(out, expected)
+
+    @onlyNativeDeviceTypes
+    @dtypes(torch.uint16, torch.uint32, torch.uint64)
+    def test_eq_ne_barebones_unsigned(self, device, dtype):
+        # The eq/ne kernels dispatch over uint16/uint32/uint64 via
+        # AT_DISPATCH_V2(... AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES)),
+        # but the standard test_torch.py comparison sweeps don't list
+        # those dtypes. Cover the same-dtype path here.
+        for shape in ((5,), (4, 5), (2, 3, 4)):
+            a = make_tensor(shape, dtype=dtype, device=device)
+            b = a.clone()
+            # Differ exactly one element so eq/ne both have True and False
+            # to report. Compute the perturbed value on the CPU to avoid
+            # invoking integer arithmetic ufuncs on the barebones types.
+            old = int(a.view(-1)[0].item())
+            new = (old + 1) % max(2, torch.iinfo(dtype).max)
+            b.view(-1)[0] = new
+            self.assertEqual(torch.eq(a, b), (a.cpu() == b.cpu()).to(device))
+            self.assertEqual(torch.ne(a, b), (a.cpu() != b.cpu()).to(device))
+            self.assertEqual(torch.eq(a, a), torch.ones_like(a, dtype=torch.bool))
+            self.assertEqual(torch.ne(a, a), torch.zeros_like(a, dtype=torch.bool))
+
+        # Non-contiguous: every-other-row slice.
+        big = make_tensor((8, 4), dtype=dtype, device=device)
+        a = big[::2]
+        b = big[1::2]
+        self.assertEqual(torch.eq(a, b), (a.cpu() == b.cpu()).to(device))
+        self.assertEqual(torch.ne(a, b), (a.cpu() != b.cpu()).to(device))
+
+        # Boundary value: max-int comparison.
+        max_val = torch.iinfo(dtype).max
+        a = torch.tensor([0, max_val, max_val - 1], dtype=dtype, device=device)
+        b = torch.tensor([0, max_val, max_val], dtype=dtype, device=device)
+        self.assertEqual(torch.eq(a, b).tolist(), [True, True, False])
+        self.assertEqual(torch.ne(a, b).tolist(), [False, False, True])
+
 
     @skipIfTorchInductor("FIXME")
     def test_hook_remove(self, device):
@@ -6218,17 +6298,18 @@ class TestTorchDeviceType(TestCase):
         with self.assertRaisesRegex(RuntimeError, msg):
             torch.nn.functional.nll_loss(x, t, weight=invalid_weight)
 
-    @dtypes(*all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16, torch.complex32))
+    @dtypes(*all_types_and_complex_and(
+        torch.bool, torch.half, torch.bfloat16, torch.complex32,
+        torch.uint16, torch.uint32, torch.uint64))
     def test_copy_(self, device, dtype):
         def can_cast(src_dtype, dst_dtype):
             # torch.can_cast(torch.int16, torch.uint8) returns True
             # which isn't actually safe-cast.
             # This function returns False in this case.
-            def is_unsigned_int(dtype):
-                return dtype is torch.uint8
+            unsigned = {torch.uint8, torch.uint16, torch.uint32, torch.uint64}
 
-            if is_unsigned_int(dst_dtype):
-                return is_unsigned_int(src_dtype)
+            if dst_dtype in unsigned:
+                return src_dtype in unsigned
             return torch.can_cast(src_dtype, dst_dtype)
 
         def make_tensor_wrapper(shape, dtype):
@@ -6239,7 +6320,9 @@ class TestTorchDeviceType(TestCase):
             return torch.randn(shape, device=device, dtype=dtype)
 
         t = make_tensor_wrapper((50,), dtype)
-        src_dtypes = all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16, torch.complex32)
+        src_dtypes = all_types_and_complex_and(
+            torch.bool, torch.half, torch.bfloat16, torch.complex32,
+            torch.uint16, torch.uint32, torch.uint64)
         for src_dtype in src_dtypes:
             src = make_tensor_wrapper((50,), dtype=src_dtype)
             t.copy_(src)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -64,7 +64,7 @@ from torch.testing._internal.common_mkldnn import reduced_f32_on_and_off
 from torch.testing._internal.common_dtype import (
     floating_types_and, get_all_math_dtypes, all_types_and_complex_and, complex_types,
     all_types_and, floating_types, floating_and_complex_types, integral_types_and,
-    get_all_qint_dtypes, all_types_complex_float8_and,
+    get_all_qint_dtypes, all_types_complex_float8_and, all_passthru_types_and,
 )
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.testing._internal.common_utils import IS_WINDOWS
@@ -6213,7 +6213,7 @@ class TestTorchDeviceType(TestCase):
             # to report. Compute the perturbed value on the CPU to avoid
             # invoking integer arithmetic ufuncs on the barebones types.
             old = int(a.view(-1)[0].item())
-            new = (old + 1) % max(2, torch.iinfo(dtype).max)
+            new = (old + 1) % torch.iinfo(dtype).max
             b.view(-1)[0] = new
             self.assertEqual(torch.eq(a, b), (a.cpu() == b.cpu()).to(device))
             self.assertEqual(torch.ne(a, b), (a.cpu() != b.cpu()).to(device))
@@ -6298,18 +6298,20 @@ class TestTorchDeviceType(TestCase):
         with self.assertRaisesRegex(RuntimeError, msg):
             torch.nn.functional.nll_loss(x, t, weight=invalid_weight)
 
-    @dtypes(*all_types_and_complex_and(
-        torch.bool, torch.half, torch.bfloat16, torch.complex32,
-        torch.uint16, torch.uint32, torch.uint64))
+    @dtypes(*all_passthru_types_and(torch.chalf))
     def test_copy_(self, device, dtype):
         def can_cast(src_dtype, dst_dtype):
             # torch.can_cast(torch.int16, torch.uint8) returns True
             # which isn't actually safe-cast.
-            # This function returns False in this case.
+            # This function returns False in this case. For unsigned
+            # destinations we require an unsigned source no wider than
+            # the destination so widening (uint8 -> uint16) round-trips
+            # losslessly but narrowing (uint16 -> uint8) is rejected.
             unsigned = {torch.uint8, torch.uint16, torch.uint32, torch.uint64}
 
             if dst_dtype in unsigned:
-                return src_dtype in unsigned
+                return (src_dtype in unsigned
+                        and src_dtype.itemsize <= dst_dtype.itemsize)
             return torch.can_cast(src_dtype, dst_dtype)
 
         def make_tensor_wrapper(shape, dtype):
@@ -6320,9 +6322,7 @@ class TestTorchDeviceType(TestCase):
             return torch.randn(shape, device=device, dtype=dtype)
 
         t = make_tensor_wrapper((50,), dtype)
-        src_dtypes = all_types_and_complex_and(
-            torch.bool, torch.half, torch.bfloat16, torch.complex32,
-            torch.uint16, torch.uint32, torch.uint64)
+        src_dtypes = all_passthru_types_and(torch.chalf)
         for src_dtype in src_dtypes:
             src = make_tensor_wrapper((50,), dtype=src_dtype)
             t.copy_(src)

--- a/torch/testing/_internal/common_dtype.py
+++ b/torch/testing/_internal/common_dtype.py
@@ -161,19 +161,16 @@ def all_types_complex_float8_and(*dtypes):
 _barebones_unsigned_types = _dispatch_dtypes((torch.uint16, torch.uint32, torch.uint64))
 
 
-def barebones_unsigned_types():
-    return _barebones_unsigned_types
-
-
 # Passthru ops (copy, fill, index, gather, scatter, flip, take, put, where, eq, ne)
 # move or select data without dtype-specific arithmetic, so they support the
 # largest common set of dtypes across CPU and CUDA. Mirrors
 # AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kBool, kHalf, kBFloat16,
 # AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES) on the C++ side. complex32 (chalf) is
-# not included because CPU scatter/gather/flip stores values through opmath_t,
-# which for complex<Half> is complex<Float> (twice the storage width). Callers
-# that need chalf coverage should add it explicitly with
-# all_passthru_types_and(torch.chalf), typically under @dtypesIfCUDA.
+# not included because the CPU dispatch for these ops does not list
+# kComplexHalf (scatter/gather additionally can't add it trivially because the
+# kernel reinterprets the destination through opmath_t = complex<float>, which
+# is twice the storage width). Callers that need chalf coverage on CUDA
+# should opt in with all_passthru_types_and(torch.chalf) under @dtypesIfCUDA.
 _all_passthru_types = (
     _all_types_and_complex
     + _dispatch_dtypes((torch.bool, torch.half, torch.bfloat16))

--- a/torch/testing/_internal/common_dtype.py
+++ b/torch/testing/_internal/common_dtype.py
@@ -158,6 +158,37 @@ def all_types_complex_float8_and(*dtypes):
     return _all_types + _complex_types + _float8_types + _validate_dtypes(*dtypes)
 
 
+_barebones_unsigned_types = _dispatch_dtypes((torch.uint16, torch.uint32, torch.uint64))
+
+
+def barebones_unsigned_types():
+    return _barebones_unsigned_types
+
+
+# Passthru ops (copy, fill, index, gather, scatter, flip, take, put, where, eq, ne)
+# move or select data without dtype-specific arithmetic, so they support the
+# largest common set of dtypes across CPU and CUDA. Mirrors
+# AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kBool, kHalf, kBFloat16,
+# AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES) on the C++ side. complex32 (chalf) is
+# not included because CPU scatter/gather/flip stores values through opmath_t,
+# which for complex<Half> is complex<Float> (twice the storage width). Callers
+# that need chalf coverage should add it explicitly with
+# all_passthru_types_and(torch.chalf), typically under @dtypesIfCUDA.
+_all_passthru_types = (
+    _all_types_and_complex
+    + _dispatch_dtypes((torch.bool, torch.half, torch.bfloat16))
+    + _barebones_unsigned_types
+)
+
+
+def all_passthru_types():
+    return _all_passthru_types
+
+
+def all_passthru_types_and(*dtypes):
+    return _all_passthru_types + _validate_dtypes(*dtypes)
+
+
 def custom_types(*dtypes):
     """Create a list of arbitrary dtypes"""
     return _empty_types + _validate_dtypes(*dtypes)


### PR DESCRIPTION
## Summary

Several operators dispatch over `uint16` / `uint32` / `uint64` via `AT_DISPATCH_V2(AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES))` but no test method enumerates those dtypes; the kernels compile and ship unexercised. Same shape for `complex32` (chalf) on flip and gather.

This PR closes those test-coverage gaps. Per @malfet's review, it also widens CPU dispatch for `index_select`, `flip`, and `scatter`/`gather` to include `AT_BAREBONES_UNSIGNED_TYPES`, so the tests run uniformly across CPU and CUDA without a `@dtypesIfCUDA` asymmetry for these dtypes.

### CPU dispatch widening

| file | change |
|---|---|
| `aten/src/ATen/native/TensorAdvancedIndexing.cpp` | `index_select_out_cpu_` 1-D path: add `AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES)` |
| `aten/src/ATen/native/cpu/IndexKernel.cpp` | `flip_kernel`: migrate to `AT_DISPATCH_V2`, add `AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES)` |
| `aten/src/ATen/native/cpu/ScatterGatherKernel.cpp` | `scatter_gather_scalar_cpu` / `_tensor_cpu`: migrate to `AT_DISPATCH_V2`, add `AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES)` |

The new dispatch lists are supersets of the previous ones, so these migrations are no-op for already-supported dtypes; they only extend coverage to uint16/32/64.

### Test coverage extensions

| test | change |
|---|---|
| `test_index_select` | `@dtypes` widened to include `torch.uint16/32/64`. Runs on CPU and CUDA. |
| `test_flip` | `@dtypes(*all_passthru_types())` (CPU + CUDA including uint16/32/64); `@dtypesIfCUDA(*all_passthru_types_and(torch.chalf))` adds chalf on CUDA only (the CPU `flip_kernel` dispatch list does not include kComplexHalf). |
| `test_gather` | `@dtypes` was `(float32, complex64)`; now `@dtypes(*all_passthru_types())`. `@dtypesIfCUDA` adds chalf. The `src.max()` branch in the body is guarded against complex and barebones-unsigned dtypes for which `torch.max` isn't defined. |
| `test_copy_` | `@dtypes(*all_passthru_types_and(torch.chalf))` adds uint16/32/64. Tightens the local `can_cast` helper so it only allows a round-trip when the source is bool or an unsigned no wider than the destination. |

### New dedicated tests in `test_torch.py`

Where the existing test can't be widened cleanly. Each runs on both CPU and CUDA since `fill_` / `where` / `eq` / `ne` already implement the barebones unsigned types on CPU:

- `test_fill_barebones_unsigned` -- covers `FillKernel`'s barebones-unsigned dispatch (CPU and CUDA) with contig, non-contig, and max-int boundary inputs.
- `test_where_barebones_unsigned` -- `torch.result_type` rejects these dtypes, so they can't ride the `test_where_scalar_handcrafted_values` sweep; cover same-dtype `where()` directly.
- `test_eq_ne_barebones_unsigned` -- same reason; cover `eq` / `ne` against a CPU reference plus non-contig and max-int boundary.

### Helper

New `all_passthru_types()` / `all_passthru_types_and()` in `torch/testing/_internal/common_dtype.py` captures the dtype set common to data-movement ops on both backends. Mirrors `AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kBool, kHalf, kBFloat16, AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES)`. The helper deliberately omits chalf because CPU dispatch for these ops doesn't list kComplexHalf; callers that need chalf coverage on CUDA opt in via `all_passthru_types_and(torch.chalf)` under `@dtypesIfCUDA`.

Authored by Claude.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01
