### PR TITLE
[docs] Document 10 public APIs in torch.nn.parallel submodules

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -680,23 +680,23 @@ coverage_ignore_functions = [
     # torch.nn.modules.rnn
     "apply_permutation",  # deprecated
     # torch.nn.parallel.comm
-    "broadcast",
-    "broadcast_coalesced",
-    "gather",
-    "reduce_add",
-    "reduce_add_coalesced",
-    "scatter",
+    # "broadcast",
+    # "broadcast_coalesced",
+    # "gather",
+    # "reduce_add",
+    # "reduce_add_coalesced",
+    # "scatter",
     # torch.nn.parallel.data_parallel
-    "data_parallel",
+    # "data_parallel",
     # torch.nn.parallel.parallel_apply
     "get_a_var",
-    "parallel_apply",
+    # "parallel_apply",
     # torch.nn.parallel.replicate
     "replicate",
     # torch.nn.parallel.scatter_gather
-    "gather",
+    # "gather",
     "is_namedtuple",
-    "scatter",
+    # "scatter",
     "scatter_kwargs",
     # torch.nn.utils.rnn
     "bind",  # looks unintentionally public

--- a/docs/source/nn.md
+++ b/docs/source/nn.md
@@ -402,6 +402,80 @@ Global Hooks For Module
     nn.parallel.DistributedDataParallel
 ```
 
+Functional API:
+
+```{eval-rst}
+.. automodule:: torch.nn.parallel.data_parallel
+```
+
+```{eval-rst}
+.. currentmodule:: torch.nn.parallel.data_parallel
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    data_parallel
+```
+
+```{eval-rst}
+.. automodule:: torch.nn.parallel.parallel_apply
+```
+
+```{eval-rst}
+.. currentmodule:: torch.nn.parallel.parallel_apply
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    parallel_apply
+```
+
+```{eval-rst}
+.. automodule:: torch.nn.parallel.scatter_gather
+```
+
+```{eval-rst}
+.. currentmodule:: torch.nn.parallel.scatter_gather
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    scatter
+    gather
+```
+
+Primitive collectives used internally by :class:`nn.DataParallel`:
+
+```{eval-rst}
+.. automodule:: torch.nn.parallel.comm
+```
+
+```{eval-rst}
+.. currentmodule:: torch.nn.parallel.comm
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    broadcast
+    broadcast_coalesced
+    reduce_add
+    reduce_add_coalesced
+    scatter
+    gather
+```
+
 ## Utilities
 
 ```{eval-rst}
@@ -654,11 +728,8 @@ floating point precision. PyTorch supports both per tensor and per channel asymm
 .. py:module:: torch.nn.modules.transformer
 .. py:module:: torch.nn.modules.upsampling
 .. py:module:: torch.nn.modules.utils
-.. py:module:: torch.nn.parallel.comm
 .. py:module:: torch.nn.parallel.distributed
-.. py:module:: torch.nn.parallel.parallel_apply
 .. py:module:: torch.nn.parallel.replicate
-.. py:module:: torch.nn.parallel.scatter_gather
 .. py:module:: torch.nn.parameter
 .. py:module:: torch.nn.utils.clip_grad
 .. py:module:: torch.nn.utils.convert_parameters


### PR DESCRIPTION
## Summary

Wires 10 previously undocumented public functions in `torch.nn.parallel.*` into the Sphinx doctree. The functions already had docstrings in source; only doc source files change.

| Module | Functions |
|---|---|
| `torch.nn.parallel.comm` | `broadcast`, `broadcast_coalesced`, `gather`, `reduce_add`, `reduce_add_coalesced`, `scatter` |
| `torch.nn.parallel.data_parallel` | `data_parallel` |
| `torch.nn.parallel.parallel_apply` | `parallel_apply` |
| `torch.nn.parallel.scatter_gather` | `gather`, `scatter` |

Deferred to follow-up PRs (no meaningful docstring yet): `get_a_var`, `replicate`, `is_namedtuple`, `scatter_kwargs`.

## Changes

- `docs/source/nn.md`: adds `automodule` + `currentmodule` + `autosummary` blocks for each of the four submodules under the existing "DataParallel Layers" section. Removes bare `.. py:module::` directives for `comm`, `parallel_apply`, and `scatter_gather` (replaced by proper `automodule` registrations).
- `docs/source/conf.py`: removes the 10 corresponding entries from `coverage_ignore_functions`.

## Test plan

- [ ] `pull / linux-docs` CI job passes (verifies `make coverage` finds 0 undocumented entries)
- [ ] `lint` CI job passes
