### PR TITLE
Drop sig parameter from gen_static_dispatch_backend_signature

### DIFF
--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -470,7 +470,7 @@ def generate_static_dispatch_backend_call(
     f: NativeFunction,
     backend_index: BackendIndex,
 ) -> str:
-    cpp_sig = gen_static_dispatch_backend_call_signature(sig, f)
+    cpp_sig = gen_static_dispatch_backend_call_signature(f)
     name = cpp_sig.name()
     exprs = translate_args(sig, cpp_sig)
     backend_metadata = backend_index.get_kernel(f)

--- a/torchgen/gen_aoti_c_shim.py
+++ b/torchgen/gen_aoti_c_shim.py
@@ -442,10 +442,7 @@ def gen_declaration_and_definition(
     return declaration_definition_cache[(base_name, device, backend_call)]
 
 
-def gen_static_dispatch_backend_call_signature(
-    sig: CppSignature | DispatcherSignature,
-    f: NativeFunction,
-) -> CppSignature:
+def gen_static_dispatch_backend_call_signature(f: NativeFunction) -> CppSignature:
     sig = DispatcherSignature.from_schema(f.func)
     cpp_sigs = CppSignatureGroup.from_native_function(
         f, method=False, fallback_binding=False
@@ -464,7 +461,7 @@ def gen_static_dispatch_backend_call(
     backend_index: BackendIndex | None = None,
 ) -> str:
     sig = DispatcherSignature.from_schema(f.func)
-    cpp_sig = gen_static_dispatch_backend_call_signature(sig, f)
+    cpp_sig = gen_static_dispatch_backend_call_signature(f)
 
     if backend_index is None:
         # Check if this is a symint function and if the function only has method variants


### PR DESCRIPTION

The first statement reassigned sig, discarding the caller's value. Remove the param and update both callers.