### PR TITLE
[MPS] Fix fill_ on byte-dtype views with misaligned storage offset

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ConstantKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ConstantKernel.metal
@@ -13,18 +13,29 @@ kernel void fill_scalar_dense(
     out[index] = fill_val;
 }
 
-// Single-byte types: each thread fills 4 elements via vec<T,4> writes.
+// Single-byte types: each thread fills 4 elements via vec<T,4> writes. The
+// vec store requires a 4-byte-aligned address, but a sliced view like x[1:]
+// hands us a buffer pointer with a 1..3 byte misalignment. Re-align the
+// pointer down to a 4-byte boundary (the same trick c10/metal/atomic.h uses
+// for atomic<uint>); the data region is then bytes [offs, offs+numel) of the
+// realigned buffer. Threads whose 4-byte slot is fully inside that region
+// issue a vec4 store, edge threads (head/tail) fall back to scalar writes.
 template <typename T>
 kernel void fill_scalar_dense_vec4(
     device T* out [[buffer(0)]],
     constant T& fill_val [[buffer(1)]],
     constant uint& numel [[buffer(2)]],
     uint index [[thread_position_in_grid]]) {
+  uint offs = reinterpret_cast<ulong>(out) & 3;
+  out = reinterpret_cast<device T*>(reinterpret_cast<device char*>(out) - offs);
   uint base = index * 4;
-  if (base + 4 <= numel) {
+  uint end = offs + numel;
+  if (base >= offs && base + 4 <= end) {
     *(device vec<T, 4>*)(out + base) = vec<T, 4>(fill_val);
   } else {
-    for (uint i = base; i < numel; i++)
+    uint start = max(base, offs);
+    uint stop = min(base + 4, end);
+    for (uint i = start; i < stop; i++)
       out[i] = fill_val;
   }
 }

--- a/aten/src/ATen/native/mps/operations/ConstantOps.mm
+++ b/aten/src/ATen/native/mps/operations/ConstantOps.mm
@@ -39,6 +39,7 @@ static void fill_mps_kernel(TensorIterator& iter, const Scalar& value) {
   const auto stream = getCurrentMPSStream();
   const auto type_str = scalarToMetalTypeString(dtype);
   const bool can_fill_linearly = self.is_non_overlapping_and_dense();
+  const bool is_byte_type = self.element_size() == 1;
 
   // For tensors with gaps or overlaps (e.g. stride-2 slices) use a 2D strided
   // kernel: tid.y indexes dim 0 directly (no division), tid.x is the linear
@@ -65,11 +66,14 @@ static void fill_mps_kernel(TensorIterator& iter, const Scalar& value) {
     return;
   }
 
-  // Single-byte dtypes (bool, uint8, int8) use vec4 kernels that fill
-  // 4 elements per thread; all others fill 1 element per thread.
-  const bool is_byte_type = self.element_size() == 1;
+  // Single-byte dtypes (bool, uint8, int8) use a vec4 kernel that fills
+  // 4 elements per thread. The vec<T,4> store requires a 4-byte-aligned
+  // address; the kernel re-aligns its buffer pointer (see ConstantKernel.metal),
+  // so the data region is shifted by `offs` bytes (0..3) of the realigned
+  // buffer and we need that many extra threads to cover the tail.
   const uint32_t numel = static_cast<uint32_t>(iter.numel());
-  const int64_t threads = is_byte_type ? (numel + 3) / 4 : numel;
+  const uint32_t offs = is_byte_type ? static_cast<uint32_t>(iter_tensor_offset(iter, 0) & 3) : 0;
+  const int64_t threads = is_byte_type ? (numel + offs + 3) / 4 : numel;
 
   auto fillPSO = lib.getPipelineStateForFunc(fmt::format("fill_scalar_dense_{}", type_str));
   dispatch_sync_with_rethrow(stream->queue(), ^() {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1012,6 +1012,20 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(tensor_mps.to(device="cpu"), tensor_cpu)
         self.assertEqual(tensor.to(device="cpu"), tensor_0)
 
+        # Regression test for https://github.com/pytorch/pytorch/issues/183631:
+        # fill_ on a byte-dtype view with a non-4-byte-aligned storage offset
+        # used to drop one byte at the vec4 boundary and clobber the byte
+        # before the view. Exercise all four offset misalignments and
+        # head/tail combinations.
+        for offs_head in range(4):
+            for offs_tail in range(4):
+                expected = torch.zeros(64, dtype=torch.int8)
+                expected[offs_head:64 - offs_tail].fill_(7)
+                actual = torch.zeros(64, dtype=torch.int8, device="mps")
+                actual[offs_head:64 - offs_tail].fill_(7)
+                self.assertEqual(actual.cpu(), expected,
+                                 f"offs_head={offs_head} offs_tail={offs_tail}")
+
     def test_cdist_large(self, device="mps"):
         for cm in ['use_mm_for_euclid_dist_if_necessary', 'use_mm_for_euclid_dist', 'donot_use_mm_for_euclid_dist']:
             x = torch.randn(100, 10, device=device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #183790

The dense vec4 kernel used for byte dtypes (bool, int8, uint8) does `*(device vec<T,4>*)(out + base) = vec<T,4>(fill_val)`. But Metal / Apple Silicon silently floors the misaligned 32-bit store's address to the nearest 4-byte boundary, which both clobbers the byte before the view and skips one byte at the 4 byte boundary inside the view.

Fix by realigning the buffer pointer inside the kernel (same trick `c10/metal/atomic.h` uses to emulate 1/2 byte atomics): mask off the low two bits of the pointer to obtain `offs` (0..3), shift the pointer down by that many bytes, and then treat the data region as bytes `[offs, offs+numel)` of the realigned buffer.
Each kernel thread still owns a 4-byte slot `[base, base+4)`; slots fully inside the data region issue a vec4 store, but fall back to scalar writes on edges.
On the host-side, bump the thread count to `(numel + offs + 3) / 4` so the dispatch still covers the tail of the shifted region.

The regression test checks all possibel head/tail combinations on a 64-element int8 tensor.

Fixes https://github.com/pytorch/pytorch/issues/183631

Authored with Claude.