### PR TITLE
[ROCm] Enable TF32 TunableOp tests for all ROCm architectures

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -28,7 +28,7 @@ from torch.testing._internal.common_utils import \
      make_fullrank_matrices_with_distinct_singular_values,
      freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
      skipIfRocmArch, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
-     runOnRocmArch, MI200_ARCH, MI300_ARCH, MI350_ARCH, NAVI_ARCH, TEST_CUDA)
+     MI200_ARCH, MI300_ARCH, MI350_ARCH, NAVI_ARCH, TEST_CUDA)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, has_cusolver, onlyCPU, skipIf, skipCUDAIfNoMagma, skipCPUIfNoLapack, precisionOverride,
      skipCUDAIf,
@@ -5932,7 +5932,6 @@ class TestLinalg(TestCase):
 
     @onlyCUDA
     @skipCUDAIfNotRocm
-    @runOnRocmArch(MI300_ARCH)
     @dtypes(torch.float)
     def test_tf32_tunableop(self, device, dtype):
         try:
@@ -5993,7 +5992,6 @@ class TestLinalg(TestCase):
 
     @onlyCUDA
     @skipCUDAIfNotRocm
-    @runOnRocmArch(MI300_ARCH)
     @dtypes(torch.float)
     def test_tf32_offline_tunableop(self, device, dtype):
         # This test is the offline version of test_tf32_tunableop


### PR DESCRIPTION
FIXES #168760
FIXES #168761

### Investigation summary

### Command to reproduce
As seen an on MI300X machine, 
```
$ PYTORCH_TEST_WITH_ROCM=1 pytest test/test_linalg.py -k "test_tf32_tunableop or test_tf32_offline_tunableop" -v -s 2>/dev/null
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.12.13, pytest-7.3.2, pluggy-1.6.0 -- /opt/conda/envs/py_3.12/bin/python3.12
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=[HealthCheck.too_slow]
rootdir: /var/lib/jenkins/pytorch
configfile: pytest.ini
plugins: rerunfailures-14.0, cpp-2.3.0, xdoctest-1.3.0, flakefinder-1.1.0, hypothesis-6.56.4, xdist-3.3.1, subtests-0.13.1
collected 3018 items / 3014 deselected / 4 selected
Running 4 items in this shard

test/test_linalg.py::TestLinalgCPU::test_tf32_offline_tunableop_cpu_float32 SKIPPED [0.0043s] (Only runs on cuda)
test/test_linalg.py::TestLinalgCPU::test_tf32_tunableop_cpu_float32 SKIPPED [0.0007s] (Only runs on cuda)
test/test_linalg.py::TestLinalgCUDA::test_tf32_offline_tunableop_cuda_float32 PASSED [7.7702s]
test/test_linalg.py::TestLinalgCUDA::test_tf32_tunableop_cuda_float32 PASSED [1.2038s]

============================================================= 2 passed, 2 skipped, 3014 deselected in 10.02s =============================================================
```

### The fix
-- In `test/test_linalg.py`, remove `@runOnRocmArch(MI300_ARCH)` decorator, enable TF32 TunableOp tests to run on all ROCm architectures
-- Remove unused `runOnRocmArch` import from `test_linalg.py`.

### Behaviour BEFORE fix
The `test_tf32_offline_tunableop` and `test_tf32_tunableop` tests pass on MI300 series GPUs, but is skipped for MI200 and MI350 series GPUs.

### Behaviour AFTER fix
The `test_tf32_offline_tunableop` and `test_tf32_tunableop` tests pass on MI200, MI300 and MI350 series GPUs.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang