### PR TITLE
Fix article and word typos in comments, docstrings, and error messages

### DIFF
--- a/torch/_custom_op/impl.py
+++ b/torch/_custom_op/impl.py
@@ -397,7 +397,7 @@ class CustomOp:
         if _C._dispatch_has_kernel_for_dispatch_key(self._qualname, "Meta"):
             raise RuntimeError(
                 f"impl_abstract(...): the operator {self._qualname} "
-                f"already has an DispatchKey::Meta implementation via a "
+                f"already has a DispatchKey::Meta implementation via a "
                 f"pre-existing torch.library or TORCH_LIBRARY registration. "
                 f"Please either remove that registration or don't call impl_abstract."
             )

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -1455,13 +1455,13 @@ p-value, which we leave for future work.
             default=accuracy,
             help="""\
 by default, when doing accuracy minification we will reject reductions which
-change the divergence from a floating point divergence to a integral/boolean
+change the divergence from a floating point divergence to an integral/boolean
 divergence.  This is because some operations like ReLU involve temporarily
 sharp boundaries that smooth out again afterwards; without requiring
 divergence on floating point, the minifier will often fixate on divergent
 boolean tensor even though this is not the true source of the divergence.
 However, rejecting these reductions makes it more difficult for the minifier
-to make process.  Using this option will let the minifier progress for ALL
+to make progress.  Using this option will let the minifier progress for ALL
 divergences--you just might not end up with a useful repro in the end.""",
         )
 

--- a/torch/_higher_order_ops/schema.py
+++ b/torch/_higher_order_ops/schema.py
@@ -18,7 +18,7 @@ class HopArgumentInfo:
     # Could give a name to the operand by default it's empty string.
     name: str
     example_value: Any
-    # Provide an default_value
+    # Provide a default_value
     default_value: Any
     # Whether this argument gets mutated in the hop subgraph.
     # For output, this should always be False

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -673,7 +673,7 @@ class FunctionModifiers:
     UNUSED = "unused (ignored and replaced with raising of an exception)"
     IGNORE = "ignore (leave as a call to Python, cannot be torch.jit.save'd)"
     EXPORT = "export (compile this function even if nothing calls it)"
-    DEFAULT = "default (compile if called from a exported function / forward)"
+    DEFAULT = "default (compile if called from an exported function / forward)"
     COPY_TO_SCRIPT_WRAPPER = (
         "if this method is not scripted, copy the python method onto the scripted model"
     )

--- a/torch/csrc/fx/node.cpp
+++ b/torch/csrc/fx/node.cpp
@@ -524,7 +524,7 @@ static int NodeBase_set_sort_key(
     void* /*closure*/) {
   NodeBase* node = reinterpret_cast<NodeBase*>(self);
   if (!PyTuple_Check(value)) {
-    PyErr_SetString(PyExc_TypeError, "_sort_key must be an tuple of ints");
+    PyErr_SetString(PyExc_TypeError, "_sort_key must be a tuple of ints");
     return -1;
   }
   Py_ssize_t size = PyTuple_GET_SIZE(value);

--- a/torch/csrc/jit/frontend/resolver.h
+++ b/torch/csrc/jit/frontend/resolver.h
@@ -12,7 +12,7 @@ using ResolverPtr = std::shared_ptr<Resolver>;
 /**
  * class Resolver
  *
- * Represents an "outer environment" in which we an look up names and return
+ * Represents an "outer environment" in which we can look up names and return
  * a corresponding SugaredValue. This is used during compilation to resolve
  * references to names which are not defined internal to the graph.
  *

--- a/torch/jit/_check.py
+++ b/torch/jit/_check.py
@@ -158,7 +158,7 @@ class AttributeTypeIsSupportedChecker(ast.NodeVisitor):
         # TODO @ansley: add `Union` once landed
 
         # NB: Even though `Tuple` is a "container", we don't want to
-        # check for it here. `Tuple` functions as an type with an
+        # check for it here. `Tuple` functions as a type with an
         # "infinite" number of subtypes, in the sense that you can have
         # `Tuple[())]`, `Tuple[T1]`, `Tuple[T2]`, `Tuple[T1, T2]`,
         # `Tuple[T2, T1]` and so on, and none of these subtypes can be

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -273,7 +273,7 @@ def infer_concrete_type_builder(nn_module, share_types=True):
         attr_type, _ = infer_type(name, item)
         if item is None:
             # Modules can be None. We don't have direct support for optional
-            # Modules, so the register it as an NoneType attribute instead.
+            # Modules, so we register it as a NoneType attribute instead.
             concrete_type_builder.add_attribute(name, attr_type.type(), False, False)
             continue
         if attr_type.success():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184215

Correct incorrect indefinite articles ("a" vs "an") and fix two word
typos: "process" → "progress" in after_aot.py and "we an" → "we can"
in resolver.h.

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98