### PR TITLE
[Context Parallel] Handle short sequence load balancing

### DIFF
--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -364,6 +364,57 @@ class RingAttentionTest(DTensorTestBase):
                     behavior,
                 )
 
+    @skip_if_lt_x_gpu(2)
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention"
+    )
+    @with_comms
+    def test_context_parallel_sdpa_short_sequence(self) -> None:
+        old_load_balance = _cp_options.enable_load_balance
+        try:
+            _cp_options.enable_load_balance = True
+            device_mesh = DeviceMesh(self.device_type, torch.arange(0, self.world_size))
+            qkv_len = self.world_size
+            for dim in [1, 2, 4, 8]:
+                with self.subTest(dim=dim):
+                    qkv = [
+                        torch.rand(
+                            (1, 1, qkv_len, dim),
+                            device=self.device_type,
+                            dtype=torch.bfloat16,
+                        )
+                        for _ in range(3)
+                    ]
+
+                    with torch.no_grad():
+                        for t in qkv:
+                            dist.broadcast(t, src=0)
+
+                    with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                        out = F.scaled_dot_product_attention(*qkv, is_causal=True)
+
+                    cp_qkv = [t.detach().clone() for t in qkv]
+                    with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                        with context_parallel(
+                            device_mesh, buffers=cp_qkv, buffer_seq_dims=[2, 2, 2]
+                        ):
+                            self.assertFalse(_cp_options.enable_load_balance)
+                            cp_out = F.scaled_dot_product_attention(
+                                *cp_qkv, is_causal=True
+                            )
+
+                        (cp_out,) = context_parallel_unshard(device_mesh, [cp_out], [2])
+
+                    torch.testing.assert_close(
+                        cp_out,
+                        out,
+                        atol=8e-3 * self.world_size,
+                        rtol=1e-3 * self.world_size,
+                    )
+        finally:
+            _cp_options.enable_load_balance = old_load_balance
+
 
 # Compile the flex_attention function
 compiled_flex_attention = torch.compile(flex_attention, dynamic=False, fullgraph=True)

--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -1272,6 +1272,7 @@ RingAttentionTestWithLocalTensor = create_local_tensor_test_class(
         # Need to make attention implementation local tensor friendly, e.g.
         # rewrite "rank local" logic
         "test_ring_attention_sdpa",
+        "test_context_parallel_sdpa_short_sequence",
     ],
 )
 

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -1577,7 +1577,9 @@ def context_parallel(
     # (:class:`_HeadTailLoadBalancer`) is used to rearrange the buffers before
     # sharding. Otherwise, we don't do any load-balance rearrange by passing
     # `None` to `_context_parallel_shard()`.
+    old_enable_load_balance = _cp_options.enable_load_balance
     load_balancer = _create_default_load_balancer(seq_length, cp_world_size, device)
+    _cp_options.enable_load_balance = load_balancer is not None
     shards = _context_parallel_buffers(
         mesh,
         cast(list[torch.Tensor | BlockMask], buffers),
@@ -1592,13 +1594,16 @@ def context_parallel(
         buffer.copy_(shard)
 
     _enable_context_parallel_dispatcher_impl(seq_dim=2, mesh=mesh)
-    yield
-    _disable_context_parallel_dispatcher_impl()
+    try:
+        yield
+    finally:
+        _disable_context_parallel_dispatcher_impl()
+        _cp_options.enable_load_balance = old_enable_load_balance
 
-    for buffer, original_buffer in zip(buffers, original_buffers):
-        if original_buffer is not None:
-            buffer.resize_(original_buffer.shape)
-            buffer.copy_(original_buffer)
+        for buffer, original_buffer in zip(buffers, original_buffers, strict=True):
+            if original_buffer is not None:
+                buffer.resize_(original_buffer.shape)
+                buffer.copy_(original_buffer)
 
 
 @torch.no_grad()

--- a/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
@@ -472,7 +472,7 @@ def _create_default_load_balancer(
 ) -> _LoadBalancer | None:
     from ._attention import _cp_options
 
-    if _cp_options.enable_load_balance:
+    if _cp_options.enable_load_balance and seq_length % (world_size * 2) == 0:
         return _HeadTailLoadBalancer(seq_length, world_size, device)
     else:
         return None


### PR DESCRIPTION

Default context parallel load balancing now only uses the head-tail balancer when the sequence length can be split into the required head and tail chunks. Shorter sequences fall back to regular CP sharding for correctness, while preserving the previous load-balance preference after the context exits.

Fixes https://github.com/pytorch/pytorch/issues/159706

Authored by Codex.
