### PR TITLE
[MPS] Validate one_hot index bounds to raise instead of silently returning zeros

### DIFF
--- a/aten/src/ATen/native/Onehot.cpp
+++ b/aten/src/ATen/native/Onehot.cpp
@@ -1,6 +1,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
 #include <ATen/DTensorState.h>
+#include <ATen/native/Onehot.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -14,6 +15,9 @@
 #endif
 
 namespace at::native {
+
+DEFINE_DISPATCH(one_hot_check_bounds_stub);
+REGISTER_NO_CPU_DISPATCH(one_hot_check_bounds_stub)
 
 Tensor one_hot(const Tensor &self, int64_t num_classes) {
     TORCH_CHECK(self.dtype() == kLong, "one_hot is only applicable to index tensor of type LongTensor.");
@@ -62,6 +66,13 @@ Tensor one_hot(const Tensor &self, int64_t num_classes) {
             //for cuda, assert that num_classes is at least 1
             TORCH_CHECK(num_classes >= 1, "num_classes should be positive");
         }
+    }
+
+    // MPS scatter has no device-side index assert, so route through an async
+    // device-side check that surfaces the same errors as CPU and CUDA without
+    // a .item() sync.
+    if (self.device().is_mps()) {
+        one_hot_check_bounds_stub(self.device().type(), self, num_classes);
     }
 
     shape.emplace_back(num_classes);

--- a/aten/src/ATen/native/Onehot.h
+++ b/aten/src/ATen/native/Onehot.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <ATen/native/DispatchStub.h>
+
+namespace at::native {
+
+using one_hot_check_bounds_fn = void(*)(const Tensor&, int64_t);
+DECLARE_DISPATCH(one_hot_check_bounds_fn, one_hot_check_bounds_stub)
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -1025,3 +1025,17 @@ REGISTER_NONZERO_KERNELS(uchar);
 REGISTER_NONZERO_KERNELS(bool);
 REGISTER_NONZERO_KERNELS(float2);
 REGISTER_NONZERO_KERNELS(half2);
+
+kernel void one_hot_check_bounds(
+    constant long* indices [[buffer(0)]],
+    constant long& num_classes [[buffer(1)]],
+    device ErrorMessages* error_buffer [[buffer(2)]],
+    uint tid [[thread_position_in_grid]]) {
+  const long idx = indices[tid];
+  if (idx < 0) {
+    TORCH_REPORT_ERROR(error_buffer, "Class values must be non-negative.");
+  } else if (idx >= num_classes) {
+    TORCH_REPORT_ERROR(
+        error_buffer, "Class values must be smaller than num_classes.");
+  }
+}

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -16,6 +16,7 @@
 #include <ATen/native/IndexKernel.h>
 #include <ATen/native/IndexingUtils.h>
 #include <ATen/native/LinearAlgebraUtils.h>
+#include <ATen/native/Onehot.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorAdvancedIndexing.h>
 #include <c10/util/SmallVector.h>
@@ -1159,7 +1160,30 @@ static void index_fill_mps_kernel(TensorIterator& iter,
   }
 }
 
+static void one_hot_check_bounds_mps(const Tensor& self, int64_t num_classes) {
+  if (self.numel() == 0) {
+    return;
+  }
+  using namespace mps;
+
+  // The kernel reads the raw index buffer in storage order; require
+  // contiguous so a thread-id maps to one element with no stride math.
+  Tensor self_c = self.contiguous();
+  const auto numel = self_c.numel();
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto encoder = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc("one_hot_check_bounds");
+      [encoder setComputePipelineState:pso];
+      mtl_setArgs(encoder, self_c, num_classes, stream->getErrorBuffer());
+      mtl_dispatch1DJob(encoder, pso, numel);
+    }
+  });
+}
+
 REGISTER_DISPATCH(index_stub, &mps::index_kernel_mps)
 REGISTER_DISPATCH(index_fill_stub, &index_fill_mps_kernel)
 REGISTER_DISPATCH(index_put_stub, &mps::index_put_kernel_mps)
+REGISTER_DISPATCH(one_hot_check_bounds_stub, &one_hot_check_bounds_mps)
 } // namespace at::native

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7819,6 +7819,26 @@ class TestMPS(TestCaseMPS):
         helper()
         helper(do_add=False)
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/170507:
+    # MPS one_hot used to silently return zeros for out-of-bounds indices.
+    # The check is async, so we force a sync to surface the error.
+    def test_one_hot_index_bounds(self):
+        with self.assertRaisesRegex(RuntimeError, "Class values must be smaller than num_classes"):
+            torch.nn.functional.one_hot(torch.tensor([8], device='mps'), num_classes=8)
+            torch.mps.synchronize()
+
+        with self.assertRaisesRegex(RuntimeError, "Class values must be non-negative"):
+            torch.nn.functional.one_hot(torch.tensor([-1], device='mps'), num_classes=8)
+            torch.mps.synchronize()
+
+        valid = torch.tensor([3, 4, 1, 0], device='mps')
+        expected = torch.nn.functional.one_hot(valid.cpu(), num_classes=5)
+        self.assertEqual(torch.nn.functional.one_hot(valid, num_classes=5), expected.to('mps'))
+
+        inferred = torch.nn.functional.one_hot(valid)
+        self.assertEqual(inferred.size(-1), 5)
+        self.assertEqual(inferred, expected.to('mps'))
+
     # Test pytorch scatter_reduce
     def test_scatter_reduce(self):
         def helper(shape, dim, idx_shape, src_shape, idx_dtype=torch.int64, reduce_str="sum"):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10147,8 +10147,8 @@ class TestNNDeviceType(NNTestCase):
         _test_module_empty_input(self, mod, inp)
 
     def test_one_hot(self, device):
-        # cuda throws device assert for invalid data
-        # xla & mps ignore out of bound indices
+        # cuda and mps surface invalid indices via an async device-side assert;
+        # xla ignores them. Only cpu raises synchronously here.
         if self.device_type == 'cpu':
             with self.assertRaises(RuntimeError):
                 torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)


### PR DESCRIPTION
## Summary
- A small Metal kernel walks the index buffer on-device and reports out-of-range / negative indices via `TORCH_REPORT_ERROR`, which `MPSStream::checkLastError` surfaces as a `RuntimeError` on the next sync. No `.item()` CPU sync. Same propagation model as the existing `index_select` / `index_put` / `embedding_bag` validation kernels and CUDA's scatter device-side assert.
- Wiring uses the standard `DispatchStub` pattern: `one_hot_check_bounds_stub` is declared in `Onehot.h`, defined in `Onehot.cpp` with `REGISTER_NO_CPU_DISPATCH` so the CPU side has no behavior change, and registered for MPS in `Indexing.mm`. `Onehot.cpp` invokes the stub only when the input is on MPS; CPU and CUDA paths are untouched.

Fixes #170507.

## Test plan
- [x] `python test/test_mps.py -v -k test_one_hot_index_bounds` (new regression test, passes; uses `torch.mps.synchronize()` to surface the async error inside `assertRaisesRegex`)
- [x] `python test/test_mps.py -v -k one_hot` (new test + existing OpInfo consistency test, both pass)
- [x] `python test/test_nn.py -v -k one_hot` (CPU and MPS variants of `test_one_hot` and `test_cross_entropy_loss_one_hot_target` all pass)
- [x] `spin quicklint` clean (clang-format autofix applied to wrap one long `TORCH_REPORT_ERROR` line)

## Notes
The Metal kernel reads the index buffer in storage order, so the host wrapper calls `.contiguous()` first (the `unsqueezed` view passed to `scatter_` later is contiguous regardless). CUDA and XPU paths are unchanged.
