### PR TITLE
[inductor][overlap] compile time: Replace O(N) set-difference with backward BFS in overlap scheduling

### DIFF
--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -109,6 +109,7 @@ class WhyNoOverlap:
             )
 
 
+@functools.cache
 def get_group_name(n: fx.Node) -> str:
     """Extract the group name from a collective operation node."""
     opt_args_kwargs = normalize_function(
@@ -542,11 +543,6 @@ class OverlapScheduler:
             self.reduce_scatter_nodes
         )
 
-        # Scheduling state
-        self.potentially_hidden_collectives = (
-            self.compute_potential_hidden_collectives()
-        )
-        self.potentially_hidden_waits = self.compute_potential_hidden_waits()
         self.in_degree = Counter(user for node in self.nodes for user in node.users)
 
         # Two separate queues: on-path (domination-based) and off-path (node_idx-based)
@@ -1270,8 +1266,6 @@ class OverlapScheduler:
         ):
             return
 
-        overlap_node_ancestors = self.node_ancestors[overlap_node]
-
         # Compile candidates - limit by distance to bound compile time
         candidates = []
         for i, collective in enumerate(self.unscheduled_collectives):
@@ -1350,7 +1344,7 @@ class OverlapScheduler:
             info = self.collective_info[collective]
 
             if (
-                collective in overlap_node_ancestors
+                collective in self.node_ancestors[overlap_node]
                 or overlap_node in self.node_ancestors[collective]
             ):
                 why("dependency conflict")
@@ -1414,8 +1408,18 @@ class OverlapScheduler:
         self, target: fx.Node, curr_overlap_node: fx.Node | None, why: WhyNoOverlap
     ) -> OrderedSet[fx.Node] | None:
         """Find path to target by collecting unscheduled dependencies."""
-        # Get unscheduled ancestors
-        unscheduled_ancestors = self.node_ancestors[target] - self.scheduled
+        # Backward BFS from target, stopping at scheduled nodes.
+        unscheduled_ancestors: OrderedSet[fx.Node] = OrderedSet()
+        seen: OrderedSet[fx.Node] = OrderedSet()
+        stack = list(target._input_nodes)
+        scheduled = self.scheduled
+        while stack:
+            n = stack.pop()
+            if n in seen or n in scheduled:
+                continue
+            seen.add(n)
+            unscheduled_ancestors.add(n)
+            stack.extend(n._input_nodes)
 
         # only schedule non distributed, non compute nodes
         for node in unscheduled_ancestors:

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -1408,7 +1408,7 @@ class OverlapScheduler:
         self, target: fx.Node, curr_overlap_node: fx.Node | None, why: WhyNoOverlap
     ) -> OrderedSet[fx.Node] | None:
         """Find path to target by collecting unscheduled dependencies."""
-        # Backward BFS from target, stopping at scheduled nodes.
+        # Backward BFS from target; stops at scheduled nodes.
         unscheduled_ancestors: OrderedSet[fx.Node] = OrderedSet()
         seen: OrderedSet[fx.Node] = OrderedSet()
         stack = list(target._input_nodes)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #183559
* #183566
* #183565
* #183564
* #183558
* __->__ #183557

_find_schedulable_path computed unscheduled ancestors via
node_ancestors[target] - self.scheduled, which copied the full ancestor
set (up to 36K entries) then called discard() for every scheduled node.
With 72K calls this produced 1.3 billion dict.pop operations.

Replace with backward BFS that walks from target through _input_nodes,
stopping at already-scheduled nodes. This visits only the unscheduled
frontier instead of the entire ancestor set.

Also cache get_group_name with @functools.cache (was 2.4M calls with
expensive normalize_function), and remove dead potentially_hidden
precomputation from __init__ (computed but never read).

Benchmark (Llama 70B, 36K nodes, TP=8):
  schedule_overlap_bucketing: 204s -> 111s (1.83x)

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo