### PR TITLE
[SymmMem] Fix missing #include <cuda.h> in CUDASymmetricMemoryTypes.hpp (#183704)

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
@@ -9,6 +9,8 @@
 
 #if defined(USE_ROCM)
 #include <hip/hip_runtime_api.h>
+#elif defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+#include <cuda.h>
 #endif
 
 namespace c10d::symmetric_memory {


### PR DESCRIPTION
Summary:

CUDASymmetricMemoryTypes.hpp uses CUmemGenericAllocationHandle when PYTORCH_C10_DRIVER_API_SUPPORTED is defined, but never includes the CUDA driver API header that provides it. In the Buck build at Meta, this define is exported from c10_cuda to all consumers via `defines`, causing a compilation error when building libtorch_nvshmem. In the OSS CMake build, the define is PRIVATE to c10_cuda so this code path is not hit by downstream targets.

Add the missing `#include <cuda.h>` under the existing `#if` guard, matching the pattern used by other files (e.g. CUDACachingAllocator.cpp).

Test Plan:
buck build fbcode//caffe2:libtorch_nvshmem_obj -c hpc_comms.use_nvshmem=stable -c nvshmem.use_static_linking=true

Verified the CUmemGenericAllocationHandle type resolves correctly and libtorch_nvshmem_obj compiles without errors.

Reviewed By: yang-yu-hang

Differential Revision: D104474961


