### PR TITLE
Fix LPPool signed fractional inputs

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -5,6 +5,8 @@
 #include <torch/nn/modules/utils.h>
 #include <torch/nn/options/pooling.h>
 
+#include <limits>
+
 namespace torch::nn::functional {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -1009,8 +1011,17 @@ inline Tensor lp_pool1d(
     ExpandingArray<1> kernel_size,
     ExpandingArray<1> stride,
     bool ceil_mode) {
+  if (norm_type == std::numeric_limits<double>::infinity()) {
+    return detail::max_pool1d(
+        torch::abs(input),
+        kernel_size,
+        stride,
+        /*padding=*/0,
+        /*dilation=*/1,
+        ceil_mode);
+  }
   Tensor out = detail::avg_pool1d(
-      input.pow(norm_type),
+      torch::abs(input).pow(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,
@@ -1057,8 +1068,17 @@ inline Tensor lp_pool2d(
     bool ceil_mode) {
   auto kw = (*kernel_size)[0];
   auto kh = (*kernel_size)[1];
+  if (norm_type == std::numeric_limits<double>::infinity()) {
+    return detail::max_pool2d(
+        torch::abs(input),
+        kernel_size,
+        stride,
+        /*padding=*/0,
+        /*dilation=*/1,
+        ceil_mode);
+  }
   Tensor out = detail::avg_pool2d(
-      input.pow(norm_type),
+      torch::abs(input).pow(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,
@@ -1107,8 +1127,17 @@ inline Tensor lp_pool3d(
   auto kd = (*kernel_size)[0];
   auto kw = (*kernel_size)[1];
   auto kh = (*kernel_size)[2];
+  if (norm_type == std::numeric_limits<double>::infinity()) {
+    return detail::max_pool3d(
+        torch::abs(input),
+        kernel_size,
+        stride,
+        /*padding=*/0,
+        /*dilation=*/1,
+        ceil_mode);
+  }
   Tensor out = detail::avg_pool3d(
-      input.pow(norm_type),
+      torch::abs(input).pow(norm_type),
       kernel_size,
       stride,
       /*padding=*/0,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1094,7 +1094,7 @@ def lp_pool3d(
     r"""
     Apply a 3D power-average pooling over an input signal composed of several input planes.
 
-    If the sum of all inputs to the power of `p` is
+    If the sum of all absolute inputs to the power of `p` is
     zero, the gradient is set to zero as well.
 
     When ``ceil_mode`` is ``True``, sliding windows may go off-bounds if they start within the left
@@ -1113,11 +1113,13 @@ def lp_pool3d(
             ceil_mode=ceil_mode,
         )
     kd, kw, kh = _triple(kernel_size)
+    if norm_type == math.inf:
+        return max_pool3d(input.abs(), kernel_size, stride, 0, 1, ceil_mode)
     if stride is not None:
-        out = avg_pool3d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool3d(input.abs().pow(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool3d(
-            input.pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
     return (
@@ -1135,7 +1137,7 @@ def lp_pool2d(
     r"""
     Apply a 2D power-average pooling over an input signal composed of several input planes.
 
-    If the sum of all inputs to the power of `p` is
+    If the sum of all absolute inputs to the power of `p` is
     zero, the gradient is set to zero as well.
 
     When ``ceil_mode`` is ``True``, sliding windows may go off-bounds if they start within the left
@@ -1154,11 +1156,13 @@ def lp_pool2d(
             ceil_mode=ceil_mode,
         )
     kw, kh = _pair(kernel_size)
+    if norm_type == math.inf:
+        return max_pool2d(input.abs(), kernel_size, stride, 0, 1, ceil_mode)
     if stride is not None:
-        out = avg_pool2d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool2d(input.abs().pow(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool2d(
-            input.pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
     return (torch.sign(out) * relu(torch.abs(out))).mul(kw * kh).pow(1.0 / norm_type)
@@ -1173,7 +1177,7 @@ def lp_pool1d(
 ) -> Tensor:
     r"""Apply a 1D power-average pooling over an input signal composed of several input planes.
 
-    If the sum of all inputs to the power of `p` is
+    If the sum of all absolute inputs to the power of `p` is
     zero, the gradient is set to zero as well.
 
     When ``ceil_mode`` is ``True``, sliding windows may go off-bounds if they start within the left
@@ -1191,11 +1195,13 @@ def lp_pool1d(
             stride=stride,
             ceil_mode=ceil_mode,
         )
+    if norm_type == math.inf:
+        return max_pool1d(input.abs(), kernel_size, stride, 0, 1, ceil_mode)
     if stride is not None:
-        out = avg_pool1d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
+        out = avg_pool1d(input.abs().pow(norm_type), kernel_size, stride, 0, ceil_mode)
     else:
         out = avg_pool1d(
-            input.pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
+            input.abs().pow(norm_type), kernel_size, padding=0, ceil_mode=ceil_mode
         )
 
     return (

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -1128,7 +1128,7 @@ class LPPool1d(_LPPoolNd):
     On each window, the function computed is:
 
     .. math::
-        f(X) = \sqrt[p]{\sum_{x \in X} x^{p}}
+        f(X) = \sqrt[p]{\sum_{x \in X} |x|^{p}}
 
     - At p = :math:`\infty`, one gets Max Pooling
     - At p = 1, one gets Sum Pooling (which is proportional to Average Pooling)
@@ -1175,7 +1175,7 @@ class LPPool2d(_LPPoolNd):
     On each window, the function computed is:
 
     .. math::
-        f(X) = \sqrt[p]{\sum_{x \in X} x^{p}}
+        f(X) = \sqrt[p]{\sum_{x \in X} |x|^{p}}
 
     - At p = :math:`\infty`, one gets Max Pooling
     - At p = 1, one gets Sum Pooling (which is proportional to average pooling)
@@ -1235,7 +1235,7 @@ class LPPool3d(_LPPoolNd):
     On each window, the function computed is:
 
     .. math::
-        f(X) = \sqrt[p]{\sum_{x \in X} x^{p}}
+        f(X) = \sqrt[p]{\sum_{x \in X} |x|^{p}}
 
     - At p = :math:`\infty`, one gets Max Pooling
     - At p = 1, one gets Sum Pooling (which is proportional to average pooling)

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -2391,14 +2391,61 @@ def module_inputs_torch_nn_LocalResponseNorm(module_info, device, dtype, require
     ]
 
 
+def _lppool_reference_fn(m, p, input):
+    del p
+    pooling_dim = input.dim() - 2
+    if pooling_dim == 1:
+        kernel_size = (m.kernel_size,)
+        if m.norm_type == math.inf:
+            return F.max_pool1d(input.abs(), m.kernel_size, m.stride, 0, 1, m.ceil_mode)
+        out = F.avg_pool1d(
+            input.abs().pow(m.norm_type), m.kernel_size, m.stride, 0, m.ceil_mode
+        )
+    elif pooling_dim == 2:
+        kernel_size = (
+            tuple(m.kernel_size)
+            if isinstance(m.kernel_size, tuple)
+            else (m.kernel_size,) * 2
+        )
+        if m.norm_type == math.inf:
+            return F.max_pool2d(input.abs(), m.kernel_size, m.stride, 0, 1, m.ceil_mode)
+        out = F.avg_pool2d(
+            input.abs().pow(m.norm_type), m.kernel_size, m.stride, 0, m.ceil_mode
+        )
+    else:
+        kernel_size = (
+            tuple(m.kernel_size)
+            if isinstance(m.kernel_size, tuple)
+            else (m.kernel_size,) * 3
+        )
+        if m.norm_type == math.inf:
+            return F.max_pool3d(input.abs(), m.kernel_size, m.stride, 0, 1, m.ceil_mode)
+        out = F.avg_pool3d(
+            input.abs().pow(m.norm_type), m.kernel_size, m.stride, 0, m.ceil_mode
+        )
+
+    return out.mul(math.prod(kernel_size)).pow(1.0 / m.norm_type)
+
+
 def module_inputs_torch_nn_LPPool1d(module_info, device, dtype, requires_grad, training, **kwargs):
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    make_signed_input = partial(make_input, low=-1, high=1)
 
     return [
         ModuleInput(
             constructor_input=FunctionInput(1.5, 2),
             forward_input=FunctionInput(make_input((1, 3, 7))),
             desc='norm'),
+        ModuleInput(
+            constructor_input=FunctionInput(2.3273891720497133, 2, 1),
+            forward_input=FunctionInput(make_signed_input((1, 3, 7))),
+            reference_fn=_lppool_reference_fn,
+            desc='signed_fractional_norm'),
+        ModuleInput(
+            constructor_input=FunctionInput(math.inf, 2, 1),
+            forward_input=FunctionInput(make_signed_input((1, 3, 7))),
+            reference_fn=_lppool_reference_fn,
+            desc='infinity_norm'),
         ModuleInput(
             constructor_input=FunctionInput(2, 2, 3),
             forward_input=FunctionInput(make_input((1, 3, 7)))),
@@ -2413,11 +2460,22 @@ def module_inputs_torch_nn_LPPool1d(module_info, device, dtype, requires_grad, t
 
 def module_inputs_torch_nn_LPPool2d(module_info, device, dtype, requires_grad, training, **kwargs):
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    make_signed_input = partial(make_input, low=-1, high=1)
 
     return [
         ModuleInput(
             constructor_input=FunctionInput(2, 2, 2),
             forward_input=FunctionInput(make_input((1, 3, 7, 7)))),
+        ModuleInput(
+            constructor_input=FunctionInput(2.3273891720497133, (2, 2), (1, 1)),
+            forward_input=FunctionInput(make_signed_input((1, 3, 7, 7))),
+            reference_fn=_lppool_reference_fn,
+            desc='signed_fractional_norm'),
+        ModuleInput(
+            constructor_input=FunctionInput(math.inf, (2, 2), (1, 1)),
+            forward_input=FunctionInput(make_signed_input((1, 3, 7, 7))),
+            reference_fn=_lppool_reference_fn,
+            desc='infinity_norm'),
         ModuleInput(
             constructor_input=FunctionInput(2, 2, 2),
             forward_input=FunctionInput(make_input((3, 7, 7))),
@@ -2432,11 +2490,22 @@ def module_inputs_torch_nn_LPPool2d(module_info, device, dtype, requires_grad, t
 
 def module_inputs_torch_nn_LPPool3d(module_info, device, dtype, requires_grad, training, **kwargs):
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    make_signed_input = partial(make_input, low=-1, high=1)
 
     return [
         ModuleInput(
             constructor_input=FunctionInput(2, 2, 2),
             forward_input=FunctionInput(make_input((1, 3, 7, 7, 7)))),
+        ModuleInput(
+            constructor_input=FunctionInput(2.3273891720497133, (2, 2, 2), (1, 1, 1)),
+            forward_input=FunctionInput(make_signed_input((1, 3, 7, 7, 7))),
+            reference_fn=_lppool_reference_fn,
+            desc='signed_fractional_norm'),
+        ModuleInput(
+            constructor_input=FunctionInput(math.inf, (2, 2, 2), (1, 1, 1)),
+            forward_input=FunctionInput(make_signed_input((1, 3, 7, 7, 7))),
+            reference_fn=_lppool_reference_fn,
+            desc='infinity_norm'),
         ModuleInput(
             constructor_input=FunctionInput(2, 2, 2),
             forward_input=FunctionInput(make_input((3, 7, 7, 7))),


### PR DESCRIPTION
Fixes `LPPool1d`, `LPPool2d`, and `LPPool3d` for signed inputs with non-integer `norm_type`.

Lp pooling should compute over `abs(input) ** p`; using `input ** p` produces NaNs for negative values when `p` is fractional. This updates the Python and C++ frontend implementations to use absolute values before exponentiation.

This also handles `norm_type=inf` by dispatching to max pooling over `abs(input)`, matching the documented `p = infinity` behavior, and updates the module docs formula accordingly.

Adds CPU regression coverage for:
- signed inputs with fractional `norm_type`
- `norm_type=inf`
