### PR TITLE
Add batching rule for count_nonzero

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesReduceOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesReduceOps.cpp
@@ -75,6 +75,14 @@ static Tensor any_decomp(const Tensor& self) {
   return at::any(self.flatten(), 0, false);
 }
 
+static Tensor count_nonzero_decomp(
+  const Tensor& self, std::optional<int64_t> dim) {
+if (dim.has_value()) {
+  return at::count_nonzero(self, IntArrayRef{*dim});
+}
+return at::count_nonzero(self, range(0, self.dim()));
+}
+
 enum class ReductionCase:uint8_t { DimArray, Dim };
 
 // Macros and templates have a difficult time dealing with enums,
@@ -464,6 +472,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   REDUCTION_WITH_KEEPDIM_ARG(argmin);
   m.impl("bucketize.Tensor", bucketize_decomp_Tensor);
   m.impl("bucketize.Scalar", bucketize_decomp_Scalar);
+  m.impl("count_nonzero", count_nonzero_decomp);
   REDUCTION_BOXED_ARGS(count_nonzero.dim_IntList, 1, KEEPDIM_CASE_FALSE, -1);
   REDUCTION_NO_KEEPDIM_ARG(cummax);
   REDUCTION_NO_KEEPDIM_ARG(cummin);

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4516,7 +4516,6 @@ class TestVmapOperatorsOpInfo(TestCase):
                 xfail("tril"),  # Exception not raised on error input
                 xfail("triu"),  # Exception not raised on error input
                 xfail("__getitem__", ""),
-                xfail("count_nonzero"),
                 xfail(
                     "nn.functional.dropout"
                 ),  # works, can't check against for loop because of randomness inconsistency


### PR DESCRIPTION
Fixes: #183536 

### Summary

- Fixes the missing vmap batching rule for count_nonzero, removing the performance warning and enabling vectorized execution under torch.vmap.


### Test:

- Removed `xfail("count_nonzero") `from `test/functorch/test_vmap.py` -- the existing opinfo-driven vmap tests now pass

cc @Chillee @samdow @kshitij12345