### PR TITLE
Document negative-input NaN behavior of PoissonNLLLoss

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3211,7 +3211,14 @@ def poisson_nll_loss(
     See :class:`~torch.nn.PoissonNLLLoss` for details.
 
     Args:
-        input: Expectation of underlying Poisson distribution.
+        input: Expectation of underlying Poisson distribution. When
+            :attr:`log_input`\ =\ ``False`` the value must be non-negative,
+            since the loss takes :math:`\log(\text{input}+\text{eps})`;
+            elements with ``input < -eps`` evaluate to ``NaN`` and propagate
+            through the reduction. If the upstream layer can produce negative
+            pre-activations, apply :func:`torch.clamp` with ``min=0`` or pass
+            the values through :func:`~torch.nn.functional.softplus` before
+            handing them to the loss.
         target: Random sample :math:`target \sim \text{Poisson}(input)`.
         log_input: If ``True`` the loss is computed as
             :math:`\exp(\text{input}) - \text{target} * \text{input}`, if ``False`` then loss is

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -298,6 +298,17 @@ class PoissonNLLLoss(_Loss):
     approximation is used for target values more than 1. For targets less or
     equal to 1 zeros are added to the loss.
 
+    .. note::
+        When :attr:`log_input`\ =\ ``False`` the input must be non-negative,
+        since the loss takes :math:`\log(\text{input}+\text{eps})`. Any
+        element of :attr:`input` with value less than ``-eps`` produces
+        ``NaN`` and the NaN propagates through the reduction. If the
+        upstream layer can produce negative pre-activations, apply
+        :func:`torch.clamp` with ``min=0`` or pass the values through
+        :func:`~torch.nn.functional.softplus` before handing them to the
+        loss. When :attr:`log_input`\ =\ ``True`` the loss is finite for
+        any real :attr:`input`.
+
     Args:
         log_input (bool, optional): if ``True`` the loss is computed as
             :math:`\exp(\text{input}) - \text{target}*\text{input}`, if ``False`` the loss is


### PR DESCRIPTION
Fixes #184030.

`PoissonNLLLoss` and the underlying `F.poisson_nll_loss` compute `input - target * log(input + eps)` when `log_input=False`. Any element of `input` smaller than `-eps` drives the `log(...)` to `NaN`, and the `NaN` propagates through the reduction. The docstring formula already shows `log(input + eps)`, but neither the `Module` docstring nor the functional docstring mentions the non-negativity requirement, so users feeding real-valued pre-activations (e.g. the output of a `Linear` with no positivity-enforcing activation) into the loss silently get `NaN` output, which is hard to root-cause from the visible API.

The reporter (#184030) suggested either rejecting negative input as a `ValueError` or documenting the contract. This PR takes the documentation path: behavior is unchanged, and the docstring update makes the input domain explicit so callers can clamp or `softplus` upstream as needed.

## What changed

- `torch/nn/functional.py::poisson_nll_loss`: extended the `input` argument description to call out the non-negativity requirement when `log_input=False`, the resulting `NaN` propagation, and the two standard workarounds (`torch.clamp(min=0)` or `torch.nn.functional.softplus`).
- `torch/nn/modules/loss.py::PoissonNLLLoss`: added a top-level `.. note::` block with the same contract, and explicitly noted that `log_input=True` is finite for any real input.

No code change; no behavior change; no new test (docs-only).

## How to verify

The reporter's repro still produces `NaN` (because behavior is unchanged), but the updated docstring now points the reader directly at the cause and the recommended fixes:

```python
import torch
torch.manual_seed(0)
loss = torch.nn.PoissonNLLLoss(log_input=False, reduction="none")
inp = torch.randn(2, 8)   # contains negatives
target = torch.rand(2, 8)
print(loss(inp, target))  # NaN-laced (as documented now)
print(loss(inp.clamp(min=0), target))  # finite (the documented fix)
```

Rendered Sphinx output for both files renders cleanly (`.. note::` and the extended `Args:` entry both follow the existing conventions in `loss.py`'s siblings).

## Notes for reviewers

Per `AGENTS.md` this PR was authored with AI assistance (Claude Code). I read the issue, traced `torch.poisson_nll_loss` from Python down to the C++ op, confirmed the formula matches `aten/src/ATen/native/Loss.cpp`, and chose the docs-only path so the change is risk-free vs. a runtime `ValueError` that would change the API contract. Happy to follow up with a stricter validation PR if maintainers prefer; this one is meant to land the cheaper half of the fix.