### PR TITLE
[BE]: Revert back to upstream uv action to solve rate-limiting

### DIFF
--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -62,7 +62,7 @@ runs:
   steps:
     - name: Setup uv
       if: ${{ !env.UV_PYTHON }}
-      uses: pytorch/test-infra/.github/actions/setup-uv@main
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: "3.12"
 

--- a/.github/actions/pytest-cache-download/action.yml
+++ b/.github/actions/pytest-cache-download/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Setup uv
       if: ${{ !env.UV_PYTHON }}
-      uses: pytorch/test-infra/.github/actions/setup-uv@main
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: "3.12"
 

--- a/.github/actions/pytest-cache-upload/action.yml
+++ b/.github/actions/pytest-cache-upload/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
     - name: Setup uv
       if: ${{ !env.UV_PYTHON }}
-      uses: pytorch/test-infra/.github/actions/setup-uv@main
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: "3.12"
 

--- a/.github/actions/reuse-old-whl/action.yml
+++ b/.github/actions/reuse-old-whl/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     - name: Setup uv
       if: ${{ !env.UV_PYTHON }}
-      uses: pytorch/test-infra/.github/actions/setup-uv@main
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: "3.12"
 

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -140,7 +140,7 @@ runs:
         fi
 
     - name: Install uv (EC2)
-      uses: pytorch/test-infra/.github/actions/setup-uv@main
+      uses: astral-sh/setup-uv@v8.1.0
       if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
       with:
         python-version: "3.12"

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -26,7 +26,7 @@ runs:
     # Always set up uv and zip files first (needed for S3, reusable for GHA fallback)
     - name: Setup uv
       if: ${{ runner.os != 'Windows' && !env.UV_PYTHON }}
-      uses: pytorch/test-infra/.github/actions/setup-uv@main
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: "3.12"
 

--- a/.github/actions/upload-utilization-stats/action.yml
+++ b/.github/actions/upload-utilization-stats/action.yml
@@ -40,7 +40,7 @@ runs:
   steps:
     - name: Setup uv
       if: ${{ !env.UV_PYTHON }}
-      uses: pytorch/test-infra/.github/actions/setup-uv@main
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: "3.12"
 

--- a/.github/templates/macos_binary_build_workflow.yml.j2
+++ b/.github/templates/macos_binary_build_workflow.yml.j2
@@ -84,7 +84,7 @@ jobs:
         run: |
           "${PYTORCH_ROOT}/.ci/wheel/install_libomp.sh"
       - name: Install uv
-        uses: pytorch/test-infra/.github/actions/setup-uv@main
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           # enable-cache persists ~/.cache/uv across nightlies (keyed on the
           # workflow file hash by default); a warm cache makes the subsequent

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -37,7 +37,7 @@ jobs:
           checkout-mode: treeless
 
       - name: Setup uv
-        uses: pytorch/test-infra/.github/actions/setup-uv@main
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.12"
           activate-environment: true

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -94,7 +94,7 @@ jobs:
           name: ${{ inputs.build_environment }}
           s3-bucket: gha-artifacts
 
-      - uses: pytorch/test-infra/.github/actions/setup-uv@main
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.12"
           activate-environment: "true"

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           "${PYTORCH_ROOT}/.ci/wheel/install_libomp.sh"
       - name: Install uv
-        uses: pytorch/test-infra/.github/actions/setup-uv@main
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           # enable-cache persists ~/.cache/uv across nightlies (keyed on the
           # workflow file hash by default); a warm cache makes the subsequent

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -50,7 +50,7 @@ jobs:
       torch_cuda_arch_list: '8.0 8.9 9.0 10.0 12.0'
       build_environment: linux-jammy-cuda13.0-py3.12-gcc11
     steps:
-      - uses: pytorch/test-infra/.github/actions/setup-uv@main
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.12"
           activate-environment: "true"


### PR DESCRIPTION
Reverts to upstream UV to properly mitigate the rate limiting as an alternative to #183643 . It now properly uses GH Actions API logged into to make the call.