### PR TITLE
Improve tiled reduction fusion scoring

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -263,6 +263,23 @@ class MixOrderReductionTest(TestBase):
         check_one_split_size(8)
         check_one_split_size(16)
 
+    def test_block_reduction_transpose_horizontal_fusion(self):
+        def f(x, block_size: int):
+            x0 = x.reshape(-1, block_size)
+            s0 = torch.amax(x0.abs(), dim=1).unsqueeze(1)
+            y0 = (x0 / s0).reshape(x.shape)
+
+            xt = x.t().contiguous()
+            x1 = xt.reshape(-1, block_size)
+            s1 = torch.amax(x1.abs(), dim=1).unsqueeze(1)
+            y1 = (x1 / s1).reshape(xt.shape)
+
+            return y0, y1.t(), s0, s1
+
+        x = torch.randn(256, 256, dtype=torch.bfloat16, device=GPU_TYPE)
+        self.check_numeric(f, (x, 32), tol=1e-2)
+        self.assertEqual(metrics.generated_kernel_count, 1)
+
     @inductor_config.patch(split_reductions=False)
     def test_non_contiguous_input(self):
         def f(x):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -7922,7 +7922,13 @@ class Scheduler:
         # This is a horizontal/common-read locality heuristic, not a
         # producer-consumer dependency match.
         buffer_overlap_score = 0
-        if score == 0 and self._can_use_buffer_overlap_scoring(node1, node2):
+        if score == 0 and self._can_use_buffer_overlap_scoring_for_reductions(
+            node1, node2
+        ):
+            buffer_overlap_score = self._score_fusion_memory_by_reduction_overlap(
+                node1, node2
+            )
+        elif score == 0 and self._can_use_buffer_overlap_scoring(node1, node2):
             buffer_overlap_score = self._score_fusion_memory_by_buffer_overlap(
                 node1, node2
             )
@@ -7949,6 +7955,9 @@ class Scheduler:
           "q + 2" and "k - 2" both read from `a` and would get a high overlap
           score, but fusing them horizontally prevents prologue fusion into mm
           (resulting in 2 kernels instead of 1).
+
+        Same-domain reductions with overlapping input buffers are handled by
+        _can_use_buffer_overlap_scoring_for_reductions instead.
 
         We allow buffer overlap scoring when:
         - The node outputs are not actually in the template's allowed_prologue_inps,
@@ -8030,6 +8039,78 @@ class Scheduler:
                         return False
 
         return True
+
+    def _can_use_buffer_overlap_scoring_for_reductions(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+    ) -> bool:
+        """
+        Allow same-domain sibling reductions to fuse when they read the same
+        buffer through different index expressions.
+
+        Exact MemoryDep matching misses patterns such as block reductions over
+        Mx1 and 1xM tiles: both reductions traverse the same source tensor with
+        the same (numel, rnumel), but one access is contiguous while the other is
+        transposed.  The backend can codegen those reductions together once the
+        scheduler gives the horizontal fusion a non-zero locality score.
+        """
+        if not (
+            node1.is_reduction()
+            and node2.is_reduction()
+            and _is_gpu_triton_backend(node1, node2)
+        ):
+            return False
+
+        if (node1.ancestors & node2.get_operation_names()) or (
+            node2.ancestors & node1.get_operation_names()
+        ):
+            return False
+
+        _, (numel1, rnumel1) = node1.group
+        _, (numel2, rnumel2) = node2.group
+        if not (
+            V.graph.sizevars.statically_known_equals(numel1, numel2)
+            and V.graph.sizevars.statically_known_equals(rnumel1, rnumel2)
+        ):
+            return False
+
+        common_read_names = OrderedSet(
+            dep.name for dep in node1.read_writes.reads
+        ) & OrderedSet(dep.name for dep in node2.read_writes.reads)
+        return any(
+            MixOrderReduction._is_full_access(name, node1)
+            and MixOrderReduction._is_full_access(name, node2)
+            for name in common_read_names
+        )
+
+    def _score_fusion_memory_by_reduction_overlap(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> int:
+        # Match _score_fusion_memory_by_buffer_overlap: symbolic dep sizes can
+        # hint as zero, but a known common full-buffer read should still clear
+        # the horizontal fusion threshold.
+        fallback_dep_size = 10
+
+        common_read_names = OrderedSet(
+            dep.name for dep in node1.read_writes.reads
+        ) & OrderedSet(dep.name for dep in node2.read_writes.reads)
+        common_read_names = OrderedSet(
+            name
+            for name in common_read_names
+            if MixOrderReduction._is_full_access(name, node1)
+            and MixOrderReduction._is_full_access(name, node2)
+        )
+        return max(
+            (
+                self.dep_size_hint(dep) or fallback_dep_size
+                for dep in itertools.chain(
+                    node1.read_writes.reads, node2.read_writes.reads
+                )
+                if dep.name in common_read_names
+            ),
+            default=0,
+        )
 
     def _score_fusion_memory_by_buffer_overlap(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184128

Allow same-domain sibling reductions that read the same full input buffer through different index expressions to get a non-zero horizontal fusion score. This lets the MX dim0/dim1 block normalization pattern lower to a single Triton kernel instead of two separate kernels.

Fixes #148682

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos