### PR TITLE
[DTensor] Use explicit hints for unbacked sharding

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -93,10 +93,8 @@ def repurpose_ops(op_db, base_test_name, derived_test_name):
 dtensor_fails = {
     # view/reshape ops: rejects flatten/split of sharded dims without redistribution
     xfail("repeat_interleave"),
-    xfail("reshape"),
     xfail("unbind"),
     xfail("unflatten"),
-    xfail("view"),
     # factory/creation ops: test harness can't convert non-tensor args to DTensor
     xfail("arange"),
     xfail("broadcast_shapes"),
@@ -239,7 +237,9 @@ dtensor_compiled_fails = {
     xfail("flatten"),
     xfail("kron"),
     xfail("ravel"),
+    xfail("reshape"),
     xfail("reshape_as"),
+    xfail("view"),
     xfail("view_as"),
     # View-type ops that decompose into as_strided (at autograd level).
     # DTensor doesn't have a sharding strategy for as_strided.
@@ -837,13 +837,11 @@ ops_unbacked_dtensor_dde = {
     xfail("nn.functional.margin_ranking_loss"),
     xfail("nn.functional.multilabel_soft_margin_loss"),
     xfail("nn.functional.pad", "constant"),
-    xfail("nn.functional.pixel_shuffle"),
     xfail("nn.functional.poisson_nll_loss"),
     xfail("nn.functional.soft_margin_loss"),
     xfail("nn.functional.triplet_margin_loss"),
     xfail("nn.functional.triplet_margin_with_distance_loss"),
     xfail("nn.functional.upsample_nearest"),
-    xfail("nn.functional.pixel_unshuffle"),
     xfail("nonzero_static"),
     xfail("permute_copy"),
     xfail("prod"),
@@ -867,7 +865,6 @@ ops_unbacked_dtensor_dde = {
     xfail("view"),
     xfail("view_as"),
     xfail("view_as_complex"),
-    xfail("view_copy"),
 }
 
 

--- a/test/distributed/tensor/test_placement_types.py
+++ b/test/distributed/tensor/test_placement_types.py
@@ -2,12 +2,27 @@
 import copy
 import itertools
 
+import sympy
+
 import torch
+from torch._subclasses import FakeTensorMode
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor._ops.utils import is_tensor_shardable
 from torch.distributed.tensor.placement_types import (
+    _hint_proves_even_shard,
     _StridedShard,
+    _StridedShardOffsetMode,
     Partial,
     Replicate,
     Shard,
+)
+from torch.fx.experimental.symbolic_shapes import (
+    free_symbols,
+    free_unbacked_symbols,
+    GuardOnDataDependentSymNode,
+    optimization_hint,
+    ShapeEnv,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
 
@@ -143,6 +158,122 @@ class PlacementTypesTestCase(TestCase):
                 index=symint_index,
                 with_padding=True,
             )
+
+    def test_hinted_unbacked_even_shard_skips_padding(self):
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+        shard = Shard(0)
+
+        with fake_mode:
+            dim_size = fake_mode.shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(dim_size, 8)
+            local_tensor = torch.empty(dim_size // 4, 4)
+            full_tensor = torch.empty(dim_size, 4)
+
+            padded = shard._maybe_pad_tensor(local_tensor, dim_size, 4)
+            unpadded = shard._maybe_unpad_tensor(full_tensor, dim_size, 4)
+
+        self.assertEqual(padded.shape, local_tensor.shape)
+        self.assertEqual(unpadded.shape, full_tensor.shape)
+
+    def test_hinted_unbacked_even_chunk_preserves_symbolic_shard_size(self):
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+
+        with fake_mode:
+            batch = fake_mode.shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(batch, 4)
+            dim_size = 4096 * batch - 2 * torch.sym_min(1024 * batch, 2048 * batch)
+            tensor = torch.empty(dim_size, 256)
+            expected_chunk_size = dim_size // 8
+
+            chunks = Shard._custom_chunk(tensor, 8, dim=0)
+
+        self.assertEqual(len(chunks), 8)
+        for chunk in chunks:
+            self.assertEqual(chunk.size(0).node.expr, expected_chunk_size.node.expr)
+            self.assertEqual(
+                free_unbacked_symbols(chunk.size(0).node.expr),
+                free_unbacked_symbols(batch.node.expr),
+            )
+
+    def test_strided_shard_preserves_symbolic_split_factor(self):
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+
+        with fake_mode:
+            split_factor = fake_mode.shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(split_factor, 4)
+            placement = _StridedShard(dim=0, split_factor=split_factor)
+
+        self.assertEqual(placement._split_factor_int(), 4)
+        self.assertEqual(
+            free_symbols(placement.split_factor), free_symbols(split_factor)
+        )
+        self.assertEqual(optimization_hint(placement.split_factor), 4)
+        self.assertEqual(fake_mode.shape_env.replacements, {})
+        deferred_asserts = [
+            runtime_assert.expr
+            for asserts in fake_mode.shape_env.deferred_runtime_asserts.values()
+            for runtime_assert in asserts
+        ]
+        self.assertIn(sympy.Eq(split_factor.node.expr, 4), deferred_asserts)
+
+    def test_unbacked_even_fallback_hint_requires_override(self):
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+
+        with fake_mode:
+            dim_size = fake_mode.shape_env.create_unbacked_symint()
+            self.assertFalse(_hint_proves_even_shard(dim_size, 4))
+
+            torch._dynamo.override_optimization_hint(dim_size, 8)
+            self.assertTrue(_hint_proves_even_shard(dim_size, 4))
+
+    def test_hinted_unbacked_shardability_adds_runtime_check(self):
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+        mesh = DeviceMesh("cpu", torch.arange(4), _init_backend=False, _rank=0)
+        spec = DTensorSpec(mesh, (Shard(1),))
+
+        with fake_mode:
+            dim_size = fake_mode.shape_env.create_unbacked_symint()
+
+            with self.assertRaises(GuardOnDataDependentSymNode):
+                is_tensor_shardable((2, dim_size), spec)
+
+            torch._dynamo.override_optimization_hint(dim_size, 16)
+            self.assertTrue(is_tensor_shardable((2, dim_size), spec))
+
+    def test_strided_shard_unbacked_local_size_avoids_chunk_guard(self):
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+
+        with fake_mode:
+            dim_size = fake_mode.shape_env.create_unbacked_symint()
+
+        local_size, offsets = _StridedShard(
+            dim=1, split_factor=9
+        ).local_shard_size_and_offset(
+            dim_size,
+            num_chunks=2,
+            rank=0,
+            offset_mode=_StridedShardOffsetMode.ALL,
+        )
+
+        self.assertTrue(free_unbacked_symbols(local_size.node.expr))
+        self.assertEqual(offsets, [])
+
+    def test_strided_shard_split_tensor_uses_unbacked_safe_chunking(self):
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+
+        with fake_mode:
+            dim_size = fake_mode.shape_env.create_unbacked_symint()
+            tensor = torch.empty(1, dim_size)
+            shards, pad_sizes = _StridedShard(dim=1, split_factor=9)._split_tensor(
+                tensor,
+                num_chunks=2,
+                with_padding=False,
+                contiguous=False,
+            )
+
+        self.assertEqual(len(shards), 2)
+        self.assertEqual(pad_sizes, [])
+        self.assertTrue(free_unbacked_symbols(shards[0].size(1).node.expr))
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -36,6 +36,7 @@ from torch.distributed.tensor._redistribute import (
     _FlattenedTransformInfo,
     _gen_transform_infos,
     _optimize_transform_infos,
+    _redistribute_cost_sort_key,
     _TransformInfo,
     disable_redistribute_transform_optimization,
     redistribute_local_tensor,
@@ -43,6 +44,7 @@ from torch.distributed.tensor._redistribute import (
 )
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _MaskPartial, _StridedShard
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -1532,6 +1534,19 @@ class DistributeWithDeviceOrderTest(DTensorContinuousTestBase):
                             src_to_dst_cost <= src_to_int_cost + int_to_dst_cost,
                             f"{tensor_shape=}, {src_order=}, {dst_order=}, {intermediate_order=}",
                         )
+
+    def test_redistribute_cost_sort_key_uses_unbacked_hint(self):
+        shape_env = ShapeEnv()
+        unbacked = shape_env.create_unbacked_symint()
+        shape_env.var_to_hint_override[unbacked.node.expr] = 8
+
+        lower_cost = 1000000.0 * (unbacked / 87.7) + 7.2
+        higher_cost = 1000000.0 * (2 * unbacked / 87.7) + 7.8
+
+        self.assertLess(
+            _redistribute_cost_sort_key(lower_cost),
+            _redistribute_cost_sort_key(higher_cost),
+        )
 
     def test_redistribute_partial_to_different_partial_not_supported(self):
         # Test that redistributing from one Partial type to another raises an error

--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -63,6 +63,61 @@ R = Replicate()
 
 
 class LocalTest(TestCase):
+    def test_strided_shard_to_replicate_preserves_even_unbacked_shape(self):
+        import torch.distributed.tensor.placement_types as placement_types
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import (
+            ShapeEnv,
+            statically_known_true,
+        )
+
+        class Mesh:
+            def size(self, mesh_dim=0):
+                return 4
+
+        pad_sizes = []
+        old_pad_tensor = placement_types.pad_tensor
+        old_all_gather = placement_types.funcol.all_gather_single
+
+        def fake_pad_tensor(tensor, pad_dim, pad_size):
+            pad_sizes.append(pad_size)
+            shape = list(tensor.shape)
+            shape[pad_dim] = shape[pad_dim] + pad_size
+            return tensor.new_empty(shape)
+
+        def fake_all_gather(tensor, gather_dim, group):
+            shape = list(tensor.shape)
+            shape[gather_dim] = shape[gather_dim] * 4
+            return tensor.new_empty(shape)
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=shape_env)
+        with fake_mode:
+            batch = shape_env.create_unbacked_symint()
+            torch._dynamo.override_optimization_hint(batch, 4)
+            local_tensor = torch.empty(512 * batch, 8)
+            placement_types.pad_tensor = fake_pad_tensor
+            placement_types.funcol.all_gather_single = fake_all_gather
+            try:
+                replicate_tensor = _StridedShard(
+                    0, split_factor=2
+                )._to_replicate_tensor(
+                    local_tensor,
+                    Mesh(),
+                    0,
+                    [2048 * batch, 8],
+                )
+            finally:
+                placement_types.pad_tensor = old_pad_tensor
+                placement_types.funcol.all_gather_single = old_all_gather
+
+        self.assertEqual(len(pad_sizes), 1)
+        self.assertTrue(statically_known_true(pad_sizes[0] == 0))
+        self.assertTrue(
+            statically_known_true(replicate_tensor.shape[0] == 2048 * batch)
+        )
+        self.assertFalse(replicate_tensor.shape[0] != 2048 * batch)
+
     def test_compute_local_shape_and_global_offset_uneven(self):
         # This case is not only 'uneven' bug also has an empty shard
         # (e.g. most DP ranks have local shape 18,4096, one has 8,4096, one has 0,4096

--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -280,6 +280,18 @@ class TestViewOps(DTensorContinuousTestBase):
         with self.assertRaisesRegex(RuntimeError, "Sharding propagation failed"):
             shard.view(8, 2, -1)
 
+    def test_split_flatten_non_first_shard_falls_back_to_replicate(self):
+        rule = view_groups((32, 4), (4, 32))
+        input_tgt, output = propagate_shape_and_sharding(
+            [Shard(1)],
+            (32, 4),
+            rule,
+            (4,),
+            strict_view=True,
+        )
+        self.assertEqual(input_tgt, [Replicate()])
+        self.assertEqual(output, [Replicate()])
+
     def test_double_shard_split_validation(self):
         """[Shard(0), Shard(0)] through Split correctly validates divisibility."""
         # Compatible: reshape (24,)→(6,4) with [Shard(0), Shard(0)] on mesh (2,3)
@@ -736,12 +748,43 @@ class TestViewOps(DTensorContinuousTestBase):
             view_shapes.extend(trailing_dims)
         return tuple(view_shapes)
 
+    def _split_flatten_replicate_fallback_mesh_dims(self, rules, placements):
+        fallback_mesh_dims = []
+        for mesh_dim, placement in enumerate(placements):
+            if not isinstance(placement, Shard):
+                continue
+
+            for rule in rules:
+                if not (
+                    isinstance(rule, Split) and isinstance(rule.input_dim, Flatten)
+                ):
+                    continue
+
+                input_dims = rule.input_dim.input_dims
+                if not all(isinstance(input_dim, InputDim) for input_dim in input_dims):
+                    raise AssertionError(f"Expected InputDim list, got {input_dims}")
+                flattened_dims = cast(list[InputDim], input_dims)
+                if any(
+                    input_dim.input_dim == placement.dim for input_dim in flattened_dims
+                ):
+                    first_dim = flattened_dims[0].input_dim
+                    if placement.dim != first_dim:
+                        fallback_mesh_dims.append(mesh_dim)
+                    break
+        return fallback_mesh_dims
+
     def _test_dtensor_flatten_split_case(self, in_shape, out_shape, placements, mesh):
         """Test a single Split(Flatten) view case.
 
-        Representable cases must produce zero communication and correct output.
-        Unrepresentable cases must raise RuntimeError with a specific message.
+        Representable cases must produce zero communication and correct output. Cases
+        that require sharding a non-first flattened input dim fall back to Replicate
+        with communication, because the plain Shard is not exactly representable.
+        Other unrepresentable cases must raise RuntimeError with a specific message.
         """
+        rules = view_groups(list(in_shape), list(out_shape))
+        fallback_mesh_dims = self._split_flatten_replicate_fallback_mesh_dims(
+            rules, placements
+        )
         nelem = math.prod(in_shape)
         global_tensor = torch.arange(nelem).view(in_shape)
         in_dt = distribute_tensor(global_tensor, mesh, placements, src_data_rank=None)
@@ -756,9 +799,14 @@ class TestViewOps(DTensorContinuousTestBase):
                 r"|is not evenly divisible by mesh dimension",
             )
             return
-        self.assertEqual(comm_mode.get_total_counts(), 0)
         expected = global_tensor.view(list(out_shape))
         self.assertEqual(out_dt.full_tensor(), expected)
+        if fallback_mesh_dims:
+            self.assertGreater(comm_mode.get_total_counts(), 0)
+            for mesh_dim in fallback_mesh_dims:
+                self.assertIsInstance(out_dt.placements[mesh_dim], Replicate)
+        else:
+            self.assertEqual(comm_mode.get_total_counts(), 0)
 
     def test_dtensor_flatten_split_multi_mesh(self):
         """Test views producing Split(Flatten) rules.
@@ -2852,9 +2900,25 @@ class TestViewOps(DTensorContinuousTestBase):
         result = view_groups([4, u9], [4, u10])
         self.assertEqual(result, (InputDim(0), InputDim(1)))
 
+        # Splitting a product by a concrete prefix should not guard on
+        # unbacked divisibility such as ``8 % (8 * u0) == 0``.
+        u11 = fresh_sym()
+        self.assertEqual(
+            view_groups([8 * u11, 256], [8, u11, 256]),
+            (
+                Split(InputDim(0), (8, u11), 0),
+                Split(InputDim(0), (8, u11), 1),
+                InputDim(1),
+            ),
+        )
+
     def test_view_groups_unbacked_sharding_propagation(self):
         """Test that sharding is correctly propagated through view_groups with symbolic shapes."""
-        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+        from torch.fx.experimental.symbolic_shapes import (
+            free_symbols,
+            optimization_hint,
+            ShapeEnv,
+        )
 
         shape_env = ShapeEnv()
 
@@ -2908,6 +2972,48 @@ class TestViewOps(DTensorContinuousTestBase):
             input_placements, from_shape, rule, mesh_sizes
         )
         self.assertEqual(out_plc, [Shard(0), Replicate()])
+
+        # Strict view with a non-leftmost shard needs _StridedShard. Preserve
+        # the symbolic split_factor as semantic placement metadata; list-based
+        # lowering can still use the explicit hint as a guarded unroll count.
+        u4_hint = fresh_sym()
+        torch._dynamo.override_optimization_hint(u4_hint, 4)
+        from_shape = (u4_hint, 16, 8)
+        to_shape = (u4_hint * 16, 8)
+        rule = view_groups(from_shape, to_shape)
+        input_placements = [Shard(1), Replicate()]
+        inp_tgt, out_plc = propagate_shape_and_sharding(
+            input_placements, from_shape, rule, mesh_sizes, strict_view=True
+        )
+        self.assertIsInstance(out_plc[0], _StridedShard)
+        self.assertEqual(out_plc[0].dim, 0)
+        self.assertEqual(out_plc[1], Replicate())
+        self.assertEqual(free_symbols(out_plc[0].split_factor), free_symbols(u4_hint))
+        self.assertEqual(optimization_hint(out_plc[0].split_factor), 4)
+        self.assertTrue(free_symbols(u4_hint))
+
+        u4_unhinted = fresh_sym()
+        from_shape = (u4_unhinted, 16, 8)
+        to_shape = (u4_unhinted * 16, 8)
+        rule = view_groups(from_shape, to_shape)
+        with self.assertRaisesRegex(RuntimeError, "symbolic _StridedShard"):
+            propagate_shape_and_sharding(
+                input_placements, from_shape, rule, mesh_sizes, strict_view=True
+            )
+
+        # Unflattening a symbolic _StridedShard should match the Split prefix
+        # factor by guarded hint without specializing the symbol.
+        u5_hint = fresh_sym()
+        torch._dynamo.override_optimization_hint(u5_hint, 8)
+        from_shape = (u5_hint * 2048, 256)
+        to_shape = (u5_hint, 2048, 256)
+        rule = view_groups(from_shape, to_shape)
+        input_placements = [_StridedShard(0, split_factor=u5_hint), Replicate()]
+        inp_tgt, out_plc = propagate_shape_and_sharding(
+            input_placements, from_shape, rule, mesh_sizes, strict_view=True
+        )
+        self.assertEqual(out_plc, [Shard(1), Replicate()])
+        self.assertTrue(free_symbols(u5_hint))
 
         # Flatten [16, u] -> [16*u] with Shard(1) on unbacked dim (non-leftmost):
         # should force replicate since non-leftmost dims can't propagate through flatten

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -228,6 +228,14 @@ def pad_tensor(
             return tensor
     elif not _are_we_tracing() and guard_or_false(pad_size == 0):
         return tensor
+    if _are_we_tracing():
+        from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
+
+        if has_free_unbacked_symbols(tensor):
+            pad_shape: list[IntLikeType] = list(tensor.shape)
+            pad_shape[pad_dim] = pad_size
+            return torch.cat([tensor, tensor.new_zeros(pad_shape)], dim=pad_dim)
+
     pad = [0, 0] * (tensor.ndim - pad_dim)
     pad[-1] = pad_size  # pyrefly: ignore[unsupported-operation]
     return torch.nn.functional.pad(tensor, pad)

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -60,6 +60,23 @@ def _setLevel_and_reinit(level: int) -> None:
 logger.setLevel = _setLevel_and_reinit  # type: ignore[method-assign]
 
 
+def _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
+    output_spec: object,
+) -> contextlib.AbstractContextManager[None]:
+    if not _are_we_tracing() or output_spec is None:
+        return contextlib.nullcontext()
+
+    from torch.fx.experimental.symbolic_shapes import (
+        _ignore_fresh_unbacked_symbols_tls_context,
+    )
+
+    # DTensor exposes the global output contract through output_spec. Fresh
+    # local fake symbols created only while redistributing or computing the
+    # per-rank tensor are implementation details and may not appear in the
+    # returned DTensor object.
+    return _ignore_fresh_unbacked_symbols_tls_context()
+
+
 def as_strided_handler(
     op_call: torch._ops.OpOverload,
     args: tuple[object, ...],
@@ -300,11 +317,14 @@ class OpDispatcher:
                 # on args first, which could potentially modify args (i.e. allgather certain arg)
                 if output_sharding.redistribute_schema is None:
                     raise AssertionError
-                self.redistribute_local_args(
-                    op_info,
-                    output_sharding.redistribute_schema,
-                    output_sharding.use_val_from_redistribute_schema,
-                )
+                with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
+                    output_sharding.output_spec
+                ):
+                    self.redistribute_local_args(
+                        op_info,
+                        output_sharding.redistribute_schema,
+                        output_sharding.use_val_from_redistribute_schema,
+                    )
 
             local_tensor_args = (
                 pytree.tree_unflatten(
@@ -366,9 +386,12 @@ class OpDispatcher:
                         with random._rng_tracker._distribute_region(
                             first_arg._spec, generator=maybe_user_generator
                         ):
-                            local_results = op_call(
-                                *local_tensor_args, **op_info.local_kwargs
-                            )
+                            with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
+                                output_sharding.output_spec
+                            ):
+                                local_results = op_call(
+                                    *local_tensor_args, **op_info.local_kwargs
+                                )
                     else:
                         # CUDA device without user generator, use HOP for traceability
                         if not isinstance(
@@ -378,16 +401,24 @@ class OpDispatcher:
                         start_offset_incr, end_offset_incr = (
                             random._rng_tracker._compute_rng_offsets(first_arg._spec)
                         )
-                        local_results = run_dtensor_rng_op(
-                            start_offset_incr,
-                            end_offset_incr,
-                            op_call,
-                            *local_tensor_args,
-                            **op_info.local_kwargs,
-                        )
+                        with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
+                            output_sharding.output_spec
+                        ):
+                            local_results = run_dtensor_rng_op(
+                                start_offset_incr,
+                                end_offset_incr,
+                                op_call,
+                                *local_tensor_args,
+                                **op_info.local_kwargs,
+                            )
                 else:
                     # No rng_tracker, meta tensor, or distribute_region disabled
-                    local_results = op_call(*local_tensor_args, **op_info.local_kwargs)
+                    with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
+                        output_sharding.output_spec
+                    ):
+                        local_results = op_call(
+                            *local_tensor_args, **op_info.local_kwargs
+                        )
             else:
                 # normal case, run local sharded op computation
                 if (
@@ -396,11 +427,19 @@ class OpDispatcher:
                     and output_sharding.redistribute_schema.op != op_call
                 ):
                     # Op was rewritten (e.g., squeeze.default → squeeze.dims)
-                    local_results = output_sharding.redistribute_schema.op(
-                        *local_tensor_args, **op_info.local_kwargs
-                    )
+                    with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
+                        output_sharding.output_spec
+                    ):
+                        local_results = output_sharding.redistribute_schema.op(
+                            *local_tensor_args, **op_info.local_kwargs
+                        )
                 else:
-                    local_results = op_call(*local_tensor_args, **op_info.local_kwargs)
+                    with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
+                        output_sharding.output_spec
+                    ):
+                        local_results = op_call(
+                            *local_tensor_args, **op_info.local_kwargs
+                        )
 
         else:
             # For a non-participating device (happens on rank that does not belong to

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -3,7 +3,7 @@
 import math
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
-from typing import cast, NamedTuple
+from typing import Any, cast, NamedTuple
 
 import torch
 from torch import Tensor
@@ -28,6 +28,7 @@ from torch.distributed.tensor._ops.utils import (
     register_op_strategy,
 )
 from torch.distributed.tensor.placement_types import (
+    _defer_symbolic_equality_assert,
     _StridedShard,
     Partial,
     Placement,
@@ -39,6 +40,53 @@ from torch.distributed.tensor.placement_types import (
 aten = torch.ops.aten
 
 Shape = tuple[int, ...]
+
+
+def _explicit_unbacked_hint(value: object) -> int | None:
+    from torch.fx.experimental.symbolic_shapes import (
+        free_unbacked_symbols,
+        optimization_hint,
+    )
+
+    if not isinstance(value, torch.SymInt):
+        return None
+    shape_env = getattr(value.node, "shape_env", None)
+    if shape_env is None:
+        return None
+    unbacked_symbols = free_unbacked_symbols(value.node.expr)
+    if not unbacked_symbols or not unbacked_symbols.issubset(
+        shape_env.var_to_hint_override.keys()
+    ):
+        return None
+    return int(optimization_hint(value, fallback=None))
+
+
+def _split_factor_hint(value: object) -> int | None:
+    if isinstance(value, int):
+        return int(value)
+    return _explicit_unbacked_hint(value)
+
+
+def _split_factor_matches(expected: object, actual: object) -> bool:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    if expected is None:
+        return False
+    if guard_or_false(expected == actual):
+        return True
+    expected_hint = _split_factor_hint(expected)
+    actual_hint = _split_factor_hint(actual)
+    if expected_hint is None or actual_hint is None or expected_hint != actual_hint:
+        return False
+    if isinstance(expected, torch.SymInt):
+        _defer_symbolic_equality_assert(
+            expected, actual_hint, reason="_StridedShard split_factor match"
+        )
+    elif isinstance(actual, torch.SymInt):
+        _defer_symbolic_equality_assert(
+            actual, expected_hint, reason="_StridedShard split_factor match"
+        )
+    return True
 
 
 class ClaimedDim(NamedTuple):
@@ -393,7 +441,11 @@ def view_groups(from_size: Shape, to_size: Shape) -> DimMap:
     - in the above, input is flattened into a single dimension and then split
       into two separate dimensions with different sizes from the input.
     """
-    from torch.fx.experimental.symbolic_shapes import guard_or_false, guard_or_true
+    from torch.fx.experimental.symbolic_shapes import (
+        free_symbols,
+        guard_or_false,
+        guard_or_true,
+    )
 
     from_nelem = prod(from_size)
     to_size = infer_size(from_nelem, normalize_sizes(to_size))
@@ -438,19 +490,50 @@ def view_groups(from_size: Shape, to_size: Shape) -> DimMap:
             from_group_dim = []
         else:
             # produces ([1], [1]),  ([2], [2]), ([2,3], [6])
-            while guard_or_true(f != t):
-                if (
-                    t % f == 0 or t > f
+            while not guard_or_false(f == t):
+                if from_idx < from_len and (
+                    to_idx >= to_len
+                    or guard_or_false(t % f == 0)
+                    or guard_or_false(t > f)
                 ):  # for easier symbolic comparisons, e.g. u0*u1 > u0
                     nf = from_size[from_idx]
                     from_group_dim.append(from_idx)
                     from_idx += 1
                     f *= nf
-                else:
+                elif to_idx < to_len and (
+                    from_idx >= from_len
+                    or guard_or_false(f % t == 0)
+                    or guard_or_false(f > t)
+                    or (free_symbols(f) and not free_symbols(t))
+                ):
                     nt = to_size[to_idx]
                     to_group_shape.append(nt)
                     to_idx += 1
                     t *= nt
+                elif from_idx < from_len and free_symbols(t) and not free_symbols(f):
+                    nf = from_size[from_idx]
+                    from_group_dim.append(from_idx)
+                    from_idx += 1
+                    f *= nf
+                elif to_idx < to_len and from_idx < from_len:
+                    # With unbacked dimensions, neither divisibility nor
+                    # ordering may be provable without a data-dependent guard.
+                    # Fall back to one conservative reshape group over the
+                    # remaining contiguous dims; sharding propagation can then
+                    # replicate if the exact split is not statically known.
+                    while from_idx < from_len:
+                        nf = from_size[from_idx]
+                        from_group_dim.append(from_idx)
+                        from_idx += 1
+                        f *= nf
+                    while to_idx < to_len:
+                        nt = to_size[to_idx]
+                        to_group_shape.append(nt)
+                        to_idx += 1
+                        t *= nt
+                    break
+                else:
+                    break
 
         if len(to_group_shape) > 0:
             flattened = Flatten.new(
@@ -638,6 +721,7 @@ class _ViewShardingPropagator:
         # Mesh dims whose _StridedShard has already been matched to an output dim.
         # Populated by _analyze_split.
         self.matched_strided_mesh_dims: set[int] = set()
+        self.strict_replicate_fallback: set[tuple[int, int]] = set()
 
     # ------------------------------------------------------------------
     # Public API: analyze → rewrite_output_placements
@@ -720,7 +804,10 @@ class _ViewShardingPropagator:
                 isinstance(p, Shard | _StridedShard)
                 and not self.shard_allowed[p.dim][mesh_dim]
             ):
-                if self.strict_view:
+                if (
+                    self.strict_view
+                    and (p.dim, mesh_dim) not in self.strict_replicate_fallback
+                ):
                     raise RuntimeError(
                         f"This operation would remove or reshape sharded "
                         f"dimension {p.dim}, which requires redistribution. "
@@ -831,7 +918,7 @@ class _ViewShardingPropagator:
                 expected_sf = self._expected_split_factor(
                     cmd, current_dim, mesh_dim, placements
                 )
-                if expected_sf == placement.split_factor:
+                if _split_factor_matches(expected_sf, placement.split_factor):
                     return mesh_dim, placement
             else:
                 return mesh_dim, placement
@@ -895,6 +982,23 @@ class _ViewShardingPropagator:
         if len(in_dims) == 0:
             return []
         in_dim = in_dims[0]
+        if isinstance(cmd.input_dim, Flatten):
+            # A plain Shard on a non-first flattened input dim would need an
+            # intermediate _StridedShard before this Split. The combined
+            # Flatten+Split rewrite does not preserve that placement exactly,
+            # so redistribute that mesh dim instead of raising later.
+            for flat_dim in cmd.input_dim.input_dims[1:]:
+                if not isinstance(flat_dim, InputDim):
+                    raise AssertionError(f"Expected InputDim, got {type(flat_dim)}")
+                for mesh_dim, placement in enumerate(self.input_src_placements):
+                    if (
+                        isinstance(placement, Shard)
+                        and placement.dim == flat_dim.input_dim
+                    ):
+                        self.shard_allowed[flat_dim.input_dim][mesh_dim] = False
+                        self.strict_replicate_fallback.add(
+                            (flat_dim.input_dim, mesh_dim)
+                        )
         out_size = cmd.group_shape[cmd.split_id]
         shard_mesh_dim, input_src_placement = self._find_shard_for_split(
             in_dim.input_dim, cmd, self.input_src_placements
@@ -1010,7 +1114,7 @@ class _ViewShardingPropagator:
         sharded_dim: int,
         mesh_dim: int,
         placements: Sequence[Placement],
-    ) -> int | None:
+    ) -> int | torch.SymInt | None:
         """Compute the residual split factor for ``cmd`` after earlier mesh dims.
 
         Starts from ``math.prod(cmd.group_shape[:cmd.split_id])`` and divides
@@ -1040,10 +1144,11 @@ class _ViewShardingPropagator:
         Returns the first output dim whose Split can accommodate the combined
         sharding (mesh_size * split_factor), or ``None`` if no dim fits.
         """
-        total_shard = self.mesh_sizes[mesh_dim] * p.split_factor
-        if self.global_input_shape[p.dim] % total_shard != 0:
+        total_shard = cast(Any, self.mesh_sizes[mesh_dim]) * p.split_factor
+        input_dim_size = cast(Any, self.global_input_shape[p.dim])
+        if input_dim_size % total_shard != 0:
             return None
-        shard_size = self.global_input_shape[p.dim] // total_shard
+        shard_size = input_dim_size // total_shard
         for candidate_dim in tgt_shard_dims:
             cmd = self.rule[candidate_dim]
             if isinstance(cmd, Split):
@@ -1126,9 +1231,9 @@ class _ViewShardingPropagator:
         if isinstance(cmd, Split) and isinstance(cmd.input_dim, Flatten):
             first_dim = cmd.input_dim.input_dims[0]
             if isinstance(first_dim, InputDim) and p.dim != first_dim.input_dim:
-                raise RuntimeError(
-                    f"Shard(dim={p.dim}) through Split(Flatten(...), {cmd.group_shape}) "
-                    f"is not supported yet for non-first flatten dims."
+                raise AssertionError(
+                    f"Shard(dim={p.dim}) should have been demoted before "
+                    f"Split(Flatten(...), {cmd.group_shape}) rewrite."
                 )
         if isinstance(cmd, (Split, InputDim)):
             # Split/InputDim: 1:1 dim mapping, sharding transfers directly.
@@ -1149,6 +1254,14 @@ class _ViewShardingPropagator:
             output_placement: Placement = Shard(tgt_shard_dim)
         else:
             split_factor = math.prod(local_tensor_shapes[input_start_idx : p.dim])
+            if isinstance(split_factor, torch.SymInt):
+                if _explicit_unbacked_hint(split_factor) is None:
+                    raise RuntimeError(
+                        "Cannot propagate strict view sharding through a symbolic "
+                        "_StridedShard split_factor without an explicit unbacked "
+                        f"hint override: split_factor={split_factor}, "
+                        f"input_shape={self.global_input_shape}, rule={self.rule}."
+                    )
             output_placement = _StridedShard(tgt_shard_dim, split_factor=split_factor)
         # Uneven sharding on a non-last flatten dim breaks _StridedShard:
         # split_factor (number of groups) must be the same on all devices,
@@ -1212,7 +1325,7 @@ class _ViewShardingPropagator:
                 expected_sf = self._expected_split_factor(
                     cmd, p.dim, mesh_dim, placements
                 )
-                if expected_sf != p.split_factor:
+                if not _split_factor_matches(expected_sf, p.split_factor):
                     continue
                 strided_shard_claimed_dims.add(ClaimedDim(p.dim, candidate_dim))
                 new_shapes = list(local_tensor_shapes)

--- a/torch/distributed/tensor/_ops/utils.py
+++ b/torch/distributed/tensor/_ops/utils.py
@@ -4,7 +4,7 @@ import functools
 import itertools
 import operator
 from collections.abc import Callable, Iterable, Sequence
-from typing import TypeAlias, TypeVar
+from typing import Any, cast, TypeAlias, TypeVar
 
 import torch
 from torch._prims_common import DimsSequenceType, DimsType
@@ -193,7 +193,12 @@ def is_tensor_shardable(
         True: assumes shardability; we return True, allowing zero-size shards at runtime when u0 < num_shards.
         False: returns False, and lower-bounding u0, e.g. torch._check(u0 >= num_shards), is needed to enable sharding.
     """
-    from torch.fx.experimental.symbolic_shapes import guard_or_false, guard_or_true
+    from torch.fx.experimental.symbolic_shapes import (
+        free_unbacked_symbols,
+        guard_or_false,
+        guard_or_true,
+        optimization_hint,
+    )
 
     if allow_unbacked_sharding not in [None, True, False]:
         raise AssertionError
@@ -202,6 +207,24 @@ def is_tensor_shardable(
         True: guard_or_false,
         False: guard_or_true,
     }[allow_unbacked_sharding]
+
+    def hint_proves_at_least(size, lower_bound: int) -> bool:
+        if guard_or_false(size >= lower_bound):
+            return True
+        if not (
+            isinstance(size, torch.SymInt)
+            and (shape_env := getattr(size.node, "shape_env", None)) is not None
+            and (unbacked_symbols := free_unbacked_symbols(size.node.expr))
+            and unbacked_symbols.issubset(shape_env.var_to_hint_override.keys())
+            and optimization_hint(size, fallback=None) >= lower_bound
+        ):
+            return False
+
+        # Shardability is a correctness property, not just an optimization.
+        # A user-provided unbacked hint can select the shardable branch, but
+        # the runtime extent must still be checked before the strategy is used.
+        torch._check(size >= lower_bound)
+        return True
 
     # number of shards in each tensor dimension
     num_shards = [1] * len(shape)
@@ -214,12 +237,16 @@ def is_tensor_shardable(
             if isinstance(placement, _StridedShard):
                 # make sure tensor dim `shard_dim` is shardable after splitting
                 # with split_factor
-                if guard_fn(
-                    shape[shard_dim] < num_shards[shard_dim] * placement.split_factor
+                lower_bound = cast(Any, num_shards[shard_dim]) * placement.split_factor
+                if not hint_proves_at_least(shape[shard_dim], lower_bound) and guard_fn(
+                    shape[shard_dim] < lower_bound
                 ):
                     return False
             else:
-                if guard_fn(shape[shard_dim] < num_shards[shard_dim]):
+                lower_bound = num_shards[shard_dim]
+                if not hint_proves_at_least(shape[shard_dim], lower_bound) and guard_fn(
+                    shape[shard_dim] < lower_bound
+                ):
                     return False
 
     return True
@@ -237,7 +264,8 @@ def is_tensor_evenly_shardable(shape: Sequence[int], spec: DTensorSpec) -> bool:
             num_shards[shard_dim] *= spec.mesh.size(i)
             if isinstance(placement, _StridedShard):
                 if (
-                    shape[shard_dim] % (placement.split_factor * num_shards[shard_dim])
+                    cast(Any, shape[shard_dim])
+                    % (placement.split_factor * num_shards[shard_dim])
                     != 0
                 ):
                     return False
@@ -264,7 +292,7 @@ def is_tensor_evenly_shardable_on_dim(
                 # than the final num_shards check and implies it.  Note:
                 # num_shards already includes spec.mesh.size(i) from this
                 # iteration, so the check covers the full shard count.
-                if shape[dim] % (placement.split_factor * num_shards) != 0:
+                if cast(Any, shape[dim]) % (placement.split_factor * num_shards) != 0:
                     return False
 
     return shape[dim] % num_shards == 0

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -9,7 +9,7 @@ import weakref
 from collections import defaultdict
 from collections.abc import Sequence
 from functools import cache
-from typing import cast, TypedDict
+from typing import Any, cast, TypedDict
 
 import torch
 import torch.distributed._functional_collectives as funcol
@@ -34,7 +34,7 @@ from torch.distributed.tensor.placement_types import (
     Replicate,
     Shard,
 )
-from torch.types import IntLikeType
+from torch.types import FloatLikeType, IntLikeType
 from torch.utils._debug_mode import get_active_debug_mode
 
 
@@ -51,6 +51,25 @@ _FORCE_MIN_COST_REDISTRIBUTION_PLAN: bool | None = None
 # consecutive same-type collectives into flattened operations is skipped,
 # and the unmodified transform_infos list is returned as-is.
 _DISABLE_REDISTRIBUTE_TRANSFORM_OPTIMIZATION: bool = False
+
+
+def _redistribute_cost_sort_key(cost: FloatLikeType) -> float:
+    if isinstance(cost, float):
+        return cost
+    if isinstance(cost, torch.SymFloat):
+        expr = cost.node.expr
+    else:
+        return float(cost)
+
+    free_symbols = expr.free_symbols
+    if not free_symbols:
+        return float(expr)
+
+    hint_overrides = cost.node.shape_env.var_to_hint_override
+    if free_symbols.issubset(hint_overrides):
+        return float(expr.xreplace(hint_overrides))
+
+    return float(cost.node.shape_env.optimization_hint(expr, fallback=None))
 
 
 @contextlib.contextmanager
@@ -1159,20 +1178,23 @@ class DTensorRedistributePlanner:
         """
         import heapq
 
-        # priority queue (cost, counter, state, path) for Dijkstra's algorithm
-        # use counter to break ties and avoid comparing DistState objects
+        # priority queue (cost_key, counter, cost, state, path) for Dijkstra's
+        # algorithm. The sort key is a non-guarding optimization hint so that
+        # symbolic communication costs do not force heapq to evaluate guards.
+        # Counter breaks ties and avoids comparing DistState objects.
         counter = 0
         pq: list[
             tuple[
                 float,
                 int,
+                FloatLikeType,
                 DTensorRedistributePlanner.DistState,
                 list[DTensorRedistributePlanner.DistState],
             ]
-        ] = [(0, counter, src_state, [src_state])]
+        ] = [(0.0, counter, 0.0, src_state, [src_state])]
         visited = set()
         while pq:
-            cost, _, current_state, path = heapq.heappop(pq)
+            _, _, cost, current_state, path = heapq.heappop(pq)
             if current_state == dst_state:
                 return path
             if current_state in visited:
@@ -1184,10 +1206,19 @@ class DTensorRedistributePlanner:
             )
             for next_state, transition_cost in next_states.items():
                 if next_state not in visited:
-                    new_cost = cost + transition_cost
+                    new_cost = cast(Any, cost) + transition_cost
                     new_path = path + [next_state]
                     counter += 1
-                    heapq.heappush(pq, (new_cost, counter, next_state, new_path))
+                    heapq.heappush(
+                        pq,
+                        (
+                            _redistribute_cost_sort_key(new_cost),
+                            counter,
+                            new_cost,
+                            next_state,
+                            new_path,
+                        ),
+                    )
         raise AssertionError(
             f"No path found from src_state {src_state} to dst_state {dst_state}"
         )

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -5,7 +5,7 @@ import functools
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import cast, TypeGuard, TypeVar
+from typing import Any, cast, TypeGuard, TypeVar
 
 import torch
 import torch._C
@@ -29,6 +29,7 @@ from torch.types import IntLikeType
 __all__ = ["Placement", "Shard", "Replicate", "Partial"]
 
 _RankTypeT = TypeVar("_RankTypeT", bound=RankType)
+_STRIDED_SHARD_BASE_SPLIT_FACTOR: Any = torch._C._distributed.StridedShard.split_factor
 
 
 # Appease TestPublicBindings.test_correct_module_names
@@ -51,6 +52,111 @@ class _StridedShardOffsetMode(IntEnum):
     FIRST = 0
     ALL = 1
     NONE = 2
+
+
+def _explicit_or_backed_hint(value: IntLikeType) -> int | None:
+    from torch.fx.experimental.symbolic_shapes import (
+        free_unbacked_symbols,
+        optimization_hint,
+    )
+
+    if isinstance(value, int):
+        return int(value)
+    if not isinstance(value, torch.SymInt):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    shape_env = getattr(value.node, "shape_env", None)
+    if shape_env is None:
+        return None
+    unbacked_symbols = free_unbacked_symbols(value.node.expr)
+    if unbacked_symbols and not unbacked_symbols.issubset(
+        shape_env.var_to_hint_override.keys()
+    ):
+        return None
+    return int(optimization_hint(value, fallback=None))
+
+
+def _guarded_hint_int(value: IntLikeType, *, reason: str) -> int:
+    if isinstance(value, int):
+        return int(value)
+    if not isinstance(value, torch.SymInt):
+        return int(value)
+    hint = _explicit_or_backed_hint(value)
+    if hint is None:
+        raise RuntimeError(
+            f"Cannot specialize symbolic {reason} without a hint: {value}"
+        )
+    _defer_symbolic_equality_assert(value, hint, reason=reason)
+    return hint
+
+
+def _defer_symbolic_equality_assert(
+    value: IntLikeType, hint: int, *, reason: str
+) -> None:
+    if not isinstance(value, torch.SymInt):
+        return
+    shape_env = getattr(value.node, "shape_env", None)
+    if shape_env is None:
+        return
+    import sympy
+
+    from torch.fx.experimental.symbolic_shapes import (
+        free_unbacked_symbols,
+        RuntimeAssert,
+    )
+    from torch.utils._traceback import CapturedTraceback
+
+    expr = sympy.Eq(value.node.expr, hint)
+    cands = sorted(
+        free_unbacked_symbols(expr),
+        key=lambda symbol: int(symbol.name[1:]),
+    )
+    key = cands[-1] if cands else None
+    runtime_asserts = shape_env.deferred_runtime_asserts.setdefault(key, [])
+    if any(runtime_assert.expr == expr for runtime_assert in runtime_asserts):
+        return
+    runtime_asserts.append(
+        RuntimeAssert(
+            expr,
+            f"Runtime assertion failed: symbolic {reason} {value.node.expr} == {hint}",
+            CapturedTraceback.extract(skip=1),
+        )
+    )
+    shape_env.num_deferred_runtime_asserts += 1
+    shape_env._update_version_counter()
+
+
+def _split_factor_key(value: IntLikeType) -> object:
+    if isinstance(value, torch.SymInt):
+        return value.node.expr
+    return int(value)
+
+
+def _sym_mod(left: IntLikeType, right: IntLikeType) -> Any:
+    return cast(Any, left) % cast(Any, right)
+
+
+def _hint_proves_even_shard(size: IntLikeType, num_chunks: IntLikeType) -> bool:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    if guard_or_false(_sym_mod(size, num_chunks) == 0):
+        return True
+    size_hint = _explicit_or_backed_hint(size)
+    chunk_hint = _explicit_or_backed_hint(num_chunks)
+    if (
+        size_hint is None
+        or chunk_hint is None
+        or chunk_hint == 0
+        or size_hint % chunk_hint != 0
+    ):
+        return False
+
+    # Padding decisions require a Python branch. Only explicit hint overrides
+    # can justify skipping padding for otherwise data-dependent sharding.
+    torch._check(_sym_mod(size, num_chunks) == 0)
+    return True
 
 
 class Shard(torch._C._distributed.Shard):
@@ -189,7 +295,7 @@ class Shard(torch._C._distributed.Shard):
 
     @staticmethod
     def _custom_chunk(
-        tensor: torch.Tensor, num_chunks: int, dim: int
+        tensor: torch.Tensor, num_chunks: IntLikeType, dim: int
     ) -> list[torch.Tensor]:
         """
         Returns list of tensor chunks along dim.
@@ -201,21 +307,29 @@ class Shard(torch._C._distributed.Shard):
 
         if tensor.dim() <= 0:
             raise AssertionError(f"Expected tensor.dim() > 0, got {tensor.dim()}")
-        if num_chunks <= 0:
+        num_chunks_int = _guarded_hint_int(num_chunks, reason="chunk count")
+        if num_chunks_int <= 0:
             raise AssertionError(f"Expected num_chunks > 0, got {num_chunks}")
 
         # TODO(pianpwk): remove the unbacked symbols check and fix AsyncTP pattern matching
         # for test_micro_pipeline_tp.py.
         if not _are_we_tracing() or not has_free_unbacked_symbols(tensor):
-            tensor_list = list(torch.chunk(tensor, num_chunks, dim=dim))
+            tensor_list = list(torch.chunk(tensor, num_chunks_int, dim=dim))
             return fill_empty_tensor_to_shards(
-                tensor_list, dim, num_chunks - len(tensor_list)
+                tensor_list, dim, num_chunks_int - len(tensor_list)
             )
         else:
             dim_size = tensor.size(dim)
+            if _hint_proves_even_shard(dim_size, num_chunks):
+                chunk_size = dim_size // num_chunks
+                return [
+                    tensor.narrow(dim, chunk_size * i, chunk_size)
+                    for i in range(num_chunks_int)
+                ]
+
             split_size = (dim_size + num_chunks - 1) // num_chunks
             chunks = []
-            for i in range(num_chunks):
+            for i in range(num_chunks_int):
                 start = torch.sym_min(split_size * i, dim_size)
                 end = torch.sym_min(split_size * (i + 1), dim_size)
                 chunks.append(tensor.narrow(dim, start, end - start))
@@ -378,8 +492,11 @@ class Shard(torch._C._distributed.Shard):
             # which should be an empty tensor
             return tensor
 
-        # Assume padding (uneven sharding) as general case for unbacked sizes.
-        is_padded = guard_or_true(tensor.size(self.dim) % num_chunks != 0)
+        # Assume padding (uneven sharding) as general case for unbacked sizes,
+        # unless an optimization hint can prove the even-shard branch.
+        is_padded = not _hint_proves_even_shard(
+            tensor.size(self.dim), num_chunks
+        ) and guard_or_true(tensor.size(self.dim) % num_chunks != 0)
         pad_sizes = None
         if is_padded:
             scattered_list, pad_sizes = self._split_tensor(
@@ -410,8 +527,11 @@ class Shard(torch._C._distributed.Shard):
     ) -> torch.Tensor:
         from torch.fx.experimental.symbolic_shapes import guard_or_true
 
-        # Assume padding (uneven sharding) as general case for unbacked sizes.
-        is_padded = guard_or_true(logical_dim_size % num_chunks != 0)
+        # Assume padding (uneven sharding) as general case for unbacked sizes,
+        # unless an optimization hint can prove the even-shard branch.
+        is_padded = not _hint_proves_even_shard(
+            logical_dim_size, num_chunks
+        ) and guard_or_true(logical_dim_size % num_chunks != 0)
 
         if is_padded:
             full_chunk_size = (logical_dim_size + num_chunks - 1) // num_chunks
@@ -432,8 +552,11 @@ class Shard(torch._C._distributed.Shard):
     ) -> torch.Tensor:
         from torch.fx.experimental.symbolic_shapes import guard_or_false, guard_or_true
 
-        # Assume padding (uneven sharding) as general case for unbacked sizes.
-        is_padded = guard_or_true(logical_dim_size % num_chunks != 0)
+        # Assume padding (uneven sharding) as general case for unbacked sizes,
+        # unless an optimization hint can prove the even-shard branch.
+        is_padded = not _hint_proves_even_shard(
+            logical_dim_size, num_chunks
+        ) and guard_or_true(logical_dim_size % num_chunks != 0)
 
         if is_padded:
             full_chunk_size = (logical_dim_size + num_chunks - 1) // num_chunks
@@ -736,8 +859,48 @@ class _StridedShard(torch._C._distributed.StridedShard):
     TODO: we should remove _StridedShard placement once we can unify it with Shard
     """
 
+    def __init__(
+        self,
+        dim: int,
+        *,
+        split_factor: IntLikeType = 1,
+        sf: IntLikeType | None = None,
+    ) -> None:
+        # The C++ placement stores the unroll count as int64_t, but view
+        # propagation may derive the split factor from symbolic shape metadata.
+        # Preserve that symbolic value on the Python wrapper and guard the
+        # concrete unroll count used by list-based lowering.
+        if sf is not None:
+            if split_factor != 1:
+                raise TypeError("_StridedShard received both split_factor and sf")
+            split_factor = sf
+        split_factor_int = _guarded_hint_int(
+            split_factor, reason="_StridedShard split_factor"
+        )
+        super().__init__(dim, split_factor=split_factor_int)
+        if isinstance(split_factor, torch.SymInt):
+            self._symbolic_split_factor = split_factor
+
+    @property
+    def split_factor(self) -> IntLikeType:  # pyrefly: ignore [bad-override]
+        symbolic_split_factor = getattr(self, "_symbolic_split_factor", None)
+        if symbolic_split_factor is not None:
+            return symbolic_split_factor
+        return int(_STRIDED_SHARD_BASE_SPLIT_FACTOR.__get__(self, type(self)))
+
+    def _split_factor_int(self) -> int:
+        return int(_STRIDED_SHARD_BASE_SPLIT_FACTOR.__get__(self, type(self)))
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, _StridedShard)
+            and self.dim == other.dim
+            and _split_factor_key(self.split_factor)
+            == _split_factor_key(other.split_factor)
+        )
+
     def __hash__(self) -> int:
-        return hash((self.dim, self.split_factor))
+        return hash((self.dim, _split_factor_key(self.split_factor)))
 
     def __repr__(self) -> str:
         """
@@ -759,8 +922,11 @@ class _StridedShard(torch._C._distributed.StridedShard):
         Returns FX-evaluable repr and required globals for Shard placement.
         Needed for passing this type as an opaque object input to a custom op.
         """
+        # FX repr cannot refer to this placement's private SymInt object. The
+        # constructor emitted a guard tying the symbolic split factor to this
+        # concrete unroll count before the placement can reach codegen.
         return (
-            f"torch.distributed.tensor.placement_types._StridedShard(dim={self.dim}, sf={self.split_factor})",
+            f"torch.distributed.tensor.placement_types._StridedShard(dim={self.dim}, sf={self._split_factor_int()})",
             {},
         )
 
@@ -772,7 +938,7 @@ class _StridedShard(torch._C._distributed.StridedShard):
         mesh: DeviceMesh,
         mesh_dim: int,
         src_data_rank: int | None = 0,
-        split_factor: int = 1,
+        split_factor: IntLikeType = 1,
     ) -> torch.Tensor:
         strided_shard_placement = cls(dim=dim, split_factor=split_factor)
         return strided_shard_placement._shard_tensor(
@@ -856,34 +1022,31 @@ class _StridedShard(torch._C._distributed.StridedShard):
         # results in the transposed left-first order.
 
         # First split: chunk into split_factor pieces
-        first_split = list(torch.chunk(tensor, self.split_factor, dim=self.dim))
-        first_split = fill_empty_tensor_to_shards(
-            first_split, self.dim, self.split_factor - len(first_split)
-        )
+        split_factor = self.split_factor
+        split_factor_int = self._split_factor_int()
+        first_split = Shard._custom_chunk(tensor, split_factor, dim=self.dim)
 
         # Second split: chunk each piece into num_chunks pieces
         second_split = []
         for s in first_split:
-            chunks = list(torch.chunk(s, num_chunks, dim=self.dim))
-            chunks = fill_empty_tensor_to_shards(
-                chunks, self.dim, num_chunks - len(chunks)
-            )
-            second_split.append(chunks)
+            second_split.append(Shard._custom_chunk(s, num_chunks, dim=self.dim))
 
         shard_list: list[torch.Tensor] = []
         for i in range(num_chunks):
             shard = torch.cat(
-                [second_split[j][i] for j in range(self.split_factor)],
+                [second_split[j][i] for j in range(split_factor_int)],
                 dim=self.dim,
             )
             if contiguous:
                 shard = shard.contiguous()
             shard_list.append(shard)
 
-        # The amount of padding is determined by the local chunk with the largest size.
         pad_sizes: list[int] = []
-        max_chunk_size = max([shard.size(self.dim) for shard in shard_list])
         if with_padding:
+            # The amount of padding is determined by the local chunk with the
+            # largest size. Avoid this Python max when padding is disabled so
+            # tracing paths can keep unbacked sizes symbolic.
+            max_chunk_size = max([shard.size(self.dim) for shard in shard_list])
             pad_sizes = [max_chunk_size - shard.size(self.dim) for shard in shard_list]
 
         return shard_list, pad_sizes
@@ -1036,8 +1199,15 @@ class _StridedShard(torch._C._distributed.StridedShard):
         # squeeze back to 1D indices tensor
         sharded_indices = [shard.view(-1) for shard in sharded_indices]
 
-        # First chunk should be one of those biggest chunks.
-        max_chunk_size = len(sharded_indices[0])
+        # First chunk should be one of those biggest chunks. Compute the size
+        # from the logical shape rather than the fake arange split so padding
+        # depends only on the original symbolic dimension and its hint.
+        max_chunk_size, _ = self.local_shard_size_and_offset(
+            logical_dim_size,
+            num_chunks,
+            rank=0,
+            offset_mode=_StridedShardOffsetMode.ALL,
+        )
         local_pad_size = max_chunk_size - local_tensor.size(self.dim)
         local_tensor_padded = pad_tensor(local_tensor, self.dim, local_pad_size)
 
@@ -1058,11 +1228,16 @@ class _StridedShard(torch._C._distributed.StridedShard):
         #
         # Build select_indices where select_indices[original_pos] = position in
         # the padded tensor that holds the element for original_pos.
-        padded_positions = []
+        padded_positions: list[torch.Tensor] = []
         for i, shard in enumerate(sharded_indices):
             base_offset = i * max_chunk_size
-            positions = base_offset + torch.arange(
-                len(shard), device=local_tensor.device
+            positions = cast(
+                torch.Tensor,
+                base_offset
+                + torch.arange(
+                    shard.numel(),
+                    device=local_tensor.device,
+                ),
             )
             padded_positions.append(positions)
 
@@ -1078,6 +1253,14 @@ class _StridedShard(torch._C._distributed.StridedShard):
 
         replicate_tensor = torch.index_select(
             replicate_tensor_permuted_padded, self.dim, select_indices
+        )
+        logical_shape = cast(list[IntLikeType], list(replicate_tensor.shape))
+        logical_shape[self.dim] = current_logical_shape[self.dim]
+        replicate_tensor = replicate_tensor.as_strided(
+            logical_shape,
+            torch._prims_common.make_contiguous_strides_for(
+                cast(list[int], logical_shape)
+            ),
         )
 
         return replicate_tensor.contiguous()
@@ -1164,6 +1347,40 @@ class _StridedShard(torch._C._distributed.StridedShard):
                   and NONE returns None.
         """
         offset_mode = _StridedShardOffsetMode(offset_mode)
+        from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
+
+        if (
+            offset_mode is not _StridedShardOffsetMode.FIRST
+            and isinstance(curr_local_size, torch.SymInt)
+            and free_unbacked_symbols(curr_local_size.node.expr)
+        ):
+            split_factor = self.split_factor
+            split_factor_int = self._split_factor_int()
+            offset = None if offset_mode is _StridedShardOffsetMode.NONE else []
+            if _hint_proves_even_shard(curr_local_size, split_factor * num_chunks):
+                return (
+                    curr_local_size // num_chunks,
+                    offset,
+                )  # pyrefly: ignore[bad-return]
+
+            local_shard_size: IntLikeType = 0
+            first_split_size = (curr_local_size + split_factor - 1) // split_factor
+            for split_idx in range(split_factor_int):
+                first_start = torch.sym_min(
+                    first_split_size * split_idx, curr_local_size
+                )
+                first_end = torch.sym_min(
+                    first_split_size * (split_idx + 1), curr_local_size
+                )
+                first_len = torch.sym_max(0, first_end - first_start)
+                second_split_size = (first_len + num_chunks - 1) // num_chunks
+                second_start = torch.sym_min(second_split_size * rank, first_len)
+                second_end = torch.sym_min(second_split_size * (rank + 1), first_len)
+                local_shard_size = local_shard_size + torch.sym_max(
+                    0, second_end - second_start
+                )
+            return local_shard_size, offset  # pyrefly: ignore[bad-return]
+
         # indices_tensor is 1D torch.arange(logical_dim_size) unsqueezed
         # so that we can reuse self._split_tensor which splits on self.dim
         shape = [1] * self.dim + [curr_local_size]

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3767,6 +3767,32 @@ class DimConstraints:
 TLS = threading.local()
 
 
+def _ignore_fresh_unbacked_symbols_tls() -> bool:
+    return getattr(TLS, "ignore_fresh_unbacked_symbols", False)
+
+
+def _ignore_fresh_unbacked_symbols_set(b: bool) -> bool:
+    prev = _ignore_fresh_unbacked_symbols_tls()
+    TLS.ignore_fresh_unbacked_symbols = b
+    return prev
+
+
+@contextmanager
+def _ignore_fresh_unbacked_symbols_tls_context() -> Generator[None, None, None]:
+    """
+    Indicates that newly allocated unbacked SymInts are intentionally discarded.
+
+    This is used by tracing-only metadata paths that do not own a ShapeEnv, but
+    still create temporary fake tensors whose fresh symbols should not be bound
+    into the surrounding graph.
+    """
+    prev = _ignore_fresh_unbacked_symbols_set(True)
+    try:
+        yield
+    finally:
+        _ignore_fresh_unbacked_symbols_set(prev)
+
+
 @dataclass(frozen=True, slots=True)
 class ShapeEnvSettings:
     """
@@ -4460,13 +4486,11 @@ class ShapeEnv:
                 self.replacements[b.node.expr] = new_var
 
     def _ignore_fresh_unbacked_symbols_tls(self) -> bool:
-        return getattr(TLS, "ignore_fresh_unbacked_symbols", False)
+        return _ignore_fresh_unbacked_symbols_tls()
 
     @record_shapeenv_event()
     def _ignore_fresh_unbacked_symbols_set(self, b: bool) -> bool:
-        prev = self._ignore_fresh_unbacked_symbols_tls()
-        TLS.ignore_fresh_unbacked_symbols = b
-        return prev
+        return _ignore_fresh_unbacked_symbols_set(b)
 
     @contextmanager
     def ignore_fresh_unbacked_symbols(self) -> Generator[None, None, None]:
@@ -4474,11 +4498,8 @@ class ShapeEnv:
         Indicates that the newly allocated unbacked SymInts are being
         discarded
         """
-        prev = self._ignore_fresh_unbacked_symbols_set(True)
-        try:
+        with _ignore_fresh_unbacked_symbols_tls_context():
             yield
-        finally:
-            self._ignore_fresh_unbacked_symbols_set(prev)
 
     @record_shapeenv_event()
     def freeze(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #183838
 * #186255
 * #183839
 * #183840
 * #183837
 * #184911
 * __->__#183545


--- --- ---

### [DTensor] Use explicit hints for unbacked sharding


DTensor sharding falls back to conservative behavior when a shard size is
unbacked because divisibility and sharding metadata often require Python
decisions. That is correct for arbitrary symbolic sizes, but it is too
conservative for tracing paths that explicitly override optimization hints and
know that a sharded dimension or strict-view split factor is stable.

This change only trusts explicit optimization hint overrides for those Python
decisions. When a hint selects a no-padding or shardable branch, the traced graph
still emits the symbolic torch._check for the correctness predicate, so runtime
values that satisfy the predicate continue to work and values that violate it
fail closed. The hint chooses the trace-time policy branch; it is not baked in as
a concrete tensor extent.

For _StridedShard, view propagation now preserves a symbolic split_factor when
the split factor came from symbolic shape propagation. The C++ placement still
needs an int64_t unroll count for list-based lowering, so the Python wrapper
stores the symbolic split factor separately and uses the explicit hint only as a
guarded unroll count. The equality assertion is deferred instead of directly
calling torch._check(symbol == hint), because the direct check immediately
refines the ShapeEnv replacement and destroys the symbolic split_factor
metadata we need to preserve.

A post-merge revert found additional gaps. First, strict view propagation could
raise for Shard on a non-first flattened input dim through a combined
Split(Flatten(...)) rule. That combined rewrite cannot preserve the exact
intermediate _StridedShard placement, so it now falls back to input replication
for that mesh dim instead of crashing. During compiled DTensor tracing, the same
redistribution path can create temporary local fake symbols while computing
per-rank shard offsets; those symbols are implementation details because DTensor
returns the global output contract through the output spec, so they are ignored
while tracing local redistribution and local compute.

Second, the ignore-fresh-symbol helper must live in this commit, not in a later
stack commit, because PR 183545 CI runs this commit independently. Third, stale
xfails are removed only where the behavior now genuinely works: eager/multithreaded
view and reshape, unbacked view_copy, and unbacked pixel_shuffle/pixel_unshuffle.
Compiled view and reshape remain xfailed because AOTAutograd alias replay still
reaches DTensor as_strided. The view fallback test is also updated to distinguish
comm-free representable cases from deliberate Replicate fallback cases, and the
_StridedShard utility test now mocks the all_gather_single path that the code
actually calls.

Assisted by Codex.

Fixes #183678

Test Plan:

```bash
pip install -e . -v --no-build-isolation --no-deps
```

```bash
PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=3 python test/distributed/tensor/test_dtensor_ops.py TestCompiledDTensorOpsCPU.test_compiled_dtensor_op_db_take_along_dim_cpu_float32 -v
PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=2 python test/distributed/tensor/test_dtensor_ops.py TestCompiledDTensorOpsCPU.test_compiled_dtensor_op_db_linalg_tensorsolve_cpu_float32 -v
PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 python test/distributed/tensor/test_dtensor_ops.py TestCompiledDTensorOpsCPU.test_compiled_dtensor_op_db_nn_functional_instance_norm_cpu_float32 -v
python test/distributed/tensor/test_view_ops.py TestViewOps.test_split_flatten_non_first_shard_falls_back_to_replicate -v
python test/distributed/tensor/test_dtensor_ops.py -k test_unbacked_dtensor_op_db_view_copy_cpu_float32 -v
python test/distributed/tensor/test_dtensor_ops.py -k test_unbacked_dtensor_op_db_nn_functional_pixel_shuffle_cpu_float32 -v
```

```bash
python -m pytest test/distributed/tensor/test_dtensor_ops.py -q -k 'test_compiled_dtensor_op_db_reshape_cpu_float32 or test_dtensor_op_db_reshape_cpu_float32 or test_dtensor_op_db_view_cpu_float32 or test_unbacked_dtensor_op_db_nn_functional_pixel_unshuffle_cpu_float32'
python -m pytest test/distributed/tensor/test_dtensor_ops.py -q -k 'test_compiled_dtensor_op_db_view_cpu_float32 or test_dtensor_op_db_view_cpu_float32'
python test/distributed/tensor/test_view_ops.py TestViewOps.test_dtensor_flatten_split_multi_mesh -v
python test/distributed/tensor/test_utils.py LocalTest.test_strided_shard_to_replicate_preserves_even_unbacked_shape -v
python test/distributed/tensor/test_dtensor_compile.py TestDTensorCompile.test_dtensor_different_gradient_placement -v
python test/distributed/tensor/test_compile_on_one_rank.py TestCompileOnOneRank.test_compiled_dtensor_rng_op_graph_consistency -v
python test/distributed/tensor/debug/test_debug_mode.py TestDTensorDebugMode.test_debug_mode_mm -v
python test/inductor/test_compiled_autograd.py TestCompiledAutograd.test_dtensor_backward_symints_do_not_reuse_native_sharding_cache -v
python test/dynamo/test_fx_graph_runnable.py FxGraphRunnableTest.test_dtensor_compile_redistribute -v
lintrunner -a
```

```bash
python -m pytest -q test/distributed/tensor/test_placement_types.py test/distributed/tensor/test_view_ops.py::TestViewOps::test_view_groups_unbacked_sharding_propagation
```

```bash
lintrunner --config=.lintrunner.toml torch/distributed/tensor/placement_types.py torch/distributed/tensor/_ops/_view_ops.py torch/distributed/tensor/_ops/utils.py test/distributed/tensor/test_placement_types.py test/distributed/tensor/test_view_ops.py
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo