### PR TITLE
Support auto_functionalized_v2 in can_fuse_into_auto_functionalized

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -444,8 +444,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
     @parametrize(
         "factory_op",
         [
-            # Skipping because of https://github.com/pytorch/pytorch/issues/170160
-            # subtest(torch.ones_like, name="ones_like"),
+            subtest(torch.ones_like, name="ones_like"),
             subtest(torch.empty_like, name="empty_like"),
         ],
     )

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -2115,6 +2115,9 @@ def solve_min_cut(
             torch.ops.higher_order.auto_functionalized_v2,
         ):
             return False
+        if b.target is torch.ops.higher_order.auto_functionalized_v2:
+            all_bases = b.kwargs.get("_all_bases")
+            return isinstance(all_bases, list) and any(a is base for base in all_bases)
         mutable_op = b.args[0]
         (
             mutable_arg_names,

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -2110,7 +2110,10 @@ def solve_min_cut(
         log.info("Ops banned from re-materialization: %s", ops_ignored)
 
     def can_fuse_into_auto_functionalized(a: fx.Node, b: fx.Node) -> bool:
-        if b.target != torch.ops.higher_order.auto_functionalized:
+        if b.target not in (
+            torch.ops.higher_order.auto_functionalized,
+            torch.ops.higher_order.auto_functionalized_v2,
+        ):
             return False
         mutable_op = b.args[0]
         (


### PR DESCRIPTION
## Summary
This PR updates `can_fuse_into_auto_functionalized` to recognize `torch.ops.higher_order.auto_functionalized_v2`.

Previously, the check only handled `torch.ops.higher_order.auto_functionalized`. This caused the fusion logic to miss cases using the newer `auto_functionalized_v2` higher-order operator. This change extends the condition to support both variants, ensuring consistent fusion behavior.

## Changes
- Modified `can_fuse_into_auto_functionalized` in `torch/_functorch/partitioners.py` to include a check for `torch.ops.higher_order.auto_functionalized_v2`.

## How I Verified
- **Manual Verification:** I modified the installed `torch` package in a local virtual environment and verified that the `auto_functionalized_v2` op is now correctly identified by the partitioner logic.
- **Environment Note:** Due to local environment constraints on Windows, I was unable to run the full C++ build/test suite. I am relying on the CI pipeline for comprehensive regression testing across all platforms.

## Notes
- This is a targeted fix to align the partitioner with recent updates to higher-order operators.
- CI validation is requested to confirm there are no side effects on existing AOTAutograd partitioning tests.

This PR is addressing this issue:
#170160

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo