### PR TITLE
Add drift-based tolerance fallback to op tests

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14919,6 +14919,10 @@ def _autograd_grad_inputs(op, sample, grad_outputs):
     leaves = pytree.tree_leaves(([sample.input, *sample.args], sample.kwargs))
     diff_out = tuple(t for t in out if isinstance(t, torch.Tensor) and t.requires_grad)
     diff_arg = tuple(t for t in leaves if isinstance(t, torch.Tensor) and t.requires_grad)
+    if len(diff_out) != len(grad_outputs):
+        raise RuntimeError(
+            f"diff_out has {len(diff_out)} tensors but grad_outputs has {len(grad_outputs)}"
+        )
     return torch.autograd.grad(diff_out, diff_arg, grad_outputs=grad_outputs, allow_unused=True)
 
 
@@ -14953,6 +14957,14 @@ class TestDriftFallbackHelper(TestCaseMPS):
         mps = torch.tensor([1.0, 3.0], dtype=torch.float32, device="mps")
         with self.assertRaises(AssertionError):
             self._call(cpu, mps, cpu.float(), dtype=torch.float32)
+
+    def test_python_scalar_outputs_reraise_immediately(self):
+        # Ops returning Python scalars (item, allclose, equal) shouldn't enter
+        # the drift path -- the assertEqual failure must propagate as-is.
+        with self.assertRaises(AssertionError):
+            self._call(1.0, 2.0, 1.0)
+        with self.assertRaises(AssertionError):
+            self._call(True, False, True)
 
     def test_cpu_meets_budget_is_real_regression(self):
         # CPU exactly matches fp32 reference; MPS is off. Real regression.

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -27,7 +27,12 @@ from torch.testing._internal import opinfo
 from torch.testing._internal.common_utils import \
     (gradcheck, gradgradcheck, parametrize, run_tests, TestCase, download_file, MACOS_VERSION, IS_CI,
      NoTest, skipIfSlowGradcheckEnv, suppress_warnings, serialTest, instantiate_parametrized_tests, xfailIf)
-from torch.testing._internal.common_mps import mps_ops_modifier, mps_ops_grad_modifier, mps_ops_error_inputs_modifier
+from torch.testing._internal.common_mps import (
+    assert_mps_match_or_drift,
+    mps_ops_modifier,
+    mps_ops_grad_modifier,
+    mps_ops_error_inputs_modifier,
+)
 from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import get_all_dtypes, integral_types
 import torch.backends.mps
@@ -14900,6 +14905,192 @@ def transform_opinfo_sample_to_cpu(sample, dtype=None):
 
     return cpu_sample
 
+
+def _call_op_ignoring_user_warnings(op, sample):
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        return op(sample.input, *sample.args, **sample.kwargs)
+
+
+def _autograd_grad_inputs(op, sample, grad_outputs):
+    """Forward op(sample) and autograd.grad wrt sample's requires_grad tensors."""
+    out = _call_op_ignoring_user_warnings(op, sample)
+    out = (out,) if isinstance(out, torch.Tensor) else tuple(out)
+    leaves = pytree.tree_leaves(([sample.input, *sample.args], sample.kwargs))
+    diff_out = tuple(t for t in out if isinstance(t, torch.Tensor) and t.requires_grad)
+    diff_arg = tuple(t for t in leaves if isinstance(t, torch.Tensor) and t.requires_grad)
+    return torch.autograd.grad(diff_out, diff_arg, grad_outputs=grad_outputs, allow_unused=True)
+
+
+class TestDriftFallbackHelper(TestCaseMPS):
+    """Unit tests for assert_mps_match_or_drift covering each branch."""
+
+    FP16_ATOL = 5e-2
+    FP16_RTOL = 5e-2
+
+    def _call(self, cpu, mps, fp32, **kwargs):
+        kwargs.setdefault("atol", self.FP16_ATOL)
+        kwargs.setdefault("rtol", self.FP16_RTOL)
+        kwargs.setdefault("dtype", torch.float16)
+        return assert_mps_match_or_drift(self, cpu, mps, lambda: fp32, **kwargs)
+
+    def test_happy_path_does_not_invoke_callback(self):
+        x = torch.tensor([1.0, 2.0], dtype=torch.float16)
+        invoked = [False]
+
+        def callback():
+            invoked[0] = True
+            return x
+
+        assert_mps_match_or_drift(
+            self, x, x.clone(), callback,
+            atol=self.FP16_ATOL, rtol=self.FP16_RTOL, dtype=torch.float16,
+        )
+        self.assertFalse(invoked[0])
+
+    def test_non_drift_dtype_reraises_immediately(self):
+        cpu = torch.tensor([1.0, 2.0], dtype=torch.float32)
+        mps = torch.tensor([1.0, 3.0], dtype=torch.float32, device="mps")
+        with self.assertRaises(AssertionError):
+            self._call(cpu, mps, cpu.float(), dtype=torch.float32)
+
+    def test_cpu_meets_budget_is_real_regression(self):
+        # CPU exactly matches fp32 reference; MPS is off. Real regression.
+        fp32 = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
+        cpu = fp32.to(torch.float16)
+        mps = torch.tensor([1.0, 2.0, 10.0], dtype=torch.float16, device="mps")
+        with self.assertRaisesRegex(AssertionError, "real regression"):
+            self._call(cpu, mps, fp32)
+
+    def test_drift_within_bound_passes(self):
+        # Both CPU and MPS drift from fp32; MPS drift <= 2 * CPU drift + atol.
+        fp32 = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
+        cpu = torch.tensor([1.5, 2.5, 3.5], dtype=torch.float16)
+        mps = torch.tensor([0.5, 1.0, 2.0], dtype=torch.float16, device="mps")
+        self._call(cpu, mps, fp32)
+
+    def test_drift_exceeds_bound_raises(self):
+        # CPU drifts by 0.5 from fp32; MPS drifts by 100 -- well beyond 2*cpu + atol.
+        fp32 = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
+        cpu = torch.tensor([1.5, 2.5, 3.5], dtype=torch.float16)
+        mps = torch.tensor([100.0, 100.0, 100.0], dtype=torch.float16, device="mps")
+        with self.assertRaisesRegex(AssertionError, "MPS drift"):
+            self._call(cpu, mps, fp32)
+
+    def test_nan_position_mismatch_is_regression(self):
+        # MPS returns 0 where CPU and fp32 return NaN -- drift math would
+        # silently accept this; the finite-alignment check must catch it.
+        fp32 = torch.tensor([1.0, float("nan"), 3.0], dtype=torch.float32)
+        cpu = fp32.to(torch.float16)
+        mps = torch.tensor([1.0, 0.0, 3.0], dtype=torch.float16, device="mps")
+        with self.assertRaisesRegex(AssertionError, "finite/non-finite"):
+            self._call(cpu, mps, fp32)
+
+    def test_aligned_nan_then_drift_passes(self):
+        # NaN positions match; finite elements drift within bound.
+        fp32 = torch.tensor([1.0, float("nan"), 3.0], dtype=torch.float32)
+        cpu = torch.tensor([1.5, float("nan"), 3.5], dtype=torch.float16)
+        mps = torch.tensor([0.5, float("nan"), 2.0], dtype=torch.float16, device="mps")
+        self._call(cpu, mps, fp32)
+
+    def test_aligned_nan_with_over_bound_drift_raises(self):
+        # Aligned NaNs must not contaminate .max() and silently accept wild drift.
+        fp32 = torch.tensor([1.0, float("nan"), 3.0], dtype=torch.float32)
+        cpu = torch.tensor([1.5, float("nan"), 3.5], dtype=torch.float16)
+        mps = torch.tensor([100.0, float("nan"), 100.0], dtype=torch.float16, device="mps")
+        with self.assertRaisesRegex(AssertionError, "MPS drift"):
+            self._call(cpu, mps, fp32)
+
+    def test_tuple_skips_passing_tensors(self):
+        # One tensor passes fixed tolerance; the other needs drift fallback.
+        fp32_0 = torch.tensor([1.0, 2.0], dtype=torch.float32)
+        cpu_0 = torch.tensor([1.001, 2.001], dtype=torch.float16)
+        mps_0 = torch.tensor([1.001, 2.001], dtype=torch.float16, device="mps")
+        fp32_1 = torch.tensor([1.0, 2.0], dtype=torch.float32)
+        cpu_1 = torch.tensor([1.5, 2.5], dtype=torch.float16)
+        mps_1 = torch.tensor([0.5, 1.0], dtype=torch.float16, device="mps")
+        self._call((cpu_0, cpu_1), (mps_0, mps_1), (fp32_0, fp32_1))
+
+    def test_tuple_with_none_entries_skipped(self):
+        # autograd.grad(allow_unused=True) yields None -- must not raise.
+        fp32 = torch.tensor([1.0], dtype=torch.float32)
+        cpu = torch.tensor([1.5], dtype=torch.float16)
+        mps = torch.tensor([0.5], dtype=torch.float16, device="mps")
+        self._call((cpu, None), (mps, None), (fp32, None))
+
+    def test_bfloat16_uses_drift_fallback(self):
+        # Same semantics as fp16; ensure bf16 is also in _DRIFT_FALLBACK_DTYPES.
+        fp32 = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
+        cpu = torch.tensor([1.5, 2.5, 3.5], dtype=torch.bfloat16)
+        mps = torch.tensor([0.5, 1.0, 2.0], dtype=torch.bfloat16, device="mps")
+        self._call(cpu, mps, fp32, dtype=torch.bfloat16)
+
+    def test_default_atol_rtol_from_dtype(self):
+        # atol=None, rtol=None must resolve to dtype defaults in the drift path.
+        # fp16 defaults are roughly atol=1e-5, rtol=1e-3; construct values that
+        # fail assertEqual under those defaults but pass the drift check.
+        fp32 = torch.tensor([1.0], dtype=torch.float32)
+        cpu = torch.tensor([1.01], dtype=torch.float16)
+        mps = torch.tensor([1.02], dtype=torch.float16, device="mps")
+        self._call(cpu, mps, fp32, atol=None, rtol=None)
+
+    def test_sequence_length_mismatch_raises(self):
+        # Silent zip truncation would miss tensors; strict=True must catch it.
+        cpu = (torch.tensor([1.5], dtype=torch.float16),
+               torch.tensor([2.5], dtype=torch.float16))
+        mps = (torch.tensor([0.5], dtype=torch.float16, device="mps"),)
+        fp32 = (torch.tensor([1.0], dtype=torch.float32),
+                torch.tensor([2.0], dtype=torch.float32))
+        with self.assertRaises((ValueError, AssertionError)):
+            self._call(cpu, mps, fp32)
+
+    def test_reverse_nan_mismatch_is_regression(self):
+        # MPS produces NaN where CPU is finite -- symmetric to the forward case.
+        fp32 = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
+        cpu = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float16)
+        mps = torch.tensor([1.0, float("nan"), 3.0], dtype=torch.float16, device="mps")
+        with self.assertRaisesRegex(AssertionError, "finite/non-finite"):
+            self._call(cpu, mps, fp32)
+
+    def test_aligned_inf_with_drifting_finites_passes(self):
+        # +inf aligned across CPU/MPS/fp32; finite values drift within bound.
+        fp32 = torch.tensor([1.0, float("inf"), 3.0], dtype=torch.float32)
+        cpu = torch.tensor([1.5, float("inf"), 3.5], dtype=torch.float16)
+        mps = torch.tensor([0.5, float("inf"), 2.0], dtype=torch.float16, device="mps")
+        self._call(cpu, mps, fp32)
+
+    def test_aligned_inf_with_over_bound_drift_raises(self):
+        # Aligned +inf must not contaminate .max() and accept wild finite drift.
+        fp32 = torch.tensor([1.0, float("inf"), 3.0], dtype=torch.float32)
+        cpu = torch.tensor([1.5, float("inf"), 3.5], dtype=torch.float16)
+        mps = torch.tensor([100.0, float("inf"), 100.0], dtype=torch.float16, device="mps")
+        with self.assertRaisesRegex(AssertionError, "MPS drift"):
+            self._call(cpu, mps, fp32)
+
+    def test_inf_position_mismatch_is_regression(self):
+        # CPU has +inf where MPS is finite.
+        fp32 = torch.tensor([1.0, float("inf"), 3.0], dtype=torch.float32)
+        cpu = torch.tensor([1.0, float("inf"), 3.0], dtype=torch.float16)
+        mps = torch.tensor([1.0, 10.0, 3.0], dtype=torch.float16, device="mps")
+        with self.assertRaisesRegex(AssertionError, "finite/non-finite"):
+            self._call(cpu, mps, fp32)
+
+    def test_plus_inf_vs_minus_inf_is_regression(self):
+        # Both non-finite at the same position but different signs -- must be caught.
+        fp32 = torch.tensor([float("inf")], dtype=torch.float32)
+        cpu = torch.tensor([float("inf")], dtype=torch.float16)
+        mps = torch.tensor([float("-inf")], dtype=torch.float16, device="mps")
+        with self.assertRaisesRegex(AssertionError, "non-finite values differ"):
+            self._call(cpu, mps, fp32)
+
+    def test_label_appears_in_error_message(self):
+        fp32 = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
+        cpu = fp32.to(torch.float16)
+        mps = torch.tensor([1.0, 2.0, 10.0], dtype=torch.float16, device="mps")
+        with self.assertRaisesRegex(AssertionError, "myop float16"):
+            self._call(cpu, mps, fp32, label="myop float16")
+
+
 class TestConsistency(TestCaseMPS):
     # TODO: This is only used while some ops are being added.
     # This list should contain all ops and dtypes eventually
@@ -15207,7 +15398,13 @@ class TestConsistency(TestCaseMPS):
                 self.assertEqual(A_herm, recon, atol=atol, rtol=rtol)
                 continue
 
-            self.assertEqual(cpu_out, mps_out, atol=atol, rtol=rtol)
+            assert_mps_match_or_drift(
+                self, cpu_out, mps_out,
+                lambda: _call_op_ignoring_user_warnings(
+                    op, transform_opinfo_sample_to_cpu(mps_sample, dtype=torch.float32)
+                ),
+                atol=atol, rtol=rtol, dtype=dtype, label=f"{op.name} {dtype}",
+            )
 
     @ops(mps_ops_grad_modifier(copy.deepcopy(test_consistency_op_db)), allowed_dtypes=MPS_GRAD_DTYPES)
     def test_output_grad_match(self, device, dtype, op):
@@ -15269,7 +15466,13 @@ class TestConsistency(TestCaseMPS):
                 recon = (Q_m * w_m.to(Q_m.dtype).unsqueeze(-2)) @ Q_m.mH
                 self.assertEqual(A_herm, recon, atol=atol, rtol=rtol)
             else:
-                self.assertEqual(cpu_out, mps_out, atol=atol, rtol=rtol)
+                assert_mps_match_or_drift(
+                    self, cpu_out, mps_out,
+                    lambda: _call_op_ignoring_user_warnings(
+                        op, transform_opinfo_sample_to_cpu(mps_sample, dtype=torch.float32)
+                    ),
+                    atol=atol, rtol=rtol, dtype=dtype, label=f"{op.name} {dtype}",
+                )
 
             #
             # Backward check
@@ -15373,7 +15576,18 @@ class TestConsistency(TestCaseMPS):
             else:
                 # TODO: Handle list inputs later
                 equal_input_types = True
-            self.assertEqual(cpu_grad_inputs, mps_grad_inputs, atol=atol, rtol=rtol, exact_dtype=equal_input_types)
+
+            assert_mps_match_or_drift(
+                self, cpu_grad_inputs, mps_grad_inputs,
+                lambda: _autograd_grad_inputs(
+                    op,
+                    transform_opinfo_sample_to_cpu(mps_sample, dtype=torch.float32),
+                    tuple(g.float() for g in cpu_grad_outputs),
+                ),
+                atol=atol, rtol=rtol, dtype=dtype,
+                label=f"{op.name} {dtype} backward",
+                exact_dtype=equal_input_types,
+            )
 
     # The CPU impl of grid_sampler_3d gives a large amount of error for half
     # precision types. So instead of testing MPS-vs-CPU outputs, test

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -2,9 +2,111 @@ import unittest
 from collections.abc import Sequence
 
 import torch
+from torch.testing._comparison import default_tolerances
 
 from .common_utils import MACOS_VERSION
 from .opinfo.core import DecorateInfo, OpInfo
+
+
+_DRIFT_FALLBACK_DTYPES = (torch.float16, torch.bfloat16)
+_DRIFT_SLACK = 2.0
+
+
+def assert_mps_match_or_drift(
+    test_case,
+    cpu_outs,
+    mps_outs,
+    fp32_outs_fn,
+    *,
+    atol,
+    rtol,
+    dtype,
+    label="",
+    **assertEqual_kwargs,
+):
+    """Compare MPS vs CPU at the target dtype. For fp16/bf16, fall back to a
+    drift check against a shared fp32 reference when assertEqual fails.
+    Accepts a single tensor pair or aligned sequences of tensors.
+
+    `fp32_outs_fn` runs only on failure. For each failing tensor: if CPU met
+    the fixed tolerance vs fp32 everywhere, raise (real regression); otherwise
+    require mps_drift <= _DRIFT_SLACK * cpu_drift + atol.
+    """
+    try:
+        test_case.assertEqual(
+            cpu_outs, mps_outs, atol=atol, rtol=rtol, **assertEqual_kwargs
+        )
+        return
+    except AssertionError:
+        if dtype not in _DRIFT_FALLBACK_DTYPES:
+            raise
+
+    if atol is None or rtol is None:
+        d_rtol, d_atol = default_tolerances(dtype)
+        atol = atol if atol is not None else d_atol
+        rtol = rtol if rtol is not None else d_rtol
+
+    def as_seq(x):
+        return (x,) if isinstance(x, torch.Tensor) else tuple(x)
+
+    cpu_seq, mps_seq, fp32_seq = (
+        as_seq(cpu_outs),
+        as_seq(mps_outs),
+        as_seq(fp32_outs_fn()),
+    )
+
+    for i, (c, m, f) in enumerate(zip(cpu_seq, mps_seq, fp32_seq, strict=True)):
+        if c is None or m is None or f is None:
+            continue
+        try:
+            test_case.assertEqual(c, m, atol=atol, rtol=rtol, **assertEqual_kwargs)
+            continue
+        except AssertionError:
+            pass
+
+        tag = label if len(cpu_seq) == 1 else f"{label}[{i}]"
+        m_cpu = m.detach().cpu()
+        finite_c = torch.isfinite(c)
+        finite_m = torch.isfinite(m_cpu)
+
+        # Non-finite mismatches would silently pass the drift math (nan contamination).
+        if not torch.equal(finite_c, finite_m):
+            raise AssertionError(
+                f"{tag}: finite/non-finite positions differ between CPU and MPS -- real regression."
+            )
+        nonfinite = ~finite_c
+        if nonfinite.any():
+            # At aligned non-finite positions, values must match exactly.
+            nf_c, nf_m = c[nonfinite], m_cpu[nonfinite]
+            both_nan = torch.isnan(nf_c) & torch.isnan(nf_m)
+            if not (both_nan | (nf_c == nf_m)).all().item():
+                raise AssertionError(
+                    f"{tag}: non-finite values differ between CPU and MPS -- real regression."
+                )
+
+        # Drift math only applies to positions where all three tensors are finite.
+        finite = finite_c & torch.isfinite(f)
+        if not finite.all():
+            c, m_cpu, f = c[finite], m_cpu[finite], f[finite]
+
+        cpu_err = (c.float() - f).abs()
+        mps_err = (m_cpu.float() - f).abs()
+
+        if (cpu_err <= atol + rtol * f.abs()).all().item():
+            raise AssertionError(
+                f"{tag}: CPU met the fixed tolerance vs fp32 but MPS did not "
+                f"-- real regression, not cross-implementation drift."
+            )
+
+        cpu_drift = cpu_err.max().item()
+        mps_drift = mps_err.max().item()
+        bound = _DRIFT_SLACK * cpu_drift + atol
+        if mps_drift > bound:
+            raise AssertionError(
+                f"{tag}: MPS drift {mps_drift:.4g} from fp32 exceeds "
+                f"{_DRIFT_SLACK:g} * CPU drift {cpu_drift:.4g} + atol "
+                f"{atol:.4g} (bound {bound:.4g})."
+            )
 
 
 if torch.backends.mps.is_available():
@@ -619,7 +721,7 @@ if torch.backends.mps.is_available():
             "nn.functional.conv2d": [torch.int64],
             "nn.functional.conv3d": [torch.int64],
             "nn.functional.conv_transpose1d": [torch.int64],
-            "nn.functional.conv_transpose2d": [torch.int64, torch.bfloat16],
+            "nn.functional.conv_transpose2d": [torch.int64],
             "nn.functional.conv_transpose3d": [
                 torch.int64,
                 torch.bfloat16,
@@ -938,12 +1040,7 @@ if torch.backends.mps.is_available():
             # draws, so we skip rather than xfail.
             "topk": [torch.float16],
             "nn.functional.pairwise_distance": [torch.float16],
-            # failed assertion `destination datatype must be fp32'
-            "nn.functional.conv1d": [torch.float16],
-            "nn.functional.conv2d": [torch.float16],
             "nn.functional.conv3d": [torch.float16],
-            "nn.functional.conv_transpose1d": [torch.float16],
-            "nn.functional.conv_transpose2d": [torch.float16],
             "nn.functional.conv_transpose3d": [torch.float16],
         }
 

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -9,6 +9,8 @@ from .opinfo.core import DecorateInfo, OpInfo
 
 
 _DRIFT_FALLBACK_DTYPES = (torch.float16, torch.bfloat16)
+# Worst case for two independent correct implementations with anti-correlated
+# rounding at the same precision (triangle inequality on individual drifts).
 _DRIFT_SLACK = 2.0
 
 
@@ -39,6 +41,9 @@ def assert_mps_match_or_drift(
         return
     except AssertionError:
         if dtype not in _DRIFT_FALLBACK_DTYPES:
+            raise
+        # Drift only applies to tensors; let Python scalars propagate as-is.
+        if not isinstance(cpu_outs, (torch.Tensor, tuple, list)):
             raise
 
     if atol is None or rtol is None:


### PR DESCRIPTION
Fixes #183621

Used for low-precision consistency tests for MPS backend ops where accumulation order can cause discrepancies. Uses the CPU discrepancy between fp32 and the target half type to produce an estimate for the tolerable drift and checks that the MPS implementation produces an output that is within this envelope.

Adds unit tests for the new `assert_mps_match_or_drift` to verify the different branches of the test function.

Removes xfails from the gradient check of conv1d/conv2d/conv_transpose1d/conv_transpose2d (in fp16) and forward check of conv_transpose2d (bf16) since they are as accurate as the corresponding CPU implementation when compared against the FP32 reference with the drift based test and start unexpectedly passing with this new condition.

### Alternative approach:
If having this as an automatic fallback check is too aggressive we can also just add another list where we maintain the ops that we think can suffer from drift caused by the accumulation and have this test route only for the ops on that list.