### PR TITLE
Support per dim marking in dynamic source list. (#183583)

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10033,6 +10033,86 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         self.assertEqual(counter.frame_count, 1)
 
+    @torch.compiler.config.patch(dynamic_sources="L['x']:0")
+    def test_dynamic_sources_per_dim_single(self):
+        builder._DYNAMIC_SOURCES = None
+
+        counter = CompileCounter()
+
+        @torch.compile(dynamic=False, backend=counter)
+        def fn(x):
+            return x * x
+
+        # Vary dim 0 only -> should not recompile (dim 0 is in the dynamic-sources list)
+        fn(torch.randn(2, 4))
+        fn(torch.randn(3, 4))
+        fn(torch.randn(4, 4))
+
+        self.assertEqual(counter.frame_count, 1)
+
+        # Now vary dim 1 -> dim 1 is NOT in the dynamic-sources list, so we should recompile
+        fn(torch.randn(4, 5))
+        self.assertEqual(counter.frame_count, 2)
+
+    @torch.compiler.config.patch(dynamic_sources="L['x']:0, L['x']:2")
+    def test_dynamic_sources_per_dim_multiple(self):
+        builder._DYNAMIC_SOURCES = None
+
+        counter = CompileCounter()
+
+        @torch.compile(dynamic=False, backend=counter)
+        def fn(x):
+            return x * x
+
+        # Varying dims 0 and 2 should not recompile
+        fn(torch.randn(2, 4, 6))
+        fn(torch.randn(3, 4, 7))
+        fn(torch.randn(4, 4, 8))
+
+        self.assertEqual(counter.frame_count, 1)
+
+        # Varying dim 1 should recompile (not in the dynamic-sources list)
+        fn(torch.randn(4, 5, 8))
+        self.assertEqual(counter.frame_count, 2)
+
+    @torch.compiler.config.patch(dynamic_sources="L['x']")
+    def test_dynamic_sources_no_dim_suffix_marks_all_dims(self):
+        # Backward-compat: an entry without ":N" still marks ALL dims dynamic.
+        builder._DYNAMIC_SOURCES = None
+
+        counter = CompileCounter()
+
+        @torch.compile(dynamic=False, backend=counter)
+        def fn(x):
+            return x * x
+
+        fn(torch.randn(2, 4))
+        fn(torch.randn(3, 5))
+        fn(torch.randn(4, 6))
+
+        self.assertEqual(counter.frame_count, 1)
+
+    @torch.compiler.config.patch(unbacked_sources="L['x']:0")
+    def test_unbacked_sources_per_dim(self):
+        builder._UNBACKED_SOURCES = None
+
+        counter = CompileCounter()
+
+        @torch.compile(dynamic=False, backend=counter)
+        def fn(x):
+            return x * x
+
+        # Varying dim 0 should not recompile
+        fn(torch.randn(2, 4))
+        fn(torch.randn(3, 4))
+        fn(torch.randn(4, 4))
+
+        self.assertEqual(counter.frame_count, 1)
+
+        # Varying dim 1 should recompile
+        fn(torch.randn(4, 5))
+        self.assertEqual(counter.frame_count, 2)
+
     def test_cannot_trace_mark_dynamic(self):
         y = torch.randn([3, 3, 3])
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2319,13 +2319,17 @@ class VariableBuilder:
         if type(value) is int:
             if not isinstance(value, int):
                 raise AssertionError(f"Expected int, got {type(value)}")
-            # allowlist has higher precedence over specialization control.
+            # The dynamic-sources list has higher precedence over specialization control.
             if is_dynamic_source(self.source.name):
-                log.debug("%s marked dynamic via source whitelist", self.source.name)
+                log.debug(
+                    "%s marked dynamic via dynamic-sources list", self.source.name
+                )
                 return self.wrap_symint(value, dynamism=DimDynamic.DYNAMIC)
 
             if is_unbacked_source(self.source.name):
-                log.debug("%s marked unbacked via source whitelist", self.source.name)
+                log.debug(
+                    "%s marked unbacked via unbacked-sources list", self.source.name
+                )
                 return self.wrap_symint(value, dynamism=DimDynamic.UNBACKED)
 
             if not config.specialize_int:
@@ -3819,11 +3823,29 @@ def get_automatic_dynamic_shapes_mark_as() -> DimDynamic:
         )
 
 
-_DYNAMIC_SOURCES: set[str] | None = None
+# Each entry is (pattern, dim) where dim is None for "all dims" or an int
+# for a single dim. The optional ":N" suffix on a source list entry restricts
+# the match to dim N of the matched tensor. List the same source multiple
+# times (e.g. "L['x']:0, L['x']:2") to target multiple specific dims.
+_DYNAMIC_SOURCES: list[tuple[str, int | None]] | None = None
 _DYNAMIC_SOURCES_CONFIG_HASH: int | None = None
 
