### PR TITLE
[ROCm][inductor] Use hipModuleLoadData in StaticCudaLauncher 

### DIFF
--- a/torch/csrc/inductor/static_launcher/cuda.cpp
+++ b/torch/csrc/inductor/static_launcher/cuda.cpp
@@ -12,8 +12,8 @@
 #include <optional>
 
 #if defined(USE_ROCM)
-#include <fstream>
 #include <hip/hip_runtime_api.h>
+#include <fstream>
 #include <iterator>
 #include <vector>
 #endif

--- a/torch/csrc/inductor/static_launcher/cuda.cpp
+++ b/torch/csrc/inductor/static_launcher/cuda.cpp
@@ -8,8 +8,8 @@
 #include <cstdint>
 
 #include <torch/csrc/utils/python_numbers.h>
-#include <fstream>
 #include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <optional>
 #include <vector>

--- a/torch/csrc/inductor/static_launcher/cuda.cpp
+++ b/torch/csrc/inductor/static_launcher/cuda.cpp
@@ -8,8 +8,11 @@
 #include <cstdint>
 
 #include <torch/csrc/utils/python_numbers.h>
+#include <fstream>
 #include <filesystem>
+#include <iterator>
 #include <optional>
+#include <vector>
 
 #if defined(USE_ROCM)
 #include <hip/hip_runtime_api.h>
@@ -102,6 +105,19 @@ CUdeviceptr getPointer(PyObject* obj) {
 
 #define SHARED_MEM_STATIC_MAX 49152 // 48 KB
 
+#if defined(USE_ROCM)
+std::vector<char> readKernelImage(const std::string& filePath) {
+  std::ifstream file(filePath, std::ios::binary);
+  TORCH_CHECK(file, "Failed to open kernel image: ", filePath);
+
+  auto begin = std::istreambuf_iterator<char>(file);
+  auto end = std::istreambuf_iterator<char>();
+  std::vector<char> image(begin, end);
+  TORCH_CHECK(!image.empty(), "Kernel image is empty: ", filePath);
+  return image;
+}
+#endif
+
 CUfunction loadKernel(
     std::string filePath,
     const std::string& funcName,
@@ -117,7 +133,8 @@ CUfunction loadKernel(
   CUfunction func = nullptr;
 
 #if defined(USE_ROCM)
-  AT_CUDA_DRIVER_CHECK(hipModuleLoad(&mod, filePath.c_str()));
+  auto image = readKernelImage(filePath);
+  AT_CUDA_DRIVER_CHECK(hipModuleLoadData(&mod, image.data()));
   AT_CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
   int shared_optin = 0;
   AT_CUDA_DRIVER_CHECK(hipDeviceGetAttribute(

--- a/torch/csrc/inductor/static_launcher/cuda.cpp
+++ b/torch/csrc/inductor/static_launcher/cuda.cpp
@@ -9,13 +9,13 @@
 
 #include <torch/csrc/utils/python_numbers.h>
 #include <filesystem>
-#include <fstream>
-#include <iterator>
 #include <optional>
-#include <vector>
 
 #if defined(USE_ROCM)
+#include <fstream>
 #include <hip/hip_runtime_api.h>
+#include <iterator>
+#include <vector>
 #endif
 
 /**
@@ -133,6 +133,8 @@ CUfunction loadKernel(
   CUfunction func = nullptr;
 
 #if defined(USE_ROCM)
+  // Unlike cuModuleLoad, hipModuleLoad keeps a file descriptor for the loaded
+  // HSACO. Load from memory to avoid retaining one FD per static launcher.
   auto image = readKernelImage(filePath);
   AT_CUDA_DRIVER_CHECK(hipModuleLoadData(&mod, image.data()));
   AT_CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));


### PR DESCRIPTION
This PR is to address an urgent CI issue where we run out of file descriptors (FDs) when running Inductor UT suites. The sympton in the CI is a "too many open files" error. It is more prone to occuring when there is insufficient sharding of a test suite. 

Example CI run: https://github.com/pytorch/pytorch/actions/runs/24415445801/job/71328493258?pr=179856
Relevant error snippet:
```
W0414 21:18:18.818000 26870 site-packages/torch/_inductor/utils.py:1375]     with os.scandir(topfd) as scandir_it:
W0414 21:18:18.818000 26870 site-packages/torch/_inductor/utils.py:1375]          ^^^^^^^^^^^^^^^^^
W0414 21:18:18.818000 26870 site-packages/torch/_inductor/utils.py:1375] OSError: [Errno 24] Too many open files: '/tmp/tmpbo_v4ubr'
FAILED [0.1944s] [ 52%]
...
  File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/torch/_inductor/runtime/static_triton_launcher.py", line 144, in load_kernel
    (self.function, self.n_regs, self.n_spills) = self.C_impl._load_kernel(
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^
torch._inductor.exc.InductorError: RuntimeError: CUDA driver error: 301
```


After investigation, the root cause is a difference in how FDs are handled between hipModuleLoad versus cuModuleLoad.

- Load ROCm static Triton launcher code objects from an in-memory HSACO buffer with `hipModuleLoadData`.
- Avoid the file-backed `hipModuleLoad` path that can retain open `.hsaco` file descriptors.
- Leave the CUDA/NVIDIA path unchanged.

Verified on an internal reproducer that artificially sets a low ulimit (-n 1024) and checks the FDs with strace.

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @mlazos