### PR TITLE
Avoid unused storage size guards for indexing

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1292,6 +1292,38 @@ class TestFxGraphCache(TestCase):
 
             self.assertEqual(res1, res2)
 
+    @largeTensorTest("3GB", device=GPU_TYPE, inductor=True)
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
+    @parametrize("device", (GPU_TYPE,))
+    def test_cache_load_no_int32_guard_on_unindexed_storage(self, device):
+        """
+        The first dimension contributes to the input storage size, but the
+        generated kernel only indexes the selected row.
+        """
+        if device == GPU_TYPE and not HAS_GPU:
+            raise unittest.SkipTest(f"requires {GPU_TYPE}")
+
+        def fn(x):
+            return x[0] + x[0]
+
+        compiled_fn = torch.compile(fn, dynamic=True)
+
+        counters.clear()
+        small = torch.ones((4, 5), device=device, dtype=torch.int8)
+        res1 = compiled_fn(small)
+        self.assertGreater(counters["inductor"]["fxgraph_cache_miss"], 0)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        counters.clear()
+        large = torch.ones((46341, 46341), device=device, dtype=torch.int8)
+        res2 = compiled_fn(large)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        self.assertEqual(res1, torch.full_like(res1, 2))
+        self.assertEqual(res2, torch.full_like(res2, 2))
+
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     @parametrize("device", (GPU_TYPE, "cpu"))

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1981,11 +1981,6 @@ class SIMDScheduling(BaseScheduling):
         numel: sympy.Expr,
         buffers: Iterable[ir.Buffer | ir.TensorBox | ir.TorchBindObject | ir.IRNode],
     ) -> bool:
-        int_max = torch.iinfo(torch.int32).max
-
-        if not expr_fits_within_32bit(numel):
-            return False
-
         # Any use of a MultiOutputLayout will create a buffer with a
         # Layout whose sizes are accounted for
         buf_sizes = [
@@ -2003,13 +1998,26 @@ class SIMDScheduling(BaseScheduling):
                     if buf.has_tensor_output()
                 ]
 
-        if not all(expr_fits_within_32bit(size) for size in buf_sizes):
+        return SIMDScheduling.can_use_32bit_indexing_with_index_sizes(numel, buf_sizes)
+
+    @staticmethod
+    def can_use_32bit_indexing_with_index_sizes(
+        numel: sympy.Expr,
+        index_sizes: Iterable[sympy.Expr],
+    ) -> bool:
+        int_max = torch.iinfo(torch.int32).max
+
+        if not expr_fits_within_32bit(numel):
+            return False
+
+        index_sizes = tuple(index_sizes)
+        if not all(expr_fits_within_32bit(size) for size in index_sizes):
             return False
 
         # Only install guards for 32-bit indexing as there is no correctness
         # issue with using 64-bit for everything
         V.graph.sizevars.check_leq(numel, int_max)  # type: ignore[arg-type]
-        for size in buf_sizes:
+        for size in index_sizes:
             V.graph.sizevars.check_leq(size, int_max)  # type: ignore[arg-type]
         return True
 

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -14,7 +14,7 @@ import torch
 from ...utils._ordered_set import OrderedSet
 from ...utils._sympy.functions import FloorDiv, ModularIndexing
 from ...utils._sympy.symbol import make_symbol, SymT
-from ..dependencies import Dep, extract_loop_body_with_args, MemoryDep
+from ..dependencies import Dep, extract_loop_body_with_args, MemoryDep, StarDep, WeakDep
 from ..runtime.hints import ReductionHint
 from ..scheduler import SchedulerNode
 from ..utils import cache_on_self
@@ -131,12 +131,7 @@ class SIMDKernelFeatures:
 
     @cache_on_self
     def select_index_dtype(self) -> torch.dtype:
-        # Gather all used buffer names
-        buffer_names: OrderedSet[str] = OrderedSet()
-        for node in self.scheduler_nodes():
-            buffer_names.update(node.get_buffer_names())
-            buffer_names.update(node.used_buffer_names())
-        buffers = [V.graph.get_buffer(name) for name in buffer_names]
+        index_sizes = self.indexing_expr_sizes()
 
         # In theory we can separately check xnumel and rnumel are <= int_max
         # but some indexers do use the full linear index so we need to be
@@ -145,9 +140,107 @@ class SIMDKernelFeatures:
 
         from .simd import SIMDScheduling
 
-        if SIMDScheduling.can_use_32bit_indexing(total_numel, buffers):
+        if (
+            index_sizes is not None
+            and SIMDScheduling.can_use_32bit_indexing_with_index_sizes(
+                total_numel, index_sizes
+            )
+        ):
             return torch.int32
         return torch.int64
+
+    def indexing_expr_sizes(self) -> tuple[sympy.Expr, ...] | None:
+        """Return upper bounds for emitted indexing expressions plus one.
+
+        32-bit indexing only requires the expressions that become kernel
+        indices to fit in int32.  Falling back to whole-buffer storage is
+        still necessary for indirect or whole-buffer dependencies, but doing
+        so for every buffer adds guards for unused storage dimensions.
+        """
+        result: list[sympy.Expr] = []
+
+        for node in self.scheduler_nodes():
+            for dep in itertools.chain(node.read_writes.reads, node.read_writes.writes):
+                if isinstance(dep, MemoryDep):
+                    if dep.is_indirect():
+                        size = self.buffer_storage_size(dep.name)
+                    else:
+                        size = self.index_expr_size(dep.index, dep.var_names, dep.size)
+                        if size is None:
+                            size = self.buffer_storage_size(dep.name)
+                    if size is not None:
+                        result.append(size)
+                    continue
+
+                if isinstance(dep, StarDep):
+                    size = self.buffer_storage_size(dep.name)
+                    if size is not None:
+                        result.append(size)
+                    continue
+
+                if isinstance(dep, WeakDep):
+                    continue
+
+                return None
+
+            for index_expr in node.read_writes.index_exprs:
+                size = self.index_expr_size(
+                    index_expr.index, index_expr.var_names, index_expr.size
+                )
+                if size is None:
+                    return None
+                result.append(size)
+
+        return tuple(result)
+
+    @staticmethod
+    def buffer_storage_size(name: str) -> sympy.Expr | None:
+        buf = V.graph.get_buffer(name)
+        if buf.has_tensor_output():
+            return V.graph.sizevars.simplify(buf.get_layout().storage_size())
+        return None
+
+    @staticmethod
+    def index_expr_size(
+        index: sympy.Expr,
+        var_names: tuple[sympy.Symbol, ...],
+        var_sizes: tuple[sympy.Expr, ...],
+    ) -> sympy.Expr | None:
+        index = V.graph.sizevars.simplify(index)
+
+        def nonnegative(expr: sympy.Expr) -> bool:
+            return V.graph.sizevars.statically_known_true(expr >= 0)
+
+        try:
+            if not var_names:
+                if nonnegative(index):
+                    return V.graph.sizevars.simplify(index + 1)
+                return None
+
+            poly = sympy.Poly(index, *var_names)
+        except (sympy.PolynomialError, TypeError):
+            return None
+
+        result = sympy.S.Zero
+        for powers, coeff in poly.terms():
+            degree = sum(powers)
+            if degree == 0:
+                if not nonnegative(coeff):
+                    return None
+                result += coeff
+                continue
+
+            if degree != 1:
+                return None
+
+            var_pos = next(i for i, power in enumerate(powers) if power)
+            if powers[var_pos] != 1 or not nonnegative(coeff):
+                return None
+            result += coeff * (var_sizes[var_pos] - 1)
+
+        if not nonnegative(result):
+            return None
+        return V.graph.sizevars.simplify(result + 1)
 
     def get_reduction_hint(
         self, tiling_scores: dict[str, int] | None = None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184294

Use the actual emitted indexing expressions to decide 32-bit indexing guards when possible, while keeping conservative storage-size fallback for indirect or whole-buffer dependencies. This avoids recompilation when a large tensor storage is present but the generated kernel only indexes a small slice.

Fixes #135492

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo