### PR TITLE
[scatter_add] Reject misaligned data_ptr / row stride in CuTeDSL override cond

### DIFF
--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -623,6 +623,110 @@ class TestScatterAddOverrideConds(TestCase):
         self_t, idx, src, _ = _make_override_triple(100, 50, (129,))
         self.assertEqual(self._conds(self_t, idx, src), (False, False))
 
+    def test_rejects_data_ptr_not_16_aligned(self):
+        # row_bytes can be 16-aligned while the effective data_ptr is not
+        # (e.g. an autograd-produced gradient buffer whose storage_offset
+        # is non-zero). TMA's cp.reduce.async.bulk and vec-scatter's
+        # LDG.128 both require 16B-aligned gmem operands, so the cond
+        # must reject regardless of row_bytes.
+        #
+        # Construction: allocate one extra element and slice from index 1,
+        # yielding a contiguous view whose data_ptr is `elem_size` bytes
+        # past the underlying allocation's 16B-aligned base.
+        M_out, M_src, D = 100, 50, 128  # D=128 -> row_bytes=512 (16-aligned)
+
+        def _misaligned(rows, cols, dtype):
+            elem = torch.empty((), dtype=dtype).element_size()
+            t = torch.empty(rows * cols + 1, device="cuda", dtype=dtype)[1:].view(rows, cols)
+            self.assertNotEqual(
+                t.data_ptr() % 16, 0,
+                msg=f"test bug: data_ptr() should be misaligned, got {t.data_ptr() % 16=}",
+            )
+            return t
+
+        idx = _expanded_idx(
+            torch.randint(0, M_out, (M_src,), device="cuda", dtype=torch.int64),
+            (D,),
+        )
+
+        # 1) Misaligned self, aligned src.
+        self_t = _misaligned(M_out, D, torch.float32).zero_()
+        src = torch.randn(M_src, D, device="cuda", dtype=torch.float32)
+        self.assertEqual(
+            self._conds(self_t, idx, src), (False, False),
+            msg="cond accepted misaligned self.data_ptr()",
+        )
+
+        # 2) Aligned self, misaligned src.
+        self_t = torch.zeros(M_out, D, device="cuda", dtype=torch.float32)
+        src = _misaligned(M_src, D, torch.float32).normal_()
+        self.assertEqual(
+            self._conds(self_t, idx, src), (False, False),
+            msg="cond accepted misaligned src.data_ptr()",
+        )
+
+        # 3) Both misaligned.
+        self_t = _misaligned(M_out, D, torch.float32).zero_()
+        src = _misaligned(M_src, D, torch.float32).normal_()
+        self.assertEqual(
+            self._conds(self_t, idx, src), (False, False),
+            msg="cond accepted misaligned self.data_ptr() and src.data_ptr()",
+        )
+
+    def test_rejects_row_stride_not_16_aligned(self):
+        # Outer row stride must be a multiple of 16 bytes so each row
+        # starts on a 16B boundary. fp32 with outer stride 129 elements
+        # (516 bytes) is element-aligned but not 16B-aligned.
+        M_out, M_src, D = 100, 50, 128
+        # Build self with outer row stride = 129 elements (not 128).
+        big_self = torch.zeros(M_out, D + 1, device="cuda", dtype=torch.float32)
+        self_t = big_self[:, :D]
+        self.assertEqual(
+            self_t.stride(0), D + 1,
+            msg=f"test bug: expected stride(0)=={D + 1}, got {self_t.stride(0)}",
+        )
+        src = torch.randn(M_src, D, device="cuda", dtype=torch.float32)
+        idx = _expanded_idx(
+            torch.randint(0, M_out, (M_src,), device="cuda", dtype=torch.int64),
+            (D,),
+        )
+        self.assertEqual(
+            self._conds(self_t, idx, src), (False, False),
+            msg="cond accepted misaligned self row stride",
+        )
+
+    def test_out_cond_rejects_misaligned_out(self):
+        # The .out impl runs the kernel on ``out``, not ``self`` (see
+        # _make_impls.out_impl). A misaligned ``out`` with aligned
+        # ``self`` must be rejected -- otherwise the kernel runs on
+        # ``out``'s misaligned data_ptr and faults with
+        # cudaErrorMisalignedAddress (the exact bug this diff prevents,
+        # just on the .out variant).
+        M_out, M_src, D = 100, 50, 128
+        self_t = torch.zeros(M_out, D, device="cuda", dtype=torch.float32)
+        src = torch.randn(M_src, D, device="cuda", dtype=torch.float32)
+        # Misaligned out: one-element pointer offset from a 16B boundary.
+        out_mis = (
+            torch.empty(M_out * D + 1, device="cuda", dtype=torch.float32)[1:]
+            .view(M_out, D)
+        )
+        self.assertNotEqual(
+            out_mis.data_ptr() % 16, 0,
+            msg=f"test bug: out should be misaligned, got {out_mis.data_ptr() % 16=}",
+        )
+        idx = _expanded_idx(
+            torch.randint(0, M_out, (M_src,), device="cuda", dtype=torch.int64),
+            (D,),
+        )
+        self.assertFalse(
+            self.impl._tma_out_cond(self_t, 0, idx, src, out=out_mis),
+            msg=".out TMA cond accepted misaligned `out`",
+        )
+        self.assertFalse(
+            self.impl._vs_out_cond(self_t, 0, idx, src, out=out_mis),
+            msg=".out vec-scatter cond accepted misaligned `out`",
+        )
+
     def test_tma_accepts_row_not_chunk_multiple(self):
         # bf16 D=264 -> row_bytes=528, 16-aligned but not a multiple of
         # chunk_bytes (512). TMA descriptor handles the partial final
@@ -774,6 +878,43 @@ class TestScatterAddOverrideCorrectness(TestCase):
         with DeterministicGuard(True):
             got = torch.scatter_add(self_t, 0, idx, src)
         self.assertEqual(got, ref)
+
+    @parametrize("which", ["self", "src", "both"])
+    def test_misaligned_data_ptr_falls_through_to_aten(self, which):
+        # End-to-end regression for the SEV-class crash where a misaligned
+        # data_ptr bypassed the cond and faulted in the TMA / vec-scatter
+        # kernel (cudaErrorMisalignedAddress from cp.reduce.async.bulk or
+        # LDG.128). With the alignment check in the cond, the call falls
+        # through to aten -- which has its own predicate plus safe
+        # fallback to indexFunc / vectorized atomicAdd -- and must
+        # produce the correct result.
+        torch.manual_seed(0)
+        M_out, M_src, D = 200, 100, 128
+
+        def _misaligned(rows, cols, dtype):
+            elem = torch.empty((), dtype=dtype).element_size()
+            t = torch.empty(rows * cols + 1, device="cuda", dtype=dtype)[1:].view(rows, cols)
+            self.assertNotEqual(t.data_ptr() % 16, 0)
+            return t
+
+        if which in ("self", "both"):
+            self_t = _misaligned(M_out, D, torch.float32).zero_()
+        else:
+            self_t = torch.zeros(M_out, D, device="cuda", dtype=torch.float32)
+        if which in ("src", "both"):
+            src = _misaligned(M_src, D, torch.float32).normal_()
+        else:
+            src = torch.randn(M_src, D, device="cuda", dtype=torch.float32)
+
+        idx_1d = torch.randint(0, M_out, (M_src,), device="cuda", dtype=torch.int64)
+        idx = _expanded_idx(idx_1d, (D,))
+
+        ref = _naive_scatter_add(self_t, idx_1d, src)
+        got = torch.scatter_add(self_t, 0, idx, src)
+        self.assertEqual(
+            got, ref, atol=1e-4, rtol=1e-4,
+            msg=f"misalignment={which}: kernel output diverges from reference",
+        )
 
 
 

--- a/torch/_native/ops/scatter_add/cutedsl_impl.py
+++ b/torch/_native/ops/scatter_add/cutedsl_impl.py
@@ -33,6 +33,12 @@ from ...registry import _OpCondFn, _OpImplFn
 
 _SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
 
+# Matches the `<16>` template parameter of fast_scatter_add_kernel_eligible
+# in caffe2/aten/src/ATen/native/cuda/IndexKernelUtils.h, and the
+# `_VEC_BYTES = 16` constant in vec_scatter_kernel.py. Required by both
+# `cp.reduce.async.bulk` (TMA path) and `LDG.128` (vec-scatter path).
+_ALIGNMENT_BYTES = 16
+
 
 @functools.cache
 def _has_cutedsl() -> bool:
@@ -157,6 +163,36 @@ def _flatten_2d_view(t: torch.Tensor) -> torch.Tensor:
     return t.as_strided((t.shape[0], N), (t.stride(0), 1))
 
 
+def _alignment_contract_ok(self: torch.Tensor, src: torch.Tensor) -> bool:
+    """16B alignment of effective ptrs and outer row strides.
+
+    Required by both override paths:
+      - TMA: ``cp.reduce.async.bulk`` requires 16B-aligned gmem operands.
+      - vec-scatter: ``LDG.128`` from ``cute.autovec_copy`` reads
+        ``_VEC_BYTES == 16`` bytes per lane; the source address must be
+        16B-aligned. Per-row stride must also be a multiple of 16 so each
+        row starts on a 16B boundary.
+
+    Mirrors ``fast_scatter_add_kernel_eligible<16>`` in
+    ``caffe2/aten/src/ATen/native/cuda/IndexKernelUtils.h``. When this
+    returns False, the cond rejects so the call falls through to aten,
+    which has its own predicate + safe fallback to
+    ``vectorized_scatter_add_kernel_launch`` / ``indexFunc{Small,Large}Index``.
+    """
+    if (
+        self.data_ptr() % _ALIGNMENT_BYTES
+        or src.data_ptr() % _ALIGNMENT_BYTES
+    ):
+        return False
+    elem = self.element_size()
+    if (
+        (self.stride(0) * elem) % _ALIGNMENT_BYTES
+        or (src.stride(0) * elem) % _ALIGNMENT_BYTES
+    ):
+        return False
+    return True
+
+
 def _flatten_for_expanded_1d(
     self: torch.Tensor, index: torch.Tensor, src: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -193,6 +229,8 @@ def _is_tma_supported(
     N = _expanded_1d_inner_size(self, dim, index, src)
     if N is None:
         return False
+    if not _alignment_contract_ok(self, src):
+        return False
     # TMA transfer size is baked in at compile time (chunk_bytes =
     # min(row_bytes, 512)); row_bytes must evenly divide by chunk_bytes
     # and chunk_bytes must be 16-byte aligned.
@@ -210,6 +248,8 @@ def _is_vec_scatter_supported(
         return False
     N = _expanded_1d_inner_size(self, dim, index, src)
     if N is None:
+        return False
+    if not _alignment_contract_ok(self, src):
         return False
     # Each lane owns vec_elems consecutive elements; the loop is either
     # fully in-bounds or fully skipped per lane. Only requirement is
@@ -247,6 +287,15 @@ def _make_cond(
             # stride can differ from prod(shape[1:]) (same relaxation as
             # self/src). Inner dims must be packed for the 2D view.
             if not _inner_contiguous(out):
+                return False
+            # The .out impl runs the kernel on ``out``, not ``self``
+            # (see _make_impls.out_impl). ``support_check`` below
+            # validates self/src alignment via _alignment_contract_ok,
+            # but ``out`` may be a distinct buffer with different
+            # alignment from ``self`` -- check it explicitly here so a
+            # misaligned ``out`` falls through to aten instead of
+            # faulting in the kernel.
+            if not _alignment_contract_ok(out, src):
                 return False
             return support_check(self, dim, index, src)
 

--- a/torch/_native/ops/scatter_add/cutedsl_impl.py
+++ b/torch/_native/ops/scatter_add/cutedsl_impl.py
@@ -179,16 +179,12 @@ def _alignment_contract_ok(self: torch.Tensor, src: torch.Tensor) -> bool:
     which has its own predicate + safe fallback to
     ``vectorized_scatter_add_kernel_launch`` / ``indexFunc{Small,Large}Index``.
     """
-    if (
-        self.data_ptr() % _ALIGNMENT_BYTES
-        or src.data_ptr() % _ALIGNMENT_BYTES
-    ):
+    if self.data_ptr() % _ALIGNMENT_BYTES or src.data_ptr() % _ALIGNMENT_BYTES:
         return False
     elem = self.element_size()
-    if (
-        (self.stride(0) * elem) % _ALIGNMENT_BYTES
-        or (src.stride(0) * elem) % _ALIGNMENT_BYTES
-    ):
+    if (self.stride(0) * elem) % _ALIGNMENT_BYTES or (
+        src.stride(0) * elem
+    ) % _ALIGNMENT_BYTES:
         return False
     return True
 


### PR DESCRIPTION
Summary:
The CuTeDSL `scatter_add` override at `torch/_native/ops/scatter_add/` (added in D105049595, reverted in D105339314, re-landed in D105407754) currently accepts inputs whose effective `data_ptr()` or outer row stride is not 16-byte aligned. Both override paths require 16B alignment of the global memory operand:

- TMA path: `cp.reduce.async.bulk` requires 16B alignment of the `gmem` operand by PTX ISA.
- vec-scatter path: `cute.autovec_copy` emits `LDG.128` with `_VEC_BYTES == 16`, which also requires 16B alignment of the source address.

When a caller hands the override a misaligned tensor (commonly an autograd-produced gradient buffer whose `storage_offset * itemsize` puts `data_ptr()` off a 16B boundary), the cond accepts, the kernel launches, and the call faults with `cudaErrorMisalignedAddress`. This mirrors the contract enforced by `fast_scatter_add_kernel_eligible<16>` in `caffe2/aten/src/ATen/native/cuda/IndexKernelUtils.h` for the native C++ kernel.

This diff adds an `_alignment_contract_ok` helper and wires it into both `_is_tma_supported` and `_is_vec_scatter_supported`. When the contract isn't satisfied, the cond returns False, the `eager_router` falls through to aten's native `scatter_add` (which has its own predicate plus safe fallback to `vectorized_scatter_add_kernel_launch` / `indexFunc{Small,Large}Index`), and the call completes correctly.

Additionally, `_make_cond`'s `requires_out` branch now calls `_alignment_contract_ok(out, src)` directly. The `.out` impl runs the kernel on `out`, not `self` (see `_make_impls.out_impl`), so `out` may have different alignment from `self`; without this check, a misaligned `out` with aligned `self` would slip past the cond and fault in the kernel -- the same SEV-class crash this diff prevents, just on the `.out` variant. (Caught by Devmate AI reviewer.)

Test Plan:
Added three new tests:

- `TestScatterAddOverrideConds.test_rejects_data_ptr_not_16_aligned`: builds tensors with `storage_offset` chosen so `data_ptr() % 16 != 0` (allocate one extra element and slice from index 1). Asserts both cond paths reject for misaligned self, misaligned src, and both misaligned.
- `TestScatterAddOverrideConds.test_rejects_row_stride_not_16_aligned`: builds a self with outer row stride of `(D+1) * elem_size`, asserts both cond paths reject.
- `TestScatterAddOverrideCorrectness.test_misaligned_data_ptr_falls_through_to_aten` (parametrized over which=self/src/both): end-to-end test that calls `torch.scatter_add` with misaligned inputs and verifies the result matches a naive CPU reference — proving the fall-through path works correctly.

Before this change the three cond tests fail (cond returns True for all misaligned cases) and the end-to-end test crashes with `cudaErrorMisalignedAddress`. After this change all three pass.

Run:
```
buck2 test fbcode//mode/opt -c fbcode.enable_gpu_sections=true \
    -c fbcode.platform010_cuda_version=12.8 -c fbcode.nvcc_arch=h100a \
    fbcode//caffe2/test:test_scatter_gather_ops_cuda -- \
    --regex 'TestScatterAddOverride'
```

All existing override tests continue to pass; only the new alignment-rejection tests change cond behavior, and only for inputs that would have faulted at kernel time.



Following Devmate reviewer feedback: also added `TestScatterAddOverrideConds.test_out_cond_rejects_misaligned_out`. The `.out` variant runs the kernel on `out`, not `self` (see `_make_impls.out_impl`), so the `requires_out` branch of `_make_cond` now calls `_alignment_contract_ok(out, src)` in addition to the existing `support_check(self, dim, index, src)`. Without this, a misaligned `out` with aligned `self` would slip past the cond and fault in the kernel -- exactly the SEV-class crash this diff prevents, just on the `.out` variant.

Reviewed By: slayton58

Differential Revision: D105569971


