### PR TITLE
Fix FakeTensor device hint in DTensor sharding propagation

### DIFF
--- a/torch/distributed/_tools/fsdp2_mem_tracker.py
+++ b/torch/distributed/_tools/fsdp2_mem_tracker.py
@@ -502,8 +502,9 @@ class FSDPMemTracker(MemTracker):
 
     def __enter__(self) -> "FSDPMemTracker":
         if self._depth == 0:
-            # Record whether the tracker itself started under FakeTensorMode.
-            self._entered_under_fake_mode = active_fake_mode() is not None
+            # None in eager, a FakeTensorMode instance in SAC.  Used in
+            # __torch_dispatch__ to skip DTensor propagation ops.
+            self._fake_mode_on_entry = active_fake_mode()
             self._register_module_and_optimizer_hooks()
             self._track_resize()
             self._peak_mem_snap = self.get_tracker_snapshot()
@@ -541,14 +542,17 @@ class FSDPMemTracker(MemTracker):
             res = args[0]
         else:
             res = func(*args, **kwargs or {})
-        # Track either:
-        # 1) tracker contexts entered under FakeTensorMode; or
-        # 2) dispatches with no active FakeTensorMode.
-        # If the tracker was entered under FakeTensorMode, track those
-        # fake-mode dispatches normally.
-        # If the tracker was not entered under FakeTensorMode, ignore later
-        # dispatches in this context that run under FakeTensorMode.
-        if self._entered_under_fake_mode or not active_fake_mode():
+        # DTensor sharding propagation may use a nested FakeTensorMode to
+        # compute output metadata (shapes, placements).  The real memory
+        # usage comes from the local op on shard data, which
+        # runs outside DTensor's fake mode.  We use identity comparison
+        # against the fake mode at tracker entry to skip propagation ops
+        # while still tracking local ops in both eager and SAC contexts.
+        #   - Eager (entry mode is None): real ops have no fake mode
+        #     (None is None), DTensor propagation ops are skipped (B is not None).
+        #   - SAC (entry mode is A): SAC ops run under mode A (A is A),
+        #     DTensor propagation ops are skipped (B is not A).
+        if active_fake_mode() is self._fake_mode_on_entry:
             # If we are tracking an optimizer state, we use the optimizer reference type.
             # If we are in backward region and not in AC region, we use the backward reference type.
             # Else we use the forward reference type.

--- a/torch/distributed/_tools/fsdp2_mem_tracker.py
+++ b/torch/distributed/_tools/fsdp2_mem_tracker.py
@@ -502,6 +502,8 @@ class FSDPMemTracker(MemTracker):
 
     def __enter__(self) -> "FSDPMemTracker":
         if self._depth == 0:
+            # Record whether the tracker itself started under FakeTensorMode.
+            self._entered_under_fake_mode = active_fake_mode() is not None
             self._register_module_and_optimizer_hooks()
             self._track_resize()
             self._peak_mem_snap = self.get_tracker_snapshot()
@@ -539,41 +541,51 @@ class FSDPMemTracker(MemTracker):
             res = args[0]
         else:
             res = func(*args, **kwargs or {})
-        # If we are tracking an optimizer state, we use the optimizer reference type.
-        # If we are in backward region and not in AC region, we use the backward reference type.
-        # Else we use the forward reference type.
-        if self._in_opt:
-            reftype = _FSDPRefType.OPT
-        elif self._mod_tracker.is_bw and not self._in_ac:
-            reftype = _FSDPRefType.TEMP
-        else:
-            reftype = _FSDPRefType.ACT
-        if func is c10d._allgather_base_.default and self._fsdp_state in [
-            _FSDPState.PRE_FW,
-            _FSDPState.PRE_BW,
-        ]:
-            # pyrefly: ignore [unsupported-operation]
-            output_tensor = args[0]
-            self._update_and_maybe_create_winfos(
-                output_tensor,
-                _FSDPRefType.ALL_GATHER,
-                update_existing=True,
-            )
-        if (
-            func is c10d._reduce_scatter_base_.default
-            and self._fsdp_state == _FSDPState.POST_BW
-        ):
-            # pyrefly: ignore [unsupported-operation]
-            input_tensor = args[1]
-            self._update_and_maybe_create_winfos(
-                input_tensor,
-                _FSDPRefType.REDUCE_SCATTER,
-                update_existing=True,
-            )
+        # Track either:
+        # 1) tracker contexts entered under FakeTensorMode; or
+        # 2) dispatches with no active FakeTensorMode.
+        # If the tracker was entered under FakeTensorMode, track those
+        # fake-mode dispatches normally.
+        # If the tracker was not entered under FakeTensorMode, ignore later
+        # dispatches in this context that run under FakeTensorMode.
+        if self._entered_under_fake_mode or not active_fake_mode():
+            # If we are tracking an optimizer state, we use the optimizer reference type.
+            # If we are in backward region and not in AC region, we use the backward reference type.
+            # Else we use the forward reference type.
+            if self._in_opt:
+                reftype = _FSDPRefType.OPT
+            elif self._mod_tracker.is_bw and not self._in_ac:
+                reftype = _FSDPRefType.TEMP
+            else:
+                reftype = _FSDPRefType.ACT
+            if func is c10d._allgather_base_.default and self._fsdp_state in [
+                _FSDPState.PRE_FW,
+                _FSDPState.PRE_BW,
+            ]:
+                # pyrefly: ignore [unsupported-operation]
+                output_tensor = args[0]
+                self._update_and_maybe_create_winfos(
+                    output_tensor,
+                    _FSDPRefType.ALL_GATHER,
+                    update_existing=True,
+                )
+            if (
+                func is c10d._reduce_scatter_base_.default
+                and self._fsdp_state == _FSDPState.POST_BW
+            ):
+                # pyrefly: ignore [unsupported-operation]
+                input_tensor = args[1]
+                self._update_and_maybe_create_winfos(
+                    input_tensor,
+                    _FSDPRefType.REDUCE_SCATTER,
+                    update_existing=True,
+                )
 
-        tree_map_only(torch.Tensor, partial(self._track, reftype), res)
-        peak_state = (
-            _FSDPModState.PEAK_BW if self._mod_tracker.is_bw else _FSDPModState.PEAK_FW
-        )
-        self._update_peak_stats(peak_state)
+            tree_map_only(torch.Tensor, partial(self._track, reftype), res)
+            peak_state = (
+                _FSDPModState.PEAK_BW
+                if self._mod_tracker.is_bw
+                else _FSDPModState.PEAK_FW
+            )
+            self._update_peak_stats(peak_state)
         return res

--- a/torch/distributed/_tools/mem_tracker.py
+++ b/torch/distributed/_tools/mem_tracker.py
@@ -880,8 +880,9 @@ class MemTracker(TorchDispatchMode):
 
     def __enter__(self) -> "MemTracker":
         if self._depth == 0:
-            # Record whether the tracker itself started under FakeTensorMode.
-            self._entered_under_fake_mode = active_fake_mode() is not None
+            # None in eager, a FakeTensorMode instance in SAC.  Used in
+            # __torch_dispatch__ to skip DTensor propagation ops.
+            self._fake_mode_on_entry = active_fake_mode()
             self._register_global_optimizer_hook()
             self._mod_tracker.register_user_hooks(
                 self._pre_fw_hook,
@@ -927,14 +928,17 @@ class MemTracker(TorchDispatchMode):
             res = args[0]
         else:
             res = func(*args, **kwargs or {})
-        # Track either:
-        # 1) tracker contexts entered under FakeTensorMode; or
-        # 2) dispatches with no active FakeTensorMode.
-        # If the tracker was entered under FakeTensorMode, track those
-        # fake-mode dispatches normally.
-        # If the tracker was not entered under FakeTensorMode, ignore later
-        # dispatches in this context that run under FakeTensorMode.
-        if self._entered_under_fake_mode or not active_fake_mode():
+        # DTensor sharding propagation may use a nested FakeTensorMode to
+        # compute output metadata (shapes, placements).  The real memory
+        # usage comes from the local op on shard data, which
+        # runs outside DTensor's fake mode.  We use identity comparison
+        # against the fake mode at tracker entry to skip propagation ops
+        # while still tracking local ops in both eager and SAC contexts.
+        #   - Eager (entry mode is None): real ops have no fake mode
+        #     (None is None), DTensor propagation ops are skipped (B is not None).
+        #   - SAC (entry mode is A): SAC ops run under mode A (A is A),
+        #     DTensor propagation ops are skipped (B is not A).
+        if active_fake_mode() is self._fake_mode_on_entry:
             # If we are tracking an optimizer state, we use the optimizer reference type.
             # If we are in backward region and not in AC region, we use the backward reference type.
             # Else we use the forward reference type.

--- a/torch/distributed/_tools/mem_tracker.py
+++ b/torch/distributed/_tools/mem_tracker.py
@@ -880,6 +880,7 @@ class MemTracker(TorchDispatchMode):
 
     def __enter__(self) -> "MemTracker":
         if self._depth == 0:
+            self._entered_under_fake_mode = active_fake_mode() is not None
             self._register_global_optimizer_hook()
             self._mod_tracker.register_user_hooks(
                 self._pre_fw_hook,
@@ -925,16 +926,19 @@ class MemTracker(TorchDispatchMode):
             res = args[0]
         else:
             res = func(*args, **kwargs or {})
-        # If we are tracking an optimizer state, we use the optimizer reference type.
-        # If we are in backward region and not in AC region, we use the backward reference type.
-        # Else we use the forward reference type.
-        if self._in_opt:
-            reftype = _MemRefType.OPT
-        elif self._mod_tracker.is_bw and not self._in_ac:
-            reftype = _MemRefType.TEMP
-        else:
-            reftype = _MemRefType.ACT
-        tree_map_only(torch.Tensor, partial(self._track, reftype), res)
-        peak_state = _ModState.PEAK_BW if self._mod_tracker.is_bw else _ModState.PEAK_FW
-        self._update_peak_stats(peak_state)
+        if self._entered_under_fake_mode or not active_fake_mode():
+            # If we are tracking an optimizer state, we use the optimizer reference type.
+            # If we are in backward region and not in AC region, we use the backward reference type.
+            # Else we use the forward reference type.
+            if self._in_opt:
+                reftype = _MemRefType.OPT
+            elif self._mod_tracker.is_bw and not self._in_ac:
+                reftype = _MemRefType.TEMP
+            else:
+                reftype = _MemRefType.ACT
+            tree_map_only(torch.Tensor, partial(self._track, reftype), res)
+            peak_state = (
+                _ModState.PEAK_BW if self._mod_tracker.is_bw else _ModState.PEAK_FW
+            )
+            self._update_peak_stats(peak_state)
         return res

--- a/torch/distributed/_tools/mem_tracker.py
+++ b/torch/distributed/_tools/mem_tracker.py
@@ -880,6 +880,7 @@ class MemTracker(TorchDispatchMode):
 
     def __enter__(self) -> "MemTracker":
         if self._depth == 0:
+            # Record whether the tracker itself started under FakeTensorMode.
             self._entered_under_fake_mode = active_fake_mode() is not None
             self._register_global_optimizer_hook()
             self._mod_tracker.register_user_hooks(
@@ -926,6 +927,13 @@ class MemTracker(TorchDispatchMode):
             res = args[0]
         else:
             res = func(*args, **kwargs or {})
+        # Track either:
+        # 1) tracker contexts entered under FakeTensorMode; or
+        # 2) dispatches with no active FakeTensorMode.
+        # If the tracker was entered under FakeTensorMode, track those
+        # fake-mode dispatches normally.
+        # If the tracker was not entered under FakeTensorMode, ignore later
+        # dispatches in this context that run under FakeTensorMode.
         if self._entered_under_fake_mode or not active_fake_mode():
             # If we are tracking an optimizer state, we use the optimizer reference type.
             # If we are in backward region and not in AC region, we use the backward reference type.

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -77,6 +77,7 @@ def _rebuild_tensor_from_dtensor_meta(arg) -> object:
         arg.tensor_meta.shape,
         arg.tensor_meta.stride,
         dtype=arg.tensor_meta.dtype,
+        device=arg.mesh.device_type,
     )
 
 


### PR DESCRIPTION
Pass `device=arg.mesh.device_type` in `_rebuild_tensor_from_dtensor_meta` so FakeTensors carry the correct device type instead of defaulting to CPU. This fixes ops like `histc` whose meta registration rejects certain dtypes on CPU.

Also guard memory tracking to skip DTensor sharding propagation ops. DTensor propagation may use a nested `FakeTensorMode` to compute output metadata (shapes, placements). The real memory usage comes from the local op on shard data, which runs outside DTensor's fake mode — so propagation ops should never be tracked.

The guard saves the `FakeTensorMode` instance active at tracker entry (`None` in eager, a `FakeTensorMode` in SAC) and only tracks ops when `active_fake_mode() is self._fake_mode_on_entry`. Since DTensor propagation creates a different nested `FakeTensorMode`, its ops are skipped in both contexts:
- Eager (entry mode is `None`): real ops have no fake mode (`None is None`), DTensor propagation ops are skipped (`B is not None`).
- SAC (entry mode is `A`): SAC ops run under mode `A` (`A is A`), DTensor propagation ops are skipped (`B is not A`).

Authored by Claude.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal