### PR TITLE
[pytorch] Delegate `dist.new_group` to custom PG subclasses (#184262)

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -2057,6 +2057,61 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
 
         self.assertTrue(pg._aborted)
 
+    def test_new_group_delegates_to_pg(self):
+        """dist.new_group delegates to default_pg.new_group if available."""
+
+        new_group_called = False
+        new_group_ranks = None
+
+        class _DelegatingPG(DummyProcessGroup):
+            def new_group(
+                self,
+                ranks,
+                timeout=None,
+                pg_options=None,
+                group_name=None,
+                group_desc=None,
+            ):
+                nonlocal new_group_called, new_group_ranks
+                new_group_called = True
+                new_group_ranks = list(ranks)
+                my_rank = self.rank()
+                if my_rank not in ranks:
+                    return None
+                return DummyProcessGroup(ranks.index(my_rank), len(ranks))
+
+        dist.Backend.register_backend(
+            "delegating",
+            lambda *args, **kwargs: _DelegatingPG(
+                args[0].group_rank, args[0].group_size
+            ),
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "delegating", rank=self.rank, world_size=self.world_size
+        )
+
+        try:
+            sub_pg = dist.new_group(ranks=[0])
+            self.assertTrue(new_group_called)
+            self.assertEqual(new_group_ranks, [0])
+
+            if self.rank == 0:
+                self.assertIsNotNone(sub_pg)
+                self.assertNotEqual(
+                    sub_pg, dist.distributed_c10d.GroupMember.NON_GROUP_MEMBER
+                )
+            else:
+                self.assertTrue(
+                    sub_pg is None
+                    or sub_pg == dist.distributed_c10d.GroupMember.NON_GROUP_MEMBER
+                )
+        finally:
+            dist.destroy_process_group()
+
 
 instantiate_parametrized_tests(CommonDistributedDataParallelTest)
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5875,6 +5875,34 @@ def _new_group_with_tag(
 
     group_name = _process_group_name(ranks, use_hashed_name=use_local_synchronization)
 
+    # If the default PG implements new_group, delegate to it. This allows
+    # custom Python PG subclasses to handle subgroup creation in a single
+    # call, avoiding the per-device creator iteration in
+    # _new_process_group_helper.
+    if hasattr(default_pg, "new_group") and callable(default_pg.new_group):
+        pg_or_none = default_pg.new_group(
+            ranks,
+            timeout=timeout,
+            pg_options=backend_options,
+            group_name=group_name,
+            group_desc=group_desc,
+        )
+        if pg_or_none is None:
+            return GroupMember.NON_GROUP_MEMBER
+
+        pg: ProcessGroup = pg_or_none  # pyrefly: ignore[bad-assignment]
+        _world.pg_group_ranks[pg] = {
+            global_rank: group_rank for group_rank, global_rank in enumerate(ranks)
+        }
+        _world.pg_map[pg] = (backend, PrefixStore(f"{group_name}/", default_store))
+        _world.pg_names[pg] = group_name
+        _register_process_group(group_name, pg)
+        pg_tag = f"ptd:{group_name}"
+        _world.tags_to_pg.setdefault(pg_tag, []).append(pg)
+        _world.pg_to_tag[pg] = pg_tag
+        _world.pg_backend_config[pg] = str(BackendConfig(backend))
+        return pg
+
     pg, pg_store = _new_process_group_helper(
         group_world_size,
         group_rank,


### PR DESCRIPTION
Summary:

If the default process group implements a `new_group` method,
`dist.new_group` now delegates to it instead of going through
`_new_process_group_helper`. This allows custom Python PG subclasses
to handle subgroup creation in a single call, avoiding the per-device
backend creator iteration that `_new_process_group_helper` performs.

Without this change, custom backends registered with `devices=["cpu",
"cuda"]` have their creator called once per device for `new_group`,
creating redundant backend instances. With this change, the PG
subclass can create the subgroup directly and return it.

The delegation only fires when the default PG has a callable
`new_group` attribute. Native PGs (ProcessGroupNCCL, ProcessGroupGloo)
do not have this method, so existing behavior is unchanged.

Test Plan: CI

Reviewed By: kapilsh

Differential Revision: D105609784


