### PR TITLE
Fix Dynamo super TensorBase method handling

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -793,6 +793,15 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         with torch.device("cpu"):
             torch.compile(mod, fullgraph=True)(x)
 
+    def test_default_device_tensor_unflatten(self):
+        def fn(x):
+            return x.unflatten(-1, (2, 3))
+
+        x = torch.randn(4, 6)
+        with torch.device("cpu"):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertEqual(opt_fn(x), fn(x))
+
     @requires_gpu
     @skipIfXpu(msg="XPU does not support flex attention")
     def test_hop(self):

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3101,20 +3101,21 @@ Get all torch.Tensor methods which are allowed to be in graph functions.
 def get_tensor_method() -> frozenset[Any]:
     disallowed_tensor_methods = {"__new__", "_make_wrapper_subclass", "_make_subclass"}
     s = set()
-    for name in dir(torch.Tensor):
-        method = getattr(torch.Tensor, name)
-        if (
-            isinstance(
-                method,
-                (
-                    types.MethodDescriptorType,
-                    types.WrapperDescriptorType,
-                    types.BuiltinFunctionType,
-                ),
-            )
-            and name not in disallowed_tensor_methods
-        ):
-            s.add(method)
+    for cls in (torch.Tensor, torch._C.TensorBase):
+        for name in dir(cls):
+            method = getattr(cls, name)
+            if (
+                isinstance(
+                    method,
+                    (
+                        types.MethodDescriptorType,
+                        types.WrapperDescriptorType,
+                        types.BuiltinFunctionType,
+                    ),
+                )
+                and name not in disallowed_tensor_methods
+            ):
+                s.add(method)
 
     # mlazos: these are functions which we handle specially in TensorVariable
     s.add(torch.Tensor.__contains__)  # type: ignore[arg-type]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183849

Allow Dynamo's super() handling to recognize tensor method descriptors from torch._C.TensorBase, covering Python Tensor wrappers such as unflatten under __torch_function__ mode.

Fixes #179853
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos