### PR TITLE
[inductor] Fix debug_sync_graph in cpp wrapper

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -76,6 +76,27 @@ class TestGpuWrapper(InductorTestCase):
         )(test_fn)
         comp()
 
+    def test_debug_sync_graph(self):
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+        if GPU_TYPE != "cuda":
+            self.skipTest("CUDA-only codegen test")
+
+        def test_fn(x):
+            return x * 2
+
+        compiled = torch.compile(
+            options={"cpp_wrapper": True, "triton.debug_sync_graph": True}
+        )(test_fn)
+        x = torch.randn(8, device=self.device)
+        result, code = test_torchinductor.run_and_get_cpp_code(compiled, x)
+        self.assertEqual(result, x * 2)
+        self.assertNotIn("torch.cuda.synchronize()", code)
+        expected_sync = (
+            "hipDeviceSynchronize" if torch.version.hip else "cudaDeviceSynchronize"
+        )
+        self.assertEqual(code.count(expected_sync), 2)
+
     def test_non_tensor_args_wrapped_on_cpu(self):
         if not RUN_GPU:
             self.skipTest("GPU not available")

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -961,6 +961,8 @@ class CppWrapperCpu(PythonWrapperCodegen):
         self._write_entry_point_signature()
         with self.prefix.indent():
             self._codegen_entry_impl_prologue()
+            if config.triton.debug_sync_graph:
+                self.generate_debug_sync(self.prefix)
             self._write_input_preamble()
             self._write_input_unpacking()
             self._write_constants_unpacking()
@@ -2049,6 +2051,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
     def codegen_exact_buffer_reuse(self, old_name: str, new_name: str, del_line: str):
         return f"auto {new_name} = std::move({old_name});  // reuse"
+
+    def generate_debug_sync(self, buffer: IndentedBuffer) -> None:
+        pass
 
     def generate_profiler_mark_wrapper_call(self, stack):
         self.wrapper_call.writeline(

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -844,6 +844,19 @@ class CppWrapperGpu(CppWrapperCpu):
         self.autotune_input_prefix = "_REAL_AUTOTUNE_INPUT"
         self._lazy_kernel_names: list[str] = []
 
+    def generate_debug_sync(self, buffer: IndentedBuffer) -> None:
+        if self.device == "cuda":
+            buffer.splice(
+                maybe_hipify_code_wrapper(
+                    """
+                    {
+                        auto status = cudaDeviceSynchronize();
+                        AOTI_TORCH_CHECK(status == cudaSuccess, cudaGetErrorString(status));
+                    }
+                    """
+                )
+            )
+
     @staticmethod
     def create(
         is_subgraph: bool,

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1664,7 +1664,7 @@ class PythonWrapperCodegen(CodeGen):
 
         with self.prefix.indent(prefix_indent):
             if config.triton.debug_sync_graph:
-                self.prefix.writeline(V.graph.device_ops.synchronize())
+                self.generate_debug_sync(self.prefix)
             phase = V.graph.get_training_phase()
             if config.annotate_training:
                 self.prefix.writeline(
@@ -2120,7 +2120,7 @@ class PythonWrapperCodegen(CodeGen):
             output_refs = self.get_output_refs()
             self.mark_output_type()
             if config.triton.debug_sync_graph:
-                self.wrapper_call.writeline(V.graph.device_ops.synchronize())
+                self.generate_debug_sync(self.wrapper_call)
 
             if config.profile_bandwidth:
                 self.generate_end_graph()
@@ -3163,6 +3163,9 @@ class PythonWrapperCodegen(CodeGen):
 
     def wrap_kernel_call(self, name, call_args):
         return f"{name}({', '.join(call_args)}){self.ending}"
+
+    def generate_debug_sync(self, buffer: IndentedBuffer) -> None:
+        buffer.writeline(V.graph.device_ops.synchronize())
 
     def generate_profiler_mark_wrapper_call(self, stack):
         self.wrapper_call.writeline("from torch.profiler import record_function")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184220

Emit native device synchronization when cpp_wrapper and triton.debug_sync_graph are both enabled, while keeping Python wrapper sync generation unchanged. Add a focused CUDA cpp-wrapper regression test for the before and after graph syncs.

Fixes #140219

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo