### PR TITLE
Fix stack-use-after-return in test cpp_extension arrayref bindings

### DIFF
--- a/test/cpp_extensions/extension.cpp
+++ b/test/cpp_extensions/extension.cpp
@@ -51,12 +51,22 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("get_complex", []() { return c10::complex<double>(1.0, 2.0); });
   m.def("get_device", []() { return at::device_of(random_tensor()).value(); });
   m.def("get_generator", []() { return at::detail::getDefaultCPUGenerator(); });
-  m.def("get_intarrayref", []() { return at::IntArrayRef({1, 2, 3}); });
+  // ArrayRef is a non-owning view; constructing it from a brace-init-list
+  // would point at a stack-temporary initializer_list and dangle once the
+  // lambda returns (caught by ASAN as stack-use-after-return). Back the
+  // values with static storage so the view stays valid.
+  m.def("get_intarrayref", []() {
+    static const int64_t data[] = {1, 2, 3};
+    return at::IntArrayRef(data, 3);
+  });
   m.def("get_memory_format", []() { return c10::get_contiguous_memory_format(); });
   m.def("get_storage", []() { return random_tensor().storage(); });
   m.def("get_symfloat", []() { return c10::SymFloat(1.0); });
   m.def("get_symint", []() { return c10::SymInt(1); });
-  m.def("get_symintarrayref", []() { return at::SymIntArrayRef({1, 2, 3}); });
+  m.def("get_symintarrayref", []() {
+    static const c10::SymInt data[] = {c10::SymInt(1), c10::SymInt(2), c10::SymInt(3)};
+    return at::SymIntArrayRef(data, 3);
+  });
   m.def("get_tensor", []() { return random_tensor(); });
   m.def("get_math_type", &get_math_type);
   m.def("roundtrip_layout", [](c10::Layout layout) -> c10::Layout { return layout; });


### PR DESCRIPTION
The two pybind lambdas

    m.def("get_intarrayref",   []() { return at::IntArrayRef({1, 2, 3}); });
    m.def("get_symintarrayref",[]() { return at::SymIntArrayRef({1, 2, 3}); });

return non-owning `ArrayRef` views of a `std::initializer_list` that lives on the lambda's stack. By the time pybind11's type-caster reads the data (e.g. `THPUtils_packInt64Array` walking the `int64_t*` to build a Python tuple), the lambda has unwound and the storage is gone. ASAN catches it as `stack-use-after-return` in `test/test_cpp_extensions_aot_*.py::TestPybindTypeCasters::test_pybind_return_types`.

Back the values with static storage so the `ArrayRef` views remain valid for the lifetime of the program. The intent of the test (exercising the type-caster for these two types) is preserved; only the storage class changes.

Authored with Claude.
