### PR TITLE
Adding support of noncontigous view for argmin and argmax in cpu codegen

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -11663,6 +11663,12 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             ],
         )
 
+    def test_argmax_argmin_noncontiguous(self):
+        def fn(x):
+            return (x.t().argmin(), x.t().argmax())
+
+        self.common(fn, (torch.randn(5, 7),))
+
     def test_argmax_argmin2(self):
         def fn(x):
             return (

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2319,6 +2319,11 @@ class CppKernel(Kernel):
 
     def reduction(self, dtype, src_dtype, reduction_type, value):
         argmax_or_argmin = reduction_type in ("argmax", "argmin")
+
+        logical_index = None
+        if argmax_or_argmin and isinstance(value, tuple):
+            value, logical_index = value
+
         reduction_key = src_dtype, reduction_type, value
         if reduction_key in self.reduction_cse.reduction_cache:
             return self.reduction_cse.reduction_cache[reduction_key]
@@ -2365,9 +2370,12 @@ class CppKernel(Kernel):
             )
         else:
             assert self.reduction_depth is not None
-            index = self.itervars[self.reduction_depth]
-            for i in range(self.reduction_depth + 1, len(self.itervars)):
-                index = index * self.ranges[i] + self.itervars[i]
+            if logical_index is not None:
+                index = logical_index
+            else:
+                index = self.itervars[self.reduction_depth]
+                for i in range(self.reduction_depth + 1, len(self.itervars)):
+                    index = index * self.ranges[i] + self.itervars[i]
             self.stores.writeline(
                 f"{acc} = {reduction_combine(reduction_type, acc, value, index=index)};"
             )
@@ -3044,6 +3052,11 @@ class CppVecKernel(CppKernel):
         argmax_or_argmin = reduction_type in ("argmax", "argmin")
         horizontal_reduction = self.tiling_idx >= self.reduction_depth
         init_dtype = src_dtype if argmax_or_argmin else dtype
+
+        logical_index = None
+        if argmax_or_argmin and isinstance(value, tuple):
+            value, logical_index = value
+
         assert isinstance(value, CppCSEVariable), value
 
         if not value.is_vec:
@@ -3162,15 +3175,23 @@ class CppVecKernel(CppKernel):
                 )
         else:
             assert self.reduction_depth is not None
-            index = self.itervars[self.reduction_depth]
-            for i in range(self.reduction_depth + 1, len(self.itervars)):
-                index = index * self.ranges[i] + self.itervars[i]
-            kwargs = {
-                "next_value": value,
-                "index": index,
-                "horizontal_reduction": horizontal_reduction,
-                "src_dtype": src_dtype,
-            }
+            if logical_index is not None:
+                kwargs = {
+                    "next_value": value,
+                    "logical_index": logical_index,
+                    "horizontal_reduction": horizontal_reduction,
+                    "src_dtype": src_dtype,
+                }
+            else:
+                index = self.itervars[self.reduction_depth]
+                for i in range(self.reduction_depth + 1, len(self.itervars)):
+                    index = index * self.ranges[i] + self.itervars[i]
+                kwargs = {
+                    "next_value": value,
+                    "index": index,
+                    "horizontal_reduction": horizontal_reduction,
+                    "src_dtype": src_dtype,
+                }
             self.stores.writeline(
                 f"{acc_vec} = {self.reduction_combine_vec(reduction_type, acc_vec, **kwargs)};"
             )
@@ -3396,6 +3417,7 @@ class CppVecKernel(CppKernel):
         next_value,
         helper_val=None,
         index: sympy.Symbol | None = None,
+        logical_index=None,
         horizontal_reduction: bool | None = None,
         src_dtype: torch.dtype | None = torch.float32,
     ):
@@ -3475,6 +3497,18 @@ class CppVecKernel(CppKernel):
                     (next_value,) = unify_mask_base_type(self.compute, (next_value,))
             n_src = self._get_num_vectors(compute_dtype)
             n_idx = self._get_num_vectors(torch.int64)
+            if logical_index is not None:
+                # Non-contiguous case: use pre-computed vector of logical indices
+                if self.tail_size:
+                    return (
+                        f"{reduction_type}_vec_impl<{cdtype}, {n_src}, {n_idx}>"
+                        f"({var}, {next_value}, {logical_index}, {cexpr_index(self.tail_size)})"
+                    )
+                else:
+                    return (
+                        f"{reduction_type}_vec_impl<{cdtype}, {n_src}, {n_idx}>"
+                        f"({var}, {next_value}, {logical_index})"
+                    )
             t_extra = ""
             arg_extra = ""
             if index is not None:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6722,11 +6722,7 @@ def _make_reduction_inner(
 
     # For argmax/argmin compute logical indices when the tensor has non-contiguous layout.
     should_compute_logical_index = False
-    if (
-        reduction_type in ("argmax", "argmin")
-        and len(reduced_sizes) > 1
-        and is_triton(x)
-    ):
+    if reduction_type in ("argmax", "argmin") and len(reduced_sizes) > 1:
         if isinstance(x.data, PermuteView):
             should_compute_logical_index = True
         elif isinstance(x.data, ir.ReinterpretView) or (

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -565,7 +565,7 @@ inline IndexValueVec<T, NV, NI>& argmin_vec_impl(
     IndexValueVec<T, NV, NI>& a,
     at::vec::VectorizedN<T, NV> value,
     at::vec::VectorizedN<int64_t, NI> index,
-    std::optional<int64_t> tail_size) {
+    std::optional<int64_t> tail_size = std::nullopt) {
   at::vec::VecMask<T, NV> vmask(a.value < value);
   at::vec::VecMask<int64_t, NI> final_mask =
       get_mask_for_argmin_argmax<T, NV, NI>(vmask, a, value, index);
@@ -588,7 +588,7 @@ inline IndexValueVec<T, NV, NI>& argmax_vec_impl(
     IndexValueVec<T, NV, NI>& a,
     at::vec::VectorizedN<T, NV> value,
     at::vec::VectorizedN<int64_t, NI> index,
-    std::optional<int64_t> tail_size) {
+    std::optional<int64_t> tail_size = std::nullopt) {
   at::vec::VecMask<T, NV> vmask(a.value > value);
   at::vec::VecMask<int64_t, NI> final_mask =
       get_mask_for_argmin_argmax<T, NV, NI>(vmask, a, value, index);


### PR DESCRIPTION
Fixes #183082 

Root Cause: Inductor's CPU codegen computes argmax/argmin indices using the physical memory iteration order rather than the logical tensor layout. When a tensor is transposed (or permuted), the kernel iterates contiguously over physical memory for vectorization efficiency but reports the raw loop counter as the result index — which corresponds to the physical offset, not the logical position in the viewed tensor.

The fix for this already existed for Triton (computing a logical linear index from the reduction coordinates), but was gated behind is_triton(x) in the lowering, and the CPU codegen had no support for consuming the (value, logical_index) tuple that the lowering produces.

Fix: Remove the Triton-only gate in lowering so that the logical index is computed for all backends, and extend the CPU scalar/vector codegen to accept and use the pre-computed logical index vector instead of deriving the index from loop iterators.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo