### PR TITLE
Use libdevice for Triton log codegen

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1185,6 +1185,27 @@ class CudaReproTests(TestCase):
         FileCheck().check("libdevice.exp").run(code[0])
         self.assertEqual(foo(inp), out)
 
+        def foo(x):
+            return x.log()
+
+        inp = torch.ones(64, device=device_type, dtype=torch.float16)
+        out, code = run_and_get_code(
+            torch.compile(
+                foo,
+                options={
+                    "deterministic": True,
+                    "fallback_random": True,
+                    "emulate_precision_casts": True,
+                    "eager_numerics.division_rounding": True,
+                    "eager_numerics.disable_ftz": True,
+                    "eager_numerics.use_pytorch_libdevice": True,
+                },
+            ),
+            inp,
+        )
+        FileCheck().check_not("tl_math.log").check("libdevice.log").run(code[0])
+        self.assertEqual(foo(inp), out)
+
     def test_uint_view_copy(self):
         @torch.compile
         def view_copy(target, source):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2044,7 +2044,7 @@ class TritonOverrides(OpOverrides):
     @maybe_upcast_float32()
     # pyrefly: ignore [bad-override]
     def log(x):
-        return f"tl_math.log({x})"
+        return f"libdevice.log({x})"
 
     @staticmethod
     @maybe_upcast_float32(convert_output=False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183827

Route Triton log codegen through libdevice so strict numerics uses the same math path as neighboring log-family ops, and cover fp16 strict-numerics codegen routing.

Fixes #180044

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos