### PR TITLE
[ci] Fix ENABLE_TORCH_TRACE on OSDC runners and perf_cli H100/B200 support

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -782,6 +782,7 @@ jobs:
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
+          ENABLE_TORCH_TRACE: ${{ inputs.enable-torch-trace }}
           VLLM_TEST_HUGGING_FACE_TOKEN: ${{ secrets.VLLM_TEST_HUGGING_FACE_TOKEN }}
           HF_CACHE: /mnt/hf_cache
           TRANSFORMERS_OFFLINE: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(steps.keep-going.outputs.labels, 'ci-refresh-hf-cache')) && '0' || '1' }}

--- a/benchmarks/dynamo/perf_cli.py
+++ b/benchmarks/dynamo/perf_cli.py
@@ -87,7 +87,7 @@ REPO = "pytorch/pytorch"
 # Regex to parse test job names like:
 # "cuda13.0-py3.10-gcc11-sm80 / test (inductor_huggingface_perf, 1, 5, linux.aws.a100)"
 JOB_RE = re.compile(
-    r"test \((?P<config>[^,]+),\s*(?P<shard>\d+),\s*(?P<num_shards>\d+),\s*(?P<runner>[^)]+)\)"
+    r"(?P<job_name>test(?:-osdc)?) \((?P<config>[^,]+),\s*(?P<shard>\d+),\s*(?P<num_shards>\d+),\s*(?P<runner>[^)]+)\)"
 )
 
 PERF_CONFIGS = re.compile(r"inductor_(huggingface|timm|torchbench)_perf")
@@ -309,6 +309,7 @@ def get_perf_jobs(jobs: list[dict]) -> list[dict]:
                 "runner": m.group("runner"),
                 "job_id": job["databaseId"],
                 "name": job["name"],
+                "job_prefix": m.group("job_name"),
             }
         )
     return perf_jobs
@@ -320,7 +321,8 @@ def s3_artifact_url(run_id: int, attempt: int, job: dict) -> str:
     num_shards = job["num_shards"]
     runner = job["runner"]
     job_id = job["job_id"]
-    filename = f"test-reports-test-{config}-{shard}-{num_shards}-{runner}_{job_id}.zip"
+    job_prefix = job.get("job_prefix", "test")
+    filename = f"test-reports-{job_prefix}-{config}-{shard}-{num_shards}-{runner}_{job_id}.zip"
     return f"{S3_URL}/{REPO}/{run_id}/{attempt}/artifact/{filename}"
 
 

--- a/benchmarks/dynamo/perf_cli.py
+++ b/benchmarks/dynamo/perf_cli.py
@@ -322,7 +322,9 @@ def s3_artifact_url(run_id: int, attempt: int, job: dict) -> str:
     runner = job["runner"]
     job_id = job["job_id"]
     job_prefix = job.get("job_prefix", "test")
-    filename = f"test-reports-{job_prefix}-{config}-{shard}-{num_shards}-{runner}_{job_id}.zip"
+    filename = (
+        f"test-reports-{job_prefix}-{config}-{shard}-{num_shards}-{runner}_{job_id}.zip"
+    )
     return f"{S3_URL}/{REPO}/{run_id}/{attempt}/artifact/{filename}"
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183718

The OSDC test path (used by H100/B200 runners) had its own env block that
was missing ENABLE_TORCH_TRACE, so torch trace was silently disabled despite
the workflow passing enable-torch-trace: "1". Also fix perf_cli.py to handle
the test-osdc job name prefix and S3 artifact path.

written with claude code

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98