### PR TITLE
Fix embedding backward decomp invalid indices

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -158,6 +158,21 @@ class CPUReproTests(TestCase):
         self.assertEqual(len(actual), 1)
         torch.testing.assert_close(actual[0], expected[0])
 
+    def test_embedding_backward_out_of_range_index_dstack(self):
+        def fn():
+            grad = torch.triu_indices(row=4, col=3, offset=-100)
+            indices = torch.randperm(n=2)
+            grad_weight = torch.ops.aten.embedding_backward(
+                grad, indices, 1, 0, False, False
+            )
+            return torch.dstack((grad_weight.unflatten(dim=-1, sizes=(12,)),))
+
+        expected = fn()
+        actual = torch.compile(fn, backend="inductor")()
+
+        self.assertEqual(actual.shape, torch.Size([1, 12, 1]))
+        self.assertEqual(actual, expected)
+
     def _check_conv_stride_constraints(self, formats):
         for fmt in formats:
             # TorchDispatch doesn't work in our cuda invocation for some reason

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1295,21 +1295,34 @@ def embedding_dense_backward(
     )
     grad_output = grad_output.to(computation_dtype)
     indices = _maybe_convert_to_dtype(indices, torch.long)  # type: ignore[assignment]
+    grad_weight_shape = (num_weights,) + grad_output.shape[indices.ndim :]
+    if num_weights == 0:
+        return grad_output.new_zeros(grad_weight_shape).to(result_dtype)
+
+    valid_indices = (indices >= 0) & (indices < num_weights)
+    safe_indices = torch.where(valid_indices, indices, torch.zeros_like(indices))
     if scale_grad_by_freq:
         counts = indices.new_zeros((num_weights,))
         ones = torch.ones_like(indices)
-        counts = aten._unsafe_index_put(counts, [indices], ones, accumulate=True)
-        grad_weights_scale = counts[indices]
+        counts = aten._unsafe_index_put(
+            counts,
+            [safe_indices],
+            torch.where(valid_indices, ones, torch.zeros_like(indices)),
+            accumulate=True,
+        )
+        grad_weights_scale = torch.where(
+            valid_indices, counts[safe_indices], torch.ones_like(indices)
+        )
         grad_output = grad_output / grad_weights_scale.unsqueeze(-1)
 
-    mask = _unsqueeze_to_dim(indices == padding_idx, grad_output.ndim)
+    mask = _unsqueeze_to_dim(
+        ~valid_indices | (indices == padding_idx), grad_output.ndim
+    )
     grad = grad_output.masked_fill(mask, 0)
-    grad_weight = grad_output.new_zeros(
-        (num_weights,) + grad_output.shape[indices.ndim :]
-    )
-    return aten._unsafe_index_put(grad_weight, [indices], grad, accumulate=True).to(
-        result_dtype
-    )
+    grad_weight = grad_output.new_zeros(grad_weight_shape)
+    return aten._unsafe_index_put(
+        grad_weight, [safe_indices], grad, accumulate=True
+    ).to(result_dtype)
 
 
 def prod(x: list[int]):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184131

Mask invalid embedding backward indices before accumulating so the decomposition matches eager behavior and avoids checked index_put fallback failures in Inductor. Add a CPU Inductor regression for the dstack repro.\n\nFixes #148397\nGenerated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo