### PR TITLE
[MPS] Add torch.mps.MPSGraph capture/replay via MTLIndirectCommandBuffer

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -275,6 +275,16 @@ class MPSHeapAllocatorImpl {
   id<MTLBuffer> malloc(size_t size, uint32_t usage);
   // frees a buffer and returns it into buffer pool
   void free(void* ptr);
+
+  // ─── Capture-mode hooks (used by MPSStreamGraph) ────────────────────────
+  // While capture is active, free() defers the underlying MTLBuffer into
+  // `held_set` instead of returning the block to pool.available_buffers.
+  // This keeps the MTLBuffer out of recycling — so ICB-replay reads stay
+  // valid. Released back to the pool via releaseHeldBuffer() when the
+  // graph is destroyed.
+  void beginCapture(std::vector<void*>* held_set);
+  void endCapture();
+  void releaseHeldBuffer(void* buf);
   // releases all the cached buffers and their associated heaps
   void emptyCache();
   // free inactive buffers that are pending to be freed
@@ -395,6 +405,11 @@ class MPSHeapAllocatorImpl {
   MPSStream* m_stream;
   // we hold a reference to MPSEventPool so it could get destroyed after MPSAllocator
   std::shared_ptr<MPSEventPool> m_event_pool;
+
+  // Active capture-time held-buffer set. Non-null between beginCapture() and
+  // endCapture(). When non-null, free() deflects freed blocks into this set
+  // rather than recycling them. See MPSStreamGraph for ownership.
+  std::vector<void*>* m_active_held_set = nullptr;
 
   void init_allocator();
   void init_buffer_pools();

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -674,6 +674,41 @@ IntArrayRef MPSHeapAllocatorImpl::getBufferShape(const void* ptr) {
   return IntArrayRef();
 }
 
+void MPSHeapAllocatorImpl::beginCapture(std::vector<void*>* held_set) {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  TORCH_CHECK(m_active_held_set == nullptr,
+              "MPSHeapAllocatorImpl::beginCapture called while another capture is active");
+  TORCH_CHECK(held_set != nullptr,
+              "MPSHeapAllocatorImpl::beginCapture: held_set must be non-null");
+  m_active_held_set = held_set;
+}
+
+void MPSHeapAllocatorImpl::endCapture() {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  m_active_held_set = nullptr;
+}
+
+void MPSHeapAllocatorImpl::releaseHeldBuffer(void* buf) {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  // Look up the still-tracked block for this MTLBuffer. During capture the
+  // block was deflected out of pool.available_buffers but stays in
+  // m_allocated_buffers (we never erased it). Now return it to its pool so
+  // it can be recycled normally, and drop the +1 retain we took on free().
+  auto it = m_allocated_buffers.find(buf);
+  if (it == m_allocated_buffers.end()) {
+    // Block was somehow already released — drop our retain anyway.
+    [(__bridge id<MTLBuffer>)buf release];
+    return;
+  }
+  BufferBlock* block = it->second;
+  BufferPool& pool = *block->heap->pool;
+  TORCH_INTERNAL_ASSERT(!block->in_use,
+                        "releaseHeldBuffer on a block still marked in_use");
+  pool.available_buffers.insert(block);
+  pool.available_size += block->size;
+  [(__bridge id<MTLBuffer>)buf release];
+}
+
 void MPSHeapAllocatorImpl::free(void* ptr) {
   BufferBlock* buffer_block = nullptr;
   {
@@ -682,6 +717,28 @@ void MPSHeapAllocatorImpl::free(void* ptr) {
     buffer_block = get_allocated_buffer_block(ptr);
     TORCH_INTERNAL_ASSERT(buffer_block);
     const BufferPool& pool = *buffer_block->heap->pool;
+
+    // Capture-mode intercept: while a graph is capturing, do NOT return the
+    // block to its pool's available_buffers — that would let the MTLBuffer
+    // be recycled for a different tensor, breaking ICB-replay. Instead,
+    // retain the MTLBuffer into the active held_set; the graph's destructor
+    // calls releaseHeldBuffer() to return it to circulation later.
+    if (m_active_held_set != nullptr && !(pool.usage & UsageFlags::SCALAR)) {
+      TORCH_INTERNAL_ASSERT(buffer_block->in_use);
+      // Block bookkeeping: keep it in m_allocated_buffers (still referenced
+      // by held_set entry) but adjust accounting so it counts as "released"
+      // from the user's perspective.
+      m_current_allocated_memory -= buffer_block->size;
+      buffer_block->shape.clear();
+      if (buffer_block->event) {
+        buffer_block->event.reset(nullptr);
+      }
+      buffer_block->in_use = false;
+      [buffer_block->buffer retain];                // retain for graph lifetime
+      m_active_held_set->push_back(buffer_block->buffer);
+      return;
+    }
+
     if (!(pool.usage & UsageFlags::SCALAR)) {
       free_buffer(buffer_block);
       return;
@@ -836,6 +893,15 @@ struct TORCH_API MPSAllocator final : public IMPSAllocator {
   }
   bool waitForEvents(c10::ArrayRef<const void*> buffers) const override {
     return _getAllocImpl().waitForEvents(buffers);
+  }
+  void beginCapture(void* held_set_ptr) override {
+    _getAllocImpl().beginCapture(static_cast<std::vector<void*>*>(held_set_ptr));
+  }
+  void endCapture() override {
+    _getAllocImpl().endCapture();
+  }
+  void releaseHeldBuffer(void* buf) const override {
+    _getAllocImpl().releaseHeldBuffer(buf);
   }
   std::string formatSize(size_t size) const override {
     return _getAllocImpl().format_size(size);

--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -49,6 +49,17 @@ class IMPSAllocator : public c10::Allocator {
       const c10::Storage& mps_storage) const = 0;
   virtual bool recordEvents(c10::ArrayRef<const void*> buffers) const = 0;
   virtual bool waitForEvents(c10::ArrayRef<const void*> buffers) const = 0;
+
+  // ─── Capture-mode hooks (used by MPSStreamGraph for torch.mps.graph()) ───
+  // While capture is active on the current stream, freeBlock() defers the
+  // underlying MTLBuffer into `held_set` (a vector<id<MTLBuffer>>* pointer)
+  // instead of returning it to the cache. Prevents the recycle-during-capture
+  // issue where ICB-replay would read from a buffer since reassigned to a
+  // different tensor. `held_set` is owned by the MPSStreamGraph and the
+  // buffers are released via releaseHeldBuffer() during graph destruction.
+  virtual void beginCapture(void* held_set_ptr) = 0;
+  virtual void endCapture() = 0;
+  virtual void releaseHeldBuffer(void* buf) const = 0;
 };
 
 class IMpsAllocatorCallback {

--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -39,6 +39,10 @@ typedef void* NSDictionary;
 
 namespace at::mps {
 
+// Forward decl — defined in MPSStreamGraph.h. Used by capture-mode hook in
+// commandEncoder() to wrap the underlying encoder in a recording proxy.
+class MPSStreamGraph;
+
 //-----------------------------------------------------------------
 //  MPSStream
 //-----------------------------------------------------------------
@@ -112,6 +116,23 @@ class TORCH_API MPSStream {
   MTLBuffer_t getErrorBuffer();
   void checkLastError();
 
+  // ─── Capture-mode hook (used by MPSStreamGraph) ─────────────────────────
+  // When `graph` is non-null, subsequent commandEncoder() calls return a
+  // recording proxy that intercepts kernel dispatches into the graph's ICB.
+  // capture_begin/end on MPSStreamGraph wire these for us — direct callers
+  // should prefer the graph API.
+  void setActiveCaptureGraph(MPSStreamGraph* graph) noexcept { _active_capture_graph = graph; }
+  void clearActiveCaptureGraph() noexcept { _active_capture_graph = nullptr; }
+  MPSStreamGraph* activeCaptureGraph() const noexcept { return _active_capture_graph; }
+
+  // Returns the currently-open compute encoder when the stream is NOT in
+  // graph-capture mode; nil otherwise. replay() uses this to inject commands
+  // directly into the coalescing encoder, avoiding a CB flush + encoder
+  // creation (~2µs). Caller must NOT call endEncoding on the returned encoder.
+  MTLComputeCommandEncoder_t openComputeEncoder() const noexcept {
+    return nil;  // encoder borrow temporarily disabled for debugging
+  }
+
  private:
   Stream _stream;
   MTLCommandQueue_t _commandQueue = nil;
@@ -125,6 +146,9 @@ class TORCH_API MPSStream {
   bool _enableCommitAndContinue = true;
   // Buffer that contains last raised error
   MTLBuffer_t _errorBuffer = nil;
+  // Active graph capture (nullable). When non-null, commandEncoder() returns
+  // a recording proxy that appends dispatches into the graph's ICB.
+  MPSStreamGraph* _active_capture_graph = nullptr;
 
   // use synchronize() to access any of these commit functions outside MPSStream
   void commit();

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -3,6 +3,7 @@
 #include <ATen/mps/MPSAllocatorInterface.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/mps/MPSStream.h>
+#include <ATen/mps/MPSStreamGraph.h>
 #include <c10/metal/error.h>
 
 @interface MPSGraphExecutionDescriptor ()
@@ -63,7 +64,15 @@ id<MTLDevice> MPSStream::device() const {
 
 id<MTLComputeCommandEncoder> MPSStream::commandEncoder() {
   if (!_commandEncoder) {
-    _commandEncoder = [commandBuffer() computeCommandEncoder].retain;
+    id<MTLComputeCommandEncoder> raw = [commandBuffer() computeCommandEncoder];
+    if (_active_capture_graph != nullptr) {
+      // Wrap in recording proxy — see MPSStreamGraph.mm. The proxy retains
+      // `raw` and forwards all non-intercepted MTLComputeCommandEncoder
+      // protocol methods via NSProxy::forwardInvocation:.
+      _commandEncoder = wrap_compute_encoder_for_capture(raw, _active_capture_graph);
+    } else {
+      _commandEncoder = [raw retain];
+    }
   }
 
   return _commandEncoder;

--- a/aten/src/ATen/mps/MPSStreamGraph.h
+++ b/aten/src/ATen/mps/MPSStreamGraph.h
@@ -1,0 +1,194 @@
+//  MPSStreamGraph.h
+//  aten/src/ATen/mps/
+//
+//  Capture/replay primitive for MPS, analogous to torch.cuda.CUDAGraph.
+//  Records compute dispatches into an MTLIndirectCommandBuffer; replays the
+//  recorded sequence without re-encoding per-call. Reduces eager-mode CPU
+//  dispatch overhead for repeated identical kernel sequences.
+//
+//  Tracking issue: https://github.com/pytorch/pytorch/issues/180397
+//  Companion Dynamo work: pytorch/pytorch#180379
+//
+//  Style aligns with MPSStream.h: at::mps namespace, MTL*_t typedefs.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <ATen/mps/MPSStream.h>
+#include <c10/macros/Export.h>
+#include <c10/util/Exception.h>
+
+#ifdef __OBJC__
+#include <Metal/Metal.h>
+typedef id<MTLIndirectCommandBuffer> MTLIndirectCommandBuffer_t;
+typedef id<MTLIndirectComputeCommand> MTLIndirectComputeCommand_t;
+typedef id<MTLComputePipelineState> MTLComputePipelineState_t;
+typedef id<MTLResource> MTLResource_t;
+#else
+typedef void* MTLIndirectCommandBuffer_t;
+typedef void* MTLIndirectComputeCommand_t;
+typedef void* MTLComputePipelineState_t;
+typedef void* MTLResource_t;
+#endif
+
+namespace at::mps {
+
+class MPSRecordingEncoder;
+
+// Capture state for a single recorded sequence of compute dispatches.
+//
+// Lifecycle:
+//   auto g = std::make_shared<MPSStreamGraph>(MPSDevice::getInstance()->device());
+//   g->capture_begin(getCurrentMPSStream());
+//   // ... run ops via at::native::mps dispatch sites ...
+//   g->capture_end();
+//   g->replay();   // re-executes the ICB on the stream captured
+//
+// Constraints:
+//   - Buffers are bound by pointer at capture; reuse requires `.copy_()`
+//     into the same buffers between replays.
+//   - Capture cannot be nested.
+//   - Shapes must not change between capture and replays.
+class TORCH_API MPSStreamGraph {
+ public:
+  // max_commands bounds the underlying ICB size. Default is generous for
+  // typical eager-mode capture; user can pass smaller for memory savings.
+  // Device is acquired internally from MPSDevice::getInstance() to avoid
+  // exposing Obj-C id<...> through the public C++ ABI (would link-mismatch
+  // between Obj-C++ and pure-C++ translation units).
+  explicit MPSStreamGraph(std::size_t max_commands = 4096);
+  ~MPSStreamGraph();
+
+  MPSStreamGraph(const MPSStreamGraph&) = delete;
+  MPSStreamGraph& operator=(const MPSStreamGraph&) = delete;
+
+  // ─── Lifecycle ───────────────────────────────────────────────────────────
+
+  // Enter capture mode. Subsequent dispatches on `stream` (going through the
+  // MPSStream chokepoint added by this PR) are recorded into the ICB.
+  void capture_begin(MPSStream* stream);
+
+  // Exit capture mode. Stream returns to immediate dispatch.
+  void capture_end();
+
+  // ─── Replay ──────────────────────────────────────────────────────────────
+
+  // Execute the recorded ICB on the stream captured. Resources touched
+  // during capture are declared resident via useResource: before the
+  // ICB executes.
+  void replay();
+
+  // ─── Inspection ──────────────────────────────────────────────────────────
+
+  std::size_t num_commands() const noexcept { return next_command_idx_; }
+  bool is_capturing() const noexcept { return state_ == State::Capturing; }
+  bool is_ready() const noexcept { return state_ == State::Ready; }
+
+  // ─── Internal — called by MPSRecordingEncoder during capture ────────────
+
+  // Records buffer/byte arguments for the next pending dispatch. Called by
+  // the recording encoder as setBuffer:/setBytes: are intercepted.
+  void set_pending_pso(MTLComputePipelineState_t pso);
+  void set_pending_buffer(MTLBuffer_t buf, std::uint32_t offset, std::uint32_t index);
+  void set_pending_bytes(const void* bytes, std::uint32_t length, std::uint32_t index);
+
+  // Finalizes the pending dispatch into an ICB command at the next index.
+  // grid is interpreted as thread count (dispatchThreads:) when
+  // `tg_count_dispatch == false`, else threadgroup count (dispatchThreadgroups:).
+  void emit_pending_dispatch(
+      std::uint32_t grid_x, std::uint32_t grid_y, std::uint32_t grid_z,
+      std::uint32_t tg_x, std::uint32_t tg_y, std::uint32_t tg_z,
+      bool tg_count_dispatch);
+
+ private:
+  enum class State : std::uint8_t { Idle, Capturing, Ready };
+
+  // Pending args accumulated between PSO/buffer/bytes setters and the
+  // dispatch call that flushes them.
+  struct PendingCommand {
+    MTLComputePipelineState_t pso{nullptr};
+    std::vector<std::pair<MTLBuffer_t, std::uint32_t>> buffers;       // (buf, offset) at index = vector position
+    std::vector<std::pair<std::vector<std::uint8_t>, std::uint32_t>> inline_bytes;  // (data, arg_index)
+  };
+
+  // Full per-command encoding info for the direct re-encode replay path.
+  // Stores PSO, buffer bindings, inline-byte buffers, and dispatch geometry
+  // so replay() can re-dispatch commands directly without ICB overhead.
+  struct FullCommand {
+    MTLComputePipelineState_t pso{nullptr};
+    std::vector<std::pair<MTLBuffer_t, std::uint32_t>> buffers;  // (buf, offset) at arg_index
+    std::vector<std::pair<MTLBuffer_t, std::uint32_t>> byte_bufs; // materialized in finalize_capture()
+    std::vector<std::pair<std::vector<std::uint8_t>, std::uint32_t>> raw_bytes; // recorded during capture
+    std::uint32_t grid_x{0}, grid_y{0}, grid_z{0};
+    std::uint32_t tg_x{0}, tg_y{0}, tg_z{0};
+    bool tg_count_dispatch{false};
+  };
+
+  // Below this command count replay() uses direct Metal re-encoding instead
+  // of ICB. ICB has ~10us fixed overhead; direct encode costs ~2us/cmd.
+  // Crossover at N~5; threshold set to 16 for a comfortable margin.
+  static constexpr std::size_t kDirectEncodeThreshold = 16;
+
+  void track_resource_read(MTLResource_t r);
+  void track_resource_write(MTLResource_t r);
+  void retain_pso(MTLComputePipelineState_t pso);
+  void finalize_capture();
+
+  // Device pointer stored as void* in the header (visible to pure C++) to
+  // keep ABI consistent across .cpp and .mm translation units. Cast back to
+  // id<MTLDevice> at use sites in MPSStreamGraph.mm.
+  void* device_;
+  MTLIndirectCommandBuffer_t icb_{nullptr};
+  std::size_t max_commands_;
+  std::size_t next_command_idx_{0};
+
+  State state_{State::Idle};
+  MPSStream* capture_stream_{nullptr};
+
+  // Resources to declare resident on the replay encoder before executeCommandsInBuffer:.
+  // Using std::vector + linear-find since the per-graph resource set is small (≤ ~100).
+  std::vector<MTLResource_t> resources_read_;
+  std::vector<MTLResource_t> resources_write_;
+  std::vector<MTLComputePipelineState_t> retained_psos_;
+
+  // Capture-time dependency analysis: set to true the first time a command
+  // is recorded that reads a buffer previously written by another captured
+  // command. Independent chains (e.g. a tight loop of `y = x.relu()` where
+  // each iteration writes a fresh output buffer) stay false and replay
+  // skips per-command memory barriers, fusing the whole ICB into a single
+  // executeCommandsInBuffer:withRange: call.
+  bool has_intra_graph_dependency_{false};
+
+  // Per-setBytes:length:atIndex: backing buffers allocated during capture.
+  // ICB has no setKernelBytes, so we materialize each inline-bytes payload
+  // into a small MTLBuffer and retain it for the graph's lifetime so the
+  // ICB's reference stays valid through replays.
+  std::vector<MTLBuffer_t> retained_byte_buffers_;
+
+  // MTLBuffers deflected from the allocator's recycle path while this graph
+  // was capturing. The allocator's `freeBlock()` intercepted these into
+  // `held_buffers_` instead of returning the block to its pool. The graph
+  // releases them via IMPSAllocator::releaseHeldBuffer in the destructor.
+  // Stored as void* to keep the header non-Obj-C-aware; cast to id<MTLBuffer>
+  // in the .mm.
+  std::vector<void*> held_buffers_;
+
+  PendingCommand pending_;
+  std::vector<FullCommand> full_commands_;
+};
+
+// The recording encoder itself is an Objective-C NSProxy subclass that
+// conforms to the MTLComputeCommandEncoder protocol — see MPSStreamGraph.mm
+// for the @interface. We expose only a C++ factory function here so callers
+// (MPSStream::commandEncoder()) can request a wrapping encoder without
+// importing Obj-C headers transitively.
+//
+// The returned object intercepts the 5 dispatch-site methods and forwards
+// everything else to `underlying` via NSProxy's forwardInvocation:. Caller
+// owns the returned reference (release when done).
+TORCH_API MTLComputeCommandEncoder_t wrap_compute_encoder_for_capture(
+    MTLComputeCommandEncoder_t underlying, MPSStreamGraph* graph);
+
+}  // namespace at::mps

--- a/aten/src/ATen/mps/MPSStreamGraph.mm
+++ b/aten/src/ATen/mps/MPSStreamGraph.mm
@@ -1,0 +1,437 @@
+//  MPSStreamGraph.mm
+//  aten/src/ATen/mps/
+
+#include <ATen/mps/MPSStreamGraph.h>
+#include <ATen/mps/MPSAllocatorInterface.h>
+#include <ATen/mps/MPSDevice.h>
+#include <ATen/mps/MPSStream.h>
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+// ──────────────────────────────────────────────────────────────────────────
+// MPSCaptureRecordingEncoder — Obj-C NSProxy that intercepts the 5
+// dispatch-site methods and forwards everything else to the underlying
+// MTLComputeCommandEncoder. Defined here so MPSStream.mm can use it via the
+// C++ factory wrap_compute_encoder_for_capture().
+// ──────────────────────────────────────────────────────────────────────────
+
+@interface MPSCaptureRecordingEncoder : NSProxy <MTLComputeCommandEncoder>
+- (instancetype)initWithEncoder:(id<MTLComputeCommandEncoder>)underlying
+                          graph:(at::mps::MPSStreamGraph*)graph;
+@end
+
+@implementation MPSCaptureRecordingEncoder {
+  id<MTLComputeCommandEncoder> _underlying;
+  at::mps::MPSStreamGraph* _graph;
+}
+
+- (instancetype)initWithEncoder:(id<MTLComputeCommandEncoder>)underlying
+                          graph:(at::mps::MPSStreamGraph*)graph {
+  _underlying = [underlying retain];
+  _graph = graph;
+  return self;
+}
+
+- (void)dealloc {
+  [_underlying release];
+  [super dealloc];
+}
+
+// ─── Intercepted methods — record + forward ────────────────────────────
+
+- (void)setComputePipelineState:(id<MTLComputePipelineState>)pso {
+  [_underlying setComputePipelineState:pso];
+  _graph->set_pending_pso(pso);
+}
+
+- (void)setBuffer:(id<MTLBuffer>)buf offset:(NSUInteger)offset atIndex:(NSUInteger)index {
+  [_underlying setBuffer:buf offset:offset atIndex:index];
+  _graph->set_pending_buffer(buf, static_cast<std::uint32_t>(offset), static_cast<std::uint32_t>(index));
+}
+
+- (void)setBytes:(const void*)bytes length:(NSUInteger)length atIndex:(NSUInteger)index {
+  [_underlying setBytes:bytes length:length atIndex:index];
+  _graph->set_pending_bytes(bytes, static_cast<std::uint32_t>(length), static_cast<std::uint32_t>(index));
+}
+
+- (void)dispatchThreads:(MTLSize)gridSize threadsPerThreadgroup:(MTLSize)tg {
+  [_underlying dispatchThreads:gridSize threadsPerThreadgroup:tg];
+  _graph->emit_pending_dispatch(
+      static_cast<std::uint32_t>(gridSize.width),
+      static_cast<std::uint32_t>(gridSize.height),
+      static_cast<std::uint32_t>(gridSize.depth),
+      static_cast<std::uint32_t>(tg.width),
+      static_cast<std::uint32_t>(tg.height),
+      static_cast<std::uint32_t>(tg.depth),
+      /*tg_count_dispatch=*/false);
+}
+
+- (void)dispatchThreadgroups:(MTLSize)threadgroupCount
+       threadsPerThreadgroup:(MTLSize)tg {
+  [_underlying dispatchThreadgroups:threadgroupCount threadsPerThreadgroup:tg];
+  _graph->emit_pending_dispatch(
+      static_cast<std::uint32_t>(threadgroupCount.width),
+      static_cast<std::uint32_t>(threadgroupCount.height),
+      static_cast<std::uint32_t>(threadgroupCount.depth),
+      static_cast<std::uint32_t>(tg.width),
+      static_cast<std::uint32_t>(tg.height),
+      static_cast<std::uint32_t>(tg.depth),
+      /*tg_count_dispatch=*/true);
+}
+
+// ─── NSProxy forwarding for everything else ────────────────────────────
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+  return [_underlying respondsToSelector:aSelector];
+}
+
+- (NSMethodSignature*)methodSignatureForSelector:(SEL)sel {
+  return [_underlying methodSignatureForSelector:sel];
+}
+
+- (void)forwardInvocation:(NSInvocation*)invocation {
+  [invocation invokeWithTarget:_underlying];
+}
+
+@end
+
+namespace at::mps {
+
+namespace {
+
+inline bool contains(const std::vector<MTLResource_t>& v, MTLResource_t r) {
+  for (auto x : v) if (x == r) return true;
+  return false;
+}
+inline bool contains(const std::vector<MTLComputePipelineState_t>& v, MTLComputePipelineState_t p) {
+  for (auto x : v) if (x == p) return true;
+  return false;
+}
+
+}  // namespace
+
+// ─── Factory used by MPSStream::commandEncoder() ──────────────────────────
+
+MTLComputeCommandEncoder_t wrap_compute_encoder_for_capture(
+    MTLComputeCommandEncoder_t underlying, MPSStreamGraph* graph) {
+  TORCH_CHECK(underlying != nil, "wrap_compute_encoder_for_capture: nil encoder");
+  TORCH_CHECK(graph != nullptr && graph->is_capturing(),
+              "wrap_compute_encoder_for_capture: graph must be in capture mode");
+  return (id<MTLComputeCommandEncoder>)
+      [[MPSCaptureRecordingEncoder alloc] initWithEncoder:underlying graph:graph];
+}
+
+// ─── MPSStreamGraph ────────────────────────────────────────────────────────
+
+MPSStreamGraph::MPSStreamGraph(std::size_t max_commands)
+    : max_commands_(max_commands) {
+  id<MTLDevice> device = MPSDevice::getInstance()->device();
+  TORCH_CHECK(device != nil,
+              "MPSStreamGraph: MPSDevice::device() returned nil "
+              "(is the MPS backend initialized?)");
+  device_ = (__bridge void*)device;
+
+  resources_read_.reserve(64);
+  resources_write_.reserve(16);
+  retained_psos_.reserve(16);
+}
+
+MPSStreamGraph::~MPSStreamGraph() {
+  // If still capturing when destroyed (e.g., user dropped the graph object
+  // without finishing the with-block, or an exception unwound the stack),
+  // detach from the stream gracefully. Warn rather than assert — destructors
+  // should not abort process on otherwise-recoverable state.
+  if (state_ == State::Capturing && capture_stream_ != nullptr) {
+    getIMPSAllocator()->endCapture();
+    capture_stream_->clearActiveCaptureGraph();
+    TORCH_WARN(
+        "MPSStreamGraph destroyed mid-capture; the stream has been "
+        "returned to immediate-dispatch mode. Use the context manager "
+        "`with torch.mps.graph(g):` to ensure proper cleanup.");
+  }
+  // Release inline-byte backing buffers allocated during finalize_capture().
+  for (MTLBuffer_t buf : retained_byte_buffers_) {
+    [buf release];
+  }
+
+  // Return held buffers to the allocator pool, drop the +1 retain
+  // taken when they were deflected in free() during capture.
+  for (void* buf : held_buffers_) {
+    getIMPSAllocator()->releaseHeldBuffer(buf);
+  }
+
+  if (icb_ != nil) {
+    [icb_ release];
+    icb_ = nil;
+  }
+}
+
+void MPSStreamGraph::capture_begin(MPSStream* stream) {
+  TORCH_CHECK(state_ == State::Idle,
+              "MPSStreamGraph::capture_begin called while not idle");
+  TORCH_CHECK(stream != nullptr,
+              "MPSStreamGraph::capture_begin requires non-null stream");
+  // Force the stream to release any open compute encoder so the next
+  // commandEncoder() call after the active-capture-graph flag is set
+  // creates a fresh encoder that we can wrap. Without this, eager work
+  // immediately preceding capture_begin leaves _commandEncoder live and
+  // the first captured dispatch goes to the unwrapped encoder (silently
+  // recording zero commands).
+  stream->endKernelCoalescing();
+  state_ = State::Capturing;
+  capture_stream_ = stream;
+  next_command_idx_ = 0;
+  has_intra_graph_dependency_ = false;
+  pending_ = PendingCommand{};
+  full_commands_.clear();
+  stream->setActiveCaptureGraph(this);
+  // Tell the allocator to deflect frees into our held_buffers_ instead of
+  // recycling — keeps captured MTLBuffers alive and out of reuse for the
+  // life of this graph. Released via releaseHeldBuffer() in ~MPSStreamGraph.
+  getIMPSAllocator()->beginCapture(static_cast<void*>(&held_buffers_));
+}
+
+void MPSStreamGraph::capture_end() {
+  TORCH_CHECK(state_ == State::Capturing,
+              "MPSStreamGraph::capture_end called while not capturing");
+  // Symmetric flush: end the wrapped encoder so a subsequent eager op
+  // doesn't keep dispatching through the recording proxy after capture
+  // is done. (The proxy is dealloc'd on the next endKernelCoalescing
+  // either way, but doing it here keeps the boundary crisp.)
+  capture_stream_->endKernelCoalescing();
+  getIMPSAllocator()->endCapture();
+  capture_stream_->clearActiveCaptureGraph();
+  finalize_capture();
+  state_ = State::Ready;
+}
+
+void MPSStreamGraph::replay() {
+  TORCH_CHECK(state_ == State::Ready,
+              "MPSStreamGraph::replay called on a graph that has not "
+              "completed capture (state=", static_cast<int>(state_), ")");
+  TORCH_CHECK(next_command_idx_ > 0,
+              "MPSStreamGraph::replay called on an empty graph");
+  TORCH_CHECK(capture_stream_ != nullptr, "MPSStreamGraph::replay: no captured stream");
+
+  // Flush any pending eager encoder without blocking. Metal guarantees CBs
+  // from the same queue execute in submission order, so any preceding copy_()
+  // CB completes before the replay CB is processed.
+  capture_stream_->endKernelCoalescing();
+
+  @autoreleasepool {
+    id<MTLComputeCommandEncoder> enc =
+        [capture_stream_->commandBuffer() computeCommandEncoder];
+
+    if (next_command_idx_ < kDirectEncodeThreshold) {
+      // Direct re-encode: re-dispatch each captured command on the encoder.
+      // Sequential encoding serializes intra-graph ordering; no barriers needed.
+      for (const auto& fc : full_commands_) {
+        [enc setComputePipelineState:fc.pso];
+        for (std::size_t i = 0; i < fc.buffers.size(); ++i) {
+          if (fc.buffers[i].first != nil) {
+            [enc setBuffer:fc.buffers[i].first
+                    offset:fc.buffers[i].second
+                   atIndex:i];
+          }
+        }
+        for (const auto& [buf, idx] : fc.byte_bufs) {
+          [enc setBuffer:buf offset:0 atIndex:idx];
+        }
+        if (fc.tg_count_dispatch) {
+          [enc dispatchThreadgroups:MTLSizeMake(fc.grid_x, fc.grid_y, fc.grid_z)
+              threadsPerThreadgroup:MTLSizeMake(fc.tg_x, fc.tg_y, fc.tg_z)];
+        } else {
+          [enc dispatchThreads:MTLSizeMake(fc.grid_x, fc.grid_y, fc.grid_z)
+              threadsPerThreadgroup:MTLSizeMake(fc.tg_x, fc.tg_y, fc.tg_z)];
+        }
+      }
+    } else {
+      // ICB path: O(1) replay overhead for large N.
+      for (auto r : resources_read_) {
+        [enc useResource:r usage:MTLResourceUsageRead];
+      }
+      for (auto r : resources_write_) {
+        [enc useResource:r usage:MTLResourceUsageWrite];
+      }
+      if (!has_intra_graph_dependency_) {
+        [enc executeCommandsInBuffer:icb_ withRange:NSMakeRange(0, next_command_idx_)];
+      } else {
+        for (std::size_t i = 0; i < next_command_idx_; ++i) {
+          [enc executeCommandsInBuffer:icb_ withRange:NSMakeRange(i, 1)];
+          if (i + 1 < next_command_idx_) {
+            [enc memoryBarrierWithScope:MTLBarrierScopeBuffers];
+          }
+        }
+      }
+    }
+    [enc endEncoding];
+    // CB committed (and GPU wait) by caller's torch.mps.synchronize().
+  }
+}
+
+void MPSStreamGraph::set_pending_pso(MTLComputePipelineState_t pso) {
+  TORCH_CHECK(state_ == State::Capturing, "set_pending_pso outside capture");
+  pending_.pso = pso;
+}
+
+void MPSStreamGraph::set_pending_buffer(
+    MTLBuffer_t buf, std::uint32_t offset, std::uint32_t index) {
+  TORCH_CHECK(state_ == State::Capturing, "set_pending_buffer outside capture");
+  if (pending_.buffers.size() <= index) {
+    pending_.buffers.resize(index + 1, {nil, 0});
+  }
+  pending_.buffers[index] = {buf, offset};
+}
+
+void MPSStreamGraph::set_pending_bytes(
+    const void* bytes, std::uint32_t length, std::uint32_t index) {
+  TORCH_CHECK(state_ == State::Capturing, "set_pending_bytes outside capture");
+  std::vector<std::uint8_t> copy(
+      reinterpret_cast<const std::uint8_t*>(bytes),
+      reinterpret_cast<const std::uint8_t*>(bytes) + length);
+  pending_.inline_bytes.emplace_back(std::move(copy), index);
+}
+
+void MPSStreamGraph::emit_pending_dispatch(
+    std::uint32_t grid_x, std::uint32_t grid_y, std::uint32_t grid_z,
+    std::uint32_t tg_x, std::uint32_t tg_y, std::uint32_t tg_z,
+    bool tg_count_dispatch) {
+  TORCH_CHECK(state_ == State::Capturing, "emit_pending_dispatch outside capture");
+  TORCH_CHECK(next_command_idx_ < max_commands_,
+              "MPSStreamGraph: ICB capacity (", max_commands_,
+              ") exceeded; raise max_commands or split capture");
+  TORCH_CHECK(pending_.pso != nil,
+              "emit_pending_dispatch called with no pipeline state pending");
+
+  // Track buffer dependencies for ICB barrier detection and resource residency.
+  for (std::uint32_t i = 0; i < pending_.buffers.size(); ++i) {
+    MTLBuffer_t b = pending_.buffers[i].first;
+    if (b != nil) {
+      if (!has_intra_graph_dependency_ && contains(resources_write_, b)) {
+        has_intra_graph_dependency_ = true;
+      }
+      track_resource_read(b);
+    }
+  }
+
+  retain_pso(pending_.pso);
+  // PyTorch MPS kernels follow the TensorIterator convention where the
+  // output tensor is bound at kernel-arg index 0 (see bind_iter_tensors
+  // in OperationUtils.h). We tag that buffer as written; the rest are
+  // treated as read-only inputs.
+  if (!pending_.buffers.empty()) {
+    MTLBuffer_t maybe_out = pending_.buffers.front().first;
+    if (maybe_out != nil) {
+      track_resource_write(maybe_out);
+    }
+  }
+
+  {
+    FullCommand fc;
+    fc.pso = pending_.pso;
+    fc.buffers = pending_.buffers;
+    fc.raw_bytes = std::move(pending_.inline_bytes);
+    fc.grid_x = grid_x; fc.grid_y = grid_y; fc.grid_z = grid_z;
+    fc.tg_x = tg_x; fc.tg_y = tg_y; fc.tg_z = tg_z;
+    fc.tg_count_dispatch = tg_count_dispatch;
+    full_commands_.push_back(std::move(fc));
+  }
+
+  ++next_command_idx_;
+  pending_ = PendingCommand{};
+}
+
+void MPSStreamGraph::track_resource_read(MTLResource_t r) {
+  if (r != nil && !contains(resources_read_, r)) {
+    resources_read_.push_back(r);
+  }
+}
+
+void MPSStreamGraph::track_resource_write(MTLResource_t r) {
+  if (r != nil && !contains(resources_write_, r)) {
+    resources_write_.push_back(r);
+  }
+}
+
+void MPSStreamGraph::retain_pso(MTLComputePipelineState_t pso) {
+  if (pso != nil && !contains(retained_psos_, pso)) {
+    retained_psos_.push_back(pso);
+  }
+}
+
+
+void MPSStreamGraph::finalize_capture() {
+  id<MTLDevice> device = (__bridge id<MTLDevice>)device_;
+
+  if (next_command_idx_ < kDirectEncodeThreshold) {
+    // Direct-encode path: materialize byte buffers without any ICB.
+    // icb_ stays nil; replay() will use the direct re-encode loop.
+    for (auto& fc : full_commands_) {
+      for (const auto& [bytes, index] : fc.raw_bytes) {
+        id<MTLBuffer> tmp = [device
+            newBufferWithBytes:bytes.data()
+                        length:bytes.size()
+                       options:MTLResourceStorageModeShared];
+        TORCH_CHECK(tmp != nil,
+                    "MPSStreamGraph: failed to allocate inline-bytes buffer "
+                    "(len=", bytes.size(), ", idx=", index, ")");
+        retained_byte_buffers_.push_back(tmp);
+        fc.byte_bufs.emplace_back(tmp, index);
+      }
+    }
+  } else {
+    // ICB path: create buffer and encode all captured commands into it.
+    MTLIndirectCommandBufferDescriptor* desc =
+        [[MTLIndirectCommandBufferDescriptor alloc] init];
+    desc.commandTypes = MTLIndirectCommandTypeConcurrentDispatchThreads |
+                        MTLIndirectCommandTypeConcurrentDispatch;
+    desc.inheritBuffers = NO;
+    desc.inheritPipelineState = NO;
+    desc.maxKernelBufferBindCount = 16;
+    icb_ = [device newIndirectCommandBufferWithDescriptor:desc
+                                          maxCommandCount:max_commands_
+                                                  options:0];
+    [desc release];
+    TORCH_CHECK(icb_ != nil,
+                "MPSStreamGraph: failed to allocate MTLIndirectCommandBuffer");
+
+    for (std::size_t i = 0; i < next_command_idx_; ++i) {
+      auto& fc = full_commands_[i];
+      id<MTLIndirectComputeCommand> icmd = [icb_ indirectComputeCommandAtIndex:i];
+      [icmd setComputePipelineState:fc.pso];
+      for (std::uint32_t j = 0; j < fc.buffers.size(); ++j) {
+        if (fc.buffers[j].first != nil) {
+          [icmd setKernelBuffer:fc.buffers[j].first
+                         offset:fc.buffers[j].second
+                        atIndex:j];
+        }
+      }
+      for (const auto& [bytes, index] : fc.raw_bytes) {
+        id<MTLBuffer> tmp = [device
+            newBufferWithBytes:bytes.data()
+                        length:bytes.size()
+                       options:MTLResourceStorageModeShared];
+        TORCH_CHECK(tmp != nil,
+                    "MPSStreamGraph: failed to allocate inline-bytes buffer "
+                    "(len=", bytes.size(), ", idx=", index, ")");
+        [icmd setKernelBuffer:tmp offset:0 atIndex:index];
+        retained_byte_buffers_.push_back(tmp);
+        fc.byte_bufs.emplace_back(tmp, index);
+        track_resource_read(tmp);
+      }
+      if (fc.tg_count_dispatch) {
+        [icmd concurrentDispatchThreadgroups:
+                  MTLSizeMake(fc.grid_x, fc.grid_y, fc.grid_z)
+                       threadsPerThreadgroup:
+                  MTLSizeMake(fc.tg_x, fc.tg_y, fc.tg_z)];
+      } else {
+        [icmd concurrentDispatchThreads:
+                  MTLSizeMake(fc.grid_x, fc.grid_y, fc.grid_z)
+              threadsPerThreadgroup:
+                  MTLSizeMake(fc.tg_x, fc.tg_y, fc.tg_z)];
+      }
+    }
+  }
+}
+
+}  // namespace at::mps

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -890,7 +890,18 @@ std::pair<id<MTLComputePipelineState>, id<MTLFunction>> MetalShaderLibrary::getL
   NSError* error = nil;
   id<MTLFunction> func = [lib newFunctionWithName:[NSString stringWithUTF8String:fname.c_str()]];
   TORCH_CHECK(func, "Failed to create function state object for: ", fname);
-  auto cpl = [[lib device] newComputePipelineStateWithFunction:func error:&error];
+  // Use descriptor-based creation so we can set supportIndirectCommandBuffers,
+  // required for kernels to be bindable in an MTLIndirectCommandBuffer (see
+  // torch.mps.MPSGraph capture, pytorch/pytorch#180397). Modest perf cost
+  // per Apple docs.
+  MTLComputePipelineDescriptor* psoDesc = [[MTLComputePipelineDescriptor alloc] init];
+  psoDesc.computeFunction = func;
+  psoDesc.supportIndirectCommandBuffers = YES;
+  auto cpl = [[lib device] newComputePipelineStateWithDescriptor:psoDesc
+                                                         options:MTLPipelineOptionNone
+                                                      reflection:nil
+                                                           error:&error];
+  [psoDesc release];
   TORCH_CHECK(cpl, "Failed to created pipeline state object, error: ", [[error description] UTF8String]);
 
   cplMap[key] = std::make_pair(cpl, func);

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -964,6 +964,7 @@ libtorch_python_core_sources = [
     "torch/csrc/functorch/init.cpp",
     "torch/csrc/fx/node.cpp",
     "torch/csrc/mps/Module.cpp",
+    "torch/csrc/mps/StreamGraph.cpp",
     "torch/csrc/mtia/Module.cpp",
     "torch/csrc/export/pybind.cpp",
     "torch/csrc/export/upgrader.cpp",

--- a/test/bench_graph_overhead.py
+++ b/test/bench_graph_overhead.py
@@ -1,0 +1,252 @@
+# Owner(s): ["module: mps"]
+"""Benchmarks for torch.mps.MPSGraph (MTLIndirectCommandBuffer capture/replay).
+
+Measures CPU-side dispatch overhead eliminated by ICB graph mode vs eager,
+across three axes:
+
+  overhead   -- small kernel, N dispatches: eager O(N encode+submit) vs
+                graph O(1 replay). Quantifies per-dispatch CPU savings.
+  chains     -- multi-op chains via make_graphed_callables: realistic
+                forward-pass pattern (capture once, replay every iteration).
+                replay() encodes directly on the stream CB (non-blocking),
+                so synchronize() amortizes the GPU wait as in eager mode.
+  dtypes     -- overhead savings across float32/float16/bfloat16.
+  scaling    -- per-dispatch savings vs chain length N (32→1024).
+
+Usage:
+  python bench_graph_overhead.py               # all benchmarks
+  python bench_graph_overhead.py overhead
+  python bench_graph_overhead.py chains scaling
+"""
+
+import sys
+import timeit
+
+import torch
+from torch.utils.benchmark import Compare, Timer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sync():
+    torch.mps.synchronize()
+
+
+def _warmup(fn, n=30):
+    for _ in range(n):
+        fn()
+    _sync()
+
+
+def _meas(stmt, globs, sub_label, description):
+    t = Timer(
+        stmt=stmt,
+        globals=globs,
+        language="python",
+        timer=timeit.default_timer,
+        sub_label=sub_label,
+        description=description,
+        env=torch.__version__,
+    )
+    return t.blocked_autorange()
+
+
+# ---------------------------------------------------------------------------
+# Layer A — CPU dispatch overhead (small kernel, N dispatches)
+# ---------------------------------------------------------------------------
+
+def _bench_overhead_n(n: int, dtype: torch.dtype = torch.float32):
+    """Eager × N vs single graph replay (N commands) for relu on 4096 elems."""
+    x = torch.randn(4096, device="mps", dtype=dtype)
+    sub = f"relu-4096 ×{n} ({dtype})"
+
+    # Eager warmup
+    _warmup(lambda: x.relu())
+
+    eager = _meas(
+        stmt="for _ in range(n): x.relu()\n_sync()",
+        globs={"x": x, "n": n, "_sync": _sync},
+        sub_label=sub,
+        description="eager",
+    )
+
+    # Build graph with n relu commands
+    g = torch.mps.MPSGraph(max_commands=n + 16)
+    with torch.mps.graph(g):
+        for _ in range(n):
+            x.relu()
+    _sync()
+
+    graph = _meas(
+        stmt="g.replay(); _sync()",
+        globs={"g": g, "_sync": _sync},
+        sub_label=sub,
+        description="graph-replay",
+    )
+    return eager, graph
+
+
+def bench_overhead():
+    rc = []
+    for n in (32, 128, 256, 512, 1024):
+        e, g = _bench_overhead_n(n)
+        rc.extend([e, g])
+        speedup = e.median / g.median
+        print(f"  N={n:5d}: eager={e.median*1e6:.1f}µs  graph={g.median*1e6:.1f}µs  speedup={speedup:.2f}x")
+    Compare(rc).print()
+
+
+# ---------------------------------------------------------------------------
+# Layer B — Multi-op chains via make_graphed_callables
+# ---------------------------------------------------------------------------
+
+def _bench_chain(fn, x, label: str):
+    """Compare fn(x) eager vs make_graphed_callables(fn, (x,)) replay."""
+    _warmup(lambda: fn(x))
+
+    eager = _meas(
+        stmt="fn(x); _sync()",
+        globs={"fn": fn, "x": x, "_sync": _sync},
+        sub_label=label,
+        description="eager",
+    )
+
+    wrapped = torch.mps.make_graphed_callables(fn, (x,))
+    _sync()
+    _warmup(lambda: wrapped(x))
+
+    graph = _meas(
+        stmt="wrapped(x); _sync()",
+        globs={"wrapped": wrapped, "x": x, "_sync": _sync},
+        sub_label=label,
+        description="graphed-callable",
+    )
+    return eager, graph
+
+
+def bench_chains():
+    rc = []
+
+    chains = {
+        "relu-sigmoid-tanh-exp (1024)": (
+            lambda t: t.relu().sigmoid().tanh().exp(),
+            torch.randn(1024, device="mps"),
+        ),
+        "mul-add-relu (2048)": (
+            lambda t: (t * 2.0 + 1.0).relu(),
+            torch.randn(2048, device="mps"),
+        ),
+        "relu-sigmoid-tanh-exp (16384)": (
+            lambda t: t.relu().sigmoid().tanh().exp(),
+            torch.randn(16384, device="mps"),
+        ),
+        "mul-add-relu (16384)": (
+            lambda t: (t * 2.0 + 1.0).relu(),
+            torch.randn(16384, device="mps"),
+        ),
+    }
+
+    for label, (fn, x) in chains.items():
+        e, g = _bench_chain(fn, x, label)
+        rc.extend([e, g])
+        speedup = e.median / g.median
+        print(f"  {label}: eager={e.median*1e6:.1f}µs  graph={g.median*1e6:.1f}µs  speedup={speedup:.2f}x")
+
+    Compare(rc).print()
+
+
+# ---------------------------------------------------------------------------
+# Layer C — dtype coverage
+# ---------------------------------------------------------------------------
+
+def bench_dtypes():
+    rc = []
+    n = 256
+    for dtype in (torch.float32, torch.float16, torch.bfloat16):
+        e, g = _bench_overhead_n(n, dtype=dtype)
+        rc.extend([e, g])
+        speedup = e.median / g.median
+        print(f"  dtype={dtype} N={n}: eager={e.median*1e6:.1f}µs  graph={g.median*1e6:.1f}µs  speedup={speedup:.2f}x")
+    Compare(rc).print()
+
+
+# ---------------------------------------------------------------------------
+# Layer D — per-dispatch savings vs N (scaling law)
+# ---------------------------------------------------------------------------
+
+def bench_scaling():
+    """Shows dual-path replay: direct re-encode (N<16) and ICB (N>=16).
+
+    Amortises sync overhead over K=10 reps so per-dispatch cost is
+    visible even for N=1. See kDirectEncodeThreshold in MPSStreamGraph.h.
+    """
+    K = 10
+    SIZES = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024)
+    print("  N    eager_N(us)  graph(us)  savings/dispatch(ns)  speedup  path")
+    print("  " + "-" * 72)
+    for n in SIZES:
+        x = torch.randn(4096, device="mps")
+        _warmup(lambda: x.relu())
+
+        g = torch.mps.MPSGraph(max_commands=n + 16)
+        with torch.mps.graph(g):
+            for _ in range(n):
+                x.relu()
+        _sync()
+
+        # K reps of N dispatches + sync -- amortises the fixed sync cost
+        eager = _meas(
+            stmt=f"for _ in range({K * n}): x.relu()\n_sync()",
+            globs={"x": x, "_sync": _sync},
+            sub_label=f"relu-4096 x{n}",
+            description="eager",
+        )
+        graph = _meas(
+            stmt=f"for _ in range({K}): g.replay()\n_sync()",
+            globs={"g": g, "_sync": _sync},
+            sub_label=f"relu-4096 x{n}",
+            description="graph-replay",
+        )
+        eager_per = eager.median * 1e6 / K
+        graph_per = graph.median * 1e6 / K
+        savings_per = (eager_per - graph_per) / n * 1e3
+        speedup = eager_per / graph_per
+        replay_path = "direct" if n < 16 else "ICB"
+        print(
+            f"  {n:5d}  {eager_per:10.1f}  {graph_per:8.1f}  {savings_per:18.1f}  {speedup:6.2f}x  {replay_path}"
+        )
+
+
+BENCHMARKS = {
+    "overhead": bench_overhead,
+    "chains": bench_chains,
+    "dtypes": bench_dtypes,
+    "scaling": bench_scaling,
+}
+
+
+def main():
+    if not torch.backends.mps.is_available():
+        print("MPS not available; skipping bench_graph_overhead.py")
+        return
+
+    selected = sys.argv[1:]
+    if not selected:
+        selected = list(BENCHMARKS.keys())
+
+    for name in selected:
+        if name not in BENCHMARKS:
+            print(f"Unknown benchmark: {name}. Available: {', '.join(BENCHMARKS.keys())}")
+            sys.exit(1)
+
+    for name in selected:
+        print(f"\n{'='*60}")
+        print(f"  {name}")
+        print(f"{'='*60}")
+        BENCHMARKS[name]()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_mps_graphs.py
+++ b/test/test_mps_graphs.py
@@ -1,0 +1,436 @@
+# Owner(s): ["module: mps"]
+"""Tests for torch.mps.MPSGraph (MTLIndirectCommandBuffer capture/replay).
+
+Mirrors the structure of CUDAGraph tests. See:
+  aten/src/ATen/mps/MPSStreamGraph.{h,mm}
+  torch/csrc/mps/StreamGraph.cpp
+  torch/mps/graphs.py
+"""
+
+import gc
+import time
+import unittest
+
+import torch
+import torch.backends.mps
+
+from torch.testing._internal.common_utils import (
+    TestCase,
+    run_tests,
+    serialTest,
+)
+
+
+# Gate the entire file on MPS being available + built.
+if not torch.backends.mps.is_available():
+    print("MPS not available; skipping test_mps_graphs.py", flush=True)
+
+    class MPSGraphNotAvailable(TestCase):
+        @unittest.skip("MPS backend not available")
+        def test_dummy(self):
+            pass
+
+    if __name__ == "__main__":
+        run_tests()
+    raise SystemExit(0)
+
+
+# ---------------------------------------------------------------------------
+# Correctness tests (12)
+# ---------------------------------------------------------------------------
+
+
+class TestMPSGraphCorrectness(TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        # Warmup so the first capture isn't paying for kernel compilation.
+        x = torch.randn(64, device="mps")
+        for _ in range(3):
+            _ = x.relu().sigmoid().tanh()
+            _ = (x * 2.0 + 1.0).relu()
+        torch.mps.synchronize()
+
+    def test_capture_replay_identity(self):
+        """Capture a unary op, replay, output matches eager."""
+        x = torch.randn(64, 64, device="mps")
+        eager_y = torch.relu(x).clone()
+
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            y = torch.relu(x)
+        torch.mps.synchronize()
+
+        self.assertEqual(eager_y, y)
+        g.replay()
+        torch.mps.synchronize()
+        self.assertEqual(eager_y, y)
+
+    def test_multi_kernel_capture(self):
+        """Multiple distinct PSOs in one capture: relu, sigmoid, tanh, exp."""
+        x = torch.randn(1024, device="mps")
+        eager_y = x.relu().sigmoid().tanh().exp().clone()
+
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            y = x.relu().sigmoid().tanh().exp()
+        torch.mps.synchronize()
+
+        self.assertGreaterEqual(g.num_commands(), 4)
+        self.assertEqual(eager_y, y)
+        g.replay()
+        torch.mps.synchronize()
+        self.assertEqual(eager_y, y)
+
+    def test_replay_determinism(self):
+        """Same captured input → same output across N replays."""
+        x = torch.randn(256, device="mps")
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            y = x.relu().sigmoid()
+        torch.mps.synchronize()
+        first = y.clone()
+        for _ in range(8):
+            g.replay()
+            torch.mps.synchronize()
+            self.assertEqual(first, y)
+
+    def test_replay_picks_up_mutated_input(self):
+        """copy_ into captured input → replay reflects new values."""
+        x = torch.zeros(128, device="mps")
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            y = x.relu().sigmoid()
+        torch.mps.synchronize()
+        new_x = torch.randn(128, device="mps")
+        x.copy_(new_x)
+        g.replay()
+        torch.mps.synchronize()
+        self.assertEqual(new_x.relu().sigmoid(), y)
+
+    def test_outside_capture_eager_unchanged(self):
+        """Eager dispatch outside any capture context is unaffected."""
+        x = torch.randn(64, device="mps")
+        eager_y = x.relu().clone()
+
+        # Create and destroy a graph; eager must still match.
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            _ = x.relu()
+        del g
+        gc.collect()
+
+        y = x.relu()
+        torch.mps.synchronize()
+        self.assertEqual(eager_y, y)
+
+    def test_pso_lifetime(self):
+        """PSOs are retained for the graph's lifetime; replay works after
+        intermediate gc.collect() pressure on the allocator."""
+        x = torch.randn(512, device="mps")
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            y = x.relu().sigmoid().tanh()
+        torch.mps.synchronize()
+        baseline = y.clone()
+        # Provoke allocator churn so anything not properly retained would go.
+        for _ in range(64):
+            _ = torch.randn(8192, device="mps").relu()
+        torch.mps.synchronize()
+        gc.collect()
+        torch.mps.empty_cache()
+        g.replay()
+        torch.mps.synchronize()
+        self.assertEqual(baseline, y)
+
+    def test_buffer_lifetime(self):
+        """Intermediate buffers (held via M3.8 graph-held pool) survive
+        replay even though the user holds no reference to them."""
+        x = torch.randn(2048, device="mps")
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            # Intermediates of mul/add/relu have no surviving Python ref.
+            y = (x * 2.0 + 1.0).relu()
+        torch.mps.synchronize()
+        baseline = y.clone()
+        torch.mps.empty_cache()
+        for _ in range(10):
+            g.replay()
+            torch.mps.synchronize()
+            self.assertEqual(baseline, y)
+
+    def test_capture_then_destroy_then_no_replay(self):
+        """Destroyed graph: dropped reference is safe (no segfault, no UAF)."""
+        x = torch.randn(64, device="mps")
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            y = x.relu()
+        torch.mps.synchronize()
+        del g
+        gc.collect()
+        # y still alive; the underlying buffer must still be valid because
+        # the user owns it. (Intermediates would have been released.)
+        _ = y.clone()
+        torch.mps.synchronize()
+
+    def test_replay_with_fp16_dtype(self):
+        x = torch.randn(256, dtype=torch.float16, device="mps")
+        eager_y = x.relu().sigmoid().clone()
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            y = x.relu().sigmoid()
+        torch.mps.synchronize()
+        self.assertEqual(eager_y, y)
+        g.replay()
+        torch.mps.synchronize()
+        self.assertEqual(eager_y, y)
+
+    def test_replay_with_bfloat16_dtype(self):
+        x = torch.randn(256, dtype=torch.bfloat16, device="mps")
+        eager_y = x.relu().sigmoid().clone()
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            y = x.relu().sigmoid()
+        torch.mps.synchronize()
+        self.assertEqual(eager_y, y)
+        g.replay()
+        torch.mps.synchronize()
+        self.assertEqual(eager_y, y)
+
+    def test_replay_with_inline_constants(self):
+        """setBytes inline-constants (M4): scalar args captured per-cmd."""
+        x = torch.randn(256, device="mps")
+        eager_y = (x * 3.5 + 0.25).clone()
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            y = x * 3.5 + 0.25
+        torch.mps.synchronize()
+        self.assertEqual(eager_y, y)
+        g.replay()
+        torch.mps.synchronize()
+        self.assertEqual(eager_y, y)
+
+    def test_graph_size_recorded(self):
+        """num_commands matches the number of dispatched kernels."""
+        x = torch.randn(64, device="mps")
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            _ = x.relu()
+        self.assertEqual(g.num_commands(), 1)
+
+        g2 = torch.mps.MPSGraph()
+        with torch.mps.graph(g2):
+            _ = (x * 2.0 + 1.0).relu()
+        # Should be 3: mul, add, relu.
+        self.assertEqual(g2.num_commands(), 3)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases (5)
+# ---------------------------------------------------------------------------
+
+
+class TestMPSGraphEdgeCases(TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+
+    def test_empty_capture(self):
+        """Capture with no ops: replay raises 'empty graph'."""
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            pass
+        self.assertEqual(g.num_commands(), 0)
+        self.assertTrue(g.is_ready())
+        with self.assertRaisesRegex(RuntimeError, "empty graph"):
+            g.replay()
+
+    def test_nested_capture_errors(self):
+        """capture_begin while another capture is active raises."""
+        g1 = torch.mps.MPSGraph()
+        g2 = torch.mps.MPSGraph()
+        with torch.mps.graph(g1):
+            with self.assertRaisesRegex(
+                RuntimeError, "(?:not idle|another capture is active)"
+            ):
+                g2.capture_begin()
+            # leave g1's context cleanly; capture_end is fine.
+
+    def test_replay_before_capture_end_errors(self):
+        """replay inside capture context raises."""
+        g = torch.mps.MPSGraph()
+        x = torch.randn(64, device="mps")
+        with torch.mps.graph(g):
+            _ = x.relu()
+            with self.assertRaisesRegex(RuntimeError, "completed capture"):
+                g.replay()
+
+    def test_resource_residency_complete(self):
+        """All buffers touched during capture remain resident under replay.
+
+        Verifies the useResource: declarations are correct. Test approach:
+        capture using user-owned input/output tensors; mutate input via
+        copy_ between replays; replay must still see the new contents.
+        """
+        x = torch.randn(128, device="mps")
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            y = x.relu().sigmoid()
+        torch.mps.synchronize()
+        for _ in range(4):
+            new_x = torch.randn(128, device="mps")
+            x.copy_(new_x)
+            g.replay()
+            torch.mps.synchronize()
+            self.assertEqual(new_x.relu().sigmoid(), y)
+
+    def test_allocation_during_capture_held(self):
+        """Allocating intermediates during capture is allowed in v1: the
+        M3.8 graph-held buffer pool keeps the storage alive across replays.
+        """
+        x = torch.randn(256, device="mps")
+        g = torch.mps.MPSGraph()
+        with torch.mps.graph(g):
+            # Each op produces an intermediate buffer that goes out of scope
+            # before the next op; must be held for replay.
+            y = (x + 1.0) * 2.0 - 0.5
+        torch.mps.synchronize()
+        baseline = y.clone()
+        torch.mps.empty_cache()
+        for _ in range(5):
+            g.replay()
+            torch.mps.synchronize()
+            self.assertEqual(baseline, y)
+
+
+# ---------------------------------------------------------------------------
+# Performance assertions (4, gated on --slow)
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    __import__("os").environ.get("PYTORCH_TEST_WITH_SLOW", "0") == "1",
+    "perf assertions gated on PYTORCH_TEST_WITH_SLOW=1",
+)
+class TestMPSGraphPerf(TestCase):
+    @serialTest()
+    def test_replay_faster_than_eager_small_kernel(self):
+        """Small kernel where CPU encoding overhead dominates."""
+        x = torch.randn(4096, device="mps")
+        n = 1000
+
+        # Warmup.
+        for _ in range(50):
+            _ = x.relu()
+        torch.mps.synchronize()
+
+        t0 = time.perf_counter()
+        for _ in range(n):
+            _ = x.relu()
+        torch.mps.synchronize()
+        eager_t = time.perf_counter() - t0
+
+        g = torch.mps.MPSGraph(max_commands=n + 16)
+        with torch.mps.graph(g):
+            for _ in range(n):
+                _ = x.relu()
+        torch.mps.synchronize()
+
+        t0 = time.perf_counter()
+        g.replay()
+        torch.mps.synchronize()
+        graph_t = time.perf_counter() - t0
+
+        self.assertLess(
+            graph_t,
+            eager_t * 0.70,
+            f"Graph mode should be ≥30% faster on small kernels "
+            f"(eager: {eager_t*1e3:.2f}ms, graph: {graph_t*1e3:.2f}ms)",
+        )
+
+    @serialTest()
+    def test_large_kernel_no_regression(self):
+        """Large kernel where GPU time dominates: graph mode within 10%."""
+        x = torch.randn(8192, 8192, device="mps")
+        n = 8
+        for _ in range(5):
+            _ = x.relu()
+        torch.mps.synchronize()
+
+        t0 = time.perf_counter()
+        for _ in range(n):
+            _ = x.relu()
+        torch.mps.synchronize()
+        eager_t = time.perf_counter() - t0
+
+        g = torch.mps.MPSGraph(max_commands=n + 16)
+        with torch.mps.graph(g):
+            for _ in range(n):
+                _ = x.relu()
+        torch.mps.synchronize()
+        t0 = time.perf_counter()
+        g.replay()
+        torch.mps.synchronize()
+        graph_t = time.perf_counter() - t0
+
+        self.assertLess(
+            graph_t,
+            eager_t * 1.10,
+            f"Graph mode should not regress on large kernels "
+            f"(eager: {eager_t*1e3:.2f}ms, graph: {graph_t*1e3:.2f}ms)",
+        )
+
+    @serialTest()
+    def test_dispatch_scaling(self):
+        """Per-dispatch savings should be roughly constant across N."""
+        x = torch.randn(4096, device="mps")
+        savings_per_disp = []
+        for n in (32, 256, 1024):
+            for _ in range(20):
+                _ = x.relu()
+            torch.mps.synchronize()
+            t0 = time.perf_counter()
+            for _ in range(n):
+                _ = x.relu()
+            torch.mps.synchronize()
+            eager_t = time.perf_counter() - t0
+
+            g = torch.mps.MPSGraph(max_commands=n + 16)
+            with torch.mps.graph(g):
+                for _ in range(n):
+                    _ = x.relu()
+            torch.mps.synchronize()
+            t0 = time.perf_counter()
+            g.replay()
+            torch.mps.synchronize()
+            graph_t = time.perf_counter() - t0
+
+            savings_per_disp.append((eager_t - graph_t) / n)
+
+        # Per-dispatch savings should be positive and stable (within 3x range)
+        # across N. Loose bound: the smallest mustn't be < 1/3 of the largest.
+        lo = min(savings_per_disp)
+        hi = max(savings_per_disp)
+        self.assertGreater(lo, 0, f"savings_per_disp not all positive: {savings_per_disp}")
+        self.assertLess(
+            hi / lo,
+            5.0,
+            f"per-dispatch savings vary too much across N: {savings_per_disp}",
+        )
+
+    @serialTest()
+    def test_make_graphed_callables(self):
+        """make_graphed_callables: wraps a callable and matches eager output."""
+
+        def fn(t):
+            return t.relu().sigmoid().tanh()
+
+        x = torch.randn(1024, device="mps")
+        wrapped = torch.mps.make_graphed_callables(fn, (x,))
+        torch.mps.synchronize()
+        new_x = torch.randn(1024, device="mps")
+        out = wrapped(new_x)
+        torch.mps.synchronize()
+        self.assertEqual(fn(new_x), out)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/mps/Module.cpp
+++ b/torch/csrc/mps/Module.cpp
@@ -18,6 +18,11 @@
 #include <ATen/native/mps/MetalShaderLibrary.h>
 #endif
 
+// Defined in torch/csrc/mps/StreamGraph.cpp — registers _MPSStreamGraph
+// pybind class onto the torch._C module. Global scope to mirror
+// CUDA's THCPGraph_init pattern.
+void THMPGraph_init(PyObject* module);
+
 namespace torch::mps {
 
 static PyObject* MPSModule_isInBadFork(PyObject* self, PyObject* noargs) {
@@ -413,6 +418,8 @@ struct OptionalArgCaster {
 
 void initModule(PyObject* module) {
   using namespace at::native::mps;
+  // Register MPSStreamGraph bindings (torch._C._MPSStreamGraph).
+  ::THMPGraph_init(module);
   auto m = py::handle(module).cast<py::module>();
   py::class_<
       DynamicMetalShaderLibrary,

--- a/torch/csrc/mps/StreamGraph.cpp
+++ b/torch/csrc/mps/StreamGraph.cpp
@@ -1,0 +1,54 @@
+//  torch/csrc/mps/StreamGraph.cpp
+//
+//  pybind11 bindings for at::mps::MPSStreamGraph, exposed to Python as
+//  torch._C._MPSStreamGraph and wrapped in torch.mps.MPSGraph for the user
+//  API. Pattern mirrors torch/csrc/cuda/Graph.cpp.
+
+#include <torch/csrc/python_headers.h>
+
+#include <pybind11/chrono.h>
+
+#include <torch/csrc/utils/pybind.h>
+
+#include <ATen/mps/MPSDevice.h>
+#include <ATen/mps/MPSStream.h>
+#include <ATen/mps/MPSStreamGraph.h>
+
+template <typename T>
+using shared_ptr_class_ = py::class_<T, std::shared_ptr<T>>;
+
+void THMPGraph_init(PyObject* module) {
+  auto torch_C_m = py::handle(module).cast<py::module>();
+
+  shared_ptr_class_<at::mps::MPSStreamGraph>(torch_C_m, "_MPSStreamGraph")
+      .def(py::init<std::size_t>(),
+           py::arg("max_commands") = 4096)
+      .def(
+          "capture_begin",
+          [](at::mps::MPSStreamGraph& self) {
+            // Use the currently-active MPS stream from the runtime. Matches
+            // CUDA's "current stream" convention; user-selected streams via
+            // `with torch.mps.stream(s):` work transparently.
+            auto* stream = at::mps::getCurrentMPSStream();
+            TORCH_CHECK(
+                stream != nullptr,
+                "MPSGraph.capture_begin: no current MPS stream "
+                "(is the MPS backend initialized?)");
+            self.capture_begin(stream);
+          })
+      .def("capture_end",
+           [](at::mps::MPSStreamGraph& self) { self.capture_end(); })
+      .def("replay", [](at::mps::MPSStreamGraph& self) { self.replay(); })
+      .def("num_commands",
+           [](const at::mps::MPSStreamGraph& self) {
+             return self.num_commands();
+           })
+      .def("is_capturing",
+           [](const at::mps::MPSStreamGraph& self) {
+             return self.is_capturing();
+           })
+      .def("is_ready",
+           [](const at::mps::MPSStreamGraph& self) {
+             return self.is_ready();
+           });
+}

--- a/torch/mps/__init__.py
+++ b/torch/mps/__init__.py
@@ -233,6 +233,7 @@ def _host_alias_storage(storage: "torch.UntypedStorage") -> "torch.UntypedStorag
 
 from . import profiler
 from .event import Event
+from .graphs import MPSGraph, graph, make_graphed_callables
 
 
 __all__ = [
@@ -252,4 +253,7 @@ __all__ = [
     "profiler",
     "recommended_max_memory",
     "is_available",
+    "MPSGraph",
+    "graph",
+    "make_graphed_callables",
 ]

--- a/torch/mps/graphs.py
+++ b/torch/mps/graphs.py
@@ -1,0 +1,138 @@
+# torch/mps/graphs.py
+#
+# User-facing API for MPS command-buffer capture/replay, analogous to
+# torch.cuda.graphs. Backed by MTLIndirectCommandBuffer via the C++ binding
+# torch._C._MPSStreamGraph.
+#
+# Usage:
+#     g = torch.mps.MPSGraph()
+#
+#     # Warmup: ensure kernel pipelines are compiled before capture.
+#     for _ in range(3):
+#         y = model(x)
+#
+#     # Capture once.
+#     with torch.mps.graph(g):
+#         y = model(x)
+#
+#     # Replay many times — bypasses per-call CPU encoding overhead.
+#     for _ in range(1000):
+#         g.replay()
+#         use(y)
+#
+# Constraints (v1):
+#   - Buffers are bound by pointer at capture; reuse requires `.copy_()`
+#     into the same storage between replays.
+#   - Capture cannot be nested.
+#   - Tensor shapes must not change between capture and replays.
+#   - Allocation inside the capture region is currently rejected.
+
+import contextlib
+from typing import Any
+
+import torch
+
+
+class MPSGraph:
+    """Capture/replay primitive for MPS streams.
+
+    Mirrors :class:`torch.cuda.CUDAGraph`. Use :func:`torch.mps.graph` as a
+    context manager rather than calling ``capture_begin``/``capture_end``
+    directly.
+    """
+
+    def __init__(self, max_commands: int = 4096) -> None:
+        self._inner = torch._C._MPSStreamGraph(max_commands)  # type: ignore[attr-defined]
+
+    def capture_begin(self) -> None:
+        """Begin recording subsequent MPS dispatches into this graph."""
+        self._inner.capture_begin()
+
+    def capture_end(self) -> None:
+        """End recording. Graph is now ready to replay."""
+        self._inner.capture_end()
+
+    def replay(self) -> None:
+        """Re-execute the captured sequence on the same stream.
+
+        Blocks until the replay completes (v1 is synchronous).
+        """
+        self._inner.replay()
+
+    def num_commands(self) -> int:
+        """Number of compute dispatches recorded."""
+        return self._inner.num_commands()
+
+    def is_capturing(self) -> bool:
+        return self._inner.is_capturing()
+
+    def is_ready(self) -> bool:
+        return self._inner.is_ready()
+
+
+@contextlib.contextmanager
+def graph(g: MPSGraph):
+    """Context manager for capturing into an :class:`MPSGraph`.
+
+    Example::
+
+        g = torch.mps.MPSGraph()
+        x = torch.randn(64, device="mps")
+        with torch.mps.graph(g):
+            y = x.relu()
+        g.replay()
+
+    All MPS dispatches inside the ``with`` block are recorded; non-MPS work
+    (CPU compute, host allocations) executes normally and is not captured.
+    """
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("torch.mps.graph: MPS backend not available")
+    g.capture_begin()
+    try:
+        yield g
+    finally:
+        g.capture_end()
+
+
+def make_graphed_callables(
+    callable_: Any,
+    sample_args: tuple,
+    *,
+    num_warmup_iters: int = 3,
+) -> Any:
+    """Wrap ``callable_`` so that subsequent calls replay a captured graph.
+
+    Pattern from :func:`torch.cuda.make_graphed_callables`. Captures with
+    ``sample_args`` after ``num_warmup_iters`` of eager warmup, then returns
+    a wrapper that copies new inputs into the captured input buffers and
+    replays.
+
+    .. warning::
+        v1 limitation: ``callable_`` must accept exactly the same tensor
+        shapes/dtypes/devices on every call. Inputs are bound by pointer
+        during capture; the wrapper rebinds them via in-place ``.copy_()``.
+    """
+    # Warmup so kernel pipelines compile before capture.
+    for _ in range(num_warmup_iters):
+        callable_(*sample_args)
+
+    g = MPSGraph()
+    with graph(g):
+        captured_out = callable_(*sample_args)
+
+    def wrapper(*new_args):
+        if len(new_args) != len(sample_args):
+            raise ValueError(
+                f"make_graphed_callables: expected {len(sample_args)} args, "
+                f"got {len(new_args)}"
+            )
+        for sample, new in zip(sample_args, new_args):
+            if isinstance(sample, torch.Tensor) and sample is not new:
+                sample.copy_(new)
+        g.replay()
+        return captured_out
+
+    return wrapper
+
+
+__all__ = ["MPSGraph", "graph", "make_graphed_callables"]


### PR DESCRIPTION
Tracking issue: #180397. Related context: #187455.

## Current status

This branch is a monolithic reference implementation, not a final reviewable PR. Please do not review it as one patch.

It needs to be split into a capture/replay stack:

1. **Capture recorder core**
   - Internal `MPSStreamGraph` command list and recording encoder/proxy.
   - Direct replay for a small captured command list.
   - No public Python API yet; prove the internal recording model first.

2. **Buffer lifetime / allocator integration**
   - Retain captured intermediates safely across replay.
   - Keep normal allocator behavior unchanged outside capture.
   - Focused lifetime tests.

3. **ICB replay path**
   - `MTLIndirectCommandBuffer` encoding/replay.
   - Direct-vs-ICB threshold.
   - Buffer dependency/barrier analysis.
   - Own benchmark for dispatch-chain overhead and crossover point.

4. **Public API**
   - `torch.mps.MPSGraph`, `torch.mps.graph`, and `torch.mps.make_graphed_callables`.
   - Python docs/tests and end-to-end benchmark.

## Reference implementation summary

The current branch adds `torch.mps.MPSGraph`, analogous to `torch.cuda.CUDAGraph`:
capture a sequence of MPS kernel dispatches once and replay it in lower CPU time
via direct re-encoding for short chains or `MTLIndirectCommandBuffer` for longer chains.

A recording encoder (`MPSCaptureRecordingEncoder`, an `NSProxy`) wraps the stream's
`MTLComputeCommandEncoder` during capture and forwards dispatch-site methods to both
the live encoder and an `MPSStreamGraph` accumulator. Replay is dual path at
`kDirectEncodeThreshold = 16`: shorter chains re-encode captured commands directly;
longer chains replay through an ICB and insert barriers where a command reads a buffer
written by a previous command. The allocator deflects freed blocks into retained
capture storage so intermediates survive replay.

Example target API for the final API split:

```python
g = torch.mps.MPSGraph()
with torch.mps.graph(g):
    y = model(x)
torch.mps.synchronize()
for _ in range(1000):
    x.copy_(new_input)
    g.replay()
    torch.mps.synchronize()
```

## Existing evidence to preserve across the split

- Tests: `test/test_mps_graphs.py` (correctness, edge cases, buffer lifetime, allocation interplay, perf-regression guards).
- Benchmark: `test/bench_graph_overhead.py`.
- Measured wins on M4 Pro for long dispatch chains, with direct-vs-ICB crossover around `N=16`.

## Test Plan

Each split PR needs its own focused test plan. The final public API PR should rerun:

```
PYTORCH_TEST_WITH_SLOW=1 python test/test_mps_graphs.py
python test/bench_graph_overhead.py overhead chains scaling dtypes
PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 python test/run_test.py --verbose --mps --keep-going
```

Authored with Claude.
