### PR TITLE
[CD][XPU] Use content-hash-tagged docker images for XPU binary builds

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -35,6 +35,13 @@ name: !{{ build_environment }}
   {%- set timeout_minutes = 420 %}
   {%- set runner_prefix = "" %}
   {%- set use_container_directive = false %}
+{%- elif "xpu" in build_environment %}
+  {%- set build_runs_on = "linux.12xlarge.memory.ephemeral" %}
+  {%- set test_runs_on  = "" %}
+  {%- set alpine_image  = "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine" %}
+  {%- set timeout_minutes = common.timeout_minutes %}
+  {%- set runner_prefix = "${{ needs.get-label-type.outputs.label-type }}" %}
+  {%- set use_container_directive = false %}
 {%- else %}
   {%- set build_runs_on = "linux.12xlarge.memory.ephemeral" %}
   {%- set test_runs_on  = "" %}{# CPU/CUDA test runners are picked per-matrix entry below #}

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -155,9 +155,37 @@ jobs:
           bash .ci/${{ inputs.PACKAGE_TYPE }}/build.sh
 
       # Bare-runner path: spawn the build container manually.
+      - name: configure aws credentials
+        id: aws_creds
+        if: ${{ !inputs.use_container_directive && inputs.build_environment != 'linux-s390x-binary-manywheel' && startsWith(github.event.ref, 'refs/tags/ciflow/') }}
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+          aws-region: us-east-1
+          role-duration-seconds: 18000
+
+      - name: Calculate docker image
+        id: calculate-docker-image
+        if: ${{ !inputs.use_container_directive && inputs.build_environment != 'linux-s390x-binary-manywheel' }}
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        with:
+          docker-registry: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/') && '308535385114.dkr.ecr.us-east-1.amazonaws.com' || 'docker.io' }}
+          docker-image-name: ${{ inputs.DOCKER_IMAGE }}
+          custom-tag-prefix: ${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
+          docker-build-dir: .ci/docker
+          docker-build-script: manywheel/build.sh
+
+      - name: Pull Docker image
+        if: ${{ !inputs.use_container_directive && inputs.build_environment != 'linux-s390x-binary-manywheel' }}
+        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        with:
+          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
+
       - name: Build PyTorch binary (docker run)
         if: ${{ !inputs.use_container_directive }}
         shell: bash
+        env:
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image || format('pytorch/{0}:{1}', inputs.DOCKER_IMAGE, inputs.DOCKER_IMAGE_TAG_PREFIX) }}
         run: |
           set -x
           container_name=$(docker run \

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -446,7 +446,7 @@ jobs:
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runs_on: linux.12xlarge.memory.ephemeral
-      use_container_directive: true
+      use_container_directive: false
       ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: ${{ matrix.pytorch_extra_install_requirements }}
       timeout-minutes: ${{ matrix.timeout_minutes }}


### PR DESCRIPTION
## Summary
- Set `use_container_directive=false` for XPU in the binary build Jinja template, so XPU builds use the `docker run` path instead of GHA's `container:` directive.
- Add `calculate-docker-image`, `pull-docker-image`, and `configure aws credentials` steps to the bare-runner path in `_binary-build-linux.yml`, reusing the `pytorch/test-infra/.github/actions/calculate-docker-image` action (matching the release/2.12 pattern). These steps are gated on `!inputs.use_container_directive` and exclude s390x.
- The `docker run` build step now uses the resolved content-hash-tagged image, with a fallback to the simple `pytorch/{image}:{prefix}` tag.

This ensures XPU binary builds pull the correct content-hash-tagged docker image.