### PR TITLE
[MPS] trace to metal

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -56,7 +56,6 @@ enum MPSReductionType {
   AMIN,
   PROD,
   MEAN,
-  TRACE,
 };
 
 static void set_apparent_shapes(NSMutableArray<NSNumber*>*& apparent_out_shape,
@@ -248,12 +247,6 @@ static void reduction_out_mps(const Tensor& input_t,
         castOutputTensor = [mpsGraph reductionMaximumPropagateNaNWithTensor:castInputTensor axes:wrappedAxes name:nil];
       } else if (reduction_type == MPSReductionType::AMIN) {
         castOutputTensor = [mpsGraph reductionMinimumPropagateNaNWithTensor:castInputTensor axes:wrappedAxes name:nil];
-      } else if (reduction_type == MPSReductionType::TRACE) {
-        MPSGraphTensor* bandPartWithTensor = [mpsGraph bandPartWithTensor:castInputTensor
-                                                                 numLower:0
-                                                                 numUpper:0
-                                                                     name:nil];
-        castOutputTensor = [mpsGraph reductionSumWithTensor:bandPartWithTensor axes:@[ @0, @1 ] name:nil];
       }
 
       MPSGraphTensor* outputTensor = castOutputTensor;
@@ -1105,22 +1098,7 @@ static void count_nonzero_kernel_mps(TensorIterator& iter) {
 
 Tensor trace_mps(const Tensor& self) {
   TORCH_CHECK(self.dim() == 2, "trace: expected a matrix, but got tensor with dim ", self.dim());
-
-  Tensor output_t =
-      at::empty({}, get_dtype_from_self(self, std::nullopt, true), std::nullopt, kMPS, std::nullopt, std::nullopt);
-
-  std::vector<int64_t> dims(self.dim());
-  std::iota(dims.begin(), dims.end(), 0);
-
-  reduction_out_mps(self,
-                    IntArrayRef(dims),
-                    false,
-                    std::nullopt,
-                    const_cast<Tensor&>(output_t),
-                    MPSReductionType::TRACE,
-                    "trace_mps");
-
-  return output_t;
+  return self.diagonal().sum();
 }
 
 TORCH_IMPL_FUNC(prod_out_mps)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5130,6 +5130,14 @@ class TestMPS(TestCaseMPS):
             for _ in range(4):
                 self.assertEqual(x.sum().item(), ref, msg=f"unstable sum for N={N}")
 
+    def test_trace_repeated(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/178497
+        torch.manual_seed(42)
+        x = torch.rand(3000, 3000, device="mps", dtype=torch.float32)
+        ref = x.trace().item()
+        for _ in range(2000):
+            self.assertEqual(x.trace().item(), ref)
+
     # Test forward max
     # Note - don't test grad now
     def test_max_el(self):


### PR DESCRIPTION
Fixes #178497
Trace was the last op from that list that was problematic on main

dtype = bfloat16

Shape | Speedup
-- | --
(100, 100) | 1.8787300923857455
(1000, 1000) | 7.8226144211061825
(10000, 10000) | 780.4135086112188
(100, 2000) | 7.6595638082927975
(2000, 100) | 6.951503305199973
(1000, 100000) | 1758.09036554368
(3321, 3321) | 157.0400754119404
(100000, 200) | 536.2271528814487

Script used:
```
import torch
import time


WARMUP_ITERS = 10
BENCH_ITERS = 1000

configs = [
    (100, 100),
    (1000, 1000),
    (10_000, 10_000),
    (100, 2_000),
    (2_000, 100),
    (1000, 100_000),
    (3321, 3321),
    (100_000, 200),
]

config_times = {}


for config in configs:
    x = torch.randn(config, device="mps", dtype=torch.bfloat16)
    for _ in range(WARMUP_ITERS):
        out = torch.trace(x)
    torch.mps.synchronize()
    
    t1 = time.perf_counter()
    for _ in range(BENCH_ITERS):
        out = torch.trace(x)
    torch.mps.synchronize()
    t2 = time.perf_counter()
    config_times[str(config)] = (t2 - t1) / BENCH_ITERS

print(config_times)
```