### PR TITLE
[MPS][BE] Cleanup _cdist_backward implementation

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Distance.h
+++ b/aten/src/ATen/native/mps/kernels/Distance.h
@@ -1,0 +1,9 @@
+#pragma once
+
+struct CdistBwdParams {
+  long B;
+  long P;
+  long R;
+  long D;
+  float p_minus_1;
+};

--- a/aten/src/ATen/native/mps/kernels/Distance.metal
+++ b/aten/src/ATen/native/mps/kernels/Distance.metal
@@ -1,15 +1,8 @@
+#include <ATen/native/mps/kernels/Distance.h>
+#include <c10/metal/common.h>
 #include <metal_stdlib>
 
 using namespace metal;
-
-// Layout must match `CdistBwdParams` in operations/Distance.mm.
-struct CdistBwdParams {
-  long B;
-  long P;
-  long R;
-  long D;
-  float p_minus_1;
-};
 
 // P_KIND: 0 = p==1, 1 = p==inf, 2 = generic. The TG precomputes
 // `grad / cdist^(p-1)` per (b, i, j) into `s_reducer`, shared across c-threads.
@@ -60,9 +53,9 @@ kernel void cdist_backward(
     if (t < tile_size) {
       const ulong g_idx = gr_row + static_cast<ulong>(j_base + t);
       const float g_val = static_cast<float>(grad[g_idx]);
-      if constexpr (P_KIND == 0) {
+      if IF_CONSTEXPR (P_KIND == 0) {
         s_reducer[t] = g_val;
-      } else if constexpr (P_KIND == 1) {
+      } else if IF_CONSTEXPR (P_KIND == 1) {
         s_reducer[t] = g_val;
         s_cdist[t] = cdist[g_idx];
       } else {
@@ -88,9 +81,9 @@ kernel void cdist_backward(
         }
         const float sij = (dij > 0.0f) ? 1.0f : -1.0f;
         const float r = s_reducer[t_off];
-        if constexpr (P_KIND == 0) {
+        if IF_CONSTEXPR (P_KIND == 0) {
           acc += r * sij;
-        } else if constexpr (P_KIND == 1) {
+        } else if IF_CONSTEXPR (P_KIND == 1) {
           if (::metal::precise::abs(dij) == s_cdist[t_off]) {
             acc += r * sij;
           }

--- a/aten/src/ATen/native/mps/operations/Distance.mm
+++ b/aten/src/ATen/native/mps/operations/Distance.mm
@@ -1,4 +1,3 @@
-//  Copyright © 2026 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/ExpandUtils.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -16,6 +15,7 @@
 #include <ATen/ops/zeros.h>
 #endif
 
+#include <ATen/native/mps/kernels/Distance.h>
 #include <cmath>
 
 namespace at::native {
@@ -24,19 +24,8 @@ using namespace mps;
 #ifndef PYTORCH_JIT_COMPILE_SHADERS
 static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #else
-#include <ATen/native/mps/Cdist_metallib.h>
+#include <ATen/native/mps/Distance_metallib.h>
 #endif
-
-// Layout must match `CdistBwdParams` in kernels/Cdist.metal.
-struct CdistBwdParams {
-  int64_t B;
-  int64_t P;
-  int64_t R;
-  int64_t D;
-  float p_minus_1;
-};
-static_assert(offsetof(CdistBwdParams, p_minus_1) == 32, "Metal struct layout mismatch");
-static_assert(sizeof(CdistBwdParams) == 40, "Metal struct size mismatch");
 
 Tensor _cdist_forward_mps(const Tensor& x1, const Tensor& x2, const double p, std::optional<int64_t> compute_mode) {
   TORCH_CHECK(x1.dim() >= 2, "cdist only supports at least 2D tensors, X1 got: ", x1.dim(), "D");
@@ -135,13 +124,7 @@ Tensor _cdist_backward_mps(const Tensor& grad,
       @autoreleasepool {
         auto compute_encoder = stream->commandEncoder();
         [compute_encoder setComputePipelineState:pso];
-        mtl_setArgs(compute_encoder,
-                    x1c.view({batch_product, r1, c}),
-                    x2c.view({batch_product, r2, c}),
-                    gradc.view({batch_product, r1, r2}),
-                    cdistc.view({batch_product, r1, r2}),
-                    out.view({batch_product, r1, c}),
-                    params);
+        mtl_setArgs(compute_encoder, x1c, x2c, gradc, cdistc, out, params);
         const MTLSize grid = MTLSizeMake(D_padded, static_cast<NSUInteger>(r1), static_cast<NSUInteger>(batch_product));
         const MTLSize tg = MTLSizeMake(tg_c, 1, 1);
         [compute_encoder dispatchThreads:grid threadsPerThreadgroup:tg];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #183615

First of all, let's keep the pattern of kernel file name equals it host counterpart (i.e. Distance.mm invokes kernels from Distance.metal)
Second, let's share the structure via header rather than define it twice and hope for the best
Third, `view` is a no-op when dispatching to metal kernels, so remove them