### PR TITLE
Clone aliased mm/addmm inputs on CPU to avoid in-place gemm

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1397,6 +1397,15 @@ static void addmm_impl_cpu_(
     m1.dtype() == m2.dtype(),
     "expected m1 and m2 to have the same dtype, but got: ", m1.dtype(), " != ", m2.dtype()
   )
+
+  // Clone inputs that alias the output; gemm cannot operate in-place. See #85852.
+  if (m1.is_same(result)) {
+    m1 = m1.clone();
+  }
+  if (m2.is_same(result)) {
+    m2 = m2.clone();
+  }
+
   // Array access is faster than .size(n) and .stride(n)
   const auto self_sizes = self.sizes();
   auto m1_strides = m1.strides();

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6412,6 +6412,43 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     def test_addmm_relu(self, device, dtype):
         self._test_addmm_impl(torch._addmm_activation, "relu", device, dtype)
 
+    @dtypes(torch.float32, torch.float64)
+    def test_mm_addmm_alias_out(self, device, dtype):
+        # Regression for https://github.com/pytorch/pytorch/issues/85852: when
+        # the out tensor aliases an input, mm/addmm on CPU silently produced
+        # wrong results because gemm cannot operate in-place.
+        for n in (4, 50):
+            A = torch.randn(n, n, device=device, dtype=dtype)
+            B = torch.randn(n, n, device=device, dtype=dtype)
+            bias = torch.randn(n, n, device=device, dtype=dtype)
+            ref_AA = torch.mm(A, A)
+            ref_AB = torch.mm(A, B)
+            ref_addmm = torch.addmm(bias, A, B)
+
+            # mm(C, C, out=C): both inputs alias out
+            C = A.clone()
+            torch.mm(C, C, out=C)
+            self.assertEqual(C, ref_AA)
+
+            # mm(C, B, out=C): mat1 aliases out
+            C = A.clone()
+            torch.mm(C, B, out=C)
+            self.assertEqual(C, ref_AB)
+
+            # mm(A, C, out=C): mat2 aliases out
+            C = B.clone()
+            torch.mm(A, C, out=C)
+            self.assertEqual(C, ref_AB)
+
+            # addmm(bias, C, B, out=C): mat1 aliases out
+            C = A.clone()
+            torch.addmm(bias, C, B, out=C)
+            self.assertEqual(C, ref_addmm)
+
+            # addmm(bias, A, C, out=C): mat2 aliases out
+            C = B.clone()
+            torch.addmm(bias, A, C, out=C)
+            self.assertEqual(C, ref_addmm)
 
     @precisionOverride({torch.double: 1e-8, torch.float: 1e-4, torch.bfloat16: 5e-2,
                         torch.half: 5e-2, torch.cfloat: 1e-4, torch.cdouble: 1e-8})


### PR DESCRIPTION
## Issue

Fixes #85852

## Summary

`addmm_impl_cpu_` delegates to BLAS `gemm`, which cannot operate in-place on its input matrices. When a caller passes the same tensor for both an input and the output (e.g. `torch.mm(C, C, out=C)`), `gemm` reads from and writes to the same buffer, silently producing corrupt results. The existing aliasing check immediately below already handles the `addmm` `self` argument (the beta accumulator); this adds the symmetric `m1`/`m2` case so that all three CPU callers of the shared impl — `mm`, `addmm`, and `_addmm_activation` — are covered with one change.

The added regression test verifies the five aliasing patterns: `mm(C,C,out=C)`, `mm(C,B,out=C)`, `mm(A,C,out=C)`, `addmm(bias,C,B,out=C)`, and `addmm(bias,A,C,out=C)`.

Verified locally against the OP's 50x50 reproducer: max abs diff drops from 260.8 (~36% of elements corrupted) to 0; the 4x4 case that previously returned all zeros now returns the correct product. The 20 related `test_addmm*` / `test_mm*` / `test_bmm*` tests all still pass.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable) — N/A
- [ ] Included benchmark results (for PRs impacting perf) — N/A; the new aliasing checks are O(1) pointer comparisons, the clone only fires in the aliased case (which previously produced wrong results, so there's no correct prior to compare against).

## BC-breaking?

No. Previously the aliased case silently returned wrong results; it now returns correct results at the cost of one tensor clone when aliasing is detected. Non-aliased callers are unaffected.

---

Disclosure: this PR was prepared with assistance from Claude Code. I'm a first-time PyTorch contributor; I noticed #85852 is not labeled "actionable" per the contributor policy, but the issue has been open and confirmed for 3+ years and I posted a recent reproduction. Happy to defer or close if maintainers would rather have the issue triaged first.