### PR TITLE
Adjust tolerances in test_two_local_buffers_in_outer_loop_fusion and

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -31,7 +31,6 @@ from torch.testing._internal.common_utils import (
     get_gcc_major_version,
     instantiate_parametrized_tests,
     IS_ARM64,
-    IS_CPU_CAPABILITY_SVE256,
     IS_CPU_EXT_SVE_SUPPORTED,
     IS_FBCODE,
     IS_MACOS,

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3522,8 +3522,6 @@ class CPUReproTests(TestCase):
                 3,
             )
 
-    @xfailIf(IS_ARM64 and not IS_CPU_CAPABILITY_SVE256)
-    # see https://github.com/pytorch/pytorch/issues/142231
     @config.patch({"fx_graph_cache": False, "fx_graph_remote_cache": False})
     def test_two_local_buffers_in_outer_loop_fusion(self):
         def fn(x):
@@ -3542,8 +3540,10 @@ class CPUReproTests(TestCase):
         with config.patch({"cpp.simdlen": None}):
             torch._dynamo.reset()
             metrics.reset()
-            atol = None
-            rtol = None
+            # Outer-loop fusion changes fp32 reduction order enough to exceed
+            # the default tolerance on numerically sensitive inputs.
+            atol = 1e-5
+            rtol = 2e-6
             if (
                 not cpu_vec_isa.valid_vec_isa_list()
                 or os.getenv("ATEN_CPU_CAPABILITY") == "default"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #183932

This removes the stale ARM non-SVE256 xfail from `test_two_local_buffers_in_outer_loop_fusion` and gives the test a small explicit tolerance, `atol=1e-5, rtol=2e-6`.

The failure is not a math-equivalence issue. We debugged the eager vs Inductor difference on V2 and isolated it to fp32 reduction-order drift:

  - replacing the reduction with direct algebra is bit-exact eager vs compiled
  - keeping the 256-term `sum(exp(...))` reduction reproduces a fixed drift of
    about `4.27e-4`
  - the `sum(softmax(...))` component differs by at most about `5.36e-7`, which is
    amplified by the local sensitivity `255 * exp(1) ~= 693`
  - together, those effects explain the observed max diff around `9e-4`

A five-seed V2 sweep on latest aarch64 CPU nightly showed only marginal default tolerance misses, with the worst observed failure count `767 / 12570624` (~0.0061%) and max default tolerance ratio about `1.075`. The chosen tolerance has margin over the observed required `rtol ~= 1.4e-6` while staying close to the default fp32 tolerance.

Validated on V2 latest aarch64 CPU nightly:
  `torch 2.13.0.dev20260515+cpu`, git
  `aff3311fabd30ebffa9153e1bcf577512291a8a1`.

The outer-loop fusion assertions are preserved:
  `inner_kernel_number == 5` and `local_buffer_number == 2`.

Fixes #142231

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo