### PR TITLE
[torch] Enable nbits radix sort in embedding_dense_backward_cuda (#183578)

### DIFF
--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -289,11 +289,13 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
   Tensor count;
   AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "embedding_dense_backward_cuda", [&] () {
     auto range = at::arange(num_indices, indices.options());
-    int64_t nbits = cuda::cub::get_num_bits(num_weights);
+    int64_t nbits = padding_idx >= 0
+      ? cuda::cub::get_num_bits(num_weights)
+      : cuda::cub::get_num_bits(num_weights - 1 - padding_idx);
     cuda::cub::radix_sort_pairs(
       indices.const_data_ptr<index_t>(), sorted_indices.mutable_data_ptr<index_t>(),
       range.const_data_ptr<index_t>(), orig_indices.mutable_data_ptr<index_t>(),
-      num_indices, false/*, 0, nbits*/);
+      num_indices, false, 0, nbits);
   });
 
   if (scale_grad_by_freq) {

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -200,11 +200,13 @@ Tensor embedding_bag_backward_cuda_sum_avg(
 
   AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "embedding_bag_backward_cuda_sum_avg", [&] () {
     auto range = at::arange(num_indices, indices.options());
-    // int64_t nbits = cuda::cub::get_num_bits(num_weights);
+    int64_t nbits = padding_idx >= 0
+      ? cuda::cub::get_num_bits(num_weights)
+      : cuda::cub::get_num_bits(num_weights - 1 - padding_idx);
     cuda::cub::radix_sort_pairs(
       indices.const_data_ptr<index_t>(), sorted_indices.mutable_data_ptr<index_t>(),
       range.const_data_ptr<index_t>(), orig_indices.mutable_data_ptr<index_t>(),
-      num_indices, false/*, 0, nbits*/);
+      num_indices, false, 0, nbits);
   });
 
   if (scale_grad_by_freq) {


### PR DESCRIPTION
Summary:

Pass nbits to CUB radix sort so only the bits needed to distinguish all index values are examined, reducing radix passes.  With less radix passes, we'll have better perf.

Test Plan:
Perf

Key results (baseline -> optimized):
- n=100K, nw=64 (7 bits): 0.136ms -> 0.098ms (1.39x speedup)
- n=100K, nw=1024 (11 bits): 0.131ms -> 0.104ms (1.26x)
- n=1M, nw=256 (9 bits): 0.382ms -> 0.348ms (1.10x)
- n=10M, nw=4096 (13 bits): 1.236ms -> 1.116ms (1.10x)
- n=50M, nw=4096 (13 bits): 5.464ms -> 4.972ms (1.10x)
- n=50M, nw=65536 (17 bits): 5.513ms -> 5.262ms (1.05x)

Correctness:

1) torch.nn.Embedding.__init__ (torch/nn/modules/sparse.py:152-160) canonicalizes negative padding_idx: `padding_idx = self.num_embeddings + padding_idx`. 
2) torch.nn.functional.embedding (torch/nn/functional.py:2551-2560) same
3) nn.EmbeddingBag.__init__ (torch/nn/modules/sparse.py:392-399) same

By the time padding_idx reaches embedding_dense_backward_cuda, it is either:
- -1: the sentinel meaning "no padding was specified"
- >= 0: a canonicalized valid index


## 3. Sample correctness verification

```python
import torch
from torch.testing._internal.common_utils import run_tests, TestCase

def emb_bwd(grad, indices, num_weights, padding_idx, sgbf):
    return torch.ops.aten.embedding_dense_backward(
        grad, indices, num_weights, padding_idx, sgbf)

class TestEmbeddingNbitsSafety(TestCase):
    def _check(self, nw, pad, idx_list):
        idx = torch.tensor(idx_list, dtype=torch.long)
        g = torch.randn(len(idx_list), 4)
        cpu = emb_bwd(g, idx, nw, pad, True)
        gpu = emb_bwd(g.cuda(), idx.cuda(), nw, pad, True)
        self.assertEqual(cpu, gpu.cpu(), atol=1e-5, rtol=1e-5)

    def test_exhaustive_small(self):
        for nw in [1,2,3,4,5,7,8,9,15,16,17,31,32,33]:
            for pad in [-1, -2, 0, nw-1]:
                self._check(nw, pad, [0,nw-1,0,nw-1,(nw-1)//2])

    def test_large_radix_path(self):
        torch.manual_seed(42)
        idx = torch.randint(0, 256, (4096,)).tolist()
        for pad in [-1, -2, 0]:
            self._check(256, pad, idx)

    def test_wrapped_neg1_e2e(self):
        w = torch.randn(8, 4, requires_grad=True)
        wc = w.detach().clone().cuda().requires_grad_(True)
        idx = torch.tensor([0, 3, 7, 3, 7, 0])
        o1 = torch.nn.functional.embedding(
            idx, w, padding_idx=-1, scale_grad_by_freq=True)
        o2 = torch.nn.functional.embedding(
            idx.cuda(), wc, padding_idx=-1, scale_grad_by_freq=True)
        g = torch.randn_like(o1); o1.backward(g); o2.backward(g.cuda())
        assert torch.allclose(w.grad, wc.grad.cpu(), atol=1e-5, rtol=1e-5)

if __name__ == "__main__":
    run_tests()
```

Reviewed By: yangw-dev

Differential Revision: D105019938


