### PR TITLE
Fix profiler event canonicalization with PEP 657 caret lines

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -1572,9 +1572,14 @@ def _canonicalize_profiler_events(events):
         node_name = event["args"].get("node_name", "")
         stack_trace = event["args"].get("stack_trace", "")
 
-        # Get the last non-empty line of the stack trace
+        # Get the last non-empty line of the stack trace that is actual source,
+        # not a caret-marker line. Python 3.11+ appends "^^^^"/"~~~~" indicator
+        # lines below the source when a FrameSummary has colno/end_colno set
+        # (e.g. dynamo-generated stack traces); those lines must be skipped so
+        # we still surface the source code line in canonicalized output.
         lines = [s.strip() for s in stack_trace.split("\n") if s.strip()]
-        stack_trace = lines[-1] if lines else ""
+        source_lines = [s for s in lines if not set(s).issubset({"^", "~", " "})]
+        stack_trace = source_lines[-1] if source_lines else ""
 
         events_with_traces.append(
             {


### PR DESCRIPTION
## Summary
- Skip PEP 657 caret/tilde marker-only lines when canonicalizing profiler event stack traces.
- Keeps Dynamo-augmented profiler event snapshots focused on the source line after FrameSummary column metadata is present.

Made with [Cursor](https://cursor.com)