### PR TITLE
[MPS] Fix SDPA vector kernel mask offset for partially broadcast masks

### DIFF
--- a/aten/src/ATen/native/mps/kernels/DecodeAttention.h
+++ b/aten/src/ATen/native/mps/kernels/DecodeAttention.h
@@ -18,7 +18,7 @@ template <typename T, int D, int V = D, bool is_causal = false, bool HAS_MASK = 
                             const constant uint3& qkv_seq_strides [[buffer(7)]],
                             const constant float& scale [[buffer(8)]],
                             const device MaskType* mask [[buffer(9)]],
-                            const constant uint3& mask_strides [[buffer(10)]],
+                            const constant uint4& mask_strides [[buffer(10)]],
                             const constant uint4& qkv_batch_strides_heads [[buffer(11)]],
                             uint3 tid [[threadgroup_position_in_grid]],
                             uint3 tpg [[threadgroups_per_grid]],
@@ -43,6 +43,7 @@ template <typename T, int D, int V = D, bool is_causal = false, bool HAS_MASK = 
   const uint mask_kv_seq_stride = mask_strides.x;
   const uint mask_q_seq_stride = mask_strides.y;
   const uint mask_head_stride = mask_strides.z;
+  const uint mask_batch_stride = mask_strides.w;
   uint inner_k_stride = BN * int(k_seq_stride);
   uint inner_v_stride = BN * int(v_seq_stride);
 
@@ -70,7 +71,8 @@ template <typename T, int D, int V = D, bool is_causal = false, bool HAS_MASK = 
   values +=
       batch_idx * v_batch_stride + kv_head_idx * v_head_stride + simd_gid * v_seq_stride + simd_lid * v_per_thread;
   if IF_CONSTEXPR (HAS_MASK) {
-    mask += bh_idx * mask_head_stride + simd_gid * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+    mask += batch_idx * mask_batch_stride + head_idx * mask_head_stride + simd_gid * mask_kv_seq_stride +
+        q_seq_idx * mask_q_seq_stride;
   }
 
   out += o_offset * V + simd_gid * v_per_thread;
@@ -183,7 +185,7 @@ template <typename T, int D, int V = D, bool is_causal = false, bool HAS_MASK = 
                                     const constant uint3& qkv_seq_strides [[buffer(9)]],
                                     const constant float& scale [[buffer(10)]],
                                     const device MaskType* mask [[buffer(11)]],
-                                    const constant uint3& mask_strides [[buffer(12)]],
+                                    const constant uint4& mask_strides [[buffer(12)]],
                                     const constant uint4& qkv_batch_strides_heads [[buffer(13)]],
                                     uint3 tid [[threadgroup_position_in_grid]],
                                     uint3 tpg [[threadgroups_per_grid]],
@@ -208,6 +210,7 @@ template <typename T, int D, int V = D, bool is_causal = false, bool HAS_MASK = 
   const int mask_kv_seq_stride = mask_strides.x;
   const int mask_q_seq_stride = mask_strides.y;
   const int mask_head_stride = mask_strides.z;
+  const uint mask_batch_stride = mask_strides.w;
   int inner_k_stride = BN * int(k_seq_stride);
   int inner_v_stride = BN * int(v_seq_stride);
   constexpr int blocks = 32;
@@ -238,8 +241,8 @@ template <typename T, int D, int V = D, bool is_causal = false, bool HAS_MASK = 
       simd_lid * v_per_thread;
   out += o_offset * blocks * V + block_idx * V + simd_lid * v_per_thread;
   if IF_CONSTEXPR (HAS_MASK) {
-    mask +=
-        bh_idx * mask_head_stride + (block_idx * BN + simd_gid) * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+    mask += batch_idx * mask_batch_stride + head_idx * mask_head_stride +
+        (block_idx * BN + simd_gid) * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
   }
   sums += o_offset * blocks + block_idx;
   maxs += o_offset * blocks + block_idx;
@@ -413,7 +416,7 @@ template <typename T, int D>
       const constant uint3& qkv_seq_strides [[buffer(7)]],                                              \
       const constant float& scale [[buffer(8)]],                                                        \
       const device MASK_TYPE* mask [[buffer(9)]],                                                       \
-      const constant uint3& mask_strides [[buffer(10)]],                                                \
+      const constant uint4& mask_strides [[buffer(10)]],                                                \
       const constant uint4& qkv_batch_strides_heads [[buffer(11)]],                                     \
       uint3 tid [[threadgroup_position_in_grid]],                                                       \
       uint3 tpg [[threadgroups_per_grid]],                                                              \
@@ -441,7 +444,7 @@ template <typename T, int D>
       const constant uint3& qkv_seq_strides [[buffer(9)]],                                                      \
       const constant float& scale [[buffer(10)]],                                                               \
       const device MASK_TYPE* mask [[buffer(11)]],                                                              \
-      const constant uint3& mask_strides [[buffer(12)]],                                                        \
+      const constant uint4& mask_strides [[buffer(12)]],                                                        \
       const constant uint4& qkv_batch_strides_heads [[buffer(13)]],                                             \
       uint3 tid [[threadgroup_position_in_grid]],                                                               \
       uint3 tpg [[threadgroups_per_grid]],                                                                      \

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -257,14 +257,13 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
 
       if (has_mask) {
         auto mask = mask_.value();
-        int nd = mask_.value().dim();
+        int nd = mask.dim();
         uint kv_seq_stride = (mask.size(3) > 1) ? mask.stride(3) : 0;
         uint q_seq_stride = (mask.size(2) > 1) ? mask.stride(2) : 0;
         uint head_stride = (mask.size(1) > 1) ? mask.stride(1) : 0;
         uint batch_stride = (mask.size(0) > 1) ? mask.stride(0) : 0;
-        mtl_setArgs<9>(computeEncoder,
-                       mask_.value(),
-                       std::array<uint32_t, 4>{kv_seq_stride, q_seq_stride, head_stride, batch_stride});
+        mtl_setArgs<9>(
+            computeEncoder, mask, std::array<uint32_t, 4>{kv_seq_stride, q_seq_stride, head_stride, batch_stride});
       }
       mtl_setArgs<11>(computeEncoder,
                       std::array<uint32_t, 4>{q_batch_stride, k_batch_stride, v_batch_stride, num_head});
@@ -356,7 +355,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
                   scale_factor);
 
       if (has_mask) {
-        Tensor mask = mask_.value();
+        auto mask = mask_.value();
         int nd = mask.dim();
         uint kv_seq_stride = (mask.size(3) > 1) ? mask.stride(3) : 0;
         uint q_seq_stride = (mask.size(2) > 1) ? mask.stride(2) : 0;

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -256,12 +256,15 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
                   scale_factor);
 
       if (has_mask) {
+        auto mask = mask_.value();
         int nd = mask_.value().dim();
-        uint kv_seq_stride = (nd >= 1 && mask_.value().size(nd - 1) > 1) ? mask_.value().stride(nd - 1) : 0;
-        uint q_seq_stride = (nd >= 2 && mask_.value().size(nd - 2) > 1) ? mask_.value().stride(nd - 2) : 0;
-        uint head_stride = (nd >= 3 && mask_.value().size(nd - 3) > 1) ? mask_.value().stride(nd - 3) : 0;
-        mtl_setArgs<9>(
-            computeEncoder, mask_.value(), std::array<uint32_t, 3>{kv_seq_stride, q_seq_stride, head_stride});
+        uint kv_seq_stride = (mask.size(3) > 1) ? mask.stride(3) : 0;
+        uint q_seq_stride = (mask.size(2) > 1) ? mask.stride(2) : 0;
+        uint head_stride = (mask.size(1) > 1) ? mask.stride(1) : 0;
+        uint batch_stride = (mask.size(0) > 1) ? mask.stride(0) : 0;
+        mtl_setArgs<9>(computeEncoder,
+                       mask_.value(),
+                       std::array<uint32_t, 4>{kv_seq_stride, q_seq_stride, head_stride, batch_stride});
       }
       mtl_setArgs<11>(computeEncoder,
                       std::array<uint32_t, 4>{q_batch_stride, k_batch_stride, v_batch_stride, num_head});
@@ -355,10 +358,12 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
       if (has_mask) {
         Tensor mask = mask_.value();
         int nd = mask.dim();
-        uint kv_seq_stride = (nd >= 1 && mask.size(nd - 1) > 1) ? mask.stride(nd - 1) : 0;
-        uint q_seq_stride = (nd >= 2 && mask.size(nd - 2) > 1) ? mask.stride(nd - 2) : 0;
-        uint head_stride = (nd >= 3 && mask.size(nd - 3) > 1) ? mask.stride(nd - 3) : 0;
-        mtl_setArgs<11>(computeEncoder, mask, std::array<uint32_t, 3>{kv_seq_stride, q_seq_stride, head_stride});
+        uint kv_seq_stride = (mask.size(3) > 1) ? mask.stride(3) : 0;
+        uint q_seq_stride = (mask.size(2) > 1) ? mask.stride(2) : 0;
+        uint head_stride = (mask.size(1) > 1) ? mask.stride(1) : 0;
+        uint batch_stride = (mask.size(0) > 1) ? mask.stride(0) : 0;
+        mtl_setArgs<11>(
+            computeEncoder, mask, std::array<uint32_t, 4>{kv_seq_stride, q_seq_stride, head_stride, batch_stride});
       }
       mtl_setArgs<13>(computeEncoder,
                       std::array<uint32_t, 4>{q_batch_stride, k_batch_stride, v_batch_stride, num_heads});

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11074,6 +11074,7 @@ class TestSDPA(TestCaseMPS):
         v: torch.Tensor,
         with_mask: bool,
         dropout_p: float = 0.0,
+        broadcast_mask: bool = False,
         is_causal: bool = False,
     ):
         q_len = q.shape[2]
@@ -11081,7 +11082,8 @@ class TestSDPA(TestCaseMPS):
         enable_gqa = q.shape[1] != k.shape[1]
 
         if with_mask:
