### PR TITLE
[TEST][CUDA] Scale inputs for test_bmm `test_bmm_large_batch_dynamic_cuda`

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -80,6 +80,7 @@ from torch.testing._internal.common_utils import (
     MACOS_VERSION,
     NAVI_ARCH,
     parametrize,
+    random_matrix_with_scaled_reduction_dim,
     runOnRocm,
     skipIfRocm,
     skipIfRocmArch,
@@ -1853,22 +1854,29 @@ class AOTInductorTestsTemplate:
         dtype = torch.float16
         model = Model()
 
+        # Scale inputs so this grid-size test is not sensitive to FP16 BMM noise.
+        def make_inputs(batch):
+            return (
+                0.5
+                * random_matrix_with_scaled_reduction_dim(
+                    M, K, batch, device=self.device, dtype=dtype, reduction_dim=-1
+                ),
+                0.5
+                * random_matrix_with_scaled_reduction_dim(
+                    K, N, batch, device=self.device, dtype=dtype, reduction_dim=-2
+                ),
+            )
+
         # Compile with small batch, then run with batch > 65535 (CUDA grid.y limit)
         compile_batch = 100
-        a = torch.randn(compile_batch, M, K, device=self.device, dtype=dtype)
-        b = torch.randn(compile_batch, K, N, device=self.device, dtype=dtype)
+        a, b = make_inputs(compile_batch)
         dim0_a = Dim("dim0_a", min=1, max=2**17)
         dynamic_shapes = {"a": {0: dim0_a}, "b": {0: dim0_a}}
         list_example_inputs = [(a, b)]
 
         # Large batch exceeding CUDA grid.y limit of 65535
         large_batch = 70000
-        list_example_inputs.append(
-            (
-                torch.randn(large_batch, M, K, device=self.device, dtype=dtype),
-                torch.randn(large_batch, K, N, device=self.device, dtype=dtype),
-            ),
-        )
+        list_example_inputs.append(make_inputs(large_batch))
         self.check_model_with_multiple_inputs(
             model,
             list_example_inputs,


### PR DESCRIPTION
Otherwise we see 1ULP failures on RTX PRO 6000

authored with codex

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo