### PR TITLE
normalize tags for torch.library.custom_op

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2594,6 +2594,39 @@ class MiniOpTest(CustomOpTestCaseBase):
 
 
 class TestCustomOpAPI(TestCase):
+    @parametrize(
+        "tags, opname",
+        [
+            subtest((torch.Tag.pointwise, "single"), name="single"),
+            subtest(([torch.Tag.pointwise], "list"), name="list"),
+            subtest(((torch.Tag.pointwise,), "tuple"), name="tuple"),
+        ],
+    )
+    def test_custom_op_tags(self, tags, opname):
+        @torch.library.custom_op(
+            f"_torch_testing::tags_{opname}",
+            mutates_args=(),
+            tags=tags,
+        )
+        def f(x: Tensor) -> Tensor:
+            return x.clone()
+
+        self.assertIn(torch.Tag.pt2_compliant_tag, f._opoverload.tags)
+        self.assertIn(torch.Tag.pointwise, f._opoverload.tags)
+
+    def test_custom_op_tags_dedup_pt2_compliant(self):
+        @torch.library.custom_op(
+            "_torch_testing::tags_dedup_pt2",
+            mutates_args=(),
+            tags=[torch.Tag.pt2_compliant_tag, torch.Tag.pointwise],
+        )
+        def f(x: Tensor) -> Tensor:
+            return x.clone()
+
+        tags = f._opoverload.tags
+        self.assertEqual(tags.count(torch.Tag.pt2_compliant_tag), 1)
+        self.assertIn(torch.Tag.pointwise, tags)
+
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_basic(self):
         @torch.library.custom_op("_torch_testing::add", mutates_args=())

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -18,7 +18,23 @@ from .effects import EffectType
 
 
 device_types_t = str | Sequence[str] | None
+tags_t = _C.Tag | Sequence[_C.Tag] | None
 log = logging.getLogger(__name__)
+
+
+def _normalize_tags(tags: tags_t) -> tuple[_C.Tag, ...]:
+    if tags is None:
+        return ()
+    if isinstance(tags, _C.Tag):
+        tags = (tags,)
+    return tuple(dict.fromkeys(tags))
+
+
+def _with_pt2_compliant_tag(tags: Sequence[_C.Tag]) -> list[_C.Tag]:
+    return [
+        _C.Tag.pt2_compliant_tag,
+        *(tag for tag in tags if tag != _C.Tag.pt2_compliant_tag),
+    ]
 
 
 @overload
@@ -30,7 +46,7 @@ def custom_op(
     mutates_args: str | Iterable[str],
     device_types: device_types_t = None,
     schema: str | None = None,
-    tags: Sequence[_C.Tag] | None = None,
+    tags: tags_t = None,
 ) -> Callable[[Callable[..., object]], "CustomOpDef"]: ...
 
 
@@ -43,7 +59,7 @@ def custom_op(
     mutates_args: str | Iterable[str],
     device_types: device_types_t = None,
     schema: str | None = None,
-    tags: Sequence[_C.Tag] | None = None,
+    tags: tags_t = None,
 ) -> "CustomOpDef": ...
 
 
@@ -56,7 +72,7 @@ def custom_op(
     mutates_args: str | Iterable[str],
     device_types: device_types_t = None,
     schema: str | None = None,
-    tags: Sequence[_C.Tag] | None = None,
+    tags: tags_t = None,
 ) -> Union[Callable[[Callable[..., object]], "CustomOpDef"], "CustomOpDef"]:
     """Wraps a function into custom operator.
 
@@ -220,13 +236,13 @@ class CustomOpDef:
         name: str,
         schema: str,
         fn: Callable,
-        tags: Sequence[_C.Tag] | None = None,
+        tags: tags_t = None,
     ) -> None:
         # Fields used to interface with the PyTorch dispatcher
         self._namespace = namespace
         self._name = name
         self._schema = schema
-        self._tags = tags if tags is not None else []
+        self._tags = _normalize_tags(tags)
 
         self._init_fn = fn
 
@@ -653,7 +669,7 @@ class CustomOpDef:
     def _define_dispatcher_op(self, schema_str: str, tags: Sequence[_C.Tag]) -> None:
         self._lib.define(
             schema_str,
-            tags=[_C.Tag.pt2_compliant_tag, *tags],
+            tags=_with_pt2_compliant_tag(tags),
         )
         self._opoverload = utils.lookup_op(self._qualname)
 

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -6,7 +6,7 @@ import warnings
 import weakref
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import contextmanager
-from typing import Any, overload, Union
+from typing import Any, overload, TypeAlias, Union
 
 import torch
 from torch import _C, _ops, Tensor
@@ -17,8 +17,8 @@ from . import autograd, utils
 from .effects import EffectType
 
 
-device_types_t = str | Sequence[str] | None
-tags_t = _C.Tag | Sequence[_C.Tag] | None
+device_types_t: TypeAlias = str | Sequence[str] | None  # noqa: PYI042
+tags_t: TypeAlias = _C.Tag | Sequence[_C.Tag] | None  # noqa: PYI042
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184205
* #184204
* #184203
* #184202
* #184201
* __->__ #184200
* #184199

Allow custom_op(..., tags=...) to accept a single torch.Tag as well as a sequence, matching Library.define.

The registration path now uses a simple order-preserving normalization so duplicate tags, including the automatically added torch.Tag.pt2_compliant_tag, do not appear twice.

Authored by Codex.