### PR TITLE
nn: raise ValueError for negative input in PoissonNLLLoss when log_input=False

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2754,6 +2754,21 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(F.gaussian_nll_loss(input, target, var_tensor, reduction='none'),
                          F.gaussian_nll_loss(input, target, var, reduction='none'))
 
+    def test_poisson_nll_loss_negative_input_raises(self):
+        # When log_input=False, input is a Poisson rate and must be non-negative.
+        # Negative values previously produced silent NaN (issue #184030).
+        target = torch.rand(2, 8)
+        neg_input = torch.full((2, 8), -0.5)
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            F.poisson_nll_loss(neg_input, target, log_input=False)
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            nn.PoissonNLLLoss(log_input=False)(neg_input, target)
+        # Non-negative input must not raise
+        pos_input = torch.rand(2, 8)
+        F.poisson_nll_loss(pos_input, target, log_input=False)
+        # log_input=True is unrestricted (no validation needed)
+        F.poisson_nll_loss(torch.randn(2, 8), target, log_input=True)
+
     def test_KLDivLoss_batch_mean(self):
         input_shape = (2, 5)
         log_prob1 = F.log_softmax(torch.randn(input_shape), 1)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3230,6 +3230,12 @@ def poisson_nll_loss(
             and :attr:`reduce` are in the process of being deprecated, and in the meantime,
             specifying either of those two args will override :attr:`reduction`. Default: ``'mean'``
 
+    .. note::
+        When :attr:`log_input` is ``False``, ``input`` represents a Poisson rate and
+        **must be non-negative**.  Negative values cause :math:`\log(\text{input}+\text{eps})`
+        to return ``NaN`` silently.  Clamp or apply :func:`~torch.nn.functional.softplus`
+        to raw model outputs before passing them to this loss.
+
     """
     if has_torch_function_variadic(input, target):
         return handle_torch_function(
@@ -3249,6 +3255,12 @@ def poisson_nll_loss(
     if reduction != "none" and reduction != "mean" and reduction != "sum":
         ret = input
         raise ValueError(reduction + " is not a valid value for reduction")
+    if not log_input and torch.is_floating_point(input) and bool((input < 0).any()):
+        raise ValueError(
+            "PoissonNLLLoss / poisson_nll_loss: input contains negative values, "
+            "which are invalid when log_input=False (input parameterises a Poisson "
+            "rate and must be non-negative). Use softplus or clamp before this loss."
+        )
 
     ret = torch.poisson_nll_loss(
         input, target, log_input, full, eps, _Reduction.get_enum(reduction)

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -325,6 +325,13 @@ class PoissonNLLLoss(_Loss):
             and :attr:`reduce` are in the process of being deprecated, and in the meantime,
             specifying either of those two args will override :attr:`reduction`. Default: ``'mean'``
 
+    .. note::
+        When :attr:`log_input` is ``False``, ``input`` represents a Poisson rate and
+        **must be non-negative**.  Negative values will raise a ``ValueError``
+        because :math:`\log(\text{input}+\text{eps})` is undefined.  Apply
+        :func:`~torch.nn.functional.softplus` or clamp to raw model outputs
+        before passing them to this loss.
+
     Examples:
 
         >>> loss = nn.PoissonNLLLoss()


### PR DESCRIPTION
## Summary

Fixes #184030.

`PoissonNLLLoss(log_input=False)` computes `input - target * log(input + eps)`. When `input` contains negative values, `log(input + eps)` returns `NaN`, which propagates silently through the reduction. Since `input` parameterises a Poisson rate, it must be non-negative by definition — negative values are mathematically invalid, not just numerically inconvenient.

**Changes:**
- Add a check in `F.poisson_nll_loss()` that raises `ValueError` when any element of `input` is negative and `log_input=False`.
- Update the docstring in both `F.poisson_nll_loss` and `nn.PoissonNLLLoss` to document the non-negativity constraint and recommend `softplus` or clamping for raw model outputs.
- Add a regression test covering the error path and the non-negative pass-through.

## Test plan

```python
import torch
import torch.nn as nn
import torch.nn.functional as F

target = torch.rand(2, 8)
neg_input = torch.full((2, 8), -0.5)

# Before this PR: returns NaN silently
# After this PR: raises ValueError
F.poisson_nll_loss(neg_input, target, log_input=False)       # ValueError
nn.PoissonNLLLoss(log_input=False)(neg_input, target)        # ValueError

# Non-negative input unaffected
F.poisson_nll_loss(torch.rand(2, 8), target, log_input=False)  # ok
F.poisson_nll_loss(torch.randn(2, 8), target, log_input=True)  # ok (unrestricted)
```

New test: `TestNN.test_poisson_nll_loss_negative_input_raises`

