### PR TITLE
Use pytorch/test-infra setup-uv wrapper in macOS binary build

### DIFF
--- a/.github/templates/macos_binary_build_workflow.yml.j2
+++ b/.github/templates/macos_binary_build_workflow.yml.j2
@@ -84,7 +84,7 @@ jobs:
         run: |
           "${PYTORCH_ROOT}/.ci/wheel/install_libomp.sh"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: pytorch/test-infra/.github/actions/setup-uv@main
         with:
           # enable-cache persists ~/.cache/uv across nightlies (keyed on the
           # workflow file hash by default); a warm cache makes the subsequent

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           "${PYTORCH_ROOT}/.ci/wheel/install_libomp.sh"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: pytorch/test-infra/.github/actions/setup-uv@main
         with:
           # enable-cache persists ~/.cache/uv across nightlies (keyed on the
           # workflow file hash by default); a warm cache makes the subsequent


### PR DESCRIPTION
## Summary

The macOS binary build template uses `astral-sh/setup-uv@v6` directly. Without
a pinned `version:`, setup-uv calls the GitHub API to resolve the latest uv
release. In PyTorch CI, setup-uv has been observed rejecting the workflow
`GITHUB_TOKEN` (logs `No (valid) GitHub token provided`) and falling back to
anonymous requests, which then hit the per-IP rate limit.

`pytorch/test-infra/.github/actions/setup-uv` exists precisely for this — it
pins a specific uv version so no API call is made. Every other `setup-uv`
caller in this repo already uses the wrapper; the macOS binary template was
the last direct caller. Switch it over and regenerate the workflow.

## Test plan

- [x] `python3 .github/scripts/generate_ci_workflows.py` regenerates the
  workflow cleanly (no diff beyond the intended change).
- [ ] Verify the next macOS nightly wheel build succeeds without hitting the
  uv setup rate-limit path.