### PR TITLE
[ROCm] Remove obsolete ROCm_Bug workaround in std::arg<c10::complex>

### DIFF
--- a/c10/util/complex.h
+++ b/c10/util/complex.h
@@ -31,18 +31,10 @@ C10_HOST_DEVICE T abs(const c10::complex<T>& z) {
 #endif
 }
 
-#if defined(USE_ROCM)
-#define ROCm_Bug(x)
-#else
-#define ROCm_Bug(x) x
-#endif
-
 template <typename T>
 C10_HOST_DEVICE T arg(const c10::complex<T>& z) {
-  return ROCm_Bug(std)::atan2(std::imag(z), std::real(z));
+  return std::atan2(std::imag(z), std::real(z));
 }
-
-#undef ROCm_Bug
 
 template <typename T>
 constexpr T norm(const c10::complex<T>& z) {


### PR DESCRIPTION
cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang