### PR TITLE
Fix `is_linear_add_bias` crash when `add_node.args[1]` is a Python float

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -939,6 +939,44 @@ class TestPatternMatcher(TestPatternMatcherBase):
             # 1 kernel for "to_lowp", 2 kernels for unary ops
             self.assertEqual(metrics.generated_kernel_count, 3)
 
+    @skipIfXpu
+    def test_linear_add_bias_float_constant(self, device="cpu"):
+        # Regression test: is_linear_add_bias should not crash when
+        # add_node.args[1] is a Python float (e.g., from `1.0 + linear_output`).
+        # See https://github.com/pytorch/pytorch/pull/183514
+        self.device = device
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.adaLN_modulation = torch.nn.Sequential(
+                    torch.nn.SiLU(),
+                    torch.nn.Linear(64, 64, bias=True),
+                )
+
+            def forward(self, c):
+                return 1.0 + self.adaLN_modulation(c)
+
+        dtypes = []
+        if is_mkldnn_bf16_supported(self.device):
+            dtypes.append(torch.bfloat16)
+        if is_mkldnn_fp16_supported(self.device):
+            dtypes.append(torch.float16)
+        for dtype in dtypes:
+            mod = M().eval()
+            v = torch.randn(2, 64)
+
+            def matcher_check_fn():
+                self.assertEqual(
+                    counters["inductor"]["mkldnn_linear_weight_pack_matcher_count"], 1
+                )
+                # The float constant should NOT be folded as bias
+                self.assertEqual(
+                    counters["inductor"]["mkldnn_linear_bias_matcher_count"], 0
+                )
+
+            self._test_common(mod, (v,), matcher_check_fn, check_autocast=dtype)
+
     @reduced_f32_on_and_off()
     def test_linear_binary(self, device="cpu"):
         self.device = device

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -1107,7 +1107,7 @@ if torch._C._has_mkldnn:
             )
             weight_meta = transpose_weight_node.args[0].meta.get("val")
             bias_node = add_node.args[1]
-            if isinstance(bias_node, int):
+            if isinstance(bias_node, (int, float)):
                 # we only folding bias if it is a constant
                 return False
             bias_meta = add_node.args[1].meta.get("val")

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -1107,10 +1107,9 @@ if torch._C._has_mkldnn:
             )
             weight_meta = transpose_weight_node.args[0].meta.get("val")
             bias_node = add_node.args[1]
-            if isinstance(bias_node, (int, float)):
-                # we only folding bias if it is a constant
+            if not isinstance(bias_node, torch.fx.Node):
                 return False
-            bias_meta = add_node.args[1].meta.get("val")
+            bias_meta = bias_node.meta.get("val")
             if weight_meta is None or bias_meta is None:
                 return False
 


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'float' object has no attribute 'meta'` in `torch/_inductor/fx_passes/mkldnn_fusion.py::is_linear_add_bias` when a Python `float` literal appears as the second argument of `aten.add.Tensor` following a `mkldnn._linear_pointwise` node in the frozen graph.

## Problem

The `is_linear_add_bias` function (used as `extra_check` for the freezing graph pattern that folds `linear + bias` into a single linear op) only guards against `int` constants:

```python
bias_node = add_node.args[1]
if isinstance(bias_node, int):
    # we only folding bias if it is a constant
    return False
bias_meta = add_node.args[1].meta.get("val")  # CRASH: 'float' has no 'meta'
```

When a float literal (e.g., `1.0` from `scale = 1.0 + linear_output`) is the second argument, it bypasses the `int` check and crashes when trying to access `.meta` on a Python float.

## Root Cause

In diffusion transformer models (e.g., `ZImageTransformer2DModel` from diffusers), patterns like:

```python
scale = 1.0 + self.adaLN_modulation(c)  # adaLN_modulation ends with nn.Linear
```

After freezing and mkldnn lowering, the FX graph contains:
```
%linear_pointwise = call_function[target=mkldnn._linear_pointwise.default](...)
%add = call_function[target=aten.add.Tensor](%linear_pointwise, 1.0)
```

The pattern `aten.add.Tensor(mkldnn._linear_pointwise.default(...), Arg())` matches structurally, and then `is_linear_add_bias` is called as `extra_check`. It crashes because `Arg()` matched the Python float `1.0`.

## Fix

```diff
- if isinstance(bias_node, int):
+ if isinstance(bias_node, (int, float)):
      # we only folding bias if it is a constant
      return False
```

## Why This Fix Is Correct

The `is_linear_add_bias` function serves as `extra_check` for a pattern that folds `linear(no bias) + add(bias_tensor)` into `linear(with bias)`. When the pattern matches, the replacement function `linear_bias_pattern` takes `add_node.args[1]` and places it into `mkldnn._linear_pointwise`'s third argument slot `B`:

```python
new_args[2] = add_node.args[1]  # B: bias
```

The op schema of `mkldnn._linear_pointwise` is:

```
(Tensor X, Tensor W, Tensor? B, str attr, Scalar?[] scalars, str? algorithm) -> Tensor Y
```

The `B` parameter requires `Tensor?`. Neither a Python `int` nor a Python `float` scalar can fill this slot — they are not tensors. The subsequent validation in `is_linear_add_bias` confirms this intent:

```python
bias_meta = add_node.args[1].meta.get("val")
if bias_meta.dim() != 1:       # only tensors have .dim()
    return False
if bias_meta.size(0) != weight_meta.size(1):  # only tensors have .size()
    return False
```

These checks only make sense for tensor values. The original `isinstance(bias_node, int)` guard with the comment _"we only folding bias if it is a constant"_ was intended to skip all non-tensor constants — `float` was simply omitted. Adding `float` to the guard completes the original intent without changing any optimization behavior.

## Reproduction

### Pure PyTorch script (test_linear_add_float.py)

```python
import os
os.environ["TORCHINDUCTOR_FREEZING"] = "1"

import torch
import torch.nn as nn

class Block(nn.Module):
    def __init__(self, dim=512):
        super().__init__()
        self.adaLN_modulation = nn.Sequential(
            nn.SiLU(),
            nn.Linear(dim, dim, bias=True),
        )

    def forward(self, c):
        # 1.0 + linear_output: after freezing + mkldnn lowering, becomes
        # aten.add.Tensor(mkldnn._linear_pointwise.default(...), 1.0)
        scale = 1.0 + self.adaLN_modulation(c)
        return scale

model = Block(512).eval().to(torch.bfloat16)
c = torch.randn(2, 512, dtype=torch.bfloat16)

compiled = torch.compile(model, backend="inductor")
with torch.no_grad():
    result = compiled(c)
print("SUCCESS, shape:", result.shape)
```

Three conditions are required:
1. `TORCHINDUCTOR_FREEZING=1` — enables weight freezing (inlining as constants)
2. `torch.no_grad()` — freezing only activates when grad is disabled
3. `torch.compile(model, ...)` — must compile the module (not `model.forward`) so freezing can access parameters

When all three are met, `nn.Linear` weights become `get_attr` constants → lowered to
`mkldnn._linear_pointwise` → `1.0 + linear_output` forms `aten.add.Tensor(mkldnn._linear_pointwise(...), 1.0)`
→ `is_linear_add_bias` crashes on the `float` constant.

### End-to-end reproduction (requires diffusers)

```bash
TORCHINDUCTOR_FREEZING=1 python -c "
import torch
from diffusers import ZImagePipeline

pipe = ZImagePipeline.from_pretrained(
    'Tongyi-MAI/Z-Image-Turbo', torch_dtype=torch.bfloat16, low_cpu_mem_usage=False
)
pipe.to('cpu')
pipe.transformer.forward = torch.compile(pipe.transformer.forward, backend='inductor')
pipe(
    'An astronaut riding a green horse',
    height=1024, width=1024, num_inference_steps=9, guidance_scale=0.0,
    generator=torch.Generator('cpu').manual_seed(42),
)
"
```

### Error Output

```
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
AttributeError: 'float' object has no attribute 'meta'

  File "torch/_inductor/fx_passes/mkldnn_fusion.py", line 1113, in is_linear_add_bias
    bias_meta = add_node.args[1].meta.get("val")
                ^^^^^^^^^^^^^^^^^^^^^
```

## Testing

After applying the fix, the Z-Image pipeline compiles and runs successfully:
- All 9 inference steps complete without error
- Output image is generated correctly

## Affected Versions

- Confirmed on `torch 2.13.0.dev20260511+cpu`
- The bug exists in any version that has the `is_linear_add_bias` function with only `int` check

## Labels

- module: inductor
- module: mkldnn
- topic: bug fix


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos