### PR TITLE
[DDE] Fix data-dependent errors in pooling meta functions

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1630,6 +1630,60 @@ class f(torch.nn.Module):
             A = torch.empty((m, n), device="meta")
             Q, R = torch.linalg.qr(A)
 
+    def _make_unbacked_size(self, shape_env):
+        u = shape_env.create_unbacked_symint()
+        torch._check_is_size(u)
+        torch._check(u >= 1)
+        return u
+
+    def test_avg_pool2d_unbacked_symint(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+
+        with fake_mode:
+            x = torch.empty(
+                (1, 3, self._make_unbacked_size(shape_env), self._make_unbacked_size(shape_env)),
+                device="meta",
+            )
+            torch.ops.aten.avg_pool2d(x, [2, 2], [2, 2], [0, 0])
+
+    def test_max_pool2d_unbacked_symint(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+
+        with fake_mode:
+            x = torch.empty(
+                (1, 3, self._make_unbacked_size(shape_env), self._make_unbacked_size(shape_env)),
+                device="meta",
+            )
+            torch.ops.aten.max_pool2d_with_indices(x, [2, 2], [2, 2])
+
+    def test_avg_pool3d_unbacked_symint(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        make_u = lambda: self._make_unbacked_size(shape_env)
+
+        with fake_mode:
+            x = torch.empty((1, 3, make_u(), make_u(), make_u()), device="meta")
+            torch.ops.aten.avg_pool3d(x, [2, 2, 2], [2, 2, 2])
+
+    def test_max_pool3d_unbacked_symint(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        make_u = lambda: self._make_unbacked_size(shape_env)
+
+        with fake_mode:
+            x = torch.empty((1, 3, make_u(), make_u(), make_u()), device="meta")
+            torch.ops.aten.max_pool3d_with_indices(x, [2, 2, 2], [2, 2, 2])
+
 
 @skipIfTorchDynamo(
     "Creating ShapeEnv fails for confusing reasons (also we never expect dynamo to see code like this)"

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4762,13 +4762,7 @@ def meta_bmm_dtype(self, mat2, out_dtype):
 
 
 def div_rtn(x, y):
-    q = x // y
-    r = x % y
-    # WARNING: explicit bool conversion here is necessary;
-    # would be fixed by SymBool
-    if r != 0 and (bool(r < 0) != bool(y < 0)):
-        q -= 1
-    return q
+    return x // y
 
 
 def pooling_output_shape_pad_lr(
@@ -4868,7 +4862,13 @@ def pool2d_shape_check(
     )
 
     torch._check(
-        outputWidth >= 1 and outputHeight >= 1,
+        outputWidth >= 1,
+        lambda: f"Given input size: ({nInputPlane}x{inputHeight}x{inputWidth}). "
+        f"Calculated output size: ({nOutputPlane}x{outputHeight}x{outputWidth}). "
+        "Output size is too small",
+    )
+    torch._check(
+        outputHeight >= 1,
         lambda: f"Given input size: ({nInputPlane}x{inputHeight}x{inputWidth}). "
         f"Calculated output size: ({nOutputPlane}x{outputHeight}x{outputWidth}). "
         "Output size is too small",
@@ -4941,30 +4941,35 @@ def pool3d_shape_check(
         )
 
     if check_input_size:  # AveragePool3d
+        for dim_in, dim_k, name_in, name_k in [
+            (itime, kT, "T", "kT"), (iheight, kH, "H", "kH"), (iwidth, kW, "W", "kW"),
+        ]:
+            torch._check(
+                dim_in >= dim_k,
+                lambda: (
+                    f"input image (T: {itime} H: {iheight} W: {iwidth}) smaller than "
+                    f"kernel size (kT: {kT} kH: {kH} kW: {kW})"
+                ),
+            )
+
+    for dim_k, dim_p in [(kT, pT), (kW, pW), (kH, pH)]:
         torch._check(
-            itime >= kT and iheight >= kH and iwidth >= kW,
+            kT / 2 >= pT,
             lambda: (
-                f"input image (T: {itime} H: {iheight} W: {iwidth}) smaller than "
-                f"kernel size (kT: {kT} kH: {kH} kW: {kW})"
+                f"pad should be smaller than or equal to half of kernel size, but got "
+                f"kT: {kT} kW: {kW} kH: {kH} padT: {pT} padW: {pW} padH: {pH}"
             ),
         )
 
-    torch._check(
-        kT / 2 >= pT and kW / 2 >= pW and kH / 2 >= pH,
-        lambda: (
-            f"pad should be smaller than or equal to half of kernel size, but got "
-            f"kT: {kT} kW: {kW} kH: {kH} padT: {pT} padW: {pW} padH: {pH}"
-        ),
-    )
-
-    torch._check(
-        otime >= 1 and owidth >= 1 and oheight >= 1,
-        lambda: (
-            f"Given input size: ({nslices}x{itime}x{iheight}x{iwidth}). "
-            f"Calculated output size: ({nslices}x{otime}x{oheight}x{owidth}). "
-            f"Output size is too small"
-        ),
-    )
+    for dim_o in [otime, owidth, oheight]:
+        torch._check(
+            dim_o >= 1,
+            lambda: (
+                f"Given input size: ({nslices}x{itime}x{iheight}x{iwidth}). "
+                f"Calculated output size: ({nslices}x{otime}x{oheight}x{owidth}). "
+                f"Output size is too small"
+            ),
+        )
 
 
 def max_pool3d_backward_shape_check(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183757
* #183754

Fix GuardOnDataDependentSymNode in pooling output shape computation:

- Simplify div_rtn(x, y) to x // y. The remainder adjustment for
  round-toward-negative-infinity is redundant in Python where // already
  floors. The old code guarded on `r != 0 and bool(r < 0) != bool(y < 0)`
  which triggers DDE on unbacked SymInts.

- Split compound `torch._check(a and b)` into separate checks in
  pool2d_shape_check and pool3d_shape_check. Python `and` on SymBools
  forces bool conversion, triggering DDE. Separate checks avoid this.

Fixes DDE for avg_pool2d, max_pool2d, avg_pool3d, max_pool3d, avg_pool1d
when spatial dimensions are unbacked SymInts with stride > 1.

Authored by Claude.