+_DIM_SUFFIX_RE: re.Pattern[str] = re.compile(r"^(.+):(\d+)$")
 
-def get_dynamic_sources() -> set[str]:
+
+def _parse_source_entry(entry: str) -> tuple[str, int | None]:
+    """Parse a source list entry into (pattern, dim).
+
+    Entries may end with an optional ``:N`` suffix where ``N`` is a literal
+    non-negative integer (the dim portion is not part of the name regex).
+    """
+    m = _DIM_SUFFIX_RE.match(entry)
+    if m:
+        return m.group(1), int(m.group(2))
+    return entry, None
+
+
+def get_dynamic_sources() -> list[tuple[str, int | None]]:
     global _DYNAMIC_SOURCES, _DYNAMIC_SOURCES_CONFIG_HASH
 
     current_hash = hash(torch.compiler.config.dynamic_sources)
@@ -3833,26 +3855,37 @@ def get_dynamic_sources() -> set[str]:
         return _DYNAMIC_SOURCES
 
     # Config has changed or first time, (re)calculate the sources
-    _DYNAMIC_SOURCES = {
-        s
+    _DYNAMIC_SOURCES = [
+        _parse_source_entry(s)
         for s in torch.compiler.config.dynamic_sources.replace(" ", "").split(",")
         if s
-    }
+    ]
     _DYNAMIC_SOURCES_CONFIG_HASH = current_hash
 
     return _DYNAMIC_SOURCES
 
 
-def is_dynamic_source(source_name: str) -> bool:
+def is_dynamic_source(source_name: str, dim: int | None = None) -> bool:
+    """Check whether ``source_name`` is in the dynamic-sources list.
+
+    If ``dim`` is None, returns True if any entry matches the source
+    name (regardless of any per-dim qualifier). This is the right semantics for
+    callers that ask "is this source dynamic at all?" (e.g. the static-shapes
+    early return, or non-tensor int sources which have no dim).
+
+    If ``dim`` is given, returns True only when a matching entry either has no
+    dim qualifier ("all dims dynamic") or its dim qualifier equals ``dim``.
+    """
     dynamic_sources = get_dynamic_sources()
-    for pattern in dynamic_sources:
+    for pattern, pat_dim in dynamic_sources:
         if pattern == source_name or re.match(pattern, source_name):
-            log.debug(
-                "%s was marked dynamic due to dynamic source allowlist pattern: %s",
-                source_name,
-                pattern,
-            )
-            return True
+            if dim is None or pat_dim is None or pat_dim == dim:
+                log.debug(
+                    "%s was marked dynamic due to dynamic-sources entry: %s",
+                    source_name,
+                    pattern if pat_dim is None else f"{pattern}:{pat_dim}",
+                )
+                return True
     return False
 
 
@@ -3888,11 +3921,13 @@ def record_automatic_dynamic(
     )
 
 
-_UNBACKED_SOURCES: set[str] | None = None
+# Same per-dim suffix syntax as _DYNAMIC_SOURCES: optional ":N" restricts the
+# match to dim N of the matched tensor.
+_UNBACKED_SOURCES: list[tuple[str, int | None]] | None = None
 _UNBACKED_SOURCES_CONFIG_HASH: int | None = None
 
 
-def get_unbacked_sources() -> set[str]:
+def get_unbacked_sources() -> list[tuple[str, int | None]]:
     global _UNBACKED_SOURCES, _UNBACKED_SOURCES_CONFIG_HASH
 
     current_hash = hash(torch.compiler.config.unbacked_sources)
@@ -3902,26 +3937,31 @@ def get_unbacked_sources() -> set[str]:
         return _UNBACKED_SOURCES
 
     # Config has changed or first time, (re)calculate the sources
-    _UNBACKED_SOURCES = {
-        s
+    _UNBACKED_SOURCES = [
+        _parse_source_entry(s)
         for s in torch.compiler.config.unbacked_sources.replace(" ", "").split(",")
         if s
-    }
+    ]
     _UNBACKED_SOURCES_CONFIG_HASH = current_hash
 
     return _UNBACKED_SOURCES
 
 
-def is_unbacked_source(source_name: str) -> bool:
+def is_unbacked_source(source_name: str, dim: int | None = None) -> bool:
+    """Check whether ``source_name`` is in the unbacked-sources list.
+
+    See :func:`is_dynamic_source` for the ``dim`` argument semantics.
+    """
     unbacked_sources = get_unbacked_sources()
-    for pattern in unbacked_sources:
+    for pattern, pat_dim in unbacked_sources:
         if pattern == source_name or re.match(pattern, source_name):
