### PR TITLE
[ONNX] Fix antialiased interpolate export to match eager

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -829,6 +829,37 @@ class DynamoExporterTest(common_utils.TestCase, _WithExport):
         onnx_program = self.export(ComplexInitModel(), (x,))
         onnx_testing.assert_onnx_program(onnx_program)
 
+    @common_utils.parametrize(
+        "mode",
+        [
+            common_utils.subtest("bilinear", name="bilinear"),
+            common_utils.subtest("bicubic", name="bicubic"),
+        ],
+    )
+    def test_interpolate_antialias_matches_eager(self, mode):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.interpolate(
+                    x.unsqueeze(0),
+                    size=(3, 5),
+                    mode=mode,
+                    align_corners=False,
+                    antialias=True,
+                ).squeeze(0)
+
+        x = torch.arange(2 * 6 * 4, dtype=torch.float32).reshape(2, 6, 4) / 10.0
+        onnx_program = self.export(Model(), (x,), opset_version=18)
+        onnx_testing.assert_onnx_program(onnx_program)
+        resize_nodes = [
+            node for node in onnx_program.model.graph if node.op_type == "Resize"
+        ]
+        self.assertEqual(len(resize_nodes), 1)
+        attrs = resize_nodes[0].attributes
+        self.assertEqual(attrs["antialias"].value, 1)
+        self.assertEqual(attrs["exclude_outside"].value, 1)
+        if mode == "bicubic":
+            self.assertEqual(attrs["cubic_coeff_a"].value, -0.5)
+
 
 @common_utils.instantiate_parametrized_tests
 class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 from typing import Sequence, TYPE_CHECKING  # noqa: UP035
 
+from onnxscript import INT64
 from onnxscript.onnx_opset import (  # type: ignore[attr-defined]
+    opset18 as op18,
     opset20 as op20,
     opset21 as op21,
     opset23 as op23,
@@ -374,3 +376,70 @@ def _aten_scaled_dot_product_attention_float_mask_onnx(
     )
     attn_weight, _ = op.Dropout(attn_weight, dropout_p)
     return op.MatMul(attn_weight, value)
+
+
+def _resize_with_antialias(
+    self: TReal,
+    output_size: INT64,
+    align_corners: bool,
+    mode: str,
+    cubic_coeff_a: float,
+) -> TReal:
+    coordinate_transformation_mode = (
+        "align_corners" if align_corners else "pytorch_half_pixel"
+    )
+    batch_and_channel = op18.Shape(self, end=2, start=0)
+    output_size_cast = op18.Cast(output_size, to=INT64.dtype)
+    full_output_size = op18.Concat(batch_and_channel, output_size_cast, axis=0)
+    return op18.Resize(
+        self,
+        None,
+        None,
+        full_output_size,
+        antialias=1,
+        coordinate_transformation_mode=coordinate_transformation_mode,
+        cubic_coeff_a=cubic_coeff_a,
+        exclude_outside=1,
+        mode=mode,
+        nearest_mode="floor",
+    )
+
+
+@onnx_impl(aten._upsample_bilinear2d_aa.default, trace_only=True)
+def aten__upsample_bilinear2d_aa(
+    self: TReal,
+    output_size: INT64,
+    align_corners: bool,
+    scales_h: float | None = None,
+    scales_w: float | None = None,
+) -> TReal:
+    """_upsample_bilinear2d_aa(Tensor self, SymInt[2] output_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor"""
+    del scales_h, scales_w
+    return _resize_with_antialias(
+        self,
+        output_size,
+        align_corners,
+        mode="linear",
+        cubic_coeff_a=-0.75,
+    )
+
+
+@onnx_impl(aten._upsample_bicubic2d_aa.default, trace_only=True)
+def aten__upsample_bicubic2d_aa(
+    self: TReal,
+    output_size: INT64,
+    align_corners: bool,
+    scales_h: float | None = None,
+    scales_w: float | None = None,
+) -> TReal:
+    """_upsample_bicubic2d_aa(Tensor self, SymInt[2] output_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor"""
+    del scales_h, scales_w  # PyTorch ignores explicit scales for the AA path.
+    # PyTorch uses cubic_coeff_a=-0.5 (Keys / PIL-compatible) for the AA bicubic
+    # kernel, as opposed to -0.75 (OpenCV-compatible) for the non-AA case.
+    return _resize_with_antialias(
+        self,
+        output_size,
+        align_corners,
+        mode="cubic",
+        cubic_coeff_a=-0.5,
+    )


### PR DESCRIPTION
F.interpolate with antialias=True did not match PyTorch eager after ONNX export. The cause is that ONNX Resize defaults exclude_outside=0 while PyTorch's eager kernels drop out of bounds samples and renormalize the filter weights to sum to one. This change adds dynamo exporter overrides for _upsample_bilinear2d_aa and _upsample_bicubic2d_aa that emit Resize with exclude_outside=1 (and cubic_coeff_a=-0.5 for the PIL compatible AA bicubic). A regression test exports both modes and checks that ORT output matches eager within tight tolerance.
Fixes #183546.