### PR TITLE
[ROCm] op benchmark: use noble nightly image

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -174,7 +174,7 @@ case "$tag" in
     ROCM_VERSION=nightly
     TRITON=yes
     KATEX=yes
-    PYTORCH_ROCM_ARCH="gfx942;gfx950"
+    PYTORCH_ROCM_ARCH="gfx950"
     ;;
   pytorch-linux-jammy-xpu-n-1-py3)
     ANACONDA_PYTHON_VERSION=3.10

--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -174,7 +174,7 @@ case "$tag" in
     ROCM_VERSION=nightly
     TRITON=yes
     KATEX=yes
-    PYTORCH_ROCM_ARCH="gfx942"
+    PYTORCH_ROCM_ARCH="gfx942;gfx950"
     ;;
   pytorch-linux-jammy-xpu-n-1-py3)
     ANACONDA_PYTHON_VERSION=3.10

--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -114,14 +114,14 @@ jobs:
       cuda-version: "13.0"
     secrets: inherit
 
-  # ROCM MI300 runner
+  # ROCM MI350 runner
   opmicrobenchmark-build-rocm:
     if: github.repository_owner == 'pytorch'
     name: opmicrobenchmark-build-rocm
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-rocm-py3_10
-      docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
+      build-environment: linux-noble-rocm-nightly-py3.12-gfx942 # this job is gfx950. Sharing build env with gfx942.
+      docker-image-name: ci-image:pytorch-linux-noble-rocm-nightly-py3
       test-matrix: |
         { include: [
           { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx950.1" },


### PR DESCRIPTION
## Summary

- Point ROCm `operator_microbenchmark` at `ci-image:pytorch-linux-noble-rocm-nightly-py3` (TheRock nightly stack) instead of the Jammy benchmarks image.
- Set `build-environment` to `linux-noble-rocm-nightly-py3.12-gfx942` to match existing nightly naming; job still runs on `linux.rocm.gpu.gfx950.1` (see comment in YAML).
- Extend `PYTORCH_ROCM_ARCH` for that image in `build.sh` to `gfx942;gfx950` so the rebuilt image includes MI350/gfx950 targets for the op-bench runner.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang