### PR TITLE
[autograd] Fix enforce_grad_layout_policy decorator state leak.

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -13939,9 +13939,14 @@ class TestAutogradDeviceType(TestCase):
         a.grad = None
 
         # --- as a decorator ---
+        torch._C._set_grad_layout_enforcement_enabled(True)
+
         @torch.autograd.enforce_grad_layout_policy(False)
         def do_backward():
             ContiguousGrad.apply(a).backward()
+
+        # Check that the flag doesn't leak during function decoration.
+        self.assertTrue(torch._C._is_grad_layout_enforcement_enabled())
 
         do_backward()
         self.assertTrue(a.grad.is_contiguous())

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -394,6 +394,10 @@ class enforce_grad_layout_policy(_DecoratorContextManager):
         torch._C._set_grad_layout_enforcement_enabled(enable)
         self.mode = enable
 
+    def __call__(self, orig_func: F) -> F:
+        torch._C._set_grad_layout_enforcement_enabled(self.prev)
+        return super().__call__(orig_func)
+
     def __enter__(self) -> None:
         pass
 


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/183867

## Changes

`enforce_grad_layout_policy` was missing a `__call__` override, causing the global `grad_layout_enforcement_enabled` flag to leak as `False` after the class was used as a decorator. This could silently affect any subsequent code running in the same process or worker thread.

Add the missing `__call__` override, following the same pattern already used by  [`set_grad_enabled`](https://github.com/pytorch/pytorch/blob/b3e08d6a6f08c53aababaf4b65de763ba2da2e15/torch/autograd/grad_mode.py#L190-L192) and [`_force_original_view_tracking`](https://github.com/pytorch/pytorch/blob/b3e08d6a6f08c53aababaf4b65de763ba2da2e15/torch/autograd/grad_mode.py#L437-L439) in the same file:

```python
def __call__(self, orig_func: F) -> F:
    torch._C._set_grad_layout_enforcement_enabled(self.prev)
    return super().__call__(orig_func)
```

Context-manager usage (`with enforce_grad_layout_policy(...)`) is unaffected.

More detailed problem description in the issue: https://github.com/pytorch/pytorch/issues/183867