### PR TITLE
[fx]: Add SymNode helper to get raw expr

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -290,6 +290,18 @@ class TestPySymInt(TestCase):
         c = create_symbool(shape_env, True)
         self.assertIs(sympy.sympify(c), c.node.expr)
 
+    def test_raw_expr(self):
+        shape_env = ShapeEnv()
+        a = create_symint(shape_env, 2)
+        raw_expr = a.node.raw_expr()
+
+        self.assertIs(raw_expr, a.node.expr)
+
+        shape_env._set_replacement(raw_expr, sympy.Integer(7), "test_raw_expr")
+
+        self.assertIs(a.node.raw_expr(), raw_expr)
+        self.assertEqual(a.node.expr, 7)
+
     def test_roundtrip(self):
         shape_env = ShapeEnv()
         x = create_symbolic_tensor("x", torch.randn(5, 4, 3), shape_env)

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -228,6 +228,9 @@ class SymNode:
         self._expr_cache = result
         return result
 
+    def raw_expr(self) -> sympy.Basic:
+        return self._expr
+
     @property
     def hint(self) -> HintType | SymInt | SymFloat | SymBool:
         return self._hint


### PR DESCRIPTION
Adds helper to access raw sympy expression without triggering replacement logic. This is useful for lowering of dynamic models in ExecuTorch where symbolic expressions are to be materialized into shape operations. Also adds a test case which highlights the differences between expr() and raw_expr().