### PR TITLE
Document functions in signal md

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -916,17 +916,6 @@ coverage_ignore_functions = [
     "validate_cuda_device",
     "validate_hpu_device",
     # torch.signal.windows.windows
-    "bartlett",
-    "blackman",
-    "cosine",
-    "exponential",
-    "gaussian",
-    "general_cosine",
-    "general_hamming",
-    "hamming",
-    "hann",
-    "kaiser",
-    "nuttall",
     # torch.utils.benchmark.examples.op_benchmark
     # torch.utils.benchmark.op_fuzzers.spectral
     "power_range",

--- a/docs/source/signal.md
+++ b/docs/source/signal.md
@@ -65,21 +65,3 @@ The `torch.signal` module, modeled after SciPy's [signal](https://docs.scipy.org
 ```{eval-rst}
 .. autofunction:: nuttall
 ```
-
-```{eval-rst}
-.. autosummary::
-    :toctree: generated
-    :nosignatures:
-
-    bartlett
-    blackman
-    cosine
-    exponential
-    gaussian
-    general_cosine
-    general_hamming
-    hamming
-    hann
-    kaiser
-    nuttall
-```

--- a/docs/source/signal.md
+++ b/docs/source/signal.md
@@ -19,49 +19,19 @@ The `torch.signal` module, modeled after SciPy's [signal](https://docs.scipy.org
 ```
 
 ```{eval-rst}
-.. currentmodule:: torch.signal.windows.windows
-```
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
 
-```{eval-rst}
-.. autofunction:: bartlett
-```
-
-```{eval-rst}
-.. autofunction:: blackman
-```
-
-```{eval-rst}
-.. autofunction:: cosine
-```
-
-```{eval-rst}
-.. autofunction:: exponential
-```
-
-```{eval-rst}
-.. autofunction:: gaussian
-```
-
-```{eval-rst}
-.. autofunction:: general_cosine
-```
-
-```{eval-rst}
-.. autofunction:: general_hamming
-```
-
-```{eval-rst}
-.. autofunction:: hamming
-```
-
-```{eval-rst}
-.. autofunction:: hann
-```
-
-```{eval-rst}
-.. autofunction:: kaiser
-```
-
-```{eval-rst}
-.. autofunction:: nuttall
+    bartlett
+    blackman
+    cosine
+    exponential
+    gaussian
+    general_cosine
+    general_hamming
+    hamming
+    hann
+    kaiser
+    nuttall
 ```

--- a/docs/source/signal.md
+++ b/docs/source/signal.md
@@ -19,6 +19,54 @@ The `torch.signal` module, modeled after SciPy's [signal](https://docs.scipy.org
 ```
 
 ```{eval-rst}
+.. currentmodule:: torch.signal.windows.windows
+```
+
+```{eval-rst}
+.. autofunction:: bartlett
+```
+
+```{eval-rst}
+.. autofunction:: blackman
+```
+
+```{eval-rst}
+.. autofunction:: cosine
+```
+
+```{eval-rst}
+.. autofunction:: exponential
+```
+
+```{eval-rst}
+.. autofunction:: gaussian
+```
+
+```{eval-rst}
+.. autofunction:: general_cosine
+```
+
+```{eval-rst}
+.. autofunction:: general_hamming
+```
+
+```{eval-rst}
+.. autofunction:: hamming
+```
+
+```{eval-rst}
+.. autofunction:: hann
+```
+
+```{eval-rst}
+.. autofunction:: kaiser
+```
+
+```{eval-rst}
+.. autofunction:: nuttall
+```
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:


### PR DESCRIPTION
Fixes #182831

## Description

- [X] Entries removed from skip list(s) in [docs/source/conf.py](https://github.com/pytorch/pytorch/blob/main/docs/source/conf.py)
- [X] Sphinx directives added to [docs/source/signal.md](https://github.com/pytorch/pytorch/blob/main/docs/source/signal.md)
- [X] make coverage passes with no new undocumented warnings for these APIs
- [] Screenshot(s) of the rendered documentation included in the PR description

## Screenshots

note auto summary was giving some warnings (`/pytorch/docs/source/generated/torch.signal.windows.cosine.rst: WARNING: document isn't included in any toctree`)

cc @svekars @sekyondaMeta @AlannaBurke