### PR TITLE
[bugfix] Adding alpha !=0 check for celu

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13510,6 +13510,16 @@ if __name__ == '__main__':
         with self.assertRaisesRegex(RuntimeError, "call out-of-place version"):
             b.backward(torch.ones(2, device=device))
 
+    def test_celu_alpha_zero_raises(self, device):
+        x = torch.tensor([-2.0], device=device)
+  
+        def f(x):
+            return torch.nn.functional.celu(x, alpha=0.0)
+
+        compiled_f = torch.compile(f, backend="inductor")
+        with self.assertRaisesRegex(Exception, "alpha cannot be 0 for CELU"):
+            compiled_f(x)
+
     @expectedFailureMeta  # https://github.com/pytorch/pytorch/issues/54897
     def test_hardswish_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13512,7 +13512,7 @@ if __name__ == '__main__':
 
     def test_celu_alpha_zero_raises(self, device):
         x = torch.tensor([-2.0], device=device)
-  
+
         def f(x):
             return torch.nn.functional.celu(x, alpha=0.0)
 

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -186,8 +186,7 @@ def celu(
 
     rhs: TensorLikeType
     if alpha is not None:
-        if alpha == 0:
-            raise ZeroDivisionError("alpha cannot be 0 for CELU")
+        torch._check(alpha != 0, lambda: "alpha cannot be 0 for CELU")
         python_type = utils.dtype_to_type(a.dtype)
         if not utils.is_weakly_lesser_type(type(alpha), python_type):
             msg = f"alpha argument of type {type(alpha)} cannot be safely cast to type {python_type}!"

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -186,6 +186,8 @@ def celu(
 
     rhs: TensorLikeType
     if alpha is not None:
+        if alpha == 0:
+            raise ZeroDivisionError("alpha cannot be 0 for CELU")
         python_type = utils.dtype_to_type(a.dtype)
         if not utils.is_weakly_lesser_type(type(alpha), python_type):
             msg = f"alpha argument of type {type(alpha)} cannot be safely cast to type {python_type}!"


### PR DESCRIPTION
fixes https://github.com/pytorch/pytorch/issues/183762. 

Reference implementation now matches c++ implementation. 

For reference:
```
Tensor celu(const Tensor & self, const Scalar& alpha) {
  TORCH_CHECK(alpha.to<double>() != 0,
      "ZeroDivisionError: alpha cannot be 0 for CELU");
  double inv_alpha = 1. / alpha.to<double>();
  return at::elu(self, alpha, Scalar(1.0), Scalar(inv_alpha));
}
```

Fixes #183762