### PR TITLE
Extend allocation-order counter to all pools via segment-level inheri…

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -166,15 +166,12 @@ void decrease_stat_array(
 struct Block;
 struct PrivatePool;
 typedef bool (*Comparison)(const Block*, const Block*);
-static bool BlockComparatorRegistrationCounter(const Block* a, const Block* b);
-static bool BlockComparatorSizeAddress(const Block* a, const Block* b);
+static bool BlockComparatorSizeCounterAddress(const Block* a, const Block* b);
 static bool BlockComparatorAddress(const Block* a, const Block* b);
 
 struct BlockPool {
   BlockPool(bool small, PrivatePool* private_pool = nullptr)
-      : blocks(
-            private_pool ? BlockComparatorRegistrationCounter
-                         : BlockComparatorSizeAddress),
+      : blocks(BlockComparatorSizeCounterAddress),
         unmapped(BlockComparatorAddress),
         is_small(small),
         owner_PrivatePool(private_pool) {}
@@ -236,13 +233,7 @@ struct Block {
         size(size),
         requested_size(0),
         pool(pool),
-        ptr(ptr) {
-    if (pool && pool->owner_PrivatePool) {
-      registration_counter =
-          registration_counter_global.fetch_add(1, std::memory_order_relaxed) +
-          1;
-    }
-  }
+        ptr(ptr) {}
 
   // constructor for search key
   // Use the default value for registration_counter and not modify
@@ -1088,22 +1079,15 @@ struct RestoreResult {
   std::vector<Block*> allocations_created;
 };
 
-bool BlockComparatorRegistrationCounter(const Block* a, const Block* b) {
+bool BlockComparatorSizeCounterAddress(const Block* a, const Block* b) {
   if (a->stream != b->stream) {
     return (uintptr_t)a->stream < (uintptr_t)b->stream;
   }
   if (a->size != b->size) {
     return a->size < b->size;
   }
-  return a->registration_counter < b->registration_counter;
-}
-
-bool BlockComparatorSizeAddress(const Block* a, const Block* b) {
-  if (a->stream != b->stream) {
-    return (uintptr_t)a->stream < (uintptr_t)b->stream;
-  }
-  if (a->size != b->size) {
-    return a->size < b->size;
+  if (a->registration_counter != b->registration_counter) {
+    return a->registration_counter < b->registration_counter;
   }
   return (uintptr_t)a->ptr < (uintptr_t)b->ptr;
 }
@@ -1968,6 +1952,7 @@ class DeviceCachingAllocator {
 
       block = new Block(device, stream, size, pool, block->ptr);
       block->expandable_segment_ = remaining->expandable_segment_;
+      block->registration_counter = remaining->registration_counter;
       block->prev = remaining->prev;
       if (block->prev) {
         block->prev->next = block;
@@ -3234,6 +3219,8 @@ class DeviceCachingAllocator {
     Block* candidate = new Block(device, stream, es->size(), pool, es->ptr());
     candidate->mapped = false;
     candidate->expandable_segment_ = es;
+    candidate->registration_counter =
+        registration_counter_global.fetch_add(1, std::memory_order_relaxed) + 1;
     pool->unmapped.insert(candidate);
     return candidate;
   }
@@ -3269,6 +3256,7 @@ class DeviceCachingAllocator {
           static_cast<char*>(to_map->ptr) + mapped_range.size);
       remaining->mapped = false;
       remaining->expandable_segment_ = to_map->expandable_segment_;
+      remaining->registration_counter = to_map->registration_counter;
       remaining->splice(to_map, to_map->next);
       pool.unmapped.insert(remaining);
       to_map->size = mapped_range.size;
@@ -3773,6 +3761,8 @@ class DeviceCachingAllocator {
     total_allocated_memory += size;
     p.block = new Block(
         p.device(), p.stream(), size, p.pool, static_cast<char*>(ptr));
+    p.block->registration_counter =
+        registration_counter_global.fetch_add(1, std::memory_order_relaxed) + 1;
     for_each_selected_stat_type(p.stat_types, [&](size_t stat_type) {
       stats.segment[stat_type].increase(1);
       stats.reserved_bytes[stat_type].increase(size);
@@ -3984,6 +3974,7 @@ class DeviceCachingAllocator {
       Block* before_free = new Block(
           block->device, block->stream, before_size, block->pool, block->ptr);
       before_free->expandable_segment_ = block->expandable_segment_;
+      before_free->registration_counter = block->registration_counter;
       before_free->splice(block->prev, block);
       block->pool->insert_into_blocks(before_free);
     }
@@ -3998,6 +3989,7 @@ class DeviceCachingAllocator {
           block->pool,
           unmapped.ptr + unmapped.size);
       after_free->expandable_segment_ = block->expandable_segment_;
+      after_free->registration_counter = block->registration_counter;
       after_free->splice(block, block->next);
       block->pool->insert_into_blocks(after_free);
     }

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7693,6 +7693,15 @@ class TestMemPool(TestCase):
         tensor_ptrs_round_1 = alloc_with_threads(
             thread_count, stream, mem_sizes, "cuda"
         )
+        # Force a split-merge cycle: allocate half-sized tensors (splits the
+        # freed blocks), then free them (triggers merges back). With per-block
+        # counters this changes the free-set ordering; with segment-level
+        # counters it stays stable.
+        splitters = [
+            torch.empty(s, dtype=torch.int8, device="cuda")
+            for s in [s * 1024 * 1024 for s in range(1, 5) for _ in range(thread_count)]
+        ]
+        del splitters
         tensor_ptrs_round_2 = alloc_with_threads(
             thread_count, stream, mem_sizes, "cuda"
         )
@@ -7805,9 +7814,20 @@ class TestMemPool(TestCase):
         with torch.cuda.use_mem_pool(pool):
             first_round_tensors = alloc_tensors()
         tensor_ptrs = [t.data_ptr() for t in first_round_tensors]
-        # for t in first_round_tensors:
-        #    del t
         del first_round_tensors
+
+        # Split-merge cycle on ONE block per stream. Each stream has
+        # three 24 MB blocks with counters [c0, c1, c2]. Splitting only
+        # the first (lowest-counter) block gives it a new, higher
+        # counter after the merge, reversing its position among the
+        # three. With per-block counters the reallocation order changes
+        # (wrong); with segment-level counters it stays stable.
+        with torch.cuda.use_mem_pool(pool):
+            with torch.cuda.stream(first_stream):
+                s1 = torch.empty(tensor_sizes[0] // 2, dtype=torch.uint8, device="cuda")
+            with torch.cuda.stream(second_stream):
+                s2 = torch.empty(tensor_sizes[0] // 2, dtype=torch.uint8, device="cuda")
+            del s1, s2
 
         with torch.cuda.use_mem_pool(pool):
             second_round_tensors = alloc_tensors()


### PR DESCRIPTION
…tance

 #183489 introduced registration_counter for deterministic allocation ordering, but scoped it to private pools with custom allocators only (e.g. NCCL's
   ncclMemAlloc) because the per-block atomic increment in the Block constructor caused regressions under multi-thread contention. CUDA graphs, which
  use private pools without a custom allocator, did not benefit from it.

  This PR brings counter-based ordering to all pools -- default pools, CUDA graph private pools, and custom allocator pools -- without touching the hot
  path. Instead of incrementing a global atomic on every new Block(), the counter is assigned only when new backing memory is obtained -- at cudaMalloc
  and new ExpandableSegment creation -- and all derived blocks (splits, remaps, unmaps) inherit the counter from their parent. Since cudaMalloc/cuMemMap
   are rare, the hot allocation path (get_free_block -> alloc_found_block with splitting) has zero new atomic operations.

  This also unifies all pools under a single comparator BlockComparatorSizeCounterAddress (stream, size, counter, address), replacing the previous two
  (BlockComparatorRegistrationCounter and BlockComparatorSizeAddress). The address tiebreaker ensures uniqueness within the std::set when multiple
  blocks from the same segment share a counter. Within a segment, splits carve from the front so address order equals allocation order; across segments,
   counter order equals creation order.

  Authored with Claude.