### PR TITLE
[CUDA] Fix float32 std/var M2 overflow by using double accumulation

### DIFF
--- a/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
@@ -12,11 +12,10 @@
 
 namespace at::native {
 
-template <typename scalar_t, typename out_t=scalar_t>
+template <typename scalar_t, typename accscalar_t = at::acc_type<scalar_t, true>, typename out_t = scalar_t>
 void std_var_kernel_impl(TensorIterator& iter, double correction, bool take_sqrt) {
   // reducing unrolling factor to 2 for welford kernel
   // This is necessary to lower register usage that leads to register spills.
-  using accscalar_t = at::acc_type<scalar_t, true>;
   using ops_t = WelfordOps<scalar_t, accscalar_t, int32_t, thrust::pair<out_t, out_t>>;
   ops_t ops(static_cast<accscalar_t>(correction), take_sqrt);
   gpu_reduce_kernel<scalar_t, out_t, 2>(iter, ops, typename ops_t::acc_t{});
@@ -30,6 +29,9 @@ static void std_var_kernel_cuda(TensorIterator& iter, double correction, bool ta
   } else if (input_dtype == kBFloat16 && iter.dtype() == kFloat) {
     // type promotion that does cast and reduction in a single kernel
     std_var_kernel_impl<at::BFloat16, float>(iter, correction, take_sqrt);
+  } else if (input_dtype == kFloat && iter.dtype() == kFloat) {
+    // float32 input: use double accumulation to avoid M2 overflow
+    std_var_kernel_impl<float, double>(iter, correction, take_sqrt);
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16,
                                     iter.dtype(), "std_cuda", [&]() {

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1423,6 +1423,40 @@ class TestReductions(TestCase):
         tensor = tensor.unsqueeze(1)
         self.assertEqual(tensor.var(0), 0.03125)
 
+    @onlyCUDA
+    def test_std_var_large_float32_no_overflow(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/180156
+        # CUDA kernel accumulated M2 in float32, causing overflow to inf for inputs
+        # where M2 ~ N * (std)^2 ~ 1000 * (1e19)^2 = 1e41 > float32 max (~3.4e38).
+        torch.manual_seed(0)
+        x = torch.randn(1000, dtype=torch.float32) * 1e19 + 1e20
+
+        # 1D: global reduce
+        ref_std = torch.std(x.double()).item()
+        ref_var = torch.var(x.double()).item()
+        device_std = torch.std(x.to(device)).cpu().item()
+        device_var = torch.var(x.to(device)).cpu().item()
+
+        self.assertFalse(math.isinf(device_std), "std overflowed to inf on large float32 input")
+        self.assertFalse(math.isinf(device_var), "var overflowed to inf on large float32 input")
+        self.assertAlmostEqual(device_std / ref_std, 1.0, places=3)
+        self.assertAlmostEqual(device_var / ref_var, 1.0, places=3)
+
+        # 2D: reduce along dim, exercises parallel combine() across thread blocks
+        x2d = x.reshape(10, 100)
+        ref_std_dim = torch.std(x2d.double(), dim=1)
+        device_std_dim = torch.std(x2d.to(device), dim=1).cpu()
+        self.assertFalse(device_std_dim.isinf().any(), "std with dim overflowed to inf")
+        self.assertTrue(
+            ((device_std_dim - ref_std_dim.float()).abs() / ref_std_dim.float().abs()).max() < 1e-3
+        )
+
+        # correction=0 (biased): correction is stored as accscalar_t, verify path works
+        ref_var_biased = torch.var(x.double(), correction=0).item()
+        device_var_biased = torch.var(x.to(device), correction=0).cpu().item()
+        self.assertFalse(math.isinf(device_var_biased), "biased var overflowed to inf")
+        self.assertAlmostEqual(device_var_biased / ref_var_biased, 1.0, places=3)
+
     @onlyCPU
     @dtypes(torch.bfloat16, torch.float16)
     def test_sum_noncontig_lowp(self, device, dtype) -> None:


### PR DESCRIPTION
## Summary

`torch.std` and `torch.var` return `inf` on CUDA for `float32` inputs
with large magnitudes, while CPU returns the correct result.

```python
import torch

torch.manual_seed(0)
x = torch.randn(1000, dtype=torch.float32) * 1e19 + 1e20

print(torch.std(x.double()))   # 1.0287e+19  (correct)
print(torch.std(x))            # 1.0287e+19  (correct, CPU)
print(torch.std(x.cuda()))     # inf          (overflow, CUDA)

Root cause: std_var_kernel_impl in ReduceMomentKernel.cu uses
at::acc_type<scalar_t, true> for the Welford accumulation type, which
resolves to float for float32 inputs on CUDA. The intermediate M2
value overflows float32's max (~3.4e38) when:

M2 ~ N × std² ~ 1000 × (1e19)² = 1e41  >  3.4e38
The CPU kernel explicitly uses double for accumulation and is unaffected.

Fix
Make accscalar_t an overridable template parameter in
std_var_kernel_impl (keeping at::acc_type<scalar_t, true> as the
default), and add an explicit float32 → double dispatch branch in
std_var_kernel_cuda so that float32 inputs always accumulate M2 in
double precision.

The Intel XPU team applied the same approach for XPU in
[intel/torch-xpu-ops#3337](https://github.com/intel/torch-xpu-ops/pull/3337).

Test
Added test_std_var_large_float32_no_overflow in test/test_reductions.py,
which covers:

1D global reduce (std and var)
2D reduce along a dimension (exercises parallel combine())
correction=0 (biased variance)
Fixes #180156 