### PR TITLE
[MPS] Migrate scatter set mode to Metal with async bounds checking

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Scatter.metal
+++ b/aten/src/ATen/native/mps/kernels/Scatter.metal
@@ -1,0 +1,177 @@
+#include <c10/metal/atomic.h>
+#include <c10/metal/error.h>
+#include <c10/metal/indexing.h>
+#include <c10/metal/utils.h>
+#include <metal_stdlib>
+
+using namespace metal;
+using namespace c10::metal;
+
+// Metal kernels implementing PyTorch's scatter with reduce='set'.
+//
+// All three kernels accept a `tid_offset` baked into the linear thread
+// index. The host chunks dispatch into <=UINT_MAX-thread launches so that
+// scatter works on tensors with > 2^32 index elements (Metal's
+// `[[thread_position_in_grid]]` is at most a `uint`).
+
+// Strided generic version for non-contiguous tensors.
+template <typename T, typename index_t>
+kernel void scatter_set(
+    device T* output [[buffer(0)]],
+    constant T* src [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long* index_sizes [[buffer(3)]],
+    constant long* output_strides [[buffer(4)]],
+    constant long* src_strides [[buffer(5)]],
+    constant long* index_strides [[buffer(6)]],
+    constant uint3& ndim_dim [[buffer(7)]],
+    constant long& dim_size [[buffer(8)]],
+    constant long& tid_offset [[buffer(9)]],
+    device ErrorMessages* error_buf [[buffer(10)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const uint ndim = ndim_dim.x;
+  const uint dim = ndim_dim.y;
+  const long tid = long(thread_index) + tid_offset;
+
+  ::metal::array<long, max_ndim> pos;
+  pos_from_thread_index<long>(tid, &pos[0], index_sizes, ndim);
+
+  const long index_offs = offset_from_coord<long>(&pos[0], index_strides, ndim);
+  long idx = long(index[index_offs]);
+  if (idx < 0 || idx >= dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension ",
+        long(dim),
+        " with size ",
+        dim_size);
+    return;
+  }
+
+  const long src_offs = offset_from_coord<long>(&pos[0], src_strides, ndim);
+  pos[dim] = idx;
+  const long out_offs = offset_from_coord<long>(&pos[0], output_strides, ndim);
+  output[out_offs] = src[src_offs];
+}
+
+// Fast path: contiguous output/src/index, src and index share shape,
+// shape matches output outside `dim`. Indexing collapses to one div + one
+// mod per thread. inner_size = prod(output.sizes()[dim+1:]) precomputed
+// on the host.
+template <typename T, typename index_t>
+kernel void scatter_set_dense(
+    device T* output [[buffer(0)]],
+    constant T* src [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long& inner_size [[buffer(3)]],
+    constant long& index_dim_size [[buffer(4)]],
+    constant long& output_dim_size [[buffer(5)]],
+    constant long& tid_offset [[buffer(6)]],
+    device ErrorMessages* error_buf [[buffer(7)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long tid = long(thread_index) + tid_offset;
+  long idx = long(index[tid]);
+  if (idx < 0 || idx >= output_dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension with size ",
+        output_dim_size);
+    return;
+  }
+  const long inner = tid % inner_size;
+  const long outer = tid / (inner_size * index_dim_size);
+  const long out_offset =
+      outer * (inner_size * output_dim_size) + idx * inner_size + inner;
+  output[out_offset] = src[tid];
+}
+
+// Same as `scatter_set_dense` but the source is a single scalar value,
+// avoiding the per-thread src read and the host-side `at::empty + fill_`
+// the legacy MPSGraph path needed for `scatter.value`.
+template <typename T, typename index_t>
+kernel void scatter_set_dense_value(
+    device T* output [[buffer(0)]],
+    constant T& value [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long& inner_size [[buffer(3)]],
+    constant long& index_dim_size [[buffer(4)]],
+    constant long& output_dim_size [[buffer(5)]],
+    constant long& tid_offset [[buffer(6)]],
+    device ErrorMessages* error_buf [[buffer(7)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long tid = long(thread_index) + tid_offset;
+  long idx = long(index[tid]);
+  if (idx < 0 || idx >= output_dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension with size ",
+        output_dim_size);
+    return;
+  }
+  const long inner = tid % inner_size;
+  const long outer = tid / (inner_size * index_dim_size);
+  const long out_offset =
+      outer * (inner_size * output_dim_size) + idx * inner_size + inner;
+  output[out_offset] = value;
+}
+
+#define REGISTER_SCATTER_SET_OP(DTYPE, IDXTYPE)                                \
+  template [[host_name("scatter_set_" #DTYPE "_" #IDXTYPE)]] kernel void       \
+  scatter_set<DTYPE, IDXTYPE>(                                                 \
+      device DTYPE * output [[buffer(0)]],                                     \
+      constant DTYPE * src [[buffer(1)]],                                      \
+      constant IDXTYPE * index [[buffer(2)]],                                  \
+      constant long* index_sizes [[buffer(3)]],                                \
+      constant long* output_strides [[buffer(4)]],                             \
+      constant long* src_strides [[buffer(5)]],                                \
+      constant long* index_strides [[buffer(6)]],                              \
+      constant uint3& ndim_dim [[buffer(7)]],                                  \
+      constant long& dim_size [[buffer(8)]],                                   \
+      constant long& tid_offset [[buffer(9)]],                                 \
+      device ErrorMessages* error_buf [[buffer(10)]],                          \
+      uint thread_index [[thread_position_in_grid]]);                          \
+  template [[host_name("scatter_set_dense_" #DTYPE "_" #IDXTYPE)]] kernel void \
+  scatter_set_dense<DTYPE, IDXTYPE>(                                           \
+      device DTYPE * output [[buffer(0)]],                                     \
+      constant DTYPE * src [[buffer(1)]],                                      \
+      constant IDXTYPE * index [[buffer(2)]],                                  \
+      constant long& inner_size [[buffer(3)]],                                 \
+      constant long& index_dim_size [[buffer(4)]],                             \
+      constant long& output_dim_size [[buffer(5)]],                            \
+      constant long& tid_offset [[buffer(6)]],                                 \
+      device ErrorMessages* error_buf [[buffer(7)]],                           \
+      uint thread_index [[thread_position_in_grid]]);                          \
+  template [[host_name("scatter_set_dense_value_" #DTYPE                       \
+                       "_" #IDXTYPE)]] kernel void                             \
+  scatter_set_dense_value<DTYPE, IDXTYPE>(                                     \
+      device DTYPE * output [[buffer(0)]],                                     \
+      constant DTYPE & value [[buffer(1)]],                                    \
+      constant IDXTYPE * index [[buffer(2)]],                                  \
+      constant long& inner_size [[buffer(3)]],                                 \
+      constant long& index_dim_size [[buffer(4)]],                             \
+      constant long& output_dim_size [[buffer(5)]],                            \
+      constant long& tid_offset [[buffer(6)]],                                 \
+      device ErrorMessages* error_buf [[buffer(7)]],                           \
+      uint thread_index [[thread_position_in_grid]])
+
+#define REGISTER_SCATTER_SET_DTYPE(DTYPE) \
+  REGISTER_SCATTER_SET_OP(DTYPE, long);   \
+  REGISTER_SCATTER_SET_OP(DTYPE, int)
+
+REGISTER_SCATTER_SET_DTYPE(float);
+REGISTER_SCATTER_SET_DTYPE(half);
+REGISTER_SCATTER_SET_DTYPE(bfloat);
+REGISTER_SCATTER_SET_DTYPE(long);
+REGISTER_SCATTER_SET_DTYPE(int);
+REGISTER_SCATTER_SET_DTYPE(short);
+REGISTER_SCATTER_SET_DTYPE(char);
+REGISTER_SCATTER_SET_DTYPE(uchar);
+REGISTER_SCATTER_SET_DTYPE(bool);
+REGISTER_SCATTER_SET_DTYPE(float2);
+REGISTER_SCATTER_SET_DTYPE(half2);

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -2,6 +2,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/TensorAdvancedIndexing.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <c10/metal/common.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -14,6 +15,165 @@
 #endif
 
 namespace at::native {
+
+namespace mps {
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Scatter_metallib.h>
+#endif
+
+// Fast path applies when output, src, and index are all contiguous, src
+// matches index's shape (no broadcasting), and index matches output's shape
+// outside `dim`. Indexing math collapses to a single mod + div per thread.
+static bool can_use_dense_scatter(const Tensor& output, const Tensor& index, int64_t dim) {
+  if (!output.is_contiguous() || !index.is_contiguous()) {
+    return false;
+  }
+  for (const auto i : c10::irange(output.dim())) {
+    if (i == dim) {
+      continue;
+    }
+    if (output.size(i) != index.size(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static int64_t dense_inner_size(const Tensor& output, int64_t dim) {
+  int64_t inner = 1;
+  for (int64_t i = dim + 1; i < output.dim(); ++i) {
+    inner *= output.size(i);
+  }
+  return inner;
+}
+
+// Metal's [[thread_position_in_grid]] is at most a `uint`, so chunk the
+// dispatch when index.numel() exceeds UINT_MAX. Each chunk reads
+// `tid_offset` and adds it to its local thread index.
+template <typename SetArgsFn>
+static void dispatch_chunked(id<MTLComputeCommandEncoder> encoder,
+                             id<MTLComputePipelineState> pso,
+                             int64_t total,
+                             SetArgsFn set_args) {
+  const int64_t chunk_size = std::numeric_limits<uint32_t>::max();
+  for (int64_t off = 0; off < total; off += chunk_size) {
+    const int64_t this_chunk = std::min<int64_t>(chunk_size, total - off);
+    set_args(off);
+    mtl_dispatch1DJob(encoder, pso, this_chunk);
+  }
+}
+
+// In-place scatter with reduce='set'. `self` already holds the output's
+// initial contents (scatter_impl in TensorAdvancedIndexing.cpp does the
+// self->out copy before invoking the stub). Reports out-of-bounds indices
+// via the stream's async error buffer; raised on the next sync via
+// MPSStream::checkLastError (matches CUDA's deferred-assert model).
+static void scatter_set_metal(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+              "scatter: expected index to be Long or Int, got ",
+              index.scalar_type());
+
+  const auto ndim = static_cast<uint32_t>(index.dim());
+  TORCH_CHECK(
+      ndim <= c10::metal::max_ndim, "scatter: tensor rank ", ndim, " exceeds Metal max of ", c10::metal::max_ndim);
+  const int64_t output_dim_size = self.size(dim);
+  const int64_t total = index.numel();
+  const bool use_dense = can_use_dense_scatter(self, index, dim) && src.is_contiguous() && src.sizes() == index.sizes();
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      if (use_dense) {
+        const int64_t inner_size = dense_inner_size(self, dim);
+        const int64_t index_dim_size = index.size(dim);
+        auto pso = lib.getPipelineStateForFunc(
+            fmt::format("scatter_set_dense_{}_{}", scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      self,
+                      src,
+                      index,
+                      inner_size,
+                      index_dim_size,
+                      output_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
+      } else {
+        auto sizes = index.sizes();
+        std::array<uint32_t, 3> ndim_dim = {ndim, static_cast<uint32_t>(dim), 0};
+        auto pso = lib.getPipelineStateForFunc(
+            fmt::format("scatter_set_{}_{}", scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      self,
+                      src,
+                      index,
+                      sizes,
+                      self.strides(),
+                      src.strides(),
+                      index.strides(),
+                      ndim_dim,
+                      output_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
+      }
+    }
+  });
+}
+
+// Dense scatter with reduce='set' and a scalar source. Avoids the
+// `at::empty + fill_` temp tensor the legacy path materialized for
+// scatter.value. Falls back to allocating a src tensor and reusing
+// scatter_set_metal when the dense layout assumptions don't hold.
+static void scatter_fill_metal(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& value) {
+  if (!can_use_dense_scatter(self, index, dim) || !index.is_contiguous()) {
+    Tensor src = at::empty(index.sizes(), self.options());
+    src.fill_(value);
+    scatter_set_metal(self, dim, index, src);
+    return;
+  }
+
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+              "scatter: expected index to be Long or Int, got ",
+              index.scalar_type());
+  const int64_t output_dim_size = self.size(dim);
+  const int64_t inner_size = dense_inner_size(self, dim);
+  const int64_t index_dim_size = index.size(dim);
+  const int64_t total = index.numel();
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      // MPSScalar owns a DataPtr (non-copyable); construct inside the block so
+      // ObjC's capture-by-value doesn't try to copy it. setBytes copies the
+      // value into the command buffer, so the local lifetime is fine.
+      MPSScalar mps_value = getMPSScalar(value, self.scalar_type());
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc(
+          fmt::format("scatter_set_dense_value_{}_{}", scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
+      [encoder setComputePipelineState:pso];
+      dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+        mtl_setArgs(encoder,
+                    self,
+                    mps_value,
+                    index,
+                    inner_size,
+                    index_dim_size,
+                    output_dim_size,
+                    tid_offset,
+                    stream->getErrorBuffer());
+      });
+    }
+  });
+}
+} // namespace mps
 
 static Tensor maybe_expand_0_dim(const Tensor& t) {
   return t.dim() == 0 ? t.view({1}) : t;
@@ -174,6 +334,9 @@ static void scatter_mps_general(const Tensor& self_arg,
     scatter_mps_general(self_real, dim, index_expanded, src_real, output_real, func_name, reduce);
     return;
   }
+
+  // reduce='set' is served by the Metal path via scatter_stub / scatter_fill_stub
+  // (registered below). MPSGraph here only handles add/prod/amin/amax.
 
   struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
@@ -346,45 +509,98 @@ static void scatter_mps_general(const Tensor& self_arg,
   }
 }
 
-TORCH_IMPL_FUNC(scatter_src_out_mps)
-(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src, const Tensor& output) {
-  scatter_mps_general(self, dim, index, src, output, "scatter_src_out_mps", "set");
+static const char* reduce_op_to_mps_string(const ReductionType& op) {
+  switch (op) {
+    case ReductionType::SUM:
+      return "add";
+    case ReductionType::PROD:
+      return "prod";
+    case ReductionType::MIN:
+      return "amin";
+    case ReductionType::MAX:
+      return "amax";
+    case ReductionType::MEAN:
+      return "mean";
+  }
+  TORCH_CHECK(false, "Unsupported reduction type: ", static_cast<int>(op));
 }
 
-TORCH_IMPL_FUNC(scatter_value_out_mps)
-(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& value, const Tensor& output) {
-  Tensor src =
-      at::empty(index.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, self.suggest_memory_format());
+// scatter_stub: in-place set with a Tensor src. self is the writable output
+// (pre-loaded by scatter_impl in TensorAdvancedIndexing.cpp).
+static void scatter_mps_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+  if (self.numel() == 0 || index.numel() == 0 || src.numel() == 0) {
+    return;
+  }
+  // Promote 0-dim views first so view_as_real keeps ranks aligned across self/index/src
+  auto self_1d = self.dim() == 0 ? self.view({1}) : self;
+  if (self_1d.is_complex()) {
+    auto self_real = at::view_as_real(self_1d);
+    auto index_expanded = expand_index_as_real(index);
+    auto src_real = at::view_as_real(maybe_expand_0_dim(src));
+    scatter_mps_kernel(self_real, dim, index_expanded, src_real);
+    return;
+  }
+  TORCH_CHECK(self.scalar_type() == src.scalar_type(), "scatter(): self and src must have the same scalar type");
+  auto self_view = self_1d;
+  auto src_view = maybe_expand_0_dim(src);
+  auto index_view = maybe_expand_0_dim(index);
+  dim = at::maybe_wrap_dim(dim, self_view.dim());
+  TORCH_CHECK(dim >= 0 && dim < self_view.dim(), "scatter(): Indexing dim ", dim, " is out of bounds of tensor");
+  TORCH_CHECK(index_view.dim() == self_view.dim() && index_view.dim() == src_view.dim(),
+              "Input, index and src must have same rank");
+  for (const auto i : c10::irange(self_view.dim())) {
+    TORCH_CHECK(index_view.size(i) <= src_view.size(i), "Index dim must not exceed src dim");
+    TORCH_CHECK(i == dim || index_view.size(i) <= self_view.size(i),
+                "Index dim must not exceed input dim except at gathering axis");
+  }
+  mps::scatter_set_metal(self_view, dim, index_view, src_view);
+}
+
+// scatter_fill_stub: in-place set with a scalar value. Uses the dense
+// scatter_set_dense_value kernel when possible (skips temp-src materialization).
+static void scatter_fill_mps_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& value) {
+  if (self.numel() == 0 || index.numel() == 0) {
+    return;
+  }
+  if (self.is_complex()) {
+    // Scalar-as-complex into a real view doesn't compose; materialize and recurse.
+    Tensor src = at::empty(index.sizes(), self.options());
+    src.fill_(value);
+    scatter_mps_kernel(self, dim, index, src);
+    return;
+  }
+  auto self_view = self.dim() == 0 ? self.view({1}) : self;
+  auto index_view = maybe_expand_0_dim(index);
+  dim = at::maybe_wrap_dim(dim, self_view.dim());
+  TORCH_CHECK(dim >= 0 && dim < self_view.dim(), "scatter(): Indexing dim ", dim, " is out of bounds of tensor");
+  TORCH_CHECK(index_view.dim() == self_view.dim(), "Input and index must have same rank");
+  for (const auto i : c10::irange(self_view.dim())) {
+    TORCH_CHECK(i == dim || index_view.size(i) <= self_view.size(i),
+                "Index dim must not exceed input dim except at gathering axis");
+  }
+  mps::scatter_fill_metal(self_view, dim, index_view, value);
+}
+
+static void scatter_add_mps_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+  scatter_mps_general(self, dim, index, src, self, "scatter_add_mps", "add");
+}
+
+static void scatter_reduce_mps_kernel(const Tensor& self,
+                                      int64_t dim,
+                                      const Tensor& index,
+                                      const Tensor& src,
+                                      const ReductionType& reduce) {
+  scatter_mps_general(self, dim, index, src, self, "scatter_reduce_mps", reduce_op_to_mps_string(reduce));
+}
+
+static void scatter_scalar_reduce_mps_kernel(const Tensor& self,
+                                             int64_t dim,
+                                             const Tensor& index,
+                                             const Scalar& value,
+                                             const ReductionType& reduce) {
+  Tensor src = at::empty(index.sizes(), self.options());
   src.fill_(value);
-  scatter_mps_general(self, dim, index, const_cast<Tensor&>(src), output, "scatter_value_out_mps", "set");
-}
-
-TORCH_IMPL_FUNC(scatter_reduce_out_mps)
-(const Tensor& self,
- int64_t dim,
- const Tensor& index,
- const Tensor& src,
- const std::string_view reduce,
- const Tensor& output) {
-  scatter_mps_general(self, dim, index, src, output, "scatter_reduce_out_mps", reduce);
-}
-
-TORCH_IMPL_FUNC(scatter_value_reduce_out_mps)
-(const Tensor& self,
- int64_t dim,
- const Tensor& index,
- const Scalar& value,
- const std::string_view reduce,
- const Tensor& output) {
-  Tensor src =
-      at::empty(index.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, self.suggest_memory_format());
-  src.fill_(value);
-  scatter_mps_general(self, dim, index, const_cast<Tensor&>(src), output, "scatter_value_reduce_out_mps", reduce);
-}
-
-TORCH_IMPL_FUNC(scatter_add_mps_out)
-(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src, const Tensor& output) {
-  scatter_mps_general(self, dim, index, src, output, "scatter_add_mps_out", "add");
+  scatter_mps_general(self, dim, index, src, self, "scatter_scalar_reduce_mps", reduce_op_to_mps_string(reduce));
 }
 
 static void scatter_reduce_two_mps_kernel(const Tensor& self,
@@ -411,5 +627,10 @@ static void scatter_reduce_two_mps_kernel(const Tensor& self,
   TORCH_CHECK(false, "Unsupported reduction type: ", static_cast<int>(reduce));
 }
 
+REGISTER_DISPATCH(scatter_stub, &scatter_mps_kernel);
+REGISTER_DISPATCH(scatter_fill_stub, &scatter_fill_mps_kernel);
+REGISTER_DISPATCH(scatter_add_stub, &scatter_add_mps_kernel);
+REGISTER_DISPATCH(scatter_reduce_stub, &scatter_reduce_mps_kernel);
+REGISTER_DISPATCH(scatter_scalar_reduce_stub, &scatter_scalar_reduce_mps_kernel);
 REGISTER_DISPATCH(scatter_reduce_two_stub, &scatter_reduce_two_mps_kernel);
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8543,8 +8543,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_src_out
-    MPS: scatter_src_out_mps
+    CPU, CUDA, MPS: scatter_src_out
 
 - func: scatter.value(Tensor self, int dim, Tensor index, Scalar value) -> Tensor
   structured_delegate: scatter.value_out
@@ -8559,8 +8558,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_value_out
-    MPS: scatter_value_out_mps
+    CPU, CUDA, MPS: scatter_value_out
 
 - func: scatter.reduce(Tensor self, int dim, Tensor index, Tensor src, *, str reduce) -> Tensor
   structured_delegate: scatter.reduce_out
@@ -8574,8 +8572,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_reduce_out
-    MPS: scatter_reduce_out_mps
+    CPU, CUDA, MPS: scatter_reduce_out
 
 - func: scatter.value_reduce(Tensor self, int dim, Tensor index, Scalar value, *, str reduce) -> Tensor
   structured_delegate: scatter.value_reduce_out
@@ -8589,8 +8586,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_value_reduce_out
-    MPS: scatter_value_reduce_out_mps
+    CPU, CUDA, MPS: scatter_value_reduce_out
 
 - func: scatter.dimname_src(Tensor self, Dimname dim, Tensor index, Tensor src) -> Tensor
   variants: function, method
@@ -8611,8 +8607,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_add
-    MPS: scatter_add_mps_out
+    CPU, CUDA, MPS: scatter_add
 
 - func: scatter_add.dimname(Tensor self, Dimname dim, Tensor index, Tensor src) -> Tensor
   variants: function, method

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14568,6 +14568,21 @@ class TestErrorInputs(TestCase):
             torch.nn.functional.embedding_bag(inputs, weight, offsets)
             torch.mps.synchronize()
 
+    def test_scatter_out_of_bounds(self, device):
+        # Regression for https://github.com/pytorch/pytorch/issues/170507
+        # one_hot is composite (zeros + scatter_); bad indices used to silently
+        # produce zeros instead of raising. MPS scatter now reports async via
+        # the stream error buffer, matching CUDA's deferred-assert behavior.
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.nn.functional.one_hot(torch.tensor([8], device=device), num_classes=8)
+            torch.mps.synchronize()
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.nn.functional.one_hot(torch.tensor([-1], device=device), num_classes=8)
+            torch.mps.synchronize()
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.zeros(3, 4, device=device).scatter_(1, torch.tensor([[4]], device=device), 1.0)
+            torch.mps.synchronize()
+
 
 class TestComplex(TestCase):
     def test_tensor_scalar_binops(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10147,14 +10147,18 @@ class TestNNDeviceType(NNTestCase):
         _test_module_empty_input(self, mod, inp)
 
     def test_one_hot(self, device):
-        # cuda throws device assert for invalid data
-        # xla & mps ignore out of bound indices
-        if self.device_type == 'cpu':
+        # cpu raises synchronously; mps reports the bad index from its scatter
+        # kernel asynchronously, surfaced on the next sync. xla still ignores.
+        if self.device_type in ('cpu', 'mps'):
             with self.assertRaises(RuntimeError):
                 torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)
+                if self.device_type == 'mps':
+                    torch.mps.synchronize()
 
             with self.assertRaises(RuntimeError):
                 torch.nn.functional.one_hot(torch.tensor([3, 4, 1, 0], device=device), 3)
+                if self.device_type == 'mps':
+                    torch.mps.synchronize()
 
         t = torch.nn.functional.one_hot(torch.tensor([3, 4, 1, 0], device=device))
         expected = torch.tensor([[0, 0, 0, 1, 0],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #184056

Fixes #170507. F.one_hot is composite -- it lowers to zeros() + scatter_(-1, self.unsqueeze(-1), 1) -- and the silent failure was in MPS scatter, whose MPSGraph scatterAlongAxis silently drops out-of-bounds indices unlike CUDA whose scatter has a device-side assert.

Drops the MPS-specific structured-kernel implementations and reuses the shared CPU/CUDA `scatter_impl` path in TensorAdvancedIndexing.cpp by registering MPS into the existing `scatter_stub` / `scatter_fill_stub` / `scatter_add_stub` / `scatter_reduce_stub` / `scatter_scalar_reduce_stub` (same pattern `scatter_reduce_two_stub` already uses). The shared impl handles dim wrap, the self->out copy, empty-numel early return, deterministic-mode branch, and reduce-init -- one definition for all backends.

Three Metal kernels back the set-mode stubs: a strided generic version, a `scatter_set_dense` fast path for contiguous output/src/index, and `scatter_set_dense_value` that takes a scalar source directly (used by scatter.value). The dense scalar path replaces the legacy `at::empty + fill_ + MPSGraph scatter` three-dispatch sequence with one Metal kernel launch. Bounds checks live inline in all three and report to the stream's async error buffer, raised on the next sync as torch.AcceleratorError (matches CUDA's deferred-assert model).

Large tensor support: `[[thread_position_in_grid]]` is a `uint`, so the host chunks dispatch into <=UINT_MAX-thread launches and threads add a `tid_offset` constant baked into the kernel args. Index numels above 2^32 work transparently. Reduce/add modes still go through MPSGraph for now via stub wrappers that call into scatter_mps_general; migrating those is follow-up work.

Perf vs PyTorch 2.12.0 on Apple M4: in-place scatter_ set is 23-46% faster across the tested shapes once the implicit out-of-place copy is removed from the comparison. one_hot is 30-60% faster across shapes. scatter_value (scalar source) is 31-51% faster thanks to the dense-value kernel, which one_hot exercises directly via `scatter_(-1, idx, 1)`.

Authored by Claude.