### PR TITLE
Fix duplicated node1 aliasing check in template prologue fusion guard

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -7281,7 +7281,7 @@ class Scheduler:
                 why("prologue fusion not implemented for kernel for these inputs")
                 return False
 
-            if node1.has_aliasing_or_mutation() or node1.has_aliasing_or_mutation():
+            if node1.has_aliasing_or_mutation() or node2.has_aliasing_or_mutation():
                 why("template prologue can only fuse functional pointwise nodes")
                 return False
 


### PR DESCRIPTION
This fixes a duplicated `node1.has_aliasing_or_mutation()` check in `torch/_inductor/scheduler.py`.

The template prologue fusion guard currently checks `node1` twice:

```python
if node1.has_aliasing_or_mutation() or node1.has_aliasing_or_mutation():
```

The second condition should check `node2` instead:

```python
if node1.has_aliasing_or_mutation() or node2.has_aliasing_or_mutation():
```

This matches the same pattern already used elsewhere in the function.

Fixes #184222


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos