### PR TITLE
nn: better error message when unsupported dtype op is run on CPU (GH #96292)

### DIFF
--- a/test/nn/test_module_hooks.py
+++ b/test/nn/test_module_hooks.py
@@ -1752,5 +1752,136 @@ class TestModuleHookNN(NNTestCase):
 instantiate_parametrized_tests(TestModuleHooks)
 instantiate_parametrized_tests(TestStateDictHooks)
 
+
+class _SVDModule(nn.Module):
+    """Module whose forward calls linalg.svd — still unsupported for fp16 on CPU."""
+
+    def __init__(self, dtype=torch.float16) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(4, 4).to(dtype))
+
+    def forward(self, x):
+        return torch.linalg.svd(self.weight)
+
+
+class _Float32SVDModule(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(4, 4))
+
+    def forward(self, x):
+        return torch.linalg.svd(self.weight)
+
+
+class _NoParamModule(nn.Module):
+    def forward(self, x):
+        return torch.linalg.svd(x.to(torch.float16))
+
+
+class TestCpuDtypeErrorHint(TestCase):
+    """Tests for the CPU dtype error hint added to Module._call_impl (GH #96292).
+
+    When a linalg / dispatch op raises a RuntimeError (or subclass such as
+    NotImplementedError) matching "not implemented for 'Half'" (or 'BFloat16')
+    and the module has matching-dtype parameters on CPU, _call_impl should
+    append a human-readable hint explaining the root cause and how to fix it.
+    """
+
+    def _make_input(self):
+        return torch.randn(4, 4)
+
+    # ------------------------------------------------------------------
+    # Fast path (no hooks)
+    # ------------------------------------------------------------------
+
+    def test_fp16_cpu_error_includes_hint(self):
+        """Fast path: hint is appended when fp16 params are on CPU."""
+        m = _SVDModule()
+        with self.assertRaises(RuntimeError) as cm:
+            m(self._make_input())
+        msg = str(cm.exception)
+        self.assertIn("torch.float16", msg)
+        self.assertIn("module.float()", msg)
+        self.assertIn("module.cuda()", msg)
+
+    def test_fp16_cpu_error_preserves_original_message(self):
+        """Fast path: original dispatch error text is still present in the message."""
+        m = _SVDModule()
+        with self.assertRaises(RuntimeError) as cm:
+            m(self._make_input())
+        self.assertIn("not implemented for", str(cm.exception))
+
+    def test_no_hint_for_float32(self):
+        """Fast path: float32 ops that fail should NOT get a dtype hint."""
+        m = _Float32SVDModule()
+        # float32 linalg.svd works fine; if it does raise, no hint should appear
+        # We just confirm the module runs without a spurious hint warning.
+        try:
+            m(self._make_input())
+        except RuntimeError as e:
+            self.assertNotIn("torch.float32", str(e))
+
+    def test_no_hint_when_no_params(self):
+        """Fast path: no hint when the module has no parameters (error is elsewhere)."""
+        m = _NoParamModule()
+        with self.assertRaises(RuntimeError) as cm:
+            m(self._make_input())
+        # The error is real, but no parameter → no hint
+        self.assertNotIn("module.float()", str(cm.exception))
+
+    def test_bf16_hint(self):
+        """Fast path: BFloat16 also gets a user-friendly hint."""
+        m = _SVDModule(dtype=torch.bfloat16)
+        with self.assertRaises(RuntimeError) as cm:
+            m(self._make_input())
+        msg = str(cm.exception)
+        self.assertIn("torch.bfloat16", msg)
+        self.assertIn("module.float()", msg)
+
+    def test_error_chaining_preserved(self):
+        """Fast path: the augmented exception chains back to the original via __cause__."""
+        m = _SVDModule()
+        with self.assertRaises(RuntimeError) as cm:
+            m(self._make_input())
+        exc = cm.exception
+        # If hint was added, a new exception (same type) is raised with `from e`
+        if "torch.float16" in str(exc):
+            self.assertIsNotNone(exc.__cause__)
+
+    # ------------------------------------------------------------------
+    # Slow path (with forward hook registered)
+    # ------------------------------------------------------------------
+
+    @skipIfTorchDynamo("hints tested outside dynamo scope")
+    def test_fp16_cpu_error_includes_hint_with_hook(self):
+        """Slow path: hint still appears when a forward hook is registered."""
+        m = _SVDModule()
+        called = []
+
+        def dummy_hook(module, input, output):
+            called.append(True)
+
+        handle = m.register_forward_hook(dummy_hook)
+        try:
+            with self.assertRaises(RuntimeError) as cm:
+                m(self._make_input())
+            self.assertIn("torch.float16", str(cm.exception))
+        finally:
+            handle.remove()
+
+    # ------------------------------------------------------------------
+    # GPU path — hint should NOT fire
+    # ------------------------------------------------------------------
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_no_hint_on_cuda_fp16(self):
+        """Hint must not appear when the module is on CUDA (fp16 works there)."""
+        m = _SVDModule().cuda()
+        try:
+            m(self._make_input().cuda())
+        except RuntimeError as e:
+            self.assertNotIn("module.float()", str(e))
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -3,6 +3,7 @@
 import functools
 import inspect
 import itertools
+import re
 import warnings
 import weakref
 from collections import namedtuple, OrderedDict
@@ -402,6 +403,54 @@ def _forward_unimplemented(self, *input: Any) -> None:
     raise NotImplementedError(
         f'Module [{type(self).__name__}] is missing the required "forward" function'
     )
+
+
+# Pattern matching C++ dispatch "not implemented" errors, e.g.:
+#   "linalg_svd_cpu" not implemented for 'Half'
+_CPU_DTYPE_NOT_IMPL_RE = re.compile(r"not implemented for '(\w+)'")
+
+# Map from C++ internal ScalarType names to torch.dtype objects.
+_INTERNAL_DTYPE_MAP: dict[str, dtype] = {
+    "Half": torch.float16,
+    "BFloat16": torch.bfloat16,
+}
+
+
+def _get_cpu_dtype_hint(module: "Module", error: RuntimeError) -> Optional[str]:
+    """Return a user-friendly hint when *error* is a CPU dtype-support error.
+
+    Returns a non-empty string when all of the following are true:
+    - *error* matches the C++ "not implemented for '<DType>'" pattern,
+    - *module* has at least one parameter of that dtype residing on CPU.
+
+    Otherwise returns ``None`` so the caller can simply ``raise``.
+    """
+    try:
+        match = _CPU_DTYPE_NOT_IMPL_RE.search(str(error))
+        if match is None:
+            return None
+        internal_name = match.group(1)
+        dtype_obj = _INTERNAL_DTYPE_MAP.get(internal_name)
+        if dtype_obj is None:
+            return None
+        try:
+            param_name = next(
+                name
+                for name, p in module.named_parameters()
+                if p.dtype == dtype_obj and p.device.type == "cpu"
+            )
+        except StopIteration:
+            return None
+        dtype_str = str(dtype_obj)
+        return (
+            f"\n\nNote: Module '{type(module).__name__}' has {dtype_str} parameters on CPU "
+            f"(e.g., '{param_name}'). Running {dtype_str} on CPU is not fully "
+            f"supported for all operations. To fix this error, either:\n"
+            f"  - Convert to float32: module.float()  or  module.to(torch.float32)\n"
+            f"  - Move to GPU:        module.cuda()"
+        )
+    except Exception:
+        return None
 
 
 class Module:
@@ -1786,7 +1835,13 @@ class Module:
         if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks
                 or _global_backward_pre_hooks or _global_backward_hooks
                 or _global_forward_hooks or _global_forward_pre_hooks):
-            return forward_call(*args, **kwargs)
+            try:
+                return forward_call(*args, **kwargs)
+            except RuntimeError as e:
+                hint = _get_cpu_dtype_hint(self, e)
+                if hint:
+                    raise type(e)(str(e) + hint) from e
+                raise
 
         result = None
         called_always_called_hooks = set()
@@ -1882,7 +1937,7 @@ class Module:
 
         try:
             return inner()
-        except Exception:
+        except Exception as exc:
             # run always called hooks if they have not already been run
             # For now only forward hooks have the always_call option but perhaps
             # this functionality should be added to full backward hooks as well.
@@ -1910,7 +1965,11 @@ class Module:
                         warnings.warn("module forward hook with ``always_call=True`` raised an exception "
                                       f"that was silenced as another error was raised in forward: {str(e)}", stacklevel=2)
                         continue
-            # raise exception raised in try block
+            # raise exception raised in try block, augmenting with dtype hint if applicable
+            if isinstance(exc, RuntimeError):
+                hint = _get_cpu_dtype_hint(self, exc)
+                if hint:
+                    raise type(exc)(str(exc) + hint) from exc
             raise
     # fmt: on
 


### PR DESCRIPTION
## Issue

Fixes #96292

## Summary

Adds a Python-level hint in `Module._call_impl` that enriches `RuntimeError` messages of the form `"op_name" not implemented for 'Half'` when the module has `fp16`/`bf16` parameters on CPU. See the design discussion in #96292.

**Before**
```
RuntimeError: "linalg_svd_cpu" not implemented for 'Half'
```

**After**
```
RuntimeError: "linalg_svd_cpu" not implemented for 'Half'

Note: Module 'MyModel' has torch.float16 parameters on CPU (e.g., 'encoder.weight').
Running torch.float16 on CPU is not fully supported for all operations. To fix this error, either:
  - Convert to float32: module.float()  or  module.to(torch.float32)
  - Move to GPU:        module.cuda()
```

Implementation: reactive regex match on the error message in `_call_impl` (both fast and slow paths), zero overhead on success path, guarded with outer `try/except` so it never suppresses the original error.

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No