### PR TITLE
Fix an issue where pybind and sleef cause rebuild without any changes

### DIFF
--- a/tools/wrap_headers.py
+++ b/tools/wrap_headers.py
@@ -18,6 +18,12 @@ EXCLUDE_PATTERNS = (
     "torch/csrc/stable/",
     "torch/csrc/inductor/aoti_torch/c/",
     "torch/csrc/inductor/aoti_torch/generated/",
+    # Third-party headers: not part of the torch stable API surface, and
+    # wrapping them creates an incremental-build cycle because the install
+    # step un-wraps them on every build (source content differs from the
+    # wrapped destination), forcing dependents to rebuild.
+    "pybind11/",
+    "sleef.h",
 )
 
 WRAP_MARKER = "#if !defined(TORCH_STABLE_ONLY) && !defined(TORCH_TARGET_VERSION)"


### PR DESCRIPTION
I noticed that building PT on the same commit without any changes still runs through some target builds, 296 targets taking ~2 min. With this change, building without any change should take ~12 sec.

## What the commit does

It adds `pybind11/` and `sleef.h` to the `EXCLUDE_PATTERNS` tuple in `tools/wrap_headers.py:16`. That script runs at install time (from `cmake/PostBuildSteps.cmake:18-25`) and wraps every installed header under `torch/include/` with:

```cpp
#if !defined(TORCH_STABLE_ONLY) && !defined(TORCH_TARGET_VERSION)
...header content...
#else
#error "This file should not be included when..."
#endif
```

Excluded headers stay untouched. After this change, pybind11 and sleef.h no longer get wrapped.

## Correctness

The matching logic is `rel.startswith(pat)` against the path relative to `torch/include/`:

- `pybind11/` correctly matches all `pybind11/*.h` (`attr.h`, `cast.h`, etc.) — confirmed they exist as a subdirectory.
- `sleef.h` correctly matches the single file at `torch/include/sleef.h` (top-level, generated from `build/include/sleef.h`).

Both `.h` files pass the `HEADER_EXTENSIONS` check. Pattern logic is fine.

## Consequences

1. **Intended:** breaks the incremental-build churn. Every install copies fresh source → wrapper writes new content → mtime bumps → any dependent that `#include`s these rebuilds, even when nothing actually changed.
2. **Behavioral:** code defining `TORCH_STABLE_ONLY`/`TORCH_TARGET_VERSION` can now include `pybind11/...` and `sleef.h` without the `#error`. That's the desired semantics — those macros gate torch's own non-stable surface, not third-party libs.
3. **Stale state:** the script is wrap-only, never unwrap. Headers already wrapped on disk (e.g. `torch/include/pybind11/pybind11.h` is currently wrapped from an earlier build) stay wrapped until the next install copies fresh source over them. Not a functional problem, just don't expect this commit alone to "clean up" existing trees.

## Gap worth flagging

Many other third-party headers in `torch/include/` are still wrapped — I checked and `dnnl.h`, `cpuinfo.h`, `clog.h`, `fp16.h`, `nnpack.h`, `xnnpack.h` all currently start with the `WRAP_MARKER`. Plus the `fbgemm/`, `fmt/`, `kineto/`, `tensorpipe/`, `oneapi/`, `google/`, `fp16/` subdirectories are also third-party.

The commit message says "wrapping them creates an incremental-build cycle" — if that's truly the failure mode, by the same logic those other libs should also be excluded. Two possibilities:

- pybind11/sleef are the only ones actually getting re-copied each build (e.g. sleef.h is regenerated in `build/include/` per build;
  pybind11 is included by downstream bindings), and the others are stable on disk after first install. That would justify the narrow scope.
- The fix is incomplete and should also list `dnnl*`, `cpuinfo.h`, `clog.h`, `fp16*`, `nnpack.h`, `xnnpack.h`, `fbgemm/`, `fmt/`, `kineto/`, `tensorpipe/`, `oneapi/`, `google/`, `ittnotify*`, `jitprofiling.h`, `fxdiv.h`, `psimd.h`, `pthreadpool.h`, `qnnpack_func.h`, `advisor-annotate.h`, `experiments-config.h`, `libittnotify.h`.

Worth confirming which case applies before landing — if it's the second, you'd want a single, broader pattern (e.g. an "allowlist" of torch-owned headers) rather than enumerating each 3p lib.

## Better architectures, roughly in order of preference

1. Invert the default. Walk installed headers and only wrap paths under ATen/, c10/, caffe2/, torch/csrc/ — minus the existing four stable carve-outs. Everything else (all third-party, plus generated/legacy stuff) is left alone. This matches the semantic: the macro is about torch's API, so only torch's API gets the guard. One list to maintain, and it's a small one that rarely changes.
2. Guard at source, not install. Put the #if block directly in the torch headers that should be guarded. No install-time script, no incremental-build cycle, no exclusion list to maintain, headers self-document their stability. Cost is a bigger one-time diff and the guards live in the source tree. This is what most libraries actually do.
3. Separate include directories. Ship stable API headers under a path like torch/include/stable/ and internal headers under torch/include/internal/. Users get stable/ on their include path by default; opting into internal/ requires an explicit flag. No preprocessor games at all. Bigger change, but it's the cleanest long-term answer and it makes the API surface visible in the directory layout.