### PR TITLE
[Reland] Skip Dynamo graph break for scalar-only bin_ops when tensorify is enabled (#183584)

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -16689,6 +16689,51 @@ class DynamoOpPromotionTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(224 <= h <= 256)
         self.assertTrue(224 <= w <= 256)
 
+    def test_tensorify_scalar_only_bin_ops(self):
+        """When tensorify is enabled, torch bin_ops on scalar-only args should
+        not graph-break. The scalars are lifted as 0-dim tensor placeholders by
+        Dynamo; the tensorify pass converts them back to tensor ops."""
+        for op, expected in [
+            (torch.add, lambda a, b: a + b),
+            (torch.sub, lambda a, b: a - b),
+            (torch.mul, lambda a, b: a * b),
+            (torch.div, lambda a, b: a / b),
+        ]:
+            with self.subTest(op=op.__name__):
+
+                def fn(a, b):
+                    return op(a, b)
+
+                compiled = torch.compile(
+                    fn, backend="eager", dynamic=True, fullgraph=True
+                )
+                result = compiled(3.5, 2.0)
+                self.assertEqual(result, expected(3.5, 2.0))
+
+    def test_tensorify_scalar_only_bin_ops_int(self):
+        """When tensorify is enabled, torch bin_ops on integer scalar-only
+        args should not graph-break either. The ints are lifted as SymInts
+        and symbolic arithmetic traces correctly."""
+
+        def fn(a, b):
+            return torch.add(a, b)
+
+        compiled = torch.compile(fn, backend="eager", dynamic=True, fullgraph=True)
+        result = compiled(5, 3)
+        self.assertEqual(result, 8)
+
+    def test_tensorify_symint_div_from_size(self):
+        """torch.div on SymInt args from tensor.size() should compile
+        without graph break when tensorify is enabled."""
+
+        def fn(x, divisor):
+            seq_len = x.size(0)
+            return torch.div(seq_len, divisor, rounding_mode="trunc")
+
+        compiled = torch.compile(fn, backend="eager", dynamic=True, fullgraph=True)
+        result = compiled(torch.randn(1024), 256)
+        self.assertEqual(result, 4)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -65,9 +65,10 @@ test_failures = {
     "test_pdl_template_and_delay_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     # Bool argmax/argmin fix is Triton-only (see #174069), skip on CPU
     "test_max_min_bool_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
-    # calling div on only symint args
+    # With tensorify enabled, SymInt div no longer graph-breaks; the full
+    # model compiles but Inductor hangs on the complex dynamic-shape graph.
     "test_AllenaiLongformerBase_repro_dynamic_shapes": TestFailure(
-        ("cpu", "cuda", "xpu", "mps")
+        ("cpu", "cuda", "xpu"), is_skip=True
     ),
     "test_argmax_argmin_with_duplicates_dynamic_shapes": TestFailure(("mps",)),
     "test_batch_norm_2d_2_dynamic_shapes": TestFailure(("mps",)),

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -5490,6 +5490,13 @@ def _set_error_on_graph_break(value: bool) -> None:
     _error_on_graph_break = value
 
 
+@functools.lru_cache(1)
+def _is_tensorify_enabled() -> bool:
+    if (env := os.getenv("TENSORIFY_PYTHON_SCALARS")) is not None:
+        return env not in ("0", "FALSE")
+    return justknobs_check("pytorch/compiler:tensorify_python_scalars")
+
+
 @torch._disable_dynamo
 def record_pregraph_bytecode_enter() -> AbstractContextManager[None]:
     cm: AbstractContextManager[None] = (

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -74,6 +74,7 @@ from ..source import (
     SyntheticLocalSource,
 )
 from ..utils import (
+    _is_tensorify_enabled,
     check_unspec_or_constant_args,
     guard_if_dyn,
     has_torch_function,
@@ -2974,11 +2975,18 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
         all_ints_or_floats = all(
             isinstance(x, SymNodeVariable) or x.is_python_constant() for x in args
         )
+        # Intentional abstraction violation: when tensorify is enabled,
+        # skip this graph break. Scalar-only bin_ops on SymInt/SymFloat
+        # args are valid symbolic arithmetic that Dynamo can trace.
+        # The tensorify pass (in AOTAutograd) will convert SymFloat
+        # scalar ops to tensor ops downstream; SymInt ops flow through
+        # as symbolic expressions.
         if (
             getattr(self.value, "__module__", "") == "torch"
             and self.value.__name__ in bin_ops
             and any_symints_or_symfloats
             and all_ints_or_floats
+            and not _is_tensorify_enabled()
         ):
             msg = f"""\
 Calling {str(self.value)} on only torch.SymInt arguments is not yet supported.

--- a/torch/fx/passes/_tensorify_python_scalars.py
+++ b/torch/fx/passes/_tensorify_python_scalars.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import operator
-import os
 from typing import Any, TYPE_CHECKING
 
 from sympy import Integer, Number, Symbol
@@ -12,10 +11,9 @@ import torch
 import torch.fx as fx
 from torch._dynamo.exc import TensorifyScalarRestartAnalysis
 from torch._dynamo.symbolic_convert import TensorifyState
-from torch._dynamo.utils import get_metrics_context
+from torch._dynamo.utils import _is_tensorify_enabled, get_metrics_context
 from torch._prims_common import get_computation_dtype
 from torch._subclasses.fake_tensor import FakeTensor
-from torch._utils_internal import justknobs_check
 from torch.fx._utils import lazy_format_graph_code
 from torch.fx.experimental.symbolic_shapes import (
     guard_scalar,
@@ -132,13 +130,7 @@ def tensorify_python_scalars(
         None
     """
 
-    knob = True
-    if (env := os.getenv("TENSORIFY_PYTHON_SCALARS")) is not None:
-        if env in ("0", "FALSE"):
-            knob = False
-    else:
-        knob = justknobs_check("pytorch/compiler:tensorify_python_scalars")
-    if not knob:
+    if not _is_tensorify_enabled():
         return None
 
     # This pass uses MetaProxy which relies on __torch_function__.


### PR DESCRIPTION
Summary:


When `tensorify_python_scalars` is enabled and `dynamic=True`, Dynamo lifts Python float/int arguments as 0-dim tensor placeholders followed by `.item()` calls, producing SymFloat/SymInt values. The tensorify pass (in AOTAutograd) converts SymFloat scalar ops back to tensor ops; SymInt ops flow through as valid symbolic arithmetic.

However, `torch.add/sub/mul/div` on all-scalar args hit a graph break in TorchInGraphFunctionVariable ("Attempted to call torch in-graph function on only torch.SymInt arguments") that was added before the tensorify infrastructure existed. This graph break prevents the graph from reaching AOTAutograd, so tensorify never runs. It also unnecessarily blocks valid SymInt arithmetic (e.g., `torch.div(tensor.size(), scalar)`).

Fix: skip the graph break when `_is_tensorify_enabled()` returns True. Scalar-only bin_ops on SymInt/SymFloat args are valid symbolic arithmetic that Dynamo can trace — SymFloat ops get converted to tensor ops by the tensorify pass, and SymInt ops flow through as symbolic expressions.

The `_is_tensorify_enabled()` helper is consolidated into `torch/_dynamo/utils.py` as the single source of truth, replacing the duplicated inline knob logic in both the Dynamo tracing check and the tensorify FX pass. Uses `functools.lru_cache(1)` so tests can call `cache_clear()` if needed.

The `test_AllenaiLongformerBase_repro_dynamic_shapes` expected failure is changed from xfail to `is_skip=True`: the test was already failing before this change (xfail due to graph break). With the graph break removed, the full model traces successfully but Inductor hangs on the complex dynamic-shape graph. Changing to skip prevents the 30-minute timeout in CI. Removed "mps" from the failure list since the test now passes there.

Changed files:
- `torch/_dynamo/utils.py`: Add shared `_is_tensorify_enabled()` (cached env var + JustKnobs check)
- `torch/_dynamo/variables/torch.py`: Import `_is_tensorify_enabled` from utils, gate graph break on tensorify being disabled
- `torch/fx/passes/_tensorify_python_scalars.py`: Replace inline knob logic with import of shared `_is_tensorify_enabled()`, remove unused `os` and `justknobs_check` imports
- `test/dynamo/test_misc.py`: Add three tests: float scalar bin_ops, int scalar bin_ops, and SymInt div from tensor.size()
- `test/inductor/test_torchinductor_dynamic_shapes.py`: Change AllenaiLongformerBase from xfail to is_skip (was already failing; now hangs instead of graph-breaking), remove "mps"

Reland of D103055794.

Test Plan:
## Unit Tests

Added three tests in `test_misc.py` (`DynamoOpPromotionTests`):
- `test_tensorify_scalar_only_bin_ops`: `torch.add/sub/mul/div(float, float)` with `dynamic=True, fullgraph=True` compiles without graph break
- `test_tensorify_scalar_only_bin_ops_int`: `torch.add(int, int)` with `dynamic=True, fullgraph=True` compiles without graph break
- `test_tensorify_symint_div_from_size`: `torch.div(tensor.size(), int)` with `dynamic=True, fullgraph=True` compiles without graph break

## AllenaiLongformerBase

Changed from xfail to `is_skip=True` on `("cpu", "cuda", "xpu")`. This test was already failing before this change (xfail due to the graph break). With the graph break removed, it hangs during Inductor compilation instead of failing quickly. Verified locally that the function traces and runs correctly with `backend="eager"` in 2.1s — the hang is Inductor-specific. Removed "mps" from the failure list since it now passes there.

Differential Revision: D105004679




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98