### PR TITLE
Fix duplicate word typo in LLVM JIT comment

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -246,7 +246,7 @@ class TORCH_API PytorchLLVMJITImpl {
   JITSymbol findSymbol(const std::string Name) {
 #if LLVM_VERSION_MAJOR >= 15
     // Starting with llvm-15, LLJIT::lookup returns an address rather than a
-    // symbol. Even though an address is what we ultimately we want, we also
+    // symbol. Even though an address is what we ultimately want, we also
     // want to avoid churning our internal APIs, so we wrap the returned address
     // in a fake JITSymbol.
     auto result = assertSuccess(LLJ->lookup(Name));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184213

Remove repeated "we" in a comment describing LLJIT::lookup behavior.

Authored with Claude (typo_terminator2).

cc @EikanWang @jgong5