### PR TITLE
Fix timeout in `test_share_memory` on error

### DIFF
--- a/test/distributed/rpc/test_share_memory.py
+++ b/test/distributed/rpc/test_share_memory.py
@@ -70,13 +70,15 @@ class TestRPCPickler(TestCase):
             try:
                 with _use_rpc_pickler(ShareMemoryRPCPickler()):
                     rpc.init_rpc("worker0", rank=0, world_size=2)
-                    m = torch.nn.Linear(1, 2)
-                    m.share_memory()
-                    rref = rpc.remote("worker1", worker_fn, args=(m,))
+                    try:
+                        m = torch.nn.Linear(1, 2)
+                        m.share_memory()
+                        rref = rpc.remote("worker1", worker_fn, args=(m,))
 
-                    rref.to_here()
+                        rref.to_here()
+                    finally:
+                        rpc.shutdown()
             finally:
-                rpc.shutdown()
                 r.join()
 
 


### PR DESCRIPTION
When the RPC init fails, e.g. due to
> RuntimeError: In operator() at tensorpipe/common/ibv.h:172 "": Invalid argument
(see https://github.com/pytorch/tensorpipe/issues/413) then the `rpc.shutdown` will hang forever waiting for processes that didn't start.

So do that only after successful `rpc.init_rpc`.