### PR TITLE
[dcp] Explicitly flush streams before os.fsync to support remote storage systems like GCS

### DIFF
--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -185,8 +185,6 @@ class TestFSSpec(ShardedTensorTestBase):
             )
 
     @with_comms(backend=BACKEND, init_rpc=False)
-    @requires_accelerator_dist_backend()
-    @skip_if_lt_x_gpu(2)
     def test_fsspec_without_fileno_support(self):
         """
         This tests that the stream is flushed and fsync degrades gracefully.

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -5,6 +5,9 @@ import tempfile
 from collections.abc import Callable
 from functools import wraps
 from typing import Any
+from unittest.mock import patch
+
+import fsspec
 
 import torch
 import torch.distributed as dist
@@ -208,9 +211,10 @@ class TestFileSystem(TestCase):
                 raise OSError("fail")
         self.assertTrue(fs.exists(read_file))
 
-    def test_fsspec_without_fileno_support(self):
+    @patch("os.sync")
+    def test_fsspec_without_fileno_support(self, mock_os_sync):
         """
-        fsspec's "memory://" protocol simulates cloud storage like GCS or S3
+        fsspec's "memory://" protocol simulates cloud storage
         by not supporting .fileno() and raising io.UnsupportedOperation.
         This tests that the stream is flushed and fsync degrades gracefully.
         """
@@ -219,13 +223,22 @@ class TestFileSystem(TestCase):
         # Create a dummy state dict
         state_dict = {"tensor": torch.randn(10)}
 
-        # Save using FsspecWriter
-        dcp.save(
-            state_dict=state_dict,
-            storage_writer=FsspecWriter(checkpoint_dir),
-            planner=dcp.DefaultSavePlanner(),
-            no_dist=True,
-        )
+        # Spy on the MemoryFile flush method to ensure it gets called
+        with patch.object(
+            fsspec.implementations.memory.MemoryFile, "flush", autospec=True
+        ) as mock_flush:
+            # Save using FsspecWriter
+            dcp.save(
+                state_dict=state_dict,
+                storage_writer=FsspecWriter(checkpoint_dir),
+                planner=dcp.DefaultSavePlanner(),
+                no_dist=True,
+            )
+
+            # Assert that flush() was explicitly called on the stream
+            self.assertTrue(
+                mock_flush.called, "Expected stream.flush() to be called explicitly."
+            )
 
         # Verify it saved properly and can be loaded
         load_dict = {"tensor": torch.zeros(10)}
@@ -237,6 +250,9 @@ class TestFileSystem(TestCase):
         )
 
         self.assertTrue(torch.allclose(state_dict["tensor"], load_dict["tensor"]))
+
+        # Assert that os.sync() was NEVER called
+        mock_os_sync.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -184,6 +184,34 @@ class TestFSSpec(ShardedTensorTestBase):
                 storage_writer=FsspecWriter(self.temp_dir, overwrite=False),
             )
 
+    @with_comms(backend=BACKEND, init_rpc=False)
+    @requires_accelerator_dist_backend()
+    @skip_if_lt_x_gpu(2)
+    def test_fsspec_without_fileno_support(self):
+        """
+        This tests that the stream is flushed and fsync degrades gracefully.
+        """
+        checkpoint_dir = f"memory://test_checkpoint"
+
+        state_dict = {"tensor": torch.randn(10, device=device_type)}
+
+        # This will crash without the stream.flush() and fsync try/except fix
+        dcp.save(
+            state_dict=state_dict,
+            storage_writer=FsspecWriter(checkpoint_dir),
+            planner=dcp.DefaultSavePlanner(),
+        )
+
+        load_dict = {"tensor": torch.zeros(10, device=device_type)}
+        dcp.load(
+            state_dict=load_dict,
+            storage_reader=FsspecReader(checkpoint_dir),
+            planner=dcp.DefaultLoadPlanner(),
+        )
+
+        self.assertTrue(
+            torch.allclose(state_dict["tensor"], load_dict["tensor"]))
+
 
 class TestFileSystem(TestCase):
     @with_temp_dir

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -184,32 +184,6 @@ class TestFSSpec(ShardedTensorTestBase):
                 storage_writer=FsspecWriter(self.temp_dir, overwrite=False),
             )
 
-    @with_comms(backend=BACKEND, init_rpc=False)
-    def test_fsspec_without_fileno_support(self):
-        """
-        This tests that the stream is flushed and fsync degrades gracefully.
-        """
-        checkpoint_dir = f"memory://test_checkpoint"
-
-        state_dict = {"tensor": torch.randn(10, device=device_type)}
-
-        # This will crash without the stream.flush() and fsync try/except fix
-        dcp.save(
-            state_dict=state_dict,
-            storage_writer=FsspecWriter(checkpoint_dir),
-            planner=dcp.DefaultSavePlanner(),
-        )
-
-        load_dict = {"tensor": torch.zeros(10, device=device_type)}
-        dcp.load(
-            state_dict=load_dict,
-            storage_reader=FsspecReader(checkpoint_dir),
-            planner=dcp.DefaultLoadPlanner(),
-        )
-
-        self.assertTrue(
-            torch.allclose(state_dict["tensor"], load_dict["tensor"]))
-
 
 class TestFileSystem(TestCase):
     @with_temp_dir
@@ -233,6 +207,36 @@ class TestFileSystem(TestCase):
             with fs.create_stream(read_file, "r") as s:
                 raise OSError("fail")
         self.assertTrue(fs.exists(read_file))
+
+    def test_fsspec_without_fileno_support(self):
+        """
+        fsspec's "memory://" protocol simulates cloud storage like GCS or S3
+        by not supporting .fileno() and raising io.UnsupportedOperation.
+        This tests that the stream is flushed and fsync degrades gracefully.
+        """
+        checkpoint_dir = "memory://test_checkpoint_with_no_file_no"
+
+        # Create a dummy state dict
+        state_dict = {"tensor": torch.randn(10)}
+
+        # Save using FsspecWriter
+        dcp.save(
+            state_dict=state_dict,
+            storage_writer=FsspecWriter(checkpoint_dir),
+            planner=dcp.DefaultSavePlanner(),
+            no_dist=True,
+        )
+
+        # Verify it saved properly and can be loaded
+        load_dict = {"tensor": torch.zeros(10)}
+        dcp.load(
+            state_dict=load_dict,
+            storage_reader=FsspecReader(checkpoint_dir),
+            planner=dcp.DefaultLoadPlanner(),
+            no_dist=True,
+        )
+
+        self.assertTrue(torch.allclose(state_dict["tensor"], load_dict["tensor"]))
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import patch
 
 import fsspec
+import fsspec.implementations.memory
 
 import torch
 import torch.distributed as dist

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -473,7 +473,7 @@ def _write_files_from_queue(
                     try:
                         os.fsync(stream.fileno())
                     except (AttributeError, UnsupportedOperation):
-                        os.sync()
+                        pass  # flush() and fsync already did what was possible for this stream/file
                 stream.close()
             result_queue.put(write_results)
     except queue.Empty:
@@ -780,7 +780,7 @@ class _FileSystemWriter(StorageWriter):
                 try:
                     os.fsync(metadata_file.fileno())
                 except (AttributeError, UnsupportedOperation):
-                    os.sync()
+                    pass  # flush() and fsync already did what was possible for this stream/file
 
         # delete in-case other checkpoints were present.
         if not self.use_collectives and self.rank is not None:

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -473,7 +473,7 @@ def _write_files_from_queue(
                     try:
                         os.fsync(stream.fileno())
                     except (AttributeError, UnsupportedOperation):
-                        pass  # flush() and fsync already did what was possible for this stream/file
+                        pass  # flush() already did what was possible for this stream
                 stream.close()
             result_queue.put(write_results)
     except queue.Empty:
@@ -780,7 +780,7 @@ class _FileSystemWriter(StorageWriter):
                 try:
                     os.fsync(metadata_file.fileno())
                 except (AttributeError, UnsupportedOperation):
-                    pass  # flush() and fsync already did what was possible for this stream/file
+                    pass  # flush() already did what was possible for this stream
 
         # delete in-case other checkpoints were present.
         if not self.use_collectives and self.rank is not None:

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -468,6 +468,9 @@ def _write_files_from_queue(
                     )
 
                 if use_fsync:
+                    # For local files, this pushes Python's internal buffers to the OS.
+                    # For cloud storage, this pushes the in-memory data over the network to remote storage.
+                    stream.flush()
                     try:
                         os.fsync(stream.fileno())
                     except (AttributeError, UnsupportedOperation):

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -468,8 +468,7 @@ def _write_files_from_queue(
                     )
 
                 if use_fsync:
-                    # For local files, this pushes Python's internal buffers to the OS.
-                    # For cloud storage, this pushes the in-memory data over the network to remote storage.
+                    # Flush Python-level buffers (OS for local files, network for cloud storage) before fsync.
                     stream.flush()
                     try:
                         os.fsync(stream.fileno())
@@ -776,8 +775,7 @@ class _FileSystemWriter(StorageWriter):
         with self.fs.create_stream(tmp_path, "wb") as metadata_file:
             pickle.dump(metadata, metadata_file)
             if self.sync_files:
-                # For local files, this pushes Python's internal buffers to the OS.
-                # For cloud storage, this pushes the in-memory data over the network to remote storage.
+                # Flush Python-level buffers (OS for local files, network for cloud storage) before fsync.
                 metadata_file.flush()
                 try:
                     os.fsync(metadata_file.fileno())

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -776,6 +776,9 @@ class _FileSystemWriter(StorageWriter):
         with self.fs.create_stream(tmp_path, "wb") as metadata_file:
             pickle.dump(metadata, metadata_file)
             if self.sync_files:
+                # For local files, this pushes Python's internal buffers to the OS.
+                # For cloud storage, this pushes the in-memory data over the network to remote storage.
+                metadata_file.flush()
                 try:
                     os.fsync(metadata_file.fileno())
                 except (AttributeError, UnsupportedOperation):

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -472,8 +472,10 @@ def _write_files_from_queue(
                     stream.flush()
                     try:
                         os.fsync(stream.fileno())
-                    except (AttributeError, UnsupportedOperation):
-                        pass  # flush() already did what was possible for this stream
+                    except (AttributeError, UnsupportedOperation) as e:
+                        warnings.warn(
+                            f"fsync not supported for this stream, relying on flush(): {e}"
+                        )
                 stream.close()
             result_queue.put(write_results)
     except queue.Empty:
@@ -779,8 +781,10 @@ class _FileSystemWriter(StorageWriter):
                 metadata_file.flush()
                 try:
                     os.fsync(metadata_file.fileno())
-                except (AttributeError, UnsupportedOperation):
-                    pass  # flush() already did what was possible for this stream
+                except (AttributeError, UnsupportedOperation) as e:
+                    warnings.warn(
+                        f"fsync not supported for this stream, relying on flush(): {e}"
+                    )
 
         # delete in-case other checkpoints were present.
         if not self.use_collectives and self.rank is not None:


### PR DESCRIPTION
Fixes #183878
[dcp] Add stream.flush() before fsync to ensure python-level buffers are explicitly flushed before relying on os.fsync(). This change also removes the unnecessary and heavy operation os.sync.