### PR TITLE
[Inductor] Fix linter from tf32 fix (#183468)

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -17,7 +17,7 @@ from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import Mod
 from torch.utils._triton import has_triton_stable_tma_api
 
-from .. import config, config as inductor_config
+from .. import config
 from ..kernel.bmm import bmm_template
 from ..kernel.mm import (
     blackwell_ws_persistent_device_tma_mm_template,


### PR DESCRIPTION
Summary:

bypass-github-export-checks "Already landed in oss, had to fix an oss linting issue"

Test Plan: CI

Differential Revision: D105236824


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo