### PR TITLE
Add out-of-range bounds check for torch.select in FakeTensor meta impl

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9909,21 +9909,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 ],
             )
 
-    def test_select_out_of_bounds(self):
-        def fn(x):
-            base = x.unsqueeze(1)
-            return torch.select(base, dim=1, index=1)
-
-        x = torch.arange(12, dtype=torch.float32, device=self.device).reshape(3, 4)
-
-        with self.assertRaises(IndexError):
-            fn(x)
-
-        # torch._check_index raises IndexError in eager, but torch.compile
-        # wraps it in a RuntimeError during graph tracing.
-        with self.assertRaisesRegex(RuntimeError, "index .* out of range"):
-            torch.compile(fn, fullgraph=True)(x)
-
     @skip_if_gpu_halide  # accuracy issue
     def test_slice_scatter(self):
         def fn(x, a):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9919,7 +9919,9 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         with self.assertRaises(IndexError):
             fn(x)
 
-        with self.assertRaises(RuntimeError):
+        # torch._check_index raises IndexError in eager, but torch.compile
+        # wraps it in a RuntimeError during graph tracing.
+        with self.assertRaisesRegex(RuntimeError, "index .* out of range"):
             torch.compile(fn, fullgraph=True)(x)
 
     @skip_if_gpu_halide  # accuracy issue

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9909,6 +9909,19 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 ],
             )
 
+    def test_select_out_of_bounds(self):
+        def fn(x):
+            base = x.unsqueeze(1)
+            return torch.select(base, dim=1, index=1)
+
+        x = torch.arange(12, dtype=torch.float32, device=self.device).reshape(3, 4)
+
+        with self.assertRaises(IndexError):
+            fn(x)
+
+        with self.assertRaises(RuntimeError):
+            torch.compile(fn, fullgraph=True)(x)
+
     @skip_if_gpu_halide  # accuracy issue
     def test_slice_scatter(self):
         def fn(x, a):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1557,6 +1557,14 @@ for t in threads:
             self.assertEqual(fake_inverse.dtype, real_inverse.dtype)
             self.assertEqual(fake_counts.dtype, real_counts.dtype)
 
+    def test_select_out_of_bounds(self):
+        with FakeTensorMode():
+            x = torch.randn(3, 4)
+            with self.assertRaisesRegex(IndexError, "index .* out of range"):
+                torch.select(x, dim=1, index=10)
+            with self.assertRaisesRegex(IndexError, "index .* out of range"):
+                torch.select(x, dim=1, index=-10)
+
 
 instantiate_parametrized_tests(FakeTensorTest)
 

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -491,20 +491,12 @@ def meta_select(
     dim = dim if dim >= 0 else dim + ndim
     size = self.size(dim)
 
-    if guard_or_false(index >= 0):
-        if guard_or_false(index >= size):
-            torch._check_index(
-                False,
-                lambda: f"select(): index {index} out of range for tensor of size "
-                f"{list(self.size())} at dimension {dim}",
-            )
-    elif guard_or_false(index < 0):
-        if guard_or_false(index < -size):
-            torch._check_index(
-                False,
-                lambda: f"select(): index {index} out of range for tensor of size "
-                f"{list(self.size())} at dimension {dim}",
-            )
+    if guard_or_false(index >= size) or guard_or_false(index < -size):
+        torch._check_index(
+            False,
+            lambda: f"select(): index {index} out of range for tensor of size "
+            f"{list(self.size())} at dimension {dim}",
+        )
 
     new_size = list(self.size())
     new_stride = list(self.stride())

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -491,6 +491,21 @@ def meta_select(
     dim = dim if dim >= 0 else dim + ndim
     size = self.size(dim)
 
+    if guard_or_false(index >= 0):
+        if guard_or_false(index >= size):
+            torch._check_index(
+                False,
+                lambda: f"select(): index {index} out of range for tensor of size "
+                f"{list(self.size())} at dimension {dim}",
+            )
+    elif guard_or_false(index < 0):
+        if guard_or_false(index < -size):
+            torch._check_index(
+                False,
+                lambda: f"select(): index {index} out of range for tensor of size "
+                f"{list(self.size())} at dimension {dim}",
+            )
+
     new_size = list(self.size())
     new_stride = list(self.stride())
 


### PR DESCRIPTION
Fixes: #183769 

Summary:

- `torch.compile` did not preserve eager error behavior for `torch.select` when the index is out of range. Eager execution correctly raises an `IndexError`, while the compiled version silently returned a tensor with invalid values from out-of-bounds memory.
- The fix adds bounds checking in `meta_select` that raises Error when the index is out of range.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo