### PR TITLE
Fix CPU argmin/argmax logical indices

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3665,6 +3665,33 @@ class CPUReproTests(TestCase):
                     f"Expected 1 vec kernel, got {metrics.generated_cpp_vec_kernel_count}"
                 )
 
+    @config.patch({"fx_graph_cache": False, "fx_graph_remote_cache": False})
+    def test_argmin_argmax_transpose_logical_index(self):
+        def check(fn, input_fn):
+            for simdlen in (None, 1):
+                with config.patch({"cpp.simdlen": simdlen}):
+                    torch._dynamo.reset()
+                    self.common(fn, input_fn())
+
+        def mutated_transpose_argmin(x):
+            x.tan_()
+            return x.t().argmin()
+
+        torch.manual_seed(0)
+        check(mutated_transpose_argmin, lambda: (torch.randn(4, 6),))
+
+        def transpose_argreduce(x):
+            y = x.t()
+            return y.argmin(), y.argmax()
+
+        def argreduce_input():
+            x = torch.zeros(4, 6)
+            x.view(-1)[1] = -10
+            x.view(-1)[7] = 10
+            return (x,)
+
+        check(transpose_argreduce, argreduce_input)
+
     @requires_vectorization
     def test_argmax_argmin_with_nan_value(self):
         def fn(x):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -210,7 +210,7 @@ def reduction_combine(
     var,
     next_value,
     helper_val=None,
-    index: sympy.Symbol | None = None,
+    index: sympy.Expr | CppCSEVariable | None = None,
     src_dtype=None,
 ):
     is_bool = src_dtype == torch.bool
@@ -2383,7 +2383,15 @@ class CppKernel(Kernel):
 
     def reduction(self, dtype, src_dtype, reduction_type, value):
         argmax_or_argmin = reduction_type in ("argmax", "argmin")
-        reduction_key = src_dtype, reduction_type, value
+        logical_index = None
+        if argmax_or_argmin and isinstance(value, tuple):
+            assert len(value) == 2
+            value, logical_index = value
+        reduction_key = (
+            src_dtype,
+            reduction_type,
+            (value, logical_index) if logical_index is not None else value,
+        )
         if reduction_key in self.reduction_cse.reduction_cache:
             return self.reduction_cse.reduction_cache[reduction_key]
 
@@ -2429,9 +2437,12 @@ class CppKernel(Kernel):
             )
         else:
             assert self.reduction_depth is not None
-            index = self.itervars[self.reduction_depth]
-            for i in range(self.reduction_depth + 1, len(self.itervars)):
-                index = index * self.ranges[i] + self.itervars[i]
+            if logical_index is None:
+                index = self.itervars[self.reduction_depth]
+                for i in range(self.reduction_depth + 1, len(self.itervars)):
+                    index = index * self.ranges[i] + self.itervars[i]
+            else:
+                index = logical_index
             self.stores.writeline(
                 f"{acc} = {reduction_combine(reduction_type, acc, value, index=index)};"
             )
@@ -3106,14 +3117,24 @@ class CppVecKernel(CppKernel):
         # Fix issue: https://github.com/pytorch/pytorch/issues/143568
         assert reduction_type in VECTORIZABLE_RTYPES
         argmax_or_argmin = reduction_type in ("argmax", "argmin")
+        logical_index = None
+        if argmax_or_argmin and isinstance(value, tuple):
+            assert len(value) == 2
+            value, logical_index = value
         horizontal_reduction = self.tiling_idx >= self.reduction_depth
         init_dtype = src_dtype if argmax_or_argmin else dtype
         assert isinstance(value, CppCSEVariable), value
+        if logical_index is not None:
+            assert isinstance(logical_index, CppCSEVariable), logical_index
 
         if not value.is_vec:
             value = self.broadcast(value)
 
-        reduction_key = src_dtype, reduction_type, value
+        reduction_key = (
+            src_dtype,
+            reduction_type,
+            (value, logical_index) if logical_index is not None else value,
+        )
         if reduction_key in self.reduction_cse.reduction_cache:
             return self.reduction_cse.reduction_cache[reduction_key]
 
@@ -3226,9 +3247,12 @@ class CppVecKernel(CppKernel):
                 )
         else:
             assert self.reduction_depth is not None
-            index = self.itervars[self.reduction_depth]
-            for i in range(self.reduction_depth + 1, len(self.itervars)):
-                index = index * self.ranges[i] + self.itervars[i]
+            if logical_index is None:
+                index = self.itervars[self.reduction_depth]
+                for i in range(self.reduction_depth + 1, len(self.itervars)):
+                    index = index * self.ranges[i] + self.itervars[i]
+            else:
+                index = logical_index
             kwargs = {
                 "next_value": value,
                 "index": index,
@@ -3459,10 +3483,11 @@ class CppVecKernel(CppKernel):
         var,
         next_value,
         helper_val=None,
-        index: sympy.Symbol | None = None,
+        index: sympy.Expr | CppCSEVariable | None = None,
         horizontal_reduction: bool | None = None,
         src_dtype: torch.dtype | None = torch.float32,
     ):
+        """Emit the C++ expression for combining vector reduction accumulators."""
         is_bool = src_dtype == torch.bool
         if reduction_type == "max":
             if self.tail_size:
@@ -3542,9 +3567,25 @@ class CppVecKernel(CppKernel):
             t_extra = ""
             arg_extra = ""
             if index is not None:
+                if isinstance(index, CppCSEVariable) and index.is_vec:
+                    assert index.dtype == torch.int64, index.dtype
+                    if self.tail_size:
+                        return (
+                            f"{reduction_type}_combine_vec<{cdtype}, {n_src}, {n_idx}>"
+                            f"({var}, {next_value}, {index}, {cexpr_index(self.tail_size)})"
+                        )
+                    return (
+                        f"{reduction_type}_combine_vec<{cdtype}, {n_src}, {n_idx}>"
+                        f"({var}, {next_value}, {index})"
+                    )
                 assert horizontal_reduction is not None
                 t_extra = f", {str(horizontal_reduction).lower()}"
-                arg_extra = f", {self._adjust_argreduce_index(index)}"
+                index_arg = (
+                    index
+                    if isinstance(index, CppCSEVariable)
+                    else self._adjust_argreduce_index(index)
+                )
+                arg_extra = f", {index_arg}"
             if self.tail_size:
                 return (
                     f"{reduction_type}_combine_vec<{cdtype}, {n_src}, {n_idx}{t_extra}>"

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1562,10 +1562,11 @@ class Reduction(Loops):
                 index: Sequence[_IntLike], rindex: Sequence[_IntLike]
             ) -> tuple[OpsValue, OpsValue]:
                 rindex = [sympy.expand(i) for i in rindex]
-                return (
-                    inner_fn(index, rindex),
-                    ops.index_expr(flatten_index(rindex), torch.int64),
-                )
+                result = inner_fn(index, rindex)
+                if isinstance(result, tuple):
+                    assert len(result) == 2
+                    return result
+                return (result, ops.index_expr(flatten_index(rindex), torch.int64))
 
             return lambda index: fn(index)[1]
         else:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -65,6 +65,7 @@ from .ir import (
     ExpandView,
     IndexingConstant,
     IRNode,
+    is_cpu,
     is_triton,
     MutableBox,
     OnlineSoftmaxReduction,
@@ -6722,7 +6723,14 @@ def _make_reduction_inner(
     if (
         reduction_type in ("argmax", "argmin")
         and len(reduced_sizes) > 1
-        and is_triton(x)
+        and (
+            is_triton(x)
+            or (
+                is_cpu(x)
+                and config.cpu_backend == "cpp"
+                and not config.disable_cpp_codegen
+            )
+        )
     ):
         if isinstance(x.data, PermuteView):
             should_compute_logical_index = True

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -629,6 +629,24 @@ inline IndexValueVec<T, NV, NI>& argmax_combine_vec(
 }
 
 template <typename T, int NV, int NI>
+inline IndexValueVec<T, NV, NI>& argmin_combine_vec(
+    IndexValueVec<T, NV, NI>& a,
+    at::vec::VectorizedN<T, NV> next_value,
+    at::vec::VectorizedN<int64_t, NI> next_index,
+    std::optional<int64_t> tail_size = std::nullopt) {
+  return argmin_vec_impl(a, next_value, next_index, tail_size);
+}
+
+template <typename T, int NV, int NI>
+inline IndexValueVec<T, NV, NI>& argmax_combine_vec(
+    IndexValueVec<T, NV, NI>& a,
+    at::vec::VectorizedN<T, NV> next_value,
+    at::vec::VectorizedN<int64_t, NI> next_index,
+    std::optional<int64_t> tail_size = std::nullopt) {
+  return argmax_vec_impl(a, next_value, next_index, tail_size);
+}
+
+template <typename T, int NV, int NI>
 inline IndexValue<T> argmin_vec_reduce_all(
     const IndexValueVec<T, NV, NI>& vec) {
   constexpr int len = at::vec::VectorizedN<T, NV>::size();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183972

Propagate logical reduction indices through CPU C++ scalar and vector argmin/argmax reductions so flattened reductions over non-contiguous tensors match eager semantics.

Fixes #174073

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo