### PR TITLE
Update dynamo benchmark expected accuracy for PegasusForCausalLM and functorch_dp_cifar10

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_huggingface_training.csv
@@ -78,7 +78,7 @@ PLBartForCausalLM,pass,6
 
 
 
-PegasusForCausalLM,pass,6
+PegasusForCausalLM,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_huggingface_training.csv
@@ -78,7 +78,7 @@ PLBartForCausalLM,pass,6
 
 
 
-PegasusForCausalLM,pass,6
+PegasusForCausalLM,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_huggingface_training.csv
@@ -78,7 +78,7 @@ PLBartForCausalLM,pass,6
 
 
 
-PegasusForCausalLM,pass,6
+PegasusForCausalLM,pass,7
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_inference.csv
@@ -114,7 +114,7 @@ fastNLP_Bert,pass,4
 
 
 
-functorch_dp_cifar10,fail_accuracy,0
+functorch_dp_cifar10,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_huggingface_training.csv
@@ -78,7 +78,7 @@ PLBartForCausalLM,pass,6
 
 
 
-PegasusForCausalLM,pass,6
+PegasusForCausalLM,pass,7
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #184267
* __->__ #184259

Summary:
Fix two persistent periodic-dynamo-benchmarks CI failures:

1. PegasusForCausalLM graph_breaks 6→7 in training mode across
   aot_eager, dynamic_aot_eager, dynamic_inductor, and dynamo_eager
   huggingface configs. The inductor_huggingface_training.csv already
   had the correct value of 7.

2. functorch_dp_cifar10 accuracy improved from fail_accuracy to pass
   in dynamic_inductor_torchbench inference.

Test Plan: CI — these CSVs are consumed by periodic-dynamo-benchmarks jobs

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98