### PR TITLE
[XPU] Relax Muon float32 tolerance in test_state_dict_with_cuda_params

### DIFF
--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -1926,6 +1926,16 @@ optim_db: list[OptimizerInfo] = [
         supported_impls=(),
         not_og_supported_flags=(),
         supports_complex=False,
+        decorators=(
+            # XPU backend kernels accumulate float32 rounding differently from CPU,
+            # resulting in small but tolerable numerical drift in state_dict parity.
+            DecorateInfo(
+                toleranceOverride({torch.float32: tol(atol=2e-5, rtol=1.3e-6)}),
+                "TestOptimRenewed",
+                "test_state_dict_with_cuda_params",
+                device_type="xpu",
+            ),
+        ),
         skips=(
             # Note on numerical differences: `compile` applies different matmul tuning,
             # which leads to deviations compared to eager mode. In the Newton-Schulz


### PR DESCRIPTION
Fixes:
https://github.com/intel/torch-xpu-ops/issues/1973

This PR adds an XPU-specific tolerance override for Muon in optimizer tests.

The override is scoped to TestOptimRenewed.test_state_dict_with_cuda_params for torch.float32 on xpu only.

This accounts for small, expected XPU versus CPU float32 accumulation differences observed in state_dict parity checks, while keeping behavior unchanged for all other devices and dtypes.

Prerequisite
Before landing this PR, merge https://github.com/intel/torch-xpu-ops/pull/3690 first.
That change is required so XPU test override naming matches DecorateInfo test-name matching.