### PR TITLE
[torchgen] Remove unreachable XPU entry from gen_empty_impl_names

### DIFF
--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -103,7 +103,6 @@ def gen_empty_impl_names(
         DispatchKey.CompositeExplicitAutogradNonFunctional,
         DispatchKey.QuantizedCPU,
         DispatchKey.QuantizedCUDA,
-        DispatchKey.XPU,
     ):
         empty_impl = "at::empty"
         empty_strided_impl = "at::empty_strided"


### PR DESCRIPTION
DispatchKey.XPU is already matched by the preceding tuple (which sets empty_impl to at::detail::empty_xpu); the elif arm could never fire for XPU. No behavior change.