### PR TITLE
ci: declare workflow-level `contents: read` on 8 workflows

### DIFF
--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -29,6 +29,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-docker:
     if: github.repository_owner == 'pytorch'

--- a/.github/workflows/build-manywheel-images-s390x.yml
+++ b/.github/workflows/build-manywheel-images-s390x.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-docker-cpu-s390x:
     if: github.repository_owner == 'pytorch'

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -28,6 +28,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   get-label-type:
     if: github.repository_owner == 'pytorch'

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [try-cherry-pick]
 
+permissions:
+  contents: read
+
 jobs:
   cherry-pick:
     name: cherry-pick-pr-${{ github.event.client_payload.pr_num }}

--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -14,6 +14,9 @@ on:
       -  ciflow/inductor-cu126/*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   bc_linter:
     if: github.repository_owner == 'pytorch'

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [try-revert]
 
+permissions:
+  contents: read
+
 jobs:
   do_revert:
     name: try_revert_pr_${{ github.event.client_payload.pr_num }}

--- a/.github/workflows/test-check-binary.yml
+++ b/.github/workflows/test-check-binary.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check_binary_linux_cpu:
     if: github.repository_owner == 'pytorch'

--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [try-rebase]
 
+permissions:
+  contents: read
+
 jobs:
   do_rebase:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 8 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `_binary-build-flash-attention-wheel-linux.yml`, `_binary-build-flash-attention-wheel-windows.yml`, `apply-lint.yml`, `check_mergeability_ghstack.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.