### PR TITLE
Diagnose duplicate invoke_subgraph backward variants

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -15,7 +15,7 @@ import torch._functorch
 import torch._inductor
 import torch._inductor.decomposition
 import torch.utils._pytree as pytree
-from functorch.compile import aot_function, make_boxed_func, nop
+from functorch.compile import aot_function, nop
 from torch._dynamo.functional_export import dynamo_graph_capture_for_export
 from torch._dynamo.testing import (
     AotEagerAndRecordGraphs,
@@ -120,19 +120,6 @@ class TestInvokeSubgraph(TestCase):
 
     @torch._dynamo.config.patch(inline_single_use_invoke_subgraph=False)
     def test_duplicate_backward_variants_warn_and_trace(self):
-        from torch._dynamo.backends.common import aot_autograd
-
-        fw_graphs = []
-        bw_graphs = []
-
-        def fw_compiler(gm, example_inputs, **kwargs):
-            fw_graphs.append(gm)
-            return make_boxed_func(gm.forward)
-
-        def bw_compiler(gm, example_inputs, **kwargs):
-            bw_graphs.append(gm)
-            return make_boxed_func(gm.forward)
-
         @nested_compile_region
         def block(x):
             return torch.sin(x) * 2.0
@@ -145,23 +132,21 @@ class TestInvokeSubgraph(TestCase):
                 return z.square().sum()
 
         torch._dynamo.reset()
+        backend = AotEagerAndRecordGraphs()
         with mock.patch("torch._logging.trace_structured") as trace_structured_mock:
             with warnings.catch_warnings(record=True) as caught:
                 warnings.simplefilter("always")
                 compiled = torch.compile(
                     Model(),
-                    backend=aot_autograd(
-                        fw_compiler=fw_compiler,
-                        bw_compiler=bw_compiler,
-                    ),
+                    backend=backend,
                     fullgraph=True,
                 )
                 x = torch.randn(4, 3, 5, requires_grad=True)
                 tail = torch.randn(4, 7, 5, requires_grad=True)
                 compiled(x, tail).backward()
 
-        self.assertEqual(len(fw_graphs), 1)
-        self.assertEqual(len(bw_graphs), 1)
+        self.assertEqual(len(backend.fw_graphs), 1)
+        self.assertEqual(len(backend.bw_graphs), 1)
         self.assertTrue(
             any(
                 "invoke_subgraph traced multiple backward graphs"
@@ -190,23 +175,14 @@ class TestInvokeSubgraph(TestCase):
         payload = duplicate_payloads[0]
         self.assertEqual(payload["new_variant_suffix"], 1)
         self.assertEqual(payload["num_variants_for_identifier"], 2)
-        self.assertEqual(len(payload["variants"]), 2)
-        variant0_tangent = payload["variants"][0]["tangents"][0]
-        variant1_tangent = payload["variants"][1]["tangents"][0]
-        self.assertEqual(variant0_tangent["forward_output_index"], 0)
-        self.assertEqual(variant0_tangent["forward_output_name"], "mul")
-        self.assertIsInstance(variant0_tangent["backward_input_name"], str)
-        self.assertEqual(variant0_tangent["shape"], [4, 3, 5])
-        self.assertEqual(variant0_tangent["stride"], [50, 5, 1])
-        self.assertFalse(variant0_tangent["is_contiguous"])
-        self.assertEqual(variant1_tangent["forward_output_index"], 0)
-        self.assertEqual(variant1_tangent["forward_output_name"], "mul")
         self.assertEqual(
-            variant1_tangent["backward_input_name"],
-            variant0_tangent["backward_input_name"],
+            payload["new_variant"]["backward_identifier"],
+            payload["backward_identifier"],
         )
-        self.assertEqual(variant1_tangent["stride"], [15, 5, 1])
-        self.assertTrue(variant1_tangent["is_contiguous"])
+        tangent = payload["new_variant"]["tangents"][0]
+        self.assertIsInstance(tangent["backward_input_name"], str)
+        self.assertEqual(tangent["shape"], [4, 3, 5])
+        self.assertEqual(tangent["stride"], [15, 5, 1])
 
     def test_make_fx_without_shape_env(self):
         """Test that make_fx with invoke_subgraph works without a ShapeEnv.

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -5,6 +5,7 @@ import contextlib
 import re
 import unittest
 import unittest.mock as mock
+import warnings
 
 from parameterized import parameterized_class
 
@@ -14,7 +15,7 @@ import torch._functorch
 import torch._inductor
 import torch._inductor.decomposition
 import torch.utils._pytree as pytree
-from functorch.compile import aot_function, nop
+from functorch.compile import aot_function, make_boxed_func, nop
 from torch._dynamo.functional_export import dynamo_graph_capture_for_export
 from torch._dynamo.testing import (
     AotEagerAndRecordGraphs,
@@ -116,6 +117,96 @@ class TestInvokeSubgraph(TestCase):
         res = aot_fn(x)
 
         self.assertEqual(ref, res)
+
+    @torch._dynamo.config.patch(inline_single_use_invoke_subgraph=False)
+    def test_duplicate_backward_variants_warn_and_trace(self):
+        from torch._dynamo.backends.common import aot_autograd
+
+        fw_graphs = []
+        bw_graphs = []
+
+        def fw_compiler(gm, example_inputs, **kwargs):
+            fw_graphs.append(gm)
+            return make_boxed_func(gm.forward)
+
+        def bw_compiler(gm, example_inputs, **kwargs):
+            bw_graphs.append(gm)
+            return make_boxed_func(gm.forward)
+
+        @nested_compile_region
+        def block(x):
+            return torch.sin(x) * 2.0
+
+        class Model(torch.nn.Module):
+            def forward(self, x, tail):
+                y0 = block(x)
+                y1 = block(y0)
+                z = torch.cat([y1, tail], dim=1)
+                return z.square().sum()
+
+        torch._dynamo.reset()
+        with mock.patch("torch._logging.trace_structured") as trace_structured_mock:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                compiled = torch.compile(
+                    Model(),
+                    backend=aot_autograd(
+                        fw_compiler=fw_compiler,
+                        bw_compiler=bw_compiler,
+                    ),
+                    fullgraph=True,
+                )
+                x = torch.randn(4, 3, 5, requires_grad=True)
+                tail = torch.randn(4, 7, 5, requires_grad=True)
+                compiled(x, tail).backward()
+
+        self.assertEqual(len(fw_graphs), 1)
+        self.assertEqual(len(bw_graphs), 1)
+        self.assertTrue(
+            any(
+                "invoke_subgraph traced multiple backward graphs"
+                in str(warning.message)
+                for warning in caught
+            )
+        )
+
+        duplicate_payloads = []
+        for call in trace_structured_mock.call_args_list:
+            args, kwargs = call
+            if not args or args[0] != "artifact":
+                continue
+            metadata_fn = kwargs.get("metadata_fn")
+            if metadata_fn is None and len(args) > 1:
+                metadata_fn = args[1]
+            if metadata_fn is None:
+                continue
+            metadata = metadata_fn()
+            if metadata.get("name") != "invoke_subgraph_backward_duplicate":
+                continue
+            payload_fn = kwargs["payload_fn"]
+            duplicate_payloads.append(payload_fn())
+
+        self.assertEqual(len(duplicate_payloads), 1)
+        payload = duplicate_payloads[0]
+        self.assertEqual(payload["new_variant_suffix"], 1)
+        self.assertEqual(payload["num_variants_for_identifier"], 2)
+        self.assertEqual(len(payload["variants"]), 2)
+        variant0_tangent = payload["variants"][0]["tangents"][0]
+        variant1_tangent = payload["variants"][1]["tangents"][0]
+        self.assertEqual(variant0_tangent["forward_output_index"], 0)
+        self.assertEqual(variant0_tangent["forward_output_name"], "mul")
+        self.assertIsInstance(variant0_tangent["backward_input_name"], str)
+        self.assertEqual(variant0_tangent["shape"], [4, 3, 5])
+        self.assertEqual(variant0_tangent["stride"], [50, 5, 1])
+        self.assertFalse(variant0_tangent["is_contiguous"])
+        self.assertEqual(variant1_tangent["forward_output_index"], 0)
+        self.assertEqual(variant1_tangent["forward_output_name"], "mul")
+        self.assertEqual(
+            variant1_tangent["backward_input_name"],
+            variant0_tangent["backward_input_name"],
+        )
+        self.assertEqual(variant1_tangent["stride"], [15, 5, 1])
+        self.assertTrue(variant1_tangent["is_contiguous"])
 
     def test_make_fx_without_shape_env(self):
         """Test that make_fx with invoke_subgraph works without a ShapeEnv.

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -839,6 +839,9 @@ class InvokeSubgraphCache(HopSubgraphCache):
         self.lazy_bwd_cache: dict[
             str, dict[tuple[object], tuple[torch.fx.GraphModule, int]]
         ] = defaultdict(dict)
+        self.lazy_bwd_debug_cache: dict[str, dict[tuple[object], object]] = defaultdict(
+            dict
+        )
         self.effects_cache: dict[
             str, set
         ] = {}  # Maps identifier -> set of effect types
@@ -879,10 +882,13 @@ class InvokeSubgraphCache(HopSubgraphCache):
         identifier: str,
         tangent_metadata: tuple[object],
         gmod: torch.fx.GraphModule,
+        debug_info: object | None = None,
     ) -> int:
         # Save the number of existing graph modules in the dictionary to get the suffix
         num_gmods = len(self.lazy_bwd_cache[identifier])
         self.lazy_bwd_cache[identifier][tangent_metadata] = (gmod, num_gmods)
+        if debug_info is not None:
+            self.lazy_bwd_debug_cache[identifier][tangent_metadata] = debug_info
         return num_gmods
 
     def get_lazy_bwd_entry(
@@ -892,6 +898,9 @@ class InvokeSubgraphCache(HopSubgraphCache):
             return (None, None)
 
         return self.lazy_bwd_cache[identifier].get(tangent_metadata, (None, None))
+
+    def get_lazy_bwd_debug_entries(self, identifier: str) -> list[object]:
+        return list(self.lazy_bwd_debug_cache.get(identifier, {}).values())
 
     def add_effects(self, identifier: str, effects: set) -> None:
         """Store the effect types for a given invoke_subgraph identifier."""

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -839,9 +839,6 @@ class InvokeSubgraphCache(HopSubgraphCache):
         self.lazy_bwd_cache: dict[
             str, dict[tuple[object], tuple[torch.fx.GraphModule, int]]
         ] = defaultdict(dict)
-        self.lazy_bwd_debug_cache: dict[str, dict[tuple[object], object]] = defaultdict(
-            dict
-        )
         self.effects_cache: dict[
             str, set
         ] = {}  # Maps identifier -> set of effect types
@@ -882,13 +879,10 @@ class InvokeSubgraphCache(HopSubgraphCache):
         identifier: str,
         tangent_metadata: tuple[object],
         gmod: torch.fx.GraphModule,
-        debug_info: object | None = None,
     ) -> int:
         # Save the number of existing graph modules in the dictionary to get the suffix
         num_gmods = len(self.lazy_bwd_cache[identifier])
         self.lazy_bwd_cache[identifier][tangent_metadata] = (gmod, num_gmods)
-        if debug_info is not None:
-            self.lazy_bwd_debug_cache[identifier][tangent_metadata] = debug_info
         return num_gmods
 
     def get_lazy_bwd_entry(
@@ -898,9 +892,6 @@ class InvokeSubgraphCache(HopSubgraphCache):
             return (None, None)
 
         return self.lazy_bwd_cache[identifier].get(tangent_metadata, (None, None))
-
-    def get_lazy_bwd_debug_entries(self, identifier: str) -> list[object]:
-        return list(self.lazy_bwd_debug_cache.get(identifier, {}).values())
 
     def add_effects(self, identifier: str, effects: set) -> None:
         """Store the effect types for a given invoke_subgraph identifier."""

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -54,6 +54,7 @@ class OutputMetadata:
     num_fw_outs: int | None = None
     indexes_with_symint: set[int] = field(default_factory=set)
     indexes_with_no_grad: set[int] = field(default_factory=set)
+    output_names: list[str | None] = field(default_factory=list)
 
 
 # This config will be stored in invoke_subgraph HOP node.meta["custom"]["nested_region_config"]
@@ -126,6 +127,116 @@ def _set_invoke_subgraph_call_id(call_id: int):
         yield
     finally:
         _invoke_subgraph_call_state.current = prev
+
+
+def summarize_backward_tangents(
+    tangents: tuple[Any, ...],
+    forward_output_indices: list[int],
+    forward_output_names: list[str | None],
+    backward_input_names: list[str | None],
+) -> list[dict[str, Any]]:
+    summaries: list[dict[str, Any]] = []
+    for idx, tangent in enumerate(tangents):
+        summary: dict[str, Any] = {
+            "index": idx,
+            "forward_output_index": forward_output_indices[idx],
+        }
+        if forward_output_names[idx] is not None:
+            summary["forward_output_name"] = forward_output_names[idx]
+        if backward_input_names[idx] is not None:
+            summary["backward_input_name"] = backward_input_names[idx]
+
+        if not isinstance(tangent, torch.Tensor):
+            summary["type"] = type(tangent).__name__
+            summaries.append(summary)
+            continue
+
+        summary.update(
+            {
+                "shape": [
+                    int(s) if isinstance(s, int) else str(s) for s in tangent.shape
+                ],
+                "stride": [
+                    int(s) if isinstance(s, int) else str(s) for s in tangent.stride()
+                ],
+                "dtype": str(tangent.dtype),
+                "device": str(tangent.device),
+                "is_contiguous": tangent.is_contiguous(),
+            }
+        )
+        summaries.append(summary)
+    return summaries
+
+
+def get_backward_tangent_input_names(
+    bw_graph: torch.fx.GraphModule,
+    num_primals: int,
+    num_tangents: int,
+) -> list[str | None]:
+    placeholders = [node for node in bw_graph.graph.nodes if node.op == "placeholder"]
+    return [
+        placeholders[num_primals + idx].name
+        if num_primals + idx < len(placeholders)
+        else None
+        for idx in range(num_tangents)
+    ]
+
+
+def warn_and_trace_duplicate_backward(
+    identifier: str | None,
+    suffix: int,
+    variant_summaries: list[object],
+) -> None:
+    if suffix == 0:
+        return
+
+    from torch._dynamo.utils import warn_once
+    from torch._logging import trace_structured
+
+    warn_once(
+        "invoke_subgraph traced multiple backward graphs for the same forward "
+        f"identifier {identifier!r}. This usually means the incoming backward "
+        "tangent metadata differs across backward invocations. This can happen "
+        "when upstream backward formulas produce gradients with different "
+        "layouts, aliases, or other tensor metadata. This can increase compile "
+        "time and code size. Use tlparse and look for the "
+        "invoke_subgraph_backward_duplicate artifact for tangent details."
+    )
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": "invoke_subgraph_backward_duplicate",
+            "encoding": "json",
+        },
+        payload_fn=lambda: {
+            "forward_identifier": identifier,
+            "backward_identifier": f"bw_{identifier}_{suffix}",
+            "new_variant_suffix": suffix,
+            "num_variants_for_identifier": suffix + 1,
+            "variants": variant_summaries,
+            "explanation": (
+                "invoke_subgraph caches backward graphs by both the forward "
+                "identifier and tangent metadata. Multiple backward variants "
+                "for one forward identifier usually mean the backward tangents "
+                "have different tensor metadata, commonly stride."
+            ),
+            "common_cause": (
+                "This can happen when equivalent forward invocations receive backward "
+                "tangents from different upstream formulas, or from the same "
+                "formula with different input metadata. For example, an "
+                "upstream backward may return a view, alias, slice, expanded "
+                "tensor, or otherwise non-contiguous gradient whose metadata "
+                "does not match the tangent seen by another use."
+            ),
+            "suggested_action": (
+                "If the duplicate backward graph is undesirable, materialize a "
+                "consistent tangent layout before the nested region backward. "
+                "One model-level workaround is a custom autograd.Function whose "
+                "forward returns the input and whose backward returns "
+                "grad.contiguous()."
+            ),
+        },
+    )
 
 
 class InvokeSubgraphHOP(HigherOrderOperator):
@@ -410,6 +521,7 @@ def create_fw_bw_graph(subgraph, operands, grad_outputs=None):
             output_metadata = OutputMetadata()
 
             output_metadata.num_fw_outs = num_fw_outs
+            output_metadata.output_names = [None] * num_fw_outs
             for idx, fw_out in enumerate(fw_outs):
                 if isinstance(fw_out, torch.SymInt):
                     output_metadata.indexes_with_symint.add(idx)
@@ -475,6 +587,11 @@ def get_output_metadata(subgraph, *operands):
     # The output node has args=(output_values,) where output_values is a tuple/list
     output_node = next(reversed(subgraph.graph.find_nodes(op="output")))
     output_metadata.num_fw_outs = len(output_node.args[0])
+    output_names = [
+        output_arg.name if isinstance(output_arg, torch.fx.Node) else None
+        for output_arg in output_node.args[0]
+    ]
+    output_metadata.output_names = output_names
 
     for idx, output_arg in enumerate(output_node.args[0]):
         if not isinstance(output_arg, torch.fx.Node):
@@ -488,7 +605,9 @@ def get_output_metadata(subgraph, *operands):
             # If we don't have complete metadata for all outputs, fall back to execution
             # This is important for correctness (e.g., detecting SymInts) even though it
             # runs side-effectful operations
-            return _get_output_metadata_by_execution(subgraph, *operands)
+            output_metadata = _get_output_metadata_by_execution(subgraph, *operands)
+            output_metadata.output_names = output_names
+            return output_metadata
 
         val = output_arg.meta["val"]
         if isinstance(val, torch.SymInt):
@@ -533,6 +652,7 @@ def _get_output_metadata_by_execution(subgraph, *operands):
 
             output_metadata = OutputMetadata()
             output_metadata.num_fw_outs = num_fw_outs
+            output_metadata.output_names = [None] * num_fw_outs
 
             for idx, fw_out in enumerate(fw_outs):
                 if isinstance(fw_out, torch.SymInt):
@@ -718,6 +838,8 @@ class InvokeSubgraphAutogradOp(torch.autograd.Function):
         # the assumption we made during the tracing of joint_graph.
         non_differentiable_indices = ctx._non_differentiable_indices
         filtered_grad_outs = []
+        filtered_grad_out_indices = []
+        filtered_grad_out_names = []
         for idx, o in enumerate(grad_outs):
             if o is None:
                 if (
@@ -736,6 +858,12 @@ class InvokeSubgraphAutogradOp(torch.autograd.Function):
                 pass
             else:
                 filtered_grad_outs.append(o)
+                filtered_grad_out_indices.append(idx)
+                filtered_grad_out_names.append(
+                    output_metadata.output_names[idx]
+                    if idx < len(output_metadata.output_names)
+                    else None
+                )
         filtered_grad_outs = tuple(filtered_grad_outs)
 
         # Important note - Even though the forward graph can be same for
@@ -818,8 +946,26 @@ class InvokeSubgraphAutogradOp(torch.autograd.Function):
                     ]
 
         if invoke_subgraph_cache and not cache_hit:
+            backward_input_names = get_backward_tangent_input_names(
+                bw_graph, len(primals), len(filtered_grad_outs)
+            )
+            tangent_summary = {
+                "backward_identifier": None,
+                "tangents": summarize_backward_tangents(
+                    filtered_grad_outs,
+                    filtered_grad_out_indices,
+                    filtered_grad_out_names,
+                    backward_input_names,
+                ),
+            }
             suffix = invoke_subgraph_cache.add_lazy_bwd_entry(
-                identifier, tangent_metadata, bw_graph
+                identifier, tangent_metadata, bw_graph, tangent_summary
+            )
+            tangent_summary["backward_identifier"] = f"bw_{identifier}_{suffix}"
+            warn_and_trace_duplicate_backward(
+                identifier,
+                suffix,
+                invoke_subgraph_cache.get_lazy_bwd_debug_entries(identifier),
             )
 
         with _set_invoke_subgraph_call_id(ctx._call_id):

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -128,14 +128,21 @@ def _set_invoke_subgraph_call_id(call_id: int):
         _invoke_subgraph_call_state.current = prev
 
 
-def summarize_backward_tangents(
+def warn_and_trace_duplicate_backward(
+    identifier: str | None,
+    suffix: int,
     bw_graph: torch.fx.GraphModule,
     num_primals: int,
     tangents: tuple[Any, ...],
-) -> list[dict[str, Any]]:
-    placeholders = [node for node in bw_graph.graph.nodes if node.op == "placeholder"]
+) -> None:
+    if suffix == 0:
+        return
 
-    summaries: list[dict[str, Any]] = []
+    from torch._dynamo.utils import warn_once
+    from torch._logging import trace_structured
+
+    placeholders = [node for node in bw_graph.graph.nodes if node.op == "placeholder"]
+    tangent_summaries: list[dict[str, Any]] = []
     for idx, tangent in enumerate(tangents):
         summary: dict[str, Any] = {}
         backward_input_idx = num_primals + idx
@@ -143,8 +150,8 @@ def summarize_backward_tangents(
             summary["backward_input_name"] = placeholders[backward_input_idx].name
 
         if not isinstance(tangent, torch.Tensor):
-            summary["type"] = type(tangent).__name__
-            summaries.append(summary)
+            summary["type"] = "non-Tensor"
+            tangent_summaries.append(summary)
             continue
 
         summary.update(
@@ -159,20 +166,7 @@ def summarize_backward_tangents(
                 "device": str(tangent.device),
             }
         )
-        summaries.append(summary)
-    return summaries
-
-
-def warn_and_trace_duplicate_backward(
-    identifier: str | None,
-    suffix: int,
-    new_variant_summary: dict[str, Any],
-) -> None:
-    if suffix == 0:
-        return
-
-    from torch._dynamo.utils import warn_once
-    from torch._logging import trace_structured
+        tangent_summaries.append(summary)
 
     warn_once(
         "invoke_subgraph traced multiple backward graphs for the same forward "
@@ -194,7 +188,10 @@ def warn_and_trace_duplicate_backward(
             "backward_identifier": f"bw_{identifier}_{suffix}",
             "new_variant_suffix": suffix,
             "num_variants_for_identifier": suffix + 1,
-            "new_variant": new_variant_summary,
+            "new_variant": {
+                "backward_identifier": f"bw_{identifier}_{suffix}",
+                "tangents": tangent_summaries,
+            },
             "explanation": (
                 "invoke_subgraph caches backward graphs by both the forward "
                 "identifier and tangent metadata. Multiple backward variants "
@@ -913,16 +910,9 @@ class InvokeSubgraphAutogradOp(torch.autograd.Function):
             suffix = invoke_subgraph_cache.add_lazy_bwd_entry(
                 identifier, tangent_metadata, bw_graph
             )
-            if suffix != 0:
-                tangent_summary = {
-                    "backward_identifier": f"bw_{identifier}_{suffix}",
-                    "tangents": summarize_backward_tangents(
-                        bw_graph,
-                        len(primals),
-                        filtered_grad_outs,
-                    ),
-                }
-                warn_and_trace_duplicate_backward(identifier, suffix, tangent_summary)
+            warn_and_trace_duplicate_backward(
+                identifier, suffix, bw_graph, len(primals), filtered_grad_outs
+            )
 
         with _set_invoke_subgraph_call_id(ctx._call_id):
             grads = invoke_subgraph(

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -54,7 +54,6 @@ class OutputMetadata:
     num_fw_outs: int | None = None
     indexes_with_symint: set[int] = field(default_factory=set)
     indexes_with_no_grad: set[int] = field(default_factory=set)
-    output_names: list[str | None] = field(default_factory=list)
 
 
 # This config will be stored in invoke_subgraph HOP node.meta["custom"]["nested_region_config"]
@@ -130,21 +129,18 @@ def _set_invoke_subgraph_call_id(call_id: int):
 
 
 def summarize_backward_tangents(
+    bw_graph: torch.fx.GraphModule,
+    num_primals: int,
     tangents: tuple[Any, ...],
-    forward_output_indices: list[int],
-    forward_output_names: list[str | None],
-    backward_input_names: list[str | None],
 ) -> list[dict[str, Any]]:
+    placeholders = [node for node in bw_graph.graph.nodes if node.op == "placeholder"]
+
     summaries: list[dict[str, Any]] = []
     for idx, tangent in enumerate(tangents):
-        summary: dict[str, Any] = {
-            "index": idx,
-            "forward_output_index": forward_output_indices[idx],
-        }
-        if forward_output_names[idx] is not None:
-            summary["forward_output_name"] = forward_output_names[idx]
-        if backward_input_names[idx] is not None:
-            summary["backward_input_name"] = backward_input_names[idx]
+        summary: dict[str, Any] = {}
+        backward_input_idx = num_primals + idx
+        if backward_input_idx < len(placeholders):
+            summary["backward_input_name"] = placeholders[backward_input_idx].name
 
         if not isinstance(tangent, torch.Tensor):
             summary["type"] = type(tangent).__name__
@@ -161,31 +157,16 @@ def summarize_backward_tangents(
                 ],
                 "dtype": str(tangent.dtype),
                 "device": str(tangent.device),
-                "is_contiguous": tangent.is_contiguous(),
             }
         )
         summaries.append(summary)
     return summaries
 
 
-def get_backward_tangent_input_names(
-    bw_graph: torch.fx.GraphModule,
-    num_primals: int,
-    num_tangents: int,
-) -> list[str | None]:
-    placeholders = [node for node in bw_graph.graph.nodes if node.op == "placeholder"]
-    return [
-        placeholders[num_primals + idx].name
-        if num_primals + idx < len(placeholders)
-        else None
-        for idx in range(num_tangents)
-    ]
-
-
 def warn_and_trace_duplicate_backward(
     identifier: str | None,
     suffix: int,
-    variant_summaries: list[object],
+    new_variant_summary: dict[str, Any],
 ) -> None:
     if suffix == 0:
         return
@@ -213,7 +194,7 @@ def warn_and_trace_duplicate_backward(
             "backward_identifier": f"bw_{identifier}_{suffix}",
             "new_variant_suffix": suffix,
             "num_variants_for_identifier": suffix + 1,
-            "variants": variant_summaries,
+            "new_variant": new_variant_summary,
             "explanation": (
                 "invoke_subgraph caches backward graphs by both the forward "
                 "identifier and tangent metadata. Multiple backward variants "
@@ -521,7 +502,6 @@ def create_fw_bw_graph(subgraph, operands, grad_outputs=None):
             output_metadata = OutputMetadata()
 
             output_metadata.num_fw_outs = num_fw_outs
-            output_metadata.output_names = [None] * num_fw_outs
             for idx, fw_out in enumerate(fw_outs):
                 if isinstance(fw_out, torch.SymInt):
                     output_metadata.indexes_with_symint.add(idx)
@@ -587,11 +567,6 @@ def get_output_metadata(subgraph, *operands):
     # The output node has args=(output_values,) where output_values is a tuple/list
     output_node = next(reversed(subgraph.graph.find_nodes(op="output")))
     output_metadata.num_fw_outs = len(output_node.args[0])
-    output_names = [
-        output_arg.name if isinstance(output_arg, torch.fx.Node) else None
-        for output_arg in output_node.args[0]
-    ]
-    output_metadata.output_names = output_names
 
     for idx, output_arg in enumerate(output_node.args[0]):
         if not isinstance(output_arg, torch.fx.Node):
@@ -605,9 +580,7 @@ def get_output_metadata(subgraph, *operands):
             # If we don't have complete metadata for all outputs, fall back to execution
             # This is important for correctness (e.g., detecting SymInts) even though it
             # runs side-effectful operations
-            output_metadata = _get_output_metadata_by_execution(subgraph, *operands)
-            output_metadata.output_names = output_names
-            return output_metadata
+            return _get_output_metadata_by_execution(subgraph, *operands)
 
         val = output_arg.meta["val"]
         if isinstance(val, torch.SymInt):
@@ -652,7 +625,6 @@ def _get_output_metadata_by_execution(subgraph, *operands):
 
             output_metadata = OutputMetadata()
             output_metadata.num_fw_outs = num_fw_outs
-            output_metadata.output_names = [None] * num_fw_outs
 
             for idx, fw_out in enumerate(fw_outs):
                 if isinstance(fw_out, torch.SymInt):
@@ -838,8 +810,6 @@ class InvokeSubgraphAutogradOp(torch.autograd.Function):
         # the assumption we made during the tracing of joint_graph.
         non_differentiable_indices = ctx._non_differentiable_indices
         filtered_grad_outs = []
-        filtered_grad_out_indices = []
-        filtered_grad_out_names = []
         for idx, o in enumerate(grad_outs):
             if o is None:
                 if (
@@ -858,12 +828,6 @@ class InvokeSubgraphAutogradOp(torch.autograd.Function):
                 pass
             else:
                 filtered_grad_outs.append(o)
-                filtered_grad_out_indices.append(idx)
-                filtered_grad_out_names.append(
-                    output_metadata.output_names[idx]
-                    if idx < len(output_metadata.output_names)
-                    else None
-                )
         filtered_grad_outs = tuple(filtered_grad_outs)
 
         # Important note - Even though the forward graph can be same for
@@ -946,27 +910,19 @@ class InvokeSubgraphAutogradOp(torch.autograd.Function):
                     ]
 
         if invoke_subgraph_cache and not cache_hit:
-            backward_input_names = get_backward_tangent_input_names(
-                bw_graph, len(primals), len(filtered_grad_outs)
-            )
-            tangent_summary = {
-                "backward_identifier": None,
-                "tangents": summarize_backward_tangents(
-                    filtered_grad_outs,
-                    filtered_grad_out_indices,
-                    filtered_grad_out_names,
-                    backward_input_names,
-                ),
-            }
             suffix = invoke_subgraph_cache.add_lazy_bwd_entry(
-                identifier, tangent_metadata, bw_graph, tangent_summary
+                identifier, tangent_metadata, bw_graph
             )
-            tangent_summary["backward_identifier"] = f"bw_{identifier}_{suffix}"
-            warn_and_trace_duplicate_backward(
-                identifier,
-                suffix,
-                invoke_subgraph_cache.get_lazy_bwd_debug_entries(identifier),
-            )
+            if suffix != 0:
+                tangent_summary = {
+                    "backward_identifier": f"bw_{identifier}_{suffix}",
+                    "tangents": summarize_backward_tangents(
+                        bw_graph,
+                        len(primals),
+                        filtered_grad_outs,
+                    ),
+                }
+                warn_and_trace_duplicate_backward(identifier, suffix, tangent_summary)
 
         with _set_invoke_subgraph_call_id(ctx._call_id):
             grads = invoke_subgraph(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #183580

Emit a warn_once and structured trace artifact when lazy invoke_subgraph backward tracing creates another graph for the same forward identifier because tangent metadata differs. The artifact records forward output and backward input names plus tangent metadata so tlparse can show what changed.


Authored by Codex.