### PR TITLE
[scatter_add cutedsl] Use post-build TI strides for eligibility

### DIFF
--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -603,15 +603,12 @@ class TestScatterAddOverrideConds(TestCase):
         cutedsl_impl.register_to_dispatch()
 
     def _conds(self, self_t, idx, src, dim=0):
-        # _is_*_supported operate on already-permuted operands. Mirror
-        # what _make_cond does: permute and feed the views.
-        permuted = self.impl._permute_to_dim0(self_t, dim, idx, src)
-        if permuted is None:
-            return (False, False)
-        self_p, src_p, idx_p = permuted
+        # _is_*_supported take (self, dim, index, src); they build the
+        # analysis iter internally and pattern-match its strides against
+        # the kernel's expected layout.
         return (
-            self.impl._is_tma_supported(self_p, idx_p, src_p),
-            self.impl._is_vec_scatter_supported(self_p, idx_p, src_p),
+            self.impl._is_tma_supported(self_t, dim, idx, src),
+            self.impl._is_vec_scatter_supported(self_t, dim, idx, src),
         )
 
     @parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])

--- a/torch/_native/ops/scatter_add/cutedsl_impl.py
+++ b/torch/_native/ops/scatter_add/cutedsl_impl.py
@@ -1,8 +1,8 @@
 """CuTeDSL override registrations for ``aten::scatter_add``.
 
-Two kernels for the ``index.unsqueeze(-1).expand(-1, ...)`` expanded-1D
-pattern (same shape for self/src/index, inner-contiguous after permuting
-``dim`` to axis 0), tried in order:
+Two kernels for the fast-path layout (self/src 2D-shaped after
+coalescing, with self contiguous on the slice axis and src either
+contiguous or row-strided), tried in order:
 
 1. **TMA** (``tma_kernel.py``, sm_90+): uses ``cp.reduce.async.bulk`` to
    offload the whole reduction to the TMA unit, 3-7x faster than aten on
@@ -12,17 +12,18 @@ pattern (same shape for self/src/index, inner-contiguous after permuting
    pre-sm_90, and sm_90+ shapes where the TMA alignment constraint isn't
    met.
 
-Both kernels assume the scatter axis is dim=0 and the inner dims pack
-contiguously. We accept any ``dim`` whose post-``movedim(dim, 0)`` layout
-satisfies that constraint -- in particular, default-contiguous tensors
-with ``dim=0`` and pre-permuted views like ``x.permute(1, 0, 2)`` with
-``dim=1``. ``_permute_to_dim0`` validates the permuted operand triple via
-``TensorIteratorConfig`` (cross-device / shape / overlap checks) before
-the path-specific support check runs.
+Eligibility mirrors aten's ``fast_scatter_add_kernel_eligible``
+(IndexKernelUtils.h): we restride ``self`` so its scatter-axis stride
+is 0 and shape matches ``index``, then build a ``TensorIterator`` on
+``(self_restrided, src_restrided, index)``. TensorIterator's coalescing
+and stride-magnitude reordering produces a 2D iterator iff the layout
+is kernel-friendly; we then pattern-match the resulting iter strides
+to confirm slice/index-axis assignment. This delegates the layout
+analysis to ``TensorIterator`` rather than reimplementing it.
 
-Anything else (non-expanded index, post-permute non-contiguous inputs,
-deterministic mode) falls through to aten. Aten is competitive or better
-on those shapes, so we intentionally don't override them.
+Anything else (non-2D-coalescing layout, dtype mismatch, deterministic
+mode) falls through to aten. Aten is competitive or better on those
+shapes, so we intentionally don't override them.
 
 In-place (``scatter_add_``) is registered explicitly; PyTorch's
 structured-delegate from ``scatter_add_`` to ``scatter_add.out`` happens
@@ -32,10 +33,9 @@ intercept the in-place method.
 
 import functools
 import importlib.util
-import math
 
 import torch
-from torch._tensor_iterator import binary_op as _ti_binary_op
+from torch._tensor_iterator import TensorIterator, TensorIteratorConfig
 
 from ... import cutedsl_utils as cu
 from ...registry import _OpCondFn, _OpImplFn
@@ -90,194 +90,160 @@ def _base_cond_ok(*tensors: torch.Tensor) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Expanded-1D helpers, shared by TMA and vec-scatter paths.
+# TI-driven layout analysis.
+#
+# Mirrors aten's pattern in ScatterGatherKernel.cu / IndexKernelUtils.h:
+# restride ``self`` so its scatter-axis stride is 0 and its shape matches
+# ``index``, then build a TensorIterator on the three. TensorIterator does
+# the broadcast / coalesce / dim reorder; we then pattern-match the post-
+# build iter strides to recognize the kernel's expected layout.
 # ---------------------------------------------------------------------------
-
-
-def _inner_contiguous(t: torch.Tensor) -> bool:
-    """True iff ``t.shape[1:]`` is packed contiguously (so flattening to
-    ``(t.shape[0], prod(t.shape[1:]))`` is a valid view), regardless of
-    the outer stride. Covers slices like ``X[:, :K]`` of a wider buffer.
-
-    Empty outer axis returns ``False``: the kernel has no work to do,
-    and letting it through means ``select(0, 0)`` below would raise.
-    """
-    if t.ndim == 0:
-        return False
-    if t.ndim == 1:
-        return t.stride(0) == 1
-    if t.shape[0] == 0:
-        return False
-    return t.select(0, 0).is_contiguous()
 
 
 def _normalize_dim(dim: int, ndim: int) -> int:
     return dim + ndim if dim < 0 else dim
 
 
-def _permute_to_dim0(
+def _scatter_add_eligibility(
     self: torch.Tensor, dim: int, index: torch.Tensor, src: torch.Tensor
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
-    """Move ``dim`` to axis 0 on all three operands and validate.
+) -> TensorIterator | None:
+    """Return the analysis TensorIterator if (self, dim, index, src) fits
+    the kernel's expected layout, else ``None``.
 
-    The downstream pipeline (``_expanded_1d_inner_size``,
-    ``_flatten_for_expanded_1d``, the kernels) hard-codes dim=0 and
-    inner-contiguous nD tensors. ``movedim(dim, 0)`` is a view, so writes
-    through the permuted ``self`` view land in the correct storage cells of
-    the user's original tensor.
-
-    Per-slice validation via TensorIterator mirrors aten's
-    ``index_func_meta_impl`` trick (TensorAdvancedIndexing.cpp:441-444): the
-    full (self, src) pair has different sizes along axis 0, but
-    ``select(0, 0)`` of each gives matching shapes that TI can sanity-check
-    for cross-device, dtype, and overlap. Aten itself doesn't run TI on the
-    full triple either -- it uses the dedicated ``scatter_shape_check``
-    helper, which is the analog of our ``_expanded_1d_inner_size`` checks
-    downstream. Permutation alone is not enough: the post-permute ``self``
-    and ``src`` must still pass ``_inner_contiguous`` for the kernel's
-    2D-view flattening to be valid -- that's checked downstream.
-    """
-    if self.ndim != src.ndim or self.ndim != index.ndim or self.ndim < 2:
-        return None
-    d = _normalize_dim(dim, self.ndim)
-    if d < 0 or d >= self.ndim:
-        return None
-    if self.shape[d] == 0 or src.shape[d] == 0:
-        return None
-    self_p = self.movedim(d, 0)
-    src_p = src.movedim(d, 0)
-    index_p = index.movedim(d, 0)
-
-    # Per-slice TensorIterator check: build a binary_op on the first slice
-    # of each post-permute operand. The slice shapes match by
-    # construction, so TI's broadcast / device / overlap rules apply
-    # cleanly -- this catches cross-device operands and inner-shape
-    # mismatches before the kernel-specific checks run.
-    try:
-        _ti_binary_op(self_p.select(0, 0), self_p.select(0, 0), src_p.select(0, 0))
-    except RuntimeError:
-        return None
-    return self_p, src_p, index_p
-
-
-def _expanded_1d_inner_size(
-    self: torch.Tensor, index: torch.Tensor, src: torch.Tensor
-) -> int | None:
-    """Return ``prod(src.shape[1:])`` when the ``index.unsqueeze(-1)
-    .expand(-1, ...)`` fast-path pattern applies on (already permuted to
-    dim=0) operands, else ``None``.
-
-    Requirements:
-      - self, src, index have the same rank (>= 2) and shape
-      - self, src have inner-dim stride 1 (outer row stride can differ
-        from prod(shape[1:]) -- e.g. a slice like ``X[:, :K]`` of a
-        wider buffer works)
-      - index.stride(i) == 0 for every axis i > 0 (the broadcast)
-      - dtype in ``_SUPPORTED_DTYPES`` and self.dtype == src.dtype
-      - index.dtype in {int32, int64} (int32 is cast to int64 on the
-        host before the kernel launches)
-
-    Caller is responsible for the dim=0 invariant: see ``_permute_to_dim0``.
+    Mirrors aten's ``fast_scatter_add_kernel_eligible`` (IndexKernelUtils.h):
+    restride ``self`` so its scatter-axis stride is 0 (shape = ``index.shape``),
+    let TensorIterator coalesce + reorder, then check that the result is
+    a 2D iter where dim 0 is the contiguous slice axis and dim 1 is the
+    scatter (index) axis.
     """
     if self.dtype not in _SUPPORTED_DTYPES or self.dtype != src.dtype:
         return None
     if index.dtype not in (torch.int32, torch.int64):
         return None
-    if self.ndim < 2:
+    if self.ndim != src.ndim or self.ndim != index.ndim or self.ndim == 0:
         return None
-    # Inner-dim stride 1, plus ensure inner dims pack contiguously so we
-    # can flatten shape[1:] into a single N. A simple sufficient check:
-    # stride of each inner axis == product of strides below it.
-    if not _inner_contiguous(self) or not _inner_contiguous(src):
+    d = _normalize_dim(dim, self.ndim)
+    if not 0 <= d < self.ndim:
         return None
-    if index.shape != src.shape or self.shape[1:] != src.shape[1:]:
+
+    self_strides = list(self.stride())
+    self_strides[d] = 0  # aten's restride_dim trick
+    try:
+        self_r = self.as_strided(index.shape, self_strides)
+        src_r = src.as_strided(index.shape, src.stride())
+        it = (
+            TensorIteratorConfig()
+            .add_output(self_r)
+            .add_const_input(src_r)
+            .add_const_input(index)
+            .set_check_mem_overlap(False)
+            .check_all_same_dtype(False)
+            .resize_outputs(False)
+            .build()
+        )
+    except RuntimeError:
         return None
-    for i in range(1, index.ndim):
-        if index.stride(i) != 0:
-            return None
-    # shape[0] == 0 on self or src is already rejected by
-    # ``_inner_contiguous`` above.
-    N = math.prod(src.shape[1:])
-    if N == 0:
+
+    if it.ndim != 2:
         return None
-    return N
-
-
-def _flatten_2d_view(t: torch.Tensor) -> torch.Tensor:
-    """Flatten ``t.shape[1:]`` into a single N. Preserves the outer row
-    stride (so a slice like ``X[:, :K]`` stays a view of the wider
-    buffer). Caller must have verified ``_inner_contiguous(t)``.
-    """
-    if t.ndim == 2:
-        return t
-    N = math.prod(t.shape[1:])
-    # Outer stride carries through unchanged; inner dims collapse to
-    # stride 1 because they were packed (cond-enforced).
-    return t.as_strided((t.shape[0], N), (t.stride(0), 1))
-
-
-def _flatten_for_expanded_1d(
-    self: torch.Tensor, index: torch.Tensor, src: torch.Tensor
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Reshape eligible nD inputs to (self_2d, index_1d, src_2d).
-
-    Caller must have verified eligibility via ``_expanded_1d_inner_size``.
-    All reshapes are views; the 1D index view is taken by selecting
-    element 0 of every broadcast axis.
-    """
-    self_2d = _flatten_2d_view(self)
-    src_2d = _flatten_2d_view(src)
-    index_1d = index
-    for _ in range(index.ndim - 1):
-        index_1d = index_1d.select(-1, 0)
-    if index_1d.dtype != torch.int64:
-        # Kernel expects int64. aten accepts both int32 and int64; we
-        # widen on the host so the kernel stays dtype-specialized.
-        index_1d = index_1d.to(torch.int64)
-    if not index_1d.is_contiguous():
-        index_1d = index_1d.contiguous()
-    return self_2d, index_1d, src_2d
+    elem = self.element_size()
+    idx_elem = index.element_size()
+    s_self, s_src, s_idx = it.strides(0), it.strides(1), it.strides(2)
+    if (
+        s_idx[0] == 0
+        and s_idx[1] == idx_elem
+        and s_self[0] == elem
+        and s_src[0] == elem
+        and s_self[1] == 0
+    ):
+        return it
+    return None
 
 
 # ---------------------------------------------------------------------------
-# Path-specific eligibility checks.
+# Per-kernel eligibility. ``it.shape[0]`` is the slice extent (N elements)
+# after coalescing; that's what the alignment / divisibility checks key on.
 # ---------------------------------------------------------------------------
 
 
 def _is_tma_supported(
-    self: torch.Tensor, index: torch.Tensor, src: torch.Tensor
+    self: torch.Tensor, dim: int, index: torch.Tensor, src: torch.Tensor
 ) -> bool:
-    """Eligibility check on (self, index, src) ALREADY permuted to dim=0."""
     if not _has_sm90_plus():
         return False
-    N = _expanded_1d_inner_size(self, index, src)
-    if N is None:
+    it = _scatter_add_eligibility(self, dim, index, src)
+    if it is None:
         return False
-    # TMA transfer size is baked in at compile time (chunk_bytes =
-    # min(row_bytes, 512)); row_bytes must evenly divide by chunk_bytes
-    # and chunk_bytes must be 16-byte aligned.
+    # TMA chunk_bytes = min(row_bytes, 512); row_bytes must evenly divide
+    # by chunk_bytes and chunk_bytes must be 16-byte aligned.
     from .tma_kernel import row_shape_supported
 
-    return row_shape_supported(self.dtype, N)
+    return row_shape_supported(self.dtype, it.shape[0])
 
 
 def _is_vec_scatter_supported(
-    self: torch.Tensor, index: torch.Tensor, src: torch.Tensor
+    self: torch.Tensor, dim: int, index: torch.Tensor, src: torch.Tensor
 ) -> bool:
-    """Eligibility check on (self, index, src) ALREADY permuted to dim=0."""
-    # ``red.global.add.noftz.bf16x2`` requires sm_90+. fp16x2 (sm_70+)
-    # and scalar fp32 atomicAdd (sm_60+) work everywhere we care about.
+    # ``red.global.add.noftz.bf16x2`` requires sm_90+. fp16x2 (sm_70+) and
+    # scalar fp32 atomicAdd (sm_60+) work everywhere we care about.
     if self.dtype is torch.bfloat16 and not _has_sm90_plus():
         return False
-    N = _expanded_1d_inner_size(self, index, src)
-    if N is None:
+    it = _scatter_add_eligibility(self, dim, index, src)
+    if it is None:
         return False
-    # Each lane owns vec_elems consecutive elements; the loop is either
+    # Each lane owns vec_elems consecutive elements; loop is either
     # fully in-bounds or fully skipped per lane. Only requirement is
-    # D % vec_elems == 0 (fp32: %4, halves: %8).
+    # N % vec_elems == 0 (fp32: %4, halves: %8).
     from .vec_scatter_kernel import vec_elems_for
 
-    return N % vec_elems_for(self.dtype) == 0
+    return it.shape[0] % vec_elems_for(self.dtype) == 0
+
+
+# ---------------------------------------------------------------------------
+# Kernel-input prep. After eligibility the kernel host functions take 2D
+# (M, N) tensors and a 1D index. We synthesize those views from the user's
+# original operands using the TI-approved geometry.
+# ---------------------------------------------------------------------------
+
+
+def _prepare_kernel_inputs(
+    self: torch.Tensor,
+    dim: int,
+    index: torch.Tensor,
+    src: torch.Tensor,
+    it: TensorIterator,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build (self_2d, index_1d, src_2d) for the kernel host functions.
+
+    Caller has verified eligibility via ``_scatter_add_eligibility``.
+    ``it.shape[0]`` is the coalesced slice extent (product of every
+    non-scatter dim of ``self``). The 2D views preserve the user's
+    original stride along ``dim`` (used by the kernel for the row stride).
+    """
+    d = _normalize_dim(dim, self.ndim)
+    N, M_src = it.shape[0], it.shape[1]
+    M_self = self.shape[d]
+    self_2d = self.as_strided((M_self, N), (self.stride(d), 1))
+    src_2d = src.as_strided((M_src, N), (src.stride(d), 1))
+    # ``index`` may be nD with broadcast (stride-0) axes alongside one
+    # data axis. Drop every broadcast axis by selecting position 0 to
+    # land on the 1D view the kernels want.
+    index_1d = index
+    while index_1d.ndim > 1:
+        ax = next(
+            (a for a in range(index_1d.ndim) if index_1d.stride(a) == 0),
+            None,
+        )
+        if ax is None:
+            raise RuntimeError(
+                "scatter_add cutedsl: index lacks a broadcast axis to collapse"
+            )
+        index_1d = index_1d.select(ax, 0)
+    if index_1d.dtype != torch.int64:
+        index_1d = index_1d.to(torch.int64)
+    if not index_1d.is_contiguous():
+        index_1d = index_1d.contiguous()
+    return self_2d, index_1d, src_2d
 
 
 # ---------------------------------------------------------------------------
@@ -293,13 +259,12 @@ def _make_cond(
     requires_out: bool = False,
 ) -> _OpCondFn:
     """Build a cond function that runs ``support_check`` behind the shared
-    boilerplate (cutedsl availability, non-deterministic mode, CUDA tensors,
-    non-COW, dtype/shape match on ``out`` when present).
+    boilerplate (cutedsl availability, non-deterministic mode, CUDA
+    tensors, non-COW, dtype/shape match on ``out`` when present).
 
-    ``support_check`` is invoked on the operands AFTER ``movedim(dim, 0)``;
-    if the permutation can't be validated by TensorIterator (cross-device,
-    shape mismatch, etc.) we reject without running the path-specific
-    check.
+    ``support_check`` is ``_is_tma_supported`` or ``_is_vec_scatter_supported``
+    -- both take ``(self, dim, index, src)`` and rebuild the analysis iter
+    internally.
     """
     if requires_out:
 
@@ -310,27 +275,16 @@ def _make_cond(
                 return False
             if out.ndim == 0:
                 return False
-            # ``out`` is structurally a clone of ``self`` from the user's
-            # perspective; permute it the same way for the inner-contig
-            # check on the post-permute view.
-            permuted = _permute_to_dim0(out, dim, index, src)
-            if permuted is None:
-                return False
-            out_p, src_p, index_p = permuted
-            if not _inner_contiguous(out_p):
-                return False
-            return support_check(out_p, index_p, src_p)
+            # ``out`` is the destination of a functional .out call; it
+            # plays the role of self in the iter analysis.
+            return support_check(out, dim, index, src)
 
         return _cond
 
     def _cond(self, dim, index, src, *args, **kwargs):
         if not _base_cond_ok(self, index, src):
             return False
-        permuted = _permute_to_dim0(self, dim, index, src)
-        if permuted is None:
-            return False
-        self_p, src_p, index_p = permuted
-        return support_check(self_p, index_p, src_p)
+        return support_check(self, dim, index, src)
 
     return _cond
 
@@ -343,24 +297,22 @@ def _copy_if_distinct(out: torch.Tensor, self: torch.Tensor) -> None:
 
 
 def _make_impls(kernel_getter):
-    """Build (functional, out, in-place) impl callables for an
-    expanded-1D-pattern kernel. ``kernel_getter`` is a zero-arg callable
-    that lazily imports and returns the ``*_scatter_add_into`` kernel; we
-    defer the import so the DSL runtime isn't pulled in at registration
-    time.
+    """Build (functional, out, in-place) impl callables.
 
-    Each impl ``movedim(dim, 0)``s the operands before kernel dispatch.
-    The permuted ``dst`` is a view of the original storage, so the kernel's
-    writes land in the correct cells of the user's tensor.
+    ``kernel_getter`` lazily imports the ``*_scatter_add_into`` kernel
+    host function (we defer to keep the DSL runtime out of registration).
+    Cond has already verified eligibility; we rebuild the iter inside the
+    impl to recover the post-coalesce geometry that ``_prepare_kernel_inputs``
+    needs. The build is pure C++ and cheap.
     """
 
     def _run(dst: torch.Tensor, dim: int, index, src) -> torch.Tensor:
-        # Cond guarantees the permuted views pass _expanded_1d_inner_size.
-        d = _normalize_dim(dim, dst.ndim)
-        dst_p = dst.movedim(d, 0)
-        src_p = src.movedim(d, 0)
-        index_p = index.movedim(d, 0)
-        dst_2d, index_1d, src_2d = _flatten_for_expanded_1d(dst_p, index_p, src_p)
+        it = _scatter_add_eligibility(dst, dim, index, src)
+        if it is None:
+            raise RuntimeError(
+                "scatter_add cutedsl: cond approved but iter rebuild failed"
+            )
+        dst_2d, index_1d, src_2d = _prepare_kernel_inputs(dst, dim, index, src, it)
         kernel_getter()(dst_2d, index_1d, src_2d)
         return dst
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184270
* #184251
* #184250

Replaces the manual `movedim`/`_inner_contiguous`/`_expanded_1d_inner_size`
machinery with aten's pattern from `ScatterGatherKernel.cu`: restride
`self` so its scatter-axis stride is 0 with shape matching `index`,
build a `TensorIterator`, and pattern-match the post-coalesce iter
strides against the kernel's expected layout. Mirrors aten's
`fast_scatter_add_kernel_eligible` from `IndexKernelUtils.h`.

Eligibility is unchanged in practice (TI's coalescing rejects exactly
the layouts our manual checks rejected, and accepts the same set the
fast path of aten accepts). The dispatch path is now a thin Python
analogue of aten's, with `TensorIterator` doing the layout analysis
rather than us reimplementing it.

Authored by Claude.