### PR TITLE
Make AOTConfig immutable in AOT stage 2

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3346,9 +3346,9 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
 
         config = self.default_config()
         config2 = self.default_config()
-        config2.aot_id = 1
+        config2 = dataclasses.replace(config2, aot_id=1)
         config3 = self.default_config()
-        config3.fw_compiler = lambda gm, inputs: gm
+        config3 = dataclasses.replace(config3, fw_compiler=lambda gm, inputs: gm)
 
         c1 = self.gen_cache_key(fn, config)
         c2 = self.gen_cache_key(fn, config2)
@@ -3358,13 +3358,16 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
 
     def test_to_cacheable_strips_runtime_only_fields(self):
         config = self.default_config()
-        config.fw_compiler = lambda gm, inputs: gm
-        config.bw_compiler = lambda gm, inputs: gm
-        config.partition_fn = lambda *args: args
-        config.decompositions = None
-        config.inference_compiler = lambda gm, inputs: gm
-        config.static_input_indices = [0]
-        config.precompile_backend_id = "backend"
+        config = dataclasses.replace(
+            config,
+            fw_compiler=lambda gm, inputs: gm,
+            bw_compiler=lambda gm, inputs: gm,
+            partition_fn=lambda *args: args,
+            decompositions=None,
+            inference_compiler=lambda gm, inputs: gm,
+            static_input_indices=[0],
+            precompile_backend_id="backend",
+        )
 
         cacheable = config.to_cacheable()
 
@@ -3381,11 +3384,15 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         base = self.gen_cache_key(fn, base_config)
 
         config_with_static_inputs = self.default_config()
-        config_with_static_inputs.static_input_indices = [0]
+        config_with_static_inputs = dataclasses.replace(
+            config_with_static_inputs, static_input_indices=[0]
+        )
         self.assertNotEqual(base, self.gen_cache_key(fn, config_with_static_inputs))
 
         config_with_backend = self.default_config()
-        config_with_backend.precompile_backend_id = "backend"
+        config_with_backend = dataclasses.replace(
+            config_with_backend, precompile_backend_id="backend"
+        )
         self.assertNotEqual(base, self.gen_cache_key(fn, config_with_backend))
 
     def test_different_graphs(self):
@@ -3406,7 +3413,7 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
 
         config = self.default_config()
         config2 = self.default_config()
-        config2.dynamic_shapes = False
+        config2 = dataclasses.replace(config2, dynamic_shapes=False)
         c1 = self.gen_cache_key(fn, config)
         c2 = self.gen_cache_key(fn, config2)
         self.assertNotEqual(c1, c2)

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -9211,6 +9211,147 @@ def forward(self, primals_1, tangents_1):
         self.assertEqual(a, a_ref * 2)
         self.assertEqual(c, c_ref)
 
+    def _compile_with_aot_stage2(
+        self,
+        f: Callable[[torch.Tensor], torch.Tensor],
+        arg: torch.Tensor,
+        *,
+        fw_compiler: Callable[[torch.fx.GraphModule, list[Any]], Callable[..., Any]],
+        bw_compiler: Callable[[torch.fx.GraphModule, list[Any]], Callable[..., Any]]
+        | None = None,
+        inference_compiler: Callable[
+            [torch.fx.GraphModule, list[Any]], Callable[..., Any]
+        ]
+        | None = None,
+    ) -> tuple[Callable[..., Any], pytree.TreeSpec, Any]:
+        from torch._functorch._aot_autograd.descriptors import PlainAOTInput
+        from torch._functorch._aot_autograd.frontend_utils import (
+            construct_fake_mode,
+            process_inputs,
+        )
+        from torch._functorch._aot_autograd.graph_compile import (
+            aot_stage1_graph_capture,
+            aot_stage2_compile,
+        )
+        from torch._functorch._aot_autograd.utils import create_tree_flattened_fn
+        from torch._functorch.aot_autograd import AOTConfig, create_aot_state
+
+        flat_args = [arg]
+        flat_fn, out_spec = create_tree_flattened_fn(f, (arg,), {})
+        aot_config = AOTConfig(
+            fw_compiler=None,
+            bw_compiler=None,
+            inference_compiler=None,
+            partition_fn=None,
+            decompositions=None,
+            num_params_buffers=0,
+            aot_id=0,
+            keep_inference_input_mutations=True,
+            enable_log=False,
+        )
+        fake_mode, shape_env = construct_fake_mode(flat_args, aot_config)
+        fake_flat_args, act_input_indices = process_inputs(
+            flat_args, aot_config, fake_mode, shape_env
+        )
+        flat_args_descs = [PlainAOTInput(i) for i in range(len(fake_flat_args))]
+
+        with ExitStack() as stack:
+            aot_state = create_aot_state(
+                stack,
+                flat_fn,
+                fake_flat_args,
+                flat_args_descs,
+                aot_config,
+                fake_mode,
+                shape_env,
+            )
+            aot_state.fw_metadata.act_input_indices = act_input_indices
+            aot_config_before_stage2 = aot_state.aot_config
+            aot_graph_capture = aot_stage1_graph_capture(aot_state, flat_fn)
+            compiled_fn, _ = aot_stage2_compile(
+                aot_state,
+                aot_graph_capture,
+                default_partition,
+                fw_compiler,
+                bw_compiler,
+                inference_compiler,
+            )
+
+        return compiled_fn, out_spec, aot_config_before_stage2
+
+    def test_aot_stage2_keeps_aot_config_immutable_for_lazy_backward(self):
+        import dataclasses
+
+        bw_compile_calls = [0]
+
+        def f(x):
+            return (x.sin() * x).sum()
+
+        def fw_compiler(gm, example_inputs):
+            return make_boxed_func(gm)
+
+        def bw_compiler(gm, example_inputs):
+            bw_compile_calls[0] += 1
+            return make_boxed_func(gm)
+
+        compiled_x = torch.randn(4, requires_grad=True)
+        eager_x = compiled_x.detach().clone().requires_grad_()
+
+        compiled_fn, out_spec, aot_config = self._compile_with_aot_stage2(
+            f,
+            compiled_x,
+            fw_compiler=fw_compiler,
+            bw_compiler=bw_compiler,
+        )
+
+        self.assertIsNone(aot_config.partition_fn)
+        self.assertIsNone(aot_config.fw_compiler)
+        self.assertIsNone(aot_config.bw_compiler)
+        self.assertIsNone(aot_config.inference_compiler)
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            aot_config.partition_fn = default_partition
+
+        compiled_out = out_spec.unflatten(compiled_fn([compiled_x]))
+        eager_out = f(eager_x)
+        self.assertEqual(bw_compile_calls[0], 0)
+        compiled_out.backward()
+        eager_out.backward()
+
+        self.assertEqual(compiled_out, eager_out)
+        self.assertEqual(compiled_x.grad, eager_x.grad)
+        self.assertEqual(bw_compile_calls[0], 1)
+
+    def test_aot_stage2_uses_explicit_inference_compiler(self):
+        fw_compile_calls = [0]
+        inference_compile_calls = [0]
+
+        def f(x):
+            return x.cos()
+
+        def fw_compiler(gm, example_inputs):
+            fw_compile_calls[0] += 1
+            return make_boxed_func(gm)
+
+        def inference_compiler(gm, example_inputs):
+            inference_compile_calls[0] += 1
+            return make_boxed_func(gm)
+
+        x = torch.randn(4)
+
+        compiled_fn, out_spec, aot_config = self._compile_with_aot_stage2(
+            f,
+            x,
+            fw_compiler=fw_compiler,
+            inference_compiler=inference_compiler,
+        )
+
+        compiled_out = out_spec.unflatten(compiled_fn([x]))
+
+        self.assertEqual(compiled_out, f(x))
+        self.assertEqual(fw_compile_calls[0], 0)
+        self.assertEqual(inference_compile_calls[0], 1)
+        self.assertIsNone(aot_config.inference_compiler)
+
     def test_collect_metadata_subclass_fw_outs_follow_input_mutation_type(self):
         from torch._functorch._aot_autograd.collect_metadata_analysis import (
             run_functionalized_fw_and_collect_metadata,

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -564,6 +564,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
                 disable_amp=disable_amp,
                 indices_of_inps_to_detach=self.indices_of_inps_to_detach,
                 lazy_backward_info=cached_lazy_backward,
+                bw_compiler=None,
                 aot_config=aot_config,
                 fw_metadata=self.runtime_metadata,
                 try_save_cache_entry=None,

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import base64
 import contextlib
+import dataclasses
 import functools
 import hashlib
 import json
@@ -943,9 +944,11 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         local: bool,
         remote: bool,
         compile_region_name: str | None = None,
-    ) -> Callable[..., Any] | None:
+    ) -> tuple[Callable[..., Any] | None, AOTConfig]:
         """
-        Load a result from the cache, and reconstruct a runtime wrapper around the object
+        Load a result from the cache, and reconstruct a runtime wrapper around
+        the object. On a cache miss, return an updated config carrying the
+        cache metadata needed to save the eventual compile result.
         """
         compiled_fn = None
         cache_info: dict[str, Any] = {}
@@ -1040,10 +1043,13 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
             # Set the cache key so we can save a cache result later
             symints = AOTAutogradCache._filter_backed_symints(args)
             if cache_key is not None:
-                aot_config.cache_info = AOTAutogradCacheInfo(
-                    cache_key,
-                    time.time_ns(),
-                    forward_symints=symints,
+                aot_config = dataclasses.replace(
+                    aot_config,
+                    cache_info=AOTAutogradCacheInfo(
+                        cache_key,
+                        time.time_ns(),
+                        forward_symints=symints,
+                    ),
                 )
 
         cache_info.update(
@@ -1079,7 +1085,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
             payload_fn=lambda: json.dumps(cache_info),
         )
 
-        return compiled_fn
+        return compiled_fn, aot_config
 
     @classmethod
     def generate_guards_expression(

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -740,8 +740,7 @@ def _get_partition_fn(
     | None,
 ) -> tuple[bool, Callable[..., tuple[torch.fx.GraphModule, torch.fx.GraphModule]]]:
     """
-    Return either the default `partition_fn` in aot_config or a HOP specific partition
-    function.
+    Return either `default_partition_fn` or a HOP specific partition function.
 
     If a HOP specific partition function is returned, used_hop_custom_partition is True.
 

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -126,14 +126,11 @@ def _should_save_cache(*compiled_fns: Callable[..., Any]) -> bool:
 
 
 @contextmanager
-def maybe_skip_decompose(aot_config: AOTConfig) -> Generator[None, None, None]:
-    old_decomp = aot_config.decompositions
-    try:
-        if config.selective_decompose:
-            aot_config.decompositions = {}
-        yield
-    finally:
-        aot_config.decompositions = old_decomp
+def maybe_skip_decompose(aot_config: AOTConfig) -> Generator[AOTConfig, None, None]:
+    if config.selective_decompose:
+        yield dataclasses.replace(aot_config, decompositions={})
+    else:
+        yield aot_config
 
 
 # Saved tensor hooks context
@@ -230,7 +227,7 @@ def aot_stage1_graph_capture(
     aot_state.fw_metadata.deterministic = torch.are_deterministic_algorithms_enabled()
     updated_flat_args: list[Any] | tuple[list[Any], list[Any]]
 
-    with maybe_skip_decompose(aot_config):
+    with maybe_skip_decompose(aot_config) as graph_capture_aot_config:
         # if config.selective_decompose, skip decomposition and apply selective_decompose
         # after we get the joint graph. See [Note: Selective Decomposition] for details.
         if aot_state.needs_autograd and not aot_config.pre_dispatch:
@@ -245,7 +242,7 @@ def aot_stage1_graph_capture(
                     flat_fn,
                     aot_state.flat_args,
                     aot_state.flat_args_descs,
-                    aot_config,
+                    graph_capture_aot_config,
                     fw_metadata=aot_state.fw_metadata,
                 )
         else:
@@ -254,7 +251,7 @@ def aot_stage1_graph_capture(
                     flat_fn,
                     aot_state.flat_args,
                     aot_state.flat_args_descs,
-                    aot_config,
+                    graph_capture_aot_config,
                     fw_metadata=aot_state.fw_metadata,
                 )
             )
@@ -347,16 +344,22 @@ def aot_stage2_compile(
         bw_compiler = fw_compiler
     if inference_compiler is None:
         inference_compiler = fw_compiler
-    # Update the AOTState with the provided compilers
-    aot_state.aot_config.partition_fn = partition_fn
-    aot_state.aot_config.fw_compiler = fw_compiler
-    aot_state.aot_config.bw_compiler = bw_compiler
-    aot_state.aot_config.inference_compiler = inference_compiler
 
     if aot_state.needs_autograd and not aot_state.aot_config.pre_dispatch:
-        return aot_stage2_autograd(aot_state, aot_graph_capture)
+        return aot_stage2_autograd(
+            aot_state,
+            aot_graph_capture,
+            partition_fn,
+            fw_compiler,
+            bw_compiler,
+        )
     else:
-        return aot_stage2_inference(aot_state, aot_graph_capture)
+        return aot_stage2_inference(
+            aot_state,
+            aot_graph_capture,
+            partition_fn,
+            inference_compiler,
+        )
 
 
 def _log_inference_graph(
@@ -399,6 +402,8 @@ def _aot_stage2b_inference_compile(
     fw_metadata: ViewAndMutationMeta,
     aot_config: AOTConfig,
     # pyrefly: ignore [implicit-any]
+    inference_compiler: Callable,
+    # pyrefly: ignore [implicit-any]
 ) -> Callable:
     return _aot_stage2b_compile_forward_or_inference(
         fw_module,
@@ -406,6 +411,7 @@ def _aot_stage2b_inference_compile(
         maybe_subclass_meta,
         fw_metadata,
         aot_config,
+        inference_compiler,
         is_inference=True,
     )[1]
 
@@ -413,9 +419,14 @@ def _aot_stage2b_inference_compile(
 def aot_stage2_inference(
     aot_state: AOTState,
     aot_graph_capture: AOTGraphCapture,
+    # pyrefly: ignore [implicit-any]
+    partition_fn: Callable,
+    # pyrefly: ignore [implicit-any]
+    inference_compiler: Callable,
 ) -> DispatchReturn:
     """
-    Handles functions that don't need autograd. Runs wrappers and compiles with fw_compiler.
+    Handles functions that don't need autograd. Runs wrappers and compiles with
+    the stage-2 inference compiler.
     """
 
     aot_config = aot_state.aot_config
@@ -438,7 +449,9 @@ def aot_stage2_inference(
     # invoke_subgraph pairs from traced torch.autograd.grad/backward calls.
     # Partition them before the remat pass so that remat duplicates the
     # already-partitioned fw subgraphs (which produce saved tensors for bw).
-    fw_module = run_joint_graph_passes_on_hops(fw_module, None, aot_config)
+    fw_module = run_joint_graph_passes_on_hops(
+        fw_module, None, aot_config, default_partition_fn=partition_fn
+    )
 
     # Apply AC rematerialization after HOP partitioning. This must happen
     # after partitioning so remat duplicates the partitioned fw subgraphs
@@ -471,6 +484,7 @@ def aot_stage2_inference(
         maybe_subclass_meta,
         fw_metadata,
         aot_config,
+        inference_compiler,
     )
 
     entry = _cache_inference_info(
@@ -718,7 +732,12 @@ def prepare_for_partitioner(
 
 
 def _get_partition_fn(
-    fw_hop_node: torch.fx.Node, aot_config: AOTConfig
+    fw_hop_node: torch.fx.Node,
+    aot_config: AOTConfig,
+    default_partition_fn: Callable[
+        ..., tuple[torch.fx.GraphModule, torch.fx.GraphModule]
+    ]
+    | None,
 ) -> tuple[bool, Callable[..., tuple[torch.fx.GraphModule, torch.fx.GraphModule]]]:
     """
     Return either the default `partition_fn` in aot_config or a HOP specific partition
@@ -731,8 +750,9 @@ def _get_partition_fn(
     used_hop_custom_partition = False
 
     # Check for HOP-specific partition function first. This is needed because
-    # run_joint_graph_passes_on_hops can be called before aot_config.partition_fn
-    # is set (e.g., in aot_stage1_graph_capture before the remat pass).
+    # run_joint_graph_passes_on_hops can be called without an outer stage-2
+    # partition function (e.g., in aot_stage1_graph_capture before the remat
+    # pass).
     if (
         fw_hop_node.target == torch._higher_order_ops.invoke_subgraph
         and "custom" in fw_hop_node.meta
@@ -775,9 +795,9 @@ def _get_partition_fn(
     # Fall back to the parent partitioner from aot_config. When the outer
     # compile is Inductor this is already `compile_fx.partition_fn` so
     # joint-graph passes run there too.
-    if aot_config.partition_fn is None:
-        raise AssertionError("aot_config.partition_fn must not be None")
-    return used_hop_custom_partition, aot_config.partition_fn
+    if default_partition_fn is None:
+        raise AssertionError("default_partition_fn must not be None")
+    return used_hop_custom_partition, default_partition_fn
 
 
 def _has_invoke_subgraph_node(gm: torch.fx.GraphModule):
@@ -793,6 +813,11 @@ def run_joint_graph_passes_on_hops(
     joint_gm: torch.fx.GraphModule,
     joint_inputs: Any,
     aot_config: AOTConfig,
+    *,
+    default_partition_fn: Callable[
+        ..., tuple[torch.fx.GraphModule, torch.fx.GraphModule]
+    ]
+    | None = None,
 ) -> torch.fx.GraphModule:
     """
     This pass runs the joint graph passes on the HOP graph. In torch.compile, we
@@ -978,7 +1003,7 @@ def run_joint_graph_passes_on_hops(
         static_lifetime_input_indices: list[int] = []
 
         used_hop_custom_partition, partition_fn = _get_partition_fn(
-            fw_hop_node, aot_config
+            fw_hop_node, aot_config, default_partition_fn
         )
 
         # Step 2) and 3) - Run joint graph passes and partitioner
@@ -1869,6 +1894,8 @@ def _partition_joint_graph_into_fw_bw(
     inner_meta: ViewAndMutationMeta,
     fw_metadata: ViewAndMutationMeta,
     aot_config: AOTConfig,
+    # pyrefly: ignore [implicit-any]
+    partition_fn: Callable,
 ) -> tuple[torch.fx.GraphModule, torch.fx.GraphModule, int]:
     # See Note: [Partitioner handling for Subclasses, Part 1]
     # See Note: [Recomputing subclass mutation handling]
@@ -1884,16 +1911,16 @@ def _partition_joint_graph_into_fw_bw(
         + num_tokens  # See Note [Side-Effectful Tokens in AOTAutograd]
     )
 
-    fx_g = run_joint_graph_passes_on_hops(fx_g, joint_inputs, aot_config)
+    fx_g = run_joint_graph_passes_on_hops(
+        fx_g, joint_inputs, aot_config, default_partition_fn=partition_fn
+    )
 
     # apply joint_gm callback here
     if callable(torch._functorch.config.joint_custom_pass):
         # pyrefly: ignore [bad-assignment]
         fx_g = torch._functorch.config.joint_custom_pass(fx_g, joint_inputs)
 
-    if aot_config.partition_fn is None:
-        raise AssertionError("aot_config.partition_fn must not be None")
-    fw_module, bw_module = aot_config.partition_fn(
+    fw_module, bw_module = partition_fn(
         fx_g,
         joint_inputs,
         num_fwd_outputs=num_inner_fwd_outputs,
@@ -2128,6 +2155,8 @@ def _aot_stage2a_partition(
     maybe_subclass_meta: SubclassMeta | None,
     fw_metadata: ViewAndMutationMeta,
     aot_config: AOTConfig,
+    # pyrefly: ignore [implicit-any]
+    partition_fn: Callable,
 ) -> tuple[torch.fx.GraphModule, torch.fx.GraphModule, int, int, list[int], list[Any]]:
     """
     Partition the joint graph into a forward graph and a backward graph. Returns:
@@ -2149,6 +2178,7 @@ def _aot_stage2a_partition(
                     inner_meta,
                     fw_metadata,
                     aot_config,
+                    partition_fn,
                 )
             )
             num_inner_fwd_outputs, joint_inputs = (
@@ -2205,6 +2235,8 @@ def _aot_stage2b_fw_compile(
     num_fw_outs_saved_for_bw: int,
     aot_config: AOTConfig,
     # pyrefly: ignore [implicit-any]
+    fw_compiler: Callable,
+    # pyrefly: ignore [implicit-any]
 ) -> tuple[list[tuple[int, ...] | None] | None, Callable]:
     return _aot_stage2b_compile_forward_or_inference(
         fw_module,
@@ -2212,6 +2244,7 @@ def _aot_stage2b_fw_compile(
         maybe_subclass_meta,
         fw_metadata,
         aot_config,
+        fw_compiler,
         is_inference=False,
         num_fw_outs_saved_for_bw=num_fw_outs_saved_for_bw,
     )
@@ -2224,6 +2257,8 @@ def _aot_stage2b_bw_compile(
     fwd_output_strides: list[tuple[int, ...] | None] | None,
     num_symints_saved_for_bw: int,
     aot_config: AOTConfig,
+    # pyrefly: ignore [implicit-any]
+    bw_compiler: Callable,
     # pyrefly: ignore [implicit-any]
 ) -> tuple[AutogradLazyBackwardCompileInfo, Callable | None]:
     """
@@ -2320,11 +2355,7 @@ def _aot_stage2b_bw_compile(
                         # GraphModule. Deepcopying tensors under fake mode is not supported and will
                         # raise when attempting to set storage.
                         bw_module_copy = copy.deepcopy(bw_module)
-                    if aot_config.bw_compiler is None:
-                        raise AssertionError("aot_config.bw_compiler must not be None")
-                    compiled_bw_func = aot_config.bw_compiler(
-                        bw_module_copy, placeholder_list
-                    )
+                    compiled_bw_func = bw_compiler(bw_module_copy, placeholder_list)
                     del bw_module_copy
                 except Exception as e:
                     if aot_config.force_non_lazy_backward_lowering:
@@ -2382,6 +2413,12 @@ def _aot_stage2b_bw_compile(
 def aot_stage2_autograd(
     aot_state: AOTState,
     aot_graph_capture: AOTGraphCapture,
+    # pyrefly: ignore [implicit-any]
+    partition_fn: Callable,
+    # pyrefly: ignore [implicit-any]
+    fw_compiler: Callable,
+    # pyrefly: ignore [implicit-any]
+    bw_compiler: Callable,
 ) -> DispatchReturn:
     """
     Autograd logic. Generates a joint graph, partitions it, manipulates the input with various wrappers,
@@ -2411,6 +2448,7 @@ def aot_stage2_autograd(
         maybe_subclass_meta,
         fw_metadata,
         aot_config,
+        partition_fn,
     )
 
     min_cut_info_str = getattr(fx_g.graph, "_min_cut_info_str", None)
@@ -2426,6 +2464,7 @@ def aot_stage2_autograd(
         fw_metadata,
         num_fw_outs_saved_for_bw,
         aot_config,
+        fw_compiler,
     )
 
     lazy_backward_info, compiled_bw_func = _aot_stage2b_bw_compile(
@@ -2435,6 +2474,7 @@ def aot_stage2_autograd(
         fwd_output_strides,
         num_symints_saved_for_bw,
         aot_config,
+        bw_compiler,
     )
 
     try_save_cache_entry, entry = _cache_autograd_info(
@@ -2463,6 +2503,7 @@ def aot_stage2_autograd(
         aot_graph_capture.wrappers,
         compiled_fw_func,
         compiled_bw_func,
+        bw_compiler,
         lazy_backward_info,
         try_save_cache_entry,  # type: ignore[arg-type]
         entry,  # type: ignore[arg-type]
@@ -2479,6 +2520,8 @@ def _aot_stage2c_make_autograd_function(
     wrappers: list[CompilerWrapper],
     compiled_fw_func: Callable[..., Any],
     compiled_bw_func: Callable[..., Any] | None,
+    # pyrefly: ignore [implicit-any]
+    bw_compiler: Callable,
     lazy_backward_info: AutogradLazyBackwardCompileInfo | None,
     try_save_cache_entry: Callable[..., Any],
     entry: GenericAOTAutogradResult[Any, Any] | None,
@@ -2503,6 +2546,7 @@ def _aot_stage2c_make_autograd_function(
         disable_amp=disable_amp,
         indices_of_inps_to_detach=_indices_of_inps_to_detach,
         lazy_backward_info=lazy_backward_info,
+        bw_compiler=bw_compiler,
         aot_config=aot_config,
         fw_metadata=fw_metadata,
         try_save_cache_entry=try_save_cache_entry,
@@ -2645,6 +2689,8 @@ def _aot_stage2b_compile_forward_or_inference(
     maybe_subclass_meta: SubclassMeta | None,
     fw_metadata: ViewAndMutationMeta,
     aot_config: AOTConfig,
+    # pyrefly: ignore [implicit-any]
+    compiler: Callable,
     *,
     is_inference: bool,
     num_fw_outs_saved_for_bw: int | None = None,
@@ -2680,7 +2726,7 @@ def _aot_stage2b_compile_forward_or_inference(
             "num_fw_outs_saved_for_bw must be provided when is_inference=False"
         )
 
-    # Determine grad context, autocast context, tracking mode, compiler
+    # Determine grad context, autocast context, and tracking mode.
     if is_inference:
         grad_ctx: Any = nullcontext
         autocast_ctx: Any = (
@@ -2689,12 +2735,10 @@ def _aot_stage2b_compile_forward_or_inference(
             else nullcontext
         )
         tracking_mode: str = "inference"
-        compiler: Any = aot_config.inference_compiler
     else:
         grad_ctx = torch.no_grad
         autocast_ctx = torch._C._DisableAutocast
         tracking_mode = "forward"
-        compiler = aot_config.fw_compiler
 
     with grad_ctx(), autocast_ctx(), track_graph_compiling(aot_config, tracking_mode):
         # Setup wrappers

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2563,6 +2563,7 @@ class AOTDispatchAutogradCompileSpec:
     lazy_backward_info: (
         AutogradLazyBackwardCompileInfo | CachedAutogradLazyBackwardCompileInfo | None
     )
+    bw_compiler: Callable[..., Any] | None
     aot_config: AOTConfig
     fw_metadata: ViewAndMutationMeta
     try_save_cache_entry: Callable[..., Any] | None
@@ -2799,6 +2800,7 @@ class _AutogradBackwardCompiler:
         AutogradLazyBackwardCompileInfo | CachedAutogradLazyBackwardCompileInfo | None
     )
     disable_amp: bool
+    bw_compiler: Callable[..., Any] | None
     aot_config: AOTConfig
     fw_metadata: ViewAndMutationMeta
     try_save_cache_entry: Callable[..., Any] | None
@@ -2845,9 +2847,9 @@ class _AutogradBackwardCompiler:
         ):
             CompileEventLogger.compilation_metric(is_forward=False)
             # See Note: [Backward graph lazy lowering]
-            if self.aot_config.bw_compiler is None:
-                raise AssertionError("aot_config.bw_compiler must not be None")
-            self.compiled_bw = self.aot_config.bw_compiler(
+            if self.bw_compiler is None:
+                raise AssertionError("bw_compiler must not be None")
+            self.compiled_bw = self.bw_compiler(
                 copy.deepcopy(bw_module), placeholder_list
             )
             # Maybe save cache entry
@@ -3266,6 +3268,7 @@ class _AOTDispatchAutogradFunctionFactory:
             compiled_bw=self.spec.compiled_bw_func,
             lazy_backward_info=self.spec.lazy_backward_info,
             disable_amp=self.spec.disable_amp,
+            bw_compiler=self.spec.bw_compiler,
             aot_config=self.spec.aot_config,
             fw_metadata=self.spec.fw_metadata,
             try_save_cache_entry=self.spec.try_save_cache_entry,

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -1115,7 +1115,7 @@ class CacheableAOTConfig:
             raise AssertionError("Can only have pre_dispatch IR for export.")
 
 
-@dataclass
+@dataclass(frozen=True)
 class AOTConfig:
     """
     Configuration for AOTDispatcher
@@ -1228,8 +1228,8 @@ class AOTState:
     # detected by doing an initial trace when we created this state.
     fw_metadata: ViewAndMutationMeta
 
-    # Top-level configuration
-    # This is morally immutable but sometimes we are naughty and mutate it.
+    # Top-level configuration. Stage-local compiler choices are threaded
+    # explicitly rather than mutating this object in place.
     aot_config: AOTConfig
 
     # When performing AOTAutograd traces and other passes, we typically

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import itertools
 import time
 from contextlib import nullcontext
 from functools import wraps
-from typing import Any, Literal, TYPE_CHECKING
+from typing import Any, cast, Literal, TYPE_CHECKING
 from typing_extensions import ParamSpec, TypeVar
 from unittest.mock import patch
 
@@ -506,20 +507,23 @@ def create_aot_state(
     # TODO: Chillee argues that dynamo itself should pass in fake tensors to
     # the list of arguments when compiling; at the moment we do not do this
 
-    if aot_config.decompositions is None:
-        aot_config.decompositions = {}
-
-    aot_config.decompositions = {
+    decompositions = aot_config.decompositions or {}
+    decompositions = {
         **aot_autograd_decompositions,
-        **aot_config.decompositions,
+        **decompositions,
     }
 
     if config.functionalize_rng_ops:
         # Update the decompositions with functionalized random decompositions
-        aot_config.decompositions = {  # type: ignore[assignment]
+        decompositions = {
             **rng_decompositions,
-            **aot_config.decompositions,
+            **decompositions,
         }
+
+    aot_config = dataclasses.replace(
+        aot_config,
+        decompositions=cast("dict[OpOverload, Callable[..., Any]]", decompositions),
+    )
 
     # Check flat_args to see if they're already fake.  If so, use that fake
     # mode instead.
@@ -1201,7 +1205,7 @@ def aot_module_simplified(
             remote = should_use_remote_autograd_cache()
             if local or remote:
                 set_feature_use("aot_autograd_remote_cache", remote)
-                compiled_fn = AOTAutogradCache.try_load(
+                compiled_fn, aot_config = AOTAutogradCache.try_load(
                     mod,
                     fake_flat_args,
                     aot_config,
@@ -1474,10 +1478,13 @@ def aot_compile_joint_with_descriptors(
 
     cache_ctx = nullcontext()
     if serializable:
-        jd._aot_state.aot_config.cache_info = AOTAutogradCacheInfo(
-            jd.cache_hash(),
-            time.time_ns(),
-            forward_symints=[],
+        jd._aot_state.aot_config = dataclasses.replace(
+            jd._aot_state.aot_config,
+            cache_info=AOTAutogradCacheInfo(
+                jd.cache_hash(),
+                time.time_ns(),
+                forward_symints=[],
+            ),
         )
         cache_ctx = torch._functorch.config.patch(
             {


### PR DESCRIPTION
## Summary
Root cause:
- `aot_stage2_compile()` mutated `AOTState.aot_config` in place to inject stage-2 compilers and partitioners, and that made it hard to reason about whether `aot_config` represented the original compile request or a later stage-local override.
- Freezing `AOTConfig` also exposed a few other in-place updates (`decompositions`, `cache_info`) that needed to become whole-object replacements or local copies.

Proposed fix:
- Mark `AOTConfig` as frozen.
- Replace the remaining setup/cache-time config writes with whole-object replacement or stage-local copies.
- Thread the stage-2 `partition_fn`, `fw_compiler`, `inference_compiler`, and lazy-backward `bw_compiler` explicitly through the stage-2 helpers and runtime wrappers instead of stashing them on `aot_config`.
- Add regression coverage for both lazy backward and inference so stage 2 leaves the config untouched.

Why this is the right long term fix:
- It gives `AOTConfig` a single stable meaning again, keeps stage-specific compiler choices local to the code that consumes them, and preserves existing lazy-backward/inference behavior without hidden mutable state.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98