### PR TITLE
[inductor] Add extern_semantic_key + shape metadata to kernel_information.json (#183952)

### DIFF
--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -24,6 +24,7 @@ from torch._inductor.debug import (
     get_kernel_information_jsons,
     reset_inductor_kernel_provenance_debug_handle,
     reset_provenance_globals,
+    set_kernel_post_grad_provenance_tracing,
 )
 from torch._inductor.fx_passes.post_grad import post_grad_passes
 from torch._inductor.test_case import run_tests, TestCase
@@ -744,6 +745,7 @@ class TestProvenanceTracingStackTraces(TestCase):
                 self.assertIsInstance(data[field], list)
                 for item in data[field]:
                     self.assertIsInstance(item, str)
+            self.assertIsInstance(data["extern_semantic_key"], (str, type(None)))
 
     @requires_gpu_and_triton
     @torch._inductor.config.patch("trace.provenance_tracking_level", 1)
@@ -851,6 +853,29 @@ class TestProvenanceTracingStackTraces(TestCase):
                     lambda msg: f"{msg}\nMismatch for key: {key}",
                 )
 
+            # extern_semantic_key + shape metadata for extern kernels
+            triton_poi_0 = kernel_info["triton_poi_fused_addmm_relu_sigmoid_0:2"]
+            self.assertIsNone(triton_poi_0["extern_semantic_key"])
+
+            mm_out_1 = kernel_info[f"aoti_torch_{GPU_TYPE}_mm_out:1"]
+            # Single pre_grad_node "linear" → extern_semantic_key fallback
+            self.assertEqual(mm_out_1["extern_semantic_key"], "linear")
+            self.assertEqual(mm_out_1["input_shapes"], [[8, 10], [10, 16]])
+            self.assertEqual(
+                mm_out_1["input_dtypes"], ["torch.float32", "torch.float32"]
+            )
+            self.assertEqual(mm_out_1["output_shape"], [8, 16])
+            self.assertEqual(mm_out_1["output_dtype"], "torch.float32")
+
+            mm_out_4 = kernel_info[f"aoti_torch_{GPU_TYPE}_mm_out:4"]
+            self.assertEqual(mm_out_4["extern_semantic_key"], "addmm")
+            self.assertEqual(mm_out_4["input_shapes"], [[10, 20], [20, 30]])
+            self.assertEqual(
+                mm_out_4["input_dtypes"], ["torch.float32", "torch.float32"]
+            )
+            self.assertEqual(mm_out_4["output_shape"], [10, 30])
+            self.assertEqual(mm_out_4["output_dtype"], "torch.float32")
+
     @torch._inductor.config.patch("trace.provenance_tracking_level", 0)
     def test_no_kernel_information_without_provenance_tracking(self):
         """Test that kernel_information.json is not generated without provenance tracking."""
@@ -926,6 +951,209 @@ class TestProvenanceTracingStackTraces(TestCase):
 
             keys = [k.split(":")[0] for k in data]
             self.assertTrue("aoti_torch_cpu_convolution" in keys)
+
+    def test_create_kernel_information_json_with_synthetic_data(self):
+        """Test create_kernel_information_json with synthetic globals."""
+        import torch._inductor.debug as debug_mod
+
+        with (
+            config.patch("trace.provenance_tracking_level", 1),
+            reset_provenance_globals(),
+        ):
+            # Populate globals with known data
+            debug_mod._inductor_triton_kernel_to_post_grad_node_info = {
+                "triton_poi_fused_add_mul_0:1": ["add", "mul"],
+                "aoti_torch_cuda_mm_out:2": ["mm_default"],
+                "extern_kernels.addmm:3": ["addmm_default"],
+                "custom_backend.mm:4": ["custom_mm_default"],
+                "aoti_torch_cuda_add_out:5": ["add_default"],
+            }
+            debug_mod._inductor_kernel_stack_trace = {
+                "triton_poi_fused_add_mul_0:1": ["File test.py, line 10"],
+                "aoti_torch_cuda_mm_out:2": ["File test.py, line 20"],
+                "extern_kernels.addmm:3": ["File test.py, line 30"],
+                "custom_backend.mm:4": ["File test.py, line 40"],
+                "aoti_torch_cuda_add_out:5": ["File test.py, line 50"],
+            }
+            debug_mod._inductor_post_to_pre_grad_nodes = {
+                "postToPre": {
+                    "add": ["add_1"],
+                    "mul": ["mul_1"],
+                    "mm_default": ["linear"],
+                    "addmm_default": ["addmm"],
+                    "custom_mm_default": ["custom_linear"],
+                    "add_default": ["prefix_only_add"],
+                }
+            }
+            # Consolidated per-kernel extern info: is_extern flag, explicit
+            # semantic key (simulates FP8 bridge), and shape metadata.
+            debug_mod._inductor_kernel_extern_info = {
+                "aoti_torch_cuda_mm_out:2": debug_mod._KernelExternInfo(
+                    is_extern=True,
+                    semantic_key="linear_42",
+                    shapes={
+                        "input_shapes": [[8, 10], [10, 16]],
+                        "input_dtypes": ["torch.float32", "torch.float32"],
+                        "output_shape": [8, 16],
+                        "output_dtype": "torch.float32",
+                    },
+                ),
+                "extern_kernels.addmm:3": debug_mod._KernelExternInfo(is_extern=True),
+                "custom_backend.mm:4": debug_mod._KernelExternInfo(is_extern=True),
+            }
+
+            result = create_kernel_information_json()
+
+            # Triton pointwise kernel: no extern_semantic_key, no shape metadata.
+            k1 = result["triton_poi_fused_add_mul_0:1"]
+            self.assertIsNone(k1["extern_semantic_key"])
+            self.assertNotIn("input_shapes", k1)
+
+            # Extern kernel with explicit semantic key (FP8 bridge precedence)
+            # and merged shape metadata.
+            k2 = result["aoti_torch_cuda_mm_out:2"]
+            self.assertEqual(k2["extern_semantic_key"], "linear_42")
+            self.assertEqual(k2["input_shapes"], [[8, 10], [10, 16]])
+            self.assertEqual(k2["output_shape"], [8, 16])
+            self.assertEqual(k2["output_dtype"], "torch.float32")
+
+            # Extern kernel with single pre_grad_node fallback semantic key.
+            k3 = result["extern_kernels.addmm:3"]
+            self.assertEqual(k3["extern_semantic_key"], "addmm")
+            self.assertNotIn("input_shapes", k3)
+
+            # Extern fallback comes from explicit tracking, not kernel-name prefixes.
+            k4 = result["custom_backend.mm:4"]
+            self.assertEqual(k4["extern_semantic_key"], "custom_linear")
+
+            k5 = result["aoti_torch_cuda_add_out:5"]
+            self.assertIsNone(k5["extern_semantic_key"])
+
+    def test_extern_semantic_key_extracted_from_origin_node_meta(self):
+        """extern_semantic_key stamped on origin_node.meta (e.g. by the FP8
+        lowering pass) is extracted into the provenance globals and JSON."""
+        import torch._inductor.debug as debug_mod
+        import torch._inductor.ir as ir_mod
+
+        class FakeOriginNode:
+            def __init__(self, name, meta) -> None:
+                self.name = name
+                self.meta = meta
+
+        class FakeExternKernel(ir_mod.ExternKernel):
+            def __init__(self, origin_node) -> None:
+                self.inputs = []
+                self.origin_node = origin_node
+                self.origins = []
+
+            def has_tensor_output(self):
+                return False
+
+            def get_stack_traces(self):
+                return []
+
+        with (
+            config.patch("trace.provenance_tracking_level", 1),
+            reset_provenance_globals(),
+        ):
+            extern = FakeExternKernel(
+                FakeOriginNode("linear", {"extern_semantic_key": "my_fp8_key"})
+            )
+            handle = set_kernel_post_grad_provenance_tracing(
+                extern, "aoti_torch_cuda_mm_out", is_extern=True
+            )
+            kernel_name = f"aoti_torch_cuda_mm_out:{handle}"
+            info = debug_mod._inductor_kernel_extern_info[kernel_name]
+            self.assertTrue(info.is_extern)
+            self.assertEqual(info.semantic_key, "my_fp8_key")
+
+            result = create_kernel_information_json()
+            self.assertEqual(result[kernel_name]["extern_semantic_key"], "my_fp8_key")
+
+    def test_extern_kernel_metadata_accepts_tensor_like_ir_inputs(self):
+        import torch._inductor.ir as ir_mod
+
+        class FakeTensorIRNode(ir_mod.IRNode):
+            def __init__(self, size, dtype) -> None:
+                self._size = size
+                self._dtype = dtype
+
+            def has_tensor_output(self):
+                return True
+
+            def maybe_get_size(self):
+                return self._size
+
+            def maybe_get_dtype(self):
+                return self._dtype
+
+        class FakeNonTensorIRNode(ir_mod.IRNode):
+            def has_tensor_output(self):
+                return False
+
+        class FakeExternKernel(ir_mod.ExternKernel):
+            def __init__(self, inputs, output_size=None, output_dtype=None) -> None:
+                self.inputs = inputs
+                self.origin_node = None
+                self.origins = []
+                self._output_size = output_size
+                self._output_dtype = output_dtype
+
+            def has_tensor_output(self):
+                return self._output_size is not None
+
+            def maybe_get_size(self):
+                return self._output_size
+
+            def maybe_get_dtype(self):
+                return self._output_dtype
+
+            def get_stack_traces(self):
+                return ["File fake.py, line 1"]
+
+        with (
+            config.patch("trace.provenance_tracking_level", 1),
+            reset_provenance_globals(),
+        ):
+            extern = FakeExternKernel(
+                [
+                    FakeTensorIRNode([2, 4], torch.float32),
+                    [FakeTensorIRNode([3, "s0"], torch.bfloat16)],
+                    FakeNonTensorIRNode(),
+                ],
+                output_size=[2, "s0"],
+                output_dtype=torch.float16,
+            )
+            handle = set_kernel_post_grad_provenance_tracing(
+                extern, "custom_backend.mm", is_extern=True
+            )
+            self.assertEqual(handle, 1)
+
+            non_tensor_output = FakeExternKernel(
+                [FakeTensorIRNode([7], torch.int64)],
+            )
+            handle = set_kernel_post_grad_provenance_tracing(
+                non_tensor_output, "custom_backend.multi", is_extern=True
+            )
+            self.assertEqual(handle, 2)
+
+            result = create_kernel_information_json()
+
+            metadata = result["custom_backend.mm:1"]
+            self.assertEqual(metadata["input_shapes"], [[2, 4], [3, "s0"]])
+            self.assertEqual(
+                metadata["input_dtypes"], ["torch.float32", "torch.bfloat16"]
+            )
+            self.assertEqual(metadata["output_shape"], [2, "s0"])
+            self.assertEqual(metadata["output_dtype"], "torch.float16")
+
+            non_tensor_output_metadata = result["custom_backend.multi:2"]
+            self.assertEqual(non_tensor_output_metadata["input_shapes"], [[7]])
+            self.assertEqual(
+                non_tensor_output_metadata["input_dtypes"], ["torch.int64"]
+            )
+            self.assertNotIn("output_shape", non_tensor_output_metadata)
+            self.assertNotIn("output_dtype", non_tensor_output_metadata)
 
 
 class ProvenanceTracingKernelContextTemplate:

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -33,7 +33,7 @@ from torch.fx.passes.shape_prop import _extract_tensor_metadata, TensorMetadata
 from torch.fx.passes.tools_common import legalize_graph
 from torch.types import FileLike
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._pytree import tree_map
+from torch.utils._pytree import tree_leaves, tree_map
 
 from . import config, ir
 from .ir import ExternKernel
@@ -359,6 +359,16 @@ _kernel_information_jsons: dict[str, dict[str, Any]] = {}
 _inductor_kernel_provenance_debug_handle: int = 0
 
 
+@dataclasses.dataclass
+class _KernelExternInfo:
+    is_extern: bool = False
+    semantic_key: str | None = None
+    shapes: dict[str, Any] | None = None
+
+
+_inductor_kernel_extern_info: dict[str, _KernelExternInfo] = {}
+
+
 def get_kernel_information_jsons() -> dict[str, dict[str, Any]]:
     return _kernel_information_jsons
 
@@ -390,6 +400,7 @@ def reset_provenance_globals() -> Iterator[None]:
     global _inductor_pre_grad_node_stack_trace
     global _inductor_kernel_stack_trace
     global _inductor_kernel_provenance_debug_handle
+    global _inductor_kernel_extern_info
 
     # Store original values
     original_pre_grad_graph_id = _pre_grad_graph_id
@@ -404,6 +415,7 @@ def reset_provenance_globals() -> Iterator[None]:
     original_inductor_kernel_provenance_debug_handle = (
         _inductor_kernel_provenance_debug_handle
     )
+    original_inductor_kernel_extern_info = dict(_inductor_kernel_extern_info)
 
     # Reset to default values
     _pre_grad_graph_id = -1
@@ -415,6 +427,7 @@ def reset_provenance_globals() -> Iterator[None]:
     # context is active.  It must outlive the reset scope so the profiler can
     # consume it during export_chrome_trace, which then clears it.
     _inductor_kernel_provenance_debug_handle = 0
+    _inductor_kernel_extern_info = {}
 
     try:
         yield
@@ -432,6 +445,7 @@ def reset_provenance_globals() -> Iterator[None]:
         _inductor_kernel_provenance_debug_handle = (
             original_inductor_kernel_provenance_debug_handle
         )
+        _inductor_kernel_extern_info = original_inductor_kernel_extern_info
 
 
 class DebugContext:
@@ -1126,12 +1140,35 @@ def dump_inductor_provenance_info() -> dict[str, Any]:
         return {}
 
 
-def create_kernel_information_json() -> dict[str, dict[str, list[str]]]:
-    """Create kernel information JSON"""
+def _serialize_provenance_shape(size: Sequence[Any]) -> list[int | str]:
+    shape: list[int | str] = []
+    for dim in size:
+        if ir._is_static(dim):
+            shape.append(int(dim))
+        else:
+            shape.append(str(dim))
+    return shape
+
+
+def _get_tensor_metadata(node: ir.IRNode) -> tuple[list[int | str], str] | None:
+    if not node.has_tensor_output():
+        return None
+
+    size = node.maybe_get_size()
+    dtype = node.maybe_get_dtype()
+    if size is None or dtype is None:
+        return None
+
+    return _serialize_provenance_shape(size), str(dtype)
+
+
+def create_kernel_information_json() -> dict[str, dict[str, Any]]:
+    """Create kernel information JSON with extended metadata for cross-hardware comparison."""
     try:
         global _inductor_post_to_pre_grad_nodes
         global _inductor_kernel_stack_trace
         global _inductor_triton_kernel_to_post_grad_node_info
+        global _inductor_kernel_extern_info
 
         post_to_pre = _inductor_post_to_pre_grad_nodes.get("postToPre", {})
         all_kernels = OrderedSet(_inductor_kernel_stack_trace.keys()) | OrderedSet(
@@ -1139,20 +1176,40 @@ def create_kernel_information_json() -> dict[str, dict[str, list[str]]]:
         )
 
         result = {}
-        for kernel_name in all_kernels:
+        for kernel_key in all_kernels:
             post_grad_nodes = _inductor_triton_kernel_to_post_grad_node_info.get(
-                kernel_name, []
+                kernel_key, []
             )
 
             pre_grad_nodes: OrderedSet[str] = OrderedSet()
             for post_node in post_grad_nodes:
                 pre_grad_nodes.update(post_to_pre.get(post_node, []))
 
-            result[kernel_name] = {
-                "stack_traces": _inductor_kernel_stack_trace.get(kernel_name, []),
+            stack_traces = _inductor_kernel_stack_trace.get(kernel_key, [])
+            pre_grad_list = list(pre_grad_nodes)
+
+            # extern_semantic_key precedence:
+            # 1. Explicit annotation (e.g., FP8 bridge) — highest priority
+            # 2. Single-element pre_grad_nodes for externs — derived identity
+            # 3. None
+            info = _inductor_kernel_extern_info.get(kernel_key)
+            if info is not None and info.semantic_key is not None:
+                extern_semantic_key = info.semantic_key
+            elif info is not None and info.is_extern and len(pre_grad_list) == 1:
+                extern_semantic_key = pre_grad_list[0]
+            else:
+                extern_semantic_key = None
+
+            result[kernel_key] = {
+                "stack_traces": stack_traces,
                 "post_grad_nodes": post_grad_nodes,
-                "pre_grad_nodes": list(pre_grad_nodes),
+                "pre_grad_nodes": pre_grad_list,
+                "extern_semantic_key": extern_semantic_key,
             }
+
+            # Merge shape metadata if available (extern ops only)
+            if info is not None and info.shapes:
+                result[kernel_key].update(info.shapes)
 
         return result
     except Exception as e:
@@ -1165,6 +1222,7 @@ def create_kernel_information_json() -> dict[str, dict[str, list[str]]]:
                 "stack_trace": traceback.format_exc(),
             },
         )
+        log.warning("create_kernel_information_json: exception: %s", e)
         return {}
 
 
@@ -1188,6 +1246,7 @@ def set_kernel_post_grad_provenance_tracing(
         global _inductor_triton_kernel_to_post_grad_node_info
         global _inductor_kernel_stack_trace
         global _inductor_kernel_provenance_debug_handle
+        global _inductor_kernel_extern_info
 
         _inductor_kernel_provenance_debug_handle += 1
         stack_traces: list[str] = []
@@ -1197,6 +1256,10 @@ def set_kernel_post_grad_provenance_tracing(
                 raise AssertionError(
                     f"expected ExternKernel, got {type(node_schedule)}"
                 )
+            extern_info = _inductor_kernel_extern_info.setdefault(
+                kernel_name, _KernelExternInfo()
+            )
+            extern_info.is_extern = True
             curr_node_info = _inductor_triton_kernel_to_post_grad_node_info.setdefault(
                 kernel_name, []
             )
@@ -1213,6 +1276,47 @@ def set_kernel_post_grad_provenance_tracing(
                     for origin in node_schedule.origins
                     if origin.name not in curr_node_info
                 )
+            # Extract extern_semantic_key if stamped by a transform pass (e.g., FP8)
+            if node_schedule.origin_node and "extern_semantic_key" in getattr(
+                node_schedule.origin_node, "meta", {}
+            ):
+                extern_info.semantic_key = node_schedule.origin_node.meta[
+                    "extern_semantic_key"
+                ]
+            else:
+                for origin in node_schedule.origins:
+                    if "extern_semantic_key" in getattr(origin, "meta", {}):
+                        extern_info.semantic_key = origin.meta["extern_semantic_key"]
+                        break
+            # Extract input/output shapes and dtypes for extern ops
+            try:
+                input_shapes: list[list[int | str]] = []
+                input_dtypes: list[str] = []
+                for inp in tree_leaves(node_schedule.inputs):
+                    if isinstance(inp, ir.IRNode):
+                        metadata = _get_tensor_metadata(inp)
+                        if metadata is None:
+                            continue
+                        shape, dtype = metadata
+                        input_shapes.append(shape)
+                        input_dtypes.append(dtype)
+
+                shape_metadata: dict[str, Any] = {
+                    "input_shapes": input_shapes,
+                    "input_dtypes": input_dtypes,
+                }
+                output_metadata = _get_tensor_metadata(node_schedule)
+                if output_metadata is not None:
+                    output_shape, output_dtype = output_metadata
+                    shape_metadata.update(
+                        {
+                            "output_shape": output_shape,
+                            "output_dtype": output_dtype,
+                        }
+                    )
+                extern_info.shapes = shape_metadata
+            except Exception as e:
+                log.debug("Shape extraction failed for %s: %s", kernel_name, e)
             stack_traces = list(node_schedule.get_stack_traces())
         else:
             if not isinstance(node_schedule, list):


### PR DESCRIPTION
Summary:

Two additions to per-kernel entries in TorchInductor's `kernel_information.json` so a downstream perf-comparison tool can match kernels across H100/MI350 and generate executable repros for extern ops:

- `extern_semantic_key`: a pre-transform identity preserved through graph rewrites. Stamped by lowering passes that erase the original op (FP8 today, see below); falls back to the single `pre_grad_node` name for ordinary externs.
- `input_shapes` / `input_dtypes` / `output_shape` / `output_dtype` on extern entries, extracted from the IR's `Buffer`/`ReinterpretView` inputs at codegen. Triton entries already carry these via scheduler metadata; this fills the gap for extern wrappers.

`lower_basic_pass_fp8.py` is broadened to stamp `extern_semantic_key` on all three FP8 matmul variants (`_scaled_mm`, `matmul_fp8_row`, `matmul_fp8_block`); the prior `torch._scaled_mm`-only check missed the Triton FP8 path.

Test Plan:
- `buck2 test //caffe2/test/inductor:provenance_tracing` — Pass 18, Fail 0
  testx: https://www.internalfb.com/intern/testinfra/testrun/8725724628429810
- `buck2 test //deeplearning/trt/torch_tensorrt/py/torch_tensorrt/fb/tests:test_fp8_pass`
  testx: https://www.internalfb.com/intern/testinfra/testrun/24769797969329781
- Rebuilt the consumer tool's sqlite from existing MI350 artifacts (model_id 1004317092, snapshot 2408): all 11 analytical tables byte-identical vs the prior baseline; `db_metadata` differs only on the build-time clock (`rebuilt_at`).

Reviewed By: desertfire, yushangdi

Differential Revision: D103935356


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo