### PR TITLE
[MPS] truncate fractional start/end to integer type in linspace when …

### DIFF
--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -205,7 +205,17 @@ Tensor& linspace_out_mps(const Scalar& start, const Scalar& end, int64_t steps, 
     MPSGraphCache* cache_ = MPSGraphCache::getInstance();
     MPSStream* stream = getCurrentMPSStream();
 
-    bool start_less_end = (start.to<double>() <= end.to<double>());
+    double start_d = start.to<double>();
+    double end_d = end.to<double>();
+    // For integer types, truncate start/end to the output type first
+    if (at::isIntegralType(result.scalar_type(), /*includeBool=*/false)) {
+      AT_DISPATCH_INTEGRAL_TYPES(result.scalar_type(), "linspace_out_mps", [&]() {
+        start_d = static_cast<double>(static_cast<scalar_t>(start_d));
+        end_d = static_cast<double>(static_cast<scalar_t>(end_d));
+      });
+    }
+
+    bool start_less_end = (start_d <= end_d);
 
     @autoreleasepool {
       std::string key = "linspace_out_mps:" + getTensorsStringKey({result}) + ":" + std::to_string(steps) +
@@ -231,15 +241,14 @@ Tensor& linspace_out_mps(const Scalar& start, const Scalar& end, int64_t steps, 
       }
 
       NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];
-      auto multiply = (end.to<double>() - start.to<double>()) / ((double)steps - 1.0f);
+      auto multiply = (end_d - start_d) / ((double)steps - 1.0);
       Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor, r);
 
-      // Create dictionary of inputs and outputs
-      MPSScalar startScalar = getMPSScalar(start, ScalarType::Float);
+      MPSScalar startScalar = getMPSScalar(Scalar(start_d), ScalarType::Float);
       feeds[cachedGraph->startTensor] = getMPSGraphTensorFromScalar(stream, startScalar);
-      MPSScalar endScalar = getMPSScalar(end, ScalarType::Float);
+      MPSScalar endScalar = getMPSScalar(Scalar(end_d), ScalarType::Float);
       feeds[cachedGraph->endTensor] = getMPSGraphTensorFromScalar(stream, endScalar);
-      MPSScalar multiplyScalar = getMPSScalar(multiply, ScalarType::Float);
+      MPSScalar multiplyScalar = getMPSScalar(Scalar(multiply), ScalarType::Float);
       feeds[cachedGraph->multiplyTensor] = getMPSGraphTensorFromScalar(stream, multiplyScalar);
 
       runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7860,6 +7860,14 @@ class TestMPS(TestCaseMPS):
             helper(5, 2, 10, dtype)
             helper(2, 2, 0, dtype)
 
+    def test_linspace_integral_fractional_endpoints(self):
+        # Fractional start/end must be truncated to the integer type before computing,
+        # matching CPU behavior (https://github.com/pytorch/pytorch/issues/137635).
+        for dtype in [torch.int8, torch.int16, torch.int32, torch.int64]:
+            cpu = torch.linspace(4.6, -2, 20, dtype=dtype)
+            mps = torch.linspace(4.6, -2, 20, dtype=dtype, device='mps')
+            self.assertEqual(mps.cpu(), cpu)
+
     # Test argange
     def test_arange(self):
         self.assertEqual(np.arange(10), torch.arange(10, device='mps'))


### PR DESCRIPTION
…dtype=int

Closes #137635. When ``dtype=int``, the endpoints are now truncated to ``int`` so the range is computed correctly. Adds a test to validate that it now matches the CPU linspace implementation (up to the floating point precision of MPS).