### PR TITLE
[Stable C Shim] Use error message retrieval shim if available at runtime

### DIFF
--- a/test/cpp_extensions/libtorch_agn_2_10_extension/csrc/my_stable_error_check.cpp
+++ b/test/cpp_extensions/libtorch_agn_2_10_extension/csrc/my_stable_error_check.cpp
@@ -1,0 +1,44 @@
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/csrc/stable/macros.h>
+#include <torch/csrc/inductor/aoti_torch/generated/c_shim_aten.h>
+
+using torch::stable::Tensor;
+
+// torch::stable::subtract using STABLE_TORCH_ERROR_CODE_CHECK (detailed error
+// message via the stable ABI) instead of TORCH_ERROR_CODE_CHECK (simple message).
+//
+// This lives in the 2.10 extension on purpose: built at a target older than 2.13,
+// STABLE_TORCH_ERROR_CODE_CHECK reaches torch_exception_get_what* through a
+// runtime symbol lookup (TORCH_DYNAMIC_VERSION_CALL), so it exercises the dynamic
+// version call path. Built at 2.13+ the same op takes the direct-call shortcut.
+inline torch::stable::Tensor our_subtract_stable_error_check(
+    const torch::stable::Tensor& self,
+    const torch::stable::Tensor& other,
+    double alpha = 1.0) {
+  AtenTensorHandle ret0;
+  STABLE_TORCH_ERROR_CODE_CHECK(
+      aoti_torch_aten_subtract_Tensor(self.get(), other.get(), alpha, &ret0));
+  return torch::stable::Tensor(ret0);
+}
+
+// Same op but with the less detailed TORCH_ERROR_CODE_CHECK, for comparison.
+inline torch::stable::Tensor our_subtract_torch_error_check(
+    const torch::stable::Tensor& self,
+    const torch::stable::Tensor& other,
+    double alpha = 1.0) {
+  AtenTensorHandle ret0;
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_aten_subtract_Tensor(self.get(), other.get(), alpha, &ret0));
+  return torch::stable::Tensor(ret0);
+}
+
+STABLE_TORCH_LIBRARY_FRAGMENT(STABLE_LIB_NAME, m) {
+  m.def("our_subtract_stable_error_check(Tensor self, Tensor other, float alpha=1.0) -> Tensor");
+  m.def("our_subtract_torch_error_check(Tensor self, Tensor other, float alpha=1.0) -> Tensor");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(STABLE_LIB_NAME, CompositeExplicitAutograd, m) {
+  m.impl("our_subtract_stable_error_check", TORCH_BOX(&our_subtract_stable_error_check));
+  m.impl("our_subtract_torch_error_check", TORCH_BOX(&our_subtract_torch_error_check));
+}

--- a/test/cpp_extensions/libtorch_agn_2_13_extension/csrc/my_exception_what.cpp
+++ b/test/cpp_extensions/libtorch_agn_2_13_extension/csrc/my_exception_what.cpp
@@ -1,36 +1,13 @@
 #include <torch/csrc/stable/library.h>
-#include <torch/csrc/stable/device.h>
-#include <torch/csrc/stable/tensor.h>
 #include <torch/csrc/stable/macros.h>
-#include <torch/csrc/inductor/aoti_torch/generated/c_shim_aten.h>
 
 #include <string>
 
-using torch::stable::Tensor;
-
-/// torch::stable::subtract with STABLE_TORCH_ERROR_CODE_CHECK instead of TORCH_ERROR_CODE_CHECK
-inline torch::stable::Tensor our_subtract_stable_error_check(
-    const torch::stable::Tensor& self,
-    const torch::stable::Tensor& other,
-    double alpha = 1.0) {
-  AtenTensorHandle ret0;
-  STABLE_TORCH_ERROR_CODE_CHECK(
-      aoti_torch_aten_subtract_Tensor(self.get(), other.get(), alpha, &ret0));
-  return torch::stable::Tensor(ret0);
-}
-
-/// Similar to the function above, but with the less detailed TORCH_ERROR_CODE_CHECK
-inline torch::stable::Tensor our_subtract_torch_error_check(
-    const torch::stable::Tensor& self,
-    const torch::stable::Tensor& other,
-    double alpha = 1.0) {
-  AtenTensorHandle ret0;
-  TORCH_ERROR_CODE_CHECK(
-      aoti_torch_aten_subtract_Tensor(self.get(), other.get(), alpha, &ret0));
-  return torch::stable::Tensor(ret0);
-}
-
-
+// Direct calls to the 2.13 exception getter shims. Unlike
+// our_subtract_stable_error_check (in the 2.10 extension, which reaches these
+// shims dynamically via TORCH_DYNAMIC_VERSION_CALL when built at an older
+// target), these call the shims directly and so can only live in the 2.13
+// extension.
 std::string my_exception_what() {
   return std::string(torch_exception_get_what());
 }
@@ -39,16 +16,11 @@ std::string my_exception_get_what_without_backtrace() {
 }
 
 STABLE_TORCH_LIBRARY_FRAGMENT(STABLE_LIB_NAME, m) {
-  m.def("our_subtract_stable_error_check(Tensor self, Tensor other, float alpha=1.0) -> Tensor");
-  m.def("our_subtract_torch_error_check(Tensor self, Tensor other, float alpha=1.0) -> Tensor");
   m.def("my_exception_what() -> str");
   m.def("my_exception_get_what_without_backtrace() -> str");
-
 }
 
 STABLE_TORCH_LIBRARY_IMPL(STABLE_LIB_NAME, CompositeExplicitAutograd, m) {
-  m.impl("our_subtract_stable_error_check", TORCH_BOX(&our_subtract_stable_error_check));
-  m.impl("our_subtract_torch_error_check", TORCH_BOX(&our_subtract_torch_error_check));
   m.impl("my_exception_what", TORCH_BOX(&my_exception_what));
   m.impl("my_exception_get_what_without_backtrace", TORCH_BOX(&my_exception_get_what_without_backtrace));
 }

--- a/test/cpp_extensions/libtorch_agn_2_13_extension/csrc/my_exception_what.cpp
+++ b/test/cpp_extensions/libtorch_agn_2_13_extension/csrc/my_exception_what.cpp
@@ -3,11 +3,10 @@
 
 #include <string>
 
-// Direct calls to the 2.13 exception getter shims. Unlike
+// Direct calls to the 2.13 exception getter shims. Also tested in
 // our_subtract_stable_error_check (in the 2.10 extension, which reaches these
 // shims dynamically via TORCH_DYNAMIC_VERSION_CALL when built at an older
-// target), these call the shims directly and so can only live in the 2.13
-// extension.
+// target).
 std::string my_exception_what() {
   return std::string(torch_exception_get_what());
 }

--- a/test/cpp_extensions/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/test_libtorch_agnostic.py
@@ -2093,8 +2093,18 @@ except RuntimeError as e:
             "^The size of tensor a \\(\\d\\) must match the size of "
             "tensor b \\(\\d\\) at non-singleton dimension \\d.*"
         )
-        # Verify that an operation using STABLE_TORCH_ERROR_CHECK provides detailed errors.
-        self.assertRaisesRegex(RuntimeError, expect_re, make_exception_stable)
+        # Verify that an operation using STABLE_TORCH_ERROR_CODE_CHECK provides the
+        # detailed error AND wraps it with the "(originally from ...)" annotation
+        # naming the failing shim call and its source location.
+        with self.assertRaises(RuntimeError) as cm:
+            make_exception_stable()
+        stable_msg = str(cm.exception)
+        self.assertRegex(stable_msg, expect_re)
+        self.assertRegex(
+            stable_msg,
+            r" \(originally from aoti_torch_aten_subtract_Tensor\(.*\) "
+            r"API call failed at .*my_stable_error_check\.cpp, line \d+\)$",
+        )
 
         # Retrieve the exception message directly.
         self.assertEqual(
@@ -2146,12 +2156,21 @@ except RuntimeError as e:
             self.assertRaisesRegex(RuntimeError, simple_re, make_exception_stable)
         else:
             # Runtime has the shim: the dynamic lookup succeeds and we get the
-            # detailed error retrieved across the C ABI boundary.
+            # detailed error retrieved across the C ABI boundary, wrapped with the
+            # "(originally from ...)" annotation naming the failing shim call.
             detailed_re = (
                 "^The size of tensor a \\(\\d\\) must match the size of "
                 "tensor b \\(\\d\\) at non-singleton dimension \\d.*"
             )
-            self.assertRaisesRegex(RuntimeError, detailed_re, make_exception_stable)
+            with self.assertRaises(RuntimeError) as cm:
+                make_exception_stable()
+            stable_msg = str(cm.exception)
+            self.assertRegex(stable_msg, detailed_re)
+            self.assertRegex(
+                stable_msg,
+                r" \(originally from aoti_torch_aten_subtract_Tensor\(.*\) "
+                r"API call failed at .*my_stable_error_check\.cpp, line \d+\)$",
+            )
 
 
 instantiate_device_type_tests(TestLibtorchAgnostic, globals(), except_for=None)

--- a/test/cpp_extensions/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/test_libtorch_agnostic.py
@@ -2108,6 +2108,51 @@ except RuntimeError as e:
             with_backtrace.count("\n") > 10
         )  # Conservative, backtrace is 25 lines.
 
+    @skipIfTorchVersionLessThan(2, 10)
+    def test_dynamic_version_call_error_message(self, device):
+        """Exercise the dynamic version call (dlsym) path.
+
+        our_subtract_stable_error_check lives in the 2.10 extension, which
+        targets 2.10 -- older than the 2.13 torch_exception_get_what* shims that
+        STABLE_TORCH_ERROR_CODE_CHECK relies on. It therefore reaches them via
+        TORCH_DYNAMIC_VERSION_CALL (a runtime symbol lookup). When the running
+        libtorch is >= 2.13 the lookup succeeds and we get the detailed message;
+        against an older runtime it falls back to the simple call-site message.
+        """
+        import libtorch_agn_2_10 as libtorch_agnostic
+
+        # Mismatched shapes so the subtract errors.
+        a = torch.randn(3, 4, device=device)
+        b = torch.randn(1, 2, device=device)
+        self.assertRaises(RuntimeError, lambda: torch.subtract(a, b))
+
+        # The non-stable check always yields the simple call-site message.
+        simple_re = (
+            "aoti_torch_aten_subtract_Tensor\\(self.get\\(\\), other.get\\(\\), alpha, &ret0\\)"
+            " API call failed at .+?, line \\d+$"
+        )
+        self.assertRaisesRegex(
+            RuntimeError,
+            simple_re,
+            lambda: libtorch_agnostic.ops.our_subtract_torch_error_check(a, b),
+        )
+
+        def make_exception_stable():
+            libtorch_agnostic.ops.our_subtract_stable_error_check(a, b)
+
+        if _torchVersionLessThan(2, 13):
+            # Runtime predates the shim: dlsym returns null, so we fall back to
+            # the same simple call-site message as the non-stable check.
+            self.assertRaisesRegex(RuntimeError, simple_re, make_exception_stable)
+        else:
+            # Runtime has the shim: the dynamic lookup succeeds and we get the
+            # detailed error retrieved across the C ABI boundary.
+            detailed_re = (
+                "^The size of tensor a \\(\\d\\) must match the size of "
+                "tensor b \\(\\d\\) at non-singleton dimension \\d.*"
+            )
+            self.assertRaisesRegex(RuntimeError, detailed_re, make_exception_stable)
+
 
 instantiate_device_type_tests(TestLibtorchAgnostic, globals(), except_for=None)
 

