### PR TITLE
changing Sleef_asinhf8_u10 to std impl

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -199,7 +199,7 @@ class Vectorized<float> {
     return Vectorized<float>(Sleef_asinf8_u10(values));
   }
   Vectorized<float> asinh() const {
-    return Vectorized<float>(Sleef_asinhf8_u10(values));
+    return map(std::asinh);
   }
   Vectorized<float> atan() const {
     return Vectorized<float>(Sleef_atanf8_u10(values));

--- a/aten/src/ATen/cpu/vec/vec512/vec512_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float.h
@@ -251,7 +251,7 @@ class Vectorized<float> {
     return Vectorized<float>(Sleef_asinf16_u10(values));
   }
   Vectorized<float> asinh() const {
-    return Vectorized<float>(Sleef_asinhf16_u10(values));
+    return map(std::asinh);
   }
   Vectorized<float> atan() const {
     return Vectorized<float>(Sleef_atanf16_u10(values));

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -6527,6 +6527,16 @@ class CPUReproTests(TestCase):
         actual = torch.compile(f, backend="inductor")(buf, idx)
         self.assertEqual(actual, expected)
 
+    def test_asinh_large_values(self):
+        def fn(x):
+            return torch.asinh(x)
+
+        x = torch.tensor([3e22, 7e25, -5e23, 1e10], dtype=torch.float32)
+        expected = fn(x)
+        actual = torch.compile(fn, backend="inductor")(x)
+
+        self.assertTrue(torch.allclose(expected, actual, rtol=1e-5, atol=1e-5))
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests


### PR DESCRIPTION
fixes #183767

I am posting this as a draft to make it clear what the problem is and serve as a place holder. This is a numerical library problem not an inductor problem IMO. Reverting to std asinh has obvious performance implications .

this will match eager behavior since it calls std::asinh.

```
static void asinh_kernel(TensorIteratorBase& iter) {
    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kBFloat16, kHalf, iter.dtype(), "asinh_cpu", [&]() {
      cpu_kernel(
        iter,
        [=](scalar_t a) -> scalar_t { return std::asinh(a); });
    });
}

```



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo