### PR TITLE
[S658886] Revert D96769355 cublasLt workspace size change

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -228,9 +228,7 @@ size_t parseCUDABlasLtWorkspaceSize() {
   }
   size_t workspace_size = 76*1024; /* Use 76 MB for hipBLASLt */
 #else
-  /* use CUDABlas default workspace size if unified */
-  /* otherwise, use default size in KiB according to #73328 */
-  size_t workspace_size = unified_cublas_and_lt_workspaces() ? parseChosenWorkspaceSize() / 1024 : 1024;
+  size_t workspace_size = 1024; /* default size in KiB according to #73328 */
 #endif
 
   if (val.has_value()) {


### PR DESCRIPTION
Summary:
D96769355 changed cublasLt workspace allocation from hardcoded 1MB to
unified workspace size (~8MB on A100, 32MB on H100/Blackwell) via
unified_cublas_and_lt_workspaces(). The FBCODE guard intended to make
this opt-in for Meta builds uses #if !defined(FBCODE), but FBCODE is
never defined (the correct macro is FBCODE_CAFFE2), so unified workspace
is always enabled.

This workspace size change causes correctness test failures (cosine
< 0.99) when combined with D101842780 (which re-enables bias fusion
by reverting D95083507). The larger workspace causes cuBLASLt to select
different algorithms, producing numerically different predictions.

Reverting the workspace sizing line to hardcoded 1024 KiB (1MB) while
leaving unified_cublas_and_lt_workspaces() and the rest of D96769355
untouched.

Test Plan:
Verified via cogwheel inplace correctness tests:
- parent(A) vs prod+graft(D)+revert(D96769355): PASS
  https://www.internalfb.com/servicelab/experiment/1153532713586286
- parent(A) vs candidateD+revert(D96769355 workspace line): PASS
  https://www.internalfb.com/servicelab/experiment/1517866206580079

SEV: S658886

Differential Revision: D105336951


