### PR TITLE
Fix index_copy decomposition shape checks

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10018,17 +10018,43 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             fn, [torch.randn(1024, 4, 2), torch.arange(4), torch.randn(4, 1, 1)]
         )
 
-    def test_index_copy_source_slice_shape_check(self):
-        x = torch.randn(4, 5, 6, device=self.device)
-        y = torch.randn(1, 1, 6, device=self.device)
-        index = torch.tensor([0, 2], device=self.device)
-        fn = torch.compile(torch.index_copy)
+    def test_index_copy_error_checks(self):
+        cases = (
+            (
+                torch.randn(4, device=self.device),
+                0,
+                torch.tensor([0, 1], device=self.device),
+                torch.tensor(1.0, device=self.device),
+                "When source is scalar",
+            ),
+            (
+                torch.randn(4, 5, device=self.device),
+                0,
+                torch.tensor([0, 1], device=self.device),
+                torch.randn(2, device=self.device),
+                "their dimensionality must match",
+            ),
+            (
+                torch.randn(4, 5, 6, device=self.device),
+                0,
+                torch.tensor([0, 2], device=self.device),
+                torch.randn(1, 1, 6, device=self.device),
+                "Source/destination tensor must have same slice shapes",
+            ),
+            (
+                torch.randn(4, 5, device=self.device),
+                0,
+                torch.tensor([0, 1], device=self.device),
+                torch.randn(3, 5, device=self.device),
+                "Number of indices",
+            ),
+        )
 
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "Source/destination tensor must have same slice shapes",
-        ):
-            fn(x, 0, index, y)
+        for x, dim, index, y, msg in cases:
+            with self.subTest(msg=msg):
+                fn = torch.compile(torch.index_copy)
+                with self.assertRaisesRegex(RuntimeError, msg):
+                    fn(x, dim, index, y)
 
     def test_index_put2(self):
         def fn(a, b, c):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10018,6 +10018,18 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             fn, [torch.randn(1024, 4, 2), torch.arange(4), torch.randn(4, 1, 1)]
         )
 
+    def test_index_copy_source_slice_shape_check(self):
+        x = torch.randn(4, 5, 6, device=self.device)
+        y = torch.randn(1, 1, 6, device=self.device)
+        index = torch.tensor([0, 2], device=self.device)
+        fn = torch.compile(torch.index_copy)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Source/destination tensor must have same slice shapes",
+        ):
+            fn(x, 0, index, y)
+
     def test_index_put2(self):
         def fn(a, b, c):
             return torch.index_put(a, [b], c, True)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3291,6 +3291,8 @@ def index_copy(x: TensorLike, dim: int, index: TensorLike, tensor: TensorLike):
 def _index_copy(
     x: TensorLike, dim: int, index: TensorLike, tensor: TensorLike, *, inplace: bool
 ):
+    from torch.fx.experimental.symbolic_shapes import sym_eq
+
     dim = utils.canonicalize_dims(x.ndim, dim)
     torch._check(
         x.device == index.device and x.device == tensor.device,
@@ -3328,7 +3330,7 @@ def _index_copy(
         tensor.shape[:dim] + tensor.shape[dim + 1 :] if tensor.ndim > 0 else ()
     )
     torch._check(
-        x_sliced_shape == tensor_sliced_shape,
+        sym_eq(x_sliced_shape, tensor_sliced_shape),
         lambda: (
             "index_copy_(): Source/destination tensor must have same slice shapes. "
             f"Destination slice shape: {x_sliced_shape} at dimension {dim} "

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3304,6 +3304,45 @@ def _index_copy(
         index.ndim <= 1,
         lambda: f"Index should have dimension 1 or 0 (got {index.ndim})",
     )
+    num_indices = index.numel()
+    if tensor.ndim == 0:
+        torch._check(
+            num_indices == 1,
+            lambda: (
+                "index_copy_(): When source is scalar, index should have "
+                f"one element (got {num_indices})"
+            ),
+        )
+    elif x.ndim != 0:
+        torch._check(
+            tensor.ndim == x.ndim,
+            lambda: (
+                "index_copy_(): When source and destination are not scalars, "
+                "their dimensionality must match. Source dimensionality "
+                f"({tensor.ndim}), destination dimensionality ({x.ndim})"
+            ),
+        )
+
+    x_sliced_shape = x.shape[:dim] + x.shape[dim + 1 :] if x.ndim > 0 else ()
+    tensor_sliced_shape = (
+        tensor.shape[:dim] + tensor.shape[dim + 1 :] if tensor.ndim > 0 else ()
+    )
+    torch._check(
+        x_sliced_shape == tensor_sliced_shape,
+        lambda: (
+            "index_copy_(): Source/destination tensor must have same slice shapes. "
+            f"Destination slice shape: {x_sliced_shape} at dimension {dim} "
+            f"and source slice shape: {tensor_sliced_shape} at dimension 0."
+        ),
+    )
+    if tensor.ndim != 0:
+        torch._check(
+            num_indices == tensor.size(dim),
+            lambda: (
+                f"index_copy_(): Number of indices ({num_indices}) should be "
+                f"equal to source.size(dim) ({tensor.size(dim)})"
+            ),
+        )
     # Treat scalars as elements of \R^1
     zero_dim = x.ndim == 0
     x1 = x.unsqueeze(0) if zero_dim else x


### PR DESCRIPTION
Fixes #144183.

This fixes a discrepancy between eager and compiled execution for `torch.index_copy`.

`index_copy` is decomposed into `index_put` for Inductor, but `index_put` supports broadcasting the source tensor. As a result, compiled execution could incorrectly accept a source tensor whose slice shape does not match the destination slice shape, while eager execution correctly raises:

```
index_copy_(): Source/destination tensor must have same slice shapes
```

The fix adds the missing native `index_copy` shape validations to the decomposition before lowering to `index_put`:

- scalar source must have exactly one index
- non-scalar source and destination must have matching dimensionality
- source and destination slice shapes must match after removing the indexed dimension
- number of indices must match `source.size(dim)`

A regression test was added to ensure `torch.compile(torch.index_copy)` now raises for the same invalid input as eager mode.

Tested with:

```
python test/inductor/test_torchinductor.py \
  CpuTests.test_index_copy_source_slice_shape_check_cpu \
  GPUTests.test_index_copy_source_slice_shape_check_cuda
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo