### PR TITLE
[ROCm][Windows] Fix load_nvrtc inconsistent-dllimport warning

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -552,6 +552,7 @@ endif()
 if(USE_CUDA)
   list(APPEND Caffe2_GPU_CU_SRCS ${Caffe2_GPU_HIP_JIT_FUSERS_SRCS})
   add_library(caffe2_nvrtc SHARED ${ATen_NVRTC_STUB_SRCS})
+  target_compile_definitions(caffe2_nvrtc PRIVATE TORCH_CUDA_BUILD_MAIN_LIB)
   if(MSVC)
     # Delay load nvcuda.dll so we can import torch compiled with cuda on a CPU-only machine
     set(DELAY_LOAD_FLAGS "-DELAYLOAD:nvcuda.dll;delayimp.lib")
@@ -640,6 +641,7 @@ if(USE_ROCM)
   # caffe2_nvrtc's stubs to driver APIs are useful for HIP.
   # See NOTE [ ATen NVRTC Stub and HIP ]
   add_library(caffe2_nvrtc SHARED ${ATen_NVRTC_STUB_SRCS})
+  target_compile_definitions(caffe2_nvrtc PRIVATE TORCH_CUDA_BUILD_MAIN_LIB)
   target_link_libraries(caffe2_nvrtc hip::amdhip64 hiprtc::hiprtc)
   target_include_directories(caffe2_nvrtc PRIVATE ${CMAKE_BINARY_DIR})
   target_compile_definitions(caffe2_nvrtc PRIVATE USE_ROCM __HIP_PLATFORM_AMD__)


### PR DESCRIPTION
### Issue
`load_nvrtc` is implemented in `aten/src/ATen/cuda/nvrtc_stub/ATenNVRTC.cpp` but linked into the `caffe2_nvrtc` shared library, not `torch_cuda` / `torch_hip`.

The declaration uses `TORCH_CUDA_CPP_API`, which is dllexport only when `TORCH_CUDA_BUILD_MAIN_LIB` is set. That define was present for `torch_cuda` / `torch_hip`, but not for `caffe2_nvrtc`, so the stub saw dllimport on the declaration while still exporting the symbol from `caffe2_nvrtc` → `-Winconsistent-dllimport`.

### Fix
Add `target_compile_definitions(caffe2_nvrtc PRIVATE TORCH_CUDA_BUILD_MAIN_LIB)` in `caffe2/CMakeLists.txt` for both the `USE_CUDA` and `USE_ROCM` branches (each branch creates `caffe2_nvrtc` for its respective stub sources).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang