### PR TITLE
[MPS] Fix welford reuduction codegen with dynamic shapes

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -190,6 +190,19 @@ class MPSBasicTests(TestCase):
             ),
         )
 
+    def test_welford_reduction_dynamic_shape(self):
+        @torch.compile(dynamic=True)
+        def fn(x):
+            return x.var(dim=-1)
+
+        # (5, 32): single-stage welford_reduce
+        # (3, 1023), (4, 5000), (7, 1025): multistage welford_reduce
+        # (1, 30000): split reduction -> welford_combine
+        for shape in [(4, 5000), (3, 1023), (7, 1025), (5, 32), (1, 30000)]:
+            x = torch.randn(*shape, device=self.device)
+            torch._dynamo.mark_dynamic(x, 1)
+            self.assertEqual(fn(x), x.var(dim=-1))
+
     def test_sdpa_split_qkv(self):
         # regression test for metal compiler bug where fused (x / A) % B
         # produces wrong results, causing incorrect reads from non-contiguous.

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -190,18 +190,18 @@ class MPSBasicTests(TestCase):
             ),
         )
 
-    def test_welford_reduction_dynamic_shape(self):
+    @parametrize("shape", [(4, 5000), (3, 1023), (7, 1025), (5, 32), (1, 30000)])
+    def test_welford_reduction_dynamic_shape(self, shape):
+        # (5, 32): single-stage welford_reduce
+        # (3, 1023), (4, 5000), (7, 1025): multistage welford_reduce
+        # (1, 30000): split reduction -> welford_combine
         @torch.compile(dynamic=True)
         def fn(x):
             return x.var(dim=-1)
 
-        # (5, 32): single-stage welford_reduce
-        # (3, 1023), (4, 5000), (7, 1025): multistage welford_reduce
-        # (1, 30000): split reduction -> welford_combine
-        for shape in [(4, 5000), (3, 1023), (7, 1025), (5, 32), (1, 30000)]:
-            x = torch.randn(*shape, device=self.device)
-            torch._dynamo.mark_dynamic(x, 1)
-            self.assertEqual(fn(x), x.var(dim=-1))
+        x = torch.randn(*shape, device=self.device)
+        torch._dynamo.mark_dynamic(x, 1)
+        self.assertEqual(fn(x), x.var(dim=-1))
 
     def test_sdpa_split_qkv(self):
         # regression test for metal compiler bug where fused (x / A) % B

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -70,22 +70,13 @@ test_failures = {
         ("cpu", "cuda", "xpu", "mps")
     ),
     "test_argmax_argmin_with_duplicates_dynamic_shapes": TestFailure(("mps",)),
-    "test_batch_norm_2d_2_dynamic_shapes": TestFailure(("mps",)),
-    "test_buffer_batch_norm_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_abs_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_floordiv_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_remainder_dynamic_shapes": TestFailure(("mps",)),
-    "test_multilayer_var_dynamic_shapes": TestFailure(("mps",)),
-    "test_multilayer_var_lowp_dynamic_shapes": TestFailure(("mps",)),
     "test_reduction2_dynamic_shapes": TestFailure(("mps",)),
     "test_reduction3_dynamic_shapes": TestFailure(("mps",)),
     "test_reduction5_dynamic_shapes": TestFailure(("mps",)),
     "test_roll_dynamic_shapes": TestFailure(("mps",)),
-    "test_std_dynamic_shapes": TestFailure(("mps",)),
-    "test_var_correction_dynamic_shapes": TestFailure(("mps",)),
-    "test_var_mean_div_by_dynamic_shapes": TestFailure(("mps",)),
-    "test_var_mean_tile_reduction_False_dynamic_shapes": TestFailure(("mps",)),
-    "test_var_mean_tile_reduction_True_dynamic_shapes": TestFailure(("mps",)),
     "test_reflection_pad2d_backward_dynamic_shapes": TestFailure(
         ("mps",), is_skip=True
     ),

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -674,6 +674,14 @@ class MetalKernel(SIMDKernel):
 
         acc_buf_size = sympy.Min(acc_buf_size, self.max_threadgroup_size)
         acc_buf_size_str = self.sexpr(acc_buf_size)
+        # metal threadgroup arrays need a compile time constant size, so
+        # fall back to the static upper bound when acc buf size is symbolic
+        # happens when dynamic=True
+        acc_buf_alloc_size = (
+            acc_buf_size
+            if isinstance(acc_buf_size, sympy.Integer)
+            else self.max_threadgroup_size
+        )
         shmem_buf_size = (
             ceildiv(acc_buf_size, self.simd_group_size)
             if isinstance(acc_buf_size, sympy.Integer)
@@ -777,7 +785,7 @@ class MetalKernel(SIMDKernel):
             )
         if reduction_type == "welford_reduce":
             if not self.multistage_reduction_entry:
-                acc_buf = self._new_idxvar(src_dtype, acc_buf_size)
+                acc_buf = self._new_idxvar(src_dtype, acc_buf_alloc_size)
                 self.compute.splice(f"{acc_buf}[{reduction_idx}] = {value};")
                 wf_res = self.cse.generate(
                     self.compute,
@@ -785,7 +793,7 @@ class MetalKernel(SIMDKernel):
                     dtype=torch.float32,
                 )
                 return _unwrap_helper(wf_res)
-            acc_buf = self._new_idxvar("float3", acc_buf_size)
+            acc_buf = self._new_idxvar("float3", acc_buf_alloc_size)
             acc_thread_var = f"{acc_buf}[{reduction_idx}]"
             self.indexing_code.splice(f"{acc_thread_var} = 0.0;")
             self.compute.writeline(
@@ -793,13 +801,13 @@ class MetalKernel(SIMDKernel):
             )
             wf_res = self.cse.generate(
                 self.stores,
-                f"c10::metal::threadgroup_welford_combine({acc_buf}, {acc_buf_size})",
+                f"c10::metal::threadgroup_welford_combine({acc_buf}, {acc_buf_size_str})",
                 dtype=torch.float32,
             )
             return _unwrap_helper(wf_res)
         if reduction_type == "welford_combine":
             assert isinstance(value, tuple), "Input to welford combine must be tuple"
-            acc_buf = self._new_idxvar("float3", acc_buf_size)
+            acc_buf = self._new_idxvar("float3", acc_buf_alloc_size)
             acc_thread_var = f"{acc_buf}[{reduction_idx}]"
             inp_value = f"float3({value[0]}, {value[1]}, {value[2]})"
             self.indexing_code.splice(f"{acc_thread_var} = 0.0;")


### PR DESCRIPTION
Fix welford reuduction codegen with dynamic shapes. Reproducer:
```
import torch

@torch.compile(dynamic=True)
def f(x):
    return x.var(dim=-1)

x = torch.randn(4, 5000, device="mps")
torch._dynamo.mark_dynamic(x, 1)
out = f(x)
```
This on main leads to:
`program_source:1049:72: error: use of undeclared identifier 'Min'
        auto tmp1 = c10::metal::threadgroup_welford_combine(tmp_acc_0, Min(1024, r0_numel));`

When you change `acc_buf_size` to `acc_buf_size_str` then a new error appears:
```
 with program_source:1040:38: error: array size is not a constant expression
        threadgroup float3 tmp_acc_0[metal::min(static_cast<decltype(1024+r0_numel)>(1024), static_cast<decltype(1024+r0_numel)>(r0_numel))];
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
program_source:1040:130: note: function parameter 'r0_numel' with unknown value cannot be used in a constant expression
        threadgroup float3 tmp_acc_0[metal::min(static_cast<decltype(1024+r0_numel)>(1024), static_cast<decltype(1024+r0_numel)>(r0_numel))];
                                                                                                                                 ^
program_source:1033:24: note: declared here
        constant long& r0_numel,
                       ^


Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo