### PR TITLE
Support lists of Inductor custom graph passes

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -2749,6 +2749,32 @@ if not torch.allclose(eager_result, compiled_result, atol=0.1, rtol=0.01):
             self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
             self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
 
+        # Lists of properly-registered custom hooks should also allow caching.
+        custom_passes = [TestCustomGraphPass(), TestCustomGraphPass()]
+        with config.patch(
+            {
+                "post_grad_custom_pre_pass": custom_passes,
+                "post_grad_custom_post_pass": custom_passes,
+                "joint_custom_pre_pass": custom_passes,
+                "joint_custom_post_pass": custom_passes,
+            }
+        ):
+            self.reset()
+            counters.clear()
+
+            # Cache miss
+            self.assertEqual(fn(a, b), compiled_fn(a, b))
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+            self.reset()
+            counters.clear()
+
+            # Cache hit
+            self.assertEqual(fn(a, b), compiled_fn(a, b))
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
 
 class TestCustomPartitionerFn(CustomPartitionerFn):
     def __init__(self):
@@ -3212,6 +3238,39 @@ class TestFxGraphCacheHashing(TestCase):
                 pickler.dumps(details1),
                 pickler.dumps(details3),
             )
+
+        custom_pass_1 = TestCustomGraphPass()
+        custom_pass_2 = TestCustomGraphPass()
+        with config.patch(
+            {"post_grad_custom_pre_pass": [custom_pass_1, custom_pass_2]}
+        ):
+            custom_pass_1._uuid = "1"
+            custom_pass_2._uuid = "2"
+            details1 = FxGraphHashDetails(None, [], {}, [])
+            details2 = FxGraphHashDetails(None, [], {}, [])
+
+            custom_pass_2._uuid = "3"
+            details3 = FxGraphHashDetails(None, [], {}, [])
+
+        with config.patch(
+            {"post_grad_custom_pre_pass": [custom_pass_2, custom_pass_1]}
+        ):
+            details4 = FxGraphHashDetails(None, [], {}, [])
+
+        gm = torch.fx.GraphModule({}, torch.fx.Graph())
+        pickler = FxGraphCachePickler(gm)
+        self.assertEqual(
+            pickler.dumps(details1),
+            pickler.dumps(details2),
+        )
+        self.assertNotEqual(
+            pickler.dumps(details1),
+            pickler.dumps(details3),
+        )
+        self.assertNotEqual(
+            pickler.dumps(details3),
+            pickler.dumps(details4),
+        )
 
     def test_hash_custom_backend_pass(self):
         """

--- a/test/inductor/test_custom_post_grad_passes.py
+++ b/test/inductor/test_custom_post_grad_passes.py
@@ -78,6 +78,19 @@ class ChangeCosCustomPass(CustomGraphPass):
         return get_hash_for_files((__file__,))
 
 
+class RecordCustomPass(CustomGraphPass):
+    def __init__(self, name, calls) -> None:
+        super().__init__()
+        self.name = name
+        self.calls = calls
+
+    def __call__(self, g: torch.fx.graph.Graph):
+        self.calls.append(self.name)
+
+    def uuid(self) -> str:
+        return self.name
+
+
 class TestPostGradCustomPrePostPass(TestCustomPassBase):
     #  mkldnn fusion's pattern_matcher
     # (torch/_inductor/fx_passes/mkldnn_fusion.py),
@@ -168,6 +181,45 @@ class TestPostGradCustomPrePostPass(TestCustomPassBase):
 
             x = torch.randn(8, dtype=torch.float32)
             torch.testing.assert_close(torch.compile(f)(x), g(x))
+
+    def test_custom_pass_list_runs_in_order(self):
+        def f(x):
+            return (x.sin() + 1).relu()
+
+        x = torch.randn(8, dtype=torch.float32)
+        for field in (
+            "post_grad_custom_pre_pass",
+            "post_grad_custom_post_pass",
+            "joint_custom_pre_pass",
+            "joint_custom_post_pass",
+            "pre_grad_custom_pass",
+        ):
+            with self.subTest(field=field):
+                calls = []
+                torch._dynamo.reset()
+                with config.patch(
+                    {
+                        field: [
+                            RecordCustomPass(f"{field}_first", calls),
+                            RecordCustomPass(f"{field}_second", calls),
+                        ]
+                    }
+                ):
+                    torch.compile(f)(x)
+                self.assertEqual(calls, [f"{field}_first", f"{field}_second"])
+
+        calls = []
+        torch._dynamo.reset()
+        with config.patch(
+            {
+                "post_grad_custom_post_pass": (
+                    RecordCustomPass("tuple_first", calls),
+                    RecordCustomPass("tuple_second", calls),
+                )
+            }
+        ):
+            torch.compile(f)(x)
+        self.assertEqual(calls, ["tuple_first", "tuple_second"])
 
     def test_custom_pre_pass(self):
         with config.patch(

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -88,7 +88,7 @@ from torch._inductor.cpu_vec_isa import pick_vec_isa
 from torch._inductor.custom_graph_pass import (
     CustomGraphModulePass,
     CustomGraphPass,
-    CustomGraphPassType,
+    CustomGraphPassCallable,
     CustomPartitionerFn,
     CustomPartitionerFnType,
     get_custom_graph_passes,
@@ -1006,14 +1006,14 @@ class CacheabilityValidator:
             get_custom_graph_passes(config.post_grad_custom_pre_pass),
             get_custom_graph_passes(config.post_grad_custom_post_pass),
         ):
-            if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
+            if not isinstance(p, CustomGraphPass) or not p.uuid():
                 self.bypass("Unsupported post grad custom pass")
         # Same with the joint custom passes
         for p in itertools.chain(
             get_custom_graph_passes(config.joint_custom_pre_pass),
             get_custom_graph_passes(config.joint_custom_post_pass),
         ):
-            if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
+            if not isinstance(p, CustomGraphPass) or not p.uuid():
                 self.bypass("Unsupported joint custom pass")
         # We should find any users of _pre_fusion_custom_pass and _fuse_ddp_communication_passes
         # and ensure they are not passing us raw callables
@@ -1107,7 +1107,7 @@ def resolve_pre_grad_pass_timing() -> Literal["early", "late"]:
         for custom_pass in custom_passes
         if not _custom_pass_has_uuid(custom_pass)
     ]
-    pass_name = (
+    missing_uuid_pass_names = (
         ", ".join(_custom_pass_name(custom_pass) for custom_pass in passes_missing_uuid)
         if passes_missing_uuid
         else "<none>"
@@ -1117,23 +1117,23 @@ def resolve_pre_grad_pass_timing() -> Literal["early", "late"]:
         supports_late = not passes_missing_uuid
         timing = "late" if supports_late else "early"
         if timing == "early" and custom_passes:
-            if pass_name not in _warned_pre_grad_pass_missing_uuid:
-                _warned_pre_grad_pass_missing_uuid.add(pass_name)
+            if missing_uuid_pass_names not in _warned_pre_grad_pass_missing_uuid:
+                _warned_pre_grad_pass_missing_uuid.add(missing_uuid_pass_names)
                 log.warning(
                     "pre_grad_custom_pass %s does not implement uuid(); "
                     "falling back to early timing (pre-grad pass cache will be bypassed). "
                     "Implement uuid() on your CustomGraphPass to enable caching.",
-                    pass_name,
+                    missing_uuid_pass_names,
                 )
                 CompileEventLogger.try_add_pt2_compile(
                     "backend_compile",
                     pre_grad_pass_missing_uuid=True,
-                    pre_grad_pass_name=pass_name,
+                    pre_grad_pass_name=missing_uuid_pass_names,
                 )
 
     if timing == "late" and passes_missing_uuid:
         raise RuntimeError(
-            f"pre_grad_custom_pass {pass_name} must implement uuid() to run late "
+            f"pre_grad_custom_pass {missing_uuid_pass_names} must implement uuid() to run late "
             "(after cache lookup). Either implement uuid() or set "
             "pre_grad_pass_timing to 'early'."
         )
@@ -1380,13 +1380,22 @@ class FxGraphHashDetails:
         raise AssertionError(f"unknown config type: {str(type(custom_pass))}")
 
     def _get_custom_pass_detail(
-        self, custom_pass: CustomGraphPassType | CustomGraphModulePass
+        self,
+        custom_pass: (
+            CustomGraphPassCallable
+            | list[CustomGraphPassCallable]
+            | tuple[CustomGraphPassCallable, ...]
+            | CustomGraphModulePass
+            | None
+        ),
     ) -> Any | None:
         if not custom_pass:
+            # Empty custom-pass lists mean no passes, matching None.
             return None
         if isinstance(custom_pass, (list, tuple)):
             return tuple(self._get_custom_pass_detail(x) for x in custom_pass)
-        assert isinstance(custom_pass, (CustomGraphPass, CustomGraphModulePass))
+        if not isinstance(custom_pass, (CustomGraphPass, CustomGraphModulePass)):
+            raise AssertionError(f"unknown custom pass type: {str(type(custom_pass))}")
         return custom_pass.uuid()
 
     def _get_custom_partitioner_fn_detail(

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -91,6 +91,7 @@ from torch._inductor.custom_graph_pass import (
     CustomGraphPassType,
     CustomPartitionerFn,
     CustomPartitionerFnType,
+    get_custom_graph_passes,
 )
 from torch._inductor.freezing_utils import has_frozen_params, is_frozen_param
 from torch._inductor.runtime.compile_tasks import _reload_python_module
@@ -998,16 +999,20 @@ class CacheabilityValidator:
         # When timing is EARLY, pre-grad passes already ran before the cache
         # lookup so there's nothing to validate here.
         if resolve_pre_grad_pass_timing() != "early":
-            if config.pre_grad_custom_pass and (
-                not isinstance(config.pre_grad_custom_pass, CustomGraphPass)
-                or not config.pre_grad_custom_pass.uuid()
-            ):
-                self.bypass("Unsupported pre grad custom pass")
-        for p in (config.post_grad_custom_pre_pass, config.post_grad_custom_post_pass):
+            for p in get_custom_graph_passes(config.pre_grad_custom_pass):
+                if not isinstance(p, CustomGraphPass) or not p.uuid():
+                    self.bypass("Unsupported pre grad custom pass")
+        for p in itertools.chain(
+            get_custom_graph_passes(config.post_grad_custom_pre_pass),
+            get_custom_graph_passes(config.post_grad_custom_post_pass),
+        ):
             if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
                 self.bypass("Unsupported post grad custom pass")
         # Same with the joint custom passes
-        for p in (config.joint_custom_pre_pass, config.joint_custom_post_pass):
+        for p in itertools.chain(
+            get_custom_graph_passes(config.joint_custom_pre_pass),
+            get_custom_graph_passes(config.joint_custom_post_pass),
+        ):
             if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
                 self.bypass("Unsupported joint custom pass")
         # We should find any users of _pre_fusion_custom_pass and _fuse_ddp_communication_passes
@@ -1077,6 +1082,14 @@ class CacheabilityValidator:
 _warned_pre_grad_pass_missing_uuid: OrderedSet[str] = OrderedSet()
 
 
+def _custom_pass_has_uuid(custom_pass: Any) -> bool:
+    return isinstance(custom_pass, CustomGraphPass) and custom_pass.uuid() is not None
+
+
+def _custom_pass_name(custom_pass: Any) -> str:
+    return getattr(custom_pass, "__qualname__", None) or type(custom_pass).__qualname__
+
+
 def resolve_pre_grad_pass_timing() -> Literal["early", "late"]:
     """Resolve the effective pre-grad pass timing from the config.
 
@@ -1088,22 +1101,22 @@ def resolve_pre_grad_pass_timing() -> Literal["early", "late"]:
     run "late", since the cache key cannot account for it.
     """
     timing: Literal["early", "late", "default"] = config.pre_grad_pass_timing
-    custom_pass = config.pre_grad_custom_pass
-    has_uuid = (
+    custom_passes = get_custom_graph_passes(config.pre_grad_custom_pass)
+    passes_missing_uuid = [
         custom_pass
-        and isinstance(custom_pass, CustomGraphPass)
-        and custom_pass.uuid() is not None
-    )
+        for custom_pass in custom_passes
+        if not _custom_pass_has_uuid(custom_pass)
+    ]
     pass_name = (
-        getattr(custom_pass, "__qualname__", None) or type(custom_pass).__qualname__
-        if custom_pass is not None
+        ", ".join(_custom_pass_name(custom_pass) for custom_pass in passes_missing_uuid)
+        if passes_missing_uuid
         else "<none>"
     )
 
     if timing == "default":
-        supports_late = custom_pass is None or has_uuid
+        supports_late = not passes_missing_uuid
         timing = "late" if supports_late else "early"
-        if timing == "early" and custom_pass:
+        if timing == "early" and custom_passes:
             if pass_name not in _warned_pre_grad_pass_missing_uuid:
                 _warned_pre_grad_pass_missing_uuid.add(pass_name)
                 log.warning(
@@ -1118,7 +1131,7 @@ def resolve_pre_grad_pass_timing() -> Literal["early", "late"]:
                     pre_grad_pass_name=pass_name,
                 )
 
-    if timing == "late" and custom_pass and not has_uuid:
+    if timing == "late" and passes_missing_uuid:
         raise RuntimeError(
             f"pre_grad_custom_pass {pass_name} must implement uuid() to run late "
             "(after cache lookup). Either implement uuid() or set "
@@ -1354,6 +1367,8 @@ class FxGraphHashDetails:
             return None
         if isinstance(custom_pass, list):
             return [self._get_custom_pass_detail_unsafe(x) for x in custom_pass]
+        if isinstance(custom_pass, tuple):
+            return tuple(self._get_custom_pass_detail_unsafe(x) for x in custom_pass)
         if isinstance(custom_pass, str):
             return custom_pass
         if isinstance(custom_pass, CustomGraphPass):
@@ -1369,6 +1384,8 @@ class FxGraphHashDetails:
     ) -> Any | None:
         if not custom_pass:
             return None
+        if isinstance(custom_pass, (list, tuple)):
+            return tuple(self._get_custom_pass_detail(x) for x in custom_pass)
         assert isinstance(custom_pass, (CustomGraphPass, CustomGraphModulePass))
         return custom_pass.uuid()
 

--- a/torch/_inductor/custom_graph_pass.py
+++ b/torch/_inductor/custom_graph_pass.py
@@ -102,9 +102,25 @@ class CustomInferenceAwareGraphPass(CustomGraphPass):
         """
 
 
