### PR TITLE
Fix using `torch.cuda.amp. autocast` with JIT on Python 3.13

### DIFF
--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -1,6 +1,5 @@
 # mypy: allow-untyped-defs
 import functools
-import sys
 from typing import Any
 from typing_extensions import deprecated
 
@@ -22,23 +21,25 @@ class autocast(torch.amp.autocast_mode.autocast):
     """
 
     # TODO: remove this conditional once we stop supporting Python < 3.13
+    # and `torch.jit.script` supports classes decorated with `deprecated`.
     # Prior to Python 3.13, inspect.signature could not retrieve the correct
     # signature information for classes decorated with @deprecated (unless
     # the __new__ static method was explicitly defined);
     #
     # However, this issue has been fixed in Python 3.13 and later versions.
-    if sys.version_info < (3, 13):
+    # `torch.jit.script` fails, because with the decorator __new__ is no
+    # longer a builtin but getting the source via `inspect`fails, as that
+    # looks up the underlying method, not the wrapper, which is a builtin
+    def __new__(
+        cls,
+        enabled: bool = True,
+        dtype: torch.dtype = torch.float16,
+        cache_enabled: bool = True,
+    ):
+        return super().__new__(cls)
 
-        def __new__(
-            cls,
-            enabled: bool = True,
-            dtype: torch.dtype = torch.float16,
-            cache_enabled: bool = True,
-        ):
-            return super().__new__(cls)
-
-        def __init_subclass__(cls):
-            pass
+    def __init_subclass__(cls):
+        pass
 
     def __init__(
         self,

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -20,16 +20,18 @@ class autocast(torch.amp.autocast_mode.autocast):
     ``torch.cuda.amp.autocast(args...)`` is deprecated. Please use ``torch.amp.autocast("cuda", args...)`` instead.
     """
 
-    # TODO: remove this conditional once we stop supporting Python < 3.13
+    # TODO: remove this conditional once we stop supporting Python < 3.13,
     # and `torch.jit.script` supports classes decorated with `deprecated`.
+    #
     # Prior to Python 3.13, inspect.signature could not retrieve the correct
     # signature information for classes decorated with @deprecated (unless
     # the __new__ static method was explicitly defined);
-    #
     # However, this issue has been fixed in Python 3.13 and later versions.
-    # `torch.jit.script` fails, because with the decorator __new__ is no
-    # longer a builtin but getting the source via `inspect`fails, as that
-    # looks up the underlying method, not the wrapper, which is a builtin
+    #
+    # `torch.jit.script` fails, because with the decorator `__new__` is no
+    # longer a builtin (as determined by `inspect.isbuiltin`) but getting
+    # the source via `inspect`fails, as that looks up the underlying method,
+    # not the wrapper, and that is a builtin for which there is no source.
     def __new__(
         cls,
         enabled: bool = True,


### PR DESCRIPTION
The `@deprecated` wrapper causes a wrapper method `__new__` to be injected. This causes it to no longer be treated as a builtin by `inspect.isbuiltin` but e.g `inspect.getsource` looks at the unwrapped function, which is still the `object.__new__` builtin and fails with
> TypeError: module, class, method, function, traceback, frame, or code object was expected, got builtin_function_or_method

In Python < 3.13 the custom `__new__` is not defined as a wrapper so it happens to work.
Fix by using the consistenly in all Python versions until JIT is fixed to handle those cases, see #183520

@fffrog 