### PR TITLE
Change pytorch_sphinx_theme to GitHub dependency

### DIFF
--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -2,7 +2,8 @@ sphinx==7.2.6
 #Description: This is used to generate PyTorch docs
 #Pinned versions: 7.2.6
 
-pytorch_sphinx_theme2==0.4.9
+git+https://github.com/pytorch/pytorch_sphinx_theme.git@2a7ed21e74b26fdd8ac23f6fa0c34547f8b1199f#egg=pytorch_sphinx_theme2
+#pytorch_sphinx_theme2==0.4.9
 #Description: This is needed to generate PyTorch docs
 #Pinned versions: 0.4.9
 


### PR DESCRIPTION
Updated pytorch_sphinx_theme dependency to use a GitHub URL.