### PR TITLE
[lint] Fix set linter nested f-string parsing

### DIFF
--- a/tools/linter/adapters/_linter/bracket_pairs.py
+++ b/tools/linter/adapters/_linter/bracket_pairs.py
@@ -16,30 +16,29 @@ def bracket_pairs(tokens: Sequence[TokenInfo]) -> dict[int, int]:
     """Returns a dictionary mapping opening to closing brackets"""
     braces: dict[int, int] = {}
     stack: list[int] = []
-    in_fstring = False
+    fstring_depth = 0
 
     for i, t in enumerate(tokens):
-        if t.type == token.OP and not in_fstring:
+        if t.type == token.OP and not fstring_depth:
             if t.string in BRACKETS:
                 stack.append(i)
             elif inv := BRACKETS_INV.get(t.string):
                 if not stack:
                     raise ParseError(t, "Never opened")
                 begin = stack.pop()
-
-                if not (stack and stack[-1] == FSTRING_START):
-                    braces[begin] = i
+                braces[begin] = i
 
                 b = tokens[begin].string
                 if b != inv:
                     raise ParseError(t, f"Mismatched braces '{b}' at {begin}")
         elif t.type == FSTRING_START:
-            stack.append(FSTRING_START)
-            in_fstring = True
+            fstring_depth += 1
         elif t.type == FSTRING_END:
-            if stack.pop() != FSTRING_START:
+            if not fstring_depth:
                 raise ParseError(t, "Mismatched FSTRING_START/FSTRING_END")
-            in_fstring = False
+            fstring_depth -= 1
+    if fstring_depth:
+        raise ParseError(t, "Left open")
     if stack:
         raise ParseError(t, "Left open")
     return braces

--- a/tools/test/test_set_linter.py
+++ b/tools/test/test_set_linter.py
@@ -78,6 +78,7 @@ class TestSetLinter(LinterTestCase):
             ("{1, 2}", 1),
             ("{One({'a': 1}), Two([{}, {2}, {1, 2}])}", 3),
             ('f" {h:{w}} "', 0),
+            ('buffer.splice(f"""{x} = {self.foo(f"{x}_idx")}""")', 0),
         )
         for s, expected in TESTS:
             pf = SetLinter.make_file(s)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #183638
* #182898
* #182897
* __->__ #183632
* #183432

The set linter's bracket parser kept f-string state in the same stack as token indices, so nested f-strings could later be interpreted as an index and crash. Track f-string nesting separately and add a regression case.

Authored by Codex.