### PR TITLE
[AO] Use metadata annotations for offloading

### DIFF
--- a/test/dynamo/test_activation_offloading.py
+++ b/test/dynamo/test_activation_offloading.py
@@ -1,4 +1,5 @@
 # Owner(s): ["oncall: pt2"]
+# flake8: noqa: B950
 
 import unittest
 from functools import partial
@@ -14,10 +15,9 @@ from functorch.compile import (
     min_cut_rematerialization_partition,
 )
 from torch._dynamo.graph_bytecode_inputs import reset_user_object_tracking
-from torch._dynamo.test_case import run_tests, TestCase
 from torch._inductor.utils import run_fw_bw_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import serialTest
+from torch.testing._internal.common_utils import run_tests, serialTest, TestCase
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -137,8 +137,7 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
             .run(bw_code)
         )
 
-    def test_partitioner_offload_ao_ops(self):
-        """Test that async offload uses ao.offload + ao.wait_tensor with keepalive."""
+    def test_partitioner_offload_sep_stream(self):
         reset_user_object_tracking()
         torch._dynamo.reset()
         with torch._functorch.config.patch(
@@ -148,59 +147,56 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
         ):
             fw_graph, bw_graph = get_fw_bw_graph(self.fn, [self.x])
 
-        fw_code = fw_graph.code
-        # Forward: ao.offload produces async CPU tensor, ao.wait_tensor synchronizes
-        (
-            FileCheck()
-            .check("ao.offload.default")
-            .check("ao.wait_tensor.default")
-            .run(fw_code)
+        self.assertExpectedInline(
+            fw_graph.code.strip(),
+            """\
+def forward(self, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6):
+    add = torch.ops.aten.add.Tensor(primals_1, primals_2);  primals_1 = primals_2 = None
+    sin = torch.ops.aten.sin.default(add)
+    add_1 = torch.ops.aten.add.Tensor(primals_3, primals_4);  primals_3 = primals_4 = None
+    sin_1 = torch.ops.aten.sin.default(add_1)
+    add_2 = torch.ops.aten.add.Tensor(sin, sin_1)
+    add_3 = torch.ops.aten.add.Tensor(primals_5, primals_6);  primals_5 = primals_6 = None
+    sin_2 = torch.ops.aten.sin.default(add_3)
+    add_4 = torch.ops.aten.add.Tensor(add_2, sin_2)
+    cos = torch.ops.aten.cos.default(add_3)
+    cos_1 = torch.ops.aten.cos.default(add_1)
+    subgraph_record_event_default = self.subgraph_record_event_default
+    control_deps = torch.ops.higher_order.control_deps((add, sin, add_1, sin_1, add_2, add_3, sin_2, add_4, cos, cos_1), subgraph_record_event_default, add, add_4, cos, cos_1);  add = sin = add_1 = sin_1 = add_2 = add_3 = sin_2 = cos = cos_1 = subgraph_record_event_default = None
+    getitem_3 = control_deps[4]
+    getitem_2 = control_deps[3]
+    getitem_1 = control_deps[2];  getitem_1 = None
+    getitem = control_deps[1]
+    subgraph_wait_event_default = self.subgraph_wait_event_default
+    control_deps_1 = torch.ops.higher_order.control_deps((control_deps,), subgraph_wait_event_default);  control_deps = subgraph_wait_event_default = control_deps_1 = None
+    record_stream_cos_1 = torch.ops.streams.record_stream.default(getitem_3, 1);  record_stream_cos_1 = None
+    cpu_offload_cos_1 = torch.ops.prims.device_put.default(getitem_3, device(type='cpu'), non_blocking = True)
+    subgraph_record_event_default_1 = self.subgraph_record_event_default_1
+    control_deps_2 = torch.ops.higher_order.control_deps((cpu_offload_cos_1,), subgraph_record_event_default_1, cpu_offload_cos_1);  subgraph_record_event_default_1 = None
+    getitem_4 = control_deps_2[1];  getitem_4 = None
+    subgraph_wait_event_default_1 = self.subgraph_wait_event_default_1
+    control_deps_3 = torch.ops.higher_order.control_deps((control_deps_2,), subgraph_wait_event_default_1);  control_deps_2 = subgraph_wait_event_default_1 = control_deps_3 = None
+    keep_alive_cos_1 = torch.ops.streams.record_stream.default(getitem_3, 0);  getitem_3 = keep_alive_cos_1 = None
+    cos_2 = torch.ops.aten.cos.default(getitem);  getitem = None
+    return (add_4, getitem_2, cpu_offload_cos_1, cos_2)""",
         )
-        # No old stream ops should be present
-        self.assertNotIn("streams.fork", fw_code)
-        self.assertNotIn("streams.join", fw_code)
-        self.assertNotIn("streams.record_stream", fw_code)
 
-        # Verify keepalive: ao.wait_tensor for offload should reference the GPU tensor
-        # (cos_1) as its 2nd arg to extend its lifetime
-        for node in fw_graph.graph.nodes:
-            if (
-                node.op == "call_function"
-                and node.target == torch.ops.ao.wait_tensor.default
-                and isinstance(node.args[0], torch.fx.Node)
-                and node.args[0].target == torch.ops.ao.offload.default
-            ):
-                self.assertEqual(len(node.args), 2)
-                offload_node = node.args[0]
-                keepalive_node = node.args[1]
-                # keepalive should be the same GPU tensor that was offloaded
-                self.assertIs(keepalive_node, offload_node.args[0])
-
-        bw_code = bw_graph.code
-        # Backward: ao.reload produces async GPU tensor, ao.wait_tensor synchronizes
-        (
-            FileCheck()
-            .check("ao.reload.default")
-            .check("ao.wait_tensor.default")
-            .run(bw_code)
+        self.assertExpectedInline(
+            bw_graph.code.strip(),
+            """\
+def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
+    mul = torch.ops.aten.mul.Tensor(tangents_1, cos);  cos = None
+    gpu_reload_cos_1 = torch.ops.prims.device_put.default(cpu_offload_cos_1, device(type='GPU_TYPE', index=0), non_blocking = True);  cpu_offload_cos_1 = None
+    subgraph_record_event_default = self.subgraph_record_event_default
+    control_deps = torch.ops.higher_order.control_deps((gpu_reload_cos_1, mul), subgraph_record_event_default, gpu_reload_cos_1, mul);  gpu_reload_cos_1 = mul = subgraph_record_event_default = None
+    getitem_1 = control_deps[2]
+    getitem = control_deps[1]
+    subgraph_wait_event_default = self.subgraph_wait_event_default
+    control_deps_1 = torch.ops.higher_order.control_deps((control_deps,), subgraph_wait_event_default);  control_deps = subgraph_wait_event_default = control_deps_1 = None
+    mul_1 = torch.ops.aten.mul.Tensor(tangents_1, getitem);  getitem = None
+    mul_2 = torch.ops.aten.mul.Tensor(tangents_1, cos_2);  tangents_1 = cos_2 = None
+    return (mul_2, mul_2, mul_1, mul_1, getitem_1, getitem_1)""".replace("GPU_TYPE", GPU_TYPE),
         )
-        self.assertNotIn("streams.fork", bw_code)
-        self.assertNotIn("streams.join", bw_code)
-
-        # Verify keepalive: ao.wait_tensor for reload should reference the CPU
-        # placeholder as its 2nd arg so its storage is freed after the H2D copy
-        for node in bw_graph.graph.nodes:
-            if (
-                node.op == "call_function"
-                and node.target == torch.ops.ao.wait_tensor.default
-                and isinstance(node.args[0], torch.fx.Node)
-                and node.args[0].target == torch.ops.ao.reload.default
-            ):
-                self.assertEqual(len(node.args), 2)
-                reload_node = node.args[0]
-                keepalive_node = node.args[1]
-                # keepalive should be the CPU placeholder that was reloaded
-                self.assertIs(keepalive_node, reload_node.args[0])
 
     def test_partitioner_offload_sep_stream_accuracy(self):
         # Run without compilation to get reference gradients
@@ -232,64 +228,69 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
                 atol=1e-5,
             )
 
-    def test_partitioner_offload_ao_ops_sink_wait(self):
-        """Test that sink_wait moves ao.wait_tensor for offload to end of forward graph."""
+    def test_partitioner_offload_sep_stream_reorder(self):
         reset_user_object_tracking()
         torch._dynamo.reset()
         with torch._functorch.config.patch(
             enable_activation_offloading=True,
             activation_offload_separate_stream=True,
             activation_offload_sink_wait=True,
-            joint_custom_pass=self.joint_custom_pass,
-        ):
-            fw_graph, _ = get_fw_bw_graph(self.fn, [self.x])
-
-        # The ao.wait_tensor for offload should be sunk to just before the output node
-        nodes = list(fw_graph.graph.nodes)
-        output_node = next(n for n in nodes if n.op == "output")
-        output_idx = nodes.index(output_node)
-
-        for node in nodes:
-            if (
-                node.op == "call_function"
-                and node.target == torch.ops.ao.wait_tensor.default
-                and isinstance(node.args[0], torch.fx.Node)
-                and node.args[0].target == torch.ops.ao.offload.default
-            ):
-                wait_idx = nodes.index(node)
-                # ao.wait_tensor should be immediately before output
-                self.assertEqual(wait_idx, output_idx - 1)
-
-    def test_partitioner_offload_ao_ops_prefetch(self):
-        """Test that prefetch moves ao.reload earlier in backward graph."""
-        reset_user_object_tracking()
-        torch._dynamo.reset()
-        with torch._functorch.config.patch(
-            enable_activation_offloading=True,
-            activation_offload_separate_stream=True,
             activation_reload_prefetch=True,
             joint_custom_pass=self.joint_custom_pass,
         ):
-            _, bw_graph = get_fw_bw_graph(self.fn, [self.x])
+            fw_graph, bw_graph = get_fw_bw_graph(self.fn, [self.x])
 
-        nodes = list(bw_graph.graph.nodes)
-        reload_nodes = [
-            n
-            for n in nodes
-            if n.op == "call_function" and n.target == torch.ops.ao.reload.default
-        ]
-        wait_nodes = [
-            n
-            for n in nodes
-            if n.op == "call_function"
-            and n.target == torch.ops.ao.wait_tensor.default
-            and isinstance(n.args[0], torch.fx.Node)
-            and n.args[0].target == torch.ops.ao.reload.default
-        ]
-        # Reload should appear before its corresponding wait (prefetched earlier)
-        for reload_node in reload_nodes:
-            wait_node = next(w for w in wait_nodes if w.args[0] is reload_node)
-            self.assertLess(nodes.index(reload_node), nodes.index(wait_node))
+        self.assertExpectedInline(
+            fw_graph.code.strip(),
+            """\
+def forward(self, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6):
+    add = torch.ops.aten.add.Tensor(primals_1, primals_2);  primals_1 = primals_2 = None
+    sin = torch.ops.aten.sin.default(add)
+    add_1 = torch.ops.aten.add.Tensor(primals_3, primals_4);  primals_3 = primals_4 = None
+    sin_1 = torch.ops.aten.sin.default(add_1)
+    add_2 = torch.ops.aten.add.Tensor(sin, sin_1)
+    add_3 = torch.ops.aten.add.Tensor(primals_5, primals_6);  primals_5 = primals_6 = None
+    sin_2 = torch.ops.aten.sin.default(add_3)
+    add_4 = torch.ops.aten.add.Tensor(add_2, sin_2)
+    cos = torch.ops.aten.cos.default(add_3)
+    cos_1 = torch.ops.aten.cos.default(add_1)
+    subgraph_record_event_default = self.subgraph_record_event_default
+    control_deps = torch.ops.higher_order.control_deps((add, sin, add_1, sin_1, add_2, add_3, sin_2, add_4, cos, cos_1), subgraph_record_event_default, add, add_4, cos, cos_1);  add = sin = add_1 = sin_1 = add_2 = add_3 = sin_2 = cos = cos_1 = subgraph_record_event_default = None
+    getitem_3 = control_deps[4]
+    getitem_2 = control_deps[3]
+    getitem_1 = control_deps[2];  getitem_1 = None
+    getitem = control_deps[1]
+    subgraph_wait_event_default = self.subgraph_wait_event_default
+    control_deps_1 = torch.ops.higher_order.control_deps((control_deps,), subgraph_wait_event_default);  control_deps = subgraph_wait_event_default = control_deps_1 = None
+    record_stream_cos_1 = torch.ops.streams.record_stream.default(getitem_3, 1);  record_stream_cos_1 = None
+    cpu_offload_cos_1 = torch.ops.prims.device_put.default(getitem_3, device(type='cpu'), non_blocking = True)
+    subgraph_record_event_default_1 = self.subgraph_record_event_default_1
+    control_deps_2 = torch.ops.higher_order.control_deps((cpu_offload_cos_1,), subgraph_record_event_default_1, cpu_offload_cos_1);  subgraph_record_event_default_1 = None
+    getitem_4 = control_deps_2[1];  getitem_4 = None
+    cos_2 = torch.ops.aten.cos.default(getitem);  getitem = None
+    subgraph_wait_event_default_2 = self.subgraph_wait_event_default_2
+    control_deps_3 = torch.ops.higher_order.control_deps((control_deps_2, cos_2), subgraph_wait_event_default_2, cos_2);  control_deps_2 = cos_2 = subgraph_wait_event_default_2 = None
+    getitem_5 = control_deps_3[1];  control_deps_3 = None
+    record_stream_default = torch.ops.streams.record_stream.default(getitem_3, 0);  getitem_3 = record_stream_default = None
+    return (add_4, getitem_2, cpu_offload_cos_1, getitem_5)""",
+        )
+
+        self.assertExpectedInline(
+            bw_graph.code.strip(),
+            """\
+def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
+    gpu_reload_cos_1 = torch.ops.prims.device_put.default(cpu_offload_cos_1, device(type='GPU_TYPE', index=0), non_blocking = True);  cpu_offload_cos_1 = None
+    subgraph_record_event_default = self.subgraph_record_event_default
+    control_deps = torch.ops.higher_order.control_deps((gpu_reload_cos_1,), subgraph_record_event_default, gpu_reload_cos_1);  gpu_reload_cos_1 = subgraph_record_event_default = None
+    getitem = control_deps[1]
+    mul = torch.ops.aten.mul.Tensor(tangents_1, cos);  cos = None
+    subgraph_wait_event_default = self.subgraph_wait_event_default
+    control_deps_1 = torch.ops.higher_order.control_deps((control_deps, mul), subgraph_wait_event_default, mul);  control_deps = mul = subgraph_wait_event_default = None
+    getitem_1 = control_deps_1[1];  control_deps_1 = None
+    mul_1 = torch.ops.aten.mul.Tensor(tangents_1, getitem);  getitem = None
+    mul_2 = torch.ops.aten.mul.Tensor(tangents_1, cos_2);  tangents_1 = cos_2 = None
+    return (mul_2, mul_2, mul_1, mul_1, getitem_1, getitem_1)""".replace("GPU_TYPE", GPU_TYPE),
+        )
 
     @serialTest()
     def test_partitioner_offload_sep_stream_reorder_accuracy(self):
@@ -329,145 +330,6 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
                 rtol=1e-5,
                 atol=1e-5,
             )
-
-    def test_wait_tensor_error_no_pending_transfer(self):
-        """Test _pop_wait raises RuntimeError for unregistered tensor."""
-        from torch._functorch._activation_offloading.offload_ops import (
-            _clear_wait_registry,
-            _pop_wait,
-        )
-
-        _clear_wait_registry()
-        x = torch.randn(4, device=GPU_TYPE)
-        with self.assertRaisesRegex(RuntimeError, "no pending transfer"):
-            _pop_wait(x)
-
-    def test_offload_reload_fake_tensor(self):
-        """Test fake tensor implementations for offload, reload, and wait_tensor."""
-        import torch._functorch._activation_offloading.offload_ops
-        from torch._subclasses.fake_tensor import FakeTensorMode
-
-        with FakeTensorMode():
-            x_gpu = torch.randn(4, 8, device=GPU_TYPE)
-
-            # offload fake: GPU -> CPU with same shape/dtype
-            cpu_result = torch.ops.ao.offload.default(x_gpu)
-            self.assertEqual(cpu_result.shape, (4, 8))
-            self.assertEqual(cpu_result.device.type, "cpu")
-            self.assertEqual(cpu_result.dtype, x_gpu.dtype)
-
-            # reload fake: CPU -> GPU with same shape/dtype
-            x_cpu = torch.randn(4, 8)
-            gpu_result = torch.ops.ao.reload.default(x_cpu, torch.device(GPU_TYPE))
-            self.assertEqual(gpu_result.shape, (4, 8))
-            self.assertEqual(gpu_result.device.type, GPU_TYPE)
-            self.assertEqual(gpu_result.dtype, x_cpu.dtype)
-
-            # wait_tensor fake: returns same tensor (aliasing)
-            wait_result = torch.ops.ao.wait_tensor.default(x_gpu)
-            self.assertEqual(wait_result.shape, x_gpu.shape)
-            self.assertEqual(wait_result.device, x_gpu.device)
-
-    def test_multiple_tensors_offload_ao_ops(self):
-        """Test offloading all saved tensors simultaneously with ao ops."""
-
-        def mark_all_cos_for_offloading(gm, joint_inputs):
-            for node in gm.graph.nodes:
-                if node.name.startswith("cos"):
-                    node.meta["should_offload"] = True
-            return gm
-
-        reset_user_object_tracking()
-        torch._dynamo.reset()
-        with torch._functorch.config.patch(
-            enable_activation_offloading=True,
-            activation_offload_separate_stream=True,
-            joint_custom_pass=mark_all_cos_for_offloading,
-        ):
-            fw_graph, bw_graph = get_fw_bw_graph(self.fn, [self.x])
-
-        fw_code = fw_graph.code
-        self.assertEqual(fw_code.count("ao.offload.default"), 3)
-        self.assertEqual(fw_code.count("ao.wait_tensor.default"), 3)
-
-        bw_code = bw_graph.code
-        self.assertEqual(bw_code.count("ao.reload.default"), 3)
-        self.assertEqual(bw_code.count("ao.wait_tensor.default"), 3)
-
-    def test_multiple_tensors_offload_ao_ops_accuracy(self):
-        """Test accuracy when offloading all saved tensors with ao ops."""
-
-        def mark_all_cos_for_offloading(gm, joint_inputs):
-            for node in gm.graph.nodes:
-                if node.name.startswith("cos"):
-                    node.meta["should_offload"] = True
-            return gm
-
-        x_ref = [x.detach().clone().requires_grad_(True) for x in self.x]
-        out_ref = self.fn(x_ref)
-        out_ref.sum().backward()
-        grads_ref = [inp.grad for inp in x_ref]
-
-        reset_user_object_tracking()
-        torch._dynamo.reset()
-        with torch._functorch.config.patch(
-            enable_activation_offloading=True,
-            activation_offload_separate_stream=True,
-            joint_custom_pass=mark_all_cos_for_offloading,
-        ):
-            fw_graph, bw_graph = get_fw_bw_graph(self.fn, [self.x])
-
-        # Verify ao ops are used (not old stream ops)
-        self.assertIn("ao.offload.default", fw_graph.code)
-        self.assertIn("ao.reload.default", bw_graph.code)
-
-        reset_user_object_tracking()
-        torch._dynamo.reset()
-        with torch._functorch.config.patch(
-            enable_activation_offloading=True,
-            activation_offload_separate_stream=True,
-            joint_custom_pass=mark_all_cos_for_offloading,
-        ):
-            x_compile = [x.detach().clone().requires_grad_(True) for x in self.x]
-            compiled_fn = torch.compile(self.fn, backend="aot_eager")
-            out_compiled = compiled_fn(x_compile)
-            out_compiled.sum().backward()
-            grads_compiled = [inp.grad for inp in x_compile]
-
-        for grad_ref, grad_compiled in zip(grads_ref, grads_compiled):
-            torch.testing.assert_close(grad_compiled, grad_ref, rtol=1e-5, atol=1e-5)
-
-    def test_inductor_offload_ao_ops(self):
-        """Test inductor code generation with ao ops."""
-        reset_user_object_tracking()
-        torch._dynamo.reset()
-
-        def run_compiled():
-            return torch.compile(self.fn)(self.x)
-
-        with torch._functorch.config.patch(
-            enable_activation_offloading=True,
-            activation_offload_separate_stream=True,
-            joint_custom_pass=self.joint_custom_pass,
-        ):
-            _, (fw_code, bw_code) = run_fw_bw_and_get_code(run_compiled)
-
-        (FileCheck().check("ao.offload").check("ao.wait_tensor").run(fw_code))
-        (FileCheck().check("ao.reload").check("ao.wait_tensor").run(bw_code))
-
-    def test_estimate_transfer_time_config(self):
-        """Test bandwidth config controls transfer time estimation."""
-        from torch._functorch._activation_offloading.activation_offloading import (
-            _estimate_transfer_time_in_ms,
-        )
-
-        size_bytes = 1024**3  # 1 GB
-        # 1 GB at 50 GB/s = 20 ms
-        with torch._functorch.config.patch(activation_offload_cpu_gpu_bw=50.0):
-            self.assertAlmostEqual(_estimate_transfer_time_in_ms(size_bytes), 20.0)
-        # 1 GB at 25 GB/s = 40 ms
-        with torch._functorch.config.patch(activation_offload_cpu_gpu_bw=25.0):
-            self.assertAlmostEqual(_estimate_transfer_time_in_ms(size_bytes), 40.0)
 
 
 @unittest.skipIf(not HAS_GPU, "requires GPU")
@@ -541,8 +403,8 @@ def forward(self, add, cpu_offload_add_1, add_3, tangents_1):
     return (mul_2, mul_2, mul_1, mul_1, mul, mul)""".replace("GPU_TYPE", GPU_TYPE),
         )
 
-    def test_default_partitioner_offload_ao_ops(self):
-        """Test ao ops with default partitioner."""
+    def test_default_partitioner_offload_sep_stream(self):
+        """Test offloading with separate streams using default partitioner"""
         reset_user_object_tracking()
         torch._dynamo.reset()
         with torch._functorch.config.patch(
@@ -554,25 +416,56 @@ def forward(self, add, cpu_offload_add_1, add_3, tangents_1):
                 self.fn, [self.x], partitioner=default_partition
             )
 
-        fw_code = fw_graph.code
-        (
-            FileCheck()
-            .check("ao.offload.default")
-            .check("ao.wait_tensor.default")
-            .run(fw_code)
+        self.assertExpectedInline(
+            fw_graph.code.strip(),
+            """\
+def forward(self, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6):
+    add = torch.ops.aten.add.Tensor(primals_1, primals_2);  primals_1 = primals_2 = None
+    sin = torch.ops.aten.sin.default(add)
+    add_1 = torch.ops.aten.add.Tensor(primals_3, primals_4);  primals_3 = primals_4 = None
+    sin_1 = torch.ops.aten.sin.default(add_1)
+    subgraph_record_event_default = self.subgraph_record_event_default
+    control_deps = torch.ops.higher_order.control_deps((add, sin, add_1, sin_1), subgraph_record_event_default, add, sin, add_1, sin_1);  sin = add_1 = sin_1 = subgraph_record_event_default = None
+    getitem_3 = control_deps[4]
+    getitem_2 = control_deps[3]
+    getitem_1 = control_deps[2]
+    getitem = control_deps[1];  getitem = None
+    subgraph_wait_event_default = self.subgraph_wait_event_default
+    control_deps_1 = torch.ops.higher_order.control_deps((control_deps,), subgraph_wait_event_default);  control_deps = subgraph_wait_event_default = control_deps_1 = None
+    record_stream_add_1 = torch.ops.streams.record_stream.default(getitem_2, 1);  record_stream_add_1 = None
+    cpu_offload_add_1 = torch.ops.prims.device_put.default(getitem_2, device(type='cpu'), non_blocking = True)
+    subgraph_record_event_default_1 = self.subgraph_record_event_default_1
+    control_deps_2 = torch.ops.higher_order.control_deps((cpu_offload_add_1,), subgraph_record_event_default_1, cpu_offload_add_1);  subgraph_record_event_default_1 = None
+    getitem_4 = control_deps_2[1];  getitem_4 = None
+    subgraph_wait_event_default_1 = self.subgraph_wait_event_default_1
+    control_deps_3 = torch.ops.higher_order.control_deps((control_deps_2,), subgraph_wait_event_default_1);  control_deps_2 = subgraph_wait_event_default_1 = control_deps_3 = None
+    keep_alive_add_1 = torch.ops.streams.record_stream.default(getitem_2, 0);  getitem_2 = keep_alive_add_1 = None
+    add_2 = torch.ops.aten.add.Tensor(getitem_1, getitem_3);  getitem_1 = getitem_3 = None
+    add_3 = torch.ops.aten.add.Tensor(primals_5, primals_6);  primals_5 = primals_6 = None
+    sin_2 = torch.ops.aten.sin.default(add_3)
+    add_4 = torch.ops.aten.add.Tensor(add_2, sin_2);  add_2 = sin_2 = None
+    return (add_4, add, cpu_offload_add_1, add_3)""",
         )
-        self.assertNotIn("streams.fork", fw_code)
-        self.assertNotIn("streams.join", fw_code)
 
-        bw_code = bw_graph.code
-        (
-            FileCheck()
-            .check("ao.reload.default")
-            .check("ao.wait_tensor.default")
-            .run(bw_code)
+        self.assertExpectedInline(
+            bw_graph.code.strip(),
+            """\
+def forward(self, add, cpu_offload_add_1, add_3, tangents_1):
+    cos = torch.ops.aten.cos.default(add_3);  add_3 = None
+    mul = torch.ops.aten.mul.Tensor(tangents_1, cos)
+    gpu_reload_add_1 = torch.ops.prims.device_put.default(cpu_offload_add_1, device(type='GPU_TYPE', index=0), non_blocking = True);  cpu_offload_add_1 = None
+    subgraph_record_event_default = self.subgraph_record_event_default
+    control_deps = torch.ops.higher_order.control_deps((gpu_reload_add_1, cos, mul), subgraph_record_event_default, gpu_reload_add_1, mul);  gpu_reload_add_1 = cos = mul = subgraph_record_event_default = None
+    getitem_1 = control_deps[2]
+    getitem = control_deps[1]
+    subgraph_wait_event_default = self.subgraph_wait_event_default
+    control_deps_1 = torch.ops.higher_order.control_deps((control_deps,), subgraph_wait_event_default);  control_deps = subgraph_wait_event_default = control_deps_1 = None
+    cos_1 = torch.ops.aten.cos.default(getitem);  getitem = None
+    mul_1 = torch.ops.aten.mul.Tensor(tangents_1, cos_1);  cos_1 = None
+    cos_2 = torch.ops.aten.cos.default(add);  add = None
+    mul_2 = torch.ops.aten.mul.Tensor(tangents_1, cos_2);  tangents_1 = cos_2 = None
+    return (mul_2, mul_2, mul_1, mul_1, getitem_1, getitem_1)""".replace("GPU_TYPE", GPU_TYPE),
         )
-        self.assertNotIn("streams.fork", bw_code)
-        self.assertNotIn("streams.join", bw_code)
 
     def test_default_partitioner_offload_accuracy(self):
         """Test that offloading with default partitioner produces correct gradients"""

--- a/torch/_functorch/_activation_offloading/activation_offloading.py
+++ b/torch/_functorch/_activation_offloading/activation_offloading.py
@@ -1,8 +1,14 @@
-"""Activation offloading for memory optimization during compilation.
+"""
+Activation offloading for memory optimization in (more like post) partitioners.
 
-This module provides functionality to offload activations to CPU during the forward
-pass and reload them during the backward pass, reducing GPU memory usage. It can be
-applied to graphs produced by both AOT Autograd partitioners and make_fx-based tracing.
+This module provides functionality to offload activations to CPU during forward pass
+and reload them during backward pass, reducing GPU memory usage.
+
+Additional TODO:
+* given the fact that PT2 stream support is in active development, testings should
+  be done once that is more finalized. A issue currently known is that with streams,
+  each iteration will have its own offload streams, but the streams should be shared
+  across the iterations.
 """
 
 import logging
@@ -11,11 +17,8 @@ from dataclasses import dataclass
 
 import torch
 import torch.fx as fx
-from torch._functorch._activation_offloading.offload_ops import (  # noqa: F401 -- registers ao::offload, ao::reload, ao::wait_tensor ops
-    offload,
-    reload,
-    wait_tensor,
-)
+from torch._dynamo.variables.streams import get_current_stream, new_event, new_stream
+from torch._inductor import config as inductor_config
 from torch._inductor.fx_passes.overlap_scheduling import benchmark_node, is_compute_node
 from torch._subclasses.fake_tensor import extract_tensor_metadata
 from torch.utils._ordered_set import OrderedSet
@@ -33,31 +36,21 @@ CPU_OFFLOAD_PREFIX = "cpu_offload_"
 GPU_RELOAD_PREFIX = "gpu_reload_"
 
 
-def _find_all_effective_users(node: fx.Node, op_types: OpTypes) -> OrderedSet[fx.Node]:
-    """Find all effective users of a node, where view ops extend the lifetime
-    of the original node. If a user is a view op, recursively find users of
-    the view."""
-    effective_users: OrderedSet[fx.Node] = OrderedSet()
-    for user in node.users:
-        if user.op == "output":
-            continue
-        effective_users.add(user)
-        if op_types.is_view(user):
-            effective_users.update(_find_all_effective_users(user, op_types))
-    return effective_users
-
-
 @dataclass
 class ReloadNodeInfo:
     """
     Information about backward reload related nodes for each reload operation.
 
-    Pattern: ao.reload → ao.wait_tensor
+    Pattern: device_put [stream metadata] → record_event → ... → wait_event
 
-    - Reload group (ao.reload): Performs the actual asynchronous data transfer.
-      Can be moved earlier in the graph to overlap with computation.
-    - Wait node (ao.wait_tensor): Synchronization point that blocks until the data
-      transfer completes. Must remain at the point where the data is first needed.
+    This pattern is divided into two logical groups for optimization purposes:
+    - Reload group (device_put → record_event):
+      Performs the actual asynchronous data transfer on a separate stream
+      (identified by node.meta["custom"]["stream"]).
+      These nodes can be moved earlier in the graph to overlap with computation.
+    - Wait group (wait_event):
+      Synchronization point that blocks until the data transfer completes.
+      This must remain at the point where the reloaded data is first needed.
     """
 
     reload_group_nodes: list[fx.Node]
@@ -100,6 +93,21 @@ def offload_activation_fw(graph: fx.Graph) -> None:
 
     op_types: OpTypes = get_default_op_list()
 
+    def find_all_effective_users(node: fx.Node) -> OrderedSet[fx.Node]:
+        """
+        Find all effective users of a node, where view ops extend the lifetime of the
+        original node. If a user is a view op, recursively find users of the view.
+        """
+        effective_users: OrderedSet[fx.Node] = OrderedSet()
+        for user in node.users:
+            if user.op == "output":
+                continue
+            effective_users.add(user)
+            if op_types.is_view(user):
+                effective_users.update(find_all_effective_users(user))
+
+        return effective_users
+
     output_node: fx.Node = graph.find_nodes(op="output")[0]
     # pyrefly: ignore [bad-assignment]
     fwd_outputs: tuple[fx.Node, ...] = output_node.args[
@@ -115,7 +123,8 @@ def offload_activation_fw(graph: fx.Graph) -> None:
             continue
 
         # Find insertion point, which is the last use
-        if all_effective_users := _find_all_effective_users(node, op_types):
+        all_effective_users: OrderedSet[fx.Node] = find_all_effective_users(node)
+        if all_effective_users := find_all_effective_users(node):
             last_user = max(all_effective_users, key=lambda n: node_to_index[n])
         else:
             last_user: fx.Node = node
@@ -183,116 +192,6 @@ def reload_activation_bw(graph: fx.Graph) -> None:
         for user in list(node.users.keys()):
             if user != gpu_node:
                 user.replace_input_with(node, gpu_node)
-
-
-def offload_activation_fw_async(graph: fx.Graph) -> None:
-    """Insert async CPU offload operations in the forward pass graph.
-
-    Uses ao.offload + ao.wait_tensor ops which encapsulate stream management
-    internally, producing a clean 2-node IR per offloaded tensor.
-    """
-
-    op_types: OpTypes = get_default_op_list()
-
-    output_node: fx.Node = graph.find_nodes(op="output")[0]
-    # pyrefly: ignore [bad-assignment]
-    fwd_outputs: tuple[fx.Node, ...] = output_node.args[
-        0
-    ]  # pyrefly: ignore [bad-assignment]
-    node_to_offload: dict[fx.Node, fx.Node] = dict()
-    node_to_index: dict[fx.Node, int] = {
-        node: idx for idx, node in enumerate(graph.nodes)
-    }
-
-    if not any(n.meta.get("saved_for_offloading", False) for n in fwd_outputs):
-        return
-
-    for node in fwd_outputs:
-        if node.meta.get("saved_for_offloading", False) is False:
-            continue
-
-        if all_effective_users := _find_all_effective_users(node, op_types):
-            last_user = max(all_effective_users, key=lambda n: node_to_index[n])
-        else:
-            last_user: fx.Node = node
-
-        with graph.inserting_after(last_user):
-            offload_node: fx.Node = graph.call_function(
-                torch.ops.ao.offload.default,
-                args=(node,),
-                name=f"async_{CPU_OFFLOAD_PREFIX}{node.name}",
-            )
-            offload_node.meta["val"] = node.meta["val"].to(torch.device("cpu"))
-            offload_node.meta["tensor_meta"] = extract_tensor_metadata(
-                offload_node.meta["val"]
-            )
-        # The keepalive=node arg extends the GPU tensor's lifetime in the
-        # graph so the allocator doesn't reclaim it before the async D2H
-        # copy completes.
-        with graph.inserting_after(offload_node):
-            wait_node: fx.Node = graph.call_function(
-                torch.ops.ao.wait_tensor.default,
-                args=(offload_node, node),
-                name=CPU_OFFLOAD_PREFIX + str(node.name),
-            )
-            wait_node.meta["val"] = offload_node.meta["val"]
-            wait_node.meta["tensor_meta"] = offload_node.meta["tensor_meta"]
-
-        node_to_offload[node] = wait_node
-
-    output_node.update_arg(
-        0, tuple(node_to_offload.get(node, node) for node in fwd_outputs)
-    )
-
-
-def reload_activation_bw_async(graph: fx.Graph) -> None:
-    """Insert async GPU reload operations in the backward pass graph.
-
-    Uses ao.reload + ao.wait_tensor ops which encapsulate stream management internally,
-    producing a clean 2-node IR per reloaded tensor.
-    """
-
-    node_to_index: dict[fx.Node, int] = {
-        node: idx for idx, node in enumerate(graph.nodes)
-    }
-
-    nodes_to_reload = [
-        n
-        for n in graph.find_nodes(op="placeholder")
-        if n.meta.get("saved_for_offloading", False)
-    ]
-    if not nodes_to_reload:
-        return
-
-    for node in nodes_to_reload:
-        if not node.users:
-            raise RuntimeError(
-                f"Offloaded tensor {node.name} has no users in the backward graph"
-            )
-        insert_point: fx.Node = min(node.users.keys(), key=lambda n: node_to_index[n])
-
-        original_device: torch.device = node.meta["original_device"]
-        with graph.inserting_before(insert_point):
-            reload_node: fx.Node = graph.call_function(
-                torch.ops.ao.reload.default,
-                args=(node, original_device),
-                name=f"async_{str(node.name).replace(CPU_OFFLOAD_PREFIX, GPU_RELOAD_PREFIX)}",
-            )
-            reload_node.meta["val"] = node.meta["val"].to(original_device)
-            reload_node.meta["tensor_meta"] = extract_tensor_metadata(
-                reload_node.meta["val"]
-            )
-            wait_node: fx.Node = graph.call_function(
-                torch.ops.ao.wait_tensor.default,
-                args=(reload_node, node),
-                name=str(node.name).replace(CPU_OFFLOAD_PREFIX, GPU_RELOAD_PREFIX),
-            )
-            wait_node.meta["val"] = reload_node.meta["val"]
-            wait_node.meta["tensor_meta"] = reload_node.meta["tensor_meta"]
-
-        for user in list(node.users.keys()):
-            if user != reload_node and user != wait_node:
-                user.replace_input_with(node, wait_node)
 
 
 def can_offload(
@@ -443,129 +342,269 @@ def offload_chosen_sets(
     reload_activation_bw(bwd_module.graph)
 
 
-def offload_chosen_sets_async(
+def _find_hook_offload_nodes(graph: fx.Graph) -> list[fx.Node]:
+    """Find prims.device_put nodes that copy GPU→CPU (from inlined hooks)."""
+    return [
+        node
+        for node in graph.nodes
+        if node.op == "call_function"
+        and node.target == torch.ops.prims.device_put.default
+        and isinstance(node.meta.get("val"), torch.Tensor)
+        and node.meta["val"].device.type == "cpu"
+        and isinstance(node.args[0], fx.Node)
+        and isinstance(node.args[0].meta.get("val"), torch.Tensor)
+        and node.args[0].meta["val"].device.type == "cuda"
+        and CPU_OFFLOAD_PREFIX not in node.name
+    ]
+
+
+def _find_hook_reload_nodes(graph: fx.Graph) -> list[fx.Node]:
+    """Find prims.device_put nodes that copy CPU→GPU (from inlined hooks)."""
+    return [
+        node
+        for node in graph.nodes
+        if node.op == "call_function"
+        and node.target == torch.ops.prims.device_put.default
+        and isinstance(node.meta.get("val"), torch.Tensor)
+        and node.meta["val"].device.type == "cuda"
+        and isinstance(node.args[0], fx.Node)
+        and isinstance(node.args[0].meta.get("val"), torch.Tensor)
+        and node.args[0].meta["val"].device.type == "cpu"
+        and GPU_RELOAD_PREFIX not in node.name
+    ]
+
+
+def put_offload_nodes_on_separate_stream(
     fwd_module: fx.GraphModule,
     bwd_module: fx.GraphModule,
 ) -> None:
     """
-    Add async offload and reload nodes using ao ops.
+    Annotate offload/reload device_put nodes with stream metadata and sync events.
 
-    Uses ao.offload/ao.reload + ao.wait_tensor which encapsulate stream management,
-    instead of device_put + explicit stream operations. Can be applied to
-    partitioned forward/backward graphs or to a joint graph produced by make_fx.
+    Args:
+        fwd_module: Forward module graph
+        bwd_module: Backward module graph
     """
-
-    offload_activation_fw_async(fwd_module.graph)
-
-    # Replace backward graph placeholders with their offloaded (CPU) counterparts.
-    # For each offloaded forward output, find the matching backward input and swap
-    # it with a new placeholder carrying the CPU tensor's metadata, then mark it
-    # for reloading.
-    bwd_inputs: dict[str, fx.Node] = {
-        node.name: node for node in bwd_module.graph.find_nodes(op="placeholder")
-    }
-    for fwd_node in fwd_module.graph.find_nodes(op="output")[0].args[0]:
-        if CPU_OFFLOAD_PREFIX not in fwd_node.name:
-            continue
-
-        bwd_node: fx.Node = bwd_inputs[fwd_node.name.replace(CPU_OFFLOAD_PREFIX, "")]
-        with bwd_module.graph.inserting_after(bwd_node):
-            bwd_offload_node: fx.Node = bwd_module.graph.placeholder(name=fwd_node.name)
-
-        bwd_offload_node.meta.update(fwd_node.meta)
-        bwd_offload_node.meta["saved_for_offloading"] = True
-        bwd_offload_node.meta["original_device"] = bwd_node.meta["val"].device
-        bwd_node.replace_all_uses_with(bwd_offload_node)
-        bwd_module.graph.erase_node(bwd_node)
-
-    reload_activation_bw_async(bwd_module.graph)
-
-
-def activation_offload_sink_wait_async(fwd_module: fx.GraphModule) -> None:
-    """Sink ao.wait_tensor operations for offload completion to the end of the graph.
-
-    This allows computation to overlap with offload operations.
-
-    NOTE: Sinking waits to the end delays GPU memory release of the source
-    tensor (kept alive via the wait's keepalive arg) until the end of the
-    compiled graph. For per-layer compile this is fine (one layer's worth of
-    memory), but for full-model compile this means offloaded GPU tensors are
-    not freed until the entire forward pass completes.
-    """
-    graph: fx.Graph = fwd_module.graph
-    output_node: fx.Node = graph.find_nodes(op="output")[0]
-
-    wait_nodes_to_sink: list[fx.Node] = [
+    fwd_offload_nodes = [
         node
-        for node in graph.nodes
-        if node.op == "call_function"
-        and node.target == torch.ops.ao.wait_tensor.default
-        and isinstance(node.args[0], fx.Node)
-        and node.args[0].op == "call_function"
-        and node.args[0].target == torch.ops.ao.offload.default
+        for node in fwd_module.graph.nodes
+        if CPU_OFFLOAD_PREFIX in node.name and node.op == "call_function"
+    ]
+    bwd_reload_nodes = [
+        node
+        for node in bwd_module.graph.nodes
+        if GPU_RELOAD_PREFIX in node.name and node.op == "call_function"
     ]
 
-    # prepend moves the node from its current position (no manual removal needed)
-    for wait_node in wait_nodes_to_sink:
-        output_node.prepend(wait_node)
+    _annotate_forward_offload_stream(fwd_module.graph, fwd_offload_nodes)
+    _annotate_backward_reload_stream(bwd_module.graph, bwd_reload_nodes)
 
 
-def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
+def _hoist_offload_device_puts(
+    graph: fx.Graph,
+    offload_nodes: list[fx.Node],
+) -> None:
+    """Move device_put nodes earlier to enable overlap with compute.
+
+    After hook inlining, device_put nodes for CPU offloading end up at the
+    return boundary of the forward graph — after ALL compute. This prevents
+    overlap because there's no compute running concurrently with the D2H copy.
+
+    This function moves each device_put to right after the last forward use
+    of its input tensor. Combined with sink_wait, this creates an overlap
+    window: the D2H copy on the offload stream runs concurrently with
+    subsequent forward compute on the default stream.
     """
-    Prefetch backward reload operations by moving ao.reload nodes earlier
-    in the graph to overlap data transfer with computation, while keeping
-    ao.wait_tensor at its original position.
+    node_to_idx: dict[fx.Node, int] = {
+        node: idx for idx, node in enumerate(graph.nodes)
+    }
+
+    for dp_node in offload_nodes:
+        tensor_node: fx.Node = dp_node.args[0]  # type: ignore[assignment]
+        if not isinstance(tensor_node, fx.Node):
+            continue
+
+        # Find the last use of tensor_node that isn't the device_put itself
+        # or the output node.
+        last_use: fx.Node | None = None
+        last_use_idx: int = -1
+        for user in tensor_node.users:
+            if user is dp_node or user.op == "output":
+                continue
+            user_idx = node_to_idx.get(user, -1)
+            if user_idx > last_use_idx:
+                last_use = user
+                last_use_idx = user_idx
+
+        if last_use is not None:
+            last_use.append(dp_node)
+            # Update index for moved node
+            node_to_idx[dp_node] = last_use_idx + 1
+
+
+def _annotate_forward_offload_stream(
+    graph: fx.Graph,
+    offload_nodes: list[fx.Node],
+) -> None:
+    """Tag forward offload device_put nodes with stream metadata and sync events.
+
+    Uses node.meta["custom"]["stream"] for stream assignment (same mechanism as
+    torch.cuda.stream() in dynamo) plus record_event/wait_event for cross-stream
+    synchronization and record_stream for CUDA allocator memory safety.
+
+    Pattern per device_put:
+      record_event(ready, default) → wait_event(ready, offload) →
+      record_stream(tensor, offload) → device_put [metadata: offload stream] →
+      record_event(done, offload) → wait_event(done, default) →
+      record_stream(tensor, default)
     """
-    graph: fx.Graph = bwd_module.graph
-    nodes_list: list[fx.Node] = list(graph.nodes)
+    if not offload_nodes:
+        return
 
-    # Identify reload + wait pairs
-    reload_patterns: dict[fx.Node, ReloadNodeInfo] = {}
-    for node in graph.nodes:
-        if not (
-            node.op == "call_function" and node.target == torch.ops.ao.reload.default
-        ):
-            continue
-        wait_node = next(
-            (u for u in node.users if u.target == torch.ops.ao.wait_tensor.default),
-            None,
-        )
-        if wait_node is None:
-            continue
-        transfer_size_bytes: int = _calculate_transfer_size(node)
-        transfer_time_ms: float = _estimate_transfer_time_in_ms(transfer_size_bytes)
-        reload_patterns[node] = ReloadNodeInfo(
-            reload_group_nodes=[node],
-            wait_event_node=wait_node,
-            transfer_size_bytes=transfer_size_bytes,
-            transfer_time_ms=transfer_time_ms,
-        )
+    current_stream_id: int = get_current_stream(
+        offload_nodes[0].args[0].meta["val"].device  # type: ignore[assignment]
+    )
+    offload_stream_id: int = new_stream()
 
-    reorder_for_prefetch(nodes_list, reload_patterns)
+    for offload_node in offload_nodes:
+        ready_event_id: int = new_event()
+        completion_event_id: int = new_event()
+        tensor_node: fx.Node = offload_node.args[0]  # type: ignore[assignment]
+
+        offload_node.meta.setdefault("custom", {})["stream"] = offload_stream_id
+
+        with graph.inserting_before(offload_node):
+            graph.call_function(
+                torch.ops.streams.record_event.default,
+                args=(ready_event_id, current_stream_id),
+            )
+            graph.call_function(
+                torch.ops.streams.wait_event.default,
+                args=(ready_event_id, offload_stream_id),
+            )
+            graph.call_function(
+                torch.ops.streams.record_stream.default,
+                args=(tensor_node, offload_stream_id),
+                name=f"record_stream_{tensor_node.name}",
+            )
+
+        with graph.inserting_after(offload_node):
+            record_node = graph.call_function(
+                torch.ops.streams.record_event.default,
+                args=(completion_event_id, offload_stream_id),
+            )
+        with graph.inserting_after(record_node):
+            wait_node = graph.call_function(
+                torch.ops.streams.wait_event.default,
+                args=(completion_event_id, current_stream_id),
+            )
+        with graph.inserting_after(wait_node):
+            graph.call_function(
+                torch.ops.streams.record_stream.default,
+                args=(tensor_node, current_stream_id),
+                name=f"keep_alive_{tensor_node.name}",
+            )
+
+
+def _annotate_backward_reload_stream(
+    graph: fx.Graph,
+    reload_nodes: list[fx.Node],
+    device: torch.device | None = None,
+) -> None:
+    """Tag backward reload device_put nodes with stream metadata and sync events.
+
+    Pattern per device_put:
+      device_put [metadata: reload stream] → record_event(done, reload) →
+      ... (other backward compute) ...
+      wait_event(done, default)  [placed at first use of the reloaded tensor]
+    """
+    if not reload_nodes:
+        return
+
+    if device is None:
+        device = reload_nodes[0].args[0].meta["original_device"]
+    current_stream_id: int = get_current_stream(device)
+    reload_stream_id: int = new_stream()
+
+    node_to_index: dict[fx.Node, int] = {
+        node: idx for idx, node in enumerate(graph.nodes)
+    }
+
+    for reload_node in reload_nodes:
+        event_id: int = new_event()
+
+        reload_node.meta.setdefault("custom", {})["stream"] = reload_stream_id
+
+        with graph.inserting_after(reload_node):
+            record_node = graph.call_function(
+                torch.ops.streams.record_event.default,
+                args=(event_id, reload_stream_id),
+            )
+
+        # Place wait_event at the first USE of the reload result so backward
+        # compute that doesn't need this tensor overlaps with the H2D copy.
+        first_user = min(
+            (u for u in reload_node.users if u != record_node),
+            key=lambda n: node_to_index.get(n, float("inf")),
+            default=None,
+        )
+        insert_point = first_user if first_user is not None else record_node
+
+        with graph.inserting_before(insert_point):
+            graph.call_function(
+                torch.ops.streams.wait_event.default,
+                args=(event_id, current_stream_id),
+            )
+
+
+def put_hook_offload_on_separate_stream(
+    fwd_module: fx.GraphModule,
+    bwd_module: fx.GraphModule,
+) -> None:
+    """Annotate hook-inlined offload/reload device_put nodes with stream metadata.
+
+    Called after maybe_inline_graph_saved_tensors_hooks in graph_compile.py.
+    """
+    fwd_offload_nodes = _find_hook_offload_nodes(fwd_module.graph)
+    bwd_reload_nodes = _find_hook_reload_nodes(bwd_module.graph)
+
+    if not fwd_offload_nodes and not bwd_reload_nodes:
+        return
+
+    # Move device_put nodes earlier so they're interleaved with compute,
+    # enabling overlap between D2H copies and subsequent forward compute.
+    if fwd_offload_nodes:
+        _hoist_offload_device_puts(fwd_module.graph, fwd_offload_nodes)
+
+    _annotate_forward_offload_stream(fwd_module.graph, fwd_offload_nodes)
+
+    if config.activation_offload_sink_wait:
+        activation_offload_sink_wait(fwd_module)
+
+    reload_device = (
+        bwd_reload_nodes[0].meta["val"].device if bwd_reload_nodes else None
+    )
+    _annotate_backward_reload_stream(
+        bwd_module.graph, bwd_reload_nodes, device=reload_device
+    )
+
+    fwd_module.recompile()
+    bwd_module.recompile()
 
 
 def _calculate_transfer_size(device_put_node: fx.Node) -> int:
     """Calculate the size in bytes of data being transferred."""
 
-    # ao.offload(tensor) -> tensor at args[0]
-    # ao.reload(tensor, device) -> tensor at args[0]
-    if device_put_node.target in (
-        torch.ops.ao.offload.default,
-        torch.ops.ao.reload.default,
-    ):
-        return _size_of(device_put_node.args[0])  # pyrefly: ignore [bad-argument-type]
-    raise ValueError(f"Unexpected transfer op: {device_put_node.target}")
+    return _size_of(device_put_node.args[0])  # pyrefly: ignore [bad-argument-type]
 
 
 def _estimate_transfer_time_in_ms(transfer_size_bytes: int) -> float:
-    """Estimate transfer time in milliseconds based on size and bandwidth.
-
-    Uses config.activation_offload_cpu_gpu_bw (GB/s) which should be set by
-    the user to match their hardware.
     """
-    return (
-        transfer_size_bytes / (1024**3) * 1_000 / config.activation_offload_cpu_gpu_bw
-    )
+    Estimate transfer time in milliseconds based on size and bandwidth.
+    NOTE: potentially could be standardized in node estimator class
+    """
+
+    return transfer_size_bytes / (1024**3) * 1_000 / inductor_config.cpu_gpu_bw
 
 
 def identify_reload_patterns(
@@ -574,67 +613,73 @@ def identify_reload_patterns(
     """
     Identify backward reload patterns in the graph.
 
-    Pattern: fork → wait_stream → device_put → record_event → join → wait_event
+    Pattern: device_put [stream metadata] → record_event → ... → wait_event
 
-    This uses position-based matching since these nodes are inserted together in
-    add_backward_reload_stream_ops() in a specific order. Since stream operations
-    do not have data dependencies between them, they are unsuitable for subgroup
-    pattern matching type of checks.
+    Reload device_put nodes are identified by their stream metadata
+    (node.meta["custom"]["stream"]), set by _annotate_backward_reload_stream.
+    The record_event immediately follows the device_put, while the wait_event
+    is placed at the first use point.
 
     Returns a dict mapping device_put node to ReloadNodeInfo containing:
-    - reload_group_nodes: fork → wait_stream → device_put → record_event → join
-    - wait_event_node: the wait_event node
+    - reload_group_nodes: [device_put, record_event]
+    - wait_event_node: the wait_event node (at first use point)
     - transfer_size_bytes: size of data being transferred
     - transfer_time_ms: estimated transfer time in milliseconds
     """
     patterns: dict[fx.Node, ReloadNodeInfo] = {}
 
-    # Find all GPU reload device_put nodes whose inputs are placeholder nodes
+    # Find all GPU reload device_put nodes with stream metadata set.
     reload_nodes: list[fx.Node] = [
         node
         for node in graph.find_nodes(
             op="call_function", target=torch.ops.prims.device_put.default
         )
-        if GPU_RELOAD_PREFIX in node.name
+        if node.args
+        and isinstance(node.args[0], fx.Node)
+        and node.meta.get("custom", {}).get("stream") is not None
         and (
-            node.args
-            and isinstance(node.args[0], fx.Node)
-            and node.args[0].op == "placeholder"
+            GPU_RELOAD_PREFIX in node.name
+            or (
+                isinstance(node.meta.get("val"), torch.Tensor)
+                and node.meta["val"].device.type == "cuda"
+                and isinstance(node.args[0].meta.get("val"), torch.Tensor)
+                and node.args[0].meta["val"].device.type == "cpu"
+            )
         )
     ]
 
-    # Extract patterns for each reload device_put node
     for reload_node in reload_nodes:
         reload_node_idx: int = node_to_idx[reload_node]
 
-        fork_node: fx.Node = nodes_list[reload_node_idx - 2]
-        wait_stream_node: fx.Node = nodes_list[reload_node_idx - 1]
+        # record_event is placed immediately after device_put
         record_event_node: fx.Node = nodes_list[reload_node_idx + 1]
-        join_node: fx.Node = nodes_list[reload_node_idx + 2]
-        wait_event_node: fx.Node = nodes_list[reload_node_idx + 3]
+        if not (
+            record_event_node.op == "call_function"
+            and record_event_node.target == torch.ops.streams.record_event.default
+        ):
+            continue
 
-        # Validate the nodes are what we expect
-        # Removed in follow-up commit
-        _validate_pattern_nodes(  # noqa: F821  # pyrefly: ignore [unknown-name]
-            fork_node,
-            wait_stream_node,
-            record_event_node,
-            join_node,
-            wait_event_node,
-        )
+        # wait_event is placed at first use point — find it by matching
+        # the event_id from record_event
+        event_id = record_event_node.args[0]
+        wait_event_node: fx.Node | None = None
+        for node in nodes_list[reload_node_idx + 2 :]:
+            if (
+                node.op == "call_function"
+                and node.target == torch.ops.streams.wait_event.default
+                and node.args[0] == event_id
+            ):
+                wait_event_node = node
+                break
 
-        # Calculate transfer size and time
+        if wait_event_node is None:
+            continue
+
         transfer_size_bytes: int = _calculate_transfer_size(reload_node)
         transfer_time_ms: float = _estimate_transfer_time_in_ms(transfer_size_bytes)
 
         patterns[reload_node] = ReloadNodeInfo(
-            reload_group_nodes=[
-                fork_node,
-                wait_stream_node,
-                reload_node,
-                record_event_node,
-                join_node,
-            ],
+            reload_group_nodes=[reload_node, record_event_node],
             wait_event_node=wait_event_node,
             transfer_size_bytes=transfer_size_bytes,
             transfer_time_ms=transfer_time_ms,
@@ -703,48 +748,72 @@ def reorder_for_prefetch(
 
 def activation_offload_sink_wait(fwd_module: fx.GraphModule) -> None:
     """
-    Sink wait_event operations for offload completion to the end of the graph.
+    Sink forward wait_event + keep_alive record_stream to the end of the
+    graph so the compute stream overlaps with D2H copies but still
+    synchronizes before returning.
 
-    This function identifies wait_event nodes for offload completion and moves them
-    to the end of the graph, allowing computation to overlap with offload operations.
+    Without sinking, the wait_event immediately after each device_put
+    forces the compute stream to block on every D2H copy. By moving it
+    to just before the output node, compute proceeds unblocked while copies
+    run on the offload stream. The final wait ensures all copies complete
+    before the forward outputs are consumed by backward.
 
-    Args:
-        fwd_module: Forward module graph
+    The keep_alive record_stream must be sunk alongside the wait_event
+    because it is the last graph reference to the source tensor. If it
+    stays at the original offload site, the inductor memory planner sees
+    the tensor as dead and may reuse its buffer for subsequent compute
+    while the D2H copy is still reading from it.
     """
     graph: fx.Graph = fwd_module.graph
     nodes_list: list[fx.Node] = list(graph.nodes)
     node_to_idx: dict[fx.Node, int] = {node: idx for idx, node in enumerate(nodes_list)}
 
-    # Find all CPU offload device_put nodes
+    output_node = next(n for n in graph.nodes if n.op == "output")
+
     offload_nodes: list[fx.Node] = [
         node
         for node in graph.find_nodes(
             op="call_function", target=torch.ops.prims.device_put.default
         )
-        if CPU_OFFLOAD_PREFIX in node.name
+        if (
+            CPU_OFFLOAD_PREFIX in node.name
+            or (
+                isinstance(node.meta.get("val"), torch.Tensor)
+                and node.meta["val"].device.type == "cpu"
+                and isinstance(node.args[0], fx.Node)
+                and isinstance(node.args[0].meta.get("val"), torch.Tensor)
+                and node.args[0].meta["val"].device.type == "cuda"
+            )
+        )
     ]
 
-    # Collect all wait_event nodes that need to be moved
-    wait_nodes_to_sink: list[fx.Node] = []
     for offload_node in offload_nodes:
         offload_idx: int = node_to_idx[offload_node]
-        wait_event_node: fx.Node = nodes_list[offload_idx + 3]
 
-        # Validate it's actually a wait_event node
-        if not (
-            wait_event_node.op == "call_function"
-            and wait_event_node.target == torch.ops.streams.wait_event.default
-        ):
-            raise ValueError(
-                f"Expected wait_event node three positions after {offload_node.name}"
-            )
+        # Pattern: ... → device_put → record_event → wait_event → keep_alive
+        # Sink wait_event and keep_alive (record_stream) to just before the
+        # output node.  The keep_alive extends cos_1's liveness so the memory
+        # planner won't reuse its buffer while the D2H copy is in flight.
+        nodes_to_sink = []
+        for offset in [1, 2, 3]:
+            if offload_idx + offset >= len(nodes_list):
+                break
+            candidate = nodes_list[offload_idx + offset]
+            if candidate.target in (
+                torch.ops.streams.wait_event.default,
+                torch.ops.streams.record_stream.default,
+            ):
+                nodes_to_sink.append(candidate)
 
-        wait_nodes_to_sink.append(wait_event_node)
-
-    # Find the output node, and move all wait_event nodes to just before the output node
-    output_node: fx.Node = graph.find_nodes(op="output")[0]
-    for wait_node in wait_nodes_to_sink:
-        output_node.prepend(wait_node)
+        for node in nodes_to_sink:
+            target = node.target
+            args = node.args
+            meta = node.meta
+            node.replace_all_uses_with(None)
+            graph.erase_node(node)
+            with graph.inserting_before(output_node):
+                new_node = graph.call_function(target, args=args)
+                new_node.meta = meta
 
 
 def activation_reload_prefetch(bwd_module: fx.GraphModule) -> None:
@@ -798,16 +867,22 @@ def enable_activation_offloading(
         return
 
     # Step 2: Add offload and reload nodes to the graphs
+    offload_chosen_sets(fwd_module, bwd_module)
+
+    # Step 3: Put offload nodes on separate stream if configured
     if config.activation_offload_separate_stream:
-        # Use async ao ops (2 nodes each: offload/reload + wait_tensor)
-        offload_chosen_sets_async(fwd_module, bwd_module)
+        put_offload_nodes_on_separate_stream(fwd_module, bwd_module)
         if config.activation_offload_sink_wait:
-            activation_offload_sink_wait_async(fwd_module)
+            activation_offload_sink_wait(fwd_module)
         if config.activation_reload_prefetch:
-            activation_reload_prefetch_async(bwd_module)
-    else:
-        # Use synchronous device_put (1 node each)
-        offload_chosen_sets(fwd_module, bwd_module)
+            activation_reload_prefetch(bwd_module)
+
+        from torch._functorch._aot_autograd.streams import (
+            wrap_all_sync_nodes_with_control_deps,
+        )
+
+        wrap_all_sync_nodes_with_control_deps(fwd_module)
+        wrap_all_sync_nodes_with_control_deps(bwd_module)
 
     fwd_module.graph.lint()
     bwd_module.graph.lint()

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -10,17 +10,25 @@ An aot_dispatch_* function:
 
 import copy
 import dataclasses
-import functools
 import itertools
 import logging
 import operator
-import threading
 import time
 import traceback
 from collections import defaultdict
 from collections.abc import Callable, Generator
-from contextlib import contextmanager, nullcontext
-from typing import Any
+from contextlib import nullcontext
+from typing import Any, TYPE_CHECKING
+
+from torch._library.fake_class_registry import FakeScriptObject
+from torch._opaque_base import OpaqueBase
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+import threading
+from contextlib import contextmanager
 
 import torch
 import torch.utils._pytree as pytree
@@ -33,10 +41,7 @@ from torch._dynamo.utils import (
     lazy_format_graph_code,
 )
 from torch._guards import CompileContext, TracingContext
-from torch._library.fake_class_registry import FakeScriptObject
-from torch._library.opaque_object import is_opaque_value
 from torch._logging import getArtifactLogger, trace_structured
-from torch._opaque_base import OpaqueBase
 from torch._subclasses import FakeTensor
 from torch._subclasses.meta_utils import is_sparse_any
 from torch.fx.experimental._backward_state import BackwardState
@@ -62,7 +67,6 @@ from .logging_utils import track_graph_compiling
 from .runtime_wrappers import (
     AOTDedupeWrapper,
     AOTDispatchAutograd,
-    AOTDispatchAutogradCompileSpec,
     AOTDispatchSubclassWrapper,
     AOTSyntheticBaseWrapper,
     AutogradLazyBackwardCompileInfo,
@@ -98,31 +102,7 @@ from .utils import (
 )
 
 
-def is_opaque_node(node: Any) -> bool:
-    """Check if a node contains an opaque or non-tensor value (e.g., ProcessGroup)."""
-    from torch._library.fake_class_registry import FakeScriptObject
-
-    if not isinstance(node, torch.fx.Node):
-        return False
-    if "val" not in getattr(node, "meta", {}):
-        return False
-    val = node.meta["val"]
-    if is_opaque_value(val):
-        return True
-    if isinstance(val, (torch.ScriptObject, FakeScriptObject)):
-        return True
-    return False
-
-
 _thread_local = threading.local()
-
-
-def _should_save_cache(*compiled_fns: Callable[..., Any]) -> bool:
-    if should_bundle_autograd_cache():
-        return True
-    return all(
-        getattr(fn, "_fx_graph_cache_key", None) is not None for fn in compiled_fns
-    )
 
 
 @contextmanager
@@ -258,6 +238,14 @@ def aot_stage1_graph_capture(
                     fw_metadata=aot_state.fw_metadata,
                 )
             )
+            # Apply AC rematerialization to forward+loss+bwd graph
+            if torch._functorch.config.remat_using_tags_for_fwd_loss_bwd_graph:
+                from torch._functorch._activation_checkpointing.remat_using_tags_for_fwd_loss_bwd_graph_pass import (
+                    remat_using_tags_for_fwd_loss_bwd_graph,
+                )
+
+                graph = remat_using_tags_for_fwd_loss_bwd_graph(graph)
+
     if config.selective_decompose:
         from torch.fx.experimental.proxy_tensor import selective_decompose
         from torch.fx.passes.regional_inductor import _needs_inductor_compile
@@ -307,6 +295,28 @@ def aot_stage2_export(
             f"expected compiled_fn to be GraphModule, got {type(compiled_fn)}"
         )
     return compiled_fn, aot_state.fw_metadata
+
+
+def sanitize_aot_config(input: AOTConfig) -> AOTConfig:
+    return AOTConfig(
+        fw_compiler=None,
+        bw_compiler=None,
+        partition_fn=None,
+        decompositions={},
+        inference_compiler=None,
+        num_params_buffers=input.num_params_buffers,
+        aot_id=input.aot_id,
+        keep_inference_input_mutations=input.keep_inference_input_mutations,
+        is_export=input.is_export,
+        no_tangents=input.no_tangents,
+        aot_autograd_arg_pos_to_source=input.aot_autograd_arg_pos_to_source,
+        dynamic_shapes=input.dynamic_shapes,
+        enable_log=input.enable_log,
+        static_input_indices=input.static_input_indices,
+        pre_dispatch=input.pre_dispatch,
+        cache_info=None,
+        precompile_backend_id=input.precompile_backend_id,
+    )
 
 
 def _get_inner_meta(
@@ -434,37 +444,6 @@ def aot_stage2_inference(
         )
     _apply_tensorify_python_scalars(fw_module)
 
-    # When trace_autograd_ops=True, the inference graph may contain fw/bw
-    # invoke_subgraph pairs from traced torch.autograd.grad/backward calls.
-    # Partition them before the remat pass so that remat duplicates the
-    # already-partitioned fw subgraphs (which produce saved tensors for bw).
-    fw_module = run_joint_graph_passes_on_hops(fw_module, None, aot_config)
-
-    # Apply AC rematerialization after HOP partitioning. This must happen
-    # after partitioning so remat duplicates the partitioned fw subgraphs
-    # (not the original unpartitioned ones).
-    if torch._functorch.config.remat_using_tags_for_fwd_loss_bwd_graph:
-        from torch._functorch._activation_checkpointing.remat_using_tags_for_fwd_loss_bwd_graph_pass import (
-            remat_using_tags_for_fwd_loss_bwd_graph,
-        )
-
-        fw_module = remat_using_tags_for_fwd_loss_bwd_graph(fw_module)
-
-    if _has_invoke_subgraph_node(fw_module):
-        trace_structured(
-            "artifact",
-            metadata_fn=lambda: {
-                "name": "aot_inference_graph_after_hop_passes",
-                "encoding": "string",
-            },
-            payload_fn=lambda: fw_module.print_readable(
-                print_output=False,
-                include_stride=True,
-                include_device=True,
-                expanded_def=True,
-            ),
-        )
-
     compiled_fw = _aot_stage2b_inference_compile(
         fw_module,
         updated_flat_args,  # type: ignore[arg-type]
@@ -503,8 +482,14 @@ def _cache_inference_info(
 
     cache_info = aot_config.cache_info
 
+    def should_save_cache() -> bool:
+        if should_bundle_autograd_cache():
+            return True
+        else:
+            return hasattr(compiled_fw, "_fx_graph_cache_key")
+
     entry: GenericAOTAutogradResult[Any, Any] | None = None
-    if cache_info is not None and _should_save_cache(compiled_fw):
+    if cache_info is not None and should_save_cache():
         time_taken_ns = time.time_ns() - cache_info.start_time_ns
         guards_expr = AOTAutogradCache.generate_guards_expression(cache_info)
         entry = AOTAutogradCache.make_entry(
@@ -520,12 +505,11 @@ def _cache_inference_info(
             indices_of_inps_to_detach=[],
             forward_time_taken_ns=time_taken_ns,
             backward_time_taken_ns=0,
-            sanitized_aot_config=aot_config.to_cacheable(),
+            sanitized_aot_config=sanitize_aot_config(aot_config),
             guards_expr=guards_expr,
             backward_state_indices=None,
             num_symints_saved_for_bw=None,
             serialized_bw_module=None,
-            min_cut_info_str=None,
         )
         AOTAutogradCache.save(
             cache_info.cache_key,
@@ -587,7 +571,7 @@ def collect_fw_donated_buffer_idxs(
         t = saved_tensors[i]
         if (
             t is not None
-            and isinstance(t, FakeTensor)
+            and isinstance(t, torch.Tensor)
             and not is_sparse_any(t)
             and StorageWeakRef(t.untyped_storage()) not in storage_refs
         ):
@@ -729,10 +713,11 @@ def _get_partition_fn(
     See Note [InvokeSubgraphHOP Partitioner]
     """
     used_hop_custom_partition = False
-
-    # Check for HOP-specific partition function first. This is needed because
-    # run_joint_graph_passes_on_hops can be called before aot_config.partition_fn
-    # is set (e.g., in aot_stage1_graph_capture before the remat pass).
+    if aot_config.partition_fn is None:
+        raise AssertionError("aot_config.partition_fn must not be None")
+    partition_fn: Callable[..., tuple[torch.fx.GraphModule, torch.fx.GraphModule]] = (
+        aot_config.partition_fn
+    )
     if (
         fw_hop_node.target == torch._higher_order_ops.invoke_subgraph
         and "custom" in fw_hop_node.meta
@@ -741,52 +726,28 @@ def _get_partition_fn(
         hop_partition_fn = fw_hop_node.meta["custom"][
             "nested_region_config"
         ].partitioner
-        if hop_partition_fn is not None:
-            if callable(hop_partition_fn):
-                raw_partitioner = hop_partition_fn
-            elif not isinstance(hop_partition_fn, str):
+        if hop_partition_fn is None:
+            # inherit the parent paritioner
+            return used_hop_custom_partition, partition_fn
+
+        if callable(hop_partition_fn):
+            partition_fn = hop_partition_fn  # pyrefly: ignore [bad-assignment]
+            used_hop_custom_partition = True
+        else:
+            if not isinstance(hop_partition_fn, str):
                 raise AssertionError(
                     f"expected hop_partition_fn to be str, got {type(hop_partition_fn)}"
                 )
-            else:
-                match hop_partition_fn:
-                    case "default_partition":
-                        raw_partitioner = (
-                            torch._functorch.partitioners.default_partition
-                        )
-                    case "min_cut_rematerialization_partition":
-                        raw_partitioner = torch._functorch.partitioners.min_cut_rematerialization_partition
-                    case _:
-                        raise ValueError(
-                            f"Unknown HOP partitioner config: {hop_partition_fn}"
-                        )
-
-            # Route through Inductor's `partition_fn` so joint-graph passes
-            # (e.g. scatter_upon_const_tensor) run on the HOP subgraph before
-            # the user-selected raw partitioner.
-            from torch._inductor.compile_fx import (
-                partition_fn as _inductor_partition_fn,
-            )
-
-            return True, functools.partial(
-                _inductor_partition_fn, partitioner_fn_override=raw_partitioner
-            )
-
-    # Fall back to the parent partitioner from aot_config. When the outer
-    # compile is Inductor this is already `compile_fx.partition_fn` so
-    # joint-graph passes run there too.
-    if aot_config.partition_fn is None:
-        raise AssertionError("aot_config.partition_fn must not be None")
-    return used_hop_custom_partition, aot_config.partition_fn
-
-
-def _has_invoke_subgraph_node(gm: torch.fx.GraphModule):
-    from torch._higher_order_ops import invoke_subgraph
-
-    for node in gm.graph.nodes:
-        if node.op == "call_function" and node.target is invoke_subgraph:
-            return True
-    return False
+            match hop_partition_fn:
+                case "default_partition":
+                    partition_fn = torch._functorch.partitioners.default_partition
+                case "min_cut_rematerialization_partition":
+                    partition_fn = torch._functorch.partitioners.min_cut_rematerialization_partition
+                case _:
+                    raise ValueError(
+                        f"Unknown HOP partitioner config: {hop_partition_fn}"
+                    )
+    return used_hop_custom_partition, partition_fn
 
 
 def run_joint_graph_passes_on_hops(
@@ -817,13 +778,6 @@ def run_joint_graph_passes_on_hops(
 
     NB: This pass works for invoke_subgraph today because we took extra care in
     the Autograd.Dispatch key of invoke_subgraph to vastly simplify Step 1.
-
-    NB: This pass only matches **top-level** invoke_subgraph HOP nodes in
-    `joint_gm`. It does not recurse into subgraph modules, so when one
-    `nested_compile_region` is invoked from inside another, the inner
-    invoke_subgraph HOPs live inside the outer's subgraph module and are not
-    paired here. Top-level HOPs are still paired correctly via `call_id`;
-    recursive partitioning of nested regions is left to downstream passes.
     """
     from torch._higher_order_ops import invoke_subgraph
 
@@ -864,69 +818,17 @@ def run_joint_graph_passes_on_hops(
     if not bw_hop_nodes:
         return joint_gm
 
-    # The fw and bw HOP counts are not necessarily equal. A fw HOP can have no
-    # corresponding bw HOP when autograd never runs backward through that call
-    # — e.g. the user does `x_d = x.detach().requires_grad_()` between two
-    # regions, or some outputs are not used in the loss. Likewise, multiple fw
-    # calls in the same compile region can share a single bw if autograd dedups
-    # or DCEs intermediate bws.
-    #
-    # Pair fw and bw HOPs by `call_id` — a per-call counter stamped by
-    # InvokeSubgraphAutogradOp's fw/bw on each FX node. This is unambiguous
-    # regardless of how autograd dispatched the backward (single outer
-    # `.backward()`, per-iter `.backward()` in a loop, interleaved regions).
-    fws_by_call_id: dict[int, torch.fx.Node] = {}
-    for fw in fw_hop_nodes:
-        cid = fw.meta.get("custom", {}).get("call_id")
-        if cid is None:
-            continue
-        if cid in fws_by_call_id:
-            raise AssertionError(
-                f"duplicate call_id={cid} on fw HOPs "
-                f"{fws_by_call_id[cid].name!r} and {fw.name!r}"
-            )
-        fws_by_call_id[cid] = fw
+    if len(fw_hop_nodes) != len(bw_hop_nodes):
+        raise AssertionError(
+            f"expected len(fw_hop_nodes) == len(bw_hop_nodes), "
+            f"got {len(fw_hop_nodes)} != {len(bw_hop_nodes)}"
+        )
 
-    bw_to_fw_hop_node: dict[torch.fx.Node, torch.fx.Node] = {}
-    paired_fws: set[torch.fx.Node] = set()
-    for bw in bw_hop_nodes:
-        cid = bw.meta.get("custom", {}).get("call_id")
-        if cid is None:
-            raise AssertionError(
-                f"bw HOP {bw.args[1]!r} has no call_id in meta['custom']"
-            )
-        fw = fws_by_call_id.get(cid)
-        if fw is None:
-            raise AssertionError(
-                f"could not find matching fw HOP for bw {bw.args[1]!r} "
-                f"with call_id={cid} (fw call_ids: {sorted(fws_by_call_id)})"
-            )
-        bw_to_fw_hop_node[bw] = fw
-        paired_fws.add(fw)
-
-    # Extra fws share a compile region with a paired bw but have no bw of
-    # their own (autograd may dedup or DCE the bw). They still must be
-    # rewritten to call the new partitioned fw subgraph, otherwise the output
-    # signatures diverge from the rewritten paired fws. Key by the bw
-    # identifier so the key matches `new_hop_graphs`.
-    fw_args_to_bw_identifier: dict[str, str] = {}
-    for bw, fw in bw_to_fw_hop_node.items():
-        fw_arg = fw.args[1]
-        bw_arg = bw.args[1]
-        if not (isinstance(fw_arg, str) and isinstance(bw_arg, str)):
-            raise AssertionError(
-                f"expected fw/bw invoke_subgraph HOP args[1] to be str identifiers, "
-                f"got fw={type(fw_arg)}, bw={type(bw_arg)}"
-            )
-        fw_args_to_bw_identifier.setdefault(fw_arg, bw_arg.removeprefix("bw"))
-    extra_fws_by_id: dict[str, list[torch.fx.Node]] = defaultdict(list)
-    for fw in fw_hop_nodes:
-        if fw in paired_fws:
-            continue
-        bw_ident_key = fw_args_to_bw_identifier.get(fw.args[1])
-        if bw_ident_key is None:
-            continue
-        extra_fws_by_id[bw_ident_key].append(fw)
+    # Create a bw to hop node mapping. This helps us in identifying the bw and
+    # fw subgraph pairs without relying on the identifier. This is important
+    # because we can have different subgraphs for bwd for same subgraph in the
+    # fwd because of differing strides in the backward.
+    bw_to_fw_hop_node = dict(zip(list(reversed(bw_hop_nodes)), fw_hop_nodes))
 
     for node in bw_hop_nodes:
         identifier = node.args[1].removeprefix("bw")
@@ -938,19 +840,7 @@ def run_joint_graph_passes_on_hops(
 
         # Collect some information from the forward hop graph
         fw_hop_node = bw_to_fw_hop_node[node]
-        fw_subgraph_attr = fw_hop_node.args[0]
-        if not isinstance(fw_subgraph_attr, torch.fx.Node):
-            raise AssertionError(
-                f"expected fw invoke_subgraph HOP args[0] to be torch.fx.Node, "
-                f"got {type(fw_subgraph_attr)}"
-            )
-        fw_subgraph_attr_target = fw_subgraph_attr.target
-        if not isinstance(fw_subgraph_attr_target, str):
-            raise AssertionError(
-                f"expected fw invoke_subgraph HOP args[0].target to be str, "
-                f"got {type(fw_subgraph_attr_target)}"
-            )
-        fw_hop_gm = getattr(joint_gm, fw_subgraph_attr_target)
+        fw_hop_gm = getattr(joint_gm, fw_hop_node.args[0].target)
         if not isinstance(fw_hop_gm, torch.fx.GraphModule):
             raise AssertionError(
                 f"expected fw_hop_gm to be GraphModule, got {type(fw_hop_gm)}"
@@ -1116,16 +1006,10 @@ def run_joint_graph_passes_on_hops(
         extra_fw_outputs = []
 
         # Insert the new_fw_hop_gm into the joint_gm
-        fw_subgraph_attr = fw_node.args[0]
-        if not isinstance(fw_subgraph_attr, torch.fx.Node):
-            raise AssertionError(
-                f"expected fw invoke_subgraph HOP args[0] to be torch.fx.Node, "
-                f"got {type(fw_subgraph_attr)}"
-            )
         with joint_gm.graph.inserting_after(fw_node):
             new_fw_mod_attr_name = add_new_hop_gm(new_fw_hop_gm, f"fw{identifier}")
             new_fw_mod_attr = joint_gm.graph.get_attr(new_fw_mod_attr_name)
-            new_fw_mod_attr.meta = copy.copy(fw_subgraph_attr.meta)
+            new_fw_mod_attr.meta = copy.copy(fw_node.args[0].meta)
 
         # new_hop_fw_gm output signature is (*fw_outs, *saved_tensors)
         with joint_gm.graph.inserting_after(new_fw_mod_attr):
@@ -1204,35 +1088,6 @@ def run_joint_graph_passes_on_hops(
 
         bw_node.replace_all_uses_with(new_bw_node)
         joint_gm.graph.erase_node(bw_node)
-
-    # Rewrite extra (unpaired) fws to call the new partitioned fw subgraph.
-    # Their additional saved-tensor outputs become dead and are pruned by
-    # eliminate_dead_code.
-    for identifier, extras in extra_fws_by_id.items():
-        if not new_hop_graphs[identifier].partitioning_done:
-            continue
-        new_fw_hop_gm = new_hop_graphs[identifier].new_fw_hop_gm
-        if new_fw_hop_gm is None:
-            continue
-        for fw_node in extras:
-            fw_subgraph_attr = fw_node.args[0]
-            if not isinstance(fw_subgraph_attr, torch.fx.Node):
-                raise AssertionError(
-                    f"expected fw invoke_subgraph HOP args[0] to be torch.fx.Node, "
-                    f"got {type(fw_subgraph_attr)}"
-                )
-            with joint_gm.graph.inserting_after(fw_node):
-                new_attr_name = add_new_hop_gm(new_fw_hop_gm, f"fw{identifier}")
-                new_attr = joint_gm.graph.get_attr(new_attr_name)
-                new_attr.meta = copy.copy(fw_subgraph_attr.meta)
-            with joint_gm.graph.inserting_after(new_attr):
-                new_fw_node = joint_gm.graph.call_function(
-                    the_function=invoke_subgraph,
-                    args=(new_attr, new_attr_name, *fw_node.args[2:]),
-                )
-                propagate_meta_info(new_fw_hop_gm, new_fw_node, fw_node)
-            fw_node.replace_all_uses_with(new_fw_node)
-            joint_gm.graph.erase_node(fw_node)
 
     joint_gm.graph.eliminate_dead_code()
     joint_gm.graph.lint()
@@ -1794,9 +1649,9 @@ def _log_fw_bw_graphs(
         )
         aot_graphs_log.info(
             "aot_config id: %s, fw_metadata=%s, inner_meta=%s",
-            aot_config.aot_id,
-            fw_metadata,
-            _get_inner_meta(maybe_subclass_meta, fw_metadata),
+            str(aot_config.aot_id),
+            str(fw_metadata),
+            str(_get_inner_meta(maybe_subclass_meta, fw_metadata)),
         )
 
         aot_graphs_log.info(
@@ -1863,265 +1718,6 @@ def _log_fw_bw_graphs(
     return fw_module_str, bw_module_str
 
 
-def _partition_joint_graph_into_fw_bw(
-    fx_g: torch.fx.GraphModule,
-    joint_inputs: list[Any] | tuple[list[Any], list[Any]],
-    inner_meta: ViewAndMutationMeta,
-    fw_metadata: ViewAndMutationMeta,
-    aot_config: AOTConfig,
-) -> tuple[torch.fx.GraphModule, torch.fx.GraphModule, int]:
-    # See Note: [Partitioner handling for Subclasses, Part 1]
-    # See Note: [Recomputing subclass mutation handling]
-    mutated_inp_runtime_indices = compute_inner_mutated_inp_indices_from_subclass_meta(
-        fw_metadata, inner_meta
-    )
-    num_tokens = len(fw_metadata.tokens)
-    num_inner_fwd_outputs = (
-        len(mutated_inp_runtime_indices)
-        + inner_meta.num_outputs
-        + inner_meta.num_intermediate_bases
-        + inner_meta.num_outputs_rng_offset
-        + num_tokens  # See Note [Side-Effectful Tokens in AOTAutograd]
-    )
-
-    fx_g = run_joint_graph_passes_on_hops(fx_g, joint_inputs, aot_config)
-
-    # apply joint_gm callback here
-    if callable(torch._functorch.config.joint_custom_pass):
-        # pyrefly: ignore [bad-assignment]
-        fx_g = torch._functorch.config.joint_custom_pass(fx_g, joint_inputs)
-
-    if aot_config.partition_fn is None:
-        raise AssertionError("aot_config.partition_fn must not be None")
-    fw_module, bw_module = aot_config.partition_fn(
-        fx_g,
-        joint_inputs,
-        num_fwd_outputs=num_inner_fwd_outputs,
-        static_lifetime_input_indices=fw_metadata.static_input_indices,
-    )
-
-    rng_states = [
-        n
-        for n in fw_module.graph.find_nodes(op="placeholder")
-        if "fwd_rng_state" in n.name
-    ]
-    fw_metadata.num_graphsafe_rng_states = len(rng_states)
-    if rng_states:
-        fw_metadata.graphsafe_rng_state_index = rng_states[0].meta["val"].device.index
-
-    return fw_module, bw_module, num_inner_fwd_outputs
-
-
-def _joint_inputs_for_forward(
-    joint_inputs: list[Any] | tuple[list[Any], list[Any]],
-) -> list[Any]:
-    return joint_inputs[0] if isinstance(joint_inputs, tuple) else joint_inputs
-
-
-def _maybe_unlift_partitioned_effect_tokens(
-    fw_module: torch.fx.GraphModule,
-    bw_module: torch.fx.GraphModule,
-    joint_inputs: list[Any] | tuple[list[Any], list[Any]],
-    fw_metadata: ViewAndMutationMeta,
-    aot_config: AOTConfig,
-    num_inner_fwd_outputs: int,
-) -> tuple[int, list[Any] | tuple[list[Any], list[Any]]]:
-    num_tokens = len(fw_metadata.tokens)
-
-    # See Note [Side-Effectful Tokens in AOTAutograd]
-    if config.unlift_effect_tokens and (
-        num_tokens > 0 or fw_metadata.num_backward_tokens > 0
-    ):
-        unlift_tokens(fw_module, fw_metadata, aot_config, bw_module)
-        num_inner_fwd_outputs -= num_tokens
-        if isinstance(joint_inputs, tuple):
-            joint_inputs = (
-                _joint_inputs_for_forward(joint_inputs)[num_tokens:],
-                joint_inputs[1],
-            )
-        else:
-            joint_inputs = joint_inputs[num_tokens:]
-
-    return num_inner_fwd_outputs, joint_inputs
-
-
-def _categorize_saved_tensors_for_backward(
-    fw_module: torch.fx.GraphModule,
-    bw_module: torch.fx.GraphModule,
-    inner_meta: ViewAndMutationMeta,
-    fw_metadata: ViewAndMutationMeta,
-    num_inner_fwd_outputs: int,
-) -> tuple[int, int]:
-    fw_outs = next(iter(fw_module.graph.find_nodes(op="output"))).args[0]
-    # we only need to bookkeep the symints that are saved for bw, not any symints
-    # the user forward might have returned in its own output
-    fw_outs_saved_for_bw = fw_outs[num_inner_fwd_outputs:]
-    num_fw_outs_saved_for_bw = len(fw_outs_saved_for_bw)
-
-    num_symints_saved_for_bw = 0
-    num_opaque_objects_saved_for_bw = 0
-    for idx, node in enumerate(fw_outs_saved_for_bw):
-        if is_sym_node(node):
-            num_symints_saved_for_bw += 1
-        elif is_opaque_node(node):
-            num_opaque_objects_saved_for_bw += 1
-        elif isinstance(node, torch.fx.Node) and "val" in getattr(node, "meta", {}):
-            if isinstance(node.meta["val"], FakeTensor):
-                # record dynamic tensor activations
-                dynamic_dims: set[int] = {
-                    dim
-                    for dim, size in enumerate(node.meta["val"].shape)
-                    if not isinstance(size, int)
-                }
-                if dynamic_dims:
-                    fw_metadata.dynamic_saved_tensors_idxs[idx] = dynamic_dims
-            elif isinstance(node.meta["val"], (FakeScriptObject, OpaqueBase)):
-                num_opaque_objects_saved_for_bw += 1
-
-    fw_metadata.num_symints_saved_for_bw = num_symints_saved_for_bw
-    fw_metadata.num_opaque_objects_saved_for_bw = num_opaque_objects_saved_for_bw
-    inner_meta.num_symints_saved_for_bw = num_symints_saved_for_bw
-    inner_meta.num_opaque_objects_saved_for_bw = num_opaque_objects_saved_for_bw
-
-    # See Note [Activations with no version counter checks in eager]
-    # Count tensors saved with no version counter check.
-    # These are tensors that were stashed on ctx (e.g., ctx.x = x) rather than
-    # via save_for_backward in an autograd.Function.
-    # The partitioner sorts these to be at the end of saved_values.
-    num_tensors_saved_with_no_vc_check = sum(
-        1
-        for node in fw_outs_saved_for_bw
-        if isinstance(node, torch.fx.Node)
-        and node.meta.get("saved_tensor_with_no_vc_check", False)
-    )
-    fw_metadata.num_tensors_saved_with_no_vc_check = num_tensors_saved_with_no_vc_check
-    inner_meta.num_tensors_saved_with_no_vc_check = num_tensors_saved_with_no_vc_check
-
-    if torch._functorch.config.donated_buffer:
-        fw_metadata.bw_donated_idxs = collect_bw_donated_buffer_idxs(
-            fw_module,
-            bw_module,
-            inner_meta,
-        )
-        inner_meta.bw_donated_idxs = fw_metadata.bw_donated_idxs
-
-    return num_fw_outs_saved_for_bw, num_symints_saved_for_bw
-
-
-# Note [Detaching inputs that never need gradients]
-# See https://github.com/pytorch/pytorch/issues/97745
-# Suppose we have a function like this that we want to compile:
-#
-# def f(x, y):
-#     return torch.mul(x, y.detach())
-#
-# What gradients should we compute for x and y?
-# By default, AOTAutograd will compute a gradient for **every** input that requires gradients,
-# and so we'll compute:
-#    x_grad_input = y
-#    y_grad_input = None
-# Does this preserve the semantics of eager mode?
-# Unfortunately, no.
-# Doing the above will cause autograd to **continue** to backprop the autograd tape
-# that was generated from constructing y.
-#
-# This is **different** from what would have happened in eager mode.
-# In eager mode, if we backprop through the output of this function, autograd will only traverse
-# the bit of the autograd tape corresponding to "x".
-# In particular, if a user had previously backpropped through y's autograd tape,
-# And then they try to backprop through the output of the above function,
-# then we'll hit the dreaded "Trying to backward through the graph a second time" error.
-#
-# You might think: If autograd sees that a gradient is None, shouldn't it stop early,
-# instead of continuing the backprop through the ancestors of that node in the graph?
-#
-# Autograd has two passes:
-# (1) a first pass that traverses the autograd graph and figures out which nodes need to be executed
-# (2) a second pass that actually goes ahead and executes each node when it becomes ready,
-#     propagating gradients
-# By the time we're executing a node and we see that it produces a None, the set of nodes to execute
-# is already locked-in.
-#
-# The fix: instead, we can recognize statically that the graph we're compiling will never contribute
-# gradients to y, and prevent autograd from trying to traverse y's autograd tape at all.
-# We can do this by manually detach'ing y before sending it through the `CompiledFunction`.
-#
-# Note that this solution is not bulletproof.
-# It's possible to construct a case where eager may or may not have tried to autograd through y,
-# depending on the actual grad_outputs that were passed in during the backward.
-# There is no easy fix for this: the simplest fix would be to run with `retain_graph=True`,
-# allowing autograd to reuse the graph.
-#
-# An example of this case is:
-# def f(x):
-#     return x.detach() * 2, x * 3
-# If we were to only backprop through outs[0], in eager, we would stop
-# If we backward only on the first output, we shouldn't send a grad through x.
-# But the custom autograd function doesn't know that: it will materialize zero grads for x * 3
-# and we will end up with a zero grad at x.
-# If we later backprop through the second output, this will also require backprop'ing through x.
-# Meaning we'll need to use `retain_graph=True` to be able to backprop through x the second time.
-def _compute_indices_of_inps_to_detach(
-    bw_module: torch.fx.GraphModule,
-    maybe_subclass_meta: SubclassMeta | None,
-    inner_meta: ViewAndMutationMeta,
-    fw_metadata: ViewAndMutationMeta,
-) -> list[int]:
-    # TODO: we should apply the below "detach inputs if their gradients are statically known to be None"
-    # optimization even if we have subclass inputs/outputs (we do not handle this today).
-    # Computing which our our inputs get None gradients is a bit more complicated,
-    # if any of our inputs are subclasses. Why?
-    # (a) we need to make sure that we call .detach() on the input subclasses, since autograd sees subclasses.
-    # (b) The grad_outputs that we AOT computed in our backward graph are the desugared tensor tensors,
-    #     so we need to figure out which subclass fw inputs they map to.
-    if maybe_subclass_meta is not None:
-        return []
-
-    indices_of_inps_to_detach: list[int] = []
-
-    # reversed() since we expect output at end of graph
-    bw_output = next(reversed(bw_module.graph.find_nodes(op="output")))
-    bw_outs = bw_output.args[0]
-
-    num_backward_tokens = inner_meta.num_backward_tokens
-    expected_bw_outs = (
-        len(fw_metadata.input_info)
-        + inner_meta.num_outputs_rng_offset
-        + num_backward_tokens
-    )
-    if len(bw_outs) != expected_bw_outs:
-        raise AssertionError(
-            f"expected len(bw_outs) == {expected_bw_outs}, got {len(bw_outs)}"
-        )
-
-    bw_outs_no_rng_no_tokens = bw_outs
-    if (inner_meta.num_outputs_rng_offset + num_backward_tokens) > 0:
-        bw_outs_no_rng_no_tokens = bw_outs[
-            : -(inner_meta.num_outputs_rng_offset + num_backward_tokens)
-        ]
-    if len(bw_outs_no_rng_no_tokens) != len(fw_metadata.input_info):
-        raise AssertionError(
-            f"expected len(bw_outs_no_rng_no_tokens) == {len(fw_metadata.input_info)}, "
-            f"got {len(bw_outs_no_rng_no_tokens)}"
-        )
-
-    for i, bw_out in enumerate(bw_outs_no_rng_no_tokens):
-        # If our input experiences a metadata mutation inside the graph (e.g. set_()),
-        # we *must* not detach, otherwise it will be the detach'd input that gets the metadata mutation
-        metadata_mutation_in_graph = (
-            fw_metadata.input_info[i].mutation_type == MutationType.MUTATED_IN_GRAPH
-            and fw_metadata.input_info[i].mutates_storage_metadata
-        )
-        is_non_leaf = (
-            fw_metadata.input_info[i].requires_grad
-            and not fw_metadata.input_info[i].is_leaf
-        )
-        if bw_out is None and not metadata_mutation_in_graph and is_non_leaf:
-            indices_of_inps_to_detach.append(i)
-
-    return indices_of_inps_to_detach
-
-
 def _aot_stage2a_partition(
     fx_g: torch.fx.GraphModule,
     joint_inputs: list[Any] | tuple[list[Any], list[Any]],
@@ -2142,25 +1738,60 @@ def _aot_stage2a_partition(
     with torch.no_grad():
         context = torch._C._DisableAutocast if disable_amp else nullcontext
         with context(), track_graph_compiling(aot_config, "joint"):
-            fw_module, bw_module, num_inner_fwd_outputs = (
-                _partition_joint_graph_into_fw_bw(
-                    fx_g,
-                    joint_inputs,
-                    inner_meta,
-                    fw_metadata,
-                    aot_config,
+            # See Note: [Partitioner handling for Subclasses, Part 1]
+            # See Note: [Recomputing subclass mutation handling]
+            mutated_inp_runtime_indices = (
+                compute_inner_mutated_inp_indices_from_subclass_meta(
+                    fw_metadata, inner_meta
                 )
             )
-            num_inner_fwd_outputs, joint_inputs = (
-                _maybe_unlift_partitioned_effect_tokens(
-                    fw_module,
-                    bw_module,
-                    joint_inputs,
-                    fw_metadata,
-                    aot_config,
-                    num_inner_fwd_outputs,
-                )
+            num_tokens = len(fw_metadata.tokens)
+            num_mutated_inp_runtime_indices = len(mutated_inp_runtime_indices)
+            num_inner_fwd_outputs = (
+                num_mutated_inp_runtime_indices
+                + inner_meta.num_outputs
+                + inner_meta.num_intermediate_bases
+                + inner_meta.num_outputs_rng_offset
+                + num_tokens  # See Note [Side-Effectful Tokens in AOTAutograd]
             )
+            fx_g = run_joint_graph_passes_on_hops(fx_g, joint_inputs, aot_config)
+
+            # apply joint_gm callback here
+            if callable(torch._functorch.config.joint_custom_pass):
+                # pyrefly: ignore [bad-assignment]
+                fx_g = torch._functorch.config.joint_custom_pass(fx_g, joint_inputs)
+
+            static_lifetime_input_indices = fw_metadata.static_input_indices
+            if aot_config.partition_fn is None:
+                raise AssertionError("aot_config.partition_fn must not be None")
+            fw_module, bw_module = aot_config.partition_fn(
+                fx_g,
+                joint_inputs,
+                num_fwd_outputs=num_inner_fwd_outputs,
+                static_lifetime_input_indices=static_lifetime_input_indices,
+            )
+            rng_states = [
+                n
+                for n in fw_module.graph.find_nodes(op="placeholder")
+                if "fwd_rng_state" in n.name
+            ]
+            fw_metadata.num_graphsafe_rng_states = len(rng_states)
+            if rng_states:
+                fw_metadata.graphsafe_rng_state_index = (
+                    rng_states[0].meta["val"].device.index
+                )
+
+            # See Note [Side-Effectful Tokens in AOTAutograd]
+            if config.unlift_effect_tokens and (
+                num_tokens > 0 or fw_metadata.num_backward_tokens > 0
+            ):
+                unlift_tokens(fw_module, fw_metadata, aot_config, bw_module)
+
+                num_inner_fwd_outputs -= num_tokens
+                joint_inputs = (
+                    joint_inputs[0][num_tokens:],
+                    joint_inputs[1],
+                )
 
             maybe_inline_graph_saved_tensors_hooks(
                 fw_module,
@@ -2170,22 +1801,183 @@ def _aot_stage2a_partition(
                 aot_config,
                 fw_metadata.static_input_indices,
             )
-            num_fw_outs_saved_for_bw, num_symints_saved_for_bw = (
-                _categorize_saved_tensors_for_backward(
+
+            if config.activation_offload_separate_stream:
+                from .._activation_offloading.activation_offloading import (
+                    put_hook_offload_on_separate_stream,
+                )
+
+                put_hook_offload_on_separate_stream(fw_module, bw_module)
+
+                from .streams import wrap_all_sync_nodes_with_control_deps
+
+                wrap_all_sync_nodes_with_control_deps(fw_module)
+                wrap_all_sync_nodes_with_control_deps(bw_module)
+
+            static_lifetime_input_indices = fw_metadata.static_input_indices
+
+            fw_outs = next(iter(fw_module.graph.find_nodes(op="output"))).args[0]
+            # we only need to bookkeep the symints that are saved for bw, not any symints
+            # the user forward might have returned in its own output
+            fw_outs_saved_for_bw = fw_outs[num_inner_fwd_outputs:]
+            num_fw_outs_saved_for_bw = len(fw_outs_saved_for_bw)
+            symint_outs_saved_for_bw = []
+            opaque_outs_saved_for_bw = []
+            for idx, node in enumerate(fw_outs_saved_for_bw):
+                if is_sym_node(node):
+                    symint_outs_saved_for_bw.append(node)
+                elif isinstance(node, torch.fx.Node) and "val" in getattr(
+                    node, "meta", {}
+                ):
+                    if isinstance(node.meta["val"], FakeTensor):
+                        # record dynamic tensor activations
+                        dynamic_dims: set[int] = {
+                            dim
+                            for dim, size in enumerate(node.meta["val"].shape)
+                            if not isinstance(size, int)
+                        }
+                        if dynamic_dims:
+                            fw_metadata.dynamic_saved_tensors_idxs[idx] = dynamic_dims
+                    elif isinstance(node.meta["val"], (FakeScriptObject, OpaqueBase)):
+                        opaque_outs_saved_for_bw.append(node)
+
+            num_symints_saved_for_bw = len(symint_outs_saved_for_bw)
+            num_opaque_objects_saved_for_bw = len(opaque_outs_saved_for_bw)
+            fw_metadata.num_symints_saved_for_bw = num_symints_saved_for_bw
+            fw_metadata.num_opaque_objects_saved_for_bw = (
+                num_opaque_objects_saved_for_bw
+            )
+            inner_meta.num_symints_saved_for_bw = num_symints_saved_for_bw
+            inner_meta.num_opaque_objects_saved_for_bw = num_opaque_objects_saved_for_bw
+
+            # See Note [Activations with no version counter checks in eager]
+            # Count tensors saved with no version counter check.
+            # These are tensors that were stashed on ctx (e.g., ctx.x = x) rather than
+            # via save_for_backward in an autograd.Function.
+            # The partitioner sorts these to be at the end of saved_values.
+            num_tensors_saved_with_no_vc_check = 0
+            for node in fw_outs_saved_for_bw:
+                if isinstance(node, torch.fx.Node) and node.meta.get(
+                    "saved_tensor_with_no_vc_check", False
+                ):
+                    num_tensors_saved_with_no_vc_check += 1
+            fw_metadata.num_tensors_saved_with_no_vc_check = (
+                num_tensors_saved_with_no_vc_check
+            )
+            inner_meta.num_tensors_saved_with_no_vc_check = (
+                num_tensors_saved_with_no_vc_check
+            )
+
+            if torch._functorch.config.donated_buffer:
+                fw_metadata.bw_donated_idxs = collect_bw_donated_buffer_idxs(
                     fw_module,
                     bw_module,
                     inner_meta,
-                    fw_metadata,
-                    num_inner_fwd_outputs,
                 )
-            )
+                inner_meta.bw_donated_idxs = fw_metadata.bw_donated_idxs
 
-        _indices_of_inps_to_detach = _compute_indices_of_inps_to_detach(
-            bw_module,
-            maybe_subclass_meta,
-            inner_meta,
-            fw_metadata,
-        )
+        # Note [Detaching inputs that never need gradients]
+        # See https://github.com/pytorch/pytorch/issues/97745
+        # Suppose we have a function like this that we want to compile:
+        #
+        # def f(x, y):
+        #     return torch.mul(x, y.detach())
+        #
+        # What gradients should we compute for x and y?
+        # By default, AOTAutograd will compute a gradient for **every** input that requires gradients,
+        # and so we'll compute:
+        #    x_grad_input = y
+        #    y_grad_input = None
+        # Does this preserve the semantics of eager mode?
+        # Unfortunately, no.
+        # Doing the above will cause autograd to **continue** to backprop the autograd tape
+        # that was generated from constructing y.
+        #
+        # This is **different** from what would have happened in eager mode.
+        # In eager mode, if we backprop through the output of this function, autograd will only traverse
+        # the bit of the autograd tape corresponding to "x".
+        # In particular, if a user had previously backpropped through y's autograd tape,
+        # And then they try to backprop through the output of the above function,
+        # then we'll hit the dreaded "Trying to backward through the graph a second time" error.
+        #
+        # You might think: If autograd sees that a gradient is None, shouldn't it stop early,
+        # instead of continuing the backprop through the ancestors of that node in the graph?
+        #
+        # Autograd has two passes:
+        # (1) a first pass that traverses the autograd graph and figures out which nodes need to be executed
+        # (2) a second pass that actually goes ahead and executes each node when it becomes ready,
+        #     propagating gradients
+        # By the time we're executing a node and we see that it produces a None, the set of nodes to execute
+        # is already locked-in.
+        #
+        # The fix: instead, we can recognize statically that the graph we're compiling will never contribute
+        # gradients to y, and prevent autograd from trying to traverse y's autograd tape at all.
+        # We can do this by manually detach'ing y before sending it through the `CompiledFunction`.
+        #
+        # Note that this solution is not bulletproof.
+        # It's possible to construct a case where eager may or may not have have tried to autograd through y,
+        # depending on the actual grad_outputs that were passed in during the backward.
+        # There is no easy fix for this: the simplest fix would be to run with `retain_graph=True`,
+        # allowing autograd to reuse the graph.
+        #
+        # An example of this case is:
+        # def f(x):
+        #     return x.detach() * 2, x * 3
+        # If we were to only backprop through outs[0], in eager, we would stop
+        # If we backward only on the first output, we shouldn't send a grad through x.
+        # But the custom autograd function doesn't know that: it will materialize zero grads for x * 3
+        # and we will end up with a zero grad at x.
+        # If we later backprop through the second output, this will also require backprop'ing through x.
+        # Meaning we'll need to use `retain_graph=True` to be able to backprop through x the second time.
+        _indices_of_inps_to_detach: list[int] = []
+
+        # reversed() since we expect output at end of graph
+        bw_output = next(reversed(bw_module.graph.find_nodes(op="output")))
+        bw_outs: Sequence[torch.fx.Node] = bw_output.args[0]  # type: ignore[assignment]
+
+        # TODO: we should apply the below "detach inputs if their gradients are statically known to be None"
+        # optimization even if we have subclass inputs/outputs (we do not handle this today).
+        # Computing which our our inputs get None gradients is a bit more complicated,
+        # if any of our inputs are subclasses. Why?
+        # (a) we need to make sure that we call .detach() on the input subclasses, since autograd sees subclasses.
+        # (b) The grad_outputs that we AOT computed in our backward graph are the desugared tensor tensors,
+        #     so we need to figure out which subclass fw inputs they map to.
+        if maybe_subclass_meta is None:
+            num_backward_tokens: int = inner_meta.num_backward_tokens
+            expected_bw_outs = (
+                len(fw_metadata.input_info)
+                + inner_meta.num_outputs_rng_offset
+                + num_backward_tokens
+            )
+            if len(bw_outs) != expected_bw_outs:
+                raise AssertionError(
+                    f"expected len(bw_outs) == {expected_bw_outs}, got {len(bw_outs)}"
+                )
+            bw_outs_no_rng_no_tokens = bw_outs
+            if (inner_meta.num_outputs_rng_offset + num_backward_tokens) > 0:
+                bw_outs_no_rng_no_tokens = bw_outs[
+                    : -(inner_meta.num_outputs_rng_offset + num_backward_tokens)
+                ]
+            if len(bw_outs_no_rng_no_tokens) != len(fw_metadata.input_info):
+                raise AssertionError(
+                    f"expected len(bw_outs_no_rng_no_tokens) == {len(fw_metadata.input_info)}, "
+                    f"got {len(bw_outs_no_rng_no_tokens)}"
+                )
+
+            for i, (bw_out) in enumerate(bw_outs_no_rng_no_tokens):
+                # If our input experiences a metadata mutation inside the graph (e.g. set_()),
+                # we *must* not detach, otherwise it will be the detach'd input that gets the metadata mutation
+                metadata_mutation_in_graph = (
+                    fw_metadata.input_info[i].mutation_type
+                    == MutationType.MUTATED_IN_GRAPH
+                    and fw_metadata.input_info[i].mutates_storage_metadata
+                )
+                is_non_leaf = (
+                    fw_metadata.input_info[i].requires_grad
+                    and not fw_metadata.input_info[i].is_leaf
+                )
+                if bw_out is None and not metadata_mutation_in_graph and is_non_leaf:
+                    _indices_of_inps_to_detach.append(i)
 
     return (
         fw_module,
@@ -2193,7 +1985,7 @@ def _aot_stage2a_partition(
         num_fw_outs_saved_for_bw,
         num_symints_saved_for_bw,
         _indices_of_inps_to_detach,
-        _joint_inputs_for_forward(joint_inputs),
+        joint_inputs[0],
     )
 
 
@@ -2413,8 +2205,6 @@ def aot_stage2_autograd(
         aot_config,
     )
 
-    min_cut_info_str = getattr(fx_g.graph, "_min_cut_info_str", None)
-
     fw_module_str, bw_module_str = _log_fw_bw_graphs(
         fw_module, bw_module, maybe_subclass_meta, fw_metadata, aot_config
     )
@@ -2452,7 +2242,6 @@ def aot_stage2_autograd(
         _indices_of_inps_to_detach,
         num_symints_saved_for_bw,
         bw_module,
-        min_cut_info_str,
     )
 
     return _aot_stage2c_make_autograd_function(
@@ -2494,20 +2283,19 @@ def _aot_stage2c_make_autograd_function(
         )
 
     disable_amp = torch._C._is_any_autocast_enabled()
-    compile_spec = AOTDispatchAutogradCompileSpec(
-        compiled_fw_func=compiled_fw_func,
-        compiled_bw_func=compiled_bw_func,
-        maybe_subclass_meta=maybe_subclass_meta,
-        num_symints_saved_for_bw=num_symints_saved_for_bw,
-        backward_state_indices=backward_state_indices,
-        disable_amp=disable_amp,
-        indices_of_inps_to_detach=_indices_of_inps_to_detach,
-        lazy_backward_info=lazy_backward_info,
-        aot_config=aot_config,
+    compiled_fn = AOTDispatchAutograd.post_compile(
+        compiled_fw_func,
+        compiled_bw_func,
+        maybe_subclass_meta,
+        num_symints_saved_for_bw,
+        backward_state_indices,
+        disable_amp,
+        _indices_of_inps_to_detach,
+        lazy_backward_info,
+        aot_config,
         fw_metadata=fw_metadata,
         try_save_cache_entry=try_save_cache_entry,
     )
-    compiled_fn = AOTDispatchAutograd.post_compile(compile_spec)
 
     if entry is not None:
         compiled_fn = SerializableCompiledFunction(compiled_fn, lambda: entry)
@@ -2544,7 +2332,6 @@ def _cache_autograd_info(
     _indices_of_inps_to_detach: list[int],
     num_symints_saved_for_bw: int,
     bw_module: torch.fx.GraphModule | None,
-    min_cut_info_str: str | None,
 ) -> tuple[
     GenericAOTAutogradResult[Any, Any] | None,
     Callable[..., Any],
@@ -2568,7 +2355,7 @@ def _cache_autograd_info(
         # NB: aot_config here is technically not needed as an argument: we could just
         # close over aot_config.cache_info, since aot_config never changes.
         # But closing over random variables is confusing IMO, so I'm leaving it.
-        def try_save_cache_entry(
+        def try_save_cache_entry(  # noqa: F811
             compiled_bw_func: Callable[..., Any],
             bw_module: torch.fx.GraphModule,
             _fw_metadata: ViewAndMutationMeta,
@@ -2576,9 +2363,15 @@ def _cache_autograd_info(
         ) -> GenericAOTAutogradResult[Any, Any] | None:
             cache_info = aot_config.cache_info
 
-            if cache_info is not None and _should_save_cache(
-                compiled_fw_func, compiled_bw_func
-            ):
+            def should_save_cache() -> bool:
+                if should_bundle_autograd_cache():
+                    return True
+                else:
+                    return hasattr(compiled_fw_func, "_fx_graph_cache_key") and hasattr(
+                        compiled_bw_func, "_fx_graph_cache_key"
+                    )
+
+            if cache_info is not None and should_save_cache():
                 if forward_time_taken_ns is None:
                     raise AssertionError("forward_time_taken_ns must not be None")
                 # TODO: technically, AOTAutograd does a *little* bit of post processing work
@@ -2607,12 +2400,11 @@ def _cache_autograd_info(
                     _indices_of_inps_to_detach,
                     forward_time_taken_ns,
                     backward_time_taken_ns,
-                    sanitized_aot_config=aot_config.to_cacheable(),
+                    sanitized_aot_config=sanitize_aot_config(aot_config),
                     guards_expr=guards_expr,
                     backward_state_indices=backward_state_indices,
                     num_symints_saved_for_bw=num_symints_saved_for_bw,
                     serialized_bw_module=serialize_graph_module(bw_module),
-                    min_cut_info_str=min_cut_info_str,
                 )
                 AOTAutogradCache.save(
                     cache_info.cache_key,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -9,10 +9,9 @@ import logging
 import math
 import operator
 import os
-import sys
 import warnings
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Collection, Iterable, Sequence
 from typing import Any, cast, TYPE_CHECKING, TypeGuard, TypeVar
 from typing_extensions import ParamSpec
 from unittest.mock import patch
@@ -80,7 +79,6 @@ from .ir import (
 )
 from .utils import (
     ceildiv,
-    convert_symint_to_expr,
     decode_device,
     is_dynamic,
     is_gpu,
@@ -202,14 +200,21 @@ def assert_nyi(cond: bool, msg: str) -> None:
         raise NotImplementedError(f"inductor does not support {msg}")
 
 
-def add_needs_realized_inputs(fn):
+def add_needs_realized_inputs(
+    fn: Collection[torch._ops.OpOverload | torch._ops.OpOverloadPacket]
+    | torch._ops.OpOverload
+    | torch._ops.OpOverloadPacket,
+) -> list[Any] | None:
     if isinstance(fn, (list, set, tuple, OrderedSet)):  # noqa: set_linter
+        # pyrefly: ignore [bad-argument-type]
         return [add_needs_realized_inputs(x) for x in fn]
-    needs_realized_inputs.add(fn)
-    if isinstance(fn, torch._ops.OpOverloadPacket):
+    if isinstance(fn, torch._ops.OpOverload):
+        needs_realized_inputs.add(fn)
+    elif isinstance(fn, torch._ops.OpOverloadPacket):
         needs_realized_inputs.update(
             getattr(fn, overload) for overload in fn.overloads()
         )
+    return None
 
 
 def add_layout_constraint(
@@ -952,9 +957,6 @@ def to_dtype_bitcast(x: TensorBox, dtype: torch.dtype, *, copy=False):
     def _get_primitive_bitwidth(dtype):
         if dtype.is_floating_point:
             return torch.finfo(dtype).bits
-        elif dtype == torch.bool:
-            # torch.iinfo doesn't support bool; bools are stored as uint8 (8 bits)
-            return 8
         else:
             return torch.iinfo(dtype).bits
 
@@ -1381,56 +1383,18 @@ def permute(x, dims):
     return TensorBox(PermuteView.create(x.data, tuple(dims)))
 
 
-# Note: logic in this function need to be always synchronized with
-# slice_forward in fake implementation.
-def _register_unbacked_slice_size_bindings(dim, start, end, step, size):
-    """Register DynamicSliceSize for any unbacked size bindings on the current FX node.
-
-    Unbacked symbols may have been allocated at trace time of the slice
-    that inductor must define so the assertion
-    new_unbacked_defs >= renamed_unbacked_bindings passes in run_node.
-
-    Returns (sym_size, sym_storage) parsed from the bindings, or (None, None).
-    """
-    from torch.fx.experimental.symbolic_shapes import (
-        CallMethodKey,
-        resolve_unbacked_bindings,
-    )
-
-    # current_node may be None when slice_ is called from template rendering
-    # (e.g. cpp_template_kernel.slice_nd) rather than FX graph lowering.
-    current_node = V.graph.current_node
-    node_unbacked_bindings = resolve_unbacked_bindings(
-        V.graph.sizevars.shape_env,
-        current_node.meta.get("unbacked_bindings", {})
-        if current_node is not None
-        else {},
-    )
-    sym_size, sym_storage = None, None
-    if node_unbacked_bindings:
-        assert len(node_unbacked_bindings) <= 2, node_unbacked_bindings
-        for sym, keypath in node_unbacked_bindings.items():
-            if keypath == (CallMethodKey("size"), pytree.SequenceKey(dim)):
-                sym_size = sym
-            elif keypath == (CallMethodKey("storage_offset"),):
-                sym_storage = sym
-        if sym_size is not None:
-            b_size = ir.DynamicSliceSize(sym_size, start, end, step, size)
-            b_size.name = V.graph.register_buffer(b_size)
-            V.graph.register_operation(b_size)
-        # NOTE: storage_offset registration is not handled here — it is only
-        # needed in the ambiguous (unbacked start/end) path, where it is
-        # handled via DynamicSelectStorageOffset after this helper returns.
-    return sym_size, sym_storage
-
-
 @register_lowering(aten.slice, type_promotion_kind=None)
-def slice_(x, dim=0, start=0, end=sys.maxsize, step=1, clamp=True):
+def slice_(x, dim=0, start=0, end=2**63, step=1, clamp=True):
     """
     Lowers a slice call, creating ExternKernels for the output size & storage offset symbols,
     if the indices are unbacked and appropriate semantics aren't known.
     If they are known (indices are static/backed/unbacked with info), a SliceView is created.
     """
+
+    from torch.fx.experimental.symbolic_shapes import (
+        CallMethodKey,
+        resolve_unbacked_bindings,
+    )
 
     assert isinstance(x, TensorBox)
     dim = _validate_dim(x, dim, 0)
@@ -1445,12 +1409,6 @@ def slice_(x, dim=0, start=0, end=sys.maxsize, step=1, clamp=True):
             and V.graph.sizevars.statically_known_leq(size, end)
             and step == 1
         ):
-            _, sym_storage = _register_unbacked_slice_size_bindings(
-                dim, start, end, step, size
-            )
-            assert sym_storage is None, (
-                "Unexpected storage_offset unbacked binding for no-op slice"
-            )
             return x
     except TypeError:
         pass
@@ -1463,62 +1421,60 @@ def slice_(x, dim=0, start=0, end=sys.maxsize, step=1, clamp=True):
         fn = lambda x: V.graph.sizevars.guard_or_false(x)  # noqa: E731
         index = sympy.expand(index)
         size = sympy.expand(size)
-        if fn(sympy.And(sympy.Ge(index, 0), sympy.Le(index, size))):
+        if fn(sympy.Ge(index, 0)) and fn(sympy.Le(index, size)):
             return index
-        elif fn(sympy.And(sympy.Lt(index, 0), sympy.Ge(index, -size))):
+        elif fn(sympy.Lt(index, 0)) and fn(sympy.Ge(index, -size)):
             return index + size
         elif fn(sympy.Gt(index, size)):
             return size
         elif fn(sympy.Lt(index, -size)):
             return 0
-        elif fn(sympy.Ge(index, 0)):
-            # If index >= 0, the resolved index is at most min(index, size).
-            return sympy.Min(index, size)
-        elif fn(sympy.Lt(index, 0)):
-            # If index < 0, wrap and clamp: the resolved index is at least 0.
-            return sympy.Max(index + size, 0)
         return None
 
     start_index, end_index = None, None
-    # ambiguous_slice=False means we know what semantics this slice call follows,
-    # and don't need to generate an extern kernel to represent the output size.
-    # This is assumed True for clamp=False
-    # (meant to follow standard indexing semantics: 0 <= index < size)
     ambiguous_slice = clamp
     if ambiguous_slice:
         start_index = compute_slice_index(start, size, 0)
-        # Special case: if end is maxsize (unbounded), use size directly
-        # This matches the logic in fake_impls.py
-        if end is not None and V.graph.sizevars.statically_known_equals(
-            end, sys.maxsize
-        ):
-            end_index = size
-        else:
-            end_index = compute_slice_index(end, size, size)
+        end_index = compute_slice_index(end, size, size)
         if start_index is not None and end_index is not None:
             start, end = start_index, end_index
             ambiguous_slice = False
 
+    # ambiguous_slice=False means we know what semantics this slice call follows,
+    # and don't need to generate an extern kernel to represent the output size.
+    # This is assumed True for clamp=False
+    # (meant to follow standard indexing semantics: 0 <= index < size)
     if not ambiguous_slice:
-        _, sym_storage = _register_unbacked_slice_size_bindings(
-            dim, start, end, step, size
-        )
-        assert sym_storage is None, (
-            "Unexpected storage_offset unbacked binding when both "
-            "start and end indices are resolved"
-        )
-
         return TensorBox(
             ir.SliceView.create(x.data, dim, start, end, step, clamp=clamp)
         )  # go to SliceView/ReinterpretView
 
-    # unbacked territory: unbacked start / end
+    # unbacked territory: create DynamicSlice ExternKernel
+    # clamp is True, unbacked start / end
     assert clamp
-    assert start_index is None or end_index is None
-    sym_size, sym_storage = _register_unbacked_slice_size_bindings(
-        dim, start, end, step, x.get_size()[dim]
+    unbacked_bindings = resolve_unbacked_bindings(
+        V.graph.sizevars.shape_env, V.graph.current_node.meta["unbacked_bindings"]
     )
-    assert sym_size is not None
+    assert unbacked_bindings is not None
+    assert len(unbacked_bindings) <= 2, unbacked_bindings
+    sym_size, sym_storage = None, None
+    for sym, keypath in unbacked_bindings.items():
+        if keypath == (CallMethodKey("size"), pytree.SequenceKey(dim)):
+            sym_size = sym
+        elif keypath == (CallMethodKey("storage_offset"),):
+            sym_storage = sym
+
+    assert start_index is None or end_index is None
+    b_size = ir.DynamicSliceSize(
+        sym_size,
+        start,
+        end,
+        step,
+        x.get_size()[dim],
+    )
+    b_size.name = V.graph.register_buffer(b_size)
+    V.graph.register_operation(b_size)
+    new_size = sym_size
 
     if x.maybe_get_layout() is None:
         # realize tensor before accessing layout
@@ -1543,7 +1499,7 @@ def slice_(x, dim=0, start=0, end=sys.maxsize, step=1, clamp=True):
 
     new_sizes = list(x.get_size())
     new_strides = list(x.get_stride())
-    new_sizes[dim] = sym_size
+    new_sizes[dim] = new_size
     new_strides[dim] *= step
     return as_strided(x, new_sizes, new_strides, new_storage_offset)
 
@@ -1562,8 +1518,6 @@ def as_strided(x, size, stride, storage_offset=None):
         # to have a cross-device view today.
         new_device = x.get_device()
         new_dtype = x.dtype
-        if storage_offset is None and x.maybe_get_layout() is not None:
-            storage_offset = x.get_layout().offset
         x = x.data.unwrap_view()
     x.realize()
     if not ir.is_storage_and_layout(x):
@@ -1974,85 +1928,6 @@ def quantized_decomposed_dequantize_per_tensor_tensor(
     )
 
 
-def _cat_inputs_recombine_reduction(inputs: list[TensorBox], dim: int) -> str | None:
-    """If all cat inputs share a common upstream reduction buffer whose
-    only consumers feed into this cat, return its name so it can be
-    excluded from the can_fuse_reduction check.
-
-    Checks common reads for an IR reduction whose numel matches the cat
-    output, then verifies via FX origins that all of the reduction's
-    consumers feed into the cat inputs."""
-    if len(inputs) < 2:
-        return None
-
-    common_reads = inputs[0].get_read_names()
-    for inp in inputs[1:]:
-        common_reads = common_reads & inp.get_read_names()
-    if not common_reads:
-        return None
-
-    # Find a common read that is an IR reduction buffer whose input
-    # numel matches the cat output numel.
-    cat_out_numel = convert_symint_to_expr(V.graph.current_node.meta["val"].numel())
-    reduction_name = None
-    reduction_buf = None
-    for name in common_reads:
-        buf = V.graph.try_get_buffer(name)
-        if (
-            buf is not None
-            and isinstance(buf, ir.ComputedBuffer)
-            and isinstance(buf.data, ir.Reduction)
-        ):
-            reduction_numel = sympy_product(buf.data.get_size()) * sympy_product(
-                buf.data.get_reduction_size()
-            )
-            if V.graph.sizevars.statically_known_equals(cat_out_numel, reduction_numel):
-                reduction_name = name
-                reduction_buf = buf
-                break
-
-    if reduction_name is None:
-        return None
-
-    # Verify the reduction doesn't have consumers outside this cat's
-    # computation. Each IR node tracks which FX nodes produced it
-    # (origins). Collect the FX origins of all cat inputs, then check
-    # that every FX user of the reduction's origins feeds into one of
-    # the cat inputs.
-    #
-    # We also tried checking IR-level users via V.graph.name_to_users,
-    # but at lowering time the cat inputs are unrealized TensorBox
-    # wrappers (not named buffers), so name_to_users entries can't be
-    # correlated back to the cat's input chain.
-    #
-    # TODO: origins is a set of FX nodes attached to IR nodes during
-    # lowering — using it for correctness is fragile. A proper
-    # buffer→FX node mapping would be better.
-    origins = getattr(reduction_buf, "origins", None)
-    if not origins:
-        return None
-
-    cat_input_origins: OrderedSet[torch.fx.Node] = OrderedSet()
-    for inp in inputs:
-        inp_origins = getattr(inp, "origins", None)
-        if inp_origins:
-            cat_input_origins.update(inp_origins)
-
-    # Check that the reduction FX node's users all feed into the cat.
-    # origins may include non-reduction nodes (e.g. pow that feeds into
-    # mean), so filter to only reduction ops via torch.Tag.reduction.
-    for origin in origins:
-        if (
-            origin.op == "call_function"
-            and isinstance(origin.target, torch._ops.OpOverload)
-            and torch.Tag.reduction in origin.target.tags
-            and not all(u in cat_input_origins for u in origin.users)
-        ):
-            return None
-
-    return reduction_name
-
-
 @register_lowering(aten.cat)
 def cat(inputs, dim=0):
     """Lower aten.cat, choosing between pointwise_cat and ConcatKernel."""
@@ -2092,26 +1967,20 @@ def cat(inputs, dim=0):
     def is_reduction(t):
         return isinstance(t, ir.ComputedBuffer) and isinstance(t.data, ir.Reduction)
 
-    def can_fuse_reduction(t, exclude: OrderedSet[str] = OrderedSet()):
+    def can_fuse_reduction(t):
         if isinstance(t, (TensorBox, ir.StorageBox)):
-            return can_fuse_reduction(unwrap_tensor(t), exclude)
+            return can_fuse_reduction(unwrap_tensor(t))
         return (
             is_reduction(t)
             or isinstance(t, ir.Pointwise)
             and any(
-                read not in exclude
-                and can_fuse_reduction(V.graph.get_buffer(read), exclude)
+                can_fuse_reduction(V.graph.get_buffer(read))
                 for read in t.get_read_names()
             )
         )
 
-    # Pointwise cat evaluates every input's computation for each
-    # output element (masked), so fusing reductions in is wasteful.
-    # Exception: when inputs just recombine a reduction's output
-    # (e.g. qknorm → RoPE → cat), we do not duplicate computation
-    recombined = _cat_inputs_recombine_reduction(inputs, dim)
-    exclude: OrderedSet[str] = OrderedSet([recombined]) if recombined else OrderedSet()
-    fusable_reduction = any(can_fuse_reduction(t, exclude) for t in inputs)
+    # fusing reducutions into computed concat buffer can cause regressions.
+    fusable_reduction = any(can_fuse_reduction(t) for t in inputs)
 
     def should_lower_cat_input(x) -> bool:
         # Unrealized inputs will not be storage and layouts, and we dont want to realize
@@ -2150,14 +2019,17 @@ def cat(inputs, dim=0):
 
         return count
 
-    # as inputs increase, possibility for register spilling also increases.
-    # Past a certain threshold we only fuse if the input kernels are simple.
+    # as of inputs increase, possibility for register spilling also increases
+    # past a certain threshold of inputs we only fuse if the if the input kernels
+    # are simple
+    # not sure if we want to expose to users via config since logic may change in future
+    MAX_COMPLEX_POINTWISE_CAT = 8
     MAX_SIMPLE_OP_COUNT = 2
 
     def additional_pointwise_ops(op: torch._ops.OpOverload):
         return op in (aten.cat.default, aten.constant_pad_nd.default)
 
-    if len(inputs) <= config.max_complex_pointwise_cat_inputs or (
+    if len(inputs) <= MAX_COMPLEX_POINTWISE_CAT or (
         (len(inputs) <= config.max_pointwise_cat_inputs)
         and all(op_count(t) <= MAX_SIMPLE_OP_COUNT for t in inputs)
     ):
@@ -2176,46 +2048,31 @@ def cat(inputs, dim=0):
 
         # Skip pointwise_cat when any cat input has a fusible (pointwise)
         # multi-consumer — ConcatKernel + NonOwningLayout avoids redundant
-        # reads. Also skip when input is an unrealized Pointwise with
-        # multiple consumers to avoid recomputation (e.g. pad-as-cat).
+        # reads.  Non-fusible users (e.g. matmul) don't benefit, so they
+        # should not prevent pointwise_cat.
         def any_input_has_multi_consumers() -> bool:
-            current_node = V.current_node
-            if current_node is None:
+            cat_node = V.current_node
+            if cat_node is None:
                 return False
-            fx_args = current_node.args[0]
-            if isinstance(fx_args, (list, tuple)):
-                input_nodes = fx_args
-            elif isinstance(fx_args, torch.fx.Node):
-                input_nodes = [fx_args]
-            else:
+            fx_args = cat_node.args[0]  # aten.cat format: cat(input_list, dim)
+            if not isinstance(fx_args, (list, tuple)):
                 return False
 
-            def is_unrealized_pointwise(x):
-                if isinstance(x, (TensorBox, ir.StorageBox)):
-                    return is_unrealized_pointwise(unwrap_tensor(x))
-                return isinstance(x, ir.Pointwise)
-
-            for arg, ir_input in zip(input_nodes, inputs):
+            def has_fusible_multi_consumer(arg):
                 if not hasattr(arg, "users") or len(arg.users) <= 1:
-                    continue
-                # input will be computed multiple times because other consumers
-                # (eg. pointwise) will also inline it. So we should realize-in-place via ConcatKernel
-                if any(is_pointwise_use(u) for u in arg.users if u is not current_node):
-                    return True
-                # If input is an unrealized Pointwise with multiple consumers, pointwise_cat
-                # will inline input without realizing it to memory, causing separate
-                # realization cost for input. So we should realize-in-place via ConcatKernel
-                if is_unrealized_pointwise(ir_input):
-                    return True
-            return False
+                    return False
+                return any(is_pointwise_use(u) for u in arg.users if u is not cat_node)
+
+            return any(has_fusible_multi_consumer(arg) for arg in fx_args)
 
         has_multi_consumers = any_input_has_multi_consumers()
 
-        horizontal_fuse_cat = (
-            all(should_lower_cat_input(inp) for inp in inputs) and not fusable_reduction
-        )
-
-        if not has_multi_consumers and (fuse_pointwise_use or horizontal_fuse_cat):
+        horizontal_fuse_cat = all(
+            should_lower_cat_input(inp) for inp in inputs
+        ) and not any(can_fuse_reduction(t) for t in inputs)
+        if not has_multi_consumers and (
+            fuse_pointwise_use or (horizontal_fuse_cat and not fusable_reduction)
+        ):
             return pointwise_cat(inputs, dim)
 
     return TensorBox(ir.ConcatKernel.create(inputs, dim))
@@ -2576,15 +2433,8 @@ def fallback_node_due_to_unsupported_type(node: torch.fx.Node, allow_cpu_inputs=
     return check_skip_condition(node, is_output=True)
 
 
-def make_fallback(
-    op,
-    layout_constraint=None,
-    warn=True,
-    override_decomp=False,
-    get_decomp_fn=None,
-):
-    check_decomps = get_decomp_fn() if get_decomp_fn is not None else decompositions
-    assert op not in check_decomps or override_decomp, (
+def make_fallback(op, layout_constraint=None, warn=True, override_decomp=False):
+    assert op not in decompositions or override_decomp, (
         f"both a fallback and a decomp for same op: {op}"
     )
     if (
@@ -2739,15 +2589,10 @@ fallback_rand_generator = fallback_handler(aten.rand.generator)
 fallback_randn_default = fallback_handler(aten.randn.default)
 fallback_randn_generator = fallback_handler(aten.randn.generator)
 make_fallback(aten.randint)
-make_fallback(aten.rand_like, override_decomp=True)
-make_fallback(aten.randn_like, override_decomp=True)
-make_fallback(aten.randint_like, override_decomp=True)
 
 # TODO: mlazos reevaluate if we want to codegen something different
 make_fallback(torch.ops.streams.record_event.default)
 make_fallback(torch.ops.streams.wait_event.default)
-make_fallback(torch.ops.streams.synchronize_event.default)
-make_fallback(torch.ops.streams.synchronize_device.default)
 
 
 @register_lowering(aten.rand)
@@ -2800,35 +2645,8 @@ def inductor_lookup_seed(seeds, index):
     )
 
 
-def get_threads_per_round(device: torch.device):
-    if not isinstance(device, torch.device):
-        device = torch.device(device)
-
-    if device.type == "cuda":
-        idx = device.index
-        if idx is None:
-            idx = torch.cuda.current_device()
-
-        prop = torch.cuda.get_device_properties(idx)
-        threads_per_round = (
-            prop.multi_processor_count * prop.max_threads_per_multi_processor
-        )
-    else:
-        _CPU_GRAIN_SIZE = 32768
-        threads_per_round = _CPU_GRAIN_SIZE
-
-    return threads_per_round
-
-
 @register_lowering(inductor_prims.random, type_promotion_kind=None)
-def inductor_random(
-    size: list[int],
-    seed: TensorBox,
-    mode: str,
-    *,
-    offset: int = 0,
-    align_dtype: torch.dtype = torch.float32,
-):
+def inductor_random(size: list[int], seed: TensorBox, mode: str, *, offset: int = 0):
     assert not config.fallback_random
     assert mode in ("rand", "randn")
     size = [*size]
@@ -2839,33 +2657,11 @@ def inductor_random(
     ).make_indexer()
     seed_loader = seed.make_loader()
 
-    if config.align_random_eager and device.type == "cuda":
-        threads_per_round = get_threads_per_round(device)
-
-        def _vec_from_dtype(dt: torch.dtype) -> int:
-            if dt in (torch.float16, torch.bfloat16):
-                return 8
-            return 4
-
-        vec = _vec_from_dtype(align_dtype)
-
-        def inner_fn(index):
-            rng_seed = seed_loader([0])
-            base_offset = seed_loader([1])
-            return ops.rand_eager(
-                rng_seed,
-                base_offset,
-                threads_per_round,
-                ops.index_expr(random_pos(index), torch.int32),
-                vec=int(vec),
-            )
-    else:
-
-        def inner_fn(index):
-            return getattr(ops, mode)(
-                seed_loader([]),
-                ops.index_expr(random_pos(index), torch.int32),
-            )
+    def inner_fn(index):
+        return getattr(ops, mode)(
+            seed_loader([]),
+            ops.index_expr(random_pos(index), torch.int32),
+        )
 
     result = Pointwise.create(
         device=device,
@@ -2875,10 +2671,6 @@ def inductor_random(
     )
     result.realize()
     return result
-
-
-make_fallback(inductor_prims.rand_eager_offset)
-make_fallback(inductor_prims.rand_eager_offsets)
 
 
 @register_lowering(inductor_prims.randint, type_promotion_kind=None)
@@ -3089,24 +2881,16 @@ def bucketize(
     return result
 
 
-def _is_tensor_irnode(x):
-    return isinstance(x, ir.IRNode) and not isinstance(
-        x, (ir.NonTensorObj, ir.OpaqueMultiOutput)
-    )
-
-
 def require_dense(_, *args, **kwargs):
     args, kwargs = pytree.tree_map_only(
-        _is_tensor_irnode, ir.ExternKernel.require_stride1, (args, kwargs)
+        ir.IRNode, ir.ExternKernel.require_stride1, (args, kwargs)
     )
     return args, kwargs
 
 
 def require_contiguous(_, *args, **kwargs):
     args, kwargs = pytree.tree_map_only(
-        _is_tensor_irnode,
-        ir.ExternKernel.require_contiguous,
-        (args, kwargs),
+        ir.IRNode, ir.ExternKernel.require_contiguous, (args, kwargs)
     )
     return args, kwargs
 
@@ -3115,18 +2899,14 @@ def require_contiguous_strides(_, *args, **kwargs):
     # TODO: combine this with require_contiguous after
     # https://github.com/pytorch/pytorch/pull/148235 lands.
     args, kwargs = pytree.tree_map_only(
-        _is_tensor_irnode,
-        ir.ExternKernel.require_contiguous_strides,
-        (args, kwargs),
+        ir.IRNode, ir.ExternKernel.require_contiguous_strides, (args, kwargs)
     )
     return args, kwargs
 
 
 def require_channels_last(_, *args, **kwargs):
     args, kwargs = pytree.tree_map_only(
-        _is_tensor_irnode,
-        ir.ExternKernel.require_channels_last,
-        (args, kwargs),
+        ir.IRNode, ir.ExternKernel.require_channels_last, (args, kwargs)
     )
     return args, kwargs
 
@@ -3158,12 +2938,9 @@ def constrain_to_fake_tensors(args, kwargs, fake_args, fake_kwargs):
 
 def constrain_to_fx_strides(fx_node, *args, **kwargs):
     def apply_constraint(arg, fx_arg):
-        if _is_tensor_irnode(arg):
-            fake_val = fx_arg.meta.get("val")
-            if not isinstance(fake_val, torch.Tensor):
-                return arg
+        if isinstance(arg, ir.IRNode):
             stride_order = ir.get_stride_order(
-                fake_val.stride(), V.graph.sizevars.shape_env
+                fx_arg.meta["val"].stride(), V.graph.sizevars.shape_env
             )
             return ir.ExternKernel.require_stride_order(arg, stride_order)
         if isinstance(arg, dict):
@@ -3177,25 +2954,17 @@ def constrain_to_fx_strides(fx_node, *args, **kwargs):
     return args, kwargs
 
 
-def constrain_to_fx_strides_if_fallback_random(fx_node, *args, **kwargs):
-    if not config.fallback_random:
-        return args, kwargs
-    return constrain_to_fx_strides(fx_node, *args, **kwargs)
-
-
 # native_dropout uses empty_like(input) internally, so bernoulli_ consumes
 # RNG values in the input's stride order. Constrain input strides to match
 # the FX graph (i.e. eager) so the dropout mask is identical.
-add_layout_constraint(
-    aten.native_dropout.default, constrain_to_fx_strides_if_fallback_random
-)
+add_layout_constraint(aten.native_dropout.default, constrain_to_fx_strides)
 
 
 def sdpa_constraint(fx_node, *args, **kwargs):
     """Apply stride constraints to SDPA inputs, ensuring dense last dimension."""
 
     def apply_constraint(idx, arg, fx_arg):
-        if not _is_tensor_irnode(arg):
+        if not isinstance(arg, ir.IRNode):
             return arg
 
         meta_val = fx_arg.meta["val"]
@@ -3246,7 +3015,7 @@ def sdpa_constraint(fx_node, *args, **kwargs):
         return result
 
     def _apply_constraint_inner(idx, arg, meta_val, meta_stride_expr, stride_order):
-        if not (meta_val.is_cuda or meta_val.is_xpu):
+        if not meta_val.is_cuda:
             return ir.ExternKernel.require_stride_order(arg, stride_order)
 
         # This is the minimum alignment required by SDPA kernels for attention_bias.
@@ -3305,14 +3074,12 @@ def sdpa_constraint(fx_node, *args, **kwargs):
                 # we can make them expanded by setting the stride equal to 0
                 if i in expanded_dims:
                     if V.graph.sizevars.statically_known_equals(
-                        Mod(out_strides[i + 1], ALIGNMENT), 0
+                        out_strides[i + 1] % ALIGNMENT, 0
                     ):
                         out_strides[i] = 0
                         continue
 
-                if not V.graph.sizevars.statically_known_equals(
-                    Mod(stride, ALIGNMENT), 0
-                ):
+                if not V.graph.sizevars.statically_known_equals(stride % ALIGNMENT, 0):
                     stride = ceildiv(stride, ALIGNMENT) * ALIGNMENT
 
                 out_strides[i] = stride
@@ -3405,6 +3172,7 @@ make_fallback(aten._addmm_activation, warn=False)
 make_fallback(aten._grouped_mm, require_dense)
 
 # Need templated kernel. Probably impossible to write efficiently
+make_fallback(aten.convolution_backward, constrain_to_fx_strides)
 make_fallback(aten._cudnn_rnn, require_dense)
 make_fallback(aten._cudnn_rnn_backward, require_contiguous)
 make_fallback(aten.miopen_rnn, require_dense)
@@ -3440,8 +3208,13 @@ make_fallback(aten._pdist_backward, require_contiguous)
 # 5) Impossible (missing triton/CPU features)
 
 # Sorting / Sorting-like
+make_fallback(aten.sort)
+make_fallback(aten.sort.stable)
+make_fallback(aten.kthvalue)
+make_fallback(aten.topk)
+make_fallback(aten.mode)
+make_fallback(aten.median)
 make_fallback(aten.nanmedian)
-make_fallback(aten.multinomial.default, warn=False)
 make_fallback(aten.randperm)
 # see: https://github.com/pytorch/pytorch/pull/121354
 make_fallback(aten.resize_)
@@ -3649,30 +3422,6 @@ def iota(
     )
 
 
-@register_lowering(aten.arange.start_step, type_promotion_kind=None)
-def arange_start_step(
-    start,
-    end,
-    step=1,
-    *,
-    dtype=None,
-    device=None,
-    layout=None,
-    pin_memory=None,
-    requires_grad=False,
-):
-    assert dtype is not None
-    length = ceildiv(end - start, step)
-    return iota(
-        length,
-        start=start,
-        step=step,
-        dtype=dtype,
-        device=device if device is not None else "cpu",
-        requires_grad=requires_grad,
-    )
-
-
 @register_lowering(aten.select_scatter, type_promotion_kind=None)
 def select_scatter(x, src, dim: int, index: int):
     src = to_dtype(src, x.get_dtype())
@@ -3784,7 +3533,7 @@ def _unwrap(x):
     return x
 
 
-@register_lowering([torch.tensor, aten.scalar_tensor, prims.scalar_tensor])
+@register_lowering([torch.tensor, aten.scalar_tensor])
 def tensor(data, *, dtype=None, device=None, layout=None, pin_memory=False):
     assert_nyi(layout in (None, torch.strided), f"layout={layout}")
     assert_nyi(not pin_memory, "pin_memory")
@@ -3966,7 +3715,7 @@ def tensor_constructor(fill_value):
     ):
         assert_nyi(names is None, "named tensors")
         assert_nyi(layout in (None, torch.strided), f"layout={layout}")
-        assert_nyi(not memory_format, "memory_format")
+        assert_nyi(not pin_memory, "pin_memory")
         device = decode_device(device)
         dtype = dtype or torch.get_default_dtype()
         if len(size) == 1 and isinstance(size[0], (list, tuple, torch.Size)):
@@ -3976,14 +3725,7 @@ def tensor_constructor(fill_value):
         for s in size:
             assert not isinstance(s, torch.SymInt)
         size = [sympy.expand(s) for s in size]
-        full_pointwise = _full(fill_value, decode_device(device), dtype, size)
-
-        if pin_memory:
-            # Realize the buffer
-            full_pointwise.realize()
-            full_pointwise.data.data.get_layout().is_pinned = True
-
-        return full_pointwise
+        return _full(fill_value, device, dtype, size)
 
     return inner
 
@@ -4529,6 +4271,7 @@ def index_put_impl_(self, indices, values, accumulate, check, may_realize=False)
         None,
         check=check,
     )
+
     values = expand(values, expected_vals_size)
     # all guards are set above during broadcast_tensors and expand
 
@@ -5018,59 +4761,6 @@ def inplace_constant_pad_nd(
     return resized_x
 
 
-def _pad_as_cat(
-    x: TensorBox, padding: Sequence[int], fill_value: float
-) -> TensorBox | None:
-    """Decompose right-pad into cat([x, fill], dim) and delegate to cat lowering.
-
-    The cat lowering already has heuristics for choosing between pointwise_cat
-    (fusion) and ConcatKernel (memory planning / zero-copy).  By routing through
-    cat() we reuse those heuristics rather than duplicating them here.
-    """
-    # Bail out for symbolic padding, dynamic shapes
-    if not all(isinstance(p, int) for p in padding):
-        return None
-
-    sizes = x.get_size()
-    ndim = len(sizes)
-    pad_pairs = list(zip(padding[::2], padding[1::2]))
-
-    # Only support single-dimension right-pad
-    pad_dim = None
-    pad_amount = None
-    for i, (left, right) in enumerate(pad_pairs):
-        if left != 0:
-            return None
-        if right > 0:
-            if pad_dim is not None:
-                return None  # multi-dim pad
-            pad_dim = ndim - 1 - i  # padding format is reversed dim order
-            pad_amount = right
-        elif right < 0:
-            return None  # trim, not pad
-
-    if pad_dim is None:
-        return None
-
-    # CPU cat always uses ConcatKernel (no pointwise_cat), which adds
-    # extra kernel launches for the fill.  Skip pad-as-cat on CPU.
-    device = x.get_device()
-    if device is not None and device.type == "cpu":
-        return None
-
-    # Build the fill tensor for the padding region
-    pad_shape = list(sizes)
-    pad_shape[pad_dim] = pad_amount
-    dtype = x.get_dtype()
-    fill_value_typed = dtype_to_type(dtype)(fill_value)
-    pad_tensor = tensor_constructor(fill_value_typed)(
-        pad_shape, dtype=dtype, device=device
-    )
-
-    counters["inductor"]["pad_rewritten_as_cat"] += 1
-    return cat([x, pad_tensor], pad_dim)
-
-
 @register_lowering(aten.constant_pad_nd, type_promotion_kind=None)
 def constant_pad_nd(x, padding, fill_value=0):
     assert (len(padding) % 2) == 0
@@ -5082,10 +4772,6 @@ def constant_pad_nd(x, padding, fill_value=0):
         if out:
             return out
             # fall through if can not inplace the padding
-
-    out = _pad_as_cat(x, padding, fill_value)
-    if out is not None:
-        return out
 
     sizes = x.get_size()
 
@@ -5166,7 +4852,7 @@ def constant_boundary_condition(
 
         mask = functools.reduce(
             ops.and_,
-            # pyrefly: ignore [bad-argument-type, no-matching-overload]
+            # pyrefly: ignore [no-matching-overload]
             [range_mask(ih[i], h[i] + padding_h[i], -padding_h[i]) for i in range(dim)],
         )
         return (
@@ -6081,7 +5767,7 @@ def upsample_nearest2d_backward(
         device=x.get_device(),
         dtype=x.get_dtype(),
         inner_fn=fn,
-        # pyrefly: ignore [bad-argument-type, no-matching-overload]
+        # pyrefly: ignore [no-matching-overload]
         ranges=list(input_size),
     )
 
@@ -7079,11 +6765,6 @@ def truncdiv(a, b):
     return ops.truncdiv(a, b)
 
 
-@make_pointwise
-def _div_rn(a, b):
-    return ops.div_rn(a, b)
-
-
 @register_lowering(aten.div, broadcast=True)
 def div_mode(a, b, rounding_mode=None):
     both_integer = is_integer_type(a) and is_integer_type(b)
@@ -7093,11 +6774,7 @@ def div_mode(a, b, rounding_mode=None):
     # see the discussion at https://github.com/triton-lang/triton/issues/605
     if rounding_mode == "floor":
         assert not both_boolean, "floordiv operands can not be boolean at the same time"
-        # Use div_rn (IEEE round-to-nearest) instead of truediv here because
-        # Triton's default division uses an approximate reciprocal, which can
-        # produce a result slightly below the true quotient and cause floor()
-        # to round down by one.
-        return floordiv(a, b) if both_integer else floor(_div_rn(a, b))
+        return floordiv(a, b) if both_integer else floor(div(a, b))
     if rounding_mode == "trunc":
         assert not both_boolean, "truncdiv operands can not be boolean at the same time"
         return truncdiv(a, b) if both_integer else trunc(div(a, b))
@@ -7404,20 +7081,11 @@ def sort_stable(x, *, stable=None, dim=-1, descending=False):
         return clone(x), _full(0, device, torch.int64, shape)
 
     dim_size = shape[dim] if len(shape) else 1
-    # Use int32 indices when decompose_sort_ops is enabled, allowing sort
-    # dimensions up to 2^31-1.  Default int16 keeps register pressure low
-    # on GPU where the bitonic network holds all indices in-block.
-    if config.triton.decompose_sort_ops:
-        idx_dtype = torch.int32
-    else:
-        idx_dtype = torch.int16
-    if not V.graph.sizevars.guard_or_false(
-        sympy.Lt(dim_size, torch.iinfo(idx_dtype).max)
-    ):
+    if not V.graph.sizevars.statically_known_lt(dim_size, torch.iinfo(torch.int16).max):
         return sort_fallback(x, stable=stable, dim=dim, descending=descending)
 
     indices = iota(
-        dim_size, start=0, step=1, dtype=idx_dtype, device=device, requires_grad=False
+        dim_size, start=0, step=1, dtype=torch.int16, device=device, requires_grad=False
     )
     view_shape = [1] * len(shape)
     if len(shape):
@@ -7444,199 +7112,6 @@ def sort_stable(x, *, stable=None, dim=-1, descending=False):
 @register_lowering(aten.sort.default, type_promotion_kind=None)
 def sort(x, dim=-1, descending=False):
     return sort_stable(x, stable=False, dim=dim, descending=descending)
-
-
-# Sort-based op lowerings
-# When config.triton.decompose_sort_ops is enabled, decompose into sort-based
-# ops so Inductor generates Triton kernels via ir.Sort.
-# Otherwise, fall back to ATen eager.
-topk_fallback = fallback_handler(aten.topk.default, add_to_fallback_set=False)
-kthvalue_fallback = fallback_handler(aten.kthvalue.default, add_to_fallback_set=False)
-median_fallback = fallback_handler(aten.median.default, add_to_fallback_set=False)
-median_dim_fallback = fallback_handler(aten.median.dim, add_to_fallback_set=False)
-mode_fallback = fallback_handler(aten.mode.default, add_to_fallback_set=False)
-
-# sort/sort.stable already have register_lowering above (sort_stable, sort).
-# They use ir.Sort directly and fall back when the dimension is too large.
-# When decompose_sort_ops is enabled, the size limit is lifted (int32 indices).
-
-
-@register_lowering(aten.median.default, type_promotion_kind=None)
-def median_default(self):
-    if not config.triton.decompose_sort_ops:
-        return median_fallback(self)
-    size = self.get_size()
-    numel = functools.reduce(operator.mul, size, sympy.Integer(1))
-    flat = view(self, [numel])
-    sorted_vals, _ = sort_stable(flat, dim=0)
-    k = (numel - 1) // 2
-    return select(sorted_vals, 0, k)
-
-
-@register_lowering(aten.median.dim, type_promotion_kind=None)
-def median_dim(self, dim, keepdim=False):
-    if not config.triton.decompose_sort_ops:
-        return median_dim_fallback(self, dim, keepdim)
-    shape = self.get_size()
-    ndim = len(shape)
-    if ndim == 0:
-        return clone(self), _full(0, self.get_device(), torch.int64, shape)
-    dim = canonicalize_dim(ndim, dim)
-    sorted_vals, sorted_idxs = sort_stable(self, stable=True, dim=dim)
-    n = shape[dim]
-    k = (n - 1) // 2
-    values = select(sorted_vals, dim, k)
-    indices = select(sorted_idxs, dim, k)
-    if keepdim:
-        values = unsqueeze(values, dim)
-        indices = unsqueeze(indices, dim)
-    return values, indices
-
-
-@register_lowering(aten.mode.default, type_promotion_kind=None)
-def mode_default(self, dim=-1, keepdim=False):
-    """Lower aten.mode via sort-based decomposition or fallback."""
-    if not config.triton.decompose_sort_ops:
-        return mode_fallback(self, dim, keepdim)
-    shape = self.get_size()
-    ndim = len(shape)
-    device = self.get_device()
-    if ndim == 0:
-        return clone(self), _full(0, device, torch.int64, shape)
-    dim = canonicalize_dim(ndim, dim)
-    sorted_vals, sorted_idxs = sort_stable(self, stable=True, dim=dim)
-    n = shape[dim]
-
-    # Position indices along dim: [0, 1, ..., n-1]
-    positions = iota(
-        n, start=0, step=1, dtype=torch.int64, device=device, requires_grad=False
-    )
-    pos_view_shape = [sympy.Integer(1)] * ndim
-    pos_view_shape[dim] = n
-    positions = view(positions, pos_view_shape)
-    positions = expand(positions, shape)
-
-    # Shift positions by -1, clamp to 0 for position 0
-    positions_loader0 = positions.make_loader()
-
-    def prev_pos_fn(idx):
-        return ops.maximum(
-            ops.sub(positions_loader0(idx), ops.constant(1, torch.int64)),
-            ops.constant(0, torch.int64),
-        )
-
-    prev_positions = Pointwise.create(
-        device=decode_device(device),
-        dtype=torch.int64,
-        inner_fn=prev_pos_fn,
-        ranges=shape,
-    )
-
-    # Gather shifted values and compare for run boundaries
-    shifted_vals = gather(sorted_vals, dim, prev_positions)
-
-    sorted_loader = sorted_vals.make_loader()
-    shifted_loader = shifted_vals.make_loader()
-    positions_loader = positions.make_loader()
-
-    # is_boundary = (sorted != shifted) | (position == 0)
-    def is_boundary_fn(idx):
-        return ops.or_(
-            ops.ne(sorted_loader(idx), shifted_loader(idx)),
-            ops.eq(positions_loader(idx), ops.constant(0, torch.int64)),
-        )
-
-    is_boundary = Pointwise.create(
-        device=decode_device(device),
-        dtype=torch.bool,
-        inner_fn=is_boundary_fn,
-        ranges=shape,
-    )
-
-    # boundary_pos = where(is_boundary, position, -1)
-    is_boundary_loader = is_boundary.make_loader()
-    positions_loader2 = positions.make_loader()
-
-    def boundary_pos_fn(idx):
-        return ops.where(
-            is_boundary_loader(idx),
-            positions_loader2(idx),
-            ops.constant(-1, torch.int64),
-        )
-
-    boundary_pos = Pointwise.create(
-        device=decode_device(device),
-        dtype=torch.int64,
-        inner_fn=boundary_pos_fn,
-        ranges=shape,
-    )
-
-    # Propagate boundary positions forward with cummax
-    last_boundary, _ = cummax(boundary_pos, dim)
-
-    # run_len = position - last_boundary + 1
-    positions_loader3 = positions.make_loader()
-    last_boundary_loader = last_boundary.make_loader()
-
-    def run_len_fn(idx):
-        return ops.add(
-            ops.sub(positions_loader3(idx), last_boundary_loader(idx)),
-            ops.constant(1, torch.int64),
-        )
-
-    run_len = Pointwise.create(
-        device=decode_device(device),
-        dtype=torch.int64,
-        inner_fn=run_len_fn,
-        ranges=shape,
-    )
-
-    # argmax returns first maximum -> end of leftmost longest run
-    max_pos = reduce_argmax(run_len, axis=dim, keepdims=True)
-    mode_vals = gather(sorted_vals, dim, max_pos)
-    mode_idxs = gather(sorted_idxs, dim, max_pos)
-
-    if not keepdim:
-        mode_vals = squeeze(mode_vals, dim)
-        mode_idxs = squeeze(mode_idxs, dim)
-
-    return mode_vals, mode_idxs
-
-
-@register_lowering(aten.topk.default, type_promotion_kind=None)
-def topk(self, k, dim=-1, largest=True, sorted=True):
-    if not config.triton.decompose_sort_ops:
-        return topk_fallback(self, k, dim, largest, sorted)
-    shape = self.get_size()
-    ndim = len(shape)
-    if ndim == 0:
-        return clone(self), _full(0, self.get_device(), torch.int64, shape)
-    dim = canonicalize_dim(ndim, dim)
-    sorted_vals, sorted_idxs = sort_stable(
-        self, stable=True, dim=dim, descending=largest
-    )
-    values = slice_(sorted_vals, dim, 0, k)
-    indices = slice_(sorted_idxs, dim, 0, k)
-    return values, indices
-
-
-@register_lowering(aten.kthvalue.default, type_promotion_kind=None)
-def kthvalue(self, k, dim=-1, keepdim=False):
-    if not config.triton.decompose_sort_ops:
-        return kthvalue_fallback(self, k, dim, keepdim)
-    shape = self.get_size()
-    ndim = len(shape)
-    if ndim == 0:
-        return clone(self), _full(0, self.get_device(), torch.int64, shape)
-    dim = canonicalize_dim(ndim, dim)
-    sorted_vals, sorted_idxs = sort_stable(self, stable=True, dim=dim)
-    # k is 1-based
-    values = select(sorted_vals, dim, k - 1)
-    indices = select(sorted_idxs, dim, k - 1)
-    if keepdim:
-        values = unsqueeze(values, dim)
-        indices = unsqueeze(indices, dim)
-    return values, indices
 
 
 def register_pointwise_numeric(op, name=None, triton_fallback=None):
@@ -7981,7 +7456,6 @@ register_foreach_pointwise(aten._foreach_clamp_max.List, minimum)
 register_foreach_pointwise(aten._foreach_clamp_max.Scalar, minimum)
 register_foreach_pointwise(aten._foreach_reciprocal, reciprocal)
 register_foreach_pointwise(aten._foreach_sign, sign)
-register_foreach_pointwise(aten._foreach_clone, clone)
 foreach_copy = register_foreach_pointwise(aten._foreach_copy, copy)
 
 
@@ -8111,11 +7585,7 @@ for method, func in magic_methods.items():
 
 
 @register_lowering(torch.sym_sum)
-def sym_sum(*args):
-    # sym_sum can be called as sym_sum([a, b]) or sym_sum(a, b).
-    # Normalize to a flat list before summing.
-    if len(args) == 1 and isinstance(args[0], (list, tuple)):
-        args = args[0]
+def sym_sum(args):
     return sympy.Add(*args)
 
 
@@ -8176,6 +7646,9 @@ def resize(x, size, *, memory_format=None):
     dtype = x.get_dtype()
     device = x.get_device_or_error()
 
+    if isinstance(x.data, ir.BaseView):
+        x.data = x.data.unwrap_view()
+
     if (
         torch.are_deterministic_algorithms_enabled()
         and torch.utils.deterministic.fill_uninitialized_memory  # type: ignore[attr-defined]
@@ -8193,18 +7666,15 @@ def resize(x, size, *, memory_format=None):
     if V.graph.sizevars.statically_known_equals(old_numel, 0):  # type: ignore[arg-type]
         return full(size, uninitialized_val, dtype=dtype, device=device)
 
-    strides = x.maybe_get_stride()
-    has_overlapping = strides is not None and any(
-        V.graph.sizevars.statically_known_equals(s, 0) for s in strides
+    x_flat = as_strided(
+        x,
+        [
+            old_numel,
+        ],
+        [
+            1,
+        ],
     )
-    if has_overlapping:
-        # overlapping: provide a contiguous logical view
-        x_flat = view(x, [old_numel])
-    else:
-        # non-overlapping: keep storage order
-        if isinstance(x.data, ir.BaseView):
-            x.data = x.data.unwrap_view()
-        x_flat = as_strided(x, [old_numel], [1])
     flat_loader = x_flat.make_loader()
     out_stride = ir.FlexibleLayout.stride_ordered_for_memory_format(size, memory_format)
     out_indexer = ir.FixedLayout(device, dtype, size, out_stride).make_indexer()
@@ -8348,25 +7818,14 @@ def control_deps_op_lowering(additional_deps, subgraph_fn, *args):
     2. Execute the target operation normally
     3. Track the dependencies for the scheduler
     """
-    # Pair lowered deps with their original FX nodes so we can handle void ops
-    # (e.g. record_event) that lower to None but still create operations that
-    # subsequent control_deps nodes (e.g. wait_event) must be ordered after.
-    original_dep_nodes = V.graph.current_node.args[0]
-    assert isinstance(original_dep_nodes, tuple)
-
+    # Realize all additional dependencies
     dep_names = []
-    for dep, orig_node in zip(additional_deps, original_dep_nodes, strict=True):
-        dep_ir_nodes = [
-            dep_leaf
-            for dep_leaf in pytree.tree_leaves(dep)
-            if isinstance(dep_leaf, IRNode)
-        ]
-        for dep_ir_node in dep_ir_nodes:
-            dep_ir_node.realize()
-            dep_names.append(dep_ir_node.get_name())
-        if isinstance(orig_node, torch.fx.Node):
-            found = V.graph._void_ctrl_dep_op_names.get(orig_node, [])
-            dep_names.extend(found)
+    for dep in additional_deps:
+        if not isinstance(dep, IRNode):
+            continue
+
+        dep.realize()
+        dep_names.append(dep.get_name())
 
     original_args = V.graph.current_node.args
     arg_offset = 2  # first two args (additional_deps, subgraph)
@@ -8380,31 +7839,6 @@ def control_deps_op_lowering(additional_deps, subgraph_fn, *args):
 
     assert additional_deps
 
-    new_ops = V.graph.operations[operation_len:]
-
-    # Store buffer names of void ops (e.g. record_event has NoneLayout) so that
-    # subsequent control_deps nodes (e.g. wait_event) can depend on them even
-    # though void ops don't produce a usable tensor value.  We detect void ops
-    # by NoneLayout rather than checking `output is None`, because the overall
-    # control_deps output may be a passthrough tuple (not None) even when the
-    # subgraph contains a void op.
-    #
-    # Skip ops that are not themselves named buffers (op.name is None).  This
-    # excludes multi-output kernels like UserDefinedTritonKernel, whose buffer
-    # identity lives on their MutationOutput children rather than the op: the
-    # op is registered only as an Operation, and Buffer.get_name() asserts on
-    # the missing self.name.  Downstream ordering for those ops is already
-    # captured through the named MutationOutput buffers they produce.
-    void_names = [
-        op.get_name()
-        for op in new_ops
-        if isinstance(op, ir.Buffer)
-        and op.name is not None
-        and isinstance(op.layout, ir.NoneLayout)
-    ]
-    if void_names:
-        V.graph._void_ctrl_dep_op_names[V.graph.current_node] = void_names
-
     # some operators, like wait_tensor, just return their input,
     # so its more robust to add dep to the operation itself,
     # otherwise you can have a cycle of
@@ -8412,7 +7846,7 @@ def control_deps_op_lowering(additional_deps, subgraph_fn, *args):
     # b = control_deps(a, mm, ...)
     # c = control_deps(b, wait, ...)
     # if c == a, then you have a cycle.
-    for op in new_ops:
+    for op in V.graph.operations[operation_len:]:
         for dep_name in dep_names:
             op_name = op.operation_name
             assert op_name is not None
@@ -8550,7 +7984,7 @@ def with_effects(token, op, *args, **kwargs):
             # Patch has_side_effects to return True
             new_op.has_side_effects = lambda: True  # pyrefly: ignore[missing-attribute]
             if prev_effect_buffer:
-                op_name = new_op.get_name()  # pyrefly: ignore[missing-attribute]
+                op_name = new_op.get_operation_name()  # pyrefly: ignore[missing-attribute]
                 V.graph.additional_star_deps[op_name].add(prev_effect_buffer.get_name())
         # Update the effectful ops chain to point to the latest operation
         V.graph.effectful_ops[effect_type] = (
@@ -8695,43 +8129,6 @@ def cvt_e8m0_rceil_lowering(inp):
     return to_dtype(result, torch.uint8)
 
 
-@register_lowering(
-    torch._higher_order_ops.inline_asm_elementwise, type_promotion_kind=None
-)
-def lower_inline_asm_elementwise(
-    *inputs, asm_str, constraints, dtype, is_pure=True, pack=1
-):
-    inputs = broadcast_tensors(*inputs)
-
-    input_dtypes = tuple(inp.get_dtype() for inp in inputs)
-    loaders = [inp.make_loader() for inp in inputs]
-
-    def inner_fn(idx):
-        vals = tuple(loader(idx) for loader in loaders)
-        result = ops.inline_asm_elementwise(
-            *vals,
-            asm=asm_str,
-            constraints=constraints,
-            dtype=dtype,
-            is_pure=is_pure,
-            pack=pack,
-            input_dtypes=input_dtypes,
-        )
-        # Inductor computes in fp32 for bf16/fp16. Upcast so fused downstream
-        # ops (reductions, etc.) see fp32 values. The Pointwise's storage dtype
-        # handles the final downcast on store.
-        if dtype in (torch.float16, torch.bfloat16):
-            result = ops.to_dtype(result, torch.float32)
-        return result
-
-    return ir.Pointwise.create(
-        device=inputs[0].get_device(),
-        dtype=dtype,
-        inner_fn=inner_fn,
-        ranges=list(inputs[0].get_size()),
-    )
-
-
 # populate lowerings defined in kernel/*
 from . import kernel
 
@@ -8744,10 +8141,12 @@ from . import quantized_lowerings
 quantized_lowerings.register_quantized_ops()
 quantized_lowerings.register_woq_mm_ops()
 
-from . import (
-    jagged_lowerings,
-    mkldnn_lowerings,  # noqa: F401  # registers oneDNN fusion ops on import
-)
+from . import mkldnn_lowerings
+
+
+mkldnn_lowerings.register_onednn_fusion_ops()
+
+from . import jagged_lowerings
 
 
 jagged_lowerings.register_jagged_ops()

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -18,7 +18,7 @@ from .virtualized import V
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable
 
     from .dependencies import Dep
     from .scheduler import BaseSchedulerNode, SchedulerBuffer
@@ -432,54 +432,6 @@ def compute_memory_timeline(
     return buf_info_list, node_to_step, buf_to_snode_last_use
 
 
-def peak_memory_from_buf_info_list(
-    buf_info_list: list[BufferInfo], num_steps: int
-) -> tuple[int, list[int]]:
-    """Compute peak and per-step live memory from buffer lifetimes.
-
-    Skip the free for graph-output buffers (`end_step == -1`); otherwise
-    `delta[0] -= size_free` would cancel the alloc.
-    """
-    delta = [0] * (num_steps + 1)
-    for bi in buf_info_list:
-        delta[bi.start_step] += bi.size_alloc
-        if bi.end_step != -1:
-            delta[bi.end_step + 1] -= bi.size_free
-
-    max_memory = 0
-    cur_memory = 0
-    memories_at_nodes = [0] * (num_steps + 1)
-    for t in range(num_steps + 1):
-        cur_memory += delta[t]
-        memories_at_nodes[t] = cur_memory
-        if cur_memory > max_memory:
-            max_memory = cur_memory
-    return max_memory, memories_at_nodes
-
-
-def live_memory_before_steps_from_buf_info_list(
-    buf_info_list: list[BufferInfo], num_steps: int
-) -> list[int]:
-    """Compute live bytes before each scheduler step runs."""
-    delta = [0] * (num_steps + 1)
-    cur_memory = 0
-    for bi in buf_info_list:
-        if isinstance(bi.buffer, FreeableInputBuffer):
-            cur_memory += bi.size_alloc
-        else:
-            delta[bi.start_step + 1] += bi.size_alloc
-
-        if bi.end_step != -1:
-            delta[bi.end_step + 1] -= bi.size_free
-
-    live_before = [0] * (num_steps + 1)
-    live_before[0] = cur_memory
-    for t in range(1, num_steps + 1):
-        cur_memory += delta[t]
-        live_before[t] = cur_memory
-    return live_before
-
-
 def estimate_peak_memory(
     nodes: list[BaseSchedulerNode],
     name_to_freeable_input_buf: dict[str, FreeableInputBuffer],
@@ -493,66 +445,29 @@ def estimate_peak_memory(
         int: peak memory
         List[int]: memory usage at each node (or each step).
     """
+
     buf_info_list, _, _ = compute_memory_timeline(
         nodes, name_to_freeable_input_buf, graph_outputs
     )
-    return peak_memory_from_buf_info_list(buf_info_list, len(nodes))
 
+    # incremental memory changes at each step
+    memory = [0 for _ in range(len(nodes) + 1)]
 
-def estimate_region_peak_memory(
-    nodes_in_window: Iterable[BaseSchedulerNode],
-    *,
-    region_start: int,
-    region_end: int,
-    step_of: Callable[[BaseSchedulerNode], int],
-    graph_outputs: OrderedSet[str],
-    cur_memory: int = 0,
-) -> int:
-    """Peak memory inside `[region_start, region_end]` for the
-    hypothetical post-reorder schedule.
+    # for each buffer, update memory when created and when freed
+    for buf_info in buf_info_list:
+        memory[buf_info.start_step] += buf_info.size_alloc
+        memory[buf_info.end_step + 1] -= buf_info.size_free
 
-    Walks `nodes_in_window` (post-rewrite, in proposed order). For
-    each node: alloc = sum of `size_alloc` over its outputs; free =
-    sum of `size_free` over `pred_buffers` whose proposed last
-    consumer is this node. Then accumulates per step starting from
-    `cur_memory` (live bytes at the window boundary) and returns
-    the maximum live bytes.
-    """
-    R = region_end - region_start + 1
-    region = [SNodeMemory(0, 0) for _ in range(R)]
+    # get peak memory by compute the cumulative memories
+    max_memory = 0
+    cur_memory = 0
+    memories_at_nodes = []
+    for t in range(len(nodes) + 1):
+        cur_memory += memory[t]
+        memories_at_nodes.append(cur_memory)
+        max_memory = max(max_memory, cur_memory)
 
-    for node in nodes_in_window:
-        s = step_of(node)
-        slot = s - region_start
-        assert 0 <= slot < R
-
-        for buf in node.get_outputs():
-            bi = buf.mpi_buffer
-            region[slot].size_alloc += bi.size_alloc
-            name = buf.get_name()
-            if name in graph_outputs:
-                continue
-            succ_steps = [step_of(n) for n in bi.succ_nodes]
-            if not succ_steps:
-                region[slot].size_free += bi.size_free
-
-        for pb in node.mpi_node.pred_buffers:
-            name = pb.get_name()
-            if name in graph_outputs:
-                continue
-            succ_steps = [step_of(n) for n in pb.mpi_buffer.succ_nodes]
-            assert succ_steps
-            if max(succ_steps) == s:
-                region[slot].size_free += pb.mpi_buffer.size_free
-
-    cur = cur_memory
-    peak = cur
-    for af in region:
-        cur += af.size_alloc
-        if cur > peak:
-            peak = cur
-        cur -= af.size_free
-    return peak
+    return (max_memory, memories_at_nodes)
 
 
 @dataclasses.dataclass
@@ -995,6 +910,17 @@ def prepare_planning_info(
     return estimated_peak_memory, name_to_freeable_input_buf
 
 
+def _is_valid_topological_order(order: list[BaseSchedulerNode]) -> bool:
+    """Check that every node appears after all its predecessors."""
+    scheduled: OrderedSet[BaseSchedulerNode] = OrderedSet()
+    for node in order:
+        for pred in node.mpi_node.pred_nodes:
+            if pred not in scheduled:
+                return False
+        scheduled.add(node)
+    return True
+
+
 def reorder_for_peak_memory(
     nodes: list[BaseSchedulerNode],
     name_to_buf: dict[str, SchedulerBuffer],
@@ -1058,6 +984,12 @@ def reorder_for_peak_memory(
             else:
                 order = method(nodes)
             assert len(order) == len(nodes)
+            if not _is_valid_topological_order(order):
+                torch_log.info(
+                    "%s produced invalid topological order, skipping",
+                    method.__name__,
+                )
+                continue
             peak_memory, _ = estimate_peak_memory(
                 order, name_to_freeable_input_buf, graph_outputs
             )
@@ -1080,7 +1012,6 @@ def reorder_for_peak_memory(
 
     # get the optimal one
     best_result = min(peak_memory_diff_methods, key=lambda x: x.peak_memory)
-
     return best_result.order
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #183804
* #183803
* __->__ #183802
* #183801

Replace fork/join ops with node.meta["custom"]["stream"] metadata for
stream assignment, keeping record_event/wait_event for synchronization
and record_stream for CUDA allocator safety. Fix get_name() →
get_operation_name() bug in additional_star_deps. Add
_is_valid_topological_order() safety net for reorder_for_peak_memory.

Authored with Claude.