### PR TITLE
[Inductor] Handle hinted and fallback unbacked symbols

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -1,12 +1,17 @@
 # Owner(s): ["module: inductor"]
 import functools
 import unittest
+from unittest import mock
+
+import sympy
 
 import torch
 from torch._dynamo import config as dynamo_config
 from torch._dynamo.exc import InternalTorchDynamoError
-from torch._inductor import config as inductor_config
+from torch._inductor import config as inductor_config, ir
+from torch._inductor.sizevars import SizeVarAllocator
 from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.virtualized import V
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_device_type import (
@@ -856,6 +861,41 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
+    @skipIfXpu(msg="standalone_compile coverage is CUDA-only")
+    @skipCPUIf(True, "requires gpu and triton")
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    def test_standalone_compile_reuses_fallback_unbacked_binding(self, device):
+        from torch._inductor import standalone_compile
+        from torch._subclasses.fake_tensor import FakeTensor
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def fn(counts, x):
+            idx = torch.repeat_interleave(counts)
+            return x[idx].sin()
+
+        counts = torch.tensor([1, 2, 1, 0], device=device, dtype=torch.int64)
+        x = torch.randn(4, 8, device=device)
+        torch._dynamo.mark_dynamic(counts, 0, min=1, max=8)
+        gm = make_fx(fn, tracing_mode="symbolic")(counts, x)
+        fake_mode = next(
+            node.meta["val"].fake_mode
+            for node in gm.graph.nodes
+            if isinstance(node.meta.get("val"), FakeTensor)
+        )
+
+        with (
+            torch._guards.tracing(torch._guards.TracingContext(fake_mode)),
+            fake_mode.shape_env.ignore_fresh_unbacked_symbols(),
+        ):
+            compiled = standalone_compile(
+                gm,
+                [counts, x],
+                dynamic_shapes="from_tracing_context",
+                options={},
+            )
+
+        torch.testing.assert_close(compiled(counts, x), fn(counts, x))
+
     @dynamo_config.patch({"capture_scalar_outputs": True})
     def test_override_optimization_hint_eager(self, device):
         """Test that override_optimization_hint updates var_to_hint_override eagerly."""
@@ -1007,6 +1047,63 @@ class TestUnbackedSymints(InductorTestCase):
         compiled_fn = torch.compile(fn, backend=fx_pass_backend, fullgraph=True)
         result = compiled_fn(t)
         self.assertEqual(result, 8)
+
+    def test_stride_order_uses_unbacked_optimization_hint(self, device):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        seq = shape_env.create_unbacked_symint()
+        torch._dynamo.override_optimization_hint(seq, 16)
+
+        stride_order = ir.get_stride_order(
+            [256 * sympy.Max(1, seq.node.expr // 2), 256, 1],
+            shape_env,
+        )
+        self.assertEqual(stride_order, [2, 1, 0])
+
+    def test_stride_ordered_uses_symbolic_divisibility(self, device):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        seq = shape_env.create_unbacked_symint().node.expr
+        sizevars = SizeVarAllocator(shape_env)
+        graph = mock.Mock(sizevars=sizevars)
+
+        layout = ir.FixedLayout(
+            torch.device(device),
+            torch.float32,
+            size=[seq, 8, 16],
+            stride=[256 * seq, 256, 1],
+        )
+        with V.set_graph_handler(graph):
+            with mock.patch.object(
+                sizevars,
+                "optimization_hint",
+                side_effect=AssertionError("unexpected optimization hint"),
+            ):
+                self.assertTrue(layout.is_stride_ordered([2, 1, 0]))
+
+    def test_stride_ordered_rejects_unproved_unbacked_layout(self, device):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        seq = shape_env.create_unbacked_symint().node.expr
+        sizevars = SizeVarAllocator(shape_env)
+        graph = mock.Mock(sizevars=sizevars)
+
+        layout = ir.FixedLayout(
+            torch.device(device),
+            torch.float32,
+            size=[seq, 2],
+            stride=[seq, 2],
+        )
+        with V.set_graph_handler(graph):
+            with mock.patch.object(
+                sizevars,
+                "optimization_hint",
+                side_effect=AssertionError("unexpected optimization hint"),
+            ):
+                self.assertFalse(layout.is_stride_ordered([1, 0]))
 
     @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -630,6 +630,8 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     return
                 code.writeline(f"int64_t {sym_or_exp} = {name_fn(base_name)}[{dim}];")
                 bound_vars.add(sym_or_exp)
+                if symbol_is_type(sym_or_exp, (SymT.UNBACKED_INT, SymT.UNBACKED_FLOAT)):
+                    self.unbacked_symbol_decls.add(str(sym_or_exp))
                 maybe_emit_replacement_aliases(sym_or_exp)
             elif isinstance(sym_or_exp, sympy.Expr):
                 undefined_symbols = [
@@ -668,6 +670,8 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 raise AssertionError("Unexpected symbol type")
             code.writeline(f"{decl} {value} = {name};")
             bound_vars.add(value)
+            if symbol_is_type(value, (SymT.UNBACKED_INT, SymT.UNBACKED_FLOAT)):
+                self.unbacked_symbol_decls.add(str(value))
             maybe_emit_replacement_aliases(value)
         elif isinstance(value, ir.TensorBox):
             for dim, size in enumerate(value.get_size()):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -4019,7 +4019,8 @@ class PythonWrapperCodegen(CodeGen):
                     )
                 elif isinstance(keypath[0], DivideByKey):
                     # TODO: need to assert divisibility
-                    # TODO: this is invalid C++ codegen
+                    if V.graph.cpp_wrapper:
+                        return go(f"({expr} / {keypath[0].divisor})", keypath[1:])
                     return go(f"{expr}.__floordiv__({keypath[0].divisor})", keypath[1:])
                 else:
                     raise AssertionError(f"unrecognized keypath {keypath}")

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4358,6 +4358,21 @@ class Layout(OutputSpec):
                 return False
         return True
 
+    @staticmethod
+    def _stride_expr_ge_or_false(left: _IntLike, right: _IntLike) -> bool:
+        """
+        Returns true if left is symbolically greater than or equal to right,
+        assuming both expressions are tensor strides.
+        """
+        sizevars = V.graph.sizevars
+        if sizevars.guard_or_false(sympy.Eq(right, 0)):
+            return True
+        if sizevars.guard_or_false(sympy.Eq(left, 0)):
+            return False
+        return sizevars.guard_or_false(
+            sympy.Ge(left, right)
+        ) or sizevars.guard_or_false(sympy.Eq(left % right, 0))
+
     def is_stride_ordered(self, order: Sequence[int]) -> bool:
         assert len(self.stride) == len(order)
 
@@ -4365,7 +4380,7 @@ class Layout(OutputSpec):
         non_1_indices = [
             i
             for i, dim in enumerate(self.size)
-            if V.graph.sizevars.optimization_hint(dim, fallback=2) != 1
+            if not V.graph.sizevars.statically_known_equals(dim, 1)
         ]
 
         stride = [self.stride[i] for i in non_1_indices]
@@ -4384,12 +4399,13 @@ class Layout(OutputSpec):
             stride_ordered[order[i]] = stride[i]
         # check if it is in ascending order
         for i in range(len(order) - 1):
-            expr = stride_ordered[i] > stride_ordered[i + 1]
-            if not isinstance(expr, bool):
-                expr = V.graph._shape_env.evaluate_expr(
-                    stride_ordered[i] > stride_ordered[i + 1], size_oblivious=True
-                )
-            if expr:
+            left = stride_ordered[i]
+            right = stride_ordered[i + 1]
+            if V.graph.sizevars.guard_or_false(sympy.Eq(left, right)):
+                continue
+            if self._stride_expr_ge_or_false(left, right):
+                return False
+            if not self._stride_expr_ge_or_false(right, left):
                 return False
         return True
 
@@ -6588,6 +6604,23 @@ class ConcatKernel(NopKernel):
         return True
 
 
+@contextlib.contextmanager
+def _track_fresh_unbacked_symbols(shape_env: ShapeEnv) -> Iterator[None]:
+    prev = shape_env._ignore_fresh_unbacked_symbols_set(False)
+    try:
+        yield
+    finally:
+        shape_env._ignore_fresh_unbacked_symbols_set(prev)
+
+
+def _fallback_kernel_symbol_tracking_context(
+    shape_env: ShapeEnv | None,
+) -> AbstractContextManager[None]:
+    if shape_env is not None and shape_env._ignore_fresh_unbacked_symbols_tls():
+        return _track_fresh_unbacked_symbols(shape_env)
+    return nullcontext()
+
+
 @ir_dataclass(frozen=False)
 class ExternKernel(InputsKernel):
     """
@@ -6939,11 +6972,15 @@ class ExternKernel(InputsKernel):
                 example_args.append(ir_node_to_tensor(x))
 
         new_args, new_kwargs = unflatten_args(example_args, real_non_tensor_args)
-        with enable_python_dispatcher():
+        shape_env = V.fake_mode.shape_env
+        with (
+            enable_python_dispatcher(),
+            _fallback_kernel_symbol_tracking_context(shape_env),
+        ):
             example_output = kernel(*new_args, **new_kwargs)
 
         unbacked_bindings: dict[sympy.Symbol, pytree.KeyPath] | None = None
-        if shape_env := V.fake_mode.shape_env:
+        if shape_env:
             node_meta_val = V.current_node.meta.get("val")
             ctx: AbstractContextManager[None] = nullcontext()
             if V.current_node.target is torch._higher_order_ops.effects.with_effects:
@@ -7128,23 +7165,18 @@ class ExternKernel(InputsKernel):
                     # size=[s0, 1, 28, 28], stride=[784, 1, 28, 1]), which is not actually necessary.
                     use_current_stride_order = is_stride_order_storage_and_layout(
                         x, order
-                    ) and not free_unbacked_symbols(x.get_layout().stride)
-                    # fix flexiblelayout to be FixedLayout with stride_order
-                    as_storage_and_layout(
-                        x,
-                        freeze=True,
-                        want_contiguous=False,
-                        stride_order=(
-                            get_stride_order(
-                                V.graph.sizevars.guarding_hints_or_throw(
-                                    x.get_layout().stride
-                                )
-                            )
-                            if use_current_stride_order
-                            else order
-                        ),
-                        allow_padding=allow_padding,
                     )
+                    if use_current_stride_order:
+                        x.freeze_layout()
+                    else:
+                        # fix flexiblelayout to be FixedLayout with stride_order
+                        as_storage_and_layout(
+                            x,
+                            freeze=True,
+                            want_contiguous=False,
+                            stride_order=order,
+                            allow_padding=allow_padding,
+                        )
                     return x
                 else:
                     # If the exact_strides is given, freeze the FlexibleLayout to a FixedLayout with the exact_strides.
@@ -7274,7 +7306,11 @@ class ExternKernel(InputsKernel):
             allow_padding=allow_padding,
             exact_strides=exact_strides,
         )
-        if order:
+        if (
+            order
+            and not free_unbacked_symbols(x.get_size())
+            and not free_unbacked_symbols(x.get_stride())
+        ):
             assert is_stride_order_storage_and_layout(x, order)
         elif expanded_dims:
             assert orig_size is not None and exact_strides is not None

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -73,6 +73,7 @@ from torch.fx.experimental._size_hinting import _sympy_subs
 from torch.fx.experimental.symbolic_shapes import (
     free_symbols,
     free_unbacked_symbols,
+    GuardOnDataDependentSymNode,
     IterateExprs,
     ShapeEnv,
 )
@@ -1509,18 +1510,37 @@ def argsort_sym(
     *,
     reverse: bool = False,
 ) -> list[int]:
+    """
+    Return a symbolic sort order for optimization-only layout heuristics.
+
+    Data-dependent comparisons can fall back to non-guarding optimization hints,
+    so callers must not use this order to make correctness decisions.
+    """
+
     def cmp(a: tuple[int, sympy.Expr], b: tuple[int, sympy.Expr]) -> int:
         a_idx, a_val = a
         b_idx, b_val = b
 
-        def evaluate(expr: bool | torch.SymInt | sympy.Expr) -> bool:
+        def evaluate(
+            expr: bool | torch.SymInt | sympy.Expr,
+            fallback: Callable[[], bool],
+        ) -> bool:
             if isinstance(expr, bool):
                 return expr
-            return shape_env.evaluate_expr(expr, size_oblivious=True)
+            try:
+                return shape_env.evaluate_expr(expr)
+            except GuardOnDataDependentSymNode:
+                return fallback()
 
-        if evaluate(a_val < b_val):
+        def hint_lt(lhs: sympy.Expr, rhs: sympy.Expr) -> bool:
+            # Stride sorting is an optimization-only ordering decision.  Keep
+            # semantic reasoning symbolic first, then fall back to explicit
+            # optimization hints when unbacked comparisons are data-dependent.
+            return shape_env.optimization_hint(lhs) < shape_env.optimization_hint(rhs)
+
+        if evaluate(a_val < b_val, lambda: hint_lt(a_val, b_val)):
             return -1
-        if evaluate(a_val > b_val):
+        if evaluate(a_val > b_val, lambda: hint_lt(b_val, a_val)):
             return 1
         # If strides are the same, prefer the original order.
         # (this matches argsort's algorithm).


### PR DESCRIPTION
Stacked PRs:
 * #183838
 * #183839
 * __->__#183840


--- --- ---

### [Inductor] Handle hinted and fallback unbacked symbols


Inductor has several codegen paths that need to reason about unbacked symbolic extents without turning policy decisions into semantic guards. Layout constraint lowering needs to recognize common symbolic stride orderings, while fallback kernels can repropagate outputs whose unbacked symbols are graph-owned and must be bound for wrapper codegen.

For stride ordering, use a stride-specific symbolic greater-or-equal proof with ordinary guarded comparisons plus divisibility reasoning. This lets Inductor prove layouts such as u0 * 256 >= 256 without relying on concrete hints, while still rejecting unproved unbacked layouts. When require_strides proves the current layout already satisfies the requested order, freeze the current layout directly instead of forcing guarding_hints_or_throw() or bailing out for every unbacked stride.

For fallback outputs, temporarily re-enable fresh unbacked symbol tracking while rerunning the fallback fake kernel. That call is the binding site for output size and stride symbols that later wrapper code references, so those symbols should go through the normal pending-symbol and compute_unbacked_bindings() path instead of being created under ignore_fresh_unbacked_symbols() and rediscovered afterward.

The C++ wrapper path also has to treat input unbacked symbols as already declared before emitting output bindings. Otherwise a fallback output binding can redeclare a symbol such as u0 and can emit Python-only __floordiv__ syntax for DivideByKey paths. Emit C++ integer division for that path and reuse the existing unbacked symbol declaration.

Finally, do not make the post-copy stride-order sanity check prove data-dependent unbacked stride inequalities. The copy has already been materialized with the requested stride order; requiring a symbolic proof there rejects valid layouts whose unbacked size may be zero or one.

These changes preserve symbolic semantics: hints are not used to create semantic layout guards, fallback output extents are bound through normal ShapeEnv tracking at the fallback output binding site, and stride/order changes copy data or freeze already-valid layouts rather than manufacturing semantic guards.

Fixes #183834

Fixes #185341

Test Plan:

```bash
python test/inductor/test_unbacked_symints.py TestUnbackedSymintsCPU.test_stride_order_uses_unbacked_optimization_hint_cpu TestUnbackedSymintsCPU.test_stride_ordered_uses_symbolic_divisibility_cpu TestUnbackedSymintsCPU.test_stride_ordered_rejects_unproved_unbacked_layout_cpu -q
```

```bash
python test/inductor/test_unbacked_symints.py TestUnbackedSymintsCUDA.test_standalone_compile_reuses_fallback_unbacked_binding_cuda TestUnbackedSymintsCUDA.test_sdfpa_unbacked_strides_cuda -q
```

```bash
python test/inductor/test_unbacked_symints.py TestUnbackedSymintsCPU.test_stride_ordered_uses_symbolic_divisibility_cpu TestUnbackedSymintsCPU.test_stride_ordered_rejects_unproved_unbacked_layout_cpu TestUnbackedSymintsCUDA.test_standalone_compile_reuses_fallback_unbacked_binding_cuda TestUnbackedSymintsCUDA.test_sdfpa_unbacked_strides_cuda -q
```

TorchTitan graph_trainer H100 integration: aot_fx_trace_deepseek_v3_sdpa_full_inductor_ep_overlap_moe_seq

This PR was authored with the assistance of an AI assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98