### PR TITLE
[flop counter] Fix _flash_attention_forward/backward layout mismatch in FlopCounterMode

### DIFF
--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -20,7 +20,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
-from torch.utils.flop_counter import sdpa_flop_count
+from torch.utils.flop_counter import sdpa_backward_flop_count, sdpa_flop_count
 
 
 try:
@@ -797,9 +797,7 @@ class TestFlopCounter(TestCase):
                     False,
                 )
 
-        dense_x = torch.randn(
-            4, 40, 4, 16, dtype=torch.bfloat16, device="cuda"
-        ).transpose(1, 2)
+        dense_x = torch.randn(4, 40, 4, 16, dtype=torch.bfloat16, device="cuda")
 
         with FlopCounterMode() as real_flop_counter_mode:
             torch.ops.aten._flash_attention_forward(
@@ -819,6 +817,67 @@ class TestFlopCounter(TestCase):
             int(get_total_flops(fake_flop_counter_mode)),
             int(get_total_flops(real_flop_counter_mode)),
         )
+
+    def test_flash_attention_forward_flop_layout(self):
+        B, S, H, D = 2, 128, 8, 64
+        q = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        k = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        v = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+
+        with FlopCounterMode() as mode:
+            torch.ops.aten._flash_attention_forward(
+                q,
+                k,
+                v,
+                None,
+                None,
+                S,
+                S,
+                0.0,
+                False,
+                False,
+            )
+
+        flash_flops = int(get_total_flops(mode))
+        expected = sdpa_flop_count((B, H, S, D), (B, H, S, D), (B, H, S, D))
+        self.assertEqual(flash_flops, expected)
+
+    def test_flash_attention_backward_flop_layout(self):
+        B, S, H, D = 2, 128, 8, 64
+        q = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        k = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        v = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        out = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        grad_out = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        logsumexp = torch.randn(B, H, S, device="meta", dtype=torch.float32)
+        rng_state = torch.zeros(2, dtype=torch.int64, device="meta")
+
+        with FlopCounterMode() as mode:
+            torch.ops.aten._flash_attention_backward(
+                grad_out,
+                q,
+                k,
+                v,
+                out,
+                logsumexp,
+                None,
+                None,
+                S,
+                S,
+                0.0,
+                False,
+                rng_state,
+                None,
+            )
+
+        bwd_flops = int(get_total_flops(mode))
+        expected = sdpa_backward_flop_count(
+            (B, H, S, D),
+            (B, H, S, D),
+            (B, H, S, D),
+            (B, H, S, D),
+        )
+        self.assertEqual(bwd_flops, expected)
 
     def test_addmm_out(self):
         def f(x):

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -453,6 +453,10 @@ def _flash_attention_forward_flop(
 ) -> int:
     """Count flops for self-attention."""
     # NB: We aren't accounting for causal attention here
+    if cum_seq_q is None and query.ndim == 4:
+        query = query.transpose(-2, -3)
+        key = key.transpose(-2, -3)
+        value = value.transpose(-2, -3)
     # in case this is a nested tensor, we unpack the individual batch elements
     # and then sum the flops per batch element
     sizes = _unpack_flash_attention_nested_shapes(
@@ -561,6 +565,11 @@ def _flash_attention_backward_flop(
     *args,
     **kwargs,
 ) -> int:
+    if cum_seq_q is None and query.ndim == 4:
+        grad_out = grad_out.transpose(-2, -3)
+        query = query.transpose(-2, -3)
+        key = key.transpose(-2, -3)
+        value = value.transpose(-2, -3)
     # in case this is a nested tensor, we unpack the individual batch elements
     # and then sum the flops per batch element
     shapes = _unpack_flash_attention_nested_shapes(


### PR DESCRIPTION
`_flash_attention_forward` and `_flash_attention_backward` receive tensors in (B, S, H, D) layout, but the flop counting functions passed them directly to `sdpa_flop_count` which assumes (B, H, S, D). This swapped heads and sequence length, producing incorrect flop counts.

Transpose non-varlen 4D tensors from BSHD to BHSD before counting. The varlen (nested tensor) path already constructed shapes correctly.

Fixes #178064