### PR TITLE
Extend Philox RNG functionalization to support XPU devices.

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -6854,7 +6854,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
             for arg, cloned_arg in zip(args, cloned_args):
                 self.assertEqual(arg.grad, cloned_arg.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @torch._functorch.config.patch(functionalize_rng_ops=True)
     def test_function(self):
         def gn(x, y):
@@ -6873,7 +6873,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
         backend = aot_autograd(fw_compiler=fw_compiler, bw_compiler=bw_compiler)
         self._validate(fn, backend, x, y)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @torch._functorch.config.patch(functionalize_rng_ops=True)
     def test_function_with_kwargs(self):
         def gn(x, y):
@@ -6896,7 +6896,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
         backend = aot_autograd(fw_compiler=fw_compiler, bw_compiler=bw_compiler)
         self._validate(fn, backend, x, y)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @torch._functorch.config.patch(functionalize_rng_ops=True)
     def test_dropout(self):
         def gn(x, y):
@@ -6907,8 +6907,8 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
                 gn, torch.sin(x), y, use_reentrant=True
             )
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=GPU_TYPE, requires_grad=True)
+        y = torch.randn(4, 4, device=GPU_TYPE, requires_grad=True)
 
         fw_compiler = functools.partial(
             count_ops, freq=1, op=torch.ops.rngprims.philox_rand.default
@@ -6922,7 +6922,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
             fn, backend, x, y, skip_check=True
         )  # dropout decomp is known to diverge with eager
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @torch._functorch.config.patch(functionalize_rng_ops=True)
     def test_dropout_inductor(self):
         def gn(x, y):
@@ -6933,8 +6933,8 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
                 gn, torch.sin(x), y, use_reentrant=True
             )
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=GPU_TYPE, requires_grad=True)
+        y = torch.randn(4, 4, device=GPU_TYPE, requires_grad=True)
 
         backend = "inductor"
         self._validate(
@@ -6972,7 +6972,7 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnt.op_count, 2)
         self.assertEqual(len(backend.graphs), 2)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @torch._functorch.config.patch(functionalize_rng_ops=True)
     def test_module(self):
         class MockModule(torch.nn.Module):

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -23,7 +23,7 @@ from torch.testing._internal.common_device_type import (
 
 from torch.testing._internal.logging_tensor import LoggingTensor, capture_logs, log_input
 import torch._prims as prims
-from torch._prims_common import CUDARngStateHelper
+from torch._prims_common import AcceleratorRngStateHelper
 from torch._prims.executor import make_traced
 import torch._refs as refs
 
@@ -283,7 +283,7 @@ class TestPrims(TestCase):
             results = []
             rng_states = []
             for _ in range(repeats):
-                rng_states.append(CUDARngStateHelper.get_torch_state_as_tuple())
+                rng_states.append(AcceleratorRngStateHelper.get_torch_state_as_tuple())
                 references.append(torch.rand(size, device=device, dtype=dtype))
 
             torch.cuda.manual_seed(123)

--- a/torch/_decomp/decompositions_for_rng.py
+++ b/torch/_decomp/decompositions_for_rng.py
@@ -20,18 +20,20 @@ def register_rng_decomposition(aten_op):
 
 
 def throw_on_unsupported_rng_device(device):
-    raise RuntimeError(
-        f"You are trying to functionalize a {device.type} RNG operator but {device.type} does not "
-        f"use Philox/counter-based RNG. Therefore, functionalizing a {device.type} RNG operator is "
-        "not supported. Supported devices: CUDA, XPU."
-    )
+    if device.type not in ("cuda", "xpu"):
+        raise RuntimeError(
+            f"You are trying to functionalize a {device.type} RNG operator but {device.type} does not "
+            f"use Philox/counter-based RNG. Therefore, functionalizing a {device.type} RNG operator is "
+            f"not supported. Supported devices: CUDA, XPU. "
+            f"We are discussing the possibility of a Philox-based RNG implementation for CPU."
+        )
 
 
 # TODO - We have to register many more distributions here, and also higher level
 # ops like dropout which have fused implementation and can hide the rand inside.
 @register_rng_decomposition(aten.rand)
 def rand(shape, dtype=None, layout=torch.strided, device=None, pin_memory=False):
-    if device and device.type not in ("cuda", "xpu"):
+    if device:
         throw_on_unsupported_rng_device(device)
     seed, offset = PhiloxStateTracker.get_state_as_tuple()
     dtype = dtype or torch.float32
@@ -52,8 +54,7 @@ def rand_like(
     memory_format=torch.preserve_format,
 ):
     device = device or x.device
-    if device.type not in ("cuda", "xpu"):
-        throw_on_unsupported_rng_device(device)
+    throw_on_unsupported_rng_device(device)
     dtype = dtype or x.dtype
     seed, offset = PhiloxStateTracker.get_state_as_tuple()
     out, offset_jump = torch.ops.rngprims.philox_rand(

--- a/torch/_decomp/decompositions_for_rng.py
+++ b/torch/_decomp/decompositions_for_rng.py
@@ -19,11 +19,11 @@ def register_rng_decomposition(aten_op):
     return decomp.register_decomposition(aten_op, rng_decompositions)
 
 
-def throw_on_non_cuda(device):
+def throw_on_unsupported_rng_device(device):
     raise RuntimeError(
         f"You are trying to functionalize a {device.type} RNG operator but {device.type} does not "
         f"use Philox/counter-based RNG. Therefore, functionalizing a {device.type} RNG operator is "
-        "not supported. We are discussing the possibility of a Philox-based RNG implementation for CPU."
+        "not supported. Supported devices: CUDA, XPU."
     )
 
 
@@ -31,8 +31,8 @@ def throw_on_non_cuda(device):
 # ops like dropout which have fused implementation and can hide the rand inside.
 @register_rng_decomposition(aten.rand)
 def rand(shape, dtype=None, layout=torch.strided, device=None, pin_memory=False):
-    if device and device.type != "cuda":
-        throw_on_non_cuda(device)
+    if device and device.type not in ("cuda", "xpu"):
+        throw_on_unsupported_rng_device(device)
     seed, offset = PhiloxStateTracker.get_state_as_tuple()
     dtype = dtype or torch.float32
     out, offset_jump = torch.ops.rngprims.philox_rand(
@@ -52,8 +52,8 @@ def rand_like(
     memory_format=torch.preserve_format,
 ):
     device = device or x.device
-    if device.type != "cuda":
-        throw_on_non_cuda(device)
+    if device.type not in ("cuda", "xpu"):
+        throw_on_unsupported_rng_device(device)
     dtype = dtype or x.dtype
     seed, offset = PhiloxStateTracker.get_state_as_tuple()
     out, offset_jump = torch.ops.rngprims.philox_rand(

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -93,6 +93,7 @@ from .subclass_utils import (
     wrap_tensor_subclasses_maybe_joint,
 )
 from .utils import (
+    _detect_rng_device_type,
     _is_tangent,
     call_and_expect_output_descs,
     maybe_to_fresh_input,
@@ -516,14 +517,8 @@ def create_functionalized_rng_ops_wrapper(
     # Detect device type from tensor arguments.
     # When trace_joint=True, args is (primals_list, tangents_list) — a nested tuple.
     # Flatten to get individual tensors before device inspection.
-    _devices = {
-        t.device.type
-        for t in pytree.arg_tree_leaves(*args)
-        if isinstance(t, torch.Tensor)
-    }
-    device_type = (
-        "cuda" if "cuda" in _devices else ("xpu" if "xpu" in _devices else "cuda")
-    )
+
+    device_type = _detect_rng_device_type(*args)
 
     fake_mode_det = detect_fake_mode()
     fake_mode: AbstractContextManager[Any] = nullcontext()

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -25,7 +25,7 @@ from torch import Tensor
 from torch._decomp.decompositions_for_rng import PhiloxStateTracker
 from torch._guards import detect_fake_mode
 from torch._opaque_base import OpaqueBase
-from torch._prims_common import CUDARngStateHelper
+from torch._prims_common import AcceleratorRngStateHelper
 from torch.fx.experimental.proxy_tensor import (
     _proxy_tensor_disable_update_tensor_tracker,
     get_proxy_mode,
@@ -512,6 +512,19 @@ def create_functionalized_rng_ops_wrapper(
     # It goes from (primals, tangents) to (seed, offset, primals, tangents)
     # At runtime, we pass on the current seed and offset. This is hidden from
     # the user.
+
+    # Detect device type from tensor arguments.
+    # When trace_joint=True, args is (primals_list, tangents_list) — a nested tuple.
+    # Flatten to get individual tensors before device inspection.
+    _devices = {
+        t.device.type
+        for t in pytree.arg_tree_leaves(*args)
+        if isinstance(t, torch.Tensor)
+    }
+    device_type = (
+        "cuda" if "cuda" in _devices else ("xpu" if "xpu" in _devices else "cuda")
+    )
+
     fake_mode_det = detect_fake_mode()
     fake_mode: AbstractContextManager[Any] = nullcontext()
     if fake_mode_det is not None:
@@ -562,26 +575,26 @@ def create_functionalized_rng_ops_wrapper(
         tuple[tuple[AOTOutput, ...], tuple[AOTOutput, ...]],
     ]:
         with (
-            patch("torch.cuda.get_rng_state", override_get_rng_state),
-            patch("torch.cuda.set_rng_state", override_set_rng_state),
+            patch(f"torch.{device_type}.get_rng_state", override_get_rng_state),
+            patch(f"torch.{device_type}.set_rng_state", override_set_rng_state),
         ):
             return append_rng_offsets(*func(primals, tangents))
 
     def traced_forward(*primals_fwd_seed_fwd_base_offset: Any) -> Any:
         # The signature is (*primals, seed, offset)
         with (
-            patch("torch.cuda.get_rng_state", override_get_rng_state),
-            patch("torch.cuda.set_rng_state", override_set_rng_state),
+            patch(f"torch.{device_type}.get_rng_state", override_get_rng_state),
+            patch(f"torch.{device_type}.set_rng_state", override_set_rng_state),
         ):
             return append_rng_offsets(*func(*primals_fwd_seed_fwd_base_offset[:-2]))
 
     if trace_joint:
         # Get the current seed and offset to setup tracing.
-        fwd_seed, fwd_base_offset = CUDARngStateHelper.get_torch_state_as_tuple(
-            fake_mode
+        fwd_seed, fwd_base_offset = AcceleratorRngStateHelper.get_torch_state_as_tuple(
+            fake_mode, device_type=device_type
         )
-        bwd_seed, bwd_base_offset = CUDARngStateHelper.get_torch_state_as_tuple(
-            fake_mode
+        bwd_seed, bwd_base_offset = AcceleratorRngStateHelper.get_torch_state_as_tuple(
+            fake_mode, device_type=device_type
         )
         PhiloxStateTracker.record_state(fwd_seed, fwd_base_offset, "forward")
         PhiloxStateTracker.record_state(bwd_seed, bwd_base_offset, "backward")
@@ -604,8 +617,8 @@ def create_functionalized_rng_ops_wrapper(
         )
     else:
         # Get the current seed and offset to setup tracing.
-        fwd_seed, fwd_base_offset = CUDARngStateHelper.get_torch_state_as_tuple(
-            fake_mode
+        fwd_seed, fwd_base_offset = AcceleratorRngStateHelper.get_torch_state_as_tuple(
+            fake_mode, device_type=device_type
         )
         PhiloxStateTracker.record_state(fwd_seed, fwd_base_offset, "forward")
         return (

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -517,8 +517,7 @@ def create_functionalized_rng_ops_wrapper(
     # Detect device type from tensor arguments.
     # When trace_joint=True, args is (primals_list, tangents_list) — a nested tuple.
     # Flatten to get individual tensors before device inspection.
-
-    device_type = _detect_rng_device_type(*args)
+    device_type = _detect_rng_device_type(pytree.arg_tree_leaves(*args))
 
     fake_mode_det = detect_fake_mode()
     fake_mode: AbstractContextManager[Any] = nullcontext()

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -92,6 +92,7 @@ from .subclass_utils import (
     wrap_tensor_subclasses,
 )
 from .utils import (
+    _detect_rng_device_type,
     call_and_expect_output_descs,
     call_func_at_runtime_with_args,
     make_boxed_func,
@@ -1143,12 +1144,6 @@ def _create_runtime_wrapper(
             return runtime_wrapper(*args, **kwargs)
 
     return _runtime_wrapper
-
-
-def _detect_rng_device_type(tensors: Sequence[Any]) -> str:
-    """Detect accelerator device type from an iterable of tensors."""
-    _devices = {t.device.type for t in tensors if isinstance(t, torch.Tensor)}
-    return "cuda" if "cuda" in _devices else ("xpu" if "xpu" in _devices else "cuda")
 
 
 # WARNING: this does NOT operate on TraceFn

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1173,7 +1173,7 @@ class FunctionalizedRngRuntimeWrapper(InductorWrapper):
                 raise AssertionError(
                     "fake_mode must not be None when functionalize_rng_ops is True"
                 )
-            # Detect device type once and store on metadata
+
             device_type = _detect_rng_device_type(flat_args)
             seed, offset = AcceleratorRngStateHelper.get_torch_state_as_tuple(
                 fake_mode, device_type=device_type

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -40,7 +40,7 @@ from torch._library.utils import is_builtin
 from torch._logging import getArtifactLogger
 from torch._opaque_base import OpaqueBase
 from torch._ops import OpOverload
-from torch._prims_common import CUDARngStateHelper
+from torch._prims_common import AcceleratorRngStateHelper
 from torch._subclasses import FakeTensor
 from torch.fx.experimental._backward_state import BackwardState
 from torch.fx.experimental.proxy_tensor import HANDLED_TYPES
@@ -1145,6 +1145,12 @@ def _create_runtime_wrapper(
     return _runtime_wrapper
 
 
+def _detect_rng_device_type(tensors: Sequence[Any]) -> str:
+    """Detect accelerator device type from an iterable of tensors."""
+    _devices = {t.device.type for t in tensors if isinstance(t, torch.Tensor)}
+    return "cuda" if "cuda" in _devices else ("xpu" if "xpu" in _devices else "cuda")
+
+
 # WARNING: this does NOT operate on TraceFn
 @dataclass
 class FunctionalizedRngRuntimeWrapper(InductorWrapper):
@@ -1172,7 +1178,11 @@ class FunctionalizedRngRuntimeWrapper(InductorWrapper):
                 raise AssertionError(
                     "fake_mode must not be None when functionalize_rng_ops is True"
                 )
-            seed, offset = CUDARngStateHelper.get_torch_state_as_tuple(fake_mode)
+            # Detect device type once and store on metadata
+            device_type = _detect_rng_device_type(flat_args)
+            seed, offset = AcceleratorRngStateHelper.get_torch_state_as_tuple(
+                fake_mode, device_type=device_type
+            )
             flat_args.extend([seed, offset])
             # We are not clearing flat_args here because
             # 1) There is a check in the debug compiler at the end
@@ -1197,10 +1207,11 @@ class FunctionalizedRngRuntimeWrapper(InductorWrapper):
 
         offset_index = runtime_metadata.num_forward_returns
         lines = ["def _functionalized_rng_wrapper(runtime_args):"]
-        lines.append("    seed, offset = _get_rng_state_()")
+        lines.append("    device_type = _detect_rng_device_type_(runtime_args)")
+        lines.append("    seed, offset = _get_rng_state_(device_type=device_type)")
         lines.append("    runtime_args.extend([seed, offset])")
         lines.append("    outs = _compiled_fn_(runtime_args)")
-        lines.append(f"    _set_offset_(outs[{offset_index}])")
+        lines.append(f"    _set_offset_(outs[{offset_index}], device_type=device_type)")
         if self.return_new_outs:
             lines.append(
                 f"    return outs[:{offset_index}] + outs[{offset_index + 1}:]"
@@ -1213,8 +1224,9 @@ class FunctionalizedRngRuntimeWrapper(InductorWrapper):
             source,
             {
                 "_compiled_fn_": compiled_fn,
-                "_get_rng_state_": CUDARngStateHelper.get_torch_state_as_tuple,
-                "_set_offset_": CUDARngStateHelper.set_new_offset,
+                "_detect_rng_device_type_": _detect_rng_device_type,
+                "_get_rng_state_": AcceleratorRngStateHelper.get_torch_state_as_tuple,
+                "_set_offset_": AcceleratorRngStateHelper.set_new_offset,
             },
             "_functionalized_rng_wrapper",
             "functionalized_rng_wrapper",
@@ -1230,6 +1242,7 @@ class FunctionalizedRngRuntimeWrapper(InductorWrapper):
         metadata: ViewAndMutationMeta,
         outs: Any,
         offset_index: int,
+        device_type: str = "cuda",
     ) -> Any:
         if metadata.is_rng_op_functionalized:
             if metadata.num_outputs_rng_offset != 1:
@@ -1237,7 +1250,9 @@ class FunctionalizedRngRuntimeWrapper(InductorWrapper):
                     f"expected num_outputs_rng_offset == 1, got {metadata.num_outputs_rng_offset}"
                 )
             new_rng_offset = outs[offset_index]
-            CUDARngStateHelper.set_new_offset(new_rng_offset)
+            AcceleratorRngStateHelper.set_new_offset(
+                new_rng_offset, device_type=device_type
+            )
             if self.return_new_outs:
                 user_outs = outs[:offset_index] + outs[offset_index + 1 :]
                 return user_outs
@@ -2973,8 +2988,10 @@ def _codegen_backward_prologue(
     if num_backward_tokens > 0:
         parts.append(f"*([None] * {num_backward_tokens})")
     if is_rng_op_functionalized:
-        G["_get_rng_state_"] = CUDARngStateHelper.get_torch_state_as_tuple
-        parts.append("*_get_rng_state_()")
+        G["_detect_rng_device_type_"] = _detect_rng_device_type
+        G["_get_rng_state_"] = AcceleratorRngStateHelper.get_torch_state_as_tuple
+        L.append("    _device_type = _detect_rng_device_type_(ctx_saved_tensors)")
+        parts.append("*_get_rng_state_(device_type=_device_type)")
     L.append(f"    all_args = [{', '.join(parts)}]")
     L.append("    del ctx_saved_tensors")
 
@@ -3057,9 +3074,11 @@ def _codegen_backward_epilogue(
             raise AssertionError(
                 f"expected num_outputs_rng_offset == 1, got {fw_metadata.num_outputs_rng_offset}"
             )
-        code_globals["_set_offset_"] = CUDARngStateHelper.set_new_offset
+        code_globals["_detect_rng_device_type_"] = _detect_rng_device_type
+        code_globals["_set_offset_"] = AcceleratorRngStateHelper.set_new_offset
         lines.append("    _oi = len(out) - 1")
-        lines.append("    _set_offset_(out[_oi])")
+        lines.append("    _device_type = _detect_rng_device_type_(out[:_oi])")
+        lines.append("    _set_offset_(out[_oi], device_type=_device_type)")
         lines.append("    out = out[:_oi] + out[_oi + 1:]")
 
     lines.append("    out = tuple(out)")

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -843,4 +843,9 @@ def _is_fwd_seed_offset(node: torch.fx.Node) -> bool:
 def _detect_rng_device_type(tensors: Sequence[Any]) -> str:
     """Detect accelerator device type from an iterable of tensors."""
     _devices = {t.device.type for t in tensors if isinstance(t, torch.Tensor)}
-    return "cuda" if "cuda" in _devices else ("xpu" if "xpu" in _devices else "cuda")
+    if "cuda" in _devices:
+        return "cuda"
+    elif "xpu" in _devices:
+        return "xpu"
+    else:
+        return "cpu"

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -838,3 +838,9 @@ def _is_fwd_seed_offset(node: torch.fx.Node) -> bool:
     return node.op == "placeholder" and (
         "fwd_seed" in str(node.target) or "fwd_base_offset" in str(node.target)
     )
+
+
+def _detect_rng_device_type(tensors: Sequence[Any]) -> str:
+    """Detect accelerator device type from an iterable of tensors."""
+    _devices = {t.device.type for t in tensors if isinstance(t, torch.Tensor)}
+    return "cuda" if "cuda" in _devices else ("xpu" if "xpu" in _devices else "cuda")

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -840,12 +840,11 @@ def _is_fwd_seed_offset(node: torch.fx.Node) -> bool:
     )
 
 
-def _detect_rng_device_type(tensors: Sequence[Any]) -> str:
-    """Detect accelerator device type from an iterable of tensors."""
+def _detect_rng_device_type(tensors: Sequence[Any]) -> str | None:
     _devices = {t.device.type for t in tensors if isinstance(t, torch.Tensor)}
     if "cuda" in _devices:
         return "cuda"
     elif "xpu" in _devices:
         return "xpu"
     else:
-        return "cpu"
+        return None

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -1,4 +1,6 @@
 # mypy: allow-untyped-defs
+from typing import cast
+
 import torch
 import torch.utils._pytree as pytree
 from torch import _prims
@@ -64,18 +66,17 @@ def philox_rand_offset(
     numel_scalar = 1
     for dim_size in shape:
         numel_scalar *= dim_size
-
     if device.type == "cuda":
+        numel = torch.scalar_tensor(numel_scalar, dtype=torch.int64)
         block_size = 256
         unroll = 4
         curand4_engine_calls = 4
         device_property = torch.cuda.get_device_properties(torch.cuda.current_device())
-        max_threads_per_processor = device_property.max_threads_per_multi_processor
-        processor_count = device_property.multi_processor_count
-        blocks_per_sm = max_threads_per_processor // block_size
-        grid_size = (numel_scalar + block_size - 1) // block_size
-        grid_size = min(grid_size, processor_count * blocks_per_sm)
-        result = ((numel_scalar - 1) // (block_size * grid_size * unroll) + 1) * curand4_engine_calls
+        blocks_per_sm = device_property.max_threads_per_multi_processor // block_size
+        num = cast(int, numel)
+        grid_size = (num + block_size - 1) // block_size
+        grid_size = min(grid_size, device_property.multi_processor_count * blocks_per_sm)
+        return ((num - 1) // (block_size * grid_size * unroll) + 1) * curand4_engine_calls
     elif device.type == "xpu":
         unroll = 4  # rand4_engine_calls are equal to unroll in XPU DistributionTemplates.h
         device_property = torch.xpu.get_device_properties(torch.xpu.current_device())

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -74,10 +74,16 @@ def philox_rand_offset(
         blocks_per_sm = device_property.max_threads_per_multi_processor // block_size
         num = cast(int, numel)
         grid_size = (num + block_size - 1) // block_size
-        grid_size = min(grid_size, device_property.multi_processor_count * blocks_per_sm)
-        return ((num - 1) // (block_size * grid_size * unroll) + 1) * curand4_engine_calls
+        grid_size = min(
+            grid_size, device_property.multi_processor_count * blocks_per_sm
+        )
+        return (
+            (num - 1) // (block_size * grid_size * unroll) + 1
+        ) * curand4_engine_calls
     elif device.type == "xpu":
-        unroll = 4  # rand4_engine_calls are equal to unroll in XPU DistributionTemplates.h
+        unroll = (
+            4  # rand4_engine_calls are equal to unroll in XPU DistributionTemplates.h
+        )
         device_property = torch.xpu.get_device_properties(torch.xpu.current_device())
         max_sub_group_size = max(device_property.sub_group_sizes)
         # group_size mirrors syclMaxWorkItemsPerSubSlice() in torch-xpu-ops

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -1,13 +1,11 @@
 # mypy: allow-untyped-defs
-from typing import cast
-
 import torch
 import torch.utils._pytree as pytree
 from torch import _prims
 from torch._C import DispatchKey
 from torch._higher_order_ops.utils import autograd_not_implemented
 from torch._ops import HigherOrderOperator
-from torch._prims_common import CUDARngStateHelper, make_contiguous_strides_for
+from torch._prims_common import AcceleratorRngStateHelper, make_contiguous_strides_for
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
@@ -17,11 +15,11 @@ from torch.fx.experimental.proxy_tensor import (
 from torch.types import _device, _dtype
 
 
-def throw_on_non_cuda(device):
+def throw_on_unsupported_rng_device(device):
     raise RuntimeError(
-        f"You are trying to functionalize a {device.type} RNG operator but {device.type} does not "
-        f"use Philox/counter-based RNG. Therefore, functionalizing a {device.type} RNG operator is "
-        "not supported. We are discussing the possibility of a Philox-based RNG implementation for CPU."
+        f"You are trying to functionalize a {device.type} RNG operator, but only cuda and xpu "
+        f"Philox/counter-based RNG functionalization is currently supported. We are discussing the "
+        f"possibility of a Philox-based RNG implementation for CPU."
     )
 
 
@@ -56,6 +54,7 @@ def philox_rand_offset_meta(
 
 def philox_rand_offset(
     shape: torch.Size,
+    device: _device,
 ):
     # For impl, look at the function calc_execution_policy in the file
     # aten/src/ATen/native/cuda/DistributionTemplates.h. The impl was copied at
@@ -63,17 +62,29 @@ def philox_rand_offset(
     numel_scalar = 1
     for dim_size in shape:
         numel_scalar *= dim_size
-    numel = torch.scalar_tensor(numel_scalar, dtype=torch.int64)
 
     block_size = 256
     unroll = 4
     curand4_engine_calls = 4
-    device_property = torch.cuda.get_device_properties(torch.cuda.current_device())
-    blocks_per_sm = device_property.max_threads_per_multi_processor // block_size
-    num = cast(int, numel)
+    if device.type == "cuda":
+        device_property = torch.cuda.get_device_properties(torch.cuda.current_device())
+        max_threads_per_processor = device_property.max_threads_per_multi_processor
+        processor_count = device_property.multi_processor_count
+    elif device.type == "xpu":
+        device_property = torch.xpu.get_device_properties(torch.xpu.current_device())
+        # TODO: XPU property mapping (max_work_group_size ≈ max_threads_per_multi_processor,
+        # max_compute_units ≈ multi_processor_count) is an approximation. XPU execution
+        # model differs from CUDA. Validate with XPU team.
+        max_threads_per_processor = device_property.max_work_group_size
+        processor_count = device_property.max_compute_units
+    else:
+        raise throw_on_unsupported_rng_device(device)
+    blocks_per_sm = max_threads_per_processor // block_size
+    num = numel_scalar
     grid_size = (num + block_size - 1) // block_size
-    grid_size = min(grid_size, device_property.multi_processor_count * blocks_per_sm)
-    return ((num - 1) // (block_size * grid_size * unroll) + 1) * curand4_engine_calls
+    grid_size = min(grid_size, processor_count * blocks_per_sm)
+    result = ((num - 1) // (block_size * grid_size * unroll) + 1) * curand4_engine_calls
+    return torch.scalar_tensor(result, dtype=torch.int64)
 
 
 def register_philox_rand():
@@ -114,14 +125,16 @@ def register_philox_rand():
         else:
             devices = [device]
 
-        if device.type != "cuda":
-            raise throw_on_non_cuda(device)
+        if device.type not in ("cuda", "xpu"):
+            raise throw_on_unsupported_rng_device(device)
 
-        with torch.random.fork_rng(devices):
-            CUDARngStateHelper.set_torch_state_tensor(seed, offset)
+        with torch.random.fork_rng(devices, device_type=device.type):
+            AcceleratorRngStateHelper.set_torch_state_tensor(
+                seed, offset, device_type=device.type
+            )
             random_values = torch.rand(shape, device=device, dtype=dtype)
 
-        return random_values, philox_rand_offset(shape)
+        return random_values, philox_rand_offset(shape, device)
 
     register_rng_prim(
         name=name,

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -65,27 +65,34 @@ def philox_rand_offset(
     for dim_size in shape:
         numel_scalar *= dim_size
 
-    block_size = 256
-    unroll = 4
-    curand4_engine_calls = 4
     if device.type == "cuda":
+        block_size = 256
+        unroll = 4
+        curand4_engine_calls = 4
         device_property = torch.cuda.get_device_properties(torch.cuda.current_device())
         max_threads_per_processor = device_property.max_threads_per_multi_processor
         processor_count = device_property.multi_processor_count
+        blocks_per_sm = max_threads_per_processor // block_size
+        grid_size = (numel_scalar + block_size - 1) // block_size
+        grid_size = min(grid_size, processor_count * blocks_per_sm)
+        result = ((numel_scalar - 1) // (block_size * grid_size * unroll) + 1) * curand4_engine_calls
     elif device.type == "xpu":
+        unroll = 4  # rand4_engine_calls are equal to unroll in XPU DistributionTemplates.h
         device_property = torch.xpu.get_device_properties(torch.xpu.current_device())
-        # TODO: XPU property mapping (max_work_group_size ≈ max_threads_per_multi_processor,
-        # max_compute_units ≈ multi_processor_count) is an approximation. XPU execution
-        # model differs from CUDA. Validate with XPU team.
-        max_threads_per_processor = device_property.max_work_group_size
-        processor_count = device_property.max_compute_units
+        max_sub_group_size = max(device_property.sub_group_sizes)
+        # group_size mirrors syclMaxWorkItemsPerSubSlice() in torch-xpu-ops
+        group_size = max_sub_group_size * device_property.gpu_eu_count_per_subslice
+        # hw_max_groups mirrors syclMaxWorkItemsPerTile() / group_size
+        max_work_items_per_tile = (
+            device_property.gpu_eu_count
+            * max_sub_group_size
+            * device_property.gpu_hw_threads_per_eu
+        )
+        hw_max_groups = max_work_items_per_tile // group_size
+        num_groups = min((numel_scalar + group_size - 1) // group_size, hw_max_groups)
+        result = ((numel_scalar - 1) // (group_size * num_groups * unroll) + 1) * unroll
     else:
         raise RuntimeError("Unexpected device type for philox_rand_offset: " + device.type)
-    blocks_per_sm = max_threads_per_processor // block_size
-    num = numel_scalar
-    grid_size = (num + block_size - 1) // block_size
-    grid_size = min(grid_size, processor_count * blocks_per_sm)
-    result = ((num - 1) // (block_size * grid_size * unroll) + 1) * curand4_engine_calls
     return torch.scalar_tensor(result, dtype=torch.int64)
 
 

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -16,11 +16,12 @@ from torch.types import _device, _dtype
 
 
 def throw_on_unsupported_rng_device(device):
-    raise RuntimeError(
-        f"You are trying to functionalize a {device.type} RNG operator, but only cuda and xpu "
-        f"Philox/counter-based RNG functionalization is currently supported. We are discussing the "
-        f"possibility of a Philox-based RNG implementation for CPU."
-    )
+    if device.type not in ("cuda", "xpu"):
+        raise RuntimeError(
+            f"You are trying to functionalize a {device.type} RNG operator, but only cuda and xpu "
+            f"Philox/counter-based RNG functionalization is currently supported. We are discussing the "
+            f"possibility of a Philox-based RNG implementation for CPU."
+        )
 
 
 def register_rng_prim(name, schema, impl_aten, impl_meta, doc, tags=None):
@@ -56,6 +57,7 @@ def philox_rand_offset(
     shape: torch.Size,
     device: _device,
 ):
+    throw_on_unsupported_rng_device(device)
     # For impl, look at the function calc_execution_policy in the file
     # aten/src/ATen/native/cuda/DistributionTemplates.h. The impl was copied at
     # commit hash 72aa0667bd16707d50eb8fa337092a1f5d11dfb6
@@ -78,7 +80,7 @@ def philox_rand_offset(
         max_threads_per_processor = device_property.max_work_group_size
         processor_count = device_property.max_compute_units
     else:
-        raise throw_on_unsupported_rng_device(device)
+        raise RuntimeError("Unexpected device type for philox_rand_offset: " + device.type)
     blocks_per_sm = max_threads_per_processor // block_size
     num = numel_scalar
     grid_size = (num + block_size - 1) // block_size
@@ -125,8 +127,7 @@ def register_philox_rand():
         else:
             devices = [device]
 
-        if device.type not in ("cuda", "xpu"):
-            raise throw_on_unsupported_rng_device(device)
+        throw_on_unsupported_rng_device(device)
 
         with torch.random.fork_rng(devices, device_type=device.type):
             AcceleratorRngStateHelper.set_torch_state_tensor(

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -59,7 +59,6 @@ def philox_rand_offset(
     shape: torch.Size,
     device: _device,
 ):
-    throw_on_unsupported_rng_device(device)
     # For impl, look at the function calc_execution_policy in the file
     # aten/src/ATen/native/cuda/DistributionTemplates.h. The impl was copied at
     # commit hash 72aa0667bd16707d50eb8fa337092a1f5d11dfb6
@@ -93,7 +92,7 @@ def philox_rand_offset(
         num_groups = min((numel_scalar + group_size - 1) // group_size, hw_max_groups)
         result = ((numel_scalar - 1) // (group_size * num_groups * unroll) + 1) * unroll
     else:
-        raise RuntimeError("Unexpected device type for philox_rand_offset: " + device.type)
+        raise throw_on_unsupported_rng_device(device)
     return torch.scalar_tensor(result, dtype=torch.int64)
 
 

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -2192,27 +2192,31 @@ def alert_not_deterministic(caller: str):
             )
 
 
-class CUDARngStateHelper:
+class AcceleratorRngStateHelper:
     @staticmethod
     def get_torch_state_as_tuple(
         fake_mode: AbstractContextManager[Any] = nullcontext(),
+        device_type: str = "cuda",
     ):
-        if not torch.cuda.is_available():
-            raise RuntimeError("CUDA not available")
+        if not getattr(torch, device_type).is_available():
+            raise RuntimeError(f"{device_type.upper()} not available")
 
         with fake_mode:
-            seed = torch.tensor(torch.cuda.initial_seed())
-            offset = torch.tensor(torch.cuda._get_rng_state_offset())
+            seed = torch.tensor(getattr(torch, device_type).initial_seed())
+            offset = torch.tensor(getattr(torch, device_type)._get_rng_state_offset())
             return seed, offset
 
     @staticmethod
-    def set_torch_state_tensor(seed, offset):
+    def set_torch_state_tensor(seed, offset, device_type: str = "cuda"):
         # Rng state is [64-bit seed, 64-bit offset]
         seed_portion = seed.reshape([1]).view(torch.uint8)
         offset_portion = offset.reshape([1]).view(torch.uint8)
         new_state = torch.cat([seed_portion, offset_portion])
-        torch.cuda.set_rng_state(new_state)
+        getattr(torch, device_type).set_rng_state(new_state)
 
     @staticmethod
-    def set_new_offset(relative_offset):
-        torch.cuda._set_rng_state_offset(relative_offset.item())
+    def set_new_offset(relative_offset, device_type: str = "cuda"):
+        getattr(torch, device_type)._set_rng_state_offset(relative_offset.item())
+
+
+CUDARngStateHelper = AcceleratorRngStateHelper  # Backward-compat alias

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -378,6 +378,8 @@ static void registerXpuDeviceProperties(PyObject* module) {
                    << ", memory_clock_rate=" << prop.memory_clock_rate
                    << "MHz, memory_bus_width=" << prop.memory_bus_width
                    << "-bit, gpu_eu_count=" << prop.gpu_eu_count
+                   << ", gpu_eu_count_per_subslice=" << prop.gpu_eu_count_per_subslice
+                   << ", gpu_hw_threads_per_eu=" << prop.gpu_hw_threads_per_eu
                    << ", gpu_subslice_count=" << gpu_subslice_count(prop)
                    << ", max_work_group_size=" << prop.max_work_group_size
                    << ", max_num_sub_groups=" << prop.max_num_sub_groups

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -334,6 +334,8 @@ static void registerXpuDeviceProperties(PyObject* module) {
       ._(version)                                                \
       ._(max_compute_units)                                      \
       ._(gpu_eu_count)                                           \
+      ._(gpu_eu_count_per_subslice)                              \
+      ._(gpu_hw_threads_per_eu)                                  \
       ._(max_work_group_size)                                    \
       ._(max_num_sub_groups)                                     \
       ._(memory_clock_rate)                                      \


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/3361.

This pull request extends RNG (random number generator) functionalization support from CUDA-only to both CUDA and XPU devices, and generalizes the supporting infrastructure accordingly. The main changes involve replacing CUDA-specific helpers and checks with device-agnostic ones, dynamically detecting the device type at runtime, and updating relevant decorators and test logic to use the new abstractions.

Key changes include:

**Device-Agnostic RNG Helpers and Device Detection:**

* Replaced all usages of `CUDARngStateHelper` with the new `AcceleratorRngStateHelper` throughout the codebase, making RNG state management compatible with both CUDA and XPU devices.
**Generalized Device Checks and RNG Logic:**

* Replaced CUDA-specific device checks (e.g., `throw_on_non_cuda`) with a generalized `throw_on_unsupported_rng_device` function, and updated all RNG decompositions and prims to use this new helper, ensuring only supported devices (CUDA, XPU) are accepted.

**Test and Decorator Updates:**

* Updated test decorators and test tensor creation to use device-agnostic logic (`@requires_gpu_and_triton` and `device=GPU_TYPE`) instead of CUDA-specific ones, so tests run correctly on both CUDA and XPU. 

**Code Generation and Runtime Wrappers:**

* Updated all code generation and runtime wrapper logic to pass and use the detected device type for RNG state management, ensuring correct behavior regardless of accelerator backend.

**Test File Maintenance:**

* Updated all test usages of the RNG state helper to use the new device-agnostic helper for consistency.

These changes collectively enable RNG functionalization to work seamlessly on both CUDA and XPU accelerators.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98