### PR TITLE
Update NVPL versions: blas 0.3.0 → 0.5.0.1, lapack 0.2.3.1 → 0.3.2

### DIFF
--- a/.ci/docker/common/install_nvpl.sh
+++ b/.ci/docker/common/install_nvpl.sh
@@ -6,15 +6,15 @@ function install_nvpl {
 
     mkdir -p /opt/nvpl/lib /opt/nvpl/include
 
-    wget https://developer.download.nvidia.com/compute/nvpl/redist/nvpl_blas/linux-sbsa/nvpl_blas-linux-sbsa-0.3.0-archive.tar.xz
-    tar xf nvpl_blas-linux-sbsa-0.3.0-archive.tar.xz
-    cp -r nvpl_blas-linux-sbsa-0.3.0-archive/lib/* /opt/nvpl/lib/
-    cp -r nvpl_blas-linux-sbsa-0.3.0-archive/include/* /opt/nvpl/include/
+    wget https://developer.download.nvidia.com/compute/nvpl/redist/nvpl_blas/linux-sbsa/nvpl_blas-linux-sbsa-0.5.0.1-archive.tar.xz
+    tar xf nvpl_blas-linux-sbsa-0.5.0.1-archive.tar.xz
+    cp -r nvpl_blas-linux-sbsa-0.5.0.1-archive/lib/* /opt/nvpl/lib/
+    cp -r nvpl_blas-linux-sbsa-0.5.0.1-archive/include/* /opt/nvpl/include/
 
-    wget https://developer.download.nvidia.com/compute/nvpl/redist/nvpl_lapack/linux-sbsa/nvpl_lapack-linux-sbsa-0.2.3.1-archive.tar.xz
-    tar xf nvpl_lapack-linux-sbsa-0.2.3.1-archive.tar.xz
-    cp -r nvpl_lapack-linux-sbsa-0.2.3.1-archive/lib/* /opt/nvpl/lib/
-    cp -r nvpl_lapack-linux-sbsa-0.2.3.1-archive/include/* /opt/nvpl/include/
+    wget https://developer.download.nvidia.com/compute/nvpl/redist/nvpl_lapack/linux-sbsa/nvpl_lapack-linux-sbsa-0.3.2-archive.tar.xz
+    tar xf nvpl_lapack-linux-sbsa-0.3.2-archive.tar.xz
+    cp -r nvpl_lapack-linux-sbsa-0.3.2-archive/lib/* /opt/nvpl/lib/
+    cp -r nvpl_lapack-linux-sbsa-0.3.2-archive/include/* /opt/nvpl/include/
 }
 
 install_nvpl


### PR DESCRIPTION
Updating NVPL to latest versions, last update in upstream was from 2 years ago in https://github.com/pytorch/pytorch/pull/132811.

blas 0.3.0 → 0.5.0.1, lapack 0.2.3.1 → 0.3.2

cc @Aidyn-A @ptrblck @nWEIdia @atalman @malfet 