### PR TITLE
Tma scatter add remove software pipelining

### DIFF
--- a/aten/src/ATen/native/cuda/TmaScatterAddKernel.cu
+++ b/aten/src/ATen/native/cuda/TmaScatterAddKernel.cu
@@ -117,30 +117,20 @@ __global__ void tma_scatter_add_kernel(
 
     extern __shared__ char smem_raw[];
 
-    // One warp per entry: lane 0 issues TMA commands, __syncwarp() synchronizes.
     constexpr int threads_per_entry = C10_WARP_SIZE;
     int entry_in_block = threadIdx.x / threads_per_entry;
     int lane = threadIdx.x - entry_in_block * threads_per_entry;
 
-    // smem layout: [data region: entries_per_block * 2 * chunk_elems scalars]
-    //              [mbarrier region: entries_per_block * 2 uint64_t, 8-byte aligned]
-    // Mbarrier memory must never alias with data targeted by TMA operations.
-    int buf_elems = 2 * chunk_elems;
-    int data_region_bytes = entries_per_block * buf_elems * static_cast<int>(sizeof(scalar_t));
+    int data_region_bytes = entries_per_block * chunk_elems * static_cast<int>(sizeof(scalar_t));
     int mbar_offset = (data_region_bytes + 7) & ~7;
 
-    scalar_t* buf0 = reinterpret_cast<scalar_t*>(smem_raw) + entry_in_block * buf_elems;
-    uint64_t* mbar0 = reinterpret_cast<uint64_t*>(smem_raw + mbar_offset) + entry_in_block * 2;
-    uint64_t* mbar1 = mbar0 + 1;
-    uint64_t* mbars[2] = {mbar0, mbar1};
+    scalar_t* buf0 = reinterpret_cast<scalar_t*>(smem_raw) + entry_in_block * chunk_elems;
+    uint64_t* mbar0 = reinterpret_cast<uint64_t*>(smem_raw + mbar_offset) + entry_in_block;
 
     if (lane == 0) {
         tma::mbar_init(mbar0, 1u);
-        tma::mbar_init(mbar1, 1u);
     }
     __syncwarp();
-
-    int mbar_phase[2] = {0, 0};
 
     {
         int entry_id = blockIdx.x * entries_per_block + entry_in_block;
@@ -153,57 +143,23 @@ __global__ void tma_scatter_add_kernel(
         const scalar_t* src_entry = src_data + static_cast<int64_t>(entry_id) * src_stride;
         scalar_t* dst_entry = self_data + ind * self_stride;
 
-        // Wait for a stage's TMA load to complete, then reduce it.
-        auto drain_chunk = [&](int stage, int off) {
-            while (!tma::mbar_try_wait_parity(
-                mbars[stage], static_cast<uint32_t>(mbar_phase[stage] & 1))) {}
-            mbar_phase[stage]++;
+        int off = blockIdx.y * chunk_elems;
+        if (off >= D) return;
 
-            int elems = min(chunk_elems, D - off);
-            uint32_t bytes = elems * sizeof(scalar_t);
-            if (lane == 0) {
-                tma::bulk_reduce_add<scalar_t>(dst_entry + off, buf0 + stage * chunk_elems, bytes);
-                tma::commit_group();
-            }
-        };
-
-        // Producer-ahead-of-consumer: issue load for current chunk,
-        // then drain previous chunk while current loads.
-        int prev_off = 0;
-        int pair_count = 0;
-        int phase = 0;
-        for (int off = blockIdx.y * chunk_elems; off < D;
-             off += gridDim.y * chunk_elems, phase++) {
-            int cur = phase & 1;
-            int cur_elems = min(chunk_elems, D - off);
-            uint32_t cur_bytes = cur_elems * sizeof(scalar_t);
-
-            // Before reusing a buffer (phase >= 2), wait for the reduce
-            // that last read from it to finish.
-            if (phase >= 2 && lane == 0) {
-                tma::wait_group_lt0();
-            }
-            __syncwarp();
-
-            if (lane == 0) {
-                tma::mbar_expect_tx(mbars[cur], cur_bytes);
-                tma::bulk_load(buf0 + cur * chunk_elems, src_entry + off, cur_bytes, mbars[cur]);
-            }
-
-            if (pair_count > 0) {
-                drain_chunk((phase - 1) & 1, prev_off);
-            }
-
-            prev_off = off;
-            pair_count++;
-        }
-
-        // Epilogue: drain the final chunk.
-        if (pair_count > 0) {
-            drain_chunk((phase - 1) & 1, prev_off);
-        }
+        int cur_elems = min(chunk_elems, D - off);
+        uint32_t cur_bytes = cur_elems * sizeof(scalar_t);
 
         if (lane == 0) {
+            tma::mbar_expect_tx(mbar0, cur_bytes);
+            tma::bulk_load(buf0, src_entry + off, cur_bytes, mbar0);
+        }
+
+        while (!tma::mbar_try_wait_parity(
+            mbar0, static_cast<uint32_t>(0))) {}
+
+        if (lane == 0) {
+            tma::bulk_reduce_add<scalar_t>(dst_entry + off, buf0, cur_bytes);
+            tma::commit_group();
             tma::wait_group_lt0();
         }
         __syncwarp();
@@ -223,22 +179,21 @@ void tma_scatter_add_kernel_launch(
     constexpr int max_threads = 256;
     // One warp per entry: lane 0 issues TMA commands, __syncwarp() synchronizes.
     constexpr int threads_per_entry = C10_WARP_SIZE;
-    int chunk_elems = std::min(D, static_cast<int>(512 / sizeof(scalar_t)));
+    int chunk_elems = std::min(D, static_cast<int>(2048 / sizeof(scalar_t)));
     int num_chunks = at::ceil_div(D, chunk_elems);
 
     int entries_per_block = max_threads / threads_per_entry;
     int grid_x = at::ceil_div(num_ind, entries_per_block);
-    // Spread chunks across grid.y but keep at least 4 per block for pipeline benefit
-    constexpr int min_chunks_per_block = 4;
-    uint32_t grid_y = std::min(
-        static_cast<uint32_t>(std::max(1, num_chunks / min_chunks_per_block)),
-        static_cast<uint32_t>(at::cuda::getCurrentDeviceProperties()->maxGridSize[1]));
     int block_size = entries_per_block * threads_per_entry;
 
-    int buf_elems = 2 * chunk_elems;
-    int data_region_bytes = entries_per_block * buf_elems * static_cast<int>(sizeof(scalar_t));
+    TORCH_INTERNAL_ASSERT(
+        num_chunks <= at::cuda::getCurrentDeviceProperties()->maxGridSize[1],
+        "scatter_add: D too large for grid.y (num_chunks=", num_chunks, ")");
+    uint32_t grid_y = static_cast<uint32_t>(num_chunks);
+
+    int data_region_bytes = entries_per_block * chunk_elems * static_cast<int>(sizeof(scalar_t));
     int mbar_offset = (data_region_bytes + 7) & ~7;
-    int smem = mbar_offset + entries_per_block * 2 * static_cast<int>(sizeof(uint64_t));
+    int smem = mbar_offset + entries_per_block * static_cast<int>(sizeof(uint64_t));
 
     int64_t self_stride = self_stride_bytes / sizeof(scalar_t);
     int64_t src_stride = src_stride_bytes / sizeof(scalar_t);

--- a/aten/src/ATen/native/cuda/TmaScatterAddKernel.cu
+++ b/aten/src/ATen/native/cuda/TmaScatterAddKernel.cu
@@ -153,6 +153,24 @@ __global__ void tma_scatter_add_kernel(
         const scalar_t* src_entry = src_data + static_cast<int64_t>(entry_id) * src_stride;
         scalar_t* dst_entry = self_data + ind * self_stride;
 
+        // Wait for a stage's TMA load to complete, then reduce it.
+        auto drain_chunk = [&](int stage, int off) {
+            while (!tma::mbar_try_wait_parity(
+                mbars[stage], static_cast<uint32_t>(mbar_phase[stage] & 1))) {}
+            mbar_phase[stage]++;
+
+            int elems = min(chunk_elems, D - off);
+            uint32_t bytes = elems * sizeof(scalar_t);
+            if (lane == 0) {
+                tma::bulk_reduce_add<scalar_t>(dst_entry + off, buf0 + stage * chunk_elems, bytes);
+                tma::commit_group();
+            }
+        };
+
+        // Producer-ahead-of-consumer: issue load for current chunk,
+        // then drain previous chunk while current loads.
+        int prev_off = 0;
+        int pair_count = 0;
         int phase = 0;
         for (int off = blockIdx.y * chunk_elems; off < D;
              off += gridDim.y * chunk_elems, phase++) {
@@ -160,8 +178,10 @@ __global__ void tma_scatter_add_kernel(
             int cur_elems = min(chunk_elems, D - off);
             uint32_t cur_bytes = cur_elems * sizeof(scalar_t);
 
+            // Before reusing a buffer (phase >= 2), wait for the reduce
+            // that last read from it to finish.
             if (phase >= 2 && lane == 0) {
-                tma::wait_group_lt1();
+                tma::wait_group_lt0();
             }
             __syncwarp();
 
@@ -169,14 +189,18 @@ __global__ void tma_scatter_add_kernel(
                 tma::mbar_expect_tx(mbars[cur], cur_bytes);
                 tma::bulk_load(buf0 + cur * chunk_elems, src_entry + off, cur_bytes, mbars[cur]);
             }
-            while (!tma::mbar_try_wait_parity(
-                mbars[cur], static_cast<uint32_t>(mbar_phase[cur] & 1))) {}
-            mbar_phase[cur]++;
 
-            if (lane == 0) {
-                tma::bulk_reduce_add<scalar_t>(dst_entry + off, buf0 + cur * chunk_elems, cur_bytes);
-                tma::commit_group();
+            if (pair_count > 0) {
+                drain_chunk((phase - 1) & 1, prev_off);
             }
+
+            prev_off = off;
+            pair_count++;
+        }
+
+        // Epilogue: drain the final chunk.
+        if (pair_count > 0) {
+            drain_chunk((phase - 1) & 1, prev_off);
         }
 
         if (lane == 0) {


### PR DESCRIPTION
Following https://github.com/pytorch/pytorch/pull/182675

**Issue:**
In `tma_scatter_add_kernel`, both TMA load and reduce are async ops. We need at least 3 smem buffers to fully pipeline the ops to avoid back-to-back wait, e.g. one for load, one for reduce, the last one for issuing a new load without waiting for the completion of the immediately issued load or reduce. 
The current main branch uses double buffers: while one buffer is used for reduce, the other can be used for load. However, **within each buffer, the load and reduce ops are serial**, each reduce must wait for a full cycle of load, with no overlap between them e, g. `load N` --> `wait load N` --> `reduce N` --> `load N + 1`--> `wait load N+1` --> `reduce N+1`.

**Fix:**
Rather than adding a 3rd buffer (explored in https://github.com/pytorch/pytorch/pull/183479, slower than non-pipelined), this PR takes a different approach: remove the pipeline entirely and use larger chunks. Each warp processes exactly one chunk, load it, wait, reduce it, done. The grid is sized so every chunk gets its own warp, and **wave-level parallelism across CTAs hides memory latency instead of per-warp software pipelining**.

The key insight is that what matters is total bytes in flight per SM. With 2 KB chunks and 64 resident warps per SM, there are 128 KB in flight per SM enough to saturate the memory subsystem. The pipeline tried to increase per-warp concurrency with multiple small 512 B buffers, but the hardware warp scheduler already provides that concurrency across warps for free.

**Performance on GB200:**
About 1.1x to 1.4x speedup vs main branch.

```
      Moderate contention (100K rows / 500K indices):
        bf16 D=512:    211 → 161 us  1.31x vs main
        bf16 D=1024:   404 → 360 us  1.12x
        bf16 D=2048:   805 → 726 us  1.11x
        bf16 D=4096:  1617 → 1464 us  1.10x
        fp32 D=1024:   805 → 730 us  1.10x
    
      High contention (100K rows / 1M–5M indices):
        bf16 D=1024 100K/1M:   799 → 712 us  1.12x
        bf16 D=1024 100K/5M:  3998 → 3562 us  1.12x
    
      High contention (10K rows — heavier atomics per row):
        bf16 D=1024 10K/500K:  312 → 213 us  1.46x
        bf16 D=2048 10K/500K:  619 → 419 us  1.48x
        bf16 D=4096 10K/500K: 1241 → 840 us  1.48x
        bf16 D=1024 10K/1M:    616 → 417 us  1.48x
        fp32 D=1024 10K/500K:  619 → 418 us  1.48x
```