### PR TITLE
fix: skip float16/bf16 downcast for argmax/argmin reduction output

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -3010,7 +3010,6 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
 
         self.assertEqual(compile_decimal, Decimal(0))
 
-    @skipIfXpu(msg="AssertionError: torch-xpu-ops: #3006")
     @config.patch(
         {"triton.use_block_ptr": True, "triton.codegen_upcast_to_fp32": False}
     )

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4759,7 +4759,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         # If BF16/F16 upcasting was done, ensure the output is downcast to the
         # expected dtype.
-        if do_upcast:
+        # Skip for argmax/argmin: their output dtype is int64 (the index),
+        # not the input floating dtype, so downcasting to original_dtype would
+        # produce a lossy int64->float16 round-trip.
+        if do_upcast and reduction_type not in ("argmax", "argmin"):
             for result in result_tuple:
                 if result.dtype != original_dtype:
                     self.post_loop_combine.writeline(


### PR DESCRIPTION
## Root Cause

`torch/_inductor/codegen/triton.py` — the post-reduction downcast guard unconditionally casts all reduction results back to `original_dtype` (float16/bf16) when `do_upcast=True`. For argmax/argmin, the output semantic dtype is int64 (the index), not the input floating dtype, so this produces a lossy int64→float16 round-trip that corrupts large index values (>2047, beyond fp16 exact integer range).

**Violated invariant:** For index-returning reductions (argmax/argmin), the output semantic dtype is the index dtype (int64), independent of the input floating dtype. The BF16/F16 upcast pathway only applies to the comparison value, not the index output.

## Fix

Add `and reduction_type not in ("argmax", "argmin")` to the post-reduction downcast guard. Remove `@skipIfXpu` from `test_float16_reduction_with_int_output`.

**2 files changed, +4/-2.**

## CUDA Reference

`aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu:24` — `gpu_reduce_kernel<scalar_t, int64_t>` hardcodes int64 output independent of input scalar type. Even when input is float16/bf16 (lines 35-38: `argmax_kernel_cuda_impl<at::Half, float>`), the upcast only affects the comparison value, not the index output dtype.

## Issue

Fixes: intel/torch-xpu-ops#3006


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo