### PR TITLE
[CUDA] Correct T lcm(const T_a_in, const T b_in) inside `Math.cuh`

### DIFF
--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -204,7 +204,7 @@ const auto gcd_string = jiterator_stringify(
 
 const auto lcm_string = jiterator_stringify(
   template <typename T>
-  T gcd(const T a_in, const T b_in) {
+  T lcm(const T a_in, const T b_in) {
     T a = abs(a_in);
     T b = abs(b_in);
 


### PR DESCRIPTION
We are in lcm_string and not in gcd_string (like above)

Contributed by Benedikt Johannes