### PR TITLE
Fix while_loop compile with empty carry and mutation-only state

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -5941,6 +5941,35 @@ def forward(self, arg0_1):
         self._check_compile(fn, inp, backend=backend)
 
     @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
+    def test_while_loop_compile_empty_carry_mutation(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("counter", torch.tensor(0, device="cpu"))
+                self.register_buffer("buf", torch.ones(8, device="cpu"))
+
+            def forward(self):
+                def cond_fn():
+                    self.counter.add_(1)
+                    return self.counter < 3
+
+                def body_fn():
+                    self.buf.add_(-1)
+                    return ()
+
+                while_loop(cond_fn, body_fn, ())
+                return self.buf.sum() + self.counter.sum().to(dtype=self.buf.dtype)
+
+        mod = M()
+        with torch.no_grad():
+            out = torch.compile(mod, backend="inductor", fullgraph=True)()
+        self.assertEqual(out.item(), -5.0)
+        self.assertEqual(mod.counter.item(), 3)
+        self.assertEqual(
+            mod.buf, torch.full((8,), -1.0, device="cpu", dtype=mod.buf.dtype)
+        )
+
+    @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
     @skipIfCrossRef  # Arg order changes with cross ref
     def test_while_loop_simple_with_linear_compile_check_graph(self):
         fn, inp = WHILE_LOOP_TESTS["simple_with_linear"]

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -423,6 +423,12 @@ auto_functionalized_v2.fallthrough(DispatchKey.AutogradCPU)
 auto_functionalized_v2.fallthrough(DispatchKey.AutogradCUDA)
 
 
+def _hops_allowing_empty_schema_returns() -> tuple[HigherOrderOperator, ...]:
+    from torch._higher_order_ops.while_loop import while_loop_op
+
+    return (while_loop_op,)
+
+
 def can_auto_functionalize(
     op: OperatorBase | HopInstance,
 ) -> bool:
@@ -888,9 +894,9 @@ def _do_auto_functionalize_v2_for_generic_mutable_operator(
     )
 
     if isinstance(op, HigherOrderOperator):
-        if len(schema.returns) <= 0:
+        if len(schema.returns) <= 0 and op not in _hops_allowing_empty_schema_returns():
             raise AssertionError(
-                f"hop is expected to return at least one output {schema}."
+                f"HOP {op} does not support zero schema returns {schema}."
             )
         if len(unwrapped_actual_out) != len(schema.returns):
             raise AssertionError(

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -159,6 +159,7 @@ def while_loop(cond_fn, body_fn, carried_inputs):
         cond_fn (Callable): A callable function that returns a boolean Scalar tensor or a python boolean.
 
         body_fn (Callable): A callable function that takes the same inputs as `cond_fn` and returns a tuple of tensors or ints
+            with the same length as ``carried_inputs`` (possibly empty when all state is updated via in-place mutation).
 
         carried_inputs (Tuple of possibly nested dict/list/tuple of tensors or ints): A tuple of inputs to cond_fn and body_fn.
             It's also the initial value of states that are carried across iterations. Note that when pass an integer as carry,

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -4194,16 +4194,19 @@ class PythonWrapperCodegen(CodeGen):
         )
         self.writeline(f"should_loop = {cond_outer_outputs[0]}")
         self.writeline("if not should_loop:")
-        if stack_output:
-            # Handle the case when loop never executes
-            for i, carried_input in enumerate(outer_carried_inputs):
-                self.writeline(EnterSubgraphLine(self, while_loop.body_subgraph.graph))
-                self.writeline(f"{name}[{i}] = {carried_input}.unsqueeze(0).clone()")
-                self.writeline(ExitSubgraphLine(self))
+        if not outer_carried_inputs:
+            self.writeline(EnterSubgraphLine(self, while_loop.body_subgraph.graph))
+            self.writeline("pass")
+            self.writeline(ExitSubgraphLine(self))
         else:
+            clone_line = (
+                "{name}[{i}] = {inp}.unsqueeze(0).clone()"
+                if stack_output
+                else "{name}[{i}] = {inp}.clone()"
+            )
             for i, carried_input in enumerate(outer_carried_inputs):
                 self.writeline(EnterSubgraphLine(self, while_loop.body_subgraph.graph))
-                self.writeline(f"{name}[{i}] = {carried_input}.clone()")
+                self.writeline(clone_line.format(name=name, i=i, inp=carried_input))
                 self.writeline(ExitSubgraphLine(self))
 
         self.writeline("while should_loop:")
@@ -4217,8 +4220,11 @@ class PythonWrapperCodegen(CodeGen):
         # Collect outputs if enabled
         if stack_output:
             self.writeline(EnterSubgraphLine(self, while_loop.body_subgraph.graph))
-            for i in range(len(outer_carried_inputs)):
-                self.writeline(f"{name}[{i + ckp_offset}].append({name}[{i}])")
+            if not outer_carried_inputs:
+                self.writeline("pass")
+            else:
+                for i in range(len(outer_carried_inputs)):
+                    self.writeline(f"{name}[{i + ckp_offset}].append({name}[{i}])")
             self.writeline(ExitSubgraphLine(self))
 
         # Condition check at end of loop

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -10327,10 +10327,8 @@ class WhileLoop(ExternKernel):
             body_fn.graph.module, fake_all_inputs
         )[3]
         mutated_idx_set = OrderedSet(mutated_idxs)
-        mutated_inputs = [all_inputs[idx] for idx in mutated_idx_set]
 
         # Create all outputs first
-        mutated_inputs_iter = iter(mutated_inputs)
         all_outputs: list[IRNode] = []
         while_loop.outputs = []
         while_loop.mutation_outputs = []
@@ -10357,7 +10355,7 @@ class WhileLoop(ExternKernel):
                 if idx in mutated_idx_set:
                     assert idx < len(carried_inputs), "only carries can be mutated."
                     # Create MutationOutput for mutated inputs
-                    mutated_input = next(mutated_inputs_iter)
+                    mutated_input = all_inputs[idx]
                     while_loop.mutation_outputs.append(
                         MutationOutput(mutated_input.layout, mutated_input, while_loop)  # type: ignore[attr-defined, union-attr]
                     )
@@ -10376,6 +10374,14 @@ class WhileLoop(ExternKernel):
                     )
                     while_loop.outputs.append(multi_out)
                     all_outputs.append(multi_out)
+
+            for idx in sorted(mutated_idx_set):
+                if idx >= len(carried_inputs_):
+                    mutated_input = all_inputs[idx]
+                    while_loop.mutation_outputs.append(
+                        MutationOutput(mutated_input.layout, mutated_input, while_loop)  # type: ignore[attr-defined, union-attr]
+                    )
+                    all_outputs.append(mutated_input)
 
         for inp, out in zip(carried_inputs, all_outputs):
             if inp.get_name() in V.graph.graph_inputs:


### PR DESCRIPTION
Fixes #182036 
- To allow zero schema returns for while_loop_op only in auto_functionalize.
- Wiring MutationOutput for buffer mutations when body_fn returns ().
- Fixing wrapper codegen when there are no outer carried inputs.
- Adding test_while_loop_compile_empty_carry_mutation (cpu/cuda).



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos