### PR TITLE
[ROCm] route fp16 backward GEMMs to rocBLAS to preserve subnormals

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -896,8 +896,8 @@ void bgemm_internal<at::Half>(CUDABLAS_BGEMM_ARGTYPES(at::Half))
   // (issue #182952). Route fp16 backward GEMMs to rocBLAS so the
   // ROCmBackwardPassGuard / fp16_alt_impl handling still applies.
   if (preferred == BlasBackend::Cublaslt &&
-      at::detail::getCUDAHooks().isGPUArch({"gfx90a"}) &&
-      at::ROCmBackwardPassGuard::is_backward_pass()) {
+      at::ROCmBackwardPassGuard::is_backward_pass() &&
+      at::detail::getCUDAHooks().isGPUArch({"gfx90a"})) {
     preferred = BlasBackend::Cublas;
   }
 #endif
@@ -937,13 +937,23 @@ void bgemm_internal<at::Half, float>(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(at::Hal
     TORCH_CHECK(false, "bgemm input type at::Half and output type float is not supported with allowFP16AccumulationCuBLAS");
   }
 
-  if (at::globalContext().blasPreferredBackend() == BlasBackend::Cublaslt) {
+  auto preferred = at::globalContext().blasPreferredBackend();
+#ifdef USE_ROCM
+  // See bgemm_internal<at::Half>: reroute fp16 backward GEMMs off hipBLASLt on
+  // gfx90a to preserve subnormals (issue #182952).
+  if (preferred == BlasBackend::Cublaslt &&
+      at::ROCmBackwardPassGuard::is_backward_pass() &&
+      at::detail::getCUDAHooks().isGPUArch({"gfx90a"})) {
+    preferred = BlasBackend::Cublas;
+  }
+#endif
+  if (preferred == BlasBackend::Cublaslt) {
     if (!bgemm_internal_cublaslt<at::Half, float>(CUDABLAS_BGEMM_ARGS(at::Half))) {
       bgemm_internal_cublas<at::Half, float>(CUDABLAS_BGEMM_ARGS(at::Half));
     }
   }
 #if defined(USE_ROCM) && !defined(_MSC_VER)
-  else if (at::globalContext().blasPreferredBackend() == BlasBackend::Ck) {
+  else if (preferred == BlasBackend::Ck) {
     TORCH_CHECK(false, "gemm input type at::Half and output type float is not supported for ROCm");
   }
 #endif
@@ -1438,8 +1448,8 @@ void gemm_internal<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half))
   // (issue #182952). Route fp16 backward GEMMs to rocBLAS so the
   // ROCmBackwardPassGuard / fp16_alt_impl handling still applies.
   if (preferred == BlasBackend::Cublaslt &&
-      at::detail::getCUDAHooks().isGPUArch({"gfx90a"}) &&
-      at::ROCmBackwardPassGuard::is_backward_pass()) {
+      at::ROCmBackwardPassGuard::is_backward_pass() &&
+      at::detail::getCUDAHooks().isGPUArch({"gfx90a"})) {
     preferred = BlasBackend::Cublas;
   }
 #endif
@@ -1480,11 +1490,21 @@ void gemm_internal<at::Half, float>(CUDABLAS_GEMM_ARGTYPES_AND_C_DTYPE(at::Half,
     TORCH_CHECK(false, "gemm input type at::Half and output type float is not supported with allowFP16AccumulationCuBLAS");
   }
 
-  if (at::globalContext().blasPreferredBackend() == BlasBackend::Cublaslt) {
+  auto preferred = at::globalContext().blasPreferredBackend();
+#ifdef USE_ROCM
+  // See gemm_internal<at::Half>: reroute fp16 backward GEMMs off hipBLASLt on
+  // gfx90a to preserve subnormals (issue #182952).
+  if (preferred == BlasBackend::Cublaslt &&
+      at::ROCmBackwardPassGuard::is_backward_pass() &&
+      at::detail::getCUDAHooks().isGPUArch({"gfx90a"})) {
+    preferred = BlasBackend::Cublas;
+  }
+#endif
+  if (preferred == BlasBackend::Cublaslt) {
     gemm_internal_cublaslt<at::Half, float>(CUDABLAS_GEMM_ARGS(at::Half));
   }
 #if defined(USE_ROCM) && !defined(_MSC_VER)
-  else if (at::globalContext().blasPreferredBackend() == BlasBackend::Ck) {
+  else if (preferred == BlasBackend::Ck) {
     TORCH_CHECK(false, "gemm input type at::Half and output type float is not supported for ROCm");
   }
 #endif

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -891,11 +891,12 @@ void bgemm_internal<at::Half>(CUDABLAS_BGEMM_ARGTYPES(at::Half))
 {
   auto preferred = at::globalContext().blasPreferredBackend();
 #ifdef USE_ROCM
-  // hipBLASLt has no equivalent of rocblas_gemm_flags_fp16_alt_impl, so a
-  // backward fp16 GEMM on the hipBLASLt path silently flushes subnormals
+  // hipBLASLt has no equivalent of rocblas_gemm_flags_fp16_alt_impl on gfx90a,
+  // so a backward fp16 GEMM on the hipBLASLt path silently flushes subnormals
   // (issue #182952). Route fp16 backward GEMMs to rocBLAS so the
   // ROCmBackwardPassGuard / fp16_alt_impl handling still applies.
   if (preferred == BlasBackend::Cublaslt &&
+      at::detail::getCUDAHooks().isGPUArch({"gfx90a"}) &&
       at::ROCmBackwardPassGuard::is_backward_pass()) {
     preferred = BlasBackend::Cublas;
   }
@@ -1432,11 +1433,12 @@ void gemm_internal<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half))
 {
   auto preferred = at::globalContext().blasPreferredBackend();
 #ifdef USE_ROCM
-  // hipBLASLt has no equivalent of rocblas_gemm_flags_fp16_alt_impl, so a
-  // backward fp16 GEMM on the hipBLASLt path silently flushes subnormals
+  // hipBLASLt has no equivalent of rocblas_gemm_flags_fp16_alt_impl on gfx90a,
+  // so a backward fp16 GEMM on the hipBLASLt path silently flushes subnormals
   // (issue #182952). Route fp16 backward GEMMs to rocBLAS so the
   // ROCmBackwardPassGuard / fp16_alt_impl handling still applies.
   if (preferred == BlasBackend::Cublaslt &&
+      at::detail::getCUDAHooks().isGPUArch({"gfx90a"}) &&
       at::ROCmBackwardPassGuard::is_backward_pass()) {
     preferred = BlasBackend::Cublas;
   }

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -889,7 +889,18 @@ void bgemm_internal<c10::complex<float>>(CUDABLAS_BGEMM_ARGTYPES(c10::complex<fl
 template <>
 void bgemm_internal<at::Half>(CUDABLAS_BGEMM_ARGTYPES(at::Half))
 {
-  if (at::globalContext().blasPreferredBackend() == BlasBackend::Cublaslt) {
+  auto preferred = at::globalContext().blasPreferredBackend();
+#ifdef USE_ROCM
+  // hipBLASLt has no equivalent of rocblas_gemm_flags_fp16_alt_impl, so a
+  // backward fp16 GEMM on the hipBLASLt path silently flushes subnormals
+  // (issue #182952). Route fp16 backward GEMMs to rocBLAS so the
+  // ROCmBackwardPassGuard / fp16_alt_impl handling still applies.
+  if (preferred == BlasBackend::Cublaslt &&
+      at::ROCmBackwardPassGuard::is_backward_pass()) {
+    preferred = BlasBackend::Cublas;
+  }
+#endif
+  if (preferred == BlasBackend::Cublaslt) {
     if (!bgemm_internal_cublaslt<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half))) {
       bgemm_internal_cublas<at::Half>(CUDABLAS_BGEMM_ARGS(at::Half));
     }
@@ -1419,11 +1430,22 @@ void gemm_internal<c10::complex<float>>(CUDABLAS_GEMM_ARGTYPES(c10::complex<floa
 template <>
 void gemm_internal<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half))
 {
-  if (at::globalContext().blasPreferredBackend() == BlasBackend::Cublaslt) {
+  auto preferred = at::globalContext().blasPreferredBackend();
+#ifdef USE_ROCM
+  // hipBLASLt has no equivalent of rocblas_gemm_flags_fp16_alt_impl, so a
+  // backward fp16 GEMM on the hipBLASLt path silently flushes subnormals
+  // (issue #182952). Route fp16 backward GEMMs to rocBLAS so the
+  // ROCmBackwardPassGuard / fp16_alt_impl handling still applies.
+  if (preferred == BlasBackend::Cublaslt &&
+      at::ROCmBackwardPassGuard::is_backward_pass()) {
+    preferred = BlasBackend::Cublas;
+  }
+#endif
+  if (preferred == BlasBackend::Cublaslt) {
     gemm_internal_cublaslt<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
   }
 #if defined(USE_ROCM) && defined(USE_ROCM_CK_GEMM)
-  else if (at::globalContext().blasPreferredBackend() == BlasBackend::Ck) {
+  else if (preferred == BlasBackend::Ck) {
     at::native::gemm_internal_ck<at::Half>(CUDABLAS_GEMM_ARGS(at::Half));
   }
 #endif

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -356,6 +356,39 @@ class TestMatmulCuda(InductorTestCase):
             torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = orig_precision
 
     @onlyCUDA
+    @skipCUDAIfNotRocm
+    @parametrize("batched", [False, True])
+    @parametrize("backend", ["cublas", "cublaslt"])
+    def test_fp16_backward_preserves_subnormals_rocm(self, backend, batched):
+        # Regression test for issue #182952. On ROCm, the hipBLASLt path for
+        # at::Half had no equivalent of rocBLAS's fp16_alt_impl, so backward
+        # fp16 GEMMs silently flushed subnormals to zero. The dispatcher now
+        # routes fp16 backward GEMMs to rocBLAS regardless of the user's
+        # preferred backend.
+        dtype = torch.float16
+        M = K = N = 64
+        sub_val = torch.finfo(dtype).tiny / 2
+        ref = M * sub_val
+        with blas_library_context(backend):
+            if batched:
+                B = 3
+                x = torch.ones(B, M, K, dtype=dtype, device="cuda")
+                w = torch.nn.Parameter(
+                    torch.ones(B, K, N, dtype=dtype, device="cuda")
+                )
+                d = torch.full((B, M, N), sub_val, dtype=dtype, device="cuda")
+            else:
+                x = torch.ones(M, K, dtype=dtype, device="cuda")
+                w = torch.nn.Parameter(
+                    torch.ones(K, N, dtype=dtype, device="cuda")
+                )
+                d = torch.full((M, N), sub_val, dtype=dtype, device="cuda")
+            (x @ w).backward(d)
+            torch.cuda.synchronize()
+            grad = w.grad.flatten()[0].item()
+            self.assertEqual(grad, ref)
+
+    @onlyCUDA
     # imported 'tol' as 'xtol' to avoid aliasing in code above
     @toleranceOverride({torch.float16: xtol(atol=1e-4, rtol=1e-4),
                         torch.bfloat16: xtol(atol=1e-4, rtol=1e-4)})

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -357,14 +357,15 @@ class TestMatmulCuda(InductorTestCase):
 
     @onlyCUDA
     @skipCUDAIfNotRocm
+    @runOnRocmArch(MI200_ARCH)
     @parametrize("batched", [False, True])
     @parametrize("backend", ["cublas", "cublaslt"])
     def test_fp16_backward_preserves_subnormals_rocm(self, backend, batched):
         # Regression test for issue #182952. On ROCm, the hipBLASLt path for
         # at::Half had no equivalent of rocBLAS's fp16_alt_impl, so backward
         # fp16 GEMMs silently flushed subnormals to zero. The dispatcher now
-        # routes fp16 backward GEMMs to rocBLAS regardless of the user's
-        # preferred backend.
+        # routes fp16 backward GEMMs to rocBLAS on gfx90a regardless of the
+        # user's preferred backend.
         dtype = torch.float16
         M = K = N = 64
         sub_val = torch.finfo(dtype).tiny / 2


### PR DESCRIPTION
Fixes #182952.

This PR changes the preferred backend for the fp16 backward GEMMs for ROCm only:
- Routes ROCm fp16 backward GEMMs from hipBLASLt to rocBLAS so backward subnormals are preserved.
- Keeps forward fp16 GEMMs on hipBLASLt while restoring `ROCmBackwardPassGuard` behavior for backward fp16 GEMMs.
- Adds matmul coverage for the ROCm fp16 subnormal gradient behavior.

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang