### PR TITLE
[ROCm] Fix test_origami import after template_heuristics rename

### DIFF
--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -472,7 +472,7 @@ class TestOrigami(TestCase):
         snippet = (
             "import os, torch\n"
             "from torch._inductor import config\n"
-            "from torch._inductor.template_heuristics import triton as th\n"
+            "from torch._inductor.heuristics.template import triton as th\n"
             "assert os.environ.get('TORCHINDUCTOR_ORIGAMI') != '1', 'env var leaked'\n"
             "assert th.origami is None, f'expected None, got {th.origami!r}'\n"
             "# Even after flipping the config knob mid-process, origami stays None\n"


### PR DESCRIPTION
PR #183275 renamed torch._inductor.template_heuristics to torch._inductor.heuristics.template but missed the subprocess snippet inside test_origami_module_gate_when_env_var_unset, so the subprocess fails with ModuleNotFoundError and the test fails consistently on every commit since.

Update the import path to match.

Authored by Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben