### PR TITLE
[ROCm] fix flaky test_honor_sm_carveout

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1857,6 +1857,10 @@ class TestFP8Matmul(TestCase):
         cu_count = torch.cuda.get_device_properties().multi_processor_count
         carveout = 66 if torch.version.cuda else cu_count // 8
 
+        # Warm up so hipBLASLt's one-time init kernel does not appear in the profile trace below.
+        scaled_mm_wrap(x_fp8, y_fp8, scale_a=x_scales, scale_b=y_scales, out_dtype=torch.bfloat16)
+        torch.cuda.synchronize()
+
         with tempfile.NamedTemporaryFile() as f:
             with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CUDA]) as prof:
                 self.assertIsNone(torch._C._get_sm_carveout_experimental())


### PR DESCRIPTION
## Issue Summary

On a cold hipBLASLt cache, `torch.profiler.profile` captures `__amd_rocclr_fillBufferAligned.kd` (hipBLASLt's first-call workspace zero) alongside the four matmul kernels the test expects, producing five events instead of four and breaking the 4-way unpack at [line 1789](https://github.com/pytorch/pytorch/blob/7137043a3e5d06adb87f16bfb080b91abaa9391d/test/test_scaled_matmul_cuda.py#L1789). 
## Fix

Added a warmup run for `scaled_mm_wrap` before the profile block makes the initialization happen prior to the capture. The carveout machinery and the seven existing assertions are unchanged. There is no error in the mm kernel or the carveout mechanism, it was purely an unpacking issue

## Test plan

- Pre-fix: 5/5 failures with `ValueError: too many values to unpack (expected 4)`
- Post-fix: 5/5 passes
```
[W514 06:51:51.920119789 Context.cpp:688] Warning: Setting the SM carveout for matmuls is a temporary experimental mitigation for performance issues, while more robust solutions are developed. It may be removed at any moment without notice. (function operator())
USDT:2026-05-14 06:51:51 640300:640300 SyncActivityProfilerHandler.cpp:59] profiler_stop
[W514 06:51:51.939640034 collection.cpp:1182] Warning: ROCTracer produced duplicate flow start: 4 (function operator())
ROCm debug info for test_honor_sm_carveout
cu_count 304
no_carveout 322.011
carveout_0 326.142
carveout 843.158
no_carveout_again 329.549
ok

----------------------------------------------------------------------
Ran 1 test in 1.254s

OK
```
- Cold-cache assertion replay (no warmup applied, `fillBuffer` filtered out of the trace) shows all 7 underlying assertions still pass confirming the warmup relocates init outside the measurement window rather than masking any defect

#### Verified on MI300X / gfx942 / ROCm 7.2.26015.

Fixes #164271

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @drisspg
