### PR TITLE
[ROCm][Windows] Fix inconsistent dllimport for HIP masquerading allocator

### DIFF
--- a/aten/src/ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/hip/HIPCachingAllocator.h>
+#include <c10/macros/Macros.h>
 #include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
 
 namespace c10 {
@@ -9,8 +10,8 @@ class DataPtr;
 namespace hip {
 namespace HIPCachingAllocatorMasqueradingAsCUDA {
 
-C10_CUDA_API c10::cuda::CUDACachingAllocator::CUDAAllocator* get();
-C10_CUDA_API void recordStreamMasqueradingAsCUDA(const DataPtr& ptr, HIPStreamMasqueradingAsCUDA stream);
+TORCH_CUDA_CPP_API c10::cuda::CUDACachingAllocator::CUDAAllocator* get();
+TORCH_CUDA_CPP_API void recordStreamMasqueradingAsCUDA(const DataPtr& ptr, HIPStreamMasqueradingAsCUDA stream);
 
 using c10::cuda::CUDACachingAllocator::raw_alloc;
 using c10::cuda::CUDACachingAllocator::raw_alloc_with_stream;


### PR DESCRIPTION
Windows clang-cl reported `-Winconsistent-dllimport`: the header used `C10_CUDA_API` (dllimport in this TU) while the definitions are exported from `torch_hip`:

```
HIPCachingAllocatorMasqueradingAsCUDA.cpp(...): warning: 'c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::get'
  redeclared without 'dllimport' attribute: 'dllexport' attribute added [-Winconsistent-dllimport]

HIPCachingAllocatorMasqueradingAsCUDA.h(...): note: previous declaration is here
  C10_CUDA_API c10::cuda::CUDACachingAllocator::CUDAAllocator* get();
```

Fix:
Substitute `C10_CUDA_API` with `TORCH_CUDA_CPP_API`

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang