### PR TITLE
[BE][MacOS] Suppress deprecated declarations warnings

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -7,8 +7,11 @@
 #include <c10/util/Exception.h>
 
 #ifdef __OBJC__
-#include <Foundation/Foundation.h>
+// Metal.h pulls in Foundation.h, which transitively includes CarbonCore
+// headers that emit a flood of -Wdeprecated-declarations on recent macOS SDKs.
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #include <Metal/Metal.h>
+C10_DIAGNOSTIC_POP()
 typedef id<MTLDevice> MTLDevice_t;
 #else
 typedef void* MTLDevice_t;

--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -11,10 +11,15 @@
 #include <c10/util/Exception.h>
 
 #ifdef __OBJC__
-#include <Foundation/Foundation.h>
+// Apple framework headers emit deprecation warnings from CarbonCore and
+// missing-attribute warnings from MPSGraph on recent macOS SDKs.
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wobjc-property-no-attribute")
 #include <Metal/Metal.h>
 #include <MetalPerformanceShaders/MetalPerformanceShaders.h>
 #include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+C10_DIAGNOSTIC_POP()
+C10_DIAGNOSTIC_POP()
 typedef MPSCommandBuffer* MPSCommandBuffer_t;
 typedef id<MTLCommandQueue> MTLCommandQueue_t;
 typedef id<MTLComputeCommandEncoder> MTLComputeCommandEncoder_t;

--- a/aten/src/ATen/native/metal/MetalCommandBuffer.h
+++ b/aten/src/ATen/native/metal/MetalCommandBuffer.h
@@ -1,4 +1,8 @@
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+C10_DIAGNOSTIC_POP()
 
 @protocol PTMetalCommandBuffer<NSObject>
 @optional

--- a/aten/src/ATen/native/metal/MetalContext.h
+++ b/aten/src/ATen/native/metal/MetalContext.h
@@ -1,6 +1,9 @@
-#import <Foundation/Foundation.h>
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+C10_DIAGNOSTIC_POP()
 #include <string>
 
 API_AVAILABLE(ios(11.0), macos(10.13))

--- a/aten/src/ATen/native/metal/MetalDevice.h
+++ b/aten/src/ATen/native/metal/MetalDevice.h
@@ -1,7 +1,11 @@
 #ifndef PYTORCH_MOBILE_METAL_DEVICE_H_
 #define PYTORCH_MOBILE_METAL_DEVICE_H_
 
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <Metal/Metal.h>
+C10_DIAGNOSTIC_POP()
 
 #include <string>
 

--- a/aten/src/ATen/native/metal/MetalNeuronType.h
+++ b/aten/src/ATen/native/metal/MetalNeuronType.h
@@ -1,8 +1,12 @@
 #ifndef MetalNeuronType_h
 #define MetalNeuronType_h
 
+#include <c10/macros/Macros.h>
+
 #import <ATen/native/metal/mpscnn/MPSCNNNeuronOp.h>
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+C10_DIAGNOSTIC_POP()
 
 #include <ATen/ATen.h>
 

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNConvOp.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNConvOp.h
@@ -1,7 +1,9 @@
 #import <ATen/native/metal/MetalConvParams.h>
 #import <ATen/native/metal/MetalNeuronType.h>
 #import <ATen/native/metal/mpscnn/MPSCNNOp.h>
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <Foundation/Foundation.h>
+C10_DIAGNOSTIC_POP()
 
 API_AVAILABLE(ios(11.0), macos(10.13))
 @interface MPSCNNConvDataSource : NSObject<MPSCNNConvolutionDataSource>

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.h
@@ -1,7 +1,9 @@
 #import <ATen/native/metal/MetalConvParams.h>
 #import <ATen/native/metal/MetalNeuronType.h>
 #import <ATen/native/metal/mpscnn/MPSCNNConvOp.h>
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <Foundation/Foundation.h>
+C10_DIAGNOSTIC_POP()
 
 API_AVAILABLE(ios(11.0), macos(10.13))
 @interface MPSCNNFullyConnectedOp : NSObject<MPSCNNOp>

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNNeuronOp.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNNeuronOp.h
@@ -1,4 +1,8 @@
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+C10_DIAGNOSTIC_POP()
 
 @interface MPSCNNNeuronOp : NSObject
 

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNOp.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNOp.h
@@ -1,5 +1,9 @@
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+C10_DIAGNOSTIC_POP()
 
 @protocol MPSCNNOp<NSObject>
 

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNUtils.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNUtils.h
@@ -1,5 +1,9 @@
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+C10_DIAGNOSTIC_POP()
 #include <string>
 
 // This is a utility macro that can be used to throw an exception when a Metal

--- a/aten/src/ATen/native/metal/mpscnn/MPSImage+Tensor.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImage+Tensor.h
@@ -1,4 +1,8 @@
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+C10_DIAGNOSTIC_POP()
 
 #include <vector>
 

--- a/aten/src/ATen/native/metal/mpscnn/MPSImageUtils.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageUtils.h
@@ -3,7 +3,9 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorUtils.h>
 
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+C10_DIAGNOSTIC_POP()
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.h
@@ -2,7 +2,9 @@
 #define MPSImageWrapper_h
 
 #import <ATen/native/metal/MetalCommandBuffer.h>
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+C10_DIAGNOSTIC_POP()
 #include <c10/util/ArrayRef.h>
 
 namespace at {

--- a/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.h
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.h
@@ -3,7 +3,11 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #import <Foundation/Foundation.h>
+C10_DIAGNOSTIC_POP()
 #include <unordered_map>
 
 @interface MetalOpTestRunner : NSObject

--- a/aten/src/ATen/native/mps/MPSGraphSequoiaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphSequoiaOps.h
@@ -1,6 +1,12 @@
 #pragma once
 
+#include <c10/macros/Macros.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wobjc-property-no-attribute")
 #include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+C10_DIAGNOSTIC_POP()
+C10_DIAGNOSTIC_POP()
 
 #if !defined(__MAC_15_0) && (!defined(MAC_OS_X_VERSION_15_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_15_0))
 

--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -1,6 +1,9 @@
 #pragma once
+#include <c10/macros/Macros.h>
 #ifdef __OBJC__
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #include <Metal/Metal.h>
+C10_DIAGNOSTIC_POP()
 typedef id<MTLLibrary> MTLLibrary_t;
 typedef id<MTLFunction> MTLFunction_t;
 typedef id<MTLComputePipelineState> MTLComputePipelineState_t;

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -26,7 +26,9 @@
 #include <ATen/ops/zeros_like.h>
 #endif
 
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 #include <MetalPerformanceShaders/MetalPerformanceShaders.h>
+C10_DIAGNOSTIC_POP()
 
 using namespace at::mps;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #183927

Wrap Apple framework includes (Foundation/Metal/MPS/MPSGraph) in MPS and mobile Metal headers with `C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED` to silence the flood of `-Wdeprecated-declarations` from CarbonCore and `-Wobjc-property-no-attribute` from MPSGraph on recent macOS SDKs.

Authored by Claude.