### PR TITLE
Fix CUDA version check for warp merge sort

### DIFF
--- a/aten/src/ATen/native/cuda/SortUtils.cuh
+++ b/aten/src/ATen/native/cuda/SortUtils.cuh
@@ -15,7 +15,7 @@
 #define HAS_WARP_MERGE_SORT() (ROCM_VERSION >= 70000)
 #else
 // CUDA: WarpMergeSort available since CUDA 11.6
-#define HAS_WARP_MERGE_SORT() (CUDA_VERSION >= 110600)
+#define HAS_WARP_MERGE_SORT() (CUDA_VERSION >= 11060)
 #endif
 
 


### PR DESCRIPTION
As referenced in the original code and PR #96223, CUDA 11.6 is explicitly required.
The correct value of the CUDA_VERSION macro for CUDA 11.6 is 11060, following the standard encoding rule: CUDA_VERSION = major * 1000 + minor * 10 + patch.This aligns with the correct usage already implemented in pytorch/third_party/kineto/libkineto/src/CuptiCbidRegistry.cpp, which defines 11060 for CUDA 11.6.

This PR fixes the incorrect version check that existed previously. Performance benchmarks were conducted on the issue case before and after the fix to verify the performance improvement.

Before fix: sortCommon(MediumRadixSort{}, key, value, dim, descending) **8.544us**
After fix: sortCommon(WarpMergeSort<128>{}, key, value, dim, descending) **4.096us**
A 2x speedup is achieved, which is consistent with the conclusion stated in PR #96223 that WarpMergeSort is used under eligible conditions.This results in up to a 2x speedup for unstable sorts and up to 15x speedup for stable sorts, depending on the input geometry.

fixs #183499 


before
Name | Self CPU % | Self CPU | CPU total % | CPU total | CPU time avg | Self CUDA | Self CUDA % | CUDA total | CUDA time avg | # of Calls
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
void at::native::radixSortKVInPlace<-2, -1, 32, 4, ...> | 0.00% | 0.000us | 0.00% | 0.000us | 0.000us | 8.544us | 63.42% | 8.544us | 8.544us | 1
Memcpy DtoD (Device -> Device) | 0.00% | 0.000us | 0.00% | 0.000us | 0.000us | 3.713us | 27.56% | 3.713us | 1.238us | 3
void (anonymous namespace)::elementwise_kernel_with_... | 0.00% | 0.000us | 0.00% | 0.000us | 0.000us | 1.216us | 9.03% | 1.216us | 1.216us | 1
cudaMemcpyAsync | 3.00% | 63.241us | 98.03% | 2.068ms | 689.455us | 0.000us | 0.00% | 0.000us | 0.000us | 3
Activity Buffer Request | 95.03% | 2.005ms | 95.03% | 2.005ms | 2.005ms | 0.000us | 0.00% | 0.000us | 0.000us | 1
cudaLaunchKernel | 1.41% | 29.713us | 1.41% | 29.713us | 14.857us | 0.000us | 0.00% | 0.000us | 0.000us | 2
cudaDeviceSynchronize | 0.56% | 11.893us | 0.56% | 11.893us | 5.947us | 0.000us | 0.00% | 0.000us | 0.000us | 2

Self CPU time total: 2.110ms
Self CUDA time total: 13.473us


after
Name | Self CPU % | Self CPU | CPU total % | CPU total | CPU time avg | Self CUDA | Self CUDA % | CUDA total | CUDA time avg | # of Calls
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
void at::native::warpMergeSortKVInPlace<-2, -1, 128,...> | 0.00% | 0.000us | 0.00% | 0.000us | 0.000us | 4.096us | 45.88% | 4.096us | 4.096us | 1
Memcpy DtoD (Device -> Device) | 0.00% | 0.000us | 0.00% | 0.000us | 0.000us | 3.615us | 40.50% | 3.615us | 1.205us | 3
void (anonymous namespace)::elementwise_kernel_with_... | 0.00% | 0.000us | 0.00% | 0.000us | 0.000us | 1.216us | 13.62% | 1.216us | 1.216us | 1
cudaMemcpyAsync | 3.39% | 72.069us | 96.96% | 2.062ms | 687.416us | 0.000us | 0.00% | 0.000us | 0.000us | 3
Activity Buffer Request | 93.57% | 1.990ms | 93.57% | 1.990ms | 1.990ms | 0.000us | 0.00% | 0.000us | 0.000us | 1
cudaLaunchKernel | 1.42% | 30.218us | 1.42% | 30.218us | 15.109us | 0.000us | 0.00% | 0.000us | 0.000us | 2
cudaDeviceGetAttribute | 0.10% | 2.151us | 0.10% | 2.151us | 0.538us | 0.000us | 0.00% | 0.000us | 0.000us | 4
cudaFuncGetAttributes | 0.64% | 13.692us | 0.64% | 13.692us | 13.692us | 0.000us | 0.00% | 0.000us | 0.000us | 1
cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags | 0.30% | 6.370us | 0.30% | 6.370us | 0.398us | 0.000us | 0.00% | 0.000us | 0.000us | 16
cudaDeviceSynchronize | 0.57% | 12.169us | 0.57% | 12.169us | 6.085us | 0.000us | 0.00% | 0.000us | 0.000us | 2


Self CPU time total: 2.127ms
Self CUDA time total: 8.927us
