### PR TITLE
[inductor][overlap][compile time] Replace O(N^2) descendant precomputation with incremental BFS

### DIFF
--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -429,8 +429,11 @@ def greedy_bucket_collective_by_mb(
     if not found_candidates:
         return []
 
-    # TODO: pearce kelly algorithm for detecting cycles
-    node_descendents = collect_node_descendants(gm.graph)
+    # Build forward adjacency list once for incremental descendant tracking
+    children: dict[torch.fx.Node, list[torch.fx.Node]] = collections.defaultdict(list)
+    for node in g.nodes:
+        for inp in node._input_nodes:
+            children[inp].append(node)
 
     nodes_groups: list[list[torch.fx.Node]] = []
     cur_group: list[torch.fx.Node] = []
@@ -451,6 +454,16 @@ def greedy_bucket_collective_by_mb(
 
     if len(cur_group) > 1:
         nodes_groups.append(cur_group)
+
+    def _add_descendants(node: torch.fx.Node, desc: OrderedSet[torch.fx.Node]) -> None:
+        """Forward BFS from node, adding all reachable nodes to desc."""
+        stack = [node]
+        while stack:
+            n = stack.pop()
+            for child in children[n]:
+                if child not in desc:
+                    desc.add(child)
+                    stack.append(child)
 
     buckets: list[list[torch.fx.Node]] = []
     for nodes in nodes_groups:
@@ -481,7 +494,7 @@ def greedy_bucket_collective_by_mb(
                 cur_bucket_descendents = OrderedSet()
             cur_bucket_size_bytes += size_bytes
             cur_bucket.append(node)
-            cur_bucket_descendents |= node_descendents[node]
+            _add_descendants(node, cur_bucket_descendents)
         if len(cur_bucket) > 1:
             buckets.append(cur_bucket)
     return buckets


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #183559
* #183566
* #183565
* #183564
* __->__ #183558
* #183557

collect_node_descendants precomputed full transitive descendant sets for
all ~36K nodes (13s profiled). These sets were only queried during
bucketing to check "is candidate X a descendant of any bucket member?"

Replace with: build a forward adjacency list once (O(N+E)), then when a
node joins a bucket, BFS forward from it to update the bucket's
descendant set incrementally. Only traverses descendants of the few
nodes actually placed into buckets.

Microbenchmark: 28-767x faster depending on graph density.

Benchmark (Llama 70B, 36K nodes, TP=8):
  schedule_overlap_bucketing: 111s -> 92s

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo