### PR TITLE
[ROCm][CI][inductor] Stabilize test_conv_with_as_strided on ROCm

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -104,7 +104,6 @@ from torch.testing._internal.common_utils import (
     IS_MACOS,
     IS_X86,
     MACOS_VERSION,
-    MI200_ARCH,
     NAVI_ARCH,
     parametrize,
     serialTest,
@@ -12943,7 +12942,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             (torch.randn(32), torch.randn(32)),
         )
 
-    @skipIfRocmArch(MI200_ARCH)
     def test_conv_with_as_strided(self):
         class Model(nn.Module):
             def __init__(self) -> None:
@@ -12969,11 +12967,17 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 )
                 return clone
 
-        self.common(
-            Model(),
-            (torch.randn(8, 256, 16, 16),),
-            check_lowp=not is_halide_backend(self.device),
-        )
+        # DeterministicGuard locks MIOpen's solver choice on gfx950. atol/rtol
+        # cover the fp16 hgemm noise floor on gfx90a. Derivation:
+        # https://github.com/pytorch/pytorch/issues/183581
+        with DeterministicGuard(True, warn_only=True):
+            self.common(
+                Model(),
+                (torch.randn(8, 256, 16, 16),),
+                check_lowp=not is_halide_backend(self.device),
+                atol=2e-3,
+                rtol=2e-3,
+            )
 
     def test_inplace_where_pointwise(self):
         # https://github.com/pytorch/pytorch/issues/96446


### PR DESCRIPTION
Fixes #183581

Two related fixes to `test_conv_with_as_strided`, both needed to keep it green across current ROCm arches:

1. Wrap the comparison in `DeterministicGuard(True, warn_only=True)`. On gfx950 MIOpen otherwise picks `ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC` for this 1x1 fp16 conv; that solver is non-deterministic across invocations and drifts ~1 fp16 ULP from the fp32 reference, blowing past rtol at near-zero output positions. Under DG, MIOpen falls back to `GemmFwd1x1_0_1` (rocBLAS hgemm), which is deterministic.

2. Drop `@skipIfRocmArch(MI200_ARCH)` and set `atol=2e-3, rtol=2e-3` on the lowp comparison. On gfx90a MIOpen already picks `GemmFwd1x1_0_1` (so DG is a no-op there); the test was skipped by #170205 with no recorded root cause. Investigation: the failure is fundamental fp16 precision -- the empirical noise floor for this conv shape is ~2**-9.5, well-predicted by tiled mixed-precision GEMM error analysis (fp32 MFMA accumulator with periodic fp16 re-rounding at K-tile boundaries). atol = 2 * fp16 eps admits the gfx90a output with 1.5x atol-only headroom and 3x combined-threshold headroom. Inductor adds zero error on top of MIOpen.

Full forward-error derivation, probe data, and empirical validation: see #183581.

Authored by Claude (Opus 4.7, 1M context).

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben
