### PR TITLE
[Inductor] Preserve `out_dtype` in `MMKernelInputs`

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2636,6 +2636,7 @@ class BaseScaledMMConfigMixin(MMTemplateConfigMixin):
             nodes,
             mat1_idx=kernel_inputs._mat1_idx,
             mat2_idx=kernel_inputs._mat2_idx,
+            out_dtype=kernel_inputs._out_dtype,
         )
 
     def _get_template_configs_impl(


### PR DESCRIPTION
Otherwise the combination of #182041 and #172512 surfaces failures on GB200

e.g.,
```
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/ir.py", line 5718, in choice_timings
    self._choice_timings[hint_override] = self._choice_timings_fn(hint_override)
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/select_algorithm.py", line 3919, in get_timings
    timings = self.do_autotuning(
              ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/select_algorithm.py", line 4203, in do_autotuning
    raise self.create_no_valid_choices(
torch._inductor.exc.InductorError: NoValidChoicesError: No choices to select. Provided reason: All choices failed to compile for backend. please consider adding ATEN into max_autotune_gemm_backends config (defined in torch/_inductor/config.py) to allow at least one choice. 
```


authored with codex

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo