### PR TITLE
Disallow bare PyObject in operator schemas

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2043,6 +2043,16 @@ Dynamic shape operator
                 lib.define("foo12(int64_t a) -> Tensor")
             with self.assertRaisesRegex(RuntimeError, "Use `float`"):
                 lib.define("foo12(double a) -> Tensor")
+            with self.assertRaisesRegex(RuntimeError, "unknown type specifier"):
+                lib.define("foo12(PyObject a) -> Tensor")
+            type_name = "torch.testing.OpaqueObjectForCustomOpsTest"
+            if torch._C._is_opaque_type_registered(type_name):
+                torch._C._unregister_opaque_type(type_name)
+            torch._C._register_opaque_type(type_name)
+            try:
+                lib.define(f"foo12({type_name} a) -> Tensor")
+            finally:
+                torch._C._unregister_opaque_type(type_name)
 
     def test_is_tensorlist_like_type(self):
         tensorlists = [

--- a/test/test_function_schema.py
+++ b/test/test_function_schema.py
@@ -11,7 +11,12 @@ class TestFunctionSchema(TestCase):
         # so far we have around 1700 registered schemas
         self.assertGreater(len(schemas), 1000)
         for schema in schemas:
-            parsed_schema = parse_schema(str(schema))
+            schema_str = str(schema)
+            if "PyObject" in schema_str:
+                # Internal opaque-type schemas print as PyObject, but bare
+                # PyObject is intentionally not a public schema spelling.
+                continue
+            parsed_schema = parse_schema(schema_str)
             self.assertEqual(parsed_schema, schema)
             self.assertTrue(parsed_schema.is_backward_compatible_with(schema))
 

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -108,9 +108,6 @@ TypePtr SchemaTypeParser::parseBaseType() {
       {"Any", c10::TypeFactory::get<c10::AnyType>()},
       {"AnyClassType", c10::TypeFactory::get<c10::AnyClassType>()},
       {"AnyEnumType", c10::TypeFactory::get<c10::AnyEnumType>()},
-      // PyObjectType::get() used directly because PyObjectType is excluded
-      // from FORALL_DYNAMIC_TYPES (not supported on xplat/mobile)
-      {"PyObject", c10::PyObjectType::get()},
   };
   auto tok = L.cur();
   if (!L.nextIf(TK_NONE) && !L.nextIf(TK_NONE_TYPE)) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184209

We accidentally allowed bare PyObject in operator schemas in https://github.com/pytorch/pytorch/pull/178116 while adding support for registered opaque type names.

This change is technically BC-breaking because the behavior was allowed in PyTorch 2.12, but it is undocumented and we do not expect users to rely on it. We also want to turn it off because it does not add much for users: the main reason people write custom ops nowadays is for torch.compile, and torch.compile will not support arbitrary PyObject inputs to custom ops.

Registered opaque type names still work, so the DTensor ProcessGroup schema path added for compile_on_one_rank continues to parse.

Authored by Codex.