### PR TITLE
[BE] Build all aarch64 + x86 CPU wheels on a single runner

### DIFF
--- a/.ci/manywheel/build_all.sh
+++ b/.ci/manywheel/build_all.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Build a manylinux wheel for every CPython version in DESIRED_PYTHONS on
+# a single runner. After the first full build, subsequent iterations only
+# recompile libtorch_python + _C for the new Python ABI (libtorch_cpu is
+# ABI-free and reused) via the cross-Python cache invalidation in
+# tools/setup_helpers/cmake.py.
+#
+# Inputs (env):
+#   PYTORCH_ROOT       Path to the PyTorch checkout.
+#   DESIRED_PYTHONS    Space-separated versions, e.g. "3.10 3.11 3.12 3.13 3.13t".
+#   GPU_ARCH_TYPE      cpu-aarch64 / cuda-aarch64 / cpu / cuda / ...
+#   PYTORCH_FINAL_PACKAGE_DIR
+#                      Parent dir; each Python's wheel lands under
+#                      "${PYTORCH_FINAL_PACKAGE_DIR}/${build_name}/".
+#   BUILD_NAME_PREFIX  e.g. "manywheel-py" -- "${desired//./_}-cpu-aarch64"
+#                      is appended.
+#   BUILD_NAME_SUFFIX  e.g. "-cpu-aarch64".
+
+set -eux -o pipefail
+
+: "${PYTORCH_ROOT:?PYTORCH_ROOT must be set}"
+: "${DESIRED_PYTHONS:?DESIRED_PYTHONS must be set (space-separated list)}"
+: "${BUILD_NAME_PREFIX:?BUILD_NAME_PREFIX must be set (e.g. manywheel-py)}"
+: "${BUILD_NAME_SUFFIX:?BUILD_NAME_SUFFIX must be set (e.g. -cpu-aarch64)}"
+: "${PYTORCH_FINAL_PACKAGE_DIR:?PYTORCH_FINAL_PACKAGE_DIR must be set}"
+
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+PARENT_OUT_DIR="${PYTORCH_FINAL_PACKAGE_DIR}"
+mkdir -p "${PARENT_OUT_DIR}"
+
+iter=0
+for desired in ${DESIRED_PYTHONS}; do
+    echo "::group::Build wheel for Python ${desired}"
+    iter_start=$(date +%s)
+
+    build_name="${BUILD_NAME_PREFIX}${desired//./_}${BUILD_NAME_SUFFIX}"
+    out_dir="${PARENT_OUT_DIR}/${build_name}"
+    mkdir -p "${out_dir}"
+
+    # Preserve build/ across iterations after the first so libtorch_cpu and
+    # third-party libs can be reused; the Python-specific bits
+    # (libtorch_python, _C.so) are invalidated by cmake.py.
+    if [[ "${iter}" -gt 0 ]]; then
+        export SKIP_SETUP_CLEAN=1
+    fi
+
+    DESIRED_PYTHON="${desired}" \
+    PYTORCH_FINAL_PACKAGE_DIR="${out_dir}" \
+        bash "${SCRIPTPATH}/build.sh"
+
+    iter_elapsed=$(( $(date +%s) - iter_start ))
+    echo "::endgroup::"
+
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        if [[ ! -s "${GITHUB_STEP_SUMMARY}" ]]; then
+            printf '| Python | Build time |\n|---|---:|\n' >> "${GITHUB_STEP_SUMMARY}"
+        fi
+        printf '| %s | %dm %ds |\n' "${desired}" "$((iter_elapsed/60))" "$((iter_elapsed%60))" \
+            >> "${GITHUB_STEP_SUMMARY}"
+    fi
+
+    iter=$((iter + 1))
+done

--- a/.ci/manywheel/build_install_deps.py
+++ b/.ci/manywheel/build_install_deps.py
@@ -56,7 +56,10 @@ def main() -> None:
 
     os.chdir(args.package_dir)
     pip_install("-qU", "-r", "requirements-build.txt")
-    subprocess.run([sys.executable, "setup.py", "clean"], check=True)
+    # Skip when sharing build/ across Pythons in build_all.sh -- the per-Python
+    # bits (libtorch_python, _C.so) are invalidated by tools/setup_helpers/cmake.py.
+    if not os.environ.get("SKIP_SETUP_CLEAN"):
+        subprocess.run([sys.executable, "setup.py", "clean"], check=True)
     pip_install("-q", "-r", "requirements.txt")
     pip_install("-q", "--pre", f"numpy=={numpy_pin()}")
 

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -20,7 +20,7 @@ name: !{{ build_environment }}
     invalidation handles the per-Python ABI bits). Everything else still runs
     on the per-Python matrix below. Add more arch types here as their inline
     build job is wired up. -#}
-{%- set unified_arch_types = ['cpu-aarch64'] %}
+{%- set unified_arch_types = ['cpu', 'cpu-aarch64'] %}
 {%- set unified_build_configs = build_configs | selectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
 {%- set matrix_build_configs = build_configs | rejectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
 
@@ -102,30 +102,36 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-{%- if unified_build_configs %}
-  {%- set first_unified = unified_build_configs[0] %}
-  # Build every CPython wheel for cpu-aarch64 on a single runner. libtorch_cpu is
-  # Python-ABI-free and shared across iterations via build/; libtorch_python and
-  # _C are recompiled per interpreter thanks to the cache invalidation in
-  # tools/setup_helpers/cmake.py.
-  manywheel-cpu-aarch64-build:
-    name: manywheel-cpu-aarch64-build
+{#- One inline build job per unified gpu_arch_type group (e.g. one for cpu,
+    one for cpu-aarch64). Each loops over all CPython versions in the group on
+    a single runner, reusing build/ across iterations. libtorch_cpu is
+    Python-ABI-free; only libtorch_python + _C are recompiled per interpreter
+    via the cmake.py cache invalidation. -#}
+{%- set unified_job_names = [] %}
+{%- for arch_type, group in unified_build_configs | groupby('gpu_arch_type') %}
+  {%- set group = group | list %}
+  {%- set first = group[0] %}
+  {%- set job_name = "manywheel-" ~ arch_type ~ "-build" %}
+  {%- set _ = unified_job_names.append(job_name) %}
+
+  !{{ job_name }}:
+    name: !{{ job_name }}
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: get-label-type
     runs-on: "!{{ runner_prefix }}!{{ build_runs_on }}"
     timeout-minutes: !{{ timeout_minutes }}
     container:
-      image: pytorch/!{{ first_unified['container_image'] }}:!{{ first_unified['container_image_tag_prefix'] }}
+      image: pytorch/!{{ first['container_image'] }}:!{{ first['container_image_tag_prefix'] }}
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
-      PACKAGE_TYPE: !{{ first_unified['package_type'] }}
-      DESIRED_CUDA: !{{ first_unified['desired_cuda'] }}
-      GPU_ARCH_TYPE: !{{ first_unified['gpu_arch_type'] }}
-      DOCKER_IMAGE: pytorch/!{{ first_unified['container_image'] }}:!{{ first_unified['container_image_tag_prefix'] }}
+      PACKAGE_TYPE: !{{ first['package_type'] }}
+      DESIRED_CUDA: !{{ first['desired_cuda'] }}
+      GPU_ARCH_TYPE: !{{ arch_type }}
+      DOCKER_IMAGE: pytorch/!{{ first['container_image'] }}:!{{ first['container_image_tag_prefix'] }}
       SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "!{{ unified_build_configs | map(attribute='python_version') | join(' ') }}"
+      DESIRED_PYTHONS: "!{{ group | map(attribute='python_version') | join(' ') }}"
       BUILD_NAME_PREFIX: "manywheel-py"
-      BUILD_NAME_SUFFIX: "-cpu-aarch64"
+      BUILD_NAME_SUFFIX: "-!{{ arch_type }}"
     steps:
       - name: Configure git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -151,14 +157,14 @@ jobs:
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
       # matrix below downloads.
-{%- for config in unified_build_configs %}
+  {%- for config in group %}
       - uses: !{{ common.upload_artifact_action }}
         with:
           name: !{{ config['build_name'] }}
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/!{{ config['build_name'] }}/*
+  {%- endfor %}
 {%- endfor %}
-{%- endif %}
 
 {%- if matrix_build_configs %}
 
@@ -216,7 +222,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [get-label-type{%- if matrix_build_configs %}, manywheel-build{%- endif %}{%- if unified_build_configs %}, manywheel-cpu-aarch64-build{%- endif %}]
+    needs: [get-label-type{%- if matrix_build_configs %}, manywheel-build{%- endif %}{%- for n in unified_job_names %}, !{{ n }}{%- endfor %}]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -330,7 +336,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: [{%- if matrix_build_configs %}manywheel-build, {% endif %}{%- if unified_build_configs %}manywheel-cpu-aarch64-build, {% endif %}manywheel-test{%- if rocm_configs %}, manywheel-test-rocm{%- endif %}{%- if xpu_configs %}, manywheel-test-xpu{%- endif %}]
+    needs: [{%- if matrix_build_configs %}manywheel-build, {% endif %}{%- for n in unified_job_names %}!{{ n }}, {% endfor %}manywheel-test{%- if rocm_configs %}, manywheel-test-rocm{%- endif %}{%- if xpu_configs %}, manywheel-test-xpu{%- endif %}]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -15,6 +15,15 @@ name: !{{ build_environment }}
 {%- set xpu_configs = build_configs | selectattr('gpu_arch_type', 'equalto', 'xpu') | list %}
 {%- set test_standard_configs = build_configs | rejectattr('gpu_arch_type', 'in', ['rocm', 'xpu']) | list %}
 
+{#- gpu_arch_types listed here are grouped into a single runner that loops over
+    CPython versions, reusing build/ across iterations (cmake.py cache
+    invalidation handles the per-Python ABI bits). Everything else still runs
+    on the per-Python matrix below. Add more arch types here as their inline
+    build job is wired up. -#}
+{%- set unified_arch_types = ['cpu-aarch64'] %}
+{%- set unified_build_configs = build_configs | selectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
+{%- set matrix_build_configs = build_configs | rejectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
+
 {#- Per-OS values that shape the build/test runner labels.
     s390x runners are self-hosted, register only with the bare `linux.s390x`
     label (no `lf.` prefix), and lack a host-level `docker` CLI compatible
@@ -93,7 +102,65 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-{%- if build_configs %}
+{%- if unified_build_configs %}
+  {%- set first_unified = unified_build_configs[0] %}
+  # Build every CPython wheel for cpu-aarch64 on a single runner. libtorch_cpu is
+  # Python-ABI-free and shared across iterations via build/; libtorch_python and
+  # _C are recompiled per interpreter thanks to the cache invalidation in
+  # tools/setup_helpers/cmake.py.
+  manywheel-cpu-aarch64-build:
+    name: manywheel-cpu-aarch64-build
+    if: ${{ github.repository_owner == 'pytorch' }}
+    needs: get-label-type
+    runs-on: "!{{ runner_prefix }}!{{ build_runs_on }}"
+    timeout-minutes: !{{ timeout_minutes }}
+    container:
+      image: pytorch/!{{ first_unified['container_image'] }}:!{{ first_unified['container_image_tag_prefix'] }}
+    env:
+      PYTORCH_ROOT: ${{ github.workspace }}
+      PACKAGE_TYPE: !{{ first_unified['package_type'] }}
+      DESIRED_CUDA: !{{ first_unified['desired_cuda'] }}
+      GPU_ARCH_TYPE: !{{ first_unified['gpu_arch_type'] }}
+      DOCKER_IMAGE: pytorch/!{{ first_unified['container_image'] }}:!{{ first_unified['container_image_tag_prefix'] }}
+      SKIP_ALL_TESTS: 1
+      DESIRED_PYTHONS: "!{{ unified_build_configs | map(attribute='python_version') | join(' ') }}"
+      BUILD_NAME_PREFIX: "manywheel-py"
+      BUILD_NAME_SUFFIX: "-cpu-aarch64"
+    steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Checkout PyTorch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 2
+          submodules: recursive
+          show-progress: false
+      - name: Populate binary env
+        shell: bash
+        run: |
+          export PYTORCH_FINAL_PACKAGE_DIR="${RUNNER_TEMP}/artifacts"
+          mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"
+          echo "PYTORCH_FINAL_PACKAGE_DIR=${PYTORCH_FINAL_PACKAGE_DIR}" >> "${GITHUB_ENV}"
+          bash .ci/pytorch/binary_populate_env.sh
+      - name: Build all wheels
+        shell: bash
+        run: |
+          # shellcheck disable=SC1091
+          source "${BINARY_ENV_FILE}"
+          bash .ci/manywheel/build_all.sh
+      # One artifact per built Python -- names must match what the test/upload
+      # matrix below downloads.
+{%- for config in unified_build_configs %}
+      - uses: !{{ common.upload_artifact_action }}
+        with:
+          name: !{{ config['build_name'] }}
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/!{{ config['build_name'] }}/*
+{%- endfor %}
+{%- endif %}
+
+{%- if matrix_build_configs %}
 
   manywheel-build:
     name: ${{ matrix.build_name }}-build
@@ -104,7 +171,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        {%- for config in build_configs %}
+        {%- for config in matrix_build_configs %}
           - desired_python: "!{{ config['python_version'] }}"
             desired_cuda: "!{{ config['desired_cuda'] }}"
             gpu_arch_version: "!{{ config['gpu_arch_version'] | default('') }}"
@@ -125,7 +192,7 @@ jobs:
         {%- endfor %}
     with:
       PYTORCH_ROOT: /pytorch
-      PACKAGE_TYPE: !{{ build_configs[0]['package_type'] }}
+      PACKAGE_TYPE: !{{ matrix_build_configs[0]['package_type'] }}
       DESIRED_CUDA: ${{ matrix.desired_cuda }}
       GPU_ARCH_VERSION: ${{ matrix.gpu_arch_version }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
@@ -149,7 +216,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, manywheel-build]
+    needs: [get-label-type{%- if matrix_build_configs %}, manywheel-build{%- endif %}{%- if unified_build_configs %}, manywheel-cpu-aarch64-build{%- endif %}]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -263,7 +330,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: [manywheel-build, manywheel-test{%- if rocm_configs %}, manywheel-test-rocm{%- endif %}{%- if xpu_configs %}, manywheel-test-xpu{%- endif %}]
+    needs: [{%- if matrix_build_configs %}manywheel-build, {% endif %}{%- if unified_build_configs %}manywheel-cpu-aarch64-build, {% endif %}manywheel-test{%- if rocm_configs %}, manywheel-test-rocm{%- endif %}{%- if xpu_configs %}, manywheel-test-xpu{%- endif %}]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -46,6 +46,83 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+  # Build every CPython wheel for cpu-aarch64 on a single runner. libtorch_cpu is
+  # Python-ABI-free and shared across iterations via build/; libtorch_python and
+  # _C are recompiled per interpreter thanks to the cache invalidation in
+  # tools/setup_helpers/cmake.py.
+  manywheel-cpu-aarch64-build:
+    name: manywheel-cpu-aarch64-build
+    if: ${{ github.repository_owner == 'pytorch' }}
+    needs: get-label-type
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.arm64.r7g.12xlarge.memory"
+    timeout-minutes: 420
+    container:
+      image: pytorch/manylinux2_28_aarch64-builder:cpu-aarch64
+    env:
+      PYTORCH_ROOT: ${{ github.workspace }}
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: cpu
+      GPU_ARCH_TYPE: cpu-aarch64
+      DOCKER_IMAGE: pytorch/manylinux2_28_aarch64-builder:cpu-aarch64
+      SKIP_ALL_TESTS: 1
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t"
+      BUILD_NAME_PREFIX: "manywheel-py"
+      BUILD_NAME_SUFFIX: "-cpu-aarch64"
+    steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Checkout PyTorch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 2
+          submodules: recursive
+          show-progress: false
+      - name: Populate binary env
+        shell: bash
+        run: |
+          export PYTORCH_FINAL_PACKAGE_DIR="${RUNNER_TEMP}/artifacts"
+          mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"
+          echo "PYTORCH_FINAL_PACKAGE_DIR=${PYTORCH_FINAL_PACKAGE_DIR}" >> "${GITHUB_ENV}"
+          bash .ci/pytorch/binary_populate_env.sh
+      - name: Build all wheels
+        shell: bash
+        run: |
+          # shellcheck disable=SC1091
+          source "${BINARY_ENV_FILE}"
+          bash .ci/manywheel/build_all.sh
+      # One artifact per built Python -- names must match what the test/upload
+      # matrix below downloads.
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_10-cpu-aarch64
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_11-cpu-aarch64
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_12-cpu-aarch64
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_13-cpu-aarch64
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14-cpu-aarch64
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14t-cpu-aarch64
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cpu-aarch64/*
 
   manywheel-build:
     name: ${{ matrix.build_name }}-build
@@ -56,15 +133,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desired_python: "3.10"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_10-cpu-aarch64"
-            timeout_minutes: 420
-            pytorch_extra_install_requirements: ""
           - desired_python: "3.10"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -93,15 +161,6 @@ jobs:
             timeout_minutes: 420
             pytorch_extra_install_requirements: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
           - desired_python: "3.11"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_11-cpu-aarch64"
-            timeout_minutes: 420
-            pytorch_extra_install_requirements: ""
-          - desired_python: "3.11"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -128,15 +187,6 @@ jobs:
             build_name: "manywheel-py3_11-cuda-aarch64-13_2"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
-          - desired_python: "3.12"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_12-cpu-aarch64"
-            timeout_minutes: 420
-            pytorch_extra_install_requirements: ""
           - desired_python: "3.12"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -165,15 +215,6 @@ jobs:
             timeout_minutes: 420
             pytorch_extra_install_requirements: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
           - desired_python: "3.13"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_13-cpu-aarch64"
-            timeout_minutes: 420
-            pytorch_extra_install_requirements: ""
-          - desired_python: "3.13"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -201,15 +242,6 @@ jobs:
             timeout_minutes: 420
             pytorch_extra_install_requirements: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
           - desired_python: "3.14"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_14-cpu-aarch64"
-            timeout_minutes: 420
-            pytorch_extra_install_requirements: ""
-          - desired_python: "3.14"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
             gpu_arch_type: "cuda-aarch64"
@@ -236,15 +268,6 @@ jobs:
             build_name: "manywheel-py3_14-cuda-aarch64-13_2"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
-          - desired_python: "3.14t"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu-aarch64"
-            docker_image: "manylinux2_28_aarch64-builder"
-            docker_image_tag_prefix: "cpu-aarch64"
-            build_name: "manywheel-py3_14t-cpu-aarch64"
-            timeout_minutes: 420
-            pytorch_extra_install_requirements: ""
           - desired_python: "3.14t"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -295,7 +318,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, manywheel-build]
+    needs: [get-label-type, manywheel-build, manywheel-cpu-aarch64-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -517,7 +540,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: [manywheel-build, manywheel-test]
+    needs: [manywheel-build, manywheel-cpu-aarch64-build, manywheel-test]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -46,10 +46,7 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
-  # Build every CPython wheel for cpu-aarch64 on a single runner. libtorch_cpu is
-  # Python-ABI-free and shared across iterations via build/; libtorch_python and
-  # _C are recompiled per interpreter thanks to the cache invalidation in
-  # tools/setup_helpers/cmake.py.
+
   manywheel-cpu-aarch64-build:
     name: manywheel-cpu-aarch64-build
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -48,6 +48,80 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
+  manywheel-cpu-build:
+    name: manywheel-cpu-build
+    if: ${{ github.repository_owner == 'pytorch' }}
+    needs: get-label-type
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.12xlarge.memory.ephemeral"
+    timeout-minutes: 240
+    container:
+      image: pytorch/manylinux2_28-builder:cpu
+    env:
+      PYTORCH_ROOT: ${{ github.workspace }}
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: cpu
+      GPU_ARCH_TYPE: cpu
+      DOCKER_IMAGE: pytorch/manylinux2_28-builder:cpu
+      SKIP_ALL_TESTS: 1
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t"
+      BUILD_NAME_PREFIX: "manywheel-py"
+      BUILD_NAME_SUFFIX: "-cpu"
+    steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Checkout PyTorch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 2
+          submodules: recursive
+          show-progress: false
+      - name: Populate binary env
+        shell: bash
+        run: |
+          export PYTORCH_FINAL_PACKAGE_DIR="${RUNNER_TEMP}/artifacts"
+          mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"
+          echo "PYTORCH_FINAL_PACKAGE_DIR=${PYTORCH_FINAL_PACKAGE_DIR}" >> "${GITHUB_ENV}"
+          bash .ci/pytorch/binary_populate_env.sh
+      - name: Build all wheels
+        shell: bash
+        run: |
+          # shellcheck disable=SC1091
+          source "${BINARY_ENV_FILE}"
+          bash .ci/manywheel/build_all.sh
+      # One artifact per built Python -- names must match what the test/upload
+      # matrix below downloads.
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_10-cpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_11-cpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_12-cpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_13-cpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14-cpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14t-cpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cpu/*
+
   manywheel-build:
     name: ${{ matrix.build_name }}-build
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -57,15 +131,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desired_python: "3.10"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_10-cpu"
-            timeout_minutes: 240
-            pytorch_extra_install_requirements: ""
           - desired_python: "3.10"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -121,15 +186,6 @@ jobs:
             timeout_minutes: 240
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2025.3.2 | intel-cmplr-lib-ur==2025.3.2 | intel-cmplr-lic-rt==2025.3.2 | intel-sycl-rt==2025.3.2 | oneccl-devel==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2025.3.1 | onemkl-sycl-blas==2025.3.1 | onemkl-sycl-dft==2025.3.1 | onemkl-sycl-lapack==2025.3.1 | onemkl-sycl-rng==2025.3.1 | onemkl-sycl-sparse==2025.3.1 | dpcpp-cpp-rt==2025.3.2 | intel-opencl-rt==2025.3.2 | mkl==2025.3.1 | intel-openmp==2025.3.2 | tbb==2022.3.1 | tcmlib==1.4.1 | umf==1.0.3 | intel-pti==0.16.0"
           - desired_python: "3.11"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_11-cpu"
-            timeout_minutes: 240
-            pytorch_extra_install_requirements: ""
-          - desired_python: "3.11"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
             gpu_arch_type: "cuda"
@@ -183,15 +239,6 @@ jobs:
             build_name: "manywheel-py3_11-xpu"
             timeout_minutes: 240
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2025.3.2 | intel-cmplr-lib-ur==2025.3.2 | intel-cmplr-lic-rt==2025.3.2 | intel-sycl-rt==2025.3.2 | oneccl-devel==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2025.3.1 | onemkl-sycl-blas==2025.3.1 | onemkl-sycl-dft==2025.3.1 | onemkl-sycl-lapack==2025.3.1 | onemkl-sycl-rng==2025.3.1 | onemkl-sycl-sparse==2025.3.1 | dpcpp-cpp-rt==2025.3.2 | intel-opencl-rt==2025.3.2 | mkl==2025.3.1 | intel-openmp==2025.3.2 | tbb==2022.3.1 | tcmlib==1.4.1 | umf==1.0.3 | intel-pti==0.16.0"
-          - desired_python: "3.12"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_12-cpu"
-            timeout_minutes: 240
-            pytorch_extra_install_requirements: ""
           - desired_python: "3.12"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -247,15 +294,6 @@ jobs:
             timeout_minutes: 240
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2025.3.2 | intel-cmplr-lib-ur==2025.3.2 | intel-cmplr-lic-rt==2025.3.2 | intel-sycl-rt==2025.3.2 | oneccl-devel==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2025.3.1 | onemkl-sycl-blas==2025.3.1 | onemkl-sycl-dft==2025.3.1 | onemkl-sycl-lapack==2025.3.1 | onemkl-sycl-rng==2025.3.1 | onemkl-sycl-sparse==2025.3.1 | dpcpp-cpp-rt==2025.3.2 | intel-opencl-rt==2025.3.2 | mkl==2025.3.1 | intel-openmp==2025.3.2 | tbb==2022.3.1 | tcmlib==1.4.1 | umf==1.0.3 | intel-pti==0.16.0"
           - desired_python: "3.13"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_13-cpu"
-            timeout_minutes: 240
-            pytorch_extra_install_requirements: ""
-          - desired_python: "3.13"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
             gpu_arch_type: "cuda"
@@ -310,15 +348,6 @@ jobs:
             timeout_minutes: 240
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2025.3.2 | intel-cmplr-lib-ur==2025.3.2 | intel-cmplr-lic-rt==2025.3.2 | intel-sycl-rt==2025.3.2 | oneccl-devel==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2025.3.1 | onemkl-sycl-blas==2025.3.1 | onemkl-sycl-dft==2025.3.1 | onemkl-sycl-lapack==2025.3.1 | onemkl-sycl-rng==2025.3.1 | onemkl-sycl-sparse==2025.3.1 | dpcpp-cpp-rt==2025.3.2 | intel-opencl-rt==2025.3.2 | mkl==2025.3.1 | intel-openmp==2025.3.2 | tbb==2022.3.1 | tcmlib==1.4.1 | umf==1.0.3 | intel-pti==0.16.0"
           - desired_python: "3.14"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_14-cpu"
-            timeout_minutes: 240
-            pytorch_extra_install_requirements: ""
-          - desired_python: "3.14"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
             gpu_arch_type: "cuda"
@@ -372,15 +401,6 @@ jobs:
             build_name: "manywheel-py3_14-xpu"
             timeout_minutes: 240
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2025.3.2 | intel-cmplr-lib-ur==2025.3.2 | intel-cmplr-lic-rt==2025.3.2 | intel-sycl-rt==2025.3.2 | oneccl-devel==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.17.2; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2025.3.1 | onemkl-sycl-blas==2025.3.1 | onemkl-sycl-dft==2025.3.1 | onemkl-sycl-lapack==2025.3.1 | onemkl-sycl-rng==2025.3.1 | onemkl-sycl-sparse==2025.3.1 | dpcpp-cpp-rt==2025.3.2 | intel-opencl-rt==2025.3.2 | mkl==2025.3.1 | intel-openmp==2025.3.2 | tbb==2022.3.1 | tcmlib==1.4.1 | umf==1.0.3 | intel-pti==0.16.0"
-          - desired_python: "3.14t"
-            desired_cuda: "cpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "cpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cpu"
-            build_name: "manywheel-py3_14t-cpu"
-            timeout_minutes: 240
-            pytorch_extra_install_requirements: ""
           - desired_python: "3.14t"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -458,7 +478,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, manywheel-build]
+    needs: [get-label-type, manywheel-build, manywheel-cpu-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -839,7 +859,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: [manywheel-build, manywheel-test, manywheel-test-rocm, manywheel-test-xpu]
+    needs: [manywheel-build, manywheel-cpu-build, manywheel-test, manywheel-test-rocm, manywheel-test-xpu]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #183931

Mirrors #181171 (macOS) for linux CPU: one job per gpu_arch_type (cpu and cpu-aarch64) loops over all CPython versions in `DESIRED_PYTHONS` and reuses `build/` across iterations. libtorch_cpu (Python-ABI-free) is shared; only libtorch_python + `_C` are recompiled per interpreter, leveraging the cmake.py cache-invalidation fix from #181147.

Template's `unified_arch_types = ['cpu', 'cpu-aarch64']` is the partition switch -- add more entries (e.g. cuda variants) to fold them into the same pattern. CUDA, ROCm, and XPU stay on the per-Python matrix; test+upload stay per-Python so failure on one Python only blocks that Python's upload.

Authored with Claude.

## Before vs after

Comparing nightly 2026-05-15 08:28 UTC (per-Python matrix) to PR run at 18:46 UTC (unified build):

| Workflow | Stage | Before | After | Δ |
|---|---|---:|---:|---:|
| linux-aarch64-binary-manywheel | Build runner-minutes (`linux.arm64.r7g.12xlarge.memory`) | **244** (6 × ~40m) | **104** (1 × 104m) | **−57%** |
| linux-aarch64-binary-manywheel | Build wall-clock | ~41m | ~104m | +2.5× |
| linux-binary-manywheel (x86) | Build runner-minutes (`linux.12xlarge.memory.ephemeral`) | **294** (6 × ~49m) | **111** (1 × 111m) | **−62%** |
| linux-binary-manywheel (x86) | Build wall-clock | ~49m | ~111m | +2.2× |

### TTS — full CPU pipeline (build → upload, aarch64)

| Phase | Nightly (before) | PR (after) |
|---|---|---|
| Build starts | 08:30:58 | 18:50:34 |
| Build ends | 09:12:35 (last) | 20:34:47 |
| Test starts | 10:58:31 (queue ≈ 1h46m) | 21:15:20 (queue ≈ 41m) |
| Test ends | 11:06:10 (last) | 21:24:40 |
| Upload ends | 11:08:41 (last) | 21:27:53 |
| **Total TTS** | **~2h37m** | **~2h37m** |

~57–62% runner-minute reduction on the expensive build runners (~140m aarch64 / ~183m x86 saved per nightly). Build wall-clock ~2.2–2.5× longer, but end-to-end TTS unchanged on aarch64 because test queueing dominated under the old layout. x86 test+upload data pending the in-progress PR run.

Data: aarch64 nightly [25908164878](https://github.com/pytorch/pytorch/actions/runs/25908164878), aarch64 PR [25935357837](https://github.com/pytorch/pytorch/actions/runs/25935357837), x86 nightly [25908164859](https://github.com/pytorch/pytorch/actions/runs/25908164859), x86 PR [25935357836](https://github.com/pytorch/pytorch/actions/runs/25935357836).
