### PR TITLE
[MPS] dropout_p loud not implemented error

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -695,6 +695,7 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
   TORCH_CHECK_NOT_IMPLEMENTED(c10::isFloatingType(value_.scalar_type()),
                               "scaled_dot_product_attention for MPS does not support dtype ",
                               value_.scalar_type());
+  TORCH_CHECK_NOT_IMPLEMENTED(dropout_p == 0.0f, "scaled_dot_product_attention for MPS does not support dropout.");
   const auto any_nested = query.is_nested() || key_.is_nested() || value_.is_nested();
   const auto all_contiguous =
       query.is_contiguous_or_false() && key_.is_contiguous_or_false() && value_.is_contiguous_or_false();

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11402,9 +11402,8 @@ class TestSDPA(TestCaseMPS):
         # should raise
         with self.assertRaisesRegex(
                 RuntimeError,
-                r"scaled_dot_product_attention for MPS does not support dropout.",
-            ):
-                F.scaled_dot_product_attention(q, q, q, dropout_p=0.2)
+                r"scaled_dot_product_attention for MPS does not support dropout."):
+            F.scaled_dot_product_attention(q, q, q, dropout_p=0.2)
 
     @parametrize("dtype", [torch.float32, torch.float16])
     @parametrize("head_dim", [64, 128])

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11393,6 +11393,19 @@ class TestSDPA(TestCaseMPS):
         tol = 0.02 if dtype == torch.float32 else 0.05
         self._run_prefill_test(q, k, v, is_causal=is_causal, tol=tol)
 
+    def test_dropout_raises_not_implemented(self):
+        torch.manual_seed(0)
+        q = torch.randn(1, 2, 4, 8, device="mps")
+        # shouldn't raise
+        y_no_drop = F.scaled_dot_product_attention(q, q, q, dropout_p=0.0)
+        y_no_drop = F.scaled_dot_product_attention(q, q, q)
+        # should raise
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"scaled_dot_product_attention for MPS does not support dropout.",
+            ):
+                F.scaled_dot_product_attention(q, q, q, dropout_p=0.2)
+
     @parametrize("dtype", [torch.float32, torch.float16])
     @parametrize("head_dim", [64, 128])
     def test_prefill_attention_multi_q_blocks(self, dtype, head_dim):


### PR DESCRIPTION
Currently dropout_p is just plumbed in but not applied in any of the kernels/MPSGraph implementations. Reproducer:
```
import torch
import torch.nn.functional as F

torch.manual_seed(0)
q = torch.randn(1, 2, 4, 8, device="mps")
# all three produce same output
y_none = F.scaled_dot_product_attention(q, q, q, dropout_p=0.0)
y_half = F.scaled_dot_product_attention(q, q, q, dropout_p=0.5)
y_high = F.scaled_dot_product_attention(q, q, q, dropout_p=0.9)
print("MPS:", torch.allclose(y_none, y_half), torch.allclose(y_none, y_high))
```

Longer plan is to of course support it but now this is just silent correctness issue