### PR TITLE
Mark TorchBench SAM accuracy as flaky

### DIFF
--- a/benchmarks/dynamo/check_accuracy.py
+++ b/benchmarks/dynamo/check_accuracy.py
@@ -17,6 +17,9 @@ flaky_models = {
     "mobilenetv3_large_100",
     # https://github.com/pytorch/pytorch/issues/163670
     "vision_maskrcnn",
+    # Old TorchBench SAM is flaky even with mask IoU checking.
+    # https://github.com/pytorch/pytorch/issues/176776
+    "sam",
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183906

Old TorchBench SAM still flakes in the inductor accuracy checker even with mask IoU comparison and repeated runs, so route it through the existing DISABLED_TEST-like flaky model path instead of failing CI.

Fixes #176776

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98