### PR TITLE
Fix TensorBoard hparams metric logging

### DIFF
--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -14,6 +14,7 @@ import numpy as np
 
 TEST_TENSORBOARD = True
 try:
+    from tensorboard.backend.event_processing import event_file_loader
     import tensorboard.summary.writer.event_file_writer  # noqa: F401
     from tensorboard.compat.proto.summary_pb2 import Summary
 except ImportError:
@@ -283,6 +284,27 @@ recall = [1.0, 0.8533334, 0.28, 0.0666667, 0.0]
 
 
 class TestTensorBoardWriter(BaseTestCase):
+    def test_add_hparams_metric_uses_scalars_plugin(self):
+        with self.createSummaryWriter() as writer:
+            writer.add_hparams(
+                {"lr": 0.1, "epochs": 3},
+                {"sss": 2},
+                run_name="run0",
+                global_step=5,
+            )
+
+        metric_values = []
+        run_dir = Path(writer.get_logdir()) / "run0"
+        for event_file in run_dir.glob("events.out.tfevents.*"):
+            for event in event_file_loader.EventFileLoader(str(event_file)).Load():
+                for value in event.summary.value:
+                    if value.tag == "sss":
+                        metric_values.append(value)
+
+        self.assertEqual(1, len(metric_values))
+        self.assertEqual("scalars", metric_values[0].metadata.plugin_data.plugin_name)
+        self.assertEqual(2, metric_values[0].tensor.float_val[0])
+
     def test_writer(self):
         with self.createSummaryWriter() as writer:
             sample_rate = 44100

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -342,7 +342,7 @@ class SummaryWriter:
             w_hp.file_writer.add_summary(ssi, global_step)
             w_hp.file_writer.add_summary(sei, global_step)
             for k, v in metric_dict.items():
-                w_hp.add_scalar(k, v, global_step)
+                w_hp.add_scalar(k, v, global_step, new_style=True)
 
     def add_scalar(
         self,


### PR DESCRIPTION
Fixes `SummaryWriter.add_hparams` metric logging so metric values are visible in TensorBoard's hparams tab.

TensorBoard's hparams backend reads metric values through the `scalars` plugin. PyTorch was writing hparams metrics with the old scalar summary format, which can still show up in the Scalars tab but does not register with the scalar plugin metadata used by hparams.

This changes `add_hparams` to write metric scalars with `new_style=True`, and adds a regression test that checks hparams metric summaries are tagged with the `scalars` plugin.

fixes - [#184078 add_params metric_dict values not shown in tensorboard hparams tab](https://github.com/pytorch/pytorch/issues/184078)