-            attn_mask = torch.zeros(q.shape[0], q.shape[1], q_len, s_len,
+            mask_heads = 1 if broadcast_mask else q.shape[1]
+            attn_mask = torch.zeros(q.shape[0], mask_heads, q_len, s_len,
                                     dtype=torch.bool, device=q.device)
             attn_mask[..., s_len // 2:] = True
 
@@ -11125,9 +11127,10 @@ class TestSDPA(TestCaseMPS):
     @parametrize("head_dim", [64, 96, 128, 256])  # supported by the fast kernel
     @parametrize("with_mask", [True, False])
     @parametrize("is_causal", [False, True])
+    @parametrize("broadcast_mask", [False, True])
     @parametrize("gqa_factor", [1, 4])
     def test_fast_vector_attention(
-        self, dtype: torch.dtype, layout: str, head_dim: int, with_mask: bool, is_causal: bool, gqa_factor: int
+        self, dtype: torch.dtype, layout: str, head_dim: int, with_mask: bool, is_causal: bool, broadcast_mask: bool, gqa_factor: int
     ):
         if is_causal and with_mask:
             self.skipTest("PyTorch SDPA disallows attn_mask together with is_causal")
@@ -11138,16 +11141,17 @@ class TestSDPA(TestCaseMPS):
         q_len = 4  # <8 so that vector fast is eligible
         s_len = 16  # smaller than 1024 so that we use the one–pass variant
         q, k, v = self.generate_qkv(batch, NH_q, q_len, s_len, head_dim, layout, dtype, NH_kv=NH_kv)
-        self.run_fast_attention_test(q, k, v, with_mask, is_causal=is_causal)
+        self.run_fast_attention_test(q, k, v, with_mask, is_causal=is_causal, broadcast_mask=broadcast_mask)
 
     @parametrize("dtype", [torch.float32])  # float16 underflows sometimes, which leads to flaky tests
     @parametrize("layout", ["contiguous", "mT", "transpose_seq_head", "permute"])
     @parametrize("head_dim", [64, 96, 128, 256])  # supported by the fast kernel
     @parametrize("with_mask", [True, False])
     @parametrize("is_causal", [False, True])
+    @parametrize("broadcast_mask", [False, True])
     @parametrize("gqa_factor", [1, 4])
     def test_fast_vector_attention_2pass(
-        self, dtype: torch.dtype, layout: str, head_dim: int, with_mask: bool, is_causal: bool, gqa_factor: int
+        self, dtype: torch.dtype, layout: str, head_dim: int, with_mask: bool, is_causal: bool, broadcast_mask: bool, gqa_factor: int
     ):
         if is_causal and with_mask:
             self.skipTest("PyTorch SDPA disallows attn_mask together with is_causal")
@@ -11158,7 +11162,7 @@ class TestSDPA(TestCaseMPS):
         q_len = 8
         s_len = 1024  # large enough to trigger the two–pass path
         q, k, v = self.generate_qkv(batch, NH_q, q_len, s_len, head_dim, layout, dtype, NH_kv=NH_kv)
-        self.run_fast_attention_test(q, k, v, with_mask, is_causal=is_causal)
+        self.run_fast_attention_test(q, k, v, with_mask, is_causal=is_causal, broadcast_mask=broadcast_mask)
 
     def test_fast_vector_permuted_inputs_regression(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/181133

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11082,10 +11082,16 @@ class TestSDPA(TestCaseMPS):
         enable_gqa = q.shape[1] != k.shape[1]
 
         if with_mask:
-            mask_heads = 1 if broadcast_mask else q.shape[1]
-            attn_mask = torch.zeros(q.shape[0], mask_heads, q_len, s_len,
-                                    dtype=torch.bool, device=q.device)
-            attn_mask[..., s_len // 2:] = True
+            if broadcast_mask:
+                attn_mask = torch.zeros(q.shape[0], 1, q_len, s_len,
+                                        dtype=q.dtype, device=q.device)
+                for b in range(q.shape[0]):
+                    col = (b * 2) % s_len
+                    attn_mask[b, 0, :, col:col + max(1, s_len // 4)] = float("-inf")
+            else:
+                attn_mask = torch.zeros(q.shape[0], q.shape[1], q_len, s_len,
+                                        dtype=torch.bool, device=q.device)
+                attn_mask[..., s_len // 2:] = True
 
             with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
                 y = F.scaled_dot_product_attention(
@@ -11135,7 +11141,7 @@ class TestSDPA(TestCaseMPS):
         if is_causal and with_mask:
             self.skipTest("PyTorch SDPA disallows attn_mask together with is_causal")
         torch.manual_seed(1729)
-        batch = 1
+        batch = 2  # >1 so that batch-stride mistakes are observable
         NH_kv = 2
         NH_q = NH_kv * gqa_factor
         q_len = 4  # <8 so that vector fast is eligible
@@ -11156,7 +11162,7 @@ class TestSDPA(TestCaseMPS):
         if is_causal and with_mask:
             self.skipTest("PyTorch SDPA disallows attn_mask together with is_causal")
         torch.manual_seed(1729)
-        batch = 1
+        batch = 2  # >1 so that batch-stride mistakes are observable
         NH_kv = 8
         NH_q = NH_kv * gqa_factor
         q_len = 8


### PR DESCRIPTION
Reproducer:
```
import torch
import torch.nn.functional as F

torch.manual_seed(0)
q = torch.randn(2, 4, 8, 64)
mask = torch.zeros(2, 1, 8, 8)
mask[0, 0, 4:, :4] = float("-inf")

y_cpu = F.scaled_dot_product_attention(q, q, q, attn_mask=mask)
y_mps = F.scaled_dot_product_attention(
    q.to("mps"), q.to("mps"), q.to("mps"), attn_mask=mask.to("mps")
)
print((y_mps.cpu() - y_cpu).abs().max().item())
# gives 0.0961458683013916
```