### PR TITLE
[bugfix] [inductor] [decomp] Add special check for inductor conv kernel when channel=0

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15136,6 +15136,23 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertEqual(compiled_out.shape, torch.Size([1, 1, 0, 0]))
         self.assertEqual(eager_out, compiled_out)
 
+    @requires_cuda
+    def test_lazy_conv_zero_in_channels_backward(self):
+        for dim in (1, 2, 3):
+            conv_cls = getattr(torch.nn, f"LazyConv{dim}d")
+            model = conv_cls(2, kernel_size=1).eval().cuda()
+            x = torch.randn(1, 0, *([8] * dim), device="cuda")
+
+            y = torch.compile(model)(x)
+            self.assertEqual(y.shape, torch.Size([1, 0, *([8] * dim)]))
+
+            y.sum().backward()
+            self.assertEqual(model.weight.shape, torch.Size([2, 0, *([1] * dim)]))
+            self.assertEqual(model.weight.grad.shape, model.weight.shape)
+            self.assertEqual(model.bias.shape, torch.Size([2]))
+            self.assertEqual(model.bias.grad.shape, model.bias.shape)
+            self.assertEqual(model.bias.grad, torch.zeros_like(model.bias))
+
     @requires_gpu()
     @config.patch(fallback_random=True)
     def test_mix_device_index(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15140,8 +15140,8 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
     def test_lazy_conv_zero_in_channels_backward(self):
         for dim in (1, 2, 3):
             conv_cls = getattr(torch.nn, f"LazyConv{dim}d")
-            model = conv_cls(2, kernel_size=1).eval().cuda()
-            x = torch.randn(1, 0, *([8] * dim), device="cuda")
+            model = conv_cls(2, kernel_size=1).eval().to(GPU_TYPE)
+            x = torch.randn(1, 0, *([8] * dim), device=GPU_TYPE)
 
             y = torch.compile(model)(x)
             self.assertEqual(y.shape, torch.Size([1, 0, *([8] * dim)]))

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -322,6 +322,7 @@ def convolution_backward(
     if statically_known_true(input.size(1) == 0) and statically_known_true(
         bias_sizes[0] != 0
     ):
+        # deal with the `input_channel=0` case
         grad_bias = grad_output.new_zeros(bias_sizes)
     else:
         grad_bias = aten.sum(grad_output, [0] + list(range(2, grad_output.dim())))

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -319,7 +319,12 @@ def convolution_backward(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if not output_mask[2] or not is_gpu(grad_output.device.type):
         return NotImplemented
-    grad_bias = aten.sum(grad_output, [0] + list(range(2, grad_output.dim())))
+    if statically_known_true(input.size(1) == 0) and statically_known_true(
+        bias_sizes[0] != 0
+    ):
+        grad_bias = grad_output.new_zeros(bias_sizes)
+    else:
+        grad_bias = aten.sum(grad_output, [0] + list(range(2, grad_output.dim())))
     grad_inp, grad_weight, _ = aten.convolution_backward(
         grad_output,
         input,

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -552,7 +552,7 @@ def convolution(
         # peel off the bias, cudnn is slower with it
         result = convolution(x, weight, None, **kwargs)
         if V.graph.sizevars.statically_known_equals(result.get_size()[1], 0):
-            # we should not add bias when the input/output channel is 0
+            # we should not add bias when the output channel is 0
             return result
         return L[aten.add](
             result, L[aten.view](bias, [result.get_size()[1]] + ndim * [1])

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -551,6 +551,8 @@ def convolution(
     if bias is not None and device_type != "cpu":
         # peel off the bias, cudnn is slower with it
         result = convolution(x, weight, None, **kwargs)
+        if V.graph.sizevars.statically_known_equals(result.get_size()[1], 0):
+            return result
         return L[aten.add](
             result, L[aten.view](bias, [result.get_size()[1]] + ndim * [1])
         )

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -457,6 +457,7 @@ def convolution(
     output_padding: Sequence[int],
     groups: int,
 ):
+    """Lower aten.convolution using Inductor convolution kernels or fallbacks."""
     stride = tuple(stride)
     padding = tuple(padding)
     dilation = tuple(dilation)

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -552,6 +552,7 @@ def convolution(
         # peel off the bias, cudnn is slower with it
         result = convolution(x, weight, None, **kwargs)
         if V.graph.sizevars.statically_known_equals(result.get_size()[1], 0):
+            # we should not add bias when the input/output channel is 0
             return result
         return L[aten.add](
             result, L[aten.view](bias, [result.get_size()[1]] + ndim * [1])


### PR DESCRIPTION
Fixes #143184
cudnn peels off the bias to deal with separately.

https://github.com/pytorch/pytorch/blob/5bd9e674fb4de5d6bb00a8e185c50eb7c7b6b913/torch/_inductor/kernel/conv.py#L552-L557

`L[aten.add](result, L[aten.view](bias, [result.get_size()[1]] + ndim * [1]))` is actually doing reshape.
However, when `channel=0`, this is not legal and subsequently throws the original issue's error.
So we let it return the resutls directly (actually it is an empty tensor)

Moreover, the issue also occurs in the backward decomposition:
originaly, `bias grad shape` follows `grad_output channel` and finally gets `[0]`
This is incorrect in **zero output-channel**. we should let `bias grad shape` follows `bias` itselft and gets the value `[2]`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo