### PR TITLE
Fix external template epilogue range renames

### DIFF
--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -351,9 +351,27 @@ class IterationRangesEntry(IterationRanges):
         return f"IterationRangesEntry({self.name}, {self.divisor}, {self.length}, {self.expr}, {self.var_ranges})"
 
     def set_name(self, name: str) -> None:
+        old_symbol = self.symbol()
         self.codegen = lambda: name  # type: ignore[assignment]
         self.codegen.cache_clear = lambda: None  # type: ignore[method-assign]
         self.name = name
+        new_symbol = self.symbol()
+        if old_symbol == new_symbol:
+            return
+
+        existing_node = self.kernel.range_tree_nodes.get(new_symbol)
+        if existing_node is not None and existing_node is not self:
+            # Some templates reuse the same textual index name for different
+            # live range entries.  Keep the existing owner in that case.
+            return
+
+        if old_symbol in self.var_list:
+            self.var_list[self.var_list.index(old_symbol)] = new_symbol
+        if old_symbol in self.var_ranges:
+            self.var_ranges[new_symbol] = self.var_ranges.pop(old_symbol)
+        if self.kernel.range_tree_nodes.get(old_symbol) is self:
+            del self.kernel.range_tree_nodes[old_symbol]
+        self.kernel.range_tree_nodes[new_symbol] = self
 
     def cache_clear(self) -> None:
         self.codegen.cache_clear()

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1408,15 +1408,7 @@ class TritonTemplateKernel(TritonKernel):
                         symbol = range_tree.symbol()
                         epilogue_index_symbols.append(symbol)
                         lookup_output = range_tree.lookup(sympy.S.One, lengths[i])
-                        old_name = lookup_output.symbol()
                         lookup_output.set_name(name)
-                        # Update var_list and var_range
-                        range_tree.var_list[range_tree.var_list.index(old_name)] = (
-                            symbol
-                        )
-                        range_val = range_tree.var_ranges[old_name]
-                        del range_tree.var_ranges[old_name]
-                        range_tree.var_ranges[symbol] = range_val
                         intermediate_lines.extend(
                             self._generate_index_from_tma_index(
                                 name,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183843

Keep SIMD iteration range metadata synchronized when template code renames range entries, so fused external template epilogues can resolve the renamed symbols during codegen.

Fixes #179959

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo