### PR TITLE
Enable SDPA constraint cache by default

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -1510,6 +1510,37 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             f"vs no caching ({copy_count_uncached})",
         )
 
+    def _test_cache_sdpa_constraint_shared_kv_default(self):
+        """Default config should avoid duplicate shared K/V SDPA input buffers."""
+        if self.device != "cuda":
+            self.skipTest("empty_strided_cuda allocation check is CUDA-specific")
+
+        def pma_attention(query, kv):
+            kv_act = torch.relu(kv)
+            return torch.nn.functional.scaled_dot_product_attention(
+                query, kv_act, kv_act
+            )
+
+        tensor_shape = (2, 2, 16, 32)
+        dtype = torch.float16
+        query = torch.randn(tensor_shape, device=self.device, dtype=dtype)
+        kv = torch.randn(tensor_shape, device=self.device, dtype=dtype)
+
+        counters.clear()
+        torch._dynamo.reset()
+        result_eager = pma_attention(query, kv)
+        result_compiled, (source_code,) = run_and_get_code(
+            torch.compile(pma_attention, fullgraph=True),
+            query.clone(),
+            kv.clone(),
+        )
+        self.assertEqual(result_eager, result_compiled, atol=1e-3, rtol=0.2)
+
+        shared_kv_allocation = (
+            "empty_strided_cuda((2, 2, 16, 32), (1024, 512, 32, 1), torch.float16)"
+        )
+        self.assertEqual(source_code.count(shared_kv_allocation), 1)
+
     def _test_sdpa_rewriter_26(self):
         def dot_prod_attention(
             query: torch.Tensor,
@@ -1690,6 +1721,7 @@ if HAS_XPU_AND_TRITON or (HAS_CUDA_AND_TRITON and PLATFORM_SUPPORTS_FUSED_ATTENT
         test_cache_sdpa_constraint_shared_kv_gpu = (
             TestSDPAPatternRewriterTemplate._test_cache_sdpa_constraint_shared_kv
         )
+        test_cache_sdpa_constraint_shared_kv_default_gpu = TestSDPAPatternRewriterTemplate._test_cache_sdpa_constraint_shared_kv_default
         test_sdpa_rewriter_28_gpu = functools.partialmethod(
             TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_28
         )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -838,7 +838,7 @@ force_layout_optimization = os.environ.get("TORCHINDUCTOR_FORCE_LAYOUT_OPT", "0"
 # creating duplicate buffers when the same tensor feeds multiple SDPA positions
 # (e.g., key=value in simplified PMA attention).
 cache_sdpa_constraint = (
-    os.environ.get("TORCHINDUCTOR_CACHE_SDPA_CONSTRAINT", "0") == "1"
+    os.environ.get("TORCHINDUCTOR_CACHE_SDPA_CONSTRAINT", "1") == "1"
 )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183958

The existing SDPA constraint cache deduplicates copies when shared K/V tensors hit the same layout requirement. Enable it by default and add a regression test for the issue repro.

Fixes #175833

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos