### PR TITLE
[c10d] Surface started-work metadata in NCCL watchdog timeouts

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2399,6 +2399,11 @@ void ProcessGroupNCCL::Watchdog::runLoop() {
             work.seq_,
             " PG status: last enqueued work: ",
             pg_->pgStatus_->lastEnqueuedSeq,
+            ", last started work: ",
+            pg_->pgStatus_->lastStartedSeq,
+            " (",
+            pg_->pgStatus_->lastStartedWorkName,
+            ")",
             ", last completed work: ",
             pg_->pgStatus_->lastCompletedSeq);
 


### PR DESCRIPTION
The PyTorch ProcessGroupNCCL watchdog currently surfaces the `lastEnqueuedSeq` and `lastCompletedSeq` when a collective timeout is detected. However, it internally tracks `lastStartedSeq` and `lastStartedWorkName`, which represents when a collective actually begins execution (as opposed to merely being enqueued).

This commit adds `lastStartedSeq` and `lastStartedWorkName` to the watchdog timeout error log. This dramatically improves distributed timeout provenance by allowing developers to distinguish between execution hangs (where `lastStartedSeq` advances but `lastCompletedSeq` does not) and queue starvation (where `lastStartedSeq` does not advance).

This is an observability-only change that does not affect runtime semantics.