### PR TITLE
[MPS] Migrate scatter/gather ops to Metal with async bounds checking

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Scatter.metal
+++ b/aten/src/ATen/native/mps/kernels/Scatter.metal
@@ -185,6 +185,41 @@ struct ScatterAtomicApply<T, ScatterReduceOp::Amax> {
   }
 };
 
+// Signed int64 amin/amax via Metal's atomic_min/max on ulong (Metal 3.1+).
+// The output buffer is pre-encoded (sign bit XOR'd, done by the host
+// scatter_signbit_xor_long kernel) so signed order matches unsigned order;
+// per-thread we encode the src value the same way.
+template <>
+struct ScatterAtomicApply<long, ScatterReduceOp::Amin> {
+  static inline void apply(device long* output, long out_offset, long src_val) {
+    const ulong encoded = ulong(src_val) ^ (1ul << 63);
+    ::metal::atomic_min_explicit(
+        reinterpret_cast<device ::metal::atomic<ulong>*>(output) + out_offset,
+        encoded,
+        ::metal::memory_order_relaxed);
+  }
+};
+template <>
+struct ScatterAtomicApply<long, ScatterReduceOp::Amax> {
+  static inline void apply(device long* output, long out_offset, long src_val) {
+    const ulong encoded = ulong(src_val) ^ (1ul << 63);
+    ::metal::atomic_max_explicit(
+        reinterpret_cast<device ::metal::atomic<ulong>*>(output) + out_offset,
+        encoded,
+        ::metal::memory_order_relaxed);
+  }
+};
+
+// Toggle the sign bit of every element. Used as the pre- and post-pass that
+// brackets a signed int64 amin/amax scatter (the encoding is its own inverse).
+kernel void scatter_signbit_xor_long(
+    device ulong* data [[buffer(0)]],
+    constant long& tid_offset [[buffer(1)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long tid = long(thread_index) + tid_offset;
+  data[tid] ^= (1ul << 63);
+}
+
 // Dense atomic scatter for one of {add, prod, amin, amax}. Shape requirements
 // match scatter_set_dense.
 template <typename T, typename index_t, ScatterReduceOp Op>
@@ -341,11 +376,17 @@ kernel void scatter_reduce_strided(
 
 // prod/amin/amax use atomic_binary_op (CAS loop). Restricted to dtypes for
 // which AtomicType<T> provides atomic_binary_op: float, int, half, bfloat,
-// short, char, uchar. bool / long / complex aren't supported here -- amin/amax
-// for complex is mathematically undefined and rejected at the meta-func level;
-// long lacks atomic_binary_op (only an eventually-consistent atomic_add).
+// short, char, uchar, bool. amin/amax for complex is undefined and rejected
+// at the meta-func level. long has its own specialization for amin/amax (via
+// Metal's 64-bit atomic_min/max on ulong with sign-flip encoding) but no
+// equivalent for prod.
 #define REGISTER_SCATTER_PROD_MIN_MAX_DTYPE(DTYPE)   \
   REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, prod, Prod); \
+  REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, amin, Amin); \
+  REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, amax, Amax)
+
+// long: amin/amax only (no atomic prod for 64-bit).
+#define REGISTER_SCATTER_AMIN_AMAX_DTYPE(DTYPE)      \
   REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, amin, Amin); \
   REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, amax, Amax)
 
@@ -374,5 +415,6 @@ REGISTER_SCATTER_OPS_FULL(uchar);
 REGISTER_SCATTER_OPS_FULL(bool);
 
 REGISTER_SCATTER_OPS_SET_ADD(long);
+REGISTER_SCATTER_AMIN_AMAX_DTYPE(long);
 REGISTER_SCATTER_OPS_SET_ADD(float2);
 REGISTER_SCATTER_OPS_SET_ADD(half2);

--- a/aten/src/ATen/native/mps/kernels/Scatter.metal
+++ b/aten/src/ATen/native/mps/kernels/Scatter.metal
@@ -7,17 +7,14 @@
 using namespace metal;
 using namespace c10::metal;
 
-// scatter_set kernel: implements PyTorch's scatter with reduce='set'.
+// Metal kernels implementing PyTorch's scatter with reduce='set'.
 //
-// For each coordinate `c` in `index`'s shape (one thread per element of
-// `index`), compute:
-//   idx = index[c]
-//   bounds-check idx in [0, dim_size); on failure, report async error.
-//   output[c with c[dim] replaced by idx] = src[c]
-//
-// The caller is responsible for pre-copying `self` into `output` when
-// they refer to different storages (out= variants); this kernel only
-// writes the scattered positions.
+// All three kernels accept a `tid_offset` baked into the linear thread
+// index. The host chunks dispatch into <=UINT_MAX-thread launches so that
+// scatter works on tensors with > 2^32 index elements (Metal's
+// `[[thread_position_in_grid]]` is at most a `uint`).
+
+// Strided generic version for non-contiguous tensors.
 template <typename T, typename index_t>
 kernel void scatter_set(
     device T* output [[buffer(0)]],
@@ -29,13 +26,15 @@ kernel void scatter_set(
     constant long* index_strides [[buffer(6)]],
     constant uint3& ndim_dim [[buffer(7)]],
     constant long& dim_size [[buffer(8)]],
-    device ErrorMessages* error_buf [[buffer(9)]],
+    constant long& tid_offset [[buffer(9)]],
+    device ErrorMessages* error_buf [[buffer(10)]],
     uint thread_index [[thread_position_in_grid]]) {
   const uint ndim = ndim_dim.x;
   const uint dim = ndim_dim.y;
+  const long tid = long(thread_index) + tid_offset;
 
   ::metal::array<long, max_ndim> pos;
-  pos_from_thread_index<long>(long(thread_index), &pos[0], index_sizes, ndim);
+  pos_from_thread_index<long>(tid, &pos[0], index_sizes, ndim);
 
   const long index_offs = offset_from_coord<long>(&pos[0], index_strides, ndim);
   long idx = long(index[index_offs]);
@@ -57,14 +56,10 @@ kernel void scatter_set(
   output[out_offs] = src[src_offs];
 }
 
-// Fast path for the common case where output, src, and index are all
-// contiguous, src and index share the same shape, and that shape matches
-// the output's shape outside `dim`. Each thread:
-//   inner = tid % inner_size       (coords below dim)
-//   outer = tid / (inner_size * index_dim_size)   (coords above dim)
-//   output[outer * output_dim_size * inner_size + idx * inner_size + inner]
-//       = src[tid]
-// inner_size = prod(output.sizes()[dim+1:]).
+// Fast path: contiguous output/src/index, src and index share shape,
+// shape matches output outside `dim`. Indexing collapses to one div + one
+// mod per thread. inner_size = prod(output.sizes()[dim+1:]) precomputed
+// on the host.
 template <typename T, typename index_t>
 kernel void scatter_set_dense(
     device T* output [[buffer(0)]],
@@ -73,9 +68,11 @@ kernel void scatter_set_dense(
     constant long& inner_size [[buffer(3)]],
     constant long& index_dim_size [[buffer(4)]],
     constant long& output_dim_size [[buffer(5)]],
-    device ErrorMessages* error_buf [[buffer(6)]],
+    constant long& tid_offset [[buffer(6)]],
+    device ErrorMessages* error_buf [[buffer(7)]],
     uint thread_index [[thread_position_in_grid]]) {
-  long idx = long(index[thread_index]);
+  const long tid = long(thread_index) + tid_offset;
+  long idx = long(index[tid]);
   if (idx < 0 || idx >= output_dim_size) {
     TORCH_REPORT_ERROR(
         error_buf,
@@ -85,11 +82,43 @@ kernel void scatter_set_dense(
         output_dim_size);
     return;
   }
-  const long inner = long(thread_index) % inner_size;
-  const long outer = long(thread_index) / (inner_size * index_dim_size);
+  const long inner = tid % inner_size;
+  const long outer = tid / (inner_size * index_dim_size);
   const long out_offset =
       outer * (inner_size * output_dim_size) + idx * inner_size + inner;
-  output[out_offset] = src[thread_index];
+  output[out_offset] = src[tid];
+}
+
+// Same as `scatter_set_dense` but the source is a single scalar value,
+// avoiding the per-thread src read and the host-side `at::empty + fill_`
+// the legacy MPSGraph path needed for `scatter.value`.
+template <typename T, typename index_t>
+kernel void scatter_set_dense_value(
+    device T* output [[buffer(0)]],
+    constant T& value [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long& inner_size [[buffer(3)]],
+    constant long& index_dim_size [[buffer(4)]],
+    constant long& output_dim_size [[buffer(5)]],
+    constant long& tid_offset [[buffer(6)]],
+    device ErrorMessages* error_buf [[buffer(7)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long tid = long(thread_index) + tid_offset;
+  long idx = long(index[tid]);
+  if (idx < 0 || idx >= output_dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension with size ",
+        output_dim_size);
+    return;
+  }
+  const long inner = tid % inner_size;
+  const long outer = tid / (inner_size * index_dim_size);
+  const long out_offset =
+      outer * (inner_size * output_dim_size) + idx * inner_size + inner;
+  output[out_offset] = value;
 }
 
 #define REGISTER_SCATTER_SET_OP(DTYPE, IDXTYPE)                                \
@@ -104,7 +133,8 @@ kernel void scatter_set_dense(
       constant long* index_strides [[buffer(6)]],                              \
       constant uint3& ndim_dim [[buffer(7)]],                                  \
       constant long& dim_size [[buffer(8)]],                                   \
-      device ErrorMessages* error_buf [[buffer(9)]],                           \
+      constant long& tid_offset [[buffer(9)]],                                 \
+      device ErrorMessages* error_buf [[buffer(10)]],                          \
       uint thread_index [[thread_position_in_grid]]);                          \
   template [[host_name("scatter_set_dense_" #DTYPE "_" #IDXTYPE)]] kernel void \
   scatter_set_dense<DTYPE, IDXTYPE>(                                           \
@@ -114,7 +144,20 @@ kernel void scatter_set_dense(
       constant long& inner_size [[buffer(3)]],                                 \
       constant long& index_dim_size [[buffer(4)]],                             \
       constant long& output_dim_size [[buffer(5)]],                            \
-      device ErrorMessages* error_buf [[buffer(6)]],                           \
+      constant long& tid_offset [[buffer(6)]],                                 \
+      device ErrorMessages* error_buf [[buffer(7)]],                           \
+      uint thread_index [[thread_position_in_grid]]);                          \
+  template [[host_name("scatter_set_dense_value_" #DTYPE                       \
+                       "_" #IDXTYPE)]] kernel void                             \
+  scatter_set_dense_value<DTYPE, IDXTYPE>(                                     \
+      device DTYPE * output [[buffer(0)]],                                     \
+      constant DTYPE & value [[buffer(1)]],                                    \
+      constant IDXTYPE * index [[buffer(2)]],                                  \
+      constant long& inner_size [[buffer(3)]],                                 \
+      constant long& index_dim_size [[buffer(4)]],                             \
+      constant long& output_dim_size [[buffer(5)]],                            \
+      constant long& tid_offset [[buffer(6)]],                                 \
+      device ErrorMessages* error_buf [[buffer(7)]],                           \
       uint thread_index [[thread_position_in_grid]])
 
 #define REGISTER_SCATTER_SET_DTYPE(DTYPE) \

--- a/aten/src/ATen/native/mps/kernels/Scatter.metal
+++ b/aten/src/ATen/native/mps/kernels/Scatter.metal
@@ -1,0 +1,134 @@
+#include <c10/metal/atomic.h>
+#include <c10/metal/error.h>
+#include <c10/metal/indexing.h>
+#include <c10/metal/utils.h>
+#include <metal_stdlib>
+
+using namespace metal;
+using namespace c10::metal;
+
+// scatter_set kernel: implements PyTorch's scatter with reduce='set'.
+//
+// For each coordinate `c` in `index`'s shape (one thread per element of
+// `index`), compute:
+//   idx = index[c]
+//   bounds-check idx in [0, dim_size); on failure, report async error.
+//   output[c with c[dim] replaced by idx] = src[c]
+//
+// The caller is responsible for pre-copying `self` into `output` when
+// they refer to different storages (out= variants); this kernel only
+// writes the scattered positions.
+template <typename T, typename index_t>
+kernel void scatter_set(
+    device T* output [[buffer(0)]],
+    constant T* src [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long* index_sizes [[buffer(3)]],
+    constant long* output_strides [[buffer(4)]],
+    constant long* src_strides [[buffer(5)]],
+    constant long* index_strides [[buffer(6)]],
+    constant uint3& ndim_dim [[buffer(7)]],
+    constant long& dim_size [[buffer(8)]],
+    device ErrorMessages* error_buf [[buffer(9)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const uint ndim = ndim_dim.x;
+  const uint dim = ndim_dim.y;
+
+  long pos[max_ndim];
+  pos_from_thread_index<long>(long(thread_index), pos, index_sizes, ndim);
+
+  const long index_offs = offset_from_coord<long>(pos, index_strides, ndim);
+  long idx = long(index[index_offs]);
+  if (idx < 0 || idx >= dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension ",
+        long(dim),
+        " with size ",
+        dim_size);
+    return;
+  }
+
+  const long src_offs = offset_from_coord<long>(pos, src_strides, ndim);
+  pos[dim] = idx;
+  const long out_offs = offset_from_coord<long>(pos, output_strides, ndim);
+  output[out_offs] = src[src_offs];
+}
+
+// Fast path for the common case where output, src, and index are all
+// contiguous, src and index share the same shape, and that shape matches
+// the output's shape outside `dim`. Each thread:
+//   inner = tid % inner_size       (coords below dim)
+//   outer = tid / (inner_size * index_dim_size)   (coords above dim)
+//   output[outer * output_dim_size * inner_size + idx * inner_size + inner]
+//       = src[tid]
+// inner_size = prod(output.sizes()[dim+1:]).
+template <typename T, typename index_t>
+kernel void scatter_set_dense(
+    device T* output [[buffer(0)]],
+    constant T* src [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long& inner_size [[buffer(3)]],
+    constant long& index_dim_size [[buffer(4)]],
+    constant long& output_dim_size [[buffer(5)]],
+    device ErrorMessages* error_buf [[buffer(6)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  long idx = long(index[thread_index]);
+  if (idx < 0 || idx >= output_dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension with size ",
+        output_dim_size);
+    return;
+  }
+  const long inner = long(thread_index) % inner_size;
+  const long outer = long(thread_index) / (inner_size * index_dim_size);
+  const long out_offset =
+      outer * (inner_size * output_dim_size) + idx * inner_size + inner;
+  output[out_offset] = src[thread_index];
+}
+
+#define REGISTER_SCATTER_SET_OP(DTYPE, IDXTYPE)                                \
+  template [[host_name("scatter_set_" #DTYPE "_" #IDXTYPE)]] kernel void       \
+  scatter_set<DTYPE, IDXTYPE>(                                                 \
+      device DTYPE * output [[buffer(0)]],                                     \
+      constant DTYPE * src [[buffer(1)]],                                      \
+      constant IDXTYPE * index [[buffer(2)]],                                  \
+      constant long* index_sizes [[buffer(3)]],                                \
+      constant long* output_strides [[buffer(4)]],                             \
+      constant long* src_strides [[buffer(5)]],                                \
+      constant long* index_strides [[buffer(6)]],                              \
+      constant uint3& ndim_dim [[buffer(7)]],                                  \
+      constant long& dim_size [[buffer(8)]],                                   \
+      device ErrorMessages* error_buf [[buffer(9)]],                           \
+      uint thread_index [[thread_position_in_grid]]);                          \
+  template [[host_name("scatter_set_dense_" #DTYPE "_" #IDXTYPE)]] kernel void \
+  scatter_set_dense<DTYPE, IDXTYPE>(                                           \
+      device DTYPE * output [[buffer(0)]],                                     \
+      constant DTYPE * src [[buffer(1)]],                                      \
+      constant IDXTYPE * index [[buffer(2)]],                                  \
+      constant long& inner_size [[buffer(3)]],                                 \
+      constant long& index_dim_size [[buffer(4)]],                             \
+      constant long& output_dim_size [[buffer(5)]],                            \
+      device ErrorMessages* error_buf [[buffer(6)]],                           \
+      uint thread_index [[thread_position_in_grid]])
+
+#define REGISTER_SCATTER_SET_DTYPE(DTYPE) \
+  REGISTER_SCATTER_SET_OP(DTYPE, long);   \
+  REGISTER_SCATTER_SET_OP(DTYPE, int)
+
+REGISTER_SCATTER_SET_DTYPE(float);
+REGISTER_SCATTER_SET_DTYPE(half);
+REGISTER_SCATTER_SET_DTYPE(bfloat);
+REGISTER_SCATTER_SET_DTYPE(long);
+REGISTER_SCATTER_SET_DTYPE(int);
+REGISTER_SCATTER_SET_DTYPE(short);
+REGISTER_SCATTER_SET_DTYPE(char);
+REGISTER_SCATTER_SET_DTYPE(uchar);
+REGISTER_SCATTER_SET_DTYPE(bool);
+REGISTER_SCATTER_SET_DTYPE(float2);
+REGISTER_SCATTER_SET_DTYPE(half2);

--- a/aten/src/ATen/native/mps/kernels/Scatter.metal
+++ b/aten/src/ATen/native/mps/kernels/Scatter.metal
@@ -121,6 +121,172 @@ kernel void scatter_set_dense_value(
   output[out_offset] = value;
 }
 
+// Reduce modes for the atomic scatter kernels below. Selected at host-side
+// pipeline lookup via the kernel name suffix.
+enum class ScatterReduceOp { Add, Prod, Amin, Amax };
+
+template <typename T>
+inline T scatter_op_prod(T a, T b) {
+  return c10::metal::mul(a, b);
+}
+template <typename T>
+inline T scatter_op_amin(T a, T b) {
+  return ::c10::metal::min(a, b);
+}
+template <typename T>
+inline T scatter_op_amax(T a, T b) {
+  return ::c10::metal::max(a, b);
+}
+
+// Tag-dispatch the atomic operation so we only instantiate the AtomicType
+// member that actually exists for a given T (e.g. AtomicType<long> has only
+// atomic_add, not atomic_binary_op).
+template <typename T, ScatterReduceOp Op>
+struct ScatterAtomicApply;
+
+template <typename T>
+struct ScatterAtomicApply<T, ScatterReduceOp::Add> {
+  static inline void apply(device T* output, long out_offset, T src_val) {
+    AtomicType<T>::atomic_add(
+        reinterpret_cast<device AtomicType_t<T>*>(output), out_offset, src_val);
+  }
+};
+
+template <typename T>
+struct ScatterAtomicApply<T, ScatterReduceOp::Prod> {
+  static inline void apply(device T* output, long out_offset, T src_val) {
+    AtomicType<T>::atomic_binary_op(
+        reinterpret_cast<device AtomicType_t<T>*>(output),
+        out_offset,
+        src_val,
+        scatter_op_prod<T>);
+  }
+};
+
+template <typename T>
+struct ScatterAtomicApply<T, ScatterReduceOp::Amin> {
+  static inline void apply(device T* output, long out_offset, T src_val) {
+    AtomicType<T>::atomic_binary_op(
+        reinterpret_cast<device AtomicType_t<T>*>(output),
+        out_offset,
+        src_val,
+        scatter_op_amin<T>);
+  }
+};
+
+template <typename T>
+struct ScatterAtomicApply<T, ScatterReduceOp::Amax> {
+  static inline void apply(device T* output, long out_offset, T src_val) {
+    AtomicType<T>::atomic_binary_op(
+        reinterpret_cast<device AtomicType_t<T>*>(output),
+        out_offset,
+        src_val,
+        scatter_op_amax<T>);
+  }
+};
+
+// Dense atomic scatter for one of {add, prod, amin, amax}. Shape requirements
+// match scatter_set_dense.
+template <typename T, typename index_t, ScatterReduceOp Op>
+kernel void scatter_reduce_dense(
+    device T* output [[buffer(0)]],
+    constant T* src [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long& inner_size [[buffer(3)]],
+    constant long& index_dim_size [[buffer(4)]],
+    constant long& output_dim_size [[buffer(5)]],
+    constant long& tid_offset [[buffer(6)]],
+    device ErrorMessages* error_buf [[buffer(7)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long tid = long(thread_index) + tid_offset;
+  long idx = long(index[tid]);
+  if (idx < 0 || idx >= output_dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension with size ",
+        output_dim_size);
+    return;
+  }
+  const long inner = tid % inner_size;
+  const long outer = tid / (inner_size * index_dim_size);
+  const long out_offset =
+      outer * (inner_size * output_dim_size) + idx * inner_size + inner;
+  ScatterAtomicApply<T, Op>::apply(output, out_offset, src[tid]);
+}
+
+// Strided atomic scatter. Generic for non-contiguous output/src/index.
+template <typename T, typename index_t, ScatterReduceOp Op>
+kernel void scatter_reduce_strided(
+    device T* output [[buffer(0)]],
+    constant T* src [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long* index_sizes [[buffer(3)]],
+    constant long* output_strides [[buffer(4)]],
+    constant long* src_strides [[buffer(5)]],
+    constant long* index_strides [[buffer(6)]],
+    constant uint3& ndim_dim [[buffer(7)]],
+    constant long& dim_size [[buffer(8)]],
+    constant long& tid_offset [[buffer(9)]],
+    device ErrorMessages* error_buf [[buffer(10)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const uint ndim = ndim_dim.x;
+  const uint dim = ndim_dim.y;
+  const long tid = long(thread_index) + tid_offset;
+
+  ::metal::array<long, max_ndim> pos;
+  pos_from_thread_index<long>(tid, &pos[0], index_sizes, ndim);
+
+  const long index_offs = offset_from_coord<long>(&pos[0], index_strides, ndim);
+  long idx = long(index[index_offs]);
+  if (idx < 0 || idx >= dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension ",
+        long(dim),
+        " with size ",
+        dim_size);
+    return;
+  }
+
+  const long src_offs = offset_from_coord<long>(&pos[0], src_strides, ndim);
+  pos[dim] = idx;
+  const long out_offs = offset_from_coord<long>(&pos[0], output_strides, ndim);
+  ScatterAtomicApply<T, Op>::apply(output, out_offs, src[src_offs]);
+}
+
+#define REGISTER_SCATTER_REDUCE_VARIANT(DTYPE, IDXTYPE, OP, OP_ENUM)          \
+  template                                                                    \
+      [[host_name("scatter_" #OP "_dense_" #DTYPE "_" #IDXTYPE)]] kernel void \
+      scatter_reduce_dense<DTYPE, IDXTYPE, ScatterReduceOp::OP_ENUM>(         \
+          device DTYPE * output [[buffer(0)]],                                \
+          constant DTYPE * src [[buffer(1)]],                                 \
+          constant IDXTYPE * index [[buffer(2)]],                             \
+          constant long& inner_size [[buffer(3)]],                            \
+          constant long& index_dim_size [[buffer(4)]],                        \
+          constant long& output_dim_size [[buffer(5)]],                       \
+          constant long& tid_offset [[buffer(6)]],                            \
+          device ErrorMessages* error_buf [[buffer(7)]],                      \
+          uint thread_index [[thread_position_in_grid]]);                     \
+  template [[host_name("scatter_" #OP "_strided_" #DTYPE                      \
+                       "_" #IDXTYPE)]] kernel void                            \
+  scatter_reduce_strided<DTYPE, IDXTYPE, ScatterReduceOp::OP_ENUM>(           \
+      device DTYPE * output [[buffer(0)]],                                    \
+      constant DTYPE * src [[buffer(1)]],                                     \
+      constant IDXTYPE * index [[buffer(2)]],                                 \
+      constant long* index_sizes [[buffer(3)]],                               \
+      constant long* output_strides [[buffer(4)]],                            \
+      constant long* src_strides [[buffer(5)]],                               \
+      constant long* index_strides [[buffer(6)]],                             \
+      constant uint3& ndim_dim [[buffer(7)]],                                 \
+      constant long& dim_size [[buffer(8)]],                                  \
+      constant long& tid_offset [[buffer(9)]],                                \
+      device ErrorMessages* error_buf [[buffer(10)]],                         \
+      uint thread_index [[thread_position_in_grid]])
+
 #define REGISTER_SCATTER_SET_OP(DTYPE, IDXTYPE)                                \
   template [[host_name("scatter_set_" #DTYPE "_" #IDXTYPE)]] kernel void       \
   scatter_set<DTYPE, IDXTYPE>(                                                 \
@@ -164,14 +330,49 @@ kernel void scatter_set_dense_value(
   REGISTER_SCATTER_SET_OP(DTYPE, long);   \
   REGISTER_SCATTER_SET_OP(DTYPE, int)
 
-REGISTER_SCATTER_SET_DTYPE(float);
-REGISTER_SCATTER_SET_DTYPE(half);
-REGISTER_SCATTER_SET_DTYPE(bfloat);
-REGISTER_SCATTER_SET_DTYPE(long);
-REGISTER_SCATTER_SET_DTYPE(int);
-REGISTER_SCATTER_SET_DTYPE(short);
-REGISTER_SCATTER_SET_DTYPE(char);
-REGISTER_SCATTER_SET_DTYPE(uchar);
-REGISTER_SCATTER_SET_DTYPE(bool);
-REGISTER_SCATTER_SET_DTYPE(float2);
-REGISTER_SCATTER_SET_DTYPE(half2);
+#define REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, OP, OP_ENUM)   \
+  REGISTER_SCATTER_REDUCE_VARIANT(DTYPE, long, OP, OP_ENUM); \
+  REGISTER_SCATTER_REDUCE_VARIANT(DTYPE, int, OP, OP_ENUM)
+
+// add: all numeric dtypes (atomic_add covers float/half/bfloat/int/short/
+// char/uchar/bool/long via the two-word trick, plus float2/half2 for complex).
+#define REGISTER_SCATTER_ADD_DTYPE(DTYPE) \
+  REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, add, Add)
+
+// prod/amin/amax use atomic_binary_op (CAS loop). Restricted to dtypes for
+// which AtomicType<T> provides atomic_binary_op: float, int, half, bfloat,
+// short, char, uchar. bool / long / complex aren't supported here -- amin/amax
+// for complex is mathematically undefined and rejected at the meta-func level;
+// long lacks atomic_binary_op (only an eventually-consistent atomic_add).
+#define REGISTER_SCATTER_PROD_MIN_MAX_DTYPE(DTYPE)   \
+  REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, prod, Prod); \
+  REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, amin, Amin); \
+  REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, amax, Amax)
+
+// Dtypes that support all of {set, add, prod, amin, amax}: float, int, half,
+// bfloat, short, char, uchar, bool -- AtomicType provides both atomic_add and
+// atomic_binary_op for these.
+#define REGISTER_SCATTER_OPS_FULL(DTYPE) \
+  REGISTER_SCATTER_SET_DTYPE(DTYPE);     \
+  REGISTER_SCATTER_ADD_DTYPE(DTYPE);     \
+  REGISTER_SCATTER_PROD_MIN_MAX_DTYPE(DTYPE)
+
+// Dtypes that support {set, add} only: long (atomic_add is eventually
+// consistent, no true 64-bit CAS for atomic_binary_op), float2/half2
+// (complex; amin/amax undefined).
+#define REGISTER_SCATTER_OPS_SET_ADD(DTYPE) \
+  REGISTER_SCATTER_SET_DTYPE(DTYPE);        \
+  REGISTER_SCATTER_ADD_DTYPE(DTYPE)
+
+REGISTER_SCATTER_OPS_FULL(float);
+REGISTER_SCATTER_OPS_FULL(half);
+REGISTER_SCATTER_OPS_FULL(bfloat);
+REGISTER_SCATTER_OPS_FULL(int);
+REGISTER_SCATTER_OPS_FULL(short);
+REGISTER_SCATTER_OPS_FULL(char);
+REGISTER_SCATTER_OPS_FULL(uchar);
+REGISTER_SCATTER_OPS_FULL(bool);
+
+REGISTER_SCATTER_OPS_SET_ADD(long);
+REGISTER_SCATTER_OPS_SET_ADD(float2);
+REGISTER_SCATTER_OPS_SET_ADD(half2);

--- a/aten/src/ATen/native/mps/kernels/Scatter.metal
+++ b/aten/src/ATen/native/mps/kernels/Scatter.metal
@@ -34,10 +34,10 @@ kernel void scatter_set(
   const uint ndim = ndim_dim.x;
   const uint dim = ndim_dim.y;
 
-  long pos[max_ndim];
-  pos_from_thread_index<long>(long(thread_index), pos, index_sizes, ndim);
+  ::metal::array<long, max_ndim> pos;
+  pos_from_thread_index<long>(long(thread_index), &pos[0], index_sizes, ndim);
 
-  const long index_offs = offset_from_coord<long>(pos, index_strides, ndim);
+  const long index_offs = offset_from_coord<long>(&pos[0], index_strides, ndim);
   long idx = long(index[index_offs]);
   if (idx < 0 || idx >= dim_size) {
     TORCH_REPORT_ERROR(
@@ -51,9 +51,9 @@ kernel void scatter_set(
     return;
   }
 
-  const long src_offs = offset_from_coord<long>(pos, src_strides, ndim);
+  const long src_offs = offset_from_coord<long>(&pos[0], src_strides, ndim);
   pos[dim] = idx;
-  const long out_offs = offset_from_coord<long>(pos, output_strides, ndim);
+  const long out_offs = offset_from_coord<long>(&pos[0], output_strides, ndim);
   output[out_offs] = src[src_offs];
 }
 

--- a/aten/src/ATen/native/mps/kernels/ScatterGather.metal
+++ b/aten/src/ATen/native/mps/kernels/ScatterGather.metal
@@ -295,8 +295,7 @@ kernel void scatter_reduce_strided(
 
 // gather: for each coord in `index` (= output) shape, read input at
 // (coord with coord[dim] replaced by index[coord]) and write to output[coord].
-// One write per output element -> no atomics needed. Bounds-check fires the
-// async error path on out-of-range indices, matching CUDA's behavior.
+// One write per output element -> no atomics needed.
 
 // Dense fast path: output and index contiguous, index.shape == output.shape,
 // input.shape == output.shape outside dim (no slicing).

--- a/aten/src/ATen/native/mps/kernels/ScatterGather.metal
+++ b/aten/src/ATen/native/mps/kernels/ScatterGather.metal
@@ -293,6 +293,85 @@ kernel void scatter_reduce_strided(
   ScatterAtomicApply<T, Op>::apply(output, out_offs, src[src_offs]);
 }
 
+// gather: for each coord in `index` (= output) shape, read input at
+// (coord with coord[dim] replaced by index[coord]) and write to output[coord].
+// One write per output element -> no atomics needed. Bounds-check fires the
+// async error path on out-of-range indices, matching CUDA's behavior.
+
+// Dense fast path: output and index contiguous, index.shape == output.shape,
+// input.shape == output.shape outside dim (no slicing).
+template <typename T, typename index_t>
+kernel void gather_dense(
+    device T* output [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long& inner_size [[buffer(3)]],
+    constant long& output_dim_size [[buffer(4)]],
+    constant long& input_dim_size [[buffer(5)]],
+    constant long& tid_offset [[buffer(6)]],
+    device ErrorMessages* error_buf [[buffer(7)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long tid = long(thread_index) + tid_offset;
+  long idx = long(index[tid]);
+  if (idx < 0 || idx >= input_dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "gather: index ",
+        idx,
+        " is out of bounds for dimension with size ",
+        input_dim_size);
+    output[tid] = T(0);
+    return;
+  }
+  const long inner = tid % inner_size;
+  const long outer = tid / (inner_size * output_dim_size);
+  const long input_offset =
+      outer * (inner_size * input_dim_size) + idx * inner_size + inner;
+  output[tid] = input[input_offset];
+}
+
+// Strided generic gather. Iterates over `index` (= output) shape per thread.
+template <typename T, typename index_t>
+kernel void gather_strided(
+    device T* output [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long* sizes [[buffer(3)]],
+    constant long* output_strides [[buffer(4)]],
+    constant long* input_strides [[buffer(5)]],
+    constant long* index_strides [[buffer(6)]],
+    constant uint3& ndim_dim [[buffer(7)]],
+    constant long& input_dim_size [[buffer(8)]],
+    constant long& tid_offset [[buffer(9)]],
+    device ErrorMessages* error_buf [[buffer(10)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const uint ndim = ndim_dim.x;
+  const uint dim = ndim_dim.y;
+  const long tid = long(thread_index) + tid_offset;
+
+  ::metal::array<long, max_ndim> pos;
+  pos_from_thread_index<long>(tid, &pos[0], sizes, ndim);
+
+  const long out_offs = offset_from_coord<long>(&pos[0], output_strides, ndim);
+  const long index_offs = offset_from_coord<long>(&pos[0], index_strides, ndim);
+  long idx = long(index[index_offs]);
+  if (idx < 0 || idx >= input_dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "gather: index ",
+        idx,
+        " is out of bounds for dimension ",
+        long(dim),
+        " with size ",
+        input_dim_size);
+    output[out_offs] = T(0);
+    return;
+  }
+  pos[dim] = idx;
+  const long input_offs = offset_from_coord<long>(&pos[0], input_strides, ndim);
+  output[out_offs] = input[input_offs];
+}
+
 #define REGISTER_SCATTER_REDUCE_VARIANT(DTYPE, IDXTYPE, OP, OP_ENUM)          \
   template                                                                    \
       [[host_name("scatter_" #OP "_dense_" #DTYPE "_" #IDXTYPE)]] kernel void \
@@ -365,6 +444,37 @@ kernel void scatter_reduce_strided(
   REGISTER_SCATTER_SET_OP(DTYPE, long);   \
   REGISTER_SCATTER_SET_OP(DTYPE, int)
 
+#define REGISTER_GATHER_OP(DTYPE, IDXTYPE)                                  \
+  template [[host_name("gather_dense_" #DTYPE "_" #IDXTYPE)]] kernel void   \
+  gather_dense<DTYPE, IDXTYPE>(                                             \
+      device DTYPE * output [[buffer(0)]],                                  \
+      constant DTYPE * input [[buffer(1)]],                                 \
+      constant IDXTYPE * index [[buffer(2)]],                               \
+      constant long& inner_size [[buffer(3)]],                              \
+      constant long& output_dim_size [[buffer(4)]],                         \
+      constant long& input_dim_size [[buffer(5)]],                          \
+      constant long& tid_offset [[buffer(6)]],                              \
+      device ErrorMessages* error_buf [[buffer(7)]],                        \
+      uint thread_index [[thread_position_in_grid]]);                       \
+  template [[host_name("gather_strided_" #DTYPE "_" #IDXTYPE)]] kernel void \
+  gather_strided<DTYPE, IDXTYPE>(                                           \
+      device DTYPE * output [[buffer(0)]],                                  \
+      constant DTYPE * input [[buffer(1)]],                                 \
+      constant IDXTYPE * index [[buffer(2)]],                               \
+      constant long* sizes [[buffer(3)]],                                   \
+      constant long* output_strides [[buffer(4)]],                          \
+      constant long* input_strides [[buffer(5)]],                           \
+      constant long* index_strides [[buffer(6)]],                           \
+      constant uint3& ndim_dim [[buffer(7)]],                               \
+      constant long& input_dim_size [[buffer(8)]],                          \
+      constant long& tid_offset [[buffer(9)]],                              \
+      device ErrorMessages* error_buf [[buffer(10)]],                       \
+      uint thread_index [[thread_position_in_grid]])
+
+#define REGISTER_GATHER_DTYPE(DTYPE) \
+  REGISTER_GATHER_OP(DTYPE, long);   \
+  REGISTER_GATHER_OP(DTYPE, int)
+
 #define REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, OP, OP_ENUM)   \
   REGISTER_SCATTER_REDUCE_VARIANT(DTYPE, long, OP, OP_ENUM); \
   REGISTER_SCATTER_REDUCE_VARIANT(DTYPE, int, OP, OP_ENUM)
@@ -390,18 +500,20 @@ kernel void scatter_reduce_strided(
   REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, amin, Amin); \
   REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, amax, Amax)
 
-// Dtypes that support all of {set, add, prod, amin, amax}: float, int, half,
-// bfloat, short, char, uchar, bool -- AtomicType provides both atomic_add and
-// atomic_binary_op for these.
+// Dtypes that support all of {gather, set, add, prod, amin, amax}: float, int,
+// half, bfloat, short, char, uchar, bool -- AtomicType provides both atomic_add
+// and atomic_binary_op for these.
 #define REGISTER_SCATTER_OPS_FULL(DTYPE) \
+  REGISTER_GATHER_DTYPE(DTYPE);          \
   REGISTER_SCATTER_SET_DTYPE(DTYPE);     \
   REGISTER_SCATTER_ADD_DTYPE(DTYPE);     \
   REGISTER_SCATTER_PROD_MIN_MAX_DTYPE(DTYPE)
 
-// Dtypes that support {set, add} only: long (atomic_add is eventually
+// Dtypes that support {gather, set, add} only: long (atomic_add is eventually
 // consistent, no true 64-bit CAS for atomic_binary_op), float2/half2
 // (complex; amin/amax undefined).
 #define REGISTER_SCATTER_OPS_SET_ADD(DTYPE) \
+  REGISTER_GATHER_DTYPE(DTYPE);             \
   REGISTER_SCATTER_SET_DTYPE(DTYPE);        \
   REGISTER_SCATTER_ADD_DTYPE(DTYPE)
 

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -67,9 +67,7 @@ static void dispatch_chunked(id<MTLComputeCommandEncoder> encoder,
 
 // In-place scatter with reduce='set'. `self` already holds the output's
 // initial contents (scatter_impl in TensorAdvancedIndexing.cpp does the
-// self->out copy before invoking the stub). Reports out-of-bounds indices
-// via the stream's async error buffer; raised on the next sync via
-// MPSStream::checkLastError (matches CUDA's deferred-assert model).
+// self->out copy before invoking the stub).
 static void scatter_set_metal(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
   TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
               "scatter: expected index to be Long or Int, got ",
@@ -267,8 +265,7 @@ static void scatter_reduce_metal(const Tensor& self,
 }
 
 // Metal gather: output[c] = input[c with c[dim] replaced by index[c]] for
-// every coord c in index's shape. Bounds-check fires the async error path
-// matching the scatter behavior. No atomics needed since each output position
+// every coord c in index's shape. No atomics needed since each output position
 // is written exactly once.
 static void gather_metal(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& output) {
   TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -20,7 +20,7 @@ namespace mps {
 #ifndef PYTORCH_JIT_COMPILE_SHADERS
 static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #else
-#include <ATen/native/mps/Scatter_metallib.h>
+#include <ATen/native/mps/ScatterGather_metallib.h>
 #endif
 
 // Fast path applies when output, src, and index are all contiguous, src
@@ -265,139 +265,108 @@ static void scatter_reduce_metal(const Tensor& self,
     }
   });
 }
+
+// Metal gather: output[c] = input[c with c[dim] replaced by index[c]] for
+// every coord c in index's shape. Bounds-check fires the async error path
+// matching the scatter behavior. No atomics needed since each output position
+// is written exactly once.
+static void gather_metal(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& output) {
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+              "gather: expected index to be Long or Int, got ",
+              index.scalar_type());
+  const auto ndim = static_cast<uint32_t>(index.dim());
+  TORCH_CHECK(
+      ndim <= c10::metal::max_ndim, "gather: tensor rank ", ndim, " exceeds Metal max of ", c10::metal::max_ndim);
+  const int64_t input_dim_size = self.size(dim);
+  const int64_t total = index.numel();
+  // Dense fast path: output/index contiguous, input.size(i) == output.size(i)
+  // for i != dim (no slicing). output.size(d) == index.size(d) for all d (gather contract).
+  bool use_dense = output.is_contiguous() && index.is_contiguous();
+  if (use_dense) {
+    for (const auto i : c10::irange(self.dim())) {
+      if (i != dim && self.size(i) != output.size(i)) {
+        use_dense = false;
+        break;
+      }
+    }
+  }
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      if (use_dense) {
+        const int64_t inner_size = dense_inner_size(output, dim);
+        const int64_t output_dim_size = output.size(dim);
+        auto pso = lib.getPipelineStateForFunc(
+            fmt::format("gather_dense_{}_{}", scalarToMetalTypeString(output), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      output,
+                      self,
+                      index,
+                      inner_size,
+                      output_dim_size,
+                      input_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
+      } else {
+        auto sizes = index.sizes();
+        std::array<uint32_t, 3> ndim_dim = {ndim, static_cast<uint32_t>(dim), 0};
+        auto pso = lib.getPipelineStateForFunc(
+            fmt::format("gather_strided_{}_{}", scalarToMetalTypeString(output), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      output,
+                      self,
+                      index,
+                      sizes,
+                      output.strides(),
+                      self.strides(),
+                      index.strides(),
+                      ndim_dim,
+                      input_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
+      }
+    }
+  });
+}
 } // namespace mps
 
 static Tensor maybe_expand_0_dim(const Tensor& t) {
   return t.dim() == 0 ? t.view({1}) : t;
 }
 
-static Tensor expand_index_as_real(const Tensor& index) {
+// gather_stub: read input at indexed positions per the gather contract. The
+// shared TORCH_IMPL_FUNC(gather_out) handles dim wrap and the empty-numel
+// early return before invoking us. Complex flows through unchanged via
+// float2/half2 templates (no view_as_real shim).
+static void gather_mps_kernel(const Tensor& result, const Tensor& self, int64_t dim, const Tensor& index) {
+  if (self.numel() == 0 || index.numel() == 0) {
+    return;
+  }
+  TORCH_CHECK(self.scalar_type() == result.scalar_type(), "gather(): self and result must have the same scalar type");
+  auto self_view = self.dim() == 0 ? self.view({1}) : self;
   auto index_view = maybe_expand_0_dim(index);
-  std::vector<int64_t> index_expanded_sizes = index_view.sizes().vec();
-  index_expanded_sizes.push_back(2);
-  auto index_expanded = index_view.unsqueeze(-1).expand(index_expanded_sizes);
-  return index_expanded;
+  auto result_view = maybe_expand_0_dim(result);
+  dim = at::maybe_wrap_dim(dim, self_view.dim());
+  TORCH_CHECK(dim >= 0 && dim < self_view.dim(), "gather(): Indexing dim ", dim, " is out of bounds of tensor");
+  TORCH_CHECK(index_view.dim() == self_view.dim() && index_view.dim() == result_view.dim(),
+              "Input, index and result must have same rank");
+  for (const auto i : c10::irange(self_view.dim())) {
+    TORCH_CHECK(i == dim || index_view.size(i) <= self_view.size(i),
+                "Index dim must not exceed input dim except at gathering axis");
+    TORCH_CHECK(result_view.size(i) == index_view.size(i), "result and index must have matching sizes");
+  }
+  mps::gather_metal(self_view, dim, index_view, result_view);
 }
 
-TORCH_IMPL_FUNC(gather_out_mps)
-(const Tensor& self_arg, int64_t dim, const Tensor& index, bool sparse_grad, const Tensor& output) {
-  using namespace mps;
-
-  if (self_arg.numel() == 0 || index.numel() == 0) {
-    return;
-  }
-  auto self = self_arg.dim() == 0 ? self_arg.view({1}) : self_arg;
-  dim = at::maybe_wrap_dim(dim, self.dim());
-
-  TORCH_CHECK(!sparse_grad, "sparse_grad not supported in MPS yet")
-  TORCH_CHECK(self.scalar_type() == output.scalar_type(), "gather(): self and output must have the same scalar type");
-  TORCH_CHECK(dim >= 0 && dim < self.dim(), "gather(): Indexing dim ", dim, " is out of bounds of tensor");
-
-  if (self.is_complex()) {
-    auto self_real = at::view_as_real(self);
-    auto index_expanded = expand_index_as_real(index);
-    auto output_real = at::view_as_real(maybe_expand_0_dim(output));
-    structured_gather_out_mps::impl(self_real, dim, index_expanded, sparse_grad, output_real);
-    return;
-  }
-
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* inputTensor_ = nil;
-    MPSGraphTensor* indexTensor_ = nil;
-    MPSGraphTensor* outputTensor_ = nil;
-  };
-
-  @autoreleasepool {
-    MPSShape* input_shape = getMPSShape(self);
-    MPSShape* index_shape = getMPSShape(index);
-    uint32_t num_input_dims = [input_shape count];
-    uint32_t num_index_dims = [index_shape count];
-    TORCH_CHECK(num_input_dims == num_index_dims, "Input and index must have same rank")
-
-    // Determine if we need to slice into the input tensor
-    bool needSlice = false;
-
-    for (const auto i : c10::irange(num_input_dims)) {
-      TORCH_CHECK(i == dim || [index_shape[i] intValue] <= [input_shape[i] intValue],
-                  "Index dim must not exceed input dim except at gathering axis")
-      if (i != dim && [index_shape[i] intValue] < [input_shape[i] intValue])
-        needSlice = true;
-    }
-    auto input_type = getMPSDataType(self);
-    auto output_type = getMPSDataType(output);
-    if (input_type == MPSDataTypeUInt8) {
-      input_type = MPSDataTypeInt8;
-    }
-    if (output_type == MPSDataTypeUInt8) {
-      output_type = MPSDataTypeInt8;
-    }
-    std::string key = "gather_out_mps" + getTensorsStringKey({self, index, output}) + ":" + std::to_string(dim);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, getMPSShape(self));
-      MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->indexTensor_ = indexTensor;
-
-      MPSGraphTensor* getInput = inputTensor;
-
-      // Slice into the input tensor IF NEEDED
-      if (needSlice) {
-        NSMutableArray<NSNumber*>* starts = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-        NSMutableArray<NSNumber*>* ends = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-        NSMutableArray<NSNumber*>* strides = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-
-        for (const auto i : c10::irange(num_input_dims)) {
-          // All strides are 1
-          strides[i] = @1;
-          // All starts are 0
-          starts[i] = @0;
-          ends[i] = (i != dim) ? index_shape[i] : input_shape[i];
-        }
-
-        getInput = [mpsGraph sliceTensor:inputTensor starts:starts ends:ends strides:strides name:nil];
-      }
-
-      // PyTorch issue #135240: MPS reshape underneath goes haywire in
-      // gatherAlongAxis before MacOS 15.2 if it has multiple dimensions but can
-      // be squeezed into 1D. We need to squeeze out the extra dims pre 15.2
-      bool workaroundSingleDim = (self_arg.squeeze().sizes().size() == 1 && self_arg.sizes().size() > 1);
-      bool isMacos15_2 = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_2_PLUS);
-      if (workaroundSingleDim and !isMacos15_2) {
-        const int64_t dims = self_arg.sizes().size();
-        int64_t size = self_arg.squeeze().sizes()[0];
-        auto shape = [[NSMutableArray alloc] initWithCapacity:dims];
-        for (int i = 0; i < dims; ++i) {
-          [shape addObject:[NSNumber numberWithInt:size]];
-        }
-        getInput = [mpsGraph broadcastTensor:getInput toShape:shape name:nil];
-        indexTensor = [mpsGraph broadcastTensor:indexTensor toShape:shape name:nil];
-      }
-      MPSGraphTensor* castIndexTensor = [mpsGraph castTensor:indexTensor
-                                                      toType:MPSDataTypeInt32
-                                                        name:(NSString* _Nonnull)nil];
-
-      C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wobjc-method-access")
-      MPSGraphTensor* outputTensor = [mpsGraph gatherAlongAxis:(NSInteger)dim
-                                             withUpdatesTensor:getInput
-                                                 indicesTensor:castIndexTensor
-                                                          name:nil];
-      C10_DIAGNOSTIC_POP()
-
-      if (workaroundSingleDim) {
-        outputTensor = [mpsGraph sliceTensor:outputTensor dimension:0 start:0 length:output.sizes()[0] name:nil];
-      }
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, input_shape, true, input_type);
-    Placeholder indexPlaceholder = Placeholder(cachedGraph->indexTensor_, index, index_shape);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output, nullptr, false, output_type);
-
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder, indexPlaceholder);
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-}
+REGISTER_DISPATCH(gather_stub, &gather_mps_kernel);
 
 static const char* reduce_op_to_mps_string(const ReductionType& op) {
   switch (op) {

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -204,11 +204,15 @@ static void scatter_reduce_metal(const Tensor& self,
   const bool use_dense = can_use_dense_scatter(self, index, dim) && src.is_contiguous() && src.sizes() == index.sizes();
   // Signed int64 amin/amax needs an encode/decode bracket so signed ordering
   // maps onto the unsigned atomic_min/max Metal exposes. Requires contiguous
-  // self so we can sweep it as a flat ulong buffer.
+  // self so we can sweep it as a flat ulong buffer. The ulong atomic_min/max
+  // intrinsic is only available at runtime on macOS 15+.
   const bool needs_signbit_xor =
       self.scalar_type() == ScalarType::Long && (std::string_view(op) == "amin" || std::string_view(op) == "amax");
-  TORCH_CHECK(!needs_signbit_xor || self.is_contiguous(),
-              "scatter_reduce(amin/amax) on int64 currently requires contiguous self");
+  if (needs_signbit_xor) {
+    TORCH_CHECK(is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS),
+                "scatter_reduce(amin/amax) on int64 requires macOS 15 or newer");
+    TORCH_CHECK(self.is_contiguous(), "scatter_reduce(amin/amax) on int64 currently requires contiguous self");
+  }
 
   MPSStream* stream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(stream->queue(), ^() {

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -464,7 +464,8 @@ static void scatter_fill_mps_kernel(const Tensor& self, int64_t dim, const Tenso
 }
 
 // Shared scatter-reduce dispatch used by add / reduce / scalar_reduce /
-// reduce_two stubs. mean is rejected via reduce_op_to_mps_string.
+// reduce_two stubs. mean accumulates as sum here; the divide-by-count
+// post-pass for scatter_reduce.two happens in shared scatter_reduce_two.
 static void scatter_reduce_dispatch(const Tensor& self,
                                     int64_t dim,
                                     const Tensor& index,
@@ -473,6 +474,9 @@ static void scatter_reduce_dispatch(const Tensor& self,
   if (self.numel() == 0 || index.numel() == 0 || src.numel() == 0) {
     return;
   }
+  // Match CPU: scatter_reduce(mean) isn't defined for bool.
+  TORCH_CHECK(reduce != ReductionType::MEAN || self.scalar_type() != ScalarType::Bool,
+              "scatter_reduce: reduce='mean' not implemented for 'Bool'");
   auto self_view = self.dim() == 0 ? self.view({1}) : self;
   auto src_view = maybe_expand_0_dim(src);
   auto index_view = maybe_expand_0_dim(index);

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -190,7 +190,7 @@ static void scatter_reduce_metal(const Tensor& self,
                                  int64_t dim,
                                  const Tensor& index,
                                  const Tensor& src,
-                                 const char* op) {
+                                 std::string_view op) {
   TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
               "scatter_reduce: expected index to be Long or Int, got ",
               index.scalar_type());
@@ -204,8 +204,7 @@ static void scatter_reduce_metal(const Tensor& self,
   // maps onto the unsigned atomic_min/max Metal exposes. Requires contiguous
   // self so we can sweep it as a flat ulong buffer. The ulong atomic_min/max
   // intrinsic is only available at runtime on macOS 15+.
-  const bool needs_signbit_xor =
-      self.scalar_type() == ScalarType::Long && (std::string_view(op) == "amin" || std::string_view(op) == "amax");
+  const bool needs_signbit_xor = self.scalar_type() == ScalarType::Long && (op == "amin" || op == "amax");
   if (needs_signbit_xor) {
     TORCH_CHECK(is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS),
                 "scatter_reduce(amin/amax) on int64 requires macOS 15 or newer");
@@ -276,9 +275,10 @@ static void gather_metal(const Tensor& self, int64_t dim, const Tensor& index, c
       ndim <= c10::metal::max_ndim, "gather: tensor rank ", ndim, " exceeds Metal max of ", c10::metal::max_ndim);
   const int64_t input_dim_size = self.size(dim);
   const int64_t total = index.numel();
-  // Dense fast path: output/index contiguous, input.size(i) == output.size(i)
-  // for i != dim (no slicing). output.size(d) == index.size(d) for all d (gather contract).
-  bool use_dense = output.is_contiguous() && index.is_contiguous();
+  // Dense fast path: output/index/self all contiguous (the dense offset
+  // formula assumes self has row-major strides) and input.size(i) ==
+  // output.size(i) for i != dim (no slicing).
+  bool use_dense = output.is_contiguous() && index.is_contiguous() && self.is_contiguous();
   if (use_dense) {
     for (const auto i : c10::irange(self.dim())) {
       if (i != dim && self.size(i) != output.size(i)) {
@@ -365,7 +365,7 @@ static void gather_mps_kernel(const Tensor& result, const Tensor& self, int64_t 
 
 REGISTER_DISPATCH(gather_stub, &gather_mps_kernel);
 
-static const char* reduce_op_to_mps_string(const ReductionType& op) {
+static std::string_view reduce_op_to_mps_string(const ReductionType& op) {
   switch (op) {
     case ReductionType::SUM:
       return "add";

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -18,7 +18,7 @@ namespace at::native {
 
 namespace mps {
 #ifndef PYTORCH_JIT_COMPILE_SHADERS
-static auto& scatterLib = MetalShaderLibrary::getBundledLibrary();
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #else
 #include <ATen/native/mps/Scatter_metallib.h>
 #endif
@@ -76,7 +76,7 @@ static void scatter_set_mps_kernel(const Tensor& self,
           inner_size *= output.size(i);
         }
         const int64_t index_dim_size = index.size(dim);
-        auto pso = scatterLib.getPipelineStateForFunc(
+        auto pso = lib.getPipelineStateForFunc(
             fmt::format("scatter_set_dense_{}_{}", scalarToMetalTypeString(output), scalarToMetalTypeString(index)));
         [encoder setComputePipelineState:pso];
         mtl_setArgs(encoder, output, src, index, inner_size, index_dim_size, output_dim_size, stream->getErrorBuffer());
@@ -84,7 +84,7 @@ static void scatter_set_mps_kernel(const Tensor& self,
       } else {
         auto sizes = index.sizes();
         std::array<uint32_t, 3> ndim_dim = {ndim, static_cast<uint32_t>(dim), 0};
-        auto pso = scatterLib.getPipelineStateForFunc(
+        auto pso = lib.getPipelineStateForFunc(
             fmt::format("scatter_set_{}_{}", scalarToMetalTypeString(output), scalarToMetalTypeString(index)));
         [encoder setComputePipelineState:pso];
         mtl_setArgs(encoder,

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -2,6 +2,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/TensorAdvancedIndexing.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <c10/metal/common.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -14,6 +15,95 @@
 #endif
 
 namespace at::native {
+
+namespace mps {
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& scatterLib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Scatter_metallib.h>
+#endif
+
+// Fast path applies when output, src, and index are all contiguous, src
+// matches index's shape (no broadcasting), and index matches output's shape
+// outside `dim`. Indexing math collapses to a single mod + div per thread.
+static bool can_use_dense_scatter_set(const Tensor& output, const Tensor& src, const Tensor& index, int64_t dim) {
+  if (!output.is_contiguous() || !src.is_contiguous() || !index.is_contiguous()) {
+    return false;
+  }
+  if (src.sizes() != index.sizes()) {
+    return false;
+  }
+  for (const auto i : c10::irange(output.dim())) {
+    if (i == dim) {
+      continue;
+    }
+    if (output.size(i) != index.size(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Metal path for scatter with reduce='set'. Reports out-of-bounds indices
+// to the stream's async error buffer, matching CUDA's deferred-assert
+// behavior (raised on the next sync via MPSStream::checkLastError).
+static void scatter_set_mps_kernel(const Tensor& self,
+                                   int64_t dim,
+                                   const Tensor& index,
+                                   const Tensor& src,
+                                   const Tensor& output) {
+  if (!output.is_same(self)) {
+    output.copy_(self);
+  }
+
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+              "scatter: expected index to be Long or Int, got ",
+              index.scalar_type());
+
+  const auto ndim = static_cast<uint32_t>(index.dim());
+  TORCH_CHECK(
+      ndim <= c10::metal::max_ndim, "scatter: tensor rank ", ndim, " exceeds Metal max of ", c10::metal::max_ndim);
+  const int64_t output_dim_size = self.size(dim);
+  const bool use_dense = can_use_dense_scatter_set(output, src, index, dim);
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      if (use_dense) {
+        int64_t inner_size = 1;
+        for (int64_t i = dim + 1; i < output.dim(); ++i) {
+          inner_size *= output.size(i);
+        }
+        const int64_t index_dim_size = index.size(dim);
+        auto pso = scatterLib.getPipelineStateForFunc(
+            fmt::format("scatter_set_dense_{}_{}", scalarToMetalTypeString(output), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        mtl_setArgs(encoder, output, src, index, inner_size, index_dim_size, output_dim_size, stream->getErrorBuffer());
+        mtl_dispatch1DJob(encoder, pso, index.numel());
+      } else {
+        auto sizes = index.sizes();
+        std::array<uint32_t, 3> ndim_dim = {ndim, static_cast<uint32_t>(dim), 0};
+        auto pso = scatterLib.getPipelineStateForFunc(
+            fmt::format("scatter_set_{}_{}", scalarToMetalTypeString(output), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        mtl_setArgs(encoder,
+                    output,
+                    src,
+                    index,
+                    sizes,
+                    output.strides(),
+                    src.strides(),
+                    index.strides(),
+                    ndim_dim,
+                    output_dim_size,
+                    stream->getErrorBuffer());
+        mtl_dispatch1DJob(encoder, pso, index.numel());
+      }
+    }
+  });
+}
+} // namespace mps
 
 static Tensor maybe_expand_0_dim(const Tensor& t) {
   return t.dim() == 0 ? t.view({1}) : t;
@@ -172,6 +262,21 @@ static void scatter_mps_general(const Tensor& self_arg,
     auto src_real = at::view_as_real(maybe_expand_0_dim(src));
     auto output_real = at::view_as_real(maybe_expand_0_dim(output));
     scatter_mps_general(self_real, dim, index_expanded, src_real, output_real, func_name, reduce);
+    return;
+  }
+
+  if (reduce == "set") {
+    auto src_view = maybe_expand_0_dim(src);
+    auto output_view = maybe_expand_0_dim(output);
+    auto index_view = maybe_expand_0_dim(index);
+    TORCH_CHECK(index_view.dim() == self.dim() && index_view.dim() == src_view.dim(),
+                "Input, index and src must have same rank");
+    for (const auto i : c10::irange(self.dim())) {
+      TORCH_CHECK(index_view.size(i) <= src_view.size(i), "Index dim must not exceed src dim");
+      TORCH_CHECK(i == dim || index_view.size(i) <= self.size(i),
+                  "Index dim must not exceed input dim except at gathering axis");
+    }
+    mps::scatter_set_mps_kernel(self, dim, index_view, src_view, output_view);
     return;
   }
 

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -173,6 +173,70 @@ static void scatter_fill_metal(const Tensor& self, int64_t dim, const Tensor& in
     }
   });
 }
+
+// Atomic Metal scatter for one of {add, prod, amin, amax}. Picks the dense
+// kernel when output/src/index are contiguous and shape-aligned outside dim,
+// strided kernel otherwise.
+static void scatter_reduce_metal(const Tensor& self,
+                                 int64_t dim,
+                                 const Tensor& index,
+                                 const Tensor& src,
+                                 const char* op) {
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+              "scatter_reduce: expected index to be Long or Int, got ",
+              index.scalar_type());
+  const auto ndim = static_cast<uint32_t>(index.dim());
+  TORCH_CHECK(
+      ndim <= c10::metal::max_ndim, "scatter: tensor rank ", ndim, " exceeds Metal max of ", c10::metal::max_ndim);
+  const int64_t output_dim_size = self.size(dim);
+  const int64_t total = index.numel();
+  const bool use_dense = can_use_dense_scatter(self, index, dim) && src.is_contiguous() && src.sizes() == index.sizes();
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      if (use_dense) {
+        const int64_t inner_size = dense_inner_size(self, dim);
+        const int64_t index_dim_size = index.size(dim);
+        auto pso = lib.getPipelineStateForFunc(
+            fmt::format("scatter_{}_dense_{}_{}", op, scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      self,
+                      src,
+                      index,
+                      inner_size,
+                      index_dim_size,
+                      output_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
+      } else {
+        auto sizes = index.sizes();
+        std::array<uint32_t, 3> ndim_dim = {ndim, static_cast<uint32_t>(dim), 0};
+        auto pso = lib.getPipelineStateForFunc(
+            fmt::format("scatter_{}_strided_{}_{}", op, scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      self,
+                      src,
+                      index,
+                      sizes,
+                      self.strides(),
+                      src.strides(),
+                      index.strides(),
+                      ndim_dim,
+                      output_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
+      }
+    }
+  });
+}
 } // namespace mps
 
 static Tensor maybe_expand_0_dim(const Tensor& t) {
@@ -307,208 +371,6 @@ TORCH_IMPL_FUNC(gather_out_mps)
   }
 }
 
-static void scatter_mps_general(const Tensor& self_arg,
-                                int64_t dim,
-                                const Tensor& index,
-                                const Tensor& src,
-                                const Tensor& output,
-                                std::string func_name,
-                                const std::string_view reduce) {
-  using namespace mps;
-
-  if (self_arg.numel() == 0 || index.numel() == 0 || src.numel() == 0) {
-    return;
-  }
-  auto self = self_arg.dim() == 0 ? self_arg.view({1}) : self_arg;
-  dim = at::maybe_wrap_dim(dim, self.dim());
-
-  TORCH_CHECK(self.scalar_type() == output.scalar_type() && output.scalar_type() == src.scalar_type(),
-              "scatter(): self, src and output must have the same scalar type");
-  TORCH_CHECK(dim >= 0 && dim < self.dim(), "scatter(): Indexing dim ", dim, " is out of bounds of tensor");
-
-  if (self.is_complex()) {
-    auto self_real = at::view_as_real(self);
-    auto index_expanded = expand_index_as_real(index);
-    auto src_real = at::view_as_real(maybe_expand_0_dim(src));
-    auto output_real = at::view_as_real(maybe_expand_0_dim(output));
-    scatter_mps_general(self_real, dim, index_expanded, src_real, output_real, func_name, reduce);
-    return;
-  }
-
-  // reduce='set' is served by the Metal path via scatter_stub / scatter_fill_stub
-  // (registered below). MPSGraph here only handles add/prod/amin/amax.
-
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* inputTensor_ = nil;
-    MPSGraphTensor* indexTensor_ = nil;
-    MPSGraphTensor* srcTensor_ = nil;
-    MPSGraphTensor* outputTensor_ = nil;
-  };
-
-  @autoreleasepool {
-    MPSShape* input_shape = getMPSShape(self);
-    MPSShape* index_shape = getMPSShape(index);
-    MPSShape* src_shape = getMPSShape(src);
-    uint32_t num_input_dims = [input_shape count];
-    uint32_t num_index_dims = [index_shape count];
-    uint32_t num_src_dims = [src_shape count];
-
-    TORCH_CHECK(num_input_dims == num_index_dims && num_index_dims == num_src_dims,
-                "Input, index and src must have same rank")
-
-    // Do we need to slice into the src tensor?
-    bool needSlice = false;
-    bool inputNeedSlice = false;
-    bool needsCast = false;
-
-    for (const auto i : c10::irange(num_input_dims)) {
-      TORCH_CHECK(i == dim || [index_shape[i] intValue] <= [input_shape[i] intValue],
-                  "Index dim must not exceed input dim except at gathering axis")
-      TORCH_CHECK([index_shape[i] intValue] <= [src_shape[i] intValue],
-                  "Index dim must not exceed input dim except at gathering axis")
-      if ([index_shape[i] intValue] < [src_shape[i] intValue])
-        needSlice = true;
-      if (i != dim && [index_shape[i] intValue] < [input_shape[i] intValue])
-        inputNeedSlice = true;
-    }
-    TORCH_CHECK(reduce != "mean", "Scatter reduce mean mode not yet supported in MPS")
-
-    MPSDataType src_type = getMPSDataType(src);
-    if (reduce != "set" || src_type == MPSDataTypeUInt8 || src_type == MPSDataTypeBool) {
-      src_type = isFloatingType(src.scalar_type()) ? MPSDataTypeFloat32 : MPSDataTypeInt32;
-      needsCast = true;
-    }
-
-    std::string key = func_name + getTensorsStringKey({self, index, src, output}) + ":" + std::to_string(dim) + ":" +
-        std::string(reduce);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-      MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
-      MPSGraphTensor* srcTensor = mpsGraphRankedPlaceHolder(mpsGraph, src);
-
-      MPSGraphTensor* outputTensor = nil;
-      MPSGraphTensor* castSrcTensor = srcTensor;
-      MPSGraphTensor* castInputTensor = inputTensor;
-
-      if (needsCast) {
-        castSrcTensor = [mpsGraph castTensor:srcTensor toType:src_type name:@"cast"];
-        castInputTensor = [mpsGraph castTensor:inputTensor toType:src_type name:@"cast"];
-      }
-      MPSGraphTensor* castIndexTensor = [mpsGraph castTensor:indexTensor toType:MPSDataTypeInt32 name:@"cast"];
-
-      MPSGraphTensor* slicedSrc = castSrcTensor;
-      MPSGraphTensor* slicedInput = castInputTensor;
-
-      // Use in case input needs to be smaller to get scatter
-      NSMutableArray<NSNumber*>* scatterInputShape = [NSMutableArray arrayWithArray:input_shape];
-
-      // Slice into the src or input tensors IF NEEDED
-      if (needSlice || inputNeedSlice) {
-        NSMutableArray<NSNumber*>* starts = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-        NSMutableArray<NSNumber*>* strides = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-        NSMutableArray<NSNumber*>* ends_src = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-
-        for (const auto i : c10::irange(num_input_dims)) {
-          strides[i] = @1;
-          starts[i] = @0;
-          ends_src[i] = index_shape[i];
-          scatterInputShape[i] = (i != dim) ? index_shape[i] : input_shape[i];
-        }
-        if (needSlice) {
-          slicedSrc = [mpsGraph sliceTensor:castSrcTensor starts:starts ends:ends_src strides:strides name:nil];
-        }
-        if (inputNeedSlice) {
-          slicedInput = [mpsGraph sliceTensor:castInputTensor
-                                       starts:starts
-                                         ends:scatterInputShape
-                                      strides:strides
-                                         name:nil];
-        }
-      }
-      MPSGraphScatterMode scatter_mode = MPSGraphScatterModeSet;
-
-      if (reduce == "sum" || reduce == "add")
-        scatter_mode = MPSGraphScatterModeAdd;
-      else if (reduce == "prod" || reduce == "multiply")
-        scatter_mode = MPSGraphScatterModeMul;
-      else if (reduce == "amax")
-        scatter_mode = MPSGraphScatterModeMax;
-      else if (reduce == "amin")
-        scatter_mode = MPSGraphScatterModeMin;
-
-      // Scatter this into the input with set mode
-      C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wobjc-method-access")
-      MPSGraphTensor* scatterTensor = [mpsGraph scatterAlongAxis:(NSInteger)dim
-                                                  withDataTensor:slicedInput
-                                                   updatesTensor:slicedSrc
-                                                   indicesTensor:castIndexTensor
-                                                            mode:scatter_mode
-                                                            name:nil];
-      C10_DIAGNOSTIC_POP()
-      if (inputNeedSlice) {
-        // Make an array of scatter indices tensors
-        NSMutableArray<MPSGraphTensor*>* indicesTensors =
-            [NSMutableArray<MPSGraphTensor*> arrayWithCapacity:num_input_dims];
-
-        // 1. Concatenate the coord tensors
-        // 2. Flatten the values
-        // 3. Scatter into input with add mode
-
-        std::vector<int> shape_data(num_input_dims);
-
-        for (const auto i : c10::irange(num_input_dims)) {
-          shape_data[i] = {[scatterInputShape[i] intValue]};
-        }
-
-        MPSGraphTensor* scatterInputShapeTensor =
-            [mpsGraph constantWithData:[NSData dataWithBytes:shape_data.data() length:num_input_dims * sizeof(int)]
-                                 shape:@[ [NSNumber numberWithUnsignedInt:num_input_dims] ]
-                              dataType:MPSDataTypeInt32];
-
-        for (const auto i : c10::irange(num_input_dims)) {
-          MPSGraphTensor* axisTensor = [mpsGraph constantWithScalar:i dataType:MPSDataTypeInt32];
-          MPSGraphTensor* scatter_currentIndexTensor = [mpsGraph coordinateAlongAxisTensor:axisTensor
-                                                                           withShapeTensor:scatterInputShapeTensor
-                                                                                      name:nil];
-          scatter_currentIndexTensor = [mpsGraph reshapeTensor:scatter_currentIndexTensor
-                                                     withShape:@[ @-1, @1 ]
-                                                          name:nil];
-          indicesTensors[i] = scatter_currentIndexTensor;
-        }
-
-        MPSGraphTensor* scatter_fullIndexTensor = [mpsGraph concatTensors:indicesTensors
-                                                                dimension:(NSInteger)1
-                                                                     name:nil];
-
-        MPSGraphTensor* flatValuesTensor = [mpsGraph reshapeTensor:scatterTensor withShape:@[ @-1 ] name:nil];
-
-        outputTensor = [mpsGraph scatterNDWithDataTensor:castInputTensor
-                                           updatesTensor:flatValuesTensor
-                                           indicesTensor:scatter_fullIndexTensor
-                                         batchDimensions:0
-                                                    mode:MPSGraphScatterModeSet
-                                                    name:nil];
-      } else {
-        outputTensor = scatterTensor;
-      }
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->srcTensor_ = srcTensor;
-      newCachedGraph->indexTensor_ = indexTensor;
-      newCachedGraph->outputTensor_ =
-          needsCast ? castMPSTensor(mpsGraph, outputTensor, output.scalar_type()) : outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, input_shape);
-    Placeholder srcPlaceholder = Placeholder(cachedGraph->srcTensor_, src, src_shape);
-    Placeholder indexPlaceholder = Placeholder(cachedGraph->indexTensor_, index, index_shape);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
-
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder, srcPlaceholder, indexPlaceholder);
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-}
-
 static const char* reduce_op_to_mps_string(const ReductionType& op) {
   switch (op) {
     case ReductionType::SUM:
@@ -520,9 +382,17 @@ static const char* reduce_op_to_mps_string(const ReductionType& op) {
     case ReductionType::MAX:
       return "amax";
     case ReductionType::MEAN:
-      return "mean";
+      // Pre-existing behavior: scatter_reduce(mean) on MPS accumulated as
+      // sum (no divide-by-count). True mean semantics is follow-up work.
+      return "add";
   }
   TORCH_CHECK(false, "Unsupported reduction type: ", static_cast<int>(op));
+}
+
+// Common pre-dispatch shape/dtype checks shared by all reduce-mode stubs.
+static void scatter_reduce_check(const Tensor& self, const Tensor& index, const Tensor& src) {
+  TORCH_CHECK(self.scalar_type() == src.scalar_type(), "scatter(): self and src must have the same scalar type");
+  TORCH_CHECK(index.dim() == self.dim() && index.dim() == src.dim(), "Input, index and src must have same rank");
 }
 
 // scatter_stub: in-place set with a Tensor src. self is the writable output
@@ -531,17 +401,10 @@ static void scatter_mps_kernel(const Tensor& self, int64_t dim, const Tensor& in
   if (self.numel() == 0 || index.numel() == 0 || src.numel() == 0) {
     return;
   }
-  // Promote 0-dim views first so view_as_real keeps ranks aligned across self/index/src
-  auto self_1d = self.dim() == 0 ? self.view({1}) : self;
-  if (self_1d.is_complex()) {
-    auto self_real = at::view_as_real(self_1d);
-    auto index_expanded = expand_index_as_real(index);
-    auto src_real = at::view_as_real(maybe_expand_0_dim(src));
-    scatter_mps_kernel(self_real, dim, index_expanded, src_real);
-    return;
-  }
   TORCH_CHECK(self.scalar_type() == src.scalar_type(), "scatter(): self and src must have the same scalar type");
-  auto self_view = self_1d;
+  // Complex types map to float2/half2 in the Metal kernels (see
+  // scalarToMetalTypeString), so no view_as_real shim is needed.
+  auto self_view = self.dim() == 0 ? self.view({1}) : self;
   auto src_view = maybe_expand_0_dim(src);
   auto index_view = maybe_expand_0_dim(index);
   dim = at::maybe_wrap_dim(dim, self_view.dim());
@@ -562,13 +425,8 @@ static void scatter_fill_mps_kernel(const Tensor& self, int64_t dim, const Tenso
   if (self.numel() == 0 || index.numel() == 0) {
     return;
   }
-  if (self.is_complex()) {
-    // Scalar-as-complex into a real view doesn't compose; materialize and recurse.
-    Tensor src = at::empty(index.sizes(), self.options());
-    src.fill_(value);
-    scatter_mps_kernel(self, dim, index, src);
-    return;
-  }
+  // MPSScalar carries c10::complex<float>/<Half> via its union and Metal kernels
+  // are templated on float2/half2, so complex scalars flow through unchanged.
   auto self_view = self.dim() == 0 ? self.view({1}) : self;
   auto index_view = maybe_expand_0_dim(index);
   dim = at::maybe_wrap_dim(dim, self_view.dim());
@@ -581,8 +439,26 @@ static void scatter_fill_mps_kernel(const Tensor& self, int64_t dim, const Tenso
   mps::scatter_fill_metal(self_view, dim, index_view, value);
 }
 
+// Shared scatter-reduce dispatch used by add / reduce / scalar_reduce /
+// reduce_two stubs. mean is rejected via reduce_op_to_mps_string.
+static void scatter_reduce_dispatch(const Tensor& self,
+                                    int64_t dim,
+                                    const Tensor& index,
+                                    const Tensor& src,
+                                    const ReductionType& reduce) {
+  if (self.numel() == 0 || index.numel() == 0 || src.numel() == 0) {
+    return;
+  }
+  auto self_view = self.dim() == 0 ? self.view({1}) : self;
+  auto src_view = maybe_expand_0_dim(src);
+  auto index_view = maybe_expand_0_dim(index);
+  dim = at::maybe_wrap_dim(dim, self_view.dim());
+  scatter_reduce_check(self_view, index_view, src_view);
+  mps::scatter_reduce_metal(self_view, dim, index_view, src_view, reduce_op_to_mps_string(reduce));
+}
+
 static void scatter_add_mps_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
-  scatter_mps_general(self, dim, index, src, self, "scatter_add_mps", "add");
+  scatter_reduce_dispatch(self, dim, index, src, ReductionType::SUM);
 }
 
 static void scatter_reduce_mps_kernel(const Tensor& self,
@@ -590,7 +466,7 @@ static void scatter_reduce_mps_kernel(const Tensor& self,
                                       const Tensor& index,
                                       const Tensor& src,
                                       const ReductionType& reduce) {
-  scatter_mps_general(self, dim, index, src, self, "scatter_reduce_mps", reduce_op_to_mps_string(reduce));
+  scatter_reduce_dispatch(self, dim, index, src, reduce);
 }
 
 static void scatter_scalar_reduce_mps_kernel(const Tensor& self,
@@ -600,7 +476,7 @@ static void scatter_scalar_reduce_mps_kernel(const Tensor& self,
                                              const ReductionType& reduce) {
   Tensor src = at::empty(index.sizes(), self.options());
   src.fill_(value);
-  scatter_mps_general(self, dim, index, src, self, "scatter_scalar_reduce_mps", reduce_op_to_mps_string(reduce));
+  scatter_reduce_dispatch(self, dim, index, src, reduce);
 }
 
 static void scatter_reduce_two_mps_kernel(const Tensor& self,
@@ -608,23 +484,7 @@ static void scatter_reduce_two_mps_kernel(const Tensor& self,
                                           const Tensor& index,
                                           const Tensor& src,
                                           const ReductionType& reduce) {
-  static const bool is_macOS_15_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
-  switch (reduce) {
-    case ReductionType::MEAN:
-    case ReductionType::SUM:
-      return scatter_mps_general(self, dim, index, src, self, "scatter_reduce_two_mps", "add");
-    case ReductionType::PROD:
-      return scatter_mps_general(self, dim, index, src, self, "scatter_reduce_two_mps", "prod");
-    case ReductionType::MIN:
-      TORCH_CHECK(self.scalar_type() != kInt || is_macOS_15_or_newer, "torch.int32 is only supported on MacOS15+");
-      TORCH_CHECK(self.scalar_type() != kLong, "not supported for torch.int64");
-      return scatter_mps_general(self, dim, index, src, self, "scatter_reduce_two_mps", "amin");
-    case ReductionType::MAX:
-      TORCH_CHECK(self.scalar_type() != kInt || is_macOS_15_or_newer, "torch.int32 is only supported on MacOS15+");
-      TORCH_CHECK(self.scalar_type() != kLong, "not supported for torch.int64");
-      return scatter_mps_general(self, dim, index, src, self, "scatter_reduce_two_mps", "amax");
-  }
-  TORCH_CHECK(false, "Unsupported reduction type: ", static_cast<int>(reduce));
+  scatter_reduce_dispatch(self, dim, index, src, reduce);
 }
 
 REGISTER_DISPATCH(scatter_stub, &scatter_mps_kernel);

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -174,6 +174,17 @@ static void scatter_fill_metal(const Tensor& self, int64_t dim, const Tensor& in
   });
 }
 
+// XOR every element's sign bit. Used as the pre- and post-pass that brackets
+// a signed int64 amin/amax scatter (Metal's atomic_min/max work on ulong,
+// so we encode signed values by flipping the sign bit to make signed order
+// match unsigned order; the encoding is its own inverse).
+static void dispatch_signbit_xor_long(id<MTLComputeCommandEncoder> encoder, MPSStream* stream, const Tensor& self) {
+  TORCH_CHECK(self.is_contiguous(), "scatter_reduce(amin/amax) on int64 requires contiguous self");
+  auto pso = lib.getPipelineStateForFunc("scatter_signbit_xor_long");
+  [encoder setComputePipelineState:pso];
+  dispatch_chunked(encoder, pso, self.numel(), [&](int64_t tid_offset) { mtl_setArgs(encoder, self, tid_offset); });
+}
+
 // Atomic Metal scatter for one of {add, prod, amin, amax}. Picks the dense
 // kernel when output/src/index are contiguous and shape-aligned outside dim,
 // strided kernel otherwise.
@@ -191,11 +202,21 @@ static void scatter_reduce_metal(const Tensor& self,
   const int64_t output_dim_size = self.size(dim);
   const int64_t total = index.numel();
   const bool use_dense = can_use_dense_scatter(self, index, dim) && src.is_contiguous() && src.sizes() == index.sizes();
+  // Signed int64 amin/amax needs an encode/decode bracket so signed ordering
+  // maps onto the unsigned atomic_min/max Metal exposes. Requires contiguous
+  // self so we can sweep it as a flat ulong buffer.
+  const bool needs_signbit_xor =
+      self.scalar_type() == ScalarType::Long && (std::string_view(op) == "amin" || std::string_view(op) == "amax");
+  TORCH_CHECK(!needs_signbit_xor || self.is_contiguous(),
+              "scatter_reduce(amin/amax) on int64 currently requires contiguous self");
 
   MPSStream* stream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      if (needs_signbit_xor) {
+        dispatch_signbit_xor_long(encoder, stream, self);
+      }
       if (use_dense) {
         const int64_t inner_size = dense_inner_size(self, dim);
         const int64_t index_dim_size = index.size(dim);
@@ -233,6 +254,9 @@ static void scatter_reduce_metal(const Tensor& self,
                       tid_offset,
                       stream->getErrorBuffer());
         });
+      }
+      if (needs_signbit_xor) {
+        dispatch_signbit_xor_long(encoder, stream, self);
       }
     }
   });

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -26,11 +26,8 @@ static auto& lib = MetalShaderLibrary::getBundledLibrary();
 // Fast path applies when output, src, and index are all contiguous, src
 // matches index's shape (no broadcasting), and index matches output's shape
 // outside `dim`. Indexing math collapses to a single mod + div per thread.
-static bool can_use_dense_scatter_set(const Tensor& output, const Tensor& src, const Tensor& index, int64_t dim) {
-  if (!output.is_contiguous() || !src.is_contiguous() || !index.is_contiguous()) {
-    return false;
-  }
-  if (src.sizes() != index.sizes()) {
+static bool can_use_dense_scatter(const Tensor& output, const Tensor& index, int64_t dim) {
+  if (!output.is_contiguous() || !index.is_contiguous()) {
     return false;
   }
   for (const auto i : c10::irange(output.dim())) {
@@ -44,18 +41,36 @@ static bool can_use_dense_scatter_set(const Tensor& output, const Tensor& src, c
   return true;
 }
 
-// Metal path for scatter with reduce='set'. Reports out-of-bounds indices
-// to the stream's async error buffer, matching CUDA's deferred-assert
-// behavior (raised on the next sync via MPSStream::checkLastError).
-static void scatter_set_mps_kernel(const Tensor& self,
-                                   int64_t dim,
-                                   const Tensor& index,
-                                   const Tensor& src,
-                                   const Tensor& output) {
-  if (!output.is_same(self)) {
-    output.copy_(self);
+static int64_t dense_inner_size(const Tensor& output, int64_t dim) {
+  int64_t inner = 1;
+  for (int64_t i = dim + 1; i < output.dim(); ++i) {
+    inner *= output.size(i);
   }
+  return inner;
+}
 
+// Metal's [[thread_position_in_grid]] is at most a `uint`, so chunk the
+// dispatch when index.numel() exceeds UINT_MAX. Each chunk reads
+// `tid_offset` and adds it to its local thread index.
+template <typename SetArgsFn>
+static void dispatch_chunked(id<MTLComputeCommandEncoder> encoder,
+                             id<MTLComputePipelineState> pso,
+                             int64_t total,
+                             SetArgsFn set_args) {
+  const int64_t chunk_size = std::numeric_limits<uint32_t>::max();
+  for (int64_t off = 0; off < total; off += chunk_size) {
+    const int64_t this_chunk = std::min<int64_t>(chunk_size, total - off);
+    set_args(off);
+    mtl_dispatch1DJob(encoder, pso, this_chunk);
+  }
+}
+
+// In-place scatter with reduce='set'. `self` already holds the output's
+// initial contents (scatter_impl in TensorAdvancedIndexing.cpp does the
+// self->out copy before invoking the stub). Reports out-of-bounds indices
+// via the stream's async error buffer; raised on the next sync via
+// MPSStream::checkLastError (matches CUDA's deferred-assert model).
+static void scatter_set_metal(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
   TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
               "scatter: expected index to be Long or Int, got ",
               index.scalar_type());
@@ -64,42 +79,97 @@ static void scatter_set_mps_kernel(const Tensor& self,
   TORCH_CHECK(
       ndim <= c10::metal::max_ndim, "scatter: tensor rank ", ndim, " exceeds Metal max of ", c10::metal::max_ndim);
   const int64_t output_dim_size = self.size(dim);
-  const bool use_dense = can_use_dense_scatter_set(output, src, index, dim);
+  const int64_t total = index.numel();
+  const bool use_dense = can_use_dense_scatter(self, index, dim) && src.is_contiguous() && src.sizes() == index.sizes();
 
   MPSStream* stream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
       if (use_dense) {
-        int64_t inner_size = 1;
-        for (int64_t i = dim + 1; i < output.dim(); ++i) {
-          inner_size *= output.size(i);
-        }
+        const int64_t inner_size = dense_inner_size(self, dim);
         const int64_t index_dim_size = index.size(dim);
         auto pso = lib.getPipelineStateForFunc(
-            fmt::format("scatter_set_dense_{}_{}", scalarToMetalTypeString(output), scalarToMetalTypeString(index)));
+            fmt::format("scatter_set_dense_{}_{}", scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
         [encoder setComputePipelineState:pso];
-        mtl_setArgs(encoder, output, src, index, inner_size, index_dim_size, output_dim_size, stream->getErrorBuffer());
-        mtl_dispatch1DJob(encoder, pso, index.numel());
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      self,
+                      src,
+                      index,
+                      inner_size,
+                      index_dim_size,
+                      output_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
       } else {
         auto sizes = index.sizes();
         std::array<uint32_t, 3> ndim_dim = {ndim, static_cast<uint32_t>(dim), 0};
         auto pso = lib.getPipelineStateForFunc(
-            fmt::format("scatter_set_{}_{}", scalarToMetalTypeString(output), scalarToMetalTypeString(index)));
+            fmt::format("scatter_set_{}_{}", scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
         [encoder setComputePipelineState:pso];
-        mtl_setArgs(encoder,
-                    output,
-                    src,
-                    index,
-                    sizes,
-                    output.strides(),
-                    src.strides(),
-                    index.strides(),
-                    ndim_dim,
-                    output_dim_size,
-                    stream->getErrorBuffer());
-        mtl_dispatch1DJob(encoder, pso, index.numel());
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      self,
+                      src,
+                      index,
+                      sizes,
+                      self.strides(),
+                      src.strides(),
+                      index.strides(),
+                      ndim_dim,
+                      output_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
       }
+    }
+  });
+}
+
+// Dense scatter with reduce='set' and a scalar source. Avoids the
+// `at::empty + fill_` temp tensor the legacy path materialized for
+// scatter.value. Falls back to allocating a src tensor and reusing
+// scatter_set_metal when the dense layout assumptions don't hold.
+static void scatter_fill_metal(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& value) {
+  if (!can_use_dense_scatter(self, index, dim) || !index.is_contiguous()) {
+    Tensor src = at::empty(index.sizes(), self.options());
+    src.fill_(value);
+    scatter_set_metal(self, dim, index, src);
+    return;
+  }
+
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+              "scatter: expected index to be Long or Int, got ",
+              index.scalar_type());
+  const int64_t output_dim_size = self.size(dim);
+  const int64_t inner_size = dense_inner_size(self, dim);
+  const int64_t index_dim_size = index.size(dim);
+  const int64_t total = index.numel();
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      // MPSScalar owns a DataPtr (non-copyable); construct inside the block so
+      // ObjC's capture-by-value doesn't try to copy it. setBytes copies the
+      // value into the command buffer, so the local lifetime is fine.
+      MPSScalar mps_value = getMPSScalar(value, self.scalar_type());
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc(
+          fmt::format("scatter_set_dense_value_{}_{}", scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
+      [encoder setComputePipelineState:pso];
+      dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+        mtl_setArgs(encoder,
+                    self,
+                    mps_value,
+                    index,
+                    inner_size,
+                    index_dim_size,
+                    output_dim_size,
+                    tid_offset,
+                    stream->getErrorBuffer());
+      });
     }
   });
 }
@@ -265,20 +335,8 @@ static void scatter_mps_general(const Tensor& self_arg,
     return;
   }
 
-  if (reduce == "set") {
-    auto src_view = maybe_expand_0_dim(src);
-    auto output_view = maybe_expand_0_dim(output);
-    auto index_view = maybe_expand_0_dim(index);
-    TORCH_CHECK(index_view.dim() == self.dim() && index_view.dim() == src_view.dim(),
-                "Input, index and src must have same rank");
-    for (const auto i : c10::irange(self.dim())) {
-      TORCH_CHECK(index_view.size(i) <= src_view.size(i), "Index dim must not exceed src dim");
-      TORCH_CHECK(i == dim || index_view.size(i) <= self.size(i),
-                  "Index dim must not exceed input dim except at gathering axis");
-    }
-    mps::scatter_set_mps_kernel(self, dim, index_view, src_view, output_view);
-    return;
-  }
+  // reduce='set' is served by the Metal path via scatter_stub / scatter_fill_stub
+  // (registered below). MPSGraph here only handles add/prod/amin/amax.
 
   struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
@@ -451,45 +509,98 @@ static void scatter_mps_general(const Tensor& self_arg,
   }
 }
 
-TORCH_IMPL_FUNC(scatter_src_out_mps)
-(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src, const Tensor& output) {
-  scatter_mps_general(self, dim, index, src, output, "scatter_src_out_mps", "set");
+static const char* reduce_op_to_mps_string(const ReductionType& op) {
+  switch (op) {
+    case ReductionType::SUM:
+      return "add";
+    case ReductionType::PROD:
+      return "prod";
+    case ReductionType::MIN:
+      return "amin";
+    case ReductionType::MAX:
+      return "amax";
+    case ReductionType::MEAN:
+      return "mean";
+  }
+  TORCH_CHECK(false, "Unsupported reduction type: ", static_cast<int>(op));
 }
 
-TORCH_IMPL_FUNC(scatter_value_out_mps)
-(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& value, const Tensor& output) {
-  Tensor src =
-      at::empty(index.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, self.suggest_memory_format());
+// scatter_stub: in-place set with a Tensor src. self is the writable output
+// (pre-loaded by scatter_impl in TensorAdvancedIndexing.cpp).
+static void scatter_mps_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+  if (self.numel() == 0 || index.numel() == 0 || src.numel() == 0) {
+    return;
+  }
+  // Promote 0-dim views first so view_as_real keeps ranks aligned across self/index/src
+  auto self_1d = self.dim() == 0 ? self.view({1}) : self;
+  if (self_1d.is_complex()) {
+    auto self_real = at::view_as_real(self_1d);
+    auto index_expanded = expand_index_as_real(index);
+    auto src_real = at::view_as_real(maybe_expand_0_dim(src));
+    scatter_mps_kernel(self_real, dim, index_expanded, src_real);
+    return;
+  }
+  TORCH_CHECK(self.scalar_type() == src.scalar_type(), "scatter(): self and src must have the same scalar type");
+  auto self_view = self_1d;
+  auto src_view = maybe_expand_0_dim(src);
+  auto index_view = maybe_expand_0_dim(index);
+  dim = at::maybe_wrap_dim(dim, self_view.dim());
+  TORCH_CHECK(dim >= 0 && dim < self_view.dim(), "scatter(): Indexing dim ", dim, " is out of bounds of tensor");
+  TORCH_CHECK(index_view.dim() == self_view.dim() && index_view.dim() == src_view.dim(),
+              "Input, index and src must have same rank");
+  for (const auto i : c10::irange(self_view.dim())) {
+    TORCH_CHECK(index_view.size(i) <= src_view.size(i), "Index dim must not exceed src dim");
+    TORCH_CHECK(i == dim || index_view.size(i) <= self_view.size(i),
+                "Index dim must not exceed input dim except at gathering axis");
+  }
+  mps::scatter_set_metal(self_view, dim, index_view, src_view);
+}
+
+// scatter_fill_stub: in-place set with a scalar value. Uses the dense
+// scatter_set_dense_value kernel when possible (skips temp-src materialization).
+static void scatter_fill_mps_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& value) {
+  if (self.numel() == 0 || index.numel() == 0) {
+    return;
+  }
+  if (self.is_complex()) {
+    // Scalar-as-complex into a real view doesn't compose; materialize and recurse.
+    Tensor src = at::empty(index.sizes(), self.options());
+    src.fill_(value);
+    scatter_mps_kernel(self, dim, index, src);
+    return;
+  }
+  auto self_view = self.dim() == 0 ? self.view({1}) : self;
+  auto index_view = maybe_expand_0_dim(index);
+  dim = at::maybe_wrap_dim(dim, self_view.dim());
+  TORCH_CHECK(dim >= 0 && dim < self_view.dim(), "scatter(): Indexing dim ", dim, " is out of bounds of tensor");
+  TORCH_CHECK(index_view.dim() == self_view.dim(), "Input and index must have same rank");
+  for (const auto i : c10::irange(self_view.dim())) {
+    TORCH_CHECK(i == dim || index_view.size(i) <= self_view.size(i),
+                "Index dim must not exceed input dim except at gathering axis");
+  }
+  mps::scatter_fill_metal(self_view, dim, index_view, value);
+}
+
+static void scatter_add_mps_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+  scatter_mps_general(self, dim, index, src, self, "scatter_add_mps", "add");
+}
+
+static void scatter_reduce_mps_kernel(const Tensor& self,
+                                      int64_t dim,
+                                      const Tensor& index,
+                                      const Tensor& src,
+                                      const ReductionType& reduce) {
+  scatter_mps_general(self, dim, index, src, self, "scatter_reduce_mps", reduce_op_to_mps_string(reduce));
+}
+
+static void scatter_scalar_reduce_mps_kernel(const Tensor& self,
+                                             int64_t dim,
+                                             const Tensor& index,
+                                             const Scalar& value,
+                                             const ReductionType& reduce) {
+  Tensor src = at::empty(index.sizes(), self.options());
   src.fill_(value);
-  scatter_mps_general(self, dim, index, const_cast<Tensor&>(src), output, "scatter_value_out_mps", "set");
-}
-
-TORCH_IMPL_FUNC(scatter_reduce_out_mps)
-(const Tensor& self,
- int64_t dim,
- const Tensor& index,
- const Tensor& src,
- const std::string_view reduce,
- const Tensor& output) {
-  scatter_mps_general(self, dim, index, src, output, "scatter_reduce_out_mps", reduce);
-}
-
-TORCH_IMPL_FUNC(scatter_value_reduce_out_mps)
-(const Tensor& self,
- int64_t dim,
- const Tensor& index,
- const Scalar& value,
- const std::string_view reduce,
- const Tensor& output) {
-  Tensor src =
-      at::empty(index.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, self.suggest_memory_format());
-  src.fill_(value);
-  scatter_mps_general(self, dim, index, const_cast<Tensor&>(src), output, "scatter_value_reduce_out_mps", reduce);
-}
-
-TORCH_IMPL_FUNC(scatter_add_mps_out)
-(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src, const Tensor& output) {
-  scatter_mps_general(self, dim, index, src, output, "scatter_add_mps_out", "add");
+  scatter_mps_general(self, dim, index, src, self, "scatter_scalar_reduce_mps", reduce_op_to_mps_string(reduce));
 }
 
 static void scatter_reduce_two_mps_kernel(const Tensor& self,
@@ -516,5 +627,10 @@ static void scatter_reduce_two_mps_kernel(const Tensor& self,
   TORCH_CHECK(false, "Unsupported reduction type: ", static_cast<int>(reduce));
 }
 
+REGISTER_DISPATCH(scatter_stub, &scatter_mps_kernel);
+REGISTER_DISPATCH(scatter_fill_stub, &scatter_fill_mps_kernel);
+REGISTER_DISPATCH(scatter_add_stub, &scatter_add_mps_kernel);
+REGISTER_DISPATCH(scatter_reduce_stub, &scatter_reduce_mps_kernel);
+REGISTER_DISPATCH(scatter_scalar_reduce_stub, &scatter_scalar_reduce_mps_kernel);
 REGISTER_DISPATCH(scatter_reduce_two_stub, &scatter_reduce_two_mps_kernel);
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9615,8 +9615,7 @@
 - func: gather.out(Tensor self, int dim, Tensor index, *, bool sparse_grad=False, Tensor(a!) out) -> Tensor(a!)
   structured: True
   dispatch:
-    CPU, CUDA: gather_out
-    MPS: gather_out_mps
+    CPU, CUDA, MPS: gather_out
 
 - func: gather(Tensor self, int dim, Tensor index, *, bool sparse_grad=False) -> Tensor
   variants: method, function

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8543,8 +8543,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_src_out
-    MPS: scatter_src_out_mps
+    CPU, CUDA, MPS: scatter_src_out
 
 - func: scatter.value(Tensor self, int dim, Tensor index, Scalar value) -> Tensor
   structured_delegate: scatter.value_out
@@ -8559,8 +8558,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_value_out
-    MPS: scatter_value_out_mps
+    CPU, CUDA, MPS: scatter_value_out
 
 - func: scatter.reduce(Tensor self, int dim, Tensor index, Tensor src, *, str reduce) -> Tensor
   structured_delegate: scatter.reduce_out
@@ -8574,8 +8572,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_reduce_out
-    MPS: scatter_reduce_out_mps
+    CPU, CUDA, MPS: scatter_reduce_out
 
 - func: scatter.value_reduce(Tensor self, int dim, Tensor index, Scalar value, *, str reduce) -> Tensor
   structured_delegate: scatter.value_reduce_out
@@ -8589,8 +8586,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_value_reduce_out
-    MPS: scatter_value_reduce_out_mps
+    CPU, CUDA, MPS: scatter_value_reduce_out
 
 - func: scatter.dimname_src(Tensor self, Dimname dim, Tensor index, Tensor src) -> Tensor
   variants: function, method
@@ -8611,8 +8607,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_add
-    MPS: scatter_add_mps_out
+    CPU, CUDA, MPS: scatter_add
 
 - func: scatter_add.dimname(Tensor self, Dimname dim, Tensor index, Tensor src) -> Tensor
   variants: function, method

--- a/c10/metal/atomic.h
+++ b/c10/metal/atomic.h
@@ -229,6 +229,14 @@ struct AtomicType<bool> {
         ::metal::memory_order_relaxed,
         ::metal::memory_order_relaxed));
   }
+  // Generic packed-CAS supports any bool op (AND for prod/amin, OR for amax).
+  static inline void atomic_binary_op(
+      device type* data,
+      long offset,
+      bool value,
+      bool (*op)(bool, bool)) {
+    atomic_binary_op_helper<bool>(data, offset, value, op);
+  }
 };
 
 // ComplexHalf atomic op

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4832,7 +4832,6 @@ class CommonTemplate:
         y = torch.tensor(0)
         self.assertEqual(fn(x, y), x + x)
 
-    @xfail_if_mps_unimplemented  # Sparse not supported
     def test_gather3(self):
         def fn(a, b):
             return torch.gather(a, 1, b, sparse_grad=True)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14569,18 +14569,44 @@ class TestErrorInputs(TestCase):
             torch.mps.synchronize()
 
     def test_scatter_out_of_bounds(self, device):
-        # Regression for https://github.com/pytorch/pytorch/issues/170507
-        # one_hot is composite (zeros + scatter_); bad indices used to silently
-        # produce zeros instead of raising. MPS scatter now reports async via
-        # the stream error buffer, matching CUDA's deferred-assert behavior.
+        # MPS scatter reports bad indices via the stream's async error buffer,
+        # raised on the next sync as torch.AcceleratorError -- matches CUDA's
+        # deferred-assert behavior.
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.zeros(3, 4, device=device).scatter_(1, torch.tensor([[4]], device=device), 1.0)
+            torch.mps.synchronize()
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.zeros(3, 4, device=device).scatter_(1, torch.tensor([[-1]], device=device), 1.0)
+            torch.mps.synchronize()
+        # scatter_add and scatter_reduce go through the atomic kernels.
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.zeros(3, 4, device=device).scatter_add_(1, torch.tensor([[4]], device=device), torch.ones(1, 1, device=device))
+            torch.mps.synchronize()
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.zeros(3, 4, device=device).scatter_reduce_(
+                1, torch.tensor([[4]], device=device), torch.ones(1, 1, device=device),
+                reduce="amax", include_self=True,
+            )
+            torch.mps.synchronize()
+
+    def test_gather_out_of_bounds(self, device):
+        # MPS gather reports bad indices via the same async error buffer
+        # used by scatter; raised on the next sync as torch.AcceleratorError.
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.gather(torch.zeros(3, 4, device=device), 1, torch.tensor([[4]], device=device))
+            torch.mps.synchronize()
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.gather(torch.zeros(3, 4, device=device), 1, torch.tensor([[-1]], device=device))
+            torch.mps.synchronize()
+
+    def test_one_hot_out_of_bounds(self, device):
+        # Regression for https://github.com/pytorch/pytorch/issues/170507 --
+        # F.one_hot used to silently return zeros for out-of-range indices on MPS.
         with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
             torch.nn.functional.one_hot(torch.tensor([8], device=device), num_classes=8)
             torch.mps.synchronize()
         with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
             torch.nn.functional.one_hot(torch.tensor([-1], device=device), num_classes=8)
-            torch.mps.synchronize()
-        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
-            torch.zeros(3, 4, device=device).scatter_(1, torch.tensor([[4]], device=device), 1.0)
             torch.mps.synchronize()
 
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14568,6 +14568,21 @@ class TestErrorInputs(TestCase):
             torch.nn.functional.embedding_bag(inputs, weight, offsets)
             torch.mps.synchronize()
 
+    def test_scatter_out_of_bounds(self, device):
+        # Regression for https://github.com/pytorch/pytorch/issues/170507
+        # one_hot is composite (zeros + scatter_); bad indices used to silently
+        # produce zeros instead of raising. MPS scatter now reports async via
+        # the stream error buffer, matching CUDA's deferred-assert behavior.
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.nn.functional.one_hot(torch.tensor([8], device=device), num_classes=8)
+            torch.mps.synchronize()
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.nn.functional.one_hot(torch.tensor([-1], device=device), num_classes=8)
+            torch.mps.synchronize()
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.zeros(3, 4, device=device).scatter_(1, torch.tensor([[4]], device=device), 1.0)
+            torch.mps.synchronize()
+
 
 class TestComplex(TestCase):
     def test_tensor_scalar_binops(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14569,9 +14569,6 @@ class TestErrorInputs(TestCase):
             torch.mps.synchronize()
 
     def test_scatter_out_of_bounds(self, device):
-        # MPS scatter reports bad indices via the stream's async error buffer,
-        # raised on the next sync as torch.AcceleratorError -- matches CUDA's
-        # deferred-assert behavior.
         with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
             torch.zeros(3, 4, device=device).scatter_(1, torch.tensor([[4]], device=device), 1.0)
             torch.mps.synchronize()
@@ -14590,8 +14587,6 @@ class TestErrorInputs(TestCase):
             torch.mps.synchronize()
 
     def test_gather_out_of_bounds(self, device):
-        # MPS gather reports bad indices via the same async error buffer
-        # used by scatter; raised on the next sync as torch.AcceleratorError.
         with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
             torch.gather(torch.zeros(3, 4, device=device), 1, torch.tensor([[4]], device=device))
             torch.mps.synchronize()
@@ -14600,8 +14595,7 @@ class TestErrorInputs(TestCase):
             torch.mps.synchronize()
 
     def test_one_hot_out_of_bounds(self, device):
-        # Regression for https://github.com/pytorch/pytorch/issues/170507 --
-        # F.one_hot used to silently return zeros for out-of-range indices on MPS.
+        # Regression for https://github.com/pytorch/pytorch/issues/170507.
         with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
             torch.nn.functional.one_hot(torch.tensor([8], device=device), num_classes=8)
             torch.mps.synchronize()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10147,14 +10147,18 @@ class TestNNDeviceType(NNTestCase):
         _test_module_empty_input(self, mod, inp)
 
     def test_one_hot(self, device):
-        # cuda and mps surface invalid indices via an async device-side assert;
-        # xla ignores them. Only cpu raises synchronously here.
-        if self.device_type == 'cpu':
+        # cpu raises synchronously; mps reports the bad index from its scatter
+        # kernel asynchronously, surfaced on the next sync. xla still ignores.
+        if self.device_type in ('cpu', 'mps'):
             with self.assertRaises(RuntimeError):
                 torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)
+                if self.device_type == 'mps':
+                    torch.mps.synchronize()
 
             with self.assertRaises(RuntimeError):
                 torch.nn.functional.one_hot(torch.tensor([3, 4, 1, 0], device=device), 3)
+                if self.device_type == 'mps':
+                    torch.mps.synchronize()
 
         t = torch.nn.functional.one_hot(torch.tensor([3, 4, 1, 0], device=device))
         expected = torch.tensor([[0, 0, 0, 1, 0],

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10147,8 +10147,8 @@ class TestNNDeviceType(NNTestCase):
         _test_module_empty_input(self, mod, inp)
 
     def test_one_hot(self, device):
-        # cuda throws device assert for invalid data
-        # xla & mps ignore out of bound indices
+        # cuda and mps surface invalid indices via an async device-side assert;
+        # xla ignores them. Only cpu raises synchronously here.
         if self.device_type == 'cpu':
             with self.assertRaises(RuntimeError):
                 torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -23369,6 +23369,12 @@ op_db: list[OpInfo] = [
         dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
         dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16),
         dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
+        # MPS: int64 amin requires macOS 15+ (ulong atomic_min intrinsic).
+        dtypesIfMPS=(
+            _dispatch_dtypes(t for t in all_types_and(torch.float16, torch.bfloat16, torch.bool) if t != torch.int64)
+            if MACOS_VERSION < 15.0
+            else all_types_and(torch.float16, torch.bfloat16, torch.bool)
+        ),
         supports_forward_ad=True,
         check_batched_forward_grad=False,
         supports_fwgrad_bwgrad=True,
@@ -23380,6 +23386,12 @@ op_db: list[OpInfo] = [
         dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
         dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16),
         dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
+        # MPS: int64 amax requires macOS 15+ (ulong atomic_max intrinsic).
+        dtypesIfMPS=(
+            _dispatch_dtypes(t for t in all_types_and(torch.float16, torch.bfloat16, torch.bool) if t != torch.int64)
+            if MACOS_VERSION < 15.0
+            else all_types_and(torch.float16, torch.bfloat16, torch.bool)
+        ),
         supports_forward_ad=True,
         check_batched_forward_grad=False,
         supports_fwgrad_bwgrad=True,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -23336,6 +23336,10 @@ op_db: list[OpInfo] = [
         # and scatter_reduce hasn't been added to the whitelist in gen_variable_type yet
         dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
         dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16),
+        # MPS: int64 prod is not supported (no atomic_binary_op for 64-bit).
+        dtypesIfMPS=_dispatch_dtypes(
+            t for t in all_types_and(torch.float16, torch.bfloat16, torch.bool) if t != torch.int64
+        ),
         dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
         sample_inputs_func=sample_inputs_scatter_reduce,
         skips=(
@@ -23353,7 +23357,8 @@ op_db: list[OpInfo] = [
         dtypes=all_types_and(torch.float16, torch.bfloat16),
         dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
         dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16),
-        dtypesIfMPS=all_types_and(torch.float16, torch.bfloat16, torch.bool),
+        # MPS: reject bool to match CPU (which raises NotImplementedError for bool mean).
+        dtypesIfMPS=all_types_and(torch.float16, torch.bfloat16),
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         sample_inputs_func=sample_inputs_scatter_reduce,
@@ -23368,11 +23373,6 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         supports_fwgrad_bwgrad=True,
         sample_inputs_func=sample_inputs_scatter_reduce,
-        skips=(
-            # MPS: not supported for torch.int64
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.int64,)),
-        ),
     ),
     OpInfo(
         'scatter_reduce',
@@ -23384,11 +23384,6 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         supports_fwgrad_bwgrad=True,
         sample_inputs_func=sample_inputs_scatter_reduce,
-        skips=(
-            # MPS: not supported for torch.int64
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.int64,)),
-        ),
     ),
     OpInfo(
         '_segment_reduce',

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -585,6 +585,9 @@ if torch.backends.mps.is_available():
             if MACOS_VERSION < 15.0
             else [torch.int64],
             "scatter_reducemean": [torch.bool],
+            # int64 lacks atomic_binary_op in Metal; the old MPSGraph path cast
+            # to int32 (silently lossy).
+            "scatter_reduceprod": [torch.int64],
             "segment_reduce": None,
             "_segment.reduce": None,
             "segment.reduce": None,

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -578,10 +578,10 @@ if torch.backends.mps.is_available():
                 torch.int32,
                 torch.int16,
             ],
-            "scatter_reducemean": [torch.bool],
             # int64 lacks atomic_binary_op in Metal; the old MPSGraph path cast
             # to int32 (silently lossy). amin/amax for int64 go through the
             # sign-flip encode + ulong atomic_min/max bracket and work fine.
+            # bool prod/mean are excluded via dtypesIfMPS in the OpInfo itself.
             "scatter_reduceprod": [torch.int64],
             "segment_reduce": None,
             "_segment.reduce": None,

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -578,15 +578,10 @@ if torch.backends.mps.is_available():
                 torch.int32,
                 torch.int16,
             ],
-            "scatter_reduceamax": [torch.int32, torch.int64]
-            if MACOS_VERSION < 15.0
-            else [torch.int64],
-            "scatter_reduceamin": [torch.int32, torch.int64]
-            if MACOS_VERSION < 15.0
-            else [torch.int64],
             "scatter_reducemean": [torch.bool],
             # int64 lacks atomic_binary_op in Metal; the old MPSGraph path cast
-            # to int32 (silently lossy).
+            # to int32 (silently lossy). amin/amax for int64 go through the
+            # sign-flip encode + ulong atomic_min/max bracket and work fine.
             "scatter_reduceprod": [torch.int64],
             "segment_reduce": None,
             "_segment.reduce": None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #184028

Migrates family of `gather` / `scatter` ops (including reduce parts) from from the legacy MPSGraph path to native Metal kernels, registers MPS into the existing stub patterns shared with CPU/CUDA.

- Uses standard dense/strided/broadcast(or scalar) pattern to match/outperform MPSGraph generated kernels.
- Uses `AtomicType<T>::atomic_add` for add flavor , and prod/amin/amax rely on `atomic_binary_op` template (packed-CAS loop).
- Bounds checks live inline in every kernel and report to the stream's async error buffer.
- Deleted `view_as_real` workarounds for complex types.

## Signed int64 amin/amax

Apple's `<metal_atomic>` exposes `atomic_min_explicit` / `atomic_max_explicit` on `device ulong*` (unsigned only) starting on macOS 15 GPUs. For signed int64 we bracket the scatter with an XOR-sign-bit pass (encode → atomic_min/max on the ulong view → decode), so signed ordering maps to the unsigned hardware op. Gated at runtime on macOS 15+.

`prod` on int64 isn't reachable through this trick (Metal has no `atomic_compare_exchange` or `atomic_prod` on 64-bit, and prod isn't a monotone reduction), so it stays in the skip list.

## Large tensor support

`[[thread_position_in_grid]]` is at most a `uint`, so the host chunks dispatch into <=UINT_MAX-thread launches and each thread reads a `tid_offset` constant. Scatter on tensors with index numel > 2^32 works transparently.

## Bool reduce ops

Added `atomic_binary_op` to `AtomicType<bool>` in `c10/metal/atomic.h` (one-liner delegating to the existing packed-uint CAS helper), so bool prod/amin (AND) and amax (OR) work through the same machinery as other dtypes. `scatter_reduce(mean, bool)` is rejected with `NotImplementedError` to match CPU.

## Performance

vs PyTorch 2.12.0 (median delta across {(1024,1024) dim=1, (512,4096) dim=1, (4096,512) dim=0, (128,128,128) dim=2}; negative = new Metal path is that much faster than the old MPSGraph baseline):

| Op | bool | int8 | uint8 | int16 | int32 | int64 | f16 | bf16 | f32 | cfloat |
|---|---|---|---|---|---|---|---|---|---|---|
| `scatter_` set (tensor src) | -51% | -24% | -49% | -28% | -29% | -37% | -28% | -23% | -30% | -62% |
| `scatter_` set (scalar) | -50% | -31% | -50% | -36% | -38% | -52% | -39% | -34% | -40% | -70% |
| `scatter_add_` | -48% | -39% | -38% | -45% | -40% | -58% | -36% | -40% | -32% | -57% |
| `scatter_reduce_(amax)` | -45% | -42% | -42% | -45% | -33% | NEW¹ | -45% | -47% | -34% | n/a |
| `scatter_reduce_(prod)` | -46% | -42% | -43% | -45% | -32% | n/a² | -40% | -44% | -34% | n/a |

¹ int64 amin/amax was previously unsupported on MPS (skipped at OpInfo). Now works on macOS 15+ via the sign-flip + ulong atomic_min/max bracket. 92-273 us depending on shape.
² int64 prod still unsupported (no Metal 64-bit atomic_binary_op even with the encoding trick).

`one_hot` itself (the original issue) gets 30-60% faster across shapes since it exercises the dense scalar path directly.

No regression on any tested shape × dtype × op combination.

<details>
<summary>Benchmark script</summary>

```python
import time, torch

def bench(fn, iters=100, warmup=20):
    for _ in range(warmup): fn()
    torch.mps.synchronize()
    t0 = time.perf_counter()
    for _ in range(iters): fn()
    torch.mps.synchronize()
    return (time.perf_counter() - t0) * 1e6 / iters

DTYPES = [torch.bool, torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64,
          torch.float16, torch.bfloat16, torch.float32, torch.complex64]
SHAPES = [((1024, 1024), 1), ((512, 4096), 1), ((4096, 512), 0), ((128, 128, 128), 2)]

def make(dt, shape, dim):
    self = torch.zeros(shape, dtype=dt, device="mps")
    if dt == torch.bool:           src = torch.ones(shape, dtype=dt, device="mps")
    elif dt.is_floating_point or dt.is_complex: src = torch.randn(shape, device="mps").to(dt)
    else:                          src = torch.randint(0, 10, shape, device="mps").to(dt)
    idx = torch.randint(0, shape[dim], shape, device="mps", dtype=torch.long)
    return self, idx, src

for shape, dim in SHAPES:
    for dt in DTYPES:
        s, i, v = make(dt, shape, dim)
        scalar = True if dt == torch.bool else (1.5 if dt.is_floating_point or dt.is_complex else 1)
        for name, fn in [
            ("set/tensor", lambda: s.scatter_(dim, i, v)),
            ("set/scalar", lambda: s.scatter_(dim, i, scalar)),
            ("add",        lambda: s.scatter_add_(dim, i, v)),
            ("amax",       lambda: s.scatter_reduce_(dim, i, v, reduce="amax", include_self=True)),
            ("prod",       lambda: s.scatter_reduce_(dim, i, v, reduce="prod", include_self=True)),
        ]:
            try: us = bench(fn)
            except Exception: us = float("nan")
            print(f"{name:12} {str(dt):<20} {str(shape):<22} {us:>8.2f}")
```

</details>

Fixes https://github.com/pytorch/pytorch/issues/170507

( as `F.one_hot` is composite -- it lowers to `zeros() + scatter_(-1, self.unsqueeze(-1), 1)`)

Authored with Claude.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo