### PR TITLE
[PyTorch][Pinned Memory] Fix stuck event blocking in CachingHostAllocator

### DIFF
--- a/aten/src/ATen/core/CachingHostAllocator.h
+++ b/aten/src/ATen/core/CachingHostAllocator.h
@@ -632,12 +632,12 @@ struct CachingHostAllocatorImpl {
   }
 
   virtual void process_events(BlockPool& pool) {
-    // process all events in the given pool until the last unready event.
+    // process all events in the given pool, skipping any that are not yet ready.
     process_events_for_specific_size(-1, pool);
   }
 
-  // If size is -1, process all events from backwards until the last unready
-  // event. Otherwise, process events for a specific size and on first ready block
+  // If size is -1, process all events, skipping any that are not yet ready.
+  // Otherwise, process events for a specific size and on first ready block
   // is found, add it to the free list and return.
   virtual void process_events_for_specific_size(int64_t size, BlockPool& pool) {
     size_t event_count = 0;
@@ -681,6 +681,12 @@ struct CachingHostAllocatorImpl {
           }
           continue;
         }
+      } else if (event_count++ > max_events) {
+        {
+          std::lock_guard<std::mutex> g(pool.events_mutex_);
+          pool.events_.push_front(std::move(*processed));
+        }
+        return;
       }
 
       // otherwise, query the event
@@ -688,17 +694,14 @@ struct CachingHostAllocatorImpl {
         // now, see if we can handle this element
         auto& event = processed->first;
         if (!query_event(event)) {
-          // push the event onto the back if it's not ready.
+          // Event not ready yet -- put it back and continue processing
+          // remaining events. A single stuck event should not block
+          // returning other completed blocks to the free list.
           {
             std::lock_guard<std::mutex> g(pool.events_mutex_);
-            if (size == -1) {
-              pool.events_.push_back(std::move(*processed));
-              return;
-            } else {
-              pool.events_.push_front(std::move(*processed));
-              continue;
-            }
+            pool.events_.push_front(std::move(*processed));
           }
+          continue;
         }
       }
 


### PR DESCRIPTION
Summary:
CONTEXT: In CachingHostAllocator, the process_events() function stops processing the entire event queue when it encounters a single incomplete CUDA event. This means one stuck or slow event can block ALL other completed blocks from being returned to the free list, causing massive pinned memory accumulation (90+ GB observed in production on GH200 hosts).

WHAT: Change the size==-1 (general event processing) path to skip incomplete events and continue processing remaining events, matching the existing behavior of the size-specific path. A single stuck event no longer blocks returning other completed blocks to the free list. The skipped event stays in the queue and gets re-checked on the next process_events() call.

This is safe because block reuse is guarded by event_count_ reaching zero per-block, not by queue ordering. The loop is bounded by max_events to prevent infinite scanning.

Test Plan:
buck build mode/opt //caffe2/c10/cuda:cuda
buck build mode/opt //caffe2:_ATen-cu

Differential Revision: D104932005


