### PR TITLE
[inductor] Silence _FastCudaLauncher ValueError on oversized kernels

### DIFF
--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -671,6 +671,16 @@ class TestFastCudaLauncher(TestCase):
         with self.assertRaises(RuntimeError):
             fast(1, 1, 1, stream, arg0)  # missing arg1
 
+    def test_too_many_args_raises_value_error(self):
+        """Verify _FastCudaLauncher raises ValueError when nArgs > MAX_ARGS (121)."""
+        from torch._C import _FastCudaLauncher
+
+        # Use a dummy CUfunction (0) — construction should fail before launch.
+        # 'O' is the pointer type code; 130 of them exceeds MAX_ARGS=121.
+        arg_tys = "O" * 130
+        with self.assertRaises(ValueError):
+            _FastCudaLauncher(0, 1, 0, arg_tys, 0)
+
 
 @requires_gpu_and_triton
 @torch._inductor.config.patch(

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2117,8 +2117,9 @@ class CachingAutotuner(KernelInterface):
                 if val is not None:
                     setattr(new_launcher, attr, val)
             return new_launcher
-        except (AttributeError, TypeError, KeyError):
-            # Expected failures - silent fallback is OK
+        except (AttributeError, TypeError, KeyError, ValueError):
+            # Expected failures - silent fallback is OK.
+            # ValueError is raised when nArgs > MAX_ARGS in the C extension.
             return None
         except Exception:
             # Unexpected failures - log for debugging


### PR DESCRIPTION
Summary:
Kernels with more than 121 arguments (the `MAX_ARGS` limit in the `_FastCudaLauncher` C extension) trigger a `ValueError` during construction. This is an expected condition — `_StaticCudaLauncher` handles it via its `launch_kernel_slow` vector-based path, and `_build_fast_launcher` correctly falls back to the original launcher.

However, `ValueError` was not listed among the expected exception types, so it fell into the generic `except Exception` branch and logged a noisy warning with full traceback on every such kernel's first launch.

This diff:
1. Adds `ValueError` to the expected exceptions in `_build_fast_launcher()`, making the fallback silent.
2. Adds a unit test verifying `_FastCudaLauncher` correctly raises `ValueError` when `nArgs > MAX_ARGS`.

No behavioral change — kernels exceeding 121 args continue to use the normal (non-fast) launcher path with identical performance characteristics as before D101027739.

Test Plan:
```
buck2 test fbcode//caffe2/test/inductor:static_triton_launcher -- 'TestFastCudaLauncher::test_too_many_args_raises_value_error'
```

Differential Revision: D105377908




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo