### PR TITLE
[Windows] Fix -Winconsistent-dllimport in tensor_numpy and tensor_new headers

### DIFF
--- a/torch/csrc/utils/tensor_new.h
+++ b/torch/csrc/utils/tensor_new.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/csrc/Export.h>
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/python_arg_parser.h>
 
@@ -26,8 +27,8 @@ namespace torch::utils {
 //
 // `only_lift_cpu_tensors=true` is useful to prevent CUDA initialization under
 // FakeTensorMode because it avoids moving concrete data to CUDA.
-TORCH_API bool only_lift_cpu_tensors();
-TORCH_API void set_only_lift_cpu_tensors(bool value);
+TORCH_PYTHON_API bool only_lift_cpu_tensors();
+TORCH_PYTHON_API void set_only_lift_cpu_tensors(bool value);
 
 at::Tensor base_tensor_ctor(PyObject* args, PyObject* kwargs);
 TORCH_PYTHON_API at::Tensor legacy_tensor_ctor(

--- a/torch/csrc/utils/tensor_numpy.h
+++ b/torch/csrc/utils/tensor_numpy.h
@@ -1,25 +1,26 @@
 #pragma once
 
 #include <ATen/core/Tensor.h>
+#include <torch/csrc/Export.h>
 #include <torch/csrc/python_headers.h>
 
 namespace torch::utils {
 
-TORCH_API PyObject* tensor_to_numpy(
+TORCH_PYTHON_API PyObject* tensor_to_numpy(
     const at::Tensor& tensor,
     bool force = false);
 
-TORCH_API at::Tensor tensor_from_numpy(
+TORCH_PYTHON_API at::Tensor tensor_from_numpy(
     PyObject* obj,
     bool warn_if_not_writeable = true);
 
-TORCH_API int aten_to_numpy_dtype(const at::ScalarType scalar_type);
-TORCH_API at::ScalarType numpy_dtype_to_aten(int dtype);
+TORCH_PYTHON_API int aten_to_numpy_dtype(const at::ScalarType scalar_type);
+TORCH_PYTHON_API at::ScalarType numpy_dtype_to_aten(int dtype);
 
-TORCH_API bool is_numpy_available();
-TORCH_API bool is_numpy_int(PyObject* obj);
-TORCH_API bool is_numpy_bool(PyObject* obj);
-TORCH_API bool is_numpy_scalar(PyObject* obj);
+TORCH_PYTHON_API bool is_numpy_available();
+TORCH_PYTHON_API bool is_numpy_int(PyObject* obj);
+TORCH_PYTHON_API bool is_numpy_bool(PyObject* obj);
+TORCH_PYTHON_API bool is_numpy_scalar(PyObject* obj);
 
 void warn_numpy_not_writeable();
 at::Tensor tensor_from_cuda_array_interface(


### PR DESCRIPTION
Declarations in `tensor_numpy.h` and `tensor_new.h` used `TORCH_API` while the symbols are defined in `torch_python`. That mismatch caused `-Winconsistent-dllimport `. With using `TORCH_PYTHON_API` instead of `TORCH_API` import/export matches the right DLL.