### PR TITLE
[docs] Add .. deprecated:: directives to torch.{cuda,cpu}.amp public APIs

### DIFF
--- a/torch/cpu/amp/autocast_mode.py
+++ b/torch/cpu/amp/autocast_mode.py
@@ -15,9 +15,11 @@ __all__ = ["autocast"]
     category=FutureWarning,
 )
 class autocast(torch.amp.autocast_mode.autocast):
-    r"""
-    See :class:`torch.autocast`.
-    ``torch.cpu.amp.autocast(args...)`` is deprecated. Please use ``torch.amp.autocast("cpu", args...)`` instead.
+    r"""See :class:`torch.autocast`.
+
+    .. deprecated:: 2.10
+        ``torch.cpu.amp.autocast(args...)`` is deprecated. Use
+        :class:`torch.amp.autocast` with ``"cpu"`` as the device type instead.
     """
 
     # TODO: remove this conditional once we stop supporting Python < 3.13

--- a/torch/cpu/amp/grad_scaler.py
+++ b/torch/cpu/amp/grad_scaler.py
@@ -7,9 +7,11 @@ __all__ = ["GradScaler"]
 
 
 class GradScaler(torch.amp.GradScaler):
-    r"""
-    See :class:`torch.amp.GradScaler`.
-    ``torch.cpu.amp.GradScaler(args...)`` is deprecated. Please use ``torch.amp.GradScaler("cpu", args...)`` instead.
+    r"""See :class:`torch.amp.GradScaler`.
+
+    .. deprecated:: 2.4
+        ``torch.cpu.amp.GradScaler(args...)`` is deprecated. Use
+        :class:`torch.amp.GradScaler` with ``"cpu"`` as the device type instead.
     """
 
     @deprecated(

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -18,7 +18,9 @@ __all__ = ["autocast", "custom_fwd", "custom_bwd"]
 class autocast(torch.amp.autocast_mode.autocast):
     r"""See :class:`torch.autocast`.
 
-    ``torch.cuda.amp.autocast(args...)`` is deprecated. Please use ``torch.amp.autocast("cuda", args...)`` instead.
+    .. deprecated:: 2.10
+        ``torch.cuda.amp.autocast(args...)`` is deprecated. Use
+        :class:`torch.amp.autocast` with ``"cuda"`` as the device type instead.
     """
 
     # TODO: remove this conditional once we stop supporting Python < 3.13
@@ -89,8 +91,9 @@ def _cast(value, dtype):
 )
 def custom_fwd(fwd=None, *, cast_inputs=None):
     """
-    ``torch.cuda.amp.custom_fwd(args...)`` is deprecated. Please use
-    ``torch.amp.custom_fwd(args..., device_type='cuda')`` instead.
+    .. deprecated:: 2.4
+        ``torch.cuda.amp.custom_fwd(args...)`` is deprecated. Use
+        :func:`torch.amp.custom_fwd` with ``device_type='cuda'`` instead.
     """
     return functools.partial(torch.amp.custom_fwd, device_type="cuda")(
         fwd=fwd, cast_inputs=cast_inputs
@@ -104,7 +107,8 @@ def custom_fwd(fwd=None, *, cast_inputs=None):
 )
 def custom_bwd(bwd):
     """
-    ``torch.cuda.amp.custom_bwd(args...)`` is deprecated. Please use
-    ``torch.amp.custom_bwd(args..., device_type='cuda')`` instead.
+    .. deprecated:: 2.4
+        ``torch.cuda.amp.custom_bwd(args...)`` is deprecated. Use
+        :func:`torch.amp.custom_bwd` with ``device_type='cuda'`` instead.
     """
     return functools.partial(torch.amp.custom_bwd, device_type="cuda")(bwd)

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -10,9 +10,11 @@ __all__ = ["GradScaler"]
 
 
 class GradScaler(torch.amp.GradScaler):
-    r"""
-    See :class:`torch.amp.GradScaler`.
-    ``torch.cuda.amp.GradScaler(args...)`` is deprecated. Please use ``torch.amp.GradScaler("cuda", args...)`` instead.
+    r"""See :class:`torch.amp.GradScaler`.
+
+    .. deprecated:: 2.4
+        ``torch.cuda.amp.GradScaler(args...)`` is deprecated. Use
+        :class:`torch.amp.GradScaler` with ``"cuda"`` as the device type instead.
     """
 
     @deprecated(


### PR DESCRIPTION
## Summary

The deprecated AMP entry points in `torch.cuda.amp` and `torch.cpu.amp` (`autocast`, `custom_fwd`, `custom_bwd`, `GradScaler`) are wrapped with `@deprecated(...)` and emit `FutureWarning` at runtime, but their docstrings only mention the deprecation in plain prose. As a result the published pages on `pytorch.org/docs` render these APIs without any visual deprecation banner — readers don't see the migration notice unless they execute the code.

This change replaces the inline prose with proper Sphinx `.. deprecated:: <version>` directives so the rendered pages show a yellow deprecation block and link to the migration target via `:class:`/`:func:` cross-references.

| Entry point | Since | Migration target |
|---|---|---|
|torch.cuda.amp.autocast` | 2.10 | `torch.amp.autocast("cuda", ...)` |
| `torch.cuda.amp.custom_fwd` | 2.4 | `torch.amp.custom_fwd(..., device_type="cuda")` |
| `torch.cuda.amp.custom_bwd` | 2.4 | `torch.amp.custom_bwd(..., device_type="cuda")` |
| `torch.cuda.amp.GradScaler` | 2.4 | `torch.amp.GradScaler("cuda", ...)` |
| `torch.cpu.amp.autocast` | 2.10 | `torch.amp.autocast("cpu", ...)` |
| `torch.cpu.amp.GradScaler` | 2.4 | `torch.amp.GradScaler("cpu", ...)` |

Versions verified via `git tag --contains` on each `@deprecated` line:
- `2.10` for the `autocast` class decorators (commit 6ba83e06a59, PR #163654)
- `2.4` for `custom_fwd` / `custom_bwd` / `GradScaler.__init__` decorators (commit 67ef2683d970, PR #126898 / #127689)

Runtime behavior is unchanged: the `@deprecated(...)` decorators still emit the same `FutureWarning`. The only effect is on the rendered HTML docs.

## Out of scope

- The page-level `:::{warning}` block in `docs/source/amp.md` (left as a top-of-page summary; the per-function blocks complement it rather than replace it).
- `torch.cuda.amp.autocast_mode._cast` — private (not in `__all__`, not in published docs).
- Other `@deprecated`-decorated entry points elsewhere in the tree (`torch.distributed.*`, `torch.utils.data.*`, `torch.jit.*`, …) — natural follow-up PRs.

## Test plan

- [ ] `pull / linux-docs` CI job builds the docs without warnings about malformed directives.
- [ ] `lint` CI job passes.
- [ ] Visual check (post-merge or locally with `make html`): the rendered `amp.html` page shows yellow deprecation blocks under each affected entry.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01