### PR TITLE
Fix Dynamo super tensor method handling

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -750,6 +750,17 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
 
             func(torch.randn(3))
 
+    def test_tensor_unflatten_default_device(self):
+        def fn(x):
+            return x.unflatten(0, (2, 2))
+
+        x = torch.randn(4, 3)
+        with torch.device("cpu"):
+            expected = fn(x)
+            actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
+
+        self.assertEqual(actual, expected)
+
     @requires_gpu
     def test_flex_attention(self):
         import torch

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3122,13 +3122,20 @@ def get_tensor_method() -> frozenset[Any]:
     return frozenset(s)
 
 
+def is_tensor_method(obj: Any) -> bool:
+    return obj in get_tensor_method() or (
+        inspect.ismethoddescriptor(obj)
+        and getattr(obj, "__objclass__", None) is torch._C.TensorBase
+    )
+
+
 """
 Return if a torch object is ATen op or torch.Tensor method.
 """
 
 
 def is_aten_op_or_tensor_method(obj: Any) -> bool:
-    return obj in get_tensor_method() or isinstance(
+    return is_tensor_method(obj) or isinstance(
         obj,
         (torch._ops.OpOverloadPacket, torch._ops.OpOverload),
     )

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -398,10 +398,9 @@ class SuperVariable(VariableTracker):
                 tx.symbolic_torch_function_state.torch_function_subclass_enabled = (
                     tx_old
                 )
-        elif (
-            isinstance(inner_fn, types.MethodDescriptorType)
-            and inner_fn in trace_rules.get_tensor_method()
-        ):
+        elif isinstance(
+            inner_fn, types.MethodDescriptorType
+        ) and trace_rules.is_tensor_method(inner_fn):
             # FunctionType but implementation is in C, we support some of these,
             # e.g., tensor ops like `torch.Tensor.to`.
             fn_var = VariableTracker.build(tx, inner_fn, source, realize=True)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -3817,14 +3817,9 @@ For now, dynamo will explicitly graph break when it encounters user code with th
         return args[0].call_method(tx, self.get_function().__name__, args[1:], kwargs)
 
     def is_tensor_method(self) -> bool:
-        from ..trace_rules import get_tensor_method
+        from ..trace_rules import is_tensor_method
 
-        return (
-            inspect.ismethoddescriptor(self.get_function())
-            and hasattr(self.get_function(), "__objclass__")
-            # pyrefly: ignore[missing-attribute]
-            and self.get_function().__objclass__ == torch._C.TensorBase
-        ) or self.get_function() in get_tensor_method()
+        return is_tensor_method(self.get_function())
 
     def torch_function_override_enabled(
         self, tx: "InstructionTranslator", args: Iterable[Any], kwargs: dict[str, Any]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183848

Recognize TensorBase method descriptors reached through super(), including Tensor.unflatten under default-device __torch_function__ dispatch, by sharing the tensor-method predicate across Dynamo tracing paths. Add focused regression coverage for compiling Tensor.unflatten with a default device active.

Fixes #179897
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos