### PR TITLE
Improve Triton noexec cache error

### DIFF
--- a/test/test_triton_utils.py
+++ b/test/test_triton_utils.py
@@ -1,0 +1,91 @@
+# Owner(s): ["module: inductor"]
+
+import importlib
+import os
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.utils import _triton as triton_utils
+
+
+class TestTritonUtils(TestCase):
+    def _run_triton_backend_load_failure(self, exc, env):
+        driver_mod = importlib.import_module("triton.runtime.driver")
+        fake_driver = SimpleNamespace(
+            active=SimpleNamespace(get_current_target=mock.Mock(side_effect=exc))
+        )
+
+        triton_utils.triton_backend.cache_clear()
+        try:
+            with (
+                mock.patch.object(driver_mod, "driver", fake_driver),
+                mock.patch.dict(os.environ, env),
+            ):
+                if "TRITON_CACHE_DIR" not in env:
+                    os.environ.pop("TRITON_CACHE_DIR", None)
+                cache_dir = triton_utils._triton_cache_dir_for_error_message()
+                with self.assertRaises(ImportError) as cm:
+                    triton_utils.triton_backend()
+        finally:
+            triton_utils.triton_backend.cache_clear()
+
+        return str(cm.exception), cache_dir
+
+    @unittest.skipUnless(triton_utils.has_triton_package(), "requires triton")
+    def test_triton_backend_reports_noexec_cache_dir(self):
+        for exc_type in (ImportError, OSError):
+            with self.subTest(exc_type=exc_type):
+                msg, _ = self._run_triton_backend_load_failure(
+                    exc_type(
+                        "/noexec/triton/hash/cuda_utils.so: "
+                        "failed to map segment from shared object"
+                    ),
+                    {"TRITON_CACHE_DIR": "/noexec/triton"},
+                )
+
+                self.assertIn("TRITON_CACHE_DIR=/noexec/triton", msg)
+                self.assertIn("noexec", msg)
+                self.assertIn("executable filesystem", msg)
+
+    @unittest.skipUnless(triton_utils.has_triton_package(), "requires triton")
+    def test_triton_backend_reports_default_cache_dir(self):
+        msg, cache_dir = self._run_triton_backend_load_failure(
+            ImportError(
+                "/default/triton/hash/cuda_utils.so: "
+                "failed to map segment from shared object"
+            ),
+            {},
+        )
+
+        self.assertIsNotNone(cache_dir)
+        self.assertIn(f"({cache_dir})", msg)
+        self.assertIn("noexec", msg)
+        self.assertIn("executable filesystem", msg)
+
+    @unittest.skipUnless(triton_utils.has_triton_package(), "requires triton")
+    def test_triton_backend_reraises_other_load_errors(self):
+        driver_mod = importlib.import_module("triton.runtime.driver")
+
+        for exc_type in (ImportError, OSError):
+            fake_driver = SimpleNamespace(
+                active=SimpleNamespace(
+                    get_current_target=mock.Mock(side_effect=exc_type("other failure"))
+                )
+            )
+
+            triton_utils.triton_backend.cache_clear()
+            try:
+                with (
+                    self.subTest(exc_type=exc_type),
+                    mock.patch.object(driver_mod, "driver", fake_driver),
+                ):
+                    with self.assertRaisesRegex(exc_type, "other failure"):
+                        triton_utils.triton_backend()
+            finally:
+                triton_utils.triton_backend.cache_clear()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -4,6 +4,35 @@ import os
 from typing import Any
 
 
+_FAILED_TO_MAP_SEGMENT_FROM_SHARED_OBJECT = "failed to map segment from shared object"
+
+
+def _triton_cache_dir_for_error_message() -> str | None:
+    if triton_cache_dir := os.environ.get("TRITON_CACHE_DIR"):
+        return triton_cache_dir
+
+    try:
+        from triton.runtime.cache import knobs
+
+        return knobs.cache.dir
+    except (AttributeError, ImportError):
+        return None
+
+
+def _raise_triton_cache_load_error(exc: BaseException) -> None:
+    cache_dir = _triton_cache_dir_for_error_message()
+    if "TRITON_CACHE_DIR" in os.environ:
+        cache_dir_msg = f" (TRITON_CACHE_DIR={cache_dir})"
+    else:
+        cache_dir_msg = f" ({cache_dir})" if cache_dir else ""
+    raise ImportError(
+        f"{exc}. This usually means Triton's cache directory{cache_dir_msg} is on "
+        "a filesystem mounted with noexec, so the dynamic loader cannot map "
+        "generated shared objects. Set TRITON_CACHE_DIR to a directory on an "
+        "executable filesystem."
+    ) from exc
+
+
 @functools.cache
 def has_triton_package() -> bool:
     try:
@@ -190,8 +219,13 @@ def triton_backend() -> Any:
     from triton.compiler.compiler import make_backend
     from triton.runtime.driver import driver
 
-    target = driver.active.get_current_target()
-    return make_backend(target)
+    try:
+        target = driver.active.get_current_target()
+        return make_backend(target)
+    except (ImportError, OSError) as e:
+        if _FAILED_TO_MAP_SEGMENT_FROM_SHARED_OBJECT in str(e):
+            _raise_triton_cache_load_error(e)
+        raise
 
 
 def _extern_libs_key(backend: Any) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184362

Report Triton cache directory guidance when backend initialization fails while loading generated shared objects from a noexec filesystem. Add coverage for the diagnostic and unchanged reraising of unrelated load errors.

Fixes #123054
Generated by my agent

cc @mlazos