### PR TITLE
Fix compiled autograd test wrapper reruns

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -5122,16 +5122,25 @@ def load_test_module(name):
         ).load_module()
 
 
-def make_wrapped(fn, ctxs):
+def _get_default_device_context_device():
+    device_context = getattr(torch._GLOBAL_DEVICE_CONTEXT, "device_context", None)
+    if device_context is None:
+        return None
+    return device_context.device
+
+
+def make_wrapped(fn, ctx_fns):
     @functools.wraps(fn)
     def wrapped(self):
         torch._dynamo.reset()
-        stack = contextlib.ExitStack()
-        for ctx in ctxs:
-            stack.enter_context(ctx)
-        out = fn(self)
-        stack.close()
-        return out
+        default_device = _get_default_device_context_device()
+        try:
+            with contextlib.ExitStack() as stack:
+                for ctx_fn in ctx_fns:
+                    stack.enter_context(ctx_fn())
+                return fn(self)
+        finally:
+            torch.set_default_device(default_device)
 
     return wrapped
 
@@ -5165,16 +5174,15 @@ def wrap_test_class(orig_cls):
             backend = lookup_backend(name)
             if not HAS_CUDA_AND_TRITON and backend == "inductor":
                 continue
-            ctxs = [
-                compiled_autograd._enable(
-                    make_compiler_fn(
-                        backend=backend,
-                        fullgraph=name not in known_graph_breaks_tests,
-                    )
-                ),
-                test_contexts.get(name, contextlib.nullcontext()),
+            compiler = make_compiler_fn(
+                backend=backend,
+                fullgraph=name not in known_graph_breaks_tests,
+            )
+            ctx_fns = [
+                functools.partial(compiled_autograd._enable, compiler),
+                test_contexts.get(name, contextlib.nullcontext),
             ]
-            dct[name] = make_wrapped(fn, ctxs)
+            dct[name] = make_wrapped(fn, ctx_fns)
 
     cls = type(
         orig_cls.__name__ + "WithCompiledAutograd",
@@ -5201,6 +5209,57 @@ class WrapTestClassTests(TestCase):
         test.setUp()
         test.tearDown()
         self.assertTrue(getattr(test, "super_called", False))
+
+    def test_make_wrapped_creates_contexts_per_invocation(self):
+        enter_count = 0
+
+        @contextlib.contextmanager
+        def ctx():
+            nonlocal enter_count
+            enter_count += 1
+            yield
+
+        def fn(self):
+            return None
+
+        wrapped = make_wrapped(fn, [ctx])
+        wrapped(self)
+        wrapped(self)
+
+        self.assertEqual(enter_count, 2)
+
+    def test_make_wrapped_closes_contexts_on_exception(self):
+        events = []
+
+        @contextlib.contextmanager
+        def ctx():
+            events.append("enter")
+            try:
+                yield
+            finally:
+                events.append("exit")
+
+        def fn(self):
+            raise RuntimeError("boom")
+
+        wrapped = make_wrapped(fn, [ctx])
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            wrapped(self)
+
+        self.assertEqual(events, ["enter", "exit"])
+
+    def test_make_wrapped_restores_default_device(self):
+        self.assertIsNone(_get_default_device_context_device())
+        starting_stack_len = torch._C._len_torch_function_stack()
+
+        def fn(self):
+            torch.set_default_device("cpu")
+
+        wrapped = make_wrapped(fn, [])
+        wrapped(self)
+
+        self.assertIsNone(_get_default_device_context_device())
+        self.assertEqual(torch._C._len_torch_function_stack(), starting_stack_len)
 
 
 known_graph_breaks_tests = {
@@ -5305,9 +5364,11 @@ known_graph_breaks_tests = {
 }
 
 test_contexts = {
-    "test_setitem_mask": config.patch(capture_dynamic_output_shape_ops=True),
-    "test_index_backward_does_not_save_tensor": config.patch(
-        capture_dynamic_output_shape_ops=True
+    "test_setitem_mask": functools.partial(
+        config.patch, capture_dynamic_output_shape_ops=True
+    ),
+    "test_index_backward_does_not_save_tensor": functools.partial(
+        config.patch, capture_dynamic_output_shape_ops=True
     ),
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183772

Create wrapped test contexts per invocation and restore leaked default device state so compiled-autograd wrapper tests remain deterministic across pytest reruns and larger ordered runs.

Fixes #180204

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo