### PR TITLE
[compile] add _transformer_encoder_layer_fwd fake tensor support

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -824,6 +824,26 @@ class TestTransformers(NNTestCase):
                 src_key_padding_mask=padding_mask,
             )
 
+    def test_transformer_encoder_layer_fwd_fake(self, device):
+        model = torch.nn.TransformerEncoder(
+            torch.nn.TransformerEncoderLayer(
+                d_model=128,
+                nhead=8,
+                dim_feedforward=256,
+                dropout=0.0,
+                batch_first=True,
+            ),
+            num_layers=2,
+        ).to(device).eval()
+
+        x = torch.rand(2, 10, 128, device=device)
+        eager_out = model(x)
+
+        compiled_model = torch.compile(model, fullgraph=True, dynamic=True)
+        compiled_out = compiled_model(x)
+
+        self.assertEqual(eager_out, compiled_out)
+
     @unittest.skipIf(sys.version_info < (3, 11), "not supported on pre-3.11 Python")
     def test_decoder_padding_and_src_mask_bool(self):
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -201,6 +201,7 @@ def meta__standard_gamma(self, generator=None):
         aten._transformer_encoder_layer_fwd.out,
     ]
 )
+@out_wrapper()
 def meta__transformer_encoder_layer_fwd(
     src: Tensor,
     embed_dim: int,
@@ -211,11 +212,11 @@ def meta__transformer_encoder_layer_fwd(
     proj_bias: Tensor,
     use_gelu: bool,
     norm_first: bool,
-    layer_norm_eps: float,
-    layer_norm_weight_1: Tensor,
-    layer_norm_bias_1: Tensor,
-    layer_norm_weight_2: Tensor,
-    layer_norm_bias_2: Tensor,
+    eps: float,
+    norm_weight_1: Tensor,
+    norm_bias_1: Tensor,
+    norm_weight_2: Tensor,
+    norm_bias_2: Tensor,
     ffn_weight_1: Tensor,
     ffn_bias_1: Tensor,
     ffn_weight_2: Tensor,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -195,6 +195,43 @@ def meta__standard_gamma(self, generator=None):
     return torch.empty_like(self)
 
 
+@register_meta(
+    [
+        aten._transformer_encoder_layer_fwd.default,
+        aten._transformer_encoder_layer_fwd.out,
+    ]
+)
+def meta__transformer_encoder_layer_fwd(
+    src: Tensor,
+    embed_dim: int,
+    num_heads: int,
+    qkv_weight: Tensor,
+    qkv_bias: Tensor,
+    proj_weight: Tensor,
+    proj_bias: Tensor,
+    use_gelu: bool,
+    norm_first: bool,
+    layer_norm_eps: float,
+    layer_norm_weight_1: Tensor,
+    layer_norm_bias_1: Tensor,
+    layer_norm_weight_2: Tensor,
+    layer_norm_bias_2: Tensor,
+    ffn_weight_1: Tensor,
+    ffn_bias_1: Tensor,
+    ffn_weight_2: Tensor,
+    ffn_bias_2: Tensor,
+    mask: torch.Tensor | None = None,
+    mask_type: int | None = None,
+) -> Tensor:
+    if src.is_nested:
+        raise NotImplementedError(
+            "_transformer_encoder_layer_fwd fake implementation does not support nested tensors"
+        )
+    if src.numel() == 0:
+        return src.clone()
+    return torch.empty_like(src)
+
+
 @register_meta([aten.linalg_cross.default, aten.linalg_cross.out])
 @out_wrapper()
 def linalg_cross(self, other, *, dim=-1):


### PR DESCRIPTION
Fixes: #183841

Adds meta registration for `_transformer_encoder_layer_fwd`.

```python
>>> import torch
>>> model = torch.nn.TransformerEncoder(
...             torch.nn.TransformerEncoderLayer(
...                 d_model=128,
...                 nhead=8,
...                 dim_feedforward=256,
...                 dropout=0.0,
...                 batch_first=True,
...             ),
...             num_layers=2,
...         ).eval()
>>> x = torch.rand(2, 10, 128, device="cpu")
>>> eager_out = model(x)
>>> compiled_model = torch.compile(model, fullgraph=True, dynamic=True)
>>> compiled_out = compiled_model(x)
>>> torch.testing.assert_close(eager_out, compiled_out)
... 
>>>
```