### PR TITLE
[distributed] Add fused scaled_mm_v2 + reduce_scatter for NVFP4 support

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1063,6 +1063,194 @@ class AsyncTPTest(MultiProcContinuousTest):
             )
         self.assertEqual(outputs[0], outputs[1])
 
+    @skip_if_rocm_multiprocess
+    @skip_if_lt_x_gpu(2)
+    @skipUnless(SM89OrLater, "Requires compute capability >= 8.9")
+    @parametrize("scatter_dim", [0, 1])
+    @parametrize("scaling", ["tensorwise", "rowwise"])
+    @parametrize("reduce_op", ["avg", "sum"])
+    def test_fused_scaled_matmul_reduce_scatter_v2(
+        self, scatter_dim: int, scaling: str, reduce_op: str
+    ) -> None:
+        self._init_process()
+
+        from torch.nn.functional import ScalingType, SwizzleType
+
+        BATCH = 8
+        M = 64
+        N = 16
+        K = 32
+        group = dist.group.WORLD
+        rank = self.rank
+
+        torch.manual_seed(42 + rank)
+        A = torch.rand(BATCH, M, K, device="cuda").to(e4m3_type)
+        B = torch.rand(N, K, device="cuda").to(e4m3_type).T
+
+        if scaling == "rowwise":
+            scale_a = [torch.full((BATCH, M, 1), 0.1, device="cuda")]
+            scale_b = [torch.full((1, N), 0.1, device="cuda")]
+            recipe_a = [ScalingType.RowWise.value]
+            recipe_b = [ScalingType.RowWise.value]
+        else:
+            scale_a = [torch.tensor(0.1, device="cuda")]
+            scale_b = [torch.tensor(0.1, device="cuda")]
+            recipe_a = [ScalingType.TensorWise.value]
+            recipe_b = [ScalingType.TensorWise.value]
+
+        swizzle_a = [SwizzleType.NO_SWIZZLE.value]
+        swizzle_b = [SwizzleType.NO_SWIZZLE.value]
+
+        output_shape = [*A.shape[:-1], B.shape[1]]
+
+        outputs = []
+        for context in test_contexts:
+            with context():
+                outputs.append(
+                    torch.ops.symm_mem.fused_scaled_matmul_reduce_scatter_v2(
+                        A,
+                        B,
+                        scale_a,
+                        recipe_a,
+                        swizzle_a,
+                        scale_b,
+                        recipe_b,
+                        swizzle_b,
+                        reduce_op,
+                        scatter_dim,
+                        scatter_dim,
+                        group.group_name,
+                        output_shape,
+                        out_dtype=torch.bfloat16,
+                    )
+                )
+
+        if not (outputs[0].stride() == outputs[1].stride()):
+            raise AssertionError(
+                f"Expected strides to match: {outputs[0].stride()} vs {outputs[1].stride()}"
+            )
+        self.assertEqual(outputs[0], outputs[1])
+
+    @skip_if_rocm_multiprocess
+    @skip_if_lt_x_gpu(2)
+    @skipUnless(SM100OrLater, "BlockWise1x16 requires SM100+")
+    @parametrize("scatter_dim", [0, 1])
+    def test_fused_scaled_matmul_reduce_scatter_v2_blockwise(
+        self, scatter_dim: int
+    ) -> None:
+        self._init_process()
+
+        from torch.nn.functional import ScalingType, SwizzleType
+
+        BATCH = 8
+        M = 256
+        N = 16
+        K = 32
+        group = dist.group.WORLD
+        rank = self.rank
+
+        torch.manual_seed(42 + rank)
+        A = torch.rand(BATCH, M, K, device="cuda").to(e4m3_type)
+        B = torch.rand(N, K, device="cuda").to(e4m3_type).T
+
+        M_flat = BATCH * M
+        scale_a = [torch.rand(M_flat, K // 16, device="cuda") * 0.2 + 0.01]
+        scale_b = [torch.rand(1, N, device="cuda") * 0.2 + 0.01]
+        recipe_a = [ScalingType.BlockWise1x16.value]
+        recipe_b = [ScalingType.TensorWise.value]
+        swizzle_a = [SwizzleType.SWIZZLE_32_4_4.value]
+        swizzle_b = [SwizzleType.NO_SWIZZLE.value]
+
+        output_shape = [*A.shape[:-1], B.shape[1]]
+
+        outputs = []
+        for context in test_contexts:
+            with context():
+                outputs.append(
+                    torch.ops.symm_mem.fused_scaled_matmul_reduce_scatter_v2(
+                        A,
+                        B,
+                        scale_a,
+                        recipe_a,
+                        swizzle_a,
+                        scale_b,
+                        recipe_b,
+                        swizzle_b,
+                        "avg",
+                        scatter_dim,
+                        scatter_dim,
+                        group.group_name,
+                        output_shape,
+                        out_dtype=torch.bfloat16,
+                    )
+                )
+
+        if not (outputs[0].stride() == outputs[1].stride()):
+            raise AssertionError(
+                f"Expected strides to match: {outputs[0].stride()} vs {outputs[1].stride()}"
+            )
+        self.assertEqual(outputs[0], outputs[1])
+
+    @skip_if_rocm_multiprocess
+    @skip_if_lt_x_gpu(2)
+    @skipUnless(SM89OrLater, "Requires compute capability >= 8.9")
+    def test_fused_scaled_matmul_reduce_scatter_v2_errors(self) -> None:
+        self._init_process()
+
+        from torch.nn.functional import ScalingType, SwizzleType
+
+        BATCH = 8
+        M = 64
+        N = 16
+        K = 32
+        group = dist.group.WORLD
+
+        A = torch.rand(BATCH, M, K, device="cuda").to(e4m3_type)
+        B = torch.rand(N, K, device="cuda").to(e4m3_type).T
+        output_shape = [*A.shape[:-1], B.shape[1]]
+
+        with _test_mode():
+            self.assertRaisesRegex(
+                ValueError,
+                "Non-default contraction_dim is not supported",
+                torch.ops.symm_mem.fused_scaled_matmul_reduce_scatter_v2,
+                A,
+                B,
+                [torch.tensor(0.1, device="cuda")],
+                [ScalingType.TensorWise.value],
+                [SwizzleType.NO_SWIZZLE.value],
+                [torch.tensor(0.1, device="cuda")],
+                [ScalingType.TensorWise.value],
+                [SwizzleType.NO_SWIZZLE.value],
+                "avg",
+                0,
+                0,
+                group.group_name,
+                output_shape,
+                None,
+                torch.bfloat16,
+                [0, 1],
+            )
+
+            self.assertRaisesRegex(
+                NotImplementedError,
+                "BlockWise scale sharding for recipe",
+                torch.ops.symm_mem.fused_scaled_matmul_reduce_scatter_v2,
+                A,
+                B,
+                [torch.rand(M * BATCH // 128, K // 128, device="cuda")],
+                [ScalingType.BlockWise128x128.value],
+                [SwizzleType.NO_SWIZZLE.value],
+                [torch.tensor(0.1, device="cuda")],
+                [ScalingType.TensorWise.value],
+                [SwizzleType.NO_SWIZZLE.value],
+                "avg",
+                0,
+                0,
+                group.group_name,
+                output_shape,
+            )
+
     @skipIf(
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -15,6 +15,9 @@ from typing_extensions import deprecated
 import torch
 import torch.distributed._functional_collectives as funcol
 import torch.distributed.distributed_c10d as c10d
+from torch._C import (
+    _ScalingType as ScalingType,  # pyrefly: ignore [missing-module-attribute]
+)
 from torch._C._autograd import DeviceType
 from torch._C._distributed_c10d import _SymmetricMemory, Work as _Work
 from torch._prims_common import make_contiguous_strides_for
@@ -471,6 +474,19 @@ lib.define(
     "Tensor? bias = None, "
     "Tensor? result_scale = None, "
     "ScalarType? out_dtype = None, "
+    "bool use_fast_accum = False) -> Tensor",
+    tags=[torch._C.Tag.needs_fixed_stride_order],
+)
+lib.define(
+    "fused_scaled_matmul_reduce_scatter_v2("
+    "Tensor A, Tensor B, "
+    "Tensor[] scale_a, int[] recipe_a, int[] swizzle_a, "
+    "Tensor[] scale_b, int[] recipe_b, int[] swizzle_b, "
+    "str reduce_op, int orig_scatter_dim, int scatter_dim_after_maybe_reshape, "
+    "str group_name, SymInt[]? output_shape, "
+    "Tensor? bias = None, "
+    "ScalarType? out_dtype = None, "
+    "int[] contraction_dim = [], "
     "bool use_fast_accum = False) -> Tensor",
     tags=[torch._C.Tag.needs_fixed_stride_order],
 )
@@ -1454,11 +1470,80 @@ def _fused_scaled_matmul_reduce_scatter_fallback(
     res = funcol.reduce_scatter_single(
         C,
         reduce_op,
-        orig_scatter_dim,  # need original scatter dim for 3D+ output tensor here
+        orig_scatter_dim,
         group_name,
     )
     res = funcol.wait_tensor(res)
     return res
+
+
+def _pipelined_scaled_matmul_reduce_scatter(
+    A_with_scatter_dim_0: torch.Tensor,
+    A_2D_with_scatter_dim_0: torch.Tensor,
+    B: torch.Tensor,
+    chunk_producer: Callable[[int, torch.Tensor], None],
+    group: c10d.ProcessGroup,
+    group_name: c10d.GroupName,
+    out_dtype: torch.dtype | None,
+    reduce_op: str,
+    orig_scatter_dim: int,
+    scatter_dim_after_maybe_reshape: int,
+    output_shape: list[int],
+) -> torch.Tensor:
+    if reduce_op == "sum":
+        reduce_fn = partial(torch.sum, dim=0)
+    elif reduce_op == "avg":
+        reduce_fn = partial(torch.mean, dim=0)
+    else:
+        raise ValueError("reduce_op must be sum or avg")
+
+    # Stacked partials will be the 2D outputs of the pipelined scaled mm, and will
+    # have the shape (A_2D_with_scatter_dim_0.shape[0], B.shape[1]) to align with
+    # the formula: (a*b,c) @ (c,d) = (a*b,d)
+    stacked_partials = A_with_scatter_dim_0.new_empty(
+        A_2D_with_scatter_dim_0.shape[0],
+        B.shape[1],
+        dtype=out_dtype or A_with_scatter_dim_0.dtype,
+    )
+
+    _pipelined_produce_and_all2all(
+        chunk_producer,
+        stacked_partials,
+        group_name,
+    )
+
+    # Transform the *unreduced* stacked 2D partial mm outputs to an *unreduced*
+    # 3D+ output, then reduce-scatter. The *unreduced* 3D+ tensor has dim 0 =
+    # `group_size`, as we have `group_size` instances of stacked partial outputs.
+    # The next dims are A's leading dims (sharded along the original scatter dim).
+    stacked_partials_3D_leading_dims = [group.size()] + list(
+        # Use A from after the dim swap 0<=>scatter_dim, but before the flatten,
+        # to get the leading dims of the 3D+ view of stacked partials.
+        A_with_scatter_dim_0.shape[:-1]
+    )
+
+    # The `group_size` leading dim has been prepended. We need to divide the
+    # sharding/scatter dim by the group size. If the original scatter dim was 0,
+    # then it is now dim 1 since the new `group_size` dim was prepended.
+    stacked_partial_scatter_dim = orig_scatter_dim if orig_scatter_dim > 0 else 1
+    stacked_partials_3D_leading_dims[stacked_partial_scatter_dim] //= group.size()
+
+    # Ensures that the transpose and reduction produce contiguous result
+    # in a single reduction kernel.
+    reduced_out = reduce_fn(
+        # View 2D stacked partials as 3D+ tensor of shape (`group_size`, ...)
+        stacked_partials.view(*stacked_partials_3D_leading_dims, -1)
+        # We originally swapped 0<=>scatter_dim_after_maybe_reshape. Now after
+        # prepending the `group_size` dim, to undo this original swap, we
+        # must swap 1<=>scatter_dim_after_maybe_reshape+1.
+        .movedim(1, scatter_dim_after_maybe_reshape + 1),
+        # Reduce along the `group_size` dim (0).
+        dim=0,
+    )
+
+    scattered_shape = list(output_shape)
+    scattered_shape[orig_scatter_dim] //= group.size()
+    return reduced_out.view(*scattered_shape)
 
 
 def _fused_scaled_matmul_reduce_scatter_impl(
@@ -1485,22 +1570,14 @@ def _fused_scaled_matmul_reduce_scatter_impl(
         raise ValueError("Invalid scatter dim for 3D+ output tensor")
     if B.dim() != 2:
         raise ValueError("B must be a matrix")
-    if reduce_op == "sum":
-        reduce_fn = partial(torch.sum, dim=0)
-    elif reduce_op == "avg":
-        reduce_fn = partial(torch.mean, dim=0)
-    else:
-        raise ValueError("reduce_op must be sum or avg")
 
     group = c10d._resolve_process_group(group_name)
 
     # Move scatter to first dim, then shard the tensor along the first dim, so the chunk producer
     # can perform matmuls along the first dim.
     A_with_scatter_dim_0 = A.movedim(scatter_dim_after_maybe_reshape, 0)
-
     # To handle case where A is 3D+, reshape to 2D to prepare for mm which requires 2D inputs.
     A_2D_with_scatter_dim_0 = A_with_scatter_dim_0.flatten(0, -2)
-
     # Partition A along the first dim to prepare for sharding across TP process group.
     A_shards = A_2D_with_scatter_dim_0.chunk(group.size())
 
@@ -1537,61 +1614,315 @@ def _fused_scaled_matmul_reduce_scatter_impl(
     else:
         raise ValueError("A_scale cannot be none for scaled_mm")
 
-    # Computing block-wise matmul along the first dim of A
     def chunk_producer(rank: int, out: torch.Tensor) -> None:
         mm_out_op(A_shards[rank], B, scale_a=A_scale_shards[rank], **kwargs, out=out)
 
-    # Stacked partials will be the 2D outputs of the pipelined scaled mm, and will
-    # have the shape (A_with_scatter_dim_0_tensor.shape[0], B.shape[1]) to align with the formula:
-    # (a*b,c) @ (c,d) = (a*b,d)
-    stacked_partials = A_with_scatter_dim_0.new_empty(
-        A_2D_with_scatter_dim_0.shape[0], B.shape[1], dtype=out_dtype or A.dtype
+    return _pipelined_scaled_matmul_reduce_scatter(
+        A_with_scatter_dim_0,
+        A_2D_with_scatter_dim_0,
+        B,
+        chunk_producer,
+        group,
+        group_name,
+        out_dtype,
+        reduce_op,
+        orig_scatter_dim,
+        scatter_dim_after_maybe_reshape,
+        output_shape,
     )
 
-    # Execute the pipelined mm/scaled_mm.
-    _pipelined_produce_and_all2all(
-        chunk_producer,
-        stacked_partials,
+
+def _shard_v2_scales_for_reduce_scatter(
+    scale_list: list[torch.Tensor],
+    recipe_list: list[int],
+    M: int,
+    group_size: int,
+) -> list[list[torch.Tensor]]:
+    """Shard a list of v2 scale tensors along the M dimension for reduce-scatter.
+
+    Each scale tensor is sharded differently depending on its scaling recipe:
+    - TensorWise: replicated to all shards
+    - RowWise: sharded along dim 0
+    - BlockWise1x16: sharded in 128-row blocks (NVFP4)
+    - BlockWise1x128/128x128: not yet supported
+    """
+    M_shard = M // group_size
+
+    result: list[list[torch.Tensor]] = [[] for _ in range(group_size)]
+    for scale, recipe in zip(scale_list, recipe_list):
+        if recipe == ScalingType.TensorWise.value:
+            for rank in range(group_size):
+                result[rank].append(scale)
+        elif recipe == ScalingType.RowWise.value:
+            shards = list(scale.chunk(group_size))
+            shards = [t if t.data_ptr() % 16 == 0 else t.clone() for t in shards]
+            for rank in range(group_size):
+                result[rank].append(shards[rank])
+        elif recipe == ScalingType.BlockWise1x16.value:
+            if scale.shape[0] != M:
+                raise ValueError(
+                    f"For BlockWise1x16 scaling, scale dim 0 ({scale.shape[0]}) "
+                    f"must match M ({M})."
+                )
+            if M_shard % 128 != 0:
+                raise ValueError(
+                    f"For BlockWise1x16 scaling, M per shard ({M_shard}) must be "
+                    f"divisible by 128. Total M={M}, group_size={group_size}."
+                )
+            shards = scale.chunk(group_size)
+            for rank in range(group_size):
+                shard = shards[rank]
+                if shard.data_ptr() % 16 != 0:
+                    shard = shard.clone()
+                result[rank].append(shard)
+        elif recipe in (
+            ScalingType.BlockWise1x128.value,
+            ScalingType.BlockWise128x128.value,
+        ):
+            raise NotImplementedError(
+                f"BlockWise scale sharding for recipe {recipe} is not yet "
+                f"supported. Contributions welcome."
+            )
+        else:
+            raise ValueError(f"Unsupported scaling recipe for sharding: {recipe}")
+
+    return result
+
+
+@torch.library.impl(lib, "fused_scaled_matmul_reduce_scatter_v2", "CUDA")
+def _fused_scaled_matmul_reduce_scatter_v2(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    scale_a: list[torch.Tensor],
+    recipe_a: list[int],
+    swizzle_a: list[int],
+    scale_b: list[torch.Tensor],
+    recipe_b: list[int],
+    swizzle_b: list[int],
+    reduce_op: str,
+    orig_scatter_dim: int,
+    scatter_dim_after_maybe_reshape: int,
+    group_name: c10d.GroupName,
+    output_shape: list[int],
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    contraction_dim: list[int] | None = None,
+    use_fast_accum: bool = False,
+) -> torch.Tensor:
+    if _is_test_mode:
+        return _fused_scaled_matmul_reduce_scatter_v2_fallback(
+            A,
+            B,
+            scale_a,
+            recipe_a,
+            swizzle_a,
+            scale_b,
+            recipe_b,
+            swizzle_b,
+            reduce_op,
+            orig_scatter_dim,
+            scatter_dim_after_maybe_reshape,
+            group_name,
+            output_shape,
+            bias,
+            out_dtype,
+            contraction_dim,
+            use_fast_accum,
+        )
+    with torch.profiler.record_function("fused_scaled_matmul_reduce_scatter_v2"):
+        return _fused_scaled_matmul_reduce_scatter_v2_impl(
+            A=A,
+            B=B,
+            scale_a=scale_a,
+            recipe_a=recipe_a,
+            swizzle_a=swizzle_a,
+            scale_b=scale_b,
+            recipe_b=recipe_b,
+            swizzle_b=swizzle_b,
+            out_dtype=out_dtype,
+            reduce_op=reduce_op,
+            orig_scatter_dim=orig_scatter_dim,
+            scatter_dim_after_maybe_reshape=scatter_dim_after_maybe_reshape,
+            group_name=group_name,
+            output_shape=output_shape,
+            bias=bias,
+            contraction_dim=contraction_dim or [],
+            use_fast_accum=use_fast_accum,
+        )
+
+
+@torch.library.impl(lib, "fused_scaled_matmul_reduce_scatter_v2", "Meta")
+def _fused_scaled_matmul_reduce_scatter_v2_fallback(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    scale_a: list[torch.Tensor],
+    recipe_a: list[int],
+    swizzle_a: list[int],
+    scale_b: list[torch.Tensor],
+    recipe_b: list[int],
+    swizzle_b: list[int],
+    reduce_op: str,
+    orig_scatter_dim: int,
+    scatter_dim_after_maybe_reshape: int,
+    group_name: c10d.GroupName,
+    output_shape: list[int],
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    contraction_dim: list[int] | None = None,
+    use_fast_accum: bool = False,
+) -> torch.Tensor:
+    if contraction_dim:
+        raise ValueError(
+            "Non-default contraction_dim is not supported for "
+            "fused_scaled_matmul_reduce_scatter_v2. The shape math assumes "
+            "contraction on A's last dim and B's first dim."
+        )
+    for s, r in zip(scale_a, recipe_a):
+        if r == ScalingType.RowWise.value and s.shape[:-1] != A.shape[:-1]:
+            raise ValueError(
+                "For row-wise scaling, the leading dims of scale_a "
+                "must match the leading dims of A "
+                f"(A shape: {A.shape}, scale_a shape: {s.shape})"
+            )
+        if r in (
+            ScalingType.BlockWise1x128.value,
+            ScalingType.BlockWise128x128.value,
+        ):
+            raise NotImplementedError(
+                f"BlockWise scale sharding for recipe {r} is not yet "
+                f"supported. Contributions welcome."
+            )
+    flat_scale_a = [
+        s.flatten(0, -2).contiguous() if r == ScalingType.RowWise.value else s
+        for s, r in zip(scale_a, recipe_a)
+    ]
+    C = torch._scaled_mm_v2(
+        A.flatten(0, -2).contiguous(),
+        B,
+        flat_scale_a,
+        recipe_a,
+        swizzle_a,
+        scale_b,
+        recipe_b,
+        swizzle_b,
+        bias,
+        out_dtype,
+        contraction_dim or [],
+        use_fast_accum,
+    )
+    C = C.view(*output_shape[:-1], B.shape[1])
+    res = funcol.reduce_scatter_single(
+        C,
+        reduce_op,
+        orig_scatter_dim,
         group_name,
     )
+    res = funcol.wait_tensor(res)
+    return res
 
-    # We now need to transform the *unreduced* stacked 2D partial mm outputs to an *unreduced* 3D+ output,
-    # then reduce-scatter. To do this, we first need to determine the shape of the unreduced 3D+ output,
-    # to reshape our stacked partials so we can apply the reduce-scatter.
-    #
-    # The *unreduced* 3D+ tensor will have dim 0 = `group_size`, as we have `group_size` instances of
-    # stacked partial outputs. The next dims will be A's leading dims (sharded along the original scatter dim),
-    # as it was the left operand of the mm op. We can use -1 as the final dim of the view to populate the rest.
-    stacked_partials_3D_leading_dims = [group.size()] + list(
-        # We use A from after the dim swap 0<=>scatter_dim, but before the flatten,
-        # to get the leading dims of the 3D+ view of stacked partials.
-        A_with_scatter_dim_0.shape[:-1]
+
+def _fused_scaled_matmul_reduce_scatter_v2_impl(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    scale_a: list[torch.Tensor],
+    recipe_a: list[int],
+    swizzle_a: list[int],
+    scale_b: list[torch.Tensor],
+    recipe_b: list[int],
+    swizzle_b: list[int],
+    out_dtype: torch.dtype | None,
+    reduce_op: str,
+    orig_scatter_dim: int,
+    scatter_dim_after_maybe_reshape: int,
+    group_name: c10d.GroupName,
+    output_shape: list[int],
+    bias: torch.Tensor | None = None,
+    contraction_dim: list[int] | None = None,
+    use_fast_accum: bool = False,
+) -> torch.Tensor:
+    if A.dim() < 2:
+        raise ValueError("A must be at least 2D")
+    if (
+        scatter_dim_after_maybe_reshape < 0
+        or scatter_dim_after_maybe_reshape >= A.dim()
+    ):
+        raise ValueError("Invalid scatter dim for input tensor")
+    if orig_scatter_dim < 0 or orig_scatter_dim >= len(output_shape):
+        raise ValueError("Invalid scatter dim for output tensor")
+    if B.dim() != 2:
+        raise ValueError("B must be a matrix")
+    if contraction_dim:
+        raise ValueError(
+            "Non-default contraction_dim is not supported for "
+            "fused_scaled_matmul_reduce_scatter_v2. The shape math assumes "
+            "contraction on A's last dim and B's first dim."
+        )
+
+    group = c10d._resolve_process_group(group_name)
+
+    A_with_scatter_dim_0 = A.movedim(scatter_dim_after_maybe_reshape, 0)
+    A_2D_with_scatter_dim_0 = A_with_scatter_dim_0.flatten(0, -2)
+    A_shards = A_2D_with_scatter_dim_0.chunk(group.size())
+
+    flat_scale_a = []
+    for s, r in zip(scale_a, recipe_a):
+        if r == ScalingType.RowWise.value:
+            if s.shape[:-1] != A.shape[:-1]:
+                raise ValueError(
+                    "For row-wise scaling, the leading dims of scale_a "
+                    "must match the leading dims of A "
+                    f"(A shape: {A.shape}, scale_a shape: {s.shape})"
+                )
+            flat_scale_a.append(
+                s.movedim(scatter_dim_after_maybe_reshape, 0)
+                .contiguous()
+                .flatten(0, -2)
+            )
+        elif r == ScalingType.BlockWise1x16.value and A.dim() > 2:
+            s_nd = s.view(*A.shape[:-1], s.shape[-1])
+            flat_scale_a.append(
+                s_nd.movedim(scatter_dim_after_maybe_reshape, 0)
+                .contiguous()
+                .flatten(0, -2)
+            )
+        else:
+            flat_scale_a.append(s)
+
+    M = A_2D_with_scatter_dim_0.shape[0]
+    scale_a_shards = _shard_v2_scales_for_reduce_scatter(
+        flat_scale_a, recipe_a, M, group.size()
     )
 
-    # The `group_size` leading dim has been prepended to `stacked_partials_3D_leading_dims`,
-    # to capture the partial output from each rank. We need to divide the sharding/scatter dim
-    # by the group size. If the original scatter dim was 0, then it is now dim 1 in this
-    # tensor, since this new `group_size` dim was prepended.
-    stacked_partial_scatter_dim = orig_scatter_dim if orig_scatter_dim > 0 else 1
-    stacked_partials_3D_leading_dims[stacked_partial_scatter_dim] //= group.size()
+    def chunk_producer(rank: int, out: torch.Tensor) -> None:
+        torch.ops.aten._scaled_mm_v2.out(
+            A_shards[rank],
+            B,
+            scale_a_shards[rank],
+            recipe_a,
+            swizzle_a,
+            scale_b,
+            recipe_b,
+            swizzle_b,
+            bias,
+            out_dtype,
+            contraction_dim or [],
+            use_fast_accum,
+            out=out,
+        )
 
-    # Ensures that the transpose and reduction produce contiguous result
-    # in a single reduction kernel.
-    reduced_out = reduce_fn(
-        # View 2D stacked partials as 3D+ tensor of shape (`group_size`, ...)
-        stacked_partials.view(*stacked_partials_3D_leading_dims, -1)
-        # We originally swapped 0<=>scatter_dim_after_maybe_reshape. Now after
-        # prepending the `group_size` dim, to undo this original swap, we
-        # must swap 1<=>scatter_dim_after_maybe_reshape+1.
-        .movedim(1, scatter_dim_after_maybe_reshape + 1),
-        # Reduce along the `group_size` dim (0).
-        dim=0,
+    return _pipelined_scaled_matmul_reduce_scatter(
+        A_with_scatter_dim_0,
+        A_2D_with_scatter_dim_0,
+        B,
+        chunk_producer,
+        group,
+        group_name,
+        out_dtype,
+        reduce_op,
+        orig_scatter_dim,
+        scatter_dim_after_maybe_reshape,
+        output_shape,
     )
-
-    # Output shape must be scattered along original scatter dim as well.
-    output_shape[orig_scatter_dim] //= group.size()
-    out = reduced_out.view(*output_shape)
-    return out
 
 
 def restride_A_for_fused_matmul_reduce_scatter(


### PR DESCRIPTION
add `fused_scaled_matmul_reduce_scatter_v2` op to `torch.distributed._symmetric_memory` to support NVFP4 quantized models in vLLM's Sequence Parallelism and Async Tensor Parallelism pipeline. The existing v1 op uses `_scaled_mm` with simple scalar/row-wise scales, but NVFP4 requires `_scaled_mm_v2` which takes list-based scale arguments with scaling recipes and swizzle patterns.

The new op handles TensorWise, RowWise, and BlockWise1x16 scale sharding for the reduce-scatter dimension, with explicit validation for NVFP4's 128-row block alignment requirement. BlockWise1x128/128x128 raises NotImplementedError until hardware is available for testing.

Also refactored the shared pipeline-reduce-scatter logic between v1 and v2 into a common `_pipelined_scaled_matmul_reduce_scatter` helper to eliminate ~40 lines of duplicated reshape/reduce/view code.

Scope is reduce-scatter only; the all-gather side is out of scope because the dispatcher doesn't support nested tensor lists (Tensor[][]).

Fixes https://github.com/pytorch/pytorch/issues/182915