### PR TITLE
[DTensor] Fix _StridedShard flag conflict during gradient accumulation

### DIFF
--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -61,11 +61,9 @@ def _propagate_use_strided_shard_flag(
         if any(isinstance(p, _StridedShard) for p in spec.placements):
             val = spec.use_strided_shard_as_shard_order
             if _use_strided is not None and _use_strided != val:
-                raise ValueError(
-                    "Conflicting use_strided_shard_as_shard_order across "
-                    f"input specs: got both {_use_strided} and {val}"
-                )
-            _use_strided = val
+                _use_strided = True
+            else:
+                _use_strided = val
 
     if _use_strided is None:
         return


### PR DESCRIPTION
## Summary
Fix `use_strided_shard_as_shard_order` flag conflict in `_propagate_use_strided_shard_flag` by preferring `True` instead of raising `ValueError` when two `_StridedShard` DTensorSpecs disagree on the flag.

## Root Cause

The view op (`aten.view`) intentionally sets `use_strided_shard_as_shard_order=False` on its output DTensorSpec (in `_view_ops.py`, line 1309) to treat `_StridedShard` as plain `Shard` for sharding propagation purposes.

When a tensor with this `False` flag is consumed by multiple modules (e.g., MoE router, shared experts, routed experts), different backward paths handle the flag differently:

1. **`to_local` backward** (Path A in `_ToTorchTensor.backward`): copies the forward spec (`flag=False`), then calls `from_local` which creates a **new** DTensorSpec that auto-detects `flag=True` (since `_StridedShard` is present in placements).

2. **`redistribute` backward** (`_redistribute_backward`): restores `previous_spec` which preserved the view op's `flag=False` from the forward pass.

When autograd accumulates these gradients via `aten.add.Tensor`, the two `_StridedShard(dim=0, sf=8)` DTensors have conflicting flags (`True` vs `False`), causing `_propagate_use_strided_shard_flag` to raise:

```
ValueError: Conflicting use_strided_shard_as_shard_order across input specs: got both True and False

Sharding propagation failed for aten.add.Tensor(
    Spec(bf16[16384, 256](_S(0, 8))),
    Spec(bf16[16384, 256](_S(0, 8)))
) on DeviceMesh((tp=2), 'cuda', stride=(1,)))
```

## Fix

A DTensorSpec with `_StridedShard` in its placements and `flag=False` is always a propagation artifact — the `False` originates from the view op's intentional override and gets carried through backward paths that preserve `previous_spec`. The correct semantic value is `True`. So we resolve the conflict by preferring `True` instead of raising.

## Reproduction

This manifests when using FSDP2 + TP with SP on MoE layers, where:
- FSDP2 produces activations with `_StridedShard` placement
- A `view` op flattens batch+sequence dims, creating `_StridedShard(0, sf=N)` with `flag=False`
- The flattened tensor is consumed by multiple TP-parallelized submodules (router, shared experts, routed experts)
- Multiple backward gradient paths produce `_StridedShard` DTensors with inconsistent flags
- Gradient accumulation (`aten.add.Tensor`) triggers the conflict

## Test plan
- Verified fix resolves the error and training completes 10 steps with correct loss convergence on Llama4 MoE debug model with dp_shard=2, tp=2, ep=2
- Existing DTensor tests should continue to pass (the fix only relaxes a strict check to a resolution)