### PR TITLE
[Test] Make nn/test_dropout.py device-agnostic for out-of-tree backends

### DIFF
--- a/test/nn/test_dropout.py
+++ b/test/nn/test_dropout.py
@@ -1,32 +1,27 @@
 # Owner(s): ["module: nn"]
 import itertools
 import random
-import unittest
 from itertools import product
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfMPS,
     expectedFailureXLA,
     instantiate_device_type_tests,
+    onlyAccelerator,
 )
 from torch.testing._internal.common_nn import freeze_rng_state, NNTestCase
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     run_tests,
     set_default_dtype,
-    TEST_PRIVATEUSE1,
 )
 
 
 class TestDropoutNN(NNTestCase):
-    _do_cuda_memory_leak_check = True
-    _do_cuda_non_default_stream = True
-
     def _test_alpha_dropout(self, cls, input):
         mean = input.mean()
         std = input.std()
@@ -58,30 +53,6 @@ class TestDropoutNN(NNTestCase):
         # no batch dims
         input = torch.randn(50, 20, 64, 64)
         self._test_alpha_dropout(nn.FeatureAlphaDropout, input)
-
-    @unittest.skipIf(
-        not (TEST_CUDA or TEST_PRIVATEUSE1), "CUDA and PRIVATEUSE1 unavailable"
-    )
-    def test_native_dropout_corner_case(self):
-        if TEST_CUDA:
-            device = "cuda"
-        elif TEST_PRIVATEUSE1:
-            device = torch._C._get_privateuse1_backend_name()
-        for train in [True, False]:
-            for p in [0.0, 1.0]:
-                for current_device in [device, "cpu"]:
-                    x = torch.randn(5).to(device=current_device).requires_grad_()
-                    x_ref = x.detach().requires_grad_()
-                    o = torch.native_dropout(x, p, train)[0]
-                    o_ref = torch.dropout(x_ref, p, train)
-                    o.sum().backward()
-                    o_ref.sum().backward()
-                    if not o.equal(o_ref):
-                        raise AssertionError("Expected o.equal(o_ref) to be True")
-                    if not x.grad.equal(x_ref.grad):
-                        raise AssertionError(
-                            "Expected x.grad.equal(x_ref.grad) to be True"
-                        )
 
     def test_invalid_dropout_p(self):
         v = torch.ones(1)
@@ -186,7 +157,7 @@ class TestDropoutNNDeviceType(NNTestCase):
 
         self._test_dropout_stride_mean_preserve(nn.Dropout, device)
 
-        if self.device_type == "cuda" or self.device_type == "cpu":
+        if self.device_type != "meta":
             input = input.bfloat16()
             self._test_dropout(nn.Dropout, device, input)
 
@@ -321,6 +292,19 @@ class TestDropoutNNDeviceType(NNTestCase):
         x = torch.tensor([]).to(device)
         out = torch.nn.functional.dropout(x)
         self.assertEqual(out.size(), x.size())
+
+    @onlyAccelerator
+    def test_native_dropout_corner_case(self, device):
+        for train in [True, False]:
+            for p in [0.0, 1.0]:
+                x = torch.randn(5, device=device).requires_grad_()
+                x_ref = x.detach().requires_grad_()
+                o = torch.native_dropout(x, p, train)[0]
+                o_ref = torch.dropout(x_ref, p, train)
+                o.sum().backward()
+                o_ref.sum().backward()
+                self.assertEqual(o, o_ref)
+                self.assertEqual(x.grad, x_ref.grad)
 
 
 instantiate_device_type_tests(TestDropoutNNDeviceType, globals(), allow_mps=True)


### PR DESCRIPTION
**Summary**

Make nn/test_dropout.py device-agnostic for out-of-tree backends
- Move test_native_dropout_corner_case from TestDropoutNN to TestDropoutNNDeviceType with @onlyAccelerator
- Broaden bfloat16 branch in test_Dropout from cuda/cpu-only to all non-meta devices
- Remove TEST_CUDA, TEST_PRIVATEUSE1 imports and unused unittest import
- Remove dead _do_cuda_memory_leak_check/_do_cuda_non_default_stream attributes from TestDropoutNN

cc: @fffrog @albanD 