### PR TITLE
Remove EC2 instance debugging on IPv6 only environments

### DIFF
--- a/.github/actions/ecr-login/action.yml
+++ b/.github/actions/ecr-login/action.yml
@@ -37,10 +37,7 @@ runs:
       run: |
         echo "::group::Checking for IAM instance profile"
         echo "Checking EC2 metadata endpoint for IAM instance profile..."
-        # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
-        # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
-        # both. --noproxy '*' avoids any corporate proxy interception, and
-        # -m 2 bounds the total time per call.
+        # Dual-stack IMDS (IPv6 [fd00:ec2::254] / IPv4 169.254.169.254) for IPv6-only EKS support.
 
         # Try IMDSv2 first (more secure, required on some instances)
         echo "Attempting IMDSv2..."

--- a/.github/actions/ecr-login/action.yml
+++ b/.github/actions/ecr-login/action.yml
@@ -37,22 +37,29 @@ runs:
       run: |
         echo "::group::Checking for IAM instance profile"
         echo "Checking EC2 metadata endpoint for IAM instance profile..."
+        # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
+        # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
+        # both. --noproxy '*' avoids any corporate proxy interception, and
+        # -m 2 bounds the total time per call.
 
         # Try IMDSv2 first (more secure, required on some instances)
         echo "Attempting IMDSv2..."
-        TOKEN=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" \
-          -H "X-aws-ec2-metadata-token-ttl-seconds: 60" \
-          --connect-timeout 2 2>/dev/null) || TOKEN=""
+        TOKEN=$(curl -sf -m 2 --noproxy '*' \
+          --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' \
+          -X PUT "http://metadata/latest/api/token" \
+          -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null) || TOKEN=""
 
         if [[ -n "$TOKEN" ]]; then
           echo "IMDSv2 token obtained, checking IAM info..."
-          IAM_INFO=$(curl -sf -H "X-aws-ec2-metadata-token: $TOKEN" \
-            "http://169.254.169.254/latest/meta-data/iam/info" \
-            --connect-timeout 2 2>/dev/null) || IAM_INFO=""
+          IAM_INFO=$(curl -sf -m 2 --noproxy '*' \
+            --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' \
+            -H "X-aws-ec2-metadata-token: $TOKEN" \
+            "http://metadata/latest/meta-data/iam/info" 2>/dev/null) || IAM_INFO=""
         else
           echo "IMDSv2 not available, trying IMDSv1..."
-          IAM_INFO=$(curl -sf --connect-timeout 2 \
-            "http://169.254.169.254/latest/meta-data/iam/info" 2>/dev/null) || IAM_INFO=""
+          IAM_INFO=$(curl -sf -m 2 --noproxy '*' \
+            --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' \
+            "http://metadata/latest/meta-data/iam/info" 2>/dev/null) || IAM_INFO=""
         fi
 
         if [[ -n "$IAM_INFO" ]]; then

--- a/.github/actions/ecr-login/action.yml
+++ b/.github/actions/ecr-login/action.yml
@@ -38,25 +38,26 @@ runs:
         echo "::group::Checking for IAM instance profile"
         echo "Checking EC2 metadata endpoint for IAM instance profile..."
         # Dual-stack IMDS (IPv6 [fd00:ec2::254] / IPv4 169.254.169.254) for IPv6-only EKS support.
+        host=metadata
 
         # Try IMDSv2 first (more secure, required on some instances)
         echo "Attempting IMDSv2..."
         TOKEN=$(curl -sf -m 2 --noproxy '*' \
-          --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' \
-          -X PUT "http://metadata/latest/api/token" \
+          --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" \
+          -X PUT "http://${host}/latest/api/token" \
           -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null) || TOKEN=""
 
         if [[ -n "$TOKEN" ]]; then
           echo "IMDSv2 token obtained, checking IAM info..."
           IAM_INFO=$(curl -sf -m 2 --noproxy '*' \
-            --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' \
+            --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" \
             -H "X-aws-ec2-metadata-token: $TOKEN" \
-            "http://metadata/latest/meta-data/iam/info" 2>/dev/null) || IAM_INFO=""
+            "http://${host}/latest/meta-data/iam/info" 2>/dev/null) || IAM_INFO=""
         else
           echo "IMDSv2 not available, trying IMDSv1..."
           IAM_INFO=$(curl -sf -m 2 --noproxy '*' \
-            --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' \
-            "http://metadata/latest/meta-data/iam/info" 2>/dev/null) || IAM_INFO=""
+            --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" \
+            "http://${host}/latest/meta-data/iam/info" 2>/dev/null) || IAM_INFO=""
         fi
 
         if [[ -n "$IAM_INFO" ]]; then

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -103,12 +103,7 @@ runs:
       run: |
         set -euo pipefail
         function get_ec2_metadata() {
-          # Pulled from instance metadata endpoint for EC2
-          # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-          # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
-          # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
-          # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
-          # enabled via HttpProtocolIpv6).
+          # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
           category=$1
           # If it is GCP runner (runner name contains gcp), do not run this
           runner_name_str=${{ runner.name }}

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -105,16 +105,27 @@ runs:
         function get_ec2_metadata() {
           # Pulled from instance metadata endpoint for EC2
           # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+          # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
+          # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
+          # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
+          # enabled via HttpProtocolIpv6).
           category=$1
           # If it is GCP runner (runner name contains gcp), do not run this
           runner_name_str=${{ runner.name }}
           if [[ -f /.inarc ]]; then
             echo "ARC Runner, no info on ec2 metadata"
+            return 0
           elif [[ $runner_name_str == *"gcp"* || $runner_name_str == *"google"* ]]; then
             echo "Runner is from Google Cloud Platform, No info on ec2 metadata"
-          else
-            curl -H "X-aws-ec2-metadata-token: $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+            return 0
           fi
+          local token
+          token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+          if [ -z "${token}" ]; then
+            echo "unavailable"
+            return 0
+          fi
+          curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"
         echo "instance-id: $(get_ec2_metadata instance-id)"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -114,13 +114,13 @@ runs:
             echo "Runner is from Google Cloud Platform, No info on ec2 metadata"
             return 0
           fi
-          local token
-          token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+          local host=metadata token
+          token=$(curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -X PUT "http://${host}/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
           if [ -z "${token}" ]; then
             echo "unavailable"
             return 0
           fi
-          curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+          curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://${host}/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"
         echo "instance-id: $(get_ec2_metadata instance-id)"

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -23,13 +23,13 @@ runs:
         function get_ec2_metadata() {
           # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
           category=$1
-          local token
-          token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+          local host=metadata token
+          token=$(curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -X PUT "http://${host}/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
           if [ -z "${token}" ]; then
             echo "unavailable"
             return 0
           fi
-          curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+          curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://${host}/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"
         echo "instance-id: $(get_ec2_metadata instance-id)"

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -21,12 +21,7 @@ runs:
       run: |
         set -euo pipefail
         function get_ec2_metadata() {
-          # Pulled from instance metadata endpoint for EC2
-          # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-          # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
-          # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
-          # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
-          # enabled via HttpProtocolIpv6).
+          # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
           category=$1
           local token
           token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -20,22 +20,25 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
-        # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
-        IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
-        if [ -n "${IMDS_TOKEN}" ]; then
-          function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            category=$1
-            curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-          }
-          echo "ami-id: $(get_ec2_metadata ami-id)"
-          echo "instance-id: $(get_ec2_metadata instance-id)"
-          echo "instance-type: $(get_ec2_metadata instance-type)"
-        else
-          echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
-        fi
+        function get_ec2_metadata() {
+          # Pulled from instance metadata endpoint for EC2
+          # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+          # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
+          # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
+          # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
+          # enabled via HttpProtocolIpv6).
+          category=$1
+          local token
+          token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+          if [ -z "${token}" ]; then
+            echo "unavailable"
+            return 0
+          fi
+          curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+        }
+        echo "ami-id: $(get_ec2_metadata ami-id)"
+        echo "instance-id: $(get_ec2_metadata instance-id)"
+        echo "instance-type: $(get_ec2_metadata instance-type)"
         echo "system info $(uname -a)"
 
     # Needed for binary builds, see: https://github.com/pytorch/pytorch/issues/73339#issuecomment-1058981560

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -20,15 +20,22 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        function get_ec2_metadata() {
-          # Pulled from instance metadata endpoint for EC2
-          # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-          category=$1
-          curl -H "X-aws-ec2-metadata-token: $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-        }
-        echo "ami-id: $(get_ec2_metadata ami-id)"
-        echo "instance-id: $(get_ec2_metadata instance-id)"
-        echo "instance-type: $(get_ec2_metadata instance-type)"
+        # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
+        # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
+        IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
+        if [ -n "${IMDS_TOKEN}" ]; then
+          function get_ec2_metadata() {
+            # Pulled from instance metadata endpoint for EC2
+            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+            category=$1
+            curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+          }
+          echo "ami-id: $(get_ec2_metadata ami-id)"
+          echo "instance-id: $(get_ec2_metadata instance-id)"
+          echo "instance-type: $(get_ec2_metadata instance-type)"
+        else
+          echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
+        fi
         echo "system info $(uname -a)"
 
     # Needed for binary builds, see: https://github.com/pytorch/pytorch/issues/73339#issuecomment-1058981560

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -18,12 +18,7 @@ concurrency:
         run: |
           set -euo pipefail
           function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
-            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
-            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
-            # enabled via HttpProtocolIpv6).
+            # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
             local token
             token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -17,22 +17,25 @@ concurrency:
         shell: bash
         run: |
           set -euo pipefail
-          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
-          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
-          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
-          if [ -n "${IMDS_TOKEN}" ]; then
-            function get_ec2_metadata() {
-              # Pulled from instance metadata endpoint for EC2
-              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-              category=$1
-              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-            }
-            echo "ami-id: $(get_ec2_metadata ami-id)"
-            echo "instance-id: $(get_ec2_metadata instance-id)"
-            echo "instance-type: $(get_ec2_metadata instance-type)"
-          else
-            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
-          fi
+          function get_ec2_metadata() {
+            # Pulled from instance metadata endpoint for EC2
+            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
+            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
+            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
+            # enabled via HttpProtocolIpv6).
+            category=$1
+            local token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            if [ -z "${token}" ]; then
+              echo "unavailable"
+              return 0
+            fi
+            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+          }
+          echo "ami-id: $(get_ec2_metadata ami-id)"
+          echo "instance-id: $(get_ec2_metadata instance-id)"
+          echo "instance-type: $(get_ec2_metadata instance-type)"
           echo "system info $(uname -a)"
 {%- endmacro -%}
 

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -20,13 +20,13 @@ concurrency:
           function get_ec2_metadata() {
             # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
-            local token
-            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            local host=metadata token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -X PUT "http://${host}/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
             if [ -z "${token}" ]; then
               echo "unavailable"
               return 0
             fi
-            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+            curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://${host}/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
           }
           echo "ami-id: $(get_ec2_metadata ami-id)"
           echo "instance-id: $(get_ec2_metadata instance-id)"

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -17,15 +17,22 @@ concurrency:
         shell: bash
         run: |
           set -euo pipefail
-          function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            category=$1
-            curl -H "X-aws-ec2-metadata-token: $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-          }
-          echo "ami-id: $(get_ec2_metadata ami-id)"
-          echo "instance-id: $(get_ec2_metadata instance-id)"
-          echo "instance-type: $(get_ec2_metadata instance-type)"
+          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
+          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
+          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
+          if [ -n "${IMDS_TOKEN}" ]; then
+            function get_ec2_metadata() {
+              # Pulled from instance metadata endpoint for EC2
+              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+              category=$1
+              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+            }
+            echo "ami-id: $(get_ec2_metadata ami-id)"
+            echo "instance-id: $(get_ec2_metadata instance-id)"
+            echo "instance-type: $(get_ec2_metadata instance-type)"
+          else
+            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
+          fi
           echo "system info $(uname -a)"
 {%- endmacro -%}
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -198,13 +198,13 @@ jobs:
           function get_ec2_metadata() {
             # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
-            local token
-            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            local host=metadata token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -X PUT "http://${host}/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
             if [ -z "${token}" ]; then
               echo "unavailable"
               return 0
             fi
-            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+            curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://${host}/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
           }
           echo "ami-id: $(get_ec2_metadata ami-id)"
           echo "instance-id: $(get_ec2_metadata instance-id)"

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -195,15 +195,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            category=$1
-            curl -H "X-aws-ec2-metadata-token: $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-          }
-          echo "ami-id: $(get_ec2_metadata ami-id)"
-          echo "instance-id: $(get_ec2_metadata instance-id)"
-          echo "instance-type: $(get_ec2_metadata instance-type)"
+          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
+          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
+          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
+          if [ -n "${IMDS_TOKEN}" ]; then
+            function get_ec2_metadata() {
+              # Pulled from instance metadata endpoint for EC2
+              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+              category=$1
+              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+            }
+            echo "ami-id: $(get_ec2_metadata ami-id)"
+            echo "instance-id: $(get_ec2_metadata instance-id)"
+            echo "instance-type: $(get_ec2_metadata instance-type)"
+          else
+            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
+          fi
           echo "system info $(uname -a)"
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -195,22 +195,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
-          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
-          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
-          if [ -n "${IMDS_TOKEN}" ]; then
-            function get_ec2_metadata() {
-              # Pulled from instance metadata endpoint for EC2
-              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-              category=$1
-              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-            }
-            echo "ami-id: $(get_ec2_metadata ami-id)"
-            echo "instance-id: $(get_ec2_metadata instance-id)"
-            echo "instance-type: $(get_ec2_metadata instance-type)"
-          else
-            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
-          fi
+          function get_ec2_metadata() {
+            # Pulled from instance metadata endpoint for EC2
+            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
+            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
+            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
+            # enabled via HttpProtocolIpv6).
+            category=$1
+            local token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            if [ -z "${token}" ]; then
+              echo "unavailable"
+              return 0
+            fi
+            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+          }
+          echo "ami-id: $(get_ec2_metadata ami-id)"
+          echo "instance-id: $(get_ec2_metadata instance-id)"
+          echo "instance-type: $(get_ec2_metadata instance-type)"
           echo "system info $(uname -a)"
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -196,12 +196,7 @@ jobs:
         run: |
           set -euo pipefail
           function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
-            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
-            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
-            # enabled via HttpProtocolIpv6).
+            # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
             local token
             token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -109,15 +109,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            category=$1
-            curl -H "X-aws-ec2-metadata-token: $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-          }
-          echo "ami-id: $(get_ec2_metadata ami-id)"
-          echo "instance-id: $(get_ec2_metadata instance-id)"
-          echo "instance-type: $(get_ec2_metadata instance-type)"
+          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
+          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
+          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
+          if [ -n "${IMDS_TOKEN}" ]; then
+            function get_ec2_metadata() {
+              # Pulled from instance metadata endpoint for EC2
+              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+              category=$1
+              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+            }
+            echo "ami-id: $(get_ec2_metadata ami-id)"
+            echo "instance-id: $(get_ec2_metadata instance-id)"
+            echo "instance-type: $(get_ec2_metadata instance-type)"
+          else
+            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
+          fi
           echo "system info $(uname -a)"
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
@@ -244,15 +251,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            category=$1
-            curl -H "X-aws-ec2-metadata-token: $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-          }
-          echo "ami-id: $(get_ec2_metadata ami-id)"
-          echo "instance-id: $(get_ec2_metadata instance-id)"
-          echo "instance-type: $(get_ec2_metadata instance-type)"
+          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
+          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
+          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
+          if [ -n "${IMDS_TOKEN}" ]; then
+            function get_ec2_metadata() {
+              # Pulled from instance metadata endpoint for EC2
+              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+              category=$1
+              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+            }
+            echo "ami-id: $(get_ec2_metadata ami-id)"
+            echo "instance-id: $(get_ec2_metadata instance-id)"
+            echo "instance-type: $(get_ec2_metadata instance-type)"
+          else
+            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
+          fi
           echo "system info $(uname -a)"
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -112,13 +112,13 @@ jobs:
           function get_ec2_metadata() {
             # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
-            local token
-            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            local host=metadata token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -X PUT "http://${host}/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
             if [ -z "${token}" ]; then
               echo "unavailable"
               return 0
             fi
-            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+            curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://${host}/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
           }
           echo "ami-id: $(get_ec2_metadata ami-id)"
           echo "instance-id: $(get_ec2_metadata instance-id)"
@@ -252,13 +252,13 @@ jobs:
           function get_ec2_metadata() {
             # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
-            local token
-            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            local host=metadata token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -X PUT "http://${host}/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
             if [ -z "${token}" ]; then
               echo "unavailable"
               return 0
             fi
-            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+            curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://${host}/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
           }
           echo "ami-id: $(get_ec2_metadata ami-id)"
           echo "instance-id: $(get_ec2_metadata instance-id)"

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -110,12 +110,7 @@ jobs:
         run: |
           set -euo pipefail
           function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
-            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
-            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
-            # enabled via HttpProtocolIpv6).
+            # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
             local token
             token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
@@ -255,12 +250,7 @@ jobs:
         run: |
           set -euo pipefail
           function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
-            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
-            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
-            # enabled via HttpProtocolIpv6).
+            # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
             local token
             token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -109,22 +109,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
-          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
-          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
-          if [ -n "${IMDS_TOKEN}" ]; then
-            function get_ec2_metadata() {
-              # Pulled from instance metadata endpoint for EC2
-              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-              category=$1
-              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-            }
-            echo "ami-id: $(get_ec2_metadata ami-id)"
-            echo "instance-id: $(get_ec2_metadata instance-id)"
-            echo "instance-type: $(get_ec2_metadata instance-type)"
-          else
-            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
-          fi
+          function get_ec2_metadata() {
+            # Pulled from instance metadata endpoint for EC2
+            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
+            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
+            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
+            # enabled via HttpProtocolIpv6).
+            category=$1
+            local token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            if [ -z "${token}" ]; then
+              echo "unavailable"
+              return 0
+            fi
+            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+          }
+          echo "ami-id: $(get_ec2_metadata ami-id)"
+          echo "instance-id: $(get_ec2_metadata instance-id)"
+          echo "instance-type: $(get_ec2_metadata instance-type)"
           echo "system info $(uname -a)"
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
@@ -251,22 +254,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
-          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
-          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
-          if [ -n "${IMDS_TOKEN}" ]; then
-            function get_ec2_metadata() {
-              # Pulled from instance metadata endpoint for EC2
-              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-              category=$1
-              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-            }
-            echo "ami-id: $(get_ec2_metadata ami-id)"
-            echo "instance-id: $(get_ec2_metadata instance-id)"
-            echo "instance-type: $(get_ec2_metadata instance-type)"
-          else
-            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
-          fi
+          function get_ec2_metadata() {
+            # Pulled from instance metadata endpoint for EC2
+            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
+            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
+            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
+            # enabled via HttpProtocolIpv6).
+            category=$1
+            local token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            if [ -z "${token}" ]; then
+              echo "unavailable"
+              return 0
+            fi
+            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+          }
+          echo "ami-id: $(get_ec2_metadata ami-id)"
+          echo "instance-id: $(get_ec2_metadata instance-id)"
+          echo "instance-type: $(get_ec2_metadata instance-type)"
           echo "system info $(uname -a)"
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -256,22 +256,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
-          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
-          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
-          if [ -n "${IMDS_TOKEN}" ]; then
-            function get_ec2_metadata() {
-              # Pulled from instance metadata endpoint for EC2
-              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-              category=$1
-              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-            }
-            echo "ami-id: $(get_ec2_metadata ami-id)"
-            echo "instance-id: $(get_ec2_metadata instance-id)"
-            echo "instance-type: $(get_ec2_metadata instance-type)"
-          else
-            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
-          fi
+          function get_ec2_metadata() {
+            # Pulled from instance metadata endpoint for EC2
+            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
+            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
+            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
+            # enabled via HttpProtocolIpv6).
+            category=$1
+            local token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            if [ -z "${token}" ]; then
+              echo "unavailable"
+              return 0
+            fi
+            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+          }
+          echo "ami-id: $(get_ec2_metadata ami-id)"
+          echo "instance-id: $(get_ec2_metadata instance-id)"
+          echo "instance-type: $(get_ec2_metadata instance-type)"
           echo "system info $(uname -a)"
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
@@ -544,22 +547,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
-          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
-          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
-          if [ -n "${IMDS_TOKEN}" ]; then
-            function get_ec2_metadata() {
-              # Pulled from instance metadata endpoint for EC2
-              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-              category=$1
-              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-            }
-            echo "ami-id: $(get_ec2_metadata ami-id)"
-            echo "instance-id: $(get_ec2_metadata instance-id)"
-            echo "instance-type: $(get_ec2_metadata instance-type)"
-          else
-            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
-          fi
+          function get_ec2_metadata() {
+            # Pulled from instance metadata endpoint for EC2
+            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
+            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
+            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
+            # enabled via HttpProtocolIpv6).
+            category=$1
+            local token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            if [ -z "${token}" ]; then
+              echo "unavailable"
+              return 0
+            fi
+            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+          }
+          echo "ami-id: $(get_ec2_metadata ami-id)"
+          echo "instance-id: $(get_ec2_metadata instance-id)"
+          echo "instance-type: $(get_ec2_metadata instance-type)"
           echo "system info $(uname -a)"
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -256,15 +256,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            category=$1
-            curl -H "X-aws-ec2-metadata-token: $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-          }
-          echo "ami-id: $(get_ec2_metadata ami-id)"
-          echo "instance-id: $(get_ec2_metadata instance-id)"
-          echo "instance-type: $(get_ec2_metadata instance-type)"
+          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
+          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
+          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
+          if [ -n "${IMDS_TOKEN}" ]; then
+            function get_ec2_metadata() {
+              # Pulled from instance metadata endpoint for EC2
+              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+              category=$1
+              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+            }
+            echo "ami-id: $(get_ec2_metadata ami-id)"
+            echo "instance-id: $(get_ec2_metadata instance-id)"
+            echo "instance-type: $(get_ec2_metadata instance-type)"
+          else
+            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
+          fi
           echo "system info $(uname -a)"
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
@@ -537,15 +544,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            category=$1
-            curl -H "X-aws-ec2-metadata-token: $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-          }
-          echo "ami-id: $(get_ec2_metadata ami-id)"
-          echo "instance-id: $(get_ec2_metadata instance-id)"
-          echo "instance-type: $(get_ec2_metadata instance-type)"
+          # IMDS link-local IPv4 (169.254.169.254) is unreachable from IPv6-only
+          # pods (e.g. EKS). Probe first; skip the banner if the endpoint is unavailable.
+          IMDS_TOKEN=$(curl --connect-timeout 2 --max-time 5 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || echo "")
+          if [ -n "${IMDS_TOKEN}" ]; then
+            function get_ec2_metadata() {
+              # Pulled from instance metadata endpoint for EC2
+              # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+              category=$1
+              curl -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+            }
+            echo "ami-id: $(get_ec2_metadata ami-id)"
+            echo "instance-id: $(get_ec2_metadata instance-id)"
+            echo "instance-type: $(get_ec2_metadata instance-type)"
+          else
+            echo "EC2 IMDS unavailable (likely non-EC2 or IPv6-only runner); skipping instance metadata."
+          fi
           echo "system info $(uname -a)"
       - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -257,12 +257,7 @@ jobs:
         run: |
           set -euo pipefail
           function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
-            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
-            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
-            # enabled via HttpProtocolIpv6).
+            # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
             local token
             token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
@@ -548,12 +543,7 @@ jobs:
         run: |
           set -euo pipefail
           function get_ec2_metadata() {
-            # Pulled from instance metadata endpoint for EC2
-            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            # IMDS may be reachable over IPv6 [fd00:ec2::254] (IPv6-only EKS pods
-            # without NAT64) or IPv4 169.254.169.254 elsewhere; --resolve tries
-            # both. Soft-fail when neither responds (off-EC2 or v6 endpoint not
-            # enabled via HttpProtocolIpv6).
+            # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
             local token
             token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -259,13 +259,13 @@ jobs:
           function get_ec2_metadata() {
             # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
-            local token
-            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            local host=metadata token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -X PUT "http://${host}/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
             if [ -z "${token}" ]; then
               echo "unavailable"
               return 0
             fi
-            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+            curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://${host}/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
           }
           echo "ami-id: $(get_ec2_metadata ami-id)"
           echo "instance-id: $(get_ec2_metadata instance-id)"
@@ -545,13 +545,13 @@ jobs:
           function get_ec2_metadata() {
             # EC2 IMDS, dual-stack: IPv6 [fd00:ec2::254] (IPv6-only EKS) + IPv4 169.254.169.254.
             category=$1
-            local token
-            token=$(curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -X PUT "http://metadata/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
+            local host=metadata token
+            token=$(curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -X PUT "http://${host}/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30" 2>/dev/null || true)
             if [ -z "${token}" ]; then
               echo "unavailable"
               return 0
             fi
-            curl -sS -m 2 --noproxy '*' --resolve 'metadata:80:[fd00:ec2::254],169.254.169.254' -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://metadata/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
+            curl -sS -m 2 --noproxy '*' --resolve "${host}:80:[fd00:ec2::254],169.254.169.254" -H "X-aws-ec2-metadata-token: ${token}" -fsSL "http://${host}/latest/meta-data/${category}" 2>/dev/null || echo "unavailable"
           }
           echo "ami-id: $(get_ec2_metadata ami-id)"
           echo "instance-id: $(get_ec2_metadata instance-id)"


### PR DESCRIPTION
IMDS in AWS EC2 is IPv4-only. 

But, as we only use this service for debugging purposes and this debug information is actually not meaningful on a K8s environment, it makes sense to silent ignore failures and not print debug information when IPv4 stack is not available.