### PR TITLE
fix: use scalar for torch.sinh, torch.acosh on f32 inputs (aten)

### DIFF
--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -181,7 +181,9 @@ class Vectorized<float> {
     return USE_SLEEF(
         Vectorized<float>(Sleef_acosfx_u10sve(values)), map(std::acos));
   }
-  // Sleef acoshf overflows for large float inputs where std::acosh is finite
+  // Sleef acoshf/sinhf/coshf overflow for large float inputs where the scalar
+  // C library returns finite results, because Sleef uses float-range
+  // intermediates internally while the scalar C library uses double precision.
   Vectorized<float> acosh() const {
     return map(std::acosh);
   }

--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -181,9 +181,9 @@ class Vectorized<float> {
     return USE_SLEEF(
         Vectorized<float>(Sleef_acosfx_u10sve(values)), map(std::acos));
   }
+  // Sleef acoshf overflows for large float inputs where std::acosh is finite
   Vectorized<float> acosh() const {
-    return USE_SLEEF(
-        Vectorized<float>(Sleef_acoshfx_u10sve(values)), map(std::acosh));
+    return map(std::acosh);
   }
   Vectorized<float> asin() const {
     return USE_SLEEF(
@@ -428,17 +428,18 @@ class Vectorized<float> {
     return USE_SLEEF(
         Vectorized<float>(Sleef_sinfx_u10sve(values)), map(std::sin));
   }
+  // Sleef sinhf/coshf overflow for large float inputs where std::sinh/cosh
+  // return finite results, because Sleef uses float-range intermediates
+  // internally while the scalar C library uses double precision.
   Vectorized<float> sinh() const {
-    return USE_SLEEF(
-        Vectorized<float>(Sleef_sinhfx_u10sve(values)), map(std::sinh));
+    return map(std::sinh);
   }
   Vectorized<float> cos() const {
     return USE_SLEEF(
         Vectorized<float>(Sleef_cosfx_u10sve(values)), map(std::cos));
   }
   Vectorized<float> cosh() const {
-    return USE_SLEEF(
-        Vectorized<float>(Sleef_coshfx_u10sve(values)), map(std::cosh));
+    return map(std::cosh);
   }
   Vectorized<float> ceil() const {
     return svrintp_f32_x(ptrue, values);

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -293,7 +293,9 @@ class Vectorized<float> {
       name, Sleef_##name##f4_u10)
 
   DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(acos)
-  // Sleef acoshf overflows for large float inputs where std::acosh is finite
+  // Sleef acoshf/sinhf/coshf overflow for large float inputs where the scalar
+  // C library returns finite results, because Sleef uses float-range
+  // intermediates internally while the scalar C library uses double precision.
   Vectorized<float> acosh() const {
     return map(std::acosh);
   }

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -293,7 +293,10 @@ class Vectorized<float> {
       name, Sleef_##name##f4_u10)
 
   DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(acos)
-  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(acosh)
+  // Sleef acoshf overflows for large float inputs where std::acosh is finite
+  Vectorized<float> acosh() const {
+    return map(std::acosh);
+  }
   DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(asin)
   DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(asinh)
   DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(atan)
@@ -449,9 +452,16 @@ class Vectorized<float> {
       Sleef_nextafterf4)
   Vectorized<float> frac() const;
   DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(sin)
-  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(sinh)
+  // Sleef sinhf/coshf overflow for large float inputs where std::sinh/cosh
+  // return finite results, because Sleef uses float-range intermediates
+  // internally while the scalar C library uses double precision.
+  Vectorized<float> sinh() const {
+    return map(std::sinh);
+  }
   DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(cos)
-  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(cosh)
+  Vectorized<float> cosh() const {
+    return map(std::cosh);
+  }
   Vectorized<float> ceil() const {
     return map(at::native::ceil_impl);
   }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -192,7 +192,9 @@ class Vectorized<float> {
   Vectorized<float> acos() const {
     return Vectorized<float>(Sleef_acosf8_u10(values));
   }
-  // Sleef acoshf overflows for large float inputs where std::acosh is finite
+  // Sleef acoshf/sinhf/coshf overflow for large float inputs where the scalar
+  // C library returns finite results, because Sleef uses float-range
+  // intermediates internally while the scalar C library uses double precision.
   Vectorized<float> acosh() const {
     return map(std::acosh);
   }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -192,8 +192,9 @@ class Vectorized<float> {
   Vectorized<float> acos() const {
     return Vectorized<float>(Sleef_acosf8_u10(values));
   }
+  // Sleef acoshf overflows for large float inputs where std::acosh is finite
   Vectorized<float> acosh() const {
-    return Vectorized<float>(Sleef_acoshf8_u10(values));
+    return map(std::acosh);
   }
   Vectorized<float> asin() const {
     return Vectorized<float>(Sleef_asinf8_u10(values));
@@ -401,14 +402,17 @@ class Vectorized<float> {
   Vectorized<float> sin() const {
     return Vectorized<float>(Sleef_sinf8_u35(values));
   }
+  // Sleef sinhf/coshf overflow for large float inputs where std::sinh/cosh
+  // return finite results, because Sleef uses float-range intermediates
+  // internally while the scalar C library uses double precision.
   Vectorized<float> sinh() const {
-    return Vectorized<float>(Sleef_sinhf8_u10(values));
+    return map(std::sinh);
   }
   Vectorized<float> cos() const {
     return Vectorized<float>(Sleef_cosf8_u35(values));
   }
   Vectorized<float> cosh() const {
-    return Vectorized<float>(Sleef_coshf8_u10(values));
+    return map(std::cosh);
   }
   Vectorized<float> ceil() const {
     return _mm256_ceil_ps(values);

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_float_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_float_vsx.h
@@ -284,7 +284,9 @@ class Vectorized<float> {
   Vectorized<float> C10_ALWAYS_INLINE acos() const {
     return {Sleef_acosf4_u10(_vec0), Sleef_acosf4_u10(_vec1)};
   }
-  // Sleef acoshf overflows for large float inputs where std::acosh is finite
+  // Sleef acoshf/sinhf/coshf overflow for large float inputs where the scalar
+  // C library returns finite results, because Sleef uses float-range
+  // intermediates internally while the scalar C library uses double precision.
   Vectorized<float> C10_ALWAYS_INLINE acosh() const {
     return map(std::acosh);
   }
@@ -375,7 +377,6 @@ class Vectorized<float> {
   Vectorized<float> C10_ALWAYS_INLINE cos() const {
     return {Sleef_cosf4_u10(_vec0), Sleef_cosf4_u10(_vec1)};
   }
-  // Sleef coshf overflows for large float inputs where std::cosh is finite
   Vectorized<float> C10_ALWAYS_INLINE cosh() const {
     return map(std::cosh);
   }
@@ -392,7 +393,6 @@ class Vectorized<float> {
   Vectorized<float> C10_ALWAYS_INLINE sin() const {
     return {Sleef_sinf4_u10(_vec0), Sleef_sinf4_u10(_vec1)};
   }
-  // Sleef sinhf overflows for large float inputs where std::sinh is finite
   Vectorized<float> C10_ALWAYS_INLINE sinh() const {
     return map(std::sinh);
   }

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_float_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_float_vsx.h
@@ -284,8 +284,9 @@ class Vectorized<float> {
   Vectorized<float> C10_ALWAYS_INLINE acos() const {
     return {Sleef_acosf4_u10(_vec0), Sleef_acosf4_u10(_vec1)};
   }
+  // Sleef acoshf overflows for large float inputs where std::acosh is finite
   Vectorized<float> C10_ALWAYS_INLINE acosh() const {
-    return {Sleef_acoshf4_u10(_vec0), Sleef_acoshf4_u10(_vec1)};
+    return map(std::acosh);
   }
   Vectorized<float> C10_ALWAYS_INLINE asin() const {
     return {Sleef_asinf4_u10(_vec0), Sleef_asinf4_u10(_vec1)};
@@ -374,8 +375,9 @@ class Vectorized<float> {
   Vectorized<float> C10_ALWAYS_INLINE cos() const {
     return {Sleef_cosf4_u10(_vec0), Sleef_cosf4_u10(_vec1)};
   }
+  // Sleef coshf overflows for large float inputs where std::cosh is finite
   Vectorized<float> C10_ALWAYS_INLINE cosh() const {
-    return {Sleef_coshf4_u10(_vec0), Sleef_coshf4_u10(_vec1)};
+    return map(std::cosh);
   }
   Vectorized<float> C10_ALWAYS_INLINE floor() const {
     return {vec_floor(_vec0), vec_floor(_vec1)};
@@ -390,8 +392,9 @@ class Vectorized<float> {
   Vectorized<float> C10_ALWAYS_INLINE sin() const {
     return {Sleef_sinf4_u10(_vec0), Sleef_sinf4_u10(_vec1)};
   }
+  // Sleef sinhf overflows for large float inputs where std::sinh is finite
   Vectorized<float> C10_ALWAYS_INLINE sinh() const {
-    return {Sleef_sinhf4_u10(_vec0), Sleef_sinhf4_u10(_vec1)};
+    return map(std::sinh);
   }
   Vectorized<float> C10_ALWAYS_INLINE tan() const {
     return {Sleef_tanf4_u10(_vec0), Sleef_tanf4_u10(_vec1)};

--- a/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
+++ b/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
@@ -1043,14 +1043,25 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented<T>()>> {
   Vectorized<T> sin() const {
     return mapSleef(Sleef_sinf4_u10, Sleef_sind2_u10);
   }
+  // Sleef sinhf/coshf overflow for large float inputs where std::sinh/cosh
+  // return finite results, because Sleef uses float-range intermediates
+  // internally while the scalar C library uses double precision.
   Vectorized<T> sinh() const {
-    return mapSleef(Sleef_sinhf4_u10, Sleef_sinhd2_u10);
+    if constexpr (std::is_same_v<T, float>) {
+      return mapOrdinary(std::sinh);
+    } else {
+      return mapSleef(Sleef_sinhf4_u10, Sleef_sinhd2_u10);
+    }
   }
   Vectorized<T> cos() const {
     return mapSleef(Sleef_cosf4_u10, Sleef_cosd2_u10);
   }
   Vectorized<T> cosh() const {
-    return mapSleef(Sleef_coshf4_u10, Sleef_coshd2_u10);
+    if constexpr (std::is_same_v<T, float>) {
+      return mapOrdinary(std::cosh);
+    } else {
+      return mapSleef(Sleef_coshf4_u10, Sleef_coshd2_u10);
+    }
   }
 
   Vectorized<T> tan() const {

--- a/aten/src/ATen/cpu/vec/vec512/vec512_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float.h
@@ -244,7 +244,9 @@ class Vectorized<float> {
   Vectorized<float> acos() const {
     return Vectorized<float>(Sleef_acosf16_u10(values));
   }
-  // Sleef acoshf overflows for large float inputs where std::acosh is finite
+  // Sleef acoshf/sinhf/coshf overflow for large float inputs where the scalar
+  // C library returns finite results, because Sleef uses float-range
+  // intermediates internally while the scalar C library uses double precision.
   Vectorized<float> acosh() const {
     return map(std::acosh);
   }

--- a/aten/src/ATen/cpu/vec/vec512/vec512_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float.h
@@ -244,8 +244,9 @@ class Vectorized<float> {
   Vectorized<float> acos() const {
     return Vectorized<float>(Sleef_acosf16_u10(values));
   }
+  // Sleef acoshf overflows for large float inputs where std::acosh is finite
   Vectorized<float> acosh() const {
-    return Vectorized<float>(Sleef_acoshf16_u10(values));
+    return map(std::acosh);
   }
   Vectorized<float> asin() const {
     return Vectorized<float>(Sleef_asinf16_u10(values));
@@ -452,14 +453,17 @@ class Vectorized<float> {
   Vectorized<float> sin() const {
     return Vectorized<float>(Sleef_sinf16_u35(values));
   }
+  // Sleef sinhf/coshf overflow for large float inputs where std::sinh/cosh
+  // return finite results, because Sleef uses float-range intermediates
+  // internally while the scalar C library uses double precision.
   Vectorized<float> sinh() const {
-    return Vectorized<float>(Sleef_sinhf16_u10(values));
+    return map(std::sinh);
   }
   Vectorized<float> cos() const {
     return Vectorized<float>(Sleef_cosf16_u35(values));
   }
   Vectorized<float> cosh() const {
-    return Vectorized<float>(Sleef_coshf16_u10(values));
+    return map(std::cosh);
   }
   Vectorized<float> ceil() const {
     return _mm512_ceil_ps(values);

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1058,6 +1058,42 @@ class CPUReproTests(TestCase):
                 )
 
     @requires_vectorization
+    def test_cosh_near_overflow(self):
+        # https://github.com/pytorch/pytorch/issues/183765
+        def fn(x):
+            return torch.cosh(x)
+
+        x = torch.tensor([88.5, 88.85, 89.0, 89.4, -88.85, -89.0]).repeat(3, 6)
+        for dtype in [torch.float32, torch.double]:
+            with torch.no_grad():
+                torch._dynamo.reset()
+                self.common(fn, (x.to(dtype),))
+
+    @requires_vectorization
+    def test_sinh_near_overflow(self):
+        # https://github.com/pytorch/pytorch/issues/183763
+        def fn(x):
+            return torch.sinh(x)
+
+        x = torch.tensor([88.5, 88.85, 89.0, -89.0, -89.2, 0.0]).repeat(3, 6)
+        for dtype in [torch.float32, torch.double]:
+            with torch.no_grad():
+                torch._dynamo.reset()
+                self.common(fn, (x.to(dtype),))
+
+    @requires_vectorization
+    def test_acosh_near_overflow(self):
+        # https://github.com/pytorch/pytorch/issues/183768
+        def fn(x):
+            return torch.acosh(x)
+
+        x = torch.tensor([2.0, 1e10, 5e22, 7e21, 9e25, 1.0]).repeat(3, 6)
+        for dtype in [torch.float32, torch.double]:
+            with torch.no_grad():
+                torch._dynamo.reset()
+                self.common(fn, (x.to(dtype),))
+
+    @requires_vectorization
     def test_asinh_with_corner_inputs(self):
         # https://github.com/pytorch/pytorch/issues/142345
 

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1067,7 +1067,9 @@ class CPUReproTests(TestCase):
         for dtype in [torch.float32, torch.double]:
             with torch.no_grad():
                 torch._dynamo.reset()
-                self.common(fn, (x.to(dtype),))
+                _x = x.to(dtype)
+                self.assertFalse(torch.cosh(_x).isinf().any())
+                self.common(fn, (_x,))
 
     @requires_vectorization
     def test_sinh_near_overflow(self):
@@ -1079,7 +1081,9 @@ class CPUReproTests(TestCase):
         for dtype in [torch.float32, torch.double]:
             with torch.no_grad():
                 torch._dynamo.reset()
-                self.common(fn, (x.to(dtype),))
+                _x = x.to(dtype)
+                self.assertFalse(torch.sinh(_x).isinf().any())
+                self.common(fn, (_x,))
 
     @requires_vectorization
     def test_acosh_near_overflow(self):
@@ -1091,7 +1095,9 @@ class CPUReproTests(TestCase):
         for dtype in [torch.float32, torch.double]:
             with torch.no_grad():
                 torch._dynamo.reset()
-                self.common(fn, (x.to(dtype),))
+                _x = x.to(dtype)
+                self.assertFalse(torch.acosh(_x).isinf().any())
+                self.common(fn, (_x,))
 
     @requires_vectorization
     def test_asinh_with_corner_inputs(self):

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3226,10 +3226,6 @@ Example::
     >>> torch.cosh(a)
     tensor([ 1.0133,  1.7860,  1.2536,  1.2805])
 
-.. note::
-   When :attr:`input` is on the CPU, the implementation of torch.cosh may use
-   the Sleef library, which rounds very large results to infinity or negative
-   infinity. See `here <https://sleef.org/purec.xhtml>`_ for details.
 """.format(**common_args),
 )
 
@@ -10059,10 +10055,6 @@ Example::
     >>> torch.sinh(a)
     tensor([ 0.5644, -0.9744, -0.1268,  1.0845])
 
-.. note::
-   When :attr:`input` is on the CPU, the implementation of torch.sinh may use
-   the Sleef library, which rounds very large results to infinity or negative
-   infinity. See `here <https://sleef.org/purec.xhtml>`_ for details.
 """.format(**common_args),
 )
 


### PR DESCRIPTION
closes #183763, #183765, #183768

It looks like the underlying issue is all related to Sleef handling of f32 (see https://github.com/shibatch/sleef/issues/364)

We replace Sleef's float `cosh/sinh/acosh` calls with `map(std::cosh)` etc. in all 6 vectorized wrapper files (NEON, AVX2, AVX-512, SVE, VSX, z/Arch). This falls back to the scalar C library which handles the full float32 range correctly. Double and half-precision paths are unaffected and left unchanged.

Of course, this also means that, for this code path, the underlying computation is no longer actually vectorized.

## Details

`torch.cosh`, `torch.sinh`, and `torch.acosh` return inf (or a wrong result) for float32 inputs near the overflow boundary, both in eager mode (large tensors) and under `torch.compile`.

The cause appears to be in `PyTorch's Vectorized<float>::cosh()` (and `sinh/acosh`), calling Sleef's SIMD implementations (Sleef_coshf4_u10, etc.). Sleef's `xcoshf` internally computes `exp(x)` using `expk2f`, which represents the result as a double-float pair (two floats for extra precision).

This extends precision but not range; the high word is still a float, so exp(88.73) overflows to inf even though cosh(88.73) ≈ 1.7e38 is well within float32 range (max ~3.4e38).

Sleef documents the valid input domain for sinhf as [-88.5, 88.5] -- see https://sleef.org/purec.xhtml#Sleef_sinh_u10 referenced in https://github.com/shibatch/sleef/issues/364; inputs outside this range may return inf even when the result is representable in float32.

The scalar C library std::coshf doesn't have this problem because it uses actual double (64-bit) for intermediate computation, which can represent exp(88.73) ≈ 3.4e38 without overflow.

The bug is in a single implementation (sleefsimdsp.c) that gets compiled for all SIMD targets, so all architectures are affected.


Note: a related overflow in `asinh` was recently fixed at the Inductor codegen level in #184105. The same Sleef root cause should apply there; the `Vectorized<float>::asinh()` scalar fallback could be done in this PR or as a follow-up

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo