### PR TITLE
Route Triton log through libdevice by default

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1178,6 +1178,18 @@ class CudaReproTests(TestCase):
         self.assertEqual(foo(inp), out)
 
         def foo(x):
+            return x.log()
+
+        out, code = run_and_get_code(torch.compile(foo), inp)
+        FileCheck().check_not("tl_math.log").check("libdevice.log").run(code[0])
+        self.assertEqual(foo(inp), out)
+
+        with config.patch(use_fast_math=True):
+            out, code = run_and_get_code(torch.compile(foo), inp)
+        FileCheck().check("tl_math.log").run(code[0])
+        self.assertEqual(foo(inp), out)
+
+        def foo(x):
             return x.sigmoid()
 
         inp = torch.ones(64, device=device_type).to(torch.float64)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2044,7 +2044,10 @@ class TritonOverrides(OpOverrides):
     @maybe_upcast_float32()
     # pyrefly: ignore [bad-override]
     def log(x):
-        return f"tl_math.log({x})"
+        if config.use_fast_math:
+            return f"tl_math.log({x})"
+        else:
+            return f"libdevice.log({x})"
 
     @staticmethod
     @maybe_upcast_float32(convert_output=False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183826

Make Triton log codegen follow the same precise libdevice routing as other transcendental ops, while preserving fast-math tl_math lowering. This fixes the strict numerics OpInfo log mismatch on ROCm.

Fixes #180045

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos