### PR TITLE
[jit] Fix unique_consecutive return type annotation for inverse/counts (#183829)

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1163,7 +1163,7 @@ def _consecutive_return_inverse_and_counts(
     return_counts=False,
     dim=None,
 ):
-    # type: (Tensor, bool, bool, Optional[int]) -> tuple[Tensor]
+    # type: (Tensor, bool, bool, Optional[int]) -> tuple[Tensor, Tensor, Tensor]
     if has_torch_function_unary(input):
         return _unique_consecutive_torch_function(
             input, return_inverse, return_counts, dim


### PR DESCRIPTION
Summary:

`torch.unique_consecutive(..., return_inverse=True, return_counts=True)` returns three tensors: output, inverse_indices, and counts.

The helper `_consecutive_return_inverse_and_counts` was annotated for TorchScript as returning `tuple[Tensor]`, but this branch actually returns `tuple[Tensor, Tensor, Tensor]`. That mismatch can make TorchScript compilation fail for scripted callsites that request both inverse indices and counts.

Update the annotations to match the actual three-tensor return type.

Test Plan: Not run. This is a TorchScript type annotation-only fix; the annotation now matches the three tensors returned when both inverse indices and counts are requested.

Reviewed By: catalinii

Differential Revision: D105104984


