### PR TITLE
[CI] Emit adhoc test rows when shard SIGTERM/timeout kills pytest before junit-xml write

### DIFF
--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -30,6 +30,21 @@ runs:
       with:
         python-version: "3.12"
 
+    # Emit one synthetic test row to s3 for any test that started running but
+    # never produced a junit-xml entry (e.g. the GHA test step was killed by
+    # timeout-minutes / run cancellation / OOM before pytest_sessionfinish).
+    # Runs only when the test step failed so the success path stays untouched;
+    # internal dedup checks for `<testcase>` presence + `made_failing_xml` so
+    # it doesn't compete with `parse_xml_and_upload_json` or the
+    # FAILED CONSISTENTLY path in run_test.py.
+    - name: Upload adhoc rows for incomplete tests
+      if: ${{ failure() && runner.os != 'Windows' }}
+      shell: bash
+      continue-on-error: true
+      run: |
+        set -euo pipefail
+        uv run --no-project --with boto3 python -m tools.testing.upload_adhoc_incomplete_tests
+
     - name: Zip artifacts for upload
       if: runner.os != 'Windows'
       shell: bash

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -56,14 +56,20 @@ runs:
     # uses different stepcurrent paths and ROCm/XPU need stepcurrent
     # copy-back from the container; both are tracked as follow-ups.
     - name: Upload adhoc rows for incomplete tests
-      if: ${{ inputs.test-conclusion == 'failure' && runner.os == 'Linux' && inputs.job-id != '' }}
+      if: ${{ (inputs.test-conclusion == 'failure' || inputs.test-conclusion == 'cancelled') && runner.os == 'Linux' && inputs.job-id != '' }}
       shell: bash
       continue-on-error: true
       env:
         JOB_ID: ${{ inputs.job-id }}
       run: |
         set -euo pipefail
-        uv run --no-project --with boto3 python -m tools.testing.upload_adhoc_incomplete_tests
+        # The helper transitively imports `tools.testing.upload_artifacts`,
+        # which pulls in `filelock` and `tools.stats.test_dashboard` (which
+        # imports `requests`). Pre-install all three so the import chain
+        # doesn't fail before `main()` runs and silently swallow incomplete-
+        # test rows under `continue-on-error: true`.
+        uv run --no-project --with boto3 --with filelock --with requests \
+          python -m tools.testing.upload_adhoc_incomplete_tests
 
     - name: Zip artifacts for upload
       if: runner.os != 'Windows'

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -19,6 +19,21 @@ inputs:
     description: S3 bucket to upload artifacts to
     required: false
     default: "gha-artifacts"
+  job-id:
+    description: |
+      The numeric GHA job id (e.g. `steps.setup-linux.outputs.job-id`). Needed
+      so the "Upload adhoc rows for incomplete tests" step can pass JOB_ID to
+      the helper. If unset, that step no-ops.
+    required: false
+    default: ""
+  test-conclusion:
+    description: |
+      The caller's test-step conclusion (e.g. `steps.test.conclusion`). Used
+      to gate the incomplete-tests helper explicitly instead of relying on
+      `failure()` (which can be ambiguous when a composite action has multiple
+      substeps). If unset, the helper step skips.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -33,14 +48,19 @@ runs:
     # Emit one synthetic test row to s3 for any test that started running but
     # never produced a junit-xml entry (e.g. the GHA test step was killed by
     # timeout-minutes / run cancellation / OOM before pytest_sessionfinish).
-    # Runs only when the test step failed so the success path stays untouched;
-    # internal dedup checks for `<testcase>` presence + `made_failing_xml` so
-    # it doesn't compete with `parse_xml_and_upload_json` or the
-    # FAILED CONSISTENTLY path in run_test.py.
+    # Gated explicitly on the caller's `test-conclusion` input so we never
+    # rely on the ambiguous composite-scope behaviour of `failure()`. The
+    # helper itself no-ops if `JOB_ID` is unset, so callers that don't pass
+    # `job-id` (today: ROCm/XPU container workflows that don't copy back
+    # `.pytest_cache/`) are safe by default. Linux-only for now — Windows
+    # uses different stepcurrent paths and ROCm/XPU need stepcurrent
+    # copy-back from the container; both are tracked as follow-ups.
     - name: Upload adhoc rows for incomplete tests
-      if: ${{ failure() && runner.os != 'Windows' }}
+      if: ${{ inputs.test-conclusion == 'failure' && runner.os == 'Linux' && inputs.job-id != '' }}
       shell: bash
       continue-on-error: true
+      env:
+        JOB_ID: ${{ inputs.job-id }}
       run: |
         set -euo pipefail
         uv run --no-project --with boto3 python -m tools.testing.upload_adhoc_incomplete_tests

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -583,6 +583,8 @@ jobs:
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.setup-linux.outputs.job-id }}
           use-gha: ${{ inputs.use-gha }}
           s3-bucket: ${{ inputs.s3-bucket }}
+          job-id: ${{ steps.setup-linux.outputs.job-id }}
+          test-conclusion: ${{ steps.test.conclusion }}
 
       - name: Collect backtraces from coredumps (if any)
         if: always()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -824,7 +824,14 @@ def run_test_retries(
                 and IS_CI
                 and options.upload_artifacts_while_running
             ):
-                upload_adhoc_failure_json(test_file, current_failure[1:-1])
+                upload_adhoc_failure_json(
+                    test_file,
+                    current_failure[1:-1],
+                    reason=(
+                        "Test failed consistently across reruns but pytest did "
+                        "not generate xml. The most likely cause is a segfault."
+                    ),
+                )
 
             if not continue_through_error:
                 print_to_file("Stopping at first consistent failure")

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -824,9 +824,19 @@ def run_test_retries(
                 and IS_CI
                 and options.upload_artifacts_while_running
             ):
+                from tools.testing.upload_artifacts import parse_pytest_nodeid
+
+                nodeid = current_failure[1:-1]
+                parsed = parse_pytest_nodeid(nodeid)
+                if parsed is None:
+                    classname, testname = "", nodeid
+                else:
+                    _, _, classname, testname = parsed
                 upload_adhoc_failure_json(
                     test_file,
-                    current_failure[1:-1],
+                    nodeid,
+                    classname=classname,
+                    testname=testname,
                     reason=(
                         "Test failed consistently across reruns but pytest did "
                         "not generate xml. The most likely cause is a segfault."

--- a/tools/test/test_upload_adhoc_incomplete_tests.py
+++ b/tools/test/test_upload_adhoc_incomplete_tests.py
@@ -1,0 +1,144 @@
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+
+# `tools.testing.upload_artifacts` imports `boto3` and `filelock` at module
+# load. Stub them out so the test runs without those packages in the env.
+for missing in ("boto3", "filelock", "requests"):
+    sys.modules.setdefault(missing, mock.MagicMock())
+
+
+from tools.testing import upload_adhoc_incomplete_tests as helper  # noqa: E402
+
+
+def _write_cache(dir_: Path, lastrun: Any, made_failing_xml: bool) -> None:
+    dir_.mkdir(parents=True, exist_ok=True)
+    (dir_ / "lastrun").write_text(json.dumps(lastrun))
+    (dir_ / "made_failing_xml").write_text(json.dumps(made_failing_xml))
+
+
+def _write_junit_xml(dir_: Path, name: str, testcases: list[tuple[str, str]]) -> None:
+    dir_.mkdir(parents=True, exist_ok=True)
+    body = "".join(
+        f'<testcase classname="{cls}" name="{n}"/>' for cls, n in testcases
+    )
+    (dir_ / name).write_text(f'<?xml version="1.0"?><testsuite>{body}</testsuite>')
+
+
+class TestUploadAdhocIncompleteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = self.enterContext(__import__("tempfile").TemporaryDirectory())
+        self.repo_root = Path(self.tmp)
+        self.stepcurrent = self.repo_root / ".pytest_cache" / "v" / "cache" / "stepcurrent"
+        self.test_reports = self.repo_root / "test" / "test-reports"
+        # Repoint the helper's module-level paths at the temp dir.
+        self.patches = [
+            mock.patch.object(helper, "REPO_ROOT", self.repo_root),
+            mock.patch.object(helper, "STEPCURRENT_DIR", self.stepcurrent),
+            mock.patch.object(helper, "TEST_REPORTS_DIR", self.test_reports),
+            mock.patch.dict(
+                os.environ,
+                {"JOB_ID": "1", "GITHUB_RUN_ID": "2", "GITHUB_RUN_ATTEMPT": "1"},
+                clear=False,
+            ),
+        ]
+        for p in self.patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_emits_for_incomplete_test_not_in_xml(self) -> None:
+        # An in-flight nodeid with no junit-xml row should produce exactly
+        # one adhoc emission.
+        _write_cache(
+            self.stepcurrent / "key1",
+            "test/dynamo/test_foo.py::TestFoo::test_bar",
+            made_failing_xml=False,
+        )
+        with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+            self.assertEqual(helper.main(), 0)
+        self.assertEqual(up.call_count, 1)
+        args, kwargs = up.call_args
+        self.assertEqual(args[0], "test/dynamo/test_foo")
+        self.assertEqual(args[1], "TestFoo::test_bar")
+        self.assertIn("SIGTERM", kwargs["reason"])
+        # Deterministic suffix keyed by (classname, testname).
+        self.assertEqual(
+            kwargs["s3_key_suffix"], "incomplete_TestFoo_test_bar"
+        )
+
+    def test_skips_when_made_failing_xml_true(self) -> None:
+        # pytest reached sessionfinish with exit != 0 — the existing failure
+        # path will have emitted the row (or the XML is correct). Skip.
+        _write_cache(
+            self.stepcurrent / "key1",
+            "test_foo.py::test_bar",
+            made_failing_xml=True,
+        )
+        with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+            self.assertEqual(helper.main(), 0)
+        up.assert_not_called()
+
+    def test_skips_when_testcase_already_in_junit_xml(self) -> None:
+        # Test ran to completion (its testcase is in the xml) and a LATER
+        # test was killed mid-run. Don't double-emit for the completed one.
+        _write_cache(
+            self.stepcurrent / "key1",
+            "test_foo.py::TestFoo::test_bar",
+            made_failing_xml=False,
+        )
+        _write_junit_xml(
+            self.test_reports,
+            "report.xml",
+            [("TestFoo", "test_bar")],
+        )
+        with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+            self.assertEqual(helper.main(), 0)
+        up.assert_not_called()
+
+    def test_skips_when_lastrun_missing_or_null(self) -> None:
+        _write_cache(
+            self.stepcurrent / "key1",
+            None,  # pytest didn't get to start any test
+            made_failing_xml=False,
+        )
+        with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+            self.assertEqual(helper.main(), 0)
+        up.assert_not_called()
+
+    def test_handles_partial_xml_gracefully(self) -> None:
+        # A partially-written xml is treated as no data so the helper still
+        # emits the synthetic row for the in-flight test.
+        _write_cache(
+            self.stepcurrent / "key1",
+            "test_foo.py::TestFoo::test_bar",
+            made_failing_xml=False,
+        )
+        self.test_reports.mkdir(parents=True, exist_ok=True)
+        (self.test_reports / "broken.xml").write_text("<testsuite><testc")
+        with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+            self.assertEqual(helper.main(), 0)
+        up.assert_called_once()
+
+    def test_handles_multiple_stepcurrent_dirs(self) -> None:
+        _write_cache(
+            self.stepcurrent / "key1",
+            "test_a.py::TestA::test_one",
+            made_failing_xml=False,
+        )
+        _write_cache(
+            self.stepcurrent / "key2",
+            "test_b.py::TestB::test_two",
+            made_failing_xml=False,
+        )
+        with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+            self.assertEqual(helper.main(), 0)
+        self.assertEqual(up.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test/test_upload_adhoc_incomplete_tests.py
+++ b/tools/test/test_upload_adhoc_incomplete_tests.py
@@ -73,9 +73,11 @@ class TestUploadAdhocIncompleteTests(unittest.TestCase):
 
     def test_emits_for_incomplete_test_not_in_xml(self) -> None:
         # An in-flight nodeid with no junit-xml row should produce exactly
-        # one adhoc emission.
+        # one adhoc emission. Use the run_test.py-style stepcurrent_key
+        # (test_file + shard + hex16 suffix) so the helper recovers
+        # `invoking_file` from the dir name, not from the nodeid path.
         _write_cache(
-            self.stepcurrent / "key1",
+            self.stepcurrent / "test_foo_1_aaaabbbbccccdddd",
             "test/dynamo/test_foo.py::TestFoo::test_bar",
             made_failing_xml=False,
         )
@@ -83,18 +85,25 @@ class TestUploadAdhocIncompleteTests(unittest.TestCase):
             self.assertEqual(helper.main(), 0)
         self.assertEqual(up.call_count, 1)
         args, kwargs = up.call_args
-        self.assertEqual(args[0], "test/dynamo/test_foo")
+        # invoking_file comes from stepcurrent_key prefix (the run_test.py
+        # invocation unit), not the nodeid path.
+        self.assertEqual(args[0], "test_foo")
         # current_failure (full nodeid) is passed positionally for the
-        # logging/legacy fallback, but explicit classname/testname kwargs
-        # override the splitter.
+        # logging/legacy fallback, but explicit kwargs override the splitter.
         self.assertEqual(args[1], "test/dynamo/test_foo.py::TestFoo::test_bar")
         self.assertEqual(kwargs["classname"], "TestFoo")
         self.assertEqual(kwargs["testname"], "test_bar")
+        # file_attr is the rootdir-relative path from the nodeid, so the row
+        # records the actual source file even when invoking_file differs.
+        self.assertEqual(kwargs["file_attr"], "test/dynamo/test_foo.py")
         self.assertIn("SIGTERM", kwargs["reason"])
-        # Deterministic suffix keyed by (classname, testname).
-        self.assertEqual(
-            kwargs["s3_key_suffix"], "incomplete_TestFoo_test_bar"
+        # Deterministic suffix: sanitized prefix + 8-char hash of full nodeid.
+        self.assertTrue(
+            kwargs["s3_key_suffix"].startswith("incomplete_TestFoo_test_bar_"),
+            f"suffix={kwargs['s3_key_suffix']!r}",
         )
+        # 8 hex chars at the end
+        self.assertRegex(kwargs["s3_key_suffix"], r"_[0-9a-f]{8}$")
 
     def test_skips_when_made_failing_xml_true(self) -> None:
         # pytest reached sessionfinish with exit != 0 — the existing failure
@@ -112,8 +121,9 @@ class TestUploadAdhocIncompleteTests(unittest.TestCase):
         # Test ran to completion (its testcase is in the xml) and a LATER
         # test was killed mid-run. Don't double-emit for the completed one.
         # Mirrors pytest xunit2 output: classname is dotted module path,
-        # `file` is the rootdir-relative test file. Helper dedups on
-        # (file, name).
+        # `file` is the rootdir-relative test file. Helper bridges xunit2's
+        # dotted classname to nodeid's bare classname via last-segment
+        # comparison, so the dedup key is (file, last_class_segment, name).
         _write_cache(
             self.stepcurrent / "key1",
             "test_foo.py::TestFoo::test_bar",
@@ -128,17 +138,31 @@ class TestUploadAdhocIncompleteTests(unittest.TestCase):
             self.assertEqual(helper.main(), 0)
         up.assert_not_called()
 
+    def test_does_not_skip_when_only_name_collides_across_classes(self) -> None:
+        # Two classes in the same file can both define `test_setup`. xunit2
+        # distinguishes via classname. The dedup must NOT suppress a real
+        # incomplete row in TestBar just because TestFoo.test_setup ran.
+        _write_cache(
+            self.stepcurrent / "key1",
+            "test_foo.py::TestBar::test_setup",
+            made_failing_xml=False,
+        )
+        _write_junit_xml(
+            self.test_reports,
+            "report.xml",
+            [("test_foo.py", "test_foo.TestFoo", "test_setup")],
+        )
+        with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+            self.assertEqual(helper.main(), 0)
+        up.assert_called_once()
+
     def test_does_not_skip_on_classname_only_match(self) -> None:
-        # Pytest xunit2 uses a dotted module classname; a bare-classname
-        # match (e.g. `TestFoo` in xml vs `TestFoo` from nodeid) is NOT
-        # enough — must dedup on (file, name). If the file differs, the
-        # adhoc row should still emit.
+        # Same classname+name but different file → must still emit.
         _write_cache(
             self.stepcurrent / "key1",
             "test_a.py::TestFoo::test_bar",
             made_failing_xml=False,
         )
-        # An unrelated XML with the same classname+name but different file.
         _write_junit_xml(
             self.test_reports,
             "other.xml",
@@ -147,6 +171,25 @@ class TestUploadAdhocIncompleteTests(unittest.TestCase):
         with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
             self.assertEqual(helper.main(), 0)
         up.assert_called_once()
+
+    def test_function_test_dedup_against_module_only_classname(self) -> None:
+        # Function-level test: nodeid has no class segment. xunit2 writes
+        # classname=<module path>. The helper's last-segment normalization
+        # treats single-segment xunit2 classnames as no-class, matching the
+        # nodeid's empty classname.
+        _write_cache(
+            self.stepcurrent / "key1",
+            "test_foo.py::test_top_level",
+            made_failing_xml=False,
+        )
+        _write_junit_xml(
+            self.test_reports,
+            "report.xml",
+            [("test_foo.py", "test_foo", "test_top_level")],
+        )
+        with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+            self.assertEqual(helper.main(), 0)
+        up.assert_not_called()
 
     def test_parametrized_nodeid_with_double_colon(self) -> None:
         # Legal parametrized id like `test_foo.py::test_bar[a::b]` must NOT
@@ -162,6 +205,30 @@ class TestUploadAdhocIncompleteTests(unittest.TestCase):
         kwargs = up.call_args.kwargs
         self.assertEqual(kwargs["classname"], "")
         self.assertEqual(kwargs["testname"], "test_bar[a::b]")
+
+    def test_lossy_sanitizer_collision_avoided_by_hash(self) -> None:
+        # `a:b`, `a::b`, `a/b`, `a b` all sanitize to `a_b`. The 8-char
+        # nodeid-hash suffix must keep them distinct.
+        for v in ("a:b", "a::b", "a/b", "a b"):
+            (self.stepcurrent / "key1").mkdir(parents=True, exist_ok=True)
+            (self.stepcurrent / "key1" / "lastrun").write_text(
+                json.dumps(f"test_foo.py::test_x[{v}]")
+            )
+            (self.stepcurrent / "key1" / "made_failing_xml").write_text("false")
+            with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+                self.assertEqual(helper.main(), 0)
+            self.assertEqual(up.call_count, 1, f"variant={v!r}")
+        # All four invocations should have produced distinct s3 keys.
+        # (Re-run all and collect.)
+        suffixes: set[str] = set()
+        for v in ("a:b", "a::b", "a/b", "a b"):
+            (self.stepcurrent / "key1" / "lastrun").write_text(
+                json.dumps(f"test_foo.py::test_x[{v}]")
+            )
+            with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+                helper.main()
+            suffixes.add(up.call_args.kwargs["s3_key_suffix"])
+        self.assertEqual(len(suffixes), 4, suffixes)
 
     def test_skips_when_lastrun_missing_or_null(self) -> None:
         _write_cache(

--- a/tools/test/test_upload_adhoc_incomplete_tests.py
+++ b/tools/test/test_upload_adhoc_incomplete_tests.py
@@ -22,18 +22,25 @@ def _write_cache(dir_: Path, lastrun: Any, made_failing_xml: bool) -> None:
     (dir_ / "made_failing_xml").write_text(json.dumps(made_failing_xml))
 
 
-def _write_junit_xml(dir_: Path, name: str, testcases: list[tuple[str, str]]) -> None:
+def _write_junit_xml(
+    dir_: Path, name: str, testcases: list[tuple[str, str, str]]
+) -> None:
+    """testcases items: (file, classname, name) — xunit2 attributes."""
     dir_.mkdir(parents=True, exist_ok=True)
     body = "".join(
-        f'<testcase classname="{cls}" name="{n}"/>' for cls, n in testcases
+        f'<testcase file="{file_attr}" classname="{cls}" name="{n}"/>'
+        for file_attr, cls, n in testcases
     )
     (dir_ / name).write_text(f'<?xml version="1.0"?><testsuite>{body}</testsuite>')
 
 
 class TestUploadAdhocIncompleteTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.tmp = self.enterContext(__import__("tempfile").TemporaryDirectory())
-        self.repo_root = Path(self.tmp)
+        import tempfile
+
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        self.repo_root = Path(tmpdir.name)
         self.stepcurrent = self.repo_root / ".pytest_cache" / "v" / "cache" / "stepcurrent"
         self.test_reports = self.repo_root / "test" / "test-reports"
         # Repoint the helper's module-level paths at the temp dir.
@@ -51,6 +58,19 @@ class TestUploadAdhocIncompleteTests(unittest.TestCase):
             p.start()
             self.addCleanup(p.stop)
 
+    def test_skips_when_job_id_missing(self) -> None:
+        _write_cache(
+            self.stepcurrent / "key1",
+            "test_foo.py::TestFoo::test_bar",
+            made_failing_xml=False,
+        )
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(helper, "upload_adhoc_failure_json") as up,
+        ):
+            self.assertEqual(helper.main(), 0)
+        up.assert_not_called()
+
     def test_emits_for_incomplete_test_not_in_xml(self) -> None:
         # An in-flight nodeid with no junit-xml row should produce exactly
         # one adhoc emission.
@@ -64,7 +84,12 @@ class TestUploadAdhocIncompleteTests(unittest.TestCase):
         self.assertEqual(up.call_count, 1)
         args, kwargs = up.call_args
         self.assertEqual(args[0], "test/dynamo/test_foo")
-        self.assertEqual(args[1], "TestFoo::test_bar")
+        # current_failure (full nodeid) is passed positionally for the
+        # logging/legacy fallback, but explicit classname/testname kwargs
+        # override the splitter.
+        self.assertEqual(args[1], "test/dynamo/test_foo.py::TestFoo::test_bar")
+        self.assertEqual(kwargs["classname"], "TestFoo")
+        self.assertEqual(kwargs["testname"], "test_bar")
         self.assertIn("SIGTERM", kwargs["reason"])
         # Deterministic suffix keyed by (classname, testname).
         self.assertEqual(
@@ -86,6 +111,9 @@ class TestUploadAdhocIncompleteTests(unittest.TestCase):
     def test_skips_when_testcase_already_in_junit_xml(self) -> None:
         # Test ran to completion (its testcase is in the xml) and a LATER
         # test was killed mid-run. Don't double-emit for the completed one.
+        # Mirrors pytest xunit2 output: classname is dotted module path,
+        # `file` is the rootdir-relative test file. Helper dedups on
+        # (file, name).
         _write_cache(
             self.stepcurrent / "key1",
             "test_foo.py::TestFoo::test_bar",
@@ -94,11 +122,46 @@ class TestUploadAdhocIncompleteTests(unittest.TestCase):
         _write_junit_xml(
             self.test_reports,
             "report.xml",
-            [("TestFoo", "test_bar")],
+            [("test_foo.py", "test_foo.TestFoo", "test_bar")],
         )
         with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
             self.assertEqual(helper.main(), 0)
         up.assert_not_called()
+
+    def test_does_not_skip_on_classname_only_match(self) -> None:
+        # Pytest xunit2 uses a dotted module classname; a bare-classname
+        # match (e.g. `TestFoo` in xml vs `TestFoo` from nodeid) is NOT
+        # enough — must dedup on (file, name). If the file differs, the
+        # adhoc row should still emit.
+        _write_cache(
+            self.stepcurrent / "key1",
+            "test_a.py::TestFoo::test_bar",
+            made_failing_xml=False,
+        )
+        # An unrelated XML with the same classname+name but different file.
+        _write_junit_xml(
+            self.test_reports,
+            "other.xml",
+            [("test_b.py", "test_b.TestFoo", "test_bar")],
+        )
+        with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+            self.assertEqual(helper.main(), 0)
+        up.assert_called_once()
+
+    def test_parametrized_nodeid_with_double_colon(self) -> None:
+        # Legal parametrized id like `test_foo.py::test_bar[a::b]` must NOT
+        # be mis-split on inner `::`.
+        _write_cache(
+            self.stepcurrent / "key1",
+            "test/test_foo.py::test_bar[a::b]",
+            made_failing_xml=False,
+        )
+        with mock.patch.object(helper, "upload_adhoc_failure_json") as up:
+            self.assertEqual(helper.main(), 0)
+        self.assertEqual(up.call_count, 1)
+        kwargs = up.call_args.kwargs
+        self.assertEqual(kwargs["classname"], "")
+        self.assertEqual(kwargs["testname"], "test_bar[a::b]")
 
     def test_skips_when_lastrun_missing_or_null(self) -> None:
         _write_cache(

--- a/tools/testing/upload_adhoc_incomplete_tests.py
+++ b/tools/testing/upload_adhoc_incomplete_tests.py
@@ -1,0 +1,167 @@
+"""
+Emit adhoc-failure rows for tests that started but never produced a junit-xml
+entry — e.g. when the GHA test step was killed by `timeout-minutes`, by
+`gh run cancel`, by an OOM-killer, or by any other SIGTERM/SIGKILL that hit
+pytest before `pytest_sessionfinish` ran.
+
+The pytest plugin `StepcurrentPlugin` (test/conftest.py) persists the
+in-flight nodeid on every `pytest_runtest_protocol` hook to
+`.pytest_cache/v/cache/stepcurrent/<key>/lastrun`. It also writes
+`made_failing_xml=true` to the same directory on `pytest_sessionfinish` when
+exitstatus != 0 — meaning pytest finished cleanly enough to emit failure xml.
+
+This script walks every `stepcurrent` subdir, reads `lastrun` and
+`made_failing_xml`, then emits one adhoc-failure JSON for each nodeid that:
+
+1. Was the last test to start running (per `lastrun`).
+2. Has NOT been flagged `made_failing_xml=true` (segfault path already
+   covered by `run_test.py::run_test_retries`).
+3. Does NOT appear as a `<testcase>` in any junit-xml under
+   `test/test-reports/**/*.xml` (i.e. pytest never wrote a row for it).
+
+Designed to be invoked from a GHA composite-action step gated `if: failure()`
+right before the existing `upload-test-artifacts` zip+upload step, so it
+fires for ANY test-step failure mode — not just SIGTERM — without competing
+with the in-process `parse_xml_and_upload_json()` path or the
+`FAILED CONSISTENTLY` path in `run_test.py`.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from tools.testing.upload_artifacts import upload_adhoc_failure_json
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+STEPCURRENT_DIR = REPO_ROOT / ".pytest_cache" / "v" / "cache" / "stepcurrent"
+TEST_REPORTS_DIR = REPO_ROOT / "test" / "test-reports"
+
+
+def _read_pytest_cache_value(path: Path) -> str | None:
+    """pytest.Cache writes JSON files; null/missing → None, string → unquoted."""
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _collect_completed_testcases() -> set[tuple[str, str]]:
+    """Build a set of (classname, name) tuples from every junit-xml on disk.
+
+    junit-xml `<testcase>` elements carry `classname` (may be empty) + `name`.
+    These match the (className, testName) split used by
+    `upload_adhoc_failure_json` so dedup is cheap.
+    """
+    completed: set[tuple[str, str]] = set()
+    if not TEST_REPORTS_DIR.is_dir():
+        return completed
+    for xml_file in glob.glob(f"{TEST_REPORTS_DIR}/**/*.xml", recursive=True):
+        try:
+            tree = ET.parse(xml_file)
+        except ET.ParseError:
+            # A partially-written XML is treated as no data — the adhoc helper
+            # will fill the gap if the relevant testcase is missing.
+            continue
+        for testcase in tree.iter("testcase"):
+            classname = testcase.get("classname") or ""
+            name = testcase.get("name") or ""
+            if name:
+                completed.add((classname, name))
+    return completed
+
+
+def _nodeid_to_emit_args(nodeid: str) -> tuple[str, str] | None:
+    """Map a pytest nodeid to (invoking_file, current_failure_arg).
+
+    A pytest nodeid is `<path>.py::<class>::<name>` or `<path>.py::<name>`.
+    `upload_adhoc_failure_json` expects:
+      - invoking_file: path without `.py` (e.g. `dynamo/test_foo`)
+      - current_failure: the `::`-delimited tail (className::testName or just
+        testName), so its own splitter recovers the same classname/name.
+    """
+    parts = nodeid.split("::")
+    if len(parts) < 2:
+        return None
+    path_part = parts[0]
+    if not path_part.endswith(".py"):
+        return None
+    invoking_file = path_part[:-3]
+    # Re-join everything after the file part; `upload_adhoc_failure_json`
+    # takes the last two `::`-separated segments.
+    current_failure = "::".join(parts[1:])
+    return invoking_file, current_failure
+
+
+def _classname_testname(current_failure: str) -> tuple[str, str]:
+    parts = current_failure.split("::")
+    if len(parts) >= 2:
+        return parts[-2], parts[-1]
+    return "", current_failure
+
+
+def main() -> int:
+    if not STEPCURRENT_DIR.is_dir():
+        print(f"No stepcurrent cache at {STEPCURRENT_DIR}; nothing to emit.")
+        return 0
+
+    completed = _collect_completed_testcases()
+    emitted = 0
+
+    for entry in sorted(STEPCURRENT_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+
+        if _read_pytest_cache_value(entry / "made_failing_xml") is True:
+            # pytest reached sessionfinish with exit != 0; failure xml was
+            # already written and the FAILED CONSISTENTLY path may have
+            # already emitted an adhoc row. Skip either way.
+            continue
+
+        lastrun = _read_pytest_cache_value(entry / "lastrun")
+        if not isinstance(lastrun, str) or not lastrun:
+            continue
+
+        emit_args = _nodeid_to_emit_args(lastrun)
+        if emit_args is None:
+            continue
+        invoking_file, current_failure = emit_args
+
+        classname, testname = _classname_testname(current_failure)
+        if (classname, testname) in completed:
+            # junit-xml already has a row for this test (it ran to completion
+            # and a later test was killed). Don't duplicate.
+            continue
+
+        reason = (
+            "Test step terminated before pytest could write junit-xml "
+            "(SIGTERM/SIGKILL — e.g. timeout-minutes, run cancellation, "
+            f"or OOM). Last test seen by stepcurrent: {lastrun}"
+        )
+        suffix = f"{classname}_{testname}".replace("/", "_").replace(" ", "_")
+        try:
+            upload_adhoc_failure_json(
+                invoking_file,
+                current_failure,
+                reason=reason,
+                s3_key_suffix=f"incomplete_{suffix}",
+            )
+        except Exception as e:  # noqa: BLE001
+            print(f"Failed to emit adhoc row for {lastrun}: {e}")
+            continue
+        emitted += 1
+        print(f"Emitted adhoc-incomplete row for {lastrun}")
+
+    print(f"upload_adhoc_incomplete_tests: emitted {emitted} row(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/testing/upload_adhoc_incomplete_tests.py
+++ b/tools/testing/upload_adhoc_incomplete_tests.py
@@ -16,21 +16,26 @@ This script walks every `stepcurrent` subdir, reads `lastrun` and
 1. Was the last test to start running (per `lastrun`).
 2. Has NOT been flagged `made_failing_xml=true` (segfault path already
    covered by `run_test.py::run_test_retries`).
-3. Has no matching `<testcase>` (keyed on the xunit2 `file` and `name`
-   attributes) in any `test/test-reports/**/*.xml` already on disk.
+3. Has no matching `<testcase>` (keyed on xunit2 `(file, classname, name)`
+   attributes, with classname compared by last segment to bridge xunit2's
+   dotted module-qualified form vs the bare class segment in the nodeid)
+   in any `test/test-reports/**/*.xml` already on disk.
 
-Designed to be invoked from a GHA composite-action step gated `if: failure()`
-right before the existing `upload-test-artifacts` zip+upload step, so it
-fires for ANY test-step failure mode — not just SIGTERM — without competing
-with the in-process `parse_xml_and_upload_json()` path or the
-`FAILED CONSISTENTLY` path in `run_test.py`.
+Designed to be invoked from a GHA composite-action step gated explicitly on
+the caller's `test-conclusion == 'failure' || 'cancelled'`, right before the
+existing `upload-test-artifacts` zip+upload step, so it fires for ANY
+test-step failure mode — not just SIGTERM — without competing with the
+in-process `parse_xml_and_upload_json()` path or the `FAILED CONSISTENTLY`
+path in `run_test.py`.
 """
 
 from __future__ import annotations
 
 import glob
+import hashlib
 import json
 import os
+import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -45,6 +50,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 STEPCURRENT_DIR = REPO_ROOT / ".pytest_cache" / "v" / "cache" / "stepcurrent"
 TEST_REPORTS_DIR = REPO_ROOT / "test" / "test-reports"
 
+# stepcurrent_key shapes from run_test.py:508-530:
+#   <test_file>                         (cpp test, line 508)
+#   <test_file>_<hex16>                 (cpp variant, line 522)
+#   <test_file>_<shard>_<hex16>         (regular, line 530)
+# `test_file` itself may contain underscores. Extract by stripping the
+# `_<shard>?_<hex16>` suffix if present.
+_STEPCURRENT_KEY_RE = re.compile(r"^(.+?)(?:_\d+)?_[a-f0-9]{16}$")
+
 
 def _read_pytest_cache_value(path: Path) -> object | None:
     """pytest.Cache writes JSON files; missing/unparseable → None."""
@@ -56,16 +69,28 @@ def _read_pytest_cache_value(path: Path) -> object | None:
         return None
 
 
-def _collect_completed_testcases() -> set[tuple[str, str]]:
-    """Build a set of (file_attr, name_attr) tuples from every junit-xml on disk.
+def _invoking_file_from_stepcurrent_key(key: str) -> str:
+    """Recover the run_test.py `test_file` (invocation unit) from the cache key."""
+    m = _STEPCURRENT_KEY_RE.match(key)
+    return m.group(1) if m else key
 
-    Keyed on the xunit2 `<testcase file="..." name="...">` attributes — those
-    match the rootdir-relative file path and the full test name (including
-    any parametrize suffix), which is what `parse_pytest_nodeid` returns for
-    the in-flight nodeid. xunit2's `classname` uses a dotted module path so we
-    deliberately avoid matching on it.
+
+def _xunit_classname_last_segment(classname: str) -> str:
+    """xunit2 emits `package.module.TestClass` for class tests, `package.module`
+    for function tests. The "last segment" is `TestClass` (class tests) or
+    the full path (function tests; we treat as no-class)."""
+    if "." not in classname:
+        return ""  # function-test xunit2 classname is just the module path
+    return classname.rsplit(".", 1)[-1]
+
+
+def _collect_completed_testcases() -> set[tuple[str, str, str]]:
+    """Build `(file, last_class_segment, name)` from every junit-xml on disk.
+
+    Match key bridges xunit2's dotted module-qualified `classname` against
+    the bare class segment that `parse_pytest_nodeid` returns.
     """
-    completed: set[tuple[str, str]] = set()
+    completed: set[tuple[str, str, str]] = set()
     if not TEST_REPORTS_DIR.is_dir():
         return completed
     for xml_file in glob.glob(f"{TEST_REPORTS_DIR}/**/*.xml", recursive=True):
@@ -77,13 +102,20 @@ def _collect_completed_testcases() -> set[tuple[str, str]]:
             continue
         for testcase in tree.iter("testcase"):
             file_attr = testcase.get("file") or ""
+            classname = testcase.get("classname") or ""
             name_attr = testcase.get("name") or ""
             if file_attr and name_attr:
-                completed.add((file_attr, name_attr))
+                completed.add(
+                    (file_attr, _xunit_classname_last_segment(classname), name_attr)
+                )
     return completed
 
 
 def _sanitize_for_s3_key(s: str) -> str:
+    # S3 keys allow most chars but we keep the existing path-safe shape and
+    # avoid `:` / `/` / `[` / `]` / whitespace which can collide between
+    # different parametrize values (`a:b` vs `a::b` vs `a/b`). The nodeid
+    # hash appended in main() preserves distinguishability.
     return (
         s.replace("/", "_")
         .replace(" ", "_")
@@ -128,9 +160,15 @@ def main() -> int:
         if parsed is None:
             print(f"Skipping unparseable nodeid: {lastrun!r}")
             continue
-        test_file_path, invoking_file, classname, testname = parsed
+        test_file_path, _, classname, testname = parsed
 
-        if (test_file_path, testname) in completed:
+        # Use the run_test.py invocation unit as `invoking_file` so this row
+        # groups with other rows from the same test_file in downstream
+        # consumers (HUD, autorevert). The pytest nodeid's path goes into
+        # `file_attr` so the row still records the true source location.
+        invoking_file = _invoking_file_from_stepcurrent_key(entry.name)
+
+        if (test_file_path, classname, testname) in completed:
             # junit-xml already has a row for this test (it ran to completion
             # and a later test was killed). Don't duplicate.
             continue
@@ -140,7 +178,12 @@ def main() -> int:
             "(SIGTERM/SIGKILL — e.g. timeout-minutes, run cancellation, "
             f"or OOM). Last test seen by stepcurrent: {lastrun}"
         )
-        suffix = _sanitize_for_s3_key(f"incomplete_{classname}_{testname}")
+        # Deterministic, collision-resistant s3 key: sanitized human-readable
+        # prefix plus an 8-char hash of the full nodeid so parametrize values
+        # like `a:b` vs `a::b` vs `a/b` don't collapse onto each other.
+        prefix = _sanitize_for_s3_key(f"incomplete_{classname}_{testname}")
+        digest = hashlib.sha256(lastrun.encode("utf-8")).hexdigest()[:8]
+        suffix = f"{prefix}_{digest}"
         try:
             upload_adhoc_failure_json(
                 invoking_file,
@@ -149,6 +192,7 @@ def main() -> int:
                 s3_key_suffix=suffix,
                 classname=classname,
                 testname=testname,
+                file_attr=test_file_path,
             )
         except Exception as e:  # noqa: BLE001
             print(f"Failed to emit adhoc row for {lastrun}: {e}")

--- a/tools/testing/upload_adhoc_incomplete_tests.py
+++ b/tools/testing/upload_adhoc_incomplete_tests.py
@@ -16,8 +16,8 @@ This script walks every `stepcurrent` subdir, reads `lastrun` and
 1. Was the last test to start running (per `lastrun`).
 2. Has NOT been flagged `made_failing_xml=true` (segfault path already
    covered by `run_test.py::run_test_retries`).
-3. Does NOT appear as a `<testcase>` in any junit-xml under
-   `test/test-reports/**/*.xml` (i.e. pytest never wrote a row for it).
+3. Has no matching `<testcase>` (keyed on the xunit2 `file` and `name`
+   attributes) in any `test/test-reports/**/*.xml` already on disk.
 
 Designed to be invoked from a GHA composite-action step gated `if: failure()`
 right before the existing `upload-test-artifacts` zip+upload step, so it
@@ -35,7 +35,10 @@ import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-from tools.testing.upload_artifacts import upload_adhoc_failure_json
+from tools.testing.upload_artifacts import (
+    parse_pytest_nodeid,
+    upload_adhoc_failure_json,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -43,8 +46,8 @@ STEPCURRENT_DIR = REPO_ROOT / ".pytest_cache" / "v" / "cache" / "stepcurrent"
 TEST_REPORTS_DIR = REPO_ROOT / "test" / "test-reports"
 
 
-def _read_pytest_cache_value(path: Path) -> str | None:
-    """pytest.Cache writes JSON files; null/missing → None, string → unquoted."""
+def _read_pytest_cache_value(path: Path) -> object | None:
+    """pytest.Cache writes JSON files; missing/unparseable → None."""
     if not path.is_file():
         return None
     try:
@@ -54,11 +57,13 @@ def _read_pytest_cache_value(path: Path) -> str | None:
 
 
 def _collect_completed_testcases() -> set[tuple[str, str]]:
-    """Build a set of (classname, name) tuples from every junit-xml on disk.
+    """Build a set of (file_attr, name_attr) tuples from every junit-xml on disk.
 
-    junit-xml `<testcase>` elements carry `classname` (may be empty) + `name`.
-    These match the (className, testName) split used by
-    `upload_adhoc_failure_json` so dedup is cheap.
+    Keyed on the xunit2 `<testcase file="..." name="...">` attributes — those
+    match the rootdir-relative file path and the full test name (including
+    any parametrize suffix), which is what `parse_pytest_nodeid` returns for
+    the in-flight nodeid. xunit2's `classname` uses a dotted module path so we
+    deliberately avoid matching on it.
     """
     completed: set[tuple[str, str]] = set()
     if not TEST_REPORTS_DIR.is_dir():
@@ -68,48 +73,38 @@ def _collect_completed_testcases() -> set[tuple[str, str]]:
             tree = ET.parse(xml_file)
         except ET.ParseError:
             # A partially-written XML is treated as no data — the adhoc helper
-            # will fill the gap if the relevant testcase is missing.
+            # will still fire if the relevant testcase is missing elsewhere.
             continue
         for testcase in tree.iter("testcase"):
-            classname = testcase.get("classname") or ""
-            name = testcase.get("name") or ""
-            if name:
-                completed.add((classname, name))
+            file_attr = testcase.get("file") or ""
+            name_attr = testcase.get("name") or ""
+            if file_attr and name_attr:
+                completed.add((file_attr, name_attr))
     return completed
 
 
-def _nodeid_to_emit_args(nodeid: str) -> tuple[str, str] | None:
-    """Map a pytest nodeid to (invoking_file, current_failure_arg).
-
-    A pytest nodeid is `<path>.py::<class>::<name>` or `<path>.py::<name>`.
-    `upload_adhoc_failure_json` expects:
-      - invoking_file: path without `.py` (e.g. `dynamo/test_foo`)
-      - current_failure: the `::`-delimited tail (className::testName or just
-        testName), so its own splitter recovers the same classname/name.
-    """
-    parts = nodeid.split("::")
-    if len(parts) < 2:
-        return None
-    path_part = parts[0]
-    if not path_part.endswith(".py"):
-        return None
-    invoking_file = path_part[:-3]
-    # Re-join everything after the file part; `upload_adhoc_failure_json`
-    # takes the last two `::`-separated segments.
-    current_failure = "::".join(parts[1:])
-    return invoking_file, current_failure
-
-
-def _classname_testname(current_failure: str) -> tuple[str, str]:
-    parts = current_failure.split("::")
-    if len(parts) >= 2:
-        return parts[-2], parts[-1]
-    return "", current_failure
+def _sanitize_for_s3_key(s: str) -> str:
+    return (
+        s.replace("/", "_")
+        .replace(" ", "_")
+        .replace("[", "_")
+        .replace("]", "_")
+        .replace(":", "_")
+    )
 
 
 def main() -> int:
     if not STEPCURRENT_DIR.is_dir():
         print(f"No stepcurrent cache at {STEPCURRENT_DIR}; nothing to emit.")
+        return 0
+
+    if not os.environ.get("JOB_ID") or not os.environ.get("GITHUB_RUN_ID"):
+        # `upload_adhoc_failure_json` would early-return anyway, but log it
+        # clearly so the CI step output flags the misconfiguration.
+        print(
+            "JOB_ID or GITHUB_RUN_ID not set in env; cannot emit adhoc rows. "
+            "The composite action must pass `job-id` and set JOB_ID/GITHUB_RUN_ID."
+        )
         return 0
 
     completed = _collect_completed_testcases()
@@ -129,13 +124,13 @@ def main() -> int:
         if not isinstance(lastrun, str) or not lastrun:
             continue
 
-        emit_args = _nodeid_to_emit_args(lastrun)
-        if emit_args is None:
+        parsed = parse_pytest_nodeid(lastrun)
+        if parsed is None:
+            print(f"Skipping unparseable nodeid: {lastrun!r}")
             continue
-        invoking_file, current_failure = emit_args
+        test_file_path, invoking_file, classname, testname = parsed
 
-        classname, testname = _classname_testname(current_failure)
-        if (classname, testname) in completed:
+        if (test_file_path, testname) in completed:
             # junit-xml already has a row for this test (it ran to completion
             # and a later test was killed). Don't duplicate.
             continue
@@ -145,13 +140,15 @@ def main() -> int:
             "(SIGTERM/SIGKILL — e.g. timeout-minutes, run cancellation, "
             f"or OOM). Last test seen by stepcurrent: {lastrun}"
         )
-        suffix = f"{classname}_{testname}".replace("/", "_").replace(" ", "_")
+        suffix = _sanitize_for_s3_key(f"incomplete_{classname}_{testname}")
         try:
             upload_adhoc_failure_json(
                 invoking_file,
-                current_failure,
+                lastrun,
                 reason=reason,
-                s3_key_suffix=f"incomplete_{suffix}",
+                s3_key_suffix=suffix,
+                classname=classname,
+                testname=testname,
             )
         except Exception as e:  # noqa: BLE001
             print(f"Failed to emit adhoc row for {lastrun}: {e}")

--- a/tools/testing/upload_artifacts.py
+++ b/tools/testing/upload_artifacts.py
@@ -208,11 +208,70 @@ def parse_xml_and_upload_json() -> None:
         print(f"Failed to parse and upload json test reports: {e}")
 
 
+def parse_pytest_nodeid(nodeid: str) -> tuple[str, str, str, str] | None:
+    """Parse a pytest nodeid into (test_file_path, invoking_file, classname, testname).
+
+    Parametrized test ids can legally contain `::` inside `[...]`
+    (e.g. `test_foo.py::test_bar[a::b]`), so a plain `split("::")` is wrong.
+    This walks the string and splits on top-level `::` only.
+
+    Returns None if `nodeid` doesn't look like a `<path>.py::...` form.
+
+    - `test_file_path`: `dynamo/test_foo.py` — rootdir-relative path, matches
+      pytest xunit2's `<testcase file="...">` attribute.
+    - `invoking_file`: `dynamo/test_foo` — what `upload_adhoc_failure_json`
+      historically expects as its first arg.
+    - `classname`: last class segment (`TestFoo`) or `""` for function tests.
+      Note: pytest xunit2 uses a dotted *module-qualified* classname; we don't
+      try to reconstruct that, so callers must dedup on `(file, testname)`.
+    - `testname`: full method name including the parametrize suffix
+      (`test_bar[a::b]`).
+    """
+    sep = ".py::"
+    idx = nodeid.find(sep)
+    if idx < 0:
+        return None
+    test_file_path = nodeid[: idx + 3]
+    invoking_file = nodeid[:idx]
+    tail = nodeid[idx + len(sep) :]
+    parts: list[str] = []
+    cur: list[str] = []
+    depth = 0
+    i = 0
+    while i < len(tail):
+        c = tail[i]
+        if c == "[":
+            depth += 1
+            cur.append(c)
+            i += 1
+        elif c == "]":
+            depth = max(0, depth - 1)
+            cur.append(c)
+            i += 1
+        elif depth == 0 and tail[i : i + 2] == "::":
+            parts.append("".join(cur))
+            cur = []
+            i += 2
+        else:
+            cur.append(c)
+            i += 1
+    parts.append("".join(cur))
+    if len(parts) >= 2:
+        classname = parts[-2]
+        testname = parts[-1]
+    else:
+        classname = ""
+        testname = parts[0]
+    return test_file_path, invoking_file, classname, testname
+
+
 def upload_adhoc_failure_json(
     invoking_file: str,
     current_failure: str,
     reason: str | None = None,
     s3_key_suffix: str | None = None,
+    classname: str | None = None,
+    testname: str | None = None,
 ) -> None:
     """
     manually upload a json to s3 indicating that a test failed without pytest
@@ -223,6 +282,10 @@ def upload_adhoc_failure_json(
     the segfault wording for callers that don't pass one. `s3_key_suffix`
     overrides the random per-call suffix used in the S3 key; pass a
     deterministic value to make repeated invocations idempotent.
+
+    `classname` and `testname` override the legacy `current_failure.split("::")`
+    parsing — pass these from `parse_pytest_nodeid` so parametrized ids that
+    contain `::` inside brackets aren't mis-split.
     """
     try:
         job_id = int(os.environ["JOB_ID"])
@@ -231,13 +294,14 @@ def upload_adhoc_failure_json(
         print(f"Failed to get job_id or workflow_id: {e}")
         return
 
-    split_failure = current_failure.split("::")
-    if len(split_failure) >= 2:
-        className = split_failure[-2]
-        testName = split_failure[-1]
-    else:
-        testName = current_failure
-        className = ""
+    if classname is None or testname is None:
+        split_failure = current_failure.split("::")
+        if len(split_failure) >= 2:
+            classname = split_failure[-2] if classname is None else classname
+            testname = split_failure[-1] if testname is None else testname
+        else:
+            testname = current_failure if testname is None else testname
+            classname = "" if classname is None else classname
 
     message = reason or (
         "The test file failed but pytest did not generate xml.  "
@@ -246,8 +310,8 @@ def upload_adhoc_failure_json(
     j = {
         "invoking_file": invoking_file,
         "file": f"{invoking_file}.py",
-        "name": testName,
-        "classname": className,
+        "name": testname,
+        "classname": classname,
         "workflow_id": workflow_id,
         "workflow_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
         "job_id": job_id,

--- a/tools/testing/upload_artifacts.py
+++ b/tools/testing/upload_artifacts.py
@@ -272,6 +272,7 @@ def upload_adhoc_failure_json(
     s3_key_suffix: str | None = None,
     classname: str | None = None,
     testname: str | None = None,
+    file_attr: str | None = None,
 ) -> None:
     """
     manually upload a json to s3 indicating that a test failed without pytest
@@ -286,6 +287,12 @@ def upload_adhoc_failure_json(
     `classname` and `testname` override the legacy `current_failure.split("::")`
     parsing — pass these from `parse_pytest_nodeid` so parametrized ids that
     contain `::` inside brackets aren't mis-split.
+
+    `file_attr` overrides the `file` JSON field. Defaults to `f"{invoking_file}.py"`
+    for backwards compatibility. Pass the true source file path (from the
+    pytest nodeid) when `invoking_file` is the discovery unit and you want
+    the row's `file` to point at the real test source — useful when an
+    inherited test lives in a different file from the one run_test.py invoked.
     """
     try:
         job_id = int(os.environ["JOB_ID"])
@@ -309,7 +316,7 @@ def upload_adhoc_failure_json(
     )
     j = {
         "invoking_file": invoking_file,
-        "file": f"{invoking_file}.py",
+        "file": file_attr if file_attr else f"{invoking_file}.py",
         "name": testname,
         "classname": classname,
         "workflow_id": workflow_id,

--- a/tools/testing/upload_artifacts.py
+++ b/tools/testing/upload_artifacts.py
@@ -208,10 +208,21 @@ def parse_xml_and_upload_json() -> None:
         print(f"Failed to parse and upload json test reports: {e}")
 
 
-def upload_adhoc_failure_json(invoking_file: str, current_failure: str) -> None:
+def upload_adhoc_failure_json(
+    invoking_file: str,
+    current_failure: str,
+    reason: str | None = None,
+    s3_key_suffix: str | None = None,
+) -> None:
     """
-    manually upload a json to s3 indicating that the entire test file failed
-    since xml was probably not generated in this case
+    manually upload a json to s3 indicating that a test failed without pytest
+    writing a junit-xml entry for it (e.g. segfault before sessionfinish, or
+    shard SIGTERM-on-timeout).
+
+    `reason` overrides the failure message written into the row; defaults to
+    the segfault wording for callers that don't pass one. `s3_key_suffix`
+    overrides the random per-call suffix used in the S3 key; pass a
+    deterministic value to make repeated invocations idempotent.
     """
     try:
         job_id = int(os.environ["JOB_ID"])
@@ -228,7 +239,10 @@ def upload_adhoc_failure_json(invoking_file: str, current_failure: str) -> None:
         testName = current_failure
         className = ""
 
-    message = "The test file failed but pytest did not generate xml.  The most likely cause is a segfault"
+    message = reason or (
+        "The test file failed but pytest did not generate xml.  "
+        "The most likely cause is a segfault"
+    )
     j = {
         "invoking_file": invoking_file,
         "file": f"{invoking_file}.py",
@@ -240,7 +254,8 @@ def upload_adhoc_failure_json(invoking_file: str, current_failure: str) -> None:
         "failure": {"message": message, "text": message},
     }
     gzipped = gzip.compress(json.dumps(j).encode("utf-8"))
-    s3_key = f"{invoking_file.replace('/', '_')}_{os.urandom(8).hex()}.json"
+    suffix = s3_key_suffix if s3_key_suffix is not None else os.urandom(8).hex()
+    s3_key = f"{invoking_file.replace('/', '_')}_{suffix}.json"
     get_s3_resource().put_object(
         Body=gzipped,
         Bucket="gha-artifacts",


### PR DESCRIPTION
## Summary

When a GHA test step is killed mid-run (`timeout-minutes`, `gh run cancel`, OOM, etc.), the in-flight pytest invocation never reaches `pytest_sessionfinish`, so its junit-xml is never written. The currently-running test silently drops out of `s3://gha-artifacts/test_jsons_while_running/` and `tests.all_test_runs`. Downstream consumers (HUD, autorevert lambda, flaky classifier) get no signal that the test ran.

The existing `upload_adhoc_failure_json` escape hatch only covers the segfault path (`FAILED CONSISTENTLY` after ≥3 reruns in `run_test.py`). This PR adds an idempotent post-step that fills the gap for any test-step termination.

## Mechanism

The pytest plugin `StepcurrentPlugin` in `test/conftest.py` already persists the in-flight nodeid on every `pytest_runtest_protocol` to `.pytest_cache/v/cache/stepcurrent/<key>/lastrun`, and writes `made_failing_xml=true` on a normal `pytest_sessionfinish` with exit != 0. Those files survive SIGKILL.

A new helper `tools/testing/upload_adhoc_incomplete_tests.py` walks the stepcurrent cache, reads `lastrun` + `made_failing_xml`, parses xunit2 `<testcase>` attributes from `test/test-reports/**/*.xml`, and emits one adhoc-failure JSON for every in-flight nodeid that has no matching `(file, last_class_segment, name)` row in any junit-xml. The new GHA composite-action step runs the helper right before the existing zip+upload step on test-step `failure` or `cancelled`.

## Idempotency / dedup

Three independent layers guarantee we never produce a duplicate row:

1. Skip when `made_failing_xml=true` — the segfault path's `upload_adhoc_failure_json` call already emitted, OR pytest finished cleanly enough to write the failure xml itself.
2. Skip when `(file, last_class_segment, name)` is already present in any junit-xml on disk. The xunit2 `classname` is dotted (`package.module.Class`); we compare last segment so the in-flight `Class` matches xunit2's `package.module.Class`. Function tests (single-segment xunit2 classname) match the nodeid's empty class segment.
3. Skip when `lastrun` is missing or null (pytest crashed before starting any test).

The S3 key is deterministic: `incomplete_<sanitized_class>_<sanitized_name>_<sha256(nodeid)[:8]>`. Re-runs of the post-step overwrite the same key. The 8-char digest prevents collisions between parametrize variants that the sanitizer would collapse (`a:b`, `a::b`, `a/b`, `a b`).

## Nodeid parsing

Parametrized ids can legally contain `::` inside `[...]` (e.g. `test_foo.py::test_bar[a::b]`), so a naive `split("::")` is wrong. This PR adds `parse_pytest_nodeid` in `tools/testing/upload_artifacts.py` with a bracket-aware top-level `::` splitter, and reuses it from both the new helper and the existing `FAILED CONSISTENTLY` caller in `run_test.py`.

## Test plan

- [ ] `python3 -m unittest tools.test.test_upload_adhoc_incomplete_tests -v` — 12 cases pass locally.
- [ ] CI: a real shard-timeout PR should now produce one row in `tests.all_test_runs` for the in-flight test with `failure.message` carrying the `"SIGTERM/SIGKILL"` reason.
- [ ] CI: shard that completes normally should NOT produce any new adhoc rows (verified by dedup against xunit2 `<testcase>`).

## Scope / follow-ups

- v1 ships **Linux only**. The composite-action gate is `inputs.test-conclusion in ('failure', 'cancelled') && runner.os == 'Linux' && inputs.job-id != ''`. The new step is otherwise inert.
- ROCm and XPU workflows run tests inside a container and copy only `test/test-reports` back. `.pytest_cache/v/cache/stepcurrent/` would need to be copied alongside for the helper to fire there. Tracked as a follow-up.
- Windows uses a different stepcurrent path; punted.
- Only `_linux-test.yml`'s first caller of `upload-test-artifacts` is updated to pass `job-id` / `test-conclusion`. Mac/Windows/ROCm/XPU/`@main` callers continue calling the composite action without those inputs — the new step skips by design.

## Review

Drafted with two rounds of adversarial review by an external model (gpt-5.5 via Codex CLI). Both rounds turned up real ship-blockers (5 each, mix of HIGH+MEDIUM); all addressed in commits `959e749` and `9c50eee`.