### PR TITLE
Fix typos in attention bias, activation, and dataloader docs

### DIFF
--- a/torch/nn/attention/bias.py
+++ b/torch/nn/attention/bias.py
@@ -87,7 +87,7 @@ class CausalBias(torch.Tensor):
     """
     A bias representing causal attention patterns. For an overview of the bias structure, see the :class:`CausalVariant` enum.
 
-    This class is used for defining causal (triangular) attention biases. For construing the bias, there exist
+    This class is used for defining causal (triangular) attention biases. For constructing the bias, there exist
     two factory functions: :func:`causal_upper_left` and :func:`causal_lower_right`.
 
     Example:

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -266,14 +266,14 @@ class Hardtanh(Module):
         super().__init__()
         if min_value is not None:
             warnings.warn(
-                "keyword argument `min_value` is deprecated and rename to `min_val`",
+                "keyword argument `min_value` is deprecated and renamed to `min_val`",
                 FutureWarning,
                 stacklevel=2,
             )
             min_val = min_value
         if max_value is not None:
             warnings.warn(
-                "keyword argument `max_value` is deprecated and rename to `max_val`",
+                "keyword argument `max_value` is deprecated and renamed to `max_val`",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -324,9 +324,9 @@ class DataLoader(Generic[_T_co]):
             # finite `__len__` because in multi-process data loading, naive
             # settings will return duplicated data (which may be desired), and
             # thus using a sampler with length matching that of dataset will
-            # cause data lost (you may have duplicates of the first couple
+            # cause data loss (you may have duplicates of the first couple
             # batches, but never see anything afterwards). Therefore,
-            # `Iterabledataset` always uses an infinite sampler, an instance of
+            # `IterableDataset` always uses an infinite sampler, an instance of
             # `_InfiniteConstantSampler` defined above.
             #
             # A custom `batch_sampler` essentially only controls the batch size.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184244

Fix several typos in docstrings and comments:
- "construing" → "constructing" in CausalBias docstring
- "rename" → "renamed" in Hardtanh deprecation warnings
- "data lost" → "data loss" in DataLoader comments
- "Iterabledataset" → "IterableDataset" in DataLoader comments

Authored with Claude (typo_terminator2).