### PR TITLE
Replace ostringstream with fmt::format in python_compiled_autograd.cpp

### DIFF
--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -1,11 +1,11 @@
 #include <torch/csrc/dynamo/python_compiled_autograd.h>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <torch/csrc/autograd/engine.h>
 #include <torch/csrc/autograd/python_function.h>
 #include <torch/csrc/dynamo/compiled_autograd.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -340,9 +340,7 @@ static variable_list validate_outputs(
 
   torch::autograd::validate_outputs(
       value, new_outputs, [&](const std::string& msg) {
-        std::ostringstream ss;
-        ss << "[Compiled Autograd Tracing:]" << msg;
-        return ss.str();
+        return fmt::format("[Compiled Autograd Tracing:]{}", msg);
       });
   return new_outputs;
 }
@@ -419,22 +417,17 @@ struct VerboseLogger : public PythonLogger {
       const std::unordered_set<CacheKey>& cached_keys,
       const CacheKey& key,
       const std::string& node_name) const {
-    std::ostringstream oss;
-    oss << "Cache miss due to new autograd node: " << node_name
-        << " with key size " << std::to_string(key.key_size)
-        << ", previous key sizes=[";
-
-    for (auto it = cached_keys.begin(); it != cached_keys.end(); it++) {
-      if (it->node_type != node_type) {
-        continue;
-      }
-      oss << it->key_size;
-      if (std::next(it) != cached_keys.end()) {
-        oss << ',';
+    std::vector<size_t> matching_sizes;
+    for (const auto& k : cached_keys) {
+      if (k.node_type == node_type) {
+        matching_sizes.push_back(k.key_size);
       }
     }
-    oss << ']';
-    std::string compile_reason = oss.str();
+    std::string compile_reason = fmt::format(
+        "Cache miss due to new autograd node: {} with key size {}, previous key sizes=[{}]",
+        node_name,
+        key.key_size,
+        fmt::join(matching_sizes, ","));
     log(PythonLogger::DEBUG, compile_reason);
     return compile_reason;
   }
@@ -442,16 +435,11 @@ struct VerboseLogger : public PythonLogger {
   std::string log_dynamic_shapes_miss(
       const std::vector<size_t>& new_dyn_sizes_idx,
       size_t all_dyn_sizes_len) const {
-    std::ostringstream oss;
-    oss << "Cache miss due to " << new_dyn_sizes_idx.size()
-        << " changed tensor shapes (total of " << all_dyn_sizes_len << "): ";
-    for (const auto i : c10::irange(new_dyn_sizes_idx.size() - 1)) {
-      oss << "sizes[" << std::to_string(new_dyn_sizes_idx[i]) << "], ";
-    }
-    oss << "sizes["
-        << std::to_string(new_dyn_sizes_idx[new_dyn_sizes_idx.size() - 1])
-        << ']';
-    std::string recompile_reason = oss.str();
+    std::string recompile_reason = fmt::format(
+        "Cache miss due to {} changed tensor shapes (total of {}): sizes[{}]",
+        new_dyn_sizes_idx.size(),
+        all_dyn_sizes_len,
+        fmt::join(new_dyn_sizes_idx, "], sizes["));
     log(PythonLogger::DEBUG, recompile_reason);
     return recompile_reason;
   }


### PR DESCRIPTION
Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @xmfan @aditvenk