### PR TITLE
feat: add XPUCodeCache tests for compilation and execution

### DIFF
--- a/test/inductor/test_cudacodecache.py
+++ b/test/inductor/test_cudacodecache.py
@@ -3,18 +3,24 @@
 import ctypes
 import shutil
 import unittest
+from unittest import mock
 
 import torch
 from torch._inductor.async_compile import AsyncCompile
-from torch._inductor.codecache import CUDACodeCache, ROCmCodeCache
+from torch._inductor.codecache import CUDACodeCache, ROCmCodeCache, XPUCodeCache
 from torch._inductor.codegen.cuda.compile_utils import _cuda_compiler
 from torch._inductor.codegen.cuda.cuda_env import nvcc_exist
 from torch._inductor.codegen.rocm.compile_command import rocm_compiler
-from torch._inductor.exc import CUDACompileError
+from torch._inductor.codegen.xpu.compile_utils import _sycl_compiler, icpx_exist
+from torch._inductor.exc import CUDACompileError, XPUCompileError
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import fresh_cache
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import TEST_WITH_ROCM
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.triton_utils import (
+    requires_gpu_and_triton,
+    requires_xpu_and_triton,
+)
 
 
 def _has_rocm_compiler():
@@ -22,15 +28,26 @@ def _has_rocm_compiler():
     return compiler is not None and shutil.which(compiler) is not None
 
 
-def _has_gpu_codecache_compiler():
-    return _has_rocm_compiler() if TEST_WITH_ROCM else nvcc_exist(_cuda_compiler())
+def _has_gpu_codecache_compiler(device_type):
+    if device_type == "xpu":
+        return icpx_exist(_sycl_compiler())
+    if TEST_WITH_ROCM:
+        return _has_rocm_compiler()
+    return nvcc_exist(_cuda_compiler())
 
 
-def _gpu_codecache():
+def _gpu_codecache(device_type):
+    if device_type == "xpu":
+        return XPUCodeCache
     return ROCmCodeCache if TEST_WITH_ROCM else CUDACodeCache
 
 
-_SOURCE_CODE = r"""
+def _compile_error(device_type):
+    return XPUCompileError if device_type == "xpu" else CUDACompileError
+
+
+# CUDA source doubles as ROCm/HIP source via the __HIPCC__ guard.
+_CUDA_SOURCE_CODE = r"""
 
 #include <stdio.h>
 
@@ -57,21 +74,68 @@ int saxpy(int n, float a, float *x, float *y) {
 }
 """
 
+# The standalone SYCL .so is not linked against libtorch, so it has no ambient
+# queue. torch passes the address of its current XPUStream's sycl::queue as the
+# trailing argument; the kernel submits to it so the USM pointers (allocated in
+# torch's context) are valid, and waits so the result is ready on return.
+_XPU_SOURCE_CODE = r"""
 
-@unittest.skipUnless(_has_gpu_codecache_compiler(), "requires nvcc or ROCm compiler")
-class TestCUDACodeCache(InductorTestCase):
-    @requires_cuda_and_triton
-    def test_cuda_load(self):
+#include <sycl/sycl.hpp>
+
+extern "C" {
+
+__attribute__((__visibility__("default")))
+int saxpy(int n, float a, float *x, float *y, void *queue_ptr) {
+  sycl::queue &q = *static_cast<sycl::queue *>(queue_ptr);
+  q.parallel_for(sycl::range<1>(n), [=](sycl::id<1> i) {
+     y[i] = a * x[i] + y[i];
+   }).wait();
+  return 0;
+}
+
+}
+"""
+
+
+def _source_code(device_type):
+    return _XPU_SOURCE_CODE if device_type == "xpu" else _CUDA_SOURCE_CODE
+
+
+def _break_kernel(source_code, device_type):
+    token = "parallel_for" if device_type == "xpu" else "saxpy_device"
+    return source_code.replace(token, token + "_wrong", 1)
+
+
+def _call_saxpy(dll, device_type, n, a, x, y):
+    args = [
+        ctypes.c_int(n),
+        ctypes.c_float(a),
+        ctypes.c_void_p(x.data_ptr()),
+        ctypes.c_void_p(y.data_ptr()),
+    ]
+    if device_type == "xpu":
+        stream = torch._C._xpu_getCurrentRawStream(x.device.index)
+        args.append(ctypes.c_void_p(stream))
+    dll.saxpy(*args)
+
+
+class TestGPUCodeCache(InductorTestCase):
+    @requires_gpu_and_triton
+    def test_gpu_load(self):
+        device = self.device_type
+        if not _has_gpu_codecache_compiler(device):
+            raise unittest.SkipTest("requires nvcc, ROCm, or SYCL compiler")
+        source_code = _source_code(device)
         with fresh_cache():
-            codecache = _gpu_codecache()
+            codecache = _gpu_codecache(device)
             # Test both .o and .so compilation.
             (
                 object_file_path,
                 object_hash_key,
                 source_code_path0,
-            ) = codecache.compile(_SOURCE_CODE, "o")
+            ) = codecache.compile(source_code, "o")
             dll_wrapper, so_hash_key, source_code_path1 = codecache.load(
-                _SOURCE_CODE, "so"
+                source_code, "so"
             )
             if TEST_WITH_ROCM:
                 self.assertTrue(object_file_path.endswith(".o"))
@@ -82,51 +146,98 @@ class TestCUDACodeCache(InductorTestCase):
                 self.assertEqual(object_hash_key, so_hash_key)
 
             # Test load and call functions in .so.
-            x = torch.rand(10).float().cuda()
-            y = torch.rand(10).float().cuda()
+            x = torch.rand(10).float().to(device)
+            y = torch.rand(10).float().to(device)
             a = 5.0
             expected_y = a * x + y
-            dll_wrapper.saxpy(
-                ctypes.c_int(10),
-                ctypes.c_float(a),
-                ctypes.c_void_p(x.data_ptr()),
-                ctypes.c_void_p(y.data_ptr()),
-            )
+            _call_saxpy(dll_wrapper, device, 10, a, x, y)
             torch.testing.assert_close(y, expected_y)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_compilation_error(self):
+        device = self.device_type
+        if not _has_gpu_codecache_compiler(device):
+            raise unittest.SkipTest("requires nvcc, ROCm, or SYCL compiler")
         with fresh_cache():
-            codecache = _gpu_codecache()
-            error_source_code = _SOURCE_CODE.replace("saxpy_device", "saxpy_wrong", 1)
-            with self.assertRaises(CUDACompileError):
+            codecache = _gpu_codecache(device)
+            error_source_code = _break_kernel(_source_code(device), device)
+            with self.assertRaises(_compile_error(device)):
                 codecache.compile(error_source_code, "o")
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_async_compile(self):
+        device = self.device_type
+        if not _has_gpu_codecache_compiler(device):
+            raise unittest.SkipTest("requires nvcc, ROCm, or SYCL compiler")
+        source_code = _source_code(device)
         with fresh_cache():
             async_compile = AsyncCompile()
-            if TEST_WITH_ROCM:
-                compiled_res = async_compile.rocm(_SOURCE_CODE, "so")
+            if device == "xpu":
+                compiled_res = async_compile.xpu(source_code, "so")
+            elif TEST_WITH_ROCM:
+                compiled_res = async_compile.rocm(source_code, "so")
             else:
-                compiled_res = async_compile.cuda(_SOURCE_CODE, "so")
+                compiled_res = async_compile.cuda(source_code, "so")
             async_compile.wait(globals())
 
             # Test load and call functions in .so.
-            x = torch.rand(5).float().cuda()
-            y = torch.rand(5).float().cuda()
+            x = torch.rand(5).float().to(device)
+            y = torch.rand(5).float().to(device)
             a = 2.0
             expected_y = a * x + y
-            compiled_res.result().saxpy(
-                ctypes.c_int(5),
-                ctypes.c_float(a),
-                ctypes.c_void_p(x.data_ptr()),
-                ctypes.c_void_p(y.data_ptr()),
-            )
+            _call_saxpy(compiled_res.result(), device, 5, a, x, y)
             torch.testing.assert_close(y, expected_y)
+
+
+instantiate_device_type_tests(
+    TestGPUCodeCache, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+)
+
+
+@requires_xpu_and_triton
+class TestXPUCodeCacheClear(InductorTestCase):
+    def test_cache_hit(self):
+        if not icpx_exist(_sycl_compiler()):
+            raise unittest.SkipTest("requires SYCL compiler")
+        with fresh_cache():
+            _, hash_key1, source_path1 = XPUCodeCache.compile(_XPU_SOURCE_CODE, "o")
+            _, hash_key2, source_path2 = XPUCodeCache.compile(_XPU_SOURCE_CODE, "o")
+            self.assertEqual(hash_key1, hash_key2)
+            self.assertEqual(source_path1, source_path2)
+
+            dll_wrapper1, so_hash1, _ = XPUCodeCache.load(_XPU_SOURCE_CODE, "so")
+            dll_wrapper2, so_hash2, _ = XPUCodeCache.load(_XPU_SOURCE_CODE, "so")
+            self.assertEqual(so_hash1, so_hash2)
+            self.assertIs(dll_wrapper1, dll_wrapper2)
+
+    def test_cache_clear_clears_dll_cache(self):
+        self.addCleanup(XPUCodeCache.cache_clear)
+        XPUCodeCache.dll_cache["fake_path.so"] = mock.MagicMock()
+        self.assertGreater(len(XPUCodeCache.dll_cache), 0)
+
+        XPUCodeCache.cache_clear()
+
+        self.assertEqual(
+            len(XPUCodeCache.dll_cache),
+            0,
+            "dll_cache should be empty after cache_clear()",
+        )
+
+    def test_cache_clear_clears_parent_cache(self):
+        self.addCleanup(XPUCodeCache.cache_clear)
+        XPUCodeCache.cache["fake_key"] = mock.MagicMock()
+        self.assertGreater(len(XPUCodeCache.cache), 0)
+
+        XPUCodeCache.cache_clear()
+
+        self.assertEqual(
+            len(XPUCodeCache.cache),
+            0,
+            "cache should be empty after cache_clear()",
+        )
 
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    run_tests("cuda")
+    run_tests()

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -5025,6 +5025,7 @@ class CUTLASSCodeCache:
 
     _SOURCE_CODE_SUFFIX: str = ""
     _BACKEND: str = ""
+    _COMPILE_ERROR: type[exc.CppCompileError] = exc.CUDACompileError
 
     @classmethod
     def cache_clear(cls) -> None:
@@ -5157,7 +5158,7 @@ class CUTLASSCodeCache:
                     cls.cache[key_with_ext] = cls.CacheEntry(
                         input_path, output_path, error_json
                     )
-                    raise exc.CUDACompileError(cmd_parts, error_output)
+                    raise cls._COMPILE_ERROR(cmd_parts, error_output)
                 if not os.path.exists(output_path):
                     cmd = cls._compile_command(
                         src_files, output_path, dst_file_ext, extra_args
@@ -5190,7 +5191,7 @@ class CUTLASSCodeCache:
                             output_path,
                             binary_remote_cache,
                         )
-                        raise exc.CUDACompileError(cmd_parts, error.output) from error
+                        raise cls._COMPILE_ERROR(cmd_parts, error.output) from error
                     except Exception as error:
                         if "COMPILE FAILED WITH" in str(error):
                             cls._record_compile_error(
@@ -5201,7 +5202,7 @@ class CUTLASSCodeCache:
                                 output_path,
                                 binary_remote_cache,
                             )
-                            raise exc.CUDACompileError(cmd_parts, str(error)) from error
+                            raise cls._COMPILE_ERROR(cmd_parts, str(error)) from error
                         raise error
                     end_time = time()
                     log_duration_msg = f"{cls._BACKEND} {operation_name} took {end_time - start_time} seconds. Command: {cmd}"
@@ -5229,7 +5230,7 @@ class CUTLASSCodeCache:
         if cache_entry.error_json is not None:
             # Restore cached Exception and raise it as if we had compiled
             cmd_parts, error_output = json.loads(cache_entry.error_json)
-            raise exc.CUDACompileError(cmd_parts, error_output.encode("utf-8"))
+            raise cls._COMPILE_ERROR(cmd_parts, error_output.encode("utf-8"))
         return (cls.cache[key_with_ext].output_path, key, input_path)
 
     @classmethod
@@ -5323,7 +5324,13 @@ from torch._inductor.codegen.xpu import compile_utils as xpu_compile_utils
 class XPUCodeCache(CUTLASSCodeCache):
     _SOURCE_CODE_SUFFIX = "cpp"
     _BACKEND = "XPU"
+    _COMPILE_ERROR: type[exc.CppCompileError] = exc.XPUCompileError
     dll_cache: dict[str, DLLWrapper] = {}
+
+    @classmethod
+    def cache_clear(cls) -> None:
+        super().cache_clear()
+        cls.dll_cache.clear()
 
     @classmethod
     def _use_re_build(cls) -> bool:

--- a/torch/_inductor/codegen/xpu/compile_utils.py
+++ b/torch/_inductor/codegen/xpu/compile_utils.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import functools
 import logging
 import os
 import shutil
@@ -14,13 +15,18 @@ from ..cuda.compile_utils import _cutlass_include_paths
 log = logging.getLogger(__name__)
 
 
+@functools.cache
+def icpx_exist(icpx_path: str | None = "icpx") -> bool:
+    return icpx_path is not None and shutil.which(icpx_path) is not None
+
+
 def _sycl_compiler() -> str:
     # Search order:
     # 0) which icpx
     # 1) config.xpu.oneapi_root
     # 2) ONEAPI_ROOT environment variable
     # 3) default system search PATH.
-    if shutil.which("icpx"):
+    if icpx_exist("icpx"):
         return "icpx"
 
     if os.path.exists(config.xpu.oneapi_root or ""):
@@ -37,8 +43,10 @@ def _sycl_compiler() -> str:
         else:
             os.environ["CPLUS_INCLUDE_PATH"] = oneapi_inclue
         return os.path.realpath(os.path.join(oneapi_root, "bin/icpx"))
-    else:
-        raise RuntimeError("Can not find Intel compiler.")
+
+    # Mirrors _cuda_compiler(): return the bare name and let the compile
+    # subprocess produce the error, so callers can probe with icpx_exist().
+    return "icpx"
 
 
 def _sycl_lib_options() -> list[str]:

--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -130,6 +130,10 @@ class CUDACompileError(CppCompileError):
     pass
 
 
+class XPUCompileError(CppCompileError):
+    pass
+
+
 class TritonMissing(ShortenTraceback):
     def __init__(self, first_useful_frame: types.FrameType | None) -> None:
         super().__init__(


### PR DESCRIPTION
## Summary

Harden and test the XPU (Intel GPU / SYCL) compile path in TorchInductor: add a dedicated `XPUCompileError`, wire it through `XPUCodeCache`, fix `cache_clear()` to also clear cached DLL wrappers, make `_sycl_compiler()` probe-friendly, and generalize the existing GPU codecache test suite to cover XPU alongside CUDA/ROCm.

Fixes intel/torch-xpu-ops#3095.

## Motivation

`XPUCodeCache` inherited CUDA behavior wholesale: compile failures surfaced as `CUDACompileError`, `cache_clear()` left `dll_cache` populated (stale `DLLWrapper`s), and there was no XPU compile/load/execute test coverage at all.

## Changes

- **`exc.py`**: add `XPUCompileError(CppCompileError)`.
- **`codecache.py`**: add a `_COMPILE_ERROR` class attribute on `CUTLASSCodeCache` (defaults to `CUDACompileError`) and raise `cls._COMPILE_ERROR` instead of the hardcoded `CUDACompileError`; `XPUCodeCache` sets it to `XPUCompileError` and overrides `cache_clear()` to also clear `dll_cache`.
- **`codegen/xpu/compile_utils.py`**: add memoized `icpx_exist()` so tests (and other callers) can probe for a SYCL compiler, and make `_sycl_compiler()` return the bare `"icpx"` name instead of raising `RuntimeError` when no toolchain is found. This mirrors `_cuda_compiler()`: the compile subprocess produces the error, and detection is a separate concern.
- **`test/inductor/test_cudacodecache.py`**: generalize the existing suite rather than adding a parallel XPU one. `TestCUDACodeCache` becomes `TestGPUCodeCache`, made device-generic via `instantiate_device_type_tests` over `("cuda", "xpu")`, so `test_gpu_load`, `test_compilation_error`, and `test_async_compile` run on both backends (each skipping if its compiler is absent). XPU-only checks live in `TestXPUCodeCacheClear`: `test_cache_hit` (source/`dll_cache` identity on repeat compile/load) plus the two hardware-independent `cache_clear` tests.

### XPU test kernel

The standalone SYCL `.so` is not linked against libtorch, so it has no ambient SYCL queue. The test kernel therefore takes the current `XPUStream`'s `sycl::queue` address as a trailing argument and submits to it, so the USM pointers allocated in torch's context are valid, then waits so the result is ready on return.

## Review notes

- The test file intentionally keeps its original path (`test/inductor/test_cudacodecache.py`) even though its contents are no longer CUDA-specific, to keep this diff readable for reviewers. The rename to `test_device_codecache.py` is tracked as a follow-up.
- `_sycl_compiler()` no longer raising is a behavior change, but its only production caller (`XPUCodeCache._compile_command`) already surfaced compile failures from the subprocess, so a missing compiler still fails loudly
- now as an `XPUCompileError` rather than a bare `RuntimeError`.

## Backward compatibility

CUDA/CUTLASS path unchanged: `_COMPILE_ERROR` still defaults to `CUDACompileError`, and the ROCm branches inside the shared tests are preserved.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo