### PR TITLE
Bump packaging in docker image to min version

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -379,7 +379,7 @@ pip==26.0.1
 pyyaml==6.0.3
 pyzstd
 setuptools==78.1.1
-packaging==24.0
+packaging==24.2
 six
 
 scons==4.5.2 ; platform_machine == "aarch64"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #180250
* #180249
* #180248
* #180247
* #180245
* #180243
* #180242
* #180239
* #180238
* #180237
* __->__ #183700

The PEP 639 migration in the following commit ("Drop setuptools
concat_license_files; adopt PEP 639 license-files") requires
setuptools>=77, which in turn requires packaging>=24.2 to validate
the PEP 639 license expressions in pyproject.toml. The CI docker
image still pinned packaging==24.0.

The version is matched to the floor declared alongside the setuptools
bump in pyproject.toml and requirements-build.txt.

Landing this one-line bump on its own so the docker image refresh
propagates independently of the license PR (gh-180237), which had
been flaking on docker image rebuild races.

Co-Generated with [Claude Code](https://claude.com/claude-code)