### PR TITLE
[inductor] _make_launchers: skip rebuilding existing launchers

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -621,7 +621,7 @@ class CachingAutotuner(KernelInterface):
             self._precompile_worker()
             if static_triton_bundle_key is not None and self.is_statically_launchable():
                 TritonBundler.put_static_autotuner(static_triton_bundle_key, self)
-            self._make_launchers()
+            self._make_launchers(self.compile_results)
             self._dynamic_scale_rblock()
 
     def _precompile_worker(self):
@@ -777,9 +777,12 @@ class CachingAutotuner(KernelInterface):
             return
         if not self._could_rblock_scale:
             return
+        new_results = []
         for new_config in self._iter_rblock_scale_candidates():
-            self.compile_results.append(self._precompile_config(new_config))  # noqa: B909
-        self._make_launchers()
+            result = self._precompile_config(new_config)
+            self.compile_results.append(result)  # noqa: B909
+            new_results.append(result)
+        self._make_launchers(new_results)
 
     def compile_by_disabling_pipelining(self, config):
         self._ensure_kernel_loaded()
@@ -809,8 +812,12 @@ class CachingAutotuner(KernelInterface):
         ) as e:
             return None, e
 
-    def _make_launchers(self):
-        if len(self.launchers) == len(self.compile_results):
+    def _make_launchers(self, compile_results):
+        """Wrap each result in ``compile_results`` into a launcher and
+        append the survivors to ``self.launchers``. Fires the all-failed
+        fallback only when ``self.launchers`` is empty AND no new launcher
+        survived this call."""
+        if not compile_results:
             return
 
         from torch._dynamo.device_interface import DeviceGuard
@@ -820,12 +827,12 @@ class CachingAutotuner(KernelInterface):
         exc = None
         # DeviceGuard ensures each launcher's binary loads onto the right device.
         with DeviceGuard(device_interface, self.triton_meta["device"]):
-            for result in self.compile_results:
+            for result in compile_results:
                 launcher, exc = self._make_launcher(result)
                 if launcher is not None:
                     launchers.append(launcher)
-            if len(launchers) == 0:
-                result = self.compile_results[-1]
+            if not self.launchers and not launchers:
+                result = compile_results[-1]
                 config = result.config
                 if (
                     isinstance(exc, (OutOfResources, torch.cuda.OutOfMemoryError))
@@ -839,7 +846,7 @@ class CachingAutotuner(KernelInterface):
                 raise RuntimeError(
                     f"No valid triton configs. {type(exc).__name__}: {exc}"
                 )
-        self.launchers = launchers
+        self.launchers.extend(launchers)
 
     def _ensure_kernel_loaded(self) -> None:
         """Reload the kernel in the parent process if needed.


### PR DESCRIPTION
Summary:
Modifies `CachingAutotuner._make_launchers` to take a list of compile results for which we make launchers, rather than making launchers for all compile results on that instance.

Previously, this would have duplicated calls to `CachingAutotuner._make_launcher` for the initial set of compile results when dynamic rblock scaling was in effect; I am unsure if this was costly in terms of overhead, but either way it is not a clean mode of execution.

Now when dynamic rblock scaling is in effect only the new compile results will be passed to `CachingAutotuner._make_launchers`.

The alternative is to infer the launchers which need to be created automatically by taking the suffix of compile results that is as long as the difference between the # of launchers and the # of compile results; this is messier, more confusing, and we'd have to handle the case where compile results don't create launchers (i.e. launcher creation fails). Prefer this solution, although it does change the `CachingAutotuner._make_launchers` callsites.

Authored by Claude.

Test Plan:
```
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:triton_heuristics
```

Differential Revision: D105116627




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo