### PR TITLE
Add XPU to externalId

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -1554,6 +1554,8 @@ int64_t KinetoEvent::externalId() const {
       type != libkineto::ActivityType::CONCURRENT_KERNEL &&
       type != libkineto::ActivityType::CUDA_RUNTIME &&
       type != libkineto::ActivityType::CUDA_DRIVER &&
+      type != libkineto::ActivityType::XPU_RUNTIME &&
+      type != libkineto::ActivityType::XPU_DRIVER &&
       type != libkineto::ActivityType::PRIVATEUSE1_RUNTIME &&
       type != libkineto::ActivityType::PRIVATEUSE1_DRIVER) {
     return static_cast<int64_t>(result_->visit(c10::overloaded(


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/3479

Updates the mapping between `libkineto::ChromeTraceLogger::handleActivity()` and `KinetoEvent::externalId()` after following change: https://github.com/pytorch/kineto/pull/1390