### PR TITLE
[AI Codemod][PerfAICT-VecRealloc] perf: call reserve() on vector to avoid unnecessary re-allocation (#183813)

### DIFF
--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -46,6 +46,7 @@ TypePtr ScriptTypeParser::subscriptToType(
       return TupleType::create({});
     }
     std::vector<TypePtr> subscript_expr_types;
+    subscript_expr_types.reserve(subscript.subscript_exprs().size());
     for (auto expr : subscript.subscript_exprs()) {
       subscript_expr_types.emplace_back(parseTypeFromExprImpl(expr));
     }


### PR DESCRIPTION
Summary:

This change was generated by pointing an AI agent at hot functions showing up in our internal profiles. It was then reviewed by a human:

This diff pre-allocates capacity for the vector `subscript_expr_types` in the Tuple branch of `ScriptTypeParser::subscriptToType` via `subscript_expr_types.reserve(subscript.subscript_exprs().size())`. The size is the exact number of subscript expressions, which equals the number of elements that will be emplaced into the vector. This avoids potential vector reallocations during the loop and matches the existing pattern already used in the Union branch of the same function.

Reviewed By: DenisYaroshevskiy

Differential Revision: D102276215


