### PR TITLE
package cuda dependencies in libtorch extraction from wheel

### DIFF
--- a/.ci/libtorch/extract_libtorch_from_wheel.py
+++ b/.ci/libtorch/extract_libtorch_from_wheel.py
@@ -101,16 +101,9 @@ def copy_libraries(torch_dir: Path, libtorch_lib: Path, platform: str) -> None:
 
 
 def fix_rpath(libtorch_lib: Path) -> None:
-    """Rewrite RPATH on all shared libraries to $ORIGIN using patchelf.
-
-    The wheel sets RPATH relative to the pip site-packages layout
-    (e.g. $ORIGIN/../../nvidia/nvshmem/lib).  For libtorch, libraries
-    live in a flat lib/ directory and NVIDIA deps come from the user's
-    system CUDA installation, so $ORIGIN is sufficient.
-
-    Requires patchelf to be available (present in manylinux2_28-builder
-    Docker images at /usr/local/bin/patchelf).
-    """
+    # Wheel RPATHs are relative to pip's site-packages layout; rewrite to
+    # $ORIGIN for the flat libtorch lib/ directory. Requires patchelf
+    # (available in manylinux2_28-builder containers).
     if sys.platform != "linux":
         raise RuntimeError(f"fix_rpath is only supported on Linux, got {sys.platform}")
 

--- a/.ci/libtorch/extract_libtorch_from_wheel.py
+++ b/.ci/libtorch/extract_libtorch_from_wheel.py
@@ -100,6 +100,42 @@ def copy_libraries(torch_dir: Path, libtorch_lib: Path, platform: str) -> None:
                     shutil.copy2(item, libtorch_lib / item.name)
 
 
+def fix_rpath(libtorch_lib: Path) -> None:
+    """Rewrite RPATH on all shared libraries to $ORIGIN using patchelf.
+
+    The wheel sets RPATH relative to the pip site-packages layout
+    (e.g. $ORIGIN/../../nvidia/nvshmem/lib).  For libtorch, libraries
+    live in a flat lib/ directory and NVIDIA deps come from the user's
+    system CUDA installation, so $ORIGIN is sufficient.
+
+    Requires patchelf to be available (present in manylinux2_28-builder
+    Docker images at /usr/local/bin/patchelf).
+    """
+    if sys.platform != "linux":
+        raise RuntimeError(f"fix_rpath is only supported on Linux, got {sys.platform}")
+
+    patchelf = shutil.which("patchelf")
+    if not patchelf:
+        raise FileNotFoundError(
+            "patchelf not found; the extraction job must run inside a "
+            "manylinux2_28-builder container that ships patchelf"
+        )
+
+    for item in libtorch_lib.iterdir():
+        if item.is_file() and (item.name.endswith(".so") or ".so." in item.name):
+            result = subprocess.run(
+                [patchelf, "--set-rpath", "$ORIGIN", "--force-rpath", str(item)],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                print(f"  Fixed rpath: {item.name}")
+            else:
+                raise RuntimeError(
+                    f"patchelf failed on {item.name}: {result.stderr.strip()}"
+                )
+
+
 def copy_includes(torch_dir: Path, libtorch_include: Path) -> None:
     torch_include = torch_dir / "include"
     if not torch_include.is_dir():
@@ -319,6 +355,8 @@ def main() -> None:
 
         # Copy components
         copy_libraries(torch_dir, libtorch_dir / "lib", args.platform)
+        if args.platform == "linux":
+            fix_rpath(libtorch_dir / "lib")
         copy_includes(torch_dir, libtorch_dir / "include")
         copy_cmake(torch_dir, libtorch_dir / "share")
         copy_bin(torch_dir, libtorch_dir / "bin", args.platform)

--- a/.ci/libtorch/extract_libtorch_from_wheel.py
+++ b/.ci/libtorch/extract_libtorch_from_wheel.py
@@ -129,6 +129,50 @@ def fix_rpath(libtorch_lib: Path) -> None:
                 )
 
 
+# CUDA toolkit dirs in the manylinux builder holding the NVIDIA runtime libs the
+# wheel needs. Only sonames found here are bundled, so system libs and the driver
+# stub (in stubs/, never searched) are left to the runtime environment.
+_CUDA_LIB_DIRS = ("/usr/local/cuda/lib64", "/usr/local/cuda/extras/CUPTI/lib64")
+
+
+def _is_cuda_variant(desired_cuda: str) -> bool:
+    return desired_cuda.startswith("cu")
+
+
+def _needed(patchelf: str, so: Path) -> list[str]:
+    r = subprocess.run(
+        [patchelf, "--print-needed", str(so)], capture_output=True, text=True
+    )
+    return r.stdout.split() if r.returncode == 0 else []
+
+
+def bundle_cuda_deps(libtorch_lib: Path) -> None:
+    """Copy the NVIDIA runtime deps the small CUDA wheel omits into lib/ so the
+    shared-with-deps tarball is self-contained (pytorch/pytorch#183971). Resolves
+    NEEDED transitively from the torch libs; fix_rpath then adds $ORIGIN so the
+    flat lib/ self-resolves. Must run in a CUDA manylinux builder."""
+    patchelf = shutil.which("patchelf")
+    search = [Path(d) for d in _CUDA_LIB_DIRS if Path(d).is_dir()]
+    if not patchelf or not search:
+        raise FileNotFoundError(
+            "needs a CUDA manylinux builder (patchelf + /usr/local/cuda)"
+        )
+    present = {p.name for p in libtorch_lib.iterdir() if p.is_file()}
+    queue = [p for p in libtorch_lib.iterdir() if p.is_file() and ".so" in p.name]
+    while queue:
+        for needed in _needed(patchelf, queue.pop()):
+            if needed in present:
+                continue
+            src = next((d / needed for d in search if (d / needed).exists()), None)
+            if not src:
+                continue
+            dest = libtorch_lib / needed
+            shutil.copy2(src, dest)  # follows symlinks -> real file named by soname
+            present.add(needed)
+            queue.append(dest)
+            print(f"  bundled CUDA dep: {needed}")
+
+
 def copy_includes(torch_dir: Path, libtorch_include: Path) -> None:
     torch_include = torch_dir / "include"
     if not torch_include.is_dir():
@@ -349,6 +393,12 @@ def main() -> None:
         # Copy components
         copy_libraries(torch_dir, libtorch_dir / "lib", args.platform)
         if args.platform == "linux":
+            # shared-with-deps must be self-contained: bundle the NVIDIA runtime
+            # libs the small wheel omits, then rewrite all RPATHs to $ORIGIN so
+            # the flat lib/ resolves both torch and bundled deps.
+            with_deps = "with-deps" in args.libtorch_variant
+            if _is_cuda_variant(args.desired_cuda) and with_deps:
+                bundle_cuda_deps(libtorch_dir / "lib")
             fix_rpath(libtorch_dir / "lib")
         copy_includes(torch_dir, libtorch_dir / "include")
         copy_cmake(torch_dir, libtorch_dir / "share")

--- a/.ci/libtorch/smoke_test_extract_libtorch.py
+++ b/.ci/libtorch/smoke_test_extract_libtorch.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Tests for the libtorch extraction pipeline."""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+from extract_libtorch_from_wheel import (
+    compute_zip_prefix,
+    copy_bin,
+    copy_cmake,
+    copy_includes,
+    copy_libraries,
+    create_libtorch_zip,
+    extract_wheel,
+    find_wheel,
+    fix_rpath,
+    get_git_hash,
+    parse_version_from_wheel,
+    write_metadata,
+)
+
+
+def _make_fake_wheel(wheel_dir: Path, version: str = "2.6.0") -> Path:
+    name = f"torch-{version}-cp310-cp310-linux_x86_64.whl"
+    wheel_path = wheel_dir / name
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        zf.writestr("torch/lib/libtorch.so", "fake")
+        zf.writestr("torch/lib/libtorch_cpu.so", "fake")
+        zf.writestr("torch/lib/libtorch_python.so", "excluded")
+        zf.writestr("torch/lib/_C.cpython-310-x86_64-linux-gnu.so", "excluded")
+        zf.writestr("torch/include/torch/torch.h", "// header")
+        zf.writestr("torch/share/cmake/Torch/TorchConfig.cmake", "# cmake")
+        zf.writestr("torch/version.py", "git_version = 'abc123'\n")
+    return wheel_path
+
+
+class TestSmokeExtraction(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self.wheel_dir = Path(self._tmp) / "wheels"
+        self.wheel_dir.mkdir()
+        self.output_dir = Path(self._tmp) / "output"
+        self.output_dir.mkdir()
+        _make_fake_wheel(self.wheel_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp)
+
+    def _extract(self, platform="linux"):
+        wheel_path = find_wheel(str(self.wheel_dir))
+        version = parse_version_from_wheel(wheel_path)
+        extract_dir = self.wheel_dir / "_tmp"
+        extract_dir.mkdir()
+        torch_dir = extract_wheel(wheel_path, extract_dir)
+
+        libtorch_dir = extract_dir / "libtorch"
+        libtorch_dir.mkdir()
+        for sub in ["lib", "bin", "include", "share"]:
+            (libtorch_dir / sub).mkdir()
+
+        copy_libraries(torch_dir, libtorch_dir / "lib", platform)
+        copy_includes(torch_dir, libtorch_dir / "include")
+        copy_cmake(torch_dir, libtorch_dir / "share")
+        copy_bin(torch_dir, libtorch_dir / "bin", platform)
+        write_metadata(libtorch_dir, version, get_git_hash(torch_dir))
+
+        prefix = compute_zip_prefix(platform, "cu126", "shared-with-deps")
+        return create_libtorch_zip(libtorch_dir, self.output_dir, prefix, version)
+
+    def test_output_zip_has_expected_files(self):
+        zip_path = self._extract()
+        with zipfile.ZipFile(zip_path) as zf:
+            names = set(zf.namelist())
+        self.assertIn("libtorch/lib/libtorch.so", names)
+        self.assertIn("libtorch/include/torch/torch.h", names)
+        self.assertTrue(any("TorchConfig.cmake" in n for n in names))
+        self.assertIn("libtorch/build-version", names)
+        self.assertIn("libtorch/build-hash", names)
+
+    def test_excluded_libs_not_in_zip(self):
+        zip_path = self._extract()
+        with zipfile.ZipFile(zip_path) as zf:
+            names = set(zf.namelist())
+        self.assertNotIn("libtorch/lib/libtorch_python.so", names)
+        self.assertFalse(any("_C.cpython" in n for n in names))
+
+    def test_metadata_content(self):
+        zip_path = self._extract()
+        with zipfile.ZipFile(zip_path) as zf:
+            self.assertEqual(zf.read("libtorch/build-version").decode().strip(), "2.6.0")  # noqa: B950
+            self.assertEqual(zf.read("libtorch/build-hash").decode().strip(), "abc123")
+
+    def test_latest_symlink_created(self):
+        self._extract()
+        symlinks = list(self.output_dir.glob("*-latest.zip"))
+        self.assertEqual(len(symlinks), 1)
+        self.assertTrue(symlinks[0].is_symlink())
+
+    def test_zip_prefix_naming(self):
+        self.assertEqual(compute_zip_prefix("linux", "cu126", "shared-with-deps"), "libtorch-shared-with-deps")  # noqa: B950
+        self.assertEqual(compute_zip_prefix("macos", "cpu", "shared-with-deps"), "libtorch-macos-arm64")  # noqa: B950
+        self.assertEqual(compute_zip_prefix("windows", "cu126", "shared-with-deps"), "libtorch-win-shared-with-deps")  # noqa: B950
+
+    def test_find_wheel_errors(self):
+        empty = Path(self._tmp) / "empty"
+        empty.mkdir()
+        with self.assertRaises(FileNotFoundError):
+            find_wheel(str(empty))
+        _make_fake_wheel(self.wheel_dir, "2.7.0")  # now two wheels
+        with self.assertRaises(RuntimeError):
+            find_wheel(str(self.wheel_dir))
+
+
+class TestFixRpath(unittest.TestCase):
+    def test_raises_on_non_linux(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "libfoo.so").write_bytes(b"fake")
+            with patch("sys.platform", "darwin"):
+                with self.assertRaises(RuntimeError):
+                    fix_rpath(Path(d))
+
+    def test_calls_patchelf_on_so_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "libtorch.so").write_bytes(b"fake")
+            Path(d, "readme.txt").write_text("not a library")
+
+            with (
+                patch("sys.platform", "linux"),
+                patch("extract_libtorch_from_wheel.shutil.which", return_value="/usr/local/bin/patchelf"),
+                patch("extract_libtorch_from_wheel.subprocess.run") as mock_run,
+            ):
+                mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+                fix_rpath(Path(d))
+
+                mock_run.assert_called_once()
+                args = mock_run.call_args[0][0]
+                self.assertEqual(args[0], "/usr/local/bin/patchelf")
+                self.assertEqual(args[1], "--set-rpath")
+                self.assertEqual(args[2], "$ORIGIN")
+                self.assertEqual(args[3], "--force-rpath")
+                self.assertIn("libtorch.so", args[4])
+
+    def test_calls_patchelf_on_versioned_so(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "libfoo.so.1").write_bytes(b"fake")
+
+            with (
+                patch("sys.platform", "linux"),
+                patch("extract_libtorch_from_wheel.shutil.which", return_value="/usr/local/bin/patchelf"),
+                patch("extract_libtorch_from_wheel.subprocess.run") as mock_run,
+            ):
+                mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+                fix_rpath(Path(d))
+                mock_run.assert_called_once()
+
+    def test_skips_non_so_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "libfoo.a").write_bytes(b"fake")
+
+            with (
+                patch("sys.platform", "linux"),
+                patch("extract_libtorch_from_wheel.shutil.which", return_value="/usr/local/bin/patchelf"),
+                patch("extract_libtorch_from_wheel.subprocess.run") as mock_run,
+            ):
+                fix_rpath(Path(d))
+                mock_run.assert_not_called()
+
+    def test_raises_if_patchelf_not_found(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "libfoo.so").write_bytes(b"fake")
+
+            with (
+                patch("sys.platform", "linux"),
+                patch("extract_libtorch_from_wheel.shutil.which", return_value=None),
+            ):
+                with self.assertRaises(FileNotFoundError):
+                    fix_rpath(Path(d))
+
+    def test_raises_on_patchelf_failure(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "libfoo.so").write_bytes(b"fake")
+
+            with (
+                patch("sys.platform", "linux"),
+                patch("extract_libtorch_from_wheel.shutil.which", return_value="/usr/local/bin/patchelf"),
+                patch("extract_libtorch_from_wheel.subprocess.run") as mock_run,
+            ):
+                mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1, stderr="cannot find section")
+                with self.assertRaises(RuntimeError):
+                    fix_rpath(Path(d))
+
+    @unittest.skipUnless(sys.platform == "linux", "patchelf only supported on Linux")
+    @unittest.skipUnless(shutil.which("patchelf"), "patchelf not installed")
+    def test_integration_with_real_patchelf(self):
+        with tempfile.TemporaryDirectory() as d:
+            so = Path(d) / "libtest.so"
+            gcc = shutil.which("gcc") or shutil.which("cc")
+            if not gcc:
+                self.skipTest("no C compiler available")
+
+            src = Path(d) / "test.c"
+            src.write_text("void foo(void) {}")
+            result = subprocess.run([gcc, "-shared", "-o", str(so), str(src)], capture_output=True)
+            if result.returncode != 0:
+                self.skipTest("failed to compile test shared library")
+
+            fix_rpath(Path(d))
+
+            result = subprocess.run(["patchelf", "--print-rpath", str(so)], capture_output=True, text=True)
+            self.assertEqual(result.stdout.strip(), "$ORIGIN")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.ci/libtorch/smoke_test_extract_libtorch.py
+++ b/.ci/libtorch/smoke_test_extract_libtorch.py
@@ -1,77 +1,82 @@
 #!/usr/bin/env python3
-"""Tests for the libtorch extraction pipeline."""
+"""Smoke test for extracted libtorch: verify rpath and that libtorch.so loads."""
 
+import argparse
+import ctypes
+import glob
 import shutil
+import subprocess
+import sys
 import tempfile
-import unittest
 import zipfile
 from pathlib import Path
 
-from extract_libtorch_from_wheel import (
-    compute_zip_prefix,
-    copy_bin,
-    copy_cmake,
-    copy_includes,
-    copy_libraries,
-    create_libtorch_zip,
-    extract_wheel,
-    find_wheel,
-    get_git_hash,
-    parse_version_from_wheel,
-    write_metadata,
-)
+
+def check_rpath(lib_dir: Path) -> None:
+    patchelf = shutil.which("patchelf")
+    if not patchelf:
+        print("patchelf not found, skipping rpath checks")
+        return
+    for so_file in sorted(lib_dir.iterdir()):
+        if not so_file.is_file():
+            continue
+        if not (so_file.name.endswith(".so") or ".so." in so_file.name):
+            continue
+        result = subprocess.run(
+            [patchelf, "--print-rpath", str(so_file)],
+            capture_output=True,
+            text=True,
+        )
+        rpath = result.stdout.strip()
+        if "$ORIGIN" not in rpath:
+            raise RuntimeError(
+                f"{so_file.name}: expected $ORIGIN in rpath, got {rpath!r}"
+            )
+        print(f"  rpath OK: {so_file.name} -> {rpath}")
 
 
-def _make_fake_wheel(wheel_dir: Path) -> Path:
-    wheel_path = wheel_dir / "torch-0.0-cp310-cp310-linux_x86_64.whl"
-    with zipfile.ZipFile(wheel_path, "w") as zf:
-        zf.writestr("torch/lib/libtorch.so", "fake")
-        zf.writestr("torch/include/torch/torch.h", "// header")
-        zf.writestr("torch/share/cmake/Torch/TorchConfig.cmake", "# cmake")
-        zf.writestr("torch/version.py", "git_version = 'abc123'\n")
-    return wheel_path
+def check_import(lib_dir: Path) -> None:
+    libtorch = lib_dir / "libtorch.so"
+    if not libtorch.exists():
+        raise FileNotFoundError(f"libtorch.so not found in {lib_dir}")
+    ctypes.CDLL(str(libtorch))
+    print(f"  import OK: loaded {libtorch.name}")
 
 
-class TestExtraction(unittest.TestCase):
-    def setUp(self):
-        self._tmp = tempfile.mkdtemp()
-        self.wheel_dir = Path(self._tmp) / "wheels"
-        self.wheel_dir.mkdir()
-        self.output_dir = Path(self._tmp) / "output"
-        self.output_dir.mkdir()
-        _make_fake_wheel(self.wheel_dir)
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        help="Directory containing the libtorch zip produced by extract_libtorch_from_wheel.py",
+    )
+    args = parser.parse_args()
 
-    def tearDown(self):
-        shutil.rmtree(self._tmp)
+    zips = [
+        p for p in args.output_dir.glob("libtorch-*.zip")
+        if "latest" not in p.name
+    ]
+    if not zips:
+        raise FileNotFoundError(f"No libtorch zip found in {args.output_dir}")
+    if len(zips) > 1:
+        raise RuntimeError(f"Multiple libtorch zips found: {zips}")
+    libtorch_zip = zips[0]
 
-    def test_extraction(self):
-        wheel_path = find_wheel(str(self.wheel_dir))
-        version = parse_version_from_wheel(wheel_path)
-        extract_dir = self.wheel_dir / "_tmp"
-        extract_dir.mkdir()
-        torch_dir = extract_wheel(wheel_path, extract_dir)
-
-        libtorch_dir = extract_dir / "libtorch"
-        libtorch_dir.mkdir()
-        for sub in ["lib", "bin", "include", "share"]:
-            (libtorch_dir / sub).mkdir()
-
-        copy_libraries(torch_dir, libtorch_dir / "lib", "linux")
-        copy_includes(torch_dir, libtorch_dir / "include")
-        copy_cmake(torch_dir, libtorch_dir / "share")
-        copy_bin(torch_dir, libtorch_dir / "bin", "linux")
-        write_metadata(libtorch_dir, version, get_git_hash(torch_dir))
-
-        prefix = compute_zip_prefix("linux", "cu126", "shared-with-deps", "x86_64")
-        zip_path = create_libtorch_zip(libtorch_dir, self.output_dir, prefix, version)
-
-        with zipfile.ZipFile(zip_path) as zf:
-            names = set(zf.namelist())
-
-        self.assertIn("libtorch/lib/libtorch.so", names)
-        self.assertIn("libtorch/include/torch/torch.h", names)
-        self.assertTrue(any("TorchConfig.cmake" in n for n in names))
+    tmp = tempfile.mkdtemp()
+    try:
+        print(f"Extracting {libtorch_zip.name} ...")
+        with zipfile.ZipFile(libtorch_zip) as zf:
+            zf.extractall(tmp)
+        lib_dir = Path(tmp) / "libtorch" / "lib"
+        if not lib_dir.is_dir():
+            raise FileNotFoundError(f"libtorch/lib not found in zip")
+        check_rpath(lib_dir)
+        check_import(lib_dir)
+        print("Smoke test passed.")
+    finally:
+        shutil.rmtree(tmp)
 
 
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/.ci/libtorch/smoke_test_extract_libtorch.py
+++ b/.ci/libtorch/smoke_test_extract_libtorch.py
@@ -2,13 +2,10 @@
 """Tests for the libtorch extraction pipeline."""
 
 import shutil
-import subprocess
-import sys
 import tempfile
 import unittest
 import zipfile
 from pathlib import Path
-from unittest.mock import patch
 
 from extract_libtorch_from_wheel import (
     compute_zip_prefix,
@@ -19,28 +16,23 @@ from extract_libtorch_from_wheel import (
     create_libtorch_zip,
     extract_wheel,
     find_wheel,
-    fix_rpath,
     get_git_hash,
     parse_version_from_wheel,
     write_metadata,
 )
 
 
-def _make_fake_wheel(wheel_dir: Path, version: str = "2.6.0") -> Path:
-    name = f"torch-{version}-cp310-cp310-linux_x86_64.whl"
-    wheel_path = wheel_dir / name
+def _make_fake_wheel(wheel_dir: Path) -> Path:
+    wheel_path = wheel_dir / "torch-0.0-cp310-cp310-linux_x86_64.whl"
     with zipfile.ZipFile(wheel_path, "w") as zf:
         zf.writestr("torch/lib/libtorch.so", "fake")
-        zf.writestr("torch/lib/libtorch_cpu.so", "fake")
-        zf.writestr("torch/lib/libtorch_python.so", "excluded")
-        zf.writestr("torch/lib/_C.cpython-310-x86_64-linux-gnu.so", "excluded")
         zf.writestr("torch/include/torch/torch.h", "// header")
         zf.writestr("torch/share/cmake/Torch/TorchConfig.cmake", "# cmake")
         zf.writestr("torch/version.py", "git_version = 'abc123'\n")
     return wheel_path
 
 
-class TestSmokeExtraction(unittest.TestCase):
+class TestExtraction(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.mkdtemp()
         self.wheel_dir = Path(self._tmp) / "wheels"
@@ -52,7 +44,7 @@ class TestSmokeExtraction(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self._tmp)
 
-    def _extract(self, platform="linux"):
+    def test_extraction(self):
         wheel_path = find_wheel(str(self.wheel_dir))
         version = parse_version_from_wheel(wheel_path)
         extract_dir = self.wheel_dir / "_tmp"
@@ -64,156 +56,21 @@ class TestSmokeExtraction(unittest.TestCase):
         for sub in ["lib", "bin", "include", "share"]:
             (libtorch_dir / sub).mkdir()
 
-        copy_libraries(torch_dir, libtorch_dir / "lib", platform)
+        copy_libraries(torch_dir, libtorch_dir / "lib", "linux")
         copy_includes(torch_dir, libtorch_dir / "include")
         copy_cmake(torch_dir, libtorch_dir / "share")
-        copy_bin(torch_dir, libtorch_dir / "bin", platform)
+        copy_bin(torch_dir, libtorch_dir / "bin", "linux")
         write_metadata(libtorch_dir, version, get_git_hash(torch_dir))
 
-        prefix = compute_zip_prefix(platform, "cu126", "shared-with-deps")
-        return create_libtorch_zip(libtorch_dir, self.output_dir, prefix, version)
+        prefix = compute_zip_prefix("linux", "cu126", "shared-with-deps", "x86_64")
+        zip_path = create_libtorch_zip(libtorch_dir, self.output_dir, prefix, version)
 
-    def test_output_zip_has_expected_files(self):
-        zip_path = self._extract()
         with zipfile.ZipFile(zip_path) as zf:
             names = set(zf.namelist())
+
         self.assertIn("libtorch/lib/libtorch.so", names)
         self.assertIn("libtorch/include/torch/torch.h", names)
         self.assertTrue(any("TorchConfig.cmake" in n for n in names))
-        self.assertIn("libtorch/build-version", names)
-        self.assertIn("libtorch/build-hash", names)
-
-    def test_excluded_libs_not_in_zip(self):
-        zip_path = self._extract()
-        with zipfile.ZipFile(zip_path) as zf:
-            names = set(zf.namelist())
-        self.assertNotIn("libtorch/lib/libtorch_python.so", names)
-        self.assertFalse(any("_C.cpython" in n for n in names))
-
-    def test_metadata_content(self):
-        zip_path = self._extract()
-        with zipfile.ZipFile(zip_path) as zf:
-            self.assertEqual(zf.read("libtorch/build-version").decode().strip(), "2.6.0")  # noqa: B950
-            self.assertEqual(zf.read("libtorch/build-hash").decode().strip(), "abc123")
-
-    def test_latest_symlink_created(self):
-        self._extract()
-        symlinks = list(self.output_dir.glob("*-latest.zip"))
-        self.assertEqual(len(symlinks), 1)
-        self.assertTrue(symlinks[0].is_symlink())
-
-    def test_zip_prefix_naming(self):
-        self.assertEqual(compute_zip_prefix("linux", "cu126", "shared-with-deps"), "libtorch-shared-with-deps")  # noqa: B950
-        self.assertEqual(compute_zip_prefix("macos", "cpu", "shared-with-deps"), "libtorch-macos-arm64")  # noqa: B950
-        self.assertEqual(compute_zip_prefix("windows", "cu126", "shared-with-deps"), "libtorch-win-shared-with-deps")  # noqa: B950
-
-    def test_find_wheel_errors(self):
-        empty = Path(self._tmp) / "empty"
-        empty.mkdir()
-        with self.assertRaises(FileNotFoundError):
-            find_wheel(str(empty))
-        _make_fake_wheel(self.wheel_dir, "2.7.0")  # now two wheels
-        with self.assertRaises(RuntimeError):
-            find_wheel(str(self.wheel_dir))
-
-
-class TestFixRpath(unittest.TestCase):
-    def test_raises_on_non_linux(self):
-        with tempfile.TemporaryDirectory() as d:
-            Path(d, "libfoo.so").write_bytes(b"fake")
-            with patch("sys.platform", "darwin"):
-                with self.assertRaises(RuntimeError):
-                    fix_rpath(Path(d))
-
-    def test_calls_patchelf_on_so_files(self):
-        with tempfile.TemporaryDirectory() as d:
-            Path(d, "libtorch.so").write_bytes(b"fake")
-            Path(d, "readme.txt").write_text("not a library")
-
-            with (
-                patch("sys.platform", "linux"),
-                patch("extract_libtorch_from_wheel.shutil.which", return_value="/usr/local/bin/patchelf"),
-                patch("extract_libtorch_from_wheel.subprocess.run") as mock_run,
-            ):
-                mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
-                fix_rpath(Path(d))
-
-                mock_run.assert_called_once()
-                args = mock_run.call_args[0][0]
-                self.assertEqual(args[0], "/usr/local/bin/patchelf")
-                self.assertEqual(args[1], "--set-rpath")
-                self.assertEqual(args[2], "$ORIGIN")
-                self.assertEqual(args[3], "--force-rpath")
-                self.assertIn("libtorch.so", args[4])
-
-    def test_calls_patchelf_on_versioned_so(self):
-        with tempfile.TemporaryDirectory() as d:
-            Path(d, "libfoo.so.1").write_bytes(b"fake")
-
-            with (
-                patch("sys.platform", "linux"),
-                patch("extract_libtorch_from_wheel.shutil.which", return_value="/usr/local/bin/patchelf"),
-                patch("extract_libtorch_from_wheel.subprocess.run") as mock_run,
-            ):
-                mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
-                fix_rpath(Path(d))
-                mock_run.assert_called_once()
-
-    def test_skips_non_so_files(self):
-        with tempfile.TemporaryDirectory() as d:
-            Path(d, "libfoo.a").write_bytes(b"fake")
-
-            with (
-                patch("sys.platform", "linux"),
-                patch("extract_libtorch_from_wheel.shutil.which", return_value="/usr/local/bin/patchelf"),
-                patch("extract_libtorch_from_wheel.subprocess.run") as mock_run,
-            ):
-                fix_rpath(Path(d))
-                mock_run.assert_not_called()
-
-    def test_raises_if_patchelf_not_found(self):
-        with tempfile.TemporaryDirectory() as d:
-            Path(d, "libfoo.so").write_bytes(b"fake")
-
-            with (
-                patch("sys.platform", "linux"),
-                patch("extract_libtorch_from_wheel.shutil.which", return_value=None),
-            ):
-                with self.assertRaises(FileNotFoundError):
-                    fix_rpath(Path(d))
-
-    def test_raises_on_patchelf_failure(self):
-        with tempfile.TemporaryDirectory() as d:
-            Path(d, "libfoo.so").write_bytes(b"fake")
-
-            with (
-                patch("sys.platform", "linux"),
-                patch("extract_libtorch_from_wheel.shutil.which", return_value="/usr/local/bin/patchelf"),
-                patch("extract_libtorch_from_wheel.subprocess.run") as mock_run,
-            ):
-                mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1, stderr="cannot find section")
-                with self.assertRaises(RuntimeError):
-                    fix_rpath(Path(d))
-
-    @unittest.skipUnless(sys.platform == "linux", "patchelf only supported on Linux")
-    @unittest.skipUnless(shutil.which("patchelf"), "patchelf not installed")
-    def test_integration_with_real_patchelf(self):
-        with tempfile.TemporaryDirectory() as d:
-            so = Path(d) / "libtest.so"
-            gcc = shutil.which("gcc") or shutil.which("cc")
-            if not gcc:
-                self.skipTest("no C compiler available")
-
-            src = Path(d) / "test.c"
-            src.write_text("void foo(void) {}")
-            result = subprocess.run([gcc, "-shared", "-o", str(so), str(src)], capture_output=True)
-            if result.returncode != 0:
-                self.skipTest("failed to compile test shared library")
-
-            fix_rpath(Path(d))
-
-            result = subprocess.run(["patchelf", "--print-rpath", str(so)], capture_output=True, text=True)
-            self.assertEqual(result.stdout.strip(), "$ORIGIN")
 
 
 if __name__ == "__main__":

--- a/.ci/libtorch/smoke_test_extract_libtorch.py
+++ b/.ci/libtorch/smoke_test_extract_libtorch.py
@@ -3,10 +3,8 @@
 
 import argparse
 import ctypes
-import glob
 import shutil
 import subprocess
-import sys
 import tempfile
 import zipfile
 from pathlib import Path
@@ -70,7 +68,7 @@ def main() -> None:
             zf.extractall(tmp)
         lib_dir = Path(tmp) / "libtorch" / "lib"
         if not lib_dir.is_dir():
-            raise FileNotFoundError(f"libtorch/lib not found in zip")
+            raise FileNotFoundError("libtorch/lib not found in zip")
         check_rpath(lib_dir)
         check_import(lib_dir)
         print("Smoke test passed.")

--- a/.ci/libtorch/smoke_test_extract_libtorch.py
+++ b/.ci/libtorch/smoke_test_extract_libtorch.py
@@ -2,7 +2,6 @@
 """Smoke test for extracted libtorch: verify rpath and that libtorch.so loads."""
 
 import argparse
-import ctypes
 import shutil
 import subprocess
 import tempfile
@@ -33,12 +32,30 @@ def check_rpath(lib_dir: Path) -> None:
         print(f"  rpath OK: {so_file.name} -> {rpath}")
 
 
-def check_import(lib_dir: Path) -> None:
-    libtorch = lib_dir / "libtorch.so"
-    if not libtorch.exists():
-        raise FileNotFoundError(f"libtorch.so not found in {lib_dir}")
-    ctypes.CDLL(str(libtorch))
-    print(f"  import OK: loaded {libtorch.name}")
+def check_bundled_deps(lib_dir: Path) -> None:
+    # Verify each bundled lib can resolve the dependencies that are ALSO bundled
+    # in lib/. A "not found" dep whose soname is present in lib/ means its RPATH
+    # was not fixed to $ORIGIN. Deps not bundled here (e.g. CUDA runtime libs)
+    # are provided by the environment and are intentionally ignored.
+    present = {p.name for p in lib_dir.iterdir() if p.is_file()}
+    failures = []
+    for so_file in sorted(lib_dir.iterdir()):
+        if not so_file.is_file():
+            continue
+        if not (so_file.name.endswith(".so") or ".so." in so_file.name):
+            continue
+        result = subprocess.run(
+            ["ldd", str(so_file)], capture_output=True, text=True
+        )
+        for line in result.stdout.splitlines():
+            if "=> not found" not in line:
+                continue
+            soname = line.split("=>", 1)[0].strip()
+            if soname in present:
+                failures.append(f"{so_file.name}: {soname} not found (RPATH not fixed)")
+    if failures:
+        raise RuntimeError("Bundled dependency resolution failed:\n" + "\n".join(failures))
+    print("  bundled deps OK")
 
 
 def main() -> None:
@@ -70,7 +87,7 @@ def main() -> None:
         if not lib_dir.is_dir():
             raise FileNotFoundError("libtorch/lib not found in zip")
         check_rpath(lib_dir)
-        check_import(lib_dir)
+        check_bundled_deps(lib_dir)
         print("Smoke test passed.")
     finally:
         shutil.rmtree(tmp)

--- a/.ci/libtorch/smoke_test_extract_libtorch.py
+++ b/.ci/libtorch/smoke_test_extract_libtorch.py
@@ -1,61 +1,12 @@
 #!/usr/bin/env python3
-"""Smoke test for extracted libtorch: verify rpath and that libtorch.so loads."""
+"""Smoke test for extracted libtorch: fully load libtorch.so via its $ORIGIN RPATH."""
 
 import argparse
+import ctypes
 import shutil
-import subprocess
 import tempfile
 import zipfile
 from pathlib import Path
-
-
-def check_rpath(lib_dir: Path) -> None:
-    patchelf = shutil.which("patchelf")
-    if not patchelf:
-        print("patchelf not found, skipping rpath checks")
-        return
-    for so_file in sorted(lib_dir.iterdir()):
-        if not so_file.is_file():
-            continue
-        if not (so_file.name.endswith(".so") or ".so." in so_file.name):
-            continue
-        result = subprocess.run(
-            [patchelf, "--print-rpath", str(so_file)],
-            capture_output=True,
-            text=True,
-        )
-        rpath = result.stdout.strip()
-        if "$ORIGIN" not in rpath:
-            raise RuntimeError(
-                f"{so_file.name}: expected $ORIGIN in rpath, got {rpath!r}"
-            )
-        print(f"  rpath OK: {so_file.name} -> {rpath}")
-
-
-def check_bundled_deps(lib_dir: Path) -> None:
-    # Verify each bundled lib can resolve the dependencies that are ALSO bundled
-    # in lib/. A "not found" dep whose soname is present in lib/ means its RPATH
-    # was not fixed to $ORIGIN. Deps not bundled here (e.g. CUDA runtime libs)
-    # are provided by the environment and are intentionally ignored.
-    present = {p.name for p in lib_dir.iterdir() if p.is_file()}
-    failures = []
-    for so_file in sorted(lib_dir.iterdir()):
-        if not so_file.is_file():
-            continue
-        if not (so_file.name.endswith(".so") or ".so." in so_file.name):
-            continue
-        result = subprocess.run(
-            ["ldd", str(so_file)], capture_output=True, text=True
-        )
-        for line in result.stdout.splitlines():
-            if "=> not found" not in line:
-                continue
-            soname = line.split("=>", 1)[0].strip()
-            if soname in present:
-                failures.append(f"{so_file.name}: {soname} not found (RPATH not fixed)")
-    if failures:
-        raise RuntimeError("Bundled dependency resolution failed:\n" + "\n".join(failures))
-    print("  bundled deps OK")
 
 
 def main() -> None:
@@ -64,31 +15,25 @@ def main() -> None:
         "--output-dir",
         required=True,
         type=Path,
-        help="Directory containing the libtorch zip produced by extract_libtorch_from_wheel.py",
+        help="Directory with the libtorch zip from extract_libtorch_from_wheel.py",
     )
     args = parser.parse_args()
 
-    zips = [
-        p for p in args.output_dir.glob("libtorch-*.zip")
-        if "latest" not in p.name
-    ]
-    if not zips:
-        raise FileNotFoundError(f"No libtorch zip found in {args.output_dir}")
-    if len(zips) > 1:
-        raise RuntimeError(f"Multiple libtorch zips found: {zips}")
-    libtorch_zip = zips[0]
+    zips = [p for p in args.output_dir.glob("libtorch-*.zip") if "latest" not in p.name]
+    if len(zips) != 1:
+        raise RuntimeError(f"Expected exactly one libtorch zip, found: {zips}")
 
     tmp = tempfile.mkdtemp()
     try:
-        print(f"Extracting {libtorch_zip.name} ...")
-        with zipfile.ZipFile(libtorch_zip) as zf:
+        with zipfile.ZipFile(zips[0]) as zf:
             zf.extractall(tmp)
-        lib_dir = Path(tmp) / "libtorch" / "lib"
-        if not lib_dir.is_dir():
-            raise FileNotFoundError("libtorch/lib not found in zip")
-        check_rpath(lib_dir)
-        check_bundled_deps(lib_dir)
-        print("Smoke test passed.")
+        libtorch = Path(tmp) / "libtorch" / "lib" / "libtorch.so"
+        # Fully dlopen libtorch.so: resolves the whole NEEDED chain through the
+        # $ORIGIN RPATH, so a missing or mis-rpath'd bundled dep (torch or NVIDIA
+        # runtime) fails here. libcuda.so.1 is dlopen'd lazily by cudart, not a
+        # load-time NEEDED, so this works on a driverless builder.
+        ctypes.CDLL(str(libtorch))
+        print(f"Smoke test passed: loaded {libtorch}")
     finally:
         shutil.rmtree(tmp)
 

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -536,19 +536,23 @@ def generate_libtorch_extraction_configs(
             ".", "_"
         )
 
-        ret.append(
-            {
-                "source_wheel_build_name": source_config["build_name"],
-                "build_name": build_name,
-                "package_type": "libtorch",
-                "libtorch_variant": libtorch_variant,
-                "libtorch_config": RELEASE,
-                "desired_cuda": desired_cuda,
-                "gpu_arch_type": gpu_arch_type,
-                "gpu_arch_version": gpu_arch_version,
-                "arch": arch,
-            }
-        )
+        lt_config: dict[str, str] = {
+            "source_wheel_build_name": source_config["build_name"],
+            "build_name": build_name,
+            "package_type": "libtorch",
+            "libtorch_variant": libtorch_variant,
+            "libtorch_config": RELEASE,
+            "desired_cuda": desired_cuda,
+            "gpu_arch_type": gpu_arch_type,
+            "gpu_arch_version": gpu_arch_version,
+            "arch": arch,
+        }
+        if "container_image" in source_config:
+            lt_config["container_image"] = source_config["container_image"]
+            lt_config["container_image_tag_prefix"] = source_config[
+                "container_image_tag_prefix"
+            ]
+        ret.append(lt_config)
 
     return ret
 

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -584,17 +584,20 @@ jobs:
       - name: Extract libtorch from wheel
         run: |
           set -eux
-          mkdir -p "${{ github.workspace }}/libtorch_output"
+          # In container jobs the github.workspace context is the host path; the
+          # mount is at $GITHUB_WORKSPACE. Use the env var so run steps and the
+          # translated download/upload action paths resolve to the same dir.
+          mkdir -p "${GITHUB_WORKSPACE}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${{ github.workspace }}/wheel_artifact" \
-            --output-dir "${{ github.workspace }}/libtorch_output" \
+            --wheel-dir "${GITHUB_WORKSPACE}/wheel_artifact" \
+            --output-dir "${GITHUB_WORKSPACE}/libtorch_output" \
             --platform linux \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT"
       - name: Smoke test extracted libtorch
         run: |
           python3 .ci/libtorch/smoke_test_extract_libtorch.py \
-            --output-dir "${{ github.workspace }}/libtorch_output"
+            --output-dir "${GITHUB_WORKSPACE}/libtorch_output"
       - uses: !{{ common.upload_artifact_action }}
         if: always()
         with:

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -557,7 +557,13 @@ jobs:
             libtorch_config: "!{{ lt_config['libtorch_config'] }}"
             source_wheel_build_name: "!{{ lt_config['source_wheel_build_name'] }}"
             build_name: "!{{ lt_config['build_name'] }}"
+          {%- if 'container_image' in lt_config %}
+            container_image: "!{{ lt_config['container_image'] }}"
+            container_image_tag_prefix: "!{{ lt_config['container_image_tag_prefix'] }}"
+          {%- endif %}
         {%- endfor %}
+    container:
+      image: pytorch/${{ matrix.container_image }}:${{ matrix.container_image_tag_prefix }}
     env:
       DESIRED_CUDA: ${{ matrix.desired_cuda }}
       LIBTORCH_VARIANT: ${{ matrix.libtorch_variant }}
@@ -575,6 +581,8 @@ jobs:
         with:
           name: ${{ matrix.source_wheel_build_name }}
           path: "${{ runner.temp }}/wheel_artifact/"
+      - name: Test libtorch extraction logic
+        run: python3 -m pytest .ci/libtorch/smoke_test_extract_libtorch.py -v
       - name: Extract libtorch from wheel
         run: |
           set -eux

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -582,7 +582,7 @@ jobs:
           name: ${{ matrix.source_wheel_build_name }}
           path: "${{ runner.temp }}/wheel_artifact/"
       - name: Test libtorch extraction logic
-        run: python3 -m pytest .ci/libtorch/smoke_test_extract_libtorch.py -v
+        run: python3 -m unittest discover -s .ci/libtorch -p smoke_test_extract_libtorch.py -v
       - name: Extract libtorch from wheel
         run: |
           set -eux

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -580,26 +580,28 @@ jobs:
         name: Download Wheel Artifact
         with:
           name: ${{ matrix.source_wheel_build_name }}
-          path: "${{ runner.temp }}/wheel_artifact/"
-      - name: Test libtorch extraction logic
-        run: python3 -m unittest discover -s .ci/libtorch -p smoke_test_extract_libtorch.py -v
+          path: "${{ github.workspace }}/wheel_artifact/"
       - name: Extract libtorch from wheel
         run: |
           set -eux
-          mkdir -p "${RUNNER_TEMP}/libtorch_output"
+          mkdir -p "${{ github.workspace }}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${RUNNER_TEMP}/wheel_artifact" \
-            --output-dir "${RUNNER_TEMP}/libtorch_output" \
+            --wheel-dir "${{ github.workspace }}/wheel_artifact" \
+            --output-dir "${{ github.workspace }}/libtorch_output" \
             --platform linux \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT"
+      - name: Smoke test extracted libtorch
+        run: |
+          python3 .ci/libtorch/smoke_test_extract_libtorch.py \
+            --output-dir "${{ github.workspace }}/libtorch_output"
       - uses: !{{ common.upload_artifact_action }}
         if: always()
         with:
           name: ${{ matrix.build_name }}
           retention-days: 14
           if-no-files-found: error
-          path: "${{ runner.temp }}/libtorch_output/"
+          path: "${{ github.workspace }}/libtorch_output/"
 
 {%- if branches == "nightly" %}
 

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -543,7 +543,7 @@ jobs:
     needs: [manywheel-build]
     runs-on: "mt-l-x86iavx512-16-128"
     container:
-      image: python:3.11
+      image: pytorch/${{ matrix.container_image }}:${{ matrix.container_image_tag_prefix }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -562,8 +562,6 @@ jobs:
             container_image_tag_prefix: "!{{ lt_config['container_image_tag_prefix'] }}"
           {%- endif %}
         {%- endfor %}
-    container:
-      image: pytorch/${{ matrix.container_image }}:${{ matrix.container_image_tag_prefix }}
     env:
       DESIRED_CUDA: ${{ matrix.desired_cuda }}
       LIBTORCH_VARIANT: ${{ matrix.libtorch_variant }}

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1737,17 +1737,20 @@ jobs:
       - name: Extract libtorch from wheel
         run: |
           set -eux
-          mkdir -p "${{ github.workspace }}/libtorch_output"
+          # In container jobs the github.workspace context is the host path; the
+          # mount is at $GITHUB_WORKSPACE. Use the env var so run steps and the
+          # translated download/upload action paths resolve to the same dir.
+          mkdir -p "${GITHUB_WORKSPACE}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${{ github.workspace }}/wheel_artifact" \
-            --output-dir "${{ github.workspace }}/libtorch_output" \
+            --wheel-dir "${GITHUB_WORKSPACE}/wheel_artifact" \
+            --output-dir "${GITHUB_WORKSPACE}/libtorch_output" \
             --platform linux \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT"
       - name: Smoke test extracted libtorch
         run: |
           python3 .ci/libtorch/smoke_test_extract_libtorch.py \
-            --output-dir "${{ github.workspace }}/libtorch_output"
+            --output-dir "${GITHUB_WORKSPACE}/libtorch_output"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1655,7 +1655,7 @@ jobs:
     needs: [manywheel-build]
     runs-on: "mt-l-x86iavx512-16-128"
     container:
-      image: python:3.11
+      image: pytorch/${{ matrix.container_image }}:${{ matrix.container_image_tag_prefix }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -1715,8 +1715,6 @@ jobs:
             build_name: "libtorch-rocm7_2-shared-with-deps-release"
             container_image: "manylinux2_28-builder"
             container_image_tag_prefix: "rocm7.2"
-    container:
-      image: pytorch/${{ matrix.container_image }}:${{ matrix.container_image_tag_prefix }}
     env:
       DESIRED_CUDA: ${{ matrix.desired_cuda }}
       LIBTORCH_VARIANT: ${{ matrix.libtorch_variant }}

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1735,7 +1735,7 @@ jobs:
           name: ${{ matrix.source_wheel_build_name }}
           path: "${{ runner.temp }}/wheel_artifact/"
       - name: Test libtorch extraction logic
-        run: python3 -m pytest .ci/libtorch/smoke_test_extract_libtorch.py -v
+        run: python3 -m unittest discover -s .ci/libtorch -p smoke_test_extract_libtorch.py -v
       - name: Extract libtorch from wheel
         run: |
           set -eux

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1668,6 +1668,8 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-cpu"
             build_name: "libtorch-cpu-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "cpu"
           - desired_cuda: "cu126"
             gpu_arch_type: "cuda"
             gpu_arch_version: "12.6"
@@ -1675,6 +1677,8 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-cuda12_6"
             build_name: "libtorch-cuda12_6-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "cuda12.6"
           - desired_cuda: "cu130"
             gpu_arch_type: "cuda"
             gpu_arch_version: "13.0"
@@ -1682,6 +1686,8 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-cuda13_0"
             build_name: "libtorch-cuda13_0-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "cuda13.0"
           - desired_cuda: "cu132"
             gpu_arch_type: "cuda"
             gpu_arch_version: "13.2"
@@ -1689,6 +1695,8 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-cuda13_2"
             build_name: "libtorch-cuda13_2-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "cuda13.2"
           - desired_cuda: "rocm7.1"
             gpu_arch_type: "rocm"
             gpu_arch_version: "7.1"
@@ -1696,6 +1704,8 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-rocm7_1"
             build_name: "libtorch-rocm7_1-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "rocm7.1"
           - desired_cuda: "rocm7.2"
             gpu_arch_type: "rocm"
             gpu_arch_version: "7.2"
@@ -1703,6 +1713,10 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-rocm7_2"
             build_name: "libtorch-rocm7_2-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "rocm7.2"
+    container:
+      image: pytorch/${{ matrix.container_image }}:${{ matrix.container_image_tag_prefix }}
     env:
       DESIRED_CUDA: ${{ matrix.desired_cuda }}
       LIBTORCH_VARIANT: ${{ matrix.libtorch_variant }}
@@ -1720,6 +1734,8 @@ jobs:
         with:
           name: ${{ matrix.source_wheel_build_name }}
           path: "${{ runner.temp }}/wheel_artifact/"
+      - name: Test libtorch extraction logic
+        run: python3 -m pytest .ci/libtorch/smoke_test_extract_libtorch.py -v
       - name: Extract libtorch from wheel
         run: |
           set -eux

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1733,26 +1733,28 @@ jobs:
         name: Download Wheel Artifact
         with:
           name: ${{ matrix.source_wheel_build_name }}
-          path: "${{ runner.temp }}/wheel_artifact/"
-      - name: Test libtorch extraction logic
-        run: python3 -m unittest discover -s .ci/libtorch -p smoke_test_extract_libtorch.py -v
+          path: "${{ github.workspace }}/wheel_artifact/"
       - name: Extract libtorch from wheel
         run: |
           set -eux
-          mkdir -p "${RUNNER_TEMP}/libtorch_output"
+          mkdir -p "${{ github.workspace }}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${RUNNER_TEMP}/wheel_artifact" \
-            --output-dir "${RUNNER_TEMP}/libtorch_output" \
+            --wheel-dir "${{ github.workspace }}/wheel_artifact" \
+            --output-dir "${{ github.workspace }}/libtorch_output" \
             --platform linux \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT"
+      - name: Smoke test extracted libtorch
+        run: |
+          python3 .ci/libtorch/smoke_test_extract_libtorch.py \
+            --output-dir "${{ github.workspace }}/libtorch_output"
       - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
           name: ${{ matrix.build_name }}
           retention-days: 14
           if-no-files-found: error
-          path: "${{ runner.temp }}/libtorch_output/"
+          path: "${{ github.workspace }}/libtorch_output/"
 
   libtorch-upload:
     name: ${{ matrix.build_name }}-upload


### PR DESCRIPTION
PR #174753 switched libtorch packaging from a dedicated CMake build to extracting from the pre-built wheels. This PR restores the old libtorch behavior that was changed in the extraction script. 

1. RPATH. Wheel .so files carry RPATHs relative to pip's site-packages layout ($ORIGIN/../../nvidia/*/lib), which doesn't exist in the libtorch tree, giving errors like `libnvshmem_host.so.3 => not found`. fix_rpath() rewrites every .so in libtorch/lib to $ORIGIN via patchelf. --force-rpath emits DT_RPATH (not DT_RUNPATH), so resolution is transitive and not overridable by LD_LIBRARY_PATH.

2. Bundled CUDA deps. The small CUDA wheel omits NVIDIA runtime libs that shared-with-deps should ship. bundle_cuda_deps() walks NEEDED transitively from the torch libs and copies any soname found under /usr/local/cuda/lib64 or /usr/local/cuda/extras/CUPTI/lib64 into lib/. Only those dirs are searched, so system libs and the driver stub stay external. Linux CUDA shared-with-deps only.

Both need patchelf and /usr/local/cuda, so the extract job moves from python:3.11 to pytorch/manylinux2_28-builder:<cuda tag>; the matrix threads container_image / container_image_tag_prefix through, and artifact paths mov
to github.workspace. 

Test plan:
smoke_test_extract_libtorch.py extracts the produced zip and fully dlopens libtorch.so, so a missing or mis-rpath'd dep fails the job.
                                                                                                                                                    
Fixes #183971

Created with Assistance from Claude