### PR TITLE
[CD][ROCm] manywheel follow-ups: drop static-link env, fix hipsparselt bundle, fail-fast on missing aux

### DIFF
--- a/.ci/manywheel/build_env_setup.py
+++ b/.ci/manywheel/build_env_setup.py
@@ -142,17 +142,13 @@ XPU_BUILD_ENV: dict[str, str] = {
     "INSTALL_TEST": "0",
 }
 
-# ROCm builds use static linking and skip debug info; mirror the original
-# build_rocm.sh. ROCM_HOME is also read by repair_wheel.py to discover libs.
-ROCM_BUILD_ENV_STATIC: dict[str, str] = {
+# ROCm builds skip debug info; mirror the original build_rocm.sh. ROCM_HOME
+# is also read by repair_wheel.py to discover libs.
+ROCM_BUILD_ENV: dict[str, str] = {
     "ROCM_HOME": "/opt/rocm",
     "MAGMA_HOME": "/opt/rocm/magma",
     "BUILD_DEBUG_INFO": "0",
     "TH_BINARY_BUILD": "1",
-    "USE_STATIC_CUDNN": "1",
-    "USE_STATIC_NCCL": "1",
-    "ATEN_STATIC_CUDA": "1",
-    "USE_CUDA_STATIC_LINK": "1",
     "INSTALL_TEST": "0",
     "FORCE_RPATH": "--force-rpath",
 }
@@ -438,7 +434,7 @@ def main() -> None:
         env_out.update(XPU_BUILD_ENV)
         print("XPU environment configured")
     elif gpu_arch_type == "rocm":
-        env_out.update(ROCM_BUILD_ENV_STATIC)
+        env_out.update(ROCM_BUILD_ENV)
         # DESIRED_CUDA is "rocmX.Y.Z" -- normalize so build_amd.py and
         # downstream tools see the rocm-prefixed form (matches build_rocm.sh).
         desired = os.environ.get("DESIRED_CUDA", "")

--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -188,9 +188,17 @@ def rocm_arch_filter(arch_list: str) -> list[str]:
 
 
 def rocm_lib_kernels(
-    rocm_home: Path, lib_subdir: str, archs: list[str]
+    rocm_home: Path,
+    lib_subdir: str,
+    archs: list[str],
+    include_common: bool = True,
 ) -> list[AuxFile]:
-    """Per-gfx kernel files under $ROCM_HOME/lib/<lib_subdir>/library/ plus the non-gfx common files."""
+    """Per-gfx kernel files under $ROCM_HOME/lib/<lib_subdir>/library/.
+
+    When include_common is True (default) also bundles non-gfx common files.
+    Set include_common=False for hipsparselt to match build_rocm.sh, which
+    intentionally shipped only arch-specific gfx kernels.
+    """
     src_dir = rocm_home / "lib" / lib_subdir / "library"
     if not src_dir.is_dir():
         return []
@@ -198,9 +206,11 @@ def rocm_lib_kernels(
     for entry in sorted(src_dir.iterdir()):
         if not entry.is_file():
             continue
-        # Pick gfx-specific files matching the arch set, plus common (non-gfx) files.
         name = entry.name
-        if "gfx" in name and not any(a in name for a in archs):
+        if "gfx" in name:
+            if not any(a in name for a in archs):
+                continue
+        elif not include_common:
             continue
         files.append(AuxFile(src=entry, rel_dest=f"lib/{lib_subdir}/library/{name}"))
     return files
@@ -228,26 +238,35 @@ def rocm_bundle(rocm_home: Path) -> tuple[list[BundledLib], list[AuxFile]]:
 
     archs = rocm_arch_filter(os.environ.get("PYTORCH_ROCM_ARCH", ""))
     aux: list[AuxFile] = []
-    for sub in ("rocblas", "hipblaslt", "hipsparselt"):
-        aux += rocm_lib_kernels(rocm_home, sub, archs)
+    # hipsparselt intentionally skips non-gfx common files (build_rocm.sh had
+    # HIPSPARSELT_OTHER_FILES commented out); rocblas/hipblaslt ship both.
+    for sub, include_common in (
+        ("rocblas", True),
+        ("hipblaslt", True),
+        ("hipsparselt", False),
+    ):
+        aux += rocm_lib_kernels(rocm_home, sub, archs, include_common=include_common)
     miopen_db = rocm_home / "share/miopen/db"
-    if miopen_db.is_dir():
-        for entry in sorted(miopen_db.iterdir()):
-            if entry.is_file() and any(a in entry.name for a in archs):
-                aux.append(AuxFile(src=entry, rel_dest=f"share/miopen/db/{entry.name}"))
+    if not miopen_db.is_dir():
+        sys.exit(f"Required ROCm MIOpen kernel-db directory not found: {miopen_db}")
+    for entry in sorted(miopen_db.iterdir()):
+        if entry.is_file() and any(a in entry.name for a in archs):
+            aux.append(AuxFile(src=entry, rel_dest=f"share/miopen/db/{entry.name}"))
     rccl_dir = rocm_home / "share/rccl/msccl-algorithms"
-    if rccl_dir.is_dir():
-        for entry in sorted(rccl_dir.iterdir()):
-            if entry.is_file():
-                aux.append(
-                    AuxFile(
-                        src=entry,
-                        rel_dest=f"share/rccl/msccl-algorithms/{entry.name}",
-                    )
+    if not rccl_dir.is_dir():
+        sys.exit(f"Required ROCm RCCL msccl-algorithms directory not found: {rccl_dir}")
+    for entry in sorted(rccl_dir.iterdir()):
+        if entry.is_file():
+            aux.append(
+                AuxFile(
+                    src=entry,
+                    rel_dest=f"share/rccl/msccl-algorithms/{entry.name}",
                 )
+            )
     amdgpu_ids = Path("/opt/amdgpu/share/libdrm/amdgpu.ids")
-    if amdgpu_ids.is_file():
-        aux.append(AuxFile(src=amdgpu_ids, rel_dest="share/libdrm/amdgpu.ids"))
+    if not amdgpu_ids.is_file():
+        sys.exit(f"Required amdgpu.ids file not found: {amdgpu_ids}")
+    aux.append(AuxFile(src=amdgpu_ids, rel_dest="share/libdrm/amdgpu.ids"))
     return libs, aux
 
 

--- a/.github/workflows/_binary-test-rocm-linux.yml
+++ b/.github/workflows/_binary-test-rocm-linux.yml
@@ -38,7 +38,7 @@ on:
       runs_on:
         required: false
         type: string
-        default: linux.rocm.gpu.gfx942.1
+        default: linux.rocm.gpu.gfx950.1
       timeout-minutes:
         required: false
         type: number


### PR DESCRIPTION
Follow-up to #182696 addressing review comments + a couple of behavior issues spotted on a second pass.

## Summary

- **`build_env_setup.py`** — Per [#182696 (comment)](https://github.com/pytorch/pytorch/pull/182696#discussion_r3230431488), removed the CUDA-specific static-linking env vars (`USE_STATIC_CUDNN`, `USE_STATIC_NCCL`, `ATEN_STATIC_CUDA`, `USE_CUDA_STATIC_LINK`) from the ROCm env. Renamed `ROCM_BUILD_ENV_STATIC` → `ROCM_BUILD_ENV`.
- **`repair_wheel.py` `rocm_lib_kernels`** — Restored original behavior for `hipsparselt`: only arch-specific gfx kernels are bundled (no non-gfx common files). The original `build_rocm.sh` had `HIPSPARSELT_OTHER_FILES` commented out intentionally; the port was unconditionally bundling both and enlarging the wheel.
- **`repair_wheel.py` `rocm_bundle`** — MIOpen kernel-db, RCCL msccl-algorithms, and `amdgpu.ids` are now required. Previously each was wrapped in `is_dir()` / `is_file()` and silently skipped if absent, which could ship a broken wheel from a misconfigured build host. Now `sys.exit`s with a clear message, matching the loud `ls`/`find` failures in the original bash.
- **`_binary-test-rocm-linux.yml`** — Per [#182696 (comment)](https://github.com/pytorch/pytorch/pull/182696#issuecomment-4435625454), switched default `runs_on` from `linux.rocm.gpu.gfx942.1` → `linux.rocm.gpu.gfx950.1`.

## Test plan

- [ ] Nightly ROCm manywheel build runs green on the new `gfx950.1` runner
- [ ] Built wheel still has the expected `hipsparselt/library/*gfx*` entries and no longer includes non-gfx common files for hipsparselt
- [ ] Build fails fast (with the new error message) if `share/miopen/db`, `share/rccl/msccl-algorithms`, or `/opt/amdgpu/share/libdrm/amdgpu.ids` is missing on the build host

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang