### PR TITLE
Fix reinplacing through view index_put

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -137,6 +137,89 @@ class TestReinplacingPassCorrectness(InductorTestCase):
 
         self._test(f)
 
+    def test_view_index_put_should_reinplace_copy_to_base(self):
+        def f(input_pos, val, cache):
+            cache_view = aten.reshape.default(cache, [4, -1])
+            val_view = aten.reshape.default(val, [-1])
+            updated = aten.index_put.default(cache_view, [input_pos], val_view)
+            updated_base = aten.reshape.default(updated, [4, 3, 4])
+            return aten.copy_.default(cache, updated_base)
+
+        input_pos = torch.tensor([1], device=device)
+        val = torch.randn(3, 4, device=device)
+        cache = torch.randn(4, 3, 4, device=device)
+
+        expected_cache = cache.clone()
+        expected = f(input_pos, val, expected_cache)
+
+        gm = make_fx(f, tracing_mode="fake")(input_pos, val, cache)
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertIn(aten.index_put_.default, targets)
+        self.assertNotIn(aten.index_put.default, targets)
+        self.assertNotIn(aten.copy_.default, targets)
+
+        actual_cache = cache.clone()
+        actual = gm(input_pos, val, actual_cache)
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual_cache, expected_cache)
+
+    def test_view_index_put_keeps_copy_when_later_view_is_live(self):
+        def f(input_pos, val, cache):
+            cache_view = aten.reshape.default(cache, [4, -1])
+            live_view = aten.select.int(cache, 0, 0)
+            val_view = aten.reshape.default(val, [-1])
+            updated = aten.index_put.default(cache_view, [input_pos], val_view)
+            live_use = aten.sin.default(live_view)
+            updated_base = aten.reshape.default(updated, [4, 3, 4])
+            copied = aten.copy_.default(cache, updated_base)
+            return live_use, copied
+
+        input_pos = torch.tensor([1], device=device)
+        val = torch.randn(3, 4, device=device)
+        cache = torch.randn(4, 3, 4, device=device)
+
+        gm = make_fx(f, tracing_mode="fake")(input_pos, val, cache)
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertIn(aten.index_put.default, targets)
+        self.assertIn(aten.copy_.default, targets)
+        self.assertNotIn(aten.index_put_.default, targets)
+
+    def test_view_index_put_rejects_non_inverse_copy_back_view(self):
+        def f(input_pos, val, cache):
+            cache_view = aten.transpose.int(cache, 0, 1)
+            updated = aten.index_put.default(cache_view, [input_pos], val)
+            copied_view = aten.as_strided.default(updated, [2, 3], [1, 2])
+            return aten.copy_.default(cache, copied_view)
+
+        input_pos = torch.tensor([1], device=device)
+        val = torch.tensor([[10.0, 20.0]], device=device)
+        cache = torch.arange(6, device=device, dtype=torch.float32).reshape(2, 3)
+
+        expected_cache = cache.clone()
+        expected = f(input_pos, val, expected_cache)
+
+        gm = make_fx(f, tracing_mode="fake")(input_pos, val, cache)
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertIn(aten.index_put.default, targets)
+        self.assertIn(aten.copy_.default, targets)
+        self.assertNotIn(aten.index_put_.default, targets)
+
+        actual_cache = cache.clone()
+        actual = gm(input_pos, val, actual_cache)
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual_cache, expected_cache)
+
     def test_counters_functionalize_old(self):
         ReinplaceCounters.clear()
 

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -27,6 +27,8 @@ from torch._inductor.virtualized import V
 from torch.fx.experimental.symbolic_shapes import (
     compute_unbacked_bindings,
     GuardOnDataDependentSymNode,
+    statically_known_true,
+    sym_eq,
 )
 from torch.fx.immutable_collections import immutable_dict, immutable_list
 from torch.fx.passes.reinplace import _is_view_op
@@ -413,6 +415,48 @@ META_ONLY_OPS = OrderedSet(
 )
 
 
+def _get_view_base(node: torch.fx.Node) -> torch.fx.Node:
+    while _is_view_op(node.target) and node.args:
+        base = node.args[0]
+        if not isinstance(base, torch.fx.Node):
+            break
+        node = base
+    return node
+
+
+def _same_tensor_metadata(lhs: torch.fx.Node, rhs: torch.fx.Node) -> bool:
+    lhs_val = lhs.meta.get("val")
+    rhs_val = rhs.meta.get("val")
+    if not isinstance(lhs_val, torch.Tensor) or not isinstance(rhs_val, torch.Tensor):
+        return False
+
+    def same_value(lhs_value, rhs_value) -> bool:
+        return statically_known_true(sym_eq(lhs_value, rhs_value))
+
+    def same_sequence(lhs_values, rhs_values) -> bool:
+        return len(lhs_values) == len(rhs_values) and all(
+            same_value(lhs_value, rhs_value)
+            for lhs_value, rhs_value in zip(lhs_values, rhs_values)
+        )
+
+    return (
+        same_sequence(lhs_val.size(), rhs_val.size())
+        and same_sequence(lhs_val.stride(), rhs_val.stride())
+        and same_value(lhs_val.storage_offset(), rhs_val.storage_offset())
+    )
+
+
+def _is_layout_preserving_view_copy_back(
+    dst: torch.fx.Node,
+    src: torch.fx.Node,
+    mutated_arg: torch.fx.Node,
+    src_base: torch.fx.Node,
+) -> bool:
+    return _same_tensor_metadata(src_base, mutated_arg) and _same_tensor_metadata(
+        src, dst
+    )
+
+
 def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
     """
     Reinplaces in-placeable operations.
@@ -435,6 +479,9 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
     copy_args_to_copy_nodes = {}
     # maps argument to the first copy_ node that mutates it.
     copy_nodes = {}
+    # maps (view_arg, inplaceable_op_node) to copy_ nodes that copy a view of
+    # the op result back into the graph input that view_arg aliases.
+    copy_args_to_copy_nodes_via_views = {}
     mutated_inputs = OrderedSet[Any]()
     storage_to_nodes = defaultdict(list)
     node_order: dict[Any, int] = {}
@@ -463,6 +510,23 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
             copy_nodes[dst] = node
 
             mutated_inputs.add(node.args[0])
+
+            src_base = _get_view_base(src)
+            if src_base is not src and isinstance(src_base.target, Callable):
+                inplaceable_op = inplaceable_ops.get(src_base.target)
+                if inplaceable_op is not None:
+                    for mutated_arg_idx in inplaceable_op.mutated_args:
+                        mutated_arg = src_base.args[mutated_arg_idx]
+                        if (
+                            isinstance(mutated_arg, torch.fx.Node)
+                            and _get_view_base(mutated_arg) is dst
+                            and _is_layout_preserving_view_copy_back(
+                                dst, src, mutated_arg, src_base
+                            )
+                        ):
+                            copy_args_to_copy_nodes_via_views[
+                                (mutated_arg, src_base)
+                            ] = node
 
     def any_use_of_views_after_node(node, shared_view_nodes, *, copy_node, mutated_arg):
         node_loc = node_order[node]
@@ -545,17 +609,52 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
 
             return True
         elif any(view.op in ("placeholder", "get_attr") for view in shared_view_nodes):
-            # This should never happen in auto_functionalize_v2 non-inference mode,
-            # since all mutated_arg are bases.
+            # If mutated_arg is a view of a graph input, we can only reinplace
+            # when a later copy_ writes this op's result back to that input.
+            copy_node = copy_args_to_copy_nodes_via_views.get((mutated_arg, node))
+            if copy_node is None:
+                return False
 
-            # If mutated arg is view of any of the inputs of the graph,
-            # do not allow for inplacing.
-            # This would require more sophisticated algorithm to handle
-            return False
+            mutated_arg_base = copy_node.args[0]
+            copy_src = copy_node.args[1]
+            if not (
+                isinstance(mutated_arg_base, torch.fx.Node)
+                and isinstance(copy_src, torch.fx.Node)
+                and _is_layout_preserving_view_copy_back(
+                    mutated_arg_base, copy_src, mutated_arg, node
+                )
+            ):
+                return False
+
+            if any_use_of_views_after_node(
+                node,
+                shared_view_nodes,
+                copy_node=copy_node,
+                mutated_arg=mutated_arg_base,
+            ):
+                return False
+            return True
         else:
             return not any_use_of_views_after_node(
                 node, shared_view_nodes, copy_node=None, mutated_arg=mutated_arg
             )
+
+    def copy_node_for_reinplaced_arg(node, mutated_arg):
+        copy_node = copy_args_to_copy_nodes.get((mutated_arg, node))
+        if copy_node is None:
+            copy_node = copy_args_to_copy_nodes_via_views.get((mutated_arg, node))
+            if copy_node is not None:
+                copy_dst = copy_node.args[0]
+                copy_src = copy_node.args[1]
+                if not (
+                    isinstance(copy_dst, torch.fx.Node)
+                    and isinstance(copy_src, torch.fx.Node)
+                    and _is_layout_preserving_view_copy_back(
+                        copy_dst, copy_src, mutated_arg, node
+                    )
+                ):
+                    return None
+        return copy_node
 
     def all_can_inplace(node, mutated_args):
         return all(can_inplace(node, arg) for arg in mutated_args)
@@ -649,7 +748,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
             )
             if should_attempt_reinplace and can_inplace(node, mutated_arg):
                 # In general, we probably do not need those optimizations.
-                copy_node = copy_args_to_copy_nodes.get((mutated_arg, node))
+                copy_node = copy_node_for_reinplaced_arg(node, mutated_arg)
                 if copy_node is not None:
                     replace_dict[copy_node] = copy_node.args[0]
                 if trigger != ReInplaceTrigger.AUTO_FUNC_V2:
@@ -691,7 +790,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
             mutated_args = [node.args[idx] for idx in inplaceable_op.mutated_args]
             if all_can_inplace(node, mutated_args) and inplaceable_op.extra_check(node):
                 for mutated_arg in mutated_args:
-                    copy_node = copy_args_to_copy_nodes.get((mutated_arg, node))
+                    copy_node = copy_node_for_reinplaced_arg(node, mutated_arg)
                     if copy_node is not None:
                         replace_dict[copy_node] = copy_node.args[0]
                 node.target = inplaceable_op.inplace_op


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184263

Allow reinplacing index_put on graph-input views when the functional result is copied back through a layout-preserving view roundtrip.

Fixes #137416

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos