### PR TITLE
[dynamo] Handle `capture_triton` as a no-op during Dynamo tracing

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4620,6 +4620,37 @@ class GraphModule(torch.nn.Module):
 
         self.assertEqual(result, torch.sin(x))
 
+    @unittest.skipIf(not HAS_GPU, "requires gpu")
+    def test_capture_triton_handled_during_tracing(self):
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def sin_kernel(x_ptr, y_ptr, n_elements, BLOCK_SIZE: "tl.constexpr"):
+            pid = tl.program_id(axis=0)
+            offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(x_ptr + offsets, mask=mask)
+            tl.store(y_ptr + offsets, tl.sin(x), mask=mask)
+
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            n_elements = x.numel()
+
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+            wrapped = torch._library.capture_triton(sin_kernel)
+            wrapped[grid](x, out, n_elements, BLOCK_SIZE=128)
+
+            return out
+
+        compiled = torch.compile(fn, fullgraph=True, backend="eager")
+
+        x = torch.randn(1024, device=device_type)
+        result = compiled(x)
+
+        self.assertEqual(result, torch.sin(x))
+
     def test_property_descriptor_on_instance(self):
         class Foo:
             def __init__(self, x):

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -4395,6 +4395,15 @@
     {
       "Gb_type": "torch.library.wrap_triton call with > 1 args",
       "Context": "args={args}, kwargs={kwargs}",
+      "Explanation": "Attempted to call `wrap_triton`/`capture_triton` with > 1 args. Dynamo does not support this.",
+      "Hints": [
+        "Remove the wrap_triton/capture_triton call or its additional args.",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "torch.library.wrap_triton call with > 1 args",
+      "Context": "args={args}, kwargs={kwargs}",
       "Explanation": "Attempted to call `torch.library.wrap_triton` or `torch._library.capture_triton` with > 1 args. Dynamo does not support this.",
       "Hints": [
         "Remove the wrap_triton/capture_triton call or its additional args.",

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -4395,9 +4395,9 @@
     {
       "Gb_type": "torch.library.wrap_triton call with > 1 args",
       "Context": "args={args}, kwargs={kwargs}",
-      "Explanation": "Attempted to call `torch.library.wrap_triton` with > 1 args. Dynamo does not support this.",
+      "Explanation": "Attempted to call `torch.library.wrap_triton` or `torch._library.capture_triton` with > 1 args. Dynamo does not support this.",
       "Hints": [
-        "Remove the torch.library.wrap_triton call or its additional args.",
+        "Remove the wrap_triton/capture_triton call or its additional args.",
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]
     }

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -401,6 +401,7 @@ manual_torch_name_rule_map: dict[
     "torch.xpu.get_rng_state": SkipFunctionVariable,
     "torch.xpu.set_rng_state": SkipFunctionVariable,
     "torch.library.wrap_triton": TorchInGraphFunctionVariable,
+    "torch._library.capture_triton": TorchInGraphFunctionVariable,
     # avoid skipping user defined modules in distributed unit tests
     "torch/testing/_internal/common_fsdp.py#forward": UserFunctionVariable,
     f"torch/testing/_internal/common_fsdp.py#{TORCH_DYNAMO_RESUME_IN_PREFIX}": UserFunctionVariable,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1047,7 +1047,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 ],
             )
 
-        @register(torch.library.wrap_triton)
+        @register(torch.library.wrap_triton, torch._library.capture_triton)
         def handle_wrap_triton(
             self,
             tx: "InstructionTranslator",
@@ -1055,15 +1055,16 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             **kwargs: VariableTracker,
         ) -> VariableTracker:
             if len(args) == 1:
-                # torch.library.wrap_triton is a no-op in dynamo
+                # wrap_triton / capture_triton is a no-op in dynamo
                 return args[0]
 
             unimplemented(
                 gb_type="torch.library.wrap_triton call with > 1 args",
                 context=f"args={args}, kwargs={kwargs}",
-                explanation="Attempted to call `torch.library.wrap_triton` with > 1 args. Dynamo does not support this.",
+                explanation="Attempted to call `wrap_triton`/`capture_triton`"
+                " with > 1 args. Dynamo does not support this.",
                 hints=[
-                    "Remove the torch.library.wrap_triton call or its additional args.",
+                    "Remove the wrap_triton/capture_triton call or its additional args.",
                     *graph_break_hints.SUPPORTABLE,
                 ],
             )


### PR DESCRIPTION
Fixes #136056

## Summary

`capture_triton` is a deprecated alias for `wrap_triton` in `torch._library.triton`. When called inside a `torch.compile` region, Dynamo skips it because `torch._library` is on `MOD_SKIPLIST` and `capture_triton` had no override in `manual_torch_name_rule_map` unlike `wrap_triton` which was fixed in PR #171289 

This PR applies the exact same special handling that `wrap_triton` already has to `capture_triton`:

- **`trace_rules.py`**: Add `torch._library.capture_triton` → `TorchInGraphFunctionVariable` to the manual rule map
- **`variables/torch.py`**: Register `capture_triton` alongside `wrap_triton` in the existing no-op handler
- **`graph_break_registry.json`**: Update GB6735 entry to mention both functions
- **`test_functions.py`**: Add `test_capture_triton_handled_during_tracing` mirroring the existing `wrap_triton` test

## Test plan

- [x] `test_wrap_triton_handled_during_tracing` — existing test still passes
- [x] `test_capture_triton_handled_during_tracing` — new test passes
- [x] `test_trace_rules.py` — 7 passed, 1 skipped (rule map integrity)
- [x] `test_triton_kernels.py` — 373 passed, 25 skipped
- [x] `test_triton_heuristics.py` — 36 passed, 4 skipped
- [x] `test_aot_autograd_cache.py` — 193 passed (3 pre-existing flaky failures, unrelated)
- [x] `test_autograd_function.py` — 68 passed
- [x] `test_misc.py` — 759 passed (1 pre-existing failure, unrelated)
- [x] `test_repros.py` — 366 passed (1 pre-existing failure, unrelated)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @ezyang @chenyang78 @rec @oulgen @aakhundov @zou3519 @davidberard98 @cleonard530
