### PR TITLE
[distributed] Add NVFP4 scaled matmul + reduce-scatter fast path #182915

### DIFF
--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1613,7 +1613,7 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter_meta(
         partial_workspace1,
     )
     group_size = c10d._get_group_size_by_name(group_name)
-    local_m = A.shape[0] // group_size
+    local_m = (A.shape[0] + group_size - 1) // group_size
     return A.new_empty((local_m, B.shape[-2]), dtype=torch.bfloat16)
 
 
@@ -1636,6 +1636,27 @@ def _get_nvfp4_nccl_rs_stripes(chunk_m: int) -> int:
     return 1
 
 
+def _get_nvfp4_nccl_rs_stripe_sizes(chunk_m: int, num_stripes: int) -> list[int]:
+    if num_stripes <= 1:
+        return [chunk_m]
+
+    aligned_rows = (chunk_m // 128) * 128
+    tail_rows = chunk_m - aligned_rows
+    num_aligned_chunks = aligned_rows // 128
+    if num_aligned_chunks == 0:
+        return [chunk_m]
+
+    num_stripes = min(num_stripes, num_aligned_chunks)
+    base_chunks = num_aligned_chunks // num_stripes
+    extra_chunks = num_aligned_chunks % num_stripes
+    stripe_ms = [
+        (base_chunks + (1 if stripe_idx < extra_chunks else 0)) * 128
+        for stripe_idx in range(num_stripes)
+    ]
+    stripe_ms[-1] += tail_rows
+    return stripe_ms
+
+
 @torch.library.impl(lib, "fused_nvfp4_scaled_matmul_reduce_scatter", "CUDA")
 def _fused_nvfp4_scaled_matmul_reduce_scatter(
     A: torch.Tensor,
@@ -1653,15 +1674,7 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter(
     partial_workspace0: Optional[torch.Tensor] = None,
     partial_workspace1: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    del tile_n
-    if reduce_op != "sum":
-        raise ValueError("fused_nvfp4_scaled_matmul_reduce_scatter only supports sum")
-    if A.dim() != 2:
-        raise ValueError("A must be a 2D tensor")
-    if B.dim() != 3:
-        raise ValueError("B must be grouped as [group_size, N, K]")
-    if B_scale.dim() != 3:
-        raise ValueError("B_scale must be grouped as [group_size, *, *]")
+    del tile_m, tile_n
     if not hasattr(torch.ops, "mslk") or not hasattr(
         torch.ops.mslk, "f4f4bf16_grouped_stacked_out"
     ):
@@ -1673,53 +1686,28 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter(
     group = c10d._resolve_process_group(group_name)
     world_size = group.size()
     total_m = A.shape[0]
-    if total_m % world_size != 0:
-        raise ValueError(
-            "fused_nvfp4_scaled_matmul_reduce_scatter currently requires "
-            "M to be divisible by group size"
-        )
-    chunk_m = total_m // world_size
-    if chunk_m % 128 != 0:
-        raise ValueError(
-            "fused_nvfp4_scaled_matmul_reduce_scatter currently requires "
-            "M / group_size to be 128-row aligned"
-        )
-    if tile_m != 128:
-        raise ValueError("fused_nvfp4_scaled_matmul_reduce_scatter expects tile_m=128")
-    if B.shape[0] != world_size:
-        raise ValueError("B first dimension must equal group size")
-    if B_scale.shape[0] != world_size:
-        raise ValueError("B_scale first dimension must equal group size")
+    chunk_m = (total_m + world_size - 1) // world_size
+    padded_total_m = chunk_m * world_size
+    group_sizes = [
+        max(0, min(chunk_m, total_m - group_idx * chunk_m))
+        for group_idx in range(world_size)
+    ]
 
     n = B.shape[-2]
-    m_sizes = torch.full((world_size,), chunk_m, device=A.device, dtype=torch.long)
-    starting_row_after_padding = (
-        torch.arange(world_size + 1, device=A.device, dtype=torch.long) * chunk_m
-    )
     alpha = (
         A_global_scale.reshape(-1).to(device=A.device, dtype=torch.float32)
         * B_global_scale.reshape(-1).to(device=A.device, dtype=torch.float32)
     )
     if alpha.numel() == 1:
         alpha = alpha.expand(world_size).contiguous()
-    elif alpha.numel() == world_size:
-        alpha = alpha.contiguous()
     else:
-        raise ValueError(
-            "A_global_scale * B_global_scale must broadcast to either one value "
-            "or group_size values"
-        )
+        alpha = alpha.contiguous()
 
-    num_stripes = _get_nvfp4_nccl_rs_stripes(chunk_m)
+    can_overlap = reduce_op == "sum"
+    num_stripes = _get_nvfp4_nccl_rs_stripes(chunk_m) if can_overlap else 1
     if num_stripes > 1:
-        num_stripe_quanta = chunk_m // 128
-        num_stripes = min(num_stripes, num_stripe_quanta)
-        base_quanta = num_stripe_quanta // num_stripes
-        extra_quanta = num_stripe_quanta % num_stripes
-        stripe_ms = [
-            (base_quanta + (1 if stripe_idx < extra_quanta else 0)) * 128
-            for stripe_idx in range(num_stripes)
-        ]
+        stripe_ms = _get_nvfp4_nccl_rs_stripe_sizes(chunk_m, num_stripes)
+        num_stripes = len(stripe_ms)
         stripe_offsets = [0]
         for stripe_m in stripe_ms:
             stripe_offsets.append(stripe_offsets[-1] + stripe_m)
@@ -1728,11 +1716,18 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter(
         output = A.new_empty((chunk_m, n), dtype=torch.bfloat16)
         expected_a_workspace_shape = (max_stripe_m * world_size, A.shape[1])
         expected_partial_workspace_shape = (max_stripe_m * world_size, n)
-        if (A_workspace0 is None) != (A_workspace1 is None):
-            raise ValueError("A ping-pong workspaces must be provided together")
-        if (partial_workspace0 is None) != (partial_workspace1 is None):
-            raise ValueError("partial ping-pong workspaces must be provided together")
-        if A_workspace0 is not None:
+        if (
+            A_workspace0 is not None
+            and A_workspace1 is not None
+            and tuple(A_workspace0.shape) == expected_a_workspace_shape
+            and tuple(A_workspace1.shape) == expected_a_workspace_shape
+            and A_workspace0.dtype == A.dtype
+            and A_workspace1.dtype == A.dtype
+            and A_workspace0.device == A.device
+            and A_workspace1.device == A.device
+            and A_workspace0.is_contiguous()
+            and A_workspace1.is_contiguous()
+        ):
             a_workspaces = [A_workspace0, A_workspace1]
         else:
             a_workspaces = [
@@ -1741,7 +1736,18 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter(
                 )
                 for _ in range(2)
             ]
-        if partial_workspace0 is not None:
+        if (
+            partial_workspace0 is not None
+            and partial_workspace1 is not None
+            and tuple(partial_workspace0.shape) == expected_partial_workspace_shape
+            and tuple(partial_workspace1.shape) == expected_partial_workspace_shape
+            and partial_workspace0.dtype == torch.bfloat16
+            and partial_workspace1.dtype == torch.bfloat16
+            and partial_workspace0.device == A.device
+            and partial_workspace1.device == A.device
+            and partial_workspace0.is_contiguous()
+            and partial_workspace1.is_contiguous()
+        ):
             partial_workspaces = [partial_workspace0, partial_workspace1]
         else:
             partial_workspaces = [
@@ -1750,31 +1756,6 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter(
                 )
                 for _ in range(2)
             ]
-        for workspace in a_workspaces:
-            if (
-                workspace is None
-                or tuple(workspace.shape) != expected_a_workspace_shape
-                or workspace.dtype != A.dtype
-                or workspace.device != A.device
-                or not workspace.is_contiguous()
-            ):
-                raise ValueError(
-                    "A workspace must be contiguous with shape "
-                    f"{expected_a_workspace_shape}, dtype {A.dtype}, device {A.device}"
-                )
-        for workspace in partial_workspaces:
-            if (
-                workspace is None
-                or tuple(workspace.shape) != expected_partial_workspace_shape
-                or workspace.dtype != torch.bfloat16
-                or workspace.device != A.device
-                or not workspace.is_contiguous()
-            ):
-                raise ValueError(
-                    "partial workspace must be contiguous with shape "
-                    f"{expected_partial_workspace_shape}, dtype torch.bfloat16, "
-                    f"device {A.device}"
-                )
         producer_stream = torch.cuda.current_stream(A.device)
         comm_stream = torch.cuda.Stream(device=A.device)
         producer_done = [torch.cuda.Event() for _ in range(2)]
@@ -1790,25 +1771,38 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter(
 
             stripe_start = stripe_offsets[stripe_idx]
             stripe_stop = stripe_offsets[stripe_idx + 1]
-            m_sizes = torch.full(
-                (world_size,), stripe_m, device=A.device, dtype=torch.long
+            stripe_group_sizes = [
+                max(0, min(stripe_stop, group_size) - stripe_start)
+                for group_size in group_sizes
+            ]
+            stripe_total_m = sum(stripe_group_sizes)
+            m_sizes = torch.tensor(
+                stripe_group_sizes, device=A.device, dtype=torch.long
             )
-            a_workspace = a_workspaces[slot][: stripe_m * world_size]
-            partial_workspace = partial_workspaces[slot][: stripe_m * world_size]
-            row_starts = (
+            a_workspace = a_workspaces[slot][:stripe_total_m]
+            partial_workspace_full = partial_workspaces[slot][
+                : stripe_m * world_size
+            ]
+            partial_workspace = partial_workspace_full[:stripe_total_m]
+            row_starts = torch.clamp(
                 torch.arange(world_size + 1, device=A.device, dtype=torch.long)
                 * chunk_m
-                + stripe_start
+                + stripe_start,
+                max=total_m,
             )
+            compact_offset = 0
             for group_idx in range(world_size):
-                a_workspace[
-                    group_idx * stripe_m : (group_idx + 1) * stripe_m
-                ].copy_(
+                group_m = stripe_group_sizes[group_idx]
+                if group_m == 0:
+                    continue
+                a_workspace[compact_offset : compact_offset + group_m].copy_(
                     A[
                         group_idx * chunk_m + stripe_start : group_idx * chunk_m
-                        + stripe_stop
+                        + stripe_start
+                        + group_m
                     ]
                 )
+                compact_offset += group_m
             torch.ops.mslk.f4f4bf16_grouped_stacked_out.default(
                 a_workspace,
                 B,
@@ -1820,13 +1814,15 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter(
                 row_starts,
                 False,
             )
+            if stripe_total_m < stripe_m * world_size:
+                partial_workspace_full[stripe_total_m : stripe_m * world_size].zero_()
             producer_done[slot].record(producer_stream)
 
             with torch.cuda.stream(comm_stream):
                 comm_stream.wait_event(producer_done[slot])
                 works[slot] = c10d.reduce_scatter_tensor(
                     output[stripe_start:stripe_stop],
-                    partial_workspace,
+                    partial_workspace_full,
                     op=c10d.ReduceOp.SUM,
                     group=group,
                     async_op=True,
@@ -1839,18 +1835,35 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter(
         producer_stream.wait_stream(comm_stream)
         return output
 
-    partials = A.new_empty((total_m, n), dtype=torch.bfloat16)
+    m_sizes = torch.tensor(group_sizes, device=A.device, dtype=torch.long)
+    starting_row_after_padding = torch.clamp(
+        torch.arange(world_size + 1, device=A.device, dtype=torch.long) * chunk_m,
+        max=total_m,
+    )
+    compact_partials = A.new_empty((total_m, n), dtype=torch.bfloat16)
     torch.ops.mslk.f4f4bf16_grouped_stacked_out.default(
         A,
         B,
         A_scale,
         B_scale,
         m_sizes,
-        partials,
+        compact_partials,
         alpha,
         starting_row_after_padding,
         False,
     )
+    if padded_total_m == total_m:
+        partials = compact_partials
+    else:
+        partials = A.new_zeros((padded_total_m, n), dtype=torch.bfloat16)
+        compact_offset = 0
+        for group_idx, group_m in enumerate(group_sizes):
+            if group_m == 0:
+                continue
+            partials[group_idx * chunk_m : group_idx * chunk_m + group_m].copy_(
+                compact_partials[compact_offset : compact_offset + group_m]
+            )
+            compact_offset += group_m
     out = funcol.reduce_scatter_tensor(partials, reduce_op, 0, group_name)
     return funcol.wait_tensor(out)
 

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -470,6 +470,12 @@ lib.define(
     "bool use_fast_accum = False) -> Tensor",
     tags=[torch._C.Tag.needs_fixed_stride_order],
 )
+lib.define(
+    "fused_nvfp4_scaled_matmul_reduce_scatter("
+    "Tensor A, Tensor B, Tensor A_scale, Tensor A_global_scale, Tensor B_scale, Tensor B_global_scale, "
+    "str reduce_op, str group_name, int tile_m=128, int tile_n=256) -> Tensor",
+    tags=[torch._C.Tag.needs_fixed_stride_order],
+)
 lib.define("_low_contention_all_gather(Tensor tensor, str group_name) -> Tensor")
 lib.define(
     "_low_contention_reduce_scatter(Tensor tensor, str reduce_op, str group_name) -> Tensor"
@@ -1572,6 +1578,111 @@ def _fused_scaled_matmul_reduce_scatter_impl(
     output_shape[orig_scatter_dim] //= group.size()
     out = reduced_out.view(*output_shape)
     return out
+
+
+@torch.library.impl(lib, "fused_nvfp4_scaled_matmul_reduce_scatter", "Meta")
+def _fused_nvfp4_scaled_matmul_reduce_scatter_meta(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    A_global_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    B_global_scale: torch.Tensor,
+    reduce_op: str,
+    group_name: c10d.GroupName,
+    tile_m: int = 128,
+    tile_n: int = 256,
+) -> torch.Tensor:
+    del A_scale, A_global_scale, B_scale, B_global_scale, reduce_op, tile_m, tile_n
+    group_size = c10d._get_group_size_by_name(group_name)
+    local_m = A.shape[0] // group_size
+    return A.new_empty((local_m, B.shape[-2]), dtype=torch.bfloat16)
+
+
+@torch.library.impl(lib, "fused_nvfp4_scaled_matmul_reduce_scatter", "CUDA")
+def _fused_nvfp4_scaled_matmul_reduce_scatter(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    A_global_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    B_global_scale: torch.Tensor,
+    reduce_op: str,
+    group_name: c10d.GroupName,
+    tile_m: int = 128,
+    tile_n: int = 256,
+) -> torch.Tensor:
+    del tile_n
+    if reduce_op != "sum":
+        raise ValueError("fused_nvfp4_scaled_matmul_reduce_scatter only supports sum")
+    if A.dim() != 2:
+        raise ValueError("A must be a 2D tensor")
+    if B.dim() != 3:
+        raise ValueError("B must be grouped as [group_size, N, K]")
+    if B_scale.dim() != 3:
+        raise ValueError("B_scale must be grouped as [group_size, *, *]")
+    if not hasattr(torch.ops, "mslk") or not hasattr(
+        torch.ops.mslk, "f4f4bf16_grouped_stacked_out"
+    ):
+        raise RuntimeError(
+            "torch.ops.mslk.f4f4bf16_grouped_stacked_out is unavailable; "
+            "rebuild with USE_MSLK=1 and the MSLK PyTorch registration source."
+        )
+
+    group = c10d._resolve_process_group(group_name)
+    world_size = group.size()
+    total_m = A.shape[0]
+    if total_m % world_size != 0:
+        raise ValueError(
+            "fused_nvfp4_scaled_matmul_reduce_scatter currently requires "
+            "M to be divisible by group size"
+        )
+    chunk_m = total_m // world_size
+    if chunk_m % 128 != 0:
+        raise ValueError(
+            "fused_nvfp4_scaled_matmul_reduce_scatter currently requires "
+            "M / group_size to be 128-row aligned"
+        )
+    if tile_m != 128:
+        raise ValueError("fused_nvfp4_scaled_matmul_reduce_scatter expects tile_m=128")
+    if B.shape[0] != world_size:
+        raise ValueError("B first dimension must equal group size")
+    if B_scale.shape[0] != world_size:
+        raise ValueError("B_scale first dimension must equal group size")
+
+    n = B.shape[-2]
+    m_sizes = torch.full((world_size,), chunk_m, device=A.device, dtype=torch.long)
+    starting_row_after_padding = (
+        torch.arange(world_size + 1, device=A.device, dtype=torch.long) * chunk_m
+    )
+    alpha = (
+        A_global_scale.reshape(-1).to(device=A.device, dtype=torch.float32)
+        * B_global_scale.reshape(-1).to(device=A.device, dtype=torch.float32)
+    )
+    if alpha.numel() == 1:
+        alpha = alpha.expand(world_size).contiguous()
+    elif alpha.numel() == world_size:
+        alpha = alpha.contiguous()
+    else:
+        raise ValueError(
+            "A_global_scale * B_global_scale must broadcast to either one value "
+            "or group_size values"
+        )
+
+    partials = A.new_empty((total_m, n), dtype=torch.bfloat16)
+    torch.ops.mslk.f4f4bf16_grouped_stacked_out.default(
+        A,
+        B,
+        A_scale,
+        B_scale,
+        m_sizes,
+        partials,
+        alpha,
+        starting_row_after_padding,
+        False,
+    )
+    out = funcol.reduce_scatter_tensor(partials, reduce_op, 0, group_name)
+    return funcol.wait_tensor(out)
 
 
 def restride_A_for_fused_matmul_reduce_scatter(

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from datetime import timedelta
 from enum import Enum
 from functools import partial
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 from typing_extensions import deprecated
 
 import torch
@@ -473,7 +473,9 @@ lib.define(
 lib.define(
     "fused_nvfp4_scaled_matmul_reduce_scatter("
     "Tensor A, Tensor B, Tensor A_scale, Tensor A_global_scale, Tensor B_scale, Tensor B_global_scale, "
-    "str reduce_op, str group_name, int tile_m=128, int tile_n=256) -> Tensor",
+    "str reduce_op, str group_name, int tile_m=128, int tile_n=256, "
+    "Tensor? A_workspace0=None, Tensor? A_workspace1=None, "
+    "Tensor? partial_workspace0=None, Tensor? partial_workspace1=None) -> Tensor",
     tags=[torch._C.Tag.needs_fixed_stride_order],
 )
 lib.define("_low_contention_all_gather(Tensor tensor, str group_name) -> Tensor")
@@ -1592,11 +1594,46 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter_meta(
     group_name: c10d.GroupName,
     tile_m: int = 128,
     tile_n: int = 256,
+    A_workspace0: Optional[torch.Tensor] = None,
+    A_workspace1: Optional[torch.Tensor] = None,
+    partial_workspace0: Optional[torch.Tensor] = None,
+    partial_workspace1: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    del A_scale, A_global_scale, B_scale, B_global_scale, reduce_op, tile_m, tile_n
+    del (
+        A_scale,
+        A_global_scale,
+        B_scale,
+        B_global_scale,
+        reduce_op,
+        tile_m,
+        tile_n,
+        A_workspace0,
+        A_workspace1,
+        partial_workspace0,
+        partial_workspace1,
+    )
     group_size = c10d._get_group_size_by_name(group_name)
     local_m = A.shape[0] // group_size
     return A.new_empty((local_m, B.shape[-2]), dtype=torch.bfloat16)
+
+
+def _nvfp4_workspace_empty(
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    try:
+        return empty(shape, dtype=dtype, device=device)
+    except Exception:
+        return torch.empty(shape, dtype=dtype, device=device)
+
+
+def _get_nvfp4_nccl_rs_stripes(chunk_m: int) -> int:
+    if chunk_m >= 16384:
+        return 4
+    if chunk_m >= 8192:
+        return 2
+    return 1
 
 
 @torch.library.impl(lib, "fused_nvfp4_scaled_matmul_reduce_scatter", "CUDA")
@@ -1611,6 +1648,10 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter(
     group_name: c10d.GroupName,
     tile_m: int = 128,
     tile_n: int = 256,
+    A_workspace0: Optional[torch.Tensor] = None,
+    A_workspace1: Optional[torch.Tensor] = None,
+    partial_workspace0: Optional[torch.Tensor] = None,
+    partial_workspace1: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     del tile_n
     if reduce_op != "sum":
@@ -1668,6 +1709,135 @@ def _fused_nvfp4_scaled_matmul_reduce_scatter(
             "A_global_scale * B_global_scale must broadcast to either one value "
             "or group_size values"
         )
+
+    num_stripes = _get_nvfp4_nccl_rs_stripes(chunk_m)
+    if num_stripes > 1:
+        num_stripe_quanta = chunk_m // 128
+        num_stripes = min(num_stripes, num_stripe_quanta)
+        base_quanta = num_stripe_quanta // num_stripes
+        extra_quanta = num_stripe_quanta % num_stripes
+        stripe_ms = [
+            (base_quanta + (1 if stripe_idx < extra_quanta else 0)) * 128
+            for stripe_idx in range(num_stripes)
+        ]
+        stripe_offsets = [0]
+        for stripe_m in stripe_ms:
+            stripe_offsets.append(stripe_offsets[-1] + stripe_m)
+        max_stripe_m = max(stripe_ms)
+
+        output = A.new_empty((chunk_m, n), dtype=torch.bfloat16)
+        expected_a_workspace_shape = (max_stripe_m * world_size, A.shape[1])
+        expected_partial_workspace_shape = (max_stripe_m * world_size, n)
+        if (A_workspace0 is None) != (A_workspace1 is None):
+            raise ValueError("A ping-pong workspaces must be provided together")
+        if (partial_workspace0 is None) != (partial_workspace1 is None):
+            raise ValueError("partial ping-pong workspaces must be provided together")
+        if A_workspace0 is not None:
+            a_workspaces = [A_workspace0, A_workspace1]
+        else:
+            a_workspaces = [
+                _nvfp4_workspace_empty(
+                    expected_a_workspace_shape, A.dtype, A.device
+                )
+                for _ in range(2)
+            ]
+        if partial_workspace0 is not None:
+            partial_workspaces = [partial_workspace0, partial_workspace1]
+        else:
+            partial_workspaces = [
+                _nvfp4_workspace_empty(
+                    expected_partial_workspace_shape, torch.bfloat16, A.device
+                )
+                for _ in range(2)
+            ]
+        for workspace in a_workspaces:
+            if (
+                workspace is None
+                or tuple(workspace.shape) != expected_a_workspace_shape
+                or workspace.dtype != A.dtype
+                or workspace.device != A.device
+                or not workspace.is_contiguous()
+            ):
+                raise ValueError(
+                    "A workspace must be contiguous with shape "
+                    f"{expected_a_workspace_shape}, dtype {A.dtype}, device {A.device}"
+                )
+        for workspace in partial_workspaces:
+            if (
+                workspace is None
+                or tuple(workspace.shape) != expected_partial_workspace_shape
+                or workspace.dtype != torch.bfloat16
+                or workspace.device != A.device
+                or not workspace.is_contiguous()
+            ):
+                raise ValueError(
+                    "partial workspace must be contiguous with shape "
+                    f"{expected_partial_workspace_shape}, dtype torch.bfloat16, "
+                    f"device {A.device}"
+                )
+        producer_stream = torch.cuda.current_stream(A.device)
+        comm_stream = torch.cuda.Stream(device=A.device)
+        producer_done = [torch.cuda.Event() for _ in range(2)]
+        comm_done = [torch.cuda.Event() for _ in range(2)]
+        works: list[Any] = [None, None]
+
+        for stripe_idx, stripe_m in enumerate(stripe_ms):
+            slot = stripe_idx % 2
+            if stripe_idx >= 2:
+                if works[slot] is not None:
+                    works[slot].wait()
+                producer_stream.wait_event(comm_done[slot])
+
+            stripe_start = stripe_offsets[stripe_idx]
+            stripe_stop = stripe_offsets[stripe_idx + 1]
+            m_sizes = torch.full(
+                (world_size,), stripe_m, device=A.device, dtype=torch.long
+            )
+            a_workspace = a_workspaces[slot][: stripe_m * world_size]
+            partial_workspace = partial_workspaces[slot][: stripe_m * world_size]
+            row_starts = (
+                torch.arange(world_size + 1, device=A.device, dtype=torch.long)
+                * chunk_m
+                + stripe_start
+            )
+            for group_idx in range(world_size):
+                a_workspace[
+                    group_idx * stripe_m : (group_idx + 1) * stripe_m
+                ].copy_(
+                    A[
+                        group_idx * chunk_m + stripe_start : group_idx * chunk_m
+                        + stripe_stop
+                    ]
+                )
+            torch.ops.mslk.f4f4bf16_grouped_stacked_out.default(
+                a_workspace,
+                B,
+                A_scale,
+                B_scale,
+                m_sizes,
+                partial_workspace,
+                alpha,
+                row_starts,
+                False,
+            )
+            producer_done[slot].record(producer_stream)
+
+            with torch.cuda.stream(comm_stream):
+                comm_stream.wait_event(producer_done[slot])
+                works[slot] = c10d.reduce_scatter_tensor(
+                    output[stripe_start:stripe_stop],
+                    partial_workspace,
+                    op=c10d.ReduceOp.SUM,
+                    group=group,
+                    async_op=True,
+                )
+                comm_done[slot].record(comm_stream)
+
+        for work in works:
+            if work is not None:
+                work.wait()
+        producer_stream.wait_stream(comm_stream)
+        return output
 
     partials = A.new_empty((total_m, n), dtype=torch.bfloat16)
     torch.ops.mslk.f4f4bf16_grouped_stacked_out.default(


### PR DESCRIPTION

The implementation uses:
- MSLK/CUTLASS NVFP4 grouped GEMM for partial matmul production
- global row offsets for NVFP4 activation scale addressing
- NCCL `reduce_scatter_tensor` for the reduction/communication path
- optional stripe-based overlap for large M
- symmetric-memory workspaces for Inductor/runtime buffer realization

## Motivation
https://github.com/pytorch/pytorch/issues/182915
NVFP4 activation scales are block-wise and layout-sensitive, so naively chunking M by TP can break scale addressing when chunk boundaries are not 128-row aligned.

This path avoids requiring `M / TP` to be 128-aligned. Instead, it uses global row offsets for scale addressing and pads the reduce-scatter workspace when needed.

## Boundary Handling

This supports:
- `M % TP != 0`
- `ceil(M / TP) % 128 != 0`
- large-M stripe overlap without falling back only to perfectly aligned shapes

For overlap, stripe starts are kept 128-row aligned when possible, and the final stripe absorbs the tail. This preserves NVFP4 scale correctness while avoiding a hard 128-row divisibility guard.


benchmark: https://paste.ubuntu.com/p/54jmMjrr45/
2 card 
```
CUDA_VISIBLE_DEVICES=6,7 \
PYTHONPATH=/root/zdj/pytorch \
/root/zdj/vllm/.venv/bin/torchrun \
  --standalone \
  --nnodes=1 \
  --nproc_per_node=2 \
  /root/zdj/pytorch/agent_space/bench_nvfp4_native_rs.py \
  --m-list 3000,8193,10000,65535,65536,65537,131071,131072,131073 \
  --gemm-n 8192 \
  --gemm-k 2048 \
  --warmup 5 \
  --iters 20 \
  --symm-backend auto \
  2>&1 | tee /tmp/nvfp4_pr_sweep_tp2_gpu67.log

```
res: 

```
RESULT M=3000 chunk_m=1500 local_m_rank0=1500 full_mm=0.0368ms nccl_rs_only=0.0759ms baseline_mm_rs=0.1127ms native_fused_rs=0.2007ms speedup=0.5618 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=8193 chunk_m=4097 local_m_rank0=4097 full_mm=0.0691ms nccl_rs_only=0.2751ms baseline_mm_rs=0.3457ms native_fused_rs=0.4073ms speedup=0.8488 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=10000 chunk_m=5000 local_m_rank0=5000 full_mm=0.0802ms nccl_rs_only=0.2180ms baseline_mm_rs=0.3003ms native_fused_rs=0.3573ms speedup=0.8406 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=65535 chunk_m=32768 local_m_rank0=32768 full_mm=0.4402ms nccl_rs_only=1.7600ms baseline_mm_rs=2.2016ms native_fused_rs=1.6727ms speedup=1.3162 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=65536 chunk_m=32768 local_m_rank0=32768 full_mm=0.4404ms nccl_rs_only=1.1578ms baseline_mm_rs=1.5946ms native_fused_rs=1.6694ms speedup=0.9552 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=65537 chunk_m=32769 local_m_rank0=32769 full_mm=0.4446ms nccl_rs_only=1.7697ms baseline_mm_rs=2.2091ms native_fused_rs=1.6820ms speedup=1.3133 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=131071 chunk_m=65536 local_m_rank0=65536 full_mm=0.8817ms nccl_rs_only=3.4561ms baseline_mm_rs=4.3036ms native_fused_rs=3.0320ms speedup=1.4194 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=131072 chunk_m=65536 local_m_rank0=65536 full_mm=0.8814ms nccl_rs_only=2.2977ms baseline_mm_rs=3.1002ms native_fused_rs=3.0270ms speedup=1.0242 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=131073 chunk_m=65537 local_m_rank0=65537 full_mm=0.8855ms nccl_rs_only=3.5169ms baseline_mm_rs=4.3465ms native_fused_rs=3.0406ms speedup=1.4295 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
```

4 card 
```
CUDA_VISIBLE_DEVICES=4,5,6,7 PYTHONPATH=/root/zdj/pytorch \
/root/zdj/vllm/.venv/bin/torchrun \
  --standalone \
  --nnodes=1 \
  --nproc_per_node=4 \
  /root/zdj/pytorch/agent_space/bench_nvfp4_native_rs.py \
  --m-list 128,129,511,512,513,3000,8193,10000,65535,65536,65537,131071,131072,131073 \
  --gemm-n 8192 \
  --gemm-k 2048 \
  --warmup 5 \
  --iters 20 \
  --symm-backend auto
```
res: 

```
RESULT M=128 chunk_m=32 local_m_rank0=32 full_mm=0.0180ms nccl_rs_only=0.0180ms baseline_mm_rs=0.0333ms native_fused_rs=0.2010ms speedup=0.1657 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=129 chunk_m=33 local_m_rank0=33 full_mm=0.0174ms nccl_rs_only=0.0289ms baseline_mm_rs=0.0491ms native_fused_rs=0.2271ms speedup=0.2160 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=511 chunk_m=128 local_m_rank0=128 full_mm=0.0179ms nccl_rs_only=0.0579ms baseline_mm_rs=0.0770ms native_fused_rs=0.2269ms speedup=0.3396 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=512 chunk_m=128 local_m_rank0=128 full_mm=0.0186ms nccl_rs_only=0.0484ms baseline_mm_rs=0.1816ms native_fused_rs=0.1755ms speedup=1.0343 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=513 chunk_m=129 local_m_rank0=129 full_mm=0.0213ms nccl_rs_only=0.0581ms baseline_mm_rs=0.2058ms native_fused_rs=0.2303ms speedup=0.8937 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=3000 chunk_m=750 local_m_rank0=750 full_mm=0.0349ms nccl_rs_only=0.0865ms baseline_mm_rs=0.1263ms native_fused_rs=0.1874ms speedup=0.6743 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=8193 chunk_m=2049 local_m_rank0=2049 full_mm=0.0694ms nccl_rs_only=0.2901ms baseline_mm_rs=0.3617ms native_fused_rs=0.4371ms speedup=0.8275 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=10000 chunk_m=2500 local_m_rank0=2500 full_mm=0.0806ms nccl_rs_only=0.2445ms baseline_mm_rs=0.3278ms native_fused_rs=0.5222ms speedup=0.6277 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=65535 chunk_m=16384 local_m_rank0=16384 full_mm=0.4441ms nccl_rs_only=1.9858ms baseline_mm_rs=2.4253ms native_fused_rs=1.7797ms speedup=1.3627 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=65536 chunk_m=16384 local_m_rank0=16384 full_mm=0.4455ms nccl_rs_only=1.3839ms baseline_mm_rs=1.8231ms native_fused_rs=1.8151ms speedup=1.0044 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=65537 chunk_m=16385 local_m_rank0=16385 full_mm=0.4486ms nccl_rs_only=2.0252ms baseline_mm_rs=2.4675ms native_fused_rs=1.8386ms speedup=1.3421 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=131071 chunk_m=32768 local_m_rank0=32768 full_mm=0.8981ms nccl_rs_only=3.9269ms baseline_mm_rs=4.7742ms native_fused_rs=3.3227ms speedup=1.4368 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=131072 chunk_m=32768 local_m_rank0=32768 full_mm=0.8966ms nccl_rs_only=2.7148ms baseline_mm_rs=3.5816ms native_fused_rs=3.3141ms speedup=1.0807 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=131073 chunk_m=32769 local_m_rank0=32769 full_mm=0.9025ms nccl_rs_only=3.9610ms baseline_mm_rs=4.8136ms native_fused_rs=3.3341ms speedup=1.4437 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
```

8 card: 
```

CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
PYTHONPATH=/root/zdj/pytorch \
/root/zdj/vllm/.venv/bin/torchrun \
  --standalone \
  --nnodes=1 \
  --nproc_per_node=8 \
  /root/zdj/pytorch/agent_space/bench_nvfp4_native_rs.py \
  --m-list 3000,8193,10000,65535,65536,65537,131071,131072,131073 \
  --gemm-n 8192 \
  --gemm-k 2048 \
  --warmup 5 \
  --iters 20 \
  --symm-backend auto \
  2>&1 | tee /tmp/nvfp4_pr_sweep_tp8_gpu01234567.log
```
res: 
```
RESULT M=3000 chunk_m=375 local_m_rank0=375 full_mm=0.0370ms nccl_rs_only=0.1237ms baseline_mm_rs=0.1617ms native_fused_rs=0.2505ms speedup=0.6454 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=8193 chunk_m=1025 local_m_rank0=1025 full_mm=0.0702ms nccl_rs_only=0.2916ms baseline_mm_rs=0.3632ms native_fused_rs=0.5169ms speedup=0.7026 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=10000 chunk_m=1250 local_m_rank0=1250 full_mm=0.0814ms nccl_rs_only=0.2491ms baseline_mm_rs=0.3330ms native_fused_rs=0.5694ms speedup=0.5849 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=1
RESULT M=65535 chunk_m=8192 local_m_rank0=8192 full_mm=0.4458ms nccl_rs_only=2.0860ms baseline_mm_rs=2.5296ms native_fused_rs=1.9276ms speedup=1.3124 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=2
RESULT M=65536 chunk_m=8192 local_m_rank0=8192 full_mm=0.4461ms nccl_rs_only=1.4961ms baseline_mm_rs=1.9350ms native_fused_rs=1.9242ms speedup=1.0056 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=2
RESULT M=65537 chunk_m=8193 local_m_rank0=8193 full_mm=0.4495ms nccl_rs_only=2.1526ms baseline_mm_rs=2.5891ms native_fused_rs=1.9717ms speedup=1.3131 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=2
RESULT M=131071 chunk_m=16384 local_m_rank0=16384 full_mm=0.8937ms nccl_rs_only=4.1507ms baseline_mm_rs=4.9543ms native_fused_rs=3.4976ms speedup=1.4165 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=131072 chunk_m=16384 local_m_rank0=16384 full_mm=0.8918ms nccl_rs_only=2.9686ms baseline_mm_rs=3.7712ms native_fused_rs=3.5151ms speedup=1.0729 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4
RESULT M=131073 chunk_m=16385 local_m_rank0=16385 full_mm=0.8956ms nccl_rs_only=4.2295ms baseline_mm_rs=5.0259ms native_fused_rs=3.5493ms speedup=1.4160 max_abs_diff=0 nrmse=0 rs_path=nccl overlap_stripes=4

```

test:

PYTHONPATH=/root/zdj/pytorch \
/root/zdj/vllm/.venv/bin/python \
  test/distributed/test_symmetric_memory.py \
  LoweringTest.test_custom_op_symm_mem_realization --passed 

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy