### PR TITLE
[Native DSL] Simplify element-size lookups

### DIFF
--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -50,10 +50,7 @@ Restrictions (enforced by the host cond in ``cutedsl_impl.py``):
     cp.reduce.async.bulk gmem operand)
 """
 
-import math
-
 import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]
-
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.cpasync as cpasync
@@ -324,7 +321,7 @@ def _chunk_elems_for(torch_dtype: torch.dtype, N: int) -> int:
     Rounded down to a multiple of ``16 / elem_bytes`` so the final
     partial chunk (if any) still satisfies the 16-byte reduce
     alignment."""
-    elem_bytes = torch.tensor([], dtype=torch_dtype).element_size()
+    elem_bytes = torch_dtype.itemsize
     row_bytes = N * elem_bytes
     chunk_bytes = min(row_bytes, _MAX_CHUNK_BYTES)
     # Ensure chunk_bytes itself is 16-aligned (true for 512, true for
@@ -371,11 +368,10 @@ def _compile_tma_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
 def min_d_divisor_for(dtype: torch.dtype) -> int:
     """Smallest value D must be divisible by so ``cp.reduce.async.bulk``
     gmem operands stay 16-byte aligned: ``D * sizeof(dtype) % 16 == 0``,
-    i.e. ``D % (16 / gcd(16, sizeof(dtype))) == 0``. fp32: %4,
-    bf16/fp16: %8.
+    i.e. ``D % (16 / sizeof(dtype)) == 0``. fp32: %4, bf16/fp16: %8.
+    Supported dtypes' itemsize divides 16, so plain // suffices.
     """
-    esize = torch.tensor([], dtype=dtype).element_size()
-    return 16 // math.gcd(16, esize)
+    return 16 // dtype.itemsize
 
 
 def row_shape_supported(dtype: torch.dtype, N: int) -> bool:
@@ -388,8 +384,7 @@ def row_shape_supported(dtype: torch.dtype, N: int) -> bool:
     16-aligned). Rows that aren't multiples of ``chunk_elems`` are
     handled via the TMA descriptor's OOB-clamp-to-zero behavior.
     """
-    esize = torch.tensor([], dtype=dtype).element_size()
-    return (N * esize) % 16 == 0
+    return (N * dtype.itemsize) % 16 == 0
 
 
 def _plan_grid(M: int, D: int, chunk_elems: int, sm: int) -> tuple[int, int, int]:

--- a/torch/_native/ops/scatter_add/vec_scatter_kernel.py
+++ b/torch/_native/ops/scatter_add/vec_scatter_kernel.py
@@ -228,7 +228,7 @@ def _compile_vec_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
 
 def vec_elems_for(dtype: torch.dtype) -> int:
     """Elements per lane per step (16-byte vector gather)."""
-    return _VEC_BYTES // torch.tensor([], dtype=dtype).element_size()
+    return _VEC_BYTES // dtype.itemsize
 
 
 def vec_scatter_add_into(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183895

Fixup unnecessary complexity in element itemsize.

Drop overly-defensive `gcd` call in divisor - all dtypes that the
initial conditional accepts divide 16, so 16 // dtye_size is sufficient.

Signed-off-by: Simon Layton <simonlayton@meta.com>