### PR TITLE
[inductor] fix torch.randperm for slice_shape node in fx_passes

### DIFF
--- a/test/inductor/pallas_expected_failures/CpuTests.test_randperm_index_slice_range_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_randperm_index_slice_range_cpu
@@ -1,0 +1,3 @@
+ERROR
+TypeError: add got incompatible shapes for broadcasting
+cannot reshape array of shape (4, 64) (size 256) into shape (8, 1, 64) (size 512)

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -777,6 +777,67 @@ class TestPatternMatcher(TestCase):
     # called in test_gpu_cpp_wrapper
     test_cat_slice_cat_xpu = test_cat_slice_cat_cuda
 
+    @parametrize("n", (8, 64))
+    def test_randperm_index(self, n):
+        def fn(x):
+            idx = torch.randperm(x.shape[0], device=x.device)
+            return x[idx]
+
+        x = torch.randn(n, 64, device=GPU_TYPE)
+        rand_opt = torch.compile(fn, backend="inductor")
+
+        torch.manual_seed(42)
+        expect = fn(x)
+
+        torch._dynamo.reset()
+        counters.clear()
+        torch.manual_seed(42)
+        actual = rand_opt(x)
+
+        self.assertEqual(expect, actual)
+        self.assertGreaterEqual(counters["inductor"]["pattern_matcher_count"], 1)
+
+    @parametrize("case", ((8, 42), (64, 42), (64, 8), (128, 64)))
+    def test_randperm_index_with_slice(self, case):
+        def fn(x, slice_shape):
+            idx = torch.randperm(x.shape[0], device=x.device)[:slice_shape]
+            return x[idx]
+
+        n, s = case
+        x = torch.randn(n, 64, device=GPU_TYPE)
+        rand_opt = torch.compile(fn, backend="inductor")
+
+        torch.manual_seed(42)
+        expect = fn(x, s)
+
+        torch._dynamo.reset()
+        counters.clear()
+        torch.manual_seed(42)
+        actual = rand_opt(x, s)
+
+        self.assertEqual(expect, actual)
+        self.assertGreaterEqual(counters["inductor"]["pattern_matcher_count"], 1)
+
+    @parametrize("n", (8, 64))
+    def test_randperm_index_2d(self, n):
+        def fn(x):
+            idx = torch.randperm(x.shape[0], device=x.device)
+            return x[idx, :]
+
+        x = torch.randn(n, 64, device=GPU_TYPE)
+        rand_opt = torch.compile(fn, backend="inductor")
+
+        torch.manual_seed(42)
+        expect = fn(x)
+
+        torch._dynamo.reset()
+        counters.clear()
+        torch.manual_seed(42)
+        actual = rand_opt(x)
+
+        self.assertEqual(expect, actual)
+        self.assertGreaterEqual(counters["inductor"]["pattern_matcher_count"], 1)
+
     def test_pointless_view_pair(self):
         def f(x):
             x = aten.view.default(x, [3, 5, 7])

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2217,6 +2217,14 @@ class CommonTemplate:
         actual = _run_and_assert_no_indirect_indexing(self, flip_opt, x)
         self.assertEqual(expect, actual)
 
+    def test_randperm_index_slice_range(self):
+        def fn(x):
+            idx = torch.randperm(x.shape[0], device=x.device)
+            return x[idx[2:6]]
+
+        for n in (8, 64):
+            self.common(fn, (torch.randn(n, 64, device=self.device),))
+
     def test__unsafe_masked_index(self):
         def fn(a, mask, idx):
             return aten._unsafe_masked_index(a, mask, idx, 1)

--- a/torch/_inductor/fx_passes/misc_patterns.py
+++ b/torch/_inductor/fx_passes/misc_patterns.py
@@ -94,13 +94,37 @@ def _misc_patterns_init(input_device: torch.device | None = None):
         randperm_index_pattern,
         # pyrefly: ignore [bad-argument-type]
         randperm_index_replacement,
-        [torch.empty(4, 8, device=device)],
+        # x.shape[0] must exceed scalar_workaround['slice_shape'] (42)
+        # so applySlice's length<=stop fast path doesn't elide
+        # the slice during pattern tracing
+        [torch.empty(64, 8, device=device)],
         # pyrefly: ignore [bad-argument-type]
         fwd_only,
         # pyrefly: ignore [bad-argument-type]
         [post_grad_patterns, joint_graph_patterns],
         # Keep this smaller than the example input dim so tracing preserves the slice.
         scalar_workaround={"slice_shape": 2},
+        skip_duplicates=True,
+    )
+
+    def randperm_index_only_pattern(x):
+        index = torch.randperm(x.shape[0], device=x.device)
+        return torch.ops.aten.index(x, (index,))
+
+    def randperm_index_only_replacement(x):
+        index = torch.randperm(x.shape[0], device=x.device)
+        return torch.ops.aten._unsafe_index(x, (index,))
+
+    register_replacement(
+        # pyrefly: ignore [bad-argument-type]
+        randperm_index_only_pattern,
+        # pyrefly: ignore [bad-argument-type]
+        randperm_index_only_replacement,
+        [torch.empty(4, 8, device=device)],
+        # pyrefly: ignore [bad-argument-type]
+        fwd_only,
+        # pyrefly: ignore [bad-argument-type]
+        [post_grad_patterns, joint_graph_patterns],
         skip_duplicates=True,
     )
 


### PR DESCRIPTION
Fixes: #183988

```python
In [1]: import torch
   ...: 
   ...: def fn(x):
   ...:     idx = torch.randperm(x.shape[0], device=x.device)
   ...:     return x[idx]
   ...: 
   ...: x = torch.randn(8, 64, device="cuda")
   ...: 
   ...: # Eager: OK
   ...: print(fn(x).shape)
   ...: 
   ...: # aot_eager: OK
   ...: torch._dynamo.reset()
   ...: print(torch.compile(fn, backend="aot_eager")(x).shape)  # torch.Size([8, 64])
   ...: 
   ...: # Inductor: WORKS FINE
   ...: torch._dynamo.reset()
   ...: print(torch.compile(fn, backend="inductor")(x).shape)
torch.Size([8, 64])
torch.Size([8, 64])
torch.Size([8, 64])

In [2]: 
```

I checked Inductor traces to verify whether the optimized kernel is being generated. The `test_randperm_index_slice_range` does not generate the optimized kernel. Should I add another entry in misc_patterns.py for that case, or is that not necessary? Thanks!

<details>
<summary>test_randperm_index</summary>

<p>

```python
In [1]: import torch
   ...: import torch._logging
   ...: import logging
   ...: 
   ...: torch._dynamo.reset()
   ...: torch._inductor.config.fx_graph_cache = False
   ...: 
   ...: torch._logging.set_logs(graph_code=True, output_code=True, inductor=logging.DEBUG)
   ...: 
   ...: @torch.compile
   ...: def fn(x):
   ...:     idx = torch.randperm(x.shape[0], device=x.device)
   ...:     return x[idx]
   ...: 
   ...: fn(torch.randn(8, 64, device="cuda"))
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] TRACED GRAPH
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]  ===== __compiled_fn_1_95a9e2b2_df4d_4a46_af10_89ffe4183058 =====
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class GraphModule(torch.nn.Module):
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]     def forward(self, L_x_: "f32[8, 64][64, 1]cuda:0"):
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         l_x_ = L_x_
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         # File: <ipython-input-1-ae16fc072177>:12 in fn, code: idx = torch.randperm(x.shape[0], device=x.device)
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         idx: "i64[8][1]cuda:0" = torch.randperm(8, device = device(type='cuda', index=0))
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         # File: <ipython-input-1-ae16fc072177>:13 in fn, code: return x[idx]
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         getitem: "f32[8, 64][64, 1]cuda:0" = l_x_[idx];  l_x_ = idx = None
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         return (getitem,)
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:39:27.713000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
I0520 02:39:27.719000 86891 /home/khushi/Documents/pytorch/torch/_inductor/async_compile.py:286] [0/0] Creating 'subprocess' pool with 32 workers
I0520 02:39:27.776000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_worker/subproc_pool.py:170] [0/0] Suppressing compile worker output due to config
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] TRACED GRAPH
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]  ===== BEFORE PRE GRAD =====
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class GraphModule(torch.nn.Module):
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]     def forward(self, L_x_: "f32[8, 64][64, 1]cuda:0"):
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         l_x_ = L_x_
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         # File: <ipython-input-1-ae16fc072177>:12 in fn, code: idx = torch.randperm(x.shape[0], device=x.device)
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         idx: "i64[8][1]cuda:0" = torch.randperm(8, device = device(type='cuda', index=0))
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         # File: <ipython-input-1-ae16fc072177>:13 in fn, code: return x[idx]
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         getitem: "f32[8, 64][64, 1]cuda:0" = l_x_[idx];  l_x_ = idx = None
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         return (getitem,)
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:39:27.780000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:39:27.917000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:942] [0/0] FX cache status: use_cache=False, local=False, remote=False, aot_mode=False, force_disable_caches=False
V0520 02:39:27.917000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1030] [0/0] FX cache bypass reason: FX cache disabled or key generation failed
I0520 02:39:27.917000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1300] [0/0] Step 3: torchinductor compiling FORWARDS graph 0
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] TRACED GRAPH
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]  ===== AFTER POST GRAD =====
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class <lambda>(torch.nn.Module):
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]     def forward(self, arg0_1: "f32[8, 64][64, 1]cuda:0"):
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         # No stacktrace found for following nodes
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         randperm_default: "i64[8][1]cuda:0" = torch.ops.aten.randperm.default(8, device = device(type='cuda', index=0), pin_memory = False)
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         # File: <ipython-input-1-ae16fc072177>:13 in fn, code: return x[idx]
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         _unsafe_index_tensor: "f32[8, 64][64, 1]cuda:0" = torch.ops.aten._unsafe_index.Tensor(arg0_1, [randperm_default]);  arg0_1 = randperm_default = None
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         return (_unsafe_index_tensor,)
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:39:27.926000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:39:27.938000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %arg0_1 : [num_users=1] = placeholder[target=arg0_1] 
V0520 02:39:27.938000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %randperm_default : [num_users=1] = call_function[target=torch.ops.aten.randperm.default](args = (8,), kwargs = {device: cuda:0, pin_memory: False}) 
V0520 02:39:27.939000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1422] [0/0]   via <function fallback_handler.<locals>.handler at 0x7b2964522140>
V0520 02:39:27.940000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %_unsafe_index_tensor : [num_users=1] = call_function[target=torch.ops.aten._unsafe_index.Tensor](args = (%arg0_1, [%randperm_default]), kwargs = {}) 
V0520 02:39:27.940000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1422] [0/0]   via <function _unsafe_index at 0x7b29643524b0>
V0520 02:39:27.952000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering return (_unsafe_index_tensor,) 
V0520 02:39:27.952000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1679] [0/0] Force channels last inputs for 0 conv for the current graph with id 0
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling FallbackKernel(
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name='torch.ops.aten.randperm.default',
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   name=buf0,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   layout=MultiOutputLayout(device=device(type='cuda', index=0)),
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   inputs=[],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   constant_args=(8, device(type='cuda', index=0), False),
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwargs={'device': device(type='cuda', index=0), 'pin_memory': False},
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   output_view=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=torch.ops.aten.randperm.default,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   cpp_kernel_name=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ordered_kwargs_for_cpp_kernel=['dtype', 'layout', 'device', 'pin_memory'],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   op_overload=aten.randperm.default,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   arg_properties=[{'name': 'n', 'type': int, 'default_value': None}],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   allarg_properties={'n': {'type': int, 'default_value': None}, 'dtype': {'type': Optional[ScalarType], 'default_value': 4}, 'layout': {'type': Optional[Layout], 'default_value': None}, 'device': {'type': Optional[Device], 'default_value': None}, 'pin_memory': {'type': Optional[bool], 'default_value': None}},
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwarg_properties=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   unbacked_bindings={},
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   mutation_outputs=[],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=randperm_default,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([randperm_default])
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] )
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling MultiOutput(
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   name=buf1,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   layout=FixedLayout('cuda:0', torch.int64, size=[8], stride=[1]),
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   inputs=[FallbackKernel(
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     python_kernel_name='torch.ops.aten.randperm.default',
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     name=buf0,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     layout=MultiOutputLayout(device=device(type='cuda', index=0)),
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     inputs=[],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     constant_args=(8, device(type='cuda', index=0), False),
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     kwargs={'device': device(type='cuda', index=0), 'pin_memory': False},
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     output_view=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     python_kernel_name=torch.ops.aten.randperm.default,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     cpp_kernel_name=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     ordered_kwargs_for_cpp_kernel=['dtype', 'layout', 'device', 'pin_memory'],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     op_overload=aten.randperm.default,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     arg_properties=[{'name': 'n', 'type': int, 'default_value': None}],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     allarg_properties={'n': {'type': int, 'default_value': None}, 'dtype': {'type': Optional[ScalarType], 'default_value': 4}, 'layout': {'type': Optional[Layout], 'default_value': None}, 'device': {'type': Optional[Device], 'default_value': None}, 'pin_memory': {'type': Optional[bool], 'default_value': None}},
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     kwarg_properties=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     unbacked_bindings={},
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     mutation_outputs=[],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     origin_node=randperm_default,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     origins=OrderedSet([randperm_default])
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   )],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   constant_args=(),
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwargs={},
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   output_view=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   cpp_kernel_name=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ordered_kwargs_for_cpp_kernel=(),
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   op_overload=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   arg_properties=[{}],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   allarg_properties={},
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwarg_properties=None,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   unbacked_bindings={},
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   mutation_outputs=[],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=randperm_default,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([randperm_default])
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] )
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling ComputedBuffer(name='buf2', layout=FixedLayout('cuda:0', torch.float32, size=[8, 64], stride=[64, 1]), data=Pointwise(
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   'cuda',
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   torch.float32,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   def inner_fn(index):
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       i0, i1 = index
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       tmp0 = ops.load(buf1, i0)
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       tmp1 = ops.load(arg0_1, i1 + 64 * tmp0)
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       return tmp1
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ranges=[8, 64],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=_unsafe_index_tensor,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([_unsafe_index_tensor]),
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   stack_traces = {,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     File "<ipython-input-1-ae16fc072177>", line 13, in fn,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       return x[idx],
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]              ~^^^^^,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   }
V0520 02:39:27.958000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
V0520 02:39:27.959000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4493] [0/0] scheduling output buf2
I0520 02:39:27.962000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1015] [0/0] Reordering for peak memory -- 3 nodes
I0520 02:39:27.962000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1049] [0/0] Baseline peak memory: 2112
I0520 02:39:27.962000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_lpmf peak memory: 2112
I0520 02:39:27.963000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_bfs peak memory: 2112
I0520 02:39:27.963000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_dfs peak memory: 2112
V0520 02:39:27.965000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8894] [0/0] [__cudagraphs] Created 1 graph partitions: 0 cudagraphable, 1 non-cudagraphable
V0520 02:39:27.965000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8901] [0/0] [__cudagraphs]   Partition 0: 3 nodes, non-cudagraphable, inputs=1, outputs=1
V0520 02:39:27.965000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op0: reason=partition includes all ops when cudagraphs is disabled, ir=FallbackKernel, fx=aten.randperm.default(8)
V0520 02:39:27.965000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op1: reason=partition includes all ops when cudagraphs is disabled, ir=MultiOutput, fx=aten.randperm.default(8)
V0520 02:39:27.965000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op2: reason=partition includes all ops when cudagraphs is disabled, ir=ComputedBuffer, fx=aten._unsafe_index.Tensor(arg0_1, [randperm_default])
V0520 02:39:27.965000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]          File "<ipython-input-1-ae16fc072177>", line 13, in fn
V0520 02:39:27.965000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]              return x[idx]
V0520 02:39:27.965000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]                     ~^^^^^
I0520 02:39:27.972000 86891 /home/khushi/Documents/pytorch/torch/_inductor/analysis/device_info.py:221] [0/0] Device NVIDIA GeForce RTX 4060 Laptop GPU not in datasheet, returning None
V0520 02:39:27.972000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op0 with estimated runtime 0.000000
I0520 02:39:27.973000 86891 /home/khushi/Documents/pytorch/torch/_inductor/analysis/device_info.py:221] [0/0] Device NVIDIA GeForce RTX 4060 Laptop GPU not in datasheet, returning None
V0520 02:39:27.973000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op1 with estimated runtime 0.000000
I0520 02:39:27.974000 86891 /home/khushi/Documents/pytorch/torch/_inductor/analysis/device_info.py:221] [0/0] Device NVIDIA GeForce RTX 4060 Laptop GPU not in datasheet, returning None
V0520 02:39:27.998000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op2 with estimated runtime 0.000016
V0520 02:39:28.012000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0] get_bounds:
V0520 02:39:28.012000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0] graph():
V0520 02:39:28.012000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %ops : [num_users=3] = placeholder[target=ops]
V0520 02:39:28.012000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index : [num_users=1] = call_module[target=get_index](args = (index0,), kwargs = {})
V0520 02:39:28.012000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %load : [num_users=1] = call_method[target=load](args = (%ops, buf1, %get_index), kwargs = {})
V0520 02:39:28.012000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %set_indirect0 : [num_users=0] = call_module[target=set_indirect0](args = (%load,), kwargs = {})
V0520 02:39:28.012000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index_1 : [num_users=1] = call_module[target=get_index](args = (index1,), kwargs = {})
V0520 02:39:28.012000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %load_1 : [num_users=1] = call_method[target=load](args = (%ops, arg0_1, %get_index_1), kwargs = {})
V0520 02:39:28.012000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index_2 : [num_users=1] = call_module[target=get_index](args = (index2,), kwargs = {})
V0520 02:39:28.012000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %store : [num_users=1] = call_method[target=store](args = (%ops, buf2, %get_index_2, %load_1, None), kwargs = {})
V0520 02:39:28.012000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     return store
V0520 02:39:28.017000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:39:28.021000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:39:28.024000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:39:28.282000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/simd.py:2096] [0/0] Generating kernel code with kernel_name: triton_poi_fused_index_0
V0520 02:39:28.283000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2605] [0/0] Finished codegen for all nodes. The list of kernel names available: OrderedSet([])
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] Output code: 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # AOT ID: ['0_inference']
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from ctypes import c_void_p, c_long, c_int
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import torch
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import math
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import random
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import os
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import tempfile
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from math import inf, nan
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from cmath import nanj
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.hooks import run_intermediate_hooks
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.utils import maybe_profile
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.codegen.memory_planning import _align as align
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch import device, empty_strided
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.async_compile import AsyncCompile
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.select_algorithm import extern_kernels
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._C._dynamo.guards import copy_if_misaligned
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton.language as tl
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.triton_heuristics import start_graph, end_graph
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._C import _cuda_getCurrentRawStream as get_raw_stream
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] aten = torch.ops.aten
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] inductor_ops = torch.ops.inductor
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] _quantized = torch.ops._quantized
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] assert_size_stride = torch._C._dynamo.guards.assert_size_stride
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] assert_alignment = torch._C._dynamo.guards.assert_alignment
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cpu = torch._C._dynamo.guards._empty_strided_cpu
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cpu_pinned = torch._C._dynamo.guards._empty_strided_cpu_pinned
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_xpu = torch._C._dynamo.guards._empty_strided_xpu
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_mtia = torch._C._dynamo.guards._empty_strided_mtia
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] reinterpret_tensor = torch._C._dynamo.guards._reinterpret_tensor
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] alloc_from_pool = torch.ops.inductor._alloc_from_pool
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] async_compile = AsyncCompile()
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # kernel path: /tmp/torchinductor_khushi/7l/c7l4ehujjtnbjkt52gnh3bol253wh7e3xwfox2geifl23quzc2pj.py
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Topologically Sorted Source Nodes: [getitem], Original ATen: [aten.index]
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Source node to ATen node mapping:
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   getitem => _unsafe_index_tensor
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Graph fragment:
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %randperm_default : Tensor "i64[8][1]cuda:0" = PlaceHolder[target=randperm_default]
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %arg0_1 : Tensor "f32[8, 64][64, 1]cuda:0" = PlaceHolder[target=arg0_1]
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %_unsafe_index_tensor : Tensor "f32[8, 64][64, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten._unsafe_index.Tensor](args = (%arg0_1, [%randperm_default]), kwargs = {})
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   return %_unsafe_index_tensor
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] triton_poi_fused_index_0 = async_compile.triton('triton_poi_fused_index_0', '''
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton.language as tl
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime import triton_helpers, triton_heuristics
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.triton_helpers import libdevice, math as tl_math
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.hints import AutotuneHint, ReductionHint, TileHint, DeviceProperties
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] triton_helpers.set_driver_to_gpu()
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] @triton_heuristics.pointwise(
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     size_hints={'x': 512}, 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     filename=__file__,
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     triton_meta={'signature': {'in_ptr0': '*i64', 'in_ptr1': '*fp32', 'out_ptr0': '*fp32', 'xnumel': 'i32', 'XBLOCK': 'constexpr'}, 'device': DeviceProperties(type='cuda', index=0, multi_processor_count=24, cc=89, major=8, regs_per_multiprocessor=65536, max_threads_per_multi_processor=1536, max_threads_per_block=1024, warp_size=32), 'constants': {}, 'native_matmul': False, 'enable_fp_fusion': True, 'launch_pdl': False, 'disable_ftz': False, 'configs': [{(0,): [['tt.divisibility', 16]], (1,): [['tt.divisibility', 16]], (2,): [['tt.divisibility', 16]], (3,): [['tt.divisibility', 16]]}]},
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     inductor_meta={'grid_type': 'Grid1D', 'kernel_name': 'triton_poi_fused_index_0', 'mutated_arg_names': [], 'optimize_mem': True, 'no_x_dim': False, 'atomic_add_found': False, 'num_load': 1, 'num_store': 1, 'num_reduction': 0, 'autotune_hints': set(), 'tiling_scores': {'x': 4160}, 'backend_hash': 'BBD37A68A7586A612C957949BBE12B7D9F577C36535ED4AB781705E7F9379632', 'assert_indirect_indexing': True, 'autotune_local_cache': True, 'autotune_pointwise': True, 'autotune_remote_cache': None, 'force_disable_caches': False, 'dynamic_scale_rblock': True, 'incremental_autotune': False, 'max_autotune': False, 'max_autotune_pointwise': False, 'min_split_scan_rblock': 256, 'spill_threshold': 16, 'store_cubin': False, 'deterministic': False, 'batch_invariant': False, 'force_filter_reduction_configs': False, 'mix_order_reduction_allow_multi_stages': True, 'dynamic_disable_pipelining': True, 'are_deterministic_algorithms_enabled': False},
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     min_elem_per_thread=0
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] )
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] @triton.jit
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def triton_poi_fused_index_0(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK : tl.constexpr):
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xnumel = 512
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xoffset = tl.program_id(0) * XBLOCK
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xindex = xoffset + tl.arange(0, XBLOCK)[:]
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xmask = xindex < xnumel
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x1 = xindex // 64
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x0 = (xindex % 64)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x2 = xindex
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp0 = tl.load(in_ptr0 + (x1), xmask, eviction_policy='evict_last')
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp1 = tl.full([XBLOCK], 8, tl.int32)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp2 = tmp0 + tmp1
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp3 = tmp0 < 0
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp4 = tl.where(tmp3, tmp2, tmp0)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp5 = tl.load(in_ptr1 + (x0 + 64*tmp4), xmask)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tl.store(out_ptr0 + (x2), tmp5, xmask)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] ''', device_str='cuda')
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] async_compile.wait(globals())
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] del async_compile
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] class Runner:
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def __init__(self, partitions):
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         self.partitions = partitions
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def recursively_apply_fns(self, fns):
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         new_callables = []
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         for fn, c in zip(fns, self.partitions):
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             new_callables.append(fn(c))
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         self.partitions = new_callables
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def call(self, args):
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         arg0_1, = args
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         args.clear()
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         with torch.cuda._DeviceGuard(0):
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             torch.cuda.set_device(0)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             # Topologically Sorted Source Nodes: [], Original ATen: [aten.randperm]
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf0 = torch.ops.aten.randperm.default(8, device=device(type='cuda', index=0), pin_memory=False)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf1 = buf0
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_size_stride(buf1, (8, ), (1, ), 'torch.ops.aten.randperm.default')
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_alignment(buf1, 16, 'torch.ops.aten.randperm.default')
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del buf0
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_size_stride(arg0_1, (8, 64), (64, 1), 'input')
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             arg0_1 = copy_if_misaligned(arg0_1)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf2 = empty_strided_cuda((8, 64), (64, 1), torch.float32)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             # Topologically Sorted Source Nodes: [getitem], Original ATen: [aten.index]
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             raw_stream0 = get_raw_stream(0)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             triton_poi_fused_index_0.run(buf1, arg0_1, buf2, 512, stream=raw_stream0)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del arg0_1
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del buf1
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         return (buf2, )
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] runner = Runner(partitions=[])
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] call = runner.call
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] recursively_apply_fns = runner.recursively_apply_fns
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def get_args():
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._dynamo.testing import rand_strided
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     arg0_1 = rand_strided((8, 64), (64, 1), device='cuda:0', dtype=torch.float32)
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     return [arg0_1]
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def benchmark_compiled_module(args, times=10, repeat=10):
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._inductor.utils import print_performance
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     fn = lambda: call(list(args))
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     return print_performance(fn, times=times, repeat=repeat, device='cuda')
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] if __name__ == "__main__":
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._inductor.wrapper_benchmark import compiled_module_main
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     args = get_args()
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     compiled_module_main('None', lambda times, repeat: benchmark_compiled_module(args, times=times, repeat=repeat))
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:39:28.285000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2725] [0/0] [__output_code] Output code written to: /tmp/torchinductor_khushi/u6/cu6xwh7bfojhvh7munooouypbbbhomndbuyvzdkoydgrqapnbbmj.py
V0520 02:39:28.289000 86891 /home/khushi/Documents/pytorch/torch/_inductor/runtime/triton_heuristics.py:472] [0/0] CachingAutotuner gets 1 configs for triton_poi_fused_index_0
V0520 02:39:28.289000 86891 /home/khushi/Documents/pytorch/torch/_inductor/runtime/triton_heuristics.py:478] [0/0] XBLOCK: 256, num_warps: 4, num_ctas: 1, num_stages: 1, maxnreg: None
V0520 02:39:28.289000 86891 /home/khushi/Documents/pytorch/torch/_inductor/runtime/triton_heuristics.py:488] [0/0] Triton cache dir: /tmp/torchinductor_khushi/triton/0
V0520 02:39:28.291000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2684] [0/0] Output code written to: /tmp/torchinductor_khushi/u6/cu6xwh7bfojhvh7munooouypbbbhomndbuyvzdkoydgrqapnbbmj.py
I0520 02:39:28.291000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2685] [0/0] [__output_code] Output code written to: /tmp/torchinductor_khushi/u6/cu6xwh7bfojhvh7munooouypbbbhomndbuyvzdkoydgrqapnbbmj.py
V0520 02:39:28.292000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1161] [0/0] FX codegen and compilation took 0.383s
I0520 02:39:28.292000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1188] [0/0] Overview info of inductor aten mms: 
I0520 02:39:28.292000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1189] [0/0] Name                           | B                    | M                    | N                    | K                    | Count               
I0520 02:39:28.292000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1194] [0/0] ----------------------------------------------------------------------------------------------------------------------------------
I0520 02:39:28.292000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1203] [0/0] Step 3: torchinductor done compiling FORWARDS graph 0
Out[1]: 
tensor([[-1.6436e+00,  1.0622e-01,  1.7428e+00, -1.0103e-01,  7.1950e-01,
         -6.2221e-01,  5.8616e-01, -3.6367e-01, -2.2363e-01, -4.5907e-01,
          3.9570e-01,  6.6058e-02, -2.0723e+00, -1.0310e+00, -9.1800e-03,
          2.1908e+00,  8.3099e-01, -2.8911e-01, -5.3779e-01, -1.0538e+00,
         -2.1834e+00, -1.0098e-01,  1.1330e+00,  1.9701e+00, -4.3122e-01,
         -2.0032e-01, -8.7366e-01,  6.0929e-01, -1.9127e-01,  8.8546e-01,
         -1.8130e+00, -2.4286e+00,  6.9704e-02, -1.0986e+00,  4.9885e-01,
         -3.0981e-01,  1.0371e+00, -3.4320e-01, -3.9918e-02, -3.6648e-02,
         -8.8069e-01,  1.8784e+00, -1.7915e+00,  3.1130e-01, -4.2281e-02,
         -7.7712e-01,  1.3368e+00, -9.0900e-01,  3.2094e-01,  5.9856e-01,
         -1.2997e-01,  1.4048e+00,  7.1392e-01,  1.3230e+00,  1.3128e+00,
         -2.7713e-01,  4.4289e-01,  6.9909e-01, -1.8115e+00,  1.2232e+00,
         -1.9910e+00, -4.3749e-02,  9.0988e-01, -1.3434e+00],
        [-5.9882e-01,  2.0249e-01, -2.1120e-01, -5.8591e-01,  7.5468e-02,
         -1.3582e-01, -8.7802e-01,  3.2680e-01,  8.2166e-01,  4.5903e-01,
          8.3582e-01,  1.3766e+00,  7.4810e-01,  3.2137e-01,  2.9021e-01,
          1.3580e+00, -6.0835e-01, -1.5702e-01, -4.9356e-01,  2.6731e-01,
         -7.8684e-01, -2.1183e-01,  1.5186e+00,  1.9673e+00,  4.2693e-02,
         -1.5164e+00,  1.6519e-01,  2.1237e-01,  7.7514e-01, -7.2208e-01,
          8.2687e-01,  1.2197e+00, -7.4620e-01,  6.9933e-01,  1.9548e-01,
          2.6261e-01, -7.0421e-02,  4.5029e-03,  1.3232e+00, -9.9124e-01,
         -4.7304e-01, -1.4022e+00,  5.7863e-01, -1.4684e+00, -4.4576e-01,
         -2.4633e+00, -4.2611e-01,  2.2934e-01,  1.8374e-01, -1.8824e+00,
         -1.2574e+00, -7.4460e-01, -3.5675e-01, -7.7542e-01,  8.6773e-01,
          5.7133e-01, -1.4131e+00,  5.4418e-01,  1.6669e+00,  2.2194e+00,
         -1.0996e+00, -1.7498e-01, -4.9971e-01, -7.1691e-01],
        [ 9.1292e-02, -1.2760e+00,  3.5551e-01, -3.6808e-01,  7.6616e-01,
         -1.4421e+00, -8.7550e-01,  6.5320e-01, -9.0612e-02,  7.9880e-01,
         -2.4145e-01, -1.7418e+00,  5.1069e-01,  1.2725e-01,  5.5691e-01,
         -9.3523e-01,  3.9437e-01, -9.0426e-01,  3.4239e-01, -4.9219e-01,
         -1.3359e+00, -1.0177e+00,  1.0212e+00, -4.2215e-01,  1.0047e+00,
         -7.9007e-01,  7.0367e-02, -1.3942e-01,  5.7544e-01, -1.9025e-01,
         -9.6954e-02,  1.5692e-01,  8.6522e-01, -3.8607e-01,  7.8788e-01,
          2.3280e+00, -7.3228e-01,  1.1312e+00,  2.0190e-01, -3.0165e-01,
          2.5442e-03, -6.2208e-01,  3.0012e-01,  6.9354e-01, -8.2556e-02,
         -1.9092e+00,  1.0773e-01, -7.9734e-01,  6.4899e-01, -4.5781e-01,
          1.0071e+00,  1.4891e+00, -7.8200e-01, -7.8143e-01,  5.7706e-01,
          9.0462e-01, -1.3024e+00, -4.2129e-01,  1.7057e-01, -2.1459e-01,
         -9.4154e-01, -1.6908e+00,  9.4427e-02, -9.6075e-01],
        [ 1.0639e+00, -8.1152e-01, -5.5509e-01,  2.4545e-02,  8.7304e-01,
          1.2401e+00,  5.7645e-01,  2.7150e+00,  2.2655e+00,  1.5762e-01,
         -1.6305e+00,  2.5359e-01,  5.4780e-01,  1.1439e+00,  4.9915e-02,
         -4.9130e-01,  1.3268e-01, -5.5922e-01,  2.1586e+00, -1.0826e+00,
          4.3112e-01,  1.0433e+00,  4.5392e-01,  5.5436e-03,  1.2761e+00,
         -1.0509e-01,  5.0213e-02, -6.1534e-01,  1.7686e+00, -4.0288e-01,
          5.3085e-01,  6.7210e-02,  1.6571e+00, -1.2490e+00, -1.5532e+00,
          1.4847e+00,  6.9166e-01,  3.8153e-01, -2.1910e+00, -1.3695e+00,
         -6.9521e-01, -1.4043e+00, -7.2125e-01,  6.7182e-01,  2.0258e+00,
         -2.3562e+00, -4.2852e-01, -4.5932e-01, -2.5776e+00, -9.7227e-01,
         -1.0103e+00, -1.8246e+00,  1.1049e+00,  5.9864e-01,  7.4619e-01,
          8.4727e-01, -2.5478e-01, -1.5756e-01, -4.0049e-01,  2.3274e-01,
          4.4023e-01,  7.6467e-01,  1.5482e-01,  1.7844e+00],
        [-7.1900e-01, -1.8814e+00, -9.8185e-01, -3.9345e-04, -4.9813e-01,
         -4.5134e-01,  8.5780e-01, -8.6406e-01, -1.5734e+00, -1.3018e+00,
          8.5437e-01, -1.0772e+00, -9.2442e-01,  2.1466e-01,  5.4130e-01,
          9.1744e-02,  5.3257e-02, -2.0822e+00,  8.0712e-01,  7.0969e-01,
         -4.0271e-01,  1.0193e+00,  6.7850e-01, -4.0774e-01, -1.3339e+00,
          1.1215e+00,  2.0828e+00, -9.8966e-01,  1.0273e+00, -1.5864e+00,
          6.9393e-01, -4.3168e-01, -4.1994e-02,  2.2392e+00, -7.7819e-02,
         -6.9579e-01, -5.7917e-01, -5.3686e-01,  5.0094e-01, -1.3125e+00,
         -2.5052e-01,  1.1227e-01,  1.1724e-02, -3.7216e-02,  3.4087e-01,
         -4.3126e-01,  9.0318e-01, -1.0098e+00, -5.6090e-01,  1.5787e+00,
          1.0259e-02, -7.6078e-01,  1.3961e+00,  6.5387e-01, -1.7262e+00,
         -4.6177e-01,  1.2414e+00, -2.6706e-01,  3.1275e-01,  3.4599e-01,
          2.3515e+00, -7.0205e-02, -6.3102e-01,  6.0684e-01],
        [ 5.5898e-01,  1.9341e+00,  5.8294e-01, -5.2177e-01,  1.2359e+00,
         -7.3382e-01,  3.4116e-01,  3.3759e-01, -9.4504e-01, -2.5667e+00,
         -7.2689e-01,  8.8685e-02,  4.1366e-01,  3.9431e-01, -5.7373e-01,
          1.6669e-01, -4.1324e-01,  1.2630e+00,  1.7925e+00,  2.6641e-01,
         -6.1352e-01,  1.7389e+00,  1.2796e+00,  6.2672e-01,  2.0024e-02,
          1.4546e-01, -2.0959e-01, -9.0333e-02, -3.6563e-01, -1.4117e-01,
         -1.2950e+00,  1.5122e+00, -1.7173e+00,  1.2691e-02, -7.0509e-01,
         -1.4094e+00, -7.3415e-01,  1.3374e+00, -9.3389e-01,  1.0462e+00,
          8.4779e-01, -1.1581e+00,  4.2738e-01,  8.1575e-01, -2.7845e+00,
          1.5973e+00, -1.3441e+00, -3.2234e-01,  1.6398e+00, -1.0563e+00,
          1.6026e-01,  1.3175e+00, -1.3791e-01,  4.4372e-01, -3.7824e-01,
          4.9543e-01, -1.4879e+00, -1.7925e-01, -1.1491e-01, -1.2120e+00,
          1.7623e+00, -6.8261e-01,  5.1631e-02, -3.0570e-01],
        [ 7.6012e-01, -1.1062e-01,  3.5018e-01, -5.9276e-01,  4.1986e-01,
          1.6978e+00,  3.0825e-01,  1.1387e+00,  3.2848e-01,  1.1947e-01,
         -2.8378e-01, -1.2855e+00,  1.4597e+00,  1.5689e-01,  5.8625e-01,
         -1.1965e+00, -2.1913e-01, -1.4166e-01,  9.3806e-01, -2.6019e-01,
          7.6307e-01,  4.0262e-01,  5.2779e-01, -2.1284e-01,  1.1709e-02,
          5.8055e-01,  3.8807e-01, -8.3299e-01,  9.9299e-01, -2.5857e-01,
         -1.1929e+00,  1.0769e+00, -4.2305e-01,  6.1887e-01,  2.2700e-01,
          1.1813e+00, -7.1028e-01,  1.0899e+00,  1.5522e+00,  5.5612e-01,
          1.5390e+00,  1.9559e-01,  8.5341e-01, -1.2614e-01, -4.0148e-01,
          8.4424e-01, -1.1424e+00,  1.1988e+00, -1.1553e-01, -5.8219e-01,
         -3.4923e-01,  5.0903e-01,  8.5934e-02,  1.0589e-01,  1.0227e+00,
         -1.7246e+00, -2.9805e-02, -1.7477e+00, -1.4752e-01, -2.5729e-01,
          2.7651e+00, -1.5596e+00,  7.8621e-01,  5.2596e-01],
        [ 2.6061e-01,  1.8764e+00, -9.4638e-02,  3.2766e-01, -2.5477e+00,
         -8.9244e-02,  3.4567e-01, -9.7247e-01, -1.4668e+00,  8.8096e-01,
         -2.9959e-02, -7.1897e-01, -5.0385e-01,  7.5036e-01, -5.0454e-01,
          1.3497e+00, -9.9577e-01,  1.1304e+00,  6.6073e-01,  1.3431e+00,
          7.3374e-01,  6.8765e-01, -5.6361e-01,  2.1151e+00, -6.8725e-02,
         -1.2141e+00,  9.1423e-01, -1.1935e+00, -8.3073e-01, -1.5843e+00,
          1.1659e+00, -8.2417e-01,  2.9419e+00, -2.2776e+00,  3.2789e-01,
         -4.8789e-01,  6.4055e-01, -2.2553e-01,  2.8882e-01,  1.5303e+00,
         -8.1646e-01, -4.5825e-01,  2.0017e+00,  1.0298e+00, -1.2447e+00,
         -8.0152e-01,  2.6524e-02, -4.6716e-01,  6.0653e-02, -1.2286e-02,
         -1.6694e+00,  2.2709e+00,  2.4096e+00,  7.7605e-01,  9.2910e-01,
          1.6353e-02, -1.2877e+00, -7.2485e-02,  1.5066e+00,  4.5107e-01,
          1.4000e+00,  1.0690e+00, -3.0480e-02, -2.9547e-01]], device='cuda:0')
```

</p>
</details>

<details>
<summary>test_randperm_index_with_slice</summary>

<p>

```python
In [2]: import torch
   ...: import torch._logging
   ...: import logging
   ...: 
   ...: torch._dynamo.reset()
   ...: torch._inductor.config.fx_graph_cache = False
   ...: 
   ...: torch._logging.set_logs(graph_code=True, output_code=True, inductor=logging.DEBUG)
   ...: 
   ...: @torch.compile
   ...: def fn(x):
   ...:     idx = torch.randperm(x.shape[0], device=x.device)[:7]
   ...:     return x[idx]
   ...: 
   ...: fn(torch.randn(8, 64, device="cuda"))
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] TRACED GRAPH
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]  ===== __compiled_fn_3_67462509_d2f7_4ee5_bd85_2c361d75bbc4 =====
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class GraphModule(torch.nn.Module):
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]     def forward(self, L_x_: "f32[8, 64][64, 1]cuda:0"):
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         l_x_ = L_x_
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         # File: <ipython-input-2-263b121b155c>:12 in fn, code: idx = torch.randperm(x.shape[0], device=x.device)[:7]
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         randperm: "i64[8][1]cuda:0" = torch.randperm(8, device = device(type='cuda', index=0))
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         idx: "i64[7][1]cuda:0" = randperm[slice(None, 7, None)];  randperm = None
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         # File: <ipython-input-2-263b121b155c>:13 in fn, code: return x[idx]
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         getitem_1: "f32[7, 64][64, 1]cuda:0" = l_x_[idx];  l_x_ = idx = None
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         return (getitem_1,)
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:43:23.551000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] TRACED GRAPH
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]  ===== BEFORE PRE GRAD =====
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class GraphModule(torch.nn.Module):
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]     def forward(self, L_x_: "f32[8, 64][64, 1]cuda:0"):
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         l_x_ = L_x_
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         # File: <ipython-input-2-263b121b155c>:12 in fn, code: idx = torch.randperm(x.shape[0], device=x.device)[:7]
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         randperm: "i64[8][1]cuda:0" = torch.randperm(8, device = device(type='cuda', index=0))
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         idx: "i64[7][1]cuda:0" = randperm[slice(None, 7, None)];  randperm = None
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         # File: <ipython-input-2-263b121b155c>:13 in fn, code: return x[idx]
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         getitem_1: "f32[7, 64][64, 1]cuda:0" = l_x_[idx];  l_x_ = idx = None
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         return (getitem_1,)
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:43:23.559000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:43:23.579000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:942] [0/0] FX cache status: use_cache=False, local=False, remote=False, aot_mode=False, force_disable_caches=False
V0520 02:43:23.579000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1030] [0/0] FX cache bypass reason: FX cache disabled or key generation failed
I0520 02:43:23.579000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1300] [0/0] Step 3: torchinductor compiling FORWARDS graph 1
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] TRACED GRAPH
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]  ===== AFTER POST GRAD =====
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class <lambda>(torch.nn.Module):
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]     def forward(self, arg0_1: "f32[8, 64][64, 1]cuda:0"):
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         # No stacktrace found for following nodes
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         randperm_default: "i64[8][1]cuda:0" = torch.ops.aten.randperm.default(8, device = device(type='cuda', index=0), pin_memory = False)
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         # File: <ipython-input-2-263b121b155c>:12 in fn, code: idx = torch.randperm(x.shape[0], device=x.device)[:7]
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         slice_tensor: "i64[7][1]cuda:0" = torch.ops.aten.slice.Tensor(randperm_default, 0, 0, 7);  randperm_default = None
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         # File: <ipython-input-2-263b121b155c>:13 in fn, code: return x[idx]
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         _unsafe_index_tensor: "f32[7, 64][64, 1]cuda:0" = torch.ops.aten._unsafe_index.Tensor(arg0_1, [slice_tensor]);  arg0_1 = slice_tensor = None
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         return (_unsafe_index_tensor,)
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:43:23.583000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:43:23.596000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %arg0_1 : [num_users=1] = placeholder[target=arg0_1] 
V0520 02:43:23.597000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %randperm_default : [num_users=1] = call_function[target=torch.ops.aten.randperm.default](args = (8,), kwargs = {device: cuda:0, pin_memory: False}) 
V0520 02:43:23.597000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1422] [0/0]   via <function fallback_handler.<locals>.handler at 0x7b2964522140>
V0520 02:43:23.598000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %slice_tensor : [num_users=1] = call_function[target=torch.ops.aten.slice.Tensor](args = (%randperm_default, 0, 0, 7), kwargs = {}) 
V0520 02:43:23.598000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1422] [0/0]   via <function slice_ at 0x7b29644e1fe0>
V0520 02:43:23.599000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %_unsafe_index_tensor : [num_users=1] = call_function[target=torch.ops.aten._unsafe_index.Tensor](args = (%arg0_1, [%slice_tensor]), kwargs = {}) 
V0520 02:43:23.599000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1422] [0/0]   via <function _unsafe_index at 0x7b29643524b0>
V0520 02:43:23.600000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering return (_unsafe_index_tensor,) 
V0520 02:43:23.600000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1679] [0/0] Force channels last inputs for 0 conv for the current graph with id 1
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling FallbackKernel(
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name='torch.ops.aten.randperm.default',
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   name=buf0,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   layout=MultiOutputLayout(device=device(type='cuda', index=0)),
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   inputs=[],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   constant_args=(8, device(type='cuda', index=0), False),
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwargs={'device': device(type='cuda', index=0), 'pin_memory': False},
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   output_view=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=torch.ops.aten.randperm.default,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   cpp_kernel_name=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ordered_kwargs_for_cpp_kernel=['dtype', 'layout', 'device', 'pin_memory'],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   op_overload=aten.randperm.default,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   arg_properties=[{'name': 'n', 'type': int, 'default_value': None}],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   allarg_properties={'n': {'type': int, 'default_value': None}, 'dtype': {'type': Optional[ScalarType], 'default_value': 4}, 'layout': {'type': Optional[Layout], 'default_value': None}, 'device': {'type': Optional[Device], 'default_value': None}, 'pin_memory': {'type': Optional[bool], 'default_value': None}},
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwarg_properties=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   unbacked_bindings={},
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   mutation_outputs=[],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=randperm_default,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([randperm_default])
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] )
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling MultiOutput(
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   name=buf1,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   layout=FixedLayout('cuda:0', torch.int64, size=[8], stride=[1]),
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   inputs=[FallbackKernel(
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     python_kernel_name='torch.ops.aten.randperm.default',
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     name=buf0,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     layout=MultiOutputLayout(device=device(type='cuda', index=0)),
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     inputs=[],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     constant_args=(8, device(type='cuda', index=0), False),
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     kwargs={'device': device(type='cuda', index=0), 'pin_memory': False},
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     output_view=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     python_kernel_name=torch.ops.aten.randperm.default,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     cpp_kernel_name=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     ordered_kwargs_for_cpp_kernel=['dtype', 'layout', 'device', 'pin_memory'],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     op_overload=aten.randperm.default,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     arg_properties=[{'name': 'n', 'type': int, 'default_value': None}],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     allarg_properties={'n': {'type': int, 'default_value': None}, 'dtype': {'type': Optional[ScalarType], 'default_value': 4}, 'layout': {'type': Optional[Layout], 'default_value': None}, 'device': {'type': Optional[Device], 'default_value': None}, 'pin_memory': {'type': Optional[bool], 'default_value': None}},
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     kwarg_properties=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     unbacked_bindings={},
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     mutation_outputs=[],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     origin_node=randperm_default,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     origins=OrderedSet([randperm_default])
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   )],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   constant_args=(),
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwargs={},
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   output_view=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   cpp_kernel_name=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ordered_kwargs_for_cpp_kernel=(),
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   op_overload=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   arg_properties=[{}],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   allarg_properties={},
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwarg_properties=None,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   unbacked_bindings={},
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   mutation_outputs=[],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=randperm_default,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([randperm_default])
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] )
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling ComputedBuffer(name='buf2', layout=FixedLayout('cuda:0', torch.float32, size=[7, 64], stride=[64, 1]), data=Pointwise(
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   'cuda',
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   torch.float32,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   def inner_fn(index):
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       i0, i1 = index
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       tmp0 = ops.load(buf1, i0)
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       tmp1 = ops.load(arg0_1, i1 + 64 * tmp0)
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       return tmp1
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ranges=[7, 64],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=_unsafe_index_tensor,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([_unsafe_index_tensor, slice_tensor]),
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   stack_traces = {,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     File "<ipython-input-2-263b121b155c>", line 13, in fn,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       return x[idx],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]              ~^^^^^,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   },
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   stack_traces = {,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     File "<ipython-input-2-263b121b155c>", line 12, in fn,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       idx = torch.randperm(x.shape[0], device=x.device)[:7],
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   }
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
V0520 02:43:23.603000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4493] [0/0] scheduling output buf2
I0520 02:43:23.605000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1015] [0/0] Reordering for peak memory -- 3 nodes
I0520 02:43:23.606000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1049] [0/0] Baseline peak memory: 1856
I0520 02:43:23.606000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_lpmf peak memory: 1856
I0520 02:43:23.606000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_bfs peak memory: 1856
I0520 02:43:23.606000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_dfs peak memory: 1856
V0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8894] [0/0] [__cudagraphs] Created 1 graph partitions: 0 cudagraphable, 1 non-cudagraphable
V0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8901] [0/0] [__cudagraphs]   Partition 0: 3 nodes, non-cudagraphable, inputs=1, outputs=1
V0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op0: reason=partition includes all ops when cudagraphs is disabled, ir=FallbackKernel, fx=aten.randperm.default(8)
V0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op1: reason=partition includes all ops when cudagraphs is disabled, ir=MultiOutput, fx=aten.randperm.default(8)
V0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op2: reason=partition includes all ops when cudagraphs is disabled, ir=ComputedBuffer, fx=aten._unsafe_index.Tensor(arg0_1, [slice_tensor])
V0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]          File "<ipython-input-2-263b121b155c>", line 13, in fn
V0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]              return x[idx]
V0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]                     ~^^^^^
I0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/analysis/device_info.py:221] [0/0] Device NVIDIA GeForce RTX 4060 Laptop GPU not in datasheet, returning None
V0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op0 with estimated runtime 0.000000
I0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/analysis/device_info.py:221] [0/0] Device NVIDIA GeForce RTX 4060 Laptop GPU not in datasheet, returning None
V0520 02:43:23.608000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op1 with estimated runtime 0.000000
V0520 02:43:23.609000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op2 with estimated runtime 0.000014
V0520 02:43:23.611000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0] get_bounds:
V0520 02:43:23.611000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0] graph():
V0520 02:43:23.611000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %ops : [num_users=3] = placeholder[target=ops]
V0520 02:43:23.611000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index : [num_users=1] = call_module[target=get_index](args = (index0,), kwargs = {})
V0520 02:43:23.611000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %load : [num_users=1] = call_method[target=load](args = (%ops, buf1, %get_index), kwargs = {})
V0520 02:43:23.611000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %set_indirect0 : [num_users=0] = call_module[target=set_indirect0](args = (%load,), kwargs = {})
V0520 02:43:23.611000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index_1 : [num_users=1] = call_module[target=get_index](args = (index1,), kwargs = {})
V0520 02:43:23.611000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %load_1 : [num_users=1] = call_method[target=load](args = (%ops, arg0_1, %get_index_1), kwargs = {})
V0520 02:43:23.611000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index_2 : [num_users=1] = call_module[target=get_index](args = (index2,), kwargs = {})
V0520 02:43:23.611000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %store : [num_users=1] = call_method[target=store](args = (%ops, buf2, %get_index_2, %load_1, None), kwargs = {})
V0520 02:43:23.611000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     return store
V0520 02:43:23.612000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:43:23.613000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:43:23.614000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:43:23.615000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/simd.py:2096] [0/0] Generating kernel code with kernel_name: triton_poi_fused_index_slice_0
V0520 02:43:23.616000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2605] [0/0] Finished codegen for all nodes. The list of kernel names available: OrderedSet([])
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] Output code: 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # AOT ID: ['1_inference']
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from ctypes import c_void_p, c_long, c_int
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import torch
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import math
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import random
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import os
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import tempfile
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from math import inf, nan
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from cmath import nanj
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.hooks import run_intermediate_hooks
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.utils import maybe_profile
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.codegen.memory_planning import _align as align
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch import device, empty_strided
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.async_compile import AsyncCompile
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.select_algorithm import extern_kernels
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._C._dynamo.guards import copy_if_misaligned
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton.language as tl
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.triton_heuristics import start_graph, end_graph
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._C import _cuda_getCurrentRawStream as get_raw_stream
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] aten = torch.ops.aten
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] inductor_ops = torch.ops.inductor
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] _quantized = torch.ops._quantized
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] assert_size_stride = torch._C._dynamo.guards.assert_size_stride
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] assert_alignment = torch._C._dynamo.guards.assert_alignment
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cpu = torch._C._dynamo.guards._empty_strided_cpu
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cpu_pinned = torch._C._dynamo.guards._empty_strided_cpu_pinned
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_xpu = torch._C._dynamo.guards._empty_strided_xpu
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_mtia = torch._C._dynamo.guards._empty_strided_mtia
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] reinterpret_tensor = torch._C._dynamo.guards._reinterpret_tensor
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] alloc_from_pool = torch.ops.inductor._alloc_from_pool
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] async_compile = AsyncCompile()
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # kernel path: /tmp/torchinductor_khushi/dm/cdm22ffts7ew44gr5uponwzirauriwdjue67xz6fi4jckaq7lenr.py
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Topologically Sorted Source Nodes: [idx, getitem_1], Original ATen: [aten.slice, aten.index]
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Source node to ATen node mapping:
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   getitem_1 => _unsafe_index_tensor
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   idx => slice_tensor
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Graph fragment:
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %randperm_default : Tensor "i64[8][1]cuda:0" = PlaceHolder[target=randperm_default]
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %arg0_1 : Tensor "f32[8, 64][64, 1]cuda:0" = PlaceHolder[target=arg0_1]
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %slice_tensor : Tensor "i64[7][1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.slice.Tensor](args = (%randperm_default, 0, 0, 7), kwargs = {})
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %_unsafe_index_tensor : Tensor "f32[7, 64][64, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten._unsafe_index.Tensor](args = (%arg0_1, [%slice_tensor]), kwargs = {})
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   return %_unsafe_index_tensor
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] triton_poi_fused_index_slice_0 = async_compile.triton('triton_poi_fused_index_slice_0', '''
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton.language as tl
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime import triton_helpers, triton_heuristics
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.triton_helpers import libdevice, math as tl_math
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.hints import AutotuneHint, ReductionHint, TileHint, DeviceProperties
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] triton_helpers.set_driver_to_gpu()
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] @triton_heuristics.pointwise(
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     size_hints={'x': 512}, 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     filename=__file__,
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     triton_meta={'signature': {'in_ptr0': '*i64', 'in_ptr1': '*fp32', 'out_ptr0': '*fp32', 'xnumel': 'i32', 'XBLOCK': 'constexpr'}, 'device': DeviceProperties(type='cuda', index=0, multi_processor_count=24, cc=89, major=8, regs_per_multiprocessor=65536, max_threads_per_multi_processor=1536, max_threads_per_block=1024, warp_size=32), 'constants': {}, 'native_matmul': False, 'enable_fp_fusion': True, 'launch_pdl': False, 'disable_ftz': False, 'configs': [{(0,): [['tt.divisibility', 16]], (1,): [['tt.divisibility', 16]], (2,): [['tt.divisibility', 16]], (3,): [['tt.divisibility', 16]]}]},
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     inductor_meta={'grid_type': 'Grid1D', 'kernel_name': 'triton_poi_fused_index_slice_0', 'mutated_arg_names': [], 'optimize_mem': True, 'no_x_dim': False, 'atomic_add_found': False, 'num_load': 1, 'num_store': 1, 'num_reduction': 0, 'autotune_hints': set(), 'tiling_scores': {'x': 3640}, 'backend_hash': 'BBD37A68A7586A612C957949BBE12B7D9F577C36535ED4AB781705E7F9379632', 'assert_indirect_indexing': True, 'autotune_local_cache': True, 'autotune_pointwise': True, 'autotune_remote_cache': None, 'force_disable_caches': False, 'dynamic_scale_rblock': True, 'incremental_autotune': False, 'max_autotune': False, 'max_autotune_pointwise': False, 'min_split_scan_rblock': 256, 'spill_threshold': 16, 'store_cubin': False, 'deterministic': False, 'batch_invariant': False, 'force_filter_reduction_configs': False, 'mix_order_reduction_allow_multi_stages': True, 'dynamic_disable_pipelining': True, 'are_deterministic_algorithms_enabled': False},
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     min_elem_per_thread=0
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] )
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] @triton.jit
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def triton_poi_fused_index_slice_0(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK : tl.constexpr):
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xnumel = 448
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xoffset = tl.program_id(0) * XBLOCK
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xindex = xoffset + tl.arange(0, XBLOCK)[:]
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xmask = xindex < xnumel
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x1 = xindex // 64
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x0 = (xindex % 64)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x2 = xindex
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp0 = tl.load(in_ptr0 + (x1), xmask, eviction_policy='evict_last')
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp1 = tl.full([XBLOCK], 8, tl.int32)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp2 = tmp0 + tmp1
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp3 = tmp0 < 0
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp4 = tl.where(tmp3, tmp2, tmp0)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp5 = tl.load(in_ptr1 + (x0 + 64*tmp4), xmask)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tl.store(out_ptr0 + (x2), tmp5, xmask)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] ''', device_str='cuda')
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] async_compile.wait(globals())
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] del async_compile
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] class Runner:
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def __init__(self, partitions):
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         self.partitions = partitions
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def recursively_apply_fns(self, fns):
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         new_callables = []
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         for fn, c in zip(fns, self.partitions):
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             new_callables.append(fn(c))
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         self.partitions = new_callables
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def call(self, args):
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         arg0_1, = args
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         args.clear()
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         with torch.cuda._DeviceGuard(0):
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             torch.cuda.set_device(0)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             # Topologically Sorted Source Nodes: [], Original ATen: [aten.randperm]
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf0 = torch.ops.aten.randperm.default(8, device=device(type='cuda', index=0), pin_memory=False)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf1 = buf0
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_size_stride(buf1, (8, ), (1, ), 'torch.ops.aten.randperm.default')
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_alignment(buf1, 16, 'torch.ops.aten.randperm.default')
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del buf0
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_size_stride(arg0_1, (8, 64), (64, 1), 'input')
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             arg0_1 = copy_if_misaligned(arg0_1)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf2 = empty_strided_cuda((7, 64), (64, 1), torch.float32)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             # Topologically Sorted Source Nodes: [idx, getitem_1], Original ATen: [aten.slice, aten.index]
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             raw_stream0 = get_raw_stream(0)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             triton_poi_fused_index_slice_0.run(buf1, arg0_1, buf2, 448, stream=raw_stream0)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del arg0_1
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del buf1
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         return (buf2, )
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] runner = Runner(partitions=[])
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] call = runner.call
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] recursively_apply_fns = runner.recursively_apply_fns
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def get_args():
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._dynamo.testing import rand_strided
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     arg0_1 = rand_strided((8, 64), (64, 1), device='cuda:0', dtype=torch.float32)
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     return [arg0_1]
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def benchmark_compiled_module(args, times=10, repeat=10):
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._inductor.utils import print_performance
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     fn = lambda: call(list(args))
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     return print_performance(fn, times=times, repeat=repeat, device='cuda')
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] if __name__ == "__main__":
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._inductor.wrapper_benchmark import compiled_module_main
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     args = get_args()
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     compiled_module_main('None', lambda times, repeat: benchmark_compiled_module(args, times=times, repeat=repeat))
V0520 02:43:23.617000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:43:23.618000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2725] [0/0] [__output_code] Output code written to: /tmp/torchinductor_khushi/dj/cdjzvapwr5tda5zggxk4fdxkmzjs4qrqfkslz3u4vnw5stpv2xtr.py
V0520 02:43:23.652000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2684] [0/0] Output code written to: /tmp/torchinductor_khushi/dj/cdjzvapwr5tda5zggxk4fdxkmzjs4qrqfkslz3u4vnw5stpv2xtr.py
I0520 02:43:23.652000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2685] [0/0] [__output_code] Output code written to: /tmp/torchinductor_khushi/dj/cdjzvapwr5tda5zggxk4fdxkmzjs4qrqfkslz3u4vnw5stpv2xtr.py
V0520 02:43:23.652000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1161] [0/0] FX codegen and compilation took 0.074s
I0520 02:43:23.652000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1188] [0/0] Overview info of inductor aten mms: 
I0520 02:43:23.652000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1189] [0/0] Name                           | B                    | M                    | N                    | K                    | Count               
I0520 02:43:23.652000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1194] [0/0] ----------------------------------------------------------------------------------------------------------------------------------
I0520 02:43:23.652000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1203] [0/0] Step 3: torchinductor done compiling FORWARDS graph 1
Out[2]: 
tensor([[-1.4185e-03,  1.2501e+00,  1.3123e-01,  9.4274e-01, -8.9212e-02,
          1.2295e+00,  5.2813e-01, -1.2843e-01, -6.1491e-01,  8.2379e-01,
          9.1446e-01,  1.2320e+00,  2.4956e-01, -1.5349e+00,  6.8879e-01,
         -9.9463e-01, -7.1307e-01, -4.5211e-02, -3.6309e-01, -1.4069e+00,
          6.7491e-01, -4.3638e-01, -1.9516e-02, -2.6601e-01, -1.1397e+00,
          8.2332e-01, -1.2420e+00,  1.3629e+00, -5.7200e-01, -1.0751e+00,
          5.0382e-01,  1.1096e-01, -2.8571e+00, -1.5176e+00, -2.7564e-01,
          5.6217e-01,  1.4862e+00,  1.0901e+00, -1.3800e+00, -1.0620e+00,
          4.2960e-01, -3.0300e-01,  6.5218e-01, -4.8543e-01,  1.2997e+00,
          1.0730e+00, -2.5631e-01,  1.1096e+00,  1.1584e+00, -7.6724e-01,
         -1.3215e-02,  4.6914e-01, -1.3331e+00, -4.3870e-01, -1.7566e+00,
         -2.2790e-02,  1.7051e-01,  5.7277e-01, -8.4505e-01, -5.2230e-01,
         -1.6539e-01, -1.0402e+00, -1.5710e+00, -1.1727e-01],
        [ 3.3014e-01,  4.6254e-01,  6.8147e-01,  2.8404e-02,  2.4006e-01,
          1.4039e+00, -2.6236e-01,  1.2462e+00,  1.2239e+00, -4.9454e-01,
         -8.6597e-02,  1.3231e-01,  1.7361e-01, -8.2358e-01,  5.2642e-01,
          2.1722e-01, -4.6266e-01, -1.0695e+00,  8.6407e-01, -4.7819e-02,
         -1.7769e+00, -7.8517e-01,  5.0383e-01,  2.6198e-01, -1.1507e+00,
         -7.1523e-01,  7.4697e-01,  1.2158e+00, -4.4794e-01,  4.6388e-01,
          5.1182e-01, -3.8147e-02,  1.2295e-01, -1.2278e+00, -1.0767e+00,
         -2.2502e-01,  2.4227e+00,  2.1492e+00,  6.3286e-01,  1.0179e+00,
         -1.1860e+00, -9.5971e-01,  8.1599e-01,  2.1460e+00,  3.3367e-01,
         -6.3279e-01, -4.9280e-01,  1.2616e+00,  1.7616e+00, -1.7166e+00,
         -2.3092e-01,  1.7170e+00,  1.5574e+00,  1.2564e-01, -3.7963e-01,
          1.1320e+00,  1.6425e+00,  1.2199e-01,  8.1076e-01,  1.7048e+00,
         -2.1727e-01,  2.0057e-02, -4.2815e-02, -1.3230e-01],
        [-3.2888e-01,  1.1588e+00, -1.9466e+00,  8.4053e-02, -1.0858e+00,
         -3.6797e-01,  1.7123e+00,  9.9609e-01,  2.3814e+00, -1.3109e+00,
         -4.8110e-01,  1.8181e+00,  6.6536e-01,  2.3739e-01, -1.5450e+00,
         -1.0235e+00, -1.1300e-01,  1.5222e+00,  6.8885e-01, -1.4257e-01,
          7.4956e-01,  6.0353e-01, -7.5444e-01,  9.7280e-01, -9.6165e-01,
         -8.1266e-01, -8.9607e-01,  7.3581e-01,  9.2799e-01, -1.6470e+00,
          3.2349e-01,  7.0905e-02,  1.3958e+00, -1.3586e-01,  2.9156e-01,
          3.7812e-03,  3.6384e-01,  1.3257e+00, -1.0058e+00, -2.0419e+00,
          1.2207e+00, -1.2316e-01, -1.0200e-01, -1.0396e+00,  7.4144e-01,
         -9.6579e-01,  1.4957e-01, -1.1880e+00, -1.4993e+00, -6.4602e-01,
         -8.6047e-01,  4.5082e-01,  3.2866e-01, -1.6757e+00, -5.6934e-01,
          7.0967e-01, -2.7298e-01, -2.3918e+00, -8.3632e-02,  1.4800e+00,
          9.2196e-01, -2.9221e-01, -7.6085e-02, -6.3821e-01],
        [-6.2028e-01, -4.7445e-01, -1.3330e-01, -6.7086e-01, -1.6090e+00,
          1.1407e+00, -2.3395e-01, -1.0148e+00,  7.2476e-01, -7.9778e-01,
         -1.4323e+00,  2.2765e+00,  8.5049e-01, -4.3920e-01,  5.4343e-01,
         -6.3804e-01, -1.2308e+00,  4.5543e-01,  7.5027e-01, -1.7216e+00,
          7.6370e-01, -3.9801e-01, -5.1330e-01,  4.9260e-01,  5.6837e-01,
          3.6315e-01,  5.7241e-01,  3.1790e+00, -7.5480e-01,  8.3408e-02,
         -4.7607e-02, -6.7366e-01, -2.2193e-01,  6.8699e-01, -1.3982e-01,
         -2.9093e-01,  1.2092e+00, -4.7139e-01, -5.1414e-01, -5.9560e-01,
         -9.4689e-01,  1.7140e+00, -1.9729e+00,  9.7839e-01, -3.3446e-01,
          2.4993e-01, -1.0966e+00, -9.4421e-01, -1.1552e+00,  8.6438e-01,
         -1.2733e-01, -5.7213e-02, -2.8586e-01, -3.8882e-01, -2.6081e-01,
         -6.8789e-01,  1.5095e+00,  1.2203e+00, -4.8114e-01, -2.2190e+00,
          3.4981e-01, -1.5332e+00,  8.9756e-02, -1.1866e+00],
        [-1.9271e-02, -2.2372e-02, -8.6092e-01, -7.7398e-01, -8.9760e-01,
         -8.0412e-01,  1.1324e+00,  9.3247e-01, -1.4091e-01,  4.7503e-01,
         -3.2785e-01, -9.8207e-01,  1.5122e+00, -5.7220e-01, -1.5879e-01,
         -5.1464e-01, -5.8076e-01, -6.5024e-01,  2.9227e-01,  1.4765e-01,
         -7.5821e-01, -1.5253e-01,  7.6401e-01,  4.4840e-02, -1.1003e+00,
         -8.8148e-01,  2.2643e+00, -1.3123e+00,  1.4681e+00, -9.3499e-02,
          1.3421e+00, -1.8506e+00, -7.7199e-01, -2.1039e+00, -6.8469e-02,
         -8.9563e-01, -1.0094e+00, -1.3869e+00, -1.3861e-01, -1.7071e+00,
          2.9794e-01, -2.7610e+00, -1.8581e-01, -5.6504e-01,  7.3764e-01,
          1.5791e+00, -2.8762e-01, -1.5334e+00,  2.5259e-01,  7.2631e-01,
          1.3593e+00,  7.1690e-01,  6.8850e-01, -2.3602e-01, -6.4838e-01,
         -2.8004e-01,  6.2083e-02,  1.5288e+00,  2.6655e+00, -6.1681e-01,
         -8.7128e-01,  2.1123e-01,  8.3726e-02,  3.6888e-01],
        [-8.1697e-01,  1.7379e+00, -2.3612e-01,  5.0333e-01,  8.6852e-01,
         -1.6776e+00,  6.3356e-02,  1.1115e+00, -6.9453e-01,  1.0370e+00,
          4.4888e-02,  4.0762e-01, -1.4589e-02,  2.5099e+00, -1.6073e+00,
          5.6530e-01, -1.3969e-01,  7.9571e-01, -1.6996e-01,  2.0731e+00,
          5.8717e-02,  1.0819e+00,  4.8890e-01, -3.9287e-01,  4.6153e-01,
          1.1292e+00, -1.4873e+00,  4.7951e-02,  9.4574e-01,  1.6052e+00,
         -3.9205e-01, -9.8329e-01,  1.3171e+00, -3.2831e-01, -6.4740e-01,
          1.1989e+00,  9.7258e-01,  1.7405e+00, -3.5521e-02,  7.1816e-01,
         -1.5887e+00, -1.0430e+00,  4.9404e-01,  1.1243e+00, -5.7798e-01,
         -8.2696e-01, -1.4149e+00, -1.2386e-01,  1.9223e+00, -3.4176e-01,
          3.2182e-01,  1.2221e-01, -1.1284e+00,  7.5637e-01, -4.5926e-01,
          3.9903e-01,  1.4080e+00,  7.7052e-01,  9.0067e-01, -1.0973e+00,
         -1.2020e+00,  1.7463e+00,  4.9070e-01,  2.4632e-01],
        [-6.8958e-01, -1.0234e-02,  6.1448e-01, -2.6740e-01,  1.3881e-01,
         -1.2629e+00, -1.5940e+00,  1.2220e+00, -5.6400e-01, -1.6013e+00,
          3.9569e-01, -5.9289e-03, -7.1269e-02,  1.6977e+00,  1.9375e+00,
          8.0529e-02, -6.1403e-01,  1.5761e-01, -4.5134e-01, -7.9401e-01,
          3.4205e-01, -2.0516e+00, -1.2060e+00,  2.0137e+00,  4.2743e-01,
          1.7869e+00,  1.0712e+00,  1.7349e+00,  3.0044e-01, -3.1430e+00,
          5.8581e-01, -1.8187e+00, -1.2262e+00,  1.7110e+00, -3.1078e-01,
         -5.8491e-01,  1.2149e-02, -1.8884e-01, -1.1134e+00,  7.8599e-01,
         -8.8032e-02, -9.9746e-03, -1.6686e-01, -4.3904e-01, -9.9259e-01,
         -1.1922e+00,  8.3362e-01, -1.7717e-01, -2.5430e+00,  2.2635e-01,
          1.3364e-01,  1.3578e+00, -8.2049e-01,  7.0159e-01, -1.4733e+00,
         -3.1936e-01,  1.7123e-01, -7.2151e-02,  8.7017e-01,  1.2262e+00,
          8.1223e-01,  2.2939e-01, -8.2625e-01, -2.0993e-01]], device='cuda:0')
```

