### PR TITLE
[CI][Infra][B200] nvidia container toolkit requires --runtime=nvidia

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Setup GPU_FLAG for docker run
         id: setup-gpu-flag
-        run: echo "GPU_FLAG=--gpus all -e NVIDIA_DRIVER_CAPABILITIES=all" >> "${GITHUB_ENV}"
+        run: echo "GPU_FLAG=--runtime=nvidia --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all" >> "${GITHUB_ENV}"
         if: ${{ steps.install-nvidia-driver.outputs.has-nvidia == 'true' || contains(matrix.runner, 'b200') }}
 
       - name: Setup SCCACHE_SERVER_PORT environment for docker run when on container


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/184277 

Proofs:
1) linux.dgx.b200.8 jobs https://github.com/pytorch/pytorch/actions/runs/26066008910/job/76641196471?pr=184293 succeeded, indicating that the runners were correctly provisioned (nvidia-container-toolkits, docker etc) 
2) linux.dgx.b200 jobs did not get regressed by this MR, e.g. https://github.com/pytorch/pytorch/actions/runs/26066009046/job/76639304120?pr=184293 provided valid signals

Edit: what is "--runtime=nvidia" please see  https://developer.nvidia.com/container-runtime

cc @ptrblck @eqy @tinglvv @atalman @malfet @huydhn @jeanschmidt 

