### PR TITLE
[ROCm] Build enablement for ASAN: ODR workaround, HIP linkage, container annotations

### DIFF
--- a/aten/src/ATen/jit_macros.h
+++ b/aten/src/ATen/jit_macros.h
@@ -2,6 +2,13 @@
 #include <ATen/cuda/CUDAConfig.h>
 #include <string>
 
-// AT_USE_JITERATOR(), controls whether we jit some elementwise kernels
+// AT_USE_JITERATOR(), controls whether we jit some elementwise kernels.
+// AT_DISABLE_JITERATOR is set by CMake when jiterator should be off.
+// Currently set under USE_ROCM + USE_ASAN, because jiterator JITs kernels
+// through hiprtc and we haven't set up an ASAN-aware hiprtc runtime.
+#ifdef AT_DISABLE_JITERATOR
+#define AT_USE_JITERATOR() false
+#else
 #define AT_USE_JITERATOR() true
+#endif
 #define jiterator_stringify(...) std::string(#__VA_ARGS__);

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1918,7 +1918,9 @@ if(BUILD_TEST)
             if(TARGET Sanitizer::address)
               target_link_libraries(${test_name}_${CPU_CAPABILITY} Sanitizer::address)
             endif()
-            if(TARGET Sanitizer::undefined)
+            # Skip UBSan on ROCm: see cmake/Dependencies.cmake (UBSan + ASAN
+            # on ROCm Clang produces misaligned ASAN globals that abort).
+            if(TARGET Sanitizer::undefined AND NOT USE_ROCM)
               target_link_libraries(${test_name}_${CPU_CAPABILITY} Sanitizer::undefined)
             endif()
           endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -119,11 +119,27 @@ if(USE_ASAN OR USE_LSAN OR USE_TSAN)
   if(USE_ASAN)
     if(TARGET Sanitizer::address)
       list(APPEND Caffe2_DEPENDENCY_LIBS Sanitizer::address)
+      # torch_hip needs the sanitizer linked so HIP-side TUs participate
+      # in the libstdc++ container annotations propagated via
+      # Sanitizer::address (see cmake/Modules/FindSanitizer.cmake).
+      if(USE_ROCM)
+        list(APPEND Caffe2_HIP_DEPENDENCY_LIBS Sanitizer::address)
+        # Disable jiterator under ROCm + ASAN: jiterator JITs kernels
+        # through hiprtc and we haven't set up an ASAN-aware hiprtc
+        # runtime. Read by the AT_USE_JITERATOR() gate in
+        # aten/src/ATen/jit_macros.h.
+        add_definitions(-DAT_DISABLE_JITERATOR)
+      endif()
     else()
       message(WARNING "ASAN not found. Suppress this warning with -DUSE_ASAN=OFF.")
       caffe2_update_option(USE_ASAN OFF)
     endif()
-    if(TARGET Sanitizer::undefined)
+    # UBSan (-fsanitize=undefined) combined with ASAN on ROCm Clang
+    # causes ASAN global metadata to reference unaligned original
+    # globals instead of aligned __sanitized_padded_global copies,
+    # triggering an unconditional alignment check abort in the ASAN
+    # runtime. Skip UBSan under USE_ROCM until that interaction is fixed.
+    if(TARGET Sanitizer::undefined AND NOT USE_ROCM)
       list(APPEND Caffe2_DEPENDENCY_LIBS Sanitizer::undefined)
     endif()
   endif()
@@ -1026,6 +1042,13 @@ if(USE_ROCM)
     endif()
     if(USE_ROCM_CK_GEMM)
       list(APPEND HIP_CXX_FLAGS -DUSE_ROCM_CK_GEMM)
+    endif()
+    # add_definitions(-DAT_DISABLE_JITERATOR) above doesn't reliably
+    # propagate to HIP TUs; mirror the pattern used for USE_ROCM and
+    # add it explicitly so the AT_USE_JITERATOR() gate in
+    # aten/src/ATen/jit_macros.h fires under hipified .cu/.cuh TUs.
+    if(USE_ASAN)
+      list(APPEND HIP_CXX_FLAGS -DAT_DISABLE_JITERATOR)
     endif()
     # CMAKE_HIP_FLAGS: flags passed to the HIP compiler for device code.
     # Architecture is handled by CMAKE_HIP_ARCHITECTURES (set in LoadHIP.cmake).

--- a/cmake/Modules/FindSanitizer.cmake
+++ b/cmake/Modules/FindSanitizer.cmake
@@ -97,12 +97,31 @@ foreach(sanitizer_name IN ITEMS address thread undefined leak memory)
     endif()
 
     if(sanitizer_name STREQUAL "address")
+      # Include HIP language so HIP-side TUs update libstdc++ container
+      # annotations consistently with cpu-side; without this the cpu-side
+      # _M_realloc_insert sets up redzones that the inlined HIP-side
+      # emplace_back fast path doesn't update, producing spurious
+      # container-overflow reports.
       target_compile_definitions(
         Sanitizer::${sanitizer_name}
         INTERFACE
-          $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<BOOL:$__CXX_${sanitizer_name}_res>>:_GLIBCXX_SANITIZE_VECTOR>
-          $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<BOOL:$__CXX_${sanitizer_name}_res>>:_GLIBCXX_SANITIZE_STD_ALLOCATOR>
+          $<$<AND:$<COMPILE_LANGUAGE:CXX,HIP>,$<BOOL:$__CXX_${sanitizer_name}_res>>:_GLIBCXX_SANITIZE_VECTOR>
+          $<$<AND:$<COMPILE_LANGUAGE:CXX,HIP>,$<BOOL:$__CXX_${sanitizer_name}_res>>:_GLIBCXX_SANITIZE_STD_ALLOCATOR>
       )
+      # Work around a Clang ASAN instrumentation issue where the global
+      # metadata references the original (potentially unaligned) global
+      # instead of the __sanitized_padded_global. Without private aliases,
+      # globals can end up at non-8-byte-aligned offsets, causing an
+      # unconditional alignment check failure in the ASAN runtime that is
+      # not suppressible via detect_odr_violation=0. Especially needed
+      # under ROCm Clang where ASAN + UBSan together exhibit the issue.
+      if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+        target_compile_options(
+          Sanitizer::${sanitizer_name}
+          INTERFACE
+          "SHELL:-mllvm -asan-use-private-alias=1"
+        )
+      endif()
       target_link_options(
         Sanitizer::${sanitizer_name}
         INTERFACE

--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -104,7 +104,10 @@ add_executable(test_jit
 )
 
 # We also build with UBSAN flag in build_asan.h
-if(USE_ASAN)
+# Skip UBSan on ROCm: combining ASAN + UBSan on ROCm Clang causes
+# misaligned ASAN global metadata, triggering spurious ASAN alignment
+# check aborts at startup.
+if(USE_ASAN AND NOT USE_ROCM)
   target_compile_options(test_jit PRIVATE "-fsanitize=undefined")
   target_link_libraries(test_jit PRIVATE "-fsanitize=undefined")
 endif()

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -89,7 +89,10 @@ set(TORCH_PYTHON_LINK_LIBRARIES
 if(USE_ASAN AND TARGET Sanitizer::address)
   list(APPEND TORCH_PYTHON_LINK_LIBRARIES Sanitizer::address)
 endif()
-if(USE_ASAN AND TARGET Sanitizer::undefined)
+# Skip UBSan on ROCm: see comment in cmake/Dependencies.cmake (UBSan + ASAN
+# on ROCm Clang produces misaligned ASAN global metadata that aborts at
+# startup).
+if(USE_ASAN AND TARGET Sanitizer::undefined AND NOT USE_ROCM)
   list(APPEND TORCH_PYTHON_LINK_LIBRARIES Sanitizer::undefined)
 endif()
 if(USE_LSAN AND TARGET Sanitizer::leak)


### PR DESCRIPTION
ROCm + ASAN builds need several coordinated pieces to compile, link, and not abort at startup. This PR lands them together so reviewers can see the full picture rather than chasing partial fixes.

1. Avoid the ASAN/UBSan ODR-violation abort
   - Add `-mllvm -asan-use-private-alias=1` to ASAN+Clang builds (`cmake/Modules/FindSanitizer.cmake`), forcing private aliases for instrumented globals so the runtime's alignment check doesn't fire on the unaligned `__sanitized_padded_global` references.
   - Skip `Sanitizer::undefined` (and the bare `-fsanitize=undefined` flag in `test/cpp/jit/CMakeLists.txt`) when `USE_ROCM` is set, to avoid re-introducing the alignment mismatch from UBSan.

2. Link Sanitizer::address into torch_hip and extend libstdc++ container annotations to HIP TUs
   - Add `Sanitizer::address` to `Caffe2_HIP_DEPENDENCY_LIBS` so torch_hip links the sanitizer.
   - Extend the existing `_GLIBCXX_SANITIZE_VECTOR` / `_GLIBCXX_SANITIZE_STD_ALLOCATOR` `target_compile_definitions` block to include `COMPILE_LANGUAGE:HIP` so HIP-side TUs update libstdc++ container annotations consistently with cpu-side, removing the largest in-tree class of container-overflow false positives.

3. Disable jiterator under ROCm + ASAN
   - jiterator JITs element-wise kernels through hiprtc, and we haven't set up an ASAN-aware hiprtc runtime. Hard-disable jiterator at compile time when `USE_ROCM AND USE_ASAN`.
   - Implementation: CMake (`cmake/Dependencies.cmake`) exports `-DAT_DISABLE_JITERATOR` (both via `add_definitions` for cpu/cuda TUs and via `HIP_CXX_FLAGS` for HIP-language TUs, since `add_definitions` doesn't reliably propagate to HIP). The `AT_USE_JITERATOR()` macro in `aten/src/ATen/jit_macros.h` checks the flag with `#ifdef AT_DISABLE_JITERATOR` — neutral name keeps the header free of GPU-backend tokens so the `ATEN_CPU` lint rule passes.

Net effect on non-ROCm-ASAN builds: zero. Each gate is on `USE_ROCM`, `USE_ASAN`, or `Clang` detection. Non-ROCm builds and non-ASAN builds behave identically to before.

Note: this does not make `detect_container_overflow=1` viable in all ROCm + ASAN runs. Other third-party libraries linked into the process (e.g. gloo) can re-introduce mismatched annotations. Anyone running the full ASAN test suite under ROCm will still want `detect_container_overflow=0` for now — this set just removes the largest in-tree contributors.

Authored with Claude.


cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang