### PR TITLE
Use CUDA libdevice for emulate precision casts

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -164,6 +164,11 @@ class TestTimer(TestCase):
 
 
 class TestSetTritonLibdevicePath(TestCase):
+    @config.patch({"compile_threads": 1, "emulate_precision_casts": True})
+    def test_emulate_precision_casts_sets_libdevice_path(self):
+        """Test eager numerics mode sets libdevice path for CUDA libdevice calls."""
+        self._test_libdevice_path_with_compilation()
+
     @config.patch({"compile_threads": 1, "eager_numerics.use_pytorch_libdevice": True})
     def test_libdevice_path_no_subprocess(self):
         """Test libdevice path is set with compile_threads=1 (no subprocess)."""
@@ -202,6 +207,40 @@ class TestSetTritonLibdevicePath(TestCase):
 
         eager_result = torch.pow(base, exp)
         compiled_result = torch.compile(torch.pow)(base, exp)
+        self.assertEqual(eager_result, compiled_result, atol=0, rtol=0)
+
+    @config.patch({"compile_threads": 1, "emulate_precision_casts": True})
+    def test_erf_bitwise_precision_with_emulate_precision_casts(self):
+        """Test that erf matches eager bitwise when eager numerics mode is active."""
+        import torch
+        from torch.utils.cpp_extension import CUDA_HOME
+
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        if CUDA_HOME is None:
+            self.skipTest("CUDA_HOME not set")
+        expected = os.path.join(CUDA_HOME, "nvvm", "libdevice", "libdevice.10.bc")
+        if not os.path.isfile(expected):
+            self.skipTest(f"libdevice not found at {expected}")
+
+        torch._dynamo.reset()
+        values = torch.tensor(
+            [
+                -3.9194295406341553,
+                -3.9188895225524902,
+                0.0,
+                1.0,
+                3.9194295406341553,
+            ],
+            device="cuda",
+            dtype=torch.float32,
+        )
+
+        def fn(x):
+            return torch.erf(x)
+
+        eager_result = fn(values)
+        compiled_result = torch.compile(fn)(values)
         self.assertEqual(eager_result, compiled_result, atol=0, rtol=0)
 
     def _test_libdevice_path_with_compilation(self):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2896,6 +2896,8 @@ class eager_numerics:
     # (0.5 * x * (1 + erf(x * sqrt(0.5)))) where a 1 ULP change in erf output
     # can flip the result of a subsequent ceil(log2(...)) and produce a
     # different uint8 encoded value (see gh-178045).
+    # This can be enabled directly; Inductor also enables it while
+    # emulate_precision_casts is active.
     use_pytorch_libdevice: bool = False
 
 

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -54,18 +54,26 @@ def _set_triton_ptxas_path() -> None:
 def _set_triton_libdevice_path() -> None:
     """
     Use the CUDA toolkit's libdevice instead of Triton's bundled version.
-    This ensures Triton's pow matches CUDA's powf for bitwise precision.
-    Gated by config.eager_numerics.use_pytorch_libdevice.
+    This ensures Triton's libdevice calls match CUDA eager numerics for bitwise
+    precision.  Gated by config.eager_numerics.use_pytorch_libdevice and by
+    config.emulate_precision_casts, which also requests eager-like numerics.
     """
     from torch._inductor import config
 
-    if not config.eager_numerics.use_pytorch_libdevice:
+    if not (
+        config.eager_numerics.use_pytorch_libdevice or config.emulate_precision_casts
+    ):
         return
 
     _set_triton_libdevice_path_impl()
 
 
 def _set_triton_libdevice_path_impl() -> None:
+    import torch
+
+    if torch.version.cuda is None:
+        return
+
     try:
         from triton import knobs
     except ImportError:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184022

Route Triton libdevice calls through the CUDA toolkit libdevice whenever emulate_precision_casts requests eager-like numerics, and add erf regression coverage for the libdevice mismatch.

Fixes #164998
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos