### PR TITLE
Preserve index_copy shape checks in decompositions

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -16870,6 +16870,21 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         result = torch.compile(fn)(x_base.clone()[:, 2:, :], index, source)
         self.assertEqual(result, expected)
 
+    def test_index_copy_invalid_source_slice_shape(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/144183
+        def fn(x, index, source):
+            return torch.index_copy(x, 0, index, source)
+
+        x = torch.randn(1, 2, device=self.device)
+        index = torch.tensor([0], device=self.device)
+        source = torch.randn(1, 1, device=self.device)
+        msg = "Source/destination tensor must have same slice shapes"
+
+        with self.assertRaisesRegex(RuntimeError, msg):
+            fn(x, index, source)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.compile(fn)(x, index, source)
+
     def test_pad_after_gelu(self):
         # Regression test for Voxtral compilation on MPS
         for dtype in [torch.float32, torch.float16, torch.bfloat16]:

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3199,6 +3199,8 @@ def index_copy(x: TensorLike, dim: int, index: TensorLike, tensor: TensorLike):
 def _index_copy(
     x: TensorLike, dim: int, index: TensorLike, tensor: TensorLike, *, inplace: bool
 ):
+    from torch.fx.experimental.symbolic_shapes import sym_eq
+
     dim = utils.canonicalize_dims(x.ndim, dim)
     torch._check(
         x.device == index.device and x.device == tensor.device,
@@ -3211,6 +3213,57 @@ def _index_copy(
     torch._check(
         index.ndim <= 1,
         lambda: f"Index should have dimension 1 or 0 (got {index.ndim})",
+    )
+    index_size = index.size(0) if index.ndim == 1 else 1
+    if tensor.ndim == 0:
+        torch._check(
+            index_size == 1,
+            lambda: (
+                "index_copy_(): When source is scalar, index should have one "
+                f"element (got {index_size})"
+            ),
+        )
+    else:
+        torch._check(
+            tensor.ndim == x.ndim or x.ndim == 0,
+            lambda: (
+                "index_copy_(): When source and destination are not scalars, "
+                "their dimensionality must match. Source dimensionality "
+                f"({tensor.ndim}), destination dimensionality ({x.ndim})"
+            ),
+        )
+    torch._check(
+        index.dtype == torch.long,
+        lambda: f"index_copy_(): Expected a long tensor for index, but got {index.dtype}",
+    )
+    torch._check(
+        x.dtype == tensor.dtype,
+        lambda: (
+            "index_copy_(): self and source expected to have the same dtype, "
+            f"but got (self) {x.dtype} and (source) {tensor.dtype}"
+        ),
+    )
+
+    x_sliced_shape = x.shape[:dim] + x.shape[dim + 1 :] if x.ndim > 0 else ()
+    tensor_sliced_shape = (
+        tensor.shape[:dim] + tensor.shape[dim + 1 :] if tensor.ndim > 0 else ()
+    )
+    torch._check(
+        sym_eq(x_sliced_shape, tensor_sliced_shape),
+        lambda: (
+            "index_copy_(): Source/destination tensor must have same slice shapes. "
+            f"Destination slice shape: {' '.join(map(str, x_sliced_shape))} "
+            f"at dimension {dim} and source slice shape: "
+            f"{' '.join(map(str, tensor_sliced_shape))} at dimension 0."
+        ),
+    )
+    tensor_size = tensor.size(dim) if tensor.ndim > 0 else 1
+    torch._check(
+        tensor.ndim == 0 or index_size == tensor_size,
+        lambda: (
+            f"index_copy_(): Number of indices ({index_size}) should be "
+            f"equal to source.size(dim) ({tensor_size})"
+        ),
     )
     # Treat scalars as elements of \R^1
     zero_dim = x.ndim == 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184171

Add eager-compatible metadata checks to the index_copy decomposition so compiled index_copy rejects invalid source slice shapes before lowering to index_put.

Fixes #144183
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos