### PR TITLE
[Test] Add tolerance and precision override mechanisms for parameteried tests

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -6,12 +6,15 @@ from contextlib import contextmanager
 
 import torch
 from torch.testing._internal.common_device_type import (
+    dtypes,
     instantiate_device_type_tests,
     onlyCUDA,
     onlyOn,
     ops,
     precisionOverride,
     PrivateUse1TestBase,
+    tol,
+    toleranceOverride,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.opinfo.core import DecorateInfo, OpInfo
@@ -205,6 +208,78 @@ class TestSupportedOpsWithOverrides(TestCase):
         type(self)._executed_combined[op.name] += 1
 
 
+class TestToleranceAndPrecisionOverrides(TestCase):
+    """Verify that tolerance_overrides and precision_overrides from
+    set_test_configs() apply to non-OpInfo tests and that decorator-level
+    overrides take precedence over class-level configs.
+    """
+
+    _actual_precisions: dict = {}
+    _actual_rtols: dict = {}
+    _expected_values: dict = {}
+
+    @classmethod
+    def tearDownClass(cls):
+        expected = cls._expected_values
+        actual_precisions = cls._actual_precisions
+        actual_rtols = cls._actual_rtols
+        for key, (exp_prec, exp_rtol) in expected.items():
+            if key not in actual_precisions:
+                raise AssertionError(f"Test variant {key} never executed")
+            act_prec = actual_precisions[key]
+            act_rtol = actual_rtols[key]
+            if act_prec != exp_prec or act_rtol != exp_rtol:
+                raise AssertionError(
+                    f"Test variant {key}: expected precision={exp_prec}, rtol={exp_rtol}, "
+                    f"got precision={act_prec}, rtol={act_rtol}"
+                )
+        super().tearDownClass()
+
+    @dtypes(torch.float32, torch.float64)
+    def test_tolerance_overrides_applied(self, device, dtype):
+        key = ("test_tolerance_overrides_applied", dtype)
+        type(self)._actual_precisions[key] = self.precision
+        type(self)._actual_rtols[key] = self.rel_tol
+
+    @dtypes(torch.float32)
+    def test_precision_overrides_applied(self, device, dtype):
+        key = ("test_precision_overrides_applied", dtype)
+        type(self)._actual_precisions[key] = self.precision
+        type(self)._actual_rtols[key] = self.rel_tol
+
+    @precisionOverride({torch.float32: 1e-5})
+    @dtypes(torch.float32)
+    def test_decorator_wins_over_config(self, device, dtype):
+        key = ("test_decorator_wins_over_config", dtype)
+        type(self)._actual_precisions[key] = self.precision
+        type(self)._actual_rtols[key] = self.rel_tol
+
+    @toleranceOverride({torch.float32: tol(atol=5e-3, rtol=5e-4)})
+    @dtypes(torch.float32)
+    def test_tolerance_decorator_wins(self, device, dtype):
+        key = ("test_tolerance_decorator_wins", dtype)
+        type(self)._actual_precisions[key] = self.precision
+        type(self)._actual_rtols[key] = self.rel_tol
+
+    @dtypes(torch.float32)
+    def test_tol_overrides_prec(self, device, dtype):
+        key = ("test_tol_overrides_prec", dtype)
+        type(self)._actual_precisions[key] = self.precision
+        type(self)._actual_rtols[key] = self.rel_tol
+
+    @dtypes(torch.float32, torch.float64)
+    def test_wildcard_fallback(self, device, dtype):
+        key = ("test_wildcard_fallback", dtype)
+        type(self)._actual_precisions[key] = self.precision
+        type(self)._actual_rtols[key] = self.rel_tol
+
+    @ops([op_precision])
+    def test_op_override_still_wins(self, device, dtype, op):
+        key = ("test_op_override_still_wins", dtype)
+        type(self)._actual_precisions[key] = self.precision
+        type(self)._actual_rtols[key] = self.rel_tol
+
+
 OPENREG_OP_OVERRIDES = {
     "op_skip": [DecorateInfo(unittest.skip("skip op_skip"))],
     "op_skip_f32": [
@@ -244,6 +319,71 @@ with _temp_test_configs(
 ):
     instantiate_device_type_tests(
         TestSupportedOpsWithOverrides, globals(), only_for=("openreg",)
+    )
+
+_openreg_tolerance_overrides = {
+    "TestToleranceAndPrecisionOverrides": {
+        "test_tolerance_overrides_applied": {
+            torch.float32: tol(atol=1e-2, rtol=1e-3),
+            torch.float64: tol(atol=1e-5, rtol=1e-6),
+        },
+        "test_tol_overrides_prec": {
+            torch.float32: tol(atol=1e-2, rtol=1e-3),
+        },
+        # Deliberately wrong values -- should NOT apply because the
+        # @toleranceOverride decorator on the test method takes precedence.
+        "test_tolerance_decorator_wins": {
+            torch.float32: tol(atol=9e-1, rtol=9e-1),
+        },
+    },
+}
+
+_openreg_precision_overrides = {
+    "TestToleranceAndPrecisionOverrides": {
+        "test_precision_overrides_applied": {
+            torch.float32: 1e-3,
+        },
+        # Deliberately wrong value -- should NOT apply because
+        # tolerance_overrides takes precedence over precision_overrides.
+        "test_tol_overrides_prec": {
+            torch.float32: 9e-1,
+        },
+        "*": {
+            torch.float32: 1e-4,
+        },
+    },
+}
+
+TestToleranceAndPrecisionOverrides._expected_values = {
+    # tolerance_overrides set both atol and rtol
+    ("test_tolerance_overrides_applied", torch.float32): (1e-2, 1e-3),
+    ("test_tolerance_overrides_applied", torch.float64): (1e-5, 1e-6),
+    # precision_overrides set atol only, rtol stays default
+    ("test_precision_overrides_applied", torch.float32): (1e-3, 0.0),
+    # @precisionOverride decorator (1e-5) wins over class-level precision_overrides (1e-4)
+    ("test_decorator_wins_over_config", torch.float32): (1e-5, 0.0),
+    # @toleranceOverride decorator (5e-3, 5e-4) wins over class-level tolerance_overrides (9e-1)
+    ("test_tolerance_decorator_wins", torch.float32): (5e-3, 5e-4),
+    # tolerance_overrides (1e-2, 1e-3) wins over precision_overrides (9e-1) at class level
+    ("test_tol_overrides_prec", torch.float32): (1e-2, 1e-3),
+    # Wildcard precision_overrides match (no specific entry, no decorator)
+    ("test_wildcard_fallback", torch.float32): (1e-4, 0.0),
+    # float64 has no wildcard match in precision_overrides -> defaults
+    ("test_wildcard_fallback", torch.float64): (0.0, 0.0),
+    # OpInfo op_overrides precisionOverride(1e-2) wins over everything
+    ("test_op_override_still_wins", torch.float32): (1e-2, 0.0),
+}
+
+with _temp_test_configs(
+    PrivateUse1TestBase,
+    op_overrides={
+        "op_precision": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
+    },
+    tolerance_overrides=_openreg_tolerance_overrides,
+    precision_overrides=_openreg_precision_overrides,
+):
+    instantiate_device_type_tests(
+        TestToleranceAndPrecisionOverrides, globals(), only_for=("openreg",)
     )
 
 if __name__ == "__main__":

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -358,6 +358,33 @@ class DeviceTypeTestBase(TestCase):
     #   }
     test_exclusions: ClassVar[dict[str, Collection[str]] | None] = None
 
+    # An optional mechanism to set per-dtype precision overrides (atol only) for
+    # tests parametrized by @dtypes. Mirrors the @precisionOverride decorator but
+    # settable by out-of-tree backends via set_test_configs().
+    #
+    # Format:
+    #   precision_overrides = {
+    #       "TestClassName": {
+    #           "test_method": {torch.float32: 1e-2},
+    #           "*": {torch.float16: 1e-1},
+    #       },
+    #   }
+    precision_overrides = None  # type: Optional[dict[str, dict[str, dict[torch.dtype, float]]]]
+
+    # An optional mechanism to set per-dtype tolerance overrides (atol + rtol) for
+    # tests parametrized by @dtypes. Mirrors the @toleranceOverride decorator but
+    # settable by out-of-tree backends via set_test_configs().
+    #
+    # Takes precedence over precision_overrides when both match the same test+dtype.
+    #
+    # Format:
+    #   tolerance_overrides = {
+    #       "TestClassName": {
+    #           "test_method": {torch.float32: tol(atol=1e-2, rtol=1e-3)},
+    #       },
+    #   }
+    tolerance_overrides = None  # type: Optional[dict[str, dict[str, dict[torch.dtype, tol]]]]
+
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
 
@@ -485,12 +512,51 @@ class DeviceTypeTestBase(TestCase):
             self.precision, self.rel_tol = self._get_tolerance_override(test, dtype)
 
     @classmethod
+    def _bake_class_level_overrides(cls, test, generic_cls, param_kwargs):
+        """Bake class-level tolerance/precision overrides into test function attrs."""
+
+        if generic_cls is None:
+            return
+
+        dtype = param_kwargs.get("dtypes", param_kwargs.get("dtype"))
+        if not dtype or isinstance(dtype, (list, tuple)):
+            return
+
+        def _resolve_class_override(key):
+            class_overrides = getattr(cls, key)
+            if class_overrides is None:
+                return None
+            test_overrides = class_overrides.get(generic_cls.__name__)
+            if test_overrides is None:
+                return None
+            for override_key in (test.__name__, "*"):
+                dtype_overrides = test_overrides.get(override_key)
+                if dtype_overrides is not None:
+                    override = dtype_overrides.get(dtype)
+                    if override is not None:
+                        return override
+            return None
+
+        for key in ("tolerance_overrides", "precision_overrides"):
+            test_overrides = getattr(test, key, None)
+            # class-level overrides should not overwrite test-level overrides
+            if test_overrides is not None and test_overrides.get(dtype) is not None:
+                continue
+            override = _resolve_class_override(key)
+            if override is not None:
+                if test_overrides is None:
+                    setattr(test, key, {})
+                getattr(test, key)[dtype] = override
+
+    @classmethod
     def set_test_configs(
         cls,
         *,
         op_overrides=None,
         op_allowlist=None,
         test_exclusions=None,
+        tolerance_overrides=None,
+        precision_overrides=None,
     ):
         """
         Sets or resets the test configuration fields.
@@ -503,6 +569,8 @@ class DeviceTypeTestBase(TestCase):
         cls.op_overrides = op_overrides
         cls.op_allowlist = op_allowlist
         cls.test_exclusions = test_exclusions
+        cls.tolerance_overrides = tolerance_overrides
+        cls.precision_overrides = precision_overrides
 
     # Creates device-specific tests.
     @classmethod
@@ -522,6 +590,10 @@ class DeviceTypeTestBase(TestCase):
             # Apply decorators based on param kwargs.
             for decorator in decorator_fn(param_kwargs):
                 test = decorator(test)
+
+            # Bake class-level tolerance/precision overrides (set via
+            # set_test_configs) into the test function
+            cls._bake_class_level_overrides(test, generic_cls, param_kwargs)
 
             # Constructs the test
             @wraps(test)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/177968

**Enhancements to test configuration system:**

* Added `precision_overrides` and `tolerance_overrides` class variables to `DeviceTypeTestBase`, allowing out-of-tree backends to set per-dtype (and per-test) precision (atol) and tolerance (atol+rtol) overrides via `set_test_configs()`. 
* Implemented `_bake_class_level_overrides` to resolve and apply class-level overrides to test methods, ensuring that decorator-level overrides always take priority over class-level configs.
* Updated `set_test_configs` and `instantiate_test_helper` to support and propagate these new override mechanisms, ensuring correct application during test instantiation.

**Expanded and improved test coverage:**

* Added `TestToleranceAndPrecisionOverrides` test class in `test_testing.py` to verify the correct application and precedence of `tolerance_overrides` and `precision_overrides`, including decorator vs. class-level vs. wildcard matching.

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD @fffrog 