### PR TITLE
Fix DTensor reduction strategy linearity

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -30,6 +30,7 @@ from torch.distributed.tensor._ops._einsum_strategy import (
     EinsumDims,
     gen_einsum_strategies,
 )
+from torch.distributed.tensor._ops._math_ops import common_reduction_strategy
 from torch.distributed.tensor._ops.utils import replicate_op_strategy
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard
@@ -444,6 +445,46 @@ class TestCostModel(DTensorOpTestBase):
         # Cost increases with earlier mesh dimensions due to the way
         # mesh dimensions are ordered (outer to inner in device hierarchy)
         self.assertGreater(cost_mesh_dim0, cost_mesh_dim1)
+
+
+class TestReductionStrategy(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.world_size = 4
+        store = FakeStore()
+        torch.distributed.init_process_group(
+            backend="fake", rank=0, world_size=self.world_size, store=store
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        torch.distributed.destroy_process_group()
+
+    def _make_spec(self, mesh: DeviceMesh, placements):
+        tensor_meta = TensorMeta(
+            shape=torch.Size([8, 8]), stride=(8, 1), dtype=torch.float32
+        )
+        return DTensorSpec(mesh, tuple(placements), tensor_meta)
+
+    def test_common_reduction_strategy_uses_per_strategy_linearity(self):
+        mesh = DeviceMesh("cpu", torch.arange(self.world_size).reshape(2, 2))
+        partial_avg_spec = self._make_spec(mesh, (Partial("avg"), Replicate()))
+        sharded_spec = self._make_spec(mesh, (Shard(0), Shard(1)))
+
+        reduction_strategy = common_reduction_strategy(
+            OpStrategy([OpSpec(partial_avg_spec), OpSpec(sharded_spec)]),
+            [0],
+            reduction_op="sum",
+        )
+
+        sharded_reduction_spec = reduction_strategy.strategies[1]
+        self.assertEqual(
+            sharded_reduction_spec.input_specs[0].placements, (Shard(0), Shard(1))
+        )
+        self.assertEqual(
+            sharded_reduction_spec.output_spec.placements,
+            (Partial("sum"), Shard(0)),
+        )
 
 
 # -------------Test op strategy registration-------------

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -266,23 +266,24 @@ def common_reduction_strategy(
     reduction_strategy = OpStrategy([])
 
     for op_spec in input_strategy.strategies:
+        is_reduction_linear = reduction_linear
         if reduction_op == "avg":
             output_spec = op_spec.output_spec
             local_shape = list(output_spec.tensor_meta.shape)  # type:ignore[union-attr]
             for dim in reduce_dims:
                 if not is_tensor_evenly_shardable_on_dim(local_shape, output_spec, dim):
                     # reduce(avg) is not linear for unevenly sharded tensors
-                    reduction_linear = False
+                    is_reduction_linear = False
                     break
 
         for p in op_spec.output_spec.placements:
             # when the partial reduction op matches the global reduction op,
             # we can delay redistribution (i.e max, max)
             if isinstance(p, Partial) and p.reduce_op != reduction_op:
-                reduction_linear = False
+                is_reduction_linear = False
                 break
 
-        if not reduction_linear:
+        if not is_reduction_linear:
             # input placements for this strategy should clear out pending sum and sharding
             # on the reduction dimension
             input_placements = replicate_reduction_dims(


### PR DESCRIPTION

Keep reduction linearity decisions scoped to each candidate strategy so a non-linear Partial(avg) candidate does not force later sharded reduction strategies through replication. Add a regression test for the affected S(0)S(1) case.

Authored with Codex.