### PR TITLE
[BE] [MPS] Route _cdist fwd and backward through cdist stubs

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -46,6 +46,15 @@ DEFINE_DISPATCH(pdist_backward_stub);
 DEFINE_DISPATCH(cdist_stub);
 DEFINE_DISPATCH(cdist_backward_stub);
 
+static inline void cdist_supported_device_check(const Tensor& x1, const Tensor& x2, const char* op) {
+  auto check = [&](DeviceType d, const char* which) {
+    TORCH_CHECK(d == kCPU || d == kCUDA || d == kXPU || d == kMPS || d == kPrivateUse1,
+                op, " only supports CPU, XPU, CUDA, MPS and PrivateUse1 devices, ", which, " got: ", d);
+  };
+  check(x1.device().type(), "X1");
+  check(x2.device().type(), "X2");
+}
+
 Tensor pairwise_distance(const Tensor& x1, const Tensor& x2, double p, double eps, bool keepdim) {
   // Since either x1 or x2 could be broadcasted
   auto x1_dim = x1.dim();
@@ -103,8 +112,7 @@ static Tensor cdist_impl(const Tensor& x1, const Tensor& x2, const double p, std
   // See Note [cdist relies on cdist_impl redispatching]
   // Keep this condition in sync with the condition at the Note
   if (!(p == 2 && (mode == 1 || (mode == 0 && (r1 > 25 || r2 > 25))))) {
-    TORCH_CHECK(device1 == kCPU || device1 == kCUDA || device1 == kXPU || device1 == kPrivateUse1, "cdist only supports CPU, XPU, CUDA and PrivateUse1 devices, X1 got: ", device1);
-    TORCH_CHECK(device2 == kCPU || device2 == kCUDA || device2 == kXPU || device2 == kPrivateUse1, "cdist only supports CPU, XPU, CUDA and PrivateUse1 devices, X2 got: ", device2);
+    cdist_supported_device_check(x1, x2, "cdist");
   }
 
   auto dim1 = x1.dim();
@@ -228,9 +236,7 @@ Tensor _cdist_backward(const Tensor& _grad, const Tensor& _x1, const Tensor& _x2
   auto grad = _grad.contiguous();
   int64_t n = x1.size(-2);
   int64_t m = x1.size(-1);
-  TORCH_CHECK(x1.device() == x2.device(),
-              "_cdist_backward expects X1 and X2 to be on the same device, got X1: ",
-              x1.device(), " and X2: ", x2.device());
+  cdist_supported_device_check(x1, x2, "_cdist_backward");
 
   Tensor grad_x1 =
       at::empty({batch_product, n, m}, x1.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);

--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -228,14 +228,13 @@ Tensor _cdist_backward(const Tensor& _grad, const Tensor& _x1, const Tensor& _x2
   auto grad = _grad.contiguous();
   int64_t n = x1.size(-2);
   int64_t m = x1.size(-1);
-  auto device1 = x1.device().type();
-  TORCH_CHECK(device1 == kCPU || device1 == kCUDA || device1 == kXPU || device1 == kPrivateUse1, "_cdist_backward only supports CPU, XPU, CUDA and PrivateUse1 devices, X1 got: ", device1);
-  auto device2 = x2.device().type();
-  TORCH_CHECK(device2 == kCPU || device2 == kCUDA || device2 == kXPU || device2 == kPrivateUse1, "_cdist_backward only supports CPU, XPU, CUDA and PrivateUse1 devices, X2 got: ", device2);
+  TORCH_CHECK(x1.device() == x2.device(),
+              "_cdist_backward expects X1 and X2 to be on the same device, got X1: ",
+              x1.device(), " and X2: ", x2.device());
 
   Tensor grad_x1 =
       at::empty({batch_product, n, m}, x1.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  cdist_backward_stub(device1, grad_x1, grad, x1, x2, p, cdist);
+  cdist_backward_stub(x1.device().type(), grad_x1, grad, x1, x2, p, cdist);
 
   // Use x1.size() here and not the original size of _x1.size() as this gradient is not taking broadcasting into account
   // Broadcasting will be handled automatically by the autograd engine

--- a/aten/src/ATen/native/mps/operations/Distance.mm
+++ b/aten/src/ATen/native/mps/operations/Distance.mm
@@ -1,5 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/ExpandUtils.h>
+#include <ATen/native/Distance.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <c10/metal/common.h>
 
@@ -7,12 +7,9 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
-#include <ATen/ops/_cdist_backward_native.h>
 #include <ATen/ops/_cdist_forward_native.h>
-#include <ATen/ops/empty.h>
 #include <ATen/ops/linalg_vector_norm.h>
 #include <ATen/ops/where.h>
-#include <ATen/ops/zeros.h>
 #endif
 
 #include <ATen/native/mps/kernels/Distance.h>
@@ -55,50 +52,41 @@ Tensor _cdist_forward_mps(const Tensor& x1, const Tensor& x2, const double p, st
   return promote ? result.to(out_dtype) : result;
 }
 
-Tensor _cdist_backward_mps(const Tensor& grad,
-                           const Tensor& x1,
-                           const Tensor& x2,
-                           const double p,
-                           const Tensor& cdist) {
+static void cdist_backward_kernel_mps(Tensor& result,
+                                      const Tensor& grad,
+                                      const Tensor& x1,
+                                      const Tensor& x2,
+                                      const double p,
+                                      const Tensor& cdist) {
+  if (p == 0.0) {
+    result.fill_(0);
+    return;
+  }
+
+  const int64_t batch_product = result.size(0);
   const int64_t r1 = x1.size(-2);
   const int64_t r2 = x2.size(-2);
   const int64_t c = x1.size(-1);
-  const std::vector<int64_t> expand_batch =
-      infer_size(x1.sizes().slice(0, x1.dim() - 2), x2.sizes().slice(0, x2.dim() - 2));
-  std::vector<int64_t> out_size(expand_batch);
-  out_size.insert(out_size.end(), {r1, c});
-
-  const int64_t batch_product = c10::multiply_integers(expand_batch);
-  if (r1 == 0 || r2 == 0 || c == 0 || batch_product == 0 || p == 0.0) {
-    return at::zeros(out_size, x1.options());
-  }
 
   // p == 2: Euclidean identity, no kernel needed.
   if (p == 2.0) {
     Tensor coeff = at::where(cdist.eq(0), 0, grad.div(cdist));
-    return x1.mul(coeff.sum(-1, /*keepdim=*/true)).sub(coeff.matmul(x2));
+    Tensor grad_x1 = x1.mul(coeff.sum(-1, /*keepdim=*/true)).sub(coeff.matmul(x2));
+    result.copy_(grad_x1.reshape({batch_product, r1, c}));
+    return;
   }
 
-  std::vector<int64_t> x2_expand_size(expand_batch);
-  x2_expand_size.insert(x2_expand_size.end(), {r2, c});
-  std::vector<int64_t> dist_expand_size(expand_batch);
-  dist_expand_size.insert(dist_expand_size.end(), {r1, r2});
-
-  const Tensor x1c = x1.expand(out_size).contiguous();
-  const Tensor x2c = x2.expand(x2_expand_size).contiguous();
-  const Tensor gradc = grad.expand(dist_expand_size).contiguous();
   // Kernel reads cdist as fp32. For p == inf with reduced precision the
   // fp16-rounded saved cdist would miss the argmax-c match, so recompute.
-  const bool reduced = at::isReducedFloatingType(x1c.scalar_type());
+  const bool reduced = at::isReducedFloatingType(x1.scalar_type());
   const Tensor cdistc = (std::isinf(p) && reduced)
-      ? at::linalg_vector_norm(x1c.to(at::kFloat).unsqueeze(-2).sub(x2c.to(at::kFloat).unsqueeze(-3)),
+      ? at::linalg_vector_norm(x1.to(at::kFloat).unsqueeze(-2).sub(x2.to(at::kFloat).unsqueeze(-3)),
                                p,
                                makeArrayRef<int64_t>(-1),
                                /*keepdim=*/false,
                                /*dtype=*/std::nullopt)
             .contiguous()
-      : cdist.expand(dist_expand_size).to(at::kFloat).contiguous();
-  const Tensor out = at::empty(out_size, x1.options());
+      : cdist.to(at::kFloat).contiguous();
 
   const CdistBwdParams params{
       .B = batch_product,
@@ -108,9 +96,9 @@ Tensor _cdist_backward_mps(const Tensor& grad,
       .p_minus_1 = static_cast<float>(p - 1.0),
   };
 
-  // Values must match `P_KIND` in kernels/Cdist.metal.
+  // Values must match `P_KIND` in kernels/Distance.metal.
   const int p_kind = std::isinf(p) ? 1 : (p == 1.0 ? 0 : 2);
-  // TG_C choices must match REGISTER_CDIST_BACKWARD_FOR_TYPE in Cdist.metal.
+  // TG_C choices must match REGISTER_CDIST_BACKWARD_FOR_TYPE in Distance.metal.
   constexpr uint32_t kSmallTG = c10::metal::simdgroup_size;
   constexpr uint32_t kLargeTG = 4 * c10::metal::simdgroup_size;
   const uint32_t tg_c = (c >= 2 * kSmallTG) ? kLargeTG : kSmallTG;
@@ -119,20 +107,20 @@ Tensor _cdist_backward_mps(const Tensor& grad,
   auto stream = getCurrentMPSStream();
   @autoreleasepool {
     auto pso = lib.getPipelineStateForFunc(
-        fmt::format("cdist_backward_{}_p{}_tg{}", scalarToMetalTypeString(x1c), p_kind, tg_c));
+        fmt::format("cdist_backward_{}_p{}_tg{}", scalarToMetalTypeString(x1), p_kind, tg_c));
     dispatch_sync_with_rethrow(stream->queue(), ^() {
       @autoreleasepool {
         auto compute_encoder = stream->commandEncoder();
         [compute_encoder setComputePipelineState:pso];
-        mtl_setArgs(compute_encoder, x1c, x2c, gradc, cdistc, out, params);
+        mtl_setArgs(compute_encoder, x1, x2, grad, cdistc, result, params);
         const MTLSize grid = MTLSizeMake(D_padded, static_cast<NSUInteger>(r1), static_cast<NSUInteger>(batch_product));
         const MTLSize tg = MTLSizeMake(tg_c, 1, 1);
         [compute_encoder dispatchThreads:grid threadsPerThreadgroup:tg];
       }
     });
   }
-
-  return out;
 }
+
+REGISTER_DISPATCH(cdist_backward_stub, &cdist_backward_kernel_mps)
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Distance.mm
+++ b/aten/src/ATen/native/mps/operations/Distance.mm
@@ -7,7 +7,6 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
-#include <ATen/ops/_cdist_forward_native.h>
 #include <ATen/ops/linalg_vector_norm.h>
 #include <ATen/ops/where.h>
 #endif
@@ -24,32 +23,19 @@ static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #include <ATen/native/mps/Distance_metallib.h>
 #endif
 
-Tensor _cdist_forward_mps(const Tensor& x1, const Tensor& x2, const double p, std::optional<int64_t> compute_mode) {
-  TORCH_CHECK(x1.dim() >= 2, "cdist only supports at least 2D tensors, X1 got: ", x1.dim(), "D");
-  TORCH_CHECK(x2.dim() >= 2, "cdist only supports at least 2D tensors, X2 got: ", x2.dim(), "D");
-  TORCH_CHECK(x1.size(-1) == x2.size(-1),
-              "X1 and X2 must have the same number of columns. X1: ",
-              x1.size(-1),
-              " X2: ",
-              x2.size(-1));
-  TORCH_CHECK(
-      at::isFloatingType(x1.scalar_type()), "cdist only supports floating-point dtypes, X1 got: ", x1.scalar_type());
-  TORCH_CHECK(
-      at::isFloatingType(x2.scalar_type()), "cdist only supports floating-point dtypes, X2 got: ", x2.scalar_type());
-  TORCH_CHECK(p >= 0, "cdist only supports non-negative p values");
-
-  const int64_t mode = compute_mode.value_or(0);
-  TORCH_CHECK(mode >= 0 && mode <= 2, "possible modes: 0, 1, 2, but was: ", mode);
-
+static void cdist_kernel_mps(Tensor& result, const Tensor& x1, const Tensor& x2, const double p) {
   // Promote fp16/bf16 to fp32 internally so the max-norm argmax selection
   // matches what the CPU reference does (which falls back to fp32 for
   // these dtypes anyway).
-  const auto out_dtype = x1.scalar_type();
+  const auto out_dtype = result.scalar_type();
   const bool promote = at::isReducedFloatingType(out_dtype);
   const auto compute_dtype = promote ? at::kFloat : out_dtype;
   auto diff = x1.to(compute_dtype).unsqueeze(-2).sub(x2.to(compute_dtype).unsqueeze(-3));
-  auto result = at::linalg_vector_norm(diff, p, makeArrayRef<int64_t>(-1), /*keepdim=*/false, /*dtype=*/std::nullopt);
-  return promote ? result.to(out_dtype) : result;
+  auto out = at::linalg_vector_norm(diff, p, makeArrayRef<int64_t>(-1), /*keepdim=*/false, /*dtype=*/std::nullopt);
+  if (promote) {
+    out = out.to(out_dtype);
+  }
+  result.copy_(out.reshape(result.sizes()));
 }
 
 static void cdist_backward_kernel_mps(Tensor& result,
@@ -121,6 +107,7 @@ static void cdist_backward_kernel_mps(Tensor& result,
   }
 }
 
+REGISTER_DISPATCH(cdist_stub, &cdist_kernel_mps)
 REGISTER_DISPATCH(cdist_backward_stub, &cdist_backward_kernel_mps)
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4651,8 +4651,7 @@
 
 - func: _cdist_backward(Tensor grad, Tensor x1, Tensor x2, float p, Tensor cdist) -> Tensor
   dispatch:
-    CPU, CUDA: _cdist_backward
-    MPS: _cdist_backward_mps
+    CPU, CUDA, MPS: _cdist_backward
   autogen: _cdist_backward.out
 
 - func: pdist(Tensor self, float p=2) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4643,9 +4643,8 @@
 
 - func: _cdist_forward(Tensor x1, Tensor x2, float p, int? compute_mode) -> Tensor
   dispatch:
-    CPU, CUDA: _cdist_forward
+    CPU, CUDA, MPS: _cdist_forward
     MTIA: _cdist_forward_mtia
-    MPS: _cdist_forward_mps
   autogen: _cdist_forward.out
   tags: core
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #183635

To share backend agnostic tensor allocation/error checking/broadcasting logic

Also replace repeated supported devices check with static void cdist_supported_device_check, that can be called from both forward and backward


Authored by Claude.