### PR TITLE
[XPU][CI] Fix setup-xpu permission error from leftover root-owned artifacts

### DIFF
--- a/.github/actions/setup-xpu/action.yml
+++ b/.github/actions/setup-xpu/action.yml
@@ -57,17 +57,17 @@ runs:
       shell: bash
       run: |
         RUNNER_ARTIFACT_DIR="${RUNNER_TEMP}/artifacts"
-        rm -rf "${RUNNER_ARTIFACT_DIR}"
+        sudo rm -rf "${RUNNER_ARTIFACT_DIR}"
         mkdir -p "${RUNNER_ARTIFACT_DIR}"
         echo "RUNNER_ARTIFACT_DIR=${RUNNER_ARTIFACT_DIR}" >> "${GITHUB_ENV}"
 
         RUNNER_TEST_RESULTS_DIR="${RUNNER_TEMP}/test-results"
-        rm -rf "${RUNNER_TEST_RESULTS_DIR}"
+        sudo rm -rf "${RUNNER_TEST_RESULTS_DIR}"
         mkdir -p "${RUNNER_TEST_RESULTS_DIR}"
         echo "RUNNER_TEST_RESULTS_DIR=${RUNNER_TEST_RESULTS_DIR}" >> "${GITHUB_ENV}"
 
         RUNNER_DOCS_DIR="${RUNNER_TEMP}/docs"
-        rm -rf "${RUNNER_DOCS_DIR}"
+        sudo rm -rf "${RUNNER_DOCS_DIR}"
         mkdir -p "${RUNNER_DOCS_DIR}"
         echo "RUNNER_DOCS_DIR=${RUNNER_DOCS_DIR}" >> "${GITHUB_ENV}"
 

--- a/.github/workflows/_binary-test-xpu-linux.yml
+++ b/.github/workflows/_binary-test-xpu-linux.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     container:
       image: pytorch/${{ inputs.DOCKER_IMAGE }}:${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
-      options: --device=/dev/dri --group-add video --group-add render
+      options: --device=/dev/dri --group-add video --group-add render -e ZE_AFFINITY_MASK
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: ${{ inputs.PACKAGE_TYPE }}
@@ -126,3 +126,9 @@ jobs:
           bash .ci/pytorch/binary_linux_test.sh
           source "${BINARY_ENV_FILE}"
           bash -x /run.sh
+
+      - name: Cleanup artifacts directory
+        if: always()
+        shell: bash
+        run: |
+          rm -rf "${RUNNER_TEMP}/artifacts"


### PR DESCRIPTION
## Summary
- Fix `Setup XPU` step failure caused by root-owned `.whl` files left behind by `_binary-test-xpu-linux` workflow
- Use `sudo rm -rf` in `setup-xpu` action for defensive cleanup
- Add artifact cleanup step at end of `_binary-test-xpu-linux` workflow
- Pass `ZE_AFFINITY_MASK` to binary test container via `options`

Fixes the permission error seen in https://github.com/pytorch/pytorch/actions/runs/25716957256/job/75739515857?pr=174370#step:3:136

cc @guangyey @chuanqiw