### PR TITLE
[Windows] Fix inconsistent dllimport for THP python binding headers

### DIFF
--- a/torch/csrc/Device.h
+++ b/torch/csrc/Device.h
@@ -6,17 +6,17 @@
 #include <ATen/Device.h>
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-struct TORCH_API THPDevice {
+struct TORCH_PYTHON_API THPDevice {
   PyObject_HEAD
   at::Device device;
 };
 
-TORCH_API extern PyTypeObject THPDeviceType;
+TORCH_PYTHON_API extern PyTypeObject THPDeviceType;
 
 inline bool THPDevice_Check(PyObject* obj) {
   return Py_TYPE(obj) == &THPDeviceType;
 }
 
-TORCH_API PyObject* THPDevice_New(const at::Device& device);
+TORCH_PYTHON_API PyObject* THPDevice_New(const at::Device& device);
 
-TORCH_API void THPDevice_init(PyObject* module);
+TORCH_PYTHON_API void THPDevice_init(PyObject* module);

--- a/torch/csrc/Dtype.h
+++ b/torch/csrc/Dtype.h
@@ -6,14 +6,14 @@
 
 constexpr int DTYPE_NAME_LEN = 64;
 
-struct TORCH_API THPDtype {
+struct TORCH_PYTHON_API THPDtype {
   PyObject_HEAD
   at::ScalarType scalar_type;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   char name[DTYPE_NAME_LEN + 1];
 };
 
-TORCH_API extern PyTypeObject THPDtypeType;
+TORCH_PYTHON_API extern PyTypeObject THPDtypeType;
 
 inline bool THPDtype_Check(PyObject* obj) {
   return Py_TYPE(obj) == &THPDtypeType;
@@ -25,8 +25,8 @@ inline bool THPPythonScalarType_Check(PyObject* obj) {
       obj == (PyObject*)(&PyLong_Type);
 }
 
-TORCH_API PyObject* THPDtype_New(
+TORCH_PYTHON_API PyObject* THPDtype_New(
     at::ScalarType scalar_type,
     const std::string& name);
 
-void THPDtype_init(PyObject* module);
+TORCH_PYTHON_API void THPDtype_init(PyObject* module);

--- a/torch/csrc/Event.h
+++ b/torch/csrc/Event.h
@@ -2,19 +2,20 @@
 #define THP_EVENT_INC
 
 #include <c10/core/Event.h>
+#include <torch/csrc/Export.h>
 #include <torch/csrc/python_headers.h>
 
-struct TORCH_API THPEvent {
+struct TORCH_PYTHON_API THPEvent {
   PyObject_HEAD
   c10::Event event;
   PyObject* weakreflist;
 };
-TORCH_API extern PyTypeObject* THPEventClass;
-TORCH_API extern PyTypeObject THPEventType;
+TORCH_PYTHON_API extern PyTypeObject* THPEventClass;
+TORCH_PYTHON_API extern PyTypeObject THPEventType;
 
-TORCH_API void THPEvent_init(PyObject* module);
-TORCH_API void THPEvent_dealloc_common(THPEvent* self);
-TORCH_API PyObject* THPEvent_new(
+TORCH_PYTHON_API void THPEvent_init(PyObject* module);
+TORCH_PYTHON_API void THPEvent_dealloc_common(THPEvent* self);
+TORCH_PYTHON_API PyObject* THPEvent_new(
     c10::DeviceType device_type,
     c10::EventFlag flag);
 inline bool THPEvent_Check(PyObject* obj) {

--- a/torch/csrc/Stream.h
+++ b/torch/csrc/Stream.h
@@ -2,11 +2,10 @@
 #define THP_STREAM_INC
 
 #include <c10/core/Stream.h>
-#include <c10/macros/Export.h>
 #include <torch/csrc/Export.h>
 #include <torch/csrc/python_headers.h>
 
-struct THPStream {
+struct TORCH_PYTHON_API THPStream {
   PyObject_HEAD
   int64_t stream_id;
   int64_t device_type;
@@ -15,10 +14,10 @@ struct THPStream {
   PyObject* context;
   PyObject* weakreflist;
 };
-extern TORCH_API PyTypeObject* THPStreamClass;
+extern TORCH_PYTHON_API PyTypeObject* THPStreamClass;
 
-void THPStream_init(PyObject* module);
-TORCH_API void THPStream_dealloc_common(THPStream* self);
+TORCH_PYTHON_API void THPStream_init(PyObject* module);
+TORCH_PYTHON_API void THPStream_dealloc_common(THPStream* self);
 
 inline bool THPStream_Check(PyObject* obj) {
   return THPStreamClass && PyObject_IsInstance(obj, (PyObject*)THPStreamClass);


### PR DESCRIPTION
On Windows, several `torch/csrc` Python binding declarations were marked with `TORCH_API`, so Windows treated them as imported from `torch_cpu`. Their definitions live in `torch_python` (`THPDevice_*`, `THPDtype_*`, `THPEvent_*`, `THPStream_*` in the corresponding .cpp files), which triggers inconsistent-dllimport / C4273 warnings.

This PR fixes that by using `TORCH_PYTHON_API` on symbols that are part of `torch_python`, matching the approach in 
#144302.

Changes
`Device.h`, `Dtype.h`, `Event.h`, `Stream.h`

Replace `TORCH_API` with `TORCH_PYTHON_API` on structs, `PyTypeObject` globals, factories, and `_init` entry points implemented in `torch_python`.
Add `TORCH_PYTHON_API` where symbols were previously unannotated but exported from `torch_python`:

- `struct THPStream, THPStream_init (Stream.h)`
- `THPDtype_init (Dtype.h)`
- `THPEvent_dealloc_common`, `THPStream_dealloc_common` (same pattern as other THP exports)

In `Event.h` and `Stream.h`, keep an explicit `#include <torch/csrc/Export.h>` alongside `python_headers.h` so `TORCH_PYTHON_API` is not relied on via transitive includes.