### PR TITLE
[Test]Refactor test/nn/test_dropout.py to be device-agnostic

### DIFF
--- a/test/nn/test_dropout.py
+++ b/test/nn/test_dropout.py
@@ -8,11 +8,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.testing._internal.common_device_type import (
     dtypes,
-    dtypesIfCUDA,
     dtypesIfMPS,
     expectedFailureXLA,
     instantiate_device_type_tests,
     onlyAccelerator,
+    onlyOn,
 )
 from torch.testing._internal.common_nn import freeze_rng_state, NNTestCase
 from torch.testing._internal.common_utils import (

--- a/test/nn/test_dropout.py
+++ b/test/nn/test_dropout.py
@@ -1,25 +1,24 @@
 # Owner(s): ["module: nn"]
 import itertools
 import random
-import unittest
 from itertools import product
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     dtypes,
+    dtypesIfCUDA,
     dtypesIfMPS,
     expectedFailureXLA,
     instantiate_device_type_tests,
+    onlyAccelerator,
 )
 from torch.testing._internal.common_nn import freeze_rng_state, NNTestCase
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     run_tests,
     set_default_dtype,
-    TEST_PRIVATEUSE1,
 )
 
 
@@ -58,30 +57,6 @@ class TestDropoutNN(NNTestCase):
         # no batch dims
         input = torch.randn(50, 20, 64, 64)
         self._test_alpha_dropout(nn.FeatureAlphaDropout, input)
-
-    @unittest.skipIf(
-        not (TEST_CUDA or TEST_PRIVATEUSE1), "CUDA and PRIVATEUSE1 unavailable"
-    )
-    def test_native_dropout_corner_case(self):
-        if TEST_CUDA:
-            device = "cuda"
-        elif TEST_PRIVATEUSE1:
-            device = torch._C._get_privateuse1_backend_name()
-        for train in [True, False]:
-            for p in [0.0, 1.0]:
-                for current_device in [device, "cpu"]:
-                    x = torch.randn(5).to(device=current_device).requires_grad_()
-                    x_ref = x.detach().requires_grad_()
-                    o = torch.native_dropout(x, p, train)[0]
-                    o_ref = torch.dropout(x_ref, p, train)
-                    o.sum().backward()
-                    o_ref.sum().backward()
-                    if not o.equal(o_ref):
-                        raise AssertionError("Expected o.equal(o_ref) to be True")
-                    if not x.grad.equal(x_ref.grad):
-                        raise AssertionError(
-                            "Expected x.grad.equal(x_ref.grad) to be True"
-                        )
 
     def test_invalid_dropout_p(self):
         v = torch.ones(1)
@@ -186,9 +161,11 @@ class TestDropoutNNDeviceType(NNTestCase):
 
         self._test_dropout_stride_mean_preserve(nn.Dropout, device)
 
-        if self.device_type == "cuda" or self.device_type == "cpu":
-            input = input.bfloat16()
-            self._test_dropout(nn.Dropout, device, input)
+    @dtypesIfCUDA(torch.bfloat16)
+    @dtypes(torch.bfloat16)
+    def test_Dropout_bfloat16(self, device, dtype):
+        input = torch.empty(1000, dtype=dtype)
+        self._test_dropout(nn.Dropout, device, input)
 
     def _test_dropoutNd_no_batch(self, dropout, input):
         input_clone = input.clone()
@@ -321,6 +298,24 @@ class TestDropoutNNDeviceType(NNTestCase):
         x = torch.tensor([]).to(device)
         out = torch.nn.functional.dropout(x)
         self.assertEqual(out.size(), x.size())
+
+    @onlyAccelerator
+    def test_native_dropout_corner_case(self, device):
+        for train in [True, False]:
+            for p in [0.0, 1.0]:
+                for current_device in [device, "cpu"]:
+                    x = torch.randn(5).to(device=current_device).requires_grad_()
+                    x_ref = x.detach().requires_grad_()
+                    o = torch.native_dropout(x, p, train)[0]
+                    o_ref = torch.dropout(x_ref, p, train)
+                    o.sum().backward()
+                    o_ref.sum().backward()
+                    if not o.equal(o_ref):
+                        raise AssertionError("Expected o.equal(o_ref) to be True")
+                    if not x.grad.equal(x_ref.grad):
+                        raise AssertionError(
+                            "Expected x.grad.equal(x_ref.grad) to be True"
+                        )
 
 
 instantiate_device_type_tests(TestDropoutNNDeviceType, globals(), allow_mps=True)

--- a/test/nn/test_dropout.py
+++ b/test/nn/test_dropout.py
@@ -161,8 +161,8 @@ class TestDropoutNNDeviceType(NNTestCase):
 
         self._test_dropout_stride_mean_preserve(nn.Dropout, device)
 
-    @dtypesIfCUDA(torch.bfloat16)
     @dtypes(torch.bfloat16)
+    @onlyOn(["cpu", "cuda"])
     def test_Dropout_bfloat16(self, device, dtype):
         input = torch.empty(1000, dtype=dtype)
         self._test_dropout(nn.Dropout, device, input)

--- a/test/nn/test_dropout.py
+++ b/test/nn/test_dropout.py
@@ -12,7 +12,6 @@ from torch.testing._internal.common_device_type import (
     expectedFailureXLA,
     instantiate_device_type_tests,
     onlyAccelerator,
-    onlyOn,
 )
 from torch.testing._internal.common_nn import freeze_rng_state, NNTestCase
 from torch.testing._internal.common_utils import (
@@ -162,7 +161,7 @@ class TestDropoutNNDeviceType(NNTestCase):
         self._test_dropout_stride_mean_preserve(nn.Dropout, device)
 
     @dtypes(torch.bfloat16)
-    @onlyOn(["cpu", "cuda"])
+    @onlyAccelerator
     def test_Dropout_bfloat16(self, device, dtype):
         input = torch.empty(1000, dtype=dtype)
         self._test_dropout(nn.Dropout, device, input)


### PR DESCRIPTION
 Moves test_native_dropout_corner_case from TestDropoutNN to TestDropoutNNDeviceType to enable device-generic testing across all accelerators.

  Changes:
  - Moved test_native_dropout_corner_case to TestDropoutNNDeviceType class
  - Added device parameter and runtime skip for CPU variant (test compares accelerator vs CPU)
  - Removed hardcoded TEST_CUDA/TEST_PRIVATEUSE1 device selection logic
  - Extended bfloat16 support to include XPU
  - Removed unused TEST_CUDA and TEST_PRIVATEUSE1 imports

Test runs on CUDA, XPU, and other accelerators; skips on CPU variant.

Tets plan:
(cuda_torch_build) [root@88fde2b2e6e0 pytorch]# TEST_CONFIG=cuda python test/nn/test_dropout.py -v
W0518 06:31:32.232000 1131 site-packages/torch/_native/cutedsl_utils.py:56] CuTeDSL operators require optional Python packages `nvidia-cutlass-dsl` and `apache-tvm-ffi`; missing optional dependency `nvidia_cutlass_dsl` (importlib.util.find_spec(nvidia_cutlass_dsl) failed)
test_AlphaDropout (__main__.TestDropoutNN.test_AlphaDropout) ... ok
test_FeatureAlphaDropout (__main__.TestDropoutNN.test_FeatureAlphaDropout) ... ok
test_invalid_dropout_p (__main__.TestDropoutNN.test_invalid_dropout_p) ... ok
test_Dropout1d_cpu_float64 (__main__.TestDropoutNNDeviceTypeCPU.test_Dropout1d_cpu_float64) ... ok
test_Dropout2d_cpu (__main__.TestDropoutNNDeviceTypeCPU.test_Dropout2d_cpu) ... ok
test_Dropout3d_cpu (__main__.TestDropoutNNDeviceTypeCPU.test_Dropout3d_cpu) ... ok
test_Dropout_cpu (__main__.TestDropoutNNDeviceTypeCPU.test_Dropout_cpu) ... ok
test_empty_dropout_cpu (__main__.TestDropoutNNDeviceTypeCPU.test_empty_dropout_cpu) ... ok
test_native_dropout_corner_case_cpu (__main__.TestDropoutNNDeviceTypeCPU.test_native_dropout_corner_case_cpu) ... skipped 'Test requires accelerator to compare with CPU'
test_Dropout1d_cuda_float64 (__main__.TestDropoutNNDeviceTypeCUDA.test_Dropout1d_cuda_float64) ... ok
test_Dropout2d_cuda (__main__.TestDropoutNNDeviceTypeCUDA.test_Dropout2d_cuda) ... ok
test_Dropout3d_cuda (__main__.TestDropoutNNDeviceTypeCUDA.test_Dropout3d_cuda) ... ok
test_Dropout_cuda (__main__.TestDropoutNNDeviceTypeCUDA.test_Dropout_cuda) ... ok
test_empty_dropout_cuda (__main__.TestDropoutNNDeviceTypeCUDA.test_empty_dropout_cuda) ... ok
test_native_dropout_corner_case_cuda (__main__.TestDropoutNNDeviceTypeCUDA.test_native_dropout_corner_case_cuda) ... ok

----------------------------------------------------------------------
Ran 15 tests in 0.541s

OK (skipped=1)


CC: @fffrog @albanD @jbschlosser 