### PR TITLE
Fix "dont" -> "don't" typos in comments

### DIFF
--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -63,7 +63,7 @@ class AotAutograd:
         if callable(self.kwargs.get("decompositions")):
             self.kwargs["decompositions"] = self.kwargs["decompositions"]()
 
-        # NB: dont delete counter increment
+        # NB: don't delete counter increment
         counters["aot_autograd"]["total"] += 1
         use_fallback = False
 

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -1169,7 +1169,7 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 # Ideally we would have just used VariableTracker.build(tx, fn,
                 # source=source) but that introduces guard on the
                 # `forward.__code__` object. Given that we already guard on the
-                # forward not present in generic dict, we dont need this guard.
+                # forward not present in generic dict, we don't need this guard.
                 return variables.UserFunctionVariable(fn, source=source).call_function(
                     tx, [self] + list(args), kwargs
                 )

--- a/torch/_inductor/bounds.py
+++ b/torch/_inductor/bounds.py
@@ -129,7 +129,7 @@ class BoundVars:
         interp.run(V.get_ops_handler(), initial_env=env)
         output = [node for node in subblock.graph.nodes if node.target == "output"]
         assert len(output) == 1
-        # dont bother unioning with value since the load from buffer will be
+        # don't bother unioning with value since the load from buffer will be
         # pessimistically assumed to be inf anyway
         return interp.env[output[0]]
 
@@ -169,7 +169,7 @@ class ValueRangeAnalysis(SymPyValueRangeAnalysis, DefaultHandler):
 
     def _default(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
         # many ops are unlikely to show up in optimizable indexing compute,
-        # so we dont have full coverage
+        # so we don't have full coverage
         return ValueRanges.unknown()
 
     def load(self, name: str, index: sympy.Expr) -> ValueRanges[Any]:

--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -747,7 +747,7 @@ def estimate_fx_collective_size(fx_node: torch.fx.Node) -> int:
     args, kwargs = fx_node.args, fx_node.kwargs
     kwargs = dict(kwargs)
 
-    # dont double count pre-allocated buffer passed in
+    # don't double count pre-allocated buffer passed in
     kwargs.pop("out", None)
 
     def tensor_bytes(t: torch.Tensor) -> int:

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -578,7 +578,7 @@ class DebugFormatter:
                 inputs = torch._subclasses.fake_utils.try_convert_fake_to_real(inputs)
                 save_dir = os.path.dirname(fd.name)
 
-            # dont try to use stable hash torchinductor compilation if saving real tensors
+            # don't try to use stable hash torchinductor compilation if saving real tensors
             # and avoid recursively trying to save real tensors inside of the inductor compilation
             # regardless
             stable_hash = torch._inductor.config.trace.save_real_tensors

--- a/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
+++ b/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
@@ -511,7 +511,7 @@ class OverlapPreservingBucketer:
             for candidate in sorted_collectives[i + 1 : i + 1 + self.max_coll_distance]:
                 candidate_bytes = self.collective_info[candidate].size_bytes
                 # proxy on memory use, if we see a too large bucket,
-                # dont look for another, later bucket
+                # don't look for another, later bucket
                 if bucket_info.total_bytes + candidate_bytes > max_bucket_bytes:
                     break
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -961,7 +961,7 @@ def tuned_scaled_mm(
     _, is_nonzero = _is_static_problem(layout)
 
     if (
-        # We dont have triton lowerings for the MX variants yet
+        # We don't have triton lowerings for the MX variants yet
         scale_a.dtype == torch.float32
         and is_nonzero
         and use_triton_template(layout, enable_float8=True, check_max_autotune=False)

--- a/torch/_inductor/runtime/debug_utils.py
+++ b/torch/_inductor/runtime/debug_utils.py
@@ -58,7 +58,7 @@ class BufferMemoryTracker:
     ) -> None:
         """Check only the delta changes since last step"""
 
-        # Check expected deaths - we dont currently distinguish between nodes which die in last step
+        # Check expected deaths - we don't currently distinguish between nodes which die in last step
         # and are returned as outputs, so skip if final_step.
         if not is_final_step:
             missing_deaths = OrderedSet(expected_freed) - self.died_since_last_step


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184214

Fix missing apostrophes in contractions across torch/_dynamo and
torch/_inductor comments for improved readability.

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98