### PR TITLE
Improve complex input error for BatchNorm

### DIFF
--- a/test/nn/test_lazy_modules.py
+++ b/test/nn/test_lazy_modules.py
@@ -689,6 +689,30 @@ class TestLazyModules(TestCase):
         self._check_lazy_batchnorm_state(nn.BatchNorm3d, nn.LazyBatchNorm3d)
         self._check_lazy_batchnorm_state(nn.BatchNorm3d, nn.LazyBatchNorm3d)
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_batchnorm_complex_cuda_error(self):
+        test_cases = [
+            (
+                nn.BatchNorm2d(3).cuda(),
+                torch.zeros((1, 3, 4, 4), device="cuda", dtype=torch.complex64),
+            ),
+            (
+                nn.BatchNorm3d(3).cuda(),
+                torch.zeros((1, 3, 4, 4, 4), device="cuda", dtype=torch.complex64),
+            ),
+            (
+                nn.LazyBatchNorm2d().cuda(),
+                torch.zeros((1, 3, 4, 4), device="cuda", dtype=torch.complex64),
+            ),
+            (
+                nn.LazyBatchNorm3d().cuda(),
+                torch.zeros((1, 3, 4, 4, 4), device="cuda", dtype=torch.complex64),
+            ),
+        ]
+
+        for module, input in test_cases:
+            with self.assertRaisesRegex(NotImplementedError, "batch_norm.*complex"):
+                module(input)
     def test_lazy_instancenorm1d(self):
         self._check_lazy_norm(nn.InstanceNorm1d, nn.LazyInstanceNorm1d, (16, 3, 6))
 

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -207,6 +207,15 @@ class _BatchNorm(_NormBase):
         passed when the update should occur (i.e. in training mode when they are tracked), or when buffer stats are
         used for normalization (i.e. in eval mode when buffers are not None).
         """
+
+        if input.is_complex():
+            dtype_name = {
+                torch.complex64: "ComplexFloat",
+                torch.complex128: "ComplexDouble",
+                torch.complex32: "ComplexHalf",
+            }.get(input.dtype, str(input.dtype))
+            raise NotImplementedError(f'"batch_norm" not implemented for \'{dtype_name}\'')
+
         return F.batch_norm(
             input,
             # If buffers are not to be tracked, ensure that they won't be updated


### PR DESCRIPTION
Fixes #184282

### Summary
This PR introduces an early complex data type check in `_BatchNorm.forward`.

Currently, CUDA `BatchNorm2d` and `BatchNorm3d`, along with `LazyBatchNorm2d` and `LazyBatchNorm3d`, can reach `cudnn_batch_norm` with complex inputs. This leads to a lower-level input and weight data type mismatch. This update causes them to fail sooner with a clearer unsupported complex error message.

### Test
Added CUDA regression coverage for:
- `BatchNorm2d`
- `BatchNorm3d`
- `LazyBatchNorm2d`
- `LazyBatchNorm3d`

Local test on Windows with CPU only:

```text
python test\nn\test_lazy_modules.py -k batchnorm_complex
OK (skipped=1)