### PR TITLE
Guard dilation to ints in convolution_backward lowering

### DIFF
--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -984,8 +984,13 @@ def convolution_backward_lowering(
 
     out_chan, in_chan, *kernel_shape = V.graph.sizevars.guard_int_seq(weight.get_size())
 
+    # The Triton bwd templates substitute DILATION_H/W into the generated
+    # kernel source, so they must be concrete Python ints. The fwd template
+    # gates on is_ones(dilation) and hard-codes dilation=1, so it can skip
+    # this guard.
     stride = tuple(V.graph.sizevars.guard_int_seq(stride))
     padding = tuple(V.graph.sizevars.guard_int_seq(padding))
+    dilation = tuple(V.graph.sizevars.guard_int_seq(dilation))
 
     input.realize()
     weight.realize()


### PR DESCRIPTION
The Triton bwd conv templates added in #178945 substitute DILATION_H/W directly into the generated kernel source via Jinja. Under dynamic shapes those values arrive as sympy symbols (e.g. s54), and the rendered kernel ends up referencing an undefined name, surfacing as:

```
  LoweringException: NameError: name 's54' is not defined
    target: aten.convolution_backward.default
```

The forward conv lowering doesn't need to guard dilation because its template hard-codes dilation=1 in the index math and the lowering gates the whole Triton branch on is_ones(dilation). The bwd templates instead parameterize DILATION_H/W to support arbitrary dilation, so the same "don't guard" assumption doesn't transfer.

Fixes the following failing tests:

```
test/inductor/test_torchinductor_codegen_dynamic_shapes.py::DynamicShapesCodegenGPUTests::
- test_conv2d_backward_parametrized_dilation_1_stride_2_padding_1_kernel_3_channels_groups5_nhwc_True_dynamic_shapes_cuda
- test_conv2d_backward_parametrized_dilation_1_stride_2_padding_1_kernel_3_channels_groups2_nhwc_True_dynamic_shapes_cuda
- test_conv2d_backward_parametrized_dilation_1_stride_2_padding_0_kernel_3_channels_groups5_nhwc_True_dynamic_shapes_cuda
- test_conv2d_backward_parametrized_dilation_1_stride_2_padding_0_kernel_3_channels_groups2_nhwc_True_dynamic_shapes_cuda
- test_conv2d_backward_parametrized_dilation_1_stride_1_padding_1_kernel_3_channels_groups5_nhwc_True_dynamic_shapes_cuda
- test_conv2d_backward_parametrized_dilation_1_stride_1_padding_1_kernel_3_channels_groups2_nhwc_True_dynamic_shapes_cuda
- test_conv2d_backward_parametrized_dilation_1_stride_1_padding_0_kernel_3_channels_groups5_nhwc_True_dynamic_shapes_cuda
- test_conv2d_backward_parametrized_dilation_1_stride_1_padding_0_kernel_3_channels_groups2_nhwc_True_dynamic_shapes_cuda
```

To reproduce the issue locally, run:

```
python test/inductor/test_torchinductor_codegen_dynamic_shapes.py -k '*DynamicShapesCodegenGPUTests*test_conv2d*'
```


Assisted-by: Claude Opus 4.7

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @chien-an-chen 