### PR TITLE
Graph break on duplicate autograd Function inputs

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -1856,6 +1856,47 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
+    def test_duplicate_input_accumulates_grad(self):
+        class Foo(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, a, b):
+                ctx.save_for_backward(a, b)
+                return a * b + a + b
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                a, b = ctx.saved_tensors
+                return grad_output * (b + 1), grad_output * (a + 1)
+
+        def fn(x):
+            return Foo.apply(x, x).sum()
+
+        def check_fallback():
+            x = torch.tensor([0.7, -1.3, 2.1, 0.05, -0.5], requires_grad=True)
+
+            x_ref = x.detach().clone().requires_grad_(True)
+            ref = fn(x_ref)
+            ref.backward()
+
+            torch._dynamo.reset()
+            x_compiled = x.detach().clone().requires_grad_(True)
+            res = torch.compile(fn, backend="eager", fullgraph=False)(x_compiled)
+            res.backward()
+
+            self.assertEqual(ref, res)
+            self.assertEqual(x_ref.grad, x_compiled.grad)
+
+        check_fallback()
+
+        torch._dynamo.reset()
+        x = torch.randn(5, requires_grad=True)
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "duplicate tensor input",
+        ):
+            out = torch.compile(fn, backend="eager", fullgraph=True)(x)
+            out.backward()
+
     def test_udf_output(self):
         class Foo:
             def __init__(self, a, b):

--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -583,11 +583,12 @@ class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
             return MyMM.apply(a, b)
 
         a = torch.randn([64, 64], dtype=torch.float32, requires_grad=True)
-        grad = a.clone()
-        res = fn(a, a)
+        b = torch.randn([64, 64], dtype=torch.float32, requires_grad=True)
+        res = fn(a, b)
+        grad = torch.randn_like(res)
         res.backward(grad)
 
-        self.assertEqual(res, MyMM.apply(a, a))
+        self.assertEqual(res, MyMM.apply(a, b))
         self.assertEqual(cnt.frame_count, 1)
 
     def test_set_materialize_grads_no_graph_break(self):

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -3618,6 +3618,16 @@
       ]
     }
   ],
+  "GB6297": [
+    {
+      "Gb_type": "autograd.Function.apply: duplicate tensor input",
+      "Context": "",
+      "Explanation": "Dynamo does not support tracing autograd.Function.apply when the same tensor is passed to multiple forward inputs.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
   "GB0262": [
     {
       "Gb_type": "unsupported contextlib.* API",

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -5242,6 +5242,22 @@ class AutogradFunctionApplyVariable(VariableTracker):
             # to the backward graph. If it is an input to the backward graph, we have to lookup bwd_freevars to get the inner proxy.
             return bwd_freevars.get(vt.proxy, vt.proxy).node  # type: ignore[attr-defined]
 
+        tensor_args_seen: list[Any] = []
+        for arg in orig_fwd_args:
+            if arg.is_tensor():
+                fake_tensor = _get_fake_value(arg)
+                if any(fake_tensor is seen for seen in tensor_args_seen):
+                    unimplemented(
+                        gb_type="autograd.Function.apply: duplicate tensor input",
+                        context="",
+                        explanation="Dynamo does not support tracing autograd.Function.apply "
+                        "when the same tensor is passed to multiple forward inputs.",
+                        hints=[
+                            *graph_break_hints.SUPPORTABLE,
+                        ],
+                    )
+                tensor_args_seen.append(fake_tensor)
+
         # Find the mapping between orig_fwd_args and bwd_out
         # pyrefly: ignore [implicit-any]
         outer_fwd_proxy_to_bwd_node = {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #184281

Dynamo's autograd.Function HOP deduplicates lifted tensor inputs, which can lose one backward contribution when the same tensor is passed to multiple forward slots. Graph break for that case so non-fullgraph compilation falls back to eager, and cover both fallback and fullgraph behavior in the autograd Function tests.

Authored by Codex.

Fixes https://github.com/pytorch/pytorch/issues/181146

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98