### PR TITLE
Fix torch.cat axis handling in Inductor pre-grad fusion

### DIFF
--- a/test/inductor/test_fx_fusion.py
+++ b/test/inductor/test_fx_fusion.py
@@ -61,15 +61,60 @@ class TestFxFusion(TestCase):
         def test_kwarg3(x, y):
             return torch.cat(tensors=[x, y], dim=0).view(128).tanh()
 
+        def test_axis(x, y):
+            return torch.cat([x, y], axis=-1).tanh()
+
+        def test_out_none(x, y):
+            return torch.cat([x, y], dim=-1, out=None).tanh()
+
         trace_func = chain_passes(torch.fx.symbolic_trace, sink_cat_after_pointwise)
         inputs = [
             torch.randn(8, 8),
             torch.randn(8, 8),
         ]
-        for f in [test_kwarg, test_arg, test_arg2, test_kwarg2, test_kwarg3]:
+        for f in [
+            test_kwarg,
+            test_arg,
+            test_arg2,
+            test_kwarg2,
+            test_kwarg3,
+            test_axis,
+            test_out_none,
+        ]:
             traced = trace_func(f, inputs)
             torch.testing.assert_close(f(*inputs), traced(*inputs))
             self.assertEqual(count_call_method(traced, "tanh"), 2)
+
+    def test_sink_cat_after_pointwise_out_kwarg(self):
+        out = torch.empty(8, 16)
+
+        def test_out(x, y):
+            return torch.cat([x, y], dim=-1, out=out).tanh()
+
+        trace_func = chain_passes(torch.fx.symbolic_trace, sink_cat_after_pointwise)
+        inputs = [
+            torch.randn(8, 8),
+            torch.randn(8, 8),
+        ]
+        traced = trace_func(test_out, inputs)
+        torch.testing.assert_close(test_out(*inputs), traced(*inputs))
+        self.assertEqual(count_call_function(traced, torch.cat), 1)
+        self.assertEqual(count_call_method(traced, "tanh"), 1)
+
+    def test_sink_cat_after_pointwise_axis_none(self):
+        def test_axis_none(x, y):
+            return torch.cat([x, y], axis=None).tanh()
+
+        traced = sink_cat_after_pointwise(torch.fx.symbolic_trace(test_axis_none))
+        self.assertEqual(count_call_function(traced, torch.cat), 1)
+        self.assertEqual(count_call_method(traced, "tanh"), 1)
+        cat_nodes = [
+            n
+            for n in traced.graph.nodes
+            if n.op == "call_function" and n.target == torch.cat
+        ]
+        self.assertEqual(cat_nodes[0].kwargs.get("axis"), None)
+        self.assertNotIn("dim", cat_nodes[0].kwargs)
 
     def test_linear_permute_fusion(self):
         class TestModule(torch.nn.Module):

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -312,9 +312,9 @@ def pre_grad_passes(
         else:
             # We only log the graph with changes to avoid the excessive compilation time
             # https://fb.workplace.com/groups/257735836456307/permalink/633533465543207/
+            numpy_compat_normalization(gm.graph)
             if example_inputs is not None:
                 gm = fuse_fx(gm, example_inputs)
-            numpy_compat_normalization(gm.graph)
             # We should always do the normalization_pass first
             if "normalization_pass" in config.pre_grad_fusion_options:
                 pattern_matcher_pass = PRE_GRAD_PATTERNS["normalization_pass"]
@@ -725,11 +725,23 @@ def sink_cat_after_pointwise(module: torch.fx.GraphModule) -> torch.fx.GraphModu
 
         if user and is_pointwise_unary(user):
             with g.inserting_before(node):
+                arg_not_provided = object()
 
-                def cat_args(tensors, dim=0):
-                    return tensors, dim
+                def cat_args(
+                    tensors,
+                    dim=arg_not_provided,
+                    axis=arg_not_provided,
+                    out=None,
+                ):
+                    if dim is arg_not_provided:
+                        dim = 0
+                    if axis is not arg_not_provided:
+                        dim = axis
+                    return tensors, dim, out
 
-                tensors, dim = cat_args(*node.args, **node.kwargs)
+                tensors, dim, out = cat_args(*node.args, **node.kwargs)
+                if out is not None or dim is None:
+                    continue
                 new_kwargs = {
                     name: val for name, val in user.kwargs.items() if name != "input"
                 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #183995

Normalize NumPy-style kwargs before early pre-grad fusion and make sink_cat_after_pointwise handle torch.cat axis/out without changing out= mutation semantics.

Fixes #171979

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo