### PR TITLE
autogenerate fake kernel for custom ops tagged with torch.Tag.inplace

### DIFF
--- a/test/custom_operator/test_inplace_tag.py
+++ b/test/custom_operator/test_inplace_tag.py
@@ -42,6 +42,23 @@ class TestInplaceTag(TestCase):
     def test_basic_inplace(self):
         self.assertTrue(is_inplace(torch.ops._TestInplaceTag.add_.default))
 
+    def test_auto_fake_kernel_inplace(self):
+        self.lib.define(
+            "auto_fake_add_(Tensor(a!) self, Tensor other) -> Tensor(a!)",
+            tags=[torch.Tag.inplace],
+        )
+        self.lib.impl(
+            "auto_fake_add_",
+            lambda self_, other: self_.add_(other),
+            "CPU",
+        )
+
+        with torch._subclasses.fake_tensor.FakeTensorMode():
+            x = torch.randn(3, 4)
+            y = torch.randn(3, 4)
+            result = torch.ops._TestInplaceTag.auto_fake_add_(x, y)
+            self.assertIs(result, x)
+
     def test_is_inplace_native(self):
         # Hand-written inplace op
         self.assertTrue(is_inplace(torch.ops.aten.abs_.default))

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -301,6 +301,9 @@ def can_generate_trivial_fake_impl(op: OpOverload) -> bool:
     if is_out(op):
         # Tag.out ops have a trivial fake impl: return the out= args in order.
         return True
+    if is_inplace(op):
+        # Tag.inplace ops have a trivial fake impl: return the mutated first arg.
+        return True
     # It's suspicious if the op is not mutable but returns nothing, so we return False out of an abundance of caution
     if not schema.is_mutable:
         return False
@@ -315,6 +318,7 @@ def generate_trivial_fake_impl(op: OpOverload, *args, **kwargs):
 
     For ops with no returns: returns None.
     For Tag.out ops: returns the out= kwargs in declaration order.
+    For Tag.inplace ops: returns the first positional arg.
     """
     if is_out(op):
         schema = op._schema
@@ -323,6 +327,8 @@ def generate_trivial_fake_impl(op: OpOverload, *args, **kwargs):
         if len(out_args) == 1:
             return out_args[0]
         return out_args
+    if is_inplace(op):
+        return args[0]
     return None
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184205
* #184204
* #184203
* #184202
* #184201
* #184200
* __->__ #184199

Custom ops tagged with torch.Tag.inplace have a schema-defined fake result: they return the mutated first argument. This adds that generated fake behavior while preserving the existing generated fake behavior for torch.Tag.out.

Authored by Codex.