### PR TITLE
Fix OOB read in CUDAStream::stream()

### DIFF
--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -298,6 +298,8 @@ cudaStream_t CUDAStream::stream() const {
   StreamId stream_id = stream_.id();
   StreamIdType st = streamIdType(stream_id);
   size_t si = streamIdIndex(stream_id);
+  initCUDAStreamsOnce();
+  check_gpu(device_index);
   if (st.isDefault()) {
     TORCH_CHECK(
         si == 0,
@@ -393,7 +395,9 @@ CUDAStream getCurrentCUDAStream(DeviceIndex device_index) {
 
 void setCurrentCUDAStream(CUDAStream stream) {
   initCUDAStreamsOnce();
-  current_streams[stream.device_index()] = stream.id();
+  auto device_index = stream.device_index();
+  check_gpu(device_index);
+  current_streams[device_index] = stream.id();
 }
 
 std::ostream& operator<<(std::ostream& stream, const CUDAStream& s) {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1346,6 +1346,15 @@ print(t.is_pinned())
         default_stream.synchronize()
         self.assertTrue(default_stream.query())
 
+    def test_stream_invalid_device_index(self):
+        # Regression test for #184034: constructing a CUDAStream with an
+        # out-of-range device_index must not OOB-index the static stream pool.
+        num_devices = torch.cuda.device_count()
+        for di in (-2, -8, num_devices, num_devices + 16, 128):
+            s = torch.cuda.Stream(stream_id=3, device_index=di, device_type=1)
+            with self.assertRaisesRegex(RuntimeError, "Device index value"):
+                _ = s.cuda_stream
+
     def test_stream_event_repr(self):
         s = torch.cuda.current_stream()
         self.assertTrue("torch.cuda.Stream" in s.__repr__())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #184237

`torch.cuda.Stream(stream_id, device_index, device_type)` accepts arbitrary integers for `device_index`, and `CUDAStream::stream()` lacked `check_gpu(device_index);`
Add regression test

Fixes https://github.com/pytorch/pytorch/issues/184034

Authored with Claude.