### PR TITLE
dynamo: don't drop stream locals across graph breaks

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -2270,6 +2270,105 @@ class <lambda>(torch.nn.Module):
         self.assertEqual(actual_default, default_s.cuda_stream)
 
 
+class TestStreamsAcrossGraphBreak(torch._dynamo.test_case.TestCase):
+    """A ``Stream`` local that is bound before a graph break and reused
+    afterwards (e.g. ``cur = torch.cuda.current_stream()`` before, then
+    ``cur.wait_event(evt)`` after) must survive the break.  Dynamo's
+    graph-break recovery code in ``symbolic_convert.py`` iterates over
+    ``locals_ctx_args`` and calls ``ctx.reconstruct_type(cg)`` on every
+    local that is a :class:`ContextWrappingVariable`.
+    :class:`StreamVariable` inherits from
+    :class:`StreamContextVariable` (the ``with torch.cuda.stream(s):``
+    context manager), which inherits from
+    :class:`FxTracebackAnnotateVariable`; the latter's
+    ``reconstruct_type`` raises ``Unsupported`` ("torch.fx.traceback.annotate
+    escaped from compiled region"), turning the otherwise-resumable
+    break into an ungraceful one.  The result is that the post-break
+    portion of the function is dropped from the captured graph and
+    silently falls back to eager -- including any
+    ``Stream.wait_event(event)`` calls that were supposed to be in the
+    graph.  The downstream effect is the same as the
+    proxy-mode-emission bug: missing cross-stream synchronisation,
+    potential ``cudaErrorStreamCaptureInvalidated`` under CUDA Graph
+    capture.
+    """
+
+    @requires_cuda
+    def test_stream_local_reused_after_graph_break(self) -> None:
+        from torch._functorch.aot_autograd import aot_module_simplified
+
+        captured: list[torch.fx.GraphModule] = []
+
+        def _fw_compiler(gm, example_inputs):
+            del example_inputs
+            captured.append(gm)
+            return gm
+
+        def _capturing_backend(gm, example_inputs):
+            return aot_module_simplified(gm, example_inputs, fw_compiler=_fw_compiler)
+
+        def _fn(x):
+            evt = torch.cuda.Event()
+            cur = torch.cuda.current_stream()
+            evt.record(cur)
+            torch._dynamo.graph_break()
+            # `cur` is reused across the break — this is the trigger.
+            cur.wait_event(evt)
+            # pyrefly: ignore [missing-attribute]
+            return torch.sigmoid(x)
+
+        torch._dynamo.reset()
+        compiled = torch.compile(_fn, backend=_capturing_backend, fullgraph=False)
+        # pyrefly: ignore [missing-attribute]
+        compiled(torch.randn(8, device="cuda"))
+        torch.cuda.synchronize()
+
+        record_op = torch.ops.streams.record_event.default
+        wait_op = torch.ops.streams.wait_event.default
+
+        # Count record_event nodes across all captured forward graphs,
+        # including any nested under control_deps subgraphs.
+        def _count_op(graph_module, target):
+            total = 0
+            for node in graph_module.graph.nodes:
+                if node.op == "call_function" and node.target is target:
+                    total += 1
+            for _name, sub in graph_module.named_children():
+                if isinstance(sub, torch.fx.GraphModule):
+                    total += _count_op(sub, target)
+            return total
+
+        total_record = sum(_count_op(gm, record_op) for gm in captured)
+        total_wait = sum(_count_op(gm, wait_op) for gm in captured)
+        total_sigmoid = sum(
+            sum(
+                1
+                for node in gm.graph.nodes
+                if node.op == "call_function"
+                and node.target is torch.ops.aten.sigmoid.default
+            )
+            for gm in captured
+        )
+
+        graphs = "\n\n".join(str(gm.graph) for gm in captured)
+        self.assertEqual(
+            total_record,
+            1,
+            f"expected 1 streams.record_event in captured graphs:\n{graphs}",
+        )
+        self.assertEqual(
+            total_wait,
+            1,
+            f"expected 1 streams.wait_event in captured graphs:\n{graphs}",
+        )
+        self.assertEqual(
+            total_sigmoid,
+            1,
+            f"expected 1 aten.sigmoid in captured graphs (post-break body "
+            f"was dropped):\n{graphs}",
+        )
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1856,7 +1856,10 @@ class OutputGraph(OutputGraphCommon):
                         "variable should never be NULL in Python < 3.12"
                     )
             meta.locals_names[k] = len(meta.locals_names)
-            if isinstance(v, ContextWrappingVariable):
+            if (
+                isinstance(v, ContextWrappingVariable)
+                and v.is_active_ctx_manager_local()
+            ):
                 target_values = (
                     () if v.target_values is None else tuple(v.target_values)
                 )

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -75,6 +75,21 @@ class ContextWrappingVariable(VariableTracker):
         self.target_values = target_values
         self.initial_values = initial_values
 
+    def is_active_ctx_manager_local(self) -> bool:
+        """Whether dynamo's graph-break recovery should track this
+        variable as an inactive-context-manager local (i.e. emit code
+        that replaces the local with the ctx-manager class so the
+        resume function can re-decorate / re-enter it).
+
+        Subclasses that are syntactically a :class:`ContextWrappingVariable`
+        but semantically just a value (e.g. :class:`StreamVariable` --
+        a stream object that *can* be used in a ``with`` block but
+        usually isn't) should override this to return ``False`` so the
+        local survives across breaks via plain value reconstruction
+        instead.
+        """
+        return True
+
     def enter(self, tx: "InstructionTranslator") -> VariableTracker:
         if hasattr(self, "_call_func"):
             self._call_func(tx, self.target_values)

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 from collections.abc import Callable
 from typing import Any, Optional
 
@@ -20,7 +21,7 @@ from ..graph_bytecode_inputs import (
 from ..source import CurrentStreamSource
 from .base import VariableTracker
 from .constant import ConstantVariable
-from .ctx_manager import FxTracebackAnnotateVariable
+from .ctx_manager import ContextWrappingVariable
 from .lazy import LazyVariableTracker
 
 
@@ -319,7 +320,7 @@ class SymbolicStreamState:
         return id(stream.value)
 
 
-class StreamContextVariable(FxTracebackAnnotateVariable):
+class StreamContextVariable(ContextWrappingVariable):
     """This represents torch.cuda.StreamContext"""
 
     @staticmethod
@@ -347,7 +348,19 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
         # to stream, from stream is the order of the arguments
         # we are entering the target, and leaving the initial stream
         tx.symbolic_stream_state.enter_stream(self.get_stream())
-        return super().enter(tx)
+        # Run torch.fx.traceback.annotate + preserve_node_meta in eager so
+        # the captured FX nodes pick up ``meta["custom"]["stream"] = idx``
+        # for inductor's stream-affinity scheduling.  This used to come from
+        # inheriting :class:`FxTracebackAnnotateVariable`, but that dragged
+        # its ``reconstruct_type`` (which raises ``Unsupported``) into the
+        # MRO of :class:`StreamVariable` and turned otherwise-graceful
+        # graph breaks ungraceful.  Inlining the annotate setup here keeps
+        # the same runtime behaviour without the inheritance baggage.
+        stack = contextlib.ExitStack()
+        stack.enter_context(torch.fx.traceback.annotate(self.target_values))
+        stack.enter_context(torch.fx.traceback.preserve_node_meta())
+        self.set_cleanup_hook(tx, lambda: stack.close())
+        return ConstantVariable.create(None)
 
     def exit(
         self, tx: "InstructionTranslator", *args: VariableTracker
@@ -355,13 +368,23 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
         # to stream, from stream is the order of the arguments
         # we are leaving the target, and entering the initial stream
         tx.symbolic_stream_state.exit_stream()
-        return super().exit(tx, *args)
+        # cleanup_assert() runs the cleanup hook installed in enter(),
+        # which closes the ExitStack and tears down the annotate +
+        # preserve_node_meta contexts in LIFO order.
+        self.cleanup_assert()
+        return ConstantVariable.create(None)
 
     def python_type(self) -> type:
         return torch.cuda.StreamContext
 
     def supports_graph_breaks(self) -> bool:
         return True
+
+    def module_name(self) -> str:
+        return "torch.cuda"
+
+    def fn_name(self) -> str:
+        return "stream"
 
     def get_stream(self) -> "StreamVariable":
         if not self.stream:

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -558,6 +558,19 @@ class StreamVariable(StreamContextVariable):
             name = codegen.tx.output.install_global_by_id(prefix, self.value)
             codegen.append_output(codegen.create_load_global(name, add=True))
 
+    def is_active_ctx_manager_local(self) -> bool:
+        # A plain ``cur = torch.cuda.current_stream()`` local is a
+        # stream value, not a context manager, even though
+        # :class:`StreamVariable` inherits from
+        # :class:`StreamContextVariable` (which models the
+        # ``with torch.cuda.stream(s):`` ctx manager).  Tell dynamo's
+        # graph-break recovery to keep this local as an ordinary value
+        # rather than try to ``reconstruct_type`` it -- otherwise it
+        # lands in :meth:`FxTracebackAnnotateVariable.reconstruct_type`
+        # which bails ungracefully with "torch.fx.traceback.annotate
+        # escaped from compiled region", dropping the post-break code.
+        return False
+
     def get_stream(self) -> "StreamVariable":
         return self
 


### PR DESCRIPTION
When a ``Stream`` local is bound before a graph break and reused after (e.g. ``cur = torch.cuda.current_stream(); evt.record(cur); ...; torch._dynamo.graph_break(); cur.wait_event(evt)``), dynamo silently drops the post-break body from the captured graph and falls back to eager for it -- including the ``Stream.wait_event(event)`` call.  The intended cross-stream synchronisation never lands in the compiled artifact.

Root cause: dynamo's graph-break recovery in
``output_graph.py`` walks every local that is a
:class:`ContextWrappingVariable` and adds it to
``locals_ctx_args``.  Later,
``symbolic_convert.create_resume`` calls
``ctx.reconstruct_type(cg)`` on each entry to emit bytecode that "replaces the local with the ctx-manager class" so the resume frame can re-enter it.  :class:`StreamVariable` inherits from :class:`StreamContextVariable` (the
``with torch.cuda.stream(s):`` ctx manager) which inherits from :class:`FxTracebackAnnotateVariable`, whose
``reconstruct_type`` unconditionally raises ``Unsupported``:

    torch.fx.traceback.annotate escaped from compiled region

The graph break turns ungraceful, the resume function is abandoned, and the post-break code is skipped.

The classification is wrong: a plain stream local is a value, not a context manager.  It only behaves like one inside a ``with torch.cuda.stream(s):`` block, and that case is handled separately by
:class:`StreamContextVariable.enter` / ``exit``.  Adding it to ``locals_ctx_args`` and trying to reconstruct it as a ctx-manager class is incorrect even when
``reconstruct_type`` happens not to raise -- the resume function should just see the stream object.

Add ``is_active_ctx_manager_local`` to
:class:`ContextWrappingVariable` (default ``True``) and override it to ``False`` on :class:`StreamVariable`.  The ``locals_ctx_args`` population filter in ``output_graph.py`` consults the predicate, so stream-typed locals are not added.  Their values survive across a graph break via the ordinary local-reconstruction path.

Tested by
``test/dynamo/test_streams.py::TestStreamsAcrossGraphBreak::test_stream_local_reused_after_graph_break``: compile a function that does ``record(cur)``,
``graph_break()``, ``cur.wait_event(evt)``, ``sigmoid(x)`` and assert the captured graphs together contain one ``streams.record_event``, one ``streams.wait_event``, and one ``aten.sigmoid``.  Without the fix the post-break ``wait_event`` and ``sigmoid`` are absent.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos