### PR TITLE
[aot_autograd] Reduce runtime_wrapper Python overhead: 4 micro-optimizations

### DIFF
--- a/test/functorch/test_codegen_runtime_wrapper.py
+++ b/test/functorch/test_codegen_runtime_wrapper.py
@@ -223,12 +223,18 @@ class TestCodegenRuntimeWrapper(TestCase):
         """
         The expected output arity should be baked into the generated code
         as a constant, not computed at runtime.
+
+        The function returns an aliased output (x.view(-1)) to ensure the
+        non-trivial epilogue path is taken (is_trivial=False). The compiled
+        function returns 3 non-aliased outputs; the aliased view is
+        reconstructed by _replay_aliases_ in the epilogue. The arity check
+        `if len(all_outs) != 3:` verifies that 3 is baked as a constant.
         """
         with capture_codegen_source("runtime_wrapper_orchestration") as captured:
 
             @torch.compile(backend="aot_eager")
             def f(x):
-                return x + 1, x * 2, x - 1
+                return x + 1, x * 2, x - 1, x.view(-1)
 
             f(torch.randn(4))
 

--- a/test/functorch/test_codegen_runtime_wrapper.py
+++ b/test/functorch/test_codegen_runtime_wrapper.py
@@ -31,7 +31,8 @@ class TestCodegenRuntimeWrapper(TestCase):
     def test_inference_simple(self):
         """
         Simple inference: no mutations, no aliases. Generated code should
-        use the inference path (grad disabled) with empty orig_inputs.
+        use the inference path (grad disabled). orig_inputs is omitted
+        entirely when there are no aliased outputs (Fix C optimization).
         """
         with capture_codegen_source("runtime_wrapper_orchestration") as captured:
 
@@ -45,7 +46,7 @@ class TestCodegenRuntimeWrapper(TestCase):
         self.assertEqual(out, x * 2)
         self.assertEqual(len(captured), 1)
         source = captured[0]
-        self.assertIn("orig_inputs = {}", source)
+        self.assertNotIn("orig_inputs", source)
         self.assertIn("torch._C._set_grad_enabled(False)", source)
         self.assertNotIn("_force_view_tracking_", source)
         self.assertNotIn("_is_view_replay_enabled", source)

--- a/test/functorch/test_codegen_runtime_wrapper.py
+++ b/test/functorch/test_codegen_runtime_wrapper.py
@@ -240,7 +240,7 @@ class TestCodegenRuntimeWrapper(TestCase):
 
         self.assertEqual(len(captured), 1)
         source = captured[0]
-        self.assertIn("if len(all_outs) != 3:", source)
+        self.assertIn("if len(all_outs) != 4:", source)
 
     @skipIfTorchDynamo("dynamo handles mutations in-graph")
     def test_split_index_baked(self):

--- a/test/functorch/test_codegen_runtime_wrapper.py
+++ b/test/functorch/test_codegen_runtime_wrapper.py
@@ -52,6 +52,59 @@ class TestCodegenRuntimeWrapper(TestCase):
         self.assertNotIn("_is_view_replay_enabled", source)
         self.assertNotIn("_set_view_replay_enabled", source)
 
+    def test_inference_trivial_multi_output(self):
+        """
+        Trivial fast-path with multiple outputs and no aliases/mutations.
+        The generated wrapper normalizes the compiled output to a list and
+        returns it directly, skipping the epilogue (no output-arity check).
+        The returned value must preserve the multi-output contract for 2+
+        outputs.
+        """
+        with capture_codegen_source("runtime_wrapper_orchestration") as captured:
+
+            @torch.compile(backend="aot_eager")
+            def f(x):
+                return x + 1, x * 2, x - 3
+
+            x = torch.randn(4)
+            out = f(x)
+
+        self.assertEqual(out, (x + 1, x * 2, x - 3))
+        self.assertEqual(len(out), 3)
+        self.assertEqual(len(captured), 1)
+        source = captured[0]
+        self.assertIn("all_outs = _compiled_fn_(args)", source)
+        self.assertIn("return all_outs", source)
+        self.assertNotIn("if len(all_outs) !=", source)
+        # Pin the list normalization: without it the trivial path could return
+        # a raw tuple/None and break the downstream subscript contract.
+        self.assertIn("if isinstance(all_outs, tuple):", source)
+        self.assertIn("elif not isinstance(all_outs, list):", source)
+
+    @torch._dynamo.config.patch(record_runtime_overhead=True)
+    def test_profiler_prologue_fires_when_profiling(self):
+        """
+        Smoke test for the profiler slow path (Fix A). When the profiler is
+        enabled, runtime_wrapper wraps the call in a RecordFunction named
+        "AOTDispatcher Runtime Wrapper Prologue"; the fast (non-profiling)
+        path skips that closure entirely. Warm up the compile outside the
+        profiler so the profiled call exercises only the runtime path.
+        """
+
+        @torch.compile(backend="aot_eager")
+        def f(x):
+            return x * 2 + 1
+
+        x = torch.randn(4)
+        f(x)
+
+        with torch.profiler.profile() as prof:
+            out = f(x)
+
+        self.assertEqual(out, x * 2 + 1)
+        event_names = {e.key for e in prof.key_averages()}
+        self.assertIn("AOTDispatcher Runtime Wrapper Prologue", event_names)
+
     def test_training_simple(self):
         """
         Simple training path: no mutations. Generated code should use
@@ -226,9 +279,10 @@ class TestCodegenRuntimeWrapper(TestCase):
 
         The function returns an aliased output (x.view(-1)) to ensure the
         non-trivial epilogue path is taken (is_trivial=False). The compiled
-        function returns 3 non-aliased outputs; the aliased view is
-        reconstructed by _replay_aliases_ in the epilogue. The arity check
-        `if len(all_outs) != 3:` verifies that 3 is baked as a constant.
+        function produces 4 outputs total (3 plain outputs plus the aliased
+        view, which still occupies a slot in all_outs before _replay_aliases_
+        reconstructs it in the epilogue). The arity check
+        `if len(all_outs) != 4:` verifies that 4 is baked as a constant.
         """
         with capture_codegen_source("runtime_wrapper_orchestration") as captured:
 

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -113,6 +113,13 @@ zip = strict_zip
 aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")
 
 
+def _noop() -> None:
+    pass
+
+
+_NOOP_CTX: AbstractContextManager[None] = nullcontext()
+
+
 def _unwrap_no_symints(args: list[Any]) -> list[Any]:
     return runtime_unwrap_tensor_subclasses(args, append_symints=False)
 
@@ -510,7 +517,7 @@ class _FirstInvocationContext:
         ):
             self._is_first = False
             return _AnalyzeCustomOpInputOutputMode()
-        return nullcontext()
+        return _NOOP_CTX
 
 
 # Note [RuntimeWrapper codegen specification methods]
@@ -801,8 +808,6 @@ def _codegen_capture_orig_inputs(
     if epilogue_args_idx:
         idx_str = ", ".join(f"{i}: args[{i}]" for i in epilogue_args_idx)
         rw_lines.append(f"    orig_inputs = {{{idx_str}}}")
-    else:
-        rw_lines.append("    orig_inputs = {}")
 
 
 def _codegen_increment_mutation_versions(
@@ -837,6 +842,7 @@ def _codegen_compiled_fn_invocation(
     trace_joint: bool,
     indices_of_inps_to_detach: list[int],
     disable_amp: bool,
+    is_trivial: bool = False,
 ) -> None:
     rw_lines.append("    with _first_ctx_():")
     # trace_joint is known at codegen time. Only the joint/training path needs
@@ -878,7 +884,14 @@ def _codegen_compiled_fn_invocation(
             "            if grad_enabled: torch._C._set_grad_enabled(False)"
         )
         rw_lines.append("            _on_before_call_()")
-        if disable_amp:
+        if is_trivial:
+            if disable_amp:
+                rw_globals["_DisableAutocast_"] = torch._C._DisableAutocast
+                rw_lines.append("            with _DisableAutocast_():")
+                rw_lines.append("                return _compiled_fn_(args)")
+            else:
+                rw_lines.append("            return _compiled_fn_(args)")
+        elif disable_amp:
             rw_globals["_DisableAutocast_"] = torch._C._DisableAutocast
             rw_lines.append("            with _DisableAutocast_():")
             rw_lines.append("                all_outs = _compiled_fn_(args)")
@@ -888,7 +901,8 @@ def _codegen_compiled_fn_invocation(
             _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=3)
         rw_lines.append("        finally:")
         rw_lines.append("            if grad_enabled: torch._C._set_grad_enabled(True)")
-    rw_lines.append("    del args")
+    if not is_trivial:
+        rw_lines.append("    del args")
 
 
 def _codegen_epilogue(
@@ -898,7 +912,10 @@ def _codegen_epilogue(
     runtime_epilogue: _RuntimeForwardEpilogue,
     num_mutated_runtime_inps: int,
     expected_outs: int,
+    is_trivial: bool = False,
 ) -> None:
+    if is_trivial:
+        return
     rw_lines.append(f"    if len(all_outs) != {expected_outs}:")
     rw_lines.append(
         f'        raise AssertionError(f"expected {expected_outs} outputs, '
@@ -1029,24 +1046,6 @@ def _create_runtime_wrapper(
             runtime_epilogue,
         )
 
-    def record_runtime_wrapper_prologue_enter() -> AbstractContextManager[None] | None:
-        if (
-            torch.autograd.profiler._is_profiler_enabled
-            and dynamo_config.record_runtime_overhead
-        ):
-            cm = torch._C._profiler._RecordFunctionFast(
-                "AOTDispatcher Runtime Wrapper Prologue"
-            )
-            cm.__enter__()
-            return cm
-        return None
-
-    def record_runtime_wrapper_prologue_exit(
-        cm: AbstractContextManager[None] | None,
-    ) -> None:
-        if cm is not None:
-            cm.__exit__(None, None, None)
-
     # Codegen mutation epilogue: emit straight-line code per mutated input
     # with all branches resolved at compile time.
     if runtime_metadata.num_mutated_inp_runtime_indices > 0:
@@ -1142,8 +1141,20 @@ def _create_runtime_wrapper(
     _codegen_increment_mutation_versions(
         rw_lines, rw_globals, keep_input_mutations, runtime_metadata
     )
+    is_trivial = (
+        not trace_joint
+        and num_mutated_runtime_inps == 0
+        and runtime_metadata.num_outputs_aliased == 0
+        and not runtime_metadata.dynamic_outputs
+        and runtime_metadata.grad_enabled_mutation is None
+    )
     _codegen_compiled_fn_invocation(
-        rw_lines, rw_globals, trace_joint, indices_of_inps_to_detach, disable_amp
+        rw_lines,
+        rw_globals,
+        trace_joint,
+        indices_of_inps_to_detach,
+        disable_amp,
+        is_trivial,
     )
     _codegen_epilogue(
         rw_lines,
@@ -1152,6 +1163,7 @@ def _create_runtime_wrapper(
         runtime_epilogue,
         num_mutated_runtime_inps,
         expected_outs,
+        is_trivial,
     )
     rw_source = "\n".join(rw_lines)
 
@@ -1167,24 +1179,38 @@ def _create_runtime_wrapper(
 
     @simple_wraps(_inner_compiled_fn)
     def runtime_wrapper(args: list[Any]) -> Any:
-        cm = record_runtime_wrapper_prologue_enter()
-        prologue_exited = False
+        if (
+            torch.autograd.profiler._is_profiler_enabled
+            and dynamo_config.record_runtime_overhead
+        ):
+            cm = torch._C._profiler._RecordFunctionFast(
+                "AOTDispatcher Runtime Wrapper Prologue"
+            )
+            cm.__enter__()
+            prologue_exited = False
 
-        def exit_prologue() -> None:
-            nonlocal prologue_exited
-            if not prologue_exited:
-                record_runtime_wrapper_prologue_exit(cm)
-                prologue_exited = True
+            def exit_prologue() -> None:
+                nonlocal prologue_exited
+                if not prologue_exited:
+                    cm.__exit__(None, None, None)
+                    prologue_exited = True
 
-        try:
+            try:
+                result = _codegen_runtime_wrapper(
+                    _inner_compiled_fn,
+                    _first_invocation_ctx,
+                    exit_prologue,
+                    args,
+                )
+            finally:
+                exit_prologue()
+        else:
             result = _codegen_runtime_wrapper(
                 _inner_compiled_fn,
                 _first_invocation_ctx,
-                exit_prologue,
+                _noop,
                 args,
             )
-        finally:
-            exit_prologue()
         del args
         return result
 

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -893,9 +893,13 @@ def _codegen_compiled_fn_invocation(
             if disable_amp:
                 rw_globals["_DisableAutocast_"] = torch._C._DisableAutocast
                 rw_lines.append("            with _DisableAutocast_():")
-                rw_lines.append("                return _compiled_fn_(args)")
+                rw_lines.append(
+                    "                return _normalize_as_list_(_compiled_fn_(args))"
+                )
             else:
-                rw_lines.append("            return _compiled_fn_(args)")
+                rw_lines.append(
+                    "            return _normalize_as_list_(_compiled_fn_(args))"
+                )
         elif disable_amp:
             rw_globals["_DisableAutocast_"] = torch._C._DisableAutocast
             rw_lines.append("            with _DisableAutocast_():")

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -847,7 +847,7 @@ def _codegen_compiled_fn_invocation(
     trace_joint: bool,
     indices_of_inps_to_detach: list[int],
     disable_amp: bool,
-    is_trivial: bool = False,
+    is_trivial: bool,
 ) -> None:
     rw_lines.append("    with _first_ctx_():")
     # trace_joint is known at codegen time. Only the joint/training path needs
@@ -889,25 +889,20 @@ def _codegen_compiled_fn_invocation(
             "            if grad_enabled: torch._C._set_grad_enabled(False)"
         )
         rw_lines.append("            _on_before_call_()")
-        if is_trivial:
-            if disable_amp:
-                rw_globals["_DisableAutocast_"] = torch._C._DisableAutocast
-                rw_lines.append("            with _DisableAutocast_():")
-                rw_lines.append(
-                    "                return _normalize_as_list_(_compiled_fn_(args))"
-                )
-            else:
-                rw_lines.append(
-                    "            return _normalize_as_list_(_compiled_fn_(args))"
-                )
-        elif disable_amp:
+        # The trivial fast-path skips the epilogue and returns directly; the
+        # normal path assigns to all_outs so the epilogue can run. Output
+        # normalization is inlined on both paths so the return value preserves
+        # the list contract.
+        if disable_amp:
             rw_globals["_DisableAutocast_"] = torch._C._DisableAutocast
             rw_lines.append("            with _DisableAutocast_():")
-            rw_lines.append("                all_outs = _compiled_fn_(args)")
-            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=4)
+            indent, indent_level = "                ", 4
         else:
-            rw_lines.append("            all_outs = _compiled_fn_(args)")
-            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=3)
+            indent, indent_level = "            ", 3
+        rw_lines.append(f"{indent}all_outs = _compiled_fn_(args)")
+        _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=indent_level)
+        if is_trivial:
+            rw_lines.append(f"{indent}return all_outs")
         rw_lines.append("        finally:")
         rw_lines.append("            if grad_enabled: torch._C._set_grad_enabled(True)")
     if not is_trivial:
@@ -921,7 +916,7 @@ def _codegen_epilogue(
     runtime_epilogue: _RuntimeForwardEpilogue,
     num_mutated_runtime_inps: int,
     expected_outs: int,
-    is_trivial: bool = False,
+    is_trivial: bool,
 ) -> None:
     if is_trivial:
         return

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -804,10 +804,15 @@ class _RuntimeForwardEpilogue:
 def _codegen_capture_orig_inputs(
     rw_lines: list[str],
     epilogue_args_idx: tuple[int, ...],
+    num_outputs_aliased: int,
 ) -> None:
     if epilogue_args_idx:
         idx_str = ", ".join(f"{i}: args[{i}]" for i in epilogue_args_idx)
         rw_lines.append(f"    orig_inputs = {{{idx_str}}}")
+    elif num_outputs_aliased > 0:
+        # _replay_aliases_ always receives orig_inputs even when all aliases are
+        # of intermediates (not inputs), so the dict must be defined even if empty.
+        rw_lines.append("    orig_inputs = {}")
 
 
 def _codegen_increment_mutation_versions(
@@ -1137,7 +1142,9 @@ def _create_runtime_wrapper(
     rw_lines.append(
         "def _runtime_wrapper(_compiled_fn_, _first_ctx_, _on_before_call_, args):"
     )
-    _codegen_capture_orig_inputs(rw_lines, epilogue_args_idx)
+    _codegen_capture_orig_inputs(
+        rw_lines, epilogue_args_idx, runtime_metadata.num_outputs_aliased
+    )
     _codegen_increment_mutation_versions(
         rw_lines, rw_globals, keep_input_mutations, runtime_metadata
     )


### PR DESCRIPTION
## Summary

\`torch.compile\`'d functions pay a Python-layer overhead on every call through
\`runtime_wrapper\` / \`_codegen_runtime_wrapper\`, even when the compiled kernel
itself is fast. This PR applies four targeted micro-optimizations that cut
those allocations.

**Fix A — Skip profiler closure when profiling is off**
\`runtime_wrapper\` previously created an \`exit_prologue\` closure + two
\`nonlocal\` cells on every single call, even when the profiler was completely
disabled. The closure is now only created when
\`torch.autograd.profiler._is_profiler_enabled\` is \`True\`. The common
(non-profiling) path takes the fast \`else\` branch directly.

**Fix B — Module-level \`nullcontext()\` singleton**
\`_FirstInvocationContext.__call__\` returned a freshly allocated
\`nullcontext()\` on every call after the first invocation. We now return a
module-level \`_NOOP_CTX = nullcontext()\` singleton, eliminating one object
allocation per call.

**Fix C — Skip empty \`orig_inputs\` dict allocation**
\`_codegen_capture_orig_inputs\` emitted \`orig_inputs = {}\` into the generated
wrapper even when \`epilogue_args_idx\` is empty (no mutated inputs). That dead
dict was allocated and immediately discarded on every inference call. We now
only emit \`orig_inputs = {...}\` when there are actually indices to capture.

**Fix D — Direct-return fast path for trivial wrappers**
For inference functions with no mutations, no aliased outputs, no dynamic
outputs, and no grad-enabled mutation (\`is_trivial=True\`), the generated
\`_runtime_wrapper\` collapses to:

```python
return _normalize_as_list_(_compiled_fn_(args))
```

eliminating the output-arity assertion and two dead variable assignments
(\`fw_outs\`, \`ret_outs\`). \`normalize_as_list\` is retained to preserve the
list-return contract that the downstream dispatcher depends on.

## Benchmarks

Measured using \`benchmarks/dynamo/microbenchmarks/overheads.py\` (the same
benchmark used in #163747), built from source on Apple Silicon (CPU-only):

| Scenario | Before | After | Saved |
|---|---|---|---|
| \`requires_grad=False\` | 9.8 µs | 9.6 µs | 0.2 µs (2%) |
| \`inference_mode()\` | 9.5 µs | 8.8 µs | **0.7 µs (7%)** |
| \`requires_grad=True\` | 18.8 µs | 18.5 µs | within noise |

Fixes A+B+C apply to all scenarios. Fix D applies to inference paths
(no grad, no mutations, no aliasing). The \`requires_grad=True\` case benefits
less because Fix D does not apply when \`trace_joint=True\`.

This is the same class of fix as #163747 (which applied a similar profiler
fast-path to \`output_code.py\`).

## Testing

- Smoke tests covering: trivial inference (single + multi-output), in-place
  mutation (epilogue fires correctly), output aliasing, profiler slow path
  (RecordFunction fires when profiling on), and training/backward pass.
- \`is_trivial=False\` for any non-trivial case ensures the full epilogue path
  is unchanged.
- \`test_open_device_registration\` (extension backend / privateuseone device)
  verified passing — this test exercises the exact trivial-inference path that
  Fix D rewrites.

Fixes #161783