### PR TITLE
Preserve eager input vals in replacement patterns

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -16,6 +16,7 @@ from torch._inductor.fx_passes import joint_graph
 from torch._inductor.pattern_matcher import (
     Arg,
     CallFunction,
+    CallFunctionVarArgs,
     fwd_only,
     gen_pattern,
     is_mutation_op,
@@ -2281,6 +2282,123 @@ class TestPatternMatcher(TestCase):
             fn, options={"post_grad_custom_post_pass": custom_pass}
         )
         compiled_fn(x, y)
+
+    def test_register_replacement_uses_eager_input_vals_for_exact_strides(self):
+        class ReproFailed(RuntimeError):
+            pass
+
+        producer_patterns = PatternMatcherPass()
+        replacement_patterns = PatternMatcherPass()
+
+        with torch.library._scoped_library("test_pm_150871", "FRAGMENT") as lib:
+            lib.define(
+                "force_channels_last(Tensor x) -> Tensor",
+                tags=[torch._C.Tag.flexible_layout],
+            )
+
+            def force_channels_last_impl(x):
+                return x.clone(memory_format=torch.channels_last)
+
+            lib.impl(
+                "force_channels_last",
+                force_channels_last_impl,
+                "CompositeExplicitAutograd",
+            )
+
+            lib.define(
+                "add_op(Tensor x, *, Tensor y) -> Tensor",
+                tags=[torch._C.Tag.needs_exact_strides],
+            )
+            lib.define(
+                "add_op_replacement(Tensor x, *, Tensor y) -> Tensor",
+                tags=[torch._C.Tag.needs_exact_strides],
+            )
+
+            def add_impl(x, *, y):
+                return x + y
+
+            def add_replacement_impl(x, *, y):
+                if not x.transpose(2, 3).is_contiguous():
+                    raise ReproFailed(f"wrong x stride: {x.stride()}")
+                if not y.transpose(2, 3).is_contiguous():
+                    raise ReproFailed(f"wrong y stride: {y.stride()}")
+                return x + y
+
+            lib.impl("add_op", add_impl, "CompositeExplicitAutograd")
+            lib.impl("add_op", add_impl, "Meta")
+            lib.impl(
+                "add_op_replacement",
+                add_replacement_impl,
+                "CompositeExplicitAutograd",
+            )
+            lib.impl("add_op_replacement", add_impl, "Meta")
+
+            @register_graph_pattern(
+                CallFunctionVarArgs(torch.ops.aten.permute),
+                pass_dict=producer_patterns,
+            )
+            def replace_permute(match, *args, **kwargs):
+                flat_args, spec = pytree.tree_flatten((args, kwargs))
+
+                def decomp(*flat_args):
+                    args, kwargs = pytree.tree_unflatten(flat_args, spec)
+                    return torch.ops.test_pm_150871.force_channels_last(
+                        torch.ops.aten.permute(*args, **kwargs)
+                    )
+
+                match.replace_by_example(decomp, flat_args)
+
+            def pattern(x, y):
+                return torch.ops.test_pm_150871.add_op.default(x, y=y)
+
+            def replacement(x, y):
+                return torch.ops.test_pm_150871.add_op_replacement.default(x, y=y)
+
+            register_replacement(
+                pattern,
+                replacement,
+                [
+                    torch.randn(4, 4, 2, 2, device=GPU_TYPE),
+                    torch.randn(4, 4, 2, 2, device=GPU_TYPE),
+                ],
+                fwd_only,
+                replacement_patterns,
+            )
+
+            replacement_eager_strides = []
+
+            def custom_pass(graph: torch.fx.Graph):
+                producer_patterns.apply(graph)
+                replacement_patterns.apply(graph)
+                for node in graph.nodes:
+                    if (
+                        node.op == "call_function"
+                        and node.target
+                        is torch.ops.test_pm_150871.add_op_replacement.default
+                    ):
+                        eager_args, eager_kwargs = node.meta["eager_input_vals"]
+                        replacement_eager_strides.append(
+                            (eager_args[0].stride(), eager_kwargs["y"].stride())
+                        )
+
+            def fn(x, y):
+                return torch.ops.test_pm_150871.add_op.default(
+                    x.transpose(2, 3), y=y.transpose(2, 3)
+                )
+
+            x = torch.randn(4, 4, 2, 2, device=GPU_TYPE)
+            y = torch.randn(4, 4, 2, 2, device=GPU_TYPE)
+            expected_x_stride = x.transpose(2, 3).stride()
+            expected_y_stride = y.transpose(2, 3).stride()
+
+            compiled_fn = torch.compile(
+                fn, fullgraph=True, options={"post_grad_custom_post_pass": custom_pass}
+            )
+            result = compiled_fn(x, y)
+            self.assertEqual(result, fn(x, y))
+            self.assertEqual(
+                replacement_eager_strides, [(expected_x_stride, expected_y_stride)]
+            )
 
     def test_metadata_propagation_graph_pattern_replace_by_example(self):
         """Verify metadata propagation for replace_by_example (single-node match)."""

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -185,6 +185,120 @@ def _transfer_meta(
         new_meta["tensor_meta"] = old_node.meta["tensor_meta"]
 
 
+def _node_meta_val(node: torch.fx.Node) -> Any:
+    return node.meta["val"] if "val" in node.meta else node.meta["example_value"]
+
+
+def _convert_fake_tensors_to_fake_mode(
+    example_vals: Any, fake_mode: FakeTensorMode
+) -> Any:
+    def convert(it):
+        if isinstance(it, FakeTensor):
+            return fake_mode.from_tensor(it)
+        return it
+
+    return torch.fx.node.map_aggregate(example_vals, convert)
+
+
+def _normalize_pytree_container_types(tree: Any) -> Any:
+    type_mapping: dict[type, type] = {
+        immutable_list: tuple,
+        list: tuple,
+        immutable_dict: dict,
+    }
+
+    def convert_type(x: Any) -> Any:
+        convert_fn = type_mapping.get(type(x))
+        if convert_fn is None:
+            return x
+        return pytree.tree_map(
+            convert_type,
+            convert_fn(x),
+            is_leaf=lambda x: type(x) in type_mapping,
+        )
+
+    return pytree.tree_map(
+        convert_type,
+        tree,
+        is_leaf=lambda x: type(x) in type_mapping,
+    )
+
+
+def _replacement_args_with_eager_input_vals(
+    match: Match,
+    arg_nodes: Sequence[Any],
+    args: Sequence[Any],
+    fake_mode: FakeTensorMode,
+) -> list[Any] | None:
+    node_to_eager_val: dict[torch.fx.Node, Any] = {}
+    node_to_arg_val: dict[torch.fx.Node, Any] = {}
+
+    def record(node: Any, val: Any) -> None:
+        if isinstance(node, torch.fx.Node) and val is not None:
+            node_to_eager_val[node] = val
+
+    for node in match.nodes:
+        if "eager_input_vals" not in node.meta:
+            continue
+        torch.utils._pytree.tree_map(
+            record,
+            _normalize_pytree_container_types((node.args, node.kwargs)),
+            _normalize_pytree_container_types(node.meta["eager_input_vals"]),
+        )
+
+    if not node_to_eager_val:
+        return None
+
+    def record_arg(node: Any, val: Any) -> None:
+        if isinstance(node, torch.fx.Node):
+            node_to_arg_val[node] = val
+
+    torch.utils._pytree.tree_map(
+        record_arg,
+        _normalize_pytree_container_types(arg_nodes),
+        _normalize_pytree_container_types(args),
+    )
+
+    used_eager_val = False
+
+    def to_example_val(node: torch.fx.Node) -> Any:
+        nonlocal used_eager_val
+        if node in node_to_eager_val:
+            used_eager_val = True
+            return node_to_eager_val[node]
+        return node_to_arg_val.get(node, _node_meta_val(node))
+
+    example_vals = list(torch.fx.map_arg(arg_nodes, to_example_val))
+    if not used_eager_val:
+        return None
+    return _convert_fake_tensors_to_fake_mode(example_vals, fake_mode)
+
+
+def _copy_eager_input_vals(
+    eager_gm: torch.fx.GraphModule, replacement_gm: torch.fx.GraphModule
+) -> bool:
+    eager_nodes = list(eager_gm.graph.nodes)
+    replacement_nodes = list(replacement_gm.graph.nodes)
+    if len(eager_nodes) != len(replacement_nodes):
+        return False
+
+    for eager_node, replacement_node in zip(eager_nodes, replacement_nodes):
+        if eager_node.op != replacement_node.op:
+            return False
+        if (
+            eager_node.op == "call_function"
+            and eager_node.target != replacement_node.target
+        ):
+            return False
+
+    for eager_node, replacement_node in zip(eager_nodes, replacement_nodes):
+        if "eager_input_vals" in eager_node.meta:
+            replacement_node.meta["eager_input_vals"] = eager_node.meta[
+                "eager_input_vals"
+            ]
+    return True
+
+
 class Match:
     """
     Represents a successfully matched pattern.
@@ -700,28 +814,7 @@ class _TargetArgsExpr(_TargetExpr):
     def pytree_flatten(
         args: Sequence[Any], kwargs: Mapping[Any, Any]
     ) -> tuple[Sequence[Any], _SimpleSpec | pytree.TreeSpec]:
-        type_mapping: dict[type, type] = {
-            immutable_list: tuple,
-            list: tuple,
-            immutable_dict: dict,
-        }
-
-        def convert_type(x: Any) -> Any:
-            cls = type(x)
-            convert_fn = type_mapping.get(cls)
-            if convert_fn is not None:
-                return pytree.tree_map(
-                    convert_type,
-                    convert_fn(x),
-                    is_leaf=lambda x: type(x) in type_mapping,
-                )
-            return x
-
-        normalized_args_tree = pytree.tree_map(
-            convert_type,
-            (args, kwargs),
-            is_leaf=lambda x: type(x) in type_mapping,
-        )
+        normalized_args_tree = _normalize_pytree_container_types((args, kwargs))
         flat, spec = pytree.tree_flatten(normalized_args_tree)
         return flat, spec
 
@@ -1532,11 +1625,8 @@ def register_replacement(
                     f"of the inputs is unused? argnames={argnames}, match.kwargs={match.kwargs}"
                 )
 
-        args = list(
-            torch.fx.map_arg(
-                [match.kwargs[name] for name in argnames], lambda n: n.meta["val"]
-            )
-        )
+        arg_nodes = [match.kwargs[name] for name in argnames]
+        args = list(torch.fx.map_arg(arg_nodes, _node_meta_val))
 
         sym_args: list[torch.SymInt] = []
         fake_mode = torch._dynamo.utils.detect_fake_mode(args)
@@ -1643,9 +1733,27 @@ def register_replacement(
 
             if is_match(specific_pattern_match) and extra_check(specific_pattern_match):
                 # trace the pattern using the shapes from the user program
-                match.replacement_graph = trace_fn(
-                    replace_fn, args, get_decomp_fn=get_decomp_fn
+                replacement_graph = trace_fn(
+                    replace_fn,
+                    args,
+                    get_decomp_fn=get_decomp_fn,
                 )
+                if eager_args := _replacement_args_with_eager_input_vals(
+                    match, arg_nodes, args, fake_mode
+                ):
+                    graph_with_eager_vals = trace_fn(
+                        replace_fn,
+                        eager_args,
+                        get_decomp_fn=get_decomp_fn,
+                    )
+                    if not _copy_eager_input_vals(
+                        graph_with_eager_vals, replacement_graph
+                    ):
+                        log.debug(
+                            "Unable to propagate eager_input_vals for replacement %s",
+                            getattr(replace_fn, "__name__", repr(replace_fn)),
+                        )
+                match.replacement_graph = replacement_graph
                 if len(match.nodes) == 1:
                     for n in match.replacement_graph.graph.nodes:
                         _transfer_meta(

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -89,6 +89,11 @@ NodeOrConstant = Constant | torch.fx.Node
 
 backend = os.environ.get("TORCHINDUCTOR_PATTERN_MATCH_BACKEND", "inductor")
 
+_PYTREE_CONTAINER_TYPE_MAPPING: dict[type, type] = {
+    immutable_list: tuple,
+    list: tuple,
+    immutable_dict: dict,
+}
 
 _debug_nodes_cache: bool | OrderedSet[str] | None = None
 _debug_nodes_env_value_cache: str | None = None
@@ -192,35 +197,29 @@ def _node_meta_val(node: torch.fx.Node) -> Any:
 def _convert_fake_tensors_to_fake_mode(
     example_vals: Any, fake_mode: FakeTensorMode
 ) -> Any:
-    def convert(it):
+    def convert(it: Any) -> Any:
         if isinstance(it, FakeTensor):
             return fake_mode.from_tensor(it)
         return it
 
-    return torch.fx.node.map_aggregate(example_vals, convert)
+    return pytree.tree_map(convert, example_vals)
 
 
 def _normalize_pytree_container_types(tree: Any) -> Any:
-    type_mapping: dict[type, type] = {
-        immutable_list: tuple,
-        list: tuple,
-        immutable_dict: dict,
-    }
-
     def convert_type(x: Any) -> Any:
-        convert_fn = type_mapping.get(type(x))
+        convert_fn = _PYTREE_CONTAINER_TYPE_MAPPING.get(type(x))
         if convert_fn is None:
             return x
         return pytree.tree_map(
             convert_type,
             convert_fn(x),
-            is_leaf=lambda x: type(x) in type_mapping,
+            is_leaf=lambda x: type(x) in _PYTREE_CONTAINER_TYPE_MAPPING,
         )
 
     return pytree.tree_map(
         convert_type,
         tree,
-        is_leaf=lambda x: type(x) in type_mapping,
+        is_leaf=lambda x: type(x) in _PYTREE_CONTAINER_TYPE_MAPPING,
     )
 
 
@@ -1749,7 +1748,7 @@ def register_replacement(
                     if not _copy_eager_input_vals(
                         graph_with_eager_vals, replacement_graph
                     ):
-                        log.debug(
+                        log.info(
                             "Unable to propagate eager_input_vals for replacement %s",
                             getattr(replace_fn, "__name__", repr(replace_fn)),
                         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184117

Trace replacement patterns with eager input values when matched nodes carry eager_input_vals, then copy only that metadata back onto the normal replacement graph so exact-stride custom ops preserve the original eager layouts.

Fixes #150871

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo