### PR TITLE
nn.functional: raise ValueError for tau <= 0 in gumbel_softmax

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11816,6 +11816,14 @@ class TestNNDeviceType(NNTestCase):
         self._test_gumbel_softmax_straight_through(device, dtype)
         self._test_gumbel_softmax_grad(device, dtype)
 
+    def test_gumbel_softmax_tau_zero_raises(self, device, dtype):
+        # tau <= 0 must raise ValueError; tau=0 previously produced NaN silently
+        logits = torch.randn(4, 8, device=device, dtype=dtype)
+        with self.assertRaisesRegex(ValueError, "tau"):
+            F.gumbel_softmax(logits, tau=0.0)
+        with self.assertRaisesRegex(ValueError, "tau"):
+            F.gumbel_softmax(logits, tau=-1.0)
+
     def _test_rnn_retain_variables(self, device, dtype):
         rnns = [nn.LSTM(10, 20, num_layers=2).to(device, dtype),
                 nn.GRU(10, 20, num_layers=2).to(device, dtype),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11816,6 +11816,9 @@ class TestNNDeviceType(NNTestCase):
         self._test_gumbel_softmax_straight_through(device, dtype)
         self._test_gumbel_softmax_grad(device, dtype)
 
+    @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfMPS(torch.float)
+    @dtypes(torch.float, torch.double)
     def test_gumbel_softmax_tau_zero_raises(self, device, dtype):
         # tau <= 0 must raise ValueError; tau=0 previously produced NaN silently
         logits = torch.randn(4, 8, device=device, dtype=dtype)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2180,7 +2180,7 @@ def gumbel_softmax(
 
     Args:
       logits: `[..., num_features]` unnormalized log probabilities
-      tau: non-negative scalar temperature
+      tau: positive scalar temperature
       hard: if ``True``, the returned samples will be discretized as one-hot vectors,
             but will be differentiated as if it is the soft sample in autograd
       dim (int): A dimension along which softmax will be computed. Default: -1.
@@ -2220,6 +2220,8 @@ def gumbel_softmax(
         )
     if eps != 1e-10:
         warnings.warn("`eps` parameter is deprecated and has no effect.", stacklevel=2)
+    if tau <= 0:
+        raise ValueError(f"gumbel_softmax() requires tau > 0, got tau={tau}")
 
     gumbels = (
         -torch.empty_like(logits, memory_format=torch.legacy_contiguous_format)


### PR DESCRIPTION
## Summary

Fixes #184031.

`F.gumbel_softmax` computes `(logits + gumbels) / tau`. When `tau=0`, this produces `±Inf`, and `softmax(Inf - Inf)` yields `NaN` for every output element. The docstring described `tau` as "non-negative" but `tau=0` has no valid interpretation — the mathematical limit as `tau → 0` is an argmax one-hot, not `NaN`.

**Changes:**
- Raise `ValueError` when `tau <= 0`, with a message that names the parameter.
- Tighten the docstring from "non-negative scalar temperature" to "positive scalar temperature".
- Add a regression test covering `tau=0` and `tau < 0`.

## Test plan

```python
import torch
import torch.nn.functional as F

logits = torch.rand(2, 8)

# Before this PR: returns all-NaN silently
# After this PR: raises ValueError
F.gumbel_softmax(logits, tau=0.0)   # ValueError
F.gumbel_softmax(logits, tau=-1.0)  # ValueError
F.gumbel_softmax(logits, tau=0.5)   # works fine
```

New test: `TestNN.test_gumbel_softmax_tau_zero_raises`