### PR TITLE
[test] Skip test_memory_profiler_viz under cudaMallocAsync

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4861,6 +4861,9 @@ class TestCudaAllocator(TestCase):
             torch.cuda.memory._record_memory_history(None)
 
     @skipIfRocm(msg="ROCTracer does not capture Python stack frames in profiler output")
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
+    )
     def test_memory_profiler_viz(self):
         with torch.profiler.profile(
             with_stack=True, profile_memory=True, record_shapes=True


### PR DESCRIPTION
Fixes #148885.

### Summary
Skip `test_memory_profiler_viz` when the CUDA allocator backend is `cudaMallocAsync`.

The test asserts that the profiler memory-visualization snapshot contains Python stack info such as `test_cuda.py` and `test_memory_profiler_viz`. Under `PYTORCH_CUDA_ALLOC_CONF="backend:cudaMallocAsync"` those assertions fail.

The adjacent memory snapshot, cycles, and memory plot tests in `TestCudaAllocator` already guard against this with:

```python
@unittest.skipIf(
    TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
)
```

`test_memory_profiler_viz` was the only test in the cluster missing this guard. This PR adds it for consistency, reusing the existing skip message verbatim.

### Test plan
CUDA was not available on the machine where this patch was prepared, so the variant could not be run locally.

Expected commands:

```bash
# After the fix, this should skip:
PYTORCH_CUDA_ALLOC_CONF="backend:cudaMallocAsync" python test/test_cuda.py TestCudaMallocAsync.test_memory_profiler_viz

# Default allocator path should remain unchanged:
python test/test_cuda.py TestCudaAllocator.test_memory_profiler_viz
```

Authored by Claude.