### PR TITLE
[SymmMem] Normalize device index in empty_strided_p2p (#183705)

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
@@ -9,6 +9,8 @@
 
 #if defined(USE_ROCM)
 #include <hip/hip_runtime_api.h>
+#elif defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+#include <cuda.h>
 #endif
 
 namespace c10d::symmetric_memory {

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -263,6 +263,13 @@ at::Tensor empty_strided_p2p(
     c10::Device device,
     const std::optional<std::string>& group_name,
     std::optional<uint64_t> alloc_id) {
+  // Ensure device has an explicit index so downstream code (e.g. TeamManager)
+  // sees a consistent device identity.
+  if (!device.has_index()) {
+    device = c10::Device(
+        device.type(),
+        c10::impl::getDeviceGuardImpl(device.type())->getDevice().index());
+  }
   if (alloc_id.has_value()) {
     return empty_strided_p2p_persistent(
         size, stride, dtype, device, group_name, *alloc_id);


### PR DESCRIPTION
Summary:

When a device without an explicit index (e.g. `torch.device("cuda")` instead of `torch.device("cuda:0")`) is passed to `symm_mem.empty()`, `device.index()` returns -1. This propagates through `empty_strided_p2p` -> allocator -> `NVSHMEMAllocation.device_idx`, and eventually into `TeamManager::get()`. The TeamManager singleton sees `cuda` (index -1) as a different device than `cuda:0` (index 0), raising a spurious "Detected use of TeamManager on multiple devices" error.

Normalize the device to always have an explicit index by querying the current device via `getDeviceGuardImpl` at the top of `empty_strided_p2p`. This is device-agnostic (works for CUDA, ROCm, etc.) and matches the pattern used by `torch.empty()` which also resolves the current device when no index is specified.

Test Plan:
Ran param comms NVSHMEM all_to_allv benchmark on 2x H100 GPUs where the device was passed as "cuda" (without index). Before this fix, TeamManager raised "multiple devices" error. After this fix, the benchmark completes successfully:

COMMS-RES-all_to_allv-float32  8192  1024  147.7us p50  0.055 GB/s algBW

Differential Revision: D104474959


