### PR TITLE
Fix CPU flex attention aliased input lowering

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -5386,6 +5386,44 @@ class GraphModule(torch.nn.Module):
 
     @supported_platform
     @skip_on_cuda
+    @skip_on_xpu
+    def test_cpu_qk_chunk_same_addmm_buffer(self, device):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.H = 2
+                self.D = 16
+                self.S = 128
+                self.project_qk = nn.Linear(self.H * self.D, self.H * self.D * 2)
+                self.project_v = nn.Linear(self.H * self.D, self.H * self.D)
+
+            def forward(self, hidden_states):
+                B = hidden_states.size(0)
+                qk = self.project_qk(hidden_states)
+                query, key = qk.chunk(2, dim=-1)
+
+                query = query.view(B, self.S, self.H, self.D).permute(0, 2, 1, 3)
+                key = key.view(B, self.S, self.H, self.D).permute(0, 2, 1, 3)
+                value = (
+                    self.project_v(hidden_states)
+                    .view(B, self.S, self.H, self.D)
+                    .permute(0, 2, 1, 3)
+                )
+
+                return flex_attention(query, key, value, score_mod=_identity)
+
+        torch.manual_seed(0)
+        x = torch.randn(1, 128, 32, device=device)
+        model = Model().to(device).eval()
+
+        with torch.no_grad():
+            eager_out = model(x)
+            compiled_out = torch.compile(model)(x)
+
+        torch.testing.assert_close(compiled_out, eager_out, rtol=1e-4, atol=1e-4)
+
+    @supported_platform
+    @skip_on_cuda
     def test_cpu_error_message_return_lse(self, device):
         make_tensor = functools.partial(
             torch.randn,

--- a/torch/_inductor/kernel/flex/flex_cpu.py
+++ b/torch/_inductor/kernel/flex/flex_cpu.py
@@ -15,7 +15,7 @@ from torch.utils._sympy.numbers import int_oo
 from torch.utils._sympy.value_ranges import ValueRanges
 
 from ...codegen.cpp_flex_attention_template import CppFlexAttentionTemplate
-from ...ir import Buffer, FixedLayout, TensorBox
+from ...ir import Buffer, ExternKernel, FixedLayout, TensorBox
 from ...select_algorithm import autotune_select_algorithm
 from .common import (
     build_subgraph_buffer,
@@ -38,6 +38,22 @@ def check_cpu_supported():
         and sys.platform != "darwin"
     )
     return supported
+
+
+def _realize_duplicate_buffer_inputs(inputs):
+    names = [inp.get_name() for inp in inputs]
+    duplicate_names = OrderedSet(name for name in names if names.count(name) > 1)
+    if not duplicate_names:
+        return inputs
+
+    # The C++ template names pointer arguments by storage buffer name.
+    # ReinterpretView inputs that share storage (for example, q/k from
+    # qk.chunk()) need distinct realized buffers so their view offsets are
+    # represented correctly at the template boundary.
+    return [
+        ExternKernel.copy_input(inp) if inp.get_name() in duplicate_names else inp
+        for inp in inputs
+    ]
 
 
 def lower_cpu(
@@ -241,10 +257,7 @@ def lower_cpu(
         ]
     )
 
-    if len(OrderedSet([query.get_name(), key.get_name(), value.get_name()])) != 3:
-        raise NotImplementedError(
-            "Unsupported for now if query, key, value are the same buffer."
-        )
+    query, key, value = _realize_duplicate_buffer_inputs([query, key, value])
     if query.get_dtype() not in [torch.float, torch.bfloat16, torch.float16]:
         raise NotImplementedError(
             "`torch.float` , `torch.float16` and `torch.bfloat16` are supported in FlexAttention for CPU device. "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184071

Materialize CPU flex attention query/key/value inputs when multiple logical views share the same underlying buffer so the C++ template receives distinct pointer arguments with the right offsets. Add a regression test for the q/k chunked addmm case.\n\nFixes #157612\nGenerated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos