### PR TITLE
[Native DSL] Oink-based cuteDSL RMSNorm

### DIFF
--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -417,6 +417,7 @@ class TestPublicBindings(TestCase):
             # available in CPU-only CI. Registrations are no-ops when the
             # runtime is missing, so it's safe to skip them here.
             cuda_dep_prefixes = (
+                "torch._native.ops.norm.",
                 "torch._native.ops.scatter_add.",
                 "torch._vendor.quack",
                 "torch._vendor.oink",

--- a/torch/_native/ops/__init__.py
+++ b/torch/_native/ops/__init__.py
@@ -1,1 +1,1 @@
-from . import bmm_outer_product, scatter_add
+from . import bmm_outer_product, norm, scatter_add

--- a/torch/_native/ops/norm/__init__.py
+++ b/torch/_native/ops/norm/__init__.py
@@ -1,0 +1,4 @@
+from .oink_rmsnorm_impl import register_rmsnorm_overrides
+
+
+register_rmsnorm_overrides()

--- a/torch/_native/ops/norm/oink_norms.py
+++ b/torch/_native/ops/norm/oink_norms.py
@@ -1,0 +1,100 @@
+"""Adaptor for oink's 2-D RMSNorm kernel interface to match ATen op signatures.
+
+These functions handle tensor reshaping, memory allocation, and call oink's
+compiled kernels through the public ``rmsnorm_forward`` / ``rmsnorm_backward``
+entry points.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+def _reshape_2d(t: torch.Tensor, M: int, N: int) -> torch.Tensor:
+    if t.ndim == 2 and t.shape[0] == M and t.shape[1] == N and t.is_contiguous():
+        return t
+    return t.reshape(M, N).contiguous()
+
+
+def _flatten_rstd(t: torch.Tensor, M: int) -> torch.Tensor:
+    if t.ndim == 1 and t.shape[0] == M:
+        return t
+    if t.is_contiguous() and t.numel() == M:
+        return t.detach().view(M)
+    return t.reshape(M).contiguous()
+
+
+def oink_rmsnorm_fwd(
+    input: torch.Tensor,
+    weight: torch.Tensor | None,
+    normalized_shape: list[int],
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # oink imports cutlass at module load; keep lazy so this file stays
+    # importable on builds without the cuteDSL deps installed.
+    from torch._vendor.oink.rmsnorm import rmsnorm_forward
+
+    input_shape = input.shape
+    N = math.prod(normalized_shape)
+    M = input.numel() // N
+
+    x = _reshape_2d(input, M, N)
+
+    if weight is not None and weight.ndim != 1:
+        weight = weight.reshape(N).contiguous()
+
+    y, rstd, _ = rmsnorm_forward(
+        x,
+        weight=weight,
+        bias=None,
+        residual=None,
+        eps=eps,
+        store_rstd=True,
+    )
+
+    y = y.reshape(input_shape)
+    stat_shape = list(input_shape[: -len(normalized_shape)]) + [1] * len(
+        normalized_shape
+    )
+    rstd = rstd.view(stat_shape)
+    return y, rstd
+
+
+def oink_rmsnorm_bwd(
+    grad_out: torch.Tensor,
+    input: torch.Tensor,
+    rstd: torch.Tensor,
+    weight: torch.Tensor | None,
+    normalized_shape: list[int],
+    dw_mask: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    from torch._vendor.oink.rmsnorm import rmsnorm_backward
+
+    N = math.prod(normalized_shape)
+    M = input.numel() // N
+
+    x = _reshape_2d(input, M, N)
+    dout = _reshape_2d(grad_out, M, N)
+    rstd_flat = _flatten_rstd(rstd, M)
+
+    # oink folds dW gating into the `weight is not None` branch; pass None
+    # for weight when the caller doesn't want dW so the kernel skips the
+    # dw_partial allocation/reduction.
+    w = weight if dw_mask else None
+
+    dx, dw, _db, _dres = rmsnorm_backward(
+        x,
+        w,
+        dout,
+        rstd_flat,
+        dresidual_out=None,
+        has_bias=False,
+        has_residual=False,
+    )
+
+    dx = dx.reshape(input.shape)
+    if dw is not None:
+        dw = dw.reshape(normalized_shape)
+    return dx, dw

--- a/torch/_native/ops/norm/oink_rmsnorm_impl.py
+++ b/torch/_native/ops/norm/oink_rmsnorm_impl.py
@@ -1,0 +1,162 @@
+"""Oink-backed RMSNorm overrides for aten fused RMSNorm operators.
+
+Uses the vendored kernelagent_oink subset at ``torch._vendor.oink``. Targets
+Blackwell (SM10.x); falls through to aten on Hopper or older.
+"""
+
+# mypy: allow-untyped-defs
+
+from __future__ import annotations
+
+import torch
+
+from ... import cutedsl_utils as cu
+
+
+# oink kernels require N (the inner dim) >= 128; below that the kernel
+# allocates an empty smem partition and crashes. See oink's aten_override.py
+# for the same gate.
+_OINK_MIN_N = 128
+
+
+def _is_supported(input: torch.Tensor) -> bool:
+    if input.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        return False
+    if input.shape[-1] < _OINK_MIN_N:
+        return False
+    major, _ = torch.cuda.get_device_capability(input.device)
+    # oink is Blackwell-only; Hopper is left to other DSL backends or aten.
+    return major >= 10
+
+
+def _shape_is_valid(
+    input: torch.Tensor,
+    normalized_shape: list[int],
+    weight: torch.Tensor | None,
+) -> bool:
+    # Mirror aten's _check_layer_norm_inputs: on any mismatch the aten path
+    # raises, so we fall through and let it produce the proper error rather
+    # than silently running the override on ill-shaped inputs.
+    n = len(normalized_shape)
+    if n < 1 or input.ndim < n:
+        return False
+    if list(input.shape[-n:]) != list(normalized_shape):
+        return False
+    if weight is not None and list(weight.shape) != list(normalized_shape):
+        return False
+    return True
+
+
+def _fused_rms_norm_cond(
+    input: torch.Tensor,
+    normalized_shape: list[int],
+    weight: torch.Tensor | None,
+    eps: float | None,
+) -> bool:
+    if not _is_supported(input):
+        return False
+    if not _shape_is_valid(input, normalized_shape, weight):
+        return False
+    # Weight must match input dtype and device for the oink kernel; mismatches
+    # are legal under aten (it casts), so fall through.
+    if weight is not None and (
+        weight.dtype != input.dtype or weight.device != input.device
+    ):
+        return False
+    # Empty inputs would feed a degenerate grid into the cuteDSL kernel.
+    if input.numel() == 0:
+        return False
+    # The override reshapes + makes contiguous, which materializes a COW input.
+    # Match bmm_outer_product's cond and fall through to aten so
+    # composite-compliance tests don't flag spurious materialization.
+    is_cow = torch._C._is_cow_tensor  # pyrefly: ignore[missing-attribute]
+    if is_cow(input):
+        return False
+    if weight is not None and is_cow(weight):
+        return False
+    return True
+
+
+def _fused_rms_norm_impl(
+    input: torch.Tensor,
+    normalized_shape: list[int],
+    weight: torch.Tensor | None,
+    eps: float | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if eps is None:
+        # Match aten/src/ATen/native/cuda/layer_norm_kernel.cu:1841-1847:
+        # aten picks eps from the accumulator dtype, which is float32 for
+        # fp16/bf16/fp32 inputs (the only dtypes our cond accepts).
+        eps = torch.finfo(torch.float32).eps
+
+    from .oink_norms import oink_rmsnorm_fwd
+
+    return oink_rmsnorm_fwd(input, weight, normalized_shape, eps)
+
+
+def _fused_rms_norm_backward_cond(
+    grad_out: torch.Tensor,
+    input: torch.Tensor,
+    normalized_shape: list[int],
+    rstd: torch.Tensor,
+    weight: torch.Tensor | None,
+    output_mask: list[bool],
+) -> bool:
+    if not _is_supported(input):
+        return False
+    if not _shape_is_valid(input, normalized_shape, weight):
+        return False
+    if weight is not None and (
+        weight.dtype != input.dtype or weight.device != input.device
+    ):
+        return False
+    if input.numel() == 0:
+        return False
+    is_cow = torch._C._is_cow_tensor  # pyrefly: ignore[missing-attribute]
+    for t in (grad_out, input, rstd, weight):
+        if t is not None and is_cow(t):
+            return False
+    return True
+
+
+def _fused_rms_norm_backward_impl(
+    grad_out: torch.Tensor,
+    input: torch.Tensor,
+    normalized_shape: list[int],
+    rstd: torch.Tensor,
+    weight: torch.Tensor | None,
+    output_mask: list[bool],
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    from .oink_norms import oink_rmsnorm_bwd
+
+    grad_input, grad_weight = oink_rmsnorm_bwd(
+        grad_out,
+        input,
+        rstd,
+        weight,
+        normalized_shape,
+        dw_mask=output_mask[1],
+    )
+
+    if not output_mask[0]:
+        grad_input = None
+    return grad_input, grad_weight
+
+
+def register_rmsnorm_overrides() -> None:
+    if not torch.cuda.is_available():
+        return
+    cu.register_op_override(
+        "aten",
+        "_fused_rms_norm",
+        "CUDA",
+        cond=_fused_rms_norm_cond,
+        impl=_fused_rms_norm_impl,
+    )
+    cu.register_op_override(
+        "aten",
+        "_fused_rms_norm_backward",
+        "CUDA",
+        cond=_fused_rms_norm_backward_cond,
+        impl=_fused_rms_norm_backward_impl,
+    )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183941
* #183940

Summary:

Add fused rmsnorm fwd/bwd overrides backed by the vendored
kernelagent-oink kernels (cuteDSL). The override gates on Blackwell
(SM10.x); on Hopper or older, calls fall through to aten so existing
behavior is preserved.

torch/_native/ops/norm/oink_rmsnorm_impl.py provides the cond/impl
pair the cuteDSL registry consumes. The cond gates on device capability
>= SM10, dtype in (fp16/bf16/fp32), inner dim >= 128, matching
normalized_shape / weight shape, matching weight dtype/device, and
non-empty non-COW tensors. Mismatches fall through to aten so the
existing error paths fire and composite-compliance tests don't flag
spurious COW materialization.

torch/_native/ops/norm/oink_norms.py is a thin adaptor that reshapes
ATen-shaped inputs into the 2-D (M, N) layout oink expects, calls
rmsnorm_forward / rmsnorm_backward, and reshapes the outputs back.
Oink imports cutlass at module load, so the adaptor uses lazy imports
to keep torch._native.ops.norm importable on CPU-only builds.

Designed to coexist with the quack-based override -- the oink cond's
stricter SM>=10 gate ensures it picks up Blackwell while quack handles
Hopper. Both register through cu.register_op_override.