### PR TITLE
migrate gram muon to pytorch (#183818)

### DIFF
--- a/test/optim/test_muon.py
+++ b/test/optim/test_muon.py
@@ -1,0 +1,611 @@
+# Owner(s): ["module: optimizer"]
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+from torch import Tensor
+from torch.optim import Muon
+from torch.optim._muon import DEFAULT_GRAM_NS_COEFFICIENTS
+from torch.testing._internal.common_utils import (
+    load_tests,
+    run_tests,
+    TestCase,
+)
+
+
+# load_tests from common_utils is used to automatically filter tests for
+# sharding on sandcastle. This line silences flake warnings
+load_tests = load_tests  # noqa: PLW0127
+
+
+class TestMuonStandardNS(TestCase):
+    """Tests for Muon with use_gram_newton_schulz=False (standard Newton-Schulz)."""
+
+    def test_basic_step(self) -> None:
+        torch.manual_seed(42)
+        param = torch.nn.Parameter(torch.randn(8, 4))
+        param.grad = torch.randn_like(param)
+
+        opt = Muon([param], use_gram_newton_schulz=False)
+        initial = param.clone()
+        opt.step()
+
+        self.assertFalse(torch.equal(param, initial))
+        self.assertTrue(param.isfinite().all())
+
+    def test_square_matrix(self) -> None:
+        torch.manual_seed(42)
+        param = torch.nn.Parameter(torch.randn(8, 8))
+        param.grad = torch.randn_like(param)
+
+        opt = Muon([param], use_gram_newton_schulz=False)
+        initial = param.clone()
+        opt.step()
+
+        self.assertFalse(torch.equal(param, initial))
+        self.assertTrue(param.isfinite().all())
+
+    def test_wide_matrix(self) -> None:
+        torch.manual_seed(42)
+        param = torch.nn.Parameter(torch.randn(4, 16))
+        param.grad = torch.randn_like(param)
+
+        opt = Muon([param], use_gram_newton_schulz=False)
+        initial = param.clone()
+        opt.step()
+
+        self.assertFalse(torch.equal(param, initial))
+        self.assertTrue(param.isfinite().all())
+
+    def test_multiple_steps(self) -> None:
+        torch.manual_seed(42)
+        param = torch.nn.Parameter(torch.randn(8, 4))
+
+        opt = Muon([param], use_gram_newton_schulz=False)
+        for _ in range(10):
+            param.grad = torch.randn_like(param)
+            opt.step()
+
+        self.assertTrue(param.isfinite().all())
+
+    def test_multiple_params(self) -> None:
+        torch.manual_seed(42)
+        p1 = torch.nn.Parameter(torch.randn(8, 4))
+        p2 = torch.nn.Parameter(torch.randn(4, 16))
+        p1.grad = torch.randn_like(p1)
+        p2.grad = torch.randn_like(p2)
+
+        opt = Muon([p1, p2], use_gram_newton_schulz=False)
+        opt.step()
+
+        self.assertTrue(p1.isfinite().all())
+        self.assertTrue(p2.isfinite().all())
+
+    def test_weight_decay(self) -> None:
+        """Weight decay should shrink parameters toward zero."""
+        torch.manual_seed(42)
+        param = torch.nn.Parameter(torch.ones(8, 4))
+        param.grad = torch.zeros_like(param)
+
+        # With lr=0 and zero grad, weight decay scale is (1 - 0 * wd) = 1.0
+        # so param should be unchanged.
+        opt = Muon([param], lr=0.0, weight_decay=0.1, use_gram_newton_schulz=False)
+        opt.step()
+        self.assertEqual(param, torch.ones(8, 4))
+
+        # With nonzero lr, weight decay should shrink params.
+        opt2 = Muon([param], lr=0.01, weight_decay=0.5, use_gram_newton_schulz=False)
+        param.grad = torch.zeros_like(param)
+        initial = param.clone()
+        opt2.step()
+        self.assertTrue((param.abs() <= initial.abs()).all())
+
+    def test_nesterov_toggle(self) -> None:
+        """nesterov=True vs False should produce different results."""
+        torch.manual_seed(42)
+        p1 = torch.nn.Parameter(torch.randn(8, 4))
+        p2 = torch.nn.Parameter(p1.clone().detach())
+
+        grad = torch.randn(8, 4)
+        p1.grad = grad.clone()
+        p2.grad = grad.clone()
+
+        opt1 = Muon([p1], nesterov=True, use_gram_newton_schulz=False)
+        opt2 = Muon([p2], nesterov=False, use_gram_newton_schulz=False)
+
+        # Need two steps for nesterov to diverge (first step momentum buf is zero).
+        opt1.step()
+        opt2.step()
+        p1.grad = torch.randn(8, 4)
+        p2.grad = p1.grad.clone()
+        opt1.step()
+        opt2.step()
+
+        self.assertFalse(torch.equal(p1, p2))
+
+
+class TestMuonVanillaRegression(TestCase):
+    """Frozen-value regression test: vanilla Muon (use_gram_newton_schulz=False)
+    must produce bit-identical output to the implementation that existed at the
+    parent of D104311008. Values were captured at that parent commit by running
+    the same setup against the pre-diff Muon. Do not regenerate these literals
+    without an explicit BC review — a mismatch means the supposedly bit-compatible
+    vanilla path has silently diverged.
+    """
+
+    # torch.manual_seed(42); p = nn.Parameter(torch.randn(8, 4));
+    # opt = Muon([p], lr=0.02, weight_decay=0.1, momentum=0.95, nesterov=True)
+    # for _ in range(5): p.grad = torch.randn_like(p); opt.step()
+    EXPECTED_PARAM_NESTEROV_TRUE: list[list[float]] = [
+        [1.938483476638794, 1.463821530342102, 0.8684228658676147, -2.107022762298584],
+        [0.6464439034461975, -1.2333816289901733, -0.05520281195640564, -1.594115972518921],
+        [-0.7017418742179871, 1.5892770290374756, -0.3630223572254181, -1.3906430006027222],
+        [-0.6950568556785583, -0.6230637431144714, -0.7075115442276001, 0.7674455046653748],
+        [1.6756398677825928, -0.14238590002059937, -0.4740765392780304, 0.41970568895339966],
+        [-0.75552898645401, 1.045496940612793, 0.8197356462478638, 1.681230068206787],
+        [1.2763956785202026, 1.2807981967926025, 0.6196531653404236, 1.2518298625946045],
+        [-0.20052097737789154, 0.02047128602862358, -0.25045672059059143, 0.7741371989250183],
+    ]
+
+    # Same setup but nesterov=False, weight_decay=0.0
+    EXPECTED_PARAM_NESTEROV_FALSE: list[list[float]] = [
+        [1.9527949094772339, 1.4754483699798584, 0.8651961088180542, -2.1447465419769287],
+        [0.6431010365486145, -1.2468913793563843, -0.0508497953414917, -1.615515112876892],
+        [-0.7089078426361084, 1.601587176322937, -0.370036244392395, -1.3938430547714233],
+        [-0.7046897411346436, -0.6338974237442017, -0.6964432597160339, 0.7840660214424133],
+        [1.7094919681549072, -0.1214023157954216, -0.4710087776184082, 0.4312562346458435],
+        [-0.7728015780448914, 1.0400207042694092, 0.8233118653297424, 1.6969393491744995],
+        [1.2878977060317993, 1.301850438117981, 0.6351599097251892, 1.2659329175949097],
+        [-0.2075868397951126, 0.010008741170167923, -0.25453078746795654, 0.7897554636001587],
+    ]
+
+    # The momentum buffer only depends on (grads, momentum), not nesterov, so
+    # both scenarios yield the same buf for the same seed.
+    EXPECTED_BUF: list[list[float]] = [
+        [-0.11098092794418335, 0.08274538069963455, 0.05440763011574745, 0.022694384679198265],
+        [0.06464089453220367, 0.04171084985136986, 0.05522793158888817, -0.024408867582678795],
+        [-0.10506078600883484, 0.16549666225910187, -0.036471910774707794, 0.048419296741485596],
+        [-0.11045779287815094, 0.2032998502254486, -0.13876627385616302, 0.06581886857748032],
+        [-0.14690940082073212, 0.005613995250314474, -0.0447036549448967, 0.0763719230890274],
+        [0.0020838298369199038, -0.01441915426403284, -0.09339231252670288, -0.025113143026828766],
+        [-0.0352008081972599, -0.03741401806473732, -0.16004668176174164, 0.17050980031490326],
+        [-0.09506358951330185, 0.007350748870521784, 0.01989450491964817, 0.16971878707408905],
+    ]
+
+    def _run_vanilla(
+        self, *, nesterov: bool, weight_decay: float
+    ) -> tuple[Tensor, Tensor]:
+        torch.manual_seed(42)
+        p = torch.nn.Parameter(torch.randn(8, 4))
+        opt = Muon(
+            [p],
+            lr=0.02,
+            weight_decay=weight_decay,
+            momentum=0.95,
+            nesterov=nesterov,
+            use_gram_newton_schulz=False,
+        )
+        for _ in range(5):
+            p.grad = torch.randn_like(p)
+            opt.step()
+        return p.detach().clone(), opt.state[p]["momentum_buffer"].clone()
+
+    def test_vanilla_nesterov_true_matches_pre_diff_baseline(self) -> None:
+        param, buf = self._run_vanilla(nesterov=True, weight_decay=0.1)
+        self.assertEqual(
+            param,
+            torch.tensor(self.EXPECTED_PARAM_NESTEROV_TRUE),
+            atol=0,
+            rtol=0,
+        )
+        self.assertEqual(buf, torch.tensor(self.EXPECTED_BUF), atol=0, rtol=0)
+
+    def test_vanilla_nesterov_false_matches_pre_diff_baseline(self) -> None:
+        param, buf = self._run_vanilla(nesterov=False, weight_decay=0.0)
+        self.assertEqual(
+            param,
+            torch.tensor(self.EXPECTED_PARAM_NESTEROV_FALSE),
+            atol=0,
+            rtol=0,
+        )
+        self.assertEqual(buf, torch.tensor(self.EXPECTED_BUF), atol=0, rtol=0)
+
+
+class TestMuonGramNS(TestCase):
+    """Tests for Muon with use_gram_newton_schulz=True (Gram Newton-Schulz)."""
+
+    def test_basic_step(self) -> None:
+        torch.manual_seed(42)
+        param = torch.nn.Parameter(torch.randn(8, 16))
+        param.grad = torch.randn_like(param)
+
+        opt = Muon([param], use_gram_newton_schulz=True)
+        initial = param.clone()
+        opt.step()
+
+        self.assertFalse(torch.equal(param, initial))
+        self.assertTrue(param.isfinite().all())
+
+    def test_tall_matrix(self) -> None:
+        torch.manual_seed(42)
+        param = torch.nn.Parameter(torch.randn(16, 4))
+        param.grad = torch.randn_like(param)
+
+        opt = Muon([param], use_gram_newton_schulz=True)
+        initial = param.clone()
+        opt.step()
+
+        self.assertFalse(torch.equal(param, initial))
+        self.assertTrue(param.isfinite().all())
+
+    def test_wide_matrix(self) -> None:
+        torch.manual_seed(42)
+        param = torch.nn.Parameter(torch.randn(4, 16))
+        param.grad = torch.randn_like(param)
+
+        opt = Muon([param], use_gram_newton_schulz=True)
+        initial = param.clone()
+        opt.step()
+
+        self.assertFalse(torch.equal(param, initial))
+        self.assertTrue(param.isfinite().all())
+
+    def test_square_matrix_falls_back_to_standard(self) -> None:
+        """Square matrix should automatically fall back to standard NS."""
+        torch.manual_seed(42)
+        param = torch.nn.Parameter(torch.randn(8, 8))
+        param.grad = torch.randn_like(param)
+
+        opt = Muon([param], use_gram_newton_schulz=True)
+        initial = param.clone()
+        opt.step()
+
+        self.assertFalse(torch.equal(param, initial))
+        self.assertTrue(param.isfinite().all())
+
+    def test_multiple_steps(self) -> None:
+        torch.manual_seed(42)
+        param = torch.nn.Parameter(torch.randn(8, 16))
+
+        opt = Muon([param], use_gram_newton_schulz=True)
+        for _ in range(10):
+            param.grad = torch.randn_like(param)
+            opt.step()
+
+        self.assertTrue(param.isfinite().all())
+
+    def test_multiple_params(self) -> None:
+        torch.manual_seed(42)
+        p1 = torch.nn.Parameter(torch.randn(8, 16))
+        p2 = torch.nn.Parameter(torch.randn(4, 32))
+        p1.grad = torch.randn_like(p1)
+        p2.grad = torch.randn_like(p2)
+
+        opt = Muon([p1, p2], use_gram_newton_schulz=True)
+        opt.step()
+
+        self.assertTrue(p1.isfinite().all())
+        self.assertTrue(p2.isfinite().all())
+
+    def test_default_is_vanilla(self) -> None:
+        """With use_gram_newton_schulz left at its default (False), the optimizer
+        should match the explicit-False configuration bit-for-bit."""
+        torch.manual_seed(42)
+        p_default = torch.nn.Parameter(torch.randn(8, 16))
+        p_explicit = torch.nn.Parameter(p_default.clone().detach())
+
+        grad = torch.randn(8, 16)
+        p_default.grad = grad.clone()
+        p_explicit.grad = grad.clone()
+
+        opt_default = Muon([p_default])
+        opt_explicit = Muon([p_explicit], use_gram_newton_schulz=False)
+        opt_default.step()
+        opt_explicit.step()
+
+        self.assertEqual(p_default, p_explicit)
+
+    def test_gram_vs_standard_differ(self) -> None:
+        """Gram NS and standard NS should produce different updates for rectangular matrices."""
+        torch.manual_seed(42)
+        p1 = torch.nn.Parameter(torch.randn(8, 16))
+        p2 = torch.nn.Parameter(p1.clone().detach())
+
+        grad = torch.randn(8, 16)
+        p1.grad = grad.clone()
+        p2.grad = grad.clone()
+
+        opt_gram = Muon([p1], use_gram_newton_schulz=True)
+        opt_std = Muon([p2], use_gram_newton_schulz=False)
+        opt_gram.step()
+        opt_std.step()
+
+        self.assertFalse(torch.equal(p1, p2))
+
+
+class TestMuonGramConfig(TestCase):
+    """Tests for the gram_newton_schulz_config dict parameter."""
+
+    def test_unknown_key_raises(self) -> None:
+        param = torch.nn.Parameter(torch.randn(8, 16))
+        with self.assertRaises(ValueError):
+            Muon(
+                [param],
+                use_gram_newton_schulz=True,
+                gram_newton_schulz_config={"bogus_key": 1},
+            )
+
+    def test_config_with_gram_disabled_raises(self) -> None:
+        """gram_newton_schulz_config requires use_gram_newton_schulz=True so
+        callers cannot accidentally configure CUDA graph (or other gram-only
+        knobs) on the vanilla path."""
+        param = torch.nn.Parameter(torch.randn(8, 16))
+        with self.assertRaises(ValueError):
+            Muon(
+                [param],
+                use_gram_newton_schulz=False,
+                gram_newton_schulz_config={"use_cuda_graph": True},
+            )
+        with self.assertRaises(ValueError):
+            Muon(
+                [param],
+                use_gram_newton_schulz=False,
+                gram_newton_schulz_config={},
+            )
+
+    def test_vanilla_default_does_not_use_cuda_graph(self) -> None:
+        """With use_gram_newton_schulz=False (default), the optimizer's stored
+        use_cuda_graph is False."""
+        param = torch.nn.Parameter(torch.randn(8, 16))
+        opt = Muon([param])
+        self.assertFalse(opt.param_groups[0]["use_cuda_graph"])
+        self.assertFalse(opt.param_groups[0]["use_gram_newton_schulz"])
+
+    def test_none_config_uses_defaults(self) -> None:
+        """None config should set gram defaults (vanilla Muon constants, [], False)."""
+        param = torch.nn.Parameter(torch.randn(8, 16))
+        opt = Muon([param], use_gram_newton_schulz=True)
+        group = opt.param_groups[0]
+        self.assertEqual(
+            group["gram_ns_coefficients"],
+            [list(c) for c in DEFAULT_GRAM_NS_COEFFICIENTS],
+        )
+        self.assertEqual(group["gram_ns_reset_iterations"], [])
+        self.assertFalse(group["use_cuda_graph"])
+
+    def test_partial_override(self) -> None:
+        """Setting only one key in the dict should leave others at defaults."""
+        param = torch.nn.Parameter(torch.randn(8, 16))
+        custom_coeffs = [[1.0, -1.0, 0.5], [2.0, -2.0, 1.0]]
+        opt = Muon(
+            [param],
+            use_gram_newton_schulz=True,
+            gram_newton_schulz_config={"gram_ns_coefficients": custom_coeffs},
+        )
+        group = opt.param_groups[0]
+        self.assertEqual(group["gram_ns_coefficients"], custom_coeffs)
+        self.assertEqual(group["gram_ns_reset_iterations"], [])
+        self.assertFalse(group["use_cuda_graph"])
+
+    def test_full_override(self) -> None:
+        param = torch.nn.Parameter(torch.randn(8, 16))
+        custom_coeffs = [[1.0, -1.0, 0.5]]
+        custom_resets = [0]
+        opt = Muon(
+            [param],
+            use_gram_newton_schulz=True,
+            gram_newton_schulz_config={
+                "gram_ns_coefficients": custom_coeffs,
+                "gram_ns_reset_iterations": custom_resets,
+                "use_cuda_graph": True,
+            },
+        )
+        group = opt.param_groups[0]
+        self.assertEqual(group["gram_ns_coefficients"], custom_coeffs)
+        self.assertEqual(group["gram_ns_reset_iterations"], custom_resets)
+        self.assertTrue(group["use_cuda_graph"])
+
+
+class TestMuonConvergence(TestCase):
+    """End-to-end functional test: Muon should drive loss down on a toy task."""
+
+    def _train_toy_regression(
+        self,
+        muon_kwargs: dict,
+        steps: int = 200,
+    ) -> tuple[float, float]:
+        """Train a 2-layer linear model on a learnable regression target.
+
+        The target is a fixed linear function of the input, so the model can
+        actually fit it. Returns (initial_loss, final_loss).
+        """
+        torch.manual_seed(0)
+        # Both weights are rectangular 2D, so the gram NS path actually runs.
+        linear1 = torch.nn.Linear(8, 16, bias=False)
+        linear2 = torch.nn.Linear(16, 4, bias=False)
+        params = list(linear1.parameters()) + list(linear2.parameters())
+
+        opt = Muon(params, lr=0.02, weight_decay=0.0, **muon_kwargs)
+
+        x = torch.randn(64, 8)
+        true_w1 = torch.randn(8, 16)
+        true_w2 = torch.randn(16, 4)
+        target = (x @ true_w1) @ true_w2
+
+        def forward_loss() -> Tensor:
+            y = linear2(linear1(x))
+            return ((y - target) ** 2).mean()
+
+        with torch.no_grad():
+            initial_loss = forward_loss().item()
+        for _ in range(steps):
+            opt.zero_grad()
+            loss = forward_loss()
+            loss.backward()
+            opt.step()
+        with torch.no_grad():
+            final_loss = forward_loss().item()
+        return initial_loss, final_loss
+
+    def test_gram_muon_reduces_loss(self) -> None:
+        """Loss should drop by at least 90% on a learnable regression target."""
+        initial, final = self._train_toy_regression({"use_gram_newton_schulz": True})
+        self.assertLess(
+            final,
+            initial * 0.1,
+            f"Gram Muon should reduce loss materially: "
+            f"initial={initial:.4f}, final={final:.4f}",
+        )
+
+    def test_vanilla_muon_reduces_loss(self) -> None:
+        """Sanity check: vanilla path also converges on the same task."""
+        initial, final = self._train_toy_regression({"use_gram_newton_schulz": False})
+        self.assertLess(
+            final,
+            initial * 0.1,
+            f"Vanilla Muon should reduce loss materially: "
+            f"initial={initial:.4f}, final={final:.4f}",
+        )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
+class TestMuonCudaGraph(TestCase):
+    """Tests for CUDA graph support in the Muon optimizer."""
+
+    def test_cuda_graph_matches_eager_gram_ns(self) -> None:
+        """CUDA graph Gram NS should produce the same result as eager Gram NS."""
+        torch.manual_seed(42)
+        p_eager = torch.nn.Parameter(torch.randn(8, 16, device="cuda"))
+        p_graph = torch.nn.Parameter(p_eager.clone().detach())
+
+        grad = torch.randn(8, 16, device="cuda")
+        p_eager.grad = grad.clone()
+        p_graph.grad = grad.clone()
+
+        opt_eager = Muon([p_eager], use_gram_newton_schulz=True)
+        opt_graph = Muon(
+            [p_graph],
+            use_gram_newton_schulz=True,
+            gram_newton_schulz_config={"use_cuda_graph": True},
+        )
+        opt_eager.step()
+        opt_graph.step()
+
+        self.assertEqual(p_eager, p_graph, atol=1e-5, rtol=0)
+
+    def test_cuda_graph_multiple_steps(self) -> None:
+        """CUDA graph should produce correct results across multiple steps."""
+        torch.manual_seed(42)
+        p_eager = torch.nn.Parameter(torch.randn(8, 16, device="cuda"))
+        p_graph = torch.nn.Parameter(p_eager.clone().detach())
+
+        opt_eager = Muon([p_eager], use_gram_newton_schulz=True)
+        opt_graph = Muon(
+            [p_graph],
+            use_gram_newton_schulz=True,
+            gram_newton_schulz_config={"use_cuda_graph": True},
+        )
+
+        for _ in range(5):
+            grad = torch.randn(8, 16, device="cuda")
+            p_eager.grad = grad.clone()
+            p_graph.grad = grad.clone()
+            opt_eager.step()
+            opt_graph.step()
+
+        self.assertEqual(p_eager, p_graph, atol=1e-4, rtol=0)
+
+    def test_cuda_graph_multiple_params_same_shape(self) -> None:
+        """Multiple params with same shape should correctly share the CUDA graph."""
+        torch.manual_seed(42)
+        p1_eager = torch.nn.Parameter(torch.randn(8, 16, device="cuda"))
+        p2_eager = torch.nn.Parameter(torch.randn(8, 16, device="cuda"))
+        p1_graph = torch.nn.Parameter(p1_eager.clone().detach())
+        p2_graph = torch.nn.Parameter(p2_eager.clone().detach())
+
+        g1 = torch.randn(8, 16, device="cuda")
+        g2 = torch.randn(8, 16, device="cuda")
+        p1_eager.grad = g1.clone()
+        p2_eager.grad = g2.clone()
+        p1_graph.grad = g1.clone()
+        p2_graph.grad = g2.clone()
+
+        opt_eager = Muon([p1_eager, p2_eager], use_gram_newton_schulz=True)
+        opt_graph = Muon(
+            [p1_graph, p2_graph],
+            use_gram_newton_schulz=True,
+            gram_newton_schulz_config={"use_cuda_graph": True},
+        )
+        opt_eager.step()
+        opt_graph.step()
+
+        self.assertEqual(p1_eager, p1_graph, atol=1e-5, rtol=0)
+        self.assertEqual(p2_eager, p2_graph, atol=1e-5, rtol=0)
+
+    def test_cuda_graph_different_configs_same_shape(self) -> None:
+        """Same-shape params in different groups with different configs should
+        use separate CUDA graphs and produce correct results."""
+        torch.manual_seed(42)
+        p1_eager = torch.nn.Parameter(torch.randn(8, 16, device="cuda"))
+        p1_graph = torch.nn.Parameter(p1_eager.clone().detach())
+        p2_eager = torch.nn.Parameter(torch.randn(8, 16, device="cuda"))
+        p2_graph = torch.nn.Parameter(p2_eager.clone().detach())
+
+        g1 = torch.randn(8, 16, device="cuda")
+        g2 = torch.randn(8, 16, device="cuda")
+        p1_eager.grad = g1.clone()
+        p2_eager.grad = g2.clone()
+        p1_graph.grad = g1.clone()
+        p2_graph.grad = g2.clone()
+
+        # Top-level use_gram_newton_schulz=True is required so that
+        # gram_newton_schulz_config is accepted; the second param group still
+        # overrides it back to False.
+        opt_eager = Muon(
+            [
+                {"params": [p1_eager], "use_gram_newton_schulz": True},
+                {"params": [p2_eager], "use_gram_newton_schulz": False},
+            ],
+            use_gram_newton_schulz=True,
+        )
+        opt_graph = Muon(
+            [
+                {"params": [p1_graph], "use_gram_newton_schulz": True},
+                {"params": [p2_graph], "use_gram_newton_schulz": False},
+            ],
+            use_gram_newton_schulz=True,
+            gram_newton_schulz_config={"use_cuda_graph": True},
+        )
+        opt_eager.step()
+        opt_graph.step()
+
+        self.assertEqual(p1_eager, p1_graph, atol=1e-5, rtol=0)
+        self.assertEqual(p2_eager, p2_graph, atol=1e-5, rtol=0)
+        self.assertFalse(torch.equal(p1_graph, p2_graph))
+
+    def test_cuda_graph_tall_matrix(self) -> None:
+        """CUDA graph should work correctly for tall matrices."""
+        torch.manual_seed(42)
+        p_eager = torch.nn.Parameter(torch.randn(32, 8, device="cuda"))
+        p_graph = torch.nn.Parameter(p_eager.clone().detach())
+
+        grad = torch.randn(32, 8, device="cuda")
+        p_eager.grad = grad.clone()
+        p_graph.grad = grad.clone()
+
+        opt_eager = Muon([p_eager], use_gram_newton_schulz=True)
+        opt_graph = Muon(
+            [p_graph],
+            use_gram_newton_schulz=True,
+            gram_newton_schulz_config={"use_cuda_graph": True},
+        )
+        opt_eager.step()
+        opt_graph.step()
+
+        self.assertEqual(p_eager, p_graph, atol=1e-5, rtol=0)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -1,9 +1,18 @@
 # mypy: allow-untyped-defs
 # mypy: disable-error-code=arg-type
-"""Implementation of the Muon optimizer."""
+"""Implementation of the Muon optimizer with optional Gram Newton-Schulz support.
+
+By default this optimizer is API-compatible with prior versions of
+torch.optim.Muon and uses the standard Newton-Schulz orthogonalization. Set
+use_gram_newton_schulz=True to opt into the Gram Newton-Schulz path for
+rectangular matrices (with automatic fallback to standard NS for square
+matrices). Pass a GramNewtonSchulzConfig TypedDict via gram_newton_schulz_config
+to override gram-specific settings.
+"""
 
 import math
-from collections.abc import MutableMapping
+from collections.abc import Callable, MutableMapping
+from typing import Any, TypedDict
 
 import torch
 from torch import Tensor
@@ -17,19 +26,162 @@ from .optimizer import (
 )
 
 
-__all__ = ["Muon"]
+__all__ = ["GramNewtonSchulzConfig", "Muon"]
+
+
+class GramNewtonSchulzConfig(TypedDict, total=False):
+    """Schema for the gram_newton_schulz_config dict consumed by Muon.
+
+    All keys are optional; missing keys fall back to module-level defaults
+    (see DEFAULT_GRAM_NS_COEFFICIENTS, DEFAULT_GRAM_NS_RESET_ITERATIONS).
+    """
+
+    gram_ns_coefficients: list[list[float]]
+    gram_ns_reset_iterations: list[int]
+    use_cuda_graph: bool
+
 
 # Constants from Keller Jordan's Muon post: https://kellerjordan.github.io/posts/muon/
 # github permlink: https://github.com/KellerJordan/Muon/blob/f90a42b28e00b8d9d2d05865fe90d9f39abcbcbd/muon.py#L16
-EPS = 1e-7
-DEFAULT_A = 3.4445
-DEFAULT_B = -4.7750
-DEFAULT_C = 2.0315
-DEFAULT_NS_STEPS = 5
+EPS: float = 1e-7
+DEFAULT_A: float = 3.4445
+DEFAULT_B: float = -4.7750
+DEFAULT_C: float = 2.0315
+DEFAULT_NS_STEPS: int = 5
+DEFAULT_GRAM_NS_RESET_ITERATIONS: list[int] = []
+# Default per-iteration (a, b, c) for Gram NS: same constants as vanilla Muon
+# repeated for every NS step. Schedules like YOU_COEFFICIENTS can be opted into
+# via gram_newton_schulz_config["gram_ns_coefficients"], but they typically
+# require a non-empty gram_ns_reset_iterations (e.g. [2]) to stay numerically
+# stable. Keeping the default identical to vanilla Muon makes Gram NS a drop-in
+# replacement that does not depend on a reset schedule.
+DEFAULT_GRAM_NS_COEFFICIENTS: list[list[float]] = [
+    [DEFAULT_A, DEFAULT_B, DEFAULT_C] for _ in range(DEFAULT_NS_STEPS)
+]
+
+# Valid keys in gram_newton_schulz_config, derived from the TypedDict schema.
+_GRAM_CONFIG_KEYS: frozenset[str] = frozenset(GramNewtonSchulzConfig.__annotations__)
+
+
+def _gram_newton_schulz(
+    X: Tensor,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+) -> Tensor:
+    """Gram Newton-Schulz orthogonalization.
+
+    Works in the Gram space (R = X @ X^T), accumulating Q and applying X = Q @ X
+    once at the end. More efficient for rectangular matrices where M << N or M >> N.
+
+    X must be a 2D matrix.
+    """
+    R = X @ X.T
+
+    I = torch.eye(R.size(0), device=X.device, dtype=X.dtype)  # noqa: E741
+    Q: Tensor = I
+
+    reset_iterations = gram_ns_reset_iterations
+
+    for i, (a, b, c) in enumerate(gram_ns_coefficients):
+        if i in reset_iterations and i != 0:
+            X = Q @ X
+            R = X @ X.T
+            Q = I
+
+        Z = torch.addmm(R, R, R, beta=b, alpha=c)
+        if i == 0 or i in reset_iterations:
+            Q = Z + a * I
+        else:
+            Q = torch.addmm(Q, Q, Z, beta=a)
+        if i < len(gram_ns_coefficients) - 1 and i + 1 not in reset_iterations:
+            RZ = torch.addmm(R, R, Z, beta=a)
+            R = torch.addmm(RZ, Z, RZ, beta=a)
+
+    X = Q @ X
+
+    return X
+
+
+def _gram_newton_schulz_batched(
+    X: Tensor,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+) -> Tensor:
+    """Batched Gram Newton-Schulz orthogonalization.
+
+    X must be a 3D tensor of shape (batch, M, N) where M <= N.
+    Processes all matrices in the batch simultaneously using batched matmuls.
+    """
+    R = X @ X.mT  # (batch, M, M)
+
+    batch_size = R.size(0)
+    I = (  # noqa: E741
+        torch.eye(R.size(-1), device=X.device, dtype=X.dtype)
+        .unsqueeze(0)
+        .expand(batch_size, -1, -1)
+        .contiguous()
+    )
+    Q: Tensor = I
+
+    reset_iterations = gram_ns_reset_iterations
+
+    for i, (a, b, c) in enumerate(gram_ns_coefficients):
+        if i in reset_iterations and i != 0:
+            X = Q @ X
+            R = X @ X.mT
+            Q = I
+
+        Z = torch.baddbmm(R, R, R, beta=b, alpha=c)
+        if i == 0 or i in reset_iterations:
+            Q = Z + a * I
+        else:
+            Q = torch.baddbmm(Q, Q, Z, beta=a)
+        if i < len(gram_ns_coefficients) - 1 and i + 1 not in reset_iterations:
+            RZ = torch.baddbmm(R, R, Z, beta=a)
+            R = torch.baddbmm(RZ, Z, RZ, beta=a)
+
+    X = Q @ X
+
+    return X
+
+
+def _zeropower_via_gram_newtonschulz_batched(
+    grads: list[Tensor],
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+    eps: float,
+) -> list[Tensor]:
+    """Batched Gram NS orthogonalization for a list of same-shape 2D gradients.
+
+    Stacks gradients into a 3D batch, runs batched Gram NS, then unstacks.
+    """
+    # Check if transposing is needed (all same shape, so check first)
+    should_transpose = grads[0].size(0) > grads[0].size(1)
+
+    # Stack into (batch, M, N)
+    X = torch.stack([g.float() for g in grads])  # (batch, M, N)
+
+    if should_transpose:
+        X = X.mT  # (batch, N, M) -> now rows <= cols
+
+    # Normalize each matrix in the batch
+    norms = X.norm(dim=(-2, -1), keepdim=True)  # (batch, 1, 1)
+    X = X / (norms + eps)
+    X = X.half()
+
+    X = _gram_newton_schulz_batched(X, gram_ns_coefficients, gram_ns_reset_iterations)
+
+    if should_transpose:
+        X = X.mT
+
+    return list(X.unbind(0))
 
 
 def _zeropower_via_newtonschulz(
-    grad: Tensor, ns_coefficients: tuple[float, float, float], ns_steps: int, eps: float
+    grad: Tensor,
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
 ) -> Tensor:
     """
     Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
@@ -70,6 +222,41 @@ def _zeropower_via_newtonschulz(
     return ortho_grad
 
 
+def _zeropower_via_gram_newtonschulz(
+    grad: Tensor,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+) -> Tensor:
+    """Orthogonalize a gradient matrix using Gram Newton-Schulz iteration.
+
+    Uses the Gram NS method for rectangular matrices and falls back to
+    standard NS for square matrices.
+    """
+    if len(grad.shape) != 2:
+        raise ValueError("Input tensor gradient must be a 2D matrix")
+
+    X = grad.float()
+
+    if should_transpose := (X.size(0) > X.size(1)):
+        X = X.T
+
+    X /= X.norm() + eps
+    X = X.half()
+
+    if X.size(0) == X.size(1):
+        return _zeropower_via_newtonschulz(grad, ns_coefficients, ns_steps, eps)
+
+    X = _gram_newton_schulz(X, gram_ns_coefficients, gram_ns_reset_iterations)
+
+    if should_transpose:
+        X = X.T
+
+    return X
+
+
 def _adjust_lr(lr: float, adjust_lr_fn: str | None, param_shape: torch.Size) -> float:
     """Default learning rate adjustment used by Muon."""
     A, B = param_shape[:2]
@@ -84,6 +271,31 @@ def _adjust_lr(lr: float, adjust_lr_fn: str | None, param_shape: torch.Size) -> 
     return lr * adjusted_ratio
 
 
+def _parse_gram_newton_schulz_config(
+    gram_newton_schulz_config: GramNewtonSchulzConfig | None,
+) -> tuple[list[list[float]], list[int], bool]:
+    """Validate and unpack a gram_newton_schulz_config dict.
+
+    Returns (gram_ns_coefficients, gram_ns_reset_iterations, use_cuda_graph),
+    filling in defaults for missing keys. None or {} yields all defaults.
+    """
+    cfg = gram_newton_schulz_config or {}
+    unknown = set(cfg) - _GRAM_CONFIG_KEYS
+    if unknown:
+        raise ValueError(
+            f"Unknown keys in gram_newton_schulz_config: {sorted(unknown)}. "
+            f"Supported keys: {sorted(_GRAM_CONFIG_KEYS)}"
+        )
+    gram_ns_coefficients = cfg.get("gram_ns_coefficients")
+    if gram_ns_coefficients is None:
+        gram_ns_coefficients = [list(c) for c in DEFAULT_GRAM_NS_COEFFICIENTS]
+    gram_ns_reset_iterations = cfg.get("gram_ns_reset_iterations")
+    if gram_ns_reset_iterations is None:
+        gram_ns_reset_iterations = list(DEFAULT_GRAM_NS_RESET_ITERATIONS)
+    use_cuda_graph = bool(cfg.get("use_cuda_graph", False))
+    return gram_ns_coefficients, gram_ns_reset_iterations, use_cuda_graph
+
+
 class Muon(Optimizer):
     def __init__(
         self,
@@ -92,10 +304,16 @@ class Muon(Optimizer):
         weight_decay: float = 0.1,
         momentum: float = 0.95,
         nesterov: bool = True,
-        ns_coefficients: tuple[float, float, float] = (DEFAULT_A, DEFAULT_B, DEFAULT_C),
+        ns_coefficients: tuple[float, float, float] = (
+            DEFAULT_A,
+            DEFAULT_B,
+            DEFAULT_C,
+        ),
         eps: float = EPS,
         ns_steps: int = DEFAULT_NS_STEPS,
         adjust_lr_fn: str | None = None,
+        use_gram_newton_schulz: bool = False,
+        gram_newton_schulz_config: GramNewtonSchulzConfig | None = None,
     ) -> None:
         if isinstance(lr, Tensor) and lr.numel() != 1:
             raise ValueError("Tensor lr must be 1-element")
@@ -113,6 +331,22 @@ class Muon(Optimizer):
                 f"Adjust learning rate function {adjust_lr_fn} is not supported"
             )
 
+        if not use_gram_newton_schulz and gram_newton_schulz_config is not None:
+            # When gram NS is disabled, the optimizer is bit-compatible with the
+            # vanilla pytorch path - no gram-specific knobs (including CUDA graph)
+            # apply. Reject the dict so callers can't silently configure a
+            # setting that has no effect.
+            raise ValueError(
+                "gram_newton_schulz_config is only valid when "
+                "use_gram_newton_schulz=True; got "
+                f"gram_newton_schulz_config={gram_newton_schulz_config!r} "
+                "with use_gram_newton_schulz=False."
+            )
+
+        gram_ns_coefficients, gram_ns_reset_iterations, use_cuda_graph = (
+            _parse_gram_newton_schulz_config(gram_newton_schulz_config)
+        )
+
         defaults = {
             "lr": lr,
             "weight_decay": weight_decay,
@@ -122,6 +356,10 @@ class Muon(Optimizer):
             "eps": eps,
             "ns_steps": ns_steps,
             "adjust_lr_fn": adjust_lr_fn,
+            "use_gram_newton_schulz": use_gram_newton_schulz,
+            "gram_ns_coefficients": gram_ns_coefficients,
+            "gram_ns_reset_iterations": gram_ns_reset_iterations,
+            "use_cuda_graph": use_cuda_graph,
         }
         super().__init__(params, defaults)
 
@@ -131,6 +369,13 @@ class Muon(Optimizer):
                     raise ValueError(
                         f"Muon only supports 2D parameters whereas we found a parameter with size: {p.size()}"
                     )
+
+        # CUDA graph cache: keyed by NS config, stores
+        # (graph, static_input_bufs, static_output_bufs).
+        self._cuda_graph_cache: dict[
+            tuple[Any, ...],
+            tuple[torch.cuda.CUDAGraph, list[Tensor], list[Tensor]],
+        ] = {}
 
     def _init_group(
         self,
@@ -162,7 +407,7 @@ class Muon(Optimizer):
         return False  # has_complex
 
     @torch.no_grad()
-    def step(self, closure=None):
+    def step(self, closure: Callable | None = None) -> float | None:
         """Performs a single optimization step."""
         loss = None
         if closure is not None:
@@ -170,10 +415,6 @@ class Muon(Optimizer):
                 loss = closure()
 
         for group in self.param_groups:
-            lr = group["lr"]
-            weight_decay = group["weight_decay"]
-            momentum = group["momentum"]
-
             params_with_grad: list[Tensor] = []
             grads: list[Tensor] = []
             muon_momentum_bufs: list[Tensor] = []
@@ -189,15 +430,20 @@ class Muon(Optimizer):
                 params_with_grad,
                 grads,
                 muon_momentum_bufs,
-                lr=lr,
-                weight_decay=weight_decay,
-                momentum=momentum,
+                lr=group["lr"],
+                weight_decay=group["weight_decay"],
+                momentum=group["momentum"],
                 nesterov=group["nesterov"],
                 ns_coefficients=group["ns_coefficients"],
-                eps=group["eps"],
                 ns_steps=group["ns_steps"],
+                eps=group["eps"],
                 adjust_lr_fn=group["adjust_lr_fn"],
                 has_complex=has_complex,
+                use_gram_newton_schulz=group["use_gram_newton_schulz"],
+                gram_ns_coefficients=group["gram_ns_coefficients"],
+                gram_ns_reset_iterations=group["gram_ns_reset_iterations"],
+                use_cuda_graph=group["use_cuda_graph"],
+                cuda_graph_cache=self._cuda_graph_cache,
             )
         return loss
 
@@ -254,6 +500,14 @@ Muon.__doc__ = (
     implementation, and "match_rms_adamw", which refers to Moonshot's implementation. This gives users the
     flexibility to choose between the two. If `adjust_lr_fn` is not specified, the default is "original".
 
+    Setting ``use_gram_newton_schulz=True`` selects an alternate orthogonalization
+    path that computes the Newton-Schulz iteration in Gram space (R = X @ X^T)
+    for rectangular matrices, with automatic fallback to the standard iteration
+    on square matrices. The Gram path also fuses momentum and parameter updates
+    across same-shape 2D parameters via ``torch._foreach_*`` ops, and can
+    optionally capture each shape group's NS computation into a CUDA graph for
+    replay on subsequent steps.
+
     For further details regarding the algorithm we refer to `Muon: An optimizer for hidden layers in neural networks`_
     and `Muon is Scalable for LLM Training`_.
     """
@@ -272,6 +526,26 @@ Muon.__doc__ = (
         ns_steps (int, optional): number of Newton–Schulz iteration steps. (default: {DEFAULT_NS_STEPS})
         adjust_lr_fn (str, optional): function to adjust learning rate. One of "original" and "match_rms_adamw".
             If not specified, we will default to use "original". (default: None)
+        use_gram_newton_schulz (bool, optional): if True, use the Gram Newton-Schulz
+            iteration for orthogonalization on rectangular matrices, with automatic
+            fallback to standard Newton-Schulz on square matrices. The Gram path
+            also fuses the per-step momentum and parameter updates across
+            same-shape 2D params via ``torch._foreach_*`` ops, and may optionally
+            capture the orthogonalization kernels into a CUDA graph. (default: False)
+        gram_newton_schulz_config (dict, optional): configuration dict for the
+            Gram Newton-Schulz path. Only valid when ``use_gram_newton_schulz=True``;
+            passing it with the flag off raises ``ValueError``. Supported keys
+            (all optional, with defaults applied per key):
+
+            - ``"gram_ns_coefficients"`` (list[list[float]]): per-iteration
+              ``(a, b, c)`` triples; one inner list per NS step.
+            - ``"gram_ns_reset_iterations"`` (list[int]): iteration indices at
+              which to materialize ``X`` from the accumulated ``Q`` and reset
+              ``Q`` to identity.
+            - ``"use_cuda_graph"`` (bool): if True, capture each per-shape NS
+              computation into a CUDA graph and replay on subsequent steps.
+
+            (default: None)
 
     Example:
         >>> # xdoctest: +SKIP
@@ -303,6 +577,181 @@ Muon.__doc__ = (
 
     """
 )
+
+
+def _ns_cudagraph(
+    inputs: list[Tensor],
+    compute_fn: Callable[[list[Tensor]], list[Tensor]],
+    cache_key: tuple[Any, ...],
+    cuda_graph_cache: dict[
+        tuple[Any, ...],
+        tuple[torch.cuda.CUDAGraph, list[Tensor], list[Tensor]],
+    ],
+) -> list[Tensor]:
+    """Run an NS-style computation with CUDA graph capture/replay.
+
+    Wraps an arbitrary `compute_fn` (which must be safe to call inside a
+    CUDA graph capture region and must return a list of newly-allocated
+    tensors) with cache lookup, static-buffer allocation, warmup, capture,
+    and replay. Returns clones of the static output buffers so callers may
+    safely retain the results across subsequent calls.
+    """
+    if cache_key not in cuda_graph_cache:
+        # Static input buffers - the exact tensors captured by the graph.
+        static_inputs = [t.clone() for t in inputs]
+        # Warmup is required before capture.
+        compute_fn(static_inputs)
+        torch.cuda.synchronize()
+
+        # Capture: static_inputs are read, static_outputs are written.
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            static_outputs = compute_fn(static_inputs)
+        cuda_graph_cache[cache_key] = (graph, static_inputs, static_outputs)
+
+    graph, static_inputs, static_outputs = cuda_graph_cache[cache_key]
+    # Copy new data into the static input buffers the graph reads from.
+    for si, t in zip(static_inputs, inputs):
+        si.copy_(t)
+    graph.replay()
+    return [so.clone() for so in static_outputs]
+
+
+def _ns_eager(
+    inputs: list[Tensor],
+    *,
+    is_square: bool,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+) -> list[Tensor]:
+    """Eager (non-CUDA-graph) NS dispatch for a same-shape group of tensors.
+
+    Routes based on shape:
+    - Square shapes: standard NS per tensor.
+    - Rectangular, len > 1: batched gram NS.
+    - Rectangular, len == 1: single gram NS.
+    """
+    if is_square:
+        return [
+            _zeropower_via_newtonschulz(t, ns_coefficients, ns_steps, eps)
+            for t in inputs
+        ]
+    if len(inputs) == 1:
+        return [
+            _zeropower_via_gram_newtonschulz(
+                inputs[0],
+                gram_ns_coefficients,
+                gram_ns_reset_iterations,
+                ns_coefficients,
+                ns_steps,
+                eps,
+            )
+        ]
+    return _zeropower_via_gram_newtonschulz_batched(
+        inputs,
+        gram_ns_coefficients,
+        gram_ns_reset_iterations,
+        eps,
+    )
+
+
+def _dispatch_ns_group(
+    inputs: list[Tensor],
+    *,
+    use_cuda_graph: bool,
+    cuda_graph_cache: dict[
+        tuple[Any, ...],
+        tuple[torch.cuda.CUDAGraph, list[Tensor], list[Tensor]],
+    ]
+    | None,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+) -> list[Tensor]:
+    """Dispatch one same-shape group through CUDA graph or eager.
+
+    Square groups fall back to standard NS individually and are not worth
+    graph capture, so they always run eager. Rectangular groups use CUDA
+    graph when enabled.
+    """
+    is_square: bool = inputs[0].size(0) == inputs[0].size(1)
+
+    def _compute(buffers: list[Tensor]) -> list[Tensor]:
+        return _ns_eager(
+            buffers,
+            is_square=is_square,
+            gram_ns_coefficients=gram_ns_coefficients,
+            gram_ns_reset_iterations=gram_ns_reset_iterations,
+            ns_coefficients=ns_coefficients,
+            ns_steps=ns_steps,
+            eps=eps,
+        )
+
+    graph_eligible = use_cuda_graph and cuda_graph_cache is not None and not is_square
+    if not graph_eligible:
+        return _compute(inputs)
+
+    cache_key = (
+        len(inputs),
+        tuple(inputs[0].shape),
+        inputs[0].device,
+        inputs[0].dtype,
+        tuple(tuple(c) for c in gram_ns_coefficients),
+        tuple(gram_ns_reset_iterations),
+        ns_coefficients,
+        ns_steps,
+        eps,
+    )
+    assert cuda_graph_cache is not None  # narrowed by graph_eligible check
+    return _ns_cudagraph(inputs, _compute, cache_key, cuda_graph_cache)
+
+
+def _run_ns(
+    updates: list[Tensor],
+    *,
+    use_cuda_graph: bool,
+    cuda_graph_cache: dict[
+        tuple[Any, ...],
+        tuple[torch.cuda.CUDAGraph, list[Tensor], list[Tensor]],
+    ]
+    | None,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+) -> list[Tensor]:
+    """Top-level NS dispatcher.
+
+    Groups updates by shape so same-shape rectangular tensors can be batched
+    through Gram NS. Each group is routed through _dispatch_ns_group.
+    """
+    shape_groups: dict[tuple[int, int], list[int]] = {}
+    for i, update in enumerate(updates):
+        shape_groups.setdefault((update.size(0), update.size(1)), []).append(i)
+    index_groups = list(shape_groups.values())
+
+    results = list(updates)
+    for indices in index_groups:
+        group_inputs = [updates[idx] for idx in indices]
+        group_results = _dispatch_ns_group(
+            group_inputs,
+            use_cuda_graph=use_cuda_graph,
+            cuda_graph_cache=cuda_graph_cache,
+            gram_ns_coefficients=gram_ns_coefficients,
+            gram_ns_reset_iterations=gram_ns_reset_iterations,
+            ns_coefficients=ns_coefficients,
+            ns_steps=ns_steps,
+            eps=eps,
+        )
+        for idx, r in zip(indices, group_results):
+            results[idx] = r
+    return results
 
 
 def _single_tensor_muon(
@@ -341,6 +790,89 @@ def _single_tensor_muon(
         param.add_(update, alpha=-adjusted_lr)
 
 
+def _gram_muon_impl(
+    params: list[Tensor],
+    grads: list[Tensor],
+    muon_momentum_bufs: list[Tensor],
+    *,
+    lr: float,
+    weight_decay: float,
+    momentum: float,
+    nesterov: bool,
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+    adjust_lr_fn: str | None,
+    has_complex: bool,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+    use_cuda_graph: bool,
+    cuda_graph_cache: dict[
+        tuple[Any, ...],
+        tuple[torch.cuda.CUDAGraph, list[Tensor], list[Tensor]],
+    ]
+    | None,
+) -> None:
+    """Gram NS Muon implementation.
+
+    Multi-tensor (foreach) variant of muon: Phase 1 fuses momentum updates
+    across all params with torch._foreach_lerp_, Phase 2 groups by shape and
+    runs the Gram NS orthogonalizer per group (optionally captured into a
+    CUDA graph; square shapes fall back to standard NS per tensor), and
+    Phase 3 fuses the parameter update with torch._foreach_mul_ for the
+    uniform weight-decay scale and one torch._foreach_add_ per shape group
+    for the shape-specific adjusted learning rate.
+    """
+    lr = _to_scalar(lr)
+    if has_complex:
+        raise ValueError("Complex parameters are not supported")
+
+    if not params:
+        return
+
+    for g in grads:
+        if g.ndim != 2:
+            raise ValueError("Param gradient must be a 2D matrix")
+
+    # Phase 1: foreach momentum-applied updates.
+    # buf <- lerp(buf, grad, 1 - momentum) for every param in one fused call.
+    torch._foreach_lerp_(muon_momentum_bufs, grads, 1 - momentum)
+    if nesterov:
+        # update = lerp(grad, buf, momentum); returns a fresh list of tensors.
+        updates = list(torch._foreach_lerp(grads, muon_momentum_bufs, momentum))
+    else:
+        updates = list(muon_momentum_bufs)
+
+    # Phase 2: shape-grouped (and optionally graph-captured) NS dispatch.
+    updates = _run_ns(
+        updates,
+        use_cuda_graph=use_cuda_graph,
+        cuda_graph_cache=cuda_graph_cache,
+        gram_ns_coefficients=gram_ns_coefficients,
+        gram_ns_reset_iterations=gram_ns_reset_iterations,
+        ns_coefficients=ns_coefficients,
+        ns_steps=ns_steps,
+        eps=eps,
+    )
+
+    # Phase 3: foreach parameter update. Weight-decay scale (1 - lr*wd) is
+    # uniform across params so it fuses across the whole list. The
+    # learning-rate add uses shape-specific alpha (via _adjust_lr) so we
+    # group params by shape and issue one foreach_add per shape group.
+    torch._foreach_mul_(params, 1 - lr * weight_decay)
+
+    shape_groups: dict[tuple[int, int], list[int]] = {}
+    for i, p in enumerate(params):
+        shape_groups.setdefault((p.size(0), p.size(1)), []).append(i)
+    for indices in shape_groups.values():
+        adjusted_lr = _adjust_lr(lr, adjust_lr_fn, params[indices[0]].shape)
+        torch._foreach_add_(
+            [params[i] for i in indices],
+            [updates[i] for i in indices],
+            alpha=-adjusted_lr,
+        )
+
+
 @_disable_dynamo_if_unsupported(single_tensor_fn=_single_tensor_muon)
 def muon(
     params: list[Tensor],
@@ -357,17 +889,47 @@ def muon(
     eps: float,
     adjust_lr_fn: str | None,
     has_complex: bool,
+    use_gram_newton_schulz: bool = False,
+    gram_ns_coefficients: list[list[float]],
+    gram_ns_reset_iterations: list[int],
+    use_cuda_graph: bool = False,
+    cuda_graph_cache: dict[
+        tuple[Any, ...],
+        tuple[torch.cuda.CUDAGraph, list[Tensor], list[Tensor]],
+    ]
+    | None = None,
 ) -> None:
     r"""Functional API that performs Muon algorithm computation.
+
+    Dispatches to the vanilla pytorch path (`_single_tensor_muon`) when
+    `use_gram_newton_schulz=False` and to the gram path (`_gram_muon_impl`)
+    when True. `gram_ns_coefficients` and `gram_ns_reset_iterations` are
+    required and only consulted on the gram path; pre-validated values come
+    from `_parse_gram_newton_schulz_config` (called in `Muon.__init__`).
 
     See :class:`~torch.optim.Muon` for details.
     """
     if foreach is not None and foreach:
         raise RuntimeError("Foreach is not supported for Muon yet")
 
-    func = _single_tensor_muon
+    if not use_gram_newton_schulz:
+        _single_tensor_muon(
+            params,
+            grads,
+            muon_momentum_bufs,
+            lr=lr,
+            weight_decay=weight_decay,
+            momentum=momentum,
+            nesterov=nesterov,
+            ns_coefficients=ns_coefficients,
+            ns_steps=ns_steps,
+            eps=eps,
+            adjust_lr_fn=adjust_lr_fn,
+            has_complex=has_complex,
+        )
+        return
 
-    func(
+    _gram_muon_impl(
         params,
         grads,
         muon_momentum_bufs,
@@ -380,4 +942,8 @@ def muon(
         eps=eps,
         adjust_lr_fn=adjust_lr_fn,
         has_complex=has_complex,
+        gram_ns_coefficients=gram_ns_coefficients,
+        gram_ns_reset_iterations=gram_ns_reset_iterations,
+        use_cuda_graph=use_cuda_graph,
+        cuda_graph_cache=cuda_graph_cache,
     )


### PR DESCRIPTION
Summary:

## Context

migrate Gram Muon support to Pytorch lib. 

The Gram Muon algorithm is from https://github.com/Dao-AILab/gram-newton-schulz/tree/main. from our tests, it achieve same NE as vanilla muon but better speed (up to 2x). 

Besides, we added some more optimization like cuda graph and batch support which is very usefully to reduce kernel overhead for many same-shape weights in the model.

## What this diff does

Adds an opt-in Gram Newton-Schulz path to `torch.optim.Muon` while leaving the default behavior unchanged.

- New `use_gram_newton_schulz: bool = False` constructor flag selects the alternate path. With the default `False`, dispatch in `muon()` early-returns into the existing `_single_tensor_muon` with the same kwargs as before — the optimizer is bit-compatible with prior `torch.optim.Muon`.
- New `gram_newton_schulz_config: GramNewtonSchulzConfig | None = None` carries gram-only knobs: per-iteration `(a, b, c)` coefficients, `gram_ns_reset_iterations`, and `use_cuda_graph`. `_parse_gram_newton_schulz_config` validates keys against the `TypedDict` schema and rejects the dict when the flag is off so callers cannot configure CUDA graph on the vanilla path silently.
- `_gram_muon_impl` is the multi-tensor implementation. **Phase 1** fuses momentum updates across all params via `torch._foreach_lerp_`, **Phase 2** groups params by shape and runs the gram orthogonalizer per group (`_gram_newton_schulz`, `_gram_newton_schulz_batched`, with auto-fallback to standard NS for square matrices), and **Phase 3** fuses the parameter update via `torch._foreach_mul_` for the uniform weight-decay scale plus one `torch._foreach_add_` per shape group for the shape-specific adjusted learning rate.
- Optional CUDA graph capture (`gram_newton_schulz_config={"use_cuda_graph": True}`) caches per-shape NS computations on `Muon._cuda_graph_cache` keyed by shape, dtype, device, coefficients, and reset iterations. Square shapes always run eager.

Test Plan:
## Test target

```
buck test fbcode//caffe2/test:optim -- TestMuon
```

Both `fbcode/caffe2/test/optim/test_muon.py` and `xplat/caffe2/test/optim/test_muon.py` are added (kept in sync). The `glob(["optim/*.py"])` in `caffe2/test/BUCK` auto-registers the new file — no `TARGETS` edit required.

## Test classes

| Class | Coverage |
|---|---|
| `TestMuonStandardNS` | Vanilla path on rectangular/square/multi-param shapes, weight decay, nesterov toggle. |
| `TestMuonGramNS` | Gram path on rectangular shapes, square-fallback, multi-step, multi-param. Includes `test_default_is_vanilla` (default kwargs match explicit `use_gram_newton_schulz=False`) and `test_gram_vs_standard_differ` (paths produce different updates for rectangular params). |
| `TestMuonGramConfig` | Validates dict schema: unknown keys rejected, dict-with-flag-off rejected, partial overrides preserve defaults, full overrides respected. |
| `TestMuonConvergence` | End-to-end convergence on a learnable 2-layer linear regression target — both gram and vanilla paths must drop loss by **>= 90%** in 200 steps. |
| `TestMuonCudaGraph` | Eager-vs-graph parity (single param, multi-param same shape, mixed-config groups, tall matrix), multi-step graph correctness. Skipped when CUDA is unavailable. |
| **`TestMuonVanillaRegression`** | **Frozen-value bit-compatibility lock.** Captured at the parent of D104311008 and asserts `atol=0, rtol=0` against the new dispatch wrapper. |

## How the regression baseline was captured

1. `sl goto b39ef94f02^` — hop to parent commit.
2. Wrote a temporary `test_muon_baseline_capture.py` that constructs a fixed-seed `Muon([nn.Parameter(torch.randn(8, 4))], lr=0.02, momentum=0.95, ...)`, runs 5 steps with `torch.randn_like(p)` grads, and dumps `param.tolist()` + `state["momentum_buffer"].tolist()` to JSON for two scenarios (`nesterov=True, weight_decay=0.1` and `nesterov=False, weight_decay=0.0`).
3. Ran `buck test fbcode//caffe2/test:optim -- TestMuonBaselineCapture` to execute the capture against the pre-diff vanilla `Muon`.
4. Read the JSON, removed the temp file, `sl goto b39ef94f02` back to the diff commit.
5. Embedded the captured float32 literals as class constants on `TestMuonVanillaRegression` and replayed the same setup with `use_gram_newton_schulz=False`.

## Result

```
buck test fbcode//caffe2/test:optim -- TestMuonVanillaRegression
Tests finished: Pass 2. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
```

Both `test_vanilla_nesterov_true_matches_pre_diff_baseline` and `test_vanilla_nesterov_false_matches_pre_diff_baseline` pass with `atol=0, rtol=0`, confirming the new dispatch wrapper preserves vanilla behavior bit-for-bit on CPU.

## Lint

```
arc lint -a fbcode/caffe2/test/optim/test_muon.py xplat/caffe2/test/optim/test_muon.py
ok No lint issues.
```

Differential Revision: D104311008


