### PR TITLE
Enable loop ordering after fusion by default

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -212,6 +212,58 @@ class ImplDetailTest(MockSchedulerTest):
 @inductor_config.patch(
     {
         "benchmark_kernel": True,
+        "triton.unique_kernel_names": True,
+    }
+)
+class LoopOrderingDefaultTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+        metrics.reset()
+
+    @unittest.skipIf(
+        "TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION" in os.environ,
+        "default behavior is overridden by the environment",
+    )
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "FP8 requires H100+ and MI300+")
+    @unittest.skipIf(not SM90OrLater, "sm89 errors out on this test")
+    def test_fp8_cast_and_t_default_enabled(self):
+        self.assertTrue(inductor_config.loop_ordering_after_fusion)
+
+        def f(x, scale):
+            x = x * scale
+            x = x.clamp(-1 * E4M3_MAX_POS, E4M3_MAX_POS)
+            x = x.to(torch.float8_e4m3fn)
+            x_t = x.t().contiguous().t()
+            return x, x_t
+
+        def cast_fp8_to_fp32(x):
+            if isinstance(x, torch.Tensor) and x.dtype in (
+                torch.float8_e5m2,
+                torch.float8_e4m3fn,
+            ):
+                return x.to(torch.float32)
+            return x
+
+        x = torch.randn(128, 256, device=GPU_TYPE, dtype=torch.bfloat16)
+        scale = torch.tensor([10.0], device=GPU_TYPE)
+        E4M3_MAX_POS = torch.finfo(torch.float8_e4m3fn).max
+
+        expected = f(x, scale)
+        actual = torch.compile(f)(x, scale)
+
+        self.assertTrue(
+            same(
+                tree_map(cast_fp8_to_fp32, expected),
+                tree_map(cast_fp8_to_fp32, actual),
+            )
+        )
+        self.assertEqual(1, metrics.generated_kernel_count)
+
+
+@inductor_config.patch(
+    {
+        "benchmark_kernel": True,
         "loop_ordering_after_fusion": True,
         "triton.unique_kernel_names": True,
     }

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -918,10 +918,7 @@ debug_fusion: bool = os.environ.get("TORCHINDUCTOR_DEBUG_FUSION") == "1"
 benchmark_fusion: bool = os.environ.get("TORCHINDUCTOR_BENCHMARK_FUSION") == "1"
 enabled_metric_tables = os.environ.get("TORCHINDUCTOR_ENABLED_METRIC_TABLES", "")
 loop_ordering_after_fusion: bool = (
-    os.environ.get(
-        "TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION", "0" if is_fbcode() else "1"
-    )
-    == "1"
+    os.environ.get("TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION", "1") == "1"
 )
 loop_reindexing_after_fusion: bool = (
     os.environ.get("TORCHINDUCTOR_LOOP_REINDEXING_AFTER_FUSION", "1") == "1"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184314

Turn on Inductor loop ordering after fusion for fbcode/default builds as well, while keeping the environment override, and add a default-config regression for fp8 cast plus transpose fusion.

Fixes #130015

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo