### PR TITLE
[inductor] Add third reduction tile for strided block pointers

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -113,7 +113,7 @@ class BlockDescriptorTestBase(InductorTestCase):
         return self._assert_tiling_ndims(code, pointwise_blocks, num_dims)
 
     def _assert_reduction_ndims(self, code, num_dims: int) -> None:
-        reduction_blocks = ["R0_BLOCK", "R1_BLOCK"]
+        reduction_blocks = ["R0_BLOCK", "R1_BLOCK", "R2_BLOCK"]
         return self._assert_tiling_ndims(code, reduction_blocks, num_dims)
 
     def _assert_tiling_ndims(self, code, blocks: list[str], num_dims: int) -> None:
@@ -952,10 +952,10 @@ class CommonTemplate:
         # Check for a single reduction dimension.
         self._assert_reduction_ndims(code, 1)
 
+    @xfail_if_use_tensor_descriptor
     def test_reduction_multiple_discontiguous_dims(self):
         """
-        Test reducing a tensor with more than one discontiguous dimension. This case
-        won't generate a block pointer, since we don'allow enough tiling dimensions.
+        Test reducing a tensor with more than one discontiguous dimension.
         """
         # Use odd shapes to frustrate block pointer analysis.
         view = self._discontiguous_tensor((3, 7, 11), self.device)
@@ -963,13 +963,36 @@ class CommonTemplate:
         result, (code,) = self._run_and_compare(
             torch.sum,
             view,
-            expected_num_block_pointers=0,
+            expected_num_block_pointers=1,
             expected_num_triton_kernels=1,
             config_patches=tiled_reduction_config,
         )
 
-        # Check for 2 reduction dimensions.
-        self._assert_reduction_ndims(code, 2)
+        # Check for 3 reduction dimensions.
+        self._assert_reduction_ndims(code, 3)
+
+    @test_torchinductor.skip_if_triton_cpu("cpp_wrapper requires CUDA")
+    @unittest.skipIf(
+        not HAS_CUDA_AND_TRITON or torch.version.hip,
+        "cpp_wrapper lazy Triton path requires CUDA",
+    )
+    def test_reduction_multiple_discontiguous_dims_cpp_wrapper(self):
+        if self.device != "cuda":
+            self.skipTest("cpp_wrapper lazy Triton path requires CUDA")
+
+        view = self._discontiguous_tensor((3, 7, 11), self.device)
+
+        with config.patch(
+            {
+                "cpp_wrapper": True,
+                "triton.use_block_ptr": True,
+                "triton.use_tensor_descriptor": False,
+                **tiled_reduction_config,
+            }
+        ):
+            result = torch.compile(torch.sum, backend="inductor")(view)
+
+        self.assertTrue(torch.allclose(torch.sum(view), result))
 
     @test_torchinductor.skip_if_triton_cpu  # Illegal instruction  File; cannot xfail because it crashes process
     def test_2d_reduction_multi_kernel(self):

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -87,7 +87,7 @@ fusion_log = torch._logging.getArtifactLogger(__name__, "fusion")
 
 pexpr = PythonPrinter().doprint
 
-all_prefixes = OrderedSet(["z", "y", "x", "r0_", "r1_"])
+all_prefixes = OrderedSet(["z", "y", "x", "r0_", "r1_", "r2_"])
 
 
 def get_max_tiles(default: int = 2) -> int:
@@ -645,7 +645,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
 
         grid_dims = ["x", "y", "z"]
         pointwise_tensor_dims = list(reversed(grid_dims))
-        reduction_dims = ["r0_", "r1_"]
+        reduction_dims = ["r0_", "r1_", "r2_"]
         if no_x_dim:
             tensor_dims = reduction_dims
         elif no_r_dim:
@@ -2716,7 +2716,7 @@ class SIMDScheduling(BaseScheduling):
         Create a tiling dict from pointwise and reduction splits.
         """
         pw_prefixes = ("z", "y", "x")
-        reduction_prefixes = ("r0_", "r1_")
+        reduction_prefixes = ("r0_", "r1_", "r2_")
         assert len(pw_tiling) <= len(pw_prefixes)
         assert len(reduction_tiling) <= len(reduction_prefixes)
 
@@ -2785,9 +2785,9 @@ class SIMDScheduling(BaseScheduling):
             if V.graph.sizevars.statically_known_equals(
                 pointwise_numel, 1
             ) and V.graph.sizevars.statically_known_gt(reduction_numel, 1):
-                # We only have at most two dimensions to tile over when emitting a
-                # reduction-only kernel.
-                max_tiles = min(max_tiles, 2)
+                # Reduction-only kernels do not use pointwise Y/Z tiles, so allow
+                # one more reduction tile to avoid collapsing odd logical dims.
+                max_tiles = min(get_max_tiles(3), 3)
             num_leading_dims = max(0, len(dims) - max_tiles)
             first_trailing_dim = num_leading_dims + 1
             collapsed_leading_dim = sympy_product(dims[:first_trailing_dim])

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -250,7 +250,7 @@ class TritonSymbols:
     Stores sympy.Symbol instances and constants associated with triton codegen.
     """
 
-    reduction_types = OrderedSet([SymT.R0_INDEX, SymT.R1_INDEX])
+    reduction_types = OrderedSet([SymT.R0_INDEX, SymT.R1_INDEX, SymT.R2_INDEX])
     block_types = OrderedSet([SymT.XBLOCK, SymT.YBLOCK, SymT.ZBLOCK, *reduction_types])
 
     block_offsets = {
@@ -4311,7 +4311,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         reduction_range_prefix = self.range_trees[-1].prefix[0]
 
         # When we do native matmtul codegen,
-        # we don't want to keep the R0_BLOCK/R1_BLOCK in the accumulator.
+        # we don't want to keep reduction block dimensions in the accumulator.
         # so instead of naively calling dense_size_str(), we filter out
         # reduction block from accumulator and only keep (Y,X).
         # In bmm (Z,Y,R)x(Z,R,X) case, we also remove z dimension from accumulator

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -116,6 +116,7 @@ class CoordescTuner:
             # does not have the R0_BLOCK field to guarantee that.
             "R0_BLOCK",
             "R1_BLOCK",
+            "R2_BLOCK",
             # the following 3 are for mm
             "BLOCK_M",
             "BLOCK_N",

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -18,6 +18,7 @@ TRITON_MAX_BLOCK = {
     "Z": 1024,
     "R0_": 4096 * 16,  # * 16 is multi-kernel only
     "R1_": 2048 * 16,  # * 16 is multi-kernel only
+    "R2_": 1024 * 16,  # * 16 is multi-kernel only
 }
 TRITON_MAX_RSPLIT = 64
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2994,9 +2994,9 @@ def _enforce_reduction_config_block_minimums(
         return configs
 
     for cfg in configs:
-        assert not (frozenset(("YBLOCK", "ZBLOCK", "R1_BLOCK")) & cfg.kwargs.keys()), (
-            f"min_xblock/min_rblock only support 2D X/R0 configs: {cfg}"
-        )
+        assert not (
+            frozenset(("YBLOCK", "ZBLOCK", "R1_BLOCK", "R2_BLOCK")) & cfg.kwargs.keys()
+        ), f"min_xblock/min_rblock only support 2D X/R0 configs: {cfg}"
         has_xblock = "XBLOCK" in cfg.kwargs
         has_rblock = "R0_BLOCK" in cfg.kwargs
         if not (has_xblock or has_rblock):
@@ -4961,6 +4961,8 @@ class GridExpr:
             "YBLOCK": f"{kernel_name}_result.yblocks[0]",
             "ZBLOCK": f"{kernel_name}_result.zblocks[0]",
             "R0_BLOCK": f"{kernel_name}_result.r0blocks[0]",
+            "R1_BLOCK": f"{kernel_name}_result.r1blocks[0]",
+            "R2_BLOCK": f"{kernel_name}_result.r2blocks[0]",
             "RSPLIT": f"{kernel_name}_result.rsplit",
             "RSPLIT_SIZE": f"{kernel_name}_result.rsplit_size",
         }

--- a/torch/_inductor/runtime/triton_lazy_compile.py
+++ b/torch/_inductor/runtime/triton_lazy_compile.py
@@ -34,6 +34,8 @@ class TritonKernelCompileResult:
     yblocks: list[int]
     zblocks: list[int]
     r0blocks: list[int]
+    r1blocks: list[int]
+    r2blocks: list[int]
     rsplit: int
     rsplit_size: int
     config_index: int | None
@@ -191,11 +193,15 @@ def run_triton_kernel_with_autotune(
         yblocks = [config.get(f"YBLOCK_{i}", 1) for i in range(num_kernels)]
         zblocks = [config.get(f"ZBLOCK_{i}", 1) for i in range(num_kernels)]
         r0blocks = [config.get(f"R0_BLOCK_{i}", 1) for i in range(num_kernels)]
+        r1blocks = [config.get(f"R1_BLOCK_{i}", 1) for i in range(num_kernels)]
+        r2blocks = [config.get(f"R2_BLOCK_{i}", 1) for i in range(num_kernels)]
     else:
         xblocks = [config.get("XBLOCK", 128)]
         yblocks = [config.get("YBLOCK", 1)]
         zblocks = [config.get("ZBLOCK", 1)]
         r0blocks = [config.get("R0_BLOCK", 1)]
+        r1blocks = [config.get("R1_BLOCK", 1)]
+        r2blocks = [config.get("R2_BLOCK", 1)]
     rsplit = config.get("RSPLIT", 1)
     rsplit_size = config.get("RSPLIT_SIZE", 1)
 
@@ -216,8 +222,9 @@ def run_triton_kernel_with_autotune(
 
     log.debug(
         "Successfully autotuned Triton kernel: cubin_path=%s, mangled_name=%s, "
-        "num_warps=%d, shared_mem=%d, xblocks=%s, yblocks=%s, zblocks=%s, r0blocks=%s, "
-        "rsplit=%d, rsplit_size=%d, config_index=%s, global_scratch=%s, profile_scratch=%s",
+        "num_warps=%d, shared_mem=%d, xblocks=%s, yblocks=%s, zblocks=%s, "
+        "r0blocks=%s, r1blocks=%s, r2blocks=%s, rsplit=%d, rsplit_size=%d, "
+        "config_index=%s, global_scratch=%s, profile_scratch=%s",
         cubin_path,
         mangled_name,
         num_warps,
@@ -226,6 +233,8 @@ def run_triton_kernel_with_autotune(
         yblocks,
         zblocks,
         r0blocks,
+        r1blocks,
+        r2blocks,
         rsplit,
         rsplit_size,
         config_index,
@@ -242,6 +251,8 @@ def run_triton_kernel_with_autotune(
         yblocks=yblocks,
         zblocks=zblocks,
         r0blocks=r0blocks,
+        r1blocks=r1blocks,
+        r2blocks=r2blocks,
         rsplit=rsplit,
         rsplit_size=rsplit_size,
         config_index=config_index,

--- a/torch/csrc/inductor/aoti_include/kernel_compile_result.h
+++ b/torch/csrc/inductor/aoti_include/kernel_compile_result.h
@@ -15,6 +15,8 @@ struct LazyKernelCompileResult {
   std::vector<int> yblocks;
   std::vector<int> zblocks;
   std::vector<int> r0blocks;
+  std::vector<int> r1blocks;
+  std::vector<int> r2blocks;
   int rsplit;
   int rsplit_size;
   int config_index;

--- a/torch/csrc/inductor/cpp_wrapper/lazy_triton_compile.h
+++ b/torch/csrc/inductor/cpp_wrapper/lazy_triton_compile.h
@@ -107,6 +107,8 @@ static inline LazyKernelCompileResult extractCompileResult(PyObject* result) {
   compile_result.yblocks = getIntListAttr(result, "yblocks");
   compile_result.zblocks = getIntListAttr(result, "zblocks");
   compile_result.r0blocks = getIntListAttr(result, "r0blocks");
+  compile_result.r1blocks = getIntListAttr(result, "r1blocks");
+  compile_result.r2blocks = getIntListAttr(result, "r2blocks");
   compile_result.rsplit = getIntAttr(result, "rsplit");
   compile_result.rsplit_size = getIntAttr(result, "rsplit_size");
   compile_result.config_index = getOptionalIntAttr(result, "config_index");

--- a/torch/utils/_sympy/symbol.py
+++ b/torch/utils/_sympy/symbol.py
@@ -36,7 +36,7 @@ class SymT(Enum):
     # Inductor: An indexing variable i0 in loops IR which ranges over non-reduced
     # dim in the loop
     INDEX = auto()
-    # Inductor: A reduction indexing (r0, r1) variables in loops IR which ranges over
+    # Inductor: Reduction indexing variables in loops IR which range over
     # reduced dim(s) in the loop
     R0_INDEX = auto()
     R1_INDEX = auto()
@@ -53,6 +53,9 @@ class SymT(Enum):
     VIEW = auto()
     # Alternate (non-modular) indexing used in halide kernels
     HALIDE = auto()
+    # Inductor: third reduction indexing variable. Keep this after the existing
+    # symbols so their enum values do not change.
+    R2_INDEX = auto()
 
 
 # Invariant: there must not be a prefix which is a prefix of another string,
@@ -77,6 +80,7 @@ prefix_str = {
     SymT.INDIRECT: "indirect",  # false aliasing?
     SymT.VIEW: "view",
     SymT.HALIDE: "h",
+    SymT.R2_INDEX: "r2_",
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184347

Allow reduction-only ND tiling to keep a third reduction dimension so odd-shaped discontiguous reductions can use Triton block pointers instead of collapsing logical dimensions into unsupported 1D-to-ND slices. Extend lazy compile metadata to carry R1/R2 block sizes and add block-pointer regressions for Python and cpp_wrapper paths.

Fixes #125077
Generated by my agent

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo