### PR TITLE
Add out tag support for all_gather_into_tensor_out and reduce_scatter_tensor_out

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -1445,6 +1445,38 @@ class CompileTest(TestCase):
         code = run_and_get_triton_code(compiled, arg)
         (FileCheck().check("all_reduce_.default(buf0, 'avg', '0')").run(code))
 
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @fresh_cache()
+    def test_compile_all_gather_into_tensor_out(self):
+        def func(input, out):
+            y = torch.ops._c10d_functional.all_gather_into_tensor_out(
+                input, self.world_size, "default", out=out
+            )
+            y = torch.ops._c10d_functional.wait_tensor(y)
+            return y + 1
+
+        input_t = torch.ones(4, device=self.device)
+        out_t = torch.empty(4 * self.world_size, device=self.device)
+        compiled = torch.compile(func)
+        result = compiled(input_t, out_t)
+        self.assertEqual(result.shape, (4 * self.world_size,))
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @fresh_cache()
+    def test_compile_reduce_scatter_tensor_out(self):
+        def func(input, out):
+            y = torch.ops._c10d_functional.reduce_scatter_tensor_out(
+                input, "sum", self.world_size, "default", out=out
+            )
+            y = torch.ops._c10d_functional.wait_tensor(y)
+            return y + 1
+
+        input_t = torch.ones(4 * self.world_size, device=self.device)
+        out_t = torch.empty(4, device=self.device)
+        compiled = torch.compile(func)
+        result = compiled(input_t, out_t)
+        self.assertEqual(result.shape, (4,))
+
 
 class ACTCompileTest(TestCase):
     """

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -620,7 +620,9 @@ TORCH_LIBRARY(_c10d_functional, m) {
                 get_process_group(group, "all_gather_into_tensor_out"),
                 output);
           }),
-      {at::Tag::pt2_compliant_tag, at::Tag::needs_contiguous_strides});
+      {at::Tag::pt2_compliant_tag,
+       at::Tag::needs_contiguous_strides,
+       at::Tag::out});
 
   m.def(
       "all_gather_into_tensor(Tensor input, int group_size, Any group_name) -> Tensor",
@@ -664,7 +666,9 @@ TORCH_LIBRARY(_c10d_functional, m) {
                 group_size,
                 get_process_group(group, "reduce_scatter_tensor"));
           }),
-      {at::Tag::pt2_compliant_tag, at::Tag::needs_contiguous_strides});
+      {at::Tag::pt2_compliant_tag,
+       at::Tag::needs_contiguous_strides,
+       at::Tag::out});
 
   m.def(
       "reduce_scatter_tensor_out(Tensor input, str reduce_op, int group_size, Any group_name, *, Tensor(a!) out) -> Tensor(a!)",


### PR DESCRIPTION
Fixes #183469

The crash of repro happens during Autograd's metadata collection phase which runs with FunctionalTensorMode active. FunctionalTensorMode.__torch_dispatch__ has an auto_functionalize_v2 that already knows out-variant custom ops. However ,this needs out tag condition to be true. Since all_gather_tensor_out and reduce_scatter_tensor_out do not have those they need extra tag of at::tag::out to be to support autofunctionalization.