### PR TITLE
[custom-ops] Validate fake kernel signature at registration time

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -5333,6 +5333,160 @@ Please use `add.register_fake` to add an fake impl.""",
             ):
                 torch.library.get_kernel("test_invalid_kernel::cpu_only_op", "CUDA")
 
+    def test_register_fake_signature_validation_standalone_path(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            lib.define("sig_val_standalone(Tensor x, int n) -> Tensor")
+
+            with self.assertRaises(TypeError):
+
+                @torch.library.register_fake(
+                    "_torch_testing::sig_val_standalone", lib=lib
+                )
+                def foo_fake(x: Tensor) -> Tensor:
+                    return x.clone()
+
+    def test_register_fake_signature_validation_missing_arg(self):
+        @torch.library.custom_op("_torch_testing::sig_val_missing", mutates_args=())
+        def foo(x: Tensor, n: int) -> Tensor:
+            return x.clone().repeat(n)
+
+        with self.assertRaises(TypeError):
+
+            @foo.register_fake
+            def foo_fake(x: Tensor) -> Tensor:
+                return x.clone()
+
+    def test_register_fake_signature_validation_extra_arg(self):
+        @torch.library.custom_op("_torch_testing::sig_val_extra", mutates_args=())
+        def foo(x: Tensor) -> Tensor:
+            return x.clone()
+
+        with self.assertRaises(TypeError):
+
+            @foo.register_fake
+            def foo_fake(x: Tensor, n: int) -> Tensor:
+                return x.clone()
+
+    def test_register_fake_signature_validation_wrong_names_ok(self):
+        @torch.library.custom_op("_torch_testing::sig_val_names", mutates_args=())
+        def foo(x: Tensor, n: int) -> Tensor:
+            return x.clone().repeat(n)
+
+        @foo.register_fake
+        def foo_fake(a: Tensor, b: int) -> Tensor:
+            return a.clone()
+
+    def test_register_fake_signature_validation_varargs_skipped(self):
+        @torch.library.custom_op("_torch_testing::sig_val_varargs", mutates_args=())
+        def foo(x: Tensor, n: int) -> Tensor:
+            return x.clone().repeat(n)
+
+        @foo.register_fake
+        def foo_fake(*args) -> Tensor:
+            return args[0].clone()
+
+    def test_register_fake_signature_validation_happy_path(self):
+        @torch.library.custom_op("_torch_testing::sig_val_happy", mutates_args=())
+        def foo(x: Tensor, n: int) -> Tensor:
+            return x.clone().repeat(n)
+
+        @foo.register_fake
+        def foo_fake(x: Tensor, n: int) -> Tensor:
+            return x.clone()
+
+    def test_register_fake_signature_validation_default_args(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            lib.define(
+                "sig_val_defaults(Tensor x, int n=0, *, float scale=1.0) -> Tensor"
+            )
+
+            @torch.library.register_fake("_torch_testing::sig_val_defaults", lib=lib)
+            def foo_fake(x: Tensor, n: int = 0) -> Tensor:
+                return x.clone()
+
+    def test_register_fake_signature_validation_runtime(self):
+        @torch.library.custom_op("_torch_testing::sig_val_runtime", mutates_args=())
+        def foo(x: Tensor, n: int) -> Tensor:
+            return x.clone().repeat(n)
+
+        @foo.register_fake
+        def foo_fake(x: Tensor, n: int) -> Tensor:
+            return x.clone()
+
+        with torch._subclasses.fake_tensor.FakeTensorMode():
+            t = torch.randn(3)
+            result = foo(t, 2)
+            self.assertEqual(result.shape, t.shape)
+
+    def test_register_fake_signature_validation_positional_default_rejected(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            lib.define("sig_val_pos_def(Tensor x, int n=0) -> Tensor")
+
+            with self.assertRaises(TypeError):
+
+                @torch.library.register_fake("_torch_testing::sig_val_pos_def", lib=lib)
+                def foo_fake(x: Tensor) -> Tensor:
+                    return x.clone()
+
+    def test_register_fake_signature_validation_kwonly_mismatch(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            lib.define("sig_val_kw(Tensor x, *, float scale=1.0) -> Tensor")
+
+            with self.assertRaises(TypeError):
+
+                @torch.library.register_fake("_torch_testing::sig_val_kw", lib=lib)
+                def foo_fake(
+                    x: Tensor, *, scale: float = 1.0, extra: int = 0
+                ) -> Tensor:
+                    return x.clone()
+
+    def test_register_fake_signature_validation_kwargs_skipped(self):
+        @torch.library.custom_op("_torch_testing::sig_val_kwargs", mutates_args=())
+        def foo(x: Tensor, n: int) -> Tensor:
+            return x.clone().repeat(n)
+
+        @foo.register_fake
+        def foo_fake(**kwargs) -> Tensor:
+            return kwargs["x"].clone()
+
+    def test_register_fake_signature_validation_unregistered_op(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            with self.assertRaises(RuntimeError):
+
+                @torch.library.register_fake("_torch_testing::nonexistent_op", lib=lib)
+                def foo_fake(x: Tensor) -> Tensor:
+                    return x.clone()
+
+    def test_register_fake_signature_validation_out_op(self):
+        @torch.library.custom_op(
+            "_torch_testing::sig_val_out",
+            mutates_args={"out"},
+            tags=torch.Tag.out,
+        )
+        def foo(x: Tensor, *, out: Tensor) -> Tensor:
+            out.copy_(x)
+            return out
+
+        @foo.register_fake
+        def foo_fake(x, *, out):
+            return out.clone()
+
+    def test_register_fake_signature_validation_out_op_missing(self):
+        @torch.library.custom_op(
+            "_torch_testing::sig_val_out_missing",
+            mutates_args={"out"},
+            tags=torch.Tag.out,
+        )
+        def foo(x: Tensor, *, out: Tensor) -> Tensor:
+            out.copy_(x)
+            return out
+
+        with self.assertRaises(TypeError):
+
+            @foo.register_fake
+            def foo_fake(x):
+                return x.clone()
+
 
 class TestLibrarySourceLocation(TestCase):
     def test_library_source_location(self):

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -598,6 +598,9 @@ class CustomOpDef:
                 "The provided fake impl will be used instead.",
                 stacklevel=2,
             )
+        from torch._library.utils import validate_fake_signature
+
+        validate_fake_signature(fn, self._opoverload._schema)
         self._abstract_fn = fn
         return fn
 

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -706,3 +706,52 @@ def is_impure(
         return True
 
     return False
+
+
+def validate_fake_signature(func: Callable, schema: _C.FunctionSchema) -> None:
+    try:
+        sig = inspect.signature(func)
+    except (ValueError, TypeError):
+        return
+    params = list(sig.parameters.values())
+
+    if any(
+        p.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        for p in params
+    ):
+        return
+
+    schema_positional = [a for a in schema.arguments if not a.kwarg_only]
+    schema_kwonly = [a for a in schema.arguments if a.kwarg_only]
+
+    func_positional = [
+        p
+        for p in params
+        if p.kind
+        in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.POSITIONAL_ONLY)
+    ]
+    func_kwonly = [p for p in params if p.kind == inspect.Parameter.KEYWORD_ONLY]
+
+    # Positional: exact count (dispatcher forwards all the caller provides).
+    # Kwarg-only: range-checked because prims omit optional kwarg-only params.
+    n_required_kw = sum(1 for a in schema_kwonly if not a.has_default_value())
+
+    pos_ok = len(func_positional) == len(schema_positional)
+    kw_ok = n_required_kw <= len(func_kwonly) <= len(schema_kwonly)
+
+    if not pos_ok or not kw_ok:
+        schema_names = [a.name for a in schema_positional] + [
+            a.name for a in schema_kwonly
+        ]
+        func_names = [p.name for p in func_positional] + [p.name for p in func_kwonly]
+        raise TypeError(
+            f"register_fake(...): the fake kernel's signature doesn't match "
+            f"the operator's schema.\n"
+            f"  operator schema: {schema}\n"
+            f"  expected {len(schema_positional)} positional and "
+            f"{n_required_kw} to {len(schema_kwonly)} keyword-only args, "
+            f"but got {len(func_positional)} positional and "
+            f"{len(func_kwonly)} keyword-only args.\n"
+            f"  schema args: ({', '.join(schema_names)})\n"
+            f"  fake kernel args: ({', '.join(func_names)})"
+        )

--- a/torch/library.py
+++ b/torch/library.py
@@ -343,6 +343,15 @@ class Library:
             caller_module_name = None
 
         qualname = f"{self.ns}::{op_name}"
+        try:
+            op = torch._library.utils.lookup_op(qualname)
+        except AttributeError as e:
+            raise RuntimeError(
+                f"register_fake(...): operator '{qualname}' has not been "
+                f"registered. Please define the operator before registering "
+                f"a fake implementation."
+            ) from e
+        torch._library.utils.validate_fake_signature(fn, op._schema)
         entry = torch._library.simple_registry.singleton.find(qualname)
         if caller_module_name is not None:
             func_to_register = _check_pystubs_once(fn, qualname, caller_module_name)


### PR DESCRIPTION
`register_fake` now checks that the fake kernel's parameter count matches the operator's schema, raising a clear TypeError immediately instead of failing with an opaque error at torch.compile time.

Positional args require exact count — the dispatcher forwards all positional args the caller provides. Kwarg-only args are range-checked (must have at least the required count) because internal prims like `prims::var` omit optional kwarg-only params.

Validation is skipped for `*args`/`**kwargs` signatures and builtins that can't be introspected.

Both registration paths are covered: `@foo.register_fake` (CustomOpDef) and `torch.library.register_fake("ns::op")` (Library._register_fake).

Fixes #181851