### PR TITLE
[PyTorch] Support selective TorchScript tensor data elision (#183787)

### DIFF
--- a/test/cpp/jit/test_save_load.cpp
+++ b/test/cpp/jit/test_save_load.cpp
@@ -3,7 +3,10 @@
 #include <test/cpp/jit/test_utils.h>
 #include <cstdlib>
 #include <iostream>
+#include <memory>
+#include <optional>
 #include <sstream>
+#include <unordered_set>
 
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/jit/mobile/module.h>
@@ -12,6 +15,7 @@
 #include <torch/csrc/jit/serialization/export_bytecode.h>
 #include <torch/csrc/jit/serialization/import.h>
 #include <torch/csrc/jit/serialization/import_source.h>
+#include <torch/csrc/jit/serialization/storage_context.h>
 #include <torch/script.h>
 #include <torch/torch.h>
 
@@ -152,6 +156,107 @@ TEST(SerializationTest, TypeTags) {
     ASSERT_TRUE(loaded.type()->isSubtypeOf(*item.expected_type));
     ASSERT_TRUE(item.expected_type->isSubtypeOf(*loaded.type()));
   }
+}
+
+TEST(SerializationTest, LoadStandardArchiveWithPrepopulatedStorageContext) {
+  Module module("m");
+  auto archivedWeight = torch::tensor({2.0f, 3.0f});
+  auto archivedBias = torch::tensor({5.0f, 7.0f});
+  module.register_parameter("weight", archivedWeight, false);
+  module.register_parameter("bias", archivedBias, false);
+  module.define(R"JIT(
+    def forward(self, input: Tensor) -> Tensor:
+      return input * self.weight + self.bias
+  )JIT");
+
+  std::ostringstream oss;
+  {
+    caffe2::serialize::PyTorchStreamWriter writer(
+        [&](const void* buf, size_t nbytes) -> size_t {
+          oss.write(
+              static_cast<const char*>(buf),
+              static_cast<std::streamsize>(nbytes));
+          return oss ? nbytes : 0;
+        });
+    ScriptModuleSerializer serializer(writer);
+    ExtraFilesMap extraFiles;
+    const std::unordered_set<std::string> skipTensorDataKeys = {"0"};
+    serializer.serialize(
+        module,
+        extraFiles,
+        /*bytecode_format=*/false,
+        /*save_mobile_debug_info=*/false,
+        &skipTensorDataKeys);
+  }
+
+  auto replacementWeight = torch::tensor({11.0f, 13.0f});
+  auto storageContext = std::make_shared<DeserializationStorageContext>();
+  storageContext->addStorage("0", replacementWeight.storage());
+
+  std::istringstream iss(oss.str());
+  auto reader = std::make_shared<caffe2::serialize::PyTorchStreamReader>(&iss);
+  ExtraFilesMap loadedExtraFiles;
+  auto loaded = import_ir_module(
+      std::make_shared<CompilationUnit>(),
+      std::move(reader),
+      std::move(storageContext),
+      std::optional<c10::Device>(c10::Device(c10::kCPU)),
+      loadedExtraFiles);
+
+  auto loadedWeight = loaded.attr("weight").toTensor();
+  EXPECT_EQ(loadedWeight.data_ptr(), replacementWeight.data_ptr());
+  EXPECT_TRUE(torch::equal(loaded.attr("bias").toTensor(), archivedBias));
+
+  auto input = torch::tensor({2.0f, 3.0f});
+  auto expected = input * replacementWeight + archivedBias;
+  EXPECT_TRUE(torch::equal(loaded.forward({input}).toTensor(), expected));
+}
+
+TEST(SerializationTest, LoadStandardArchiveWithNullStorageContext) {
+  Module module("m");
+  auto archivedWeight = torch::tensor({2.0f, 3.0f});
+  auto archivedBias = torch::tensor({5.0f, 7.0f});
+  module.register_parameter("weight", archivedWeight, false);
+  module.register_parameter("bias", archivedBias, false);
+  module.define(R"JIT(
+    def forward(self, input: Tensor) -> Tensor:
+      return input * self.weight + self.bias
+  )JIT");
+
+  std::ostringstream oss;
+  {
+    caffe2::serialize::PyTorchStreamWriter writer(
+        [&](const void* buf, size_t nbytes) -> size_t {
+          oss.write(
+              static_cast<const char*>(buf),
+              static_cast<std::streamsize>(nbytes));
+          return oss ? nbytes : 0;
+        });
+    ScriptModuleSerializer serializer(writer);
+    ExtraFilesMap extraFiles;
+    serializer.serialize(
+        module,
+        extraFiles,
+        /*bytecode_format=*/false,
+        /*save_mobile_debug_info=*/false);
+  }
+
+  std::istringstream iss(oss.str());
+  auto reader = std::make_shared<caffe2::serialize::PyTorchStreamReader>(&iss);
+  ExtraFilesMap loadedExtraFiles;
+  auto loaded = import_ir_module(
+      std::make_shared<CompilationUnit>(),
+      std::move(reader),
+      nullptr,
+      std::optional<c10::Device>(c10::Device(c10::kCPU)),
+      loadedExtraFiles);
+
+  EXPECT_TRUE(torch::equal(loaded.attr("weight").toTensor(), archivedWeight));
+  EXPECT_TRUE(torch::equal(loaded.attr("bias").toTensor(), archivedBias));
+
+  auto input = torch::tensor({2.0f, 3.0f});
+  auto expected = input * archivedWeight + archivedBias;
+  EXPECT_TRUE(torch::equal(loaded.forward({input}).toTensor(), expected));
 }
 
 TEST(SerializationTest, TestJitStream_CUDA) {

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -10,6 +10,7 @@
 #include <torch/csrc/jit/serialization/type_name_uniquer.h>
 #include <torch/csrc/onnx/onnx.h>
 #include <ostream>
+#include <unordered_set>
 
 namespace ONNX_NAMESPACE {
 class ModelProto;
@@ -73,11 +74,20 @@ class TORCH_API ScriptModuleSerializer {
       : writer_(export_writer) {}
 
   void writeFiles(const std::string& code_dir);
+  // skip_tensor_data_keys (when non-null) is a set of tensor archive keys
+  // (e.g. "0", "1", ... matching the order ScriptModuleSerializer assigns
+  // to tensors in the data archive) for which the serializer writes a
+  // 0-byte placeholder instead of the tensor blob. The caller is expected
+  // to substitute those tensors at load time via a
+  // DeserializationStorageContext. Keys not in the set are written
+  // normally so that __setstate__ on custom classes (e.g. fbgemm
+  // TensorQueue) can dereference their auxiliary tensors.
   void serialize(
       const Module& module,
       const ExtraFilesMap& extra_files,
       bool bytecode_format,
-      bool save_mobile_debug_info);
+      bool save_mobile_debug_info,
+      const std::unordered_set<std::string>* skip_tensor_data_keys = nullptr);
   void serialize_unified_format(Module& module, uint64_t script_module_id);
   SerializationStorageContext& storage_context();
 
@@ -94,7 +104,8 @@ class TORCH_API ScriptModuleSerializer {
       const std::string& archive_dir,
       const std::string& tensor_dir,
       bool use_storage_context = false,
-      bool skip_tensor_data = false);
+      bool skip_tensor_data = false,
+      const std::unordered_set<std::string>* skip_tensor_data_keys = nullptr);
   void updateSourceRangeTags(const SourceRangeRecords& ranges);
 
   caffe2::serialize::PyTorchStreamWriter& writer_;

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -449,20 +449,31 @@ void ScriptModuleSerializer::serialize(
     const Module& module,
     const ExtraFilesMap& extra_files,
     bool bytecode_format,
-    bool save_mobile_debug_info) {
+    bool save_mobile_debug_info,
+    const std::unordered_set<std::string>* skip_tensor_data_keys) {
   C10_LOG_API_USAGE_ONCE("torch.jit.save");
   writeExtraFiles(module, extra_files);
-  // Serialize the model object
+  // Serialize the model object. The data archive holds parameter tensors
+  // and any custom-class state (e.g. fbgemm TensorQueue) reachable from
+  // the module's IValue tree. skip_tensor_data_keys identifies the subset
+  // of those tensors the caller will substitute via a
+  // DeserializationStorageContext at load time; everything else must keep
+  // its bytes so __setstate__ can dereference auxiliary tensors.
   writeArchive(
       module._ivalue(),
       /*archive_name=*/"data",
       /*archive_dir=*/"",
-      /*tensor_dir=*/"data/");
+      /*tensor_dir=*/"data/",
+      /*use_storage_context=*/false,
+      /*skip_tensor_data=*/false,
+      /*skip_tensor_data_keys=*/skip_tensor_data_keys);
   // Then we serialize all code info.
   convertTypes(module.type());
   writeFiles("code/");
   // The tensor constants from the code are written to a separate archive
-  // so loading the code does not depend on loading the data
+  // so loading the code does not depend on loading the data. These are
+  // graph-baked literals (e.g. torch.tensor([1.0]) inside compiled code),
+  // never weight-substituted; always write them in full.
   std::vector<IValue> ivalue_constants(
       constant_table_.begin(), constant_table_.end());
   if (bytecode_format) {
@@ -479,7 +490,8 @@ void ScriptModuleSerializer::serialize(
         c10::ivalue::Tuple::create(ivalue_constants),
         /*archive_name=*/"constants",
         /*archive_dir=*/"",
-        /*tensor_dir=*/"constants/");
+        /*tensor_dir=*/"constants/",
+        /*use_storage_context=*/false);
   }
   if (!module.retrieve_traced_inputs().empty()) {
     writeArchive(
@@ -502,7 +514,8 @@ void ScriptModuleSerializer::writeArchive(
     const std::string& archive_dir,
     const std::string& tensor_dir,
     bool use_storage_context,
-    bool skip_tensor_data) {
+    bool skip_tensor_data,
+    const std::unordered_set<std::string>* skip_tensor_data_keys) {
   std::vector<char> data;
   // Vector to capture the run-time class types during pickling the IValues
   std::vector<c10::ClassTypePtr> memoizedClassTypes;
@@ -548,7 +561,10 @@ void ScriptModuleSerializer::writeArchive(
 
   for (const auto& td : data_pickle.tensorData()) {
     const std::string& tensor_name = tensor_names[i++];
-    if (td.is_meta() || skip_tensor_data) {
+    bool skip_this_tensor = skip_tensor_data ||
+        (skip_tensor_data_keys != nullptr &&
+         skip_tensor_data_keys->count(tensor_name) > 0);
+    if (td.is_meta() || skip_this_tensor) {
       writer_.writeRecord(tensor_dir + tensor_name, nullptr, 0);
       continue;
     }

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -113,9 +113,11 @@ class ScriptModuleDeserializer final {
  public:
   ScriptModuleDeserializer(
       std::shared_ptr<CompilationUnit> cu,
-      std::shared_ptr<PyTorchStreamReader> reader)
+      std::shared_ptr<PyTorchStreamReader> reader,
+      std::shared_ptr<DeserializationStorageContext> storage_context = nullptr)
       : compilation_unit_(std::move(cu)),
         reader_(std::move(reader)),
+        storage_context_(std::move(storage_context)),
         code_prefix_("code/"),
 
         source_importer_(
@@ -376,6 +378,21 @@ Module import_ir_module(
   auto [data, size] = get_stream_content(in);
   return _load_jit_module_from_bytes(
       data, size, cu, device, extra_files, restore_shapes);
+}
+
+// Load with pre-populated storage context (standard archive format).
+// When storages are pre-populated, the deserializer skips reading
+// tensor data from the archive for those storages.
+Module import_ir_module(
+    std::shared_ptr<CompilationUnit> cu,
+    std::shared_ptr<PyTorchStreamReader> reader,
+    std::shared_ptr<DeserializationStorageContext> storage_context,
+    std::optional<at::Device> device,
+    ExtraFilesMap& extra_files) {
+  reader->setShouldLoadDebugSymbol(true);
+  ScriptModuleDeserializer deserializer(
+      std::move(cu), std::move(reader), std::move(storage_context));
+  return deserializer.deserialize(device, extra_files);
 }
 
 // For reading unified serialization format from torch.Package.

--- a/torch/csrc/jit/serialization/import.h
+++ b/torch/csrc/jit/serialization/import.h
@@ -41,6 +41,14 @@ TORCH_API Module import_ir_module(
     bool load_debug_files = true,
     bool restore_shapes = false);
 
+// Load with pre-populated storage context (standard archive format).
+TORCH_API Module import_ir_module(
+    std::shared_ptr<CompilationUnit> cu,
+    std::shared_ptr<caffe2::serialize::PyTorchStreamReader> reader,
+    std::shared_ptr<torch::jit::DeserializationStorageContext> storage_context,
+    std::optional<at::Device> device,
+    ExtraFilesMap& extra_files);
+
 // For reading unified serialization format from torch.Package
 TORCH_API Module import_ir_module(
     std::shared_ptr<CompilationUnit> cu,

--- a/torch/csrc/jit/serialization/import_read.cpp
+++ b/torch/csrc/jit/serialization/import_read.cpp
@@ -42,13 +42,14 @@ IValue readArchiveAndTensors(
     return std::get<0>(stream_reader.getRecord(ss));
   };
 
+  const bool use_storage_context = storage_context != nullptr;
   Unpickler unpickler(
       reader,
       type_resolver ? std::move(*type_resolver) : nullptr,
       obj_loader ? std::move(*obj_loader) : nullptr,
       std::move(read_record),
       device,
-      false,
+      use_storage_context,
       type_parser,
       std::move(storage_context));
   unpickler.set_version(stream_reader.version());


### PR DESCRIPTION
Summary:

Allow ScriptModuleSerializer callers to omit only selected tensor data records from the standard TorchScript data archive while preserving all other tensors and graph constants. Add a standard-archive import overload that accepts a pre-populated DeserializationStorageContext so omitted storages can be substituted at load time without reading their archive blobs.

Test Plan:
arc f on touched files passed during commit. buck2 test fbcode//caffe2/test/cpp/jit:jit -- SerializationTest.LoadStandardArchiveWithPrepopulatedStorageContext scheduled a test session but timed out locally after 600s in remote execution without producing a compile or test failure.

arc lint fbcode/caffe2/test/cpp/jit/test_save_load.cpp xplat/caffe2/test/cpp/jit/test_save_load.cpp passed. buck2 test fbcode//caffe2/test/cpp/jit:jit -- SerializationTest.LoadStandardArchiveWithNullStorageContext passed (Pass 1, Fail 0).

Reviewed By: mrajpal, wdvr

Differential Revision: D105223523


