### PR TITLE
Fix SDPA rewriter 12 test pattern

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -2,6 +2,8 @@
 import functools
 import itertools
 import math
+import os
+from unittest import mock
 
 import torch
 import torch._inductor.config
@@ -70,6 +72,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         override_check_equal=False,
         dtype=torch.float,
         rtol=0.2,
+        expected_fused_attention_patterns=None,
     ):
         if args1 is None:
             tensor_shape = (4, 2, 16, 32)
@@ -102,13 +105,34 @@ class TestSDPAPatternRewriterTemplate(TestCase):
 
             counters.clear()
             torch.manual_seed(1234)
-            result2, source_code = run_and_get_code(
-                torch.compile(dot_prod_attention, fullgraph=True),
-                *(args2 + dropout_arg),
+            expected_fused_attention_pattern = (
+                expected_fused_attention_patterns.get(training)
+                if expected_fused_attention_patterns is not None
+                else None
             )
+            if expected_fused_attention_pattern is not None:
+                with mock.patch.dict(
+                    os.environ, {"TORCHINDUCTOR_PATTERN_MATCH_DEBUG": "__none__"}
+                ):
+                    result2, source_code = run_and_get_code(
+                        torch.compile(dot_prod_attention, fullgraph=True),
+                        *(args2 + dropout_arg),
+                    )
+            else:
+                result2, source_code = run_and_get_code(
+                    torch.compile(dot_prod_attention, fullgraph=True),
+                    *(args2 + dropout_arg),
+                )
             source_code = "\n".join(source_code)
             if has_fuse_pattern:
                 self.assertGreaterEqual(counters["inductor"]["fuse_attention"], 1)
+            if expected_fused_attention_pattern is not None:
+                self.assertGreaterEqual(
+                    counters["inductor_pattern_matcher_per_pattern"][
+                        expected_fused_attention_pattern
+                    ],
+                    1,
+                )
             if contains:
                 # many of the patterns get re-expanded in dispatcher
                 self.assertIn(
@@ -799,17 +823,22 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             q = query.transpose(1, 2)
             k = key.transpose(1, 2)
             v = value.transpose(1, 2)
-            return torch.nn.functional.dropout(
+            attn_weight = torch.nn.functional.dropout(
                 torch.matmul(q, k.transpose(-2, -1))
                 .div(math.sqrt(key.shape[-1]))
-                .softmax(dim=-1)
-                .matmul(v),
+                .softmax(dim=-1),
                 p=0.4,
                 training=training,
                 inplace=False,
             )
+            return attn_weight.matmul(v)
 
-        self._check_common(dot_prod_attention, contains=False, has_dropout=True)
+        self._check_common(
+            dot_prod_attention,
+            contains=False,
+            has_dropout=True,
+            expected_fused_attention_patterns={True: "_sfdp_pattern_12_training"},
+        )
 
     def _test_sdpa_prev_13(self):
         def dot_prod_attention(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184295

Update the SDPA rewriter 12 test so the dropout is applied to attention weights before the value matmul, matching the actual pattern being exercised. Add an exact per-pattern assertion for the training case to catch regressions.

Fixes #135407

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo