### PR TITLE
[MPS] Fix fill_ ignoring storage offset for byte types

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ConstantKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ConstantKernel.metal
@@ -54,6 +54,16 @@ REGISTER_FILL_BYTE_OP(char);
 REGISTER_FILL_BYTE_OP(uchar);
 REGISTER_FILL_BYTE_OP(bool);
 
+// Non-vectorized variant for byte types when the buffer offset isn't 4-byte
+// aligned (misaligned vec4 stores are undefined behavior on Metal).
+#define REGISTER_FILL_BYTE_NOVEC_OP(T)                              \
+  template [[host_name("fill_scalar_dense_novec_" #T)]] kernel void \
+  fill_scalar_dense<T>(device T*, constant T&, constant uint&, uint)
+
+REGISTER_FILL_BYTE_NOVEC_OP(char);
+REGISTER_FILL_BYTE_NOVEC_OP(uchar);
+REGISTER_FILL_BYTE_NOVEC_OP(bool);
+
 // 2D dispatch: tid.y = dim-0 index (no division), tid.x = linear index for
 // dims 1..ndim-1. For an N-dim tensor this requires N-1 divisions instead of N,
 // and consecutive threads in x access consecutive addresses in the innermost

--- a/aten/src/ATen/native/mps/operations/ConstantOps.mm
+++ b/aten/src/ATen/native/mps/operations/ConstantOps.mm
@@ -66,12 +66,16 @@ static void fill_mps_kernel(TensorIterator& iter, const Scalar& value) {
   }
 
   // Single-byte dtypes (bool, uint8, int8) use vec4 kernels that fill
-  // 4 elements per thread; all others fill 1 element per thread.
+  // 4 elements per thread, but only when the buffer offset is 4-byte aligned;
+  // misaligned vec4 stores are undefined behavior on Metal.
   const bool is_byte_type = self.element_size() == 1;
   const uint32_t numel = static_cast<uint32_t>(iter.numel());
-  const int64_t threads = is_byte_type ? (numel + 3) / 4 : numel;
+  const bool use_vec4 = is_byte_type && (iter_tensor_offset(iter, 0) % 4 == 0);
+  const int64_t threads = use_vec4 ? (numel + 3) / 4 : numel;
 
-  auto fillPSO = lib.getPipelineStateForFunc(fmt::format("fill_scalar_dense_{}", type_str));
+  const auto kernel_name = (is_byte_type && !use_vec4) ? fmt::format("fill_scalar_dense_novec_{}", type_str)
+                                                       : fmt::format("fill_scalar_dense_{}", type_str);
+  auto fillPSO = lib.getPipelineStateForFunc(kernel_name);
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = stream->commandEncoder();

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1012,19 +1012,16 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(tensor_mps.to(device="cpu"), tensor_cpu)
         self.assertEqual(tensor.to(device="cpu"), tensor_0)
 
-    def test_fill_storage_offset_byte_types(self):
-        # Regression test for https://github.com/pytorch/pytorch/issues/183631
-        # The vec4 fill kernel requires 4-byte aligned buffer offsets;
-        # misaligned offsets (e.g. x[1:] on a bool tensor) caused writes
-        # to land at wrong positions.
-        for dtype in [torch.bool, torch.uint8, torch.int8]:
-            for offset in range(1, 8):
-                x_mps = torch.zeros(16, dtype=dtype, device="mps")
-                x_cpu = torch.zeros(16, dtype=dtype, device="cpu")
-                fill_val = True if dtype == torch.bool else 42
-                x_mps[offset:].fill_(fill_val)
-                x_cpu[offset:].fill_(fill_val)
-                self.assertEqual(x_mps, x_cpu)
+    # Regression test for https://github.com/pytorch/pytorch/issues/183631
+    @parametrize("dtype", [torch.bool, torch.uint8, torch.int8])
+    def test_fill_storage_offset_byte_types(self, dtype):
+        for offset in range(1, 8):
+            x_mps = torch.zeros(16, dtype=dtype, device="mps")
+            x_cpu = torch.zeros(16, dtype=dtype, device="cpu")
+            fill_val = True if dtype == torch.bool else 42
+            x_mps[offset:].fill_(fill_val)
+            x_cpu[offset:].fill_(fill_val)
+            self.assertEqual(x_mps, x_cpu)
 
     def test_cdist_large(self, device="mps"):
         for cm in ['use_mm_for_euclid_dist_if_necessary', 'use_mm_for_euclid_dist', 'donot_use_mm_for_euclid_dist']:

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1012,6 +1012,20 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(tensor_mps.to(device="cpu"), tensor_cpu)
         self.assertEqual(tensor.to(device="cpu"), tensor_0)
 
+    def test_fill_storage_offset_byte_types(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/183631
+        # The vec4 fill kernel requires 4-byte aligned buffer offsets;
+        # misaligned offsets (e.g. x[1:] on a bool tensor) caused writes
+        # to land at wrong positions.
+        for dtype in [torch.bool, torch.uint8, torch.int8]:
+            for offset in range(1, 8):
+                x_mps = torch.zeros(16, dtype=dtype, device="mps")
+                x_cpu = torch.zeros(16, dtype=dtype, device="cpu")
+                fill_val = True if dtype == torch.bool else 42
+                x_mps[offset:].fill_(fill_val)
+                x_cpu[offset:].fill_(fill_val)
+                self.assertEqual(x_mps, x_cpu)
+
     def test_cdist_large(self, device="mps"):
         for cm in ['use_mm_for_euclid_dist_if_necessary', 'use_mm_for_euclid_dist', 'donot_use_mm_for_euclid_dist']:
             x = torch.randn(100, 10, device=device)


### PR DESCRIPTION
## Summary

`Tensor.fill_()` on an offset view of a byte-type tensor (bool, uint8, int8) on MPS writes to incorrect positions. The vec4 fill kernel stores 4 elements per thread via `*(device vec<T,4>*)`, but when the buffer offset isn't 4-byte aligned (e.g. `x[1:]` on a bool tensor), the store is misaligned — undefined behavior on Metal that silently shifts all writes.

- Register a non-vectorized `fill_scalar_dense` kernel for byte types (`fill_scalar_dense_novec_{type}`)
- Check buffer offset alignment in dispatch; use scalar kernel when misaligned, preserve vec4 for aligned case

Fixes #183631

## Test plan

- [x] Verified the exact repro from the issue — `x[0]` stays `False` after `x[1:].fill_(True)`
- [x] Tested bool, uint8, int8 with offset views
- [x] Tested offsets 1–7 (all misaligned cases)
- [x] Tested aligned offset (multiple of 4) still uses vec4 path
- [x] Tested contiguous tensor with no offset (regression check)