### PR TITLE
ci: fail docker-builds GHCR push step on first error

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -146,10 +146,11 @@ jobs:
           max_attempts: 5
           retry_wait_seconds: 90
           command: |
+            set -euo pipefail
             ghcr_image="ghcr.io/pytorch/ci-image"
             tag=${ECR_DOCKER_IMAGE##*:}
             # Push docker image to the ghcr.io
-            echo $GHCR_PAT | docker login ghcr.io -u pytorch --password-stdin
+            echo "$GHCR_PAT" | docker login ghcr.io -u pytorch --password-stdin
             docker tag "${ECR_DOCKER_IMAGE}" "${ghcr_image}:${tag}"
             docker push "${ghcr_image}:${tag}"
             # Also push a tag without the hash for easier reference


### PR DESCRIPTION
## Summary

- The `Push to https://ghcr.io/` step in `docker-builds.yml` runs its inline command without `set -e`, so a failed `docker push` of the hash-suffixed tag (e.g. `unknown blob` from GHCR) is silently followed by the floating-tag push; the latter's exit code is reported as the step result. The step turns green even though the hash-pinned tag never landed in `ghcr.io/pytorch/ci-image`, which then breaks any downstream job that pulls by hash.
- Add `set -euo pipefail` so any failing command aborts the script and lets `nick-fields/retry` (`max_attempts: 5`) actually retry the push.
- Quote `$GHCR_PAT` so `set -u` doesn't blow up on an unset secret and so the value isn't subject to word splitting.

## Example of the silent failure

- Workflow run: https://github.com/pytorch/pytorch/actions/runs/25873660612
- Job: `docker-build (linux.12xlarge, pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11)` (id `76035235980`), reported `success`.
- Step `Push to https://ghcr.io/` logged:

  ```
  18:21:38  046e51c41075: Pushed
  18:23:24  unknown blob
  18:23:24  The push refers to repository [ghcr.io/pytorch/ci-image]
  ...
  ```

  The first `docker push` (hash-suffixed tag) ended with `unknown blob`, but without `set -e` the script kept going and ran the floating-tag `docker push`, whose success became the step's exit code.

- Resulting registry state (verified via `GET /v2/pytorch/ci-image/manifests/<ref>`):
  - `ghcr.io/pytorch/ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11` -> 200 (digest `sha256:e5a5d4a0…`)
  - `ghcr.io/pytorch/ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11-fa9576f08de09a361cd81462405cc7ae5f031e17` -> 404

With this change the same scenario would have failed the step, triggering the `nick-fields/retry` (`max_attempts: 5`) loop to re-push the hash tag.

## Test plan

- [ ] PR's own `docker-builds` run (the workflow is path-triggered on `.github/workflows/docker-builds.yml`) succeeds end-to-end and uploads both the hash-pinned and floating tags.
- [ ] After this lands, re-run the failed `docker-build (pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11)` matrix job (run `25873660612`) to backfill the missing `ghcr.io/pytorch/ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11-fa9576f08de09a361cd81462405cc7ae5f031e17` tag.

Authored by Claude.