</p>
</details>

<details>
<summary>test_randperm_index_slice_range</summary>

<p>

```python
In [3]: import torch
   ...: import torch._logging
   ...: import logging
   ...: 
   ...: torch._dynamo.reset()
   ...: torch._inductor.config.fx_graph_cache = False
   ...: 
   ...: torch._logging.set_logs(graph_code=True, output_code=True, inductor=logging.DEBUG)
   ...: 
   ...: @torch.compile
   ...: def fn(x):
   ...:     idx = torch.randperm(x.shape[0], device=x.device)
   ...:     return x[idx[2:6]]
   ...: 
   ...: fn(torch.randn(8, 64, device="cuda"))
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] TRACED GRAPH
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]  ===== __compiled_fn_5_0cb28a70_73e9_478f_84e5_30458b63db96 =====
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class GraphModule(torch.nn.Module):
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]     def forward(self, L_x_: "f32[8, 64][64, 1]cuda:0"):
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         l_x_ = L_x_
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         # File: <ipython-input-3-79b77fea9450>:12 in fn, code: idx = torch.randperm(x.shape[0], device=x.device)
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         idx: "i64[8][1]cuda:0" = torch.randperm(8, device = device(type='cuda', index=0))
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         # File: <ipython-input-3-79b77fea9450>:13 in fn, code: return x[idx[2:6]]
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         getitem: "i64[4][1]cuda:0" = idx[slice(2, 6, None)];  idx = None
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         getitem_1: "f32[4, 64][64, 1]cuda:0" = l_x_[getitem];  l_x_ = getitem = None
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         return (getitem_1,)
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:44:45.224000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] TRACED GRAPH
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]  ===== BEFORE PRE GRAD =====
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class GraphModule(torch.nn.Module):
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]     def forward(self, L_x_: "f32[8, 64][64, 1]cuda:0"):
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         l_x_ = L_x_
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         # File: <ipython-input-3-79b77fea9450>:12 in fn, code: idx = torch.randperm(x.shape[0], device=x.device)
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         idx: "i64[8][1]cuda:0" = torch.randperm(8, device = device(type='cuda', index=0))
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         # File: <ipython-input-3-79b77fea9450>:13 in fn, code: return x[idx[2:6]]
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         getitem: "i64[4][1]cuda:0" = idx[slice(2, 6, None)];  idx = None
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         getitem_1: "f32[4, 64][64, 1]cuda:0" = l_x_[getitem];  l_x_ = getitem = None
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         return (getitem_1,)
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:44:45.232000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:44:45.248000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:942] [0/0] FX cache status: use_cache=False, local=False, remote=False, aot_mode=False, force_disable_caches=False
V0520 02:44:45.248000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1030] [0/0] FX cache bypass reason: FX cache disabled or key generation failed
I0520 02:44:45.248000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1300] [0/0] Step 3: torchinductor compiling FORWARDS graph 2
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] TRACED GRAPH
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]  ===== AFTER POST GRAD =====
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class <lambda>(torch.nn.Module):
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]     def forward(self, arg0_1: "f32[8, 64][64, 1]cuda:0"):
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         # File: <ipython-input-3-79b77fea9450>:12 in fn, code: idx = torch.randperm(x.shape[0], device=x.device)
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         randperm: "i64[8][1]cuda:0" = torch.ops.aten.randperm.default(8, device = device(type='cuda', index=0), pin_memory = False)
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         # File: <ipython-input-3-79b77fea9450>:13 in fn, code: return x[idx[2:6]]
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         slice_1: "i64[4][1]cuda:0" = torch.ops.aten.slice.Tensor(randperm, 0, 2, 6);  randperm = None
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         index: "f32[4, 64][64, 1]cuda:0" = torch.ops.aten.index.Tensor(arg0_1, [slice_1]);  arg0_1 = slice_1 = None
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         return (index,)
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:44:45.254000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:44:45.303000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %arg0_1 : [num_users=1] = placeholder[target=arg0_1] 
V0520 02:44:45.304000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %randperm : [num_users=1] = call_function[target=torch.ops.aten.randperm.default](args = (8,), kwargs = {device: cuda:0, pin_memory: False}) 
V0520 02:44:45.304000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1422] [0/0]   via <function fallback_handler.<locals>.handler at 0x7b2964522140>
V0520 02:44:45.305000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %slice_1 : [num_users=1] = call_function[target=torch.ops.aten.slice.Tensor](args = (%randperm, 0, 2, 6), kwargs = {}) 
V0520 02:44:45.305000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1422] [0/0]   via <function slice_ at 0x7b29644e1fe0>
V0520 02:44:45.306000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %index : [num_users=1] = call_function[target=torch.ops.aten.index.Tensor](args = (%arg0_1, [%slice_1]), kwargs = {}) 
V0520 02:44:45.306000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1422] [0/0]   via <function index at 0x7b2964352350>
V0520 02:44:45.306000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering return (index,) 
V0520 02:44:45.307000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1679] [0/0] Force channels last inputs for 0 conv for the current graph with id 2
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling FallbackKernel(
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name='torch.ops.aten.randperm.default',
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   name=buf0,
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   layout=MultiOutputLayout(device=device(type='cuda', index=0)),
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   inputs=[],
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   constant_args=(8, device(type='cuda', index=0), False),
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwargs={'device': device(type='cuda', index=0), 'pin_memory': False},
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   output_view=None,
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=torch.ops.aten.randperm.default,
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   cpp_kernel_name=None,
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ordered_kwargs_for_cpp_kernel=['dtype', 'layout', 'device', 'pin_memory'],
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   op_overload=aten.randperm.default,
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   arg_properties=[{'name': 'n', 'type': int, 'default_value': None}],
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   allarg_properties={'n': {'type': int, 'default_value': None}, 'dtype': {'type': Optional[ScalarType], 'default_value': 4}, 'layout': {'type': Optional[Layout], 'default_value': None}, 'device': {'type': Optional[Device], 'default_value': None}, 'pin_memory': {'type': Optional[bool], 'default_value': None}},
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwarg_properties=None,
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   unbacked_bindings={},
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   mutation_outputs=[],
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=randperm,
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([randperm]),
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   stack_traces = {,
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     File "<ipython-input-3-79b77fea9450>", line 12, in fn,
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       idx = torch.randperm(x.shape[0], device=x.device),
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   }
V0520 02:44:45.309000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] )
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling MultiOutput(
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=None,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   name=buf1,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   layout=FixedLayout('cuda:0', torch.int64, size=[8], stride=[1]),
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   inputs=[FallbackKernel(
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     python_kernel_name='torch.ops.aten.randperm.default',
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     name=buf0,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     layout=MultiOutputLayout(device=device(type='cuda', index=0)),
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     inputs=[],
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     constant_args=(8, device(type='cuda', index=0), False),
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     kwargs={'device': device(type='cuda', index=0), 'pin_memory': False},
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     output_view=None,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     python_kernel_name=torch.ops.aten.randperm.default,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     cpp_kernel_name=None,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     ordered_kwargs_for_cpp_kernel=['dtype', 'layout', 'device', 'pin_memory'],
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     op_overload=aten.randperm.default,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     arg_properties=[{'name': 'n', 'type': int, 'default_value': None}],
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     allarg_properties={'n': {'type': int, 'default_value': None}, 'dtype': {'type': Optional[ScalarType], 'default_value': 4}, 'layout': {'type': Optional[Layout], 'default_value': None}, 'device': {'type': Optional[Device], 'default_value': None}, 'pin_memory': {'type': Optional[bool], 'default_value': None}},
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     kwarg_properties=None,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     unbacked_bindings={},
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     mutation_outputs=[],
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     origin_node=randperm,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     origins=OrderedSet([randperm]),
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     stack_traces = {,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       File "<ipython-input-3-79b77fea9450>", line 12, in fn,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]         idx = torch.randperm(x.shape[0], device=x.device),
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     ,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     }
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   )],
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   constant_args=(),
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwargs={},
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   output_view=None,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=None,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   cpp_kernel_name=None,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ordered_kwargs_for_cpp_kernel=(),
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   op_overload=None,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   arg_properties=[{}],
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   allarg_properties={},
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwarg_properties=None,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   unbacked_bindings={},
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   mutation_outputs=[],
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=randperm,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([randperm]),
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   stack_traces = {,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     File "<ipython-input-3-79b77fea9450>", line 12, in fn,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       idx = torch.randperm(x.shape[0], device=x.device),
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   }
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] )
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling ComputedBuffer(name='buf2', layout=FixedLayout('cuda:0', torch.float32, size=[4, 64], stride=[64, 1]), data=Pointwise(
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   'cuda',
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   torch.float32,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   def inner_fn(index):
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       i0, i1 = index
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       tmp0 = ops.load(buf1, 2 + i0)
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       tmp1 = ops.load(arg0_1, i1 + 64 * tmp0)
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       return tmp1
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ranges=[4, 64],
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=index,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([index, slice_1]),
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   stack_traces = {,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     File "<ipython-input-3-79b77fea9450>", line 13, in fn,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       return x[idx[2:6]],
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]              ~^^^^^^^^^^,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   },
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   stack_traces = {,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     File "<ipython-input-3-79b77fea9450>", line 13, in fn,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       return x[idx[2:6]],
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]                ~~~^^^^^,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   }
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
V0520 02:44:45.310000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4493] [0/0] scheduling output buf2
I0520 02:44:45.313000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1015] [0/0] Reordering for peak memory -- 3 nodes
I0520 02:44:45.313000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1049] [0/0] Baseline peak memory: 1088
I0520 02:44:45.313000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_lpmf peak memory: 1088
I0520 02:44:45.313000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_bfs peak memory: 1088
I0520 02:44:45.313000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_dfs peak memory: 1088
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8894] [0/0] [__cudagraphs] Created 1 graph partitions: 0 cudagraphable, 1 non-cudagraphable
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8901] [0/0] [__cudagraphs]   Partition 0: 3 nodes, non-cudagraphable, inputs=1, outputs=1
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op0: reason=partition includes all ops when cudagraphs is disabled, ir=FallbackKernel, fx=aten.randperm.default(8)
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]          File "<ipython-input-3-79b77fea9450>", line 12, in fn
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]              idx = torch.randperm(x.shape[0], device=x.device)
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op1: reason=partition includes all ops when cudagraphs is disabled, ir=MultiOutput, fx=aten.randperm.default(8)
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]          File "<ipython-input-3-79b77fea9450>", line 12, in fn
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]              idx = torch.randperm(x.shape[0], device=x.device)
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op2: reason=partition includes all ops when cudagraphs is disabled, ir=ComputedBuffer, fx=aten.index.Tensor(arg0_1, [slice_1])
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]          File "<ipython-input-3-79b77fea9450>", line 13, in fn
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]              return x[idx[2:6]]
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]                     ~^^^^^^^^^^
I0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/analysis/device_info.py:221] [0/0] Device NVIDIA GeForce RTX 4060 Laptop GPU not in datasheet, returning None
V0520 02:44:45.315000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op0 with estimated runtime 0.000000
I0520 02:44:45.316000 86891 /home/khushi/Documents/pytorch/torch/_inductor/analysis/device_info.py:221] [0/0] Device NVIDIA GeForce RTX 4060 Laptop GPU not in datasheet, returning None
V0520 02:44:45.316000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op1 with estimated runtime 0.000000
V0520 02:44:45.316000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op2 with estimated runtime 0.000008
V0520 02:44:45.318000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0] get_bounds:
V0520 02:44:45.318000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0] graph():
V0520 02:44:45.318000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %ops : [num_users=3] = placeholder[target=ops]
V0520 02:44:45.318000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index : [num_users=1] = call_module[target=get_index](args = (index0,), kwargs = {})
V0520 02:44:45.318000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %load : [num_users=1] = call_method[target=load](args = (%ops, buf1, %get_index), kwargs = {})
V0520 02:44:45.318000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %set_indirect0 : [num_users=0] = call_module[target=set_indirect0](args = (%load,), kwargs = {})
V0520 02:44:45.318000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index_1 : [num_users=1] = call_module[target=get_index](args = (index1,), kwargs = {})
V0520 02:44:45.318000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %load_1 : [num_users=1] = call_method[target=load](args = (%ops, arg0_1, %get_index_1), kwargs = {})
V0520 02:44:45.318000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index_2 : [num_users=1] = call_module[target=get_index](args = (index2,), kwargs = {})
V0520 02:44:45.318000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %store : [num_users=1] = call_method[target=store](args = (%ops, buf2, %get_index_2, %load_1, None), kwargs = {})
V0520 02:44:45.318000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     return store
V0520 02:44:45.319000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:44:45.321000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:44:45.322000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:44:45.323000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/simd.py:2096] [0/0] Generating kernel code with kernel_name: triton_poi_fused_index_slice_0
V0520 02:44:45.323000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2605] [0/0] Finished codegen for all nodes. The list of kernel names available: OrderedSet([])
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] Output code: 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # AOT ID: ['2_inference']
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from ctypes import c_void_p, c_long, c_int
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import torch
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import math
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import random
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import os
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import tempfile
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from math import inf, nan
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from cmath import nanj
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.hooks import run_intermediate_hooks
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.utils import maybe_profile
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.codegen.memory_planning import _align as align
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch import device, empty_strided
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.async_compile import AsyncCompile
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.select_algorithm import extern_kernels
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._C._dynamo.guards import copy_if_misaligned
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton.language as tl
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.triton_heuristics import start_graph, end_graph
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._C import _cuda_getCurrentRawStream as get_raw_stream
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] aten = torch.ops.aten
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] inductor_ops = torch.ops.inductor
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] _quantized = torch.ops._quantized
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] assert_size_stride = torch._C._dynamo.guards.assert_size_stride
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] assert_alignment = torch._C._dynamo.guards.assert_alignment
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cpu = torch._C._dynamo.guards._empty_strided_cpu
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cpu_pinned = torch._C._dynamo.guards._empty_strided_cpu_pinned
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_xpu = torch._C._dynamo.guards._empty_strided_xpu
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_mtia = torch._C._dynamo.guards._empty_strided_mtia
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] reinterpret_tensor = torch._C._dynamo.guards._reinterpret_tensor
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] alloc_from_pool = torch.ops.inductor._alloc_from_pool
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] async_compile = AsyncCompile()
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # kernel path: /tmp/torchinductor_khushi/ls/clstlf4iipyxgcxk5iwtjpott3sw472ejf4mvnqfeodenku2ktdy.py
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Topologically Sorted Source Nodes: [getitem, getitem_1], Original ATen: [aten.slice, aten.index]
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Source node to ATen node mapping:
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   getitem => slice_1
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   getitem_1 => index
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Graph fragment:
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %randperm : Tensor "i64[8][1]cuda:0" = PlaceHolder[target=randperm]
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %arg0_1 : Tensor "f32[8, 64][64, 1]cuda:0" = PlaceHolder[target=arg0_1]
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %slice_1 : Tensor "i64[4][1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.slice.Tensor](args = (%randperm, 0, 2, 6), kwargs = {})
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %index : Tensor "f32[4, 64][64, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten.index.Tensor](args = (%arg0_1, [%slice_1]), kwargs = {})
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   return %index
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] triton_poi_fused_index_slice_0 = async_compile.triton('triton_poi_fused_index_slice_0', '''
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton.language as tl
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime import triton_helpers, triton_heuristics
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.triton_helpers import libdevice, math as tl_math
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.hints import AutotuneHint, ReductionHint, TileHint, DeviceProperties
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] triton_helpers.set_driver_to_gpu()
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] @triton_heuristics.pointwise(
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     size_hints={'x': 256}, 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     filename=__file__,
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     triton_meta={'signature': {'in_ptr0': '*i64', 'in_ptr1': '*fp32', 'out_ptr0': '*fp32', 'xnumel': 'i32', 'XBLOCK': 'constexpr'}, 'device': DeviceProperties(type='cuda', index=0, multi_processor_count=24, cc=89, major=8, regs_per_multiprocessor=65536, max_threads_per_multi_processor=1536, max_threads_per_block=1024, warp_size=32), 'constants': {}, 'native_matmul': False, 'enable_fp_fusion': True, 'launch_pdl': False, 'disable_ftz': False, 'configs': [{(0,): [['tt.divisibility', 16]], (1,): [['tt.divisibility', 16]], (2,): [['tt.divisibility', 16]], (3,): [['tt.divisibility', 16]]}]},
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     inductor_meta={'grid_type': 'Grid1D', 'kernel_name': 'triton_poi_fused_index_slice_0', 'mutated_arg_names': [], 'optimize_mem': True, 'no_x_dim': False, 'atomic_add_found': False, 'num_load': 1, 'num_store': 1, 'num_reduction': 0, 'autotune_hints': set(), 'tiling_scores': {'x': 2080}, 'backend_hash': 'BBD37A68A7586A612C957949BBE12B7D9F577C36535ED4AB781705E7F9379632', 'assert_indirect_indexing': True, 'autotune_local_cache': True, 'autotune_pointwise': True, 'autotune_remote_cache': None, 'force_disable_caches': False, 'dynamic_scale_rblock': True, 'incremental_autotune': False, 'max_autotune': False, 'max_autotune_pointwise': False, 'min_split_scan_rblock': 256, 'spill_threshold': 16, 'store_cubin': False, 'deterministic': False, 'batch_invariant': False, 'force_filter_reduction_configs': False, 'mix_order_reduction_allow_multi_stages': True, 'dynamic_disable_pipelining': True, 'are_deterministic_algorithms_enabled': False},
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     min_elem_per_thread=0
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] )
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] @triton.jit
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def triton_poi_fused_index_slice_0(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK : tl.constexpr):
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xnumel = 256
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xoffset = tl.program_id(0) * XBLOCK
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xindex = xoffset + tl.arange(0, XBLOCK)[:]
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xmask = xindex < xnumel
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x1 = xindex // 64
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x0 = (xindex % 64)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x2 = xindex
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp0 = tl.load(in_ptr0 + (2 + x1), xmask, eviction_policy='evict_last')
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp1 = tl.full([XBLOCK], 8, tl.int32)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp2 = tmp0 + tmp1
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp3 = tmp0 < 0
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp4 = tl.where(tmp3, tmp2, tmp0)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tl.device_assert(((0 <= tmp4) & (tmp4 < 8)) | ~(xmask), "index out of bounds: 0 <= tmp4 < 8")
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp6 = tl.load(in_ptr1 + (x0 + 64*tmp4), xmask)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tl.store(out_ptr0 + (x2), tmp6, xmask)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] ''', device_str='cuda')
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] async_compile.wait(globals())
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] del async_compile
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] class Runner:
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def __init__(self, partitions):
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         self.partitions = partitions
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def recursively_apply_fns(self, fns):
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         new_callables = []
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         for fn, c in zip(fns, self.partitions):
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             new_callables.append(fn(c))
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         self.partitions = new_callables
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def call(self, args):
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         arg0_1, = args
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         args.clear()
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         with torch.cuda._DeviceGuard(0):
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             torch.cuda.set_device(0)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             # Topologically Sorted Source Nodes: [idx], Original ATen: [aten.randperm]
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf0 = torch.ops.aten.randperm.default(8, device=device(type='cuda', index=0), pin_memory=False)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf1 = buf0
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_size_stride(buf1, (8, ), (1, ), 'torch.ops.aten.randperm.default')
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_alignment(buf1, 16, 'torch.ops.aten.randperm.default')
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del buf0
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_size_stride(arg0_1, (8, 64), (64, 1), 'input')
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             arg0_1 = copy_if_misaligned(arg0_1)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf2 = empty_strided_cuda((4, 64), (64, 1), torch.float32)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             # Topologically Sorted Source Nodes: [getitem, getitem_1], Original ATen: [aten.slice, aten.index]
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             raw_stream0 = get_raw_stream(0)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             triton_poi_fused_index_slice_0.run(buf1, arg0_1, buf2, 256, stream=raw_stream0)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del arg0_1
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del buf1
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         return (buf2, )
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] runner = Runner(partitions=[])
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] call = runner.call
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] recursively_apply_fns = runner.recursively_apply_fns
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def get_args():
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._dynamo.testing import rand_strided
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     arg0_1 = rand_strided((8, 64), (64, 1), device='cuda:0', dtype=torch.float32)
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     return [arg0_1]
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def benchmark_compiled_module(args, times=10, repeat=10):
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._inductor.utils import print_performance
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     fn = lambda: call(list(args))
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     return print_performance(fn, times=times, repeat=repeat, device='cuda')
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] if __name__ == "__main__":
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._inductor.wrapper_benchmark import compiled_module_main
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     args = get_args()
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     compiled_module_main('None', lambda times, repeat: benchmark_compiled_module(args, times=times, repeat=repeat))
V0520 02:44:45.325000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:44:45.326000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2725] [0/0] [__output_code] Output code written to: /tmp/torchinductor_khushi/tx/ctxgmaj44ryq4yp53q5pc6hwk2dxr53f2nny6hadpzmkjetggj5b.py
V0520 02:44:45.465000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2684] [0/0] Output code written to: /tmp/torchinductor_khushi/tx/ctxgmaj44ryq4yp53q5pc6hwk2dxr53f2nny6hadpzmkjetggj5b.py
I0520 02:44:45.465000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2685] [0/0] [__output_code] Output code written to: /tmp/torchinductor_khushi/tx/ctxgmaj44ryq4yp53q5pc6hwk2dxr53f2nny6hadpzmkjetggj5b.py
V0520 02:44:45.465000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1161] [0/0] FX codegen and compilation took 0.217s
I0520 02:44:45.466000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1188] [0/0] Overview info of inductor aten mms: 
I0520 02:44:45.466000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1189] [0/0] Name                           | B                    | M                    | N                    | K                    | Count               
I0520 02:44:45.466000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1194] [0/0] ----------------------------------------------------------------------------------------------------------------------------------
I0520 02:44:45.466000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1203] [0/0] Step 3: torchinductor done compiling FORWARDS graph 2
V0520 02:44:45.546000 86891 /home/khushi/Documents/pytorch/torch/_inductor/runtime/triton_heuristics.py:1399] Benchmark all input configs for triton_poi_fused_index_slice_0, get:
V0520 02:44:45.546000 86891 /home/khushi/Documents/pytorch/torch/_inductor/runtime/triton_heuristics.py:1401] XBLOCK: 256, num_warps: 4, num_ctas: 1, num_stages: 1, maxnreg: None: 0.004032, nreg 24, nspill 0, #shared-mem 0
V0520 02:44:45.546000 86891 /home/khushi/Documents/pytorch/torch/_inductor/runtime/triton_heuristics.py:1401] XBLOCK: 128, num_warps: 4, num_ctas: 1, num_stages: 1, maxnreg: None: 0.004096, nreg 24, nspill 0, #shared-mem 0
V0520 02:44:45.547000 86891 /home/khushi/Documents/pytorch/torch/_inductor/runtime/triton_heuristics.py:1477] Best config for triton_poi_fused_index_slice_0: XBLOCK: 256, num_warps: 4, num_ctas: 1, num_stages: 1, maxnreg: None: 0.004032, nreg 24, nspill 0, #shared-mem 0
V0520 02:44:45.547000 86891 /home/khushi/Documents/pytorch/torch/_inductor/runtime/autotune_cache.py:348] Save heuristic tuning result to /tmp/torchinductor_khushi/ls/61b31063e8fea3897eab3e96f1f0bea934ba0b59d0ad72fcc6c86bd83b411c30.best_config
Out[3]: 
tensor([[ 1.2039e+00, -1.2676e+00,  7.2417e-01,  1.7606e+00, -5.8461e-02,
          5.6323e-01,  1.0173e+00,  7.6710e-01,  3.8532e-01, -7.7765e-01,
          5.4020e-01, -1.5656e+00, -2.2326e+00,  1.7773e-01,  3.0751e-01,
          1.0566e+00,  1.1818e+00,  6.6298e-02,  3.0919e-02, -6.0156e-01,
          6.6021e-01, -1.1822e-02,  9.2217e-01,  4.6773e-02, -1.3486e+00,
         -1.0134e+00, -1.3270e+00,  3.9826e-01,  5.1588e-01,  1.2365e+00,
         -1.5475e+00, -2.4853e+00, -1.3008e+00, -8.3491e-01,  3.6795e-03,
          8.2891e-01,  7.6778e-01, -1.2526e+00,  7.4148e-01, -1.8698e-01,
         -2.7887e-01,  2.6203e-01, -1.1103e+00, -7.7967e-01,  5.8039e-01,
         -1.1553e+00, -9.6102e-01, -1.0889e+00, -2.7541e-01,  1.5213e+00,
          1.8657e+00, -5.9587e-01,  1.3333e+00,  7.7769e-01,  1.1295e+00,
         -1.2730e+00, -1.0750e-01,  1.8723e-01,  5.3019e-01,  8.3103e-01,
          5.5016e-01,  5.3696e-01, -1.3052e+00, -1.3255e+00],
        [ 9.0993e-02,  8.8748e-01, -3.5080e-01,  3.2324e-01,  9.8375e-01,
         -1.5703e-01,  4.1996e-01, -5.7133e-01, -1.4909e+00,  2.6334e-01,
         -1.3073e+00,  8.2452e-01,  1.0775e-01,  1.4802e+00, -5.4774e-02,
         -1.9354e-03,  7.4689e-01, -3.5039e-01, -1.1981e+00, -3.2211e-01,
         -6.0113e-01,  1.9025e-01,  6.8222e-01, -2.7722e-01,  2.2706e-01,
         -1.0537e+00, -5.6971e-01, -1.4974e-01,  8.9587e-01, -3.4372e-01,
          1.2366e-01,  7.6569e-01,  3.7815e-01, -1.0379e+00, -1.6382e-01,
          6.8644e-02, -1.5195e+00, -1.7925e+00,  1.4121e-01,  7.7657e-01,
          8.5787e-01,  9.4823e-01, -2.5785e-01, -7.8964e-01,  1.0067e+00,
         -1.2809e+00, -1.0422e+00, -4.1364e-01,  4.8882e-01,  6.1321e-01,
          1.0582e+00, -1.4321e+00, -1.1111e+00, -7.6815e-01, -2.6235e-01,
         -1.7205e+00, -6.9716e-03, -6.6795e-01, -5.1710e-01, -5.8349e-01,
          5.5824e-01, -8.6037e-01,  2.8992e-01,  8.8686e-01],
        [ 1.7115e+00,  2.0397e+00,  2.7770e+00,  1.8609e+00, -3.5208e-01,
          7.6266e-01,  5.2125e-01, -2.3809e+00,  9.2804e-01, -8.4443e-01,
         -8.6898e-01, -3.4427e-01,  5.0477e-01,  3.4380e-01, -4.3130e-01,
          1.0453e-01, -1.2302e+00, -8.9382e-01, -5.6553e-01,  2.8796e-01,
         -2.9724e-01, -5.2015e-01,  6.7165e-02,  2.5870e-01, -1.5169e+00,
         -8.9412e-01, -8.8298e-01, -7.3496e-01, -1.2338e+00, -1.2631e+00,
          2.3585e-01,  9.9628e-01, -2.7355e-01, -6.1708e-01,  8.2311e-01,
         -1.4704e+00,  4.3087e-01,  1.2495e+00,  3.2920e-01,  6.1567e-01,
         -4.0758e-01,  4.6792e-02, -1.2374e+00, -7.5734e-01,  6.1508e-01,
          5.2168e-01,  7.0317e-01,  8.2070e-01,  6.8846e-01, -8.7405e-01,
         -1.1899e-01, -1.9043e+00,  2.6183e-01,  1.8694e-01, -3.0152e-01,
          7.5312e-01, -6.0751e-01, -1.1280e+00, -1.3338e+00,  1.8356e-01,
          1.4607e+00,  1.0195e-01, -9.4094e-01, -2.8275e-01],
        [-1.2278e+00, -1.1554e-01, -4.4641e-01, -1.1735e+00,  1.3054e+00,
         -3.2682e-01, -8.7566e-01,  8.2095e-01, -1.3254e+00, -7.1926e-01,
          8.3226e-01,  8.4783e-01, -8.3896e-01,  6.9642e-01,  3.9088e-01,
         -8.7401e-01,  1.0698e+00,  6.8022e-01, -1.0933e+00, -5.6798e-01,
         -1.3204e+00,  8.2048e-01, -1.4062e+00,  1.3896e+00, -7.9632e-01,
         -2.9629e-01,  3.1591e-01,  1.0510e+00,  2.2450e-01, -3.9261e-01,
          1.4547e+00,  1.0665e+00, -1.0496e+00, -3.2319e-02,  4.4223e-01,
          1.3242e+00, -3.3254e-01,  4.8327e-01,  1.6811e+00,  2.7931e-01,
          2.2171e-01, -5.1603e-02, -9.4163e-02,  6.0683e-01, -8.2910e-01,
          6.5850e-01, -8.1953e-01,  2.6816e-01,  1.4215e-01, -3.2261e-01,
          2.1801e-01,  9.0369e-01,  1.1114e+00,  7.1220e-01, -1.0442e+00,
          1.3292e+00, -9.5315e-01, -4.8846e-01, -1.3272e+00,  2.3805e-01,
         -1.3927e+00, -4.7171e-01, -1.8125e+00, -1.7815e+00]], device='cuda:0')

```

</p>
</details>

<details>
<summary>test_randperm_index_2d</summary>

<p>

```python
In [4]: import torch
   ...: import torch._logging
   ...: import logging
   ...: 
   ...: torch._dynamo.reset()
   ...: torch._inductor.config.fx_graph_cache = False
   ...: 
   ...: torch._logging.set_logs(graph_code=True, output_code=True, inductor=logging.DEBUG)
   ...: 
   ...: @torch.compile
   ...: def fn(x):
   ...:     idx = torch.randperm(x.shape[0], device=x.device)
   ...:     return x[idx, :]
   ...: 
   ...: fn(torch.randn(8, 64, device="cuda"))
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] TRACED GRAPH
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]  ===== __compiled_fn_7_4358e0db_609e_4c4e_b373_51c683aec1d2 =====
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class GraphModule(torch.nn.Module):
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]     def forward(self, L_x_: "f32[8, 64][64, 1]cuda:0"):
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         l_x_ = L_x_
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         # File: <ipython-input-4-a512b08a21ff>:12 in fn, code: idx = torch.randperm(x.shape[0], device=x.device)
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         idx: "i64[8][1]cuda:0" = torch.randperm(8, device = device(type='cuda', index=0))
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         # File: <ipython-input-4-a512b08a21ff>:13 in fn, code: return x[idx, :]
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         getitem: "f32[8, 64][64, 1]cuda:0" = l_x_[(idx, slice(None, None, None))];  l_x_ = idx = None
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code]         return (getitem,)
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:46:12.767000 86891 /home/khushi/Documents/pytorch/torch/_dynamo/output_graph.py:2772] [0/0] [__graph_code] 
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] TRACED GRAPH
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]  ===== BEFORE PRE GRAD =====
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class GraphModule(torch.nn.Module):
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]     def forward(self, L_x_: "f32[8, 64][64, 1]cuda:0"):
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         l_x_ = L_x_
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         # File: <ipython-input-4-a512b08a21ff>:12 in fn, code: idx = torch.randperm(x.shape[0], device=x.device)
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         idx: "i64[8][1]cuda:0" = torch.randperm(8, device = device(type='cuda', index=0))
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         # File: <ipython-input-4-a512b08a21ff>:13 in fn, code: return x[idx, :]
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         getitem: "f32[8, 64][64, 1]cuda:0" = l_x_[(idx, slice(None, None, None))];  l_x_ = idx = None
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs]         return (getitem,)
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:46:12.775000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:2633] [0/0] [__pre_grad_graphs] 
V0520 02:46:12.789000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:942] [0/0] FX cache status: use_cache=False, local=False, remote=False, aot_mode=False, force_disable_caches=False
V0520 02:46:12.789000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1030] [0/0] FX cache bypass reason: FX cache disabled or key generation failed
I0520 02:46:12.790000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1300] [0/0] Step 3: torchinductor compiling FORWARDS graph 3
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] TRACED GRAPH
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]  ===== AFTER POST GRAD =====
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]  /home/khushi/Documents/pytorch/torch/fx/_lazy_graph_module.py class <lambda>(torch.nn.Module):
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]     def forward(self, arg0_1: "f32[8, 64][64, 1]cuda:0"):
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         # No stacktrace found for following nodes
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         randperm_default: "i64[8][1]cuda:0" = torch.ops.aten.randperm.default(8, device = device(type='cuda', index=0), pin_memory = False)
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         # File: <ipython-input-4-a512b08a21ff>:13 in fn, code: return x[idx, :]
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         _unsafe_index_tensor: "f32[8, 64][64, 1]cuda:0" = torch.ops.aten._unsafe_index.Tensor(arg0_1, [randperm_default]);  arg0_1 = randperm_default = None
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs]         return (_unsafe_index_tensor,)
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:46:12.793000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1380] [0/0] [__post_grad_graphs] 
V0520 02:46:12.803000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %arg0_1 : [num_users=1] = placeholder[target=arg0_1] 
V0520 02:46:12.803000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %randperm_default : [num_users=1] = call_function[target=torch.ops.aten.randperm.default](args = (8,), kwargs = {device: cuda:0, pin_memory: False}) 
V0520 02:46:12.803000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1422] [0/0]   via <function fallback_handler.<locals>.handler at 0x7b2964522140>
V0520 02:46:12.804000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering %_unsafe_index_tensor : [num_users=1] = call_function[target=torch.ops.aten._unsafe_index.Tensor](args = (%arg0_1, [%randperm_default]), kwargs = {}) 
V0520 02:46:12.804000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1422] [0/0]   via <function _unsafe_index at 0x7b29643524b0>
V0520 02:46:12.805000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1808] [0/0] lowering return (_unsafe_index_tensor,) 
V0520 02:46:12.805000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:1679] [0/0] Force channels last inputs for 0 conv for the current graph with id 3
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling FallbackKernel(
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name='torch.ops.aten.randperm.default',
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   name=buf0,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   layout=MultiOutputLayout(device=device(type='cuda', index=0)),
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   inputs=[],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   constant_args=(8, device(type='cuda', index=0), False),
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwargs={'device': device(type='cuda', index=0), 'pin_memory': False},
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   output_view=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=torch.ops.aten.randperm.default,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   cpp_kernel_name=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ordered_kwargs_for_cpp_kernel=['dtype', 'layout', 'device', 'pin_memory'],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   op_overload=aten.randperm.default,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   arg_properties=[{'name': 'n', 'type': int, 'default_value': None}],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   allarg_properties={'n': {'type': int, 'default_value': None}, 'dtype': {'type': Optional[ScalarType], 'default_value': 4}, 'layout': {'type': Optional[Layout], 'default_value': None}, 'device': {'type': Optional[Device], 'default_value': None}, 'pin_memory': {'type': Optional[bool], 'default_value': None}},
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwarg_properties=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   unbacked_bindings={},
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   mutation_outputs=[],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=randperm_default,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([randperm_default])
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] )
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling MultiOutput(
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   name=buf1,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   layout=FixedLayout('cuda:0', torch.int64, size=[8], stride=[1]),
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   inputs=[FallbackKernel(
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     python_kernel_name='torch.ops.aten.randperm.default',
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     name=buf0,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     layout=MultiOutputLayout(device=device(type='cuda', index=0)),
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     inputs=[],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     constant_args=(8, device(type='cuda', index=0), False),
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     kwargs={'device': device(type='cuda', index=0), 'pin_memory': False},
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     output_view=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     python_kernel_name=torch.ops.aten.randperm.default,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     cpp_kernel_name=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     ordered_kwargs_for_cpp_kernel=['dtype', 'layout', 'device', 'pin_memory'],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     op_overload=aten.randperm.default,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     arg_properties=[{'name': 'n', 'type': int, 'default_value': None}],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     allarg_properties={'n': {'type': int, 'default_value': None}, 'dtype': {'type': Optional[ScalarType], 'default_value': 4}, 'layout': {'type': Optional[Layout], 'default_value': None}, 'device': {'type': Optional[Device], 'default_value': None}, 'pin_memory': {'type': Optional[bool], 'default_value': None}},
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     kwarg_properties=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     unbacked_bindings={},
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     mutation_outputs=[],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     origin_node=randperm_default,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     origins=OrderedSet([randperm_default])
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   )],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   constant_args=(),
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwargs={},
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   output_view=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   python_kernel_name=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   cpp_kernel_name=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ordered_kwargs_for_cpp_kernel=(),
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   op_overload=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   arg_properties=[{}],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   allarg_properties={},
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   kwarg_properties=None,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   unbacked_bindings={},
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   mutation_outputs=[],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=randperm_default,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([randperm_default])
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] )
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] scheduling ComputedBuffer(name='buf2', layout=FixedLayout('cuda:0', torch.float32, size=[8, 64], stride=[64, 1]), data=Pointwise(
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   'cuda',
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   torch.float32,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   def inner_fn(index):
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       i0, i1 = index
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       tmp0 = ops.load(buf1, i0)
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       tmp1 = ops.load(arg0_1, i1 + 64 * tmp0)
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       return tmp1
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ranges=[8, 64],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origin_node=_unsafe_index_tensor,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   origins=OrderedSet([_unsafe_index_tensor]),
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   stack_traces = {,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]     File "<ipython-input-4-a512b08a21ff>", line 13, in fn,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]       return x[idx, :],
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]              ~^^^^^^^^,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   ,
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0]   }
V0520 02:46:12.807000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4404] [0/0] ), _split_size=None, _original_inner_fn=None, _original_ranges=None, _original_reduction_ranges=None)
V0520 02:46:12.808000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:4493] [0/0] scheduling output buf2
I0520 02:46:12.810000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1015] [0/0] Reordering for peak memory -- 3 nodes
I0520 02:46:12.810000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1049] [0/0] Baseline peak memory: 2112
I0520 02:46:12.810000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_lpmf peak memory: 2112
I0520 02:46:12.811000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_bfs peak memory: 2112
I0520 02:46:12.811000 86891 /home/khushi/Documents/pytorch/torch/_inductor/memory.py:1067] [0/0] topological_sort_dfs peak memory: 2112
V0520 02:46:12.812000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8894] [0/0] [__cudagraphs] Created 1 graph partitions: 0 cudagraphable, 1 non-cudagraphable
V0520 02:46:12.813000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8901] [0/0] [__cudagraphs]   Partition 0: 3 nodes, non-cudagraphable, inputs=1, outputs=1
V0520 02:46:12.813000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op0: reason=partition includes all ops when cudagraphs is disabled, ir=FallbackKernel, fx=aten.randperm.default(8)
V0520 02:46:12.813000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op1: reason=partition includes all ops when cudagraphs is disabled, ir=MultiOutput, fx=aten.randperm.default(8)
V0520 02:46:12.813000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8929] [0/0] [__cudagraphs]     op2: reason=partition includes all ops when cudagraphs is disabled, ir=ComputedBuffer, fx=aten._unsafe_index.Tensor(arg0_1, [randperm_default])
V0520 02:46:12.813000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]          File "<ipython-input-4-a512b08a21ff>", line 13, in fn
V0520 02:46:12.813000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]              return x[idx, :]
V0520 02:46:12.813000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:8936] [0/0] [__cudagraphs]                     ~^^^^^^^^
I0520 02:46:12.813000 86891 /home/khushi/Documents/pytorch/torch/_inductor/analysis/device_info.py:221] [0/0] Device NVIDIA GeForce RTX 4060 Laptop GPU not in datasheet, returning None
V0520 02:46:12.813000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op0 with estimated runtime 0.000000
I0520 02:46:12.813000 86891 /home/khushi/Documents/pytorch/torch/_inductor/analysis/device_info.py:221] [0/0] Device NVIDIA GeForce RTX 4060 Laptop GPU not in datasheet, returning None
V0520 02:46:12.813000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op1 with estimated runtime 0.000000
V0520 02:46:12.814000 86891 /home/khushi/Documents/pytorch/torch/_inductor/scheduler.py:9130] [0/0] Generating code for node op2 with estimated runtime 0.000016
V0520 02:46:12.815000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0] get_bounds:
V0520 02:46:12.815000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0] graph():
V0520 02:46:12.815000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %ops : [num_users=3] = placeholder[target=ops]
V0520 02:46:12.815000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index : [num_users=1] = call_module[target=get_index](args = (index0,), kwargs = {})
V0520 02:46:12.815000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %load : [num_users=1] = call_method[target=load](args = (%ops, buf1, %get_index), kwargs = {})
V0520 02:46:12.815000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %set_indirect0 : [num_users=0] = call_module[target=set_indirect0](args = (%load,), kwargs = {})
V0520 02:46:12.815000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index_1 : [num_users=1] = call_module[target=get_index](args = (index1,), kwargs = {})
V0520 02:46:12.815000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %load_1 : [num_users=1] = call_method[target=load](args = (%ops, arg0_1, %get_index_1), kwargs = {})
V0520 02:46:12.815000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %get_index_2 : [num_users=1] = call_module[target=get_index](args = (index2,), kwargs = {})
V0520 02:46:12.815000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     %store : [num_users=1] = call_method[target=store](args = (%ops, buf2, %get_index_2, %load_1, None), kwargs = {})
V0520 02:46:12.815000 86891 /home/khushi/Documents/pytorch/torch/_inductor/bounds.py:81] [0/0]     return store
V0520 02:46:12.816000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:46:12.817000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:46:12.817000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/triton.py:2715] [0/0] Cannot use TMA descriptor for load / store since:  Requires triton>=3.4.0, a CUDA device with cc>=9.0 and `use_tensor_descriptor` and `assume_aligned_inputs` options enabled
V0520 02:46:12.818000 86891 /home/khushi/Documents/pytorch/torch/_inductor/codegen/simd.py:2096] [0/0] Generating kernel code with kernel_name: triton_poi_fused_index_0
V0520 02:46:12.819000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2605] [0/0] Finished codegen for all nodes. The list of kernel names available: OrderedSet([])
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] Output code: 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # AOT ID: ['3_inference']
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from ctypes import c_void_p, c_long, c_int
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import torch
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import math
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import random
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import os
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import tempfile
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from math import inf, nan
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from cmath import nanj
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.hooks import run_intermediate_hooks
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.utils import maybe_profile
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.codegen.memory_planning import _align as align
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch import device, empty_strided
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.async_compile import AsyncCompile
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.select_algorithm import extern_kernels
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._C._dynamo.guards import copy_if_misaligned
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton.language as tl
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.triton_heuristics import start_graph, end_graph
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._C import _cuda_getCurrentRawStream as get_raw_stream
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] aten = torch.ops.aten
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] inductor_ops = torch.ops.inductor
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] _quantized = torch.ops._quantized
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] assert_size_stride = torch._C._dynamo.guards.assert_size_stride
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] assert_alignment = torch._C._dynamo.guards.assert_alignment
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cpu = torch._C._dynamo.guards._empty_strided_cpu
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cpu_pinned = torch._C._dynamo.guards._empty_strided_cpu_pinned
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_xpu = torch._C._dynamo.guards._empty_strided_xpu
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] empty_strided_mtia = torch._C._dynamo.guards._empty_strided_mtia
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] reinterpret_tensor = torch._C._dynamo.guards._reinterpret_tensor
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] alloc_from_pool = torch.ops.inductor._alloc_from_pool
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] async_compile = AsyncCompile()
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # kernel path: /tmp/torchinductor_khushi/7l/c7l4ehujjtnbjkt52gnh3bol253wh7e3xwfox2geifl23quzc2pj.py
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Topologically Sorted Source Nodes: [getitem], Original ATen: [aten.index]
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Source node to ATen node mapping:
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   getitem => _unsafe_index_tensor
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] # Graph fragment:
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %randperm_default : Tensor "i64[8][1]cuda:0" = PlaceHolder[target=randperm_default]
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %arg0_1 : Tensor "f32[8, 64][64, 1]cuda:0" = PlaceHolder[target=arg0_1]
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   %_unsafe_index_tensor : Tensor "f32[8, 64][64, 1]cuda:0"[num_users=1] = call_function[target=torch.ops.aten._unsafe_index.Tensor](args = (%arg0_1, [%randperm_default]), kwargs = {})
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] #   return %_unsafe_index_tensor
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] triton_poi_fused_index_0 = async_compile.triton('triton_poi_fused_index_0', '''
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] import triton.language as tl
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime import triton_helpers, triton_heuristics
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.triton_helpers import libdevice, math as tl_math
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] from torch._inductor.runtime.hints import AutotuneHint, ReductionHint, TileHint, DeviceProperties
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] triton_helpers.set_driver_to_gpu()
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] @triton_heuristics.pointwise(
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     size_hints={'x': 512}, 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     filename=__file__,
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     triton_meta={'signature': {'in_ptr0': '*i64', 'in_ptr1': '*fp32', 'out_ptr0': '*fp32', 'xnumel': 'i32', 'XBLOCK': 'constexpr'}, 'device': DeviceProperties(type='cuda', index=0, multi_processor_count=24, cc=89, major=8, regs_per_multiprocessor=65536, max_threads_per_multi_processor=1536, max_threads_per_block=1024, warp_size=32), 'constants': {}, 'native_matmul': False, 'enable_fp_fusion': True, 'launch_pdl': False, 'disable_ftz': False, 'configs': [{(0,): [['tt.divisibility', 16]], (1,): [['tt.divisibility', 16]], (2,): [['tt.divisibility', 16]], (3,): [['tt.divisibility', 16]]}]},
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     inductor_meta={'grid_type': 'Grid1D', 'kernel_name': 'triton_poi_fused_index_0', 'mutated_arg_names': [], 'optimize_mem': True, 'no_x_dim': False, 'atomic_add_found': False, 'num_load': 1, 'num_store': 1, 'num_reduction': 0, 'autotune_hints': set(), 'tiling_scores': {'x': 4160}, 'backend_hash': 'BBD37A68A7586A612C957949BBE12B7D9F577C36535ED4AB781705E7F9379632', 'assert_indirect_indexing': True, 'autotune_local_cache': True, 'autotune_pointwise': True, 'autotune_remote_cache': None, 'force_disable_caches': False, 'dynamic_scale_rblock': True, 'incremental_autotune': False, 'max_autotune': False, 'max_autotune_pointwise': False, 'min_split_scan_rblock': 256, 'spill_threshold': 16, 'store_cubin': False, 'deterministic': False, 'batch_invariant': False, 'force_filter_reduction_configs': False, 'mix_order_reduction_allow_multi_stages': True, 'dynamic_disable_pipelining': True, 'are_deterministic_algorithms_enabled': False},
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     min_elem_per_thread=0
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] )
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] @triton.jit
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def triton_poi_fused_index_0(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK : tl.constexpr):
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xnumel = 512
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xoffset = tl.program_id(0) * XBLOCK
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xindex = xoffset + tl.arange(0, XBLOCK)[:]
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     xmask = xindex < xnumel
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x1 = xindex // 64
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x0 = (xindex % 64)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     x2 = xindex
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp0 = tl.load(in_ptr0 + (x1), xmask, eviction_policy='evict_last')
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp1 = tl.full([XBLOCK], 8, tl.int32)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp2 = tmp0 + tmp1
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp3 = tmp0 < 0
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp4 = tl.where(tmp3, tmp2, tmp0)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tmp5 = tl.load(in_ptr1 + (x0 + 64*tmp4), xmask)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     tl.store(out_ptr0 + (x2), tmp5, xmask)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] ''', device_str='cuda')
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] async_compile.wait(globals())
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] del async_compile
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] class Runner:
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def __init__(self, partitions):
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         self.partitions = partitions
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def recursively_apply_fns(self, fns):
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         new_callables = []
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         for fn, c in zip(fns, self.partitions):
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             new_callables.append(fn(c))
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         self.partitions = new_callables
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     def call(self, args):
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         arg0_1, = args
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         args.clear()
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         with torch.cuda._DeviceGuard(0):
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             torch.cuda.set_device(0)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             # Topologically Sorted Source Nodes: [], Original ATen: [aten.randperm]
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf0 = torch.ops.aten.randperm.default(8, device=device(type='cuda', index=0), pin_memory=False)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf1 = buf0
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_size_stride(buf1, (8, ), (1, ), 'torch.ops.aten.randperm.default')
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_alignment(buf1, 16, 'torch.ops.aten.randperm.default')
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del buf0
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             assert_size_stride(arg0_1, (8, 64), (64, 1), 'input')
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             arg0_1 = copy_if_misaligned(arg0_1)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             buf2 = empty_strided_cuda((8, 64), (64, 1), torch.float32)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             # Topologically Sorted Source Nodes: [getitem], Original ATen: [aten.index]
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             raw_stream0 = get_raw_stream(0)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             triton_poi_fused_index_0.run(buf1, arg0_1, buf2, 512, stream=raw_stream0)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del arg0_1
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]             del buf1
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]         return (buf2, )
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] runner = Runner(partitions=[])
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] call = runner.call
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] recursively_apply_fns = runner.recursively_apply_fns
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def get_args():
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._dynamo.testing import rand_strided
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     arg0_1 = rand_strided((8, 64), (64, 1), device='cuda:0', dtype=torch.float32)
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     return [arg0_1]
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] def benchmark_compiled_module(args, times=10, repeat=10):
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._inductor.utils import print_performance
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     fn = lambda: call(list(args))
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     return print_performance(fn, times=times, repeat=repeat, device='cuda')
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] if __name__ == "__main__":
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     from torch._inductor.wrapper_benchmark import compiled_module_main
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     args = get_args()
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code]     compiled_module_main('None', lambda times, repeat: benchmark_compiled_module(args, times=times, repeat=repeat))
V0520 02:46:12.820000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2714] [0/0] [__output_code] 
V0520 02:46:12.821000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2725] [0/0] [__output_code] Output code written to: /tmp/torchinductor_khushi/sd/csdqfb4uquj277p63cpkrmqw66e55desfa5as7m7slhunn3tcyo2.py
V0520 02:46:12.866000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2684] [0/0] Output code written to: /tmp/torchinductor_khushi/sd/csdqfb4uquj277p63cpkrmqw66e55desfa5as7m7slhunn3tcyo2.py
I0520 02:46:12.866000 86891 /home/khushi/Documents/pytorch/torch/_inductor/graph.py:2685] [0/0] [__output_code] Output code written to: /tmp/torchinductor_khushi/sd/csdqfb4uquj277p63cpkrmqw66e55desfa5as7m7slhunn3tcyo2.py
V0520 02:46:12.867000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1161] [0/0] FX codegen and compilation took 0.078s
I0520 02:46:12.867000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1188] [0/0] Overview info of inductor aten mms: 
I0520 02:46:12.867000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1189] [0/0] Name                           | B                    | M                    | N                    | K                    | Count               
I0520 02:46:12.867000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1194] [0/0] ----------------------------------------------------------------------------------------------------------------------------------
I0520 02:46:12.867000 86891 /home/khushi/Documents/pytorch/torch/_inductor/compile_fx.py:1203] [0/0] Step 3: torchinductor done compiling FORWARDS graph 3
Out[4]: 
tensor([[-1.0772e+00, -1.1764e+00, -1.1002e+00, -3.0652e-01,  1.7069e+00,
          1.7481e-01,  1.8611e+00, -8.8423e-01,  3.8871e-01,  1.0919e-01,
         -4.2005e-01, -5.4105e-01, -1.6412e+00,  5.3374e-01,  1.0509e-02,
         -2.1357e-01, -8.8582e-01,  1.5891e+00, -1.3417e+00,  1.9418e+00,
          4.8931e-01, -4.3238e-01, -9.4855e-01, -9.8122e-01, -1.1431e+00,
         -8.9194e-02, -1.4125e+00,  1.0245e+00,  1.6815e-01,  4.2045e-01,
         -2.5462e-01, -6.5280e-01, -4.7319e-01, -6.2644e-01, -7.1668e-01,
         -1.1579e+00,  2.7614e+00,  8.5873e-01, -8.8519e-01,  2.7235e-01,
         -4.2788e-01,  8.9622e-01, -1.1160e+00, -9.9040e-01, -9.8374e-01,
          6.5118e-01, -7.3946e-01,  4.0595e-02, -2.9491e+00, -1.1468e-01,
         -7.2369e-01,  4.7082e-01, -1.3057e-01,  1.8888e+00,  1.4599e+00,
          1.9323e+00,  3.3874e-01, -6.9376e-01,  1.2478e+00,  1.3874e-01,
          3.1487e-01, -2.7053e-02,  4.8843e-02,  6.8325e-01],
        [ 8.0514e-01, -2.0948e-01,  1.3364e-01,  2.9215e-01,  1.1901e+00,
          6.9319e-01,  1.3671e+00,  9.2689e-01,  8.9206e-02,  2.7245e-01,
          1.0452e+00,  1.8148e+00,  2.8341e+00,  1.4701e+00,  5.6865e-01,
          1.9397e+00, -1.0928e-01, -1.1980e+00, -9.3176e-01,  5.9262e-01,
          2.2055e-01,  1.0389e+00, -1.8851e-01, -1.0764e+00, -7.2223e-02,
          7.9915e-01,  9.5716e-01,  1.2777e+00,  7.0674e-02,  4.4864e-01,
         -9.9391e-02, -1.2083e+00,  5.2675e-01, -1.9110e+00, -8.1705e-01,
          4.5152e-01,  2.2324e+00,  1.1186e+00, -9.9605e-01, -9.7208e-01,
          2.1864e+00, -8.2310e-02, -7.0935e-02, -2.5502e-01, -1.6222e-01,
          1.3302e+00, -7.7129e-01, -5.5158e-01, -1.0349e+00, -4.0748e-01,
          1.0309e+00, -1.3900e+00, -2.9124e-01,  3.0190e-01,  6.9851e-01,
         -2.4813e+00, -1.9056e-01, -1.6087e+00, -1.7919e+00,  7.0926e-02,
         -1.7950e+00, -3.6068e-01, -2.1987e+00, -1.0541e+00],
        [-5.0827e-01,  7.6445e-01, -1.5733e+00, -1.8165e+00, -1.9675e+00,
         -1.7059e-01,  1.3446e+00, -1.0787e+00, -2.5129e-01, -7.5670e-01,
         -2.6673e-01,  4.4469e-02, -4.3911e-01, -4.3663e-01, -9.2887e-03,
         -2.2832e-01, -6.6355e-01,  6.1326e-01, -9.9845e-01, -1.3058e+00,
          1.3119e+00, -4.5630e-01,  1.6016e+00,  6.2301e-01, -1.0889e-01,
         -4.1015e-02, -2.2782e+00, -5.8886e-01,  1.1297e-02,  1.4793e+00,
          1.0512e+00,  8.0451e-02,  4.5430e-01,  1.5886e+00, -8.6208e-01,
          4.8011e-01, -8.5056e-01,  5.5519e-01, -1.5650e+00, -1.8242e+00,
         -2.9469e-02, -1.3093e-02,  1.5014e-01,  2.5739e-01,  8.0829e-01,
          6.0717e-01, -6.6027e-01,  1.3389e+00, -2.5817e-01, -1.3171e+00,
         -3.5851e-01,  9.5287e-01,  1.6252e-01, -7.5119e-01, -1.3320e+00,
         -2.6668e+00, -1.6750e+00, -4.6423e-01,  3.9265e-01, -7.3002e-01,
         -9.9650e-01,  3.4569e-01,  7.2506e-01,  8.3396e-01],
        [-5.1042e-01, -3.1922e-02, -3.1629e-01, -1.2328e+00, -1.4347e-01,
          1.2334e+00,  5.7523e-01, -1.0018e+00, -2.4715e-01, -5.6494e-01,
         -5.1615e-01,  7.6930e-01, -1.3548e-01,  7.0922e-01, -1.3980e+00,
          2.1479e-01, -2.2735e+00, -7.3713e-01,  3.7745e-01, -6.7506e-01,
         -1.4698e+00, -1.2550e+00, -1.1360e+00, -1.9524e-01, -1.8512e-01,
         -6.2244e-01,  4.8535e-02,  2.4041e-01,  2.3893e+00, -2.8089e+00,
         -4.0214e-01, -7.6832e-01, -1.7655e-01, -1.1797e+00, -8.5107e-02,
         -4.2683e-01, -4.7914e-01, -6.9054e-01, -5.9009e-01, -3.4325e-01,
          4.2245e-01,  7.2982e-01, -2.3007e-01, -9.3908e-01,  3.7344e-01,
         -9.0577e-01, -1.0401e+00, -3.7939e-01,  9.6245e-03,  4.6769e-01,
         -6.7095e-01,  3.3408e-01, -1.1727e-01,  9.1682e-01, -7.5530e-01,
         -2.6526e+00, -1.2988e+00, -6.2700e-01,  6.2961e-01,  9.1505e-01,
          1.4188e-01,  6.7825e-01, -5.1929e-01, -7.1256e-01],
        [ 2.0261e+00,  7.6466e-01,  7.5955e-03,  3.5122e-01,  3.6104e-01,
          6.6834e-01, -6.4469e-01,  2.1159e+00,  5.6820e-01, -2.3297e+00,
          1.3393e-02,  6.1072e-01,  7.2767e-01, -6.1864e-01, -5.4122e-01,
          8.6902e-02,  1.5173e+00,  1.2427e+00,  1.0275e+00, -7.2955e-01,
         -3.9608e-01, -3.2035e-01, -4.0846e-01, -8.3419e-01,  5.3178e-01,
         -1.1073e+00, -1.4904e-01, -8.4016e-01,  8.1271e-01, -1.7195e-01,
          3.9507e-01,  5.6091e-01, -2.7077e-01, -3.2209e-01, -3.8708e-01,
          3.6076e-01,  3.9056e-01,  2.3625e+00, -1.7068e+00, -7.6140e-01,
          3.0365e-01,  1.1512e+00,  6.2551e-01,  1.5299e+00, -2.0047e+00,
          1.5851e-03,  3.5974e-01,  5.5332e-01, -7.8644e-01, -1.5115e+00,
          1.5176e+00,  1.1728e+00, -1.6690e+00,  3.3063e-01,  1.3209e+00,
          1.9512e+00, -5.6463e-01, -6.0459e-01, -3.3767e-01,  2.0716e+00,
         -1.0909e+00, -2.0630e-01, -6.7761e-01, -3.1627e-01],
        [ 9.8546e-02,  1.4079e+00,  1.6871e-01,  1.7822e+00,  1.8393e+00,
          2.0391e+00, -5.4488e-02,  1.4667e+00,  7.4213e-01,  2.3089e+00,
          8.2240e-02, -7.9358e-01,  1.2368e+00,  1.9569e+00,  8.0554e-01,
          1.2597e-01, -4.6419e-01, -1.7477e+00, -3.0874e-01,  9.7397e-01,
         -1.0663e-01, -8.3753e-01,  8.5028e-01,  1.3517e-01,  9.4391e-01,
         -1.5576e+00,  6.2181e-01, -1.2491e+00,  4.8220e-01,  9.1374e-01,
          3.4028e-02, -2.1301e-01, -1.6979e+00, -7.8156e-02, -1.1902e-01,
         -6.6932e-01, -1.2137e+00,  4.5921e-02,  1.4223e-01, -3.4948e-01,
          3.3793e-01,  8.9668e-01, -4.4348e-01,  1.6621e+00,  1.0550e+00,
          2.4787e+00, -6.8196e-01,  8.3504e-01, -1.7759e+00, -1.7383e+00,
          1.6023e+00,  2.6166e+00, -3.4786e-01, -8.0214e-01,  7.8694e-01,
         -9.4918e-01, -1.1439e+00,  3.8476e-01, -1.2684e+00,  7.8836e-01,
         -9.6562e-01,  5.8240e-01, -1.8325e+00,  2.0285e-01],
        [ 7.2568e-01, -1.7547e+00,  9.5731e-01,  2.4503e-01,  4.9403e-01,
          2.7791e-01, -5.9867e-01, -1.2868e+00, -2.5417e-01, -3.8649e-01,
          9.9507e-01, -1.9592e-01, -8.2021e-01, -6.4267e-02, -3.1580e-01,
          6.1271e-02,  6.1174e-01,  8.5296e-01, -6.1035e-01,  5.4149e-01,
         -1.9336e+00,  1.0516e+00, -1.0669e+00,  1.3182e-01,  1.9009e+00,
         -7.8743e-01, -7.6054e-01,  1.3990e+00,  5.4158e-01, -4.4789e-01,
         -6.5417e-01, -4.5757e-01, -1.4788e+00, -1.1765e-01, -1.3235e-01,
         -4.9377e-01,  9.7265e-01, -1.3956e+00, -4.5456e-01,  6.5681e-01,
          6.8283e-01,  6.7939e-02,  2.6378e-01,  2.5507e-01, -1.6847e-01,
          2.2967e+00, -1.2624e+00,  2.4132e+00,  1.4561e-01,  7.7803e-02,
         -2.0891e-01, -1.8109e+00,  1.2151e+00, -2.7847e+00, -4.3106e-01,
          3.5364e-01,  1.9183e+00,  9.5713e-01, -2.0721e-01,  3.6168e-01,
          3.2509e-01, -7.2979e-02,  4.5825e-01,  5.1935e-01],
        [-1.2299e-02, -1.0190e-01,  6.3852e-02,  9.7017e-01,  2.4197e+00,
         -1.7348e+00, -3.8530e-01, -1.6045e+00,  1.0882e-02,  1.0246e-01,
          5.7845e-01, -1.8984e-01, -7.0510e-01, -7.0929e-02, -7.1989e-02,
          6.9042e-01, -1.0264e+00,  1.3988e+00, -9.3026e-01, -9.0344e-01,
          9.6877e-01,  2.1240e-03,  2.4422e+00,  3.6751e-01,  2.0657e-01,
          1.4777e+00,  5.9758e-01,  5.4878e-01, -2.1680e-01, -1.7820e+00,
          1.2011e+00, -1.4232e+00,  1.0393e+00,  1.6192e+00, -4.5003e-01,
          8.2434e-01, -7.3287e-01, -8.0178e-01,  2.0538e+00,  2.8168e-01,
          4.3011e-01, -1.0650e+00, -2.4043e+00, -1.2932e+00,  9.9908e-01,
         -1.1667e+00, -1.3240e+00, -8.7560e-01,  1.0373e-01,  1.5660e+00,
         -8.3628e-01,  2.3321e-01, -3.6393e-01,  1.1370e+00, -7.0626e-01,
         -2.6559e-01,  5.2159e-01,  1.7041e+00, -1.3686e-01,  1.7195e-01,
         -2.3452e-02,  5.0874e-01, -1.5573e+00,  2.3791e-01]], device='cuda:0')
```

</p>
</details>

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98