-CustomGraphPassType: TypeAlias = (
-    CustomGraphPass | Callable[[torch.fx.graph.Graph], None] | None
+CustomGraphPassCallable: TypeAlias = (
+    CustomGraphPass | Callable[[torch.fx.graph.Graph], None]
 )
+CustomGraphPassType: TypeAlias = (
+    CustomGraphPassCallable
+    | list[CustomGraphPassCallable]
+    | tuple[CustomGraphPassCallable, ...]
+    | None
+)
+
+
+def get_custom_graph_passes(
+    custom_pass: CustomGraphPassType,
+) -> tuple[CustomGraphPassCallable, ...]:
+    if custom_pass is None:
+        return ()
+    if isinstance(custom_pass, (list, tuple)):
+        return tuple(custom_pass)
+    return (custom_pass,)
 
 
 @lru_cache(1)

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -24,6 +24,7 @@ from torch.multiprocessing.reductions import StorageWeakRef
 from torch.utils._ordered_set import OrderedSet
 
 from .. import config
+from ..custom_graph_pass import get_custom_graph_passes
 from ..pattern_matcher import (
     Arg,
     CallFunction,
@@ -655,9 +656,9 @@ def joint_graph_passes(
     # must occur before other passes
     canonicalize_aten_ir_passes(graph)
 
-    if config.joint_custom_pre_pass is not None:
+    for joint_custom_pre_pass in get_custom_graph_passes(config.joint_custom_pre_pass):
         GraphTransformObserver(graph, "joint_custom_pre_pass").apply_graph_pass(
-            config.joint_custom_pre_pass
+            joint_custom_pre_pass
         )
         count += 1
 
@@ -698,9 +699,11 @@ def joint_graph_passes(
         # we'll instead explicitly turn off the config
         count += replace_random_passes(graph)
 
-    if config.joint_custom_post_pass is not None:
+    for joint_custom_post_pass in get_custom_graph_passes(
+        config.joint_custom_post_pass
+    ):
         GraphTransformObserver(graph, "joint_custom_post_pass").apply_graph_pass(
-            config.joint_custom_post_pass
+            joint_custom_post_pass
         )
         count += 1
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -15,7 +15,10 @@ import torch.utils._pytree as pytree
 from torch import fx
 from torch._decomp import register_decomposition
 from torch._dynamo.utils import counters
-from torch._inductor.custom_graph_pass import CustomInferenceAwareGraphPass
+from torch._inductor.custom_graph_pass import (
+    CustomInferenceAwareGraphPass,
+    get_custom_graph_passes,
+)
 from torch._inductor.virtualized import ops  # noqa: F401
 from torch._logging import trace_structured
 from torch._prims_common import is_boolean_dtype, is_expandable_to, is_integer_dtype
@@ -161,7 +164,9 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
 
     fake_tensor_updater = FakeTensorUpdater(gm)
 
-    if post_grad_custom_pre_pass := config.post_grad_custom_pre_pass:
+    for post_grad_custom_pre_pass in get_custom_graph_passes(
+        config.post_grad_custom_pre_pass
+    ):
         if isinstance(post_grad_custom_pre_pass, CustomInferenceAwareGraphPass):
             post_grad_custom_pre_pass = functools.partial(
                 post_grad_custom_pre_pass, is_inference=is_inference
@@ -245,7 +250,9 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
             )
         )
 
-    if post_grad_custom_post_pass := config.post_grad_custom_post_pass:
+    for post_grad_custom_post_pass in get_custom_graph_passes(
+        config.post_grad_custom_post_pass
+    ):
         if isinstance(post_grad_custom_post_pass, CustomInferenceAwareGraphPass):
             post_grad_custom_post_pass = functools.partial(
                 post_grad_custom_post_pass, is_inference=is_inference

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -22,6 +22,7 @@ from torch.nn import functional as F
 from torch.nn.utils.fusion import fuse_conv_bn_eval, fuse_conv_bn_weights
 
 from .. import config
+from ..custom_graph_pass import get_custom_graph_passes
 from ..fx_utils import matches_module_function_pattern
 from ..pattern_matcher import (
     init_once_fakemode,
@@ -353,9 +354,9 @@ def pre_grad_passes(
                 apply_gumbel_max_trick_pass.apply
             )
 
-    if config.pre_grad_custom_pass is not None:
+    for pre_grad_custom_pass in get_custom_graph_passes(config.pre_grad_custom_pass):
         GraphTransformObserver(gm, "pre_grad_custom_pass").apply_graph_pass(
-            config.pre_grad_custom_pass
+            pre_grad_custom_pass
         )
 
     stable_topological_sort(gm.graph)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184108

Allow Inductor custom graph pass config fields to accept list or tuple values, running each pass in order and including their UUIDs in FX graph cache keys.

Fixes #151876

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo