### PR TITLE
[MPS] fix missing barrier in welford reductions

### DIFF
--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -304,6 +304,7 @@ float3 threadgroup_welford_reduce(threadgroup T* data, unsigned size) {
     m += delta / (idx + 1);
     m2 += delta * (data[idx] - m);
   }
+  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
   return float3(m, m2, size);
 }
 
@@ -326,6 +327,7 @@ float3 threadgroup_welford_combine(threadgroup T* data, unsigned size) {
   for (unsigned idx = 1; idx < size; ++idx) {
     rc = welford_combine(rc, data[idx]);
   }
+  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
   return rc;
 }
 

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -124,6 +124,25 @@ class MPSBasicTests(TestCase):
 
         self.common(fn, (torch.rand(10), torch.ones(10)))
 
+    def test_batchnorm_train_running_stats(self):
+        # Regression test: missing closing threadgroup_barrier in
+        # threadgroup_welford_{reduce,combine}
+        torch.manual_seed(0)
+        xs = [torch.randn(16, 8, 4, 4) for _ in range(10)]
+
+        def run(device, compile_):
+            torch.manual_seed(0)
+            bn = torch.nn.BatchNorm2d(8).to(device).train()
+            f = torch.compile(bn) if compile_ else bn
+            for x in xs:
+                f(x.to(device))
+            return bn.running_mean.cpu(), bn.running_var.cpu()
+
+        m_ref, v_ref = run("cpu", False)
+        m_mps, v_mps = run("mps", True)
+        self.assertEqual(m_mps, m_ref)
+        self.assertEqual(v_mps, v_ref)
+
     def test_compile_numpy_scalar(self):
         def fn(x, y):
             return x / y


### PR DESCRIPTION
Add missing barrier in welford reductions, now without it:
```
import torch
import torch.nn as nn

torch.manual_seed(0)
xs = [torch.randn(16, 8, 4, 4) for _ in range(10)]


def run(device, compile_):
    torch.manual_seed(0)
    bn = nn.BatchNorm2d(8).to(device).train()
    f = torch.compile(bn) if compile_ else bn
    for x in xs:
        f(x.to(device))
    return bn.running_mean.cpu(), bn.running_var.cpu()


m_cpu, v_cpu = run("cpu", False)
m_mps, v_mps = run("mps", True)

print("mean max abs diff:", (m_cpu - m_mps).abs().max().item())
print("var  max abs diff:", (v_cpu - v_mps).abs().max().item())
print("var ratio (mps/cpu):", (v_mps / v_cpu).abs().max().item())
```

```
mean max abs diff: 0.014949405565857887
var  max abs diff: 0.03771340847015381
var ratio (mps/cpu): 1.0361438989639282
```

with the change:
```
mean max abs diff: 1.210719347000122e-08
var  max abs diff: 1.7881393432617188e-07
var ratio (mps/cpu): 1.000000238418579
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo