### PR TITLE
[Windows] Fix TORCH_API on InitTorchScriptBackend for torch_cpu on Windows

### DIFF
--- a/torch/csrc/lazy/ts_backend/ts_backend_impl.h
+++ b/torch/csrc/lazy/ts_backend/ts_backend_impl.h
@@ -47,6 +47,6 @@ class TORCH_API TSData : public torch::lazy::BackendData {
 
 TORCH_API torch::lazy::BackendImplInterface* GetTSBackendImpl();
 
-TORCH_PYTHON_API void InitTorchScriptBackend();
+TORCH_API void InitTorchScriptBackend();
 
 } // namespace torch::lazy


### PR DESCRIPTION
When building `torch_cpu` on Windows with clang-cl the following `-Winconsistent-dllimport` warning occures:

```
torch/csrc/lazy/ts_backend/ts_backend_impl.cpp(272,6): warning: 'torch::lazy::InitTorchScriptBackend' redeclared without 'dllimport' attribute: 'dllexport' attribute added [-Winconsistent-dllimport]
  272 | void InitTorchScriptBackend() {
      |      ^
C:/b/pytorch_fork\torch/csrc/lazy/ts_backend/ts_backend_impl.h(50,23): note: previous declaration is here
   50 | TORCH_PYTHON_API void InitTorchScriptBackend();
```

## Root cause

On Windows, import/export attributes must match between the declaration (header) and the definition (`.cpp`) for symbols that cross a DLL boundary.

| Macro | Controlled by | Meaning in `torch_cpu` TU |
|--------|----------------|---------------------------|
| **`TORCH_API`** | **`CAFFE2_BUILD_MAIN_LIB`** | **`dllexport`** (building `torch_cpu`) |
| **`TORCH_PYTHON_API`** | **`THP_BUILD_MAIN_LIB`** | **`dllimport`** (symbol assumed to live in `torch_python`) |
`InitTorchScriptBackend()` is defined in:

- `torch/csrc/lazy/ts_backend/ts_backend_impl.cpp`

That file is compiled into `torch_cpu` (`-Dtorch_cpu_EXPORTS`, `CAFFE2_BUILD_MAIN_LIB`), not `torch_python`.

The header incorrectly declared it with `TORCH_PYTHON_API`, so the declaration said `dllimport` while the `.cpp` definition was exported from `torch_cpu` → `-Winconsistent-dllimport`, promoted to error by CMake policy on main libtorch DLLs.

`GetTSBackendImpl()` in the same header already used **`TORCH_API`** correctly.

## Fix

In `torch/csrc/lazy/ts_backend/ts_backend_impl.h`:

```diff
- TORCH_PYTHON_API void InitTorchScriptBackend();
+ TORCH_API void InitTorchScriptBackend();
```

Callers in `torch_python` (e.g. `torch/csrc/lazy/python/init.cpp`) should `dllimport` this symbol from `torch_cpu`, which is what `TORCH_API` provides when `CAFFE2_BUILD_MAIN_LIB` is unset.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @nkhasbag-nv