### PR TITLE
[ROCm][Windows] Don't set USE_ROCM_CK_SDPA on Windows

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -208,7 +208,7 @@ if(USE_FLASH_ATTENTION)
         if(ENV{USE_ROCM_CK_SDPA} EQUAL 1)
           caffe2_update_option(USE_ROCM_CK_SDPA ON)
         endif()
-    else()
+    elseif(NOT WIN32)
       caffe2_update_option(USE_ROCM_CK_SDPA ON)
     endif()
     # CK SDPA only supports gfx942/gfx950. Auto-disable when none of those archs


### PR DESCRIPTION
@alugorey I just finished confirming this fixes it. This was the simplest change to make for the fix. I tried making `caffe2_update_option(USE_ROCM_CK_SDPA NOT WIN32)`, but that didn't work and this felt safer.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang