### PR TITLE
[Test] Make autograd/test_functional.py device-agnostic for out-of-tree backends.

### DIFF
--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -6,7 +6,6 @@ import warnings
 
 import torch
 import torch.autograd.functional as autogradF
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
     gradcheck,
     gradgradcheck,
@@ -14,6 +13,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     subtest,
+    TEST_ACCELERATOR,
     TestCase,
 )
 from torch.testing._internal.logging_tensor import LoggingTensor
@@ -648,12 +648,13 @@ class TestAutogradFunctional(TestCase):
         for inputs in test_cases:
             self._test_construct_standard_basis_for(inputs)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "test requires an accelerator")
     @base_and_logging_tensor
-    def test_construct_standard_basis_for_cuda(self, ctors):
+    def test_construct_standard_basis_for_accelerator(self, ctors):
+        device = torch.accelerator.current_accelerator().type
         test_cases = [
-            (ctors.randn(2), ctors.randn(3, device="cuda")),
-            (ctors.randn(3, device="cuda"), ctors.randn(2)),
+            (ctors.randn(2), ctors.randn(3, device=device)),
+            (ctors.randn(3, device=device), ctors.randn(2)),
         ]
 
         for inputs in test_cases:
@@ -961,11 +962,13 @@ class TestAutogradFunctional(TestCase):
         y = ctors.randn(1)
         self._check_jacobian_vectorize_correctness(h, (x, y))
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "test requires an accelerator")
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_different_devices(self, ctors):
+        device = torch.accelerator.current_accelerator().type
+
         def f(x, y):
-            return x * y, (x * y).cuda()
+            return x * y, (x * y).to(device)
 
         x = ctors.randn(3)
         y = ctors.randn(3)

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -6,6 +6,7 @@ import warnings
 
 import torch
 import torch.autograd.functional as autogradF
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     gradcheck,
     gradgradcheck,
@@ -13,7 +14,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     subtest,
-    TEST_ACCELERATOR,
     TestCase,
 )
 from torch.testing._internal.logging_tensor import LoggingTensor
@@ -648,18 +648,6 @@ class TestAutogradFunctional(TestCase):
         for inputs in test_cases:
             self._test_construct_standard_basis_for(inputs)
 
-    @unittest.skipIf(not TEST_ACCELERATOR, "test requires an accelerator")
-    @base_and_logging_tensor
-    def test_construct_standard_basis_for_accelerator(self, ctors):
-        device = torch.accelerator.current_accelerator().type
-        test_cases = [
-            (ctors.randn(2), ctors.randn(3, device=device)),
-            (ctors.randn(3, device=device), ctors.randn(2)),
-        ]
-
-        for inputs in test_cases:
-            self._test_construct_standard_basis_for(inputs)
-
     def _test_vectorize_raises_no_warnings(self, api, ctors):
         # vmap is an experimental prototype. When someone calls torch.vmap,
         # it raises a python warning. This test checks that
@@ -961,18 +949,6 @@ class TestAutogradFunctional(TestCase):
         x = ctors.randn([])
         y = ctors.randn(1)
         self._check_jacobian_vectorize_correctness(h, (x, y))
-
-    @unittest.skipIf(not TEST_ACCELERATOR, "test requires an accelerator")
-    @base_and_logging_tensor
-    def test_jacobian_vectorize_correctness_different_devices(self, ctors):
-        device = torch.accelerator.current_accelerator().type
-
-        def f(x, y):
-            return x * y, (x * y).to(device)
-
-        x = ctors.randn(3)
-        y = ctors.randn(3)
-        self._check_jacobian_vectorize_correctness(f, (x, y))
 
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_different_dtype(self, ctors):
@@ -1741,6 +1717,48 @@ class TestAutogradFunctional(TestCase):
 
 
 instantiate_parametrized_tests(TestAutogradFunctional)
+
+
+class TestAutogradFunctionalDeviceType(TestCase):
+    def _test_construct_standard_basis_for(self, inputs):
+        numels = tuple(tensor.numel() for tensor in inputs)
+        results = autogradF._construct_standard_basis_for(inputs, numels)
+        for result, inp in zip(results, inputs):
+            self.assertEqual(result.dtype, inp.dtype)
+            self.assertEqual(result.device, inp.device)
+        results = torch.cat(
+            [result.to(device="cpu", dtype=torch.float) for result in results], dim=1
+        )
+        expected = torch.eye(results[0].shape[0], dtype=torch.float)
+        self.assertEqual(results, expected)
+
+    @base_and_logging_tensor
+    def test_construct_standard_basis_for(self, device, ctors):
+        test_cases = [
+            (ctors.randn(2), ctors.randn(3, device=device)),
+            (ctors.randn(3, device=device), ctors.randn(2)),
+        ]
+
+        for inputs in test_cases:
+            self._test_construct_standard_basis_for(inputs)
+
+    @base_and_logging_tensor
+    def test_jacobian_vectorize_correctness_different_devices(self, device, ctors):
+        def f(x, y):
+            return x * y, (x * y).to(device)
+
+        x = ctors.randn(3)
+        y = ctors.randn(3)
+        expected = autogradF.jacobian(f, (x, y), vectorize=False)
+        result = autogradF.jacobian(f, (x, y), vectorize=True)
+        self.assertEqual(result, expected)
+        result_forward = autogradF.jacobian(
+            f, (x, y), strategy="forward-mode", vectorize=True
+        )
+        self.assertEqual(result_forward, expected)
+
+
+instantiate_device_type_tests(TestAutogradFunctionalDeviceType, globals(), except_for="cpu")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -6,6 +6,7 @@ import warnings
 
 import torch
 import torch.autograd.functional as autogradF
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     gradcheck,
     gradgradcheck,
@@ -14,7 +15,6 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skipIfTorchDynamo,
     subtest,
-    TEST_ACCELERATOR,
     TestCase,
 )
 from torch.testing._internal.logging_tensor import LoggingTensor
@@ -649,18 +649,6 @@ class TestAutogradFunctional(TestCase):
         for inputs in test_cases:
             self._test_construct_standard_basis_for(inputs)
 
-    @unittest.skipIf(not TEST_ACCELERATOR, "test requires an accelerator")
-    @base_and_logging_tensor
-    def test_construct_standard_basis_for_accelerator(self, ctors):
-        device = torch.accelerator.current_accelerator().type
-        test_cases = [
-            (ctors.randn(2), ctors.randn(3, device=device)),
-            (ctors.randn(3, device=device), ctors.randn(2)),
-        ]
-
-        for inputs in test_cases:
-            self._test_construct_standard_basis_for(inputs)
-
     def _test_vectorize_raises_no_warnings(self, api, ctors):
         # vmap is an experimental prototype. When someone calls torch.vmap,
         # it raises a python warning. This test checks that
@@ -964,18 +952,6 @@ class TestAutogradFunctional(TestCase):
         x = ctors.randn([])
         y = ctors.randn(1)
         self._check_jacobian_vectorize_correctness(h, (x, y))
-
-    @unittest.skipIf(not TEST_ACCELERATOR, "test requires an accelerator")
-    @base_and_logging_tensor
-    def test_jacobian_vectorize_correctness_different_devices(self, ctors):
-        device = torch.accelerator.current_accelerator().type
-
-        def f(x, y):
-            return x * y, (x * y).to(device)
-
-        x = ctors.randn(3)
-        y = ctors.randn(3)
-        self._check_jacobian_vectorize_correctness(f, (x, y))
 
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_different_dtype(self, ctors):
@@ -1744,6 +1720,48 @@ class TestAutogradFunctional(TestCase):
 
 
 instantiate_parametrized_tests(TestAutogradFunctional)
+
+
+class TestAutogradFunctionalDeviceType(TestCase):
+    def _test_construct_standard_basis_for(self, inputs):
+        numels = tuple(tensor.numel() for tensor in inputs)
+        results = autogradF._construct_standard_basis_for(inputs, numels)
+        for result, inp in zip(results, inputs):
+            self.assertEqual(result.dtype, inp.dtype)
+            self.assertEqual(result.device, inp.device)
+        results = torch.cat(
+            [result.to(device="cpu", dtype=torch.float) for result in results], dim=1
+        )
+        expected = torch.eye(results[0].shape[0], dtype=torch.float)
+        self.assertEqual(results, expected)
+
+    @base_and_logging_tensor
+    def test_construct_standard_basis_for(self, device, ctors):
+        test_cases = [
+            (ctors.randn(2), ctors.randn(3, device=device)),
+            (ctors.randn(3, device=device), ctors.randn(2)),
+        ]
+
+        for inputs in test_cases:
+            self._test_construct_standard_basis_for(inputs)
+
+    @base_and_logging_tensor
+    def test_jacobian_vectorize_correctness_different_devices(self, device, ctors):
+        def f(x, y):
+            return x * y, (x * y).to(device)
+
+        x = ctors.randn(3)
+        y = ctors.randn(3)
+        expected = autogradF.jacobian(f, (x, y), vectorize=False)
+        result = autogradF.jacobian(f, (x, y), vectorize=True)
+        self.assertEqual(result, expected)
+        result_forward = autogradF.jacobian(
+            f, (x, y), strategy="forward-mode", vectorize=True
+        )
+        self.assertEqual(result_forward, expected)
+
+
+instantiate_device_type_tests(TestAutogradFunctionalDeviceType, globals(), except_for="cpu")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -6,7 +6,6 @@ import warnings
 
 import torch
 import torch.autograd.functional as autogradF
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
     gradcheck,
     gradgradcheck,
@@ -15,6 +14,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skipIfTorchDynamo,
     subtest,
+    TEST_ACCELERATOR,
     TestCase,
 )
 from torch.testing._internal.logging_tensor import LoggingTensor
@@ -649,12 +649,13 @@ class TestAutogradFunctional(TestCase):
         for inputs in test_cases:
             self._test_construct_standard_basis_for(inputs)
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "test requires an accelerator")
     @base_and_logging_tensor
-    def test_construct_standard_basis_for_cuda(self, ctors):
+    def test_construct_standard_basis_for_accelerator(self, ctors):
+        device = torch.accelerator.current_accelerator().type
         test_cases = [
-            (ctors.randn(2), ctors.randn(3, device="cuda")),
-            (ctors.randn(3, device="cuda"), ctors.randn(2)),
+            (ctors.randn(2), ctors.randn(3, device=device)),
+            (ctors.randn(3, device=device), ctors.randn(2)),
         ]
 
         for inputs in test_cases:
@@ -964,11 +965,13 @@ class TestAutogradFunctional(TestCase):
         y = ctors.randn(1)
         self._check_jacobian_vectorize_correctness(h, (x, y))
 
-    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "test requires an accelerator")
     @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_different_devices(self, ctors):
+        device = torch.accelerator.current_accelerator().type
+
         def f(x, y):
-            return x * y, (x * y).cuda()
+            return x * y, (x * y).to(device)
 
         x = ctors.randn(3)
         y = ctors.randn(3)

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1917,8 +1917,7 @@ class TestNNParametrizationDevice(NNTestCase):
             self.assertEqual(m(input), expected_output)
 
 
-only_for = ("cpu", "cuda")
-instantiate_device_type_tests(TestNNParametrizationDevice, globals(), only_for=only_for)
+instantiate_device_type_tests(TestNNParametrizationDevice, globals())
 instantiate_parametrized_tests(TestNNParametrization)
 
 if __name__ == "__main__":

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1917,7 +1917,8 @@ class TestNNParametrizationDevice(NNTestCase):
             self.assertEqual(m(input), expected_output)
 
 
-instantiate_device_type_tests(TestNNParametrizationDevice, globals())
+only_for = ("cpu", "cuda")
+instantiate_device_type_tests(TestNNParametrizationDevice, globals(), only_for=only_for)
 instantiate_parametrized_tests(TestNNParametrization)
 
 if __name__ == "__main__":

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1921,7 +1921,8 @@ class TestNNParametrizationDevice(NNTestCase):
             self.assertEqual(m(input), expected_output)
 
 
-instantiate_device_type_tests(TestNNParametrizationDevice, globals())
+only_for = ("cpu", "cuda")
+instantiate_device_type_tests(TestNNParametrizationDevice, globals(), only_for=only_for)
 instantiate_parametrized_tests(TestNNParametrization)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace hardcoded CUDA references with device-agnostic equivalents so out-of-tree accelerator backends can run these tests.

  - Replace TEST_CUDA with TEST_ACCELERATOR
  - Replace device=cuda and .cuda() with torch.accelerator API
  - Remove common_cuda import (no longer needed)

Verified all 124 tests pass on both CPU and CUDA configurations.