### PR TITLE
Use pop in place of last() + drop() in JIT runtime

### DIFF
--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
@@ -608,14 +608,7 @@ static RegisterOperators reg_guard({
                   flattened_input_dims,
                   flattened_input_striding,
                   num_symbolic_dims](Stack& stack) {
-            // Copy inputs out before dropping. drop() = stack.erase(...),
-            // which destroys the IValues; iterating last(stack, num_inputs)
-            // afterwards dereferences destroyed elements (Tensor refcount
-            // use-after-free; ASAN flags it as container-overflow at the
-            // toTensor() call below).
-            // TODO - smallvector here ?
-            std::vector<IValue> inputs(stack.end() - num_inputs, stack.end());
-            drop(stack, num_inputs);
+            auto inputs = pop(stack, num_inputs);
             // each invocation we need to reset what value of each symbolic
             // symbol is.
             // TODO: could this be a reference and not allocated on

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -771,9 +771,8 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
                 forked_fn.get_executor().getPlanFor(stack).code, taskLauncher_);
             InterpreterContinuation continuation(
                 forked_interpreter,
-                Stack(stack.end() - inst.N, stack.end()),
+                pop(stack, static_cast<size_t>(inst.N)),
                 getDistAutogradContextId());
-            drop(stack, inst.N);
             push(stack, forked_interpreter.getFuture());
             taskLauncher_(std::move(continuation));
           }
@@ -793,7 +792,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
               }
               out_type = TupleType::create(out_types);
             }
-            auto args = std::vector<IValue>(stack.end() - inst.N, stack.end());
+            auto args = pop(stack, static_cast<size_t>(inst.N));
             auto aw = c10::make_intrusive<c10::ivalue::Await>(out_type);
             aw->setArgs(std::move(args));
             aw->setFn(
@@ -814,7 +813,6 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
                   }
                   return c10::ivalue::Tuple::create(jit::last(s, n_out));
                 });
-            drop(stack, inst.N);
             push(stack, std::move(aw));
           }
             INST_NEXT;

--- a/torch/csrc/jit/runtime/static/fusion.cpp
+++ b/torch/csrc/jit/runtime/static/fusion.cpp
@@ -43,10 +43,7 @@ static Operation createStaticSubgraphRuntime(const Node* node) {
   auto num_inputs = module->num_inputs();
   return [module, num_inputs](Stack& stack) {
     RECORD_FUNCTION("Static Runtime", std::vector<c10::IValue>());
-    auto inps = torch::jit::last(stack, num_inputs);
-    // TODO maybe avoid call to vec
-    auto outputs = (*module)(inps.vec(), {});
-    torch::jit::drop(stack, num_inputs);
+    auto outputs = (*module)(torch::jit::pop(stack, num_inputs), {});
 
     if (module->num_outputs() > 1) {
       for (auto& o : outputs.toTupleRef().elements()) {

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -315,10 +315,7 @@ void namedTupleConstruct(
     Stack& stack,
     c10::TypePtr tuple_type,
     size_t num_inputs) {
-  std::vector<IValue> elems{
-      std::make_move_iterator(stack.end() - num_inputs),
-      std::make_move_iterator(stack.end())};
-  drop(stack, num_inputs);
+  auto elems = pop(stack, num_inputs);
   push(
       stack,
       c10::ivalue::Tuple::createNamed(std::move(elems), std::move(tuple_type)));


### PR DESCRIPTION
This PR uses pop to simplify stack handling code and avoid subtle bugs.
cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @EikanWang