### PR TITLE
[ROCm] Remove redundant ROCm scale-mode branch in CUDABlas

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1947,11 +1947,7 @@ int get_scale_mode(ScalingType scaling_type, ScalarType scale_dtype, bool use_fa
     case ScalingType::BlockWise1x32:
       TORCH_CHECK(scale_dtype == kFloat8_e8m0fnu);
 #if CUDA_VERSION >= 12080 || (defined(USE_ROCM) && ROCM_VERSION >= 70000)
-#ifdef USE_ROCM
-      return HIPBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0;
-#else
       return CUBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0;
-#endif // USE_ROCM
 #else
       TORCH_CHECK(false, "scaled_gemm with `torch.float8_e8m0fnu` scales of 1x32 blocks is only supported for CUDA 12.8 and above");
 #endif // if CUDA_VERSION >= 12080


### PR DESCRIPTION
Use CUBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0 so hipify can translate it using torch/utils/hipify/cuda_to_hip_mappings.py.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang