### PR TITLE
[Inductor][ROCm] Add XCD remapping to flex_attention forward kernel

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -4178,6 +4178,50 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
     @supported_platform
     @skip_on_cpu
+    def test_xcd_remap_correctness(self, device):
+        """XCD remap should produce identical results to no remap for all H values."""
+        for H in [8, 16, 32, 64]:
+            B, S, D = 1, 512, 64
+            make_tensor = functools.partial(
+                torch.randn,
+                (B, H, S, D),
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            q, k, v = make_tensor(), make_tensor(), make_tensor()
+            block_mask = create_block_mask(
+                _causal_mask, B, H, S, S, device=device
+            )
+
+            remap_opts = {"ENABLE_XCD_REMAP": True, "NUM_XCDS": 8}
+            no_remap_opts = {"ENABLE_XCD_REMAP": False, "NUM_XCDS": 1}
+
+            torch._dynamo.reset()
+            out_remap = torch.compile(
+                lambda q, k, v, bm: flex_attention(
+                    q, k, v, block_mask=bm, kernel_options=remap_opts
+                ),
+                fullgraph=True,
+            )(q, k, v, block_mask)
+
+            torch._dynamo.reset()
+            out_no_remap = torch.compile(
+                lambda q, k, v, bm: flex_attention(
+                    q, k, v, block_mask=bm, kernel_options=no_remap_opts
+                ),
+                fullgraph=True,
+            )(q, k, v, block_mask)
+
+            torch.testing.assert_close(
+                out_remap,
+                out_no_remap,
+                atol=0.0,
+                rtol=0.0,
+                msg=f"XCD remap mismatch at H={H}",
+            )
+
+    @supported_platform
+    @skip_on_cpu
     def test_backend_auto_matches_triton_large(self, device):
         """BACKEND='AUTO' should follow Triton heuristics on large shapes."""
         make_tensor = functools.partial(

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -379,6 +379,21 @@ def flex_attention(
 
     set_head_dim_values(kernel_options, qk_head_dim, v_head_dim, V.graph.sizevars)
 
+    if torch.version.hip is not None:
+        _capability = torch.cuda.get_device_capability()
+        # CDNA3+ (gfx942/gfx950) GPUs have multiple XCDs with separate L2 caches.
+        # Remap head indices so consecutive heads land on the same XCD for better
+        # L2 reuse of shared K/V data.
+        if _capability >= (9, 4):
+            kernel_options.setdefault("ENABLE_XCD_REMAP", True)
+            kernel_options.setdefault("NUM_XCDS", 8)
+        else:
+            kernel_options.setdefault("ENABLE_XCD_REMAP", False)
+            kernel_options.setdefault("NUM_XCDS", 1)
+    else:
+        kernel_options.setdefault("ENABLE_XCD_REMAP", False)
+        kernel_options.setdefault("NUM_XCDS", 1)
+
     choices: list[Any] = []
 
     dtype = query.get_dtype()

--- a/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
@@ -48,6 +48,21 @@
     q_start = tl.program_id(0).to(INDEX_DTYPE)
     off_zq = tl.program_id(1).to(INDEX_DTYPE)
     off_hq = tl.program_id(2).to(INDEX_DTYPE)
+    if ENABLE_XCD_REMAP:
+        # On multi-XCD GPUs (e.g. MI300X/MI350X), the hardware round-robin spreads
+        # consecutive program IDs across XCDs with separate L2 caches. Remap head
+        # indices so that consecutive heads land on the same XCD, improving L2
+        # reuse for shared K/V data across heads within a batch element.
+        pids_per_xcd = (HQ + NUM_XCDS - 1) // NUM_XCDS
+        remainder = HQ % NUM_XCDS
+        tall_xcds = NUM_XCDS if remainder == 0 else remainder
+        xcd = off_hq % NUM_XCDS
+        local_pid = off_hq // NUM_XCDS
+        if xcd < tall_xcds:
+            off_hq = xcd * pids_per_xcd + local_pid
+        else:
+            off_hq = tall_xcds * pids_per_xcd + (xcd - tall_xcds) * (pids_per_xcd - 1) + local_pid
+        off_hq = off_hq.to(INDEX_DTYPE)
 
     # We support two cases for batch dimension. a) (ZKV == ZQ) where off_zkv = off_zq.
     # b) (ZKV == 1 and ZQ > 1) where KV is broadcasted along the batch dimension and off_zkv=0.

--- a/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
@@ -53,11 +53,12 @@
         # consecutive program IDs across XCDs with separate L2 caches. Remap head
         # indices so that consecutive heads land on the same XCD, improving L2
         # reuse for shared K/V data across heads within a batch element.
-        pids_per_xcd = (HQ + NUM_XCDS - 1) // NUM_XCDS
-        remainder = HQ % NUM_XCDS
-        tall_xcds = NUM_XCDS if remainder == 0 else remainder
-        xcd = off_hq % NUM_XCDS
-        local_pid = off_hq // NUM_XCDS
+        num_xcds_i = tl.full([], NUM_XCDS, dtype=INDEX_DTYPE)
+        pids_per_xcd = (HQ + num_xcds_i - 1) // num_xcds_i
+        remainder = HQ % num_xcds_i
+        tall_xcds = tl.where(remainder == 0, num_xcds_i, remainder)
+        xcd = off_hq % num_xcds_i
+        local_pid = off_hq // num_xcds_i
         if xcd < tall_xcds:
             off_hq = xcd * pids_per_xcd + local_pid
         else:

--- a/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_attention.py.jinja
@@ -213,7 +213,7 @@
 
     acc = acc / l_i[:, None]
     idx_zq = tl.program_id(1).to(INDEX_DTYPE)
-    idx_hq = tl.program_id(2).to(INDEX_DTYPE)
+    idx_hq = off_hq
     idx_m = offs_m[:, None].to(INDEX_DTYPE)
     idx_d = tl.arange(0, V_HEAD_DIM_ROUNDED)[None, :].to(INDEX_DTYPE)
 


### PR DESCRIPTION
On AMD MI300X/MI350X GPUs with multiple XCDs (chiplets), the default round-robin workgroup scheduling can place related head computations on different XCDs with separate L2 caches. This adds a program ID remapping on the head axis (program_id(2)) so that consecutive head indices are grouped onto the same XCD, improving L2 cache locality for shared K/V data.

The remapping is gated by two new kernel constexprs:
- ENABLE_XCD_REMAP: True on ROCm, False otherwise
- NUM_XCDS: 8 for MI300X/MI350X, 1 otherwise

The remap logic follows the same approach used in the handwritten Flash Attention v3 Triton kernel for AMD GPUs.

Benchmarks on MI350X (H=64, D=128, bf16, causal, default autotuned config):

     B      S     without        with    delta
     1  16384   556.5 TF   569.9 TF    +2.4%
     2   8192   494.5 TF   493.1 TF    -0.3%
     4   4096   408.1 TF   415.8 TF    +1.9%
     8   2048   373.4 TF   379.3 TF    +1.6%

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben