### PR TITLE
get torch.library.custom_op to understand torch.Tag.out

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -843,6 +843,28 @@ class TestCustomOp(CustomOpTestCaseBase):
         schema = torch.library.infer_schema(foo_impl, op_name="myop", mutates_args={})
         self.assertExpectedInline(schema, "myop(Tensor x) -> Tensor")
 
+        def inplace_fn(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        schema = torch.library.infer_schema(
+            inplace_fn,
+            mutates_args={"x"},
+            tags=torch.Tag.inplace,
+        )
+        self.assertExpectedInline(schema, "(Tensor(a0!) x) -> Tensor(a0!)")
+
+        def out_fn(x: torch.Tensor, *, out: torch.Tensor) -> torch.Tensor:
+            return out
+
+        schema = torch.library.infer_schema(
+            out_fn,
+            mutates_args={"out"},
+            tags=torch.Tag.out,
+        )
+        self.assertExpectedInline(
+            schema, "(Tensor x, *, Tensor(a1!) out) -> Tensor(a1!)"
+        )
+
         # Ensure that a global in this file is properly found & evaluated.
         def stringy_fn(x: torch.Tensor) -> "MyList[torch.Tensor]":
             return [torch.randn_like(x)]
@@ -2627,6 +2649,18 @@ class TestCustomOpAPI(TestCase):
         self.assertEqual(tags.count(torch.Tag.pt2_compliant_tag), 1)
         self.assertIn(torch.Tag.pointwise, tags)
 
+    def test_custom_op_inplace_out_tags_mutually_exclusive(self):
+        def f(x: Tensor, *, out: Tensor) -> Tensor:
+            return out
+
+        with self.assertRaisesRegex(AssertionError, "mutually exclusive"):
+            torch.library.custom_op(
+                "_torch_testing::inplace_out_tags_mutually_exclusive",
+                f,
+                mutates_args={"x", "out"},
+                tags=[torch.Tag.inplace, torch.Tag.out],
+            )
+
     def test_custom_op_inplace_tag(self):
         @torch.library.custom_op(
             "_torch_testing::inplace_tag",
@@ -2684,8 +2718,67 @@ class TestCustomOpAPI(TestCase):
         def f(x: Tensor) -> Tensor:
             return x
 
+        schema = f._opoverload._schema
+        self.assertTrue(schema.arguments[0].alias_info.is_write)
+        self.assertTrue(schema.returns[0].alias_info.is_write)
+        self.assertEqual(
+            schema.arguments[0].alias_info.before_set,
+            schema.returns[0].alias_info.before_set,
+        )
+
         x = torch.randn(3)
         self.assertIs(f(x), x)
+
+    def test_custom_op_inplace_tag_autograd(self):
+        @torch.library.custom_op(
+            "_torch_testing::inplace_tag_autograd",
+            mutates_args={"x"},
+            tags=torch.Tag.inplace,
+        )
+        def f(x: Tensor, y: Tensor) -> Tensor:
+            x.add_(y)
+            return x
+
+        x = torch.randn(3, requires_grad=True)
+        y = torch.randn(3)
+        expected = x.detach() + y
+        result = f(x, y)
+        self.assertEqual(x, expected)
+        self.assertTrue(result.requires_grad)
+        with self.assertRaisesRegex(RuntimeError, "no autograd formula"):
+            result.sum().backward()
+
+    @skipIfTorchDynamo("recursive dynamo")
+    @requires_compile
+    @parametrize(
+        "backend, fullgraph",
+        [
+            subtest(("eager", False), name="eager"),
+            subtest(("eager", True), name="eager_fullgraph"),
+            subtest(("inductor", True), name="inductor_fullgraph"),
+        ],
+    )
+    def test_custom_op_inplace_tag_compile(self, backend, fullgraph):
+        name = f"{backend}_{'fullgraph' if fullgraph else 'default'}"
+
+        @torch.library.custom_op(
+            f"_torch_testing::inplace_tag_compile_{name}",
+            mutates_args={"x"},
+            tags=torch.Tag.inplace,
+        )
+        def f(x: Tensor, y: Tensor) -> Tensor:
+            x.add_(y)
+            return x
+
+        def fn(x, y):
+            return f(x, y)
+
+        x = torch.randn(3)
+        y = torch.randn(3)
+        expected = x + y
+        result = torch.compile(fn, backend=backend, fullgraph=fullgraph)(x, y)
+        self.assertIs(result, x)
+        self.assertEqual(x, expected)
 
     def test_custom_op_inplace_tag_no_positional_arg(self):
         def f(*, x: Tensor) -> Tensor:
@@ -2745,6 +2838,279 @@ class TestCustomOpAPI(TestCase):
                 f,
                 mutates_args={"x"},
                 tags=torch.Tag.inplace,
+            )
+
+    def test_custom_op_out_tag(self):
+        @torch.library.custom_op(
+            "_torch_testing::out_tag",
+            mutates_args={"out"},
+            tags=torch.Tag.out,
+        )
+        def f(x: Tensor, y: Tensor, *, out: Tensor) -> Tensor:
+            out.copy_(x + y)
+            return out
+
+        self.assertIn(torch.Tag.out, f._opoverload.tags)
+        schema = f._opoverload._schema
+        self.assertTrue(schema.arguments[2].kwarg_only)
+        self.assertTrue(schema.arguments[2].alias_info.is_write)
+        self.assertTrue(schema.returns[0].alias_info.is_write)
+        self.assertEqual(
+            schema.arguments[2].alias_info.before_set,
+            schema.returns[0].alias_info.before_set,
+        )
+
+        x = torch.randn(3)
+        y = torch.randn(3)
+        out = torch.empty_like(x)
+        result = f(x, y, out=out)
+        self.assertIs(result, out)
+        self.assertEqual(out, x + y)
+
+        with torch._subclasses.fake_tensor.FakeTensorMode():
+            fake_x = torch.randn(3)
+            fake_y = torch.randn(3)
+            fake_out = torch.empty_like(fake_x)
+            fake_result = f(fake_x, fake_y, out=fake_out)
+            self.assertIs(fake_result, fake_out)
+
+    @skipIfTorchDynamo("recursive dynamo")
+    @requires_compile
+    @parametrize(
+        "backend, fullgraph",
+        [
+            subtest(("eager", False), name="eager"),
+            subtest(("eager", True), name="eager_fullgraph"),
+            subtest(("inductor", True), name="inductor_fullgraph"),
+        ],
+    )
+    def test_custom_op_out_tag_compile(self, backend, fullgraph):
+        name = f"{backend}_{'fullgraph' if fullgraph else 'default'}"
+
+        @torch.library.custom_op(
+            f"_torch_testing::out_tag_compile_{name}",
+            mutates_args={"out"},
+            tags=torch.Tag.out,
+        )
+        def f(x: Tensor, y: Tensor, *, out: Tensor) -> Tensor:
+            out.copy_(x + y)
+            return out
+
+        def fn(x, y, out):
+            return f(x, y, out=out)
+
+        x = torch.randn(3)
+        y = torch.randn(3)
+        out = torch.empty_like(x)
+        expected = x + y
+        result = torch.compile(fn, backend=backend, fullgraph=fullgraph)(x, y, out)
+        if backend == "eager":
+            self.assertIs(result, out)
+        self.assertEqual(out, expected)
+        self.assertEqual(result, expected)
+
+    def test_custom_op_out_tag_multiple_returns(self):
+        @torch.library.custom_op(
+            "_torch_testing::out_tag_multiple_returns",
+            mutates_args={"add_out", "mul_out"},
+            tags=torch.Tag.out,
+        )
+        def f(
+            x: Tensor, y: Tensor, *, add_out: Tensor, mul_out: Tensor
+        ) -> tuple[Tensor, Tensor]:
+            add_out.copy_(x + y)
+            mul_out.copy_(x * y)
+            return add_out, mul_out
+
+        schema = f._opoverload._schema
+        out_args = schema.arguments[2:]
+        self.assertTrue(all(arg.kwarg_only for arg in out_args))
+        self.assertEqual(len(schema.returns), 2)
+        for arg, ret in zip(out_args, schema.returns):
+            self.assertTrue(arg.alias_info.is_write)
+            self.assertTrue(ret.alias_info.is_write)
+            self.assertEqual(
+                arg.alias_info.before_set,
+                ret.alias_info.before_set,
+            )
+
+        x = torch.randn(3)
+        y = torch.randn(3)
+        add_out = torch.empty_like(x)
+        mul_out = torch.empty_like(x)
+        result = f(x, y, add_out=add_out, mul_out=mul_out)
+        self.assertIs(result[0], add_out)
+        self.assertIs(result[1], mul_out)
+        self.assertEqual(add_out, x + y)
+        self.assertEqual(mul_out, x * y)
+
+        with torch._subclasses.fake_tensor.FakeTensorMode():
+            fake_x = torch.randn(3)
+            fake_y = torch.randn(3)
+            fake_add_out = torch.empty_like(fake_x)
+            fake_mul_out = torch.empty_like(fake_x)
+            fake_result = f(
+                fake_x,
+                fake_y,
+                add_out=fake_add_out,
+                mul_out=fake_mul_out,
+            )
+            self.assertIs(fake_result[0], fake_add_out)
+            self.assertIs(fake_result[1], fake_mul_out)
+
+    def test_custom_op_out_tag_returns_wrong_tensor(self):
+        @torch.library.custom_op(
+            "_torch_testing::out_tag_returns_wrong_tensor",
+            mutates_args={"out"},
+            tags=torch.Tag.out,
+        )
+        def f(x: Tensor, *, out: Tensor) -> Tensor:
+            return x
+
+        with self.assertRaisesRegex(RuntimeError, "mutable keyword-only arguments"):
+            f(torch.randn(3), out=torch.empty(3))
+
+    def test_custom_op_out_tag_autograd(self):
+        @torch.library.custom_op(
+            "_torch_testing::out_tag_autograd",
+            mutates_args={"out"},
+            tags=torch.Tag.out,
+        )
+        def f(x: Tensor, *, out: Tensor) -> Tensor:
+            out.copy_(x.sin())
+            return out
+
+        error_msg = (
+            r"functions with out=\.\.\. arguments don't support automatic "
+            "differentiation"
+        )
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            f(torch.randn(3, requires_grad=True), out=torch.empty(3))
+
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            f(torch.randn(3), out=torch.empty(3, requires_grad=True))
+
+        x = torch.randn(3, requires_grad=True)
+        out = torch.empty(3, requires_grad=True)
+        with torch.no_grad():
+            result = f(x, out=out)
+        self.assertIs(result, out)
+        self.assertTrue(out.requires_grad)
+        self.assertIsNone(out.grad_fn)
+        self.assertEqual(out, x.sin())
+
+    def test_custom_op_out_tag_register_autograd(self):
+        @torch.library.custom_op(
+            "_torch_testing::out_tag_register_autograd",
+            mutates_args={"out"},
+            tags=torch.Tag.out,
+        )
+        def f(x: Tensor, *, out: Tensor) -> Tensor:
+            out.copy_(x.sin())
+            return out
+
+        def backward(ctx, grad):
+            return grad
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Out variants do not support autograd"
+        ):
+            f.register_autograd(backward)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Out variants do not support autograd"
+        ):
+            torch.library.register_autograd(f, backward)
+
+    def test_library_register_autograd_out_tag_low_level(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            lib.define(
+                "out_tag_register_autograd_low_level(Tensor x, *, Tensor(a!) out) -> Tensor(a!)",
+                tags=torch.Tag.out,
+            )
+
+            def backward(ctx, grad):
+                return grad
+
+            with self.assertRaisesRegex(
+                RuntimeError, "Out variants do not support autograd"
+            ):
+                torch.library.register_autograd(
+                    "_torch_testing::out_tag_register_autograd_low_level",
+                    backward,
+                    lib=lib,
+                )
+
+    def test_custom_op_out_tag_positional_mutable_arg(self):
+        def f(x: Tensor, out: Tensor) -> Tensor:
+            return out
+
+        with self.assertRaisesRegex(ValueError, "keyword-only"):
+            torch.library.custom_op(
+                "_torch_testing::out_tag_positional_mutable_arg",
+                f,
+                mutates_args={"out"},
+                tags=torch.Tag.out,
+            )
+
+    def test_custom_op_out_tag_no_mutable_out(self):
+        def f(x: Tensor, *, out: Tensor) -> Tensor:
+            return out
+
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            torch.library.custom_op(
+                "_torch_testing::out_tag_no_mutable_out",
+                f,
+                mutates_args=(),
+                tags=torch.Tag.out,
+            )
+
+    def test_custom_op_out_tag_optional_mutable_out(self):
+        def f(x: Tensor, *, out: Optional[Tensor]) -> Tensor:
+            return x if out is None else out
+
+        with self.assertRaisesRegex(ValueError, "only supports"):
+            torch.library.custom_op(
+                "_torch_testing::out_tag_optional_mutable_out",
+                f,
+                mutates_args={"out"},
+                tags=torch.Tag.out,
+            )
+
+    def test_custom_op_out_tag_list_mutable_out(self):
+        def f(x: Tensor, *, out: List[Tensor]) -> Tensor:
+            return out[0]
+
+        with self.assertRaisesRegex(ValueError, "only supports"):
+            torch.library.custom_op(
+                "_torch_testing::out_tag_list_mutable_out",
+                f,
+                mutates_args={"out"},
+                tags=torch.Tag.out,
+            )
+
+    def test_custom_op_out_tag_return_mismatch(self):
+        def f(x: Tensor, *, out1: Tensor, out2: Tensor) -> Tensor:
+            return out1
+
+        with self.assertRaisesRegex(ValueError, "return annotation"):
+            torch.library.custom_op(
+                "_torch_testing::out_tag_return_mismatch",
+                f,
+                mutates_args={"out1", "out2"},
+                tags=torch.Tag.out,
+            )
+
+    def test_custom_op_out_tag_single_return_tuple_mismatch(self):
+        def f(x: Tensor, *, out: Tensor) -> tuple[Tensor]:
+            return (out,)
+
+        with self.assertRaisesRegex(ValueError, "return annotation"):
+            torch.library.custom_op(
+                "_torch_testing::out_tag_single_return_tuple_mismatch",
+                f,
+                mutates_args={"out"},
+                tags=torch.Tag.out,
             )
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")

--- a/torch/_library/autograd.py
+++ b/torch/_library/autograd.py
@@ -106,6 +106,17 @@ def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
     # The dispatcher passes any keyword-only-args as kwargs and the
     # rest of the args (even if specified as kwargs) as args.
     def autograd_impl(keyset, *args, **keyword_only_args):
+        if utils.is_out(op):
+            if _C.is_grad_enabled() and _C._any_requires_grad(
+                *args, **keyword_only_args
+            ):
+                raise RuntimeError(
+                    f"{op._opname}(): functions with out=... arguments don't "
+                    "support automatic differentiation, but one of the arguments "
+                    "requires grad."
+                )
+            return forward_no_grad(*args, Metadata(keyset, keyword_only_args))
+
         if _C.is_grad_enabled() and _C._any_requires_grad(*args):
             result = Generated.apply(*args, Metadata(keyset, keyword_only_args))  # type: ignore[attr-defined]
         else:

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -107,7 +107,10 @@ def custom_op(
             Example: "(Tensor x, int y) -> (Tensor, Tensor)".
         tags (Tag | Sequence[Tag] | None): one or more tags to apply to the
             operator. Use ``torch.Tag.inplace`` for operators that mutate their
-            first Tensor argument and return it.
+            first Tensor argument and return it. Use ``torch.Tag.out`` for
+            operators that mutate keyword-only output tensors and return them.
+            Like PyTorch's built-in ``out=`` operators, ``torch.Tag.out``
+            custom ops do not support autograd.
 
     The following types are supported for the wrapped function's input parameters:
 
@@ -189,6 +192,25 @@ def custom_op(
         >>> assert result is x
         >>> assert torch.allclose(x, expected)
         >>>
+        >>> # Example of a custom op with out= semantics
+        >>> @custom_op(
+        >>>     "mylib::numpy_sin_out",
+        >>>     mutates_args={"out"},
+        >>>     device_types="cpu",
+        >>>     tags=torch.Tag.out,
+        >>> )
+        >>> def numpy_sin_out(x: Tensor, *, out: Tensor) -> Tensor:
+        >>>     x_np = x.numpy()
+        >>>     out_np = out.numpy()
+        >>>     np.sin(x_np, out=out_np)
+        >>>     return out
+        >>>
+        >>> x = torch.randn(3)
+        >>> out = torch.empty_like(x)
+        >>> result = numpy_sin_out(x, out=out)
+        >>> assert result is out
+        >>> assert torch.allclose(out, x.sin())
+        >>>
         >>> # Example of a factory function
         >>> @torch.library.custom_op("mylib::bar", mutates_args={}, device_types="cpu")
         >>> def bar(device: torch.device) -> Tensor:
@@ -218,7 +240,7 @@ def custom_op(
             schema_str = torch.library.infer_schema(
                 fn,
                 mutates_args=mutates_args,
-                _tags=normalized_tags,
+                tags=normalized_tags,
             )
         else:
             schema_str = schema
@@ -280,6 +302,8 @@ class CustomOpDef:
         self._vmap_fn: Callable | None = None
         self._autocast_dtype: dict[str, _dtype | None] = {}
         self._is_inplace = False
+        self._is_out = False
+        self._out_kwarg_names: tuple[str, ...] = ()
 
         self._lib = get_library_allowing_overwrite(self._namespace, self._name)
         self._register_to_dispatcher(self._tags)
@@ -427,6 +451,25 @@ class CustomOpDef:
                                     f"{self._name} (with implementation in {get_module()}): "
                                     "An operator tagged with torch.Tag.inplace must "
                                     "return its first argument."
+                                )
+                        elif self._is_out:
+                            out_kwarg_names = self._out_kwarg_names
+                            if len(out_kwarg_names) == 1:
+                                returns_out_args = result is kwargs[out_kwarg_names[0]]
+                            else:
+                                returns_out_args = (
+                                    isinstance(result, tuple)
+                                    and len(result) == len(out_kwarg_names)
+                                    and all(
+                                        result[i] is kwargs[name]
+                                        for i, name in enumerate(out_kwarg_names)
+                                    )
+                                )
+                            if not returns_out_args:
+                                raise RuntimeError(
+                                    f"{self._name} (with implementation in {get_module()}): "
+                                    "An operator tagged with torch.Tag.out must "
+                                    "return its mutable keyword-only arguments."
                                 )
                         elif not schema._is_view_op():
                             utils._c_check_aliasing_constraint(
@@ -671,6 +714,11 @@ class CustomOpDef:
 
         """
         schema = self._opoverload._schema
+        if utils.is_out(self._opoverload):
+            raise RuntimeError(
+                f"Cannot register autograd formula for operator tagged with "
+                f"torch.Tag.out: {self}. Out variants do not support autograd."
+            )
         if not utils.is_functional_schema(schema, allow_valid_view=True):
             raise RuntimeError(
                 f"Cannot register autograd formula for non-functional operator "
@@ -687,12 +735,16 @@ class CustomOpDef:
         self._validate_schema(cpp_schema, schema_str)
         self._define_dispatcher_op(schema_str, tags)
         self._is_inplace = utils.is_inplace(self._opoverload)
+        self._is_out = utils.is_out(self._opoverload)
+        if self._is_out:
+            _, out_kwarg_names = utils.mutated_args_kwargs(self._opoverload._schema)
+            self._out_kwarg_names = tuple(out_kwarg_names)
         self._register_fake_dispatcher_impl()
         self._register_autograd_dispatcher_impl()
         self._register_adinplaceorview_dispatcher_impl()
 
     def _validate_schema(self, schema: _C.FunctionSchema, schema_str: str) -> None:
-        if utils.has_kwarg_only_tensors(schema):
+        if utils.has_kwarg_only_tensors(schema) and torch.Tag.out not in self._tags:
             # If you want to support this, the progression is:
             # - supporting kwarg-only Tensors that are non-differentiable
             # - supporting kwarg-only Tensors (regardless of differentiability)

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -27,7 +27,7 @@ def infer_schema(
     *,
     mutates_args,
     op_name: str | None = None,
-    _tags: typing.Sequence[torch.Tag] = (),
+    tags: torch.Tag | typing.Sequence[torch.Tag] | None = (),
 ) -> str:
     r"""Parses the schema of a given function with type hints. The schema is inferred from the
     function's type hints, and can be used to define a new operator.
@@ -49,6 +49,9 @@ def infer_schema(
             name is not included in the inferred schema. Note that the input schema to
             ``torch.library.Library.define`` requires a operator name.
         mutates_args ("unknown" | Iterable[str]): The arguments that are mutated in the function.
+        tags (Tag | Sequence[Tag] | None): one or more tags to apply to the
+            inferred schema. Use ``torch.Tag.inplace`` or ``torch.Tag.out`` to
+            infer the conventional aliasing for those operator kinds.
 
     Returns:
         The inferred schema.
@@ -70,7 +73,16 @@ def infer_schema(
     # inspect.signature() and we no longer need to deal with stringified
     # annotations below.
     sig = inspect.signature(prototype_function)
-    is_inplace = torch.Tag.inplace in _tags
+    if tags is None:
+        tags = ()
+    elif isinstance(tags, torch.Tag):
+        tags = (tags,)
+    is_inplace = torch.Tag.inplace in tags
+    is_out = torch.Tag.out in tags
+    if is_inplace and is_out:
+        raise AssertionError(
+            "torch.Tag.inplace and torch.Tag.out are mutually exclusive"
+        )
     if type(mutates_args) is not str:
         mutates_args = tuple(mutates_args)
 
@@ -118,6 +130,8 @@ def infer_schema(
     first_positional_arg_name = None
     first_positional_arg_schema_type = None
     first_positional_arg_alias = None
+    out_arg_aliases = []
+    out_arg_names = []
     for idx, (name, param) in enumerate(sig.parameters.items()):
         if not supported_param(param):
             error_fn("We do not support positional-only args, varargs, or varkwargs.")
@@ -179,6 +193,7 @@ def infer_schema(
             first_positional_arg_schema_type = schema_type
             first_positional_arg_alias = f"a{idx}"
 
+        is_mutated = False
         if type(mutates_args) is str:
             if mutates_args != UNKNOWN_MUTATES:
                 raise ValueError(
@@ -186,13 +201,24 @@ def infer_schema(
                     "the arguments that are mutated or the string 'unknown'. "
                 )
             if schema_type.startswith("Tensor"):
+                is_mutated = True
                 schema_type = f"Tensor(a{idx}!){schema_type[len('Tensor') :]}"
         elif name in mutates_args:
+            is_mutated = True
             if not schema_type.startswith("Tensor"):
                 error_fn(
                     f"Parameter {name} is in mutable_args but only Tensors or collections of Tensors can be mutated"
                 )
             schema_type = f"Tensor(a{idx}!){schema_type[len('Tensor') :]}"
+        if is_out and is_mutated:
+            if param.kind != inspect.Parameter.KEYWORD_ONLY:
+                error_fn("torch.Tag.out requires mutable arguments to be keyword-only.")
+            if schema_type != f"Tensor(a{idx}!)":
+                error_fn(
+                    "torch.Tag.out only supports mutable keyword-only Tensor arguments."
+                )
+            out_arg_aliases.append(f"a{idx}")
+            out_arg_names.append(name)
         seen_args.add(name)
         if param.default is inspect.Parameter.empty:
             # pyrefly: ignore [bad-argument-type]
@@ -241,8 +267,17 @@ def infer_schema(
                 "torch.Tag.inplace requires mutates_args to contain exactly "
                 f"the first positional argument, got {mutates_args}."
             )
+    if is_out and len(out_arg_aliases) == 0:
+        error_fn(
+            "torch.Tag.out requires at least one mutable keyword-only Tensor argument."
+        )
     return_annotation, _ = unstringify_type(sig.return_annotation)
-    ret = parse_return(return_annotation, error_fn)
+    if is_out:
+        ret = _infer_out_return_schema(
+            return_annotation, out_arg_aliases, out_arg_names, error_fn
+        )
+    else:
+        ret = parse_return(return_annotation, error_fn)
     if is_inplace:
         if ret != "Tensor":
             error_fn(
@@ -366,6 +401,33 @@ def parse_return(annotation, error_fn):
     if len(args) == 1:
         output_ty = "(" + output_ty + ")"
     return "(" + output_ty + ")"
+
+
+def _infer_out_return_schema(
+    return_annotation,
+    out_arg_aliases,
+    out_arg_names,
+    error_fn,
+):
+    if len(out_arg_aliases) == 1:
+        return_annotation_matches_out_args = return_annotation is Tensor
+    else:
+        return_annotation_matches_out_args = typing.get_origin(
+            return_annotation
+        ) is tuple and typing.get_args(return_annotation) == (Tensor,) * len(
+            out_arg_aliases
+        )
+
+    if not return_annotation_matches_out_args:
+        error_fn(
+            "torch.Tag.out requires the return annotation to match the "
+            f"mutable keyword-only Tensor arguments {tuple(out_arg_names)}."
+        )
+
+    aliased_returns = [f"Tensor({out_arg_alias}!)" for out_arg_alias in out_arg_aliases]
+    if len(aliased_returns) == 1:
+        return aliased_returns[0]
+    return f"({', '.join(aliased_returns)})"
 
 
 SUPPORTED_PARAM_TYPES = get_supported_param_types()

--- a/torch/library.py
+++ b/torch/library.py
@@ -1407,6 +1407,11 @@ def register_autograd(
     qualname = op
     op = torch._library.utils.lookup_op(qualname)
     schema = op._schema
+    if _library.utils.is_out(op):
+        raise RuntimeError(
+            f"Cannot register autograd formula for operator tagged with "
+            f"torch.Tag.out: {op}. Out variants do not support autograd."
+        )
     if not _library.utils.is_functional_schema(schema):
         raise RuntimeError(
             f"Cannot register autograd formula for non-functional operator "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184205
* #184204
* #184203
* __->__ #184202
* #184201
* #184200
* #184199

Users can tag their torch.library.custom_op with torch.Tag.out. This PR allows the custom_op path to accept these operators, infers the standard out-variant schema shape from mutable keyword-only Tensor outputs, adds runtime checks that Python kernels return the actual out tensors, and mirrors native out= autograd behavior by rejecting grad-enabled calls and autograd registration.

This also exposes tags= on torch.library.infer_schema so the schema inference behavior can be used directly, and adds compile coverage for the new inplace/out custom op paths.

Test Plan:
python -m py_compile torch/_library/infer_schema.py torch/_library/custom_ops.py test/test_custom_ops.py
python test/test_custom_ops.py -k infer_schema_supported
python test/test_custom_ops.py -k inplace_tag
python test/test_custom_ops.py -k out_tag
python test/test_custom_ops.py -k library_register_autograd
python test/test_custom_ops.py -k custom_op
python test/custom_operator/test_inplace_tag.py
python test/custom_operator/test_out_variant.py
git diff --check
lintrunner -a

Authored by Codex.