### PR TITLE
[ROCm][CI] Remove sandbox distributed jobs; restore periodic-rocm-mi200 cron schedule

### DIFF
--- a/.github/workflows/periodic-rocm-mi200.yml
+++ b/.github/workflows/periodic-rocm-mi200.yml
@@ -1,8 +1,8 @@
 name: periodic-rocm-mi200
 
 on:
-  #schedule:
-    #- cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
+  schedule:
+    - cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
   push:
     tags:
       - ciflow/periodic-rocm-mi200/*

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -58,9 +58,6 @@ jobs:
           { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.mi210.1.test" },
           { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.mi210.1.test" },
           { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.mi210.1.test" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.mi210.2.test" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.mi210.2.test" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.mi210.2.test" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
Move distributed jobs out of trunk-rocm-sandbox and into periodic-rocm-mi200. The mi200 distributed jobs have been consistently performing well and not timing out. See here for more information:

https://hud.pytorch.org/hud/pytorch/pytorch/d431d3e0ebdb15df3b5c02852e9e1d5ae1d60b18/1?per_page=50&name_filter=trunk-rocm-sandbox%20%2F%20linux-jammy-rocm-py3.10%20%2F%20test%20(distributed%2C&mergeEphemeralLF=true

Tested here: https://github.com/pytorch/pytorch/actions/runs/25929006989/job/76217841629?pr=183914
Authored w/ assistance from cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang