### PR TITLE
[distributed][docs] Fix group_src docstring in irecv

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2666,7 +2666,7 @@ def irecv(
         group (ProcessGroup, optional): The process group to work on. If None,
             the default process group will be used.
         tag (int, optional): Tag to match recv with remote send
-        group_src (int, optional): Destination rank on ``group``.  Invalid to specify both ``src`` and ``group_src``.
+        group_src (int, optional): Source rank on ``group``.  Invalid to specify both ``src`` and ``group_src``.
 
     Returns:
         A distributed request object.


### PR DESCRIPTION
The `group_src` parameter in `irecv` is described as "Destination rank" but it specifies the source rank to receive from. This is consistent with the `src` parameter description ("Source rank") in the same function.