--- a/tools/linter/adapters/_stable_shim_utils.py
+++ b/tools/linter/adapters/_stable_shim_utils.py
@@ -155,7 +155,7 @@ MULTILINE_MATCHERS = [
 
 
 def dynamic_call_parser(buffer: str, current_version: tuple[int, int, int] | None):
-    pattern = r"TORCH_DYNAMIC_VERSION_CALL_(\d+)_(\d+)_(\d+)\(([^,]*),([^\)]*)\)"
+    pattern = r"TORCH_DYNAMIC_VERSION_CALL_(\d+)_(\d+)_(\d+)\(([^,]+),([^,\)]+)"
     buffer_without_space = buffer.replace(" ", "").replace("\n", "")
     res = re.findall(pattern, buffer_without_space)
     if not res:

--- a/tools/linter/adapters/_stable_shim_utils.py
+++ b/tools/linter/adapters/_stable_shim_utils.py
@@ -154,6 +154,31 @@ MULTILINE_MATCHERS = [
 ]
 
 
+def dynamic_call_parser(buffer: str, current_version: tuple[int, int, int] | None):
+    pattern = r"TORCH_DYNAMIC_VERSION_CALL_(\d+)_(\d+)_(\d+)\(([^,]*),([^\)]*)\)"
+    buffer_without_space = buffer.replace(" ", "").replace("\n", "")
+    res = re.findall(pattern, buffer_without_space)
+    if not res:
+        raise RuntimeError(
+            f"Failed to parse dynamic version call pattern on buffer: {repr(buffer)}"
+        )
+    major, minor, patch = res[0][0:3]
+    dynamic_version = (int(major), int(minor), int(patch))
+    fallback_identifier = res[0][3]
+    dynamic_lookup_identifier = res[0][4]
+    return [
+        IdentifierUse(fallback_identifier, version=current_version),
+        IdentifierUse(dynamic_lookup_identifier, version=dynamic_version),
+    ]
+
+
+DYNAMIC_VERSION_CALL_IDENTIFIER_MATCHER = MultilineMatcher(
+    start_pattern=r".*TORCH_DYNAMIC_VERSION_CALL_\d+_\d+_\d+",
+    end_pattern=";",
+    handler=dynamic_call_parser,
+)
+
+
 class MatcherAccumulator:
     """
     This class accumulates into a buffer whenever one of the start patterns of the matchers

--- a/tools/linter/adapters/_stable_shim_utils.py
+++ b/tools/linter/adapters/_stable_shim_utils.py
@@ -164,11 +164,11 @@ def dynamic_call_parser(buffer: str, current_version: tuple[int, int, int] | Non
         )
     major, minor, patch = res[0][0:3]
     dynamic_version = (int(major), int(minor), int(patch))
-    fallback_identifier = res[0][3]
-    dynamic_lookup_identifier = res[0][4]
+    dynamic_lookup_identifier = res[0][3]
+    fallback_identifier = res[0][4]
     return [
-        IdentifierUse(fallback_identifier, version=current_version),
         IdentifierUse(dynamic_lookup_identifier, version=dynamic_version),
+        IdentifierUse(fallback_identifier, version=current_version),
     ]
 
 

--- a/tools/linter/adapters/stable_shim_usage_linter.py
+++ b/tools/linter/adapters/stable_shim_usage_linter.py
@@ -20,6 +20,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
 
 from tools.linter.adapters._stable_shim_utils import (
+    DYNAMIC_VERSION_CALL_IDENTIFIER_MATCHER,
     IdentifierMatcher,
     LintMessage,
     LintSeverity,
@@ -148,18 +149,24 @@ def check_file(
         lines = f.readlines()
 
     # Generate the matchers from the provided function names.
-    matchers = [
+    matchers = [DYNAMIC_VERSION_CALL_IDENTIFIER_MATCHER] + [
         IdentifierMatcher.word(function_name) for function_name in shim_functions
     ]
 
     tracker = PreprocessorTracker(matchers)
 
     for line_num, line in enumerate(lines, 1):
-        tracker.process_line(line)
+        if tracker.process_line(line):
+            # Not regular code, no need to analyse it.
+            continue
+
         for identifier_version in tracker.identifiers_used():
             version_of_block = identifier_version.version
             func_name = identifier_version.identifier
-            required_version = shim_functions[func_name]
+            required_version = shim_functions.get(func_name)
+            if required_version is None:
+                # Shim function has no version specified, so must always be available.
+                continue
 
             major, minor, patch = required_version
             required_macro = f"TORCH_VERSION_{major}_{minor}_{patch}"

--- a/tools/test/stable_shim_usage_linter_data/sample_usage.h
+++ b/tools/test/stable_shim_usage_linter_data/sample_usage.h
@@ -149,3 +149,10 @@ const auto& error_msg_without3 = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
 const auto& error_msg_without4 = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
     unversioned_function, function_2_13_2);
 #endif
+
+// Case 20: Incorrect even with trailing args; the target shim exceeds the dynamic
+// version call. Confirms trailing __VA_ARGS__ do not confuse identifier extraction.
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_2
+const auto& with_trailing_args = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
+    unversioned_function, function_2_13_2, some_arg, other_arg);
+#endif

--- a/tools/test/stable_shim_usage_linter_data/sample_usage.h
+++ b/tools/test/stable_shim_usage_linter_data/sample_usage.h
@@ -130,29 +130,29 @@ void insufficient_new_struct_usage() {
 // Case 16: Correct; dynamic version call without any outer scope, fallback function unversioned, target shim equal to
 // dynamic version call macro.
 const auto& error_msg_without1 = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
-    unversioned_function, function_2_11_0);
+    function_2_11_0, unversioned_function);
 
 // Case 17: Incorrect, fallback function version requires version newer than the current block.
 #if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_11_0
 const auto& error_msg_without2 = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
-    function_2_12_1, function_2_11_0);
+    function_2_11_0, function_2_12_1);
 #endif
 
 // Case 18: Correct, fallback function version is lower than current block, target still equal.
 #if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_2
 const auto& error_msg_without3 = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
-    function_2_12_1, function_2_11_0);
+    function_2_11_0, function_2_12_1);
 #endif
 
 // Case 19: Incorrect, target version function exceeds dynamic version call.
 #if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_2
 const auto& error_msg_without4 = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
-    unversioned_function, function_2_13_2);
+    function_2_13_2, unversioned_function);
 #endif
 
 // Case 20: Incorrect even with trailing args; the target shim exceeds the dynamic
 // version call. Confirms trailing __VA_ARGS__ do not confuse identifier extraction.
 #if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_2
 const auto& with_trailing_args = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
-    unversioned_function, function_2_13_2, some_arg, other_arg);
+    function_2_13_2, unversioned_function, some_arg, other_arg);
 #endif

--- a/tools/test/stable_shim_usage_linter_data/sample_usage.h
+++ b/tools/test/stable_shim_usage_linter_data/sample_usage.h
@@ -126,3 +126,26 @@ void insufficient_new_struct_usage() {
   NewOpaqueClass* cls = nullptr; // ERROR: requires 2.11, have 2.10
 }
 #endif
+
+// Case 16: Correct; dynamic version call without any outer scope, fallback function unversioned, target shim equal to
+// dynamic version call macro.
+const auto& error_msg_without1 = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
+    unversioned_function, function_2_11_0);
+
+// Case 17: Incorrect, fallback function version requires version newer than the current block.
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_11_0
+const auto& error_msg_without2 = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
+    function_2_12_1, function_2_11_0);
+#endif
+
+// Case 18: Correct, fallback function version is lower than current block, target still equal.
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_2
+const auto& error_msg_without3 = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
+    function_2_12_1, function_2_11_0);
+#endif
+
+// Case 19: Incorrect, target version function exceeds dynamic version call.
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_2
+const auto& error_msg_without4 = TORCH_DYNAMIC_VERSION_CALL_2_11_0(
+    unversioned_function, function_2_13_2);
+#endif

--- a/tools/test/test_stable_shim_usage_linter.py
+++ b/tools/test/test_stable_shim_usage_linter.py
@@ -157,6 +157,7 @@ class TestStableShimUsageLinter(unittest.TestCase):
         # Line 126: insufficient version (2.10) for NewOpaqueClass (needs 2.11)
         # Line 138: insufficient version (2.11) for fallback (needs 2.11)
         # Line 150: insufficient version (2.12.2) for target (needs 2.13.2)
+        # Line 157: insufficient version (2.11) for target (needs 2.13.2), with trailing args
 
         expected_errors = [
             (15, "unversioned-shim-call", "simple_versioned_func"),
@@ -174,6 +175,7 @@ class TestStableShimUsageLinter(unittest.TestCase):
             (126, "insufficient-version-for-shim-call", "NewOpaqueClass"),
             (138, "insufficient-version-for-shim-call", "function_2_12_1"),
             (150, "insufficient-version-for-shim-call", "function_2_13_2"),
+            (157, "insufficient-version-for-shim-call", "function_2_13_2"),
         ]
 
         self.assertEqual(

--- a/tools/test/test_stable_shim_usage_linter.py
+++ b/tools/test/test_stable_shim_usage_linter.py
@@ -155,6 +155,8 @@ class TestStableShimUsageLinter(unittest.TestCase):
         # Line 110: unversioned call to NewOpaqueStruct (needs 2.11)
         # Line 125: insufficient version (2.10) for NewOpaqueStruct (needs 2.11)
         # Line 126: insufficient version (2.10) for NewOpaqueClass (needs 2.11)
+        # Line 138: insufficient version (2.11) for fallback (needs 2.11)
+        # Line 150: insufficient version (2.12.2) for target (needs 2.13.2)
 
         expected_errors = [
             (15, "unversioned-shim-call", "simple_versioned_func"),
@@ -170,6 +172,8 @@ class TestStableShimUsageLinter(unittest.TestCase):
             (110, "unversioned-shim-call", "NewOpaqueStruct"),
             (125, "insufficient-version-for-shim-call", "NewOpaqueStruct"),
             (126, "insufficient-version-for-shim-call", "NewOpaqueClass"),
+            (138, "insufficient-version-for-shim-call", "function_2_12_1"),
+            (150, "insufficient-version-for-shim-call", "function_2_13_2"),
         ]
 
         self.assertEqual(

--- a/tools/test/test_stable_shim_utils.py
+++ b/tools/test/test_stable_shim_utils.py
@@ -10,6 +10,7 @@ sys.path.append(str(REPO_ROOT))
 import re
 
 from tools.linter.adapters._stable_shim_utils import (
+    DYNAMIC_VERSION_CALL_IDENTIFIER_MATCHER,
     FUNCTION_IDENTIFIER_MATCHER,
     IdentifierMatcher,
     IdentifierUse,
@@ -235,6 +236,46 @@ class TestStableShimUtils(unittest.TestCase):
             8: ["short1", "short2"],
         }
         result = self._run_match_on_sample(sample, matcher, expected_version)
+
+        self.assertEqual(result, expected)
+
+    def test_dynamic_version_call_identifier(self):
+        """
+        This unit tests confirms the dynamic version call macro is parsed correctly and that its versioning guarantees
+        are correct.
+        """
+        matcher = MatcherAccumulator([DYNAMIC_VERSION_CALL_IDENTIFIER_MATCHER])
+        expected_version = (2, 13, 7)
+        matcher.set_scope_version(expected_version)
+
+        sample = """
+        const auto& error_msg = TORCH_DYNAMIC_VERSION_CALL_2_13_0(
+            torch_shim_bc_const_char_ptr, torch_exception_get_what);
+
+        const auto& error_msg = TORCH_DYNAMIC_VERSION_CALL_2_10_0(
+            super_old_fallback, something_from_2_10);
+        """
+
+        expected = {
+            3: [
+                IdentifierUse(
+                    identifier="torch_shim_bc_const_char_ptr", version=(2, 13, 7)
+                ),
+                IdentifierUse(
+                    identifier="torch_exception_get_what", version=(2, 13, 0)
+                ),
+            ],
+            6: [
+                IdentifierUse(identifier="super_old_fallback", version=(2, 13, 7)),
+                IdentifierUse(identifier="something_from_2_10", version=(2, 10, 0)),
+            ],
+        }
+        result = {}
+        for li, line in enumerate(sample.split("\n"), 1):
+            matcher.process_line(line)
+            res = matcher.identifiers_used()
+            if res:
+                result[li] = res
 
         self.assertEqual(result, expected)
 

--- a/tools/test/test_stable_shim_utils.py
+++ b/tools/test/test_stable_shim_utils.py
@@ -279,6 +279,42 @@ class TestStableShimUtils(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+    def test_dynamic_version_call_with_trailing_args(self):
+        """
+        The dynamic version call macro is variadic: it forwards trailing args to
+        the shim/fallback. The parser must still pick out only the fallback and
+        shim identifiers, even when those trailing args contain commas or nested
+        parens.
+        """
+        matcher = MatcherAccumulator([DYNAMIC_VERSION_CALL_IDENTIFIER_MATCHER])
+        matcher.set_scope_version((2, 13, 0))
+
+        sample = """
+        auto a = TORCH_DYNAMIC_VERSION_CALL_2_13_0(
+            bc_with_args, shim_with_args, self.get(), other.get(), alpha);
+
+        auto b = TORCH_DYNAMIC_VERSION_CALL_2_10_0(no_args_fallback, no_args_shim);
+        """
+
+        expected = {
+            3: [
+                IdentifierUse(identifier="bc_with_args", version=(2, 13, 0)),
+                IdentifierUse(identifier="shim_with_args", version=(2, 13, 0)),
+            ],
+            5: [
+                IdentifierUse(identifier="no_args_fallback", version=(2, 13, 0)),
+                IdentifierUse(identifier="no_args_shim", version=(2, 10, 0)),
+            ],
+        }
+        result = {}
+        for li, line in enumerate(sample.split("\n"), 1):
+            matcher.process_line(line)
+            res = matcher.identifiers_used()
+            if res:
+                result[li] = res
+
+        self.assertEqual(result, expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test/test_stable_shim_utils.py
+++ b/tools/test/test_stable_shim_utils.py
@@ -250,24 +250,24 @@ class TestStableShimUtils(unittest.TestCase):
 
         sample = """
         const auto& error_msg = TORCH_DYNAMIC_VERSION_CALL_2_13_0(
-            torch_shim_bc_const_char_ptr, torch_exception_get_what);
+            torch_exception_get_what, torch_shim_bc_const_char_ptr);
 
         const auto& error_msg = TORCH_DYNAMIC_VERSION_CALL_2_10_0(
-            super_old_fallback, something_from_2_10);
+            something_from_2_10, super_old_fallback);
         """
 
         expected = {
             3: [
                 IdentifierUse(
-                    identifier="torch_shim_bc_const_char_ptr", version=(2, 13, 7)
+                    identifier="torch_exception_get_what", version=(2, 13, 0)
                 ),
                 IdentifierUse(
-                    identifier="torch_exception_get_what", version=(2, 13, 0)
+                    identifier="torch_shim_bc_const_char_ptr", version=(2, 13, 7)
                 ),
             ],
             6: [
-                IdentifierUse(identifier="super_old_fallback", version=(2, 13, 7)),
                 IdentifierUse(identifier="something_from_2_10", version=(2, 10, 0)),
+                IdentifierUse(identifier="super_old_fallback", version=(2, 13, 7)),
             ],
         }
         result = {}
@@ -282,28 +282,28 @@ class TestStableShimUtils(unittest.TestCase):
     def test_dynamic_version_call_with_trailing_args(self):
         """
         The dynamic version call macro is variadic: it forwards trailing args to
-        the shim/fallback. The parser must still pick out only the fallback and
-        shim identifiers, even when those trailing args contain commas or nested
-        parens.
+        the shim/fallback. The parser must still pick out only the shim and
+        fallback identifiers, even when those trailing args contain commas or
+        nested parens.
         """
         matcher = MatcherAccumulator([DYNAMIC_VERSION_CALL_IDENTIFIER_MATCHER])
         matcher.set_scope_version((2, 13, 0))
 
         sample = """
         auto a = TORCH_DYNAMIC_VERSION_CALL_2_13_0(
-            bc_with_args, shim_with_args, self.get(), other.get(), alpha);
+            shim_with_args, bc_with_args, self.get(), other.get(), alpha);
 
-        auto b = TORCH_DYNAMIC_VERSION_CALL_2_10_0(no_args_fallback, no_args_shim);
+        auto b = TORCH_DYNAMIC_VERSION_CALL_2_10_0(no_args_shim, no_args_fallback);
         """
 
         expected = {
             3: [
-                IdentifierUse(identifier="bc_with_args", version=(2, 13, 0)),
                 IdentifierUse(identifier="shim_with_args", version=(2, 13, 0)),
+                IdentifierUse(identifier="bc_with_args", version=(2, 13, 0)),
             ],
             5: [
-                IdentifierUse(identifier="no_args_fallback", version=(2, 13, 0)),
                 IdentifierUse(identifier="no_args_shim", version=(2, 10, 0)),
+                IdentifierUse(identifier="no_args_fallback", version=(2, 13, 0)),
             ],
         }
         result = {}

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -53,20 +53,19 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
 //
 // Return type is inferred from the return value of FALLBACK_FUNCTION.
 #if !defined(C10_MOBILE) && !defined(_WIN32)
-#define TORCH_DYNAMIC_VERSION_CALL(                                   \
-    VERSION_SHIM_PRESENT, FALLBACK_FUNCTION, SHIM_FUNCTION, ...)      \
-  ([]() {                                                             \
-    if (aoti_torch_abi_version() >= VERSION_SHIM_PRESENT) {           \
-      const auto fn_ptr = dlsym(RTLD_DEFAULT, #SHIM_FUNCTION);        \
-      if (fn_ptr) {                                                   \
-        using ReturnType =                                            \
-            std::invoke_result_t<decltype(&FALLBACK_FUNCTION), void>; \
-        const auto typed_ptr =                                        \
-            reinterpret_cast<ReturnType (*)(__VA_ARGS__)>(fn_ptr);    \
-        return (typed_ptr)(__VA_ARGS__);                              \
-      }                                                               \
-    }                                                                 \
-    return FALLBACK_FUNCTION(__VA_ARGS__);                            \
+#define TORCH_DYNAMIC_VERSION_CALL(                                  \
+    VERSION_SHIM_PRESENT, FALLBACK_FUNCTION, SHIM_FUNCTION, ...)     \
+  ([]() {                                                            \
+    if (aoti_torch_abi_version() >= VERSION_SHIM_PRESENT) {          \
+      const auto fn_ptr = dlsym(RTLD_DEFAULT, #SHIM_FUNCTION);       \
+      if (fn_ptr) {                                                  \
+        using ReturnType = decltype(FALLBACK_FUNCTION(__VA_ARGS__)); \
+        const auto typed_ptr =                                       \
+            reinterpret_cast<ReturnType (*)(__VA_ARGS__)>(fn_ptr);   \
+        return (typed_ptr)(__VA_ARGS__);                             \
+      }                                                              \
+    }                                                                \
+    return FALLBACK_FUNCTION(__VA_ARGS__);                           \
   })()
 #else
 // On a platform without dlsym, so immediately call the fallback function.

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -7,7 +7,9 @@
 #include <sstream>
 #include <stdexcept>
 
-#ifndef _WIN32
+#if defined(_WIN32)
+#include <windows.h>
+#else
 #include <dlfcn.h>
 #endif
 
@@ -38,54 +40,84 @@
 #endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_10_0
 
 HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
-// Fallback for functions that produce const char* types, returns a nullptr.
-[[maybe_unused]] static const char* torch_shim_bc_const_char_ptr(...) {
+// Look up a symbol already loaded in the current process. Used to reach
+// stable-ABI shims that were added after the extension's TORCH_TARGET_VERSION
+// when the running libtorch is new enough to provide them. Returns nullptr if
+// the symbol is absent or the platform has no in-process dynamic lookup. This
+// is the single place that holds the per-platform lookup; the macros below are
+// platform agnostic.
+[[maybe_unused]] static void* lookup_stable_symbol(const char* name) {
+#if defined(C10_MOBILE)
+  (void)name;
+  return nullptr;
+#elif defined(_WIN32)
+  // Windows has no RTLD_DEFAULT equivalent, so resolve against the modules that
+  // export the stable shims. Today these live in torch_cpu.dll and
+  // torch_cuda.dll, so try each in turn. GetModuleHandleW does not take a
+  // reference on the returned handle.
+  const wchar_t* dlls[] = {L"torch_cpu.dll", L"torch_cuda.dll"};
+  for (const wchar_t* dll : dlls) {
+    HMODULE handle = GetModuleHandleW(dll);
+    if (handle != nullptr) {
+      void* sym = reinterpret_cast<void*>(GetProcAddress(handle, name));
+      if (sym != nullptr) {
+        return sym;
+      }
+    }
+  }
+  return nullptr;
+#else
+  return dlsym(RTLD_DEFAULT, name);
+#endif
+}
+
+// Fallback for the const char* exception getters, returns a nullptr. A fallback
+// MUST share the exact signature (return type and arguments) of the shim it
+// backs: the looked-up pointer is called through decltype(&FALLBACK_FUNCTION).
+[[maybe_unused]] static const char* torch_shim_bc_const_char_ptr() {
   return nullptr;
 }
 HIDDEN_NAMESPACE_END(torch, stable, detail)
 
-// This macro allows for an at-runtime lookup of a symbol, this is relatively
-// expensive and should only be done in exceptional circumstances, it only
-// supports platforms that have dlsym available.
+// IMPORTANT: this macro is intended for RARE, EXCEPTIONAL use only. It performs
+// an at-runtime symbol lookup (dlsym / GetProcAddress), which is relatively
+// expensive and only works on platforms that support dynamic symbol lookup.
+// Reach for it only when an older-target extension genuinely needs a newer shim
+// that would otherwise be unavailable (e.g. richer error messages); prefer
+// normal version-guarded shim calls everywhere else.
 //
-// We structure these macro's as immediately invoked lambda's to be able to
-// 'return' a value from the macro call.
+// Calls SHIM_FUNCTION via the runtime lookup when the running libtorch is at
+// least VERSION_SHIM_PRESENT, otherwise calls FALLBACK_FUNCTION.
 //
-// Return type is inferred from the return value of FALLBACK_FUNCTION.
-#if !defined(C10_MOBILE) && !defined(_WIN32)
+// We structure this macro as an immediately-invoked lambda so it can 'return' a
+// value from the macro call. The called pointer type is derived from
+// FALLBACK_FUNCTION, which must therefore share SHIM_FUNCTION's exact signature
+// (including arguments).
 #define TORCH_DYNAMIC_VERSION_CALL(                                    \
     VERSION_SHIM_PRESENT, FALLBACK_FUNCTION, SHIM_FUNCTION, ...)       \
-  ([]() {                                                              \
-    if (aoti_torch_abi_version() >= VERSION_SHIM_PRESENT) {            \
-      const auto fn_ptr = dlsym(RTLD_DEFAULT, #SHIM_FUNCTION);         \
-      if (fn_ptr) {                                                    \
+  ([&]() {                                                             \
+    if (aoti_torch_abi_version() >= (VERSION_SHIM_PRESENT)) {          \
+      void* fn_ptr =                                                   \
+          torch::stable::detail::lookup_stable_symbol(#SHIM_FUNCTION); \
+      if (fn_ptr != nullptr) {                                         \
         using FunctionType = decltype(&FALLBACK_FUNCTION);             \
-        const auto typed_ptr = reinterpret_cast<FunctionType>(fn_ptr); \
-        return (typed_ptr)(__VA_ARGS__);                               \
+        return reinterpret_cast<FunctionType>(fn_ptr)(__VA_ARGS__);    \
       }                                                                \
     }                                                                  \
     return FALLBACK_FUNCTION(__VA_ARGS__);                             \
   })()
-#else
-// On a platform without dlsym, so immediately call the fallback function.
-#define TORCH_DYNAMIC_VERSION_CALL(                              \
-    VERSION_SHIM_PRESENT, FALLBACK_FUNCTION, SHIM_FUNCTION, ...) \
-  ([]() { return FALLBACK_FUNCTION(__VA_ARGS__); })()
-#endif
 
-// Entry point for dynamic version calls that exist from 2.13.0 and onward.
-// Putting the version expectation in the macro ensures we can bypass the symbol
-// lookup if the target version exceeds the version in which this shim function
-// was added.
+// Entry point for dynamic version calls for shims added in 2.13.0. Putting the
+// version expectation in the macro lets us bypass the symbol lookup entirely
+// when the target version already includes the shim and call it directly;
+// otherwise we fall through to the runtime lookup.
 #if TORCH_TARGET_VERSION >= TORCH_VERSION_2_13_0
-// Target version is greater than version that added the method, we can call the
-// shim.
+// Target version already includes the shim, call it directly.
 #define TORCH_DYNAMIC_VERSION_CALL_2_13_0( \
     FALLBACK_FUNCTION, SHIM_FUNCTION, ...) \
-  ([]() { return SHIM_FUNCTION(__VA_ARGS__); })()
+  ([&]() { return SHIM_FUNCTION(__VA_ARGS__); })()
 #else
-// Target version is less than the version that added the shim, try a dynamic
-// lookup.
+// Target version predates the shim, try a dynamic lookup.
 #define TORCH_DYNAMIC_VERSION_CALL_2_13_0( \
     FALLBACK_FUNCTION, SHIM_FUNCTION, ...) \
   TORCH_DYNAMIC_VERSION_CALL(              \

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -8,6 +8,16 @@
 #include <stdexcept>
 
 #if defined(_WIN32)
+// Keep windows.h lean and stop it from defining the min()/max() macros, which
+// would otherwise clobber std::min/std::max (and numeric_limits::max) in the
+// torch headers that include this one. Guarded so we never redefine a flag the
+// including translation unit already set.
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #else
 #include <dlfcn.h>
@@ -154,10 +164,10 @@ HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
 }
 HIDDEN_NAMESPACE_END(torch, stable, detail)
 
-// This macro is similar to the header-only macro TORCH_ERROR_CODE_CHECK, but
-// this macro is NOT header-only! It depends on the stable ABI but provides more
-// info in the exception, including the error message as retrieved through the c
-// shims from the original error message.
+// This macro is similar to the header-only macro TORCH_ERROR_CODE_CHECK,
+// but this macro is NOT header-only! It depends on the stable ABI but
+// provides more info in the exception, including the error message as
+// retrieved through the c shims from the original error message.
 #define STABLE_TORCH_ERROR_CODE_CHECK(call)                            \
   if ((call) != TORCH_SUCCESS) {                                       \
     torch::stable::detail::throw_exception(#call, __FILE__, __LINE__); \

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -94,7 +94,7 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
 // FALLBACK_FUNCTION, which must therefore share SHIM_FUNCTION's exact signature
 // (including arguments).
 #define TORCH_DYNAMIC_VERSION_CALL(                                    \
-    VERSION_SHIM_PRESENT, FALLBACK_FUNCTION, SHIM_FUNCTION, ...)       \
+    VERSION_SHIM_PRESENT, SHIM_FUNCTION, FALLBACK_FUNCTION, ...)       \
   ([&]() {                                                             \
     if (aoti_torch_abi_version() >= (VERSION_SHIM_PRESENT)) {          \
       void* fn_ptr =                                                   \
@@ -114,14 +114,14 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
 #if TORCH_TARGET_VERSION >= TORCH_VERSION_2_13_0
 // Target version already includes the shim, call it directly.
 #define TORCH_DYNAMIC_VERSION_CALL_2_13_0( \
-    FALLBACK_FUNCTION, SHIM_FUNCTION, ...) \
+    SHIM_FUNCTION, FALLBACK_FUNCTION, ...) \
   ([&]() { return SHIM_FUNCTION(__VA_ARGS__); })()
 #else
 // Target version predates the shim, try a dynamic lookup.
 #define TORCH_DYNAMIC_VERSION_CALL_2_13_0( \
-    FALLBACK_FUNCTION, SHIM_FUNCTION, ...) \
+    SHIM_FUNCTION, FALLBACK_FUNCTION, ...) \
   TORCH_DYNAMIC_VERSION_CALL(              \
-      TORCH_VERSION_2_13_0, FALLBACK_FUNCTION, SHIM_FUNCTION, __VA_ARGS__)
+      TORCH_VERSION_2_13_0, SHIM_FUNCTION, FALLBACK_FUNCTION, __VA_ARGS__)
 #endif
 
 HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
@@ -131,7 +131,7 @@ HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
     int64_t line) {
   std::stringstream ss;
   const auto& error_msg_without = TORCH_DYNAMIC_VERSION_CALL_2_13_0(
-      torch_shim_bc_const_char_ptr, torch_exception_get_what_without_backtrace);
+      torch_exception_get_what_without_backtrace, torch_shim_bc_const_char_ptr);
   if (error_msg_without) {
     ss << error_msg_without;
     ss << " (originally from " << call << " API call failed at " << file
@@ -141,7 +141,7 @@ HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
   }
 
   const auto& error_msg = TORCH_DYNAMIC_VERSION_CALL_2_13_0(
-      torch_shim_bc_const_char_ptr, torch_exception_get_what);
+      torch_exception_get_what, torch_shim_bc_const_char_ptr);
   if (error_msg) {
     std::time_t t = std::time(nullptr);
     std::tm tm = *std::localtime(&t);

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -111,7 +111,7 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
 // version expectation in the macro lets us bypass the symbol lookup entirely
 // when the target version already includes the shim and call it directly;
 // otherwise we fall through to the runtime lookup.
-#if TORCH_TARGET_VERSION >= TORCH_VERSION_2_13_0
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_13_0
 // Target version already includes the shim, call it directly.
 #define TORCH_DYNAMIC_VERSION_CALL_2_13_0( \
     SHIM_FUNCTION, FALLBACK_FUNCTION, ...) \
@@ -122,7 +122,7 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
     SHIM_FUNCTION, FALLBACK_FUNCTION, ...) \
   TORCH_DYNAMIC_VERSION_CALL(              \
       TORCH_VERSION_2_13_0, SHIM_FUNCTION, FALLBACK_FUNCTION, __VA_ARGS__)
-#endif
+#endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_13_0
 
 HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
 [[maybe_unused]] C10_NOINLINE static void throw_exception(
@@ -147,7 +147,7 @@ HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
     std::tm tm = *std::localtime(&t);
     std::cerr << "[" << std::put_time(&tm, "%H:%M:%S") << " " << file << ":"
               << line
-              << "] Exception across libtorch C API boundary:" << error_msg;
+              << "] Exception across libtorch C API boundary: " << error_msg;
   }
 
   throw std::runtime_error(ss.str());

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -114,7 +114,8 @@ HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
     std::time_t t = std::time(nullptr);
     std::tm tm = *std::localtime(&t);
     std::cerr << "[" << std::put_time(&tm, "%H:%M:%S") << " " << file << ":"
-              << line << "] Exception across libtorch C API boundary:" << error_msg;
+              << line
+              << "] Exception across libtorch C API boundary:" << error_msg;
   }
 
   throw std::runtime_error(ss.str());

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -118,6 +118,8 @@ HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
       torch_shim_bc_const_char_ptr, torch_exception_get_what);
   if (error_msg) {
     std::cerr << "] Exception across libtorch C API boundary:" << error_msg;
+  } else {
+    std::cerr << "] API call failed: " << call << error_msg;
   }
 
   throw std::runtime_error(ss.str());

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -53,19 +53,18 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
 //
 // Return type is inferred from the return value of FALLBACK_FUNCTION.
 #if !defined(C10_MOBILE) && !defined(_WIN32)
-#define TORCH_DYNAMIC_VERSION_CALL(                                  \
-    VERSION_SHIM_PRESENT, FALLBACK_FUNCTION, SHIM_FUNCTION, ...)     \
-  ([]() {                                                            \
-    if (aoti_torch_abi_version() >= VERSION_SHIM_PRESENT) {          \
-      const auto fn_ptr = dlsym(RTLD_DEFAULT, #SHIM_FUNCTION);       \
-      if (fn_ptr) {                                                  \
-        using ReturnType = decltype(FALLBACK_FUNCTION(__VA_ARGS__)); \
-        const auto typed_ptr =                                       \
-            reinterpret_cast<ReturnType (*)(__VA_ARGS__)>(fn_ptr);   \
-        return (typed_ptr)(__VA_ARGS__);                             \
-      }                                                              \
-    }                                                                \
-    return FALLBACK_FUNCTION(__VA_ARGS__);                           \
+#define TORCH_DYNAMIC_VERSION_CALL(                                    \
+    VERSION_SHIM_PRESENT, FALLBACK_FUNCTION, SHIM_FUNCTION, ...)       \
+  ([]() {                                                              \
+    if (aoti_torch_abi_version() >= VERSION_SHIM_PRESENT) {            \
+      const auto fn_ptr = dlsym(RTLD_DEFAULT, #SHIM_FUNCTION);         \
+      if (fn_ptr) {                                                    \
+        using FunctionType = decltype(&FALLBACK_FUNCTION);             \
+        const auto typed_ptr = reinterpret_cast<FunctionType>(fn_ptr); \
+        return (typed_ptr)(__VA_ARGS__);                               \
+      }                                                                \
+    }                                                                  \
+    return FALLBACK_FUNCTION(__VA_ARGS__);                             \
   })()
 #else
 // On a platform without dlsym, so immediately call the fallback function.
@@ -109,17 +108,13 @@ HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
     ss << call << " API call failed at " << file << ", line " << line;
   }
 
-  std::time_t t = std::time(nullptr);
-  std::tm tm = *std::localtime(&t);
-  std::cerr << "[" << std::put_time(&tm, "%H:%M:%S") << " " << file << ":"
-            << line;
-
   const auto& error_msg = TORCH_DYNAMIC_VERSION_CALL_2_13_0(
       torch_shim_bc_const_char_ptr, torch_exception_get_what);
   if (error_msg) {
-    std::cerr << "] Exception across libtorch C API boundary:" << error_msg;
-  } else {
-    std::cerr << "] API call failed: " << call << error_msg;
+    std::time_t t = std::time(nullptr);
+    std::tm tm = *std::localtime(&t);
+    std::cerr << "[" << std::put_time(&tm, "%H:%M:%S") << " " << file << ":"
+              << line << "] Exception across libtorch C API boundary:" << error_msg;
   }
 
   throw std::runtime_error(ss.str());

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -102,7 +102,7 @@ HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
   const auto& error_msg_without = TORCH_DYNAMIC_VERSION_CALL_2_13_0(
       torch_shim_bc_const_char_ptr, torch_exception_get_what_without_backtrace);
   if (error_msg_without) {
-    ss <<  error_msg_without;
+    ss << error_msg_without;
     ss << " (originally from " << call << " API call failed at " << file
        << ", line " << line << ")";
   } else {

--- a/torch/csrc/stable/macros.h
+++ b/torch/csrc/stable/macros.h
@@ -7,6 +7,10 @@
 #include <sstream>
 #include <stdexcept>
 
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+
 #if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_10_0
 
 // Users of this macro are expected to include cuda_runtime.h
@@ -33,7 +37,62 @@
 
 #endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_10_0
 
-#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_13_0
+HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
+// Fallback for functions that produce const char* types, returns a nullptr.
+[[maybe_unused]] static const char* torch_shim_bc_const_char_ptr(...) {
+  return nullptr;
+}
+HIDDEN_NAMESPACE_END(torch, stable, detail)
+
+// This macro allows for an at-runtime lookup of a symbol, this is relatively
+// expensive and should only be done in exceptional circumstances, it only
+// supports platforms that have dlsym available.
+//
+// We structure these macro's as immediately invoked lambda's to be able to
+// 'return' a value from the macro call.
+//
+// Return type is inferred from the return value of FALLBACK_FUNCTION.
+#if !defined(C10_MOBILE) && !defined(_WIN32)
+#define TORCH_DYNAMIC_VERSION_CALL(                                   \
+    VERSION_SHIM_PRESENT, FALLBACK_FUNCTION, SHIM_FUNCTION, ...)      \
+  ([]() {                                                             \
+    if (aoti_torch_abi_version() >= VERSION_SHIM_PRESENT) {           \
+      const auto fn_ptr = dlsym(RTLD_DEFAULT, #SHIM_FUNCTION);        \
+      if (fn_ptr) {                                                   \
+        using ReturnType =                                            \
+            std::invoke_result_t<decltype(&FALLBACK_FUNCTION), void>; \
+        const auto typed_ptr =                                        \
+            reinterpret_cast<ReturnType (*)(__VA_ARGS__)>(fn_ptr);    \
+        return (typed_ptr)(__VA_ARGS__);                              \
+      }                                                               \
+    }                                                                 \
+    return FALLBACK_FUNCTION(__VA_ARGS__);                            \
+  })()
+#else
+// On a platform without dlsym, so immediately call the fallback function.
+#define TORCH_DYNAMIC_VERSION_CALL(                              \
+    VERSION_SHIM_PRESENT, FALLBACK_FUNCTION, SHIM_FUNCTION, ...) \
+  ([]() { return FALLBACK_FUNCTION(__VA_ARGS__); })()
+#endif
+
+// Entry point for dynamic version calls that exist from 2.13.0 and onward.
+// Putting the version expectation in the macro ensures we can bypass the symbol
+// lookup if the target version exceeds the version in which this shim function
+// was added.
+#if TORCH_TARGET_VERSION >= TORCH_VERSION_2_13_0
+// Target version is greater than version that added the method, we can call the
+// shim.
+#define TORCH_DYNAMIC_VERSION_CALL_2_13_0( \
+    FALLBACK_FUNCTION, SHIM_FUNCTION, ...) \
+  ([]() { return SHIM_FUNCTION(__VA_ARGS__); })()
+#else
+// Target version is less than the version that added the shim, try a dynamic
+// lookup.
+#define TORCH_DYNAMIC_VERSION_CALL_2_13_0( \
+    FALLBACK_FUNCTION, SHIM_FUNCTION, ...) \
+  TORCH_DYNAMIC_VERSION_CALL(              \
+      TORCH_VERSION_2_13_0, FALLBACK_FUNCTION, SHIM_FUNCTION, __VA_ARGS__)
+#endif
 
 HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
 [[maybe_unused]] C10_NOINLINE static void throw_exception(
@@ -41,16 +100,28 @@ HIDDEN_NAMESPACE_BEGIN(torch, stable, detail)
     const char* file,
     int64_t line) {
   std::stringstream ss;
-  ss << torch_exception_get_what_without_backtrace();
-  ss << " (originally from " << call << " API call failed at " << file
-     << ", line " << line << ')';
+  const auto& error_msg_without = TORCH_DYNAMIC_VERSION_CALL_2_13_0(
+      torch_shim_bc_const_char_ptr, torch_exception_get_what_without_backtrace);
+  if (error_msg_without) {
+    ss <<  error_msg_without;
+    ss << " (originally from " << call << " API call failed at " << file
+       << ", line " << line << ")";
+  } else {
+    ss << call << " API call failed at " << file << ", line " << line;
+  }
 
   std::time_t t = std::time(nullptr);
   std::tm tm = *std::localtime(&t);
-  std::cerr << '[' << std::put_time(&tm, "%H:%M:%S") << ' ' << file << ':'
-            << line << "] Exception across libtorch C API boundary: "
-            << torch_exception_get_what();
-  throw std::runtime_error(std::move(ss).str());
+  std::cerr << "[" << std::put_time(&tm, "%H:%M:%S") << " " << file << ":"
+            << line;
+
+  const auto& error_msg = TORCH_DYNAMIC_VERSION_CALL_2_13_0(
+      torch_shim_bc_const_char_ptr, torch_exception_get_what);
+  if (error_msg) {
+    std::cerr << "] Exception across libtorch C API boundary:" << error_msg;
+  }
+
+  throw std::runtime_error(ss.str());
 }
 HIDDEN_NAMESPACE_END(torch, stable, detail)
 
@@ -62,7 +133,3 @@ HIDDEN_NAMESPACE_END(torch, stable, detail)
   if ((call) != TORCH_SUCCESS) {                                       \
     torch::stable::detail::throw_exception(#call, __FILE__, __LINE__); \
   }
-
-#else
-#define STABLE_TORCH_ERROR_CODE_CHECK(call) TORCH_ERROR_CODE_CHECK(call)
-#endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_13_0


### PR DESCRIPTION
## Issue
Issue:  https://github.com/pytorch/pytorch/issues/179427
Followup from PR comment: https://github.com/pytorch/pytorch/pull/180135#pullrequestreview-4247248063

## Summary

This introduces helpers that retrieve the error message if the necessary function shims are available to do so using a runtime check with `dlsym`, this ensures that good diagnostic information can be provided even if `TORCH_TARGET_VERSION` is lower than the version in which the functions to retrieve the errors were introduced (2.13).

It also introduces a new helper macro that that can select a function based on the target and runtime version, best explained with an example:
```cpp
const auto returned_value = TORCH_DYNAMIC_VERSION_CALL_2_13_0(fallback_function, newer_function);
```
If the `TORCH_TARGET_VERSION >= TORCH_VERSION_2_13_0` this becomes a passthrough to `newer_function`. If the target version is lower, this checks whether the runtime version `aoti_torch_abi_version() >= VERSION_SHIM_PRESENT`, and thus whether it should have the `newer_function` if it does, it is retrieved with `dlsym` and called.

This functionality was originally proposed in 8aab600fdfa00bdd2d4dc6955f96c0c5188c689b in the forementioned PR, but backed out because combined with its unit testing it became unwieldy. This PR proposes the (isolated) change again for discussion. The original comment [there](https://github.com/pytorch/pytorch/pull/180135#issuecomment-4384403573) explained some of the design and considerations.

@janeyx99 