### PR TITLE
Tag _c10d_functional {all_gather,reduce_scatter}_tensor_out as out variants

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -1445,6 +1445,60 @@ class CompileTest(TestCase):
         code = run_and_get_triton_code(compiled, arg)
         (FileCheck().check("all_reduce_.default(buf0, 'avg', '0')").run(code))
 
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @fresh_cache()
+    def test_compile_all_gather_into_tensor_out(self):
+        def func(input, out):
+            y = torch.ops._c10d_functional.all_gather_into_tensor_out(
+                input, self.world_size, "0", out=out
+            )
+            y = torch.ops._c10d_functional.wait_tensor(y)
+            return y + 1
+
+        input_t = torch.ones(4, device=self.device)
+        out_t = torch.empty(4 * self.world_size, device=self.device)
+        compiled = torch.compile(func, fullgraph=True)
+        result = compiled(input_t, out_t)
+        self.assertEqual(result.shape, (4 * self.world_size,))
+
+        code = run_and_get_triton_code(compiled, input_t, out_t)
+        buf = find_buffer_assignments(code)[0]
+        (
+            FileCheck()
+            .check(f"{buf} = empty")
+            .check("torch.ops._c10d_functional.all_gather_into_tensor_out.default(")
+            .check_same(f"out={buf}")
+            .check(f"torch.ops._c10d_functional.wait_tensor.default({buf})")
+            .run(code)
+        )
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @fresh_cache()
+    def test_compile_reduce_scatter_tensor_out(self):
+        def func(input, out):
+            y = torch.ops._c10d_functional.reduce_scatter_tensor_out(
+                input, "sum", self.world_size, "0", out=out
+            )
+            y = torch.ops._c10d_functional.wait_tensor(y)
+            return y + 1
+
+        input_t = torch.ones(4 * self.world_size, device=self.device)
+        out_t = torch.empty(4, device=self.device)
+        compiled = torch.compile(func, fullgraph=True)
+        result = compiled(input_t, out_t)
+        self.assertEqual(result.shape, (4,))
+
+        code = run_and_get_triton_code(compiled, input_t, out_t)
+        buf = find_buffer_assignments(code)[0]
+        (
+            FileCheck()
+            .check(f"{buf} = empty")
+            .check("torch.ops._c10d_functional.reduce_scatter_tensor_out.default(")
+            .check_same(f"out={buf}")
+            .check(f"torch.ops._c10d_functional.wait_tensor.default({buf})")
+            .run(code)
+        )
+
 
 class ACTCompileTest(TestCase):
     """

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -620,7 +620,9 @@ TORCH_LIBRARY(_c10d_functional, m) {
                 get_process_group(group, "all_gather_into_tensor_out"),
                 output);
           }),
-      {at::Tag::pt2_compliant_tag, at::Tag::needs_contiguous_strides});
+      {at::Tag::pt2_compliant_tag,
+       at::Tag::needs_contiguous_strides,
+       at::Tag::out});
 
   m.def(
       "all_gather_into_tensor(Tensor input, int group_size, Any group_name) -> Tensor",
@@ -682,7 +684,9 @@ TORCH_LIBRARY(_c10d_functional, m) {
                 get_process_group(group, "reduce_scatter_tensor_out"),
                 output);
           }),
-      {at::Tag::pt2_compliant_tag, at::Tag::needs_contiguous_strides});
+      {at::Tag::pt2_compliant_tag,
+       at::Tag::needs_contiguous_strides,
+       at::Tag::out});
 
   m.def(
       "reduce_scatter_tensor_coalesced(Tensor[] inputs, str reduce_op, int group_size, Any group_name) -> Tensor[]",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183597

Without at::Tag::out, AOTAutograd's functionalization pass rejects these
custom ops because their schemas return Tensor(a!) (the return aliases the
mutable `out` arg). The tag declares the standard out-variant contract --
mutable args are write-only and are returned in order -- which lets
functionalization and auto_functionalize_v2 lower the call the same way
they handle ATen *_out ops, instead of bailing with "Found a custom
(non-ATen) operator whose output has alias annotations".

Adds two CompileTest regression tests that torch.compile the _out ops
under a fake process group and FileCheck the generated Triton wrapper to
confirm the op is lowered with `out=<inductor-allocated buf>` followed by
`wait_tensor` on the same buffer.

Authored with Claude Code.

All cred goes to @krastogi-in  