### PR TITLE
test tagged custom ops with manual schemas

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2859,6 +2859,50 @@ class TestCustomOpAPI(TestCase):
                 tags=torch.Tag.inplace,
             )
 
+    def test_custom_op_inplace_tag_manual_schema(self):
+        @torch.library.custom_op(
+            "_torch_testing::inplace_tag_manual_schema",
+            mutates_args={"x"},
+            schema="(Tensor(a!) x, Tensor y) -> Tensor(a!)",
+            tags=torch.Tag.inplace,
+        )
+        def f(x, y):
+            x.add_(y)
+            return x
+
+        self.assertIn(torch.Tag.inplace, f._opoverload.tags)
+        schema = f._opoverload._schema
+        self.assertTrue(schema.arguments[0].alias_info.is_write)
+        self.assertTrue(schema.returns[0].alias_info.is_write)
+        self.assertEqual(
+            schema.arguments[0].alias_info.before_set,
+            schema.returns[0].alias_info.before_set,
+        )
+
+        x = torch.randn(3)
+        y = torch.randn(3)
+        expected = x + y
+        result = f(x, y)
+        self.assertIs(result, x)
+        self.assertEqual(x, expected)
+
+        with torch._subclasses.fake_tensor.FakeTensorMode():
+            fake_x = torch.randn(3)
+            fake_y = torch.randn(3)
+            self.assertIs(f(fake_x, fake_y), fake_x)
+
+    def test_custom_op_inplace_tag_bad_manual_schema(self):
+        with self.assertRaisesRegex(ValueError, "return must alias"):
+
+            @torch.library.custom_op(
+                "_torch_testing::inplace_tag_bad_manual_schema",
+                mutates_args={"x"},
+                schema="(Tensor(a!) x) -> Tensor",
+                tags=torch.Tag.inplace,
+            )
+            def f(x):
+                return x
+
     def test_custom_op_out_tag(self):
         @torch.library.custom_op(
             "_torch_testing::out_tag",
@@ -3174,6 +3218,52 @@ class TestCustomOpAPI(TestCase):
                 mutates_args={"out"},
                 tags=torch.Tag.out,
             )
+
+    def test_custom_op_out_tag_manual_schema(self):
+        @torch.library.custom_op(
+            "_torch_testing::out_tag_manual_schema",
+            mutates_args={"out"},
+            schema="(Tensor x, Tensor y, *, Tensor(a!) out) -> Tensor(a!)",
+            tags=torch.Tag.out,
+        )
+        def f(x, y, *, out):
+            out.copy_(x + y)
+            return out
+
+        self.assertIn(torch.Tag.out, f._opoverload.tags)
+        schema = f._opoverload._schema
+        self.assertTrue(schema.arguments[2].kwarg_only)
+        self.assertTrue(schema.arguments[2].alias_info.is_write)
+        self.assertTrue(schema.returns[0].alias_info.is_write)
+        self.assertEqual(
+            schema.arguments[2].alias_info.before_set,
+            schema.returns[0].alias_info.before_set,
+        )
+
+        x = torch.randn(3)
+        y = torch.randn(3)
+        out = torch.empty_like(x)
+        result = f(x, y, out=out)
+        self.assertIs(result, out)
+        self.assertEqual(out, x + y)
+
+        with torch._subclasses.fake_tensor.FakeTensorMode():
+            fake_x = torch.randn(3)
+            fake_y = torch.randn(3)
+            fake_out = torch.empty_like(fake_x)
+            self.assertIs(f(fake_x, fake_y, out=fake_out), fake_out)
+
+    def test_custom_op_out_tag_bad_manual_schema(self):
+        with self.assertRaisesRegex(ValueError, "keyword-only"):
+
+            @torch.library.custom_op(
+                "_torch_testing::out_tag_bad_manual_schema",
+                mutates_args={"out"},
+                schema="(Tensor x, Tensor(a!) out) -> Tensor(a!)",
+                tags=torch.Tag.out,
+            )
+            def f(x, out):
+                return out
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_basic(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184205
* __->__ #184204
* #184203
* #184202
* #184201
* #184200
* #184199

Manual schema support for torch.Tag.inplace and torch.Tag.out already works because custom_op forwards tags through to Library.define, which owns the tag-specific schema validation. Add coverage for valid manual inplace/out schemas and for bad schemas surfacing the low-level validation errors.

Test Plan:
python -m py_compile test/test_custom_ops.py
python test/test_custom_ops.py -k manual_schema
python test/test_custom_ops.py -k custom_op
python test/custom_operator/test_inplace_tag.py
python test/custom_operator/test_out_variant.py
git diff --check
lintrunner -a

Authored by Codex.