### PR TITLE
Support float8 dtypes in index_copy on CPU and CUDA

### DIFF
--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -271,8 +271,8 @@ void index_copy_kernel(
   int64_t dim,
   int64_t self_dim_size,
   int64_t self_dim_stride) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, kComplexHalf,
-    iter.dtype(), "index_copy_cpu", [&] {
+  AT_DISPATCH_V2(
+    iter.dtype(), "index_copy_cpu", AT_WRAP([&] {
     auto handle_nonzero_idx_stride = [&](char** data, const int64_t* strides, int64_t n) {
       auto* self_data_bytes = data[0];
       auto* index_data_bytes = data[1];
@@ -326,7 +326,10 @@ void index_copy_kernel(
     } else {
       iter.for_each(loop);
     }
-  });
+  }),
+    AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX),
+    kComplexHalf, kHalf, kBool, kBFloat16,
+    AT_EXPAND(AT_FLOAT8_TYPES));
 }
 
 template <typename scalar_t>

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -254,12 +254,16 @@ static void index_copy_kernel(
   // See note [Writing Nondeterministic Operations]
   // Nondeterministic when index contains duplicate entries
   // this kernel will not be called when torch.use_deterministic_algorithms(True)
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
-    at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, kComplexHalf,
-    iter.dtype(), "index_copy_cuda", [&] {
-    using dtype = OpaqueType<sizeof(scalar_t)>;
-    index_copy_kernel_impl<dtype>(iter, dim, self_dim_size, self_dim_stride);
-  });
+  AT_DISPATCH_V2(
+    iter.dtype(),
+    "index_copy_cuda",
+    AT_WRAP([&] {
+      using dtype = OpaqueType<sizeof(scalar_t)>;
+      index_copy_kernel_impl<dtype>(iter, dim, self_dim_size, self_dim_stride);
+    }),
+    AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX),
+    kComplexHalf, kHalf, kBool, kBFloat16,
+    AT_EXPAND(AT_FLOAT8_TYPES));
 }
 
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1902,7 +1902,7 @@ class TestIndexing(TestCase):
                         kwargs = {"atol": 0.02, "rtol": 0.1}
                     self.assertEqual(dest, expected, **kwargs)
 
-    @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
+    @dtypes(*all_types_complex_float8_and(torch.half, torch.bool, torch.bfloat16))
     @dtypesIfMPS(*all_mps_types_and(torch.bool, torch.cfloat))
     def test_index_copy(self, device, dtype):
         # We just test for num_copy <= num_dest, as otherwise there are repeated indices
@@ -1946,7 +1946,7 @@ class TestIndexing(TestCase):
     # onlyNativeDeviceTypes due to an XLA error:
     # https://github.com/pytorch/pytorch/issues/53256
     @onlyNativeDeviceTypes
-    @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
+    @dtypes(*all_types_complex_float8_and(torch.half, torch.bool, torch.bfloat16))
     @dtypesIfMPS(*all_mps_types_and(torch.bool, torch.cfloat))
     def test_index_copy_scalars(self, device, dtype):
         # Create the 8 possible combinations of scalar sizes for target / index / source


### PR DESCRIPTION
Fixes #180855.

### Summary
Adds float8 dtype support to `torch.index_copy` on both CPU and CUDA. The issue's repro

```python
import torch
input = torch.empty(1, dtype=torch.float8_e5m2)
index = torch.tensor([0])
source = torch.empty(1, dtype=torch.float8_e5m2)
torch.index_copy(input, 0, index, source)
```

currently raises `NotImplementedError: "index_copy_cpu" not implemented for 'Float8_e5m2'` (and an analogous error on CUDA).

`index_copy` is a pure element-wise copy. The CPU kernel writes via `c10::load` (a `reinterpret_cast`) and the CUDA kernel operates on `OpaqueType<sizeof(scalar_t)>` — neither does arithmetic or type conversion, so all five float8 variants are safe to add.

This mirrors how `index_select` (also a pure-copy op) supports float8: both its CPU and CUDA dispatches use `AT_DISPATCH_V2` with `AT_EXPAND(AT_FLOAT8_TYPES)`. The macro and helper (`all_types_complex_float8_and`) are reused unchanged.

### Out of scope
`index_add` / `index_add_` is mentioned in the issue comment but multiplies by `alpha` and accumulates, so float8 arithmetic concerns apply. That op is tracked separately under #113663 and is not touched here.

### Files changed
- `aten/src/ATen/native/cpu/IndexKernel.cpp` — `index_copy_kernel` macro swap
- `aten/src/ATen/native/cuda/IndexKernel.cu` — `index_copy_kernel` macro swap
- `test/test_indexing.py` — `test_index_copy` and `test_index_copy_scalars` parametrization

### Test plan
PyTorch was not built locally (no source build environment), so the CPU and CUDA variants were not exercised here. Expected commands:

```bash
python test/test_indexing.py TestIndexingCPU.test_index_copy_cpu_float8_e5m2
python test/test_indexing.py TestIndexingCPU.test_index_copy_scalars_cpu_float8_e5m2
python test/test_indexing.py TestIndexingCUDA.test_index_copy_cuda_float8_e5m2
python test/test_indexing.py TestIndexingCUDA.test_index_copy_scalars_cuda_float8_e5m2
```

Relying on PyTorch CI to validate the device-specific kernel builds.

Authored by Claude.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01