### PR TITLE
[dynamo] don't error on skipped frame if fullgraph=True and non-default stance is set

### DIFF
--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -361,6 +361,16 @@ torch.compile with fullgraph=True found no compiled frames. Skipped frames:
   - my_function (test_compile.py:N): Dynamo tracing is disabled""",
                 )
 
+    def test_fullgraph_no_error_with_non_default_stance(self):
+        @torch.compile(fullgraph=True, backend="eager", dynamic=False)
+        def fn(x, n):
+            return x + n
+
+        fn(torch.ones(3), 1)
+        with torch.compiler.set_stance("eager_on_recompile"):
+            result = fn(torch.ones(3), 2)
+        self.assertEqual(result, torch.ones(3) + 2)
+
     def test_fullgraph_exported_module_no_error(self):
         class M(torch.nn.Module):
             def forward(self, x):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1161,7 +1161,7 @@ class _TorchDynamoContext:
                         set_eval_frame(None)
                         if fullgraph_count_enabled and call_succeeded:
                             count = set_fullgraph_compiled_frame_count(-1)
-                            if count == 0:
+                            if count == 0 and _stance.stance == "default":
                                 skip_reasons = get_skip_reasons()
                                 msg = "torch.compile with fullgraph=True found no compiled frames."
                                 if skip_reasons:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183623
* #183596

Address step 3 of https://github.com/pytorch/pytorch/issues/181817

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98