### PR TITLE
[Inductor][Bucketing] Isolate bucketing traces from ambient unbacked symbols

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -25,6 +25,7 @@ from torch._inductor.comms import (
 )
 from torch._inductor.compile_fx import compile_fx as inductor_compile_fx
 from torch._inductor.fx_passes.bucketing import (
+    _trace as bucketing_trace,
     is_all_gather_into_tensor,
     is_all_reduce_tensor,
     is_all_to_all_tensor,
@@ -37,8 +38,10 @@ from torch._inductor.scheduler import (
     get_estimate_runtime_cache_key_from_snode,
 )
 from torch._inductor.utils import fresh_inductor_cache, run_and_get_triton_code
+from torch._subclasses import FakeTensorMode
 from torch.distributed.distributed_c10d import GroupMember
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_distributed import (
     _dynamo_dist_per_rank_init,
@@ -58,6 +61,22 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.utils._python_dispatch import TorchDispatchMode
+
+
+class TestBucketingTrace(torch._dynamo.test_case.TestCase):
+    def test_trace_ignores_ambient_pending_unbacked_symbols(self):
+        fake_mode = FakeTensorMode(
+            allow_non_fake_inputs=True,
+            shape_env=ShapeEnv(),
+        )
+        x = fake_mode.from_tensor(torch.randn(2, 2), static_shapes=True)
+        ambient = fake_mode.shape_env.create_unbacked_symint().node.expr
+        self.assertIn(ambient, fake_mode.shape_env.pending_fresh_unbacked_symbols)
+
+        gm = bucketing_trace(lambda x: x + 1, (x,))
+
+        self.assertIn(ambient, fake_mode.shape_env.pending_fresh_unbacked_symbols)
+        FileCheck().check("aten.add").run(gm.code)
 
 
 @requires_accelerator_dist_backend(["nccl", "xccl"])

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -952,14 +952,29 @@ def _trace(fn, inps) -> torch.fx.GraphModule:  # type: ignore[no-untyped-def]
     with dynamo_timed("fx.bucketing._trace", log_pt2_compile_event=True):
         fake_mode = detect_fake_mode(inps)
         assert fake_mode is not None
-        with fake_mode, enable_python_dispatcher():
-            out = make_fx(fn)(*inps)
-            for node in out.graph.find_nodes(
-                op="call_function", target=torch.ops.aten.detach.default
-            ):
-                node.replace_all_uses_with(node.args[0])
-                out.graph.erase_node(node)
-            return out
+        shape_env = fake_mode.shape_env
+        pending_unbacked = None
+        ignorable_unbacked = None
+        if shape_env is not None:
+            pending_unbacked = list(shape_env.pending_fresh_unbacked_symbols)
+            ignorable_unbacked = list(shape_env.ignorable_fresh_unbacked_symbols)
+            shape_env.pending_fresh_unbacked_symbols.clear()
+            shape_env.ignorable_fresh_unbacked_symbols.clear()
+        try:
+            with fake_mode, enable_python_dispatcher():
+                out = make_fx(fn)(*inps)
+        finally:
+            if shape_env is not None:
+                assert pending_unbacked is not None
+                assert ignorable_unbacked is not None
+                shape_env.pending_fresh_unbacked_symbols[:] = pending_unbacked
+                shape_env.ignorable_fresh_unbacked_symbols[:] = ignorable_unbacked
+        for node in out.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.detach.default
+        ):
+            node.replace_all_uses_with(node.args[0])
+            out.graph.erase_node(node)
+        return out
 
 
 def _insert_fn_trace_before_node(  # type: ignore[no-untyped-def]


### PR DESCRIPTION
Stacked PRs:
 * #183545
 * #183544
 * __->__#183495


--- --- ---

### [Inductor][Bucketing] Isolate bucketing traces from ambient unbacked symbols

Fixes https://github.com/pytorch/pytorch/issues/183679

Bucketing traces small collective rewrite helpers with make_fx while reusing the FakeTensorMode from the surrounding graph. When that shared ShapeEnv already has pending fresh unbacked symbols from an outer dynamic-shape trace, make_fx's unbacked binding validation can try to account for symbols that are unrelated to the bucket inputs and outputs.

This shows up when a static bucket trace runs after a graph trace that introduced unbacked activation symbols: the bucket trace itself only sees static parameter or gradient tensors, but compute_unbacked_bindings observes the ShapeEnv's global pending_fresh_unbacked_symbols and errors on ambient symbols it cannot bind.

Snapshot and clear pending/ignorable fresh unbacked symbols around the nested bucketing make_fx trace, then restore the ambient state afterward. This keeps bucketing responsible only for symbols produced by its own trace while preserving the outer ShapeEnv bookkeeping for the caller.

Add a regression that creates an ambient pending unbacked symbol in a FakeTensorMode, traces a static bucketing helper, and verifies the ambient symbol remains pending after the trace.

Test Plan:
python test/distributed/test_inductor_collectives.py -k test_trace_ignores_ambient_pending_unbacked_symbols -v
lintrunner --config=.lintrunner.toml torch/_inductor/fx_passes/bucketing.py test/distributed/test_inductor_collectives.py


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo