### PR TITLE
Validate delta type in nn.HuberLoss constructor

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1140,6 +1140,10 @@ class HuberLoss(_Loss):
     __constants__ = ["reduction", "delta"]
 
     def __init__(self, reduction: str = "mean", delta: float = 1.0) -> None:
+        if not isinstance(delta, (float, int)):
+            raise TypeError(
+                f"delta must be a float or int, got: {type(delta)}"
+            )
         super().__init__(reduction=reduction)
         self.delta = delta
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1141,9 +1141,7 @@ class HuberLoss(_Loss):
 
     def __init__(self, reduction: str = "mean", delta: float = 1.0) -> None:
         if not isinstance(delta, (float, int)):
-            raise TypeError(
-                f"delta must be a float or int, got: {type(delta)}"
-            )
+            raise TypeError(f"delta must be a float or int, got: {type(delta)}")
         super().__init__(reduction=reduction)
         self.delta = delta
 

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -4048,6 +4048,19 @@ def module_error_inputs_torch_nn_Pad3d(module_info, device, dtype, requires_grad
     ]
 
 
+def module_error_inputs_torch_nn_HuberLoss(module_info, device, dtype, requires_grad, training, **kwargs):
+    return [
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(delta=1.0 + 0.0j),
+            ),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=TypeError,
+            error_regex=r"delta must be a float or int, got: <class 'complex'>",
+        ),
+    ]
+
+
 _macos15_or_newer = torch.backends.mps.is_available() and torch.backends.mps.is_macos_or_newer(15, 0)
 
 
@@ -4577,6 +4590,7 @@ module_db: list[ModuleInfo] = [
                ),
     ModuleInfo(torch.nn.HuberLoss,
                module_inputs_func=module_inputs_torch_nn_HuberLoss,
+               module_error_inputs_func=module_error_inputs_torch_nn_HuberLoss,
                skips=(
                    # No channels_last support for loss functions.
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format'),


### PR DESCRIPTION
Fixes #133796

`nn.HuberLoss(delta=1.+0.j)` silently accepts a complex value even though the error message for the underlying `huber_loss()` function states that delta must be a float. Other invalid types like strings are also accepted by the constructor but fail later with confusing errors.

This adds an explicit type check in `HuberLoss.__init__` that rejects non-numeric delta values (e.g. complex, str) with a clear `TypeError`. Ints and bools are still accepted for backward compatibility since `int` is a reasonable numeric type and `bool` is a subclass of `int`.

**Changes:**
- `torch/nn/modules/loss.py`: Add `isinstance(delta, (float, int))` check in `__init__`
- `torch/testing/_internal/common_modules.py`: Add `ErrorModuleInput` test for complex delta

cc @mikaylagawarecki @albanD