### PR TITLE
Run EC2 and OSDC in parallel on all workflows via ciflow tag pushes

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -155,11 +155,12 @@ on:
 jobs:
   build:
     # Don't run on forked repos.
-    # Experiment (https://github.com/pytorch/pytorch/issues/183242): on
-    # pull_request events, always run the EC2 route so that callers passing
-    # use-arc=true execute OSDC in shadow mode alongside EC2. Pushed commits
-    # and scheduled workflows continue to honor use-arc as usual.
-    if: github.repository_owner == 'pytorch' && (!inputs.use-arc || github.event_name == 'pull_request')
+    # Experiment (https://github.com/pytorch/pytorch/issues/183242): always run
+    # the EC2 route on pull_request events and on ciflow/* tag pushes so that
+    # callers passing use-arc=true execute OSDC in shadow mode alongside EC2.
+    # Direct pushes to main/release branches and scheduled workflows continue
+    # to honor use-arc as usual (exactly one route).
+    if: github.repository_owner == 'pytorch' && (!inputs.use-arc || github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/ciflow/'))
     # Skip runner_prefix on the EC2 route during the OSDC shadow-mode
     # experiment: the prefix (e.g. mt-) is meant for OSDC runner labels and
     # would turn an EC2 label like linux.c7i.2xlarge into mt-linux.c7i.2xlarge,

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -132,11 +132,12 @@ env:
 jobs:
   test:
     # Don't run on forked repos or empty test matrix.
-    # Experiment (https://github.com/pytorch/pytorch/issues/183242): on
-    # pull_request events, always run the EC2 route so that callers passing
-    # use-arc=true execute OSDC in shadow mode alongside EC2. Pushed commits
-    # and scheduled workflows continue to honor use-arc as usual.
-    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix).include) != '[]' && (!inputs.use-arc || github.event_name == 'pull_request')
+    # Experiment (https://github.com/pytorch/pytorch/issues/183242): always run
+    # the EC2 route on pull_request events and on ciflow/* tag pushes so that
+    # callers passing use-arc=true execute OSDC in shadow mode alongside EC2.
+    # Direct pushes to main/release branches and scheduled workflows continue
+    # to honor use-arc as usual (exactly one route).
+    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix).include) != '[]' && (!inputs.use-arc || github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/ciflow/'))
     strategy:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false

--- a/.github/workflows/attention_op_microbenchmark.yml
+++ b/.github/workflows/attention_op_microbenchmark.yml
@@ -62,6 +62,7 @@ jobs:
       build-environment: ${{ needs.attn-microbenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.attn-microbenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.attn-microbenchmark-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.attn-microbenchmark-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -101,6 +102,7 @@ jobs:
       build-environment: ${{ needs.opmicrobenchmark-build-b200.outputs.build-environment }}
       docker-image: ${{ needs.opmicrobenchmark-build-b200.outputs.docker-image }}
       test-matrix: ${{ needs.opmicrobenchmark-build-b200.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.opmicrobenchmark-build-b200.outputs.test-matrix-osdc }}
       use-arc: true
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/h100-symm-mem.yml
+++ b/.github/workflows/h100-symm-mem.yml
@@ -62,6 +62,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-symm.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-symm.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-symm.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-symm.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/inductor-micro-benchmark.yml
+++ b/.github/workflows/inductor-micro-benchmark.yml
@@ -61,6 +61,7 @@ jobs:
       build-environment: ${{ needs.build.outputs.build-environment }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       use-arc: ${{ needs.get-default-label-prefix.outputs.use-arc == 'true' }}
       python-version: "3.10"

--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -63,6 +63,7 @@ jobs:
       build-environment: ${{ needs.build.outputs.build-environment }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       # disable monitor in perf tests for more investigation
       disable-monitor: false
       monitor-log-interval: 15

--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -152,6 +152,7 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-deterministic_perf-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       # disable monitor in perf tests, next step is to enable it
       disable-monitor: false
@@ -177,6 +178,7 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true-deterministic_perf-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 1440
       # disable monitor in perf tests, next step is to enable it
       disable-monitor: false
@@ -204,6 +206,7 @@ jobs:
       dashboard-tag: training-${{ inputs.training || 'true' }}-inference-${{ inputs.inference || 'true' }}-default-${{ inputs.default || 'true' }}-dynamic-${{ inputs.dynamic || 'true' }}-cudagraphs-${{ inputs.cudagraphs || 'true' }}-cppwrapper-${{ inputs.cppwrapper || 'false' }}-aotinductor-${{ inputs.aotinductor || 'false' }}-maxautotune-${{ inputs.maxautotune || 'false' }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs || 'false' }}-deterministic_perf-${{ inputs.deterministic_perf || 'false' }}-batch_invariant_accuracy-${{ inputs.batch_invariant_accuracy || 'false' }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       # disable monitor in perf tests for more investigation
       disable-monitor: false

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -132,6 +132,7 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       disable-monitor: false
       monitor-log-interval: 15
@@ -154,6 +155,7 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 1440
       # disable monitor in perf tests, next step is to enable it
       disable-monitor: false
@@ -177,6 +179,7 @@ jobs:
       dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-default-${{ inputs.default }}-dynamic-${{ inputs.dynamic }}-cudagraphs-${{ inputs.cudagraphs }}-cppwrapper-${{ inputs.cppwrapper }}-aotinductor-${{ inputs.aotinductor }}-maxautotune-${{ inputs.maxautotune }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       disable-monitor: false
       monitor-log-interval: 15

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -66,6 +66,7 @@ jobs:
       build-environment: ${{ needs.inductor-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.inductor-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -99,6 +100,7 @@ jobs:
       build-environment: ${{ needs.inductor-halide-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-halide-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-halide-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.inductor-halide-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.12"
       compiler: gcc11
@@ -131,6 +133,7 @@ jobs:
       build-environment: ${{ needs.inductor-pallas-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-pallas-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-pallas-cpu-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.inductor-pallas-cpu-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.12"
       compiler: gcc11
@@ -163,6 +166,7 @@ jobs:
       build-environment: ${{ needs.inductor-triton-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-triton-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-triton-cpu-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.inductor-triton-cpu-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.12"
       compiler: gcc11
@@ -196,6 +200,7 @@ jobs:
       build-environment: ${{ needs.inductor-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-cpu-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.inductor-cpu-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -233,6 +238,7 @@ jobs:
       build-environment: linux-jammy-py${{ matrix.python-version }}-clang18
       docker-image: ${{ needs.get-label-type.outputs.use-arc == 'true' && 'ghcr.io/pytorch/' || '' }}ci-image:pytorch-linux-jammy-py${{ matrix.python-version }}-clang18
       test-matrix: ${{ needs.inductor-cpu-core-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.inductor-cpu-core-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "${{ matrix.python-version }}"
       compiler: clang18

--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -65,6 +65,7 @@ jobs:
       build-environment: ${{ needs.opmicrobenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.opmicrobenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.opmicrobenchmark-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.opmicrobenchmark-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -104,6 +105,7 @@ jobs:
       build-environment: ${{ needs.opmicrobenchmark-build-b200.outputs.build-environment }}
       docker-image: ${{ needs.opmicrobenchmark-build-b200.outputs.docker-image }}
       test-matrix: ${{ needs.opmicrobenchmark-build-b200.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.opmicrobenchmark-build-b200.outputs.test-matrix-osdc }}
       use-arc: true
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/operator_microbenchmark_compare.yml
+++ b/.github/workflows/operator_microbenchmark_compare.yml
@@ -75,6 +75,7 @@ jobs:
       build-environment: ${{ needs.build-cuda.outputs.build-environment }}
       docker-image: ${{ needs.build-cuda.outputs.docker-image }}
       test-matrix: ${{ needs.build-cuda.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.build-cuda.outputs.test-matrix-osdc }}
     secrets: inherit
 
   # ---- CUDA build for B200 (sm100) ----
@@ -112,6 +113,7 @@ jobs:
       build-environment: ${{ needs.build-b200.outputs.build-environment }}
       docker-image: ${{ needs.build-b200.outputs.docker-image }}
       test-matrix: ${{ needs.build-b200.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.build-b200.outputs.test-matrix-osdc }}
       use-arc: true
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -77,6 +77,7 @@ jobs:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11-sm86
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm86-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm86-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm86-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -112,6 +113,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: clang18
@@ -149,6 +151,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix-osdc }}
       sync-tag: asan-test
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"

--- a/.github/workflows/test-b200.yml
+++ b/.github/workflows/test-b200.yml
@@ -81,6 +81,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm100-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm100-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm100-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm100-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/test-h100.yml
+++ b/.github/workflows/test-h100.yml
@@ -66,6 +66,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -134,6 +134,7 @@ jobs:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -359,6 +360,7 @@ jobs:
       build-environment: ${{ needs.verify-cachebench-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.verify-cachebench-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.verify-cachebench-cpu-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.verify-cachebench-cpu-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -396,6 +398,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3-clang18-executorch-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3-clang18-executorch-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3-clang18-executorch-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-py3-clang18-executorch-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
     secrets: inherit
 
@@ -451,6 +454,7 @@ jobs:
       build-environment: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc13

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -54,6 +54,7 @@ jobs:
       build-environment: linux-jammy-py3.14t-clang18-tsan
       docker-image: ${{ needs.linux-jammy-py3_14t-clang18-tsan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_14t-clang18-tsan-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-py3_14t-clang18-tsan-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.14t"
       compiler: clang18


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/pull/183243, this is to be cleaned up once https://github.com/pytorch/pytorch/issues/183242 concludes

## Summary

Three changes that together let workflow runs (via `ciflow/*`) execute EC2 and OSDC test routes in parallel during the OSDC shadow-mode experiment.

### 1. `trunk.yml` plumbing

Mirror #183243's `pull.yml` change so the four `_linux-test.yml` callers forward the OSDC-remapped test matrix emitted by `_linux-build.yml`. Without this, `test-osdc` falls back to the EC2 test matrix and would schedule OSDC tests against non-`mt-` runner labels. Sites touched:

- `linux-jammy-cuda13_0-py3_10-gcc11-test`
- `verify-cachebench-cpu-test`
- `linux-jammy-py3-clang18-executorch-test`
- `linux-jammy-aarch64-py3_10-gcc13-test`

### 2. Widened shadow-mode guard in `_linux-build.yml` / `_linux-test.yml`

The guard from #183243 was `github.event_name == 'pull_request'`. That excludes trunk runs, which are `push` events. Add `startsWith(github.ref, 'refs/tags/ciflow/')` so ciflow tag pushes also dual-route. Direct pushes to `main` / `release/*` / `landchecks/*` use `refs/heads/...` and are not matched, so they keep the original single-route behavior (use-arc selects one).

### 3. Extend `test-matrix-osdc` plumbing to the remaining OSDC-migrated workflows

Apply the same `test-matrix-osdc: ${{ needs.<build>.outputs.test-matrix-osdc }}` pattern to every `_linux-test.yml` caller in the rest of the OSDC-migrated workflows so `test-osdc` routes to the OSDC-remapped labels for those flows too. 13 files, 27 sites: `attention_op_microbenchmark.yml`, `h100-symm-mem.yml`, `inductor-micro-benchmark.yml`, `inductor-perf-compare.yml`, `inductor-perf-test-nightly.yml`, `inductor-perf-test-nightly-h100.yml`, `inductor-unittest.yml`, `operator_microbenchmark.yml`, `operator_microbenchmark_compare.yml`, `slow.yml`, `test-b200.yml`, `test-h100.yml`, `tsan.yml`.

`pull.yml` is already plumbed (#183243). `nightly.yml` migrates only the build side (no `_linux-test.yml` caller). The ROCm test job in the operator microbenchmark workflows uses `_rocm-test.yml` and is left alone.

### Where each event lands now

| Event | `use-arc=true` | `use-arc=false` |
|---|---|---|
| pull_request | EC2 + OSDC (unchanged) | EC2 only |
| push to ciflow/* tag | **EC2 + OSDC (new)** | EC2 only |
| push to main/release/landchecks | OSDC only | EC2 only |
| schedule / workflow_dispatch | OSDC only | EC2 only |

Part of #183242. To be reverted once that experiment concludes.

## Test plan

- [ ] Push a ciflow/trunk tag and confirm both the EC2 `build`/`test` jobs and the `build-osdc`/`test-osdc` jobs execute (not `skipped`).
- [ ] Push a ciflow tag for one of the newly-plumbed workflows (e.g. `ciflow/slow/*` or `ciflow/inductor/*`) and confirm `test-osdc` runs against `mt-`-prefixed runner labels.
- [ ] Confirm a direct merge to `main` does **not** dual-route (only one of EC2/OSDC runs based on `use-arc`).
- [ ] Confirm scheduled trunk runs and `workflow_dispatch` runs are unchanged.

Authored by Claude.