### PR TITLE
[ROCm] Avoid ASAN UBSan interaction that aborts at startup

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1915,7 +1915,9 @@ if(BUILD_TEST)
             if(TARGET Sanitizer::address)
               target_link_libraries(${test_name}_${CPU_CAPABILITY} Sanitizer::address)
             endif()
-            if(TARGET Sanitizer::undefined)
+            # Skip UBSan on ROCm: see cmake/Dependencies.cmake (UBSan + ASAN
+            # on ROCm Clang produces misaligned ASAN globals that abort).
+            if(TARGET Sanitizer::undefined AND NOT USE_ROCM)
               target_link_libraries(${test_name}_${CPU_CAPABILITY} Sanitizer::undefined)
             endif()
           endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -123,7 +123,11 @@ if(USE_ASAN OR USE_LSAN OR USE_TSAN)
       message(WARNING "ASAN not found. Suppress this warning with -DUSE_ASAN=OFF.")
       caffe2_update_option(USE_ASAN OFF)
     endif()
-    if(TARGET Sanitizer::undefined)
+    # UBSan (-fsanitize=undefined) combined with ASAN on ROCm Clang causes
+    # ASAN global metadata to reference unaligned original globals instead
+    # of aligned __sanitized_padded_global copies, triggering an unconditional
+    # alignment check abort in the ASAN runtime.
+    if(TARGET Sanitizer::undefined AND NOT USE_ROCM)
       list(APPEND Caffe2_DEPENDENCY_LIBS Sanitizer::undefined)
     endif()
   endif()

--- a/cmake/Modules/FindSanitizer.cmake
+++ b/cmake/Modules/FindSanitizer.cmake
@@ -103,6 +103,19 @@ foreach(sanitizer_name IN ITEMS address thread undefined leak memory)
           $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<BOOL:$__CXX_${sanitizer_name}_res>>:_GLIBCXX_SANITIZE_VECTOR>
           $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<BOOL:$__CXX_${sanitizer_name}_res>>:_GLIBCXX_SANITIZE_STD_ALLOCATOR>
       )
+      # Work around an ASAN instrumentation bug where the global metadata
+      # references the original (potentially unaligned) global instead of
+      # the __sanitized_padded_global. Without private aliases, string
+      # literals can end up at non-8-byte-aligned offsets in .rodata,
+      # causing an unconditional alignment check failure in the ASAN
+      # runtime that is not suppressible via detect_odr_violation=0.
+      if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+        target_compile_options(
+          Sanitizer::${sanitizer_name}
+          INTERFACE
+          "SHELL:-mllvm -asan-use-private-alias=1"
+        )
+      endif()
       target_link_options(
         Sanitizer::${sanitizer_name}
         INTERFACE

--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -104,7 +104,9 @@ add_executable(test_jit
 )
 
 # We also build with UBSAN flag in build_asan.h
-if(USE_ASAN)
+# Skip UBSan on ROCm: combining ASAN + UBSan on ROCm Clang causes misaligned
+# global metadata, triggering spurious ASAN alignment check aborts.
+if(USE_ASAN AND NOT USE_ROCM)
   target_compile_options(test_jit PRIVATE "-fsanitize=undefined")
   target_link_libraries(test_jit PRIVATE "-fsanitize=undefined")
 endif()

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -91,7 +91,10 @@ set(TORCH_PYTHON_LINK_LIBRARIES
 if(USE_ASAN AND TARGET Sanitizer::address)
   list(APPEND TORCH_PYTHON_LINK_LIBRARIES Sanitizer::address)
 endif()
-if(USE_ASAN AND TARGET Sanitizer::undefined)
+# Skip UBSan on ROCm: see comment in cmake/Dependencies.cmake (UBSan + ASAN
+# on ROCm Clang produces misaligned ASAN global metadata that aborts at
+# startup).
+if(USE_ASAN AND TARGET Sanitizer::undefined AND NOT USE_ROCM)
   list(APPEND TORCH_PYTHON_LINK_LIBRARIES Sanitizer::undefined)
 endif()
 if(USE_LSAN AND TARGET Sanitizer::leak)


### PR DESCRIPTION
ROCm LLVM 22's ASAN instrumentation, when combined with UBSan (`-fsanitize=undefined`), produces ASAN global metadata in the `asan_globals` ELF section that references the original globals at non-8-byte-aligned offsets instead of the aligned `__sanitized_padded_global` copies. The ASAN runtime's unconditional alignment check in `RegisterGlobal()` then aborts at startup with an `odr-violation` message.

Two coordinated changes work around it:

1. Add `-mllvm -asan-use-private-alias=1` to ASAN-instrumented Clang builds (in `cmake/Modules/FindSanitizer.cmake`). This forces ASAN to emit private aliases for instrumented globals, which sidesteps the alignment mismatch.

2. Skip UBSan (`Sanitizer::undefined` and the bare `-fsanitize=undefined` flag) when `USE_ROCM` is set, in the four CMake files that link UBSan into ROCm-affected targets:
   - `cmake/Dependencies.cmake` (`Caffe2_DEPENDENCY_LIBS`)
   - `torch/CMakeLists.txt` (`torch_python`)
   - `caffe2/CMakeLists.txt` (vec test targets)
   - `test/cpp/jit/CMakeLists.txt` (`test_jit`)

Both pieces are required: the alias flag fixes most cases, the skip-UBSan gate covers the residual targets where UBSan re-introduces the mismatch.

Net effect on non-ROCm builds: zero — the alias flag is gated to Clang (no GCC effect, and Clang already accepts it harmlessly even outside ASAN), and the UBSan skip is gated to `USE_ROCM`. ROCm-ASAN builds no longer abort at startup with the bogus `odr-violation`.

Authored with Claude.


cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang