### PR TITLE
Use libdevice log for strict Inductor numerics

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1185,6 +1185,17 @@ class CudaReproTests(TestCase):
         FileCheck().check("libdevice.exp").run(code[0])
         self.assertEqual(foo(inp), out)
 
+    @skipIfXpu(msg="Test relies on CUDA/HIP libdevice naming")
+    @config.patch({"eager_numerics.use_pytorch_libdevice": True})
+    def test_log_eager_numerics_uses_libdevice(self):
+        def foo(x):
+            return x.log()
+
+        inp = torch.ones(64, device=device_type, dtype=torch.float16)
+        out, code = run_and_get_code(torch.compile(foo), inp)
+        FileCheck().check_not("tl_math.log").check("libdevice.log").run(code[0])
+        self.assertEqual(foo(inp), out)
+
     def test_uint_view_copy(self):
         @torch.compile
         def view_copy(target, source):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2044,6 +2044,10 @@ class TritonOverrides(OpOverrides):
     @maybe_upcast_float32()
     # pyrefly: ignore [bad-override]
     def log(x):
+        if config.eager_numerics.use_pytorch_libdevice:
+            # Strict numerics should use the backend math library entry point.
+            # On ROCm this maps to OCML and avoids Triton's generic log lowering.
+            return f"libdevice.log({x})"
         return f"tl_math.log({x})"
 
     @staticmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183783

Route Triton log codegen through libdevice when strict eager numerics request PyTorch libdevice math, matching the other transcendental functions and avoiding ROCm fp16 mismatches in the exhaustive unary OpInfo numerics test.

Fixes #180067

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos