### PR TITLE
Fix FlexAttention fallback config selection

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -3351,6 +3351,157 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             out_mixed = (compiled_fn(q, k, v, _identity)).mean()
             out_mixed.backward()
 
+    def _run_with_first_failed_flex_choice(
+        self,
+        target_name,
+        fn,
+        *,
+        seen=None,
+        selected=None,
+    ):
+        from torch._inductor.runtime.triton_heuristics import NoTritonConfigsError
+        from torch._inductor.select_algorithm import (
+            get_algorithm_selector_cache,
+            TritonTemplateCaller,
+        )
+
+        torch._dynamo.reset()
+        get_algorithm_selector_cache().cache_clear()
+        if seen is None:
+            seen = []
+        if selected is None:
+            selected = []
+
+        handled_names = {"flex_attention", "flex_attention_backward"}
+        original_precompile = TritonTemplateCaller.precompile
+        original_output_node = TritonTemplateCaller.output_node
+
+        def precompile(choice):
+            kernel_name = choice.bmreq.kernel_name.removeprefix("triton_")
+            if kernel_name not in handled_names:
+                return original_precompile(choice)
+            if kernel_name == target_name:
+                seen.append(choice)
+                if len(seen) == 1:
+                    raise NoTritonConfigsError(
+                        "No valid triton configs. OutOfResources: mocked"
+                    )
+                if len(seen) > 2:
+                    raise AssertionError(
+                        f"precompiled unused {target_name} fallback choice"
+                    )
+            return None
+
+        def output_node(choice):
+            if choice.bmreq.kernel_name == f"triton_{target_name}":
+                selected.append(choice)
+            return original_output_node(choice)
+
+        with (
+            config.patch({"fx_graph_cache": False, "fx_graph_remote_cache": False}),
+            patch.object(
+                TritonTemplateCaller,
+                "precompile",
+                new=precompile,
+            ),
+            patch.object(TritonTemplateCaller, "output_node", new=output_node),
+        ):
+            fn()
+
+        return seen, selected
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @patch.object(torch._inductor.config, "max_autotune", False)
+    def test_fallback_on_fwd_precompile_failure(self, device):
+        def run():
+            q, k, v = (
+                torch.randn(1, 1, 128, 64, device=device, dtype=torch.float16)
+                for _ in range(3)
+            )
+            torch.compile(flex_attention, fullgraph=True)(
+                q, k, v, _identity, kernel_options={"BACKEND": "TRITON"}
+            )
+
+        seen, selected = self._run_with_first_failed_flex_choice("flex_attention", run)
+        self.assertEqual(len(seen), 2)
+        self.assertEqual(selected, [seen[1]])
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @patch.object(torch._inductor.config, "max_autotune", False)
+    def test_fallback_on_bwd_precompile_failure(self, device):
+        def run():
+            q, k, v = (
+                torch.randn(
+                    1,
+                    1,
+                    128,
+                    64,
+                    device=device,
+                    dtype=torch.float16,
+                    requires_grad=True,
+                )
+                for _ in range(3)
+            )
+            out = torch.compile(flex_attention, fullgraph=True)(
+                q, k, v, _identity, kernel_options={"BACKEND": "TRITON"}
+            )
+            out.sum().backward()
+
+        seen, selected = self._run_with_first_failed_flex_choice(
+            "flex_attention_backward", run
+        )
+        self.assertEqual(len(seen), 2)
+        self.assertEqual(selected, [seen[1]])
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @patch.object(torch._inductor.config, "max_autotune", False)
+    @patch.object(torch._inductor.config, "flex_fallback_max_configs", 1)
+    def test_fallback_respects_max_configs(self, device):
+        seen = []
+
+        def run():
+            q, k, v = (
+                torch.randn(1, 1, 128, 64, device=device, dtype=torch.float16)
+                for _ in range(3)
+            )
+            torch.compile(flex_attention, fullgraph=True)(
+                q, k, v, _identity, kernel_options={"BACKEND": "TRITON"}
+            )
+
+        with self.assertRaisesRegex(InductorError, "All choices failed to compile"):
+            self._run_with_first_failed_flex_choice("flex_attention", run, seen=seen)
+        self.assertEqual(len(seen), 1)
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @patch.object(torch._inductor.config, "max_autotune", False)
+    def test_no_fallback_when_user_pins_fwd_config(self, device):
+        seen = []
+
+        def run():
+            q, k, v = (
+                torch.randn(1, 1, 128, 64, device=device, dtype=torch.float16)
+                for _ in range(3)
+            )
+            torch.compile(flex_attention, fullgraph=True)(
+                q,
+                k,
+                v,
+                _identity,
+                kernel_options={"BACKEND": "TRITON", "fwd_BLOCK_M": 64},
+            )
+
+        with self.assertRaisesRegex(InductorError, "All choices failed to compile"):
+            self._run_with_first_failed_flex_choice("flex_attention", run, seen=seen)
+        self.assertEqual(len(seen), 1)
+
     @supported_platform
     @patch.object(torch._inductor.config, "max_autotune", True)
     def test_max_autotune(self, device):

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -9,6 +9,7 @@ from unittest import expectedFailure
 from unittest.mock import patch
 
 import torch
+from torch._inductor import config
 from torch._inductor.exc import InductorError
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
@@ -1740,6 +1741,133 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
                 compiled_fn(q, k, v, _identity, kernel_options=kernel_options)
             ).mean()
             out_mixed.backward()
+
+    def _run_with_first_failed_decode_choice(
+        self,
+        fn,
+        *,
+        seen=None,
+        selected=None,
+    ):
+        from torch._inductor.runtime.triton_heuristics import NoTritonConfigsError
+        from torch._inductor.select_algorithm import (
+            get_algorithm_selector_cache,
+            TritonTemplateCaller,
+        )
+
+        torch._dynamo.reset()
+        get_algorithm_selector_cache().cache_clear()
+        if seen is None:
+            seen = []
+        if selected is None:
+            selected = []
+
+        original_precompile = TritonTemplateCaller.precompile
+        original_output_node = TritonTemplateCaller.output_node
+
+        def precompile(choice):
+            if choice.bmreq.kernel_name != "triton_flex_decoding":
+                return original_precompile(choice)
+            seen.append(choice)
+            if len(seen) == 1:
+                raise NoTritonConfigsError(
+                    "No valid triton configs. OutOfResources: mocked"
+                )
+            if len(seen) > 2:
+                raise AssertionError("precompiled unused flex_decoding fallback choice")
+            return None
+
+        def output_node(choice):
+            if choice.bmreq.kernel_name == "triton_flex_decoding":
+                selected.append(choice)
+            return original_output_node(choice)
+
+        with (
+            config.patch({"fx_graph_cache": False, "fx_graph_remote_cache": False}),
+            patch.object(
+                TritonTemplateCaller,
+                "precompile",
+                new=precompile,
+            ),
+            patch.object(TritonTemplateCaller, "output_node", new=output_node),
+        ):
+            fn()
+
+        return seen, selected
+
+    @supported_platform
+    @skip_on_xpu
+    @unittest.skipIf(test_device[0] == "cpu", "Skip on CPU")
+    @patch.object(torch._inductor.config, "max_autotune", False)
+    def test_decode_fallback_on_precompile_failure(self, device):
+        def run():
+            q, k, v = (
+                torch.randn(1, 1, 64, 64, device=device, dtype=torch.float16)
+                for _ in range(3)
+            )
+            torch.compile(flex_attention, fullgraph=True)(
+                q,
+                k,
+                v,
+                _identity,
+                kernel_options={"BACKEND": "TRITON_DECODE"},
+            )
+
+        seen, selected = self._run_with_first_failed_decode_choice(run)
+        self.assertEqual(len(seen), 2)
+        self.assertEqual(selected, [seen[1]])
+
+    @supported_platform
+    @skip_on_xpu
+    @unittest.skipIf(test_device[0] == "cpu", "Skip on CPU")
+    @patch.object(torch._inductor.config, "max_autotune", False)
+    @patch.object(torch._inductor.config, "flex_fallback_max_configs", 1)
+    def test_decode_fallback_respects_max_configs(self, device):
+        seen = []
+
+        def run():
+            q, k, v = (
+                torch.randn(1, 1, 64, 64, device=device, dtype=torch.float16)
+                for _ in range(3)
+            )
+            torch.compile(flex_attention, fullgraph=True)(
+                q,
+                k,
+                v,
+                _identity,
+                kernel_options={"BACKEND": "TRITON_DECODE"},
+            )
+
+        with self.assertRaisesRegex(InductorError, "All choices failed to compile"):
+            self._run_with_first_failed_decode_choice(run, seen=seen)
+        self.assertEqual(len(seen), 1)
+
+    @supported_platform
+    @skip_on_xpu
+    @unittest.skipIf(test_device[0] == "cpu", "Skip on CPU")
+    @patch.object(torch._inductor.config, "max_autotune", False)
+    def test_no_decode_fallback_when_user_pins(self, device):
+        seen = []
+
+        def run():
+            q, k, v = (
+                torch.randn(1, 1, 64, 64, device=device, dtype=torch.float16)
+                for _ in range(3)
+            )
+            torch.compile(flex_attention, fullgraph=True)(
+                q,
+                k,
+                v,
+                _identity,
+                kernel_options={
+                    "BACKEND": "TRITON_DECODE",
+                    "fwd_BLOCK_N": 64,
+                },
+            )
+
+        with self.assertRaisesRegex(InductorError, "All choices failed to compile"):
+            self._run_with_first_failed_decode_choice(run, seen=seen)
+        self.assertEqual(len(seen), 1)
 
     @supported_platform
     @patch.object(torch._inductor.config, "max_autotune", True)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -681,6 +681,13 @@ max_autotune_flex_search_space: Literal["DEFAULT", "EXHAUSTIVE"] = os.environ.ge
     "TORCHINDUCTOR_MAX_AUTOTUNE_FLEX_SEARCH_SPACE", "DEFAULT"
 ).upper()  # type: ignore[assignment]
 
+# Maximum number of FlexAttention fallback configs to compile-check when
+# max_autotune is disabled.
+flex_fallback_max_configs: int = max(
+    int(os.environ.get("TORCHINDUCTOR_FLEX_FALLBACK_MAX_CONFIGS", "5")),
+    1,
+)
+
 
 # Fall back to ATen for all ops by default, except those nodes that users explicitly
 # annotated with regional inductor compile. Please read torch.fx.passes.regional_inductor

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -7,7 +7,7 @@ import logging
 import math
 import warnings
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, cast, TYPE_CHECKING
 
 import sympy
@@ -17,6 +17,7 @@ from torch._inductor.virtualized import V
 from torch.nn.attention.flex_attention import _Backend
 from torch.utils._sympy.functions import FloorDiv, Mod
 
+from ... import config
 from ...ir import ComputedBuffer, ExternKernel, FixedLayout, TensorBox
 from ...lowering import empty, empty_strided, lowerings, register_lowering, to_dtype
 from ...select_algorithm import (
@@ -59,6 +60,113 @@ log = logging.getLogger(__name__)
 aten = torch.ops.aten
 prims = torch.ops.prims
 Expr = sympy.Expr
+
+_FWD_TUNING_KEYS = (
+    "BLOCK_M",
+    "BLOCK_N",
+    "num_warps",
+    "num_stages",
+    "num_consumer_groups",
+    "num_buffers_warp_spec",
+)
+_BWD_TUNING_KEYS = (
+    "BLOCK_M1",
+    "BLOCK_N1",
+    "BLOCK_M2",
+    "BLOCK_N2",
+    "num_warps",
+    "num_stages",
+    "num_consumer_groups",
+    "num_buffers_warp_spec",
+)
+
+
+def _has_user_pinned_tuning(
+    kernel_options: dict[str, Any],
+    keys: tuple[str, ...],
+    prefix: str,
+) -> bool:
+    return any(
+        name in kernel_options or f"{prefix}_{name}" in kernel_options for name in keys
+    )
+
+
+def _unique_configs(configs):
+    unique = []
+    for cfg in configs:
+        if cfg not in unique:
+            unique.append(cfg)
+    return unique
+
+
+def _limit_fallback_configs(configs):
+    return configs[: config.flex_fallback_max_configs]
+
+
+def _with_fwd_fallback_configs(configs):
+    if config.max_autotune or not configs:
+        return configs
+
+    default_config = configs[0]
+    fallback_configs = list(configs)
+    for stages in range(default_config.num_stages - 1, 0, -1):
+        fallback_configs.append(replace(default_config, num_stages=stages))
+    fallback_configs.extend(
+        [
+            replace(
+                default_config,
+                block_m=min(default_config.block_m, 64),
+                block_n=min(default_config.block_n, 32),
+                num_stages=min(default_config.num_stages, 2),
+                num_warps=4,
+            ),
+            replace(
+                default_config,
+                block_m=min(default_config.block_m, 32),
+                block_n=min(default_config.block_n, 32),
+                num_stages=1,
+                num_warps=4,
+            ),
+            replace(
+                default_config,
+                block_m=16,
+                block_n=16,
+                num_stages=1,
+                num_warps=4,
+            ),
+        ]
+    )
+    return _limit_fallback_configs(_unique_configs(fallback_configs))
+
+
+def _with_bwd_fallback_configs(configs):
+    if config.max_autotune or not configs:
+        return configs
+
+    default_config = configs[0]
+    fallback_configs = [
+        *configs,
+        replace(default_config, num_stages=1),
+        replace(
+            default_config,
+            block_m1=min(default_config.block_m1, 32),
+            block_n1=min(default_config.block_n1, 32),
+            block_m2=min(default_config.block_m2, 32),
+            block_n2=min(default_config.block_n2, 32),
+            num_stages=1,
+            num_warps=4,
+        ),
+        replace(
+            default_config,
+            block_m1=16,
+            block_n1=16,
+            block_m2=16,
+            block_n2=16,
+            num_stages=1,
+            num_warps=4,
+        ),
+    ]
+    return _limit_fallback_configs(_unique_configs(fallback_configs))
 
 
 def _sanitize_kernel_options_for_triton(
@@ -386,6 +494,9 @@ def flex_attention(
     configs: list[FlexConfig] = V.choices.get_flex_attention_fwd_configs(
         head_dim, dtype, query.get_device().type
     )
+    user_pinned = _has_user_pinned_tuning(kernel_options, _FWD_TUNING_KEYS, "fwd")
+    if not user_pinned:
+        configs = _with_fwd_fallback_configs(configs)
 
     # Mark SPARSE_KV_BLOCK_SIZE & SPARSE_Q_BLOCK_SIZE as static shapes and add guards.
     SPARSE_KV_BLOCK_SIZE = V.graph.sizevars.guard_int(SPARSE_KV_BLOCK_SIZE)
@@ -505,6 +616,7 @@ def flex_attention(
         [x for x in inputs_for_autotuning if isinstance(x, torch._inductor.ir.IRNode)],
         layout,
         input_gen_fns=input_gen_fns,
+        precompile_only=not config.max_autotune,
     )
 
     # need subgraph inputs and outputs to analyze all symints used in flex attention
@@ -913,6 +1025,9 @@ def flex_attention_backward(*args, **kwargs):
     configs: list[FlexBwDConfig] = V.choices.get_flex_attention_bwd_configs(
         head_dim, dtype, query.get_device().type
     )
+    user_pinned = _has_user_pinned_tuning(kernel_options, _BWD_TUNING_KEYS, "bwd")
+    if not user_pinned:
+        configs = _with_bwd_fallback_configs(configs)
 
     # Default config for warp specialization
     num_consumer_groups, num_buffers_warp_spec = 0, 0
@@ -1042,6 +1157,7 @@ def flex_attention_backward(*args, **kwargs):
         [x for x in inputs_for_autotuning if isinstance(x, torch._inductor.ir.IRNode)],
         layout_broadcasted_k,
         input_gen_fns=input_gen_fns,
+        precompile_only=not config.max_autotune,
     )  # [Bq, Hkv, seq_len_kv, k_head_dim]
 
     # need subgraph inputs and outputs to analyze all symints used in flex attention

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -2,6 +2,7 @@
 """Triton Implementation of the flex_attention Kernel for short query length (FlexDecoding)"""
 
 import logging
+from dataclasses import replace
 from typing import Any
 
 import sympy
@@ -10,7 +11,7 @@ import torch
 from torch._inductor.virtualized import V
 from torch.utils._sympy.functions import FloorDiv, Mod
 
-from ... import ir
+from ... import config, ir
 from ...ir import FixedLayout, FlexibleLayout
 from ...lowering import empty, empty_strided, lowerings
 from ...runtime.runtime_utils import ceildiv, is_power_of_2, next_power_of_2
@@ -35,6 +36,51 @@ aten = torch.ops.aten
 prims = torch.ops.prims
 
 log = logging.getLogger(__name__)
+
+_DECODE_TUNING_KEYS = (
+    "BLOCK_M",
+    "BLOCK_N",
+    "SPLIT_KV",
+    "num_warps",
+    "num_stages",
+    "num_consumer_groups",
+    "num_buffers_warp_spec",
+)
+
+
+def _has_user_pinned_decode_tuning(kernel_options: dict[str, Any]) -> bool:
+    return any(
+        name in kernel_options or f"fwd_{name}" in kernel_options
+        for name in _DECODE_TUNING_KEYS
+    )
+
+
+def _with_decode_fallback_configs(configs):
+    if config.max_autotune or not configs:
+        return configs
+
+    default_config = configs[0]
+    fallback_configs = [
+        *configs,
+        replace(
+            default_config,
+            block_n=min(default_config.block_n, 32),
+            num_stages=1,
+            num_warps=2,
+        ),
+        replace(
+            default_config,
+            block_n=min(default_config.block_n, 16),
+            num_stages=1,
+            num_warps=2,
+        ),
+    ]
+
+    unique = []
+    for cfg in fallback_configs:
+        if cfg not in unique:
+            unique.append(cfg)
+    return unique[: config.flex_fallback_max_configs]
 
 
 def _use_flex_decoding(query, kv_indices, value, kernel_options, enable_gqa) -> bool:
@@ -240,6 +286,9 @@ def create_flex_decoding_kernel(*args, **kwargs):
     configs = V.choices.get_flex_decode_configs(
         head_dim, dtype, query.get_device().type
     )
+    user_pinned = _has_user_pinned_decode_tuning(kernel_options)
+    if not user_pinned:
+        configs = _with_decode_fallback_configs(configs)
 
     # TODO: fix autotuning.
 
@@ -420,6 +469,7 @@ def create_flex_decoding_kernel(*args, **kwargs):
         inputs_for_flex_decoding,
         layout_acc,
         input_gen_fns=input_gen_fns,
+        precompile_only=not config.max_autotune,
     )
 
     # need subgraph inputs and outputs to analyze all symints used in flex attention

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -78,8 +78,13 @@ from .fx_utils import count_flops_fx
 from .ir import ChoiceCaller, PrimitiveInfoType
 from .ops_handler import StoreMode
 from .runtime.hints import DeviceProperties
-from .runtime.triton_compat import HAS_WARP_SPEC
-from .runtime.triton_heuristics import FixedGrid
+from .runtime.triton_compat import (
+    HAS_WARP_SPEC,
+    IntelGPUError,
+    OutOfResources,
+    PTXASError,
+)
+from .runtime.triton_heuristics import FixedGrid, NoTritonConfigsError
 from .utils import (
     ceildiv,
     do_bench_using_profiling,
@@ -3778,6 +3783,49 @@ class AlgorithmSelectorCache(PersistentCache):
         else:
             return choices[0]
 
+    @staticmethod
+    def _is_fallbackable_precompile_error(exc: Exception) -> bool:
+        if isinstance(
+            exc,
+            (
+                CUDACompileError,
+                NoTritonConfigsError,
+                OutOfResources,
+                PTXASError,
+                IntelGPUError,
+                torch.cuda.OutOfMemoryError,
+            ),
+        ):
+            return True
+        return isinstance(exc, RuntimeError) and str(exc).startswith(
+            "No valid triton configs"
+        )
+
+    def precompile_first_valid_choice(
+        self, choices: list[ChoiceCaller]
+    ) -> ChoiceCaller | None:
+        exceptions: list[tuple[ChoiceCaller, BaseException]] = []
+        for choice in choices:
+            if not isinstance(choice, TritonTemplateCaller):
+                if exceptions:
+                    _log_autotune_exceptions(exceptions)
+                return choice
+            try:
+                with restore_stdout_stderr():
+                    choice.precompile()
+            except Exception as e:
+                if not self._is_fallbackable_precompile_error(e):
+                    raise
+                choice.mark_failed()
+                exceptions.append((choice, e))
+                continue
+            if exceptions:
+                _log_autotune_exceptions(exceptions)
+            return choice
+        if exceptions:
+            _log_autotune_exceptions(exceptions)
+        return None
+
     def __call__(
         self,
         name,
@@ -3796,6 +3844,7 @@ class AlgorithmSelectorCache(PersistentCache):
         is_collective=False,
         min_speedup_threshold: float = 1.0,  # Only pick non-fallback if faster by this ratio
         benchmark_with_cudagraphs: bool = False,  # Use CUDA graphs for ExternKernelCaller benchmarking
+        precompile_only: bool = False,
     ):
         from .codegen.cutlass.kernel import CUTLASSTemplateCaller
 
@@ -3822,13 +3871,13 @@ class AlgorithmSelectorCache(PersistentCache):
             raise self.create_no_valid_choices(name, "No choices exist for backend.")
         log.debug("Max autotune selects from %s choices.", len(choices))
 
-        if len(choices) == 1:
+        if len(choices) == 1 and not precompile_only:
             if not isinstance(choices[0], CUTLASSTemplateCaller):
                 # CUTLASSTemplateCaller still needs to go through the autotuning process to retrieve workspace size.
                 node = choices[0].output_node()
                 return node, choices[0]
 
-        if config.deterministic:
+        if config.deterministic and not precompile_only:
             choice = self.pick_deterministic_choice(choices)
             node = choice.output_node()
             return node, choice
@@ -3839,6 +3888,24 @@ class AlgorithmSelectorCache(PersistentCache):
         if config.autotune_in_subproc or has_cutlass:
             # Warmup the subprocess pool early so it's ready for benchmarking
             torch._inductor.autotune_process.get_tuning_process_pool()
+
+        if precompile_only:
+            if not use_pipelined_autotuning():
+                with dynamo_timed(
+                    f"{name}_template_precompiling",
+                    log_pt2_compile_event=True,
+                    dynamo_compile_column_us="compile_time_autotune_time_us",
+                ):
+                    choice = self.precompile_first_valid_choice(choices)
+            else:
+                choice = self.precompile_first_valid_choice(choices)
+
+            if choice is None:
+                raise self.create_no_valid_choices(
+                    name, "All choices failed to compile for backend."
+                )
+            node = choice.output_node()
+            return node, choice
 
         precompile_fn = self.make_precompile_fn(
             choices,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184238

Compile-check FlexAttention fallback choices when max-autotune is disabled so invalid default Triton configs can fall through to smaller viable configs without benchmarking. Respect user-pinned kernel options and keep max-autotune on the existing autotune path.

Fixes #139131
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos