### PR TITLE
Fix silent int64 precision loss in F.pad constant mode

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7840,6 +7840,15 @@ class TestConstantPadNd(TestCase):
         nhwc_padded = torch.constant_pad_nd(nhwc_tensor, [1, 2], 0.5)
         self.assertTrue(nhwc_padded.is_contiguous(memory_format=torch.channels_last))
 
+    def test_pad_preserves_int64_fill_value(self):
+        iinfo = torch.iinfo(torch.int64)
+        for v in (2**53 + 1, -(2**53 + 1), iinfo.max, iinfo.min):
+            with self.subTest(value=v):
+                out = F.pad(
+                    torch.tensor([v], dtype=torch.int64), pad=(0, 1), value=v
+                )
+                self.assertEqual(out.tolist(), [v, v])
+
 
 class TestAddRelu(TestCase):
     def test_add_relu(self):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5627,6 +5627,7 @@ def pad(
         ):
             # F.pad routes value through a C++ double; Python ints above
             # 2**53 lose precision. constant_pad_nd takes a Scalar.
+            # See https://github.com/pytorch/pytorch/issues/170798
             return torch.constant_pad_nd(input, pad, value)
     return torch._C._nn.pad(input, pad, mode, value)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5618,6 +5618,16 @@ def pad(
                 return importlib.import_module(
                     "torch._decomp.decompositions"
                 )._replication_pad(input, pad)
+        if (
+            mode == "constant"
+            and value is not None
+            and not isinstance(value, float)
+            and not input.is_floating_point()
+            and not input.is_complex()
+        ):
+            # F.pad routes value through a C++ double; Python ints above
+            # 2**53 lose precision. constant_pad_nd takes a Scalar.
+            return torch.constant_pad_nd(input, pad, value)
     return torch._C._nn.pad(input, pad, mode, value)
 
 


### PR DESCRIPTION
## Issue

Fixes #170798

## Summary

`F.pad` declares `value` as `float?`, so a Python int whose magnitude
exceeds `2**53` is silently truncated when it crosses into the C++
binding. For integer tensors with an integer fill value, dispatch
directly to `constant_pad_nd`, which takes a `Scalar` and preserves
the value. `native_functions.yaml` is unchanged, so no FC freeze
applies. This is the Python-side approach @mikaylagawarecki suggested
on the prior attempt #171418.

Regression test in `TestConstantPadNd` covers `2**53 + 1`,
`-(2**53 + 1)`, `int64.max`, and `int64.min`. Without this patch,
3 of the 4 subtests fail on `main`.

## Checklist

- [x] Passes lint (`lintrunner -a`)
- [x] Added/updated tests
- [ ] Updated documentation (not applicable)
- [ ] Included benchmark results (not applicable)

## BC-breaking?

No