### PR TITLE
[Test] Make test_shape_ops.py device-agnostic for out-of-tree backends.

### DIFF
--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -17,9 +17,8 @@ from torch.testing._internal.common_device_type import (
     dtypesIfXPU,
     instantiate_device_type_tests,
     largeTensorTest,
+    onlyAccelerator,
     onlyCPU,
-    onlyNativeDeviceTypes,
-    onlyOn,
 )
 from torch.testing._internal.common_dtype import (
     all_types,
@@ -269,7 +268,6 @@ class TestShapeOps(TestCase):
         self.assertEqual(expected.shape, result.shape)
         self.assertEqual(expected, result)
 
-    @onlyNativeDeviceTypes
     @dtypes(*all_types())
     @dtypesIfCUDA(*all_types_and(torch.half))
     @dtypesIfXPU(*all_types_and(torch.half))
@@ -577,7 +575,7 @@ class TestShapeOps(TestCase):
                     np_fn = partial(np.flip, axis=flip_dim)
                     self.compare_with_numpy(torch_fn, np_fn, data)
 
-    @onlyOn(["cuda", "xpu"])  # CPU is too slow
+    @onlyAccelerator  # CPU is too slow
     @largeTensorTest("17GB")  # 4 tensors of 4GB (in, out) x (torch, numpy) + 1GB
     @largeTensorTest(
         "81GB", "cpu"
@@ -783,7 +781,6 @@ class TestShapeOps(TestCase):
         self.assertEqual(traced_nontuple, expected_nontuple)
         self.assertEqual(traced_out, expected_nontuple)
 
-    @onlyNativeDeviceTypes
     def test_nonzero_discontiguous(self, device):
         shape = (4, 4)
         tensor = torch.randint(2, shape, device=device)


### PR DESCRIPTION
Remove device restrictions that prevented out-of-tree backends from running shape ops tests:

  - Remove @onlyNativeDeviceTypes from test_trace and test_nonzero_discontiguous since they have no device-specific logic.
  - Replace @onlyOn([cuda, xpu]) with @onlyAccelerator on test_flip_large_tensor so any accelerator can run it.
  - Clean up unused imports (onlyNativeDeviceTypes, onlyOn).

Test Plan:
- `PYTORCH_TESTING_DEVICE_ONLY_FOR=cuda python -m pytest test/test_shape_ops.py -v` (95 passed, 5 skipped)
- `PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu python -m pytest test/test_shape_ops.py -v` (96 passed, 1 skipped, 2 xfailed)