### PR TITLE
[inductor] Fix TOCTOU race in DebugContext.create_debug_dir

### DIFF
--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -412,9 +412,13 @@ class DebugContext:
                 "torchinductor",
                 f"{folder_name}.{n}",
             )
-            if not os.path.exists(dirname):
-                os.makedirs(dirname)
+            try:
+                os.makedirs(dirname, exist_ok=False)
                 return dirname
+            except FileExistsError:
+                # Another process (e.g. a peer rank with the same debug_dir)
+                # created this counter slot first; advance to the next n.
+                continue
         return None
 
     def __init__(self) -> None:


### PR DESCRIPTION
## Bug

`DebugContext.create_debug_dir` in `torch/_inductor/debug.py` has a classic check-then-act race:

```python
for n in DebugContext._counter:
    dirname = os.path.join(debug_dir, "torchinductor", f"{folder_name}.{n}")
    if not os.path.exists(dirname):   # check
        os.makedirs(dirname)           # act  ← not atomic
        return dirname
```

When multiple processes compile graphs concurrently with the same `config.trace.debug_dir`, two or more processes can pass `os.path.exists()` on the same counter slot before either calls `os.makedirs()`, and the losers raise `FileExistsError`, killing compile.

## Symptom

```
File ".../torch/_inductor/compile_fx.py", line 821, in compile_fx_inner
    stack.enter_context(DebugContext())
File ".../torch/_inductor/debug.py", line 485, in __enter__
    self._path = self.create_debug_dir(get_aot_graph_name())
File ".../torch/_inductor/debug.py", line 406, in create_debug_dir
    os.makedirs(dirname)
FileExistsError: [Errno 17] File exists: '.../torchinductor/model__1_inference_0.0'
```

## Repro

Any setup where multiple processes point `config.trace.debug_dir` at the same filesystem path and call `torch._inductor.compile(...)` in close succession (typical after a collective barrier in distributed tests). The process-local AOT counter starts at the same value in every process, so they all attempt the same `model__N_inference_M.0` slot first; two processes passing `os.path.exists()` between each other's `os.makedirs()` is enough to crash.

On fast local NVMe the race window is narrow enough that processes usually arrive serialized and the existing retry loop produces `.0` / `.1` / `.2` / `.3` cleanly. On slower shared CI storage `os.makedirs` latency widens beyond the inter-process arrival gap and the failure becomes deterministic (3 consecutive CI runs hit it).

## Fix

Replace the non-atomic check-then-create with `try: os.makedirs(dirname, exist_ok=False) / except FileExistsError: continue`. Same retry semantics (advance to the next `n` on collision), but the collision is detected at the action site, making the check+act atomic from the caller's perspective. `exist_ok=False` is explicit to flag intent — `exist_ok=True` would NOT be a correct fix because multiple processes would then silently end up sharing the same directory.

## Test plan

The race is timing-dependent (TOCTOU windows are microseconds on a hot path), so a deterministic regression test would need to monkey-patch `os.path.exists` / `os.makedirs` to force the interleaving. Happy to add a mock-based unit test if reviewers want — let me know.

The existing `for n in DebugContext._counter` retry loop is preserved; the only behavioral change is that a collision is now handled at the `makedirs` site instead of propagating as an uncaught `FileExistsError`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo