### PR TITLE
[OSDC] Fall back to GHA artifacts for TD download

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -673,6 +673,8 @@ jobs:
       - name: Download TD artifacts
         continue-on-error: true
         uses: pytorch/pytorch/.github/actions/download-td-artifacts@main
+        with:
+          use-gha: ${{ steps.aws-creds.outcome != 'success' || inputs.use-gha }}
 
       - name: Download Windows torch wheel for cross-compilation
         if: matrix.win_torch_wheel_artifact != ''


### PR DESCRIPTION
## Summary

The `test-osdc` job in `_linux-test.yml` currently can't pick up the Target Determination selection on the OSDC runner. The `Configure AWS credentials` step (assume `arn:aws:iam::308535385114:role/arc` via OIDC) fails inside the OSDC container — the GHA OIDC token isn't surfaced to `aws-actions/configure-aws-credentials` despite `id-token: write` being granted at both the workflow (`pull.yml`) and job (`_linux-test.yml::test-osdc`) levels. The action logs:

```
##[group]Run aws-actions/configure-aws-credentials@…
with:
  role-to-assume: arn:aws:iam::308535385114:role/arc
  …
It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? …
##[error]Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```

Because the credentials step is `continue-on-error: true`, the job continues with no AWS creds. The next step `Download TD artifacts` then errors with `Missing credentials in config, if using AWS_CONFIG_FILE, set AWS_SDK_LOAD_CONFIG=1` and no `td_results.json` lands in `.additional_ci_files/`. `run_test.py` falls back to running the full suite, while EC2 `test` jobs apply a ~25% TD reduction — and that asymmetry is what surfaced the `test_transformers` / `test_overrides` import-time crashes on OSDC that pytorch/pytorch#184274 was tracking.

`target_determination.yml` already double-publishes `td_results.json`: once to S3 via `seemethere/upload-artifact-s3@v5` and once to GHA artifacts via `actions/upload-artifact@v4`. The OSDC job's `download-build-artifacts` step already takes the GHA path when `aws-creds` didn't succeed:

```yaml
- name: Download build artifacts
  uses: pytorch/pytorch/.github/actions/download-build-artifacts@main
  with:
    name: ${{ inputs.build-environment }}
    s3-bucket: ${{ inputs.s3-bucket }}
    use-gha: ${{ steps.aws-creds.outcome != 'success' || inputs.use-gha }}
```

This PR mirrors that pattern on the TD download step so OSDC consumes the TD selection via the GHA path. It does not change any behavior for EC2 jobs (their `aws-creds` step doesn't exist on that path, so `steps.aws-creds.outcome` is empty / unequal to `'success'` only for OSDC where the step is present and failed — EC2 keeps the S3 path). Forked PRs benefit too, since the GHA artifact download works without AWS creds.

Related: #184274.

## Test plan

- [ ] After this lands, an OSDC `test-osdc (dynamo_wrapped, *)` run on the same SHA as #184274's failing examples should show `Running NN% of tests based on TD` in the job log and skip the modules TD excluded (matching the EC2 `test` shard counts).
- [ ] Confirm no regression on EC2 `test` jobs (they should still download `td_results.json` from S3 as before — `steps.aws-creds` doesn't run in the EC2 job, so the conditional doesn't apply).