### PR TITLE
[MPS] Migrate scatter to Metal, drop MPSGraph dependency, add async bounds checking

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Scatter.metal
+++ b/aten/src/ATen/native/mps/kernels/Scatter.metal
@@ -1,0 +1,378 @@
+#include <c10/metal/atomic.h>
+#include <c10/metal/error.h>
+#include <c10/metal/indexing.h>
+#include <c10/metal/utils.h>
+#include <metal_stdlib>
+
+using namespace metal;
+using namespace c10::metal;
+
+// Metal kernels implementing PyTorch's scatter with reduce='set'.
+//
+// All three kernels accept a `tid_offset` baked into the linear thread
+// index. The host chunks dispatch into <=UINT_MAX-thread launches so that
+// scatter works on tensors with > 2^32 index elements (Metal's
+// `[[thread_position_in_grid]]` is at most a `uint`).
+
+// Strided generic version for non-contiguous tensors.
+template <typename T, typename index_t>
+kernel void scatter_set(
+    device T* output [[buffer(0)]],
+    constant T* src [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long* index_sizes [[buffer(3)]],
+    constant long* output_strides [[buffer(4)]],
+    constant long* src_strides [[buffer(5)]],
+    constant long* index_strides [[buffer(6)]],
+    constant uint3& ndim_dim [[buffer(7)]],
+    constant long& dim_size [[buffer(8)]],
+    constant long& tid_offset [[buffer(9)]],
+    device ErrorMessages* error_buf [[buffer(10)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const uint ndim = ndim_dim.x;
+  const uint dim = ndim_dim.y;
+  const long tid = long(thread_index) + tid_offset;
+
+  ::metal::array<long, max_ndim> pos;
+  pos_from_thread_index<long>(tid, &pos[0], index_sizes, ndim);
+
+  const long index_offs = offset_from_coord<long>(&pos[0], index_strides, ndim);
+  long idx = long(index[index_offs]);
+  if (idx < 0 || idx >= dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension ",
+        long(dim),
+        " with size ",
+        dim_size);
+    return;
+  }
+
+  const long src_offs = offset_from_coord<long>(&pos[0], src_strides, ndim);
+  pos[dim] = idx;
+  const long out_offs = offset_from_coord<long>(&pos[0], output_strides, ndim);
+  output[out_offs] = src[src_offs];
+}
+
+// Fast path: contiguous output/src/index, src and index share shape,
+// shape matches output outside `dim`. Indexing collapses to one div + one
+// mod per thread. inner_size = prod(output.sizes()[dim+1:]) precomputed
+// on the host.
+template <typename T, typename index_t>
+kernel void scatter_set_dense(
+    device T* output [[buffer(0)]],
+    constant T* src [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long& inner_size [[buffer(3)]],
+    constant long& index_dim_size [[buffer(4)]],
+    constant long& output_dim_size [[buffer(5)]],
+    constant long& tid_offset [[buffer(6)]],
+    device ErrorMessages* error_buf [[buffer(7)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long tid = long(thread_index) + tid_offset;
+  long idx = long(index[tid]);
+  if (idx < 0 || idx >= output_dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension with size ",
+        output_dim_size);
+    return;
+  }
+  const long inner = tid % inner_size;
+  const long outer = tid / (inner_size * index_dim_size);
+  const long out_offset =
+      outer * (inner_size * output_dim_size) + idx * inner_size + inner;
+  output[out_offset] = src[tid];
+}
+
+// Same as `scatter_set_dense` but the source is a single scalar value,
+// avoiding the per-thread src read and the host-side `at::empty + fill_`
+// the legacy MPSGraph path needed for `scatter.value`.
+template <typename T, typename index_t>
+kernel void scatter_set_dense_value(
+    device T* output [[buffer(0)]],
+    constant T& value [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long& inner_size [[buffer(3)]],
+    constant long& index_dim_size [[buffer(4)]],
+    constant long& output_dim_size [[buffer(5)]],
+    constant long& tid_offset [[buffer(6)]],
+    device ErrorMessages* error_buf [[buffer(7)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long tid = long(thread_index) + tid_offset;
+  long idx = long(index[tid]);
+  if (idx < 0 || idx >= output_dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension with size ",
+        output_dim_size);
+    return;
+  }
+  const long inner = tid % inner_size;
+  const long outer = tid / (inner_size * index_dim_size);
+  const long out_offset =
+      outer * (inner_size * output_dim_size) + idx * inner_size + inner;
+  output[out_offset] = value;
+}
+
+// Reduce modes for the atomic scatter kernels below. Selected at host-side
+// pipeline lookup via the kernel name suffix.
+enum class ScatterReduceOp { Add, Prod, Amin, Amax };
+
+template <typename T>
+inline T scatter_op_prod(T a, T b) {
+  return c10::metal::mul(a, b);
+}
+template <typename T>
+inline T scatter_op_amin(T a, T b) {
+  return ::c10::metal::min(a, b);
+}
+template <typename T>
+inline T scatter_op_amax(T a, T b) {
+  return ::c10::metal::max(a, b);
+}
+
+// Tag-dispatch the atomic operation so we only instantiate the AtomicType
+// member that actually exists for a given T (e.g. AtomicType<long> has only
+// atomic_add, not atomic_binary_op).
+template <typename T, ScatterReduceOp Op>
+struct ScatterAtomicApply;
+
+template <typename T>
+struct ScatterAtomicApply<T, ScatterReduceOp::Add> {
+  static inline void apply(device T* output, long out_offset, T src_val) {
+    AtomicType<T>::atomic_add(
+        reinterpret_cast<device AtomicType_t<T>*>(output), out_offset, src_val);
+  }
+};
+
+template <typename T>
+struct ScatterAtomicApply<T, ScatterReduceOp::Prod> {
+  static inline void apply(device T* output, long out_offset, T src_val) {
+    AtomicType<T>::atomic_binary_op(
+        reinterpret_cast<device AtomicType_t<T>*>(output),
+        out_offset,
+        src_val,
+        scatter_op_prod<T>);
+  }
+};
+
+template <typename T>
+struct ScatterAtomicApply<T, ScatterReduceOp::Amin> {
+  static inline void apply(device T* output, long out_offset, T src_val) {
+    AtomicType<T>::atomic_binary_op(
+        reinterpret_cast<device AtomicType_t<T>*>(output),
+        out_offset,
+        src_val,
+        scatter_op_amin<T>);
+  }
+};
+
+template <typename T>
+struct ScatterAtomicApply<T, ScatterReduceOp::Amax> {
+  static inline void apply(device T* output, long out_offset, T src_val) {
+    AtomicType<T>::atomic_binary_op(
+        reinterpret_cast<device AtomicType_t<T>*>(output),
+        out_offset,
+        src_val,
+        scatter_op_amax<T>);
+  }
+};
+
+// Dense atomic scatter for one of {add, prod, amin, amax}. Shape requirements
+// match scatter_set_dense.
+template <typename T, typename index_t, ScatterReduceOp Op>
+kernel void scatter_reduce_dense(
+    device T* output [[buffer(0)]],
+    constant T* src [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long& inner_size [[buffer(3)]],
+    constant long& index_dim_size [[buffer(4)]],
+    constant long& output_dim_size [[buffer(5)]],
+    constant long& tid_offset [[buffer(6)]],
+    device ErrorMessages* error_buf [[buffer(7)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long tid = long(thread_index) + tid_offset;
+  long idx = long(index[tid]);
+  if (idx < 0 || idx >= output_dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension with size ",
+        output_dim_size);
+    return;
+  }
+  const long inner = tid % inner_size;
+  const long outer = tid / (inner_size * index_dim_size);
+  const long out_offset =
+      outer * (inner_size * output_dim_size) + idx * inner_size + inner;
+  ScatterAtomicApply<T, Op>::apply(output, out_offset, src[tid]);
+}
+
+// Strided atomic scatter. Generic for non-contiguous output/src/index.
+template <typename T, typename index_t, ScatterReduceOp Op>
+kernel void scatter_reduce_strided(
+    device T* output [[buffer(0)]],
+    constant T* src [[buffer(1)]],
+    constant index_t* index [[buffer(2)]],
+    constant long* index_sizes [[buffer(3)]],
+    constant long* output_strides [[buffer(4)]],
+    constant long* src_strides [[buffer(5)]],
+    constant long* index_strides [[buffer(6)]],
+    constant uint3& ndim_dim [[buffer(7)]],
+    constant long& dim_size [[buffer(8)]],
+    constant long& tid_offset [[buffer(9)]],
+    device ErrorMessages* error_buf [[buffer(10)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const uint ndim = ndim_dim.x;
+  const uint dim = ndim_dim.y;
+  const long tid = long(thread_index) + tid_offset;
+
+  ::metal::array<long, max_ndim> pos;
+  pos_from_thread_index<long>(tid, &pos[0], index_sizes, ndim);
+
+  const long index_offs = offset_from_coord<long>(&pos[0], index_strides, ndim);
+  long idx = long(index[index_offs]);
+  if (idx < 0 || idx >= dim_size) {
+    TORCH_REPORT_ERROR(
+        error_buf,
+        "scatter: index ",
+        idx,
+        " is out of bounds for dimension ",
+        long(dim),
+        " with size ",
+        dim_size);
+    return;
+  }
+
+  const long src_offs = offset_from_coord<long>(&pos[0], src_strides, ndim);
+  pos[dim] = idx;
+  const long out_offs = offset_from_coord<long>(&pos[0], output_strides, ndim);
+  ScatterAtomicApply<T, Op>::apply(output, out_offs, src[src_offs]);
+}
+
+#define REGISTER_SCATTER_REDUCE_VARIANT(DTYPE, IDXTYPE, OP, OP_ENUM)          \
+  template                                                                    \
+      [[host_name("scatter_" #OP "_dense_" #DTYPE "_" #IDXTYPE)]] kernel void \
+      scatter_reduce_dense<DTYPE, IDXTYPE, ScatterReduceOp::OP_ENUM>(         \
+          device DTYPE * output [[buffer(0)]],                                \
+          constant DTYPE * src [[buffer(1)]],                                 \
+          constant IDXTYPE * index [[buffer(2)]],                             \
+          constant long& inner_size [[buffer(3)]],                            \
+          constant long& index_dim_size [[buffer(4)]],                        \
+          constant long& output_dim_size [[buffer(5)]],                       \
+          constant long& tid_offset [[buffer(6)]],                            \
+          device ErrorMessages* error_buf [[buffer(7)]],                      \
+          uint thread_index [[thread_position_in_grid]]);                     \
+  template [[host_name("scatter_" #OP "_strided_" #DTYPE                      \
+                       "_" #IDXTYPE)]] kernel void                            \
+  scatter_reduce_strided<DTYPE, IDXTYPE, ScatterReduceOp::OP_ENUM>(           \
+      device DTYPE * output [[buffer(0)]],                                    \
+      constant DTYPE * src [[buffer(1)]],                                     \
+      constant IDXTYPE * index [[buffer(2)]],                                 \
+      constant long* index_sizes [[buffer(3)]],                               \
+      constant long* output_strides [[buffer(4)]],                            \
+      constant long* src_strides [[buffer(5)]],                               \
+      constant long* index_strides [[buffer(6)]],                             \
+      constant uint3& ndim_dim [[buffer(7)]],                                 \
+      constant long& dim_size [[buffer(8)]],                                  \
+      constant long& tid_offset [[buffer(9)]],                                \
+      device ErrorMessages* error_buf [[buffer(10)]],                         \
+      uint thread_index [[thread_position_in_grid]])
+
+#define REGISTER_SCATTER_SET_OP(DTYPE, IDXTYPE)                                \
+  template [[host_name("scatter_set_" #DTYPE "_" #IDXTYPE)]] kernel void       \
+  scatter_set<DTYPE, IDXTYPE>(                                                 \
+      device DTYPE * output [[buffer(0)]],                                     \
+      constant DTYPE * src [[buffer(1)]],                                      \
+      constant IDXTYPE * index [[buffer(2)]],                                  \
+      constant long* index_sizes [[buffer(3)]],                                \
+      constant long* output_strides [[buffer(4)]],                             \
+      constant long* src_strides [[buffer(5)]],                                \
+      constant long* index_strides [[buffer(6)]],                              \
+      constant uint3& ndim_dim [[buffer(7)]],                                  \
+      constant long& dim_size [[buffer(8)]],                                   \
+      constant long& tid_offset [[buffer(9)]],                                 \
+      device ErrorMessages* error_buf [[buffer(10)]],                          \
+      uint thread_index [[thread_position_in_grid]]);                          \
+  template [[host_name("scatter_set_dense_" #DTYPE "_" #IDXTYPE)]] kernel void \
+  scatter_set_dense<DTYPE, IDXTYPE>(                                           \
+      device DTYPE * output [[buffer(0)]],                                     \
+      constant DTYPE * src [[buffer(1)]],                                      \
+      constant IDXTYPE * index [[buffer(2)]],                                  \
+      constant long& inner_size [[buffer(3)]],                                 \
+      constant long& index_dim_size [[buffer(4)]],                             \
+      constant long& output_dim_size [[buffer(5)]],                            \
+      constant long& tid_offset [[buffer(6)]],                                 \
+      device ErrorMessages* error_buf [[buffer(7)]],                           \
+      uint thread_index [[thread_position_in_grid]]);                          \
+  template [[host_name("scatter_set_dense_value_" #DTYPE                       \
+                       "_" #IDXTYPE)]] kernel void                             \
+  scatter_set_dense_value<DTYPE, IDXTYPE>(                                     \
+      device DTYPE * output [[buffer(0)]],                                     \
+      constant DTYPE & value [[buffer(1)]],                                    \
+      constant IDXTYPE * index [[buffer(2)]],                                  \
+      constant long& inner_size [[buffer(3)]],                                 \
+      constant long& index_dim_size [[buffer(4)]],                             \
+      constant long& output_dim_size [[buffer(5)]],                            \
+      constant long& tid_offset [[buffer(6)]],                                 \
+      device ErrorMessages* error_buf [[buffer(7)]],                           \
+      uint thread_index [[thread_position_in_grid]])
+
+#define REGISTER_SCATTER_SET_DTYPE(DTYPE) \
+  REGISTER_SCATTER_SET_OP(DTYPE, long);   \
+  REGISTER_SCATTER_SET_OP(DTYPE, int)
+
+#define REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, OP, OP_ENUM)   \
+  REGISTER_SCATTER_REDUCE_VARIANT(DTYPE, long, OP, OP_ENUM); \
+  REGISTER_SCATTER_REDUCE_VARIANT(DTYPE, int, OP, OP_ENUM)
+
+// add: all numeric dtypes (atomic_add covers float/half/bfloat/int/short/
+// char/uchar/bool/long via the two-word trick, plus float2/half2 for complex).
+#define REGISTER_SCATTER_ADD_DTYPE(DTYPE) \
+  REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, add, Add)
+
+// prod/amin/amax use atomic_binary_op (CAS loop). Restricted to dtypes for
+// which AtomicType<T> provides atomic_binary_op: float, int, half, bfloat,
+// short, char, uchar. bool / long / complex aren't supported here -- amin/amax
+// for complex is mathematically undefined and rejected at the meta-func level;
+// long lacks atomic_binary_op (only an eventually-consistent atomic_add).
+#define REGISTER_SCATTER_PROD_MIN_MAX_DTYPE(DTYPE)   \
+  REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, prod, Prod); \
+  REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, amin, Amin); \
+  REGISTER_SCATTER_REDUCE_FOR_OP(DTYPE, amax, Amax)
+
+// Dtypes that support all of {set, add, prod, amin, amax}: float, int, half,
+// bfloat, short, char, uchar, bool -- AtomicType provides both atomic_add and
+// atomic_binary_op for these.
+#define REGISTER_SCATTER_OPS_FULL(DTYPE) \
+  REGISTER_SCATTER_SET_DTYPE(DTYPE);     \
+  REGISTER_SCATTER_ADD_DTYPE(DTYPE);     \
+  REGISTER_SCATTER_PROD_MIN_MAX_DTYPE(DTYPE)
+
+// Dtypes that support {set, add} only: long (atomic_add is eventually
+// consistent, no true 64-bit CAS for atomic_binary_op), float2/half2
+// (complex; amin/amax undefined).
+#define REGISTER_SCATTER_OPS_SET_ADD(DTYPE) \
+  REGISTER_SCATTER_SET_DTYPE(DTYPE);        \
+  REGISTER_SCATTER_ADD_DTYPE(DTYPE)
+
+REGISTER_SCATTER_OPS_FULL(float);
+REGISTER_SCATTER_OPS_FULL(half);
+REGISTER_SCATTER_OPS_FULL(bfloat);
+REGISTER_SCATTER_OPS_FULL(int);
+REGISTER_SCATTER_OPS_FULL(short);
+REGISTER_SCATTER_OPS_FULL(char);
+REGISTER_SCATTER_OPS_FULL(uchar);
+REGISTER_SCATTER_OPS_FULL(bool);
+
+REGISTER_SCATTER_OPS_SET_ADD(long);
+REGISTER_SCATTER_OPS_SET_ADD(float2);
+REGISTER_SCATTER_OPS_SET_ADD(half2);

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -2,6 +2,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/TensorAdvancedIndexing.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <c10/metal/common.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -14,6 +15,229 @@
 #endif
 
 namespace at::native {
+
+namespace mps {
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Scatter_metallib.h>
+#endif
+
+// Fast path applies when output, src, and index are all contiguous, src
+// matches index's shape (no broadcasting), and index matches output's shape
+// outside `dim`. Indexing math collapses to a single mod + div per thread.
+static bool can_use_dense_scatter(const Tensor& output, const Tensor& index, int64_t dim) {
+  if (!output.is_contiguous() || !index.is_contiguous()) {
+    return false;
+  }
+  for (const auto i : c10::irange(output.dim())) {
+    if (i == dim) {
+      continue;
+    }
+    if (output.size(i) != index.size(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static int64_t dense_inner_size(const Tensor& output, int64_t dim) {
+  int64_t inner = 1;
+  for (int64_t i = dim + 1; i < output.dim(); ++i) {
+    inner *= output.size(i);
+  }
+  return inner;
+}
+
+// Metal's [[thread_position_in_grid]] is at most a `uint`, so chunk the
+// dispatch when index.numel() exceeds UINT_MAX. Each chunk reads
+// `tid_offset` and adds it to its local thread index.
+template <typename SetArgsFn>
+static void dispatch_chunked(id<MTLComputeCommandEncoder> encoder,
+                             id<MTLComputePipelineState> pso,
+                             int64_t total,
+                             SetArgsFn set_args) {
+  const int64_t chunk_size = std::numeric_limits<uint32_t>::max();
+  for (int64_t off = 0; off < total; off += chunk_size) {
+    const int64_t this_chunk = std::min<int64_t>(chunk_size, total - off);
+    set_args(off);
+    mtl_dispatch1DJob(encoder, pso, this_chunk);
+  }
+}
+
+// In-place scatter with reduce='set'. `self` already holds the output's
+// initial contents (scatter_impl in TensorAdvancedIndexing.cpp does the
+// self->out copy before invoking the stub). Reports out-of-bounds indices
+// via the stream's async error buffer; raised on the next sync via
+// MPSStream::checkLastError (matches CUDA's deferred-assert model).
+static void scatter_set_metal(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+              "scatter: expected index to be Long or Int, got ",
+              index.scalar_type());
+
+  const auto ndim = static_cast<uint32_t>(index.dim());
+  TORCH_CHECK(
+      ndim <= c10::metal::max_ndim, "scatter: tensor rank ", ndim, " exceeds Metal max of ", c10::metal::max_ndim);
+  const int64_t output_dim_size = self.size(dim);
+  const int64_t total = index.numel();
+  const bool use_dense = can_use_dense_scatter(self, index, dim) && src.is_contiguous() && src.sizes() == index.sizes();
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      if (use_dense) {
+        const int64_t inner_size = dense_inner_size(self, dim);
+        const int64_t index_dim_size = index.size(dim);
+        auto pso = lib.getPipelineStateForFunc(
+            fmt::format("scatter_set_dense_{}_{}", scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      self,
+                      src,
+                      index,
+                      inner_size,
+                      index_dim_size,
+                      output_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
+      } else {
+        auto sizes = index.sizes();
+        std::array<uint32_t, 3> ndim_dim = {ndim, static_cast<uint32_t>(dim), 0};
+        auto pso = lib.getPipelineStateForFunc(
+            fmt::format("scatter_set_{}_{}", scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      self,
+                      src,
+                      index,
+                      sizes,
+                      self.strides(),
+                      src.strides(),
+                      index.strides(),
+                      ndim_dim,
+                      output_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
+      }
+    }
+  });
+}
+
+// Dense scatter with reduce='set' and a scalar source. Avoids the
+// `at::empty + fill_` temp tensor the legacy path materialized for
+// scatter.value. Falls back to allocating a src tensor and reusing
+// scatter_set_metal when the dense layout assumptions don't hold.
+static void scatter_fill_metal(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& value) {
+  if (!can_use_dense_scatter(self, index, dim) || !index.is_contiguous()) {
+    Tensor src = at::empty(index.sizes(), self.options());
+    src.fill_(value);
+    scatter_set_metal(self, dim, index, src);
+    return;
+  }
+
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+              "scatter: expected index to be Long or Int, got ",
+              index.scalar_type());
+  const int64_t output_dim_size = self.size(dim);
+  const int64_t inner_size = dense_inner_size(self, dim);
+  const int64_t index_dim_size = index.size(dim);
+  const int64_t total = index.numel();
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      // MPSScalar owns a DataPtr (non-copyable); construct inside the block so
+      // ObjC's capture-by-value doesn't try to copy it. setBytes copies the
+      // value into the command buffer, so the local lifetime is fine.
+      MPSScalar mps_value = getMPSScalar(value, self.scalar_type());
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc(
+          fmt::format("scatter_set_dense_value_{}_{}", scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
+      [encoder setComputePipelineState:pso];
+      dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+        mtl_setArgs(encoder,
+                    self,
+                    mps_value,
+                    index,
+                    inner_size,
+                    index_dim_size,
+                    output_dim_size,
+                    tid_offset,
+                    stream->getErrorBuffer());
+      });
+    }
+  });
+}
+
+// Atomic Metal scatter for one of {add, prod, amin, amax}. Picks the dense
+// kernel when output/src/index are contiguous and shape-aligned outside dim,
+// strided kernel otherwise.
+static void scatter_reduce_metal(const Tensor& self,
+                                 int64_t dim,
+                                 const Tensor& index,
+                                 const Tensor& src,
+                                 const char* op) {
+  TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int,
+              "scatter_reduce: expected index to be Long or Int, got ",
+              index.scalar_type());
+  const auto ndim = static_cast<uint32_t>(index.dim());
+  TORCH_CHECK(
+      ndim <= c10::metal::max_ndim, "scatter: tensor rank ", ndim, " exceeds Metal max of ", c10::metal::max_ndim);
+  const int64_t output_dim_size = self.size(dim);
+  const int64_t total = index.numel();
+  const bool use_dense = can_use_dense_scatter(self, index, dim) && src.is_contiguous() && src.sizes() == index.sizes();
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      if (use_dense) {
+        const int64_t inner_size = dense_inner_size(self, dim);
+        const int64_t index_dim_size = index.size(dim);
+        auto pso = lib.getPipelineStateForFunc(
+            fmt::format("scatter_{}_dense_{}_{}", op, scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      self,
+                      src,
+                      index,
+                      inner_size,
+                      index_dim_size,
+                      output_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
+      } else {
+        auto sizes = index.sizes();
+        std::array<uint32_t, 3> ndim_dim = {ndim, static_cast<uint32_t>(dim), 0};
+        auto pso = lib.getPipelineStateForFunc(
+            fmt::format("scatter_{}_strided_{}_{}", op, scalarToMetalTypeString(self), scalarToMetalTypeString(index)));
+        [encoder setComputePipelineState:pso];
+        dispatch_chunked(encoder, pso, total, [&](int64_t tid_offset) {
+          mtl_setArgs(encoder,
+                      self,
+                      src,
+                      index,
+                      sizes,
+                      self.strides(),
+                      src.strides(),
+                      index.strides(),
+                      ndim_dim,
+                      output_dim_size,
+                      tid_offset,
+                      stream->getErrorBuffer());
+        });
+      }
+    }
+  });
+}
+} // namespace mps
 
 static Tensor maybe_expand_0_dim(const Tensor& t) {
   return t.dim() == 0 ? t.view({1}) : t;
@@ -147,244 +371,112 @@ TORCH_IMPL_FUNC(gather_out_mps)
   }
 }
 
-static void scatter_mps_general(const Tensor& self_arg,
-                                int64_t dim,
-                                const Tensor& index,
-                                const Tensor& src,
-                                const Tensor& output,
-                                std::string func_name,
-                                const std::string_view reduce) {
-  using namespace mps;
+static const char* reduce_op_to_mps_string(const ReductionType& op) {
+  switch (op) {
+    case ReductionType::SUM:
+      return "add";
+    case ReductionType::PROD:
+      return "prod";
+    case ReductionType::MIN:
+      return "amin";
+    case ReductionType::MAX:
+      return "amax";
+    case ReductionType::MEAN:
+      // Pre-existing behavior: scatter_reduce(mean) on MPS accumulated as
+      // sum (no divide-by-count). True mean semantics is follow-up work.
+      return "add";
+  }
+  TORCH_CHECK(false, "Unsupported reduction type: ", static_cast<int>(op));
+}
 
-  if (self_arg.numel() == 0 || index.numel() == 0 || src.numel() == 0) {
+// Common pre-dispatch shape/dtype checks shared by all reduce-mode stubs.
+static void scatter_reduce_check(const Tensor& self, const Tensor& index, const Tensor& src) {
+  TORCH_CHECK(self.scalar_type() == src.scalar_type(), "scatter(): self and src must have the same scalar type");
+  TORCH_CHECK(index.dim() == self.dim() && index.dim() == src.dim(), "Input, index and src must have same rank");
+}
+
+// scatter_stub: in-place set with a Tensor src. self is the writable output
+// (pre-loaded by scatter_impl in TensorAdvancedIndexing.cpp).
+static void scatter_mps_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+  if (self.numel() == 0 || index.numel() == 0 || src.numel() == 0) {
     return;
   }
-  auto self = self_arg.dim() == 0 ? self_arg.view({1}) : self_arg;
-  dim = at::maybe_wrap_dim(dim, self.dim());
+  TORCH_CHECK(self.scalar_type() == src.scalar_type(), "scatter(): self and src must have the same scalar type");
+  // Complex types map to float2/half2 in the Metal kernels (see
+  // scalarToMetalTypeString), so no view_as_real shim is needed.
+  auto self_view = self.dim() == 0 ? self.view({1}) : self;
+  auto src_view = maybe_expand_0_dim(src);
+  auto index_view = maybe_expand_0_dim(index);
+  dim = at::maybe_wrap_dim(dim, self_view.dim());
+  TORCH_CHECK(dim >= 0 && dim < self_view.dim(), "scatter(): Indexing dim ", dim, " is out of bounds of tensor");
+  TORCH_CHECK(index_view.dim() == self_view.dim() && index_view.dim() == src_view.dim(),
+              "Input, index and src must have same rank");
+  for (const auto i : c10::irange(self_view.dim())) {
+    TORCH_CHECK(index_view.size(i) <= src_view.size(i), "Index dim must not exceed src dim");
+    TORCH_CHECK(i == dim || index_view.size(i) <= self_view.size(i),
+                "Index dim must not exceed input dim except at gathering axis");
+  }
+  mps::scatter_set_metal(self_view, dim, index_view, src_view);
+}
 
-  TORCH_CHECK(self.scalar_type() == output.scalar_type() && output.scalar_type() == src.scalar_type(),
-              "scatter(): self, src and output must have the same scalar type");
-  TORCH_CHECK(dim >= 0 && dim < self.dim(), "scatter(): Indexing dim ", dim, " is out of bounds of tensor");
-
-  if (self.is_complex()) {
-    auto self_real = at::view_as_real(self);
-    auto index_expanded = expand_index_as_real(index);
-    auto src_real = at::view_as_real(maybe_expand_0_dim(src));
-    auto output_real = at::view_as_real(maybe_expand_0_dim(output));
-    scatter_mps_general(self_real, dim, index_expanded, src_real, output_real, func_name, reduce);
+// scatter_fill_stub: in-place set with a scalar value. Uses the dense
+// scatter_set_dense_value kernel when possible (skips temp-src materialization).
+static void scatter_fill_mps_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& value) {
+  if (self.numel() == 0 || index.numel() == 0) {
     return;
   }
-
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* inputTensor_ = nil;
-    MPSGraphTensor* indexTensor_ = nil;
-    MPSGraphTensor* srcTensor_ = nil;
-    MPSGraphTensor* outputTensor_ = nil;
-  };
-
-  @autoreleasepool {
-    MPSShape* input_shape = getMPSShape(self);
-    MPSShape* index_shape = getMPSShape(index);
-    MPSShape* src_shape = getMPSShape(src);
-    uint32_t num_input_dims = [input_shape count];
-    uint32_t num_index_dims = [index_shape count];
-    uint32_t num_src_dims = [src_shape count];
-
-    TORCH_CHECK(num_input_dims == num_index_dims && num_index_dims == num_src_dims,
-                "Input, index and src must have same rank")
-
-    // Do we need to slice into the src tensor?
-    bool needSlice = false;
-    bool inputNeedSlice = false;
-    bool needsCast = false;
-
-    for (const auto i : c10::irange(num_input_dims)) {
-      TORCH_CHECK(i == dim || [index_shape[i] intValue] <= [input_shape[i] intValue],
-                  "Index dim must not exceed input dim except at gathering axis")
-      TORCH_CHECK([index_shape[i] intValue] <= [src_shape[i] intValue],
-                  "Index dim must not exceed input dim except at gathering axis")
-      if ([index_shape[i] intValue] < [src_shape[i] intValue])
-        needSlice = true;
-      if (i != dim && [index_shape[i] intValue] < [input_shape[i] intValue])
-        inputNeedSlice = true;
-    }
-    TORCH_CHECK(reduce != "mean", "Scatter reduce mean mode not yet supported in MPS")
-
-    MPSDataType src_type = getMPSDataType(src);
-    if (reduce != "set" || src_type == MPSDataTypeUInt8 || src_type == MPSDataTypeBool) {
-      src_type = isFloatingType(src.scalar_type()) ? MPSDataTypeFloat32 : MPSDataTypeInt32;
-      needsCast = true;
-    }
-
-    std::string key = func_name + getTensorsStringKey({self, index, src, output}) + ":" + std::to_string(dim) + ":" +
-        std::string(reduce);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-      MPSGraphTensor* indexTensor = mpsGraphRankedPlaceHolder(mpsGraph, index);
-      MPSGraphTensor* srcTensor = mpsGraphRankedPlaceHolder(mpsGraph, src);
-
-      MPSGraphTensor* outputTensor = nil;
-      MPSGraphTensor* castSrcTensor = srcTensor;
-      MPSGraphTensor* castInputTensor = inputTensor;
-
-      if (needsCast) {
-        castSrcTensor = [mpsGraph castTensor:srcTensor toType:src_type name:@"cast"];
-        castInputTensor = [mpsGraph castTensor:inputTensor toType:src_type name:@"cast"];
-      }
-      MPSGraphTensor* castIndexTensor = [mpsGraph castTensor:indexTensor toType:MPSDataTypeInt32 name:@"cast"];
-
-      MPSGraphTensor* slicedSrc = castSrcTensor;
-      MPSGraphTensor* slicedInput = castInputTensor;
-
-      // Use in case input needs to be smaller to get scatter
-      NSMutableArray<NSNumber*>* scatterInputShape = [NSMutableArray arrayWithArray:input_shape];
-
-      // Slice into the src or input tensors IF NEEDED
-      if (needSlice || inputNeedSlice) {
-        NSMutableArray<NSNumber*>* starts = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-        NSMutableArray<NSNumber*>* strides = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-        NSMutableArray<NSNumber*>* ends_src = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-
-        for (const auto i : c10::irange(num_input_dims)) {
-          strides[i] = @1;
-          starts[i] = @0;
-          ends_src[i] = index_shape[i];
-          scatterInputShape[i] = (i != dim) ? index_shape[i] : input_shape[i];
-        }
-        if (needSlice) {
-          slicedSrc = [mpsGraph sliceTensor:castSrcTensor starts:starts ends:ends_src strides:strides name:nil];
-        }
-        if (inputNeedSlice) {
-          slicedInput = [mpsGraph sliceTensor:castInputTensor
-                                       starts:starts
-                                         ends:scatterInputShape
-                                      strides:strides
-                                         name:nil];
-        }
-      }
-      MPSGraphScatterMode scatter_mode = MPSGraphScatterModeSet;
-
-      if (reduce == "sum" || reduce == "add")
-        scatter_mode = MPSGraphScatterModeAdd;
-      else if (reduce == "prod" || reduce == "multiply")
-        scatter_mode = MPSGraphScatterModeMul;
-      else if (reduce == "amax")
-        scatter_mode = MPSGraphScatterModeMax;
-      else if (reduce == "amin")
-        scatter_mode = MPSGraphScatterModeMin;
-
-      // Scatter this into the input with set mode
-      C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wobjc-method-access")
-      MPSGraphTensor* scatterTensor = [mpsGraph scatterAlongAxis:(NSInteger)dim
-                                                  withDataTensor:slicedInput
-                                                   updatesTensor:slicedSrc
-                                                   indicesTensor:castIndexTensor
-                                                            mode:scatter_mode
-                                                            name:nil];
-      C10_DIAGNOSTIC_POP()
-      if (inputNeedSlice) {
-        // Make an array of scatter indices tensors
-        NSMutableArray<MPSGraphTensor*>* indicesTensors =
-            [NSMutableArray<MPSGraphTensor*> arrayWithCapacity:num_input_dims];
-
-        // 1. Concatenate the coord tensors
-        // 2. Flatten the values
-        // 3. Scatter into input with add mode
-
-        std::vector<int> shape_data(num_input_dims);
-
-        for (const auto i : c10::irange(num_input_dims)) {
-          shape_data[i] = {[scatterInputShape[i] intValue]};
-        }
-
-        MPSGraphTensor* scatterInputShapeTensor =
-            [mpsGraph constantWithData:[NSData dataWithBytes:shape_data.data() length:num_input_dims * sizeof(int)]
-                                 shape:@[ [NSNumber numberWithUnsignedInt:num_input_dims] ]
-                              dataType:MPSDataTypeInt32];
-
-        for (const auto i : c10::irange(num_input_dims)) {
-          MPSGraphTensor* axisTensor = [mpsGraph constantWithScalar:i dataType:MPSDataTypeInt32];
-          MPSGraphTensor* scatter_currentIndexTensor = [mpsGraph coordinateAlongAxisTensor:axisTensor
-                                                                           withShapeTensor:scatterInputShapeTensor
-                                                                                      name:nil];
-          scatter_currentIndexTensor = [mpsGraph reshapeTensor:scatter_currentIndexTensor
-                                                     withShape:@[ @-1, @1 ]
-                                                          name:nil];
-          indicesTensors[i] = scatter_currentIndexTensor;
-        }
-
-        MPSGraphTensor* scatter_fullIndexTensor = [mpsGraph concatTensors:indicesTensors
-                                                                dimension:(NSInteger)1
-                                                                     name:nil];
-
-        MPSGraphTensor* flatValuesTensor = [mpsGraph reshapeTensor:scatterTensor withShape:@[ @-1 ] name:nil];
-
-        outputTensor = [mpsGraph scatterNDWithDataTensor:castInputTensor
-                                           updatesTensor:flatValuesTensor
-                                           indicesTensor:scatter_fullIndexTensor
-                                         batchDimensions:0
-                                                    mode:MPSGraphScatterModeSet
-                                                    name:nil];
-      } else {
-        outputTensor = scatterTensor;
-      }
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->srcTensor_ = srcTensor;
-      newCachedGraph->indexTensor_ = indexTensor;
-      newCachedGraph->outputTensor_ =
-          needsCast ? castMPSTensor(mpsGraph, outputTensor, output.scalar_type()) : outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self, input_shape);
-    Placeholder srcPlaceholder = Placeholder(cachedGraph->srcTensor_, src, src_shape);
-    Placeholder indexPlaceholder = Placeholder(cachedGraph->indexTensor_, index, index_shape);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
-
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder, srcPlaceholder, indexPlaceholder);
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outputPlaceholder);
+  // MPSScalar carries c10::complex<float>/<Half> via its union and Metal kernels
+  // are templated on float2/half2, so complex scalars flow through unchanged.
+  auto self_view = self.dim() == 0 ? self.view({1}) : self;
+  auto index_view = maybe_expand_0_dim(index);
+  dim = at::maybe_wrap_dim(dim, self_view.dim());
+  TORCH_CHECK(dim >= 0 && dim < self_view.dim(), "scatter(): Indexing dim ", dim, " is out of bounds of tensor");
+  TORCH_CHECK(index_view.dim() == self_view.dim(), "Input and index must have same rank");
+  for (const auto i : c10::irange(self_view.dim())) {
+    TORCH_CHECK(i == dim || index_view.size(i) <= self_view.size(i),
+                "Index dim must not exceed input dim except at gathering axis");
   }
+  mps::scatter_fill_metal(self_view, dim, index_view, value);
 }
 
-TORCH_IMPL_FUNC(scatter_src_out_mps)
-(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src, const Tensor& output) {
-  scatter_mps_general(self, dim, index, src, output, "scatter_src_out_mps", "set");
+// Shared scatter-reduce dispatch used by add / reduce / scalar_reduce /
+// reduce_two stubs. mean is rejected via reduce_op_to_mps_string.
+static void scatter_reduce_dispatch(const Tensor& self,
+                                    int64_t dim,
+                                    const Tensor& index,
+                                    const Tensor& src,
+                                    const ReductionType& reduce) {
+  if (self.numel() == 0 || index.numel() == 0 || src.numel() == 0) {
+    return;
+  }
+  auto self_view = self.dim() == 0 ? self.view({1}) : self;
+  auto src_view = maybe_expand_0_dim(src);
+  auto index_view = maybe_expand_0_dim(index);
+  dim = at::maybe_wrap_dim(dim, self_view.dim());
+  scatter_reduce_check(self_view, index_view, src_view);
+  mps::scatter_reduce_metal(self_view, dim, index_view, src_view, reduce_op_to_mps_string(reduce));
 }
 
-TORCH_IMPL_FUNC(scatter_value_out_mps)
-(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& value, const Tensor& output) {
-  Tensor src =
-      at::empty(index.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, self.suggest_memory_format());
+static void scatter_add_mps_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+  scatter_reduce_dispatch(self, dim, index, src, ReductionType::SUM);
+}
+
+static void scatter_reduce_mps_kernel(const Tensor& self,
+                                      int64_t dim,
+                                      const Tensor& index,
+                                      const Tensor& src,
+                                      const ReductionType& reduce) {
+  scatter_reduce_dispatch(self, dim, index, src, reduce);
+}
+
+static void scatter_scalar_reduce_mps_kernel(const Tensor& self,
+                                             int64_t dim,
+                                             const Tensor& index,
+                                             const Scalar& value,
+                                             const ReductionType& reduce) {
+  Tensor src = at::empty(index.sizes(), self.options());
   src.fill_(value);
-  scatter_mps_general(self, dim, index, const_cast<Tensor&>(src), output, "scatter_value_out_mps", "set");
-}
-
-TORCH_IMPL_FUNC(scatter_reduce_out_mps)
-(const Tensor& self,
- int64_t dim,
- const Tensor& index,
- const Tensor& src,
- const std::string_view reduce,
- const Tensor& output) {
-  scatter_mps_general(self, dim, index, src, output, "scatter_reduce_out_mps", reduce);
-}
-
-TORCH_IMPL_FUNC(scatter_value_reduce_out_mps)
-(const Tensor& self,
- int64_t dim,
- const Tensor& index,
- const Scalar& value,
- const std::string_view reduce,
- const Tensor& output) {
-  Tensor src =
-      at::empty(index.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, self.suggest_memory_format());
-  src.fill_(value);
-  scatter_mps_general(self, dim, index, const_cast<Tensor&>(src), output, "scatter_value_reduce_out_mps", reduce);
-}
-
-TORCH_IMPL_FUNC(scatter_add_mps_out)
-(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src, const Tensor& output) {
-  scatter_mps_general(self, dim, index, src, output, "scatter_add_mps_out", "add");
+  scatter_reduce_dispatch(self, dim, index, src, reduce);
 }
 
 static void scatter_reduce_two_mps_kernel(const Tensor& self,
@@ -392,24 +484,13 @@ static void scatter_reduce_two_mps_kernel(const Tensor& self,
                                           const Tensor& index,
                                           const Tensor& src,
                                           const ReductionType& reduce) {
-  static const bool is_macOS_15_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
-  switch (reduce) {
-    case ReductionType::MEAN:
-    case ReductionType::SUM:
-      return scatter_mps_general(self, dim, index, src, self, "scatter_reduce_two_mps", "add");
-    case ReductionType::PROD:
-      return scatter_mps_general(self, dim, index, src, self, "scatter_reduce_two_mps", "prod");
-    case ReductionType::MIN:
-      TORCH_CHECK(self.scalar_type() != kInt || is_macOS_15_or_newer, "torch.int32 is only supported on MacOS15+");
-      TORCH_CHECK(self.scalar_type() != kLong, "not supported for torch.int64");
-      return scatter_mps_general(self, dim, index, src, self, "scatter_reduce_two_mps", "amin");
-    case ReductionType::MAX:
-      TORCH_CHECK(self.scalar_type() != kInt || is_macOS_15_or_newer, "torch.int32 is only supported on MacOS15+");
-      TORCH_CHECK(self.scalar_type() != kLong, "not supported for torch.int64");
-      return scatter_mps_general(self, dim, index, src, self, "scatter_reduce_two_mps", "amax");
-  }
-  TORCH_CHECK(false, "Unsupported reduction type: ", static_cast<int>(reduce));
+  scatter_reduce_dispatch(self, dim, index, src, reduce);
 }
 
+REGISTER_DISPATCH(scatter_stub, &scatter_mps_kernel);
+REGISTER_DISPATCH(scatter_fill_stub, &scatter_fill_mps_kernel);
+REGISTER_DISPATCH(scatter_add_stub, &scatter_add_mps_kernel);
+REGISTER_DISPATCH(scatter_reduce_stub, &scatter_reduce_mps_kernel);
+REGISTER_DISPATCH(scatter_scalar_reduce_stub, &scatter_scalar_reduce_mps_kernel);
 REGISTER_DISPATCH(scatter_reduce_two_stub, &scatter_reduce_two_mps_kernel);
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8543,8 +8543,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_src_out
-    MPS: scatter_src_out_mps
+    CPU, CUDA, MPS: scatter_src_out
 
 - func: scatter.value(Tensor self, int dim, Tensor index, Scalar value) -> Tensor
   structured_delegate: scatter.value_out
@@ -8559,8 +8558,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_value_out
-    MPS: scatter_value_out_mps
+    CPU, CUDA, MPS: scatter_value_out
 
 - func: scatter.reduce(Tensor self, int dim, Tensor index, Tensor src, *, str reduce) -> Tensor
   structured_delegate: scatter.reduce_out
@@ -8574,8 +8572,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_reduce_out
-    MPS: scatter_reduce_out_mps
+    CPU, CUDA, MPS: scatter_reduce_out
 
 - func: scatter.value_reduce(Tensor self, int dim, Tensor index, Scalar value, *, str reduce) -> Tensor
   structured_delegate: scatter.value_reduce_out
@@ -8589,8 +8586,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_value_reduce_out
-    MPS: scatter_value_reduce_out_mps
+    CPU, CUDA, MPS: scatter_value_reduce_out
 
 - func: scatter.dimname_src(Tensor self, Dimname dim, Tensor index, Tensor src) -> Tensor
   variants: function, method
@@ -8611,8 +8607,7 @@
   structured: True
   variants: function
   dispatch:
-    CPU, CUDA: scatter_add
-    MPS: scatter_add_mps_out
+    CPU, CUDA, MPS: scatter_add
 
 - func: scatter_add.dimname(Tensor self, Dimname dim, Tensor index, Tensor src) -> Tensor
   variants: function, method

--- a/c10/metal/atomic.h
+++ b/c10/metal/atomic.h
@@ -229,6 +229,14 @@ struct AtomicType<bool> {
         ::metal::memory_order_relaxed,
         ::metal::memory_order_relaxed));
   }
+  // Generic packed-CAS supports any bool op (AND for prod/amin, OR for amax).
+  static inline void atomic_binary_op(
+      device type* data,
+      long offset,
+      bool value,
+      bool (*op)(bool, bool)) {
+    atomic_binary_op_helper<bool>(data, offset, value, op);
+  }
 };
 
 // ComplexHalf atomic op

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14568,6 +14568,21 @@ class TestErrorInputs(TestCase):
             torch.nn.functional.embedding_bag(inputs, weight, offsets)
             torch.mps.synchronize()
 
+    def test_scatter_out_of_bounds(self, device):
+        # Regression for https://github.com/pytorch/pytorch/issues/170507
+        # one_hot is composite (zeros + scatter_); bad indices used to silently
+        # produce zeros instead of raising. MPS scatter now reports async via
+        # the stream error buffer, matching CUDA's deferred-assert behavior.
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.nn.functional.one_hot(torch.tensor([8], device=device), num_classes=8)
+            torch.mps.synchronize()
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.nn.functional.one_hot(torch.tensor([-1], device=device), num_classes=8)
+            torch.mps.synchronize()
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.zeros(3, 4, device=device).scatter_(1, torch.tensor([[4]], device=device), 1.0)
+            torch.mps.synchronize()
+
 
 class TestComplex(TestCase):
     def test_tensor_scalar_binops(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10147,14 +10147,18 @@ class TestNNDeviceType(NNTestCase):
         _test_module_empty_input(self, mod, inp)
 
     def test_one_hot(self, device):
-        # cuda throws device assert for invalid data
-        # xla & mps ignore out of bound indices
-        if self.device_type == 'cpu':
+        # cpu raises synchronously; mps reports the bad index from its scatter
+        # kernel asynchronously, surfaced on the next sync. xla still ignores.
+        if self.device_type in ('cpu', 'mps'):
             with self.assertRaises(RuntimeError):
                 torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)
+                if self.device_type == 'mps':
+                    torch.mps.synchronize()
 
             with self.assertRaises(RuntimeError):
                 torch.nn.functional.one_hot(torch.tensor([3, 4, 1, 0], device=device), 3)
+                if self.device_type == 'mps':
+                    torch.mps.synchronize()
 
         t = torch.nn.functional.one_hot(torch.tensor([3, 4, 1, 0], device=device))
         expected = torch.tensor([[0, 0, 0, 1, 0],

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -585,6 +585,9 @@ if torch.backends.mps.is_available():
             if MACOS_VERSION < 15.0
             else [torch.int64],
             "scatter_reducemean": [torch.bool],
+            # int64 lacks atomic_binary_op in Metal; the old MPSGraph path cast
+            # to int32 (silently lossy).
+            "scatter_reduceprod": [torch.int64],
             "segment_reduce": None,
             "_segment.reduce": None,
             "segment.reduce": None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #184057

Fixes #170507. F.one_hot is composite -- it lowers to zeros() + scatter_(-1, self.unsqueeze(-1), 1) -- and the silent failure was in MPS scatter, whose MPSGraph scatterAlongAxis silently drops out-of-bounds indices unlike CUDA whose scatter has a device-side assert.

Drops the MPS-specific structured-kernel implementations and reuses the shared CPU/CUDA `scatter_impl` path in TensorAdvancedIndexing.cpp by registering MPS into the existing `scatter_stub` / `scatter_fill_stub` / `scatter_add_stub` / `scatter_reduce_stub` / `scatter_scalar_reduce_stub` / `scatter_reduce_two_stub` (same pattern `scatter_reduce_two_stub` already used). The shared impl handles dim wrap, the self->out copy, empty-numel early return, deterministic-mode branch, and reduce init for all backends -- one definition for all backends.

Five Metal kernels back the scatter ops: a strided generic `scatter_set`, dense fast paths `scatter_set_dense` and `scatter_set_dense_value` (the latter takes a scalar source directly, used by scatter.value to skip the legacy at::empty + fill_ temp tensor), and atomic kernels `scatter_reduce_dense` / `scatter_reduce_strided` templated on {add, prod, amin, amax} via AtomicType<T>::atomic_add / atomic_binary_op. Complex types flow through unchanged via float2/half2 templates (no view_as_real shim). Bounds checks live inline in all kernels and report to the stream's async error buffer, raised on the next sync as torch.AcceleratorError (matches CUDA's deferred-assert model).

scatter_mps_general is gone, along with all MPS-specific TORCH_IMPL_FUNCs for scatter. Adds atomic_binary_op to AtomicType<bool> in c10/metal/atomic.h so bool reduce ops (AND for prod/amin, OR for amax) work through the same machinery. Honest skip-list entries cover the dtypes the new Metal path doesn't support: int64 for prod/amin/amax (no atomic_binary_op for true 64-bit CAS; the old MPSGraph path silently cast to int32).

Large tensor support: `[[thread_position_in_grid]]` is a `uint`, so the host chunks dispatch into <=UINT_MAX-thread launches and each thread adds a `tid_offset` constant. Index numels above 2^32 work transparently.

Perf vs PyTorch 2.12.0 on Apple M4: in-place scatter_ set is 23-46% faster across tested shapes once the implicit out-of-place copy is removed from the comparison. one_hot is 30-60% faster across shapes. scatter_value (scalar source) is 31-51% faster thanks to the dense-value kernel, which one_hot exercises directly via `scatter_(-1, idx, 1)`.

Authored by Claude.