### PR TITLE
Generalize torch.library.register_autocast to be device-agnostic

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -3523,9 +3523,9 @@ with warnings.catch_warnings(record=True) as w:
                 self.assertTrue(called)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator.")
     def test_library_register_autocast(self):
-        for device in ["cuda", "cpu"]:
+        for device in [torch.accelerator.current_accelerator().type, "cpu"]:
             for mode in ["function", "qualname", "opoverload"]:
 
                 @torch.library.custom_op("mylib::my_sin", mutates_args=())
@@ -3549,9 +3549,9 @@ with warnings.catch_warnings(record=True) as w:
                 self.assertEqual(y.dtype, torch.float16)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator.")
     def test_library_register_autocast_low_level(self):
-        for device in ["cuda", "cpu"]:
+        for device in [torch.accelerator.current_accelerator().type, "cpu"]:
             for mode in ["qualname", "opoverload"]:
                 with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
                     lib.define("my_sin(Tensor x) -> Tensor")
@@ -3666,6 +3666,16 @@ with warnings.catch_warnings(record=True) as w:
         with torch.autocast("cpu", dtype=torch.float16):
             y4 = my_sin(x2)
         self.assertEqual(y4.dtype, torch.float16)
+
+        # Nested autocast: verifies no infinite redispatch when both keys are active.
+        with (
+            torch.autocast("cpu", dtype=torch.float16),
+            torch.autocast(device_type, dtype=torch.float16),
+        ):
+            y5 = my_sin(x1)
+            y6 = my_sin(x2)
+        self.assertEqual(y5.dtype, torch.float16)
+        self.assertEqual(y6.dtype, torch.float16)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_library_register_autograd(self):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -56,6 +56,7 @@ from torch.testing._internal.common_utils import (
     skipIfXpu,
     subtest,
     TemporaryFileName,
+    TEST_ACCELERATOR,
     TEST_XPU,
     TestCase,
 )
@@ -3578,9 +3579,9 @@ with warnings.catch_warnings(record=True) as w:
                     self.assertEqual(y.dtype, torch.float16)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator.")
     def test_library_register_autocast_list_input(self):
-        for device in ["cuda", "cpu"]:
+        for device in [torch.accelerator.current_accelerator().type, "cpu"]:
             for mode in ["function", "qualname", "opoverload"]:
 
                 @torch.library.custom_op("mylib::my_add_sin", mutates_args=())
@@ -3606,9 +3607,9 @@ with warnings.catch_warnings(record=True) as w:
                 self.assertEqual(y.dtype, torch.float16)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator.")
     def test_library_register_autocast_multiple_times(self):
-        for device in ["cuda", "cpu"]:
+        for device in [torch.accelerator.current_accelerator().type, "cpu"]:
 
             @torch.library.custom_op("mylib::my_sin", mutates_args=())
             def my_sin(x: Tensor) -> Tensor:
@@ -3629,17 +3630,18 @@ with warnings.catch_warnings(record=True) as w:
             self.assertEqual(y2.dtype, torch.float16)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator.")
     def test_library_register_autocast_multiple_times_different_devices(self):
         @torch.library.custom_op("mylib::my_sin", mutates_args=())
         def my_sin(x: Tensor) -> Tensor:
             return torch.sin(x)
 
-        # Register autocast for CUDA
-        torch.library.register_autocast(my_sin, "cuda", torch.float16)
+        # Register autocast for the current accelerator
+        device_type = torch.accelerator.current_accelerator().type
+        torch.library.register_autocast(my_sin, device_type, torch.float16)
 
-        x1 = torch.randn(3, dtype=torch.float32, device="cuda")
-        with torch.autocast("cuda", dtype=torch.float16):
+        x1 = torch.randn(3, dtype=torch.float32, device=device_type)
+        with torch.autocast(device_type, dtype=torch.float16):
             y1 = my_sin(x1)
         self.assertEqual(y1.dtype, torch.float16)
 
@@ -3651,10 +3653,10 @@ with warnings.catch_warnings(record=True) as w:
             y2 = my_sin(x2)
         self.assertEqual(y2.dtype, torch.float16)
 
-        # Register CUDA autocast for the second time
-        torch.library.register_autocast(my_sin, "cuda", torch.float16)
+        # Register accelerator autocast for the second time
+        torch.library.register_autocast(my_sin, device_type, torch.float16)
 
-        with torch.autocast("cuda", dtype=torch.float16):
+        with torch.autocast(device_type, dtype=torch.float16):
             y3 = my_sin(x1)
         self.assertEqual(y3.dtype, torch.float16)
 

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -858,7 +858,7 @@ class CustomOpDef:
 
         Args:
             op (str | OpOverload): The operator to register an autocast dispatch rule to.
