### PR TITLE
[Test] Add distributed_backend() hook to DeviceTypeTestBase

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -246,5 +246,15 @@ with _temp_test_configs(
         TestSupportedOpsWithOverrides, globals(), only_for=("openreg",)
     )
 
+
+class TestDistributedBackendHook(TestCase):
+    def test_distributed_backend_for_openreg(self, device):
+        self.assertEqual(type(self).distributed_backend(), "occl")
+
+
+instantiate_device_type_tests(
+    TestDistributedBackendHook, globals(), only_for=("openreg",)
+)
+
 if __name__ == "__main__":
     run_tests()

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 import torch
+import torch.distributed as dist
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
@@ -247,6 +248,7 @@ with _temp_test_configs(
     )
 
 
+@unittest.skipIf(not dist.is_available(), "Distributed not available, skipping tests")
 class TestDistributedBackendHook(TestCase):
     def test_distributed_backend_for_openreg(self, device):
         self.assertEqual(type(self).distributed_backend(), "occl")

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -410,6 +410,15 @@ class DeviceTypeTestBase(TestCase):
         return cls.device_type
 
     @classmethod
+    def distributed_backend(cls) -> str:
+        """
+        Default distributed backend for this device type.
+        """
+        import torch.distributed as dist
+
+        return dist.get_default_backend_for_device(cls.device_type)
+
+    @classmethod
     def _get_test_exclusions(cls, test_class_name):
         test_exclusions = getattr(cls, "test_exclusions", None)
         if test_exclusions is not None and test_class_name in test_exclusions:


### PR DESCRIPTION
fixes #184177 

## Summary

Add `distributed_backend()` hook to `DeviceTypeTestBase` as a device-level extension point for default distributed backend selection.

