### PR TITLE
[Inductor][Bucketing] Make collective bucketing tolerate hinted unbacked SymInts

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -26,10 +26,12 @@ from torch._inductor.comms import (
 from torch._inductor.compile_fx import compile_fx as inductor_compile_fx
 from torch._inductor.fx_passes.bucketing import (
     _trace as bucketing_trace,
+    all_gather_merge_fn_to_trace_custom_ops,
     is_all_gather_into_tensor,
     is_all_reduce_tensor,
     is_all_to_all_tensor,
     is_reduce_scatter_tensor,
+    reduce_scatter_merge_fn_to_trace_custom_ops,
 )
 from torch._inductor.scheduler import (
     _get_mm_like_fn,
@@ -64,6 +66,17 @@ from torch.utils._python_dispatch import TorchDispatchMode
 
 
 class TestBucketingTrace(torch._dynamo.test_case.TestCase):
+    def _make_hinted_unbacked_chunked_fake_inputs(self, *, hint=None):
+        fake_mode = FakeTensorMode(
+            allow_non_fake_inputs=True,
+            shape_env=ShapeEnv(),
+        )
+        with fake_mode:
+            u = fake_mode.shape_env.create_unbacked_symint()
+            if hint is not None:
+                torch._dynamo.override_optimization_hint(u, hint)
+            return torch.empty(u // 2, 4), torch.empty(u // 2, 4)
+
     def test_trace_ignores_ambient_pending_unbacked_symbols(self):
         fake_mode = FakeTensorMode(
             allow_non_fake_inputs=True,
@@ -77,6 +90,73 @@ class TestBucketingTrace(torch._dynamo.test_case.TestCase):
 
         self.assertIn(ambient, fake_mode.shape_env.pending_fresh_unbacked_symbols)
         FileCheck().check("aten.add").run(gm.code)
+
+    def test_all_gather_bucket_trace_accepts_hinted_unbacked_chunk_numel(self):
+        x, y = self._make_hinted_unbacked_chunked_fake_inputs(hint=8)
+
+        gm = bucketing_trace(
+            lambda a, b: all_gather_merge_fn_to_trace_custom_ops(
+                [a, b],
+                "0",
+                2,
+                torch.float32,
+                [torch.float32, torch.float32],
+                0,
+            ),
+            (x, y),
+        )
+
+        FileCheck().check("sym_numel").check("_pre_bucket_all_gather").run(gm.code)
+        symbolic_shapes = [
+            str(node.meta["val"].shape)
+            for node in gm.graph.nodes
+            if "val" in node.meta and isinstance(node.meta["val"], torch.Tensor)
+        ]
+        self.assertTrue(any("u0" in shape for shape in symbolic_shapes))
+        self.assertTrue(any("16*((u0//2))" in shape for shape in symbolic_shapes))
+
+    def test_all_gather_bucket_trace_requires_unbacked_chunk_hint(self):
+        x, y = self._make_hinted_unbacked_chunked_fake_inputs()
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Collective bucketing requires hinted symbolic sizes",
+        ):
+            bucketing_trace(
+                lambda a, b: all_gather_merge_fn_to_trace_custom_ops(
+                    [a, b],
+                    "0",
+                    2,
+                    torch.float32,
+                    [torch.float32, torch.float32],
+                    0,
+                ),
+                (x, y),
+            )
+
+    def test_reduce_scatter_bucket_trace_preserves_hinted_unbacked_chunk_shapes(self):
+        x, y = self._make_hinted_unbacked_chunked_fake_inputs(hint=8)
+
+        gm = bucketing_trace(
+            lambda a, b: reduce_scatter_merge_fn_to_trace_custom_ops(
+                [a, b],
+                "0",
+                2,
+                "sum",
+                torch.float32,
+                torch.device("cuda"),
+            ),
+            (x, y),
+        )
+
+        FileCheck().check("sym_numel").check("_pre_bucket_reduce_scatter").run(gm.code)
+        symbolic_shapes = [
+            str(node.meta["val"].shape)
+            for node in gm.graph.nodes
+            if "val" in node.meta and isinstance(node.meta["val"], torch.Tensor)
+        ]
+        self.assertTrue(any("u0" in shape for shape in symbolic_shapes))
+        self.assertTrue(any("(u0//4)" in shape for shape in symbolic_shapes))
 
 
 @requires_accelerator_dist_backend(["nccl", "xccl"])

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1686,6 +1686,25 @@ class TestForeachGroupsUnit(InductorTestCase):
         self.assertTrue(torch.allclose(result_with, result_without))
 
 
+class TestNodeRuntimeEstimationUnit(InductorTestCase):
+    def test_compute_estimation_logging_handles_symbolic_scalar_meta(self):
+        from torch._inductor.fx_passes.node_runtime_estimation import (
+            _log_compute_estimations,
+        )
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        y = graph.placeholder("y")
+        x.meta["val"] = torch.empty(2, 3)
+        y.meta["val"] = ShapeEnv().create_unbacked_symint()
+        add = graph.call_function(torch.ops.aten.add.Tensor, (x, y))
+        add.meta["val"] = torch.empty(2, 3)
+        graph.output(add)
+
+        _log_compute_estimations([add], [1.0], [1.0])
+
+
 def _make_pge_trace(
     collectives=None,
     matmuls=None,

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 from collections.abc import Callable
 from typing import Any, Literal, TYPE_CHECKING, TypeAlias
 
+import sympy
+
 import torch
 import torch.distributed as dist
 import torch.utils._pytree as pytree
@@ -96,13 +98,14 @@ def _compute_foreach_groups(
     Returns a flat list with -1 as group delimiter, or None if only one group exists.
     For example, groups [[0, 2], [1]] would be encoded as [0, 2, -1, 1].
     """
-    from torch.fx.experimental.symbolic_shapes import guarding_hint_or_throw
-
     groups: defaultdict[tuple[torch.dtype, torch.dtype, tuple[int, ...]], list[int]] = (
         defaultdict(list)
     )
     for i, (ag_in, out_dtype) in enumerate(zip(ag_ins, out_dtypes)):
-        shape = tuple(guarding_hint_or_throw(s) for s in ag_in.shape)
+        shape = tuple(
+            _hint_int_or_raise(s, context="all-gather foreach grouping")
+            for s in ag_in.shape
+        )
         key = (ag_in.dtype, out_dtype, shape)
         groups[key].append(i)
 
@@ -117,6 +120,64 @@ def _compute_foreach_groups(
             result.append(-1)
 
     return result
+
+
+# Bucketing has two separate shape contracts:
+#
+# 1. Semantic tensor shapes stay symbolic.  The traced bucket merge graph must
+#    preserve runtime tensor expressions such as numel(), split sizes,
+#    torch.empty extents, narrow offsets/lengths, and reshape shapes.  Those
+#    values describe actual tensor semantics and must not be specialized from
+#    optimization hints.
+#
+# 2. Optimization-policy choices may use hints.  Bucket byte accounting and
+#    foreach grouping need Python integers to decide how to group collectives.
+#    For those policy-only decisions, concrete ints, backed SymInts, hinted
+#    unbacked SymInts, and derived expressions from hinted symbols are valid.
+#    Unhinted symbolic values fail fast instead of forcing guards or guessing.
+#
+# In short: hints may decide which bucket/group we choose, but they must never
+# replace symbolic sizes in the graph we trace for the bucketed collective.
+def _hint_int_or_raise(value: object, *, context: str) -> int:
+    if type(value) is int:
+        return value
+
+    if not isinstance(value, torch.SymInt):
+        raise AssertionError(f"Expected int or SymInt for {context}, got {type(value)}")
+
+    node = value.node
+    if node._hint is not None:
+        return int(node._hint)
+    shape_env = node.shape_env
+    if shape_env is None:
+        raise AssertionError(f"ShapeEnv is required to hint {context}: {value}")
+
+    expr = sympy.sympify(node.expr).xreplace(shape_env.replacements)
+    expr = expr.xreplace(shape_env.backed_var_to_val)
+    expr = expr.xreplace(shape_env.var_to_hint_override)
+    if isinstance(expr, sympy.Expr):
+        expr = expr.expand(identity=True)
+    if getattr(expr, "free_symbols", None):
+        raise RuntimeError(
+            f"Could not extract optimization hint for {context}: {value}. "
+            "Collective bucketing requires hinted symbolic sizes for policy "
+            "decisions."
+        )
+    return int(expr)
+
+
+def _numel_hint_or_raise(tensor: torch.Tensor, *, context: str) -> int:
+    return _hint_int_or_raise(tensor.numel(), context=context)
+
+
+def _size_bytes_hint_or_raise(
+    tensor: torch.Tensor,
+    *,
+    dtype: torch.dtype | None = None,
+    context: str,
+) -> int:
+    element_size = tensor.element_size() if dtype is None else dtype.itemsize
+    return _numel_hint_or_raise(tensor, context=context) * element_size
 
 
 def _get_collective_node_from_wait(node: torch.fx.Node) -> torch.fx.Node | None:
@@ -483,9 +544,13 @@ def greedy_bucket_collective_by_mb(
                 continue
             assert "val" in node.meta
             n_val = node.meta["val"]
-            out_size_bytes = n_val.numel() * n_val.element_size()
+            out_size_bytes = _size_bytes_hint_or_raise(
+                n_val, context="collective bucket output size"
+            )
             n_input_val = node.all_input_nodes[0].meta["val"]
-            in_size_bytes = n_input_val.numel() * n_input_val.element_size()
+            in_size_bytes = _size_bytes_hint_or_raise(
+                n_input_val, context="collective bucket input size"
+            )
             size_bytes = max(out_size_bytes, in_size_bytes)
             if cur_bucket_size_bytes + size_bytes > bucket_size_bytes and cur_bucket:
                 # Current bucket is full, create new bucket

--- a/torch/_inductor/fx_passes/node_runtime_estimation.py
+++ b/torch/_inductor/fx_passes/node_runtime_estimation.py
@@ -292,7 +292,10 @@ def _log_compute_estimations(
                 continue
             if "val" in arg.meta:
                 t = arg.meta["val"]
-                ret += f" {dtype_abbrs[t.dtype]}{tuple(t.shape)}"
+                if isinstance(t, torch.Tensor):
+                    ret += f" {dtype_abbrs[t.dtype]}{tuple(t.shape)}"
+                elif isinstance(t, torch.SymInt):
+                    ret += f" SymInt({t})"
         return ret
 
     headers = [


### PR DESCRIPTION
Stacked PRs:
 * #184911
 * #183840
 * #183839
 * #183838
 * #183837
 * #183545
 * __->__#183544


--- --- ---

### [Inductor][Bucketing] Make collective bucketing tolerate hinted unbacked SymInts


Collective bucketing uses tensor metadata for two distinct purposes. The
bucket merge graph needs symbolic tensor shapes to remain symbolic, while
bucket sizing and foreach grouping need concrete values only as
optimization-policy estimates.

Contract:

- Semantic tensor shape paths must stay symbolic. Expressions such as
  x.numel(), x.shape[0] // group_size, split sizes, torch.empty symbolic
  extents, narrow offsets/lengths, and reshape shapes describe runtime
  tensor semantics and must not be specialized from hints.

- Optimization-policy paths may use concrete hints. Bucket byte-size
  accounting and foreach grouping are policy decisions, so hinted unbacked
  SymInts are supported there, but unhinted unbacked SymInts fail fast with
  a clear bucketing error.

- Hints are not a promise to specialize graph shapes. They are used only
  for sizing/grouping decisions where a Python integer is required to choose
  an optimization policy.

- The supported symbolic policy values are concrete ints, backed SymInts,
  unbacked SymInts with optimization hints, and derived expressions from
  those hinted symbols such as u0 // 2 and hidden * (u0 // 2).

Replace the policy uses of concrete shape extraction with local hint helpers
that evaluate concrete ints, direct SymInt hints, and ShapeEnv optimization
hint overrides. If a symbolic policy value cannot be resolved from hints,
fail with a clear bucketing error instead of falling back to unbacked-symbol
heuristics or forcing a guarding specialization.

Leave semantic merge-function sizes symbolic: numel(), split sizes, empty
sizes, narrow extents, and reshape shapes continue to flow into the traced
bucket graph as symbolic expressions. This lets hinted unbacked chunk
expressions such as u0 // 2 survive through all-gather and reduce-scatter
bucketing.

Add trace-only coverage for hinted unbacked chunked fake tensors in
all-gather and reduce-scatter bucket traces, plus a no-hint failure case for
optimization-policy grouping. Also make compute-estimation artifact logging
tolerate scalar symbolic metadata on FX node arguments; those symbols are
valid metadata, but they are not tensor-like values with dtype/shape.

Fixes #183676

Test Plan:

python test/distributed/test_inductor_collectives.py -k TestBucketingTrace -v

python test/distributed/test_inductor_collectives.py TestCollectivesInductor.test_all_gather_bucket_bucket_mode_custom_ops TestCollectivesInductor.test_reduce_scatter_bucket_bucket_mode_custom_ops -v

python test/distributed/test_overlap_bucketing_unit.py TestNodeRuntimeEstimationUnit.test_compute_estimation_logging_handles_symbolic_scalar_meta -v

lintrunner --config=.lintrunner.toml torch/_inductor/fx_passes/bucketing.py torch/_inductor/fx_passes/node_runtime_estimation.py test/distributed/test_inductor_collectives.py test/distributed/test_overlap_bucketing_unit.py

pytest torchtitan/experiments/graph_trainer/tests/test_passes.py::TestChunkPasses::test_chunk_pass_guardrails_and_pipeline_order -q

pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics::test_moe_dsv3_ep_overlap_aot_fx_trace_vs_eager_chunked -q


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo