### PR TITLE
Validate dim in cummax/cummin meta for empty tensors

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2870,6 +2870,15 @@ class TestTorchDeviceType(TestCase):
                     'Dimension out of range'):
                 op(x, -46)
 
+            # The fake/meta path must reject the same invalid dims. Previously it
+            # silently accepted them for empty non-scalar tensors, diverging from
+            # eager under torch.compile / export tracing.
+            from torch._subclasses.fake_tensor import FakeTensorMode
+            with FakeTensorMode():
+                fake_x = torch.empty([1, 0], device=device)
+                with self.assertRaisesRegex(IndexError, 'Dimension out of range'):
+                    op(fake_x, 100)
+
             # Check that op over a zero length dimension doesn't crash on backprop.
             # Also check that op over other dimensions in a tensor with a zero-length
             # dimension also works

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -282,8 +282,9 @@ def linalg_matrix_sqrth(self):
 def cummaxmin(self, dim):
     values = torch.empty(self.shape, device=self.device, dtype=self.dtype)
     indices = torch.empty(self.shape, device=self.device, dtype=torch.int64)
-    if self.numel() != 0 and self.ndim != 0:
-        # Checks that dim is within bounds
+    if self.ndim != 0:
+        # Checks that dim is within bounds. Done for empty tensors too so the
+        # fake/meta path matches eager, which validates dim regardless of numel.
         maybe_wrap_dim(dim, self.ndim)
     return values, indices
 


### PR DESCRIPTION
The eager side of this was fixed in #188361 (invalid `dim` on empty
non-scalar tensors now raises `IndexError`). This PR fixes the remaining
gap in the `cummaxmin` meta registration, which still skipped validation
when `numel() == 0`:

```python
if self.numel() != 0 and self.ndim != 0:
    maybe_wrap_dim(dim, self.ndim)
```

Because the fake/meta path skipped the check, tracing (torch.compile /
export) silently accepted out-of-range dims for empty non-scalar tensors
while eager raised. Dropping the `numel()` guard makes the meta validate
`dim` whenever `ndim != 0`, matching eager.

Test: added a `FakeTensorMode` check next to the existing eager
range-check in `test_cummax_cummin`, asserting the fake path raises
`IndexError` for an empty tensor with an out-of-range dim.

Follow-up to #188361; original report #131273.