### PR TITLE
[ROCm][CI] Stop setting CUDA_VISIBLE_DEVICES on ROCm

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -195,8 +195,11 @@ if [[ -d "${HF_CACHE}" && "$TEST_CONFIG" != "onnx" ]]; then
 fi
 
 if [[ "$TEST_CONFIG" == 'default' ]]; then
-  export CUDA_VISIBLE_DEVICES=0
-  export HIP_VISIBLE_DEVICES=0
+  if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+    export HIP_VISIBLE_DEVICES=0
+  else
+    export CUDA_VISIBLE_DEVICES=0
+  fi
 fi
 
 if [[ "$TEST_CONFIG" == 'distributed' ]] && [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then


### PR DESCRIPTION
On ROCm builds, `.ci/pytorch/test.sh` exported both `CUDA_VISIBLE_DEVICES` and `HIP_VISIBLE_DEVICES` for the default test config. The HIP/HSA runtime warns on stderr (`agent.cpp:554] Conflicting visibility of agent-N between HIP_VISIBLE_DEVICES and CUDA_VISIBLE_DEVICES`) whenever both are set and the two filters resolve to a different visible agent, which happens on the multi-GPU CI runners. The warning is benign but leaks into stderr during `import torch` and breaks `dynamo/test_logging.py::LoggingTests::test_logs_out`, which compares subprocess stderr against the `TORCH_LOGS_OUT` file byte-for-byte.

`CUDA_VISIBLE_DEVICES` is also redundant on a HIP build: `torch.cuda._parse_visible_devices` already prefers `HIP_VISIBLE_DEVICES` and ignores `CUDA_VISIBLE_DEVICES` when it's set.

Set only `HIP_VISIBLE_DEVICES` on ROCm, only `CUDA_VISIBLE_DEVICES` otherwise. Matches the existing pattern at line 202 for the distributed config.

Authored by Claude.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang