### PR TITLE
Fix redundant flex attention dot casts

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 import torch
 import torch.nn as nn
 from torch._dynamo.testing import CompileCounterWithBackend, normalize_gm
+from torch._functorch import config as functorch_config
 from torch._inductor import config, metrics
 from torch._inductor.exc import InductorError
 from torch._inductor.runtime.triton_compat import HAS_WARP_SPEC
@@ -4168,6 +4169,78 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             kernel_options={"BLOCK_M": 16},
         )
         FileCheck().check("BLOCK_M : tl.constexpr = 16").run(code[0])
+
+    @supported_platform
+    @skip_on_cpu
+    def test_matching_dtype_codegen_skips_identity_dot_operand_casts(self, device):
+        B, L, H, D = 1, 128, 2, 64
+
+        def mask_mod(b, h, q, kv):
+            return q != kv
+
+        make_tensor = functools.partial(
+            torch.randn,
+            (B, L, H, D),
+            device=device,
+            dtype=torch.float16,
+            requires_grad=True,
+        )
+        q, k, v = (
+            x.transpose(1, 2) for x in (make_tensor(), make_tensor(), make_tensor())
+        )
+        block_mask = create_block_mask(mask_mod, B, H, L, L, device=device)
+
+        with (
+            config.patch(
+                {
+                    "enable_caching_generated_triton_templates": False,
+                    "force_disable_caches": True,
+                    "fx_graph_cache": False,
+                    "fx_graph_remote_cache": False,
+                }
+            ),
+            functorch_config.patch({"enable_autograd_cache": False}),
+        ):
+            _, code = run_and_get_code(
+                torch.compile(flex_attention, fullgraph=True),
+                q,
+                k,
+                v,
+                block_mask=block_mask,
+            )
+
+        self.assertIn("tl.dot(q, k", code[0])
+        self.assertNotIn("k = k.to(q.dtype)", code[0])
+        self.assertNotIn("v.to(q.dtype)", code[0])
+        self.assertNotIn("fp_downcast_rounding", code[0])
+
+    @supported_platform
+    @skip_on_cpu
+    def test_mixed_dtype_codegen_keeps_dot_operand_casts(self, device):
+        q = torch.randn((1, 2, 128, 64), device=device, dtype=torch.float32)
+        k = torch.randn((1, 2, 128, 64), device=device, dtype=torch.float16)
+        v = torch.randn((1, 2, 128, 64), device=device, dtype=torch.float16)
+
+        with (
+            config.patch(
+                {
+                    "enable_caching_generated_triton_templates": False,
+                    "force_disable_caches": True,
+                    "fx_graph_cache": False,
+                    "fx_graph_remote_cache": False,
+                }
+            ),
+            functorch_config.patch({"enable_autograd_cache": False}),
+        ):
+            _, code = run_and_get_code(
+                torch.compile(flex_attention, fullgraph=True),
+                q,
+                k,
+                v,
+            )
+
+        self.assertIn("k = k.to(q.dtype)", code[0])
+        self.assertIn("v_for_dot = v.to(q.dtype)", code[0])
 
     @supported_platform
     @skip_on_cpu

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -378,6 +378,8 @@ def flex_attention(
         )
 
     set_head_dim_values(kernel_options, qk_head_dim, v_head_dim, V.graph.sizevars)
+    kernel_options["QK_SAME_DTYPE"] = query.get_dtype() == key.get_dtype()
+    kernel_options["QV_SAME_DTYPE"] = query.get_dtype() == value.get_dtype()
 
     choices: list[Any] = []
 

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -271,6 +271,8 @@ def create_flex_decoding_kernel(*args, **kwargs):
     )
 
     set_head_dim_values(kernel_options, qk_head_dim, v_head_dim, V.graph.sizevars)
+    kernel_options["QK_SAME_DTYPE"] = query.get_dtype() == key.get_dtype()
+    kernel_options["QV_SAME_DTYPE"] = query.get_dtype() == value.get_dtype()
 
     kernel_options.setdefault(
         "BLOCK_M",

--- a/torch/_inductor/kernel/flex/templates/common.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/common.py.jinja
@@ -38,7 +38,9 @@ def forward_block_mn(
     {%- endif %}
 
     k = tl.trans(k)
+    {%- if not QK_SAME_DTYPE %}
     k = k.to(q.dtype)
+    {%- endif %}
     # -- compute qk ---
     qk = tl.dot(q, k, input_precision=FLOAT32_PRECISION) # TODO: use cuda matmul when q_len <= 2.
     if not PRESCALE_QK:
@@ -112,7 +114,12 @@ def forward_block_mn(
     offs_v = tl.arange(0, V_HEAD_DIM_ROUNDED)
     v = load_checked_2d(V, offs_n_load, offs_v, stride_vn, stride_vk, IS_DIVISIBLE, SAFE_HEAD_DIM, KV_LEN, V_HEAD_DIM)
     {%- endif %}
-    acc = tl.dot(p.to(MATMUL_PRECISION), v.to(q.dtype), acc, input_precision=FLOAT32_PRECISION)
+    {%- if QV_SAME_DTYPE %}
+    v_for_dot = v
+    {%- else %}
+    v_for_dot = v.to(q.dtype)
+    {%- endif %}
+    acc = tl.dot(p.to(MATMUL_PRECISION), v_for_dot, acc, input_precision=FLOAT32_PRECISION)
 
     # -- update m_i
     m_i = m_ij


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184024

Avoid emitting identity dtype casts for flex attention dot operands when query, key, and value already use matching dtypes. This keeps mixed-dtype casts intact while reducing unnecessary Triton IR conversion chains.

Fixes #164813

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo