### PR TITLE
[FSDP] Flatten multi-dim DP shard axes in sharding spec

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -418,12 +418,63 @@ class FSDPParam:
 
         self._spmd_mesh = spmd_mesh
         self._spmd_placements: tuple[Placement, ...] = tuple(new_placements)
-        self._sharding_spec = DTensorSpec(
-            self._spmd_mesh,
-            self._spmd_placements,
-            tensor_meta=self._unsharded_dtensor_spec.tensor_meta,
+        self._sharding_spec = self._build_spmd_sharding_spec(
+            dp_dim_names, dp_shard_indices, fsdp_placement,
         )
         return cast(DTensor, param)._local_tensor
+
+    def _build_spmd_sharding_spec(
+        self,
+        dp_dim_names: "DataParallelMeshDims",
+        dp_shard_indices: list[int],
+        fsdp_placement: Shard,
+    ) -> DTensorSpec:
+        """Build the DTensorSpec for the sharded parameter/gradient.
+
+        When multiple DP shard dims exist (e.g. dp_shard + cp), flatten
+        them into one axis so the parameter and gradient DTensor have one
+        Shard axis for DP.
+        """
+        spmd_mesh = self._spmd_mesh
+        spmd_placements = self._spmd_placements
+        tensor_meta = self._unsharded_dtensor_spec.tensor_meta
+
+        if len(dp_shard_indices) <= 1:
+            return DTensorSpec(
+                spmd_mesh, spmd_placements, tensor_meta=tensor_meta
+            )
+
+        shard_names_set = set(dp_dim_names.shard_names)
+        replicate_names_set = set(dp_dim_names.replicate_names)
+
+        # Walk spmd_mesh.mesh_dim_names in order. Replace consecutive DP
+        # shard dims with the flattened DP mesh; keep non-DP dims as-is.
+        submeshes: list[DeviceMesh] = []
+        spec_placements: list[Placement] = []
+        skip = 0
+        for i, name in enumerate(spmd_mesh.mesh_dim_names):
+            if skip > 0:
+                skip -= 1
+                continue
+            if name in shard_names_set:
+                submeshes.append(self.mesh_info.mesh)
+                if isinstance(self.mesh_info, HSDPMeshInfo):
+                    spec_placements.append(Replicate())
+                spec_placements.append(fsdp_placement)
+                skip = len(dp_dim_names.shard_names) - 1
+            elif name in replicate_names_set and isinstance(
+                self.mesh_info, HSDPMeshInfo
+            ):
+                # HSDP replicate is inserted by the shard branch above.
+                continue
+            else:
+                submeshes.append(spmd_mesh[name])
+                spec_placements.append(spmd_placements[i])
+
+        spec_mesh = DeviceMesh._concatenate(submeshes)
+        return DTensorSpec(
+            spec_mesh, tuple(spec_placements), tensor_meta=tensor_meta
+        )
 
     def _init_sharding_spec_tp(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #182730
* __->__ #183624
* #180936
* #180937

When fully_shard receives multiple DP shard dimensions via DataParallelMeshDims (e.g. dp_shard + cp), _get_mesh_info_from_named_dims already flattens them into a single process group for the all-gather and reduce-scatter. However, _init_sharding_spec_spmd was building the sharding spec on the original SPMD mesh with separate axes, so the parameter and gradient DTensors exposed N separate Shard axes instead of one.

This caused two problems for downstream consumers like clip_grad_norm_:
- DTensor's _NormPartial reduction happened per-axis sequentially, producing different float32 summation order than the legacy path (which has a single flattened fsdp axis).
- The extra Shard(0) dimension for CP is actually incorrect (should be _StridedSharded)

Fix: add _build_spmd_sharding_spec which reuses mesh_info.mesh (the already-flattened DP mesh from _get_mesh_info_from_named_dims) and concatenates it with non-DP submeshes following spmd_mesh.mesh_dim_names order. When there is only one DP shard dim, the method is a no-op.

Verified bit-identical loss and grad_norm between legacy and full_dtensor at 500 steps across FSDP+CP+TP, HSDP+CP, and HSDP+TP configurations (with --debug.deterministic).