### PR TITLE
Fix Inductor cache dir fallback for unmapped users

### DIFF
--- a/test/inductor/test_cache_dir_utils.py
+++ b/test/inductor/test_cache_dir_utils.py
@@ -1,0 +1,53 @@
+# Owner(s): ["module: inductor"]
+
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest import mock
+
+from torch._inductor.runtime import cache_dir_utils
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestCacheDirUtils(TestCase):
+    def test_default_cache_dir_falls_back_to_uid(self):
+        for exception in (
+            KeyError("getpwuid(): uid not found: 1001"),
+            ModuleNotFoundError("No module named 'pwd'"),
+            OSError("getpwuid(): uid not found: 1001"),
+        ):
+            with (
+                self.subTest(exception=type(exception)),
+                mock.patch.object(
+                    cache_dir_utils.getpass,
+                    "getuser",
+                    side_effect=exception,
+                ),
+                mock.patch.object(
+                    cache_dir_utils.os, "getuid", return_value=1001, create=True
+                ),
+                mock.patch.object(cache_dir_utils, "is_fbcode", return_value=False),
+            ):
+                self.assertEqual(
+                    cache_dir_utils.default_cache_dir(),
+                    os.path.join(tempfile.gettempdir(), "torchinductor_uid_1001"),
+                )
+
+    def test_default_cache_dir_falls_back_without_getuid(self):
+        with (
+            mock.patch.object(
+                cache_dir_utils.getpass,
+                "getuser",
+                side_effect=OSError("user unavailable"),
+            ),
+            mock.patch.object(cache_dir_utils, "os", SimpleNamespace(path=os.path)),
+            mock.patch.object(cache_dir_utils, "is_fbcode", return_value=False),
+        ):
+            self.assertEqual(
+                cache_dir_utils.default_cache_dir(),
+                os.path.join(tempfile.gettempdir(), "torchinductor_unknown_user"),
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/runtime/cache_dir_utils.py
+++ b/torch/_inductor/runtime/cache_dir_utils.py
@@ -20,7 +20,12 @@ def cache_dir() -> str:
 
 
 def default_cache_dir() -> str:
-    sanitized_username = re.sub(r'[\\/:*?"<>|]', "_", getpass.getuser())
+    try:
+        username = getpass.getuser()
+    except (KeyError, ModuleNotFoundError, OSError):
+        getuid = getattr(os, "getuid", None)
+        username = f"uid_{getuid()}" if callable(getuid) else "unknown_user"
+    sanitized_username = re.sub(r'[\\/:*?"<>|]', "_", username)
     return os.path.join(
         tempfile.gettempdir() if not is_fbcode() else "/var/tmp",
         "torchinductor_" + sanitized_username,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184208

Handle getpass.getuser() failures when deriving the default Inductor cache directory by falling back to a UID-derived name when available, or a deterministic unknown-user name otherwise. Adds focused coverage for POSIX and non-POSIX fallback paths. This supersedes the abandoned approach from pytorch/pytorch#160667.

Fixes #140765

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos