### PR TITLE
Fix #183469: Add out tag to c10d_functional out-variant ops for functionalization

### DIFF
--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -2300,6 +2300,18 @@ def forward(self, arg0_1):
         )
         self.assertEqual(fx_g_cpp.code.strip(), fx_g.code.strip())
 
+    def test_c10d_functional_out_ops_can_functionalize(self):
+        from torch._higher_order_ops.auto_functionalize import can_auto_functionalize
+        from torch._library.utils import is_out
+
+        ag_out = torch.ops._c10d_functional.all_gather_into_tensor_out.default
+        rs_out = torch.ops._c10d_functional.reduce_scatter_tensor_out.default
+
+        self.assertTrue(is_out(ag_out))
+        self.assertTrue(is_out(rs_out))
+        self.assertTrue(can_auto_functionalize(ag_out))
+        self.assertTrue(can_auto_functionalize(rs_out))
+
 
 @xfail_inherited_tests(
     [

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -620,7 +620,9 @@ TORCH_LIBRARY(_c10d_functional, m) {
                 get_process_group(group, "all_gather_into_tensor_out"),
                 output);
           }),
-      {at::Tag::pt2_compliant_tag, at::Tag::needs_contiguous_strides, at::Tag::out});
+      {at::Tag::pt2_compliant_tag,
+       at::Tag::needs_contiguous_strides,
+       at::Tag::out});
 
   m.def(
       "all_gather_into_tensor(Tensor input, int group_size, Any group_name) -> Tensor",
@@ -682,7 +684,9 @@ TORCH_LIBRARY(_c10d_functional, m) {
                 get_process_group(group, "reduce_scatter_tensor_out"),
                 output);
           }),
-      {at::Tag::pt2_compliant_tag, at::Tag::needs_contiguous_strides, at::Tag::out});
+      {at::Tag::pt2_compliant_tag,
+       at::Tag::needs_contiguous_strides,
+       at::Tag::out});
 
   m.def(
       "reduce_scatter_tensor_coalesced(Tensor[] inputs, str reduce_op, int group_size, Any group_name) -> Tensor[]",

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -620,7 +620,7 @@ TORCH_LIBRARY(_c10d_functional, m) {
                 get_process_group(group, "all_gather_into_tensor_out"),
                 output);
           }),
-      {at::Tag::pt2_compliant_tag, at::Tag::needs_contiguous_strides});
+      {at::Tag::pt2_compliant_tag, at::Tag::needs_contiguous_strides, at::Tag::out});
 
   m.def(
       "all_gather_into_tensor(Tensor input, int group_size, Any group_name) -> Tensor",
@@ -682,7 +682,7 @@ TORCH_LIBRARY(_c10d_functional, m) {
                 get_process_group(group, "reduce_scatter_tensor_out"),
                 output);
           }),
-      {at::Tag::pt2_compliant_tag, at::Tag::needs_contiguous_strides});
+      {at::Tag::pt2_compliant_tag, at::Tag::needs_contiguous_strides, at::Tag::out});
 
   m.def(
       "reduce_scatter_tensor_coalesced(Tensor[] inputs, str reduce_op, int group_size, Any group_name) -> Tensor[]",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183616

The `_c10d_functional::all_gather_into_tensor_out` and
`_c10d_functional::reduce_scatter_tensor_out` operators were registered
with `pt2_compliant_tag` and `needs_contiguous_strides` but were missing
the `out` tag. Without it, `can_auto_functionalize()` didn't recognize
them as out-variant ops and refused to handle their aliased return
annotations (`Tensor(a!)`). This caused the ops to fall through to the
C++ functionalization fallback, which unconditionally rejects custom
operators with alias annotations -- hence the "Found a custom (non-ATen)
operator whose output has alias annotations" error when using these ops
under `torch.compile`.

The fix is a one-line-per-op tag addition: `at::Tag::out`. This lets
`is_out()` return True, which makes `can_auto_functionalize()` accept
the aliased returns (they're fine for out ops since the mutable args are
write-only output buffers), and routes through
`do_auto_functionalize_v2` which handles the out-op aliasing correctly.

So basically these ops showed up to the functionalization party without
their VIP badge (`Tag::out`) and got bounced by the C++ fallback bouncer.
Now they have the right credentials and can waltz right through.

Authored by Claude.