### PR TITLE
[Native DSL] Vendor kernelagent-oink library

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -44,6 +44,7 @@ project-excludes = [
   "torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**",
   "torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py",
   "torch/_vendor/quack/**",
+  "torch/_vendor/oink/**",
 ]
 ignore-missing-imports = [
     # XPU memory symbols not present for builds without XPU support

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -419,6 +419,7 @@ class TestPublicBindings(TestCase):
             cuda_dep_prefixes = (
                 "torch._native.ops.scatter_add.",
                 "torch._vendor.quack",
+                "torch._vendor.oink",
             )
             if (
                 mod in private_allowlist

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2478,6 +2478,7 @@ class TestImports(TestCase):
                            "torch.include",  # torch include files after install
                            "torch._inductor.kernel.vendored_templates.cutedsl",  # depends on cutlass
                            "torch._vendor.quack",  # depends on cutlass / cuda-python
+                           "torch._vendor.oink",  # depends on cutlass / cuda-python
                            ]
         if IS_WINDOWS or IS_MACOS or IS_JETSON:
             # Distributed should be importable on Windows(except nn.api.), but not on Mac

--- a/tools/vendoring/oink/vendor.sh
+++ b/tools/vendoring/oink/vendor.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Vendor a subset of the kernelagent_oink library into torch/_vendor/oink.
+#
+# Usage:
+#   tools/vendoring/oink/vendor.sh <sha>                    # clone upstream
+#   tools/vendoring/oink/vendor.sh <sha> <local-checkout>   # use existing clone
+#
+# Pipeline:
+#   1. fetch upstream at <sha>
+#   2. copy whitelisted modules + LICENSE into torch/_vendor/oink/
+#   3. apply tools/vendoring/oink/patches/*.patch (if any)
+#   4. rewrite `kernelagent_oink.blackwell.*` imports to package-relative
+#   5. verify copyright/license notices still match upstream
+#   6. write a fresh __init__.py recording the SHA and upstream version
+#
+# If a patch fails, upstream has drifted -- inspect the .rej and re-roll.
+# If notice verification fails, a patch moved or removed an attribution
+# line -- fix the patch rather than the check.
+
+set -euo pipefail
+
+UPSTREAM_URL="https://github.com/meta-pytorch/KernelAgent.git"
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../.." && pwd)
+DEST="$REPO_ROOT/torch/_vendor/oink"
+PATCHES_DIR="$SCRIPT_DIR/patches"
+
+# Path inside the upstream checkout where the blackwell modules live.
+UPSTREAM_SRC_SUBDIR="oink/src/kernelagent_oink/blackwell"
+
+# Modules that rmsnorm depends on (transitively). Everything else upstream
+# ships -- cross_entropy, softmax, layernorm, oink_custom_ops, etc. -- is
+# deliberately excluded.
+FILES=(
+    _cutedsl_cache.py
+    _rmsnorm_impl.py
+    _rmsnorm_simple_weightonly.py
+    _rmsnorm_smallm_cuda.py
+    fast_launch.py
+    lite_quack.py
+    rmsnorm.py
+)
+
+die()   { echo "vendor_oink: $*" >&2; exit 1; }
+usage() { echo "usage: $0 <sha> [local-kernelagent-checkout]" >&2; exit 2; }
+
+# Echo the path to a kernelagent checkout at $sha. If $local is given,
+# validate it's at the requested SHA; otherwise clone into a tmpdir and
+# register a cleanup trap on the caller's shell.
+fetch_upstream() {
+    local sha=$1 local_checkout=${2:-}
+
+    if [[ -n "$local_checkout" ]]; then
+        local head
+        head=$(git -C "$local_checkout" rev-parse HEAD)
+        [[ "$head" == "$sha"* || "$sha" == "$head"* ]] \
+            || die "$local_checkout is at $head, not $sha"
+        echo "$local_checkout"
+        return
+    fi
+
+    local tmp
+    tmp=$(mktemp -d -t oink-vendor-XXXXXX)
+    # shellcheck disable=SC2064  # expand $tmp now, not at trap time
+    trap "rm -rf '$tmp'" EXIT
+    git clone --quiet "$UPSTREAM_URL" "$tmp"
+    git -C "$tmp" checkout --quiet "$sha"
+    echo "$tmp"
+}
+
+extract_version() {
+    local pyproject=$1 version
+    version=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$pyproject" | head -1)
+    [[ -n "$version" ]] || die "could not parse version from $pyproject"
+    echo "$version"
+}
+
+copy_pristine() {
+    local upstream=$1
+    for f in "${FILES[@]}"; do
+        cp "$upstream/$UPSTREAM_SRC_SUBDIR/$f" "$DEST/$f"
+    done
+    # Apache-2.0 attribution: kernelagent_oink is redistributed under its
+    # upstream license, which must accompany the vendored source.
+    cp "$upstream/LICENSE" "$DEST/LICENSE"
+}
+
+apply_patches() {
+    shopt -s nullglob
+    for p in "$PATCHES_DIR"/*.patch; do
+        patch -p1 -d "$DEST" --no-backup-if-mismatch --forward < "$p"
+    done
+    shopt -u nullglob
+}
+
+# Rewrite the three `kernelagent_oink.blackwell.*` import forms actually
+# used in the vendored subset. Using [ \t] (not \s) keeps each match on a
+# single line so blank lines aren't eaten by the substitution.
+rewrite_imports() {
+    for f in "${FILES[@]}"; do
+        sed -i -E '
+            # from kernelagent_oink.blackwell.X import Y -> from .X import Y
+            s|^([ \t]*)from kernelagent_oink\.blackwell\.([[:alnum:]_.]+) import |\1from .\2 import |
+
+            # from kernelagent_oink.blackwell import X as Y -> from . import X as Y
+            s|^([ \t]*)from kernelagent_oink\.blackwell import ([[:alnum:]_]+) as ([[:alnum:]_]+)[ \t]*$|\1from . import \2 as \3|
+
+            # from kernelagent_oink.blackwell import X -> from . import X
+            s|^([ \t]*)from kernelagent_oink\.blackwell import |\1from . import |
+        ' "$DEST/$f"
+    done
+}
+
+# Guard against patches or import rewrites accidentally dropping or
+# relocating a copyright/license/SPDX line. Each vendored .py must carry
+# the same notice lines on the same line numbers as its upstream source.
+# Bails on the first mismatch so the operator can inspect before the
+# commit lands.
+verify_notices() {
+    local upstream=$1
+    local pattern='[Cc]opyright|[Ll]icense|SPDX|[Aa]ll [Rr]ights [Rr]eserved'
+    for f in "${FILES[@]}"; do
+        if ! diff -u \
+                <(grep -nE "$pattern" "$upstream/$UPSTREAM_SRC_SUBDIR/$f" || true) \
+                <(grep -nE "$pattern" "$DEST/$f" || true) \
+                > /dev/null; then
+            echo "vendor_oink: notice drift in $f:" >&2
+            diff -u \
+                <(grep -nE "$pattern" "$upstream/$UPSTREAM_SRC_SUBDIR/$f" || true) \
+                <(grep -nE "$pattern" "$DEST/$f" || true) >&2 || true
+            die "attribution must match upstream byte-for-byte; fix the patch"
+        fi
+    done
+    cmp -s "$upstream/LICENSE" "$DEST/LICENSE" \
+        || die "LICENSE differs from upstream"
+}
+
+write_init() {
+    local sha=$1 version=$2
+    # Heredoc is unquoted so $sha and $version interpolate. The \`\` escapes
+    # keep reStructuredText-style ``double backticks`` literal in the output.
+    cat > "$DEST/__init__.py" <<EOF
+"""Vendored subset of the kernelagent_oink library
+(https://github.com/meta-pytorch/KernelAgent).
+
+Upstream SHA: $sha (kernelagent-oink $version)
+
+Only the modules required by torch._native.ops.norm.oink_rmsnorm_impl are
+vendored. Imports are rewritten to be package-relative so this copy is
+independent of any \`\`kernelagent_oink\`\` top-level package that may be
+installed via pip.
+"""
+__version__ = "$version"
+
+from .rmsnorm import rmsnorm_forward, rmsnorm_backward  # noqa: E402
+
+
+__all__ = [
+    "rmsnorm_forward",
+    "rmsnorm_backward",
+]
+EOF
+}
+
+main() {
+    [[ $# -eq 1 || $# -eq 2 ]] || usage
+    local sha=$1 local_checkout=${2:-} upstream version
+
+    upstream=$(fetch_upstream "$sha" "$local_checkout")
+    version=$(extract_version "$upstream/oink/pyproject.toml")
+
+    mkdir -p "$DEST"
+    rm -f "$DEST"/*.py "$DEST/LICENSE"
+
+    copy_pristine "$upstream"
+    apply_patches
+    rewrite_imports
+    verify_notices "$upstream"
+    write_init "$sha" "$version"
+
+    echo "Vendored kernelagent-oink @ $sha (kernelagent-oink $version) into torch/_vendor/oink"
+}
+
+main "$@"

--- a/torch/_vendor/README.md
+++ b/torch/_vendor/README.md
@@ -46,3 +46,39 @@ Instructions to update the subset of quack being vendored:
   - Update the files to be copied (`FILES`)
   - Update the `rewrite_imports` methods is there are more patterns required
 - Add any extra patchsets needed in `tools/vendoring/quack/patches`
+
+## `oink`
+
+This is a subset of the `kernelagent-oink` library (Blackwell SM10.x CuTeDSL
+kernels), currently vendoring the following operators:
+
+- RMSNorm
+
+Note: Imports are rewritten from absolute `kernelagent_oink.blackwell.module`
+to relative `.module`. The subset does not vendor any `@custom_op` /
+`@register_fake` decorators (oink keeps those in a separate
+`oink_custom_ops.py` module that is excluded from the whitelist).
+
+Source: https://github.com/meta-pytorch/KernelAgent
+
+Vendored version: `0.1.0`
+Vendored SHA: `54b1331d2f5fc7e615c39e3057b836ecc5e2c10a`
+
+Instructions to update:
+
+Run the following script:
+
+```
+tools/vendoring/oink/vendor.sh <NEW_SHA>
+
+# Or if you have an existing local clone:
+
+tools/vendoring/oink/vendor.sh <NEW_SHA> /path/to/local/KernelAgent
+```
+
+Instructions to update the subset of oink being vendored:
+
+- In the `vendor.sh` script:
+  - Update the files to be copied (`FILES`)
+  - Update the `rewrite_imports` method if more patterns are required
+- Add any extra patchsets needed in `tools/vendoring/oink/patches`

--- a/torch/_vendor/oink/LICENSE
+++ b/torch/_vendor/oink/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/torch/_vendor/oink/__init__.py
+++ b/torch/_vendor/oink/__init__.py
@@ -1,0 +1,19 @@
+"""Vendored subset of the kernelagent_oink library
+(https://github.com/meta-pytorch/KernelAgent).
+
+Upstream SHA: 54b1331d2f5fc7e615c39e3057b836ecc5e2c10a (kernelagent-oink 0.1.0)
+
+Only the modules required by torch._native.ops.norm.oink_rmsnorm_impl are
+vendored. Imports are rewritten to be package-relative so this copy is
+independent of any ``kernelagent_oink`` top-level package that may be
+installed via pip.
+"""
+__version__ = "0.1.0"
+
+from .rmsnorm import rmsnorm_forward, rmsnorm_backward  # noqa: E402
+
+
+__all__ = [
+    "rmsnorm_forward",
+    "rmsnorm_backward",
+]

--- a/torch/_vendor/oink/_cutedsl_cache.py
+++ b/torch/_vendor/oink/_cutedsl_cache.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CuTeDSL cache setup shared by Blackwell kernel modules.
+
+CuTeDSL cache bytecode is version-sensitive.  The default global cache
+(``/tmp/$USER/cutlass_python_cache``) can be shared across environments with
+incompatible ``nvidia-cutlass-dsl`` versions, producing noisy warnings and
+lost cache reuse.  Call this helper before importing ``cutlass`` in modules
+that compile CuTeDSL kernels.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import os
+import re
+
+
+def ensure_versioned_cutedsl_cache_dir() -> None:
+    """Set a version-scoped CuTeDSL cache directory when the user did not.
+
+    The path format intentionally matches the historical per-module logic:
+    ``$TMPDIR/$USER/cutlass_python_cache_<nvidia-cutlass-dsl-version>``.
+    If ``CUTE_DSL_CACHE_DIR`` is already set, leave it untouched.
+    """
+    if "CUTE_DSL_CACHE_DIR" in os.environ:
+        return
+    try:
+        dsl_ver = importlib.metadata.version("nvidia-cutlass-dsl")
+    except Exception:
+        dsl_ver = "unknown"
+    dsl_ver = re.sub(r"[^0-9A-Za-z]+", "_", dsl_ver)
+    user = os.environ.get("USER") or os.environ.get("USERNAME") or "user"
+    tmp = os.environ.get("TMPDIR") or "/tmp"
+    os.environ["CUTE_DSL_CACHE_DIR"] = os.path.join(
+        tmp, user, f"cutlass_python_cache_{dsl_ver}"
+    )

--- a/torch/_vendor/oink/_rmsnorm_impl.py
+++ b/torch/_vendor/oink/_rmsnorm_impl.py
@@ -1,0 +1,3487 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SM100 RMSNorm kernels for Oink's CuteDSL Blackwell path."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, replace
+
+# Vendored/adapted from Quack's SM100 RMSNorm with Oink-specific B200 tuning.
+
+from ._cutedsl_cache import ensure_versioned_cutedsl_cache_dir
+
+ensure_versioned_cutedsl_cache_dir()
+
+try:
+    import cutlass  # type: ignore  # noqa: F401
+except Exception as e:
+    raise ImportError(
+        "kernelagent_oink.blackwell.rmsnorm requires CuTeDSL's Python package "
+        "(`cutlass`, typically provided by `nvidia-cutlass-dsl`)."
+    ) from e
+
+import torch  # noqa: E402
+from torch import Tensor  # noqa: E402
+
+import cuda.bindings.driver as cuda  # provided by NVIDIA cuda-python  # noqa: E402
+
+import cutlass  # noqa: E402
+import cutlass.cute as cute  # noqa: E402
+from cutlass import Float32, Int32, const_expr  # noqa: E402
+from cutlass.cute import runtime as rt  # noqa: E402
+from cutlass.cute.runtime import from_dlpack  # noqa: E402
+
+# Shared fast-launch helpers.
+from .fast_launch import (  # noqa: E402
+    GenericFastLaunch as _GenericFastLaunch,
+    StableF32Arg as _StableF32Arg,
+    StableI32Arg as _StableI32Arg,
+    _env_flag,
+    build_fast_launcher as _build_generic_fast_launcher,
+)
+from ._rmsnorm_smallm_cuda import (  # noqa: E402
+    try_rmsnorm_smallm_noweight_cuda,
+)
+from ._rmsnorm_simple_weightonly import (  # noqa: E402
+    try_simple_weightonly_rmsnorm_forward,
+)
+from . import lite_quack as qutils  # noqa: E402
+from .lite_quack import (  # noqa: E402
+    _KERNEL_ACCEPTS_LAYOUT_ARGS,
+    TORCH2CUTE_DTYPE,
+    RMSNormBackward as BaseRMSNormBackward,
+    convert_from_dlpack as convert_from_dlpack_cute,
+    get_sm_count,
+    row_reduce,
+)
+
+# Simple compile cache declared early so direct execution works
+_PTR_COMPILE_CACHE = {}
+
+
+# Cached fp32 ones row for GEMM-based partial reductions.
+_DW_REDUCE_ONES_CACHE: dict[tuple[int, int], Tensor] = {}
+
+
+def _get_dw_reduce_ones(device_index: int, sm_count: int) -> Tensor:
+    key = (int(device_index), int(sm_count))
+    ones = _DW_REDUCE_ONES_CACHE.get(key)
+    if ones is None or ones.shape != (1, sm_count) or ones.device.index != device_index:
+        ones = torch.ones(
+            (1, sm_count),
+            device=torch.device("cuda", device_index),
+            dtype=torch.float32,
+        )
+        _DW_REDUCE_ONES_CACHE[key] = ones
+    return ones
+
+
+def _reduce_partial_sum_fp32(partial: Tensor, *, device_index: int) -> Tensor:
+    """Reduce a (sm_count, N) fp32 partial buffer into an (N,) fp32 result."""
+    assert partial.dtype is torch.float32
+    assert partial.dim() == 2
+    ones = _get_dw_reduce_ones(device_index, int(partial.shape[0]))
+    return torch.mm(ones, partial).squeeze(0)
+
+
+# Fused-add schedule knobs; set env vars before importing to override.
+_DIRECT_GMEM_POLICY = (
+    os.environ.get("OINK_RMSNORM_DIRECT_GMEM", "auto").strip().lower() or "auto"
+)
+_COPY_BITS_POLICY = (
+    os.environ.get("OINK_RMSNORM_COPY_BITS", "auto").strip().lower() or "auto"
+)
+_ENABLE_STAGE2 = _env_flag("OINK_RMSNORM_ENABLE_STAGE2", default=False)
+
+# Forward dispatch control.
+_FORCE_RMSNORM_STAGE2_FWD = _env_flag(
+    "KERNELAGENT_OINK_FORCE_RMSNORM_STAGE2", default=False
+)
+
+
+def _direct_gmem_from_policy(*, default: bool) -> bool:
+    """Resolve the direct-GMEM schedule flag from the (import-time) policy string."""
+    if _DIRECT_GMEM_POLICY in {"0", "false", "no", "off"}:
+        return False
+    if _DIRECT_GMEM_POLICY in {"1", "true", "yes", "on"}:
+        return True
+    return default
+
+
+def _copy_bits_from_policy(*, default: int, can_use_256: bool) -> int:
+    """Resolve copy width (in bits) from the (import-time) policy string."""
+    if _COPY_BITS_POLICY == "64":
+        return 64
+    if _COPY_BITS_POLICY == "128":
+        return 128
+    if _COPY_BITS_POLICY == "256" and can_use_256:
+        return 256
+    return default
+
+
+def _weight_assumed_align(
+    *,
+    default: int,
+    weight: Tensor | None,
+    weight_dtype: type[cutlass.Numeric] | None,
+) -> int:
+    if (
+        weight is not None
+        and weight_dtype is not None
+        and weight_dtype.width == 32
+        and (weight.data_ptr() % 32) == 0
+    ):
+        return 32
+    return int(default)
+
+
+@dataclass(frozen=True)
+class _ForwardLaunchConfig:
+    direct_gmem: bool
+    use_async: bool
+    copy_bits: int
+    assumed_align: int
+    weight_assumed_align: int
+    stage: int
+    tpr_override: int | None
+    nt_override: int | None
+    cluster_n_override: int | None
+
+
+def _resolve_forward_launch_config(
+    *,
+    M: int,
+    N: int,
+    dtype: type[cutlass.Numeric],
+    x: Tensor,
+    weight: Tensor | None,
+    weight_dtype: type[cutlass.Numeric] | None,
+    aligned_tensors: tuple[Tensor | None, ...],
+) -> _ForwardLaunchConfig:
+    direct_gmem_default = bool(
+        dtype.width == 16 and N in {128, 512, 4096, 6144, 7168, 8192}
+    )
+    if (
+        dtype.width == 16
+        and N == 1536
+        and weight_dtype is not None
+        and weight_dtype.width == 16
+    ):
+        direct_gmem_default = True
+    if weight_dtype is not None and weight_dtype.width == 32 and N == 7168:
+        direct_gmem_default = False
+    direct_gmem = _direct_gmem_from_policy(default=direct_gmem_default)
+    use_async = not direct_gmem
+
+    can_use_256 = bool(
+        dtype.width == 16
+        and (weight_dtype is None or weight_dtype.width == 16)
+        and (x.data_ptr() % 32) == 0
+        and all(t is None or (t.data_ptr() % 32) == 0 for t in aligned_tensors)
+    )
+    default_copy_bits = 256 if can_use_256 else 128
+    if dtype.width == 16 and N == 128:
+        default_copy_bits = 128
+    if dtype.width == 16 and N in {512, 1536, 4096}:
+        default_copy_bits = 128
+    if dtype.width == 16 and weight_dtype is not None and weight_dtype.width == 32:
+        default_copy_bits = 128 if N == 4096 else 64
+
+    copy_bits = _copy_bits_from_policy(
+        default=default_copy_bits, can_use_256=can_use_256
+    )
+    # cp.async supports at most 128 bits per instruction.  The copy atom clamps
+    # async copies to 128b, so keep the TV layout's vector width in sync with the
+    # emitted copy width; otherwise shapes such as DSv4 N=1536 can leave half of
+    # each logical vector tile uninitialized.
+    if use_async and copy_bits > 128:
+        copy_bits = 128
+    if use_async and copy_bits < 128:
+        use_async = False
+
+    assumed_align = 32 if copy_bits >= 256 else 16
+    weight_assumed_align = _weight_assumed_align(
+        default=assumed_align,
+        weight=weight,
+        weight_dtype=weight_dtype,
+    )
+    tpr_override, nt_override, cluster_n_override = _forward_launch_overrides(
+        M=int(M),
+        N=int(N),
+        dtype=dtype,
+        weight_dtype=weight_dtype,
+        direct_gmem=bool(direct_gmem),
+    )
+
+    stage = 1
+    if (
+        _ENABLE_STAGE2
+        and dtype.width == 16
+        and N == 7168
+        and (not direct_gmem)
+        and M >= 4096
+    ):
+        stage = 2
+
+    return _ForwardLaunchConfig(
+        direct_gmem=bool(direct_gmem),
+        use_async=bool(use_async),
+        copy_bits=int(copy_bits),
+        assumed_align=int(assumed_align),
+        weight_assumed_align=int(weight_assumed_align),
+        stage=int(stage),
+        tpr_override=tpr_override,
+        nt_override=nt_override,
+        cluster_n_override=cluster_n_override,
+    )
+
+
+def _should_force_stage2_forward(
+    *,
+    x: Tensor,
+    weight: Tensor | None,
+    bias: Tensor | None,
+    residual: Tensor | None,
+    store_rstd: bool,
+) -> bool:
+    if bias is not None or residual is not None or store_rstd:
+        return False
+    if weight is None or x.dtype not in (torch.float16, torch.bfloat16):
+        return False
+    if weight.dtype not in (x.dtype, torch.float32):
+        return False
+
+    M, N = int(x.shape[0]), int(x.shape[1])
+
+    if weight.dtype is torch.float32:
+        if N == 7168 and M >= 16384:
+            return True
+        if N in {6144, 8192} and M >= 65536:
+            return True
+        return False
+    return False
+
+
+def _forward_launch_overrides(
+    *,
+    M: int,
+    N: int,
+    dtype: type[cutlass.Numeric],
+    weight_dtype: type[cutlass.Numeric] | None,
+    direct_gmem: bool,
+) -> tuple[int | None, int | None, int | None]:
+    """Return optional `(threads_per_row, num_threads, cluster_n)` overrides."""
+    tpr_default: int | None = None
+    nt_default: int | None = None
+    cluster_n_default: int | None = None
+
+    if (
+        dtype.width == 16
+        and weight_dtype is not None
+        and weight_dtype.width == 16
+        and N == 1536
+        and direct_gmem
+        and M >= 4096
+    ):
+        tpr_default = 32
+        nt_default = 32
+    if (
+        dtype.width == 16
+        and weight_dtype is not None
+        and weight_dtype.width == 32
+        and N == 7168
+        and (not direct_gmem)
+        and M < 16384
+    ):
+        tpr_default = 128
+        nt_default = 128
+
+    def _env_int(name: str) -> int | None:
+        val = os.environ.get(name, "").strip()
+        return int(val) if val else None
+
+    tpr = _env_int("OINK_RMSNORM_TPR")
+    nt = _env_int("OINK_RMSNORM_NT")
+    cluster_n = _env_int("OINK_RMSNORM_CLUSTER_N")
+    return (
+        tpr_default if tpr is None else tpr,
+        nt_default if nt is None else nt,
+        cluster_n_default if cluster_n is None else cluster_n,
+    )
+
+
+def _force_stage2_forward_launch_config(
+    launch_cfg: _ForwardLaunchConfig,
+    *,
+    M: int,
+    N: int,
+    dtype: type[cutlass.Numeric],
+    weight: Tensor | None,
+    weight_dtype: type[cutlass.Numeric] | None,
+) -> _ForwardLaunchConfig:
+    if (
+        dtype.width != 16
+        or weight is None
+        or weight_dtype is None
+        or weight_dtype.width != 32
+    ):
+        return launch_cfg
+    if N == 7168 and M >= 16384:
+        stage = 1
+        tpr_override, nt_override = 128, 128
+    elif M >= 65536 and N in {6144, 8192}:
+        stage = 2
+        tpr_override, nt_override = 128, (128 if N == 6144 else 256)
+    else:
+        return launch_cfg
+    return replace(
+        launch_cfg,
+        direct_gmem=False,
+        use_async=True,
+        copy_bits=128,
+        assumed_align=16,
+        weight_assumed_align=_weight_assumed_align(
+            default=16,
+            weight=weight,
+            weight_dtype=weight_dtype,
+        ),
+        stage=stage,
+        tpr_override=tpr_override,
+        nt_override=nt_override,
+        cluster_n_override=None,
+    )
+
+
+def _override_simple_weight_only_forward_launch_config(
+    launch_cfg: _ForwardLaunchConfig,
+    *,
+    M: int,
+    N: int,
+    dtype: type[cutlass.Numeric],
+    weight: Tensor | None,
+    weight_dtype: type[cutlass.Numeric] | None,
+) -> _ForwardLaunchConfig:
+    if (
+        _DIRECT_GMEM_POLICY != "auto"
+        or _COPY_BITS_POLICY != "auto"
+        or os.environ.get("OINK_RMSNORM_TPR", "").strip()
+        or os.environ.get("OINK_RMSNORM_NT", "").strip()
+        or os.environ.get("OINK_RMSNORM_CLUSTER_N", "").strip()
+        or _ENABLE_STAGE2
+    ):
+        return launch_cfg
+    if (
+        dtype.width != 16
+        or weight is None
+        or weight_dtype is None
+        or weight_dtype.width != 16
+        or M < 4096
+    ):
+        return launch_cfg
+
+    if N == 7168:
+        if M >= 262144:
+            return launch_cfg
+        stage = 2
+        if M == 131072:
+            tpr_override, nt_override = 64, 64
+        elif M >= 65536:
+            tpr_override, nt_override = 128, 128
+        else:
+            tpr_override, nt_override = None, None
+    elif N == 8192 and M >= 65536:
+        stage = 1
+        tpr_override, nt_override = 128, 128
+    else:
+        return launch_cfg
+
+    return replace(
+        launch_cfg,
+        direct_gmem=False,
+        use_async=True,
+        copy_bits=128,
+        assumed_align=16,
+        weight_assumed_align=_weight_assumed_align(
+            default=16,
+            weight=weight,
+            weight_dtype=weight_dtype,
+        ),
+        stage=stage,
+        tpr_override=tpr_override,
+        nt_override=nt_override,
+        cluster_n_override=None,
+    )
+
+
+def _make_gmem_ptr(
+    dtype: type[cutlass.Numeric],
+    device_ptr: int,
+    *,
+    assumed_align: int,
+):
+    return rt.make_ptr(
+        dtype,
+        int(device_ptr),
+        mem_space=rt.AddressSpace.gmem,
+        assumed_align=int(assumed_align),
+    )
+
+
+def _make_optional_gmem_ptr(
+    tensor: Tensor | None,
+    dtype: type[cutlass.Numeric],
+    *,
+    assumed_align: int,
+):
+    return (
+        None
+        if tensor is None
+        else _make_gmem_ptr(dtype, tensor.data_ptr(), assumed_align=assumed_align)
+    )
+
+
+def _apply_launch_overrides(
+    op: object,
+    *,
+    tpr_override: int | None,
+    nt_override: int | None,
+    cluster_n_override: int | None,
+) -> None:
+    if tpr_override is not None:
+        op._tpr_override = tpr_override  # type: ignore[attr-defined]
+    if nt_override is not None:
+        op._nt_override = nt_override  # type: ignore[attr-defined]
+    if cluster_n_override is not None:
+        op._cluster_n_override = cluster_n_override  # type: ignore[attr-defined]
+
+
+def _specialized_bf16_threads(N: int, copy_bits: int) -> tuple[int, int] | None:
+    if N == 128:
+        return 16, 128
+    if N == 1536:
+        return 96, 96
+    if N == 7168:
+        return 224, 224
+    if N == 6144:
+        threads = 192 if copy_bits >= 256 else 256
+        return threads, threads
+    if N == 8192:
+        return 256, 256
+    return None
+
+
+def _current_stream_handle(device_index: int) -> int:
+    if torch.cuda.current_device() != device_index:
+        torch.cuda.set_device(device_index)
+    return int(torch.cuda.current_stream().cuda_stream)
+
+
+def _make_rmsnorm_op(
+    N: int,
+    dtype: type[cutlass.Numeric],
+    *,
+    stage: int,
+    copy_bits: int,
+    use_async: bool,
+    direct_gmem: bool,
+    tpr_override: int | None = None,
+    nt_override: int | None = None,
+    cluster_n_override: int | None = None,
+):
+    op = RMSNormSM100(
+        N,
+        dtype,
+        stage=stage,
+        copy_bits=copy_bits,
+        use_async=use_async,
+        direct_gmem=direct_gmem,
+    )
+    _apply_launch_overrides(
+        op,
+        tpr_override=tpr_override,
+        nt_override=nt_override,
+        cluster_n_override=cluster_n_override,
+    )
+    return op
+
+
+def _match_stride(tensor: Tensor | None, ref: Tensor | None) -> Tensor | None:
+    if tensor is None or ref is None or tensor.stride() == ref.stride():
+        return tensor
+    out = torch.empty_strided(
+        ref.shape, ref.stride(), device=ref.device, dtype=ref.dtype
+    )
+    out.copy_(tensor)
+    return out
+
+
+def _rmsnorm_ref_outputs(
+    x: Tensor,
+    weight: Tensor | None,
+    bias: Tensor | None,
+    residual: Tensor | None,
+    eps: float,
+    store_rstd: bool,
+) -> tuple[Tensor, Tensor | None, Tensor | None]:
+    y = _match_stride(rmsnorm_ref(x, weight, bias, residual, eps), x)
+    rstd = None
+    if store_rstd:
+        xf = x.float()
+        if residual is not None:
+            xf = xf + residual.float()
+        rstd = torch.rsqrt(xf.square().mean(dim=-1) + eps).to(torch.float32)
+    residual_out = None
+    if residual is not None:
+        residual_out = _match_stride(
+            (x.float() + residual.float()).to(x.dtype), residual
+        )
+    return y, rstd, residual_out
+
+
+def _make_forward_ptrs(
+    *,
+    x: Tensor,
+    out: Tensor,
+    dtype: type[cutlass.Numeric],
+    launch_cfg: _ForwardLaunchConfig,
+    weight: Tensor | None = None,
+    weight_dtype: type[cutlass.Numeric] | None = None,
+    bias: Tensor | None = None,
+    residual: Tensor | None = None,
+    residual_out: Tensor | None = None,
+    rstd: Tensor | None = None,
+):
+    return (
+        _make_gmem_ptr(dtype, x.data_ptr(), assumed_align=launch_cfg.assumed_align),
+        _make_optional_gmem_ptr(
+            weight,
+            weight_dtype or dtype,
+            assumed_align=launch_cfg.weight_assumed_align,
+        ),
+        _make_optional_gmem_ptr(bias, dtype, assumed_align=launch_cfg.assumed_align),
+        _make_optional_gmem_ptr(
+            residual, dtype, assumed_align=launch_cfg.assumed_align
+        ),
+        _make_gmem_ptr(dtype, out.data_ptr(), assumed_align=launch_cfg.assumed_align),
+        _make_optional_gmem_ptr(
+            residual_out,
+            dtype,
+            assumed_align=launch_cfg.assumed_align,
+        ),
+        _make_optional_gmem_ptr(rstd, cutlass.Float32, assumed_align=4),
+    )
+
+
+def _make_fused_add_ptrs(
+    *,
+    x: Tensor,
+    weight: Tensor,
+    residual: Tensor,
+    dtype: type[cutlass.Numeric],
+    assumed_align: int,
+):
+    return (
+        _make_gmem_ptr(dtype, x.data_ptr(), assumed_align=assumed_align),
+        _make_gmem_ptr(dtype, weight.data_ptr(), assumed_align=assumed_align),
+        _make_gmem_ptr(dtype, residual.data_ptr(), assumed_align=assumed_align),
+    )
+
+
+def _apply_backward_launch_overrides(
+    op: object,
+    *,
+    atomic_dw: bool,
+    N: int,
+    dtype: type[cutlass.Numeric],
+    weight_dtype: type[cutlass.Numeric],
+) -> None:
+    if atomic_dw:
+        return
+    if (
+        N == 4096
+        and dtype.width == 16
+        and (weight_dtype.width == 16 or weight_dtype is cutlass.Float32)
+    ):
+        op._tpr_override = 256  # type: ignore[attr-defined]
+        op._nt_override = 256  # type: ignore[attr-defined]
+        return
+    if N == 6144 and dtype is cutlass.Float16 and weight_dtype is cutlass.Float32:
+        op._tpr_override = 128  # type: ignore[attr-defined]
+        op._nt_override = 256  # type: ignore[attr-defined]
+
+
+def _make_bwd_ptrs(
+    *,
+    x: Tensor,
+    weight: Tensor,
+    dout: Tensor,
+    rstd: Tensor,
+    dx: Tensor,
+    dw_partial: Tensor,
+    dtype: type[cutlass.Numeric],
+    weight_dtype: type[cutlass.Numeric],
+    assumed_align_x: int,
+    assumed_align_w: int,
+    assumed_align_dw: int,
+):
+    return (
+        _make_gmem_ptr(dtype, x.data_ptr(), assumed_align=assumed_align_x),
+        _make_gmem_ptr(weight_dtype, weight.data_ptr(), assumed_align=assumed_align_w),
+        _make_gmem_ptr(dtype, dout.data_ptr(), assumed_align=assumed_align_x),
+        _make_gmem_ptr(cutlass.Float32, rstd.data_ptr(), assumed_align=assumed_align_x),
+        _make_gmem_ptr(dtype, dx.data_ptr(), assumed_align=assumed_align_x),
+        _make_gmem_ptr(
+            cutlass.Float32,
+            dw_partial.data_ptr(),
+            assumed_align=assumed_align_dw,
+        ),
+    )
+
+
+def _make_rmsnorm_fallback_launch(
+    *,
+    compiled: object,
+    stream: cuda.CUstream,
+    assumed_align: int,
+    assumed_align_w: int,
+    weight_dtype: type[cutlass.Numeric] | None,
+):
+    def _fallback_launch(
+        *,
+        x: Tensor,
+        weight: Tensor | None,
+        out: Tensor,
+        M: int,
+        N: int,
+        ld: int,
+        eps: float,
+        **_: object,
+    ) -> None:
+        dtype = TORCH2CUTE_DTYPE[x.dtype]
+        ptr_x = _make_gmem_ptr(dtype, x.data_ptr(), assumed_align=assumed_align)
+        ptr_out = _make_gmem_ptr(dtype, out.data_ptr(), assumed_align=assumed_align)
+        ptr_w = _make_optional_gmem_ptr(
+            weight,
+            weight_dtype or dtype,
+            assumed_align=assumed_align_w,
+        )
+        compiled(
+            ptr_x,
+            ptr_w,
+            None,
+            None,
+            ptr_out,
+            None,
+            None,
+            Int32(M),
+            Int32(N),
+            Int32(ld),
+            stream,
+            Float32(eps),
+        )
+
+    return _fallback_launch
+
+
+def _make_fused_add_fallback_launch(
+    *,
+    compiled: object,
+    stream: cuda.CUstream,
+    assumed_align: int,
+):
+    def _fallback_launch(
+        *,
+        x: Tensor,
+        weight: Tensor,
+        residual: Tensor,
+        M: int,
+        N: int,
+        ld_x: int,
+        eps: float,
+        **_: object,
+    ) -> None:
+        dtype = TORCH2CUTE_DTYPE[x.dtype]
+        ptr_x, ptr_w, ptr_res = _make_fused_add_ptrs(
+            x=x,
+            weight=weight,
+            residual=residual,
+            dtype=dtype,
+            assumed_align=assumed_align,
+        )
+        compiled(
+            ptr_x,
+            ptr_w,
+            ptr_res,
+            Int32(M),
+            Int32(N),
+            Int32(ld_x),
+            stream,
+            Float32(eps),
+        )
+
+    return _fallback_launch
+
+
+def _make_rmsnorm_bwd_fallback_launch(
+    *,
+    compiled: object,
+    stream: cuda.CUstream,
+    assumed_align_x: int,
+    assumed_align_w: int,
+    assumed_align_dw: int,
+    weight_dtype: type[cutlass.Numeric] | None,
+):
+    def _fallback_launch(
+        *,
+        x: Tensor,
+        weight: Tensor | None,
+        dout: Tensor,
+        rstd: Tensor,
+        dx: Tensor,
+        dw_partial: Tensor | None,
+        M: int,
+        N: int,
+        ld: int,
+        sm_count: int,
+        **_: object,
+    ) -> None:
+        dtype = TORCH2CUTE_DTYPE[x.dtype]
+        ptr_x = _make_gmem_ptr(dtype, x.data_ptr(), assumed_align=assumed_align_x)
+        ptr_dout = _make_gmem_ptr(dtype, dout.data_ptr(), assumed_align=assumed_align_x)
+        ptr_dx = _make_gmem_ptr(dtype, dx.data_ptr(), assumed_align=assumed_align_x)
+        ptr_rstd = _make_gmem_ptr(
+            TORCH2CUTE_DTYPE[rstd.dtype],
+            rstd.data_ptr(),
+            assumed_align=assumed_align_x,
+        )
+        ptr_w = _make_optional_gmem_ptr(
+            weight,
+            weight_dtype or dtype,
+            assumed_align=assumed_align_w,
+        )
+        ptr_dw_partial = _make_optional_gmem_ptr(
+            dw_partial,
+            TORCH2CUTE_DTYPE[dw_partial.dtype]
+            if dw_partial is not None
+            else cutlass.Float32,
+            assumed_align=assumed_align_dw,
+        )
+        compiled(
+            ptr_x,
+            ptr_w,
+            ptr_dout,
+            ptr_rstd,
+            ptr_dx,
+            ptr_dw_partial,
+            Int32(M),
+            Int32(N),
+            Int32(ld),
+            Int32(sm_count),
+            stream,
+        )
+
+    return _fallback_launch
+
+
+def _get_fast_ptr_rmsnorm_bwd_launcher(
+    *,
+    compiled: object,
+    dtype: type[cutlass.Numeric],
+    weight_dtype: type[cutlass.Numeric] | None,
+    N: int,
+    device_index: int,
+    stream_handle: int,
+    has_weight: bool,
+    has_dw_partial: bool,
+    assumed_align_x: int,
+    assumed_align_w: int,
+    assumed_align_dw: int,
+) -> _GenericFastLaunch | None:
+    assumed_align_x = int(assumed_align_x)
+    assumed_align_w = int(assumed_align_w)
+    assumed_align_dw = int(assumed_align_dw)
+    key = (
+        "ptr_bwd_fast",
+        id(compiled),
+        N,
+        dtype,
+        weight_dtype,
+        device_index,
+        int(stream_handle),
+        has_weight,
+        has_dw_partial,
+        assumed_align_x,
+        assumed_align_w,
+        assumed_align_dw,
+    )
+    ptr_x = _make_gmem_ptr(dtype, 0, assumed_align=assumed_align_x)
+    ptr_w = (
+        _make_gmem_ptr(weight_dtype or dtype, 0, assumed_align=assumed_align_w)
+        if has_weight
+        else None
+    )
+    ptr_dout = _make_gmem_ptr(dtype, 0, assumed_align=assumed_align_x)
+    ptr_rstd = _make_gmem_ptr(cutlass.Float32, 0, assumed_align=assumed_align_x)
+    ptr_dx = _make_gmem_ptr(dtype, 0, assumed_align=assumed_align_x)
+    ptr_dw_partial = (
+        _make_gmem_ptr(cutlass.Float32, 0, assumed_align=assumed_align_dw)
+        if has_dw_partial
+        else None
+    )
+    arg_m = _StableI32Arg(0)
+    arg_n = _StableI32Arg(N)
+    arg_ld = _StableI32Arg(N)
+    arg_sm_count = _StableI32Arg(0)
+    return _build_generic_fast_launcher(
+        key=key,
+        compiled=compiled,
+        device_index=device_index,
+        stream_handle=stream_handle,
+        execution_args_builder=lambda stream: (
+            ptr_x,
+            ptr_w,
+            ptr_dout,
+            ptr_rstd,
+            ptr_dx,
+            ptr_dw_partial,
+            arg_m,
+            arg_n,
+            arg_ld,
+            arg_sm_count,
+            stream,
+        ),
+        keepalive_items=(
+            ptr_x,
+            ptr_w,
+            ptr_dout,
+            ptr_rstd,
+            ptr_dx,
+            ptr_dw_partial,
+            arg_m,
+            arg_n,
+            arg_ld,
+            arg_sm_count,
+        ),
+        ptr_slots=(
+            (ptr_x, "x"),
+            (ptr_w, "weight"),
+            (ptr_dout, "dout"),
+            (ptr_rstd, "rstd"),
+            (ptr_dx, "dx"),
+            (ptr_dw_partial, "dw_partial"),
+        ),
+        scalar_slots=(
+            (arg_m, "M", -1),
+            (arg_ld, "ld", -1),
+            (arg_sm_count, "sm_count", -1),
+        ),
+        fallback_launch_builder=lambda stream: _make_rmsnorm_bwd_fallback_launch(
+            compiled=compiled,
+            stream=stream,
+            assumed_align_x=assumed_align_x,
+            assumed_align_w=assumed_align_w,
+            assumed_align_dw=assumed_align_dw,
+            weight_dtype=weight_dtype if has_weight else None,
+        ),
+    )
+
+
+def _get_fast_ptr_rmsnorm_launcher(
+    *,
+    compiled: object,
+    dtype: type[cutlass.Numeric],
+    weight_dtype: type[cutlass.Numeric] | None = None,
+    N: int,
+    device_index: int,
+    stream_handle: int,
+    has_weight: bool,
+    assumed_align: int = 16,
+    assumed_align_w: int | None = None,
+    eps: float,
+) -> _GenericFastLaunch | None:
+    assumed_align = int(assumed_align)
+    assumed_align_w = int(assumed_align if assumed_align_w is None else assumed_align_w)
+    key = (
+        "ptr_fast",
+        id(compiled),
+        N,
+        dtype,
+        weight_dtype,
+        device_index,
+        int(stream_handle),
+        has_weight,
+        assumed_align,
+        assumed_align_w,
+    )
+    ptr_x = _make_gmem_ptr(dtype, 0, assumed_align=assumed_align)
+    ptr_out = _make_gmem_ptr(dtype, 0, assumed_align=assumed_align)
+    ptr_w = (
+        _make_gmem_ptr(weight_dtype or dtype, 0, assumed_align=assumed_align_w)
+        if has_weight
+        else None
+    )
+    arg_m = _StableI32Arg(0)
+    arg_n = _StableI32Arg(N)
+    arg_ld = _StableI32Arg(N)
+    arg_eps = _StableF32Arg(eps)
+    return _build_generic_fast_launcher(
+        key=key,
+        compiled=compiled,
+        device_index=device_index,
+        stream_handle=stream_handle,
+        execution_args_builder=lambda stream: (
+            ptr_x,
+            ptr_w,
+            None,
+            None,
+            ptr_out,
+            None,
+            None,
+            arg_m,
+            arg_n,
+            arg_ld,
+            stream,
+            arg_eps,
+        ),
+        keepalive_items=(ptr_x, ptr_w, ptr_out, arg_m, arg_n, arg_ld, arg_eps),
+        ptr_slots=((ptr_x, "x"), (ptr_w, "weight"), (ptr_out, "out")),
+        scalar_slots=(
+            (arg_m, "M", -1),
+            (arg_ld, "ld", -1),
+            (arg_eps, "eps", float("nan")),
+        ),
+        fallback_launch_builder=lambda stream: _make_rmsnorm_fallback_launch(
+            compiled=compiled,
+            stream=stream,
+            assumed_align=assumed_align,
+            assumed_align_w=assumed_align_w,
+            weight_dtype=weight_dtype if has_weight else None,
+        ),
+    )
+
+
+def _get_fast_ptr_fused_add_rmsnorm_launcher(
+    *,
+    compiled: object,
+    dtype: type[cutlass.Numeric],
+    N: int,
+    device_index: int,
+    stream_handle: int,
+    copy_bits: int,
+    use_async: bool,
+    tpr: int,
+    direct_gmem: bool,
+    assumed_align: int,
+    eps: float,
+) -> _GenericFastLaunch | None:
+    assumed_align = int(assumed_align)
+    key = (
+        "ptr_fused_add_fast",
+        id(compiled),
+        N,
+        dtype,
+        device_index,
+        int(stream_handle),
+        int(copy_bits),
+        bool(use_async),
+        int(tpr),
+        bool(direct_gmem),
+        assumed_align,
+    )
+    ptr_x = _make_gmem_ptr(dtype, 0, assumed_align=assumed_align)
+    ptr_res = _make_gmem_ptr(dtype, 0, assumed_align=assumed_align)
+    ptr_w = _make_gmem_ptr(dtype, 0, assumed_align=assumed_align)
+    arg_m = _StableI32Arg(0)
+    arg_n = _StableI32Arg(N)
+    arg_ld_x = _StableI32Arg(N)
+    arg_eps = _StableF32Arg(eps)
+    return _build_generic_fast_launcher(
+        key=key,
+        compiled=compiled,
+        device_index=device_index,
+        stream_handle=stream_handle,
+        execution_args_builder=lambda stream: (
+            ptr_x,
+            ptr_w,
+            ptr_res,
+            arg_m,
+            arg_n,
+            arg_ld_x,
+            stream,
+            arg_eps,
+        ),
+        keepalive_items=(ptr_x, ptr_w, ptr_res, arg_m, arg_n, arg_ld_x, arg_eps),
+        ptr_slots=((ptr_x, "x"), (ptr_w, "weight"), (ptr_res, "residual")),
+        scalar_slots=(
+            (arg_m, "M", -1),
+            (arg_ld_x, "ld_x", -1),
+            (arg_eps, "eps", float("nan")),
+        ),
+        fallback_launch_builder=lambda stream: _make_fused_add_fallback_launch(
+            compiled=compiled,
+            stream=stream,
+            assumed_align=assumed_align,
+        ),
+    )
+
+
+# -------------------------
+# Copy helpers (allow up to 256b)
+# -------------------------
+
+
+@cute.jit
+def get_copy_atom_bw(
+    dtype: type[cutlass.Numeric], num_copy_elems: int, is_async: bool = False
+) -> cute.CopyAtom:
+    # cp.async (SIMT) supports up to 128b per op; use 256b for sync when possible
+    max_bits = const_expr(128 if is_async else 256)
+    num_copy_bits = const_expr(min(max_bits, num_copy_elems * dtype.width))
+    from cutlass.cute.nvgpu import cpasync
+
+    # Prefer GLOBAL cache policy for bulk streaming reads at large M.
+    copy_op = (
+        cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL)
+        if is_async
+        else cute.nvgpu.CopyUniversalOp()
+    )
+    return cute.make_copy_atom(copy_op, dtype, num_bits_per_copy=num_copy_bits)
+
+
+@cute.jit
+def copy_tiled(
+    src: cute.Tensor,
+    dst: cute.Tensor,
+    *,
+    pred: cute.Tensor | None = None,
+    num_copy_elems: int = 1,
+    is_async: bool = False,
+) -> None:
+    atom = get_copy_atom_bw(src.element_type, num_copy_elems, is_async)
+    cute.copy(atom, src, dst, pred=pred)
+
+
+# -------------------------
+# RMSNorm Kernel (SM100)
+# -------------------------
+
+
+class RMSNormSM100:
+    def __init__(
+        self,
+        N: int,
+        dtype: type[cutlass.Numeric],
+        stage: int | None = None,
+        *,
+        copy_bits: int = 128,
+        use_async: bool = True,
+        direct_gmem: bool = False,
+    ):
+        self.N = N
+        self.dtype = dtype
+        # Match Quack default for RMSNorm: stage = 1 unless explicitly overridden
+        self.stage = 1 if stage is None else stage
+        self.reduction_dtype = cutlass.Float32
+        self.copy_bits = int(copy_bits)
+        self.use_async = bool(use_async)
+        self.direct_gmem = bool(direct_gmem)
+
+    def _threads_per_row(self) -> int:
+        tpr = getattr(self, "_tpr_override", None)
+        if tpr is not None:
+            return int(tpr)
+
+        if self.dtype.width == 16:
+            special = _specialized_bf16_threads(self.N, self.copy_bits)
+            if special is not None:
+                return special[0]
+
+        N = self.N
+        if N <= 1024:
+            return 32
+        if N <= 4096:
+            return 128
+        if N <= 8192:
+            return 128
+        return 256
+
+    def _cluster_n(self) -> int:
+        cn = getattr(self, "_cluster_n_override", None)
+        if cn is not None:
+            return int(cn)
+        N = self.N
+        if N <= 8192:
+            return 1
+        limits = (
+            ((16 * 1024, 2), (32 * 1024, 2), (64 * 1024, 4), (128 * 1024, 8))
+            if const_expr(self.dtype.width == 16)
+            else ((32 * 1024, 1), (64 * 1024, 2), (128 * 1024, 4), (256 * 1024, 8))
+        )
+        for bound, cluster_n in limits:
+            if N <= bound:
+                return cluster_n
+        return 16
+
+    def _num_threads(self) -> int:
+        nt = getattr(self, "_nt_override", None)
+        if nt is not None:
+            return int(nt)
+        if self.dtype.width == 16:
+            special = _specialized_bf16_threads(self.N, self.copy_bits)
+            if special is not None:
+                return special[1]
+        if self.N <= 1024:
+            return 32
+        return 128 if self.N <= 16384 else 256
+
+    def _tv_layout(self, num_copy_bits: int = 256) -> tuple[cute.Shape, cute.Layout]:
+        vecsize = num_copy_bits // self.dtype.width
+        num_threads = self._num_threads()
+        assert num_threads % cute.arch.WARP_SIZE == 0
+        tpr = self._threads_per_row()
+        cluster_n = self._cluster_n()
+        num_cols_vec = cute.ceil_div(self.N, vecsize)
+        num_blocks_N = cute.ceil_div(num_cols_vec, tpr * cluster_n)
+        cols_per_block = num_threads // tpr
+        tiler_mn = (cols_per_block, vecsize * num_blocks_N * tpr)
+        tv_layout = cute.make_layout(
+            ((tpr, cols_per_block), (vecsize, num_blocks_N)),
+            stride=(
+                (vecsize * cols_per_block, 1),
+                (cols_per_block, cols_per_block * vecsize * tpr),
+            ),
+        )
+        return tiler_mn, tv_layout
+
+    def _smem_bytes(self, tiler_mn, num_warps) -> int:
+        return (
+            cute.size_in_bytes(self.dtype, cute.make_layout(tiler_mn))
+            + self.stage
+            * num_warps
+            * self._cluster_n()
+            * (self.reduction_dtype.width // 8)
+            + self.stage * (cutlass.Int64.width // 8)
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        mX: cute.Tensor,
+        mW: cute.Tensor | None,
+        mB: cute.Tensor | None,
+        mRes: cute.Tensor | None,
+        mO: cute.Tensor,
+        mResO: cute.Tensor | None,
+        mRstd: cute.Tensor | None,
+        stream: cuda.CUstream,
+        eps: Float32 = 1e-6,
+    ):
+        # Make last dim static (N)
+        semistatic_shape = (*mX.shape[:-1], self.N)
+
+        def new_stride(t):
+            return (
+                cute.assume(t.stride[0], divby=256 // t.element_type.width),
+                t.stride[1],
+            )
+
+        mX, mRes, mO, mResO = [
+            cute.make_tensor(
+                t.iterator, cute.make_layout(semistatic_shape, stride=new_stride(t))
+            )
+            if const_expr(t is not None)
+            else None
+            for t in (mX, mRes, mO, mResO)
+        ]
+        assert mX.element_type == self.dtype
+        assert mO.element_type == self.dtype
+
+        copy_bits = int(self.copy_bits)
+        tiler_mn, tv_layout = self._tv_layout(num_copy_bits=copy_bits)
+        num_threads = (
+            cute.size(tv_layout, mode=[0])
+            if _KERNEL_ACCEPTS_LAYOUT_ARGS
+            else self._num_threads()
+        )
+        num_warps = num_threads // cute.arch.WARP_SIZE
+        threads_per_row = (
+            tv_layout.shape[0][0]
+            if _KERNEL_ACCEPTS_LAYOUT_ARGS
+            else self._threads_per_row()
+        )
+        warps_per_row = max(threads_per_row // cute.arch.WARP_SIZE, 1)
+        cluster_n = self._cluster_n()
+
+        if const_expr(mW is not None):
+            mW = cute.make_tensor(
+                mW.iterator,
+                cute.prepend(mW.layout, cute.make_layout((tiler_mn[0],), stride=(0,))),
+            )
+        if const_expr(mB is not None):
+            mB = cute.make_tensor(
+                mB.iterator,
+                cute.prepend(mB.layout, cute.make_layout((tiler_mn[0],), stride=(0,))),
+            )
+        if const_expr(mRstd is not None):
+            mRstd = cute.make_tensor(
+                mRstd.iterator,
+                cute.append(mRstd.layout, cute.make_layout((self.N,), stride=(0,))),
+            )
+
+        # No SMEM reload mode switch; overlap is controlled in the K-loop path
+
+        # Compute smem usage considering staged buffers.
+        #
+        # In direct-gmem mode, we skip the gmem->smem tiles entirely and only
+        # keep the reduction buffers in shared memory.
+        stage_bufs = 2 if self.stage > 1 else 1
+        tile_bytes_x = (
+            cute.size_in_bytes(self.dtype, cute.make_layout(tiler_mn)) * stage_bufs
+            if const_expr(not self.direct_gmem)
+            else 0
+        )
+        tile_bytes_res = (
+            cute.size_in_bytes(mRes.element_type, cute.make_layout(tiler_mn))
+            * stage_bufs
+            if const_expr(mRes is not None and not self.direct_gmem)
+            else 0
+        )
+        red_bytes = (
+            self.stage * num_warps * cluster_n * (self.reduction_dtype.width // 8)
+        )
+        # mbarriers are only allocated/used for cluster_n>1. Some CuTeDSL builds
+        # require mbarrier state to be 16B-aligned in shared memory; account for
+        # the alignment padding when computing dynamic smem bytes.
+        smem_bytes = tile_bytes_x + tile_bytes_res + red_bytes
+        if cluster_n > 1:
+            # Align up to 16B before placing the mbarrier array.
+            smem_bytes = ((smem_bytes + 15) // 16) * 16
+            smem_bytes += self.stage * (cutlass.Int64.width // 8)
+
+        kernel = (
+            self.kernel(
+                mX,
+                mW,
+                mB,
+                mRes,
+                mO,
+                mResO,
+                mRstd,
+                eps,
+                tv_layout,
+                tiler_mn,
+                const_expr(cluster_n),
+                const_expr(num_warps),
+                const_expr(warps_per_row),
+                const_expr(threads_per_row),
+            )
+            if _KERNEL_ACCEPTS_LAYOUT_ARGS
+            else self.kernel(
+                mX,
+                mW,
+                mB,
+                mRes,
+                mO,
+                mResO,
+                mRstd,
+                eps,
+            )
+        )
+        kernel.launch(
+            grid=[cute.ceil_div(mX.shape[0], tiler_mn[0]), cluster_n, 1],
+            block=[num_threads, 1, 1],
+            cluster=([1, cluster_n, 1] if cluster_n > 1 else None),
+            smem=smem_bytes,
+            stream=stream,
+        )
+
+    @cute.jit
+    def launch_from_ptrs(
+        self,
+        ptr_x: cute.Pointer,
+        ptr_w: cute.Pointer | None,
+        ptr_b: cute.Pointer | None,
+        ptr_res: cute.Pointer | None,
+        ptr_out: cute.Pointer,
+        ptr_res_out: cute.Pointer | None,
+        ptr_rstd: cute.Pointer | None,
+        M: Int32,
+        N_dyn: Int32,
+        ld: Int32,
+        stream: cuda.CUstream,
+        eps: Float32 = 1e-6,
+    ):
+        """Pointer-based entrypoint to reuse the existing RMSNorm schedule.
+
+        This reconstructs cute.Tensor views from raw pointers plus sizes,
+        avoiding any DLPack conversions at the Python boundary.
+        """
+        # Use a dynamic N for the leading-dimension stride so that the
+        # subsequent cute.assume(...) in __call__ sees a dynamic expression
+        # rather than a plain Python int.
+        # The compile-time N for the kernel (self.N) is still used to
+        # specialize the schedule.
+        # Assume row-major [M, N] with an arbitrary leading-dimension stride
+        # (common for padded-row / packed-attention layouts).
+        layout_mn = cute.make_layout((M, N_dyn), stride=(ld, 1))
+        layout_n = cute.make_layout((N_dyn,), stride=(1,))
+        layout_m = cute.make_layout((M,), stride=(1,))
+
+        mX = cute.make_tensor(ptr_x, layout_mn)
+        mO = cute.make_tensor(ptr_out, layout_mn)
+
+        mRes = (
+            cute.make_tensor(ptr_res, layout_mn)
+            if const_expr(ptr_res is not None)
+            else None
+        )
+        mResO = (
+            cute.make_tensor(ptr_res_out, layout_mn)
+            if const_expr(ptr_res_out is not None)
+            else None
+        )
+        mW = (
+            cute.make_tensor(ptr_w, layout_n) if const_expr(ptr_w is not None) else None
+        )
+        mB = (
+            cute.make_tensor(ptr_b, layout_n) if const_expr(ptr_b is not None) else None
+        )
+        mRstd = (
+            cute.make_tensor(ptr_rstd, layout_m)
+            if const_expr(ptr_rstd is not None)
+            else None
+        )
+
+        # Reuse the main JIT entry to launch the scheduled kernel.
+        self.__call__(mX, mW, mB, mRes, mO, mResO, mRstd, stream, eps)
+
+    @cute.jit
+    def launch_from_ptrs_fused_add_inplace(
+        self,
+        ptr_x: cute.Pointer,
+        ptr_w: cute.Pointer,
+        ptr_res: cute.Pointer,
+        M: Int32,
+        N_dyn: Int32,
+        ld_x: Int32,
+        stream: cuda.CUstream,
+        eps: Float32 = 1e-6,
+    ):
+        """Pointer-based entrypoint for vLLM-style fused_add_rms_norm semantics.
+
+        This specialized entrypoint supports:
+        - `x` / output with an arbitrary leading-dimension stride (`ld_x`), and
+        - `residual` / residual-out as a contiguous [M, N] tensor (ld_res = N).
+
+        Both `x` and `residual` are updated in-place:
+          residual <- x + residual
+          x <- RMSNorm(residual) * weight
+        """
+        layout_x = cute.make_layout((M, N_dyn), stride=(ld_x, 1))
+        layout_res = cute.make_layout((M, N_dyn), stride=(N_dyn, 1))
+        layout_n = cute.make_layout((N_dyn,), stride=(1,))
+
+        mX = cute.make_tensor(ptr_x, layout_x)
+        mO = cute.make_tensor(ptr_x, layout_x)
+        mRes = cute.make_tensor(ptr_res, layout_res)
+        mResO = cute.make_tensor(ptr_res, layout_res)
+        mW = cute.make_tensor(ptr_w, layout_n)
+
+        self.__call__(
+            mX,
+            mW,
+            None,  # bias
+            mRes,
+            mO,
+            mResO,
+            None,  # rstd
+            stream,
+            eps,
+        )
+
+    @cute.jit
+    def _kernel_impl(
+        self,
+        mX: cute.Tensor,
+        mW: cute.Tensor | None,
+        mB: cute.Tensor | None,
+        mRes: cute.Tensor | None,
+        mO: cute.Tensor,
+        mResO: cute.Tensor | None,
+        mRstd: cute.Tensor | None,
+        eps: Float32,
+        tv_layout: cute.Layout,
+        tiler_mn: cute.Shape,
+        cluster_n: cutlass.Constexpr[int],
+        num_warps: cutlass.Constexpr[int],
+        warps_per_row: cutlass.Constexpr[int],
+        threads_per_row: cutlass.Constexpr[int],
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        if const_expr(cluster_n > 1):
+            cta_rank_in_cluster = cute.arch.block_idx_in_cluster()
+        else:
+            cta_rank_in_cluster = const_expr(0)
+        n_off = cta_rank_in_cluster * tiler_mn[1]
+
+        smem = cutlass.utils.SmemAllocator()
+        # Allocate one or two SMEM buffers depending on stage depth
+        sX0 = (
+            smem.allocate_tensor(
+                mX.element_type,
+                cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+                byte_alignment=32,
+            )
+            if const_expr(not self.direct_gmem)
+            else None
+        )
+        sX1 = (
+            smem.allocate_tensor(
+                mX.element_type,
+                cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+                byte_alignment=32,
+            )
+            if const_expr(self.stage > 1 and not self.direct_gmem)
+            else None
+        )
+        sRes0 = (
+            smem.allocate_tensor(
+                mRes.element_type,
+                cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+                byte_alignment=32,
+            )
+            if const_expr(mRes is not None and not self.direct_gmem)
+            else None
+        )
+        sRes1 = (
+            smem.allocate_tensor(
+                mRes.element_type,
+                cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+                byte_alignment=32,
+            )
+            if const_expr(mRes is not None and self.stage > 1 and not self.direct_gmem)
+            else None
+        )
+
+        # Reduction buffers + mbar for cluster reduce (reused by row_reduce helper)
+        red_layout = cute.make_ordered_layout(
+            (num_warps // warps_per_row, (warps_per_row, cluster_n), self.stage),
+            order=(1, 0, 2),
+        )
+        reduction_buffer = smem.allocate_tensor(
+            self.reduction_dtype, red_layout, byte_alignment=4
+        )
+        if const_expr(cluster_n > 1):
+            # Some CuTeDSL builds appear sensitive to the shared-memory alignment of
+            # mbarrier state. `SmemAllocator.allocate_array` does not currently
+            # expose an alignment parameter, so allocate an Int64 tensor with an
+            # explicit alignment and pass its iterator as the pointer.
+            mbar_tensor = smem.allocate_tensor(
+                cutlass.Int64,
+                cute.make_layout((self.stage,), stride=(1,)),
+                byte_alignment=16,
+            )
+            mbar_ptr = mbar_tensor.iterator
+        else:
+            mbar_ptr = None
+
+        shape = mX.shape
+        idX = cute.make_identity_tensor(shape)
+        limit_k = shape[1] - n_off
+
+        # Tiled copy setup
+        num_copy_elems_X = tv_layout.shape[1][0]
+        use_async = const_expr(
+            self.use_async and self.N >= 1024 and not self.direct_gmem
+        )
+        copy_atom = get_copy_atom_bw(
+            mX.element_type, num_copy_elems_X, is_async=use_async
+        )
+        thr_copy = cute.make_tiled_copy(copy_atom, tv_layout, tiler_mn).get_slice(tidx)
+
+        # Tail predicate for the N dimension (when tile width > N). Reuse this
+        # for W/B loads so we never read past the end of those 1D tensors.
+        is_even_N_wb = const_expr(shape[1] == tiler_mn[1] * cluster_n)
+        if const_expr(not is_even_N_wb):
+            cX0 = cute.local_tile(idX, tiler_mn, (0, 0))
+            tXp_wb = qutils.predicate_k(thr_copy.partition_S(cX0), limit=limit_k)
+        else:
+            tXp_wb = None
+
+        # Weight/bias loads:
+        #
+        # - Direct-GMEM schedule: load weight/bias up front to hide latency.
+        # - Staged SMEM schedule: loading after the reduction reduces register
+        #   pressure during the long-scoreboard reduction phase (better for large-M),
+        #   but it measurably hurts small-M latency for the non-fused (no residual,
+        #   no bias) case. For that specific case, prefetch weight up front as well.
+        tXrW = None
+        tXrB = None
+        prefetch_w_early = bool(
+            mW is not None and (self.direct_gmem or (mRes is None and mB is None))
+        )
+        if const_expr(prefetch_w_early):
+            gW = cute.local_tile(
+                qutils.domain_offset_i64((0, n_off), mW), tiler_mn, (0, 0)
+            )
+            tXgW = thr_copy.partition_S(gW)
+            tXrW = cute.make_fragment_like(tXgW)
+            if const_expr(not is_even_N_wb):
+                tXrW.fill(0)
+            cute.copy(
+                get_copy_atom_bw(mW.element_type, num_copy_elems_X, is_async=False),
+                tXgW,
+                tXrW,
+                pred=tXp_wb,
+            )
+        if const_expr(self.direct_gmem and mB is not None):
+            gB = cute.local_tile(
+                qutils.domain_offset_i64((0, n_off), mB), tiler_mn, (0, 0)
+            )
+            tXgB = thr_copy.partition_S(gB)
+            tXrB = cute.make_fragment_like(tXgB)
+            if const_expr(not is_even_N_wb):
+                tXrB.fill(0)
+            cute.copy(
+                get_copy_atom_bw(mB.element_type, num_copy_elems_X, is_async=False),
+                tXgB,
+                tXrB,
+                pred=tXp_wb,
+            )
+
+        # Non-persistent per-CTA execution (one tile in M)
+        self._init_cluster(tidx, mbar_ptr)
+
+        mX_i, mRes_i, mO_i, mResO_i = [
+            qutils.domain_offset_i64((bidx * tiler_mn[0], 0), t)
+            if t is not None
+            else None
+            for t in (mX, mRes, mO, mResO)
+        ]
+        mX_i, mRes_i, mO_i, mResO_i = [
+            qutils.domain_offset_i64((0, n_off), t) if t is not None else None
+            for t in (mX_i, mRes_i, mO_i, mResO_i)
+        ]
+        gX_i = cute.local_tile(mX_i, tiler_mn, (0, 0))
+        gO_i = cute.local_tile(mO_i, tiler_mn, (0, 0))
+        gRes_i = (
+            cute.local_tile(mRes_i, tiler_mn, (0, 0))
+            if const_expr(mRes is not None)
+            else None
+        )
+        gResO_i = (
+            cute.local_tile(mResO_i, tiler_mn, (0, 0))
+            if const_expr(mResO is not None)
+            else None
+        )
+        gRstd_i = (
+            cute.local_tile(mRstd, tiler_mn, (bidx, 0))
+            if const_expr(mRstd is not None)
+            else None
+        )
+        cX_i = cute.local_tile(idX, tiler_mn, (bidx, 0))
+
+        # Common identity/row index partitions reused by both default and K-loop paths
+        tXcX_i = thr_copy.partition_S(cX_i)[(0, None), None, None]
+        row_i = tXcX_i[0][0]
+        tXgRstd_i = (
+            thr_copy.partition_D(gRstd_i) if const_expr(mRstd is not None) else None
+        )
+
+        # Stage-2 intra-row K-loop cp.async path for the large-`N` Blackwell
+        # rows where the legacy stage-2 fallback was still measurably ahead of
+        # the generic one-row schedule.
+        if const_expr(
+            self.stage > 1
+            and not self.direct_gmem
+            and use_async
+            and cluster_n == 1
+            and (shape[1] == 6144 or shape[1] == 7168 or shape[1] == 8192)
+        ):
+            vecsize = tv_layout.shape[1][0]
+            tpr = threads_per_row
+            target_tile_n = const_expr(4096 if shape[1] != 8192 else 8192)
+            tile_factor = const_expr(target_tile_n // (vecsize * tpr))
+            if const_expr(tile_factor > 0):
+                tile_n = vecsize * tpr * tile_factor
+                num_tiles = cute.ceil_div(shape[1], tile_n)
+
+                tiler_mn_tile = (tiler_mn[0], tile_n)
+                sX0_tile = cute.local_tile(sX0, tiler_mn_tile, (0, 0))
+                sX1_tile = cute.local_tile(sX1, tiler_mn_tile, (0, 0))
+                sRes0_tile = (
+                    cute.local_tile(sRes0, tiler_mn_tile, (0, 0))
+                    if const_expr(mRes is not None)
+                    else None
+                )
+                sRes1_tile = (
+                    cute.local_tile(sRes1, tiler_mn_tile, (0, 0))
+                    if const_expr(mRes is not None)
+                    else None
+                )
+
+                tv_layout_tile = cute.make_layout(
+                    ((tpr, tiler_mn[0]), (vecsize, tile_factor)),
+                    stride=(
+                        (vecsize * tiler_mn[0], 1),
+                        (tiler_mn[0], tiler_mn[0] * vecsize * tpr),
+                    ),
+                )
+                thr_copy_tile = cute.make_tiled_copy(
+                    copy_atom, tv_layout_tile, tiler_mn_tile
+                ).get_slice(tidx)
+
+                # Accumulate per-thread partial sums across tiles; reduce once.
+                sum_sq_thread = cute.Float32(0.0)
+
+                # Preload tile 0 into sX0/sRes0.
+                k_off0 = const_expr(0) * tile_n
+                gX_0 = cute.local_tile(
+                    qutils.domain_offset_i64((0, k_off0), mX_i), tiler_mn_tile, (0, 0)
+                )
+                tXgX_0 = thr_copy_tile.partition_S(gX_0)
+                tXsX_0 = thr_copy_tile.partition_D(sX0_tile)
+                cX_0 = cute.local_tile(
+                    cute.domain_offset((0, k_off0), cX_i), tiler_mn_tile, (0, 0)
+                )
+                tXc_0 = thr_copy_tile.partition_S(cX_0)
+                tXp_0 = qutils.predicate_k(tXc_0, limit=limit_k)
+
+                tXp_ping = tXp_0
+                tXp_pong = tXp_0
+
+                if row_i < shape[0]:
+                    copy_tiled(
+                        tXgX_0,
+                        tXsX_0,
+                        num_copy_elems=vecsize,
+                        is_async=True,
+                        pred=tXp_0,
+                    )
+                    if const_expr(mRes is not None):
+                        gRes_0 = cute.local_tile(
+                            qutils.domain_offset_i64((0, k_off0), mRes_i),
+                            tiler_mn_tile,
+                            (0, 0),
+                        )
+                        tXgRes_0 = thr_copy_tile.partition_S(gRes_0)
+                        tXsRes_0 = thr_copy_tile.partition_D(sRes0_tile)
+                        copy_tiled(
+                            tXgRes_0,
+                            tXsRes_0,
+                            num_copy_elems=vecsize,
+                            is_async=True,
+                            pred=tXp_0,
+                        )
+                cute.arch.cp_async_commit_group()
+
+                for t in cutlass.range_constexpr(num_tiles):
+                    next_t = t + 1
+                    if next_t < num_tiles:
+                        k_off_n = next_t * tile_n
+                        gX_n = cute.local_tile(
+                            qutils.domain_offset_i64((0, k_off_n), mX_i),
+                            tiler_mn_tile,
+                            (0, 0),
+                        )
+                        tXgX_n = thr_copy_tile.partition_S(gX_n)
+                        cX_n = cute.local_tile(
+                            cute.domain_offset((0, k_off_n), cX_i),
+                            tiler_mn_tile,
+                            (0, 0),
+                        )
+                        tXc_n = thr_copy_tile.partition_S(cX_n)
+                        tXp_n = qutils.predicate_k(tXc_n, limit=limit_k)
+
+                        if const_expr((t % 2) == 0):
+                            tXsX_n = thr_copy_tile.partition_D(sX1_tile)
+                            tXsRes_n = (
+                                thr_copy_tile.partition_D(sRes1_tile)
+                                if const_expr(mRes is not None)
+                                else None
+                            )
+                            tXp_pong = tXp_n
+                        else:
+                            tXsX_n = thr_copy_tile.partition_D(sX0_tile)
+                            tXsRes_n = (
+                                thr_copy_tile.partition_D(sRes0_tile)
+                                if const_expr(mRes is not None)
+                                else None
+                            )
+                            tXp_ping = tXp_n
+
+                        if row_i < shape[0]:
+                            copy_tiled(
+                                tXgX_n,
+                                tXsX_n,
+                                num_copy_elems=vecsize,
+                                is_async=True,
+                                pred=tXp_n,
+                            )
+                            if const_expr(mRes is not None):
+                                gRes_n = cute.local_tile(
+                                    qutils.domain_offset_i64((0, k_off_n), mRes_i),
+                                    tiler_mn_tile,
+                                    (0, 0),
+                                )
+                                tXgRes_n = thr_copy_tile.partition_S(gRes_n)
+                                copy_tiled(
+                                    tXgRes_n,
+                                    tXsRes_n,
+                                    num_copy_elems=vecsize,
+                                    is_async=True,
+                                    pred=tXp_n,
+                                )
+                        cute.arch.cp_async_commit_group()
+
+                    cute.arch.cp_async_wait_group(1 if next_t < num_tiles else 0)
+
+                    # Current tile buffer (ping/pong).
+                    if const_expr((t % 2) == 0):
+                        tXsX_cur = thr_copy_tile.partition_D(sX0_tile)
+                        tXsRes_cur = (
+                            thr_copy_tile.partition_D(sRes0_tile)
+                            if const_expr(mRes is not None)
+                            else None
+                        )
+                        pred_cur = tXp_ping
+                    else:
+                        tXsX_cur = thr_copy_tile.partition_D(sX1_tile)
+                        tXsRes_cur = (
+                            thr_copy_tile.partition_D(sRes1_tile)
+                            if const_expr(mRes is not None)
+                            else None
+                        )
+                        pred_cur = tXp_pong
+
+                    k_off = t * tile_n
+                    gX_t = cute.local_tile(
+                        qutils.domain_offset_i64((0, k_off), mX_i),
+                        tiler_mn_tile,
+                        (0, 0),
+                    )
+                    tXgX_t = thr_copy_tile.partition_S(gX_t)
+                    tXrX_t = cute.make_fragment_like(tXgX_t)
+                    cute.autovec_copy(tXsX_cur, tXrX_t)
+                    x_t = tXrX_t.load().to(cute.Float32)
+                    if const_expr(mRes is not None):
+                        gRes_t = cute.local_tile(
+                            qutils.domain_offset_i64((0, k_off), mRes_i),
+                            tiler_mn_tile,
+                            (0, 0),
+                        )
+                        tXgRes_t = thr_copy_tile.partition_S(gRes_t)
+                        tXrRes_t = cute.make_fragment_like(tXgRes_t)
+                        cute.autovec_copy(tXsRes_cur, tXrRes_t)
+                        x_t += tXrRes_t.load().to(cute.Float32)
+
+                    if const_expr(mResO is not None):
+                        gResO_t = cute.local_tile(
+                            qutils.domain_offset_i64((0, k_off), mResO_i),
+                            tiler_mn_tile,
+                            (0, 0),
+                        )
+                        tXgResO_t = thr_copy_tile.partition_D(gResO_t)
+                        tXrResO_t = cute.make_fragment_like(tXgResO_t)
+                        tXrResO_t.store(x_t.to(tXrResO_t.element_type))
+                        if row_i < shape[0]:
+                            copy_tiled(
+                                tXrResO_t,
+                                tXgResO_t,
+                                num_copy_elems=vecsize,
+                                is_async=False,
+                                pred=pred_cur,
+                            )
+
+                    sum_sq_thread = sum_sq_thread + (x_t * x_t).reduce(
+                        cute.ReductionOp.ADD,
+                        init_val=0.0,
+                        reduction_profile=0,
+                    )
+
+                sum_sq = row_reduce(
+                    sum_sq_thread,
+                    cute.ReductionOp.ADD,
+                    threads_per_row,
+                    reduction_buffer[None, None, 0],
+                    mbar_ptr,
+                    init_val=0.0,
+                )
+                rstd = cute.math.rsqrt(sum_sq / shape[1] + eps, fastmath=True)
+
+                if const_expr(mRstd is not None):
+                    if tXcX_i[0][1] == 0 and row_i < shape[0]:
+                        tXgRstd_i[0] = rstd
+
+                for t in cutlass.range_constexpr(num_tiles):
+                    k_off = t * tile_n
+                    cX_t = cute.local_tile(
+                        cute.domain_offset((0, k_off), cX_i), tiler_mn_tile, (0, 0)
+                    )
+                    tXc_t = thr_copy_tile.partition_S(cX_t)
+                    tXp_t = qutils.predicate_k(tXc_t, limit=limit_k)
+
+                    if const_expr((t % 2) == 0):
+                        tXsX_cur = thr_copy_tile.partition_D(sX0_tile)
+                        tXsRes_cur = (
+                            thr_copy_tile.partition_D(sRes0_tile)
+                            if const_expr(mRes is not None)
+                            else None
+                        )
+                    else:
+                        tXsX_cur = thr_copy_tile.partition_D(sX1_tile)
+                        tXsRes_cur = (
+                            thr_copy_tile.partition_D(sRes1_tile)
+                            if const_expr(mRes is not None)
+                            else None
+                        )
+
+                    gX_t = cute.local_tile(
+                        qutils.domain_offset_i64((0, k_off), mX_i),
+                        tiler_mn_tile,
+                        (0, 0),
+                    )
+                    tXgX_t = thr_copy_tile.partition_S(gX_t)
+                    tXrX_t = cute.make_fragment_like(tXgX_t)
+                    cute.autovec_copy(tXsX_cur, tXrX_t)
+                    x_t = tXrX_t.load().to(cute.Float32)
+                    if const_expr(mRes is not None):
+                        gRes_t = cute.local_tile(
+                            qutils.domain_offset_i64((0, k_off), mRes_i),
+                            tiler_mn_tile,
+                            (0, 0),
+                        )
+                        tXgRes_t = thr_copy_tile.partition_S(gRes_t)
+                        tXrRes_t = cute.make_fragment_like(tXgRes_t)
+                        cute.autovec_copy(tXsRes_cur, tXrRes_t)
+                        x_t += tXrRes_t.load().to(cute.Float32)
+
+                    y_t = x_t * rstd
+                    if const_expr(mW is not None):
+                        gW_t = cute.local_tile(
+                            qutils.domain_offset_i64((0, k_off), mW),
+                            tiler_mn_tile,
+                            (0, 0),
+                        )
+                        tWgW_t = thr_copy_tile.partition_S(gW_t)
+                        tWrW_t = cute.make_fragment_like(tWgW_t)
+                        copy_tiled(
+                            tWgW_t,
+                            tWrW_t,
+                            num_copy_elems=vecsize,
+                            is_async=False,
+                            pred=tXp_t,
+                        )
+                        y_t = y_t * tWrW_t.load().to(cute.Float32)
+                    if const_expr(mB is not None):
+                        gB_t = cute.local_tile(
+                            qutils.domain_offset_i64((0, k_off), mB),
+                            tiler_mn_tile,
+                            (0, 0),
+                        )
+                        tWgB_t = thr_copy_tile.partition_S(gB_t)
+                        tWrB_t = cute.make_fragment_like(tWgB_t)
+                        copy_tiled(
+                            tWgB_t,
+                            tWrB_t,
+                            num_copy_elems=vecsize,
+                            is_async=False,
+                            pred=tXp_t,
+                        )
+                        y_t = y_t + tWrB_t.load().to(cute.Float32)
+
+                    gO_t = cute.local_tile(
+                        qutils.domain_offset_i64((0, k_off), mO_i),
+                        tiler_mn_tile,
+                        (0, 0),
+                    )
+                    tXgO_t = thr_copy_tile.partition_D(gO_t)
+                    tXrO_t = cute.make_fragment_like(tXgO_t)
+                    tXrO_t.store(y_t.to(tXrO_t.element_type))
+                    if row_i < shape[0]:
+                        copy_tiled(
+                            tXrO_t,
+                            tXgO_t,
+                            num_copy_elems=vecsize,
+                            is_async=False,
+                            pred=tXp_t,
+                        )
+
+                return
+
+        # Single-stage path: one-row-per-CTA
+        tXgX_i = thr_copy.partition_S(gX_i)
+        tXgRes_i = (
+            thr_copy.partition_S(gRes_i) if const_expr(mRes is not None) else None
+        )
+        tXgO_i = thr_copy.partition_D(gO_i)
+        tXgResO_i = (
+            thr_copy.partition_D(gResO_i) if const_expr(mResO is not None) else None
+        )
+        # tXgRstd_i / tXcX_i / row_i prepared above
+        is_even_N_i = const_expr(shape[1] == tiler_mn[1] * cluster_n)
+        tXpX_i = (
+            qutils.predicate_k(thr_copy.partition_S(cX_i), limit=limit_k)
+            if not is_even_N_i
+            else None
+        )
+
+        tXrX = cute.make_fragment_like(tXgX_i)
+        tXrRes = (
+            cute.make_fragment_like(tXgRes_i) if const_expr(mRes is not None) else None
+        )
+        if const_expr(self.direct_gmem):
+            if const_expr(not is_even_N_i):
+                tXrX.fill(0)
+                if const_expr(tXrRes is not None):
+                    tXrRes.fill(0)
+            if row_i < shape[0]:
+                cute.copy(copy_atom, tXgX_i, tXrX, pred=tXpX_i)
+                if const_expr(tXrRes is not None):
+                    cute.copy(copy_atom, tXgRes_i, tXrRes, pred=tXpX_i)
+        else:
+            # If N is not a multiple of the tile width, the predicated gmem->smem
+            # copies leave out-of-bounds lanes uninitialized. Clear the SMEM tile
+            # so masked lanes read as 0 for reduction/output.
+            if const_expr(not is_even_N_i):
+                thr_copy.partition_D(sX0).fill(0)
+                if const_expr(mRes is not None):
+                    thr_copy.partition_D(sRes0).fill(0)
+
+            if row_i < shape[0]:
+                cute.copy(copy_atom, tXgX_i, thr_copy.partition_D(sX0), pred=tXpX_i)
+                if const_expr(mRes is not None):
+                    cute.copy(
+                        copy_atom, tXgRes_i, thr_copy.partition_D(sRes0), pred=tXpX_i
+                    )
+            if const_expr(use_async):
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(0)
+
+            cute.autovec_copy(thr_copy.partition_D(sX0), tXrX)
+            if const_expr(tXrRes is not None):
+                cute.autovec_copy(thr_copy.partition_D(sRes0), tXrRes)
+        x_red = tXrX.load().to(cute.Float32)
+        if const_expr(tXrRes is not None):
+            x_red += tXrRes.load().to(cute.Float32)
+
+        if const_expr(mResO is not None):
+            tXrResO = cute.make_fragment_like(tXgResO_i)
+            tXrResO.store(x_red.to(tXrResO.element_type))
+            if row_i < shape[0]:
+                cute.copy(
+                    get_copy_atom_bw(
+                        tXrResO.element_type, num_copy_elems_X, is_async=False
+                    ),
+                    tXrResO,
+                    tXgResO_i,
+                    pred=tXpX_i,
+                )
+
+        sum_sq = row_reduce(
+            x_red * x_red,
+            cute.ReductionOp.ADD,
+            threads_per_row,
+            reduction_buffer[None, None, 0],
+            mbar_ptr,
+            init_val=0.0,
+        )
+        rstd = cute.math.rsqrt(sum_sq / shape[1] + eps, fastmath=True)
+
+        if const_expr(mRstd is not None):
+            if (
+                tXcX_i[0][1] == 0
+                and row_i < shape[0]
+                and (cluster_n == 1 or cute.arch.block_idx_in_cluster() == 0)
+            ):
+                tXgRstd_i[0] = rstd
+
+        if const_expr(not self.direct_gmem and (mRes is not None or mB is not None)):
+            # Load weight/bias after the reduction so they don't inflate register
+            # pressure during the long-scoreboard reduction phase (helping occupancy
+            # when registers are the limiting factor).
+            if const_expr(mW is not None):
+                gW = cute.local_tile(
+                    qutils.domain_offset_i64((0, n_off), mW), tiler_mn, (0, 0)
+                )
+                tXgW = thr_copy.partition_S(gW)
+                tXrW = cute.make_fragment_like(tXgW)
+                if const_expr(not is_even_N_wb):
+                    tXrW.fill(0)
+                cute.copy(
+                    get_copy_atom_bw(mW.element_type, num_copy_elems_X, is_async=False),
+                    tXgW,
+                    tXrW,
+                    pred=tXp_wb,
+                )
+            if const_expr(mB is not None):
+                gB = cute.local_tile(
+                    qutils.domain_offset_i64((0, n_off), mB), tiler_mn, (0, 0)
+                )
+                tXgB = thr_copy.partition_S(gB)
+                tXrB = cute.make_fragment_like(tXgB)
+                if const_expr(not is_even_N_wb):
+                    tXrB.fill(0)
+                cute.copy(
+                    get_copy_atom_bw(mB.element_type, num_copy_elems_X, is_async=False),
+                    tXgB,
+                    tXrB,
+                    pred=tXp_wb,
+                )
+
+        # Reuse `x_red` (x + residual, in fp32) for the output path so we don't
+        # keep both `tXrX` and `tXrRes` fragments live across the reduction.
+        y = x_red * rstd
+        if const_expr(mW is not None):
+            y = y * tXrW.load().to(cute.Float32)
+        if const_expr(mB is not None):
+            y = y + tXrB.load().to(cute.Float32)
+
+        tXrO = cute.make_fragment_like(tXgO_i)
+        tXrO.store(y.to(tXrO.element_type))
+        if row_i < shape[0]:
+            cute.copy(
+                get_copy_atom_bw(tXrO.element_type, num_copy_elems_X, is_async=False),
+                tXrO,
+                tXgO_i,
+                pred=tXpX_i,
+            )
+
+    if _KERNEL_ACCEPTS_LAYOUT_ARGS:
+
+        @cute.kernel
+        def kernel(
+            self,
+            mX: cute.Tensor,
+            mW: cute.Tensor | None,
+            mB: cute.Tensor | None,
+            mRes: cute.Tensor | None,
+            mO: cute.Tensor,
+            mResO: cute.Tensor | None,
+            mRstd: cute.Tensor | None,
+            eps: Float32,
+            tv_layout: cute.Layout,
+            tiler_mn: cute.Shape,
+            cluster_n: cutlass.Constexpr[int],
+            num_warps: cutlass.Constexpr[int],
+            warps_per_row: cutlass.Constexpr[int],
+            threads_per_row: cutlass.Constexpr[int],
+        ):
+            self._kernel_impl(
+                mX,
+                mW,
+                mB,
+                mRes,
+                mO,
+                mResO,
+                mRstd,
+                eps,
+                tv_layout,
+                tiler_mn,
+                cluster_n,
+                num_warps,
+                warps_per_row,
+                threads_per_row,
+            )
+    else:
+
+        @cute.kernel
+        def kernel(
+            self,
+            mX: cute.Tensor,
+            mW: cute.Tensor | None,
+            mB: cute.Tensor | None,
+            mRes: cute.Tensor | None,
+            mO: cute.Tensor,
+            mResO: cute.Tensor | None,
+            mRstd: cute.Tensor | None,
+            eps: Float32,
+        ):
+            copy_bits = int(self.copy_bits)
+            tiler_mn, tv_layout = self._tv_layout(num_copy_bits=copy_bits)
+            num_threads = self._num_threads()
+            num_warps = num_threads // cute.arch.WARP_SIZE
+            threads_per_row = self._threads_per_row()
+            warps_per_row = max(threads_per_row // cute.arch.WARP_SIZE, 1)
+            cluster_n = self._cluster_n()
+            self._kernel_impl(
+                mX,
+                mW,
+                mB,
+                mRes,
+                mO,
+                mResO,
+                mRstd,
+                eps,
+                tv_layout,
+                tiler_mn,
+                const_expr(cluster_n),
+                const_expr(num_warps),
+                const_expr(warps_per_row),
+                const_expr(threads_per_row),
+            )
+
+    @cute.jit
+    def _init_cluster(self, tidx: cutlass.Int32, mbar_ptr: cute.Pointer | None):
+        if const_expr(mbar_ptr is not None):
+            if tidx < self.stage:
+                cute.arch.mbarrier_init(mbar_ptr + tidx, 1)
+            cute.arch.mbarrier_init_fence()
+            cute.arch.cluster_arrive_relaxed()
+
+
+def _can_use_ptr_path(
+    x: Tensor,
+    weight: Tensor | None,
+    bias: Tensor | None,
+    residual: Tensor | None,
+) -> bool:
+    """Return whether the pointer-path forward entry is safe."""
+    if x.stride(1) != 1:
+        return False
+    # All participating tensors are interpreted as the same element type
+    # (derived from x.dtype) in the pointer-based path. If dtypes differ,
+    # we'd read the wrong bit patterns and silently produce incorrect output.
+    if residual is not None and residual.dtype != x.dtype:
+        return False
+    if weight is not None and weight.dtype != x.dtype:
+        # Allow the common "Quack-style" API where weights are fp32 even when
+        # activations are bf16/fp16. The pointer path constructs a weight tensor
+        # view with the correct element type (fp32) inside the compiled graph.
+        if weight.dtype is not torch.float32:
+            return False
+        if x.dtype not in (torch.float16, torch.bfloat16):
+            return False
+    if bias is not None and bias.dtype != x.dtype:
+        return False
+    # The kernel assumes `ld` satisfies a divisibility constraint used by
+    # cute.assume(..., divby=...) for vectorization.
+    elem_bits = TORCH2CUTE_DTYPE[x.dtype].width
+    divby = 256 // elem_bits
+    if (x.stride(0) % divby) != 0:
+        return False
+    # The kernel uses 128-bit vectorized copies (16B). Require at least 16B
+    # alignment on all participating tensors to avoid misaligned global loads.
+    if (x.data_ptr() % 16) != 0:
+        return False
+    if residual is not None and residual.stride(1) != 1:
+        return False
+    if residual is not None and residual.stride(0) != x.stride(0):
+        return False
+    if residual is not None and (residual.data_ptr() % 16) != 0:
+        return False
+    if weight is not None and not weight.is_contiguous():
+        return False
+    if bias is not None and not bias.is_contiguous():
+        return False
+    if weight is not None:
+        # For fp32 weights we use 256b universal copies (32B) by default.
+        # Require 32B alignment so the compiler can safely vectorize loads.
+        if weight.dtype is torch.float32:
+            if (weight.data_ptr() % 32) != 0:
+                return False
+        else:
+            if (weight.data_ptr() % 16) != 0:
+                return False
+    if bias is not None and (bias.data_ptr() % 16) != 0:
+        return False
+    return True
+
+
+def _can_use_ptr_path_fused_add_inplace(
+    x: Tensor,
+    weight: Tensor,
+    residual: Tensor,
+) -> bool:
+    """Return whether the pointer-path fused-add entry is safe."""
+    if x.stride(1) != 1:
+        return False
+    if residual.dtype != x.dtype:
+        return False
+    if weight.dtype != x.dtype:
+        return False
+    if residual.stride(1) != 1:
+        return False
+    if not residual.is_contiguous():
+        return False
+    if not weight.is_contiguous():
+        return False
+
+    dtype = TORCH2CUTE_DTYPE[x.dtype]
+    divby = 256 // dtype.width
+    if (x.stride(0) % divby) != 0:
+        return False
+    if (residual.stride(0) % divby) != 0:
+        return False
+
+    if (x.data_ptr() % 16) != 0:
+        return False
+    if (residual.data_ptr() % 16) != 0:
+        return False
+    if (weight.data_ptr() % 16) != 0:
+        return False
+    return True
+
+
+def _can_use_ptr_path_bwd(
+    x: Tensor,
+    weight: Tensor | None,
+    dout: Tensor,
+    rstd: Tensor,
+) -> bool:
+    """Return whether the pointer-path backward entry is safe."""
+    if x.dim() != 2 or dout.dim() != 2:
+        return False
+    if rstd.dim() != 1:
+        return False
+    if x.shape != dout.shape:
+        return False
+    if rstd.numel() != x.shape[0]:
+        return False
+    # SM100 backward kernel assumes N is divisible by 8 (for 256b fp32 stores
+    # into dw_partial rows).
+    if (x.shape[1] % 8) != 0:
+        return False
+    if x.stride(1) != 1 or dout.stride(1) != 1:
+        return False
+    if dout.stride(0) != x.stride(0):
+        return False
+    if dout.dtype != x.dtype:
+        return False
+    if rstd.dtype != torch.float32 or not rstd.is_contiguous():
+        return False
+    if weight is None:
+        return False
+    if weight.dim() != 1 or weight.shape[0] != x.shape[1]:
+        return False
+    if not weight.is_contiguous():
+        return False
+    if weight.dtype != x.dtype:
+        if weight.dtype is not torch.float32:
+            return False
+        if x.dtype not in (torch.float16, torch.bfloat16):
+            return False
+
+    dtype = TORCH2CUTE_DTYPE[x.dtype]
+    divby = 256 // dtype.width
+    if (x.stride(0) % divby) != 0:
+        return False
+
+    if (x.data_ptr() % 16) != 0:
+        return False
+    if (dout.data_ptr() % 16) != 0:
+        return False
+    # Torch CUDA allocations are typically >=256B aligned, but keep the check
+    # explicit so we never assume tighter alignment than is true.
+    if (rstd.data_ptr() % 4) != 0:
+        return False
+    if (weight.data_ptr() % (32 if weight.dtype is torch.float32 else 16)) != 0:
+        return False
+    return True
+
+
+def _rmsnorm_forward_ptr(
+    x: Tensor,
+    weight: Tensor | None,
+    bias: Tensor | None,
+    residual: Tensor | None,
+    eps: float,
+    store_rstd: bool,
+    *,
+    force_stage2: bool = False,
+) -> tuple[Tensor, Tensor | None, Tensor | None]:
+    """Pointer-path RMSNorm forward that bypasses DLPack."""
+    assert x.is_cuda
+    assert x.dim() == 2, "Use (M, N) tensor; flatten batch/seq beforehand."
+    M, N = x.shape
+
+    # Preserve padded-row layouts by matching the input stride.
+    out = torch.empty_strided(x.shape, x.stride(), device=x.device, dtype=x.dtype)
+    residual_out: Tensor | None = None
+    rstd: Tensor | None = None
+
+    if residual is not None:
+        residual_out = torch.empty_strided(
+            residual.shape,
+            residual.stride(),
+            device=residual.device,
+            dtype=residual.dtype,
+        )
+    if store_rstd:
+        rstd = torch.empty(M, device=x.device, dtype=torch.float32)
+
+    _rmsnorm_forward_ptr_into(
+        x=x,
+        weight=weight,
+        bias=bias,
+        residual=residual,
+        out=out,
+        residual_out=residual_out,
+        rstd=rstd,
+        eps=eps,
+        force_stage2=force_stage2,
+    )
+    return out, rstd, residual_out
+
+
+def _rmsnorm_forward_ptr_into(
+    x: Tensor,
+    weight: Tensor | None,
+    bias: Tensor | None,
+    residual: Tensor | None,
+    out: Tensor,
+    residual_out: Tensor | None,
+    rstd: Tensor | None,
+    eps: float,
+    force_stage2: bool = False,
+) -> None:
+    """Launch pointer-path forward into preallocated outputs."""
+    assert x.is_cuda
+    assert x.dim() == 2, "Use (M, N) tensor; flatten batch/seq beforehand."
+    M, N = x.shape
+    device_index = x.get_device()
+    dtype = TORCH2CUTE_DTYPE[x.dtype]
+
+    if bias is None and residual is None and residual_out is None and rstd is None:
+        stream_handle = _current_stream_handle(device_index)
+        has_weight = weight is not None
+
+        if not has_weight and try_rmsnorm_smallm_noweight_cuda(x, out, float(eps)):
+            return
+
+        if has_weight and try_simple_weightonly_rmsnorm_forward(
+            x,
+            weight,
+            out,
+            float(eps),
+        ):
+            return
+
+        weight_dtype = TORCH2CUTE_DTYPE[weight.dtype] if has_weight else None
+        launch_cfg = _resolve_forward_launch_config(
+            M=int(M),
+            N=int(N),
+            dtype=dtype,
+            x=x,
+            weight=weight,
+            weight_dtype=weight_dtype,
+            aligned_tensors=(out, weight),
+        )
+        launch_cfg = _override_simple_weight_only_forward_launch_config(
+            launch_cfg,
+            M=int(M),
+            N=int(N),
+            dtype=dtype,
+            weight=weight,
+            weight_dtype=weight_dtype,
+        )
+        if force_stage2:
+            launch_cfg = _force_stage2_forward_launch_config(
+                launch_cfg,
+                M=int(M),
+                N=int(N),
+                dtype=dtype,
+                weight=weight,
+                weight_dtype=weight_dtype,
+            )
+
+        compiled_key = (
+            "ptr",
+            N,
+            dtype,
+            weight_dtype,
+            False,
+            has_weight,
+            False,
+            False,
+            False,
+            launch_cfg.stage,
+            launch_cfg.copy_bits,
+            launch_cfg.use_async,
+            launch_cfg.direct_gmem,
+            launch_cfg.assumed_align,
+            launch_cfg.weight_assumed_align,
+            launch_cfg.tpr_override,
+            launch_cfg.nt_override,
+            launch_cfg.cluster_n_override,
+            device_index,
+        )
+        compiled = _PTR_COMPILE_CACHE.get(compiled_key)
+        if compiled is None:
+            op = _make_rmsnorm_op(
+                N,
+                dtype,
+                stage=launch_cfg.stage,
+                copy_bits=launch_cfg.copy_bits,
+                use_async=launch_cfg.use_async,
+                direct_gmem=launch_cfg.direct_gmem,
+                tpr_override=launch_cfg.tpr_override,
+                nt_override=launch_cfg.nt_override,
+                cluster_n_override=launch_cfg.cluster_n_override,
+            )
+            ld_val = int(x.stride(0))
+            ptr_x, ptr_w, _, _, ptr_out, _, _ = _make_forward_ptrs(
+                x=x,
+                weight=weight,
+                out=out,
+                dtype=dtype,
+                weight_dtype=weight_dtype,
+                launch_cfg=launch_cfg,
+            )
+            stream = cuda.CUstream(stream_handle)
+            ld = Int32(ld_val)
+            compiled = cute.compile(
+                op.launch_from_ptrs,
+                ptr_x,
+                ptr_w,
+                None,
+                None,
+                ptr_out,
+                None,
+                None,
+                Int32(M),
+                Int32(N),
+                ld,
+                stream,
+                Float32(eps),
+            )
+            _PTR_COMPILE_CACHE[compiled_key] = compiled
+
+        launcher = _get_fast_ptr_rmsnorm_launcher(
+            compiled=compiled,
+            dtype=dtype,
+            weight_dtype=weight_dtype,
+            N=N,
+            device_index=device_index,
+            stream_handle=stream_handle,
+            has_weight=has_weight,
+            assumed_align=launch_cfg.assumed_align,
+            assumed_align_w=launch_cfg.weight_assumed_align,
+            eps=eps,
+        )
+        ld_val = int(x.stride(0))
+        if launcher is not None:
+            launcher.launch(x=x, weight=weight, out=out, M=M, N=N, ld=ld_val, eps=eps)
+            return
+
+        ptr_x, ptr_w, _, _, ptr_out, _, _ = _make_forward_ptrs(
+            x=x,
+            weight=weight,
+            out=out,
+            dtype=dtype,
+            weight_dtype=weight_dtype,
+            launch_cfg=launch_cfg,
+        )
+        stream = cuda.CUstream(stream_handle)
+        ld = Int32(ld_val)
+        compiled(
+            ptr_x,
+            ptr_w,
+            None,
+            None,
+            ptr_out,
+            None,
+            None,
+            Int32(M),
+            Int32(N),
+            ld,
+            stream,
+            Float32(eps),
+        )
+        return
+
+    weight_dtype = TORCH2CUTE_DTYPE[weight.dtype] if weight is not None else None
+    launch_cfg = _resolve_forward_launch_config(
+        M=int(M),
+        N=int(N),
+        dtype=dtype,
+        x=x,
+        weight=weight,
+        weight_dtype=weight_dtype,
+        aligned_tensors=(out, weight, bias, residual, residual_out),
+    )
+    if force_stage2:
+        launch_cfg = _force_stage2_forward_launch_config(
+            launch_cfg,
+            M=int(M),
+            N=int(N),
+            dtype=dtype,
+            weight=weight,
+            weight_dtype=weight_dtype,
+        )
+
+    stream_handle = _current_stream_handle(device_index)
+    key = (
+        "ptr",
+        N,
+        dtype,
+        weight_dtype,
+        residual is not None,
+        weight is not None,
+        bias is not None,
+        residual_out is not None,
+        rstd is not None,
+        launch_cfg.stage,
+        launch_cfg.copy_bits,
+        launch_cfg.use_async,
+        launch_cfg.direct_gmem,
+        launch_cfg.assumed_align,
+        launch_cfg.weight_assumed_align,
+        launch_cfg.tpr_override,
+        launch_cfg.nt_override,
+        launch_cfg.cluster_n_override,
+        device_index,
+    )
+    compiled = _PTR_COMPILE_CACHE.get(key)
+    if compiled is None:
+        op = _make_rmsnorm_op(
+            N,
+            dtype,
+            stage=launch_cfg.stage,
+            copy_bits=launch_cfg.copy_bits,
+            use_async=launch_cfg.use_async,
+            direct_gmem=launch_cfg.direct_gmem,
+            tpr_override=launch_cfg.tpr_override,
+            nt_override=launch_cfg.nt_override,
+            cluster_n_override=launch_cfg.cluster_n_override,
+        )
+        ptr_x, ptr_w, ptr_b, ptr_res, ptr_out, ptr_res_out, ptr_rstd = (
+            _make_forward_ptrs(
+                x=x,
+                weight=weight,
+                bias=bias,
+                residual=residual,
+                out=out,
+                residual_out=residual_out,
+                rstd=rstd,
+                dtype=dtype,
+                weight_dtype=weight_dtype,
+                launch_cfg=launch_cfg,
+            )
+        )
+        stream = cuda.CUstream(stream_handle)
+        ld = Int32(int(x.stride(0)))
+        compiled = cute.compile(
+            op.launch_from_ptrs,
+            ptr_x,
+            ptr_w,
+            ptr_b,
+            ptr_res,
+            ptr_out,
+            ptr_res_out,
+            ptr_rstd,
+            Int32(M),
+            Int32(N),
+            ld,
+            stream,
+            Float32(eps),
+        )
+        _PTR_COMPILE_CACHE[key] = compiled
+    ptr_x, ptr_w, ptr_b, ptr_res, ptr_out, ptr_res_out, ptr_rstd = _make_forward_ptrs(
+        x=x,
+        weight=weight,
+        bias=bias,
+        residual=residual,
+        out=out,
+        residual_out=residual_out,
+        rstd=rstd,
+        dtype=dtype,
+        weight_dtype=weight_dtype,
+        launch_cfg=launch_cfg,
+    )
+    stream = cuda.CUstream(stream_handle)
+    ld = Int32(int(x.stride(0)))
+    compiled(
+        ptr_x,
+        ptr_w,
+        ptr_b,
+        ptr_res,
+        ptr_out,
+        ptr_res_out,
+        ptr_rstd,
+        Int32(M),
+        Int32(N),
+        ld,
+        stream,
+        Float32(eps),
+    )
+
+
+def _fused_add_rmsnorm_forward_ptr_inplace(
+    x: Tensor,
+    residual: Tensor,
+    weight: Tensor,
+    eps: float,
+) -> None:
+    """Pointer-based fused_add_rmsnorm that updates `x` and `residual` in-place."""
+    assert x.is_cuda
+    assert x.dim() == 2
+    assert residual.is_cuda
+    assert residual.dim() == 2
+    assert x.shape == residual.shape
+
+    M, N = x.shape
+    device_index = x.get_device()
+    dtype = TORCH2CUTE_DTYPE[x.dtype]
+    stage = 1
+
+    stream_handle = _current_stream_handle(device_index)
+
+    copy_bits = 128
+    # DSv3 fused-add prefers direct GMEM on smaller M and staged loads on larger M.
+    direct_gmem = _direct_gmem_from_policy(
+        default=bool(dtype.width == 16 and N == 7168 and M <= 16384)
+    )
+    use_async = not direct_gmem
+    tpr_override: int | None = None
+    nt_override: int | None = None
+
+    if _ENABLE_STAGE2 and dtype.width == 16 and N == 7168 and M >= 4096:
+        stage = 2
+        direct_gmem = False
+        use_async = True
+
+    can_use_256 = bool(
+        direct_gmem
+        and dtype.width == 16
+        and (x.data_ptr() % 32) == 0
+        and (residual.data_ptr() % 32) == 0
+        and (weight.data_ptr() % 32) == 0
+    )
+    assumed_align = 32 if can_use_256 else 16
+    if can_use_256:
+        copy_bits = 256
+
+    copy_bits = _copy_bits_from_policy(default=copy_bits, can_use_256=can_use_256)
+    if copy_bits == 128:
+        assumed_align = 16
+    elif copy_bits == 256 and can_use_256:
+        assumed_align = 32
+    else:
+        copy_bits = 128
+        assumed_align = 16
+
+    key = (
+        "ptr_fused_add_inplace",
+        N,
+        dtype,
+        stage,
+        device_index,
+        copy_bits,
+        use_async,
+        tpr_override,
+        nt_override,
+        direct_gmem,
+        None,
+    )
+    compiled = _PTR_COMPILE_CACHE.get(key)
+    if compiled is None:
+        op = _make_rmsnorm_op(
+            N,
+            dtype,
+            stage=stage,
+            copy_bits=copy_bits,
+            use_async=use_async,
+            direct_gmem=direct_gmem,
+            tpr_override=tpr_override,
+            nt_override=nt_override,
+            cluster_n_override=None,
+        )
+        ptr_x, ptr_w, ptr_res = _make_fused_add_ptrs(
+            x=x,
+            weight=weight,
+            residual=residual,
+            dtype=dtype,
+            assumed_align=assumed_align,
+        )
+        stream = cuda.CUstream(stream_handle)
+        ld_x = Int32(int(x.stride(0)))
+        compiled = cute.compile(
+            op.launch_from_ptrs_fused_add_inplace,
+            ptr_x,
+            ptr_w,
+            ptr_res,
+            Int32(M),
+            Int32(N),
+            ld_x,
+            stream,
+            Float32(eps),
+        )
+        _PTR_COMPILE_CACHE[key] = compiled
+    launcher = _get_fast_ptr_fused_add_rmsnorm_launcher(
+        compiled=compiled,
+        dtype=dtype,
+        N=N,
+        device_index=device_index,
+        stream_handle=stream_handle,
+        copy_bits=copy_bits,
+        use_async=use_async,
+        tpr=tpr_override or 0,
+        direct_gmem=direct_gmem,
+        assumed_align=assumed_align,
+        eps=eps,
+    )
+    if launcher is not None:
+        launcher.launch(
+            x=x,
+            weight=weight,
+            residual=residual,
+            M=M,
+            N=N,
+            ld_x=int(x.stride(0)),
+            eps=eps,
+        )
+        return
+
+    # Fall back to the regular compiled call if fast-launch is unavailable.
+    ptr_x, ptr_w, ptr_res = _make_fused_add_ptrs(
+        x=x,
+        weight=weight,
+        residual=residual,
+        dtype=dtype,
+        assumed_align=assumed_align,
+    )
+    stream = cuda.CUstream(stream_handle)
+    ld_x = Int32(int(x.stride(0)))
+    compiled(ptr_x, ptr_w, ptr_res, Int32(M), Int32(N), ld_x, stream, Float32(eps))
+
+
+# -------------------------
+# Public API (forward + verify)
+# -------------------------
+
+
+def rmsnorm_forward(
+    x: Tensor,
+    weight: Tensor | None = None,
+    bias: Tensor | None = None,
+    residual: Tensor | None = None,
+    eps: float = 1e-6,
+    store_rstd: bool = False,
+) -> tuple[Tensor, Tensor | None, Tensor | None]:
+    assert x.is_cuda
+    assert x.dim() == 2, "Use (M, N) tensor; flatten batch/seq beforehand."
+    force_stage2 = _FORCE_RMSNORM_STAGE2_FWD or _should_force_stage2_forward(
+        x=x,
+        weight=weight,
+        bias=bias,
+        residual=residual,
+        store_rstd=store_rstd,
+    )
+
+    use_ptr = _can_use_ptr_path(x, weight, bias, residual)
+
+    if use_ptr:
+        return _rmsnorm_forward_ptr(
+            x,
+            weight,
+            bias,
+            residual,
+            eps,
+            store_rstd,
+            force_stage2=force_stage2,
+        )
+    return _rmsnorm_ref_outputs(x, weight, bias, residual, eps, store_rstd)
+
+
+def rmsnorm_ref(
+    x: Tensor,
+    w: Tensor | None = None,
+    b: Tensor | None = None,
+    residual: Tensor | None = None,
+    eps: float = 1e-6,
+) -> Tensor:
+    xf = x.float()
+    if residual is not None:
+        xf = xf + residual.float()
+    rstd = torch.rsqrt(xf.square().mean(dim=-1, keepdim=True) + eps)
+    y = xf * rstd
+    if w is not None:
+        y = y * w.float()
+    if b is not None:
+        y = y + b.float()
+    return y.to(x.dtype)
+
+
+def fused_add_rmsnorm_forward(
+    x: Tensor,
+    residual: Tensor,
+    weight: Tensor,
+    eps: float = 1e-6,
+) -> tuple[Tensor, Tensor]:
+    """Return `(RMSNorm(x + residual), x + residual)` with vLLM semantics."""
+    assert x.is_cuda and residual.is_cuda
+    assert x.shape == residual.shape
+    assert x.dtype == residual.dtype
+
+    orig_shape = x.shape
+    N = orig_shape[-1]
+
+    x_2d = x.view(-1, N)
+    res_2d = residual.view(-1, N)
+
+    y_2d, _rstd, z_2d = rmsnorm_forward(
+        x_2d,
+        weight=weight,
+        bias=None,
+        residual=res_2d,
+        eps=eps,
+        store_rstd=False,
+    )
+
+    y = y_2d.view(orig_shape)
+    z = z_2d.view(orig_shape)
+    return y, z
+
+
+def fused_add_rmsnorm_forward_inplace(
+    x: Tensor,
+    residual: Tensor,
+    weight: Tensor,
+    eps: float = 1e-6,
+) -> tuple[Tensor, Tensor]:
+    """In-place fused-add RMSNorm returning `(x, residual)` for vLLM."""
+    fused_add_rmsnorm_inplace_(x, residual, weight, eps=eps)
+    return x, residual
+
+
+def fused_add_rmsnorm_inplace_(
+    x: Tensor,
+    residual: Tensor,
+    weight: Tensor,
+    eps: float = 1e-6,
+) -> None:
+    """Lowest-overhead in-place fused-add RMSNorm entrypoint."""
+    assert x.is_cuda and residual.is_cuda
+    assert x.shape == residual.shape
+    assert x.dtype == residual.dtype
+
+    N = x.shape[-1]
+    x_2d = x if x.dim() == 2 else x.view(-1, N)
+    res_2d = residual if residual.dim() == 2 else residual.view(-1, N)
+
+    # Fast path: vLLM-compatible layout where x may be strided/padded but
+    # residual is contiguous. This updates both tensors in-place without
+    # additional allocations.
+    if _can_use_ptr_path_fused_add_inplace(x_2d, weight, res_2d):
+        _fused_add_rmsnorm_forward_ptr_inplace(x_2d, res_2d, weight, eps)
+        return None
+
+    # Fallback: allocate via the regular fused path, then copy results into
+    # the user-provided buffers so that semantics remain identical.
+    y, z = fused_add_rmsnorm_forward(x, residual, weight, eps)
+    x.copy_(y)
+    residual.copy_(z)
+    return None
+
+
+# -------------------------
+# Backward kernel (SM100)
+# -------------------------
+
+
+class RMSNormBackwardSM100(BaseRMSNormBackward):
+    """SM100-tuned wrapper around `lite_quack.RMSNormBackward`."""
+
+    def __init__(self, dtype: cutlass.Numeric, N: int):
+        super().__init__(dtype, N)
+
+    def _get_num_threads(self) -> int:
+        nt = getattr(self, "_nt_override", None)
+        if nt is not None:
+            return int(nt)
+        return super()._get_num_threads()
+
+    def _calculate_threads_per_row(self) -> int:
+        tpr = getattr(self, "_tpr_override", None)
+        if tpr is not None:
+            return int(tpr)
+        return super()._calculate_threads_per_row()
+
+    @cute.jit
+    def launch_from_ptrs(
+        self,
+        ptr_x: cute.Pointer,
+        ptr_w: cute.Pointer,
+        ptr_dout: cute.Pointer,
+        ptr_rstd: cute.Pointer,
+        ptr_dx: cute.Pointer,
+        ptr_dw_partial: cute.Pointer,
+        M: Int32,
+        N_dyn: Int32,
+        ld: Int32,
+        sm_count: Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        """Pointer-based backward entry that bypasses DLPack."""
+        # `dw_partial` stores use 256b fp32 vectors, so require N to stay /8 aligned.
+        N_assumed = cute.assume(N_dyn, divby=8)
+
+        layout_mn = cute.make_layout((M, N_assumed), stride=(ld, 1))
+        layout_n = cute.make_layout((N_assumed,), stride=(1,))
+        layout_m = cute.make_layout((M,), stride=(1,))
+        # Default: write a full (sm_count, N) partial buffer (Quack-style),
+        # then reduce on the host with `torch.sum(dim=0)`.
+        #
+        # Optional: atomic-reduce directly into a single (N,) buffer by using
+        # a broadcasted leading dimension (stride0 = 0). This avoids the extra
+        # reduction kernel launch and is primarily used for tiny-M regimes.
+        if const_expr(self.atomic_dw):
+            layout_partial = cute.make_layout((sm_count, N_assumed), stride=(0, 1))
+        else:
+            layout_partial = cute.make_layout(
+                (sm_count, N_assumed), stride=(N_assumed, 1)
+            )
+
+        mX = cute.make_tensor(ptr_x, layout_mn)
+        mW = cute.make_tensor(ptr_w, layout_n)
+        mdO = cute.make_tensor(ptr_dout, layout_mn)
+        mRstd = cute.make_tensor(ptr_rstd, layout_m)
+        mdX = cute.make_tensor(ptr_dx, layout_mn)
+        mdW = cute.make_tensor(ptr_dw_partial, layout_partial)
+
+        self.__call__(
+            mX,
+            mW,
+            mdO,
+            None,  # dresidual_out
+            mRstd,
+            mdX,
+            mdW,
+            None,  # dresidual
+            None,  # db_partial
+            sm_count,
+            stream,
+        )
+
+    def _get_num_threads(self) -> int:
+        # Keep 128 threads only up to N=4k; use 256 for larger rows to ensure
+        # threads_per_row <= num_threads across buckets.
+        nt = getattr(self, "_nt_override", None)
+        if nt is not None:
+            return int(nt)
+        return 128 if self.N <= 4096 else 256
+
+    def _calculate_threads_per_row(self) -> int:
+        tpr = getattr(self, "_tpr_override", None)
+        if tpr is not None:
+            return int(tpr)
+        # Match Quack's backward tiling: use 256 threads/row for N > 4096.
+        #
+        # The earlier "mirror forward" policy (128 threads/row for N<=8192)
+        # regresses DSv3 backward at N=6144/7168/8192 on SM100.
+        N = self.N
+        for limit, threads in [(64, 8), (128, 16), (256, 32), (512, 64), (4096, 128)]:
+            if N <= limit:
+                return threads
+        return 256
+
+    def _set_cluster_n(self) -> None:
+        # Reuse the SM100 forward cluster growth policy so large-N shapes can
+        # fan out across multiple CTAs in the same row.
+        cn = getattr(self, "_cluster_n_override", None)
+        if cn is not None:
+            self.cluster_n = int(cn)
+            return
+
+        N = self.N
+        if N <= 8192:
+            cluster_n = 1
+        elif self.dtype.width == 16:
+            if N <= 16 * 1024:
+                cluster_n = 2
+            elif N <= 32 * 1024:
+                cluster_n = 2
+            elif N <= 64 * 1024:
+                cluster_n = 4
+            elif N <= 128 * 1024:
+                cluster_n = 8
+            else:
+                cluster_n = 16
+        else:
+            if N <= 32 * 1024:
+                cluster_n = 1
+            elif N <= 64 * 1024:
+                cluster_n = 2
+            elif N <= 128 * 1024:
+                cluster_n = 4
+            elif N <= 256 * 1024:
+                cluster_n = 8
+            else:
+                cluster_n = 16
+        self.cluster_n = cluster_n
+
+    @cute.jit
+    def __call__(
+        self,
+        mX: cute.Tensor,
+        mW: cute.Tensor | None,
+        mdO: cute.Tensor,
+        mdResO: cute.Tensor | None,
+        mRstd: cute.Tensor,
+        mdX: cute.Tensor,
+        mdW: cute.Tensor | None,
+        mdRes: cute.Tensor | None,
+        mdB: cute.Tensor | None,
+        sm_count: Int32,
+        stream: cuda.CUstream,
+    ):
+        # Match forward's 32B alignment on the leading dimension to unlock
+        # wider vectorization when legal.
+        semistatic_shape = (*mX.shape[:-1], self.N)
+
+        def new_stride(t):
+            return (
+                cute.assume(t.stride[0], divby=256 // t.element_type.width),
+                t.stride[1],
+            )
+
+        mX, mdO, mdResO, mdX, mdRes = [
+            cute.make_tensor(
+                t.iterator, cute.make_layout(semistatic_shape, stride=new_stride(t))
+            )
+            if const_expr(t is not None)
+            else None
+            for t in (mX, mdO, mdResO, mdX, mdRes)
+        ]
+
+        self._set_cluster_n()
+        largest_dtype_width = const_expr(
+            max(
+                mX.element_type.width,
+                mdO.element_type.width,
+                mdX.element_type.width,
+                mdResO.element_type.width if mdResO is not None else 0,
+                mdRes.element_type.width if mdRes is not None else 0,
+            )
+        )
+        tiler_mn, tv_layout = self._get_tv_layout(
+            num_copy_bits=128 // largest_dtype_width * mX.element_type.width
+        )
+        num_threads = (
+            cute.size(tv_layout, mode=[0])
+            if _KERNEL_ACCEPTS_LAYOUT_ARGS
+            else self._get_num_threads()
+        )
+        num_warps = num_threads // cute.arch.WARP_SIZE
+        if const_expr(mW is not None):
+            mW_expanded_layout = cute.prepend(
+                mW.layout, cute.make_layout((tiler_mn[0],), stride=(0,))
+            )
+            mW = cute.make_tensor(mW.iterator, mW_expanded_layout)
+
+        num_blocks = sm_count
+        kernel = (
+            self.kernel(
+                mX, mW, mdO, mdResO, mRstd, mdX, mdW, mdB, mdRes, tv_layout, tiler_mn
+            )
+            if _KERNEL_ACCEPTS_LAYOUT_ARGS
+            else self.kernel(mX, mW, mdO, mdResO, mRstd, mdX, mdW, mdB, mdRes)
+        )
+        kernel.launch(
+            grid=[num_blocks, self.cluster_n, 1],
+            block=[num_threads, 1, 1],
+            cluster=[1, self.cluster_n, 1] if self.cluster_n > 1 else None,
+            smem=self._smem_size_in_bytes(
+                tiler_mn, num_warps, do_dtype=mdO.element_type
+            ),
+            stream=stream,
+        )
+
+
+_BWD_COMPILE_CACHE: dict[tuple[object, ...], object] = {}
+_BWD_PTR_COMPILE_CACHE: dict[tuple[object, ...], object] = {}
+
+
+def _rmsnorm_bwd_sm100(
+    x: Tensor,
+    weight: Tensor | None,
+    dout: Tensor,
+    rstd: Tensor,
+    dx: Tensor,
+    dw_partial: Tensor | None,
+    db_partial: Tensor | None = None,
+    dresidual_out: Tensor | None = None,
+    dresidual: Tensor | None = None,
+    sm_count: int | None = None,
+) -> None:
+    """SM100-specific RMSNorm backward dispatch.
+
+    Mirrors Quack's `quack.rmsnorm._rmsnorm_bwd`, but instantiates
+    `RMSNormBackwardSM100` (SM100-tuned heuristics).
+    """
+    assert x.dim() == 2, "Input must be 2D"
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    assert x.dtype in (torch.float16, torch.bfloat16, torch.float32)
+
+    if weight is not None:
+        assert weight.dim() == 1
+        assert x.shape[-1] == weight.shape[0]
+        assert weight.is_cuda
+        assert weight.dtype in (torch.float32, torch.bfloat16, torch.float16)
+    if dresidual_out is not None:
+        assert dresidual_out.shape == x.shape
+        assert dresidual_out.is_cuda
+        assert dresidual_out.dtype in (torch.float16, torch.bfloat16, torch.float32)
+    if dresidual is not None:
+        assert dresidual.shape == x.shape
+        assert dresidual.is_cuda
+        assert dresidual.dtype in (torch.float16, torch.bfloat16, torch.float32)
+
+    M, N = x.size(0), x.size(1)
+    if dw_partial is None and db_partial is None:
+        assert sm_count is not None
+    else:
+        sm_count = (
+            dw_partial.shape[0] if dw_partial is not None else db_partial.shape[0]
+        )
+
+    # Match Quack's conversion strategy for activations/gradients: keep the
+    # (M, N) layout dynamic without enforcing additional compact-shape
+    # constraints. This reduces per-call Python overhead for small-M shapes.
+    def _convert_layout_dynamic(t: Tensor) -> cute.Tensor:
+        return from_dlpack(t.detach(), assumed_align=16).mark_layout_dynamic(
+            leading_dim=1
+        )
+
+    x_tensor, dout_tensor, dres_out_tensor, dx_tensor, dres_tensor = [
+        _convert_layout_dynamic(t) if t is not None else None
+        for t in (x, dout, dresidual_out, dx, dresidual)
+    ]
+
+    if weight is not None:
+        weight_dtype = TORCH2CUTE_DTYPE[weight.dtype]
+        weight_tensor = convert_from_dlpack_cute(
+            weight.detach(),
+            leading_dim=0,
+            divisibility=128 // weight_dtype.width,
+        )
+    else:
+        weight_tensor = None
+
+    dw_partial_tensor = (
+        from_dlpack(dw_partial, assumed_align=16).mark_compact_shape_dynamic(mode=0)
+        if dw_partial is not None
+        else None
+    )
+    db_partial_tensor = (
+        from_dlpack(db_partial, assumed_align=16).mark_compact_shape_dynamic(mode=0)
+        if db_partial is not None
+        else None
+    )
+    rstd_tensor = from_dlpack(rstd.detach(), assumed_align=4).mark_layout_dynamic(
+        leading_dim=0
+    )
+
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = (
+        M,
+        N,
+        x_tensor.element_type,
+        weight_tensor.element_type if weight is not None else None,
+        db_partial.dtype if db_partial is not None else None,
+        dresidual.dtype if dresidual is not None else None,
+        dresidual_out.dtype if dresidual_out is not None else None,
+    )
+    kernel = _BWD_COMPILE_CACHE.get(compile_key)
+    if kernel is None:
+        op = RMSNormBackwardSM100(x_tensor.element_type, N)
+
+        # Shape-specific tuning overrides for DSv3-style N=8192 rows.
+        if isinstance(op, RMSNormBackwardSM100) and N == 8192:
+            if M >= 65536:
+                op._tpr_override = 256  # type: ignore[attr-defined]
+                op._nt_override = 256  # type: ignore[attr-defined]
+            elif M >= 16384:
+                op._tpr_override = 256  # type: ignore[attr-defined]
+
+        kernel = cute.compile(
+            op,
+            x_tensor,
+            weight_tensor,
+            dout_tensor,
+            dres_out_tensor,
+            rstd_tensor,
+            dx_tensor,
+            dw_partial_tensor,
+            dres_tensor,
+            db_partial_tensor,
+            Int32(sm_count if sm_count is not None else 0),
+            current_stream,
+        )
+        _BWD_COMPILE_CACHE[compile_key] = kernel
+
+    kernel(
+        x_tensor,
+        weight_tensor,
+        dout_tensor,
+        dres_out_tensor,
+        rstd_tensor,
+        dx_tensor,
+        dw_partial_tensor,
+        dres_tensor,
+        db_partial_tensor,
+        Int32(sm_count if sm_count is not None else 0),
+        current_stream,
+    )
+
+
+def _rmsnorm_bwd_sm100_ptr(
+    x: Tensor,
+    weight: Tensor,
+    dout: Tensor,
+    rstd: Tensor,
+    dx: Tensor,
+    dw_partial: Tensor,
+    sm_count: int,
+    *,
+    atomic_dw: bool = False,
+) -> None:
+    """Pointer-path SM100 RMSNorm backward launch."""
+    assert _can_use_ptr_path_bwd(x, weight, dout, rstd)
+    assert dx.shape == x.shape
+    assert dx.dtype == x.dtype
+    assert dw_partial.dtype == torch.float32
+
+    M, N = x.size(0), x.size(1)
+    if atomic_dw:
+        assert dw_partial.dim() == 1 and dw_partial.numel() == N
+        assert dw_partial.is_contiguous()
+    else:
+        assert dw_partial.dim() == 2 and dw_partial.shape[1] == N
+    device_index = x.get_device()
+    dtype = TORCH2CUTE_DTYPE[x.dtype]
+    weight_dtype = TORCH2CUTE_DTYPE[weight.dtype]
+    assumed_align_x = 16
+    assumed_align_w = 32 if weight.dtype is torch.float32 else 16
+    assumed_align_dw = 32
+    assert (dw_partial.data_ptr() % assumed_align_dw) == 0
+
+    stream_handle = _current_stream_handle(device_index)
+    stream = cuda.CUstream(stream_handle)
+
+    ld_val = int(x.stride(0))
+    key = (
+        "bwd_ptr",
+        N,
+        dtype,
+        weight_dtype,
+        int(assumed_align_x),
+        int(assumed_align_w),
+        int(assumed_align_dw),
+        device_index,
+        bool(atomic_dw),
+    )
+    compiled = _BWD_PTR_COMPILE_CACHE.get(key)
+    if compiled is None:
+        op = RMSNormBackwardSM100(dtype, N)
+        op.atomic_dw = bool(atomic_dw)
+        _apply_backward_launch_overrides(
+            op,
+            atomic_dw=bool(atomic_dw),
+            N=N,
+            dtype=dtype,
+            weight_dtype=weight_dtype,
+        )
+        ptr_x, ptr_w, ptr_dout, ptr_rstd, ptr_dx, ptr_dw = _make_bwd_ptrs(
+            x=x,
+            weight=weight,
+            dout=dout,
+            rstd=rstd,
+            dx=dx,
+            dw_partial=dw_partial,
+            dtype=dtype,
+            weight_dtype=weight_dtype,
+            assumed_align_x=assumed_align_x,
+            assumed_align_w=assumed_align_w,
+            assumed_align_dw=assumed_align_dw,
+        )
+        compiled = cute.compile(
+            op.launch_from_ptrs,
+            ptr_x,
+            ptr_w,
+            ptr_dout,
+            ptr_rstd,
+            ptr_dx,
+            ptr_dw,
+            Int32(M),
+            Int32(N),
+            Int32(ld_val),
+            Int32(int(sm_count)),
+            stream,
+        )
+        _BWD_PTR_COMPILE_CACHE[key] = compiled
+
+    launcher = _get_fast_ptr_rmsnorm_bwd_launcher(
+        compiled=compiled,
+        dtype=dtype,
+        weight_dtype=weight_dtype,
+        N=N,
+        device_index=device_index,
+        stream_handle=stream_handle,
+        has_weight=True,
+        has_dw_partial=True,
+        assumed_align_x=assumed_align_x,
+        assumed_align_w=assumed_align_w,
+        assumed_align_dw=assumed_align_dw,
+    )
+    if launcher is not None:
+        launcher.launch(
+            x=x,
+            weight=weight,
+            dout=dout,
+            rstd=rstd,
+            dx=dx,
+            dw_partial=dw_partial,
+            M=M,
+            N=N,
+            ld=ld_val,
+            sm_count=int(sm_count),
+        )
+        return
+
+    ptr_x, ptr_w, ptr_dout, ptr_rstd, ptr_dx, ptr_dw = _make_bwd_ptrs(
+        x=x,
+        weight=weight,
+        dout=dout,
+        rstd=rstd,
+        dx=dx,
+        dw_partial=dw_partial,
+        dtype=dtype,
+        weight_dtype=weight_dtype,
+        assumed_align_x=assumed_align_x,
+        assumed_align_w=assumed_align_w,
+        assumed_align_dw=assumed_align_dw,
+    )
+    compiled(
+        ptr_x,
+        ptr_w,
+        ptr_dout,
+        ptr_rstd,
+        ptr_dx,
+        ptr_dw,
+        Int32(M),
+        Int32(N),
+        Int32(ld_val),
+        Int32(int(sm_count)),
+        stream,
+    )
+
+
+def rmsnorm_backward(
+    x: Tensor,
+    weight: Tensor | None,
+    dout: Tensor,
+    rstd: Tensor,
+    dresidual_out: Tensor | None = None,
+    has_bias: bool = False,
+    has_residual: bool = False,
+) -> tuple[Tensor, Tensor | None, Tensor | None, Tensor | None]:
+    """Public SM100 RMSNorm backward entry matching Quack's signature."""
+    device = x.device
+    M, N = x.size(0), x.size(1)
+    dx = torch.empty_like(x)
+    if dresidual_out is not None and dresidual_out.dtype != dx.dtype:
+        dresidual = torch.empty_like(x, dtype=dresidual_out.dtype)
+    else:
+        dresidual = None
+
+    sm_count = get_sm_count(N, device, M=M, dtype=x.dtype)
+
+    # Clamp small N=4096 cases back to Quack's baseline to avoid allocator churn.
+    if N == 4096 and M <= 8192 and x.dtype in (torch.float16, torch.bfloat16):
+        num_sms = qutils.get_num_sms(device)
+        sm_count = min(int(sm_count), int(num_sms) * 2)
+
+    use_atomic_dw = False
+    # Large fp32-weight DSv3 backward prefers atomically accumulating dW.
+    if (
+        weight is not None
+        and (not has_bias)
+        and (not has_residual)
+        and dresidual_out is None
+        and dresidual is None
+        and N == 8192
+        and weight.dtype is torch.float32
+        and M >= 65536
+        and x.dtype in (torch.float16, torch.bfloat16)
+        and _can_use_ptr_path_bwd(x, weight, dout, rstd)
+    ):
+        use_atomic_dw = True
+
+    if weight is not None:
+        if use_atomic_dw:
+            dw_partial = torch.zeros(N, device=device, dtype=torch.float32)
+        else:
+            dw_partial = torch.empty(sm_count, N, device=device, dtype=torch.float32)
+    else:
+        dw_partial = None
+    db_partial = (
+        torch.empty(sm_count, N, device=device, dtype=torch.float32)
+        if has_bias
+        else None
+    )
+
+    if (
+        weight is not None
+        and dw_partial is not None
+        and (not has_bias)
+        and (not has_residual)
+        and dresidual_out is None
+        and dresidual is None
+        and _can_use_ptr_path_bwd(x, weight, dout, rstd)
+    ):
+        _rmsnorm_bwd_sm100_ptr(
+            x=x,
+            weight=weight,
+            dout=dout,
+            rstd=rstd,
+            dx=dx,
+            dw_partial=dw_partial,
+            sm_count=int(sm_count),
+            atomic_dw=bool(use_atomic_dw),
+        )
+    else:
+        _rmsnorm_bwd_sm100(
+            x,
+            weight,
+            dout,
+            rstd,
+            dx,
+            dw_partial,
+            db_partial,
+            dresidual_out,
+            dresidual,
+            sm_count,
+        )
+
+    if weight is not None and dw_partial is not None:
+        if use_atomic_dw:
+            dw_fp32 = dw_partial
+        else:
+            dw_fp32 = _reduce_partial_sum_fp32(dw_partial, device_index=x.get_device())
+        dw = dw_fp32 if weight.dtype is torch.float32 else dw_fp32.to(weight.dtype)
+    else:
+        dw = None
+    db = db_partial.sum(dim=0).to(weight.dtype) if has_bias else None
+    if has_residual and dresidual is None:
+        dresidual = dx
+    return dx, dw, db, dresidual
+
+
+rmsnorm_bwd = rmsnorm_backward

--- a/torch/_vendor/oink/_rmsnorm_simple_weightonly.py
+++ b/torch/_vendor/oink/_rmsnorm_simple_weightonly.py
@@ -1,0 +1,391 @@
+"""Measured same-dtype bf16 RMSNorm forward specializations.
+
+This module implements a narrow fast path for row-major bf16 tensors with a
+bf16 1D weight and no residual/bias/rstd outputs.  The math is
+``y = x * rsqrt(mean(x * x) + eps) * weight`` with fp32 reduction/multiply and
+bf16 output.  The shape table below is deliberately measured and narrow; shapes
+not listed fall back to the generic RMSNorm pointer path.
+"""
+# ruff: noqa: E402  # CuTeDSL cache setup must run before importing cutlass.
+
+from dataclasses import dataclass
+
+import cuda.bindings.driver as cuda
+import torch
+from torch import Tensor
+
+from ._cutedsl_cache import ensure_versioned_cutedsl_cache_dir
+
+ensure_versioned_cutedsl_cache_dir()
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+from cutlass import Float32, Int32
+from cutlass.cute.runtime import make_ptr
+
+from .fast_launch import (
+    StableF32Arg,
+    StableI32Arg,
+    build_fast_launcher,
+)
+from .lite_quack import row_reduce_add
+
+_COMPILED_CACHE: dict[tuple[object, int, int, int], object] = {}
+
+_SIMPLE_WEIGHTONLY_SHAPES: dict[tuple[int, int], tuple[int, int]] = {
+    # DeepSeek-V4-Flash q_lora same-dtype RMSNorm shape.  Larger M and the
+    # kv/per-head N=512 cases are faster through the generic pointer path on SM103.
+    (4096, 1536): (96, 96),
+    # DeepSeek-V3 hidden-state same-dtype RMSNorm shapes.
+    (4096, 6144): (192, 192),
+    (4096, 7168): (224, 224),
+    (4096, 8192): (256, 256),
+    (16384, 7168): (128, 128),
+    (16384, 8192): (128, 128),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _SimpleWeightOnlyConfig:
+    COPY_BITS = 128
+
+    dtype: cutlass.Numeric
+    N: int
+    threads_per_row: int
+    num_threads: int
+
+    @property
+    def vec_size(self) -> int:
+        return self.COPY_BITS // self.dtype.width
+
+    @property
+    def rows_per_block(self) -> int:
+        return self.num_threads // self.threads_per_row
+
+    @property
+    def num_vec_blocks(self) -> int:
+        return self.N // (self.vec_size * self.threads_per_row)
+
+    @property
+    def cols_per_tile(self) -> int:
+        return self.vec_size * self.num_vec_blocks * self.threads_per_row
+
+    @property
+    def warps_per_row(self) -> int:
+        return max(self.threads_per_row // 32, 1)
+
+    @property
+    def cache_key(self) -> tuple[object, int, int, int]:
+        return (
+            self.dtype,
+            int(self.N),
+            int(self.threads_per_row),
+            int(self.num_threads),
+        )
+
+    @staticmethod
+    def make_tv_layout(
+        threads_per_row: int,
+        rows_per_block: int,
+        vec_size: int,
+        num_vec_blocks: int,
+    ):
+        shape = ((threads_per_row, rows_per_block), (vec_size, num_vec_blocks))
+        stride = (
+            (vec_size * rows_per_block, 1),
+            (rows_per_block, rows_per_block * vec_size * threads_per_row),
+        )
+        return shape, stride
+
+    def smem_bytes(self) -> int:
+        return (
+            self.rows_per_block * self.cols_per_tile * (self.dtype.width // 8)
+            + self.rows_per_block * self.warps_per_row * 4
+        )
+
+
+class _SimpleWeightOnlyRMSNorm:
+    def __init__(self, cfg: _SimpleWeightOnlyConfig):
+        self.cfg = cfg
+
+    @cute.jit
+    def __call__(
+        self, x_ptr, w_ptr, o_ptr, M: Int32, eps: Float32, stream: cuda.CUstream
+    ):
+        cfg = self.cfg
+        mX = cute.make_tensor(x_ptr, cute.make_layout((M, cfg.N), stride=(cfg.N, 1)))
+        mW = cute.make_tensor(w_ptr, cute.make_layout((cfg.N,), stride=(1,)))
+        mO = cute.make_tensor(o_ptr, cute.make_layout((M, cfg.N), stride=(cfg.N, 1)))
+        tv_shape, tv_stride = _SimpleWeightOnlyConfig.make_tv_layout(
+            cfg.threads_per_row,
+            cfg.rows_per_block,
+            cfg.vec_size,
+            cfg.num_vec_blocks,
+        )
+        tv_layout = cute.make_layout(tv_shape, stride=tv_stride)
+        tiler_mn = (cfg.rows_per_block, cfg.cols_per_tile)
+        self.kernel(mX, mW, mO, eps, tv_layout, tiler_mn).launch(
+            grid=[cute.ceil_div(M, cfg.rows_per_block), 1, 1],
+            block=[cfg.num_threads, 1, 1],
+            smem=cfg.smem_bytes(),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mX: cute.Tensor,
+        mW: cute.Tensor,
+        mO: cute.Tensor,
+        eps: Float32,
+        tv_layout: cute.Layout,
+        tiler_mn: cute.Shape,
+    ):
+        cfg = self.cfg
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        M = mX.shape[0]
+        threads_per_row = tv_layout.shape[0][0]
+        warps_per_row = max(threads_per_row // 32, 1)
+        rows_per_block = tiler_mn[0]
+
+        smem = utils.SmemAllocator()
+        sX = smem.allocate_tensor(
+            mX.element_type,
+            cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+            byte_alignment=16,
+        )
+        reduction_buffer = smem.allocate_tensor(
+            Float32,
+            cute.make_ordered_layout(
+                (rows_per_block, (warps_per_row, 1)), order=(1, 0)
+            ),
+            byte_alignment=4,
+        )
+
+        idX = cute.make_identity_tensor(mX.shape)
+        gX = cute.local_tile(mX, tiler_mn, (bidx, 0))
+        gO = cute.local_tile(mO, tiler_mn, (bidx, 0))
+        cX = cute.local_tile(idX, tiler_mn, (bidx, 0))
+
+        mW2 = cute.make_tensor(
+            mW.iterator,
+            cute.prepend(mW.layout, cute.make_layout((tiler_mn[0],), stride=(0,))),
+        )
+        gW = cute.local_tile(mW2, tiler_mn, (0, 0))
+
+        copy_atom_load_x = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(),
+            mX.element_type,
+            num_bits_per_copy=_SimpleWeightOnlyConfig.COPY_BITS,
+        )
+        copy_atom_load_w = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            mX.element_type,
+            num_bits_per_copy=_SimpleWeightOnlyConfig.COPY_BITS,
+        )
+        copy_atom_store = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            mO.element_type,
+            num_bits_per_copy=_SimpleWeightOnlyConfig.COPY_BITS,
+        )
+
+        tiled_copy_x = cute.make_tiled_copy(copy_atom_load_x, tv_layout, tiler_mn)
+        tiled_copy_w = cute.make_tiled_copy(copy_atom_load_w, tv_layout, tiler_mn)
+        tiled_copy_o = cute.make_tiled_copy(copy_atom_store, tv_layout, tiler_mn)
+
+        thr_copy_x = tiled_copy_x.get_slice(tidx)
+        thr_copy_w = tiled_copy_w.get_slice(tidx)
+        thr_copy_o = tiled_copy_o.get_slice(tidx)
+
+        tXgX = thr_copy_x.partition_S(gX)
+        tXsX = thr_copy_x.partition_D(sX)
+        tXgO = thr_copy_o.partition_D(gO)
+        tXcX = thr_copy_x.partition_S(cX)
+        tXrX = cute.make_fragment_like(tXgX)
+        tXrO = cute.make_fragment_like(tXgO)
+        tWgW = thr_copy_w.partition_S(gW)
+        tWrW = cute.make_fragment_like(tWgW)
+
+        row_coord = tXcX[(0, 0), 0, 0]
+        row_in_bounds = row_coord[0] < M
+
+        if row_in_bounds:
+            cute.copy(copy_atom_load_x, tXgX, tXsX)
+        cute.arch.cp_async_commit_group()
+        cute.copy(copy_atom_load_w, tWgW, tWrW)
+        cute.arch.cp_async_wait_group(0)
+
+        cute.autovec_copy(tXsX, tXrX)
+        x = tXrX.load().to(Float32)
+        sum_sq = row_reduce_add(
+            x * x, threads_per_row, reduction_buffer, None, None, Float32(0.0)
+        )
+        rstd = cute.math.rsqrt(sum_sq / cfg.N + eps, fastmath=True)
+        cute.arch.barrier()
+
+        cute.autovec_copy(tXsX, tXrX)
+        x = tXrX.load().to(Float32)
+        w = tWrW.load().to(Float32)
+        y = x * rstd * w
+        tXrO.store(y.to(cfg.dtype))
+        if row_in_bounds:
+            cute.copy(copy_atom_store, tXrO, tXgO)
+
+
+def _get_simple_weightonly_config(
+    x: Tensor,
+    weight: Tensor,
+    out: Tensor,
+) -> _SimpleWeightOnlyConfig | None:
+    if (
+        x.dtype is not torch.bfloat16
+        or weight.dtype is not x.dtype
+        or out.dtype is not x.dtype
+    ):
+        return None
+    if not x.is_cuda or not weight.is_cuda or not out.is_cuda:
+        return None
+    if x.dim() != 2 or out.dim() != 2 or weight.dim() != 1:
+        return None
+    if x.shape != out.shape or int(weight.shape[0]) != int(x.shape[1]):
+        return None
+    if (
+        x.stride() != (int(x.shape[1]), 1)
+        or out.stride() != x.stride()
+        or weight.stride() != (1,)
+    ):
+        return None
+    M, N = int(x.shape[0]), int(x.shape[1])
+    threads = _SIMPLE_WEIGHTONLY_SHAPES.get((M, N))
+    if threads is None:
+        return None
+    threads_per_row, num_threads = threads
+    return _SimpleWeightOnlyConfig(
+        dtype=cutlass.BFloat16,
+        N=N,
+        threads_per_row=threads_per_row,
+        num_threads=num_threads,
+    )
+
+
+def _get_compiled(cfg: _SimpleWeightOnlyConfig, stream: cuda.CUstream):
+    key = cfg.cache_key
+    compiled = _COMPILED_CACHE.get(key)
+    if compiled is None:
+        kernel = _SimpleWeightOnlyRMSNorm(cfg)
+        compiled = cute.compile(
+            kernel,
+            make_ptr(cfg.dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cfg.dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cfg.dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+            Int32(1),
+            Float32(1e-6),
+            stream,
+        )
+        _COMPILED_CACHE[key] = compiled
+    return compiled
+
+
+def _get_fast_launcher(
+    *,
+    compiled: object,
+    cfg: _SimpleWeightOnlyConfig,
+    device_index: int,
+    stream_handle: int,
+    eps: float,
+):
+    ptr_x = make_ptr(cfg.dtype, 0, cute.AddressSpace.gmem, assumed_align=16)
+    ptr_w = make_ptr(cfg.dtype, 0, cute.AddressSpace.gmem, assumed_align=16)
+    ptr_o = make_ptr(cfg.dtype, 0, cute.AddressSpace.gmem, assumed_align=16)
+    arg_m = StableI32Arg(0)
+    arg_eps = StableF32Arg(eps)
+    key = (
+        "simple_weightonly_fast",
+        id(compiled),
+        cfg.dtype,
+        int(cfg.N),
+        int(cfg.threads_per_row),
+        int(cfg.num_threads),
+        int(device_index),
+        int(stream_handle),
+    )
+    return build_fast_launcher(
+        key=key,
+        compiled=compiled,
+        device_index=device_index,
+        stream_handle=stream_handle,
+        execution_args_builder=lambda stream: (
+            ptr_x,
+            ptr_w,
+            ptr_o,
+            arg_m,
+            arg_eps,
+            stream,
+        ),
+        keepalive_items=(ptr_x, ptr_w, ptr_o, arg_m, arg_eps),
+        ptr_slots=((ptr_x, "x"), (ptr_w, "weight"), (ptr_o, "out")),
+        scalar_slots=((arg_m, "M", -1), (arg_eps, "eps", float("nan"))),
+        fallback_launch_builder=lambda stream: (
+            lambda **kwargs: compiled(
+                make_ptr(
+                    cfg.dtype,
+                    kwargs["x"].data_ptr(),
+                    cute.AddressSpace.gmem,
+                    assumed_align=16,
+                ),
+                make_ptr(
+                    cfg.dtype,
+                    kwargs["weight"].data_ptr(),
+                    cute.AddressSpace.gmem,
+                    assumed_align=16,
+                ),
+                make_ptr(
+                    cfg.dtype,
+                    kwargs["out"].data_ptr(),
+                    cute.AddressSpace.gmem,
+                    assumed_align=16,
+                ),
+                Int32(kwargs["M"]),
+                Float32(kwargs["eps"]),
+                stream,
+            )
+        ),
+    )
+
+
+def try_simple_weightonly_rmsnorm_forward(
+    x: Tensor,
+    weight: Tensor,
+    out: Tensor,
+    eps: float,
+) -> bool:
+    cfg = _get_simple_weightonly_config(x, weight, out)
+    if cfg is None:
+        return False
+    device_index = int(x.device.index)
+    stream_handle = int(torch.cuda.current_stream(x.device).cuda_stream)
+    stream = cuda.CUstream(stream_handle)
+    compiled = _get_compiled(cfg, stream)
+    launcher = _get_fast_launcher(
+        compiled=compiled,
+        cfg=cfg,
+        device_index=device_index,
+        stream_handle=stream_handle,
+        eps=float(eps),
+    )
+    if launcher is not None and int(x.shape[0]) <= 4096:
+        launcher.launch(x=x, weight=weight, out=out, M=int(x.shape[0]), eps=float(eps))
+        return True
+    compiled(
+        make_ptr(cfg.dtype, x.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(
+            cfg.dtype, weight.data_ptr(), cute.AddressSpace.gmem, assumed_align=16
+        ),
+        make_ptr(cfg.dtype, out.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        Int32(int(x.shape[0])),
+        Float32(float(eps)),
+        stream,
+    )
+    return True

--- a/torch/_vendor/oink/_rmsnorm_smallm_cuda.py
+++ b/torch/_vendor/oink/_rmsnorm_smallm_cuda.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import os
+import subprocess
+import threading
+from pathlib import Path
+
+import torch
+from torch import Tensor
+
+_CUDA_HOME = "/usr/local/cuda-13.0"
+_NVCC = f"{_CUDA_HOME}/bin/nvcc"
+_CACHE_DIR = Path(os.environ.get("CUTE_DSL_CACHE_DIR", "/tmp")) / "oink_smallm_cuda"
+_BUILD_LOCK = threading.Lock()
+_LAUNCHER_NOWEIGHT = None
+_LAUNCHER_NOWEIGHT_LARGE = None
+_LAUNCHER_NOWEIGHT_LARGE_FP32 = None
+_BUILD_FAILED = False
+
+_CUDA_SRC = r"""
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+template <int NumThreads>
+__device__ __forceinline__ float warp_reduce_sum(float x) {
+#pragma unroll
+  for (int offset = NumThreads / 2; offset >= 1; offset /= 2) {
+    x += __shfl_down_sync(0xffffffff, x, offset, NumThreads);
+  }
+  return __shfl_sync(0xffffffff, x, 0, NumThreads);
+}
+
+constexpr int kHidden = 4096;
+constexpr int kBf16PerFloat4 = sizeof(float4) / sizeof(__nv_bfloat16);
+constexpr int kFloat4sPerThread = 4;
+constexpr int kRowThreads = 128;
+constexpr int kElemsPerThread = kFloat4sPerThread * kBf16PerFloat4;
+constexpr int kWarpsPerRow = kRowThreads / 32;
+constexpr int kFloat4sPerRow = kHidden / kBf16PerFloat4;
+constexpr float kInvHidden = 1.0f / float(kHidden);
+
+__device__ __forceinline__ float bf16_square_fma(float sum, __nv_bfloat16 x) {
+  asm("fma.rn.f32.bf16 %0, %1, %1, %0;"
+      : "+f"(sum)
+      : "h"(*(reinterpret_cast<unsigned short*>(&x))));
+  return sum;
+}
+
+__global__ __launch_bounds__(kRowThreads) void rmsnorm_noweight_4096_bf16_kernel(
+    int M,
+    float eps,
+    const float4* __restrict__ input,
+    float4* __restrict__ output) {
+  const int row = blockIdx.x;
+  if (row >= M) {
+    return;
+  }
+
+  __shared__ float partial[kWarpsPerRow];
+  __shared__ float denom;
+
+  const int lane = threadIdx.x & 31;
+  const int warp_id = threadIdx.x >> 5;
+  const int row_vec_base = row * kFloat4sPerRow;
+
+  float vals[kElemsPerThread];
+
+#pragma unroll
+  for (int i = 0; i < kFloat4sPerThread; ++i) {
+    const int vec_idx = row_vec_base + i * kRowThreads + threadIdx.x;
+    float4 v = input[vec_idx];
+    const __nv_bfloat16* p = reinterpret_cast<const __nv_bfloat16*>(&v);
+#pragma unroll
+    for (int j = 0; j < kBf16PerFloat4; ++j) {
+      vals[i * kBf16PerFloat4 + j] = __bfloat162float(p[j]);
+    }
+  }
+
+  float sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < kElemsPerThread; ++i) {
+    sum += vals[i] * vals[i];
+  }
+
+  const float warp_sum = warp_reduce_sum<32>(sum);
+  if (lane == 0) {
+    partial[warp_id] = warp_sum;
+  }
+  __syncthreads();
+
+  float total = 0.0f;
+  if (warp_id == 0) {
+    total = lane < kWarpsPerRow ? partial[lane] : 0.0f;
+    total = warp_reduce_sum<32>(total);
+    if (lane == 0) {
+      denom = rsqrtf(eps + total * kInvHidden);
+    }
+  }
+  __syncthreads();
+
+  const float scale = denom;
+
+#pragma unroll
+  for (int i = 0; i < kElemsPerThread; ++i) {
+    vals[i] *= scale;
+  }
+
+#pragma unroll
+  for (int i = 0; i < kFloat4sPerThread; ++i) {
+    float4 outv;
+    __nv_bfloat16* p = reinterpret_cast<__nv_bfloat16*>(&outv);
+#pragma unroll
+    for (int j = 0; j < kBf16PerFloat4; ++j) {
+      p[j] = __float2bfloat16(vals[i * kBf16PerFloat4 + j]);
+    }
+    const int vec_idx = row_vec_base + i * kRowThreads + threadIdx.x;
+    output[vec_idx] = outv;
+  }
+}
+
+extern "C" void launch_rmsnorm_noweight_4096_bf16(
+    int M,
+    float eps,
+    const void* input,
+    void* output,
+    void* stream) {
+  rmsnorm_noweight_4096_bf16_kernel<<<M, kRowThreads, 0, static_cast<cudaStream_t>(stream)>>>(
+      M,
+      eps,
+      reinterpret_cast<const float4*>(input),
+      reinterpret_cast<float4*>(output));
+}
+
+template <int kVectorFloat4PerThread>
+__global__ void rmsnorm_noweight_4096_bf16_warp_kernel(
+    int M,
+    float eps,
+    const float4* __restrict__ input,
+    float4* __restrict__ output) {
+  constexpr int kThreadGroupSize = 32;
+  constexpr int kElemsPerThreadWarp = kVectorFloat4PerThread * kBf16PerFloat4;
+
+  const int sample_idx = blockIdx.x * blockDim.y + threadIdx.y;
+  if (sample_idx >= M) {
+    return;
+  }
+
+  float4 row_data[kVectorFloat4PerThread];
+  __nv_bfloat16* row_bf16 = reinterpret_cast<__nv_bfloat16*>(row_data);
+
+#pragma unroll
+  for (int i = 0; i < kVectorFloat4PerThread; ++i) {
+    row_data[i] = input[
+        sample_idx * kThreadGroupSize * kVectorFloat4PerThread
+        + i * kThreadGroupSize + threadIdx.x];
+  }
+
+  float sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < kElemsPerThreadWarp; ++i) {
+    sum = bf16_square_fma(sum, row_bf16[i]);
+  }
+  sum = warp_reduce_sum<32>(sum);
+  const float denom = rsqrtf(eps + sum * kInvHidden);
+  const __nv_bfloat16 denom_bf16 = __float2bfloat16_rn(denom);
+
+#pragma unroll
+  for (int i = 0; i < kElemsPerThreadWarp; ++i) {
+    row_bf16[i] = __hmul(row_bf16[i], denom_bf16);
+  }
+
+#pragma unroll
+  for (int i = 0; i < kVectorFloat4PerThread; ++i) {
+    const int idx =
+        sample_idx * kThreadGroupSize * kVectorFloat4PerThread
+        + i * kThreadGroupSize + threadIdx.x;
+    output[idx] = row_data[i];
+  }
+}
+
+extern "C" void launch_rmsnorm_noweight_4096_bf16_warp(
+    int M,
+    float eps,
+    const void* input,
+    void* output,
+    void* stream,
+    int cta_dim_y) {
+  const int rows_per_cta = cta_dim_y > 0 ? cta_dim_y : 1;
+  dim3 block(32, rows_per_cta);
+  dim3 grid((M + rows_per_cta - 1) / rows_per_cta);
+  rmsnorm_noweight_4096_bf16_warp_kernel<16>
+      <<<grid, block, 0, static_cast<cudaStream_t>(stream)>>>(
+          M,
+          eps,
+          reinterpret_cast<const float4*>(input),
+          reinterpret_cast<float4*>(output));
+}
+
+template <int kVectorFloat4PerThread>
+__global__ void rmsnorm_noweight_4096_bf16_warp_fp32_kernel(
+    int M,
+    float eps,
+    const float4* __restrict__ input,
+    float4* __restrict__ output) {
+  constexpr int kThreadGroupSize = 32;
+  constexpr int kElemsPerThreadWarp = kVectorFloat4PerThread * kBf16PerFloat4;
+
+  const int sample_idx = blockIdx.x * blockDim.y + threadIdx.y;
+  if (sample_idx >= M) {
+    return;
+  }
+
+  float data[kElemsPerThreadWarp];
+
+#pragma unroll
+  for (int i = 0; i < kVectorFloat4PerThread; ++i) {
+    float4 input_v = input[
+        sample_idx * kThreadGroupSize * kVectorFloat4PerThread
+        + i * kThreadGroupSize + threadIdx.x];
+    const __nv_bfloat16* temp = reinterpret_cast<const __nv_bfloat16*>(&input_v);
+#pragma unroll
+    for (int j = 0; j < kBf16PerFloat4; ++j) {
+      data[i * kBf16PerFloat4 + j] = __bfloat162float(temp[j]);
+    }
+  }
+
+  float sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < kElemsPerThreadWarp; ++i) {
+    sum += data[i] * data[i];
+  }
+  sum = warp_reduce_sum<32>(sum);
+  const float denom = rsqrtf(eps + sum * kInvHidden);
+
+#pragma unroll
+  for (int i = 0; i < kElemsPerThreadWarp; ++i) {
+    data[i] *= denom;
+  }
+
+#pragma unroll
+  for (int i = 0; i < kVectorFloat4PerThread; ++i) {
+    float4 output_v;
+    __nv_bfloat16* temp = reinterpret_cast<__nv_bfloat16*>(&output_v);
+#pragma unroll
+    for (int j = 0; j < kBf16PerFloat4; ++j) {
+      temp[j] = __float2bfloat16(data[i * kBf16PerFloat4 + j]);
+    }
+    output[
+        sample_idx * kThreadGroupSize * kVectorFloat4PerThread
+        + i * kThreadGroupSize + threadIdx.x] = output_v;
+  }
+}
+
+extern "C" void launch_rmsnorm_noweight_4096_bf16_warp_fp32(
+    int M,
+    float eps,
+    const void* input,
+    void* output,
+    void* stream,
+    int cta_dim_y) {
+  const int rows_per_cta = cta_dim_y > 0 ? cta_dim_y : 1;
+  dim3 block(32, rows_per_cta);
+  dim3 grid((M + rows_per_cta - 1) / rows_per_cta);
+  rmsnorm_noweight_4096_bf16_warp_fp32_kernel<16>
+      <<<grid, block, 0, static_cast<cudaStream_t>(stream)>>>(
+          M,
+          eps,
+          reinterpret_cast<const float4*>(input),
+          reinterpret_cast<float4*>(output));
+}
+"""
+
+
+def _smallm_bounds() -> tuple[int, int]:
+    min_m = int(os.environ.get("OINK_RMSNORM_SMALLM_MIN_M", "4096"))
+    max_m = int(os.environ.get("OINK_RMSNORM_SMALLM_MAX_M", "4096"))
+    return min_m, max_m
+
+
+def _largem_bounds() -> tuple[int, int]:
+    min_m = int(os.environ.get("OINK_RMSNORM_LARGEM_MIN_M", "8192"))
+    max_m = int(os.environ.get("OINK_RMSNORM_LARGEM_MAX_M", str(1 << 30)))
+    return min_m, max_m
+
+
+def _largem_cta_dim_y(M: int) -> int:
+    override = os.environ.get("OINK_RMSNORM_LARGEM_CTA_DIM_Y", "").strip()
+    if override:
+        return max(1, int(override))
+    if M < 12288:
+        return 1
+    if M < 65536:
+        return 2
+    return 4
+
+
+def _largem_variant() -> str:
+    variant = os.environ.get("OINK_RMSNORM_LARGEM_VARIANT", "auto").strip().lower()
+    return variant or "auto"
+
+
+def _disabled() -> bool:
+    val = os.environ.get("OINK_RMSNORM_DISABLE_SMALLM_CUDA", "").strip().lower()
+    return val in {"1", "true", "yes", "on"}
+
+
+def _artifact_paths() -> tuple[Path, Path]:
+    digest = hashlib.sha1(_CUDA_SRC.encode("utf-8")).hexdigest()[:12]
+    build_dir = _CACHE_DIR / digest
+    cu_path = build_dir / "rmsnorm_smallm.cu"
+    so_path = build_dir / "librmsnorm_smallm.so"
+    return cu_path, so_path
+
+
+def _build_launcher():
+    global \
+        _LAUNCHER_NOWEIGHT, \
+        _LAUNCHER_NOWEIGHT_LARGE, \
+        _LAUNCHER_NOWEIGHT_LARGE_FP32, \
+        _BUILD_FAILED
+    if _disabled() or _BUILD_FAILED:
+        return None
+    if _LAUNCHER_NOWEIGHT is not None:
+        return _LAUNCHER_NOWEIGHT
+    with _BUILD_LOCK:
+        if _LAUNCHER_NOWEIGHT is not None:
+            return _LAUNCHER_NOWEIGHT
+        if _BUILD_FAILED:
+            return None
+        cu_path, so_path = _artifact_paths()
+        try:
+            cu_path.parent.mkdir(parents=True, exist_ok=True)
+            if not so_path.exists():
+                cu_path.write_text(_CUDA_SRC)
+                env = os.environ.copy()
+                env["PATH"] = f"{_CUDA_HOME}/bin:{env.get('PATH', '')}"
+                cmd = [
+                    _NVCC,
+                    "-arch=sm_100",
+                    "-O3",
+                    "--shared",
+                    "-Xcompiler=-fPIC",
+                    str(cu_path),
+                    "-o",
+                    str(so_path),
+                ]
+                subprocess.run(cmd, env=env, check=True, capture_output=True, text=True)
+            lib = ctypes.CDLL(str(so_path))
+            fn_noweight = lib.launch_rmsnorm_noweight_4096_bf16
+            fn_noweight.argtypes = [
+                ctypes.c_int,
+                ctypes.c_float,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+            ]
+            fn_noweight.restype = None
+            fn_noweight_large = lib.launch_rmsnorm_noweight_4096_bf16_warp
+            fn_noweight_large.argtypes = [
+                ctypes.c_int,
+                ctypes.c_float,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_int,
+            ]
+            fn_noweight_large.restype = None
+            fn_noweight_large_fp32 = lib.launch_rmsnorm_noweight_4096_bf16_warp_fp32
+            fn_noweight_large_fp32.argtypes = [
+                ctypes.c_int,
+                ctypes.c_float,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_int,
+            ]
+            fn_noweight_large_fp32.restype = None
+            _LAUNCHER_NOWEIGHT = fn_noweight
+            _LAUNCHER_NOWEIGHT_LARGE = fn_noweight_large
+            _LAUNCHER_NOWEIGHT_LARGE_FP32 = fn_noweight_large_fp32
+        except Exception:
+            _BUILD_FAILED = True
+            return None
+    return _LAUNCHER_NOWEIGHT
+
+
+def can_use_smallm_noweight_cuda(x: Tensor, out: Tensor) -> bool:
+    if x.dtype is not torch.bfloat16 or out.dtype is not torch.bfloat16:
+        return False
+    if not x.is_cuda or not out.is_cuda:
+        return False
+    if x.dim() != 2 or out.dim() != 2 or x.shape != out.shape:
+        return False
+    if int(x.shape[1]) != 4096:
+        return False
+    if x.stride() != (4096, 1) or out.stride() != (4096, 1):
+        return False
+    min_m, max_m = _smallm_bounds()
+    return min_m <= int(x.shape[0]) <= max_m
+
+
+def can_use_largem_noweight_cuda(x: Tensor, out: Tensor) -> bool:
+    if x.dtype is not torch.bfloat16 or out.dtype is not torch.bfloat16:
+        return False
+    if not x.is_cuda or not out.is_cuda:
+        return False
+    if x.dim() != 2 or out.dim() != 2 or x.shape != out.shape:
+        return False
+    if int(x.shape[1]) != 4096:
+        return False
+    if x.stride() != (4096, 1) or out.stride() != (4096, 1):
+        return False
+    min_m, max_m = _largem_bounds()
+    return min_m <= int(x.shape[0]) <= max_m
+
+
+def try_rmsnorm_smallm_noweight_cuda(x: Tensor, out: Tensor, eps: float) -> bool:
+    launcher = _build_launcher()
+    if launcher is None:
+        return False
+    stream = torch.cuda.current_stream(x.device).cuda_stream
+    if can_use_smallm_noweight_cuda(x, out):
+        launcher(
+            int(x.shape[0]),
+            float(eps),
+            ctypes.c_void_p(int(x.data_ptr())),
+            ctypes.c_void_p(int(out.data_ptr())),
+            ctypes.c_void_p(int(stream)),
+        )
+        return True
+    if can_use_largem_noweight_cuda(x, out) and _LAUNCHER_NOWEIGHT_LARGE is not None:
+        variant = _largem_variant()
+        launcher = _LAUNCHER_NOWEIGHT_LARGE
+        if variant == "fp32" and _LAUNCHER_NOWEIGHT_LARGE_FP32 is not None:
+            launcher = _LAUNCHER_NOWEIGHT_LARGE_FP32
+        launcher(
+            int(x.shape[0]),
+            float(eps),
+            ctypes.c_void_p(int(x.data_ptr())),
+            ctypes.c_void_p(int(out.data_ptr())),
+            ctypes.c_void_p(int(stream)),
+            int(_largem_cta_dim_y(int(x.shape[0]))),
+        )
+        return True
+    return False

--- a/torch/_vendor/oink/fast_launch.py
+++ b/torch/_vendor/oink/fast_launch.py
@@ -1,0 +1,224 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Host-side fast-launch helpers for CuTeDSL pointer entrypoints.
+
+CuTeDSL's Python runtime typically marshals each kernel call by allocating
+`Int32` / `Float32` wrappers and runtime `Pointer` descriptors per invocation.
+For latency-sensitive cases (small/medium M), this overhead can dominate.
+
+These helpers provide:
+- Stable scalar argument wrappers (`StableI32Arg`, `StableF32Arg`) that avoid
+  per-call ctypes allocations.
+- In-place mutation of runtime pointer descriptors (`set_runtime_ptr`) so a
+  compiled kernel can be launched repeatedly with different raw device pointers
+  without rebuilding argument objects.
+- A small thread-local cache to store packed args objects (when supported by the
+  installed CuTeDSL version).
+
+All of this relies on a few private-ish CuTeDSL internals. Callers must treat
+fast-launch as an optional optimization and fall back to the normal launch
+path if those internals are unavailable.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import threading
+from typing import Any
+
+import cuda.bindings.driver as cuda  # type: ignore
+
+_FAST_LAUNCH_TLS = threading.local()
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+# Fast-launch uses internal CuTeDSL plumbing (packed args + pointer descriptors).
+# Keep it enabled by default in our pinned environment, but allow disabling it
+# via env var and auto-disable it if CuTeDSL internals change.
+_ENABLE_FAST_LAUNCH = _env_flag("OINK_CUTEDSL_FAST_LAUNCH", default=True)
+_FAST_LAUNCH_SUPPORTED = True
+
+
+def fast_launch_enabled() -> bool:
+    return _ENABLE_FAST_LAUNCH and _FAST_LAUNCH_SUPPORTED
+
+
+def disable_fast_launch() -> None:
+    """Globally disable fast-launch for all consumers (rmsnorm, layernorm, etc.).
+
+    This is intentionally global: if CuTeDSL internals are missing or changed,
+    the failure applies to every kernel module, not just the one that hit it
+    first.  Disabling once avoids repeated slow AttributeError fallbacks.
+    """
+    global _FAST_LAUNCH_SUPPORTED
+    _FAST_LAUNCH_SUPPORTED = False
+
+
+def tls_cache() -> dict[tuple[Any, ...], Any]:
+    cache = getattr(_FAST_LAUNCH_TLS, "cache", None)
+    if cache is None:
+        cache = {}
+        _FAST_LAUNCH_TLS.cache = cache
+    return cache
+
+
+class StableI32Arg:
+    """A stable Int32 runtime arg (avoids per-call Int32().__c_pointers__ allocations)."""
+
+    def __init__(self, value: int):
+        self._c_value = ctypes.c_int32(int(value))
+        self._c_pointer = ctypes.cast(ctypes.pointer(self._c_value), ctypes.c_void_p)
+
+    def set(self, value: int) -> None:
+        self._c_value.value = int(value)
+
+    def __c_pointers__(self):
+        return [self._c_pointer]
+
+
+class StableF32Arg:
+    """A stable Float32 runtime arg (avoids per-call Float32().__c_pointers__ allocations)."""
+
+    def __init__(self, value: float):
+        self._c_value = ctypes.c_float(float(value))
+        self._c_pointer = ctypes.cast(ctypes.pointer(self._c_value), ctypes.c_void_p)
+
+    def set(self, value: float) -> None:
+        self._c_value.value = float(value)
+
+    def __c_pointers__(self):
+        return [self._c_pointer]
+
+
+def set_runtime_ptr(ptr: Any, device_ptr: int) -> None:
+    """Update a CuTeDSL runtime Pointer descriptor in-place.
+
+    This relies on internal runtime pointer fields (`_desc`, `_pointer`, etc.).
+    If these internals change in a future CuTeDSL upgrade, this function may
+    raise AttributeError; callers should catch it and fall back.
+    """
+    device_ptr = int(device_ptr)
+    ptr._pointer = device_ptr  # type: ignore[attr-defined]
+    if getattr(ptr, "_c_pointer", None) is None:
+        ptr.__c_pointers__()  # type: ignore[attr-defined]
+    ptr._desc.value = device_ptr  # type: ignore[attr-defined]
+
+
+class GenericFastLaunch:
+    def __init__(
+        self,
+        *,
+        capi_func: object,
+        executor: object,
+        packed_args: object,
+        keepalive: tuple[object, ...],
+        ptr_slots: tuple[tuple[object | None, str], ...],
+        scalar_slots: tuple[tuple[object, str, object], ...],
+        fallback_launch,
+    ):
+        self._capi_func = capi_func
+        self._packed_args = packed_args
+        self._keepalive = keepalive
+        self._cuda_result = getattr(executor, "cuda_result", None)
+        self._use_fast_launch = True
+        self._ptr_slots = ptr_slots
+        self._ptr_last = [-1] * len(ptr_slots)
+        self._scalar_slots = scalar_slots
+        self._scalar_last = [initial for _, _, initial in scalar_slots]
+        self._fallback_launch = fallback_launch
+
+    def launch(self, **kwargs) -> None:
+        if not fast_launch_enabled() or not self._use_fast_launch:
+            self._fallback_launch(**kwargs)
+            return
+        try:
+            for idx, (runtime_ptr, tensor_name) in enumerate(self._ptr_slots):
+                if runtime_ptr is None:
+                    continue
+                device_ptr = kwargs[tensor_name].data_ptr()
+                if device_ptr != self._ptr_last[idx]:
+                    set_runtime_ptr(runtime_ptr, device_ptr)
+                    self._ptr_last[idx] = device_ptr
+            for idx, (stable_arg, arg_name, _) in enumerate(self._scalar_slots):
+                value = kwargs[arg_name]
+                if value != self._scalar_last[idx]:
+                    stable_arg.set(value)
+                    self._scalar_last[idx] = value
+        except AttributeError:
+            self._use_fast_launch = False
+            disable_fast_launch()
+            self._fallback_launch(**kwargs)
+            return
+
+        if self._cuda_result is not None:
+            self._cuda_result.value = 0
+        ret = self._capi_func(self._packed_args)  # type: ignore[misc]
+        if ret != 0:
+            raise RuntimeError(f"CuTeDSL capi_func returned non-zero: {ret}")
+        if self._cuda_result is not None:
+            err = int(self._cuda_result.value)
+            if err != 0:
+                raise RuntimeError(f"CuTeDSL kernel launch failed (cuda_result={err})")
+
+
+def build_fast_launcher(
+    *,
+    key: tuple[object, ...],
+    compiled: object,
+    device_index: int,
+    stream_handle: int,
+    execution_args_builder,
+    keepalive_items: tuple[object, ...],
+    ptr_slots: tuple[tuple[object | None, str], ...],
+    scalar_slots: tuple[tuple[object, str, object], ...],
+    fallback_launch_builder,
+):
+    if not fast_launch_enabled():
+        return None
+    cache = tls_cache()
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+
+    stream = cuda.CUstream(int(stream_handle))
+    executor = compiled.to(device_index)  # type: ignore[attr-defined]
+    try:
+        exe_args, adapted_args = executor.generate_execution_args(
+            *execution_args_builder(stream)
+        )
+        packed_args = executor._get_invoke_packed_args(list(exe_args))  # type: ignore[attr-defined]
+        capi_func = compiled.capi_func  # type: ignore[attr-defined]
+    except AttributeError:
+        disable_fast_launch()
+        return None
+
+    launcher = GenericFastLaunch(
+        capi_func=capi_func,
+        executor=executor,
+        packed_args=packed_args,
+        keepalive=(executor, *keepalive_items, stream, *adapted_args),
+        ptr_slots=ptr_slots,
+        scalar_slots=scalar_slots,
+        fallback_launch=fallback_launch_builder(stream),
+    )
+    cache[key] = launcher
+    return launcher

--- a/torch/_vendor/oink/lite_quack.py
+++ b/torch/_vendor/oink/lite_quack.py
@@ -1,0 +1,1463 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Lightweight local clone of the small subset of Quack helpers that the SM100
+RMSNorm CuteDSL kernels depend on.
+
+This module intentionally avoids importing the `quack` package so that
+KernelAgent Oink SM100 kernels can run without Quack installed, while keeping
+numerical behaviour and performance identical to the reference kernels.
+
+Reference implementation provenance:
+- Quack repo: https://github.com/Dao-AILab/quack
+- Base commit: c227eb56abc1b434f366d31b9d4a6ab4f00e8900
+  ("[RmsNorm] Compile with tvm-ffi and fake tensors")
+"""
+
+import importlib.metadata
+import math
+import operator
+import re
+from collections.abc import Callable
+from functools import partial
+from typing import Type
+
+import cuda.bindings.driver as cuda  # type: ignore
+import torch
+from torch import Tensor
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir.dialects import llvm, nvvm, vector
+
+
+def _parse_version_tuple(version: str) -> tuple[int, int, int]:
+    parts = version.split(".")
+    nums: list[int] = []
+    for part in parts[:3]:
+        match = re.match(r"^(\d+)", part)
+        nums.append(int(match.group(1)) if match is not None else 0)
+    while len(nums) < 3:
+        nums.append(0)
+    return nums[0], nums[1], nums[2]
+
+
+def _cutlass_dsl_version() -> tuple[int, int, int] | None:
+    try:
+        return _parse_version_tuple(importlib.metadata.version("nvidia-cutlass-dsl"))
+    except Exception:
+        return None
+
+
+_CUTLASS_DSL_VERSION = _cutlass_dsl_version()
+# CuTeDSL 4.3.4 tightened some kernel argument expectations (notably around
+# passing Layout/Shape/Constexpr objects into @cute.kernel functions). Keep the
+# older signature for <4.3.4, but switch to a 4.3.4+ compatible signature when
+# we detect 4.3.4+ (or when version detection is unavailable).
+_KERNEL_ACCEPTS_LAYOUT_ARGS = (
+    _CUTLASS_DSL_VERSION is not None and _CUTLASS_DSL_VERSION < (4, 3, 4)
+)
+
+# Cache device properties lookups (notably `multi_processor_count`) since some
+# dispatch paths call `get_sm_count` inside tight benchmark loops.
+_DEVICE_NUM_SMS_CACHE: dict[int, int] = {}
+
+
+def get_num_sms(device: torch.device) -> int:
+    """Return the number of SMs for a CUDA device (cached)."""
+    device_index = device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    device_index = int(device_index)
+    cached = _DEVICE_NUM_SMS_CACHE.get(device_index)
+    if cached is not None:
+        return cached
+    num_sms = int(torch.cuda.get_device_properties(device_index).multi_processor_count)
+    _DEVICE_NUM_SMS_CACHE[device_index] = num_sms
+    return num_sms
+
+
+# -------------------------
+# Dtype mapping (from quack.cute_dsl_utils)
+# -------------------------
+
+TORCH2CUTE_DTYPE = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float32: cutlass.Float32,
+}
+
+
+# -------------------------
+# Tensor conversion helpers (from quack.utils)
+# -------------------------
+
+
+def convert_from_dlpack(
+    x: Tensor,
+    leading_dim: int,
+    alignment: int = 16,
+    divisibility: int = 1,
+) -> cute.Tensor:
+    return (
+        from_dlpack(x, assumed_align=alignment)
+        .mark_layout_dynamic(leading_dim=leading_dim)
+        .mark_compact_shape_dynamic(
+            mode=leading_dim,
+            stride_order=x.dim_order(),
+            divisibility=divisibility,
+        )
+    )
+
+
+# -------------------------
+# SM90/SM100 cluster helpers (from quack.utils)
+# -------------------------
+
+
+@dsl_user_op
+def elem_pointer(
+    x: cute.Tensor, coord: cute.Coord, *, loc=None, ip=None
+) -> cute.Pointer:
+    return x.iterator + cute.crd2idx(coord, x.layout, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def set_block_rank(
+    smem_ptr: cute.Pointer,
+    peer_cta_rank_in_cluster: cute.Int32,
+    *,
+    loc=None,
+    ip=None,
+) -> cutlass.Int32:
+    """Map the given smem pointer to the address at another CTA rank in the cluster."""
+    smem_ptr_i32 = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [smem_ptr_i32, peer_cta_rank_in_cluster.ir_value()],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def store_shared_remote(
+    val: float | Float32 | Int32 | cutlass.Int64,
+    smem_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    peer_cta_rank_in_cluster: cute.typing.Int,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    remote_smem_ptr_i32 = set_block_rank(
+        smem_ptr,
+        peer_cta_rank_in_cluster,
+        loc=loc,
+        ip=ip,
+    ).ir_value()
+    remote_mbar_ptr_i32 = set_block_rank(
+        mbar_ptr,
+        peer_cta_rank_in_cluster,
+        loc=loc,
+        ip=ip,
+    ).ir_value()
+    if const_expr(isinstance(val, float)):
+        val = Float32(val)
+    assert isinstance(val, (Float32, Int32, cutlass.Int64)), (
+        "val must be Float32, Int32, or Int64"
+    )
+    suffix = {Float32: "f32", Int32: "s32", cutlass.Int64: "s64"}[type(val)]
+    constraint = {Float32: "f", Int32: "r", cutlass.Int64: "l"}[type(val)]
+    llvm.inline_asm(
+        None,
+        [remote_smem_ptr_i32, val.ir_value(loc=loc, ip=ip), remote_mbar_ptr_i32],
+        f"st.async.shared::cluster.mbarrier::complete_tx::bytes.{suffix} [$0], $1, [$2];",
+        f"r,{constraint},r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def atomic_add_f32(
+    a: float | Float32, gmem_ptr: cute.Pointer, *, loc=None, ip=None
+) -> Float32:
+    """Atomic add into global memory (float32)."""
+    from cutlass import CUDA_VERSION
+
+    # NVVM atomicrmw API changed in CUDA 13.x: older builds (notably CUDA 12.9)
+    # require an explicit result type, while newer builds infer it.
+    if CUDA_VERSION.major == 12 and CUDA_VERSION.minor == 9:
+        return nvvm.atomicrmw(
+            res=T.f32(),
+            op=nvvm.AtomicOpKind.FADD,
+            ptr=gmem_ptr.llvm_ptr,
+            a=Float32(a).ir_value(loc=loc, ip=ip),
+            loc=loc,
+            ip=ip,
+        )
+    return nvvm.atomicrmw(
+        op=nvvm.AtomicOpKind.FADD,
+        ptr=gmem_ptr.llvm_ptr,
+        a=Float32(a).ir_value(loc=loc, ip=ip),
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def atomic_add_tensor_f32(
+    src: cute.Tensor,
+    dst: cute.Tensor,
+    *,
+    pred: cute.Tensor | None = None,
+) -> None:
+    """Atomic-add a register fragment into a GMEM tile (float32)."""
+    if const_expr(pred is None):
+        for i in cutlass.range_constexpr(cute.size(src.shape)):
+            coord = cute.idx2crd(i, src.shape)
+            atomic_add_f32(src[i], elem_pointer(dst, coord))
+    else:
+        for i in cutlass.range_constexpr(cute.size(src.shape)):
+            # CuTeDSL 4.3.4+ disallows introducing new tuple-typed values inside
+            # a dynamic `if`. Compute `coord` unconditionally, then predicate the
+            # atomic update.
+            coord = cute.idx2crd(i, src.shape)
+            if pred[i]:
+                atomic_add_f32(src[i], elem_pointer(dst, coord))
+
+
+@cute.jit
+def predicate_k(tAcA: cute.Tensor, limit: cutlass.Int32) -> cute.Tensor:
+    # Only compute predicates for the "k" dimension. For the mn dimension, we will use "if".
+    tApA = cute.make_fragment(
+        cute.make_layout(
+            (
+                cute.size(tAcA, mode=[0, 1]),
+                cute.size(tAcA, mode=[1]),
+                cute.size(tAcA, mode=[2]),
+            ),
+            stride=(cute.size(tAcA, mode=[2]), 0, 1),
+        ),
+        cutlass.Boolean,
+    )
+    for rest_v in cutlass.range_constexpr(tApA.shape[0]):
+        for rest_k in cutlass.range_constexpr(tApA.shape[2]):
+            tApA[rest_v, 0, rest_k] = cute.elem_less(
+                tAcA[(0, rest_v), 0, rest_k][1], limit
+            )
+    return tApA
+
+
+@dsl_user_op
+def domain_offset_i64(
+    coord: cute.Coord, tensor: cute.Tensor, *, loc=None, ip=None
+) -> cute.Tensor:
+    flat_coord_i64 = tuple(cutlass.Int64(c) for c in cute.flatten(coord))
+    flat_stride = cute.flatten_to_tuple(tensor.stride)
+    assert len(flat_coord_i64) == len(flat_stride), (
+        "Coordinate and stride must have the same length"
+    )
+    offset = sum(c * s for c, s in zip(flat_coord_i64, flat_stride))
+    assert isinstance(tensor.iterator, cute.Pointer)
+    new_ptr = cute.make_ptr(
+        tensor.element_type,
+        tensor.iterator.toint() + offset * tensor.element_type.width // 8,
+        tensor.memspace,
+        assumed_align=tensor.iterator.max_alignment,
+    )
+    return cute.make_tensor(new_ptr, tensor.layout)
+
+
+@dsl_user_op
+def coord_offset_i64(
+    idx: cute.typing.Int,
+    tensor: cute.Tensor,
+    dim: int,
+    *,
+    loc=None,
+    ip=None,
+) -> cute.Tensor:
+    offset = cutlass.Int64(idx) * cute.size(tensor.stride[dim])
+    assert isinstance(tensor.iterator, cute.Pointer)
+    new_ptr = cute.make_ptr(
+        tensor.element_type,
+        tensor.iterator.toint() + offset * tensor.element_type.width // 8,
+        tensor.memspace,
+        assumed_align=tensor.iterator.max_alignment,
+    )
+    return cute.make_tensor(new_ptr, tensor.layout)
+
+
+@cute.jit
+def fill_oob(
+    tXsX: cute.Tensor, tXpX: cute.Tensor | None, fill_value: cutlass.Numeric
+) -> None:
+    """Fill out-of-bounds values in shared memory tensor."""
+    tXrX_fill = cute.make_fragment_like(tXsX[(None, 0), None, 0])
+    tXrX_fill.fill(fill_value)
+    for rest_v in cutlass.range_constexpr(const_expr(tXsX.shape[0][1])):
+        for rest_k in cutlass.range_constexpr(const_expr(tXsX.shape[2])):
+            if const_expr(tXpX is not None):
+                if not tXpX[rest_v, 0, rest_k]:
+                    cute.autovec_copy(tXrX_fill, tXsX[(None, rest_v), None, rest_k])
+            else:
+                cute.autovec_copy(tXrX_fill, tXsX[(None, rest_v), None, rest_k])
+
+
+@dsl_user_op
+def f32x2_to_i64(a: Float32, b: Float32, *, loc=None, ip=None) -> cutlass.Int64:
+    """Pack two f32 values into a single i64.
+
+    This mirrors quack.utils.f32x2_to_i64 and is used by online_softmax_reduce
+    to store (max, sum_exp) pairs in an Int64 reduction buffer.
+    """
+    vec_f32x2 = vector.from_elements(
+        T.vector(2, T.f32()),
+        (a.ir_value(loc=loc, ip=ip), b.ir_value(loc=loc, ip=ip)),
+        loc=loc,
+        ip=ip,
+    )
+    vec_i64x1 = vector.bitcast(T.vector(1, T.i64()), vec_f32x2, loc=loc, ip=ip)
+    res = cutlass.Int64(
+        vector.extract(
+            vec_i64x1, dynamic_position=[], static_position=[0], loc=loc, ip=ip
+        )
+    )
+    return res
+
+
+@dsl_user_op
+def i64_to_f32x2(c: cutlass.Int64, *, loc=None, ip=None) -> tuple[Float32, Float32]:
+    """Unpack a single i64 into two f32 values, inverse of f32x2_to_i64."""
+    vec_i64x1 = vector.from_elements(
+        T.vector(1, T.i64()),
+        (c.ir_value(loc=loc, ip=ip),),
+        loc=loc,
+        ip=ip,
+    )
+    vec_f32x2 = vector.bitcast(T.vector(2, T.f32()), vec_i64x1, loc=loc, ip=ip)
+    res0 = Float32(
+        vector.extract(
+            vec_f32x2, dynamic_position=[], static_position=[0], loc=loc, ip=ip
+        )
+    )
+    res1 = Float32(
+        vector.extract(
+            vec_f32x2, dynamic_position=[], static_position=[1], loc=loc, ip=ip
+        )
+    )
+    return res0, res1
+
+
+# -------------------------
+# Reduction helpers (from quack.reduce)
+# -------------------------
+
+
+@cute.jit
+def warp_reduce(
+    val: cute.TensorSSA | cute.Numeric,
+    op: Callable,
+    width: cutlass.Constexpr[int] = cute.arch.WARP_SIZE,
+) -> cute.TensorSSA | cute.Numeric:
+    if cutlass.const_expr(isinstance(val, cute.TensorSSA)):
+        res = cute.make_fragment(val.shape, val.dtype)
+        res.store(val)
+        for i in cutlass.range_constexpr(cute.size(val.shape)):
+            res[i] = warp_reduce(res[i], op, width)
+        return res.load()
+    return cute.arch.warp_reduction(val, op, threads_in_group=width)
+
+
+@cute.jit
+def block_reduce(
+    val: cute.Numeric,
+    op: Callable,
+    reduction_buffer: cute.Tensor,
+    init_val: cute.Numeric = 0.0,
+) -> cute.Numeric:
+    """reduction_buffer has shape (num_warps / warp_per_row, warps_per_row)."""
+    lane_idx, warp_idx = cute.arch.lane_idx(), cute.arch.warp_idx()
+    warps_per_row = cute.size(reduction_buffer.shape[1])
+    row_idx, col_idx = warp_idx // warps_per_row, warp_idx % warps_per_row
+    if lane_idx == 0:
+        reduction_buffer[row_idx, col_idx] = val
+    cute.arch.barrier()
+    block_reduce_val = init_val
+    if lane_idx < warps_per_row:
+        block_reduce_val = reduction_buffer[row_idx, lane_idx]
+    return warp_reduce(block_reduce_val, op)
+
+
+@cute.jit
+def cluster_reduce(
+    val: cute.Numeric,
+    op: Callable,
+    reduction_buffer: cute.Tensor,
+    mbar_ptr: cute.Pointer,
+    init_val: cute.Numeric = 0.0,
+    phase: cutlass.Int32 | None = None,
+) -> cute.Numeric:
+    """reduction_buffer has shape (num_warps / warps_per_row, (warps_per_row, cluster_n))."""
+    cta_rank_in_cluster = cute.arch.block_idx_in_cluster()
+    lane_idx, warp_idx = cute.arch.lane_idx(), cute.arch.warp_idx()
+    rows_per_block, (warps_per_row, cluster_n) = reduction_buffer.shape
+    row_idx, col_idx = warp_idx // warps_per_row, warp_idx % warps_per_row
+    if warp_idx == 0:
+        with cute.arch.elect_one():
+            num_warps = rows_per_block * warps_per_row
+            cute.arch.mbarrier_arrive_and_expect_tx(
+                mbar_ptr,
+                num_warps * cluster_n * reduction_buffer.element_type.width // 8,
+            )
+    if lane_idx < cluster_n:
+        store_shared_remote(
+            val,
+            elem_pointer(reduction_buffer, (row_idx, (col_idx, cta_rank_in_cluster))),
+            mbar_ptr,
+            peer_cta_rank_in_cluster=lane_idx,
+        )
+    cute.arch.mbarrier_wait(mbar_ptr, phase=phase if phase is not None else 0)
+    block_reduce_val = init_val
+    num_iter = cute.ceil_div(warps_per_row * cluster_n, cute.arch.WARP_SIZE)
+    for i in cutlass.range_constexpr(num_iter):
+        idx = lane_idx + i * cute.arch.WARP_SIZE
+        if idx < cute.size(reduction_buffer, mode=[1]):
+            block_reduce_val = op(block_reduce_val, reduction_buffer[row_idx, idx])
+    return warp_reduce(block_reduce_val, op)
+
+
+@cute.jit
+def block_or_cluster_reduce(
+    val: cute.Numeric,
+    op: Callable,
+    reduction_buffer: cute.Tensor,
+    mbar_ptr: cute.Pointer | None,
+    phase: cutlass.Int32 | None = None,
+    init_val: cute.Numeric = 0.0,
+) -> cute.Numeric:
+    """Perform either block or cluster reduction based on whether mbar_ptr is provided."""
+    if cutlass.const_expr(mbar_ptr is None):
+        return block_reduce(val, op, reduction_buffer, init_val=init_val)
+    return cluster_reduce(
+        val, op, reduction_buffer, mbar_ptr, init_val=init_val, phase=phase
+    )
+
+
+@cute.jit
+def row_reduce(
+    x: cute.TensorSSA | cute.Numeric,
+    op: cute.ReductionOp,
+    threads_per_row: cutlass.Constexpr[int],
+    reduction_buffer: cute.Tensor | None = None,
+    mbar_ptr: cute.Pointer | None = None,
+    phase: cutlass.Int32 | None = None,
+    init_val: cute.Numeric = 0.0,
+    hook_fn: Callable | None = None,
+) -> cute.Numeric:
+    """reduction_buffer must have shape (num_warps / warps_per_row, (warps_per_row, cluster_n))."""
+    if cutlass.const_expr(isinstance(x, cute.TensorSSA)):
+        val = x.reduce(op, init_val=init_val, reduction_profile=0)
+    else:
+        val = x
+    warp_op = {
+        cute.ReductionOp.ADD: operator.add,
+        cute.ReductionOp.MAX: cute.arch.fmax
+        if cutlass.const_expr(x.dtype == Float32)
+        else max,
+        cute.ReductionOp.MIN: min,
+        cute.ReductionOp.MUL: operator.mul,
+    }[op]
+    val = warp_reduce(
+        val,
+        warp_op,
+        width=min(threads_per_row, cute.arch.WARP_SIZE),
+    )
+    if cutlass.const_expr(hook_fn is not None):
+        hook_fn()
+    if cutlass.const_expr(reduction_buffer is not None):
+        warps_per_row, cluster_n = reduction_buffer.shape[1]
+        assert cluster_n == 1 or mbar_ptr is not None, (
+            "mbar_ptr must be provided for cluster reduction"
+        )
+        if cutlass.const_expr(warps_per_row > 1 or cluster_n > 1):
+            val = block_or_cluster_reduce(
+                val,
+                warp_op,
+                reduction_buffer,
+                mbar_ptr,
+                phase=phase,
+                init_val=init_val,
+            )
+    return val
+
+
+@cute.jit
+def row_reduce_add(
+    x: cute.TensorSSA | cute.Numeric,
+    threads_per_row: cutlass.Constexpr[int],
+    reduction_buffer: cute.Tensor | None = None,
+    mbar_ptr: cute.Pointer | None = None,
+    phase: cutlass.Int32 | None = None,
+    init_val: cute.Numeric = 0.0,
+    hook_fn: Callable | None = None,
+) -> cute.Numeric:
+    """Specialized row_reduce for ADD reductions.
+
+    This mirrors row_reduce but hardcodes the ADD operation so we avoid
+    dynamic dispatch on the reduction op. It is used by bandwidth-bound
+    kernels like RMSNorm backward where the reduction is always ADD in
+    Float32.
+    """
+    if cutlass.const_expr(isinstance(x, cute.TensorSSA)):
+        val = x.reduce(cute.ReductionOp.ADD, init_val=init_val, reduction_profile=0)
+    else:
+        val = x
+    val = warp_reduce(
+        val,
+        operator.add,
+        width=min(threads_per_row, cute.arch.WARP_SIZE),
+    )
+    if cutlass.const_expr(hook_fn is not None):
+        hook_fn()
+    if cutlass.const_expr(reduction_buffer is not None):
+        warps_per_row, cluster_n = reduction_buffer.shape[1]
+        assert cluster_n == 1 or mbar_ptr is not None, (
+            "mbar_ptr must be provided for cluster reduction"
+        )
+        if cutlass.const_expr(warps_per_row > 1 or cluster_n > 1):
+            val = block_or_cluster_reduce(
+                val,
+                operator.add,
+                reduction_buffer,
+                mbar_ptr,
+                phase=phase,
+                init_val=init_val,
+            )
+    return val
+
+
+@cute.jit
+def online_softmax_reduce(
+    x: cute.TensorSSA,
+    threads_per_row: cutlass.Constexpr[int],
+    reduction_buffer: cute.Tensor | None = None,
+    mbar_ptr: cute.Pointer | None = None,
+    hook_fn: Callable | None = None,
+    phase: cutlass.Int32 | None = None,
+    return_exp_x: bool = False,
+) -> tuple[Float32, Float32, cute.TensorSSA | None]:
+    """Online softmax reduction over a row.
+
+    This mirrors quack.reduce.online_softmax_reduce and computes:
+      - max_x: row-wise maximum of x
+      - sum_exp_x: row-wise sum of exp(x - max_x)
+      - exp_x (optional): per-element exp(x - max_x_final) if return_exp_x is True
+    """
+    assert x.dtype == Float32, "x must be of type Float32"
+    # reduction_buffer must have shape (num_warps / warps_per_row, (warps_per_row, cluster_n), 2)
+    max_x = warp_reduce(
+        x.reduce(cute.ReductionOp.MAX, init_val=-Float32.inf, reduction_profile=0),
+        cute.arch.fmax,
+        width=min(threads_per_row, cute.arch.WARP_SIZE),
+    )
+    log2_e = math.log2(math.e)
+    exp_x = cute.math.exp2(x * log2_e - (max_x * log2_e), fastmath=True)
+    sum_exp_x = warp_reduce(
+        exp_x.reduce(cute.ReductionOp.ADD, init_val=0.0, reduction_profile=0),
+        operator.add,
+        width=min(threads_per_row, cute.arch.WARP_SIZE),
+    )
+    if cutlass.const_expr(hook_fn is not None):
+        hook_fn()
+    if cutlass.const_expr(reduction_buffer is not None):
+        rows_per_block, (warps_per_row, cluster_n) = reduction_buffer.shape
+        assert cluster_n == 1 or mbar_ptr is not None, (
+            "mbar_ptr must be provided for cluster reduction"
+        )
+        if cutlass.const_expr(warps_per_row > 1 or cluster_n > 1):
+            assert reduction_buffer.element_type == cutlass.Int64, (
+                "reduction_buffer must be of type Int64"
+            )
+            lane_idx, warp_idx = cute.arch.lane_idx(), cute.arch.warp_idx()
+            row_idx, col_idx = warp_idx // warps_per_row, warp_idx % warps_per_row
+            if cutlass.const_expr(mbar_ptr is None):
+                if lane_idx == 0:
+                    reduction_buffer[row_idx, col_idx] = f32x2_to_i64(max_x, sum_exp_x)
+                cute.arch.barrier()
+                max_x_single_warp = -Float32.inf
+                sum_exp_x = 0.0
+                if lane_idx < warps_per_row:
+                    max_x_single_warp, sum_exp_x = i64_to_f32x2(
+                        reduction_buffer[row_idx, lane_idx]
+                    )
+                max_x_final = warp_reduce(max_x_single_warp, cute.arch.fmax)
+                sum_exp_x *= cute.math.exp(
+                    max_x_single_warp - max_x_final, fastmath=True
+                )
+                sum_exp_x = warp_reduce(sum_exp_x, operator.add)
+                if cutlass.const_expr(return_exp_x):
+                    exp_x *= cute.math.exp(max_x - max_x_final, fastmath=True)
+                max_x = max_x_final
+            else:
+                cta_rank_in_cluster = cute.arch.block_idx_in_cluster()
+                if warp_idx == 0:
+                    with cute.arch.elect_one():
+                        num_warps = rows_per_block * warps_per_row
+                        cute.arch.mbarrier_arrive_and_expect_tx(
+                            mbar_ptr,
+                            num_warps
+                            * cluster_n
+                            * reduction_buffer.element_type.width
+                            // 8,
+                        )
+                if lane_idx < cluster_n:
+                    store_shared_remote(
+                        f32x2_to_i64(max_x, sum_exp_x),
+                        elem_pointer(
+                            reduction_buffer, (row_idx, (col_idx, cta_rank_in_cluster))
+                        ),
+                        mbar_ptr,
+                        peer_cta_rank_in_cluster=lane_idx,
+                    )
+                cute.arch.mbarrier_wait(
+                    mbar_ptr, phase=phase if phase is not None else 0
+                )
+                num_iter = cute.ceil_div(warps_per_row * cluster_n, cute.arch.WARP_SIZE)
+                max_x_single_warp = cute.make_fragment(num_iter, Float32)
+                max_x_single_warp.fill(-Float32.inf)
+                sum_exp_x_single_warp = cute.make_fragment(num_iter, Float32)
+                sum_exp_x_single_warp.fill(0.0)
+                for i in cutlass.range_constexpr(num_iter):
+                    idx = lane_idx + i * cute.arch.WARP_SIZE
+                    if idx < cute.size(reduction_buffer, mode=[1]):
+                        max_x_single_warp[i], sum_exp_x_single_warp[i] = i64_to_f32x2(
+                            reduction_buffer[row_idx, idx]
+                        )
+                max_x_final = max_x_single_warp.load().reduce(
+                    cute.ReductionOp.MAX,
+                    init_val=-Float32.inf,
+                    reduction_profile=0,
+                )
+                max_x_final = warp_reduce(max_x_final, cute.arch.fmax)
+                sum_exp_x = 0.0
+                for i in cutlass.range_constexpr(num_iter):
+                    sum_exp_x += sum_exp_x_single_warp[i] * cute.math.exp(
+                        max_x_single_warp[i] - max_x_final,
+                        fastmath=True,
+                    )
+                sum_exp_x = warp_reduce(sum_exp_x, operator.add)
+                if cutlass.const_expr(return_exp_x):
+                    exp_x *= cute.math.exp(max_x - max_x_final, fastmath=True)
+                max_x = max_x_final
+    return max_x, sum_exp_x, (exp_x if cutlass.const_expr(return_exp_x) else None)
+
+
+# -------------------------
+# Copy helpers (minimal subset of quack.copy_utils)
+# -------------------------
+
+
+@dsl_user_op
+def get_copy_atom(
+    dtype: Type[cutlass.Numeric],
+    num_copy_elems: int,
+    is_async: bool = False,
+    *,
+    loc=None,
+    ip=None,
+) -> cute.CopyAtom:
+    from cutlass.cute.nvgpu import cpasync
+
+    # cp.async is limited to 128b per op; synchronous vectorized copies can go wider.
+    max_bits = const_expr(128 if is_async else 256)
+    num_copy_bits = const_expr(min(max_bits, num_copy_elems * dtype.width))
+    # Match Quack's default cp.async cache policy (leave cache_mode unspecified).
+    copy_op = cpasync.CopyG2SOp() if is_async else cute.nvgpu.CopyUniversalOp()
+    return cute.make_copy_atom(
+        copy_op, dtype, num_bits_per_copy=num_copy_bits, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def copy(
+    src: cute.Tensor,
+    dst: cute.Tensor,
+    *,
+    pred: cute.Tensor | None = None,
+    num_copy_elems: int = 1,
+    is_async: bool = False,
+    loc=None,
+    ip=None,
+    **kwargs,
+) -> None:
+    copy_atom = get_copy_atom(
+        src.element_type, num_copy_elems, is_async, loc=loc, ip=ip
+    )
+    cute.copy(copy_atom, src, dst, pred=pred, loc=loc, ip=ip, **kwargs)
+
+
+# -------------------------
+# Reduction base (from quack.reduction_base)
+# -------------------------
+
+
+class ReductionBase:
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        N: int,
+        stage: int,
+        reduction_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+    ):
+        self.dtype = dtype
+        self.N = N
+        self.stage = stage
+        self.reduction_dtype = reduction_dtype
+
+    def _calculate_threads_per_row(self) -> int:
+        raise NotImplementedError()
+
+    def _set_cluster_n(self) -> None:
+        self.cluster_n = 1
+
+    def _get_num_threads(self) -> int:
+        return 128 if self.N <= 16384 else 256
+
+    def _get_tv_layout(
+        self, num_copy_bits: int = 128
+    ) -> tuple[cute.Shape, cute.Layout]:
+        """Return (tiler_mn, tv_layout) for SM100 reduction kernels.
+
+        This intentionally mirrors Quack's `ReductionBase._get_tiled_copy(...)`:
+        - `tiler_mn` spans the full N range for the CTA, including any "K-loop"
+          repeats (`num_blocks_N`).
+        - `tv_layout` is the *tiled* thread/value layout used by CuTe's copy
+          partitioning (does **not** bake in `num_blocks_N`), matching
+          `quack.copy_utils.tiled_copy_2d(...).layout_tv_tiled`.
+        """
+        if num_copy_bits > 128:
+            raise ValueError(
+                f"num_copy_bits={num_copy_bits} exceeds 128b; Quack-style SM100 reduction "
+                "tiling assumes <=128b vectorization (cp.async and common CopyAtoms)."
+            )
+        vecsize = num_copy_bits // self.dtype.width
+        assert self.N % vecsize == 0, (
+            f"Input N {self.N} is not divisible by vector size {vecsize}"
+        )
+        num_threads = self._get_num_threads()
+        assert num_threads % cute.arch.WARP_SIZE == 0
+
+        threads_per_row = self._calculate_threads_per_row()
+        self._set_cluster_n()
+        num_blocks_N = cute.ceil_div(
+            self.N // vecsize, threads_per_row * self.cluster_n
+        )
+        cols_per_block = num_threads // threads_per_row
+        tiler_mn = (cols_per_block, vecsize * num_blocks_N * threads_per_row)
+
+        # Construct the same tv layout that Quack gets from `tiled_copy_2d(...).layout_tv_tiled`.
+        copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dtype,
+            num_bits_per_copy=num_copy_bits,
+        )
+        thr_layout = cute.make_ordered_layout(
+            (cols_per_block, threads_per_row),
+            order=(1, 0),
+        )
+        val_layout = cute.make_layout((1, vecsize))
+        tv_layout = cute.make_tiled_copy_tv(
+            copy_atom, thr_layout, val_layout
+        ).layout_tv_tiled
+        return tiler_mn, tv_layout
+
+    def _smem_size_in_bytes(self, tiler_mn, num_warps: int) -> int:
+        # Mirror the allocation order used by the SM100 reduction kernels:
+        #   1) sX (byte_alignment=16)
+        #   2) reduction_buffer (byte_alignment=8)
+        #   3) mbar_ptr (Int64, 8B)
+        #
+        # CuTeDSL's SmemAllocator may insert padding between allocations to satisfy
+        # alignment. Be conservative and round up offsets accordingly so we never
+        # under-allocate dynamic shared memory.
+
+        def _align_up(x: int, align: int) -> int:
+            return ((x + align - 1) // align) * align
+
+        sx_bytes = int(cute.size_in_bytes(self.dtype, cute.make_layout(tiler_mn)))
+        reduction_bytes = int(
+            self.stage * num_warps * self.cluster_n * (self.reduction_dtype.width // 8)
+        )
+        mbar_bytes = int(self.stage * (cutlass.Int64.width // 8))
+
+        offset = _align_up(sx_bytes, 16)
+        offset = _align_up(offset, 8) + reduction_bytes
+        offset = _align_up(offset, 8) + mbar_bytes
+        return int(offset)
+
+    def _get_reduction_buffer_layout(
+        self, tv_layout: cute.Layout, cluster_n: int
+    ) -> cute.Layout:
+        num_warps = cute.size(tv_layout, mode=[0]) // cute.arch.WARP_SIZE
+        warps_per_row = (
+            num_warps
+            if cutlass.const_expr(cute.rank(tv_layout.shape[0]) == 1)
+            else max(tv_layout.shape[0][0] // cute.arch.WARP_SIZE, 1)
+        )
+        return cute.make_ordered_layout(
+            (num_warps // warps_per_row, (warps_per_row, cluster_n), self.stage),
+            order=(1, 0, 2),
+        )
+
+    def _allocate_reduction_buffer_and_mbar(
+        self,
+        smem: cutlass.utils.SmemAllocator,
+        tv_layout: cute.Layout,
+        is_persistent: bool = False,
+    ) -> tuple[cute.Tensor, cute.Pointer | None]:
+        reduction_buffer = smem.allocate_tensor(
+            self.reduction_dtype,
+            self._get_reduction_buffer_layout(tv_layout, self.cluster_n),
+            byte_alignment=8,
+        )
+        if cutlass.const_expr(self.cluster_n > 1):
+            mbar_ptr = smem.allocate_array(
+                cutlass.Int64,
+                num_elems=self.stage if not is_persistent else self.stage * 2,
+            )
+        else:
+            mbar_ptr = None
+        return reduction_buffer, mbar_ptr
+
+    @cute.jit
+    def _initialize_cluster(
+        self,
+        tidx: cutlass.Int32,
+        mbar_ptr: cute.Pointer | None,
+        num_warps: int,
+        is_persistent: bool = False,
+    ) -> None:
+        if cutlass.const_expr(self.cluster_n > 1 and mbar_ptr is not None):
+            if tidx < self.stage:
+                cute.arch.mbarrier_init(mbar_ptr + tidx, 1)
+                if cutlass.const_expr(is_persistent):
+                    cute.arch.mbarrier_init(
+                        mbar_ptr + self.stage + tidx,
+                        num_warps * self.cluster_n,
+                    )
+            cute.arch.mbarrier_init_fence()
+            cute.arch.cluster_arrive_relaxed()
+
+
+# -------------------------
+# RMSNorm backward base (from quack.rmsnorm.RMSNormBackward)
+# -------------------------
+
+
+class RMSNormBackward(ReductionBase):
+    def __init__(self, dtype: cutlass.Numeric, N: int):
+        # 2 stages for double buffering when computing mean of x_hat * wdy
+        super().__init__(dtype, N, stage=2, reduction_dtype=Float32)
+        self.reload_wdy = None if N <= 16 * 1024 else "smem"
+        # Optional optimization: atomically accumulate mdW into a single (N,)
+        # buffer instead of writing an (sm_count, N) partial buffer + torch.sum.
+        self.atomic_dw = False
+        if self.N > 128 * 1024 and self.dtype.width >= 32:
+            raise ValueError(
+                "RMSNormBackward does not support N > 128k with dtype >= 32 bits"
+            )
+
+    def _get_num_threads(self) -> int:
+        return 128 if self.N <= 4096 else 256
+
+    def _calculate_threads_per_row(self) -> int:
+        N = self.N
+        return (
+            8
+            if N <= 64
+            else (
+                16
+                if N <= 128
+                else (
+                    32
+                    if N <= 256
+                    else (64 if N <= 512 else (128 if N <= 4096 else 256))
+                )
+            )
+        )
+
+    def _set_cluster_n(self) -> None:
+        N = self.N
+        cluster_n = (
+            1
+            if N <= 8 * 1024
+            else (
+                2
+                if N <= 16 * 1024
+                else (4 if N <= 32 * 1024 else (8 if N <= 64 * 1024 else 16))
+            )
+        )
+        self.cluster_n = cluster_n
+
+    def _smem_size_in_bytes(self, tiler_mn, num_warps: int, do_dtype=None) -> int:
+        if do_dtype is None:
+            do_dtype = self.dtype
+        return (
+            cute.size_in_bytes(self.dtype, cute.make_layout(tiler_mn)) * 2
+            + cute.size_in_bytes(do_dtype, cute.make_layout(tiler_mn)) * 2
+            + self.stage
+            * num_warps
+            * self.cluster_n
+            * (self.reduction_dtype.width // 8)
+            + self.stage * (cutlass.Int64.width // 8) * 2
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        mX: cute.Tensor,
+        mW: cute.Tensor | None,
+        mdO: cute.Tensor,
+        mdResO: cute.Tensor | None,
+        mRstd: cute.Tensor,
+        mdX: cute.Tensor,
+        mdW: cute.Tensor | None,
+        mdRes: cute.Tensor | None,
+        mdB: cute.Tensor | None,
+        sm_count: Int32,
+        stream: cuda.CUstream,
+    ):
+        semistatic_shape = (*mX.shape[:-1], self.N)
+
+        def new_stride(t):
+            return (
+                cute.assume(t.stride[0], divby=128 // t.element_type.width),
+                t.stride[1],
+            )
+
+        mX, mdO, mdResO, mdX, mdRes = [
+            cute.make_tensor(
+                t.iterator, cute.make_layout(semistatic_shape, stride=new_stride(t))
+            )
+            if const_expr(t is not None)
+            else None
+            for t in (mX, mdO, mdResO, mdX, mdRes)
+        ]
+        self._set_cluster_n()
+        largest_dtype_width = const_expr(
+            max(
+                mX.element_type.width,
+                mW.element_type.width if mW is not None else 0,
+                mdO.element_type.width,
+                mdX.element_type.width,
+                mdResO.element_type.width if mdResO is not None else 0,
+                mdRes.element_type.width if mdRes is not None else 0,
+            )
+        )
+        # Quack-style policy: cap the *largest* dtype to 128b, then scale the
+        # activation copy width down proportionally (e.g. fp16 + fp32-weight
+        # => 64b activation vectors so the fp32 path stays at 128b).
+        num_copy_bits = const_expr(128 // largest_dtype_width * mX.element_type.width)
+        tiler_mn, tv_layout = self._get_tv_layout(num_copy_bits=int(num_copy_bits))
+        num_threads = (
+            cute.size(tv_layout, mode=[0])
+            if _KERNEL_ACCEPTS_LAYOUT_ARGS
+            else self._get_num_threads()
+        )
+        num_warps = num_threads // cute.arch.WARP_SIZE
+        if const_expr(mW is not None):
+            mW_expanded_layout = cute.prepend(
+                mW.layout,
+                cute.make_layout((tiler_mn[0],), stride=(0,)),
+            )
+            mW = cute.make_tensor(mW.iterator, mW_expanded_layout)
+
+        # NOTE: `sm_count` is the launch grid x-dimension. When `cluster_n > 1`,
+        # this is effectively a "cluster count" heuristic (total CTAs =
+        # sm_count * cluster_n), matching Quack's naming/launch shape.
+        num_blocks = sm_count
+        kernel = (
+            self.kernel(
+                mX, mW, mdO, mdResO, mRstd, mdX, mdW, mdB, mdRes, tv_layout, tiler_mn
+            )
+            if _KERNEL_ACCEPTS_LAYOUT_ARGS
+            else self.kernel(mX, mW, mdO, mdResO, mRstd, mdX, mdW, mdB, mdRes)
+        )
+        kernel.launch(
+            grid=[num_blocks, self.cluster_n, 1],
+            block=[num_threads, 1, 1],
+            cluster=[1, self.cluster_n, 1] if self.cluster_n > 1 else None,
+            smem=self._smem_size_in_bytes(
+                tiler_mn, num_warps, do_dtype=mdO.element_type
+            ),
+            stream=stream,
+        )
+
+    @cute.jit
+    def _kernel_impl(
+        self,
+        mX: cute.Tensor,
+        mW: cute.Tensor | None,
+        mdO: cute.Tensor,
+        mdResO: cute.Tensor | None,
+        mRstd: cute.Tensor,
+        mdX: cute.Tensor,
+        mdW: cute.Tensor | None,
+        mdB: cute.Tensor | None,
+        mdRes: cute.Tensor | None,
+        tv_layout: cute.Layout,
+        tiler_mn: cute.Shape,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx_start, _, _ = cute.arch.block_idx()
+        gdim, _, _ = cute.arch.grid_dim()
+        if const_expr(self.cluster_n > 1):
+            cluster_y = cute.arch.block_idx()[1]
+        else:
+            cluster_y = const_expr(0)
+
+        shape = mX.shape
+        M = shape[0]
+        is_even_N = const_expr(shape[1] == tiler_mn[1] * self.cluster_n)
+
+        idX = cute.make_identity_tensor(shape)
+
+        smem = cutlass.utils.SmemAllocator()
+        smem_layout = cute.make_ordered_layout(
+            (tiler_mn[0], tiler_mn[1], 2), order=(1, 0, 2)
+        )
+        sX = smem.allocate_tensor(mX.element_type, smem_layout, byte_alignment=16)
+        sdO = smem.allocate_tensor(mdO.element_type, smem_layout, byte_alignment=16)
+        reduction_buffer, mbar_ptr = self._allocate_reduction_buffer_and_mbar(
+            smem,
+            tv_layout,
+            is_persistent=True,
+        )
+        if const_expr(mbar_ptr is not None):
+            mbar_full_ptr, mbar_empty_ptr = mbar_ptr, mbar_ptr + 2
+        else:
+            mbar_full_ptr, mbar_empty_ptr = None, None
+
+        num_copy_elems_X = (
+            tv_layout.shape[1]
+            if cutlass.const_expr(cute.rank(tv_layout.shape[1]) == 1)
+            else tv_layout.shape[1][0]
+        )
+        threads_per_row = (
+            tv_layout.shape[0]
+            if cutlass.const_expr(cute.rank(tv_layout.shape[0]) == 1)
+            else tv_layout.shape[0][0]
+        )
+        copy_atom_load_X = get_copy_atom(
+            mX.element_type, num_copy_elems_X, is_async=False
+        )
+        thr_layout = cute.make_ordered_layout(
+            (tiler_mn[0], threads_per_row), order=(1, 0)
+        )
+        val_layout = cute.make_layout((1, num_copy_elems_X))
+        thr_copy_X = cute.make_tiled_copy_tv(
+            copy_atom_load_X, thr_layout, val_layout
+        ).get_slice(tidx)
+        copy_fn = partial(copy, num_copy_elems=num_copy_elems_X)
+
+        gX, gdO, gdResO, gdX, gdRes, cX = [
+            cute.local_tile(mT, tiler_mn, (None, cluster_y)) if mT is not None else None
+            for mT in (mX, mdO, mdResO, mdX, mdRes, idX)
+        ]
+        gW = cute.local_tile(mW, tiler_mn, (0, cluster_y)) if mW is not None else None
+        gdW, gdB = [
+            cute.local_tile(mT, (1, tiler_mn[1]), (bidx_start, cluster_y))
+            if const_expr(mT is not None)
+            else None
+            for mT in (mdW, mdB)
+        ]
+
+        tXgX = thr_copy_X.partition_S(gX)
+        tXsX = thr_copy_X.partition_D(sX)
+        tXgdO = thr_copy_X.partition_S(gdO)
+        tXsdO = thr_copy_X.partition_D(sdO)
+        tXgdX = thr_copy_X.partition_D(gdX)
+        if const_expr(mdResO is not None):
+            tXgdResO = thr_copy_X.partition_S(gdResO)
+        if const_expr(mdRes is not None):
+            tXgdRes = thr_copy_X.partition_D(gdRes)
+        tXcX = thr_copy_X.partition_S(cX)[(0, None), None, None, None]
+
+        tXrX, tXrdO, tXrdX = [
+            cute.make_fragment_like(thr[None, None, None, 0])
+            for thr in (tXgX, tXgdO, tXgdX)
+        ]
+        tXrdResO = None
+        if const_expr(mdResO is not None):
+            tXrdResO = cute.make_fragment_like(tXgdResO[None, None, None, 0])
+        tXrdRes = None
+        if const_expr(mdRes is not None):
+            tXrdRes = cute.make_fragment_like(tXgdRes[None, None, None, 0])
+
+        tXpX = (
+            predicate_k(thr_copy_X.partition_S(cX[None, None, 0]), limit=shape[1])
+            if not is_even_N
+            else None
+        )
+
+        tXgdW, tXrdW = None, None
+        tXgdB, tXrdB = None, None
+        if const_expr(mdW is not None):
+            tXgdW = thr_copy_X.partition_S(gdW)
+            tXrdW = cute.make_fragment_like(tXgdW, Float32)
+        if const_expr(mdB is not None):
+            tXgdB = thr_copy_X.partition_S(gdB)
+            tXrdB = cute.make_fragment_like(tXgdB, Float32)
+
+        num_warps = cute.size(tv_layout, mode=[0]) // cute.arch.WARP_SIZE
+
+        self._initialize_cluster(tidx, mbar_ptr, num_warps, is_persistent=True)
+
+        tXrW = None
+        if const_expr(mW is not None):
+            tXgW = thr_copy_X.partition_S(gW)
+            tXrW = cute.make_fragment_like(tXgW)
+            if not is_even_N:
+                tXrW.fill(0.0)
+            copy_fn(tXgW, tXrW, pred=tXpX)
+
+        row = tXcX[None, None, None, bidx_start][0][0]
+        if row < M:
+            tXgX_cur = coord_offset_i64(bidx_start, tXgX, dim=3)[None, None, None, 0]
+            tXgdO_cur = coord_offset_i64(bidx_start, tXgdO, dim=3)[None, None, None, 0]
+            copy_fn(tXgX_cur, tXsX[None, None, None, 0], pred=tXpX, is_async=True)
+            copy_fn(tXgdO_cur, tXsdO[None, None, None, 0], pred=tXpX, is_async=True)
+        elif tiler_mn[0] > 1:
+            fill_oob(tXsX[None, None, None, 0], None, fill_value=mX.element_type.zero)
+            fill_oob(tXsdO[None, None, None, 0], None, fill_value=mdO.element_type.zero)
+        cute.arch.cp_async_commit_group()
+
+        if const_expr(self.cluster_n > 1):
+            cute.arch.cluster_wait()
+
+        if const_expr(mdW is not None):
+            tXrdW.fill(0.0)
+        if const_expr(mdB is not None):
+            tXrdB.fill(0.0)
+        stage = Int32(0)
+        producer_phase = Int32(1)
+        consumer_phase = Int32(0)
+        for bidx in cutlass.range(bidx_start, cute.ceil_div(M, tiler_mn[0]), gdim):
+            row = tXcX[None, None, None, bidx][0][0]
+            if row + gdim * tiler_mn[0] < M:
+                tXgX_cur = coord_offset_i64(bidx + gdim, tXgX, dim=3)[
+                    None, None, None, 0
+                ]
+                tXgdO_cur = coord_offset_i64(bidx + gdim, tXgdO, dim=3)[
+                    None, None, None, 0
+                ]
+                copy_fn(
+                    tXgX_cur,
+                    tXsX[None, None, None, stage ^ 1],
+                    pred=tXpX,
+                    is_async=True,
+                )
+                copy_fn(
+                    tXgdO_cur,
+                    tXsdO[None, None, None, stage ^ 1],
+                    pred=tXpX,
+                    is_async=True,
+                )
+            elif tiler_mn[0] > 1:
+                fill_oob(
+                    tXsX[None, None, None, stage ^ 1],
+                    None,
+                    fill_value=mX.element_type.zero,
+                )
+                fill_oob(
+                    tXsdO[None, None, None, stage ^ 1],
+                    None,
+                    fill_value=mdO.element_type.zero,
+                )
+            cute.arch.cp_async_commit_group()
+            rstd_val = cutlass.Float.zero
+            if row < M or tiler_mn[0] == 1:
+                rstd_val = mRstd[row]
+            if const_expr(mdResO is not None):
+                tXgdResO_cur = coord_offset_i64(bidx, tXgdResO, dim=3)[
+                    None, None, None, 0
+                ]
+                if row < M or tiler_mn[0] == 1:
+                    copy_fn(tXgdResO_cur, tXrdResO, pred=tXpX)
+                elif tiler_mn[0] > 1:
+                    tXrdResO.fill(0.0)
+            cute.arch.cp_async_wait_group(1)
+            cute.autovec_copy(tXsX[None, None, None, stage], tXrX)
+            x = tXrX.load().to(cute.Float32)
+            cute.autovec_copy(tXsdO[None, None, None, stage], tXrdO)
+            dout = tXrdO.load().to(cute.Float32)
+            x_hat = x * rstd_val
+            wdy = dout
+            if const_expr(mW is not None):
+                wdy *= tXrW.load().to(Float32)
+            if const_expr(self.cluster_n > 1):
+                cute.arch.mbarrier_wait(mbar_empty_ptr + stage, producer_phase)
+            mean_xhat_wdy = (
+                row_reduce_add(
+                    x_hat * wdy,
+                    threads_per_row,
+                    reduction_buffer[None, None, stage],
+                    (mbar_full_ptr + stage if const_expr(self.cluster_n > 1) else None),
+                    phase=consumer_phase,
+                    init_val=0.0,
+                )
+                / shape[1]
+            )
+
+            if const_expr(self.cluster_n > 1):
+                cute.arch.fence_proxy(
+                    cute.arch.ProxyKind.async_shared,
+                    space=cute.arch.SharedSpace.shared_cta,
+                )
+                cute.arch.sync_warp()
+                lane_idx = cute.arch.lane_idx()
+                if lane_idx < self.cluster_n:
+                    cute.arch.mbarrier_arrive(
+                        mbar_empty_ptr + stage,
+                        peer_cta_rank_in_cluster=lane_idx,
+                    )
+
+            if const_expr(self.reload_wdy == "smem"):
+                cute.autovec_copy(tXsdO[None, None, None, stage], tXrdO)
+                dout = tXrdO.load().to(cute.Float32)
+                wdy = dout
+                if const_expr(mW is not None):
+                    wdy *= tXrW.load().to(Float32)
+
+            dx = (wdy - x_hat * mean_xhat_wdy) * rstd_val
+            if const_expr(mdResO is not None):
+                dx += tXrdResO.load().to(cute.Float32)
+            tXrdX.store(dx.to(tXrdX.element_type))
+            if row < M or tiler_mn[0] == 1:
+                tXgdX_cur = coord_offset_i64(bidx, tXgdX, dim=3)[None, None, None, 0]
+                copy_fn(tXrdX, tXgdX_cur, pred=tXpX)
+            if const_expr(mdRes is not None):
+                tXrdRes.store(dx.to(tXrdRes.element_type))
+                tXgdRes_cur = coord_offset_i64(bidx, tXgdRes, dim=3)[
+                    None, None, None, 0
+                ]
+                if row < M or tiler_mn[0] == 1:
+                    copy_fn(tXrdRes, tXgdRes_cur, pred=tXpX)
+            if const_expr(mdW is not None):
+                tXrdW.store(tXrdW.load() + dout * x_hat)
+            if const_expr(mdB is not None):
+                tXrdB.store(tXrdB.load() + dout)
+
+            stage ^= 1
+            if stage == 0:
+                consumer_phase ^= 1
+                producer_phase ^= 1
+
+        if const_expr(tiler_mn[0] > 1):
+            if const_expr(mdW is not None):
+                sdW = cute.make_tensor(
+                    cute.recast_ptr(sX.iterator, dtype=cute.Float32),
+                    cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+                )
+                tXsdW = thr_copy_X.partition_D(sdW)
+                cute.arch.barrier()
+                row0 = tXcX[None, None, None, 0][0][0]
+                if row0 > 0:
+                    cute.autovec_copy(tXrdW, tXsdW)
+                cute.arch.barrier()
+                if row0 == 0:
+                    for i in cutlass.range_constexpr(1, const_expr(tiler_mn[0])):
+                        tXrdW_other = cute.make_fragment_like(tXrdW)
+                        tXsdW_other = cute.make_tensor(
+                            tXsdW.iterator + i * sdW.stride[0],
+                            tXsdW.layout,
+                        )
+                        cute.autovec_copy(tXsdW_other, tXrdW_other)
+                        tXrdW.store(tXrdW.load() + tXrdW_other.load())
+                    if const_expr(self.atomic_dw):
+                        atomic_add_tensor_f32(tXrdW, tXgdW, pred=tXpX)
+                    else:
+                        copy_fn(tXrdW, tXgdW, pred=tXpX)
+                cute.arch.barrier()
+            if const_expr(mdB is not None):
+                sdB = cute.make_tensor(
+                    cute.recast_ptr(sX.iterator, dtype=cute.Float32),
+                    cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+                )
+                tXsdB = thr_copy_X.partition_D(sdB)
+                cute.arch.barrier()
+                row0 = tXcX[None, None, None, 0][0][0]
+                if row0 > 0:
+                    cute.autovec_copy(tXrdB, tXsdB)
+                cute.arch.barrier()
+                if row0 == 0:
+                    for i in cutlass.range_constexpr(1, const_expr(tiler_mn[0])):
+                        tXrdB_other = cute.make_fragment_like(tXrdB)
+                        tXsdB_other = cute.make_tensor(
+                            tXsdB.iterator + i * sdB.stride[0],
+                            tXsdB.layout,
+                        )
+                        cute.autovec_copy(tXsdB_other, tXrdB_other)
+                        tXrdB.store(tXrdB.load() + tXrdB_other.load())
+                    copy_fn(tXrdB, tXgdB, pred=tXpX)
+        else:
+            if const_expr(mdW is not None):
+                if const_expr(self.atomic_dw):
+                    atomic_add_tensor_f32(tXrdW, tXgdW, pred=tXpX)
+                else:
+                    copy_fn(tXrdW, tXgdW, pred=tXpX)
+            if const_expr(mdB is not None):
+                copy_fn(tXrdB, tXgdB, pred=tXpX)
+
+        if const_expr(self.cluster_n > 1):
+            stage ^= 1
+            if stage == 0:
+                producer_phase ^= 1
+            cute.arch.mbarrier_wait(mbar_empty_ptr + stage, producer_phase)
+
+    if _KERNEL_ACCEPTS_LAYOUT_ARGS:
+
+        @cute.kernel
+        def kernel(
+            self,
+            mX: cute.Tensor,
+            mW: cute.Tensor | None,
+            mdO: cute.Tensor,
+            mdResO: cute.Tensor | None,
+            mRstd: cute.Tensor,
+            mdX: cute.Tensor,
+            mdW: cute.Tensor | None,
+            mdB: cute.Tensor | None,
+            mdRes: cute.Tensor | None,
+            tv_layout: cute.Layout,
+            tiler_mn: cute.Shape,
+        ):
+            self._kernel_impl(
+                mX,
+                mW,
+                mdO,
+                mdResO,
+                mRstd,
+                mdX,
+                mdW,
+                mdB,
+                mdRes,
+                tv_layout,
+                tiler_mn,
+            )
+    else:
+
+        @cute.kernel
+        def kernel(
+            self,
+            mX: cute.Tensor,
+            mW: cute.Tensor | None,
+            mdO: cute.Tensor,
+            mdResO: cute.Tensor | None,
+            mRstd: cute.Tensor,
+            mdX: cute.Tensor,
+            mdW: cute.Tensor | None,
+            mdB: cute.Tensor | None,
+            mdRes: cute.Tensor | None,
+        ):
+            largest_dtype_width = const_expr(
+                max(
+                    mX.element_type.width,
+                    mdO.element_type.width,
+                    mdX.element_type.width,
+                    mdResO.element_type.width if mdResO is not None else 0,
+                    mdRes.element_type.width if mdRes is not None else 0,
+                )
+            )
+            tiler_mn, tv_layout = self._get_tv_layout(
+                num_copy_bits=128 // largest_dtype_width * mX.element_type.width
+            )
+            self._kernel_impl(
+                mX,
+                mW,
+                mdO,
+                mdResO,
+                mRstd,
+                mdX,
+                mdW,
+                mdB,
+                mdRes,
+                tv_layout,
+                tiler_mn,
+            )
+
+
+# -------------------------
+# SM count helper (from quack.rmsnorm._get_sm_count)
+# -------------------------
+
+
+def get_sm_count(
+    N: int,
+    device: torch.device,
+    M: int | None = None,
+    dtype: torch.dtype | None = None,
+) -> int:
+    """
+    SM count heuristic for reduction-style kernels.
+
+    This starts from Quack's _get_sm_count policy and layers on SM100 /
+    DSv3-specific tuning so that:
+      - For DSv3-style shapes (large-M, N in {6144, 8192}, fp16/bf16),
+        sm_count is reduced for very large M to cut down the number of
+        dw_partial/db_partial rows that ever hit HBM.
+      - For Quack-suite hidden=4096, small-M shapes, sm_count is modestly
+        increased to improve SM occupancy, matching the existing SM100
+        tuning used by both RMSNorm and LayerNorm.
+    """
+    num_sms = get_num_sms(device)
+
+    sm_count_multiple = (
+        16
+        if N <= 256
+        else (8 if N <= 1024 else (4 if N <= 2048 else (2 if N <= 4096 else 1)))
+    )
+    sm_count = num_sms
+    if N <= 8192:
+        sm_count = sm_count * sm_count_multiple
+    elif N <= 16384:
+        sm_count = sm_count // 2
+    else:
+        sm_count = sm_count * 2
+
+    # Quack-suite tuning: for small-M, hidden=4096 shapes (M<=8192) and
+    # 16-bit dtypes, increase sm_count to improve occupancy. This mirrors
+    # the existing SM100 RMSNorm/LayerNorm heuristics.
+    if (
+        dtype in (torch.float16, torch.bfloat16)
+        and M is not None
+        and M <= 8192
+        and N == 4096
+    ):
+        sm_count = min(sm_count * 2, num_sms * 4)
+
+    return sm_count

--- a/torch/_vendor/oink/rmsnorm.py
+++ b/torch/_vendor/oink/rmsnorm.py
@@ -1,0 +1,45 @@
+"""Compact public facade for the Blackwell RMSNorm implementation.
+
+The heavy kernel implementation lives in `._rmsnorm_impl` so this module stays
+small and easy to navigate while preserving the historical public import path:
+
+    from . import rmsnorm
+"""
+
+from __future__ import annotations
+
+from . import _rmsnorm_impl as _impl
+
+__doc__ = _impl.__doc__
+
+get_copy_atom_bw = _impl.get_copy_atom_bw
+copy_tiled = _impl.copy_tiled
+RMSNormSM100 = _impl.RMSNormSM100
+rmsnorm_forward = _impl.rmsnorm_forward
+rmsnorm_ref = _impl.rmsnorm_ref
+fused_add_rmsnorm_forward = _impl.fused_add_rmsnorm_forward
+fused_add_rmsnorm_forward_inplace = _impl.fused_add_rmsnorm_forward_inplace
+fused_add_rmsnorm_inplace_ = _impl.fused_add_rmsnorm_inplace_
+RMSNormBackwardSM100 = _impl.RMSNormBackwardSM100
+rmsnorm_backward = _impl.rmsnorm_backward
+
+__all__ = [
+    "get_copy_atom_bw",
+    "copy_tiled",
+    "RMSNormSM100",
+    "rmsnorm_forward",
+    "rmsnorm_ref",
+    "fused_add_rmsnorm_forward",
+    "fused_add_rmsnorm_forward_inplace",
+    "fused_add_rmsnorm_inplace_",
+    "RMSNormBackwardSM100",
+    "rmsnorm_backward",
+]
+
+
+def __getattr__(name: str):
+    return getattr(_impl, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(dir(_impl)))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #183941
* __->__ #183940

Summary:

Vendor a subset of the kernelagent-oink library
(https://github.com/meta-pytorch/KernelAgent) under torch._vendor.oink.

Only the modules needed by the upcoming cuteDSL RMSNorm override are
vendored (rmsnorm.py) -- softmax/cross-entropy/layernorm and other
unrelated paths are excluded for now. Imports within the vendored tree
are rewritten to be relative, so this copy is fully independent of any
kernelagent_oink package installed via pip.

Note: Pyrefly disabled for this new directory

Added tooling to generate the vendored subset:

    tools/vendoring/oink/vendor.sh <sha>                    # clones upstream
    tools/vendoring/oink/vendor.sh <sha> <local-checkout>   # reuses a clone

This pulls upstream at the provided hash, strips out the necessary
files, and applies the included patchset. This should a) make updating
the vendored files easier in the future and b) be extendible later on if
we want to add more functionality - add to the list of files to be
brought in, and create a new patch-set for those files. Also makes sure
upstream LICENSE file is copied & copyright/attribution between
upstream & vendored is bitwise identical.

Upstream SHA: 54b1331d2f5fc7e615c39e3057b836ecc5e2c10a (kernelagent-oink 0.1.0)