### PR TITLE
Use SVE `exp_u20`/`fexp_u20` for SVE128

### DIFF
--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -22,6 +22,59 @@ namespace at::vec {
 // accessed as `at::vec`.
 inline namespace CPU_CAPABILITY {
 
+#if defined(CPU_CAPABILITY_SVE128) || defined(CPU_CAPABILITY_SVE256)
+// Implementation from Arm Optimized Routines:
+// https://github.com/ARM-software/optimized-routines/blob/v26.01/math/aarch64/experimental/sve/sv_expf_inline.h
+static inline svfloat32_t fexp_u20(svfloat32_t values) {
+  // fast exponential intended for cases where outputs will be downcasted to
+  // FP16 / BF16 (e.g. attention softmax).
+  // Accurate within 1 ULP for FP16
+  // Accurate within 1 ULP for BF16 for inputs in [-87.346, max_float] &
+  // clamps
+  //  inputs < -87.346 to zero.
+  // Implementation is similar to exp_u20, but:
+  // - approximates exp(r) - 1 as r instead of r + 0.5 r^2
+  // - does not split natural log (ln) into high / low parts
+  // - avoids special case code by clamping exp(x) to 0 for x < -87.346 and
+  // inf for x > 88.717
+
+  constexpr float upper_bound = 0x1.62dea4p+6f;
+  constexpr float lower_bound = -0x1.5d619ap+6f;
+
+  const svfloat32_t ln2 = svdup_n_f32(0x1.62e43p-1f);
+  const svfloat32_t inv_ln2 = svdup_n_f32(0x1.715476p+0f);
+
+  constexpr float shift = 0x1.803f8p17f;
+
+  // exp(x) = 2^n (1 + poly(r)), with 1 + poly(r) in [1/sqrt(2),sqrt(2)]
+  // x = ln2*n + r, with r in [-ln2/2, ln2/2] and poly(r) ~= r.
+
+  // n = round(x/(ln2/N))
+  svfloat32_t z = svmad_x(svptrue_b32(), inv_ln2, values, shift);
+  svfloat32_t n = svsub_x(svptrue_b32(), z, shift);
+
+  // n = round(x/(ln2/N))
+  svfloat32_t r = svmls_x(svptrue_b32(), values, n, ln2);
+
+  // scale = 2^(n/N)
+  svfloat32_t scale = svexpa(svreinterpret_u32(z));
+
+  // poly(r) = exp(r) - 1 ~= r
+  svfloat32_t y = svmla_x(svptrue_b32(), scale, scale, r);
+
+  // clamp to 0, inf
+  y = svsel_f32(
+      svcmplt_f32(svptrue_b32(), values, svdup_n_f32(lower_bound)),
+      svdup_n_f32(0.0f),
+      y);
+  y = svsel_f32(
+      svcmpgt_f32(svptrue_b32(), values, svdup_n_f32(upper_bound)),
+      svdup_n_f32(INFINITY),
+      y);
+  return y;
+}
+#endif
+
 #if defined(CPU_CAPABILITY_SVE256)
 
 template <>
@@ -285,56 +338,8 @@ class Vectorized<float> {
     svfloat32_t poly = svmla_x(svptrue_b32(), r, r2, c1);
     return svmla_x(svptrue_b32(), scale, scale, poly);
   }
-  // Implementation from Arm Optimized Routines:
-  // https://github.com/ARM-software/optimized-routines/blob/v26.01/math/aarch64/experimental/sve/sv_expf_inline.h
   Vectorized<float> fexp_u20() const {
-    // fast exponential intended for cases where outputs will be downcasted to
-    // FP16 / BF16 (e.g. attention softmax).
-    // Accurate within 1 ULP for FP16
-    // Accurate within 1 ULP for BF16 for inputs in [-87.346, max_float] &
-    // clamps
-    //  inputs < -87.346 to zero.
-    // Implementation is similar to exp_u20, but:
-    // - approximates exp(r) - 1 as r instead of r + 0.5 r^2
-    // - does not split natural log (ln) into high / low parts
-    // - avoids special case code by clamping exp(x) to 0 for x < -87.346 and
-    // inf for x > 88.717
-
-    constexpr float upper_bound = 0x1.62dea4p+6f;
-    constexpr float lower_bound = -0x1.5d619ap+6f;
-
-    const svfloat32_t ln2 = svdup_n_f32(0x1.62e43p-1f);
-    const svfloat32_t inv_ln2 = svdup_n_f32(0x1.715476p+0f);
-
-    constexpr float shift = 0x1.803f8p17f;
-
-    // exp(x) = 2^n (1 + poly(r)), with 1 + poly(r) in [1/sqrt(2),sqrt(2)]
-    // x = ln2*n + r, with r in [-ln2/2, ln2/2] and poly(r) ~= r.
-
-    // n = round(x/(ln2/N))
-    svfloat32_t z = svmad_x(svptrue_b32(), inv_ln2, values, shift);
-    svfloat32_t n = svsub_x(svptrue_b32(), z, shift);
-
-    // n = round(x/(ln2/N))
-    svfloat32_t r = svmls_x(svptrue_b32(), values, n, ln2);
-
-    // scale = 2^(n/N)
-    svfloat32_t scale = svexpa(svreinterpret_u32(z));
-
-    // poly(r) = exp(r) - 1 ~= r
-    svfloat32_t y = svmla_x(svptrue_b32(), scale, scale, r);
-
-    // clamp to 0, inf
-    y = svsel_f32(
-        svcmplt_f32(svptrue_b32(), values, svdup_n_f32(lower_bound)),
-        svdup_n_f32(0.0f),
-        y);
-    y = svsel_f32(
-        svcmpgt_f32(svptrue_b32(), values, svdup_n_f32(upper_bound)),
-        svdup_n_f32(INFINITY),
-        y);
-
-    return y;
+    return at::vec::fexp_u20(values);
   }
   Vectorized<float> fmod(const Vectorized<float>& q) const {
     USE_SLEEF(

--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -26,6 +26,9 @@ inline namespace CPU_CAPABILITY {
 // Implementation copied from Arm Optimized Routines:
 // https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/expf.c
 static inline svfloat32_t exp_u20_fast_path(svfloat32_t values) {
+  // For |x| >= 0x1.5d5e2ap+6f (~87.34), exp(x) may overflow or become
+  // subnormal, which FEXPA does not handle accurately; callers should handle
+  // those inputs separately.
   const svfloat32_t ln2_hi = svdup_n_f32(0x1.62e4p-1f);
   const svfloat32_t ln2_lo = svdup_n_f32(0x1.7f7d1cp-20f);
   const svfloat32_t c1 = svdup_n_f32(0.5f);

--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -23,6 +23,34 @@ namespace at::vec {
 inline namespace CPU_CAPABILITY {
 
 #if defined(CPU_CAPABILITY_SVE128) || defined(CPU_CAPABILITY_SVE256)
+// Implementation copied from Arm Optimized Routines:
+// https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/expf.c
+static inline svfloat32_t exp_u20_fast_path(svfloat32_t values) {
+  const svfloat32_t ln2_hi = svdup_n_f32(0x1.62e4p-1f);
+  const svfloat32_t ln2_lo = svdup_n_f32(0x1.7f7d1cp-20f);
+  const svfloat32_t c1 = svdup_n_f32(0.5f);
+  const svfloat32_t inv_ln2 = svdup_n_f32(0x1.715476p+0f);
+
+  const float shift = 0x1.803f8p17f;
+
+  /* n = round(x/(ln2/N)).  */
+  svfloat32_t z = svmad_x(svptrue_b32(), inv_ln2, values, shift);
+  svfloat32_t n = svsub_x(svptrue_b32(), z, shift);
+
+  /* r = x - n*ln2/N.  */
+  svfloat32_t r = values;
+  r = svmls_x(svptrue_b32(), r, n, ln2_hi);
+  r = svmls_x(svptrue_b32(), r, n, ln2_lo);
+
+  /* scale = 2^(n/N).  */
+  svfloat32_t scale = svexpa(svreinterpret_u32(z));
+
+  /* poly(r) = exp(r) - 1 ~= r + 0.5 r^2.  */
+  svfloat32_t r2 = svmul_x(svptrue_b32(), r, r);
+  svfloat32_t poly = svmla_x(svptrue_b32(), r, r2, c1);
+  return svmla_x(svptrue_b32(), scale, scale, poly);
+}
+
 // Implementation from Arm Optimized Routines:
 // https://github.com/ARM-software/optimized-routines/blob/v26.01/math/aarch64/experimental/sve/sv_expf_inline.h
 static inline svfloat32_t fexp_u20(svfloat32_t values) {
@@ -305,8 +333,6 @@ class Vectorized<float> {
     return USE_SLEEF(
         Vectorized<float>(Sleef_expm1fx_u10sve(values)), map(std::expm1));
   }
-  // Implementation copied from Arm Optimized Routines:
-  // https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/expf.c
   Vectorized<float> exp_u20() const {
     // special case to handle special inputs that are too large or too small
     // i.e. where there's at least one element x, s.t. |x| >= 87.3...
@@ -314,29 +340,7 @@ class Vectorized<float> {
     if (svptest_any(svptrue_b32(), is_special_case)) {
       return exp();
     }
-    const svfloat32_t ln2_hi = svdup_n_f32(0x1.62e4p-1f);
-    const svfloat32_t ln2_lo = svdup_n_f32(0x1.7f7d1cp-20f);
-    const svfloat32_t c1 = svdup_n_f32(0.5f);
-    const svfloat32_t inv_ln2 = svdup_n_f32(0x1.715476p+0f);
-
-    const float shift = 0x1.803f8p17f;
-
-    /* n = round(x/(ln2/N)).  */
-    svfloat32_t z = svmad_x(svptrue_b32(), inv_ln2, values, shift);
-    svfloat32_t n = svsub_x(svptrue_b32(), z, shift);
-
-    /* r = x - n*ln2/N.  */
-    svfloat32_t r = values;
-    r = svmls_x(svptrue_b32(), r, n, ln2_hi);
-    r = svmls_x(svptrue_b32(), r, n, ln2_lo);
-
-    /* scale = 2^(n/N).  */
-    svfloat32_t scale = svexpa(svreinterpret_u32(z));
-
-    /* poly(r) = exp(r) - 1 ~= r + 0.5 r^2.  */
-    svfloat32_t r2 = svmul_x(svptrue_b32(), r, r);
-    svfloat32_t poly = svmla_x(svptrue_b32(), r, r2, c1);
-    return svmla_x(svptrue_b32(), scale, scale, poly);
+    return at::vec::exp_u20_fast_path(values);
   }
   Vectorized<float> fexp_u20() const {
     return at::vec::fexp_u20(values);

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -11,6 +11,10 @@
 #include <sleef.h>
 #endif
 
+#if defined(CPU_CAPABILITY_SVE128)
+#include <ATen/cpu/vec/sve/vec_float.h>
+#endif
+
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-default")
 
 // Sleef offers vectorized versions of some transcedentals
@@ -43,7 +47,7 @@ inline namespace CPU_CAPABILITY {
 #define USE_SLEEF(sleef_code, non_sleef_code) non_sleef_code
 #endif
 
-#if defined(CPU_CAPABILITY_SVE128) && defined(AT_BUILD_ARM_VEC256_WITH_SLEEF)
+#if defined(CPU_CAPABILITY_SVE128)
 // With -msve-vector-bits=128, svfloat32_t and float32x4_t have identical layout
 // so these conversions compile to zero instructions.
 static inline svfloat32_t neon_to_sve(float32x4_t v) {
@@ -376,6 +380,12 @@ class Vectorized<float> {
   Vectorized<float> exp_u20() const {
     return vexpq_f32_u20();
   }
+#if defined(CPU_CAPABILITY_SVE128)
+  // SVE128 uses the ASIMD wrapper type, but can still reuse the SVE fexp.
+  Vectorized<float> fexp_u20() const {
+    return sve_to_neon(at::vec::fexp_u20(neon_to_sve(values)));
+  }
+#else
   Vectorized<float> fexp_u20() const {
     // fast exponential intended for cases where outputs will be downcasted to
     // FP16 / BF16 (e.g. attention softmax). Accurate within 1 ULP for FP16
@@ -419,6 +429,7 @@ class Vectorized<float> {
     y = vbslq_f32(gt_upper, vdupq_n_f32(INFINITY), y);
     return y;
   }
+#endif
   DEFINE_SLEEF_COMPATIBLE_BINARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(
       fmod,
       Sleef_fmodf4)

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -377,15 +377,27 @@ class Vectorized<float> {
 
     return vfmaq_f32(scale, poly, scale);
   }
-  Vectorized<float> exp_u20() const {
-    return vexpq_f32_u20();
-  }
 #if defined(CPU_CAPABILITY_SVE128)
-  // SVE128 uses the ASIMD wrapper type, but can still reuse the SVE fexp.
+  // SVE128 uses the ASIMD wrapper type, but can still reuse the SVE exp
+  // helpers.
+  Vectorized<float> exp_u20() const {
+    // special case to handle special inputs that are too large or too small
+    // i.e. where there's at least one element x, s.t. |x| >= 87.3...
+    svfloat32_t sve_values = neon_to_sve(values);
+    svbool_t is_special_case =
+        svacgt(svptrue_b32(), sve_values, 0x1.5d5e2ap+6f);
+    if (svptest_any(svptrue_b32(), is_special_case)) {
+      return exp();
+    }
+    return sve_to_neon(at::vec::exp_u20_fast_path(sve_values));
+  }
   Vectorized<float> fexp_u20() const {
     return sve_to_neon(at::vec::fexp_u20(neon_to_sve(values)));
   }
 #else
+  Vectorized<float> exp_u20() const {
+    return vexpq_f32_u20();
+  }
   Vectorized<float> fexp_u20() const {
     // fast exponential intended for cases where outputs will be downcasted to
     // FP16 / BF16 (e.g. attention softmax). Accurate within 1 ULP for FP16


### PR DESCRIPTION
This PR makes the SVE128 CPU capability use the SVE `exp_u20` and `fexp_u20` implementations from #161049 and #177645 for the float vectorizer path used by CPU FlashAttention/SDPA.

The SVE128 vectorizer still uses the 128-bit ASIMD `float32x4_t` type for `Vectorized<float>`, but it is compiled with SVE enabled and `-msve-vector-bits=128`. This lets the SVE128 implementation reuse the existing SVE `exp_u20(svfloat32_t)` and `fexp_u20(svfloat32_t)` functions by converting between `float32x4_t` and `svfloat32_t` using the helpers introduced in #176256.

## Implementation
The patch:

* hoists the existing SVE `exp_u20_fast_path`/`fexp_u20` implementations so they can be reused by both SVE256 and SVE128 code paths
* keeps SVE256 behavior unchanged by calling the hoisted helper from `Vectorized<float>::exp_u20()`/`Vectorized<float>::fexp_u20()`
* adds SVE128 `Vectorized<float>::exp_u20()`/`Vectorized<float>::fexp_u20()` overrides that call the SVE helpers through no-op `float32x4_t`/`svfloat32_t` conversions

## Performance

Using the SDPA benchmark from #177645, here are the scaled-dot-production-attention speedups (vs current) achieved on a 96-core Neoverse V2 instance (`c8g.metal-24xl`):
### FP32 (exp_u20)
| Case | 1 thread | 8 threads | 16 threads | 32 threads | 64 threads | 96 threads |
|---|---:|---:|---:|---:|---:|---:|
| `llama_prefill_s2048_bs1` | +3.6% | +3.2% | +3.0% | +2.6% | +2.9% | +5.2% |
| `llama_decode_t4096_bs1` | +1.7% | +1.1% | -0.6% | +1.5% | -0.2% | +1.1% |
| `mllama_vision_lv6400_bs1` | +7.6% | +6.3% | +6.4% | +6.1% | +6.0% | +5.6% |
| `whisper_enc_1500_bs1` | +9.2% | +8.3% | +7.7% | +7.4% | +6.8% | +5.3% |
| `whisper_enc_1500_bs8` | +9.2% | +7.6% | +7.6% | +7.3% | +6.8% | +6.1% |

### BF16 (fexp_u20)
| Case | 1 thread | 8 threads | 16 threads | 32 threads | 64 threads | 96 threads |
|---|---:|---:|---:|---:|---:|---:|
| `llama_prefill_s2048_bs1` | +6.9% | +6.7% | +6.5% | +5.7% | +4.9% | +4.9% |
| `llama_decode_t4096_bs1` | +1.2% | +2.1% | +3.0% | -1.1% | +0.7% | +1.9% |
| `mllama_vision_lv6400_bs1` | +10.1% | +9.8% | +9.7% | +8.5% | +7.4% | +7.2% |
| `whisper_enc_1500_bs1` | +11.5% | +11.5% | +11.6% | +8.5% | +8.6% | +8.6% |
| `whisper_enc_1500_bs8` | +11.5% | +11.5% | +11.5% | +9.6% | +7.9% | +8.6% |

Shape legend:

| Case | B | Hq | Hkv | Lq | Lk | D | causal | gqa |
|---|---:|---:|---:|---:|---:|---:|---|---|
| `llama_prefill_s2048_bs1` | 1 | 32 | 8 | 2048 | 2048 | 128 | True | True |
| `llama_decode_t4096_bs1` | 1 | 32 | 8 | 1 | 2048 | 128 | False | True |
| `mllama_vision_lv6400_bs1` | 1 | 16 | 16 | 6400 | 6400 | 80 | False | False |
| `whisper_enc_1500_bs1` | 1 | 20 | 20 | 1500 | 1500 | 64 | False | False |
| `whisper_enc_1500_bs8` | 8 | 20 | 20 | 1500 | 1500 | 64 | False | False |

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @fadara01 