### PR TITLE
Fix checkpoint context cleanup on forward errors

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3,6 +3,7 @@
 
 import collections
 import contextlib
+import contextvars
 import functools
 import gc
 import io
@@ -7861,6 +7862,70 @@ for shape in [(1,), ()]:
             out = checkpoint(
                 lambda x: x.sin(), x, use_reentrant=True, context_fn=context_fn
             )
+
+    def test_checkpointing_without_reentrant_context_fn_exits_on_forward_exception(
+        self,
+    ):
+        active_context = contextvars.ContextVar("active_context", default=False)
+        events = []
+        exit_exc = []
+
+        class Context:
+            def __enter__(self):
+                events.append("enter")
+                self.token = active_context.set(True)
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                events.append("exit")
+                exit_exc.append((exc_type, exc_value))
+                active_context.reset(self.token)
+
+        def context_fn():
+            return Context(), contextlib.nullcontext()
+
+        def fn(x):
+            self.assertTrue(active_context.get())
+            raise RuntimeError("forward failed")
+
+        exc = None
+        x = torch.tensor(1.0, requires_grad=True)
+        try:
+            checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
+        except RuntimeError as e:
+            exc = e
+
+        self.assertIsNotNone(exc)
+        self.assertEqual(events, ["enter", "exit"])
+        self.assertEqual(exit_exc[0][0], RuntimeError)
+        self.assertEqual(str(exit_exc[0][1]), "forward failed")
+        self.assertFalse(active_context.get())
+
+    def test_checkpointing_without_reentrant_context_fn_cannot_suppress_forward_exception(
+        self,
+    ):
+        class Context:
+            def __enter__(self):
+                pass
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                self.exc_type = exc_type
+                self.exc_value = exc_value
+                return True
+
+        context = Context()
+
+        def context_fn():
+            return context, contextlib.nullcontext()
+
+        def fn(x):
+            raise ValueError("forward failed")
+
+        x = torch.tensor(1.0, requires_grad=True)
+        with self.assertRaisesRegex(RuntimeError, "context_fn suppressed"):
+            checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
+
+        self.assertEqual(context.exc_type, ValueError)
+        self.assertEqual(str(context.exc_value), "forward failed")
 
     def test_checkpoint_warns_if_use_reentrant_not_passed_explcitly(self):
         a = torch.randn(1, requires_grad=True)

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import contextlib
 import itertools
 import platform
+import sys
 import uuid
 import warnings
 import weakref
@@ -515,7 +516,19 @@ def checkpoint(
         )
         # Runs pre-forward logic
         next(gen)
-        ret = function(*args, **kwargs)
+        try:
+            ret = function(*args, **kwargs)
+        except BaseException:
+            try:
+                gen.throw(*sys.exc_info())
+            except StopIteration as e:
+                raise RuntimeError(
+                    "torch.utils.checkpoint: the forward context provided by "
+                    "context_fn suppressed an exception raised during the "
+                    "checkpointed forward. This is not supported because "
+                    "checkpoint cannot return a value for a failed forward."
+                ) from e
+            raise
         # Runs post-forward logic
         try:
             next(gen)
@@ -1684,8 +1697,20 @@ def _checkpoint_without_reentrant_generator(
 
     new_frame.save_inputs(*args)
 
+    forward_context_suppressed_exc = False
     with _checkpoint_hook(new_frame), forward_context:
-        yield
+        try:
+            yield
+        except BaseException:
+            forward_context_suppressed_exc = True
+            raise
+    if forward_context_suppressed_exc:
+        raise RuntimeError(
+            "torch.utils.checkpoint: the forward context provided by "
+            "context_fn suppressed an exception raised during the "
+            "checkpointed forward. This is not supported because checkpoint "
+            "cannot return a value for a failed forward."
+        )
     new_frame.forward_completed = True
 
     if getattr(device_module, "_initialized", False) and \

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import contextlib
 import itertools
 import platform
-import sys
 import uuid
 import warnings
 import weakref
@@ -518,22 +517,26 @@ def checkpoint(
         next(gen)
         try:
             ret = function(*args, **kwargs)
-        except BaseException:
+        except BaseException as e:
             try:
-                gen.throw(*sys.exc_info())
-            except StopIteration as e:
+                gen.throw(e)
+            except StopIteration as stop:
                 raise RuntimeError(
                     "torch.utils.checkpoint: the forward context provided by "
                     "context_fn suppressed an exception raised during the "
                     "checkpointed forward. This is not supported because "
                     "checkpoint cannot return a value for a failed forward."
-                ) from e
+                ) from stop
             raise
         # Runs post-forward logic
         try:
             next(gen)
         except StopIteration:
             return ret
+        raise AssertionError(
+            "torch.utils.checkpoint: expected context_fn generator to yield "
+            "exactly twice, but it yielded more than twice."
+        )
 
 
 def checkpoint_sequential(functions, segments, input, use_reentrant=None, **kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184218
* __->__ #184018

Throw forward exceptions into the non-reentrant checkpoint generator so custom forward contexts see the original exception while unwinding. Reject context managers that suppress the forward exception, since checkpoint cannot return a value for a failed forward.

Add regression tests covering ContextVar cleanup, original exception delivery to __exit__, and unsupported suppression.

Authored by Codex.

cc @soulitzer