### PR TITLE
Refactor test_flip_large_tensor to be device-agnostic in test-shape-ops

### DIFF
--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -19,7 +19,6 @@ from torch.testing._internal.common_device_type import (
     largeTensorTest,
     onlyCPU,
     onlyNativeDeviceTypes,
-    onlyOn,
 )
 from torch.testing._internal.common_dtype import (
     all_types,
@@ -577,13 +576,16 @@ class TestShapeOps(TestCase):
                     np_fn = partial(np.flip, axis=flip_dim)
                     self.compare_with_numpy(torch_fn, np_fn, data)
 
-    @onlyOn(["cuda", "xpu"])  # CPU is too slow
     @largeTensorTest("17GB")  # 4 tensors of 4GB (in, out) x (torch, numpy) + 1GB
     @largeTensorTest(
         "81GB", "cpu"
     )  # even for CUDA test, sufficient system memory is required
     @unittest.skipIf(IS_JETSON, "Too large for Jetson")
     def test_flip_large_tensor(self, device):
+        # Skip CPU - too slow for 17GB tensor test
+        if self.device_type == "cpu":
+            self.skipTest("CPU is too slow for large tensor test")
+
         t_in = torch.empty(2**32 + 1, dtype=torch.uint8).random_()
         torch_fn = partial(torch.flip, dims=(0,))
         np_fn = partial(np.flip, axis=0)


### PR DESCRIPTION
Refactor test/test_shape_ops.py to be device-generic by replacing @onlyOn decorator with runtime CPU skip to enable test execution on all accelerators including out of tree devices via PrivateUse1.

**Changes in test/test_shape_ops.py:**

- Remove imports: onlyOn from torch.testing._internal.common_device_type
- Remove @onlyOn(["cuda", "xpu"]) decorator from test_flip_large_tensor method
- Add runtime CPU skip: if self.device_type == "cpu": self.skipTest("CPU is too slow for large tensor test")
- The test uses only generic PyTorch operations (torch.empty, torch.flip) and compare_with_numpy helper, making it truly device-agnostic

**Test Plan:**

- Verified test skips on CPU: test_flip_large_tensor_cpu ... skipped 'CPU is too slow for large tensor test' OK (skipped=1)
- Verified test passes on CUDA: test_flip_large_tensor_cuda ... ok Ran 1 test in 10.961s OK