-            log.debug(
-                "%s was marked unbacked due to unbacked source allowlist pattern: %s",
-                source_name,
-                pattern,
-            )
-            return True
+            if dim is None or pat_dim is None or pat_dim == dim:
+                log.debug(
+                    "%s was marked unbacked due to unbacked-sources entry: %s",
+                    source_name,
+                    pattern if pat_dim is None else f"{pattern}:{pat_dim}",
+                )
+                return True
     return False
 
 
@@ -4121,12 +4161,12 @@ def _automatic_dynamic(
             config.automatic_dynamic_shapes and frame_state_entry.is_stride_dynamic(i)
         )
 
-        if is_dynamic_source(name):
-            log.debug("%s marked dynamic via source whitelist", name)
+        if is_dynamic_source(name, i):
+            log.debug("%s dim %d marked dynamic via dynamic-sources list", name, i)
             automatic_dynamic_size = True
 
-        if is_unbacked_source(name):
-            log.debug("%s marked unbacked via source whitelist", name)
+        if is_unbacked_source(name, i):
+            log.debug("%s dim %d marked unbacked via unbacked-sources list", name, i)
             automatic_dynamic_size = True
 
         automatic_dynamic = automatic_dynamic_size or automatic_dynamic_stride
@@ -4179,7 +4219,7 @@ def _automatic_dynamic(
         constraint_sizes.append(constraint_size)
         constraint_strides.append(constraint_stride)
 
-        if marked_unbacked or is_unbacked_source(name):
+        if marked_unbacked or is_unbacked_source(name, i):
             dynamic_size = DimDynamic.UNBACKED
         elif (
             constraint_size is not None

--- a/torch/compiler/config.py
+++ b/torch/compiler/config.py
@@ -109,11 +109,30 @@ Force disables all caching -- This will take precedence over and override any ot
 dynamic_sources: str = Config(
     env_name_default="TORCH_COMPILE_DYNAMIC_SOURCES", default=""
 )
-"""
+r"""
 Comma delimited list of sources that should be marked as dynamic. Primarily useful for large
 models with graph breaks where you need intermediate tensors and ints to be marked dynamic.
 
-This whitelist is dominant over all other flags dynamic=False, force_nn_module_property_static_shapes
+Each entry is either an exact source name or a Python regex (regex applies only to the
+source name, not to the dim) matched with ``re.match``. An optional ``:N`` suffix restricts
+the entry to dim ``N`` of the matched tensor; without the suffix all dims are marked dynamic.
+``N`` must be a literal non-negative integer. To target multiple dims of the same source,
+list it multiple times. Examples::
+
+    L['x']                  # all dims of x dynamic (current behavior)
+    L['x']:0                # only dim 0 of x dynamic
+    L['x']:0, L['x']:2      # dims 0 and 2 of x dynamic
+
+Regex examples (``re.match`` anchors at the start, not the end)::
+
+    L\['x.*'\]              # all sources whose name starts with L['x (e.g. L['x'], L['x1'])
+    L\['x.*'\]:0            # dim 0 dynamic for every source matching L['x.*
+    .*                      # mark every source dynamic (all dims)
+    .*:0                    # mark dim 0 dynamic for every tensor source
+
+The ``:N`` suffix is ignored for non-tensor (int/scalar) sources, which have no dim.
+
+Entries in this list are dominant over all other flags dynamic=False, force_nn_module_property_static_shapes
 and force_parameter_static_shapes.
 """
 
@@ -124,7 +143,10 @@ unbacked_sources: str = Config(
 Comma delimited list of sources that should be marked as unbacked. Primarily useful for large
 models with graph breaks where you need intermediate tensors marked unbacked.
 
-This whitelist is dominant over all other flags dynamic=False, force_nn_module_property_static_shapes
+Supports the same ``:N`` per-dim suffix syntax as ``dynamic_sources``; see that config's
+docstring for details.
+
+Entries in this list are dominant over all other flags dynamic=False, force_nn_module_property_static_shapes
 and force_parameter_static_shapes.
 """
 


### PR DESCRIPTION
Summary:

Add per-dim marking support to the dynamic_sources / unbacked_sources allow lists.

Previously, an entry in TORCH_COMPILE_DYNAMIC_SOURCES (or TORCH_COMPILE_UNBACKED_SOURCES) marked every dim of the matched tensor as dynamic. This PR extends each entry with an optional :N suffix that scopes the marking to a single dim:

L['x']                 # all dims of x dynamic (existing behavior, unchanged)
L['x']:0               # only dim 0 of x dynamic
L['x']:0, L['x']:2     # dims 0 and 2 dynamic,
L\['x.*'\]:0           # regex name match, dim 0 only

The :N portion must be a literal non-negative integer; regex still applies only to the source-name portion. The suffix is unambiguous because real Dynamo source names never end in :digits (they end in ], ), ', >).

Test Plan: added unit tests

Differential Revision: D105026259




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98