### PR TITLE
[ROCm][Windows] Apply per-config HIP optimization flags via CMAKE_HIP_FLAGS

### DIFF
--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -146,8 +146,13 @@ if(WIN32)
   # Override them all with GNU-style rules for clang++.
 
   # Compile: use GNU-style flags (-o, -isystem) instead of MSVC-style.
+  # Force -O3 on the compile line. The per-config CMAKE_HIP_FLAGS_RELEASE
+  # values do not reliably reach <FLAGS> here, so HIP code silently fell back
+  # to clang++'s -O0 default and caused a 99% conv2d perf regression on
+  # Windows ROCm (TheRock#5157). Putting -O3 directly in the compile rule
+  # guarantees it.
   set(CMAKE_HIP_COMPILE_OBJECT
-    "<CMAKE_HIP_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -x hip -c <SOURCE>")
+    "<CMAKE_HIP_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -O3 -o <OBJECT> -x hip -c <SOURCE>")
   set(CMAKE_INCLUDE_SYSTEM_FLAG_HIP "-isystem ")
   set(CMAKE_HIP_DEPFILE_FORMAT gcc)
   set(CMAKE_DEPFILE_FLAGS_HIP "-MD -MT <DEP_TARGET> -MF <DEP_FILE>")

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -126,18 +126,35 @@ if(WIN32)
   # CMake 4.3.0+ regression: the Windows-MSVC platform module seeds
   # CMAKE_HIP_FLAGS{,_<CONFIG>} with MSVC-style defaults (/DWIN32 /D_WINDOWS,
   # /O2 /Ob2 /DNDEBUG) when C/CXX use clang-cl. clang++ (GNU frontend) for HIP
-  # rejects them. Strip them and reinstate GNU equivalents. Not needed on
-  # CMake 4.2.x, but safe to run there too.
+  # rejects them. Strip them out. Not needed on CMake 4.2.x, but safe there.
   foreach(_cfg "" _DEBUG _RELEASE _MINSIZEREL _RELWITHDEBINFO)
     if(DEFINED CMAKE_HIP_FLAGS${_cfg})
       string(REGEX REPLACE "(^| )/[a-zA-Z][a-zA-Z0-9_:=.]*" "" CMAKE_HIP_FLAGS${_cfg} "${CMAKE_HIP_FLAGS${_cfg}}")
       string(STRIP "${CMAKE_HIP_FLAGS${_cfg}}" CMAKE_HIP_FLAGS${_cfg})
     endif()
   endforeach()
-  string(APPEND CMAKE_HIP_FLAGS_RELEASE " -O3 -DNDEBUG")
-  string(APPEND CMAKE_HIP_FLAGS_RELWITHDEBINFO " -O2 -DNDEBUG -g")
-  string(APPEND CMAKE_HIP_FLAGS_MINSIZEREL " -Os -DNDEBUG")
-  string(APPEND CMAKE_HIP_FLAGS_DEBUG " -O0 -g")
+
+  # Reinstate GNU-equivalent optimization flags. The generated HIP compile
+  # rule's <FLAGS> includes CMAKE_HIP_FLAGS but, on this code path, does
+  # not include CMAKE_HIP_FLAGS_<CONFIG> (verified via build.ninja), so
+  # appending to the per-config variables is dead code. Inject the per-config
+  # flags into CMAKE_HIP_FLAGS instead, gated on CMAKE_BUILD_TYPE for
+  # single-config generators (Ninja, Makefiles). Without this, clang++
+  # falls back to -O0 and HIP kernels are unoptimized (~99% conv2d FP16
+  # perf regression on gfx1150; TheRock#5157, #183853).
+  if(NOT CMAKE_CONFIGURATION_TYPES)
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" _hip_cfg)
+    if(_hip_cfg STREQUAL "DEBUG")
+      string(APPEND CMAKE_HIP_FLAGS " -O0 -g")
+    elseif(_hip_cfg STREQUAL "RELWITHDEBINFO")
+      string(APPEND CMAKE_HIP_FLAGS " -O2 -DNDEBUG -g")
+    elseif(_hip_cfg STREQUAL "MINSIZEREL")
+      string(APPEND CMAKE_HIP_FLAGS " -Os -DNDEBUG")
+    else()  # Release or unset
+      string(APPEND CMAKE_HIP_FLAGS " -O3 -DNDEBUG")
+    endif()
+    unset(_hip_cfg)
+  endif()
 endif()
 
 if(WIN32)
@@ -146,13 +163,8 @@ if(WIN32)
   # Override them all with GNU-style rules for clang++.
 
   # Compile: use GNU-style flags (-o, -isystem) instead of MSVC-style.
-  # Force -O3 on the compile line. The per-config CMAKE_HIP_FLAGS_RELEASE
-  # values do not reliably reach <FLAGS> here, so HIP code silently fell back
-  # to clang++'s -O0 default and caused a 99% conv2d perf regression on
-  # Windows ROCm (TheRock#5157). Putting -O3 directly in the compile rule
-  # guarantees it.
   set(CMAKE_HIP_COMPILE_OBJECT
-    "<CMAKE_HIP_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -O3 -o <OBJECT> -x hip -c <SOURCE>")
+    "<CMAKE_HIP_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -x hip -c <SOURCE>")
   set(CMAKE_INCLUDE_SYSTEM_FLAG_HIP "-isystem ")
   set(CMAKE_HIP_DEPFILE_FORMAT gcc)
   set(CMAKE_DEPFILE_FLAGS_HIP "-MD -MT <DEP_TARGET> -MF <DEP_FILE>")


### PR DESCRIPTION
## Issue

Fixes ROCm/TheRock#5157.
Fixes https://github.com/pytorch/pytorch/issues/183853.

Windows ROCm HIP code was effectively compiled at `-O0` after #180485 + #183365 landed, causing a ~99% conv2d FP16 perf regression on gfx1150 (bisected and validated by @astrelsky and @adityas-amd at ROCm/TheRock#5157).

## Diagnosis

After #183365 stripped the MSVC-style `/O2 /Ob2 /DNDEBUG` out of `CMAKE_HIP_FLAGS_RELEASE` and re-appended GNU `-O3 -DNDEBUG`, the actual build command still came up unoptimized. Inspecting the generated `build.ninja` shows why:

- `CMAKE_HIP_FLAGS` contents (e.g. `--offload-compress -std=c++20 --offload-arch=...`) **do** reach the `$FLAGS` ninja variable used by every HIP compile.
- `CMAKE_HIP_FLAGS_<CONFIG>` contents (e.g. `-O3 -DNDEBUG`) **do not**.

That's the actual cause of the `-O0` fallback — `CMAKE_HIP_FLAGS_RELEASE` is dead code on the Windows HIP compile path.

## Fix

- Drop the dead `string(APPEND CMAKE_HIP_FLAGS_<CONFIG> ...)` lines.
- Inject the appropriate `-O{3,2,0,s}` plus `-DNDEBUG`/`-g` directly into `CMAKE_HIP_FLAGS`, gated on `CMAKE_BUILD_TYPE`. This works for single-config generators (Ninja, Makefiles), which is what the Windows ROCm build uses.
- Drop the `-O3` from the compile rule template so non-Release configs aren't tainted.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @adityas-amd @astrelsky