### PR TITLE
[Test] Add device_count() hook to DeviceTypeTestBase

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -246,5 +246,22 @@ with _temp_test_configs(
         TestSupportedOpsWithOverrides, globals(), only_for=("openreg",)
     )
 
+
+class TestDeviceCountHook(TestCase):
+    # Smoke test that DeviceTypeTestBase.device_count() resolves the count from
+    # the instantiated device-specific class's device_type.
+    def test_device_count_for_openreg(self, device):
+        self.assertEqual(
+            type(self).device_type,
+            "openreg",
+        )
+        self.assertEqual(
+            type(self).device_count(),
+            torch.get_device_module(type(self).device_type).device_count(),
+        )
+
+
+instantiate_device_type_tests(TestDeviceCountHook, globals(), only_for=("openreg",))
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -451,6 +451,11 @@ class DeviceTypeTestBase(TestCase):
                 cls.setUpClass()
             return cls.get_primary_device()
 
+    @classmethod
+    def device_count(cls) -> int:
+        """Returns the number of available devices for this device type."""
+        return torch.get_device_module(cls.device_type).device_count()
+
     # Returns a list of strings representing all available devices of this
     # device type. The primary device must be the first string in the list
     # and the list must contain no duplicates.


### PR DESCRIPTION
Fixes #184325

## Summary

Add `device_count()` hook to `DeviceTypeTestBase` as a device-level extension point for querying available device count.