### PR TITLE
[Inductor] Remove unused inductor_config alias to unbreak trunk lint

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -17,7 +17,7 @@ from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import Mod
 from torch.utils._triton import has_triton_stable_tma_api
 
-from .. import config, config as inductor_config
+from .. import config
 from ..kernel.bmm import bmm_template
 from ..kernel.mm import (
     blackwell_ws_persistent_device_tma_mm_template,


### PR DESCRIPTION
## Why

Trunk lint (`lintrunner-noclang-all / lint`) has been red since [`ffe4180`](https://github.com/pytorch/pytorch/commit/ffe4180ca9b2fbb9040b3476067e9e63a24b3966) (16:31 UTC 2026-05-14). The file imports both `config` and `config as inductor_config` on line 20, but `inductor_config` is never referenced anywhere else in the file (`config` is used 35+ times in the body). RUFF F401 fires on the unused alias.

P1 alerts: [pytorch/alerting-infra#4638](https://github.com/pytorch/alerting-infra/issues/4638) (auto-closed), [#4648](https://github.com/pytorch/alerting-infra/issues/4648) (currently open). AI auto-diagnostics investigation: [meta-pytorch/pytorch-gha-infra#1165](https://github.com/meta-pytorch/pytorch-gha-infra/issues/1165).

## Why re-file vs re-land #183468?

This is the same one-line fix as [#183468](https://github.com/pytorch/pytorch/pull/183468). That PR has been auto-reverted twice in a row by the internal codesync system because the originating internal diff (D104872670) is in a reverted state. The land/revert cycle has cost ~7 hours of red trunk so far:

- 2026-05-13 02:18 UTC — [`5eacd08`](https://github.com/pytorch/pytorch/commit/5eacd085c3823431f177575c27188ac2820bf610) lands
- 2026-05-14 16:31 UTC — [`ffe4180`](https://github.com/pytorch/pytorch/commit/ffe4180ca9b2fbb9040b3476067e9e63a24b3966) auto-reverts (facebook-github-tools, "Diff reverted internally")
- 2026-05-14 21:06 UTC — [`bf41234`](https://github.com/pytorch/pytorch/commit/bf412345f3398208851651f46f1d9967da458f29) re-lands
- 2026-05-14 21:29 UTC — [`f0df5b9`](https://github.com/pytorch/pytorch/commit/f0df5b9016349fa160255ae529597c1b5c099457) auto-reverts again

Filing from a fresh branch with no internal-diff coupling so the auto-revert trigger does not re-fire on this PR.

## Test plan

- [x] Same one-line change as the previously-landed-green #183468.
- [x] Verified locally that `inductor_config` is the unused symbol (only appears on line 20; `config` is used in 35+ body references).
- [ ] Lint CI on this PR should be green.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @PaulZhang12 @georgehong @malfet