### PR TITLE
[ROCm][CI] add gfx950 CDNA2OrLater() in common_cuda.py

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -67,7 +67,7 @@ def CDNA3OrLater():
     return evaluate_gfx_arch_within(["gfx942", "gfx950"])
 
 def CDNA2OrLater():
-    return evaluate_gfx_arch_within(["gfx90a", "gfx942"])
+    return evaluate_gfx_arch_within(["gfx90a", "gfx942", "gfx950"])
 
 def evaluate_platform_supports_flash_attention():
     if TEST_WITH_ROCM:


### PR DESCRIPTION
See [this comment in this PR](https://github.com/pytorch/pytorch/pull/183474#pullrequestreview-4276838775) for detailed info.

gfx950, or the MI350 series GPUs, belongs to CDNA4: https://www.amd.com/en/products/accelerators/instinct/mi350/mi350x.html

The function CDNA2OrLater() in `torch/testing/_internal/common_cuda.py` was missing it, added in this PR. 

### ADDITIONAL Investigative Summary

The following 2 tickets are about `int4_mm` that was previously gated on MI355X due to the aforementioned issue:
FIXES https://github.com/pytorch/pytorch/issues/168764
FIXES https://github.com/pytorch/pytorch/issues/168765

```
$ grep -rn "CDNA2\|gfx90a\|gfx942" aten/src/ATen/native/cuda/int4mm.cu 2>/dev/null | head -10
143:static bool isCDNA2orLater(int index) {
144:    return at::detail::getCUDAHooks().isGPUArch({"gfx90a", "gfx942", "gfx950"}, index);
629:    printf("__builtin_amdgcn_mfma_f32_16x16x16bf16_1k is only supported on AMD gpu arch greater than or equal to CDNA2\n");
1112:  if (!isCDNA2orLater(A.device().index())) {
1113:    TORCH_CHECK(false, "_weight_int4pack_mm_cuda is only supported on AMD gpu arch greater than or equal to CDNA2");
1307:  if (!isCDNA2orLater(in.device().index())) {
1308:    TORCH_CHECK(false, "_convert_weight_to_int4pack_cuda is only supported on AMD gpu arch greater than or equal to CDNA2");
```

This indicates int4mm is already supported on gfx950. 

### Testing BEFORE fix
on an MI355X / gfx950 machine,
```
$ PYTORCH_TEST_WITH_ROCM=1 pytest test/test_linalg.py -k "test__int4_mm or test_compile_int4_mm" -v -s 2>/dev/null 
=================================================================================== test session starts ==================================================================================== 
platform linux -- Python 3.12.13, pytest-7.3.2, pluggy-1.6.0 -- /opt/conda/envs/py_3.12/bin/python3.12 cachedir:
.pytest_cache hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=
[HealthCheck.too_slow] rootdir: /var/lib/jenkins/pytorch configfile: pytest.ini plugins: xdoctest-1.3.0, hypothesis-6.56.4, 
subtests-0.13.1, flakefinder-1.1.0, rerunfailures-14.0, cpp-2.3.0, xdist-3.3.1 collected 3018 items / 2986 deselected / 32 
selected Running 32 items in this shard

...
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_32_k_32_n_48_cuda SKIPPED [0.0007s] (_convert_weight_to_int4pack_cuda is supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_32_k_32_n_64_cuda SKIPPED [0.0005s] (_convert_weight_to_int4pack_cuda is supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_32_k_64_n_48_cuda SKIPPED [0.0004s] (_convert_weight_to_int4pack_cuda is supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_32_k_64_n_64_cuda SKIPPED [0.0004s] (_convert_weight_to_int4pack_cuda is supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_64_k_32_n_48_cuda SKIPPED [0.0004s] (_convert_weight_to_int4pack_cuda is supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_64_k_32_n_64_cuda SKIPPED [0.0005s] (_convert_weight_to_int4pack_cuda is supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_64_k_64_n_48_cuda SKIPPED [0.0004s] (_convert_weight_to_int4pack_cuda is supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_64_k_64_n_64_cuda SKIPPED [0.0004s] (_convert_weight_to_int4pack_cuda is supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_32_k_32_n_48_cuda SKIPPED [0.0004s] (_convert_weight_to_int4pack_cuda supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_32_k_32_n_64_cuda SKIPPED [0.0004s] (_convert_weight_to_int4pack_cuda supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_32_k_64_n_48_cuda SKIPPED [0.0003s] (_convert_weight_to_int4pack_cuda supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_32_k_64_n_64_cuda SKIPPED [0.0005s] (_convert_weight_to_int4pack_cuda supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_64_k_32_n_48_cuda SKIPPED [0.0003s] (_convert_weight_to_int4pack_cuda supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_64_k_32_n_64_cuda SKIPPED [0.0003s] (_convert_weight_to_int4pack_cuda supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_64_k_64_n_48_cuda SKIPPED [0.0003s] (_convert_weight_to_int4pack_cuda supported only for CDNA2 or later) 
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_64_k_64_n_64_cuda SKIPPED [0.0004s] (_convert_weight_to_int4pack_cuda supported only for CDNA2 or later)
===================================================================== 16 passed, 16 skipped, 2986 deselected in 2.47s ======================================================================
```

### Testing AFTER fix and re-compiling:
on an MI355X / gfx950 machine,
```
$ PYTORCH_TEST_WITH_ROCM=1 pytest test/test_linalg.py -k "test__int4_mm or test_compile_int4_mm" -v -s 2>/dev/null
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.12.13, pytest-7.3.2, pluggy-1.6.0 -- /opt/conda/envs/py_3.12/bin/python3.12
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=[HealthCheck.too_slow]
rootdir: /var/lib/jenkins/pytorch
configfile: pytest.ini
plugins: xdoctest-1.3.0, hypothesis-6.56.4, subtests-0.13.1, flakefinder-1.1.0, rerunfailures-14.0, cpp-2.3.0, xdist-3.3.1
collected 3018 items / 2986 deselected / 32 selected
Running 32 items in this shard

...
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_32_k_32_n_48_cuda PASSED [3.1637s]
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_32_k_32_n_64_cuda PASSED [0.0160s]
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_32_k_64_n_48_cuda PASSED [0.0136s]
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_32_k_64_n_64_cuda PASSED [0.0031s]
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_64_k_32_n_48_cuda PASSED [0.0029s]
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_64_k_32_n_64_cuda PASSED [0.0028s]
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_64_k_64_n_48_cuda PASSED [0.0028s]
test/test_linalg.py::TestLinalgCUDA::test__int4_mm_m_64_k_64_n_64_cuda PASSED [0.0027s]
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_32_k_32_n_48_cuda PASSED [0.1767s]
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_32_k_32_n_64_cuda PASSED [0.0508s]
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_32_k_64_n_48_cuda PASSED [0.1332s]
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_32_k_64_n_64_cuda PASSED [0.0040s]
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_64_k_32_n_48_cuda PASSED [0.0544s]
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_64_k_32_n_64_cuda PASSED [0.0041s]
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_64_k_64_n_48_cuda PASSED [0.0565s]
test/test_linalg.py::TestLinalgCUDA::test_compile_int4_mm_m_64_k_64_n_64_cuda PASSED [0.0042s]
===================================================================================== 32 passed, 2986 deselected in 6.53s ======================================================================================
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang