### PR TITLE
get torch.library.custom_op to understand torch.Tag.inplace

### DIFF
--- a/test/custom_operator/test_inplace_tag.py
+++ b/test/custom_operator/test_inplace_tag.py
@@ -114,6 +114,20 @@ class TestInplaceTag(TestCase):
                 tags=[torch.Tag.inplace],
             )
 
+    def test_return_not_tensor(self):
+        with self.assertRaisesRegex(ValueError, "return must be a Tensor"):
+            self.lib.define(
+                "bad_return_type(Tensor(a!) self) -> int(a!)",
+                tags=[torch.Tag.inplace],
+            )
+
+    def test_return_not_mutable_alias(self):
+        with self.assertRaisesRegex(ValueError, "return must be a mutable alias"):
+            self.lib.define(
+                "bad_return_mutability(Tensor(a!) self) -> Tensor(a)",
+                tags=[torch.Tag.inplace],
+            )
+
     def test_return_wrong_alias(self):
         with self.assertRaisesRegex(ValueError, "return the first mutable argument"):
             self.lib.define(

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2627,6 +2627,126 @@ class TestCustomOpAPI(TestCase):
         self.assertEqual(tags.count(torch.Tag.pt2_compliant_tag), 1)
         self.assertIn(torch.Tag.pointwise, tags)
 
+    def test_custom_op_inplace_tag(self):
+        @torch.library.custom_op(
+            "_torch_testing::inplace_tag",
+            mutates_args={"x"},
+            tags=torch.Tag.inplace,
+        )
+        def f(x: Tensor, y: Tensor) -> Tensor:
+            x.add_(y)
+            return x
+
+        self.assertIn(torch.Tag.inplace, f._opoverload.tags)
+        schema = f._opoverload._schema
+        self.assertTrue(schema.arguments[0].alias_info.is_write)
+        self.assertTrue(schema.returns[0].alias_info.is_write)
+        self.assertEqual(
+            schema.arguments[0].alias_info.before_set,
+            schema.returns[0].alias_info.before_set,
+        )
+
+        x = torch.randn(3)
+        y = torch.randn(3)
+        expected = x + y
+        result = f(x, y)
+        self.assertIs(result, x)
+        self.assertEqual(x, expected)
+
+        with torch._subclasses.fake_tensor.FakeTensorMode():
+            fake_x = torch.randn(3)
+            fake_y = torch.randn(3)
+            fake_result = f(fake_x, fake_y)
+            self.assertIs(fake_result, fake_x)
+
+    def test_custom_op_inplace_tag_returns_wrong_tensor(self):
+        @torch.library.custom_op(
+            "_torch_testing::inplace_tag_returns_wrong_tensor",
+            mutates_args={"x"},
+            tags=torch.Tag.inplace,
+        )
+        def f(x: Tensor, y: Tensor) -> Tensor:
+            x.add_(y)
+            return y
+
+        with self.assertRaisesRegex(RuntimeError, "must return its first argument"):
+            f(torch.randn(3), torch.randn(3))
+
+    def test_custom_op_inplace_tag_mutates_args_iterable(self):
+        def mutates_args():
+            yield "x"
+
+        @torch.library.custom_op(
+            "_torch_testing::inplace_tag_mutates_args_iterable",
+            mutates_args=mutates_args(),
+            tags=torch.Tag.inplace,
+        )
+        def f(x: Tensor) -> Tensor:
+            return x
+
+        x = torch.randn(3)
+        self.assertIs(f(x), x)
+
+    def test_custom_op_inplace_tag_no_positional_arg(self):
+        def f(*, x: Tensor) -> Tensor:
+            return x
+
+        with self.assertRaisesRegex(ValueError, "torch.Tag.inplace"):
+            torch.library.custom_op(
+                "_torch_testing::inplace_tag_no_positional_arg",
+                f,
+                mutates_args={"x"},
+                tags=torch.Tag.inplace,
+            )
+
+    def test_custom_op_inplace_tag_first_arg_not_tensor(self):
+        def f(x: int, y: Tensor) -> Tensor:
+            return y
+
+        with self.assertRaisesRegex(ValueError, "first positional argument"):
+            torch.library.custom_op(
+                "_torch_testing::inplace_tag_first_arg_not_tensor",
+                f,
+                mutates_args={"y"},
+                tags=torch.Tag.inplace,
+            )
+
+    def test_custom_op_inplace_tag_mutates_non_first_arg(self):
+        def f(x: Tensor, y: Tensor) -> Tensor:
+            return y
+
+        with self.assertRaisesRegex(ValueError, "mutates_args"):
+            torch.library.custom_op(
+                "_torch_testing::inplace_tag_mutates_non_first_arg",
+                f,
+                mutates_args={"y"},
+                tags=torch.Tag.inplace,
+            )
+
+    def test_custom_op_inplace_tag_return_none(self):
+        def f(x: Tensor) -> None:
+            pass
+
+        with self.assertRaisesRegex(ValueError, "return annotation"):
+            torch.library.custom_op(
+                "_torch_testing::inplace_tag_return_none",
+                f,
+                mutates_args={"x"},
+                tags=torch.Tag.inplace,
+            )
+
+    def test_custom_op_inplace_tag_multiple_returns(self):
+        def f(x: Tensor) -> tuple[Tensor, Tensor]:
+            return x, x
+
+        with self.assertRaisesRegex(ValueError, "return annotation"):
+            torch.library.custom_op(
+                "_torch_testing::inplace_tag_multiple_returns",
+                f,
+                mutates_args={"x"},
+                tags=torch.Tag.inplace,
+            )
+
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_basic(self):
         @torch.library.custom_op("_torch_testing::add", mutates_args=())

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -105,6 +105,9 @@ def custom_op(
             annotations. We recommend letting us infer a schema unless you
             have a specific reason not to.
             Example: "(Tensor x, int y) -> (Tensor, Tensor)".
+        tags (Tag | Sequence[Tag] | None): one or more tags to apply to the
+            operator. Use ``torch.Tag.inplace`` for operators that mutate their
+            first Tensor argument and return it.
 
     The following types are supported for the wrapped function's input parameters:
 
@@ -168,6 +171,24 @@ def custom_op(
         >>> numpy_sin_inplace(x)
         >>> assert torch.allclose(x, expected)
         >>>
+        >>> # Example of a custom op with inplace semantics
+        >>> @custom_op(
+        >>>     "mylib::numpy_sin_",
+        >>>     mutates_args={"x"},
+        >>>     device_types="cpu",
+        >>>     tags=torch.Tag.inplace,
+        >>> )
+        >>> def numpy_sin_(x: Tensor) -> Tensor:
+        >>>     x_np = x.numpy()
+        >>>     np.sin(x_np, out=x_np)
+        >>>     return x
+        >>>
+        >>> x = torch.randn(3)
+        >>> expected = x.sin()
+        >>> result = numpy_sin_(x)
+        >>> assert result is x
+        >>> assert torch.allclose(x, expected)
+        >>>
         >>> # Example of a factory function
         >>> @torch.library.custom_op("mylib::bar", mutates_args={}, device_types="cpu")
         >>> def bar(device: torch.device) -> Tensor:
@@ -192,13 +213,18 @@ def custom_op(
     def inner(fn: Callable[..., object]) -> CustomOpDef:
         import torch
 
+        normalized_tags = _normalize_tags(tags)
         if schema is None:
-            schema_str = torch.library.infer_schema(fn, mutates_args=mutates_args)
+            schema_str = torch.library.infer_schema(
+                fn,
+                mutates_args=mutates_args,
+                _tags=normalized_tags,
+            )
         else:
             schema_str = schema
 
         namespace, opname = name.split("::")
-        result = CustomOpDef(namespace, opname, schema_str, fn, tags)
+        result = CustomOpDef(namespace, opname, schema_str, fn, normalized_tags)
         if schema is not None:
             # Check that schema's alias annotations match those of `mutates_args`.
             expected = set()
@@ -253,6 +279,7 @@ class CustomOpDef:
         self._torch_dispatch_fns: dict[type, Callable] = {}
         self._vmap_fn: Callable | None = None
         self._autocast_dtype: dict[str, _dtype | None] = {}
+        self._is_inplace = False
 
         self._lib = get_library_allowing_overwrite(self._namespace, self._name)
         self._register_to_dispatcher(self._tags)
@@ -394,7 +421,14 @@ class CustomOpDef:
                             return inspect.getmodule(fn)
 
                         schema = self._opoverload._schema
-                        if not schema._is_view_op():
+                        if self._is_inplace:
+                            if result is not args[0]:
+                                raise RuntimeError(
+                                    f"{self._name} (with implementation in {get_module()}): "
+                                    "An operator tagged with torch.Tag.inplace must "
+                                    "return its first argument."
+                                )
+                        elif not schema._is_view_op():
                             utils._c_check_aliasing_constraint(
                                 self._name,
                                 args,
@@ -652,6 +686,7 @@ class CustomOpDef:
         cpp_schema = _C.parse_schema(schema_str)
         self._validate_schema(cpp_schema, schema_str)
         self._define_dispatcher_op(schema_str, tags)
+        self._is_inplace = utils.is_inplace(self._opoverload)
         self._register_fake_dispatcher_impl()
         self._register_autograd_dispatcher_impl()
         self._register_adinplaceorview_dispatcher_impl()

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -27,6 +27,7 @@ def infer_schema(
     *,
     mutates_args,
     op_name: str | None = None,
+    _tags: typing.Sequence[torch.Tag] = (),
 ) -> str:
     r"""Parses the schema of a given function with type hints. The schema is inferred from the
     function's type hints, and can be used to define a new operator.
@@ -69,6 +70,9 @@ def infer_schema(
     # inspect.signature() and we no longer need to deal with stringified
     # annotations below.
     sig = inspect.signature(prototype_function)
+    is_inplace = torch.Tag.inplace in _tags
+    if type(mutates_args) is not str:
+        mutates_args = tuple(mutates_args)
 
     def error_fn(what):
         raise ValueError(f"infer_schema(func): {what} Got func with signature {sig})")
@@ -111,6 +115,9 @@ def infer_schema(
     params = []
     seen_args = set()
     saw_kwarg_only_arg = False
+    first_positional_arg_name = None
+    first_positional_arg_schema_type = None
+    first_positional_arg_alias = None
     for idx, (name, param) in enumerate(sig.parameters.items()):
         if not supported_param(param):
             error_fn("We do not support positional-only args, varargs, or varkwargs.")
@@ -164,6 +171,14 @@ def infer_schema(
         if schema_type is None:
             raise AssertionError(f"schema_type is None for param {name}")
 
+        if (
+            param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+            and first_positional_arg_name is None
+        ):
+            first_positional_arg_name = name
+            first_positional_arg_schema_type = schema_type
+            first_positional_arg_alias = f"a{idx}"
+
         if type(mutates_args) is str:
             if mutates_args != UNKNOWN_MUTATES:
                 raise ValueError(
@@ -212,8 +227,28 @@ def infer_schema(
                 f"mutates_args should contain the names of all args that the "
                 f"custom op mutates, or just the string 'unknown' if you don't know."
             )
+    if is_inplace:
+        if first_positional_arg_name is None:
+            error_fn("torch.Tag.inplace requires a positional Tensor argument.")
+        if first_positional_arg_schema_type != "Tensor":
+            error_fn(
+                "torch.Tag.inplace requires the first positional argument to be a Tensor."
+            )
+        if type(mutates_args) is str or set(mutates_args) != {
+            first_positional_arg_name
+        }:
+            error_fn(
+                "torch.Tag.inplace requires mutates_args to contain exactly "
+                f"the first positional argument, got {mutates_args}."
+            )
     return_annotation, _ = unstringify_type(sig.return_annotation)
     ret = parse_return(return_annotation, error_fn)
+    if is_inplace:
+        if ret != "Tensor":
+            error_fn(
+                "torch.Tag.inplace requires the return annotation to be torch.Tensor."
+            )
+        ret = f"Tensor({first_positional_arg_alias}!)"
     if op_name is not None:
         return f"{op_name}({', '.join(params)}) -> {ret}"
     return f"({', '.join(params)}) -> {ret}"

--- a/torch/library.py
+++ b/torch/library.py
@@ -177,10 +177,20 @@ def _validate_inplace_schema(schema: "str | torch._C.FunctionSchema") -> None:
             f"(the first argument). Got {len(returns)} returns. Got: {schema}"
         )
     ret = returns[0]
+    if not isinstance(ret.type, torch.TensorType):
+        raise ValueError(
+            f"Schema tagged with torch.Tag.inplace must return the first mutable argument "
+            f"(return must be a Tensor, got type '{ret.type}'). Got: {schema}"
+        )
     if ret.alias_info is None:
         raise ValueError(
             f"Schema tagged with torch.Tag.inplace must return the first mutable argument "
             f"(return must alias the first argument). Got: {schema}"
+        )
+    if not ret.alias_info.is_write:
+        raise ValueError(
+            f"Schema tagged with torch.Tag.inplace must return the first mutable argument "
+            f"(return must be a mutable alias, e.g., Tensor(a!)). Got: {schema}"
         )
     if ret.alias_info.before_set != first_arg.alias_info.before_set:
         raise ValueError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184205
* #184204
* #184203
* #184202
* __->__ #184201
* #184200
* #184199

Teach custom_op(..., tags=torch.Tag.inplace) to infer the standard inplace schema shape: the first Tensor argument is mutable and the single return aliases it mutably.

This also validates the supported inferred shape, updates the runtime alias check for inplace custom ops, and tightens low-level inplace schema validation for invalid return types and non-mutable aliases.

Authored by Codex.