-            device_type(str):  Device type to use. 'cuda', `cpu`, `xpu`, or any other device type that supports autocast.
+            device_type(str):  Device type to use. 'cuda', 'cpu', 'xpu', or any other device type that supports autocast.
                 The type is the same as the `type` attribute of a :class:`torch.device`.
                 Thus, you may obtain the device type of a tensor using `Tensor.device.type`.
             cast_inputs (:class:`torch.dtype`): When custom op runs in an autocast-enabled region,
@@ -909,7 +909,7 @@ class CustomOpDef:
             ):
                 return self._opoverload(*_cast(args, device_type, cast_inputs))
 
-        if need_register and self._autocast_dtype.get(device_type) is not None:
+        if need_register:
             self._lib.impl(self._name, kernel, autocast_key, with_keyset=True)
 
         return kernel

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -853,36 +853,37 @@ class CustomOpDef:
     ):
         r"""Register an autocast dispatch rule for this custom op.
 
-        Valid `device_type` include: "cpu" and "cuda".
+            Valid ``device_type`` values include any device type that supports autocast.
+        See :func:`torch.amp.is_autocast_available` for details.
 
-        Args:
-            op (str | OpOverload): The operator to register an autocast dispatch rule to.
-            device_type(str):  Device type to use. 'cuda' or 'cpu'.
-                The type is the same as the `type` attribute of a :class:`torch.device`.
-                Thus, you may obtain the device type of a tensor using `Tensor.device.type`.
-            cast_inputs (:class:`torch.dtype`): When custom op runs in an autocast-enabled region,
-                casts incoming floating-point Tensors to the target dtype (non-floating-point Tensors
-                are not affected), then executes custom op with autocast disabled.
-            lib (Optional[Library]): If provided, the lifetime of this registration
+            Args:
+                op (str | OpOverload): The operator to register an autocast dispatch rule to.
+                device_type(str):  Device type to use. 'cuda', `cpu`, `xpu`, or any other device type that supports autocast.
+                    The type is the same as the `type` attribute of a :class:`torch.device`.
+                    Thus, you may obtain the device type of a tensor using `Tensor.device.type`.
+                cast_inputs (:class:`torch.dtype`): When custom op runs in an autocast-enabled region,
+                    casts incoming floating-point Tensors to the target dtype (non-floating-point Tensors
+                    are not affected), then executes custom op with autocast disabled.
+                lib (Optional[Library]): If provided, the lifetime of this registration
 
-        Examples::
-            >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)
-            >>> import torch
-            >>> from torch import Tensor
-            >>> from torch.library import custom_op
-            >>>
-            >>> # Create a custom op that works on cuda
-            >>> @torch.library.custom_op("mylib::my_sin", mutates_args=())
-            >>> def my_sin(x: Tensor) -> Tensor:
-            >>>     return torch.sin(x)
-            >>>
-            >>> # Register autocast dispatch rule for the cuda device
-            >>> torch.library.register_autocast("mylib::my_sin", "cuda", torch.float16)
-            >>>
-            >>> x = torch.randn(3, dtype=torch.float32, device="cuda")
-            >>> with torch.autocast("cuda", dtype=torch.float16):
-            >>>     y = torch.ops.mylib.my_sin(x)
-            >>> assert y.dtype == torch.float16
+            Examples::
+                >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)
+                >>> import torch
+                >>> from torch import Tensor
+                >>> from torch.library import custom_op
+                >>>
+                >>> # Create a custom op that works on cuda
+                >>> @torch.library.custom_op("mylib::my_sin", mutates_args=())
+                >>> def my_sin(x: Tensor) -> Tensor:
+                >>>     return torch.sin(x)
+                >>>
+                >>> # Register autocast dispatch rule for the cuda device
+                >>> torch.library.register_autocast("mylib::my_sin", "cuda", torch.float16)
+                >>>
+                >>> x = torch.randn(3, dtype=torch.float32, device="cuda")
+                >>> with torch.autocast("cuda", dtype=torch.float16):
+                >>>     y = torch.ops.mylib.my_sin(x)
+                >>> assert y.dtype == torch.float16
 
         """
         if not isinstance(device_type, str):

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -853,37 +853,37 @@ class CustomOpDef:
     ):
         r"""Register an autocast dispatch rule for this custom op.
 
-            Valid ``device_type`` values include any device type that supports autocast.
+        Valid ``device_type`` values include any device type that supports autocast.
         See :func:`torch.amp.is_autocast_available` for details.
 
-            Args:
-                op (str | OpOverload): The operator to register an autocast dispatch rule to.
-                device_type(str):  Device type to use. 'cuda', `cpu`, `xpu`, or any other device type that supports autocast.
-                    The type is the same as the `type` attribute of a :class:`torch.device`.
-                    Thus, you may obtain the device type of a tensor using `Tensor.device.type`.
-                cast_inputs (:class:`torch.dtype`): When custom op runs in an autocast-enabled region,
-                    casts incoming floating-point Tensors to the target dtype (non-floating-point Tensors
-                    are not affected), then executes custom op with autocast disabled.
-                lib (Optional[Library]): If provided, the lifetime of this registration
+        Args:
+            op (str | OpOverload): The operator to register an autocast dispatch rule to.
+            device_type(str):  Device type to use. 'cuda', `cpu`, `xpu`, or any other device type that supports autocast.
+                The type is the same as the `type` attribute of a :class:`torch.device`.
+                Thus, you may obtain the device type of a tensor using `Tensor.device.type`.
+            cast_inputs (:class:`torch.dtype`): When custom op runs in an autocast-enabled region,
+                casts incoming floating-point Tensors to the target dtype (non-floating-point Tensors
+                are not affected), then executes custom op with autocast disabled.
+            lib (Optional[Library]): If provided, the lifetime of this registration
 
-            Examples::
-                >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)
-                >>> import torch
-                >>> from torch import Tensor
-                >>> from torch.library import custom_op
-                >>>
-                >>> # Create a custom op that works on cuda
-                >>> @torch.library.custom_op("mylib::my_sin", mutates_args=())
-                >>> def my_sin(x: Tensor) -> Tensor:
-                >>>     return torch.sin(x)
-                >>>
-                >>> # Register autocast dispatch rule for the cuda device
-                >>> torch.library.register_autocast("mylib::my_sin", "cuda", torch.float16)
-                >>>
-                >>> x = torch.randn(3, dtype=torch.float32, device="cuda")
-                >>> with torch.autocast("cuda", dtype=torch.float16):
-                >>>     y = torch.ops.mylib.my_sin(x)
-                >>> assert y.dtype == torch.float16
+        Examples::
+            >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)
+            >>> import torch
+            >>> from torch import Tensor
+            >>> from torch.library import custom_op
+            >>>
+            >>> # Create a custom op that works on cuda
+            >>> @torch.library.custom_op("mylib::my_sin", mutates_args=())
+            >>> def my_sin(x: Tensor) -> Tensor:
+            >>>     return torch.sin(x)
+            >>>
+            >>> # Register autocast dispatch rule for the cuda device
+            >>> torch.library.register_autocast("mylib::my_sin", "cuda", torch.float16)
+            >>>
+            >>> x = torch.randn(3, dtype=torch.float32, device="cuda")
+            >>> with torch.autocast("cuda", dtype=torch.float16):
+            >>>     y = torch.ops.mylib.my_sin(x)
+            >>> assert y.dtype == torch.float16
 
         """
         if not isinstance(device_type, str):

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -236,7 +236,7 @@ class CustomOpDef:
         self._backward_fn: Callable | None = None
         self._torch_dispatch_fns: dict[type, Callable] = {}
         self._vmap_fn: Callable | None = None
-        self._autocast_dtype: _dtype | None = None
+        self._autocast_dtype: dict[str, _dtype | None] = {}
 
         self._lib = get_library_allowing_overwrite(self._namespace, self._name)
         self._register_to_dispatcher(self._tags)
@@ -892,8 +892,8 @@ class CustomOpDef:
         if not torch._C._is_autocast_available(device_type):
             raise ValueError(f"Device type '{device_type}' does not support autocast.")
 
-        need_register = self._autocast_dtype is None
-        self._autocast_dtype = cast_inputs
+        need_register = self._autocast_dtype.get(device_type) is None
+        self._autocast_dtype[device_type] = cast_inputs
         autocast_key = "Autocast" + torch._C._dispatch_key_for_device(device_type)
         autocast_dispatch_key = getattr(torch._C.DispatchKey, autocast_key)
 
@@ -907,7 +907,7 @@ class CustomOpDef:
             ):
                 return self._opoverload(*_cast(args, device_type, cast_inputs))
 
-        if need_register and self._autocast_dtype:
+        if need_register and self._autocast_dtype.get(device_type) is not None:
             self._lib.impl(self._name, kernel, autocast_key, with_keyset=True)
 
         return kernel

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -894,9 +894,7 @@ class CustomOpDef:
 
         need_register = self._autocast_dtype is None
         self._autocast_dtype = cast_inputs
-        autocast_key = (
-            "Autocast" + torch._C._dispatch_key_for_device(device_type).upper()
-        )
+        autocast_key = "Autocast" + torch._C._dispatch_key_for_device(device_type)
         autocast_dispatch_key = getattr(torch._C.DispatchKey, autocast_key)
 
         def kernel(_, *args, **kwargs):

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -236,8 +236,7 @@ class CustomOpDef:
         self._backward_fn: Callable | None = None
         self._torch_dispatch_fns: dict[type, Callable] = {}
         self._vmap_fn: Callable | None = None
-        self._autocast_cuda_dtype: _dtype | None = None
-        self._autocast_cpu_dtype: _dtype | None = None
+        self._autocast_dtype: _dtype | None = None
 
         self._lib = get_library_allowing_overwrite(self._namespace, self._name)
         self._register_to_dispatcher(self._tags)
@@ -890,31 +889,28 @@ class CustomOpDef:
             raise ValueError(
                 f"Expected `device_type` of type `str`, got: `{type(device_type)}`"
             )
-        if device_type not in ["cpu", "cuda"]:
-            raise ValueError(f"Unknown device type: {device_type}")
+        if not torch._C._is_autocast_available(device_type):
+            raise ValueError(f"Device type '{device_type}' does not support autocast.")
 
-        need_register_cuda = self._autocast_cuda_dtype is None
-        need_register_cpu = self._autocast_cpu_dtype is None
-        if device_type == "cuda":
-            self._autocast_cuda_dtype = cast_inputs
-        else:
-            self._autocast_cpu_dtype = cast_inputs
+        need_register = self._autocast_dtype is None
+        self._autocast_dtype = cast_inputs
+        autocast_key = (
+            "Autocast" + torch._C._dispatch_key_for_device(device_type).upper()
+        )
+        autocast_dispatch_key = getattr(torch._C.DispatchKey, autocast_key)
 
         def kernel(_, *args, **kwargs):
             if len(kwargs) != 0:
                 raise AssertionError(
                     f"Custom ops do not support kwargs yet, got {list(kwargs.keys())}"
                 )
-            autocast_keyset = torch._C.DispatchKeySet(
-                torch._C.DispatchKey.AutocastCPU
-            ) | torch._C.DispatchKeySet(torch._C.DispatchKey.AutocastCUDA)
-            with torch._C._ExcludeDispatchKeyGuard(autocast_keyset):
+            with torch._C._ExcludeDispatchKeyGuard(
+                torch._C.DispatchKeySet(autocast_dispatch_key)
+            ):
                 return self._opoverload(*_cast(args, device_type, cast_inputs))
 
-        if need_register_cuda and self._autocast_cuda_dtype:
-            self._lib.impl(self._name, kernel, "AutocastCUDA", with_keyset=True)
-        elif need_register_cpu and self._autocast_cpu_dtype:
-            self._lib.impl(self._name, kernel, "AutocastCPU", with_keyset=True)
+        if need_register and self._autocast_dtype:
+            self._lib.impl(self._name, kernel, autocast_key, with_keyset=True)
 
         return kernel
 

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -893,7 +893,8 @@ class CustomOpDef:
             raise ValueError(f"Device type '{device_type}' does not support autocast.")
 
         need_register = self._autocast_dtype.get(device_type) is None
-        self._autocast_dtype[device_type] = cast_inputs
+        if need_register:
+            self._autocast_dtype[device_type] = cast_inputs
         autocast_key = "Autocast" + torch._C._dispatch_key_for_device(device_type)
         autocast_dispatch_key = getattr(torch._C.DispatchKey, autocast_key)
 

--- a/torch/library.py
+++ b/torch/library.py
@@ -1067,7 +1067,7 @@ def register_autocast(
 
     Args:
         op (str | OpOverload): The operator to register an autocast dispatch rule to.
-        device_type(str):  Device type to use. 'cuda', `cpu`, `xpu`, or any other device type that supports autocast.
+        device_type(str):  Device type to use. 'cuda', 'cpu', 'xpu', or any other device type that supports autocast.
             The type is the same as the `type` attribute of a :class:`torch.device`.
             Thus, you may obtain the device type of a tensor using `Tensor.device.type`.
         cast_inputs (:class:`torch.dtype`): When custom op runs in an autocast-enabled region,

--- a/torch/library.py
+++ b/torch/library.py
@@ -1062,11 +1062,12 @@ def register_autocast(
 ):
     r"""Register an autocast dispatch rule for this custom op.
 
-    Valid `device_type` include: "cpu" and "cuda".
+    Valid ``device_type`` values include any device type that supports autocast.
+    See :func:`torch.amp.is_autocast_available` for details.
 
     Args:
         op (str | OpOverload): The operator to register an autocast dispatch rule to.
-        device_type(str):  Device type to use. 'cuda' or 'cpu'.
+        device_type(str):  Device type to use. 'cuda', `cpu`, `xpu`, or any other device type that supports autocast.
             The type is the same as the `type` attribute of a :class:`torch.device`.
             Thus, you may obtain the device type of a tensor using `Tensor.device.type`.
         cast_inputs (:class:`torch.dtype`): When custom op runs in an autocast-enabled region,

--- a/torch/library.py
+++ b/torch/library.py
@@ -1095,8 +1095,8 @@ def register_autocast(
 
     """
     op = _resolve_op_for_registration(op, "register_autocast")
-    if device_type not in ["cpu", "cuda"]:
-        raise ValueError(f"Unknown device type: {device_type}")
+    if not torch._C._is_autocast_available(device_type):
+        raise ValueError(f"Device type '{device_type}' does not support autocast.")
 
     if isinstance(op, CustomOpDef):
         return op.register_autocast(device_type, cast_inputs)
@@ -1106,6 +1106,9 @@ def register_autocast(
     namespace, opname = torch._library.utils.parse_namespace(qualname)
     use_lib = _library_for_registration(namespace, lib)
 
+    autocast_key = "Autocast" + torch._C._dispatch_key_for_device(device_type).upper()
+    autocast_dispatch_key = getattr(torch._C.DispatchKey, autocast_key)
+
     def _maybe_override_py_impl(op: torch._ops.OpOverload, dispatch_key):
         def inner(kernel):
             if op.has_kernel_for_dispatch_key(dispatch_key):
@@ -1114,15 +1117,13 @@ def register_autocast(
 
         return inner
 
-    @_maybe_override_py_impl(_op, torch._C.DispatchKey.AutocastCPU)
-    @_maybe_override_py_impl(_op, torch._C.DispatchKey.AutocastCUDA)
+    @_maybe_override_py_impl(_op, autocast_dispatch_key)
     def _autocast_py_impl(*args, **kwargs):
         if len(kwargs) != 0:
             raise AssertionError("Custom ops do not support kwargs yet.")
-        autocast_keyset = torch._C.DispatchKeySet(
-            torch._C.DispatchKey.AutocastCPU
-        ) | torch._C.DispatchKeySet(torch._C.DispatchKey.AutocastCUDA)
-        with torch._C._ExcludeDispatchKeyGuard(autocast_keyset):
+        with torch._C._ExcludeDispatchKeyGuard(
+            torch._C.DispatchKeySet(autocast_dispatch_key)
+        ):
             return _op(*_cast(args, device_type, cast_inputs))
 
     def kernel(_, *args, **kwargs):
@@ -1130,11 +1131,7 @@ def register_autocast(
             raise AssertionError("Custom ops do not support kwargs yet.")
         return _autocast_py_impl(*args, **kwargs)
 
-    if device_type == "cuda":
-        return use_lib.impl(opname, kernel, "AutocastCUDA", with_keyset=True)
-    else:
-        # device_type is "cpu"
-        return use_lib.impl(opname, kernel, "AutocastCPU", with_keyset=True)
+    return use_lib.impl(opname, kernel, autocast_key, with_keyset=True)
 
 
 def register_fake(

--- a/torch/library.py
+++ b/torch/library.py
@@ -1106,7 +1106,7 @@ def register_autocast(
     namespace, opname = torch._library.utils.parse_namespace(qualname)
     use_lib = _library_for_registration(namespace, lib)
 
-    autocast_key = "Autocast" + torch._C._dispatch_key_for_device(device_type).upper()
+    autocast_key = "Autocast" + torch._C._dispatch_key_for_device(device_type)
     autocast_dispatch_key = getattr(torch._C.DispatchKey, autocast_key)
 
     def _maybe_override_py_impl(op: torch._ops.OpOverload, dispatch_key):

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -133,6 +133,7 @@ class DispatchKey(Enum):
     Autocast = auto()
     AutocastCPU = auto()
     AutocastCUDA = auto()
+    AutocastXPU = auto()
     Batched = auto()
     VmapMode = auto()
     FuncTorchGradWrapper = auto()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183689

# Motivation
Currently, `torch.library.register_autocast` only support cpu and cuda. This PR intends to support this feature on all device that support autocast.
