### PR TITLE
[Bugfix] Improper iteration order for reduction operations for non-contiguous tensors on cpu

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -6684,6 +6684,18 @@ class CPUReproTests(TestCase):
                 # Compiled output should match eager mode (whether Eager produces
                 # inf or finite numbers, it shouldn't degrade into unexpected NaNs).
                 self.assertEqual(eager_out, compiled_out)
+    def test_reduction_transpose(self):
+        def f(x: torch.Tensor) -> torch.Tensor:
+            x.sin_()
+            y = x.t()
+            return y.argmin()
+
+        torch.manual_seed(21)
+
+        x = torch.randn(5, 7, device="cpu")
+        expected = f(x.clone())
+        actual = torch.compile(f, backend="inductor")(x.clone())
+        self.assertEqual(actual, expected)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -6684,6 +6684,7 @@ class CPUReproTests(TestCase):
                 # Compiled output should match eager mode (whether Eager produces
                 # inf or finite numbers, it shouldn't degrade into unexpected NaNs).
                 self.assertEqual(eager_out, compiled_out)
+
     def test_reduction_transpose(self):
         def f(x: torch.Tensor) -> torch.Tensor:
             x.sin_()

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -65,6 +65,7 @@ from .ir import (
     ExpandView,
     IndexingConstant,
     IRNode,
+    is_cpu,
     is_triton,
     MutableBox,
     OnlineSoftmaxReduction,
@@ -72,6 +73,7 @@ from .ir import (
     PermuteView,
     Pointwise,
     Reduction,
+    ReinterpretView,
     SqueezeView,
     TensorBox,
     validate_ir,
@@ -6795,6 +6797,16 @@ def make_reduction(
             and is_triton(x)
         ):
             x = to_dtype(x, torch.int32)
+
+        # For argmax/argmin on CPU, make non-contiguous tensors contiguous.
+        # The C++ backend iterates in memory order not logical order.
+        if (
+            reduction_type in ("argmax", "argmin")
+            and is_cpu(x)
+            and isinstance(x.data, (PermuteView, ReinterpretView))
+        ):
+            x = ir.ExternKernel.require_contiguous(clone(x))
+
         kwargs = _make_reduction_inner(
             x,
             axis=axis,


### PR DESCRIPTION
fixes #183894

The error seems to only be an issue for cpu. verified it is not an issue with cuda. 

The critical part is that the code generated iterates through memory order not logical order, which becomes a problem for transposed tensors.

See output code. 

```cpp
for (int64_t x0 = static_cast<int64_t>(0L);
     x0 < static_cast<int64_t>(35L);
     x0 += static_cast<int64_t>(16L))
{
    if (C10_LIKELY(
            x0 >= static_cast<int64_t>(0) &&
            x0 < static_cast<int64_t>(32L)))
    {
        auto tmp0 = at::vec::Vectorized<float>::loadu(
            out_ptr0 + static_cast<int64_t>(x0),
            static_cast<int64_t>(16));

        tmp_acc0_vec = argmin_combine_vec<float, 1, 2, true>(tmp_acc0_vec, tmp0, x0);
    }
}

```

The pr changes the tensor to contiguous memory to avoid exactly when view/transpose is used. Copied tensor is only used for argmax/argmin computation so it will not effect later operations. Perf for contiguous case in unchanged.  

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo