### PR TITLE
[DDE] Fix data-dependent errors in meta functions

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -539,10 +539,10 @@ def glu_backward(grad_output: Tensor, self: Tensor, dim: int) -> Tensor:
         raise AssertionError("glu does not support 0-dimensional tensors")
     wrap_dim = utils.canonicalize_dim(self.dim(), dim)
     nIn = self.size(wrap_dim)
-    if nIn % 2 != 0:
-        raise AssertionError(
-            f"Halving dimension must be even, but dimension {wrap_dim} is size {nIn}"
-        )
+    torch._check(
+        nIn % 2 == 0,
+        lambda: f"Halving dimension must be even, but dimension {wrap_dim} is size {nIn}",
+    )
     inputSize = nIn // 2
     firstHalf = self.narrow(wrap_dim, 0, inputSize)
     secondHalf = self.narrow(wrap_dim, inputSize, inputSize)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1560,7 +1560,7 @@ def lu_unpack_meta(
     sizes = list(LU.shape)
     m = sizes[-2]
     n = sizes[-1]
-    k = min(m, n)
+    k = sym_min(m, n)
     sizes[-1] = m
     if unpack_pivots:
         P = LU.new_empty(sizes)
@@ -1610,7 +1610,7 @@ def linalg_qr_meta(A: Tensor, mode: str = "reduced") -> tuple[Tensor, Tensor]:
 
     m = A.shape[-2]
     n = A.shape[-1]
-    k = min(m, n)
+    k = sym_min(m, n)
 
     if compute_q:
         Q_shape = list(A.shape)
@@ -7920,12 +7920,10 @@ def linear_backward(input_, grad_output_, weight_, output_mask):
 
 @register_meta(aten.pixel_shuffle.default)
 def meta_pixel_shuffle(self, upscale_factor):
-    if not (
-        len(self.shape) > 2 and self.shape[-3] % (upscale_factor * upscale_factor) == 0
-    ):
-        raise AssertionError(
-            f"Invalid input shape for pixel_shuffle: {self.shape} with upscale_factor = {upscale_factor}"
-        )
+    torch._check(
+        len(self.shape) > 2 and self.shape[-3] % (upscale_factor * upscale_factor) == 0,
+        lambda: f"Invalid input shape for pixel_shuffle: {self.shape} with upscale_factor = {upscale_factor}",
+    )
 
     def is_channels_last(ten):
         return torch._prims_common.suggest_memory_format(ten) == torch.channels_last
@@ -7947,7 +7945,9 @@ def meta_pixel_shuffle(self, upscale_factor):
     out_shape = (*self.shape[:-3], C, Hr, Wr)
 
     out = self.new_empty(out_shape)
-    out = out.to(memory_format=pick_memory_format())  # type: ignore[call-overload]
+    fmt = pick_memory_format()
+    if fmt is not torch.contiguous_format:
+        out = out.to(memory_format=fmt)  # type: ignore[call-overload]
     return out
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183736

Fix GuardOnDataDependentSymNode errors in four meta/decomp functions:

- lu_unpack_meta, linalg_qr_meta: min(m, n) -> sym_min(m, n) to avoid
  eager comparison on unbacked SymInts. Matches existing pattern in
  linalg_lu_meta and linalg_lu_factor_ex_meta.
- meta_pixel_shuffle: convert validation branch to torch._check for
  deferred runtime assertion. Skip redundant contiguous_format .to()
  call to avoid internal guard on symbolic channel dim.
- glu_backward: convert validation branch to torch._check.

Authored by Claude (DDE Fix Framework).