### PR TITLE
[inductor] Use _LazyGraphModule for control_deps subgraphs

### DIFF
--- a/torch/_inductor/fx_passes/control_dependencies.py
+++ b/torch/_inductor/fx_passes/control_dependencies.py
@@ -15,6 +15,7 @@ import torch.utils._pytree as pytree
 from torch._C import DispatchKey
 from torch._higher_order_ops.utils import register_fake
 from torch._ops import HigherOrderOperator
+from torch.fx._lazy_graph_module import _LazyGraphModule
 from torch.utils._ordered_set import OrderedSet
 
 
@@ -279,4 +280,4 @@ def _create_subgraph_for_node(
         if "val" in result.meta:
             out.meta["val"] = result.meta["val"]
 
-    return fx.GraphModule(owning_module, subgraph)
+    return _LazyGraphModule(owning_module, subgraph)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #183560
* #183559
* #183558
* #183557

preserve_node_ordering creates ~9K small subgraph GraphModules for
control dependency HOP nodes. Each triggered eager recompile() to
generate Python code that is never executed directly. Use
_LazyGraphModule to defer code generation until actually needed.

Benchmark (Llama 70B, 36K nodes, TP=8):
  schedule_overlap_bucketing: 25s -> 22s

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo