### PR TITLE
[MPS] hardsigmoid nan fixes

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -65,7 +65,7 @@ REGISTER_UNARY_OP(relu, bool, bool);
 struct hardsigmoid_functor {
   template <typename T>
   inline T operator()(const T x) {
-    float r = (float(x) + 3.0f) / 6.0f;
+    const auto r = (x + 3.0f) / 6.0f;
     return static_cast<T>(r > 1.0f ? 1.0f : (r < 0.0f ? 0.0f : r));
   }
 };

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -65,7 +65,9 @@ REGISTER_UNARY_OP(relu, bool, bool);
 struct hardsigmoid_functor {
   template <typename T>
   inline T operator()(const T x) {
-    return static_cast<T>(min(max(x + 3.0f, .0f), 6.f) / 6.f);
+    return ::metal::isnan(x)
+        ? static_cast<T>(NAN)
+        : static_cast<T>(min(max(x + 3.0f, .0f), 6.f) / 6.f);
   }
 };
 

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -65,9 +65,8 @@ REGISTER_UNARY_OP(relu, bool, bool);
 struct hardsigmoid_functor {
   template <typename T>
   inline T operator()(const T x) {
-    return ::metal::isnan(x)
-        ? static_cast<T>(NAN)
-        : static_cast<T>(min(max(x + 3.0f, .0f), 6.f) / 6.f);
+    float r = (float(x) + 3.0f) / 6.0f;
+    return static_cast<T>(r > 1.0f ? 1.0f : (r < 0.0f ? 0.0f : r));
   }
 };
 

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -281,6 +281,20 @@ def relu(a: TensorLikeType, inplace: bool = False) -> TensorLikeType:
     return torch.where(torch.le(a, 0), 0, a)
 
 
+@_inplace_wrapper
+@elementwise_type_promotion_wrapper(
+    type_promoting_args=("a",),
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+)
+def hardsigmoid(a: TensorLikeType, inplace: bool = False) -> TensorLikeType:
+    """
+    Reference implementation of torch.nn.functional.hardsigmoid
+    """
+    if inplace:
+        raise NotImplementedError
+    return torch.where(torch.isnan(a), a, torch.clamp(a / 6 + 0.5, 0, 1))
+
+
 @register_decomposition(aten.channel_shuffle)
 @out_wrapper()
 def channel_shuffle(input: TensorLikeType, groups: int) -> TensorLikeType:

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -292,7 +292,7 @@ def hardsigmoid(a: TensorLikeType, inplace: bool = False) -> TensorLikeType:
     """
     if inplace:
         raise NotImplementedError
-    return torch.where(torch.isnan(a), a, torch.clamp(a / 6 + 0.5, 0, 1))
+    return torch.clamp(a / 6 + 0.5, 0, 1)
 
 
 @register_decomposition(aten.channel_shuffle)

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -282,6 +282,7 @@ def relu(a: TensorLikeType, inplace: bool = False) -> TensorLikeType:
 
 
 @_inplace_wrapper
+@out_wrapper()
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("a",),
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
@@ -290,8 +291,6 @@ def hardsigmoid(a: TensorLikeType, inplace: bool = False) -> TensorLikeType:
     """
     Reference implementation of torch.nn.functional.hardsigmoid
     """
-    if inplace:
-        raise NotImplementedError
     return torch.clamp(a / 6 + 0.5, 0, 1)
 
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -25067,6 +25067,11 @@ python_ref_db = [
         ),
     ),
     ElementwiseUnaryPythonRefInfo(
+        "_refs.nn.functional.hardsigmoid",
+        torch_opinfo_name="nn.functional.hardsigmoid",
+        supports_out=False,
+    ),
+    ElementwiseUnaryPythonRefInfo(
         "_refs.nn.functional.relu",
         torch_opinfo_name="nn.functional.relu",
         supports_out=True,


### PR DESCRIPTION
hardsigmoid nan fixes on MPS + enable tests. I think that should be all the ops unless I've missed something. reproducer:
```
import torch

a = torch.tensor([float('nan'), 1.0, 2.0, 3.0, -4.0, 2.0], device="mps")
out = torch.nn.functional.hardsigmoid(a)
print(out)
```

converts nan to 0.0 on mps