### PR TITLE
[ROCm] Fix maybe_hipify_code_wrapper for bare-token inputs

### DIFF
--- a/torch/_inductor/codegen/aoti_hipify_utils.py
+++ b/torch/_inductor/codegen/aoti_hipify_utils.py
@@ -28,9 +28,11 @@ def maybe_hipify_code_wrapper(source_codes: str, force_hipify: bool = False) -> 
     # keyword at the beginning of code line. However, this can happen in codegen,
     # which will cause the pattern to not match.
 
-    # Note that lookahead (?=\W) is still needed to keep hipification idomponent, for example
-    # we need to skip replacing "getStreamFromExternal" in "getStreamFromExternalMasqueradingAsCUDA"
-    RE_PYTORCH_PREPROCESSOR = re.compile(rf"({PYTORCH_TRIE.export_to_regex()})(?=\W)")
+    # Note that lookahead (?=\W|$) is still needed to keep hipification idempotent, for example
+    # we need to skip replacing "getStreamFromExternal" in "getStreamFromExternalMasqueradingAsCUDA".
+    # End-of-string must also count as a boundary so bare-token inputs like "CUfunction"
+    # (returned by device_codegen.cpp_kernel_type()) get hipified too.
+    RE_PYTORCH_PREPROCESSOR = re.compile(rf"({PYTORCH_TRIE.export_to_regex()})(?=\W|$)")
 
     source_codes = RE_PYTORCH_PREPROCESSOR.sub(c2_repl, source_codes)  # type: ignore[arg-type]
     return source_codes


### PR DESCRIPTION
The hipify regex used `(?=\W)` lookahead to stay idempotent and avoid partial matches (e.g. not mangling `getStreamFromExternal` inside `getStreamFromExternalMasqueradingAsCUDA`). However, end-of-string is not a non-word character, so calling `maybe_hipify_code_wrapper` on a bare token like `"CUfunction"` returned it unchanged.

This regressed in #182953, which restructured the JIT lazy-Triton kernel decl in `cpp_wrapper_gpu.py` to call hipify on `device_codegen.cpp_kernel_type()` directly (a bare `"CUfunction"`) instead of on the full formed `"static CUfunction <name> = nullptr;"` line. On ROCm builds the generated wrapper then emits `static CUfunction triton_... = nullptr;`, which fails to compile because the CUDA driver header is not in scope:

  error: 'CUfunction' does not name a type

Test affected (DynamicShapesCodegenCpuTests runs it on ROCm machines because of `@requires_gpu_and_triton`):

  test/inductor/test_torchinductor_codegen_dynamic_shapes.py::
    DynamicShapesCodegenCpuTests::
      test_cpu_scalar_with_gpu_tensor_cpp_dynamic_shapes_cpu

Fix: extend the lookahead to `(?=\W|$)` so bare-token inputs also hipify. Idempotency is preserved because the post-hipification identifiers (e.g. `hipFunction_t`) are not present in `PYTORCH_TRIE`.

Authored by Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben