### PR TITLE
[MPS] fix nans for relu

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -47,7 +47,7 @@ REGISTER_BINARY_ALPHA_OP(shrink_backward, bfloat, bfloat, bfloat);
 struct relu_functor {
   template <typename T>
   inline T operator()(const T x) {
-    return x > T(0) ? x : T(0);
+    return x < T(0) ? T(0) : x;
   }
 };
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13553,21 +13553,6 @@ if __name__ == '__main__':
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             F.leaky_relu_(x)
 
-    @dtypes(torch.float32, torch.float16, torch.bfloat16)
-    def test_relu_nan_inf(self, device, dtype):
-        x = torch.tensor(
-            [float('nan'), float('inf'), float('-inf'), 1.0, -1.0, 0.0],
-            device=device, dtype=dtype,
-        )
-        expected = torch.tensor(
-            [float('nan'), float('inf'), 0.0, 1.0, 0.0, 0.0],
-            device=device, dtype=dtype,
-        )
-        self.assertEqual(torch.relu(x), expected, equal_nan=True)
-        y = x.clone()
-        y.relu_()
-        self.assertEqual(y, expected, equal_nan=True)
-
     # Merge into OpInfo?
     @expectedFailureMPS  # NotImplementedError: aten::rrelu_with_noise_ https://github.com/pytorch/pytorch/issues/77764
     def test_leaky_relu_inplace_with_neg_slope(self, device):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13553,6 +13553,21 @@ if __name__ == '__main__':
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             F.leaky_relu_(x)
 
+    @dtypes(torch.float32, torch.float16, torch.bfloat16)
+    def test_relu_nan_inf(self, device, dtype):
+        x = torch.tensor(
+            [float('nan'), float('inf'), float('-inf'), 1.0, -1.0, 0.0],
+            device=device, dtype=dtype,
+        )
+        expected = torch.tensor(
+            [float('nan'), float('inf'), 0.0, 1.0, 0.0, 0.0],
+            device=device, dtype=dtype,
+        )
+        self.assertEqual(torch.relu(x), expected, equal_nan=True)
+        y = x.clone()
+        y.relu_()
+        self.assertEqual(y, expected, equal_nan=True)
+
     # Merge into OpInfo?
     @expectedFailureMPS  # NotImplementedError: aten::rrelu_with_noise_ https://github.com/pytorch/pytorch/issues/77764
     def test_leaky_relu_inplace_with_neg_slope(self, device):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -25065,17 +25065,6 @@ python_ref_db = [
         "_refs.nn.functional.relu",
         torch_opinfo_name="nn.functional.relu",
         supports_out=True,
-        skips=(
-            # TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref',
-                device_type='mps', dtypes=(torch.float16, torch.bfloat16, torch.float32)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.float16, torch.bfloat16, torch.float32)
-            ),
-        ),
     ),
     ElementwiseUnaryPythonRefInfo(
         "_refs.nn.functional.relu6",


### PR DESCRIPTION
Fix relu not propagating nans, added test for both nans and infs just in case. Doing this now:
```
import torch
print("cpu:", torch.relu(torch.tensor([float("nan")])))
print("mps:", torch.relu(torch.tensor([float("nan")], device="mps")))
```

leads to:
```
cpu: tensor([nan])
mps: tensor([0.], device='mps:0')
```