### PR TITLE
[OSDC] Point linux.arm64.m7g.metal at the Graviton3 bare-metal pool

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -80,7 +80,7 @@ runner_mapping:
   linux.arm64.m7g.4xlarge: l-arm64g3-16-62                       # m7g.4xlarge
   linux.arm64.m8g.4xlarge: l-arm64g4-16-62                       # m8g.4xlarge
   linux.arm64.r7g.12xlarge.memory: l-arm64g3-61-463              # r7g.12xlarge
-  linux.arm64.m7g.metal: l-barm64g4-62-226                       # m7g.metal
+  linux.arm64.m7g.metal: l-barm64g3-62-226                       # m7g.metal
 
 
   # ---- x86 GPU — A100 (p4de family) ----


### PR DESCRIPTION
## Summary

Switches the OSDC backing for `linux.arm64.m7g.metal` from `l-barm64g4-62-226` (AWS Graviton4, `m8g.16xlarge` virtualized dedicated node) to `l-barm64g3-62-226` (AWS Graviton3, true `m7g.metal` bare-metal).

Fixes #184284.

## Why

The current mapping silently substitutes the wrong silicon (G4 instead of G3) and isn't true AWS bare-metal — defeating the noise-isolation requirement that the `m7g.metal` runner exists for (inductor CPU perf benchmarks). The OSDC pool name `l-barm64g4-62-226` advertises Graviton4 in its label, so the deception was internally consistent on the OSDC side; only the arc.yaml mapping was wrong.

## Ready to land

This depends on **pytorch/ci-infra#591** which adds the new `l-barm64g3-62-226` pool (and its underlying `m7g.metal` Karpenter fleet). Land sequence:

1. Merge pytorch/ci-infra#591.
2. ci-infra deploy pipeline rolls out the new ARC scale set + Karpenter NodePool to prod EKS.
3. Validate that `m7g.metal` capacity is actually provisionable (capacity reservation / ODCR may be required — bare-metal SKUs are supply-constrained).
4. **Only then** merge this PR.

If this lands before step 3 completes, every job dispatched to `linux.arm64.m7g.metal` will sit in the queue with no scale set listening.

## Test plan

- [ ] pytorch/ci-infra#591 merged and deployed to prod.
- [ ] One CI run on a workflow using `linux.arm64.m7g.metal` (e.g., inductor CPU perf) completes successfully and runs on an actual `m7g.metal` node (`uname -m` = aarch64, `cat /sys/devices/virtual/dmi/id/product_name` shows the bare-metal SKU).

## Other arm64 silicon mismatches

pytorch/ci-infra#591 also fixes the OSDC backings for `linux.arm64.2xlarge[.ephemeral]` (Graviton4 → Graviton2 t4g.2xlarge) and `linux.arm64.m7g.4xlarge` (Graviton4 → Graviton3 m7g.8xlarge). Those fixes happen entirely on the OSDC side; this arc.yaml file needs no further changes for them.

Authored by Claude.