### PR TITLE
[MPS] Fix _amp_foreach_non_finite_check_and_unscale_ zeroing fp16/bf16 grads

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Amp.metal
+++ b/aten/src/ATen/native/mps/kernels/Amp.metal
@@ -21,7 +21,7 @@ kernel void ampNonFiniteCheckAndUnscale(
     constant AmpNonFiniteCheckAndUnscaleArgs<T>& pointerArgs [[buffer(0)]],
     constant MetadataArguments& metadata [[buffer(1)]],
     device float& foundInf [[buffer(2)]],
-    constant T& invScale [[buffer(3)]],
+    constant float& invScale [[buffer(3)]],
     uint local_tid [[thread_position_in_threadgroup]],
     uint tgSize [[threads_per_threadgroup]],
     uint group_id [[threadgroup_position_in_grid]]) {
@@ -38,11 +38,11 @@ kernel void ampNonFiniteCheckAndUnscale(
 
   for (uint i = local_tid; i < chunk_size; i += threadGroupSize) {
     uint index = offset + i;
-    T val = data[index];
+    float val = static_cast<float>(data[index]);
     if (!isfinite(val)) {
       foundInf = 1.0f;
     }
-    data[index] = (invScale == static_cast<T>(1.0) ? val : val * invScale);
+    data[index] = static_cast<T>(invScale == 1.0f ? val : val * invScale);
   }
 }
 
@@ -50,13 +50,13 @@ template <typename T>
 kernel void ampNonFiniteCheckAndUnscaleSingle(
     device T* data [[buffer(0)]],
     device float& foundInf [[buffer(1)]],
-    constant T& invScale [[buffer(2)]],
+    constant float& invScale [[buffer(2)]],
     uint tid [[thread_position_in_grid]]) {
-  T val = data[tid];
+  float val = static_cast<float>(data[tid]);
   if (!isfinite(val)) {
     foundInf = 1.0f;
   }
-  data[tid] = (invScale == T(1.0) ? val : val * invScale);
+  data[tid] = static_cast<T>(invScale == 1.0f ? val : val * invScale);
 }
 
 template <typename T>
@@ -87,7 +87,7 @@ kernel void ampUpdateScale(
           pointerArgs [[buffer(0)]],                                        \
       constant MetadataArguments & metadata [[buffer(1)]],                  \
       device float& foundInf [[buffer(2)]],                                 \
-      constant DTYPE& invScale [[buffer(3)]],                               \
+      constant float& invScale [[buffer(3)]],                               \
       uint local_tid [[thread_position_in_threadgroup]],                    \
       uint tgSize [[threads_per_threadgroup]],                              \
       uint group_id [[threadgroup_position_in_grid]])
@@ -98,7 +98,7 @@ kernel void ampUpdateScale(
       ampNonFiniteCheckAndUnscaleSingle<DTYPE>(                              \
           device DTYPE * data [[buffer(0)]],                                 \
           device float& foundInf [[buffer(1)]],                              \
-          constant DTYPE& invScale [[buffer(2)]],                            \
+          constant float& invScale [[buffer(2)]],                            \
           uint tid [[thread_position_in_grid]])
 
 #define INSTANTIATE_AMP_UPDATE_SCALE(DTYPE)                    \

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -348,6 +348,20 @@ class TestAutocastMPS(TestCase):
         self.assertEqual(updated_linear1_weight_cpu, updated_linear1_weight_mps, atol=6e-4, rtol=1e-6)
         self.assertEqual(updated_linear2_weight_cpu, updated_linear2_weight_mps, atol=6e-4, rtol=1e-6)
 
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_amp_foreach_non_finite_check_and_unscale_low_precision_grads(self, dtype):
+        # Regression: kernel type-punned the fp32 inv_scale buffer as half/bfloat,
+        # zeroing fp16/bf16 grads
+        def make_tensor(data):
+            return torch.tensor(data, device="mps", dtype=dtype)
+        inv_scale = torch.tensor([0.5], device="mps")
+        found_inf = torch.zeros(1, device="mps")
+        grads = [make_tensor([1.0, 2.0, -4.0, 0.0]), make_tensor([8.0, 16.0, float("inf"), float("nan")])]
+        torch._amp_foreach_non_finite_check_and_unscale_(grads, found_inf, inv_scale)
+        self.assertEqual(grads[0], make_tensor([0.5, 1.0, -2.0, 0.0]))
+        self.assertEqual(grads[1][:2], make_tensor([4.0, 8.0]))
+        self.assertEqual(found_inf.item(), 1.0)
+
 # Expand TestCase class with Memory Leak Detection on MPS device
 class TestCaseMPS(TestCase):
     _do_mps_memory_leak_check = True


### PR DESCRIPTION
Fixes `_amp_foreach_non_finite_check_and_unscale_` on MPS: kernel declared inv_scale as half/bfloatt but the host binded a fp32 buffer, which zero'd fp16/bf16 grads. Now it matches CUDA(doing math in fp32). Example reproducer below

CPU trains, MPS is stuck before the change
```
import torch, torch.nn as nn

torch.manual_seed(0)

for dev in ("cpu", "mps"):
    torch.manual_seed(0)
    m = nn.Linear(8, 1).to(dev, dtype=torch.bfloat16)
    opt = torch.optim.SGD(m.parameters(), lr=0.01)
    scaler = torch.amp.GradScaler(dev, init_scale=2.0)
    x = torch.randn(16, 8, dtype=torch.bfloat16).to(dev)
    y = torch.randn(16, 1, dtype=torch.bfloat16).to(dev)
    for _ in range(100):
        opt.zero_grad()
        loss = ((m(x) - y) ** 2).mean()
        scaler.scale(loss).backward()
        scaler.step(opt); scaler.update()
        print(dev, "loss:", loss.item())
```

out:
```
cpu loss: 1.7890625
cpu loss: 1.7578125
cpu loss: 1.7109375
cpu loss: 1.6796875
cpu loss: 1.6484375
cpu loss: 1.6171875
cpu loss: 1.5859375
cpu loss: 1.5625
cpu loss: 1.53125
cpu loss: 1.5078125
cpu loss: 1.484375
cpu loss: 1.46875
cpu loss: 1.4453125
cpu loss: 1.421875
cpu loss: 1.3984375
cpu loss: 1.3828125
cpu loss: 1.359375
cpu loss: 1.3515625
cpu loss: 1.328125
cpu loss: 1.3125
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
mps loss: 1.7890625
```