### PR TITLE
[pipelining] Add guards for non-float tensors when building pipeline

### DIFF
--- a/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
+++ b/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
@@ -186,7 +186,7 @@ class TestDTensorPPUnitTests(MultiProcContinuousTest):
         """Test that to_tensor/to_dtensor don't set requires_grad on non-float dtypes."""
         self.init_pg()
         mesh = self._make_mesh()
-    
+
         # _TensorMeta: non-float with requires_grad=True in metadata should not crash
         for dtype in [torch.long, torch.int32, torch.bool]:
             meta = _TensorMeta(
@@ -198,7 +198,7 @@ class TestDTensorPPUnitTests(MultiProcContinuousTest):
             t = meta.to_tensor(self.device)
             self.assertEqual(t.dtype, dtype)
             self.assertFalse(t.requires_grad)
-    
+
         # _TensorMeta: float with requires_grad=True should still work
         float_meta = _TensorMeta(
             shape=torch.Size([4, 8]),
@@ -208,7 +208,7 @@ class TestDTensorPPUnitTests(MultiProcContinuousTest):
         )
         t = float_meta.to_tensor(self.device)
         self.assertTrue(t.requires_grad)
-    
+
         # _DTensorMeta: non-float with requires_grad=True should not crash
         for dtype in [torch.long, torch.int32]:
             dt_meta = _DTensorMeta(

--- a/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
+++ b/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
@@ -182,6 +182,51 @@ class TestDTensorPPUnitTests(MultiProcContinuousTest):
         self.assertIn("DTensor", str(ctx.exception))
 
     @_requires_multi_gpu
+    def test_tensor_meta_non_float_requires_grad_guard(self):
+        """Test that to_tensor/to_dtensor don't set requires_grad on non-float dtypes."""
+        self.init_pg()
+        mesh = self._make_mesh()
+    
+        # _TensorMeta: non-float with requires_grad=True in metadata should not crash
+        for dtype in [torch.long, torch.int32, torch.bool]:
+            meta = _TensorMeta(
+                shape=torch.Size([4, 8]),
+                stride=(8, 1),
+                dtype=dtype,
+                requires_grad=True,  # would crash without the guard
+            )
+            t = meta.to_tensor(self.device)
+            self.assertEqual(t.dtype, dtype)
+            self.assertFalse(t.requires_grad)
+    
+        # _TensorMeta: float with requires_grad=True should still work
+        float_meta = _TensorMeta(
+            shape=torch.Size([4, 8]),
+            stride=(8, 1),
+            dtype=torch.float32,
+            requires_grad=True,
+        )
+        t = float_meta.to_tensor(self.device)
+        self.assertTrue(t.requires_grad)
+    
+        # _DTensorMeta: non-float with requires_grad=True should not crash
+        for dtype in [torch.long, torch.int32]:
+            dt_meta = _DTensorMeta(
+                shape=torch.Size([4, 8]),
+                stride=(8, 1),
+                dtype=dtype,
+                requires_grad=True,
+                global_shape=torch.Size([8, 8]),
+                global_stride=(8, 1),
+                placements=(Shard(0),),
+                mesh_dim_names=("tp",),
+                mesh_layout=mesh._layout,
+            )
+            dt = dt_meta.to_dtensor(self.device, mesh)
+            self.assertEqual(dt.dtype, dtype)
+            self.assertFalse(dt.requires_grad)
+
+    @_requires_multi_gpu
     def test_dtensor_meta_extraction_and_roundtrip(self):
         """Test _DTensorMeta: extraction and roundtrip for Shard/Replicate."""
         self.init_pg()

--- a/test/distributed/pipelining/test_pipe.py
+++ b/test/distributed/pipelining/test_pipe.py
@@ -120,6 +120,35 @@ class PipeTests(TestCase):
             """)
         print("Qualname check passed")
 
+    def test_pipeline_with_non_float_inputs(self):
+        """Test that pipeline() handles non-float tensors crossing stage boundaries."""
+    
+        class EmbeddingModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embed = torch.nn.Embedding(100, 64)
+                self.linear = torch.nn.Linear(64, 64)
+    
+            def forward(self, input_ids, mask):
+                x = self.embed(input_ids)
+                pipe_split()
+                x = self.linear(x)
+                x = x * mask.unsqueeze(-1).float()
+                return x
+    
+        model = EmbeddingModel()
+        input_ids = torch.randint(0, 100, (2, 16))
+        mask = torch.ones(2, 16, dtype=torch.bool)
+    
+        # This should not raise "only Tensors of floating point dtype can require gradients"
+        pipe = pipeline(model, mb_args=(input_ids, mask))
+        self.assertEqual(pipe.num_stages, 2)
+    
+        # Verify non-float tensors don't have requires_grad in metadata
+        ref_out = model(input_ids, mask)
+        out = pipe(input_ids, mask)[0]
+        torch.testing.assert_close(out, ref_out)
+
 
 instantiate_parametrized_tests(PipeTests)
 

--- a/test/distributed/pipelining/test_pipe.py
+++ b/test/distributed/pipelining/test_pipe.py
@@ -122,28 +122,28 @@ class PipeTests(TestCase):
 
     def test_pipeline_with_non_float_inputs(self):
         """Test that pipeline() handles non-float tensors crossing stage boundaries."""
-    
+
         class EmbeddingModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()
                 self.embed = torch.nn.Embedding(100, 64)
                 self.linear = torch.nn.Linear(64, 64)
-    
+
             def forward(self, input_ids, mask):
                 x = self.embed(input_ids)
                 pipe_split()
                 x = self.linear(x)
                 x = x * mask.unsqueeze(-1).float()
                 return x
-    
+
         model = EmbeddingModel()
         input_ids = torch.randint(0, 100, (2, 16))
         mask = torch.ones(2, 16, dtype=torch.bool)
-    
+
         # This should not raise "only Tensors of floating point dtype can require gradients"
         pipe = pipeline(model, mb_args=(input_ids, mask))
         self.assertEqual(pipe.num_stages, 2)
-    
+
         # Verify non-float tensors don't have requires_grad in metadata
         ref_out = model(input_ids, mask)
         out = pipe(input_ids, mask)[0]

--- a/torch/distributed/pipelining/_utils.py
+++ b/torch/distributed/pipelining/_utils.py
@@ -196,17 +196,17 @@ class _DTensorMeta(_TensorMeta):
         local_tensor = _make_tensor_from_meta(self, device)
         # Set requires_grad after from_local() so that the from_local
         # operation itself is not recorded in the autograd graph.
-        return cast(
-            DTensor,
-            DTensor.from_local(
-                local_tensor,
-                device_mesh=mesh,
-                placements=self.placements,
-                shape=self.global_shape,
-                stride=self.global_stride,
-                run_check=False,
-            ).requires_grad_(self.requires_grad),
+        dt = DTensor.from_local(
+            local_tensor,
+            device_mesh=mesh,
+            placements=self.placements,
+            shape=self.global_shape,
+            stride=self.global_stride,
+            run_check=False,
         )
+        if self.requires_grad and dt.is_floating_point():
+            dt = dt.requires_grad_(True)
+        return cast(DTensor, dt)
 
     def get_diff(self, other: _TensorMeta) -> list[str]:
         """Return field-by-field differences, including DTensor-specific fields.

--- a/torch/distributed/pipelining/_utils.py
+++ b/torch/distributed/pipelining/_utils.py
@@ -93,7 +93,8 @@ class _TensorMeta:
             An empty strided tensor on ``device``.
         """
         t = _make_tensor_from_meta(self, device)
-        t.requires_grad_(self.requires_grad)
+        if t.is_floating_point():
+            t.requires_grad_(self.requires_grad)
         return t
 
     def get_diff(self, other: _TensorMeta) -> list[str]:

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -1358,11 +1358,12 @@ class _PipelineStage(_PipelineStageBase):
             src_stage = self.get_stage_index_of_submod(arg_node.name)
 
             # Create metadata directly with correct requires_grad.
+            # Guard for non-float tensors.
             tensor_meta = _TensorMeta(
                 shape=example_value.shape,
                 stride=example_value.stride(),
                 dtype=example_value.dtype,
-                requires_grad=self.has_backward,
+                requires_grad=self.has_backward and example_value.is_floating_point(),
             )
 
             logger.debug(
@@ -1373,7 +1374,7 @@ class _PipelineStage(_PipelineStageBase):
                 tensor_meta.dtype,
             )
             buffer = _make_tensor_from_meta(tensor_meta, self.device)
-            if self.has_backward:
+            if self.has_backward and example_value.is_floating_point():
                 buffer.requires_grad_(True)
 
             return _RecvInfo(
@@ -1464,7 +1465,7 @@ class _PipelineStage(_PipelineStageBase):
                     shape=val.shape,
                     stride=val.stride(),
                     dtype=val.dtype,
-                    requires_grad=self.has_backward,
+                    requires_grad=self.has_backward and val.is_floating_point(),
                 )
             )
         self._stage_meta.outputs = tuple(output_metas)


### PR DESCRIPTION
Fixes #183024. Tested working with code below by manually applying the patch over 2.11. Analysis and initial patches found using AI. Manually applied and tested patches.

<details>

<summary> Test code, run with torchrun on 2 gpus </summary>

```python
import torch
import torch.distributed as dist
from torch.distributed.pipelining import pipeline, SplitPoint, PipelineStage, Schedule1F1B
from transformers import AutoModelForCausalLM
import os

# Initialize torchrun's distributed environment
pp_group = dist.init_process_group(backend="nccl")
rank = dist.get_rank()
world_size = dist.get_world_size()
local_rank = int(os.environ["LOCAL_RANK"])

# Assign this specific process to its designated GPU
device = torch.device(f"cuda:{local_rank}")
torch.cuda.set_device(device)

print(f"[Rank {rank}] Starting model init on {device}")

# GPT2
model_id = "openai-community/gpt2"

device_count = torch.cuda.device_count()
model = AutoModelForCausalLM.from_pretrained(model_id)
print(model)

# kv cache is enabled by default and causes other issues with dynamo tracing/pipelining, disabling
model.config.use_cache = False

# run on 2 or more gpus
split_spec = {
    f"transformer.h.5": SplitPoint.END,
} 
model = model.to(device)

pipe_module = pipeline(
    module=model,
    mb_args=(),
    mb_kwargs={
        'input_ids': torch.zeros((1, 512), dtype=torch.long).to(device),
        'attention_mask': torch.ones((1, 512), dtype=torch.bool).to(device)
    },
    split_spec=split_spec,
)

stage = pipe_module.build_stage(rank, device, pp_group)


# placeholder loss function
def loss_fn(outputs, other):
    if isinstance(outputs, tuple):
        return outputs[0]
    elif isinstance(outputs, torch.Tensor):
        logits = outputs
    else:
        logits = outputs['logits']
    loss = logits.sum() - other.sum()
    return loss

schedule = Schedule1F1B(stage, n_microbatches=4, loss_fn=loss_fn)

if rank == 0:
    inputs = {
        'input_ids': torch.zeros((4, 512), dtype=torch.long).to(device),
        'attention_mask': torch.ones((4, 512), dtype=torch.bool).to(device),
    }

    schedule.step(
        **inputs
    )
elif rank == world_size - 1:
    losses = []
    output = schedule.step(target=torch.randn(4, 512).to(device), losses=losses)
    print(f"losses: {losses}")
else:
    schedule.step()
```

</details>

<details>

<summary> Prompt and Initial AI output </summary>

Prompt:

Analyze, triage, and provide me with a fix for this github issue

`https://github.com/pytorch/pytorch/issues/183024`

Z.ai agent response:

I'll analyze this GitHub issue for you. Let me start by fetching the issue details and understanding the problem.
Let me extract the actual issue content more cleanly.
Now let me look at the PyTorch source code for the specific failing function to understand the bug deeply.
Now I have a complete picture. Let me also verify the related backward code path to ensure the fix is comprehensive.
I now have a comprehensive understanding of the issue. Here's my full analysis, triage, and proposed fix:

---

## 🔍 Issue Analysis: PyTorch #183024

### **Title:** [pipelining] Unable to use PP with HF transformers models due to non-float inputs

### **Bug Summary**
When using PyTorch's Pipeline Parallelism (`torch.distributed.pipelining`) with HuggingFace transformer models (GPT2, LLaMA, etc.), the pipeline crashes with:
```
RuntimeError: only Tensors of floating point dtype can require gradients
```

---

## 🧬 Root Cause

The root cause is a **dtype-agnostic `requires_grad` assignment** in the pipeline stage infrastructure. When `has_backward=True` (training mode), the code **unconditionally** sets `requires_grad=True` on **all** activation receive/send buffers — including non-float tensors like `input_ids` (`torch.long`) and `attention_mask` (`torch.bool`). PyTorch only allows floating-point tensors to require gradients (a fundamental constraint since [Issue #37680, open since 2020](https://github.com/pytorch/pytorch/issues/37680)).

The crash occurs at **three specific locations**:

### **Location 1: `torch/distributed/pipelining/stage.py` — `create_recv_tensor` inside `_create_act_recv_info`** (PRIMARY CRASH)

```python
# Lines ~1361-1377 (broken)
tensor_meta = _TensorMeta(
    shape=example_value.shape,
    stride=example_value.stride(),
    dtype=example_value.dtype,
    requires_grad=self.has_backward,  # ← BUG: True for ALL dtypes
)
buffer = _make_tensor_from_meta(tensor_meta, self.device)
if self.has_backward:
    buffer.requires_grad_(True)  # ← CRASH: non-float tensors can't require grad
```

This is the **exact crash point** from the traceback. When the pipeline creates receive buffers for intermediate activations between stages, it encounters `input_ids` (dtype=`torch.long`) or `attention_mask` (dtype=`torch.bool`) and tries to set `requires_grad_(True)`, which is illegal.

### **Location 2: `torch/distributed/pipelining/stage.py` — `_create_act_send_info`** (SECONDARY)

```python
# Lines ~1462-1468 (broken)
output_metas.append(
    _TensorMeta(
        shape=val.shape,
        stride=val.stride(),
        dtype=val.dtype,
        requires_grad=self.has_backward,  # ← Same bug for outputs
    )
)
```

### **Location 3: `torch/distributed/pipelining/_utils.py` — `_TensorMeta.to_tensor`** (LATENT)

```python
# Line ~96 (broken)
t = _make_tensor_from_meta(self, device)
t.requires_grad_(self.requires_grad)  # ← Crashes if requires_grad=True and dtype is non-float
return t
```

### **Additional Related Bug: `torch/distributed/pipelining/_backward.py` — `_get_grad_fn_or_grad_acc`**

Even after fixing the above, the backward pass has a **second bug** waiting to surface. The function `_get_grad_fn_or_grad_acc` assumes its argument is always a `torch.Tensor`:

```python
def _get_grad_fn_or_grad_acc(t: torch.Tensor) -> Node | None:
    if t.requires_grad and t.grad_fn is None:  # ← AttributeError if t is not a Tensor
        ...
```

This is called via `map(_get_grad_fn_or_grad_acc, input_values)` in `stage_backward_input`, where `input_values` can contain non-tensor objects. While the immediate crash is masked by Location 1, once that's fixed, this will be the **next crash site**.

---

## 🔧 Proposed Fix

The fix is to **guard `requires_grad=True` with a `tensor.is_floating_point()` check** at all affected locations. This is semantically correct because:
- Non-float tensors (integer, boolean) **never** produce meaningful gradients
- Their gradient in the backward pass should be `None`
- This is consistent with PyTorch's autograd semantics

### **Patch 1: `torch/distributed/pipelining/stage.py` — `create_recv_tensor`**

```python
def create_recv_tensor(placeholder, arg_node):
    example_value = placeholder.meta["val"]

    # ... (DTensor check unchanged) ...

    if arg_node.op == "placeholder":
        return _RecvInfo(
            input_name=f"root_input_{placeholder.name}",
            source=None,
            buffer=None,
            tensor_meta=_TensorMeta.from_tensor(example_value),
            is_root_arg=True,
        )

    # Received activation from a previous stage.
    while arg_node.target is operator.getitem:
        arg_node = arg_node.args[0]

    if arg_node.op != "call_module":
        raise PipeliningMetadataError(
            f"Expecting call_module, got {arg_node.op}"
        )
    src_stage = self.get_stage_index_of_submod(arg_node.name)

    # FIX: Only set requires_grad for floating-point tensors
    needs_grad = self.has_backward and example_value.is_floating_point()

    tensor_meta = _TensorMeta(
        shape=example_value.shape,
        stride=example_value.stride(),
        dtype=example_value.dtype,
        requires_grad=needs_grad,  # ← was: self.has_backward
    )

    buffer = _make_tensor_from_meta(tensor_meta, self.device)
    if needs_grad:  # ← was: if self.has_backward
        buffer.requires_grad_(True)

    return _RecvInfo(
        arg_node.name,
        src_stage,
        buffer,
        tensor_meta,
    )
```

### **Patch 2: `torch/distributed/pipelining/stage.py` — `_create_act_send_info`**

```python
# Inside _create_act_send_info, where output_metas are built:
output_metas.append(
    _TensorMeta(
        shape=val.shape,
        stride=val.stride(),
        dtype=val.dtype,
        requires_grad=self.has_backward and val.is_floating_point(),  # ← was: self.has_backward
    )
)
```

### **Patch 3: `torch/distributed/pipelining/_utils.py` — `_TensorMeta.to_tensor`**

```python
def to_tensor(self, device: torch.device | str) -> torch.Tensor:
    t = _make_tensor_from_meta(self, device)
    if self.requires_grad and t.is_floating_point():  # ← was: unconditionally
        t.requires_grad_(True)
    return t
```

### **Patch 4: `torch/distributed/pipelining/_backward.py` — `_get_grad_fn_or_grad_acc`**

```python
def _get_grad_fn_or_grad_acc(t: torch.Tensor) -> Node | None:
    # FIX: Guard against non-tensor inputs
    if not isinstance(t, torch.Tensor):
        return None
    if t.requires_grad and t.grad_fn is None:
        viewed_t = t.view_as(t)
        grad_fn = viewed_t.grad_fn
        if grad_fn is not None:
            return grad_fn.next_functions[0][0]
        else:
            raise RuntimeError(
                "Attempted to get grad_fn, but got None."
                "Is this being created in a no-grad context?"
            )
    else:
        return t.grad_fn
```

---

## 📊 Triage Assessment

| Aspect | Rating |
|--------|--------|
| **Severity** | 🔴 **High** — Completely blocks pipeline parallelism for any model with non-float inputs (all HF transformer models) |
| **Impact** | 🔴 **High** — Affects GPT2, LLaMA, BERT, T5 — essentially all popular transformer architectures |
| **Workaround?** | 🟡 **Difficult** — Would require rewriting models to avoid passing non-float tensors between stages, or monkey-patching the pipelining internals |
| **Fix Complexity** | 🟢 **Low** — Four surgical `is_floating_point()` / `isinstance` guards, no architectural changes |
| **Regression Risk** | 🟢 **Low** — The fix only restricts `requires_grad` for cases that already crash; float tensors are unaffected |

### Why PRs #182182 and #182644 Don't Fix This
- **PR #182182** fixes None gradient handling for float tensors that are unused — it doesn't address the dtype mismatch
- **PR #182644** fixes FX graph node ordering — it doesn't touch the `requires_grad` logic at all
- This is a **distinct, orthogonal bug** that needs its own fix

---

## 🚀 Suggested Next Steps

1. **File a PR** against `pytorch/pytorch` with the four patches above
2. **Add regression tests** that pipeline an HF model (even a tiny one like GPT2-small) with `input_ids` and `attention_mask`
3. **Coordinate with PR #182182** — both fixes are needed for full pipeline parallelism support, and they should be tested together since they both touch the backward path

Prompt:

Check your work

Z.ai agent response:

Good call — let me verify my analysis against the actual PyTorch source code. I'll cross-check each claim.
Now I have verified all the source code against my original analysis. Let me also check one more thing — whether the `to_tensor` method is actually called in the crash path or not.
Now let me verify the secondary bug claim about `_get_grad_fn_or_grad_acc` — whether it would actually be hit in the backward path after fixing the primary bug.
Good — my verification is complete. Here's the **corrected and refined** analysis:

---

## ✅ Verification Results

### Claims Confirmed ✅

| Claim | Status | Evidence |
|-------|--------|----------|
| **Primary crash: `create_recv_tensor` sets `requires_grad=self.has_backward` unconditionally** | ✅ **Confirmed** | Exact match with source at `stage.py` lines ~1361-1377 |
| **Primary crash: `buffer.requires_grad_(True)` when `self.has_backward`** | ✅ **Confirmed** | Line ~1377, crashes for `torch.long`/`torch.bool` tensors |
| **Secondary bug: `_create_act_send_info` uses same `requires_grad=self.has_backward` pattern** | ✅ **Confirmed** | Line ~1467, same unconditional pattern for outputs |
| **Latent bug: `_TensorMeta.to_tensor()` calls `t.requires_grad_(self.requires_grad)` unconditionally** | ✅ **Confirmed** | `_utils.py` line ~96, same crash pattern |
| **PR #182182 does NOT fix this** | ✅ **Confirmed** | It fixes None gradient handling for float tensors, not the dtype mismatch |
| **PR #182644 does NOT fix this** | ✅ **Confirmed** | It fixes FX graph node ordering, doesn't touch `requires_grad` logic |
| **`is_floating_point()` guard is the correct fix** | ✅ **Confirmed** | Semantically correct: non-float tensors can never produce meaningful gradients in PyTorch |

### Claim Clarified ⚠️

| Claim | Status | Correction |
|-------|--------|------------|
| **`_get_grad_fn_or_grad_acc` will crash next after the primary fix** | ⚠️ **Partially correct** | This IS a real bug, but it's for a **different scenario** — when non-Tensor Python objects (int, bool, None) appear in `input_values`. In the HF GPT2 pipeline case specifically, `input_values` contains `torch.Tensor` objects (just non-float ones), which after the primary fix will have `requires_grad=False` and work fine. The `isinstance` guard is still a valid defense-in-depth fix but is **not directly triggered** by this issue. |

### Revised Fix Assessment

**Patch 1 (`create_recv_tensor`)** — **Essential, directly fixes the crash** ✅

**Patch 2 (`_create_act_send_info`)** — **Important, prevents same crash for non-float outputs crossing stage boundaries** ✅  
(Not triggered in GPT2 specifically since embedding outputs are float, but needed for models where non-float tensors cross stages)

**Patch 3 (`_TensorMeta.to_tensor`)** — **Defensive, prevents latent crash if this method is called with `requires_grad=True` on non-float metadata** ✅

**Patch 4 (`_get_grad_fn_or_grad_acc`)** — **Separate bug, defense-in-depth** ⚠️  
Should be framed as a separate fix for the torchtitan #3112 scenario (non-Tensor Python objects in `input_values`), not as part of the immediate fix for issue #183024.

---

### Bottom Line

My original analysis was **substantially correct**. The three core patches (1, 2, 3) are accurate and necessary. Patch 4 is a valid bug fix but should be presented as an **orthogonal improvement** rather than a direct consequence of fixing issue #183024. The root cause, severity assessment, and fix approach all hold up under verification.

</details>