### PR TITLE
dynamo: Preserve eager torch.full validation for nn.Parameter fill values in Dynamo

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -6106,6 +6106,22 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
         with self.assertRaises(torch._dynamo.exc.Unsupported):
             opt_mod(x)
 
+    def test_full_with_parameter_subclass_fill_value_raises(self):
+        class MyParam(torch.nn.Parameter):
+            pass
+
+        def func(x):
+            return torch.full((2,), x)
+
+        x = MyParam(torch.tensor(2.5))
+
+        with self.assertRaises(TypeError):
+            func(x)
+
+        func_compiled = torch.compile(func, backend="eager", fullgraph=True)
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            func_compiled(x)
+
     def test_full_with_tensor_subclass_fill_value(self):
         class MyTensor(torch.Tensor):
             pass

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -6087,6 +6087,40 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(result_a, torch.full((2,), 3.14, dtype=torch.float32))
         self.assertEqual(result_b, torch.full((2,), 2.71, dtype=torch.float32))
 
+    def test_full_with_parameter_fill_value_raises(self):
+        class Mod(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.fill_value = torch.nn.Parameter(torch.tensor(2.5))
+
+            def forward(self, x):
+                return torch.full((x.shape[0], x.shape[1], 2), self.fill_value)
+
+        mod = Mod()
+        x = torch.randn(3, 4)
+
+        with self.assertRaises(TypeError):
+            mod(x)
+
+        opt_mod = torch.compile(mod, backend="eager", fullgraph=True)
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            opt_mod(x)
+
+    def test_full_with_tensor_subclass_fill_value(self):
+        class MyTensor(torch.Tensor):
+            pass
+
+        def func(x):
+            return torch.full((2,), x)
+
+        x = torch.tensor(5.0).as_subclass(MyTensor)
+        expected = func(x)
+
+        func_compiled = torch.compile(func, backend="eager", fullgraph=True)
+        result = func_compiled(x)
+
+        self.assertEqual(result, expected)
+
 
 instantiate_parametrized_tests(FunctionTests)
 instantiate_parametrized_tests(DefaultsTests)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1596,7 +1596,10 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             fill_value: VariableTracker,
             **kwargs: VariableTracker,
         ) -> VariableTracker | None:
-            if fill_value.is_tensor():
+            if (
+                fill_value.is_tensor()
+                and fill_value.python_type() is not torch.nn.Parameter
+            ):
                 # Decompose: create empty tensor and fill it
                 # This avoids the scalar extraction at compile time
                 empty_result = TorchInGraphFunctionVariable(torch.empty).call_function(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1596,9 +1596,8 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             fill_value: VariableTracker,
             **kwargs: VariableTracker,
         ) -> VariableTracker | None:
-            if (
-                fill_value.is_tensor()
-                and fill_value.python_type() is not torch.nn.Parameter
+            if fill_value.is_tensor() and not issubclass(
+                fill_value.python_type(), torch.nn.Parameter
             ):
                 # Decompose: create empty tensor and fill it
                 # This avoids the scalar extraction at compile time


### PR DESCRIPTION
## Summary

Fixes #183900
Fix a Dynamo eager-parity bug where `torch.compile` rewrites:

```python
torch.full(size, fill_value=tensor_like)
```

into:

```python
torch.empty(size, ...).fill_(tensor_like)
```

for tensor `fill_value`s.

That rewrite is correct for ordinary tensor scalar inputs, but it is too permissive
for `torch.nn.Parameter`. Eager rejects:

```python
torch.full(..., fill_value=nn.Parameter(...))
```

with a `TypeError`, while compiled execution previously returned a valid tensor.

This change keeps the rewrite for supported tensor cases, but skips it for
`torch.nn.Parameter` so compiled execution no longer accepts an input that eager
rejects.

## Repro

```python
import torch
import torch.nn as nn

class M(nn.Module):
    def __init__(self):
        super().__init__()
        self.fill_value = nn.Parameter(torch.tensor(2.5))

    def forward(self, x):
        return torch.full((x.shape[0], x.shape[1], 2), self.fill_value)
```

Before this change:

- eager: `TypeError`
- compiled: returns `OK (...)`

After this change:

- eager: `TypeError`
- compiled: errors instead of silently accepting the invalid input

## Root Cause

Dynamo has a special-case handler for `torch.full` in
`torch/_dynamo/variables/torch.py`.

When `fill_value.is_tensor()` is true, it rewrites `torch.full(...)` to
`torch.empty(...).fill_(...)` to avoid scalar extraction during tracing.

That bypasses `torch.full`'s normal eager argument validation. For
`torch.nn.Parameter`, this changes program semantics:

- eager validates `fill_value` at the `torch.full` API boundary and rejects it
- the rewritten compiled form never goes through that validation path

## Why only `nn.Parameter` for now

This PR intentionally uses the narrower fix:

```python
fill_value.is_tensor() and fill_value.python_type() is not torch.nn.Parameter
```

instead of restricting the rewrite to exact `torch.Tensor`.

I checked that broader alternative and found it would be too strong: eager and
compiled both currently accept tensor subclass fill values, so changing the
rewrite to exact `torch.Tensor` would regress valid existing behavior.

So the current scope is:

- preserve the existing rewrite for ordinary tensor cases, including tensor
  subclasses that are already accepted
- block the rewrite only for `torch.nn.Parameter`, where we have a confirmed
  eager-vs-compiled mismatch

This keeps the fix minimal and semantics-preserving for currently supported
inputs.

If we later find other tensor-like cases that also bypass eager validation
incorrectly, we can generalize the rule from there with concrete evidence.

## Fix

Update the Dynamo `torch.full` handler to skip the `empty(...).fill_(...)`
rewrite when `fill_value.python_type() is torch.nn.Parameter`.

Add regression coverage for:

- `nn.Parameter` fill values still raising under `torch.compile`
- tensor subclass fill values continuing to work

## Testing

Added tests in `test/dynamo/test_functions.py` for:

- `test_full_with_parameter_fill_value_raises`
- `test_full_with_tensor_subclass_fill_value`

Local checks run:

- `python -m py_compile torch/_dynamo/variables/torch.py test/dynamo/test_functions.py`
- `ruff check torch/_dynamo/variables/torch.py`

I also validated the runtime behavior in an installed environment:

- tensor subclass fill values still compile and run
- `nn.Parameter` fill values no longer produce a successful compiled result

I did not run the full in-tree test suite locally, so i'll be relying on CI for repo side verification

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos