### PR TITLE
Fix native matmul config numel cap

### DIFF
--- a/test/inductor/test_coordinate_descent_tuner.py
+++ b/test/inductor/test_coordinate_descent_tuner.py
@@ -6,7 +6,12 @@ from unittest import mock
 
 import torch
 from torch._inductor.runtime import triton_heuristics
-from torch._inductor.runtime.hints import TRITON_MAX_BLOCK
+from torch._inductor.runtime.hints import (
+    native_matmul_block_numel,
+    native_matmul_persistent_rblock,
+    TRITON_MAX_BLOCK,
+    TRITON_MAX_TENSOR_NUMEL,
+)
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.common_utils import IS_LINUX
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
@@ -113,6 +118,144 @@ class TestCoordinateDescentTuner(TestCase):
         self.assertTrue(tuner.value_too_large("XBLOCK", max_block["X"] * 2))
         self.assertFalse(tuner.value_too_large("R0_BLOCK", max_block["R0_"]))
         self.assertTrue(tuner.value_too_large("R0_BLOCK", max_block["R0_"] * 2))
+
+    def test_native_matmul_block_numel_limit(self):
+        tuner = CoordescTuner(is_native_matmul=True)
+
+        valid_config = triton.Config(
+            {"YBLOCK": 128, "XBLOCK": 128, "R0_BLOCK": 64},
+            num_warps=8,
+            num_stages=1,
+        )
+        self.assertTrue(tuner.is_valid_config(valid_config))
+
+        invalid_configs = [
+            {"YBLOCK": 128, "XBLOCK": 256, "R0_BLOCK": 64},
+            {"YBLOCK": 256, "XBLOCK": 128, "R0_BLOCK": 64},
+            {"YBLOCK": 128, "XBLOCK": 128, "R0_BLOCK": 128},
+        ]
+        for kwargs in invalid_configs:
+            self.assertFalse(
+                tuner.is_valid_config(triton.Config(kwargs, num_warps=8, num_stages=1))
+            )
+
+        regular_tuner = CoordescTuner(is_native_matmul=False)
+        self.assertTrue(
+            regular_tuner.is_valid_config(
+                triton.Config(invalid_configs[0], num_warps=8, num_stages=1)
+            )
+        )
+
+    def test_native_matmul_rejects_invalid_neighbours(self):
+        tuner = CoordescTuner(
+            is_native_matmul=True,
+            size_hints={"x": 16384, "y": 2048, "r0_": 2048},
+        )
+        baseline = triton.Config(
+            {"YBLOCK": 128, "XBLOCK": 128, "R0_BLOCK": 64},
+            num_warps=8,
+            num_stages=1,
+        )
+
+        for field in ("XBLOCK", "YBLOCK", "R0_BLOCK"):
+            for cfg in tuner.get_neighbour_configs(baseline, field):
+                self.assertLessEqual(
+                    native_matmul_block_numel(cfg.kwargs),
+                    TRITON_MAX_TENSOR_NUMEL,
+                )
+
+    def test_native_matmul_persistent_uses_rblock_hint_for_limit(self):
+        tuner = CoordescTuner(
+            is_native_matmul=True,
+            size_hints={"x": 16384, "y": 2048, "r0_": 2048},
+        )
+
+        valid_config = triton.Config(
+            {"YBLOCK": 32, "XBLOCK": 16},
+            num_warps=8,
+            num_stages=1,
+        )
+        self.assertTrue(tuner.is_valid_config(valid_config))
+
+        invalid_config = triton.Config(
+            {"YBLOCK": 32, "XBLOCK": 32},
+            num_warps=8,
+            num_stages=1,
+        )
+        self.assertFalse(tuner.is_valid_config(invalid_config))
+
+        neighbours = tuner.get_neighbour_configs(valid_config, "XBLOCK")
+        self.assertNotIn(32, [cfg.kwargs["XBLOCK"] for cfg in neighbours])
+
+    def test_native_matmul_persistent_uses_min_rblock_for_limit(self):
+        size_hints = {"x": 4096, "y": 4096, "r0_": 1}
+        tuner = CoordescTuner(
+            is_native_matmul=True,
+            size_hints=size_hints,
+        )
+        r0_block = native_matmul_persistent_rblock(size_hints["r0_"])
+
+        baseline = triton.Config(
+            {"YBLOCK": 256, "XBLOCK": 256},
+            num_warps=8,
+            num_stages=1,
+        )
+        self.assertEqual(
+            native_matmul_block_numel(baseline.kwargs, r0_block=r0_block),
+            TRITON_MAX_TENSOR_NUMEL,
+        )
+        self.assertTrue(tuner.is_valid_config(baseline))
+
+        invalid_config = triton.Config(
+            {"YBLOCK": 256, "XBLOCK": 512},
+            num_warps=8,
+            num_stages=1,
+        )
+        self.assertFalse(tuner.is_valid_config(invalid_config))
+
+        neighbours = tuner.get_neighbour_configs(baseline, "XBLOCK")
+        self.assertNotIn(512, [cfg.kwargs["XBLOCK"] for cfg in neighbours])
+
+    def test_native_matmul_persistent_uses_meta_rblock_for_limit(self):
+        size_hints = {"x": 4096, "y": 4096, "r0_": 64}
+        effective_rblock = 1024
+        tuner = CoordescTuner(
+            is_native_matmul=True,
+            size_hints=size_hints,
+            inductor_meta={"native_matmul_persistent_rblock": effective_rblock},
+        )
+
+        baseline = triton.Config(
+            {"YBLOCK": 32, "XBLOCK": 32},
+            num_warps=8,
+            num_stages=1,
+        )
+        self.assertEqual(
+            native_matmul_block_numel(baseline.kwargs, r0_block=effective_rblock),
+            TRITON_MAX_TENSOR_NUMEL,
+        )
+        self.assertTrue(tuner.is_valid_config(baseline))
+
+        invalid_config = triton.Config(
+            {"YBLOCK": 64, "XBLOCK": 32},
+            num_warps=8,
+            num_stages=1,
+        )
+        self.assertLessEqual(
+            native_matmul_block_numel(
+                invalid_config.kwargs,
+                r0_block=native_matmul_persistent_rblock(size_hints["r0_"]),
+            ),
+            TRITON_MAX_TENSOR_NUMEL,
+        )
+        self.assertGreater(
+            native_matmul_block_numel(invalid_config.kwargs, r0_block=effective_rblock),
+            TRITON_MAX_TENSOR_NUMEL,
+        )
+        self.assertFalse(tuner.is_valid_config(invalid_config))
+
+        neighbours = tuner.get_neighbour_configs(baseline, "YBLOCK")
+        self.assertNotIn(64, [cfg.kwargs["YBLOCK"] for cfg in neighbours])
 
     def test_combo_tunable_fields_flow_into_tunable_fields(self):
         """``inductor_meta["combo_coordesc_field_order"]`` must be

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -42,16 +42,22 @@ from torch._inductor.runtime.hints import (
     AutotuneHint,
     DeviceProperties,
     HeuristicType,
+    native_matmul_block_numel,
+    native_matmul_persistent_rblock,
     TRITON_MAX_BLOCK,
+    TRITON_MAX_TENSOR_NUMEL,
 )
 from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
     _enforce_reduction_config_block_minimums,
+    _persistent_reduction_configs,
+    _reduction_configs,
     autotune_hints_to_configs,
     cached_autotune,
     CachingAutotuner,
     CachingAutotunerPlugin,
     DEFER,
+    make_matmul_triton_config,
     template,
     triton_config,
 )
@@ -96,6 +102,67 @@ class TestTritonHeuristics(TestCase):
             if key not in cfg.kwargs:
                 continue
             self.assertTrue(cfg.kwargs[key] <= TRITON_MAX_BLOCK[label])
+
+    def test_native_matmul_config_block_numel_limit(self):
+        device = DeviceProperties(
+            type="cuda",
+            index=0,
+            multi_processor_count=1,
+            cc=80,
+            major=8,
+            max_threads_per_block=1024,
+            warp_size=32,
+        )
+        triton_meta = {"native_matmul": True, "device": device}
+
+        for size_hints in (
+            {"x": 1, "y": 1, "r0_": 1},
+            {"x": 1, "y": 1, "z": 1, "r0_": 1},
+        ):
+            cfgs = _reduction_configs(
+                size_hints=size_hints,
+                inductor_meta={},
+                triton_meta=triton_meta,
+            )
+            self.assertTrue(cfgs)
+            for cfg in cfgs:
+                self.assertLessEqual(
+                    native_matmul_block_numel(cfg.kwargs),
+                    TRITON_MAX_TENSOR_NUMEL,
+                )
+
+        for size_hints, inductor_meta in (
+            ({"x": 4096, "y": 4096, "r0_": 1}, {}),
+            ({"x": 16384, "y": 2048, "r0_": 2048}, {}),
+            (
+                {"x": 4096, "y": 4096, "r0_": 64},
+                {"native_matmul_persistent_rblock": 1024},
+            ),
+            ({"x": 4096, "y": 4096, "z": 128, "r0_": 1}, {}),
+            ({"x": 16384, "y": 2048, "z": 128, "r0_": 2048}, {}),
+            (
+                {"x": 4096, "y": 4096, "z": 128, "r0_": 64},
+                {"native_matmul_persistent_rblock": 1024},
+            ),
+        ):
+            cfgs = _persistent_reduction_configs(
+                size_hints=size_hints,
+                inductor_meta=inductor_meta,
+                triton_meta=triton_meta,
+            )
+            rblock = inductor_meta.get(
+                "native_matmul_persistent_rblock",
+                native_matmul_persistent_rblock(size_hints["r0_"]),
+            )
+            self.assertTrue(cfgs)
+            for cfg in cfgs:
+                self.assertLessEqual(
+                    native_matmul_block_numel(cfg.kwargs, r0_block=rblock),
+                    TRITON_MAX_TENSOR_NUMEL,
+                )
+
+        with self.assertRaisesRegex(AssertionError, "exceeds Triton maximum"):
+            make_matmul_triton_config({"x": 256, "y": 128, "r": 64}, 8, 1)
 
     def test_reduction_min_block_preserves_tile_product(self):
         cfg = _enforce_reduction_config_block_minimums(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -53,6 +53,7 @@ from ..runtime.benchmarking import benchmarker
 from ..runtime.hints import (
     AutotuneHint,
     DeviceProperties,
+    native_matmul_persistent_rblock,
     ReductionHint,
     TRITON_MAX_BLOCK,
     TRITON_MAX_RSPLIT,
@@ -5753,6 +5754,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             out["min_rblock"] = self.min_rblock
         if self.cooperative_reduction:
             out["persistent_reduction"] = self.persistent_reduction
+        if (rblock := self._get_native_matmul_persistent_rblock()) is not None:
+            out["native_matmul_persistent_rblock"] = rblock
         if self.add_persistent_rblock:
             out["add_persistent_rblock"] = True
         if (
@@ -6076,6 +6079,21 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             return val
 
         return val
+
+    def _get_native_matmul_persistent_rblock(self) -> int | None:
+        if (
+            not self.is_native_matmul
+            or not self.persistent_reduction
+            or self.cooperative_reduction
+        ):
+            return None
+
+        rblocks = [
+            native_matmul_persistent_rblock(self._get_persistent_RBLOCK(tree.numel))
+            for tree in self.range_trees
+            if tree.is_reduction
+        ]
+        return math.prod(rblocks) if rblocks else None
 
     @staticmethod
     def has_persistent_RBLOCK(rnumel):

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING
 from torch.utils._ordered_set import OrderedSet
 
 from ..utils import get_max_numwarps
-from .hints import TRITON_MAX_BLOCK
+from .hints import (
+    native_matmul_block_numel,
+    native_matmul_persistent_rblock,
+    TRITON_MAX_BLOCK,
+    TRITON_MAX_TENSOR_NUMEL,
+)
 from .runtime_utils import red_text, triton_config_to_hashable
 
 
@@ -240,6 +245,19 @@ class CoordescTuner:
             xblock = config.kwargs["XBLOCK"]
             split_size = config.kwargs["RSPLIT_SIZE"]
             return xblock <= split_size
+        if self.is_native_matmul:
+            r0_block = None
+            if "R0_BLOCK" not in config.kwargs:
+                r0_block = self.inductor_meta.get("native_matmul_persistent_rblock")
+                if r0_block is None and self.size_hints is not None:
+                    r0_block_hint = self.size_hints.get("r0_")
+                    if r0_block_hint is not None:
+                        r0_block = native_matmul_persistent_rblock(r0_block_hint)
+            if (
+                native_matmul_block_numel(config.kwargs, r0_block=r0_block)
+                > TRITON_MAX_TENSOR_NUMEL
+            ):
+                return False
         return True
 
     def get_all_tuning_directions(

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -20,6 +20,23 @@ TRITON_MAX_BLOCK = {
     "R1_": 2048 * 16,  # * 16 is multi-kernel only
 }
 TRITON_MAX_RSPLIT = 64
+TRITON_MAX_TENSOR_NUMEL = 1 << 20
+TRITON_DOT_MIN_BLOCK = 16
+
+
+def native_matmul_block_numel(
+    kwargs: typing.Mapping[str, int], r0_block: int | None = None
+) -> int:
+    return (
+        kwargs.get("XBLOCK", 1)
+        * kwargs.get("YBLOCK", 1)
+        * kwargs.get("ZBLOCK", 1)
+        * (kwargs.get("R0_BLOCK", 1) if r0_block is None else r0_block)
+    )
+
+
+def native_matmul_persistent_rblock(r0_block: int) -> int:
+    return max(r0_block, TRITON_DOT_MIN_BLOCK)
 
 
 class ReductionHint(Enum):

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -46,10 +46,13 @@ from .hints import (
     AutotuneHint,
     DeviceProperties,
     HeuristicType,
+    native_matmul_block_numel,
+    native_matmul_persistent_rblock,
     ReductionHint,
     TileHint,
     TRITON_MAX_BLOCK,
     TRITON_MAX_RSPLIT,
+    TRITON_MAX_TENSOR_NUMEL,
 )
 from .runtime_utils import (
     cache_dir,
@@ -2982,6 +2985,45 @@ def check_max_block(cfg: dict[str, int]):
             )
 
 
+def _check_native_matmul_block_numel(
+    kwargs: dict[str, int], r0_block: int | None = None
+) -> None:
+    block_numel = native_matmul_block_numel(kwargs, r0_block=r0_block)
+    if block_numel > TRITON_MAX_TENSOR_NUMEL:
+        raise AssertionError(
+            f"Block numel {block_numel} exceeds Triton maximum "
+            f"{TRITON_MAX_TENSOR_NUMEL}"
+        )
+
+
+def _native_matmul_config_under_numel_limit(
+    cfg: Config, r0_block: int | None = None
+) -> bool:
+    return (
+        native_matmul_block_numel(cfg.kwargs, r0_block=r0_block)
+        <= TRITON_MAX_TENSOR_NUMEL
+    )
+
+
+def _cap_native_matmul_configs(configs: list[Config], r0_block: int) -> list[Config]:
+    capped_configs: list[Config] = []
+    for cfg in configs:
+        cfg = copy.deepcopy(cfg)
+        while not _native_matmul_config_under_numel_limit(cfg, r0_block=r0_block):
+            shrinkable_fields = [
+                field for field in ("XBLOCK", "YBLOCK") if cfg.kwargs.get(field, 1) > 16
+            ]
+            if not shrinkable_fields:
+                break
+            field = max(shrinkable_fields, key=lambda field: cfg.kwargs[field])
+            cfg.kwargs[field] //= 2
+
+        if _native_matmul_config_under_numel_limit(cfg, r0_block=r0_block):
+            capped_configs.append(cfg)
+
+    return unique_configs(capped_configs)
+
+
 def _enforce_reduction_config_block_minimums(
     configs: list[Config],
     size_hints: dict[str, int],
@@ -3827,6 +3869,7 @@ def make_matmul_triton_config(sizes: dict[str, int], num_warps: int, num_stages:
     }
     # Remove keys with None values (i.e., missing in sizes)
     config = {k: v for k, v in config.items() if v is not None}
+    _check_native_matmul_block_numel(config)
     return Config(config, num_warps=num_warps, num_stages=num_stages)
 
 
@@ -4420,12 +4463,13 @@ def _persistent_reduction_configs(
     inductor_meta=None,
     triton_meta=None,
 ):
+    inductor_meta = {} if inductor_meta is None else inductor_meta
     # Under deterministic mode, canonicalize the batch-dim hint so the
     # candidate-config branching below (e.g. xnumel // 8 < 128) doesn't pick
     # a different (XBLOCK, num_warps) for bs=N vs bs=N/2. Different picks
     # change the bf16 reduction order and break batch invariance in
     # persistent reductions like LayerNorm.
-    if inductor_meta and inductor_meta.get("batch_invariant"):
+    if inductor_meta.get("batch_invariant"):
         size_hints = dict(size_hints)
         if "x" in size_hints:
             size_hints["x"] = max(size_hints["x"], 4096)
@@ -4436,16 +4480,22 @@ def _persistent_reduction_configs(
     MAX_PERSISTENT_BLOCK_NUMEL = 4096
 
     if triton_meta.get("native_matmul"):
+        native_matmul_rblock = inductor_meta.get("native_matmul_persistent_rblock")
+        if native_matmul_rblock is None:
+            native_matmul_rblock = native_matmul_persistent_rblock(rnumel)
+
         if len(size_hints) == 3:
-            return [
+            configs = [
                 make_matmul_triton_config(sizes, num_warps, num_stages)
                 for sizes, num_warps, num_stages in triton_native_persistent_mm_configs
             ]
+            return _cap_native_matmul_configs(configs, native_matmul_rblock)
         elif len(size_hints) == 4:
-            return [
+            configs = [
                 make_matmul_triton_config(sizes, num_warps, num_stages)
                 for sizes, num_warps, num_stages in triton_native_persistent_bmm_configs
             ]
+            return _cap_native_matmul_configs(configs, native_matmul_rblock)
         else:
             raise NotImplementedError("native matmul only supports mm/bmm pattern")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184011

Reject native matmul autotune configs whose generated block tensors would exceed Triton's tensor numel limit, including persistent reductions with implicit R blocks.

Fixes #167050
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos