### PR TITLE
[CUDA] Change argmax to int64_t for better numerics

### DIFF
--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -193,7 +193,7 @@ __global__ void adaptivemaxgradinput(
       const T *ptr_gradOutput = gradOutput_dt + oh*osizeW + ow;
       const int64_t *ptr_ind = indices_dt + oh*osizeW + ow;
       T grad_delta = *ptr_gradOutput;
-      int argmax = (*ptr_ind);
+      int64_t argmax = (*ptr_ind);
       gradInput_d[argmax] += grad_delta;
     }
   }


### PR DESCRIPTION
We got int64_t for ptr_ind as well, so I'm pretty sure that (while not tested) this should be correct for better numerics

Contributed by Benedikt Johannes