### PR TITLE
[FakeTensor] Add hinted symbolic storage size metadata

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1365,6 +1365,17 @@ class FakeTensorTest(TestCase):
         self.assertEqual(out.shape, (4 * 2 * (seq // 2), 256))
         self.assertTrue(free_unbacked_symbols(out.shape[0]))
 
+    def test_meta_storage_trace_uses_hint_for_symbolic_size(self):
+        from torch._subclasses.meta_utils import MetaStorageDesc, MetaStorageId
+
+        shape_env = ShapeEnv()
+        size = shape_env.create_unbacked_symint()
+        torch._dynamo.override_optimization_hint(size, 16)
+
+        metadata = MetaStorageDesc(MetaStorageId(0), 3 * size, None).as_json(1)
+        self.assertEqual(metadata["size"], "3*u0")
+        self.assertEqual(metadata["size_hint"], 48)
+
     def test_matmul_rank4_unbacked_batch_dim(self):
         fake_mode, (q, k) = self.fake_with_unbacked_batch(
             torch.randn(4, 2, 8, 16),

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -528,11 +528,19 @@ class MetaStorageDesc:
     data: torch.UntypedStorage | None
 
     def as_json(self, describer_id: _DescriberId) -> dict[str, object]:
-        return {
+        metadata: dict[str, object] = {
             "id": self.id,
             "describer_id": describer_id,
             "size": self.size if isinstance(self.size, int) else repr(self.size),
         }
+        if isinstance(self.size, torch.SymInt):
+            node = self.size.node
+            free_symbols = node.expr.free_symbols
+            if free_symbols and all(
+                symbol in node.shape_env.var_to_hint_override for symbol in free_symbols
+            ):
+                metadata["size_hint"] = node.shape_env.optimization_hint(node.expr)
+        return metadata
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION

Trace tooling serializes FakeTensor storage metadata to JSON. When the
storage size is a hinted SymInt, the trace can have both useful pieces of
information:

- the symbolic storage expression, which preserves provenance for downstream
  trace consumers;
- the optimization hint, which gives diagnostic/policy tooling a concrete
  expected extent when one was explicitly provided.

Keep the existing `size` field symbolic for symbolic storage sizes and add a
separate `size_hint` field only when every free symbol in the storage-size
expression has an explicit optimization hint override. This preserves the
existing symbolic trace contract while exposing concrete policy metadata
without specializing tensor shapes or changing runtime semantics.

Fixes #183835

Test Plan:

python test/test_fake_tensor.py FakeTensorTest.test_meta_storage_trace_uses_hint_for_symbolic_size -q

lintrunner --config=.lintrunner.toml torch/_subclasses/meta_utils.py test/test_fake_tensor.py


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo