### PR TITLE
[inductor] Cache scheduler coalescing analysis

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -1240,12 +1240,10 @@ class MemoryCoalescingTest(MockSchedulerTest):
     @parametrize("dynamic", (False, True))
     def test_tiled_coalesce_analysis(self, downcast_transposed_v, dynamic):
         # test one pw var, one red var
-        from torch._inductor import tiling_utils
-
         def fn(nodes):
             self.assertTrue(len(nodes) == 1)
 
-            coalesce_analysis = tiling_utils.analyze_memory_coalescing(nodes[0])
+            coalesce_analysis = nodes[0].get_coalesce_analysis()
 
             i_vars = coalesce_analysis.norm_read_writes.index_vars
 
@@ -1282,15 +1280,13 @@ class MemoryCoalescingTest(MockSchedulerTest):
         def foo(x):
             return (*torch.var_mean(x, [1, 3]),)
 
-        from torch._inductor import tiling_utils
-
         inp = torch.randn(1, 2, 4, 8, device=GPU_TYPE)
         out_eager = foo(inp)
 
         def fn(nodes):
             self.assertTrue(len(nodes) == 1)
 
-            coalesce_analysis = tiling_utils.analyze_memory_coalescing(nodes[0])
+            coalesce_analysis = nodes[0].get_coalesce_analysis()
             red_vars = coalesce_analysis.norm_read_writes.reduce_vars
 
             self.assertTrue(len(red_vars) == 2)
@@ -1363,12 +1359,10 @@ class MemoryCoalescingTest(MockSchedulerTest):
 
     @parametrize("dynamic", (False, True))
     def test_induced_fused_tiling(self, dynamic):
-        from torch._inductor import tiling_utils
-
         def fn(nodes):
             self.assertTrue(len(nodes) == 1)
 
-            coalesce_analysis = tiling_utils.analyze_memory_coalescing(nodes[0])
+            coalesce_analysis = nodes[0].get_coalesce_analysis()
             self.assertEqual(coalesce_analysis.suggested_split.tiling_factor, 64)
             return nodes
 
@@ -1519,12 +1513,10 @@ class TestTiling(TestCase):
 
         x = self.T("cont")
 
-        from torch._inductor import tiling_utils
-
         def fn(nodes):
             self.assertTrue(len(nodes) == 1)
 
-            coalesce_analysis = tiling_utils.analyze_memory_coalescing(nodes[0])
+            coalesce_analysis = nodes[0].get_coalesce_analysis()
             if coalesce_analysis is None:
                 raise AssertionError
 
@@ -1574,13 +1566,12 @@ class TestTiling(TestCase):
         - Read of w: uncoalesced (uses indirect index)
         - Write to output: coalesced (contiguous)
         """
-        from torch._inductor import tiling_utils
         from torch.utils._sympy.symbol import symbol_is_type, SymT
 
         def fn(nodes):
             self.assertTrue(len(nodes) == 1)
 
-            coalesce_analysis = tiling_utils.analyze_memory_coalescing(nodes[0])
+            coalesce_analysis = nodes[0].get_coalesce_analysis()
             self.assertIsNotNone(coalesce_analysis)
 
             # Should have exactly 1 uncoalesced access (the indirect weight read)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -20,7 +20,6 @@ import torch
 import torch._logging
 from torch._inductor import metrics
 from torch._inductor.ir import MultiTemplateBuffer
-from torch._inductor.tiling_utils import analyze_memory_coalescing
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 from torch.fx.immutable_collections import immutable_dict
 from torch.utils._ordered_set import OrderedSet
@@ -1973,7 +1972,7 @@ class SIMDScheduling(BaseScheduling):
             if len(nodes) != len(node.get_nodes()):
                 assert self.scheduler
                 node = scheduler.FusedSchedulerNode(self.scheduler, nodes)
-            coalesce_analysis = analyze_memory_coalescing(node)
+            coalesce_analysis = node.get_coalesce_analysis()
         else:
             coalesce_analysis = None
 
@@ -2468,7 +2467,7 @@ class SIMDScheduling(BaseScheduling):
                     assert isinstance(
                         pn, (scheduler.FusedSchedulerNode, scheduler.SchedulerNode)
                     )
-                    coalesce_analysis = analyze_memory_coalescing(pn)
+                    coalesce_analysis = pn.get_coalesce_analysis()
                 else:
                     coalesce_analysis = None
                 features = SIMDKernelFeatures(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from torch._inductor.codegen.wrapper import EnterCudaStreamContextLine
 
     from .codegen.wrapper import PythonWrapperCodegen
+    from .tiling_utils import CoalesceVarAnalysis
 
 import sympy
 
@@ -726,7 +727,19 @@ class BaseSchedulerNode:
     def set_read_writes(self, rw: dependencies.ReadWrites) -> None:
         self.read_writes = rw
         self.unmet_dependencies = self.read_writes.reads
+        self.clear_read_writes_dependent_caches()
         self.prune_deps()
+
+    def clear_read_writes_dependent_caches(self) -> None:
+        self.get_coalesce_analysis.clear_cache(self)
+
+    @cache_on_self
+    def get_coalesce_analysis(self) -> CoalesceVarAnalysis | None:
+        from .tiling_utils import _analyze_memory_coalescing
+
+        if not isinstance(self, (SchedulerNode, FusedSchedulerNode)):
+            return None
+        return _analyze_memory_coalescing(self)
 
     def set_last_usage(
         self, future_used_buffers: OrderedSet[str], mutation_real_name: dict[str, str]
@@ -1672,6 +1685,10 @@ class SchedulerNode(BaseSchedulerNode):
             .rename(self.mutation_renames)
         )
 
+        self.clear_loop_body_dependent_caches(need_clear_tiling_cache)
+
+    def clear_loop_body_dependent_caches(self, need_clear_tiling_cache: bool) -> None:
+        self.clear_read_writes_dependent_caches()
         self.pointwise_read_writes.clear_cache(self)
 
         if need_clear_tiling_cache:
@@ -1697,8 +1714,6 @@ class SchedulerNode(BaseSchedulerNode):
 
     def restore_loop_state(self, state: tuple[Any, ...]) -> None:
         """Restore state from snapshot_loop_state."""
-        from .codegen.simd import SIMDScheduling
-
         (
             self._body,
             self._sizes,
@@ -1706,8 +1721,7 @@ class SchedulerNode(BaseSchedulerNode):
             self.read_writes,
             self.unmet_dependencies,
         ) = state
-        self.pointwise_read_writes.clear_cache(self)
-        SIMDScheduling.candidate_tilings.cache_clear()
+        self.clear_loop_body_dependent_caches(need_clear_tiling_cache=True)
 
     def apply_new_loop_order(self, new_order: Sequence[int]) -> None:
         self._body = self._body.reorder_iter_loops(

--- a/torch/_inductor/tiling_utils.py
+++ b/torch/_inductor/tiling_utils.py
@@ -680,10 +680,13 @@ class CoalesceVarAnalysis:
     suggested_split: VarTiling | None = None
 
 
-def analyze_memory_coalescing(
+def _analyze_memory_coalescing(
     fused_node: Union["FusedSchedulerNode", "SchedulerNode"],
 ) -> CoalesceVarAnalysis | None:
     """
+    Implementation for BaseSchedulerNode.get_coalesce_analysis().
+    Call that node method so loop-transform cache invalidation is honored.
+
     Find variables that coalesce the reads and writes and score the total size.
 
     If uncoalesced memory expressions are found, look for additionally tiling of variables


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #182898
* #182897
* #183432
* #182896
* __->__ #183585

Route coalescing analysis through scheduler nodes so repeated tiling decisions can reuse the normalized read/write analysis while the existing loop-state invalidation paths clear derived caches after loop rewrites and rollback. The raw tiling utility helper is kept private to make the cached node method the intended API.\n\nAuthored with Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo