### PR TITLE
Fix AotAutograd aliased-output replay for traceable wrapper subclasses

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -17,7 +17,10 @@ import torch.nn as nn
 from torch._C import FileCheck
 from torch._dynamo.functional_export import dynamo_graph_capture_for_export
 from torch._dynamo.testing import AotEagerAndRecordGraphs
-from torch._functorch._aot_autograd.autograd_cache import check_cacheable
+from torch._functorch._aot_autograd.autograd_cache import (
+    AOTAutogradCache,
+    check_cacheable,
+)
 from torch._functorch.aot_autograd import aot_export_joint_with_descriptors
 from torch._guards import tracing
 from torch._inductor.utils import run_and_get_triton_code
@@ -48,6 +51,7 @@ from torch.distributed.tensor.parallel import (
 )
 from torch.distributed.tensor.placement_types import _StridedShard, Placement
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch.multiprocessing.reductions import StorageWeakRef
 from torch.testing._internal.common_device_type import skipXPUIf
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import get_devtype
@@ -2974,6 +2978,89 @@ class TestDTensorCompileE2E(DTensorTestBase):
         replicated_inp = DTensor.from_local(inp, mesh, [Replicate()], run_check=False)
         output = sharded_net(replicated_inp)
         self.assertEqual(output.full_tensor(), ref_out)
+
+    @with_comms
+    @parametrize("backend", ["aot_eager", "inductor"])
+    @parametrize("dynamic", [False, True])
+    def test_compile_dtensor_output_alias_replay(self, backend, dynamic):
+        mesh = self.build_device_mesh()
+
+        def fn(x: DTensor) -> tuple[DTensor, DTensor]:
+            y = x + 1
+            aux = y[:, :1]
+            return y, aux
+
+        view_replay_options = (
+            (True, False) if backend == "inductor" and not dynamic else (True,)
+        )
+        for view_replay_for_aliased_outputs in view_replay_options:
+            with self.subTest(
+                view_replay_for_aliased_outputs=view_replay_for_aliased_outputs
+            ):
+                x_local_ref = torch.randn(
+                    2, 2, device=self.device_type, requires_grad=True
+                )
+                x_ref = DTensor.from_local(
+                    x_local_ref, mesh, [Replicate()], run_check=False
+                )
+                y_ref, aux_ref = fn(x_ref)
+
+                x_local = x_local_ref.detach().clone().requires_grad_(True)
+                x = DTensor.from_local(x_local, mesh, [Replicate()], run_check=False)
+                with patch(
+                    "torch._functorch.config.view_replay_for_aliased_outputs",
+                    view_replay_for_aliased_outputs,
+                ):
+                    torch._dynamo.reset()
+                    AOTAutogradCache.clear()
+                    y, aux = torch.compile(
+                        fn, backend=backend, fullgraph=True, dynamic=dynamic
+                    )(x)
+
+                self.assertEqual(y.full_tensor(), y_ref.full_tensor())
+                self.assertEqual(aux.full_tensor(), aux_ref.full_tensor())
+                self.assertIsNotNone(aux.grad_fn)
+                self.assertTrue(aux.to_local()._is_view())
+                self.assertEqual(
+                    StorageWeakRef(y.to_local().untyped_storage()),
+                    StorageWeakRef(aux.to_local().untyped_storage()),
+                )
+
+                (y_ref.full_tensor().sum() + aux_ref.full_tensor().sum()).backward()
+                (y.full_tensor().sum() + aux.full_tensor().sum()).backward()
+                self.assertEqual(x_local_ref.grad, x_local.grad)
+
+    @with_comms
+    def test_compile_dtensor_output_alias_replay_placement_changing_view(self):
+        mesh = self.build_device_mesh()
+
+        def fn(x: DTensor) -> tuple[DTensor, DTensor]:
+            y = x + 1
+            aux = y.transpose(0, 1)
+            return y, aux
+
+        x_local_ref = torch.randn(2, 4, device=self.device_type, requires_grad=True)
+        x_ref = DTensor.from_local(x_local_ref, mesh, [Shard(0)], run_check=False)
+        y_ref, aux_ref = fn(x_ref)
+
+        x_local = x_local_ref.detach().clone().requires_grad_(True)
+        x = DTensor.from_local(x_local, mesh, [Shard(0)], run_check=False)
+        y, aux = torch.compile(fn, backend="inductor", fullgraph=True)(x)
+
+        self.assertEqual(aux.placements, aux_ref.placements)
+        self.assertEqual(y.to_local(), y_ref.to_local())
+        self.assertEqual(aux.to_local(), aux_ref.to_local())
+        self.assertEqual(aux.full_tensor(), aux_ref.full_tensor())
+        self.assertIsNotNone(aux.grad_fn)
+        self.assertTrue(aux.to_local()._is_view())
+        self.assertEqual(
+            StorageWeakRef(y.to_local().untyped_storage()),
+            StorageWeakRef(aux.to_local().untyped_storage()),
+        )
+
+        (y_ref.full_tensor().sum() + aux_ref.full_tensor().sum()).backward()
+        (y.full_tensor().sum() + aux.full_tensor().sum()).backward()
+        self.assertEqual(x_local_ref.grad, x_local.grad)
 
     @with_comms
     def test_unbacked_illegal_views(self):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -73,6 +73,7 @@ from torch._inductor.output_code import MockFXGraphCacheOutput
 from torch._subclasses.fake_tensor import DynamicOutputShapeException, FakeTensorMode
 from torch.fx.experimental.proxy_tensor import is_sym_node
 from torch.fx.experimental.symbolic_shapes import GuardOnDataDependentSymNode, ShapeEnv
+from torch.multiprocessing.reductions import StorageWeakRef
 from torch.nn.attention.flex_attention import flex_attention
 from torch.nn.utils.rnn import PackedSequence
 from torch.testing import FileCheck
@@ -111,6 +112,7 @@ from torch.testing._internal.subclasses import WrapperSubclass
 from torch.testing._internal.two_tensor import TwoTensor, TwoTensorMode
 from torch.utils._python_dispatch import (
     is_traceable_wrapper_subclass,
+    return_and_correct_aliasing,
     TorchDispatchMode,
 )
 
@@ -10316,6 +10318,310 @@ metadata incorrectly.
         self.assertEqual(b_ref.grad.a, b_test.grad.a)
         self.assertEqual(b_ref.grad.b, b_test.grad.b)
 
+    def test_output_alias_of_intermediate_wrapper_subclass_legacy_replay(self):
+        def f(x):
+            y = x + 1
+            aux = y[:, :1]
+            return y, aux
+
+        for backend in ("aot_eager", "inductor"):
+            for dynamic in (False, True):
+                with self.subTest(backend=backend, dynamic=dynamic):
+                    x_ref = WrapperSubclass(torch.randn(3, 3, requires_grad=True))
+                    y_ref, aux_ref = f(x_ref)
+
+                    x = WrapperSubclass(x_ref.a.detach().clone().requires_grad_(True))
+                    torch._dynamo.reset()
+                    AOTAutogradCache.clear()
+                    y, aux = torch.compile(
+                        f, backend=backend, fullgraph=True, dynamic=dynamic
+                    )(x)
+
+                    self.assertIsInstance(y, WrapperSubclass)
+                    self.assertIsInstance(aux, WrapperSubclass)
+                    self.assertEqual(y_ref.a, y.a)
+                    self.assertEqual(aux_ref.a, aux.a)
+
+                    self.assertEqual(
+                        StorageWeakRef(y.a.untyped_storage()),
+                        StorageWeakRef(aux.a.untyped_storage()),
+                    )
+
+                    (y_ref.sum() + aux_ref.sum()).backward()
+                    (y.sum() + aux.sum()).backward()
+                    self.assertIsNotNone(x_ref.grad)
+                    self.assertIsNotNone(x.grad)
+                    self.assertEqual(x_ref.grad.a, x.grad.a)
+
+    def test_output_alias_of_intermediate_subclass_view_meta_replay(self):
+        def f(x):
+            y = x + 1
+            aux = y[:, :1]
+            return y, aux
+
+        for backend in ("aot_eager", "inductor"):
+            for dynamic in (False, True):
+                for view_replay_for_aliased_outputs in (False, True):
+                    with self.subTest(
+                        backend=backend,
+                        dynamic=dynamic,
+                        view_replay_for_aliased_outputs=view_replay_for_aliased_outputs,
+                    ):
+                        x_ref = ConstantExtraMetadataTensor(
+                            torch.randn(3, 3, requires_grad=True)
+                        )
+                        y_ref, aux_ref = f(x_ref)
+
+                        x = ConstantExtraMetadataTensor(
+                            x_ref.elem.detach().clone().requires_grad_(True)
+                        )
+                        with patch(
+                            "torch._functorch.config.view_replay_for_aliased_outputs",
+                            view_replay_for_aliased_outputs,
+                        ):
+                            torch._dynamo.reset()
+                            AOTAutogradCache.clear()
+                            y, aux = torch.compile(
+                                f, backend=backend, fullgraph=True, dynamic=dynamic
+                            )(x)
+
+                        self.assertIsInstance(y, ConstantExtraMetadataTensor)
+                        self.assertIsInstance(aux, ConstantExtraMetadataTensor)
+                        self.assertEqual(y_ref.elem, y.elem)
+                        self.assertEqual(aux_ref.elem, aux.elem)
+                        self.assertExpectedInline(
+                            str(aux.grad_fn.__class__), """<class 'SliceBackward0'>"""
+                        )
+
+                        self.assertEqual(
+                            StorageWeakRef(y.untyped_storage()),
+                            StorageWeakRef(aux.untyped_storage()),
+                        )
+
+                        (y_ref.sum() + aux_ref.sum()).backward()
+                        (y.sum() + aux.sum()).backward()
+                        self.assertEqual(x_ref.grad.elem, x.grad.elem)
+
+    @patch("torch._dynamo.config.assume_static_by_default", False)
+    def test_output_alias_of_intermediate_subclass_view_meta_replay_automatic_dynamic_fallback(
+        self,
+    ):
+        def f(x, sz):
+            y = x + 1
+            aux = y.view(sz)
+            return y, aux
+
+        x_ref = ConstantExtraMetadataTensor(torch.randn(2, 2, requires_grad=True))
+        y_ref, aux_ref = f(x_ref, (4,))
+
+        x = ConstantExtraMetadataTensor(
+            x_ref.elem.detach().clone().requires_grad_(True)
+        )
+        torch._dynamo.reset()
+        AOTAutogradCache.clear()
+        # Automatic-dynamic makes `sz` symbolic, so subclass alias replay keeps
+        # the dense-style as_strided fallback for this output today.
+        y, aux = torch.compile(f, backend="aot_eager", fullgraph=True)(x, (4,))
+
+        self.assertIsInstance(y, ConstantExtraMetadataTensor)
+        self.assertIsInstance(aux, ConstantExtraMetadataTensor)
+        self.assertEqual(y_ref.elem, y.elem)
+        self.assertEqual(aux_ref.elem, aux.elem)
+        self.assertEqual(
+            StorageWeakRef(y.untyped_storage()),
+            StorageWeakRef(aux.untyped_storage()),
+        )
+
+        self.assertIsNotNone(aux.grad_fn)
+        self.assertExpectedInline(
+            str(aux.grad_fn.__class__), """<class 'AsStridedBackward0'>"""
+        )
+
+        (y_ref.sum() + aux_ref.sum()).backward()
+        (y.sum() + aux.sum()).backward()
+        self.assertIsNotNone(x_ref.grad)
+        self.assertIsNotNone(x.grad)
+        self.assertEqual(x_ref.grad.elem, x.grad.elem)
+
+    def test_output_alias_of_intermediate_subclass_view_meta_replay_signature_mismatch(
+        self,
+    ):
+        class DivergentViewMetadataTensor(torch.Tensor):
+            @staticmethod
+            def __new__(cls, a, b, outer_size=None, outer_stride=None):
+                if outer_size is None:
+                    outer_size = a.size()
+                if outer_stride is None:
+                    outer_stride = a.stride()
+                return torch.Tensor._make_wrapper_subclass(
+                    cls,
+                    outer_size,
+                    strides=outer_stride,
+                    storage_offset=a.storage_offset(),
+                    device=a.device,
+                    layout=a.layout,
+                    requires_grad=a.requires_grad,
+                    dtype=a.dtype,
+                )
+
+            def __init__(self, a, b, outer_size=None, outer_stride=None):
+                self.a = a
+                self.b = b
+
+            def __tensor_flatten__(self):
+                return ["a", "b"], "ctx"
+
+            @staticmethod
+            def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
+                if meta != "ctx":
+                    raise AssertionError(f"unexpected meta: {meta}")
+                return DivergentViewMetadataTensor(
+                    inner_tensors["a"],
+                    inner_tensors["b"],
+                    outer_size,
+                    outer_stride,
+                )
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args, kwargs):
+                if kwargs is None:
+                    kwargs = {}
+                args_a = pytree.tree_map_only(cls, lambda x: x.a, args)
+                args_b = pytree.tree_map_only(cls, lambda x: x.b, args)
+                kwargs_a = pytree.tree_map_only(cls, lambda x: x.a, kwargs)
+                kwargs_b = pytree.tree_map_only(cls, lambda x: x.b, kwargs)
+
+                out_a = func(*args_a, **kwargs_a)
+                out_b = func(*args_b, **kwargs_b)
+                if func is torch.ops.aten.slice.Tensor:
+                    out_b = pytree.tree_map_only(
+                        torch.Tensor,
+                        lambda t: t.transpose(0, 1).transpose(0, 1),
+                        out_b,
+                    )
+
+                out_a_flat, spec = pytree.tree_flatten(out_a)
+                out_b_flat = pytree.tree_leaves(out_b)
+                out_flat = [
+                    cls(a, b) if isinstance(a, torch.Tensor) else a
+                    for a, b in zip(out_a_flat, out_b_flat, strict=True)
+                ]
+                out = pytree.tree_unflatten(out_flat, spec)
+                return return_and_correct_aliasing(func, args, kwargs, out)
+
+        def f(x):
+            y = x + 1
+            aux = y[:, :1]
+            return y, aux
+
+        x_ref = DivergentViewMetadataTensor(
+            torch.randn(3, 3, requires_grad=True),
+            torch.randn(3, 3, requires_grad=True),
+        )
+        f(x_ref)
+        x = DivergentViewMetadataTensor(
+            x_ref.a.detach().clone().requires_grad_(True),
+            x_ref.b.detach().clone().requires_grad_(True),
+        )
+        compiled_f = aot_function(
+            f,
+            fw_compiler=nop,
+            bw_compiler=nop,
+            partition_fn=min_cut_rematerialization_partition,
+        )
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "different outer view signatures",
+        ):
+            compiled_f(x)
+
+    def test_output_alias_of_intermediate_subclass_view_meta_replay_runtime_metadata_mismatch(
+        self,
+    ):
+        class RuntimeMetadataMismatchTensor(torch.Tensor):
+            view_ctx = "compile_ctx"
+
+            @staticmethod
+            def __new__(cls, elem, meta="base_ctx", outer_size=None, outer_stride=None):
+                if outer_size is None:
+                    outer_size = elem.size()
+                if outer_stride is None:
+                    outer_stride = elem.stride()
+                return torch.Tensor._make_wrapper_subclass(
+                    cls,
+                    outer_size,
+                    strides=outer_stride,
+                    storage_offset=elem.storage_offset(),
+                    device=elem.device,
+                    layout=elem.layout,
+                    requires_grad=elem.requires_grad,
+                    dtype=elem.dtype,
+                )
+
+            def __init__(
+                self, elem, meta="base_ctx", outer_size=None, outer_stride=None
+            ):
+                self.elem = elem
+                self.meta = meta
+
+            def __tensor_flatten__(self):
+                return ["elem"], self.meta
+
+            @staticmethod
+            def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
+                return RuntimeMetadataMismatchTensor(
+                    inner_tensors["elem"], meta, outer_size, outer_stride
+                )
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args, kwargs):
+                if kwargs is None:
+                    kwargs = {}
+                args_inner = pytree.tree_map_only(cls, lambda x: x.elem, args)
+                kwargs_inner = pytree.tree_map_only(cls, lambda x: x.elem, kwargs)
+                out_inner = func(*args_inner, **kwargs_inner)
+                out_inner_flat, spec = pytree.tree_flatten(out_inner)
+
+                def wrap(o_inner):
+                    if not isinstance(o_inner, torch.Tensor):
+                        return o_inner
+                    meta = (
+                        cls.view_ctx
+                        if func is torch.ops.aten.slice.Tensor
+                        else "base_ctx"
+                    )
+                    return cls(o_inner, meta)
+
+                out = pytree.tree_unflatten([wrap(o) for o in out_inner_flat], spec)
+                return return_and_correct_aliasing(func, args, kwargs, out)
+
+        def f(x):
+            y = x + 1
+            aux = y[:, :1]
+            return y, aux
+
+        RuntimeMetadataMismatchTensor.view_ctx = "compile_ctx"
+        x = RuntimeMetadataMismatchTensor(
+            torch.randn(3, 3, requires_grad=True), "base_ctx"
+        )
+        compiled_f = aot_function(
+            f,
+            fw_compiler=nop,
+            bw_compiler=nop,
+            partition_fn=min_cut_rematerialization_partition,
+        )
+        compiled_f(x)
+
+        RuntimeMetadataMismatchTensor.view_ctx = "runtime_ctx"
+        x2 = RuntimeMetadataMismatchTensor(
+            torch.randn(3, 3, requires_grad=True), "base_ctx"
+        )
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "outer replay does not reconstruct wrapper metadata",
+        ):
+            compiled_f(x2)
+
     @torch._functorch.config.patch(
         {
             "disable_guess_zero_tangent_for_mutated_input_subclass": True,
@@ -12669,6 +12975,21 @@ class TestAOTAutogradWithCache(TestAOTAutogradWithDynamo):
                 dynamic=dynamic,
                 make_inputs_subclasses=make_inputs_subclasses,
             )
+
+    def test_output_alias_of_intermediate_subclass_view_meta_replay_dynamic_cache(
+        self,
+    ):
+        def f(x):
+            y = x + 1
+            aux = y.view(x.shape[0] * x.shape[1])
+            return y, aux
+
+        self.verify_aot_autograd(
+            f,
+            [ConstantExtraMetadataTensor(torch.randn(2, 2, requires_grad=True))],
+            dynamic=True,
+        )
+        self.assertTrue(self.inductor_cache.cache)
 
     def test_input_mutation_false_aliasing(self):
         # This test is disabled because it fails in strict cache mode

--- a/torch/_C/_functionalization.pyi
+++ b/torch/_C/_functionalization.pyi
@@ -6,6 +6,8 @@ from torch.types import _bool
 class ViewMeta:
     has_symbolic_inputs: _bool
 
+    def as_tuple(self) -> tuple[object, ...]: ...
+
 # Returns the list of ViewMeta instances of the given functional tensor.
 #
 # Although we do have python bindings for their types, we won't

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -45,6 +45,7 @@ from .functional_utils import (
     from_fun,
     has_data_mutation,
     has_metadata_mutation,
+    maybe_get_output_view_meta_sequence,
     MetadataKey,
     to_fun,
     ViewMetaSequence,
@@ -649,32 +650,36 @@ from a multi-output view call"
             # The FunctionalTensor will be saved if one of the 2 conditions below
             # is true:
             view_meta_sequence = None
-            if (
-                # 1. If the output_type is either of:
-                #    (i) alias_of_intermediate;
-                #    (ii) alias_of_intermediate_save_as_output; or
-                #    (iii) alias_of_intermediate_base_is_user_output.
-                #
+            if output_type in (
+                OutputType.alias_of_intermediate,
+                OutputType.alias_of_intermediate_save_as_output,
+                OutputType.alias_of_intermediate_base_is_user_output,
+            ):
                 # No need to worry about in-place view operations here, since
                 # this functionalization step eliminates mutations.
                 #
                 # i.e. we have access to the actual base tensor, before the
                 # in-place operation was applied.
-                output_type
-                in (
-                    OutputType.alias_of_intermediate,
-                    OutputType.alias_of_intermediate_save_as_output,
-                    OutputType.alias_of_intermediate_base_is_user_output,
-                )
-            ) or (
+                # In the primary subclass -> subclass metadata pass, `o` can be
+                # a traceable wrapper subclass here, so recurse into its attrs
+                # instead of requiring a bare FunctionalTensor.
+                if isinstance(o, Tensor):
+                    view_meta_sequence = maybe_get_output_view_meta_sequence(o)
+            elif (
                 # 2. If the output_type is alias_of_input, and no in-place view
-                #    operation was run on the input (base tensor).
+                #    operation was run on the input (base tensor), then we can
+                #    replay dense-tensor views from the saved FunctionalTensor.
                 #
-                # In this case, we need to check for metadata mutation because
-                # the runtime explicitly reconstructs the inputs, before actually
-                # reconstructing the outputs. Due to in-place view operations, the
-                # fully reconstructed input may not be this output base tensor
-                # anymore.
+                #    If metadata mutation did happen, the runtime explicitly
+                #    reconstructs the inputs before replaying outputs, so the
+                #    fully reconstructed input may no longer be this output's
+                #    original base tensor.
+                #
+                # Metadata is collected both on the primary subclass ->
+                # subclass graph and on a later dense -> dense re-collection;
+                # only the dense pass sees `o` as a bare FunctionalTensor here,
+                # so subclass alias-of-input replay is intentionally out of
+                # scope for this branch.
                 output_type == OutputType.alias_of_input
                 and base_idx is not None
                 and not input_info[base_idx].mutates_metadata

--- a/torch/_functorch/_aot_autograd/functional_utils.py
+++ b/torch/_functorch/_aot_autograd/functional_utils.py
@@ -9,12 +9,12 @@ This file contains utilities related to functionalization in AOTAutograd:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, TypeGuard
+from typing import Any, TYPE_CHECKING, TypeGuard
 
 import torch
 from torch import Tensor
 from torch._C import _functionalization
-from torch._custom_class_base import CustomClassBase
+from torch._custom_class_base import CustomClassBase, OpaqueBase
 from torch._logging import getArtifactLogger
 from torch._subclasses.fake_tensor import FakeTensor
 from torch._subclasses.functional_tensor import FunctionalTensor
@@ -25,6 +25,10 @@ from torch.utils._python_dispatch import (
     is_traceable_wrapper_subclass,
     transform_subclass,
 )
+
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 aot_joint_log = getArtifactLogger(__name__, "aot_joint_graph")
@@ -316,7 +320,9 @@ def gen_alias_from_base(
     aliased_base_tensor: Tensor,
     target_meta_tensor: Tensor,
     target_requires_grad: bool,
-    target_view_meta_sequence: ViewMetaSequence | None = None,
+    target_view_meta_sequence: ViewMetaSequence
+    | SubclassViewMetaSequence
+    | None = None,
     *,
     replay_views: bool,
 ) -> Tensor:
@@ -336,22 +342,44 @@ def gen_alias_from_base(
     # functions applied to itself (collected during functionalization) so as
     # to replay them (view functions) on the aliased_base_tensor.
     if (
-        replay_views
-        and target_view_meta_sequence is not None
-        and not any(vm.has_symbolic_inputs for vm in target_view_meta_sequence.sequence)
+        target_view_meta_sequence is not None
+        and not target_view_meta_sequence.has_symbolic_inputs()
     ):
-        out = _functionalization.apply_view_meta_sequence(
-            aliased_base_tensor, target_view_meta_sequence.sequence
-        )
-        # If re-applying the ViewMeta sequence succeeded, there should be no more
-        # problems going forward. We just check we got to the target shape and
-        # patch requires_grad flag.
-        if out.shape != target_meta_tensor.shape:
-            raise AssertionError(
-                "incorrect out shape after application of ViewMeta sequence: "
-                f"{tuple(out.shape)} (actual) vs {tuple(target_meta_tensor.shape)} (expected)"
+        if isinstance(target_view_meta_sequence, SubclassViewMetaSequence):
+            # Wrapper subclasses like DTensor cannot safely fall back to the
+            # dense as_strided path when replay is disabled internally.
+            representative_view_meta_sequence = (
+                target_view_meta_sequence.representative_outer_view_meta_sequence()
             )
-        return patch_requires_grad(out)
+            # Subclass replay intentionally fails closed. Falling back to the
+            # dense as_strided path can preserve the inner tensor view while
+            # silently dropping wrapper metadata carried in __tensor_flatten__
+            # ctx (for example DTensor placement metadata).
+            if representative_view_meta_sequence is None:
+                raise NotImplementedError(
+                    "AOTAutograd cannot replay aliased subclass views when wrapper "
+                    "attrs have different outer view signatures."
+                )
+
+            # Only validated outer replay is supported for subclass view
+            # reconstruction. Rebuilding the wrapper from inner views would lose
+            # wrapper-level autograd metadata like the outer view edge.
+            out = _functionalization.apply_view_meta_sequence(
+                aliased_base_tensor, representative_view_meta_sequence.sequence
+            )
+            if _view_meta_matches_tensor(
+                out, target_meta_tensor, target_view_meta_sequence
+            ):
+                return patch_requires_grad(out)
+            raise NotImplementedError(
+                "AOTAutograd cannot replay aliased subclass views when outer "
+                "replay does not reconstruct wrapper metadata."
+            )
+        elif replay_views:
+            out = _replay_view_meta_sequence(
+                aliased_base_tensor, target_meta_tensor, target_view_meta_sequence
+            )
+            return patch_requires_grad(out)
 
     # Try to do view-replay if possible.
     # fall back to .as_strided() if we can't.
@@ -477,9 +505,13 @@ class ViewMetaSequence:
         return f"ViewMetaSequence({types})"
 
     def __eq__(self, other: object) -> bool:
-        # If other is None, then it probably means that we weren't able to recreate
-        # the ViewMeta sequence. One example is when we update the view metadata by
-        # calling: create_synthetic_base_metadata.
+        # WARNING: __eq__(None) is a legacy wildcard used only for debug metadata
+        # comparisons. Runtime code should use identity checks instead of !=
+        # because this comparison is intentionally asymmetric.
+        #
+        # If other is None, then it probably means that we weren't able to
+        # recreate the ViewMeta sequence. One example is when we update the
+        # view metadata by calling: create_synthetic_base_metadata.
         if other is None:
             return True
 
@@ -488,6 +520,185 @@ class ViewMetaSequence:
             return NotImplemented
 
         return self.metadata == other.metadata
+
+    def has_symbolic_inputs(self) -> bool:
+        return any(vm.has_symbolic_inputs for vm in self.sequence)
+
+    def make_runtime_safe(self) -> ViewMetaSequence | None:
+        if self.has_symbolic_inputs():
+            return None
+        return self
+
+
+def _view_meta_signature(
+    view_meta_sequence: ViewMetaSequence,
+) -> tuple[tuple[type[object], tuple[object, ...]], ...]:
+    return tuple(
+        (type(view_meta), view_meta.as_tuple())
+        for view_meta in view_meta_sequence.sequence
+    )
+
+
+@dataclass
+class SubclassViewMetaSequence:
+    attrs: Mapping[str, ViewMetaSequence | SubclassViewMetaSequence]
+    metadata: MetadataKey
+
+    def __repr__(self) -> str:
+        attrs = ", ".join(f"{name}={meta!r}" for name, meta in self.attrs.items())
+        return f"SubclassViewMetaSequence({attrs})"
+
+    def __eq__(self, other: object) -> bool:
+        if other is None:
+            # Mirror the ViewMetaSequence warning above: __eq__(None) is a
+            # debug-only wildcard and runtime code should prefer identity checks.
+            # If other is None, then it probably means that we weren't able to
+            # recreate the ViewMeta sequence for one of the subclass attrs.
+            return True
+
+        if not isinstance(other, SubclassViewMetaSequence):
+            return NotImplemented
+
+        return self.metadata == other.metadata and self.attrs == other.attrs
+
+    def has_symbolic_inputs(self) -> bool:
+        return any(attr_meta.has_symbolic_inputs() for attr_meta in self.attrs.values())
+
+    def make_runtime_safe(self) -> SubclassViewMetaSequence | None:
+        # Keep subclass replay all-or-nothing at runtime: if any attr has
+        # symbolic view metadata, disable replay for the whole wrapper and
+        # fall back to the legacy reconstruction path for that output.
+        if self.has_symbolic_inputs():
+            return None
+        return self
+
+    def representative_outer_view_meta_sequence(self) -> ViewMetaSequence | None:
+        representative = None
+        representative_signature = None
+        for attr_meta in self.attrs.values():
+            candidate = (
+                attr_meta
+                if isinstance(attr_meta, ViewMetaSequence)
+                else attr_meta.representative_outer_view_meta_sequence()
+            )
+            if candidate is None:
+                continue
+
+            candidate_signature = _view_meta_signature(candidate)
+            if representative is None:
+                representative = candidate
+                representative_signature = candidate_signature
+            elif candidate_signature != representative_signature:
+                return None
+        return representative
+
+
+def _view_meta_matches_tensor(
+    out: Tensor,
+    target_meta_tensor: Tensor,
+    target_view_meta_sequence: ViewMetaSequence | SubclassViewMetaSequence,
+) -> bool:
+    # Compare against the concrete runtime target tensor here. The serialized
+    # ViewMetaSequence metadata can retain symbolic traced expressions even when
+    # replay reconstructed the right concrete runtime view.
+    if not has_same_metadata(out, target_meta_tensor):
+        return False
+
+    if isinstance(target_view_meta_sequence, ViewMetaSequence):
+        return True
+
+    if not (
+        is_traceable_wrapper_subclass(out)
+        and is_traceable_wrapper_subclass(target_meta_tensor)
+    ):
+        return False
+
+    out_wrapper_attrs, out_ctx = out.__tensor_flatten__()
+    target_wrapper_attrs, target_ctx = target_meta_tensor.__tensor_flatten__()
+    if out_wrapper_attrs != target_wrapper_attrs or out_ctx != target_ctx:
+        return False
+
+    for attr in target_wrapper_attrs:
+        out_inner = getattr(out, attr)
+        target_inner = getattr(target_meta_tensor, attr)
+        attr_meta = target_view_meta_sequence.attrs.get(attr)
+
+        if attr_meta is None:
+            match target_inner:
+                case Tensor():
+                    if not isinstance(out_inner, Tensor) or not has_same_metadata(
+                        out_inner, target_inner
+                    ):
+                        return False
+                case OpaqueBase():
+                    if out_inner != target_inner:
+                        return False
+                case unexpected:
+                    raise AssertionError(
+                        f"expected Tensor or OpaqueBase, got {type(unexpected)}"
+                    )
+            continue
+
+        if not isinstance(out_inner, Tensor):
+            raise AssertionError(f"expected Tensor for output attr {attr}")
+        if not isinstance(target_inner, Tensor):
+            raise AssertionError(f"expected Tensor for target attr {attr}")
+        if not _view_meta_matches_tensor(out_inner, target_inner, attr_meta):
+            return False
+
+    return True
+
+
+def maybe_get_output_view_meta_sequence(
+    tensor: Tensor,
+) -> ViewMetaSequence | SubclassViewMetaSequence | None:
+    if isinstance(tensor, FunctionalTensor):
+        return ViewMetaSequence(tensor)
+
+    if not is_traceable_wrapper_subclass(tensor):
+        return None
+
+    attrs, ctx = tensor.__tensor_flatten__()
+    # Subclasses that reconstruct with no flatten metadata rely on the existing
+    # outer view/autograd replay path today. Replaying only the inner tensor
+    # views loses that outer autograd metadata, so keep using the old path.
+    if ctx is None:
+        return None
+    attr_metas: dict[str, ViewMetaSequence | SubclassViewMetaSequence] = {}
+    for attr in attrs:
+        match getattr(tensor, attr):
+            case Tensor() as inner:
+                inner_meta = maybe_get_output_view_meta_sequence(inner)
+                if inner_meta is not None:
+                    attr_metas[attr] = inner_meta
+            case OpaqueBase():
+                pass
+            case unexpected:
+                raise AssertionError(
+                    f"expected Tensor or OpaqueBase, got {type(unexpected)}"
+                )
+
+    if not attr_metas:
+        return None
+
+    return SubclassViewMetaSequence(attr_metas, MetadataKey.make(tensor))
+
+
+def _replay_view_meta_sequence(
+    aliased_base_tensor: Tensor,
+    target_meta_tensor: Tensor,
+    target_view_meta_sequence: ViewMetaSequence,
+) -> Tensor:
+    out = _functionalization.apply_view_meta_sequence(
+        aliased_base_tensor, target_view_meta_sequence.sequence
+    )
+    if out.shape != target_meta_tensor.shape:
+        raise AssertionError(
+            "incorrect out shape after application of ViewMeta sequence: "
+            f"{tuple(out.shape)} (actual) vs {tuple(target_meta_tensor.shape)} "
+            "(expected)"
+        )
+    return out
 
 
 # new_arg and arg here are either:

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -23,7 +23,11 @@ from torch.fx.experimental._backward_state import BackwardState
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 from .. import config
-from .functional_utils import _check_if_mutation_can_be_in_graph, ViewMetaSequence
+from .functional_utils import (
+    _check_if_mutation_can_be_in_graph,
+    SubclassViewMetaSequence,
+    ViewMetaSequence,
+)
 from .utils import strict_zip
 
 
@@ -123,7 +127,7 @@ class OutputAliasInfo:
     # We need to wrap the actual list of ViewMeta with this class so that
     # we compare the ViewMeta elements appropriately, i.e. their type and
     # the elements returned by the `as_tuple()` call.
-    view_meta_sequence: ViewMetaSequence | None = None
+    view_meta_sequence: ViewMetaSequence | SubclassViewMetaSequence | None = None
 
 
 class MutationType(Enum):
@@ -761,10 +765,17 @@ class ViewAndMutationMeta:
         # be used at runtime anyway (gen_alias_from_base skips view replay for
         # symbolic inputs) and the SymInt references make it unpicklable.
         for i, out_info in enumerate(self.output_info):
-            if out_info.view_meta_sequence is not None and any(
-                vm.has_symbolic_inputs for vm in out_info.view_meta_sequence.sequence
-            ):
-                self.output_info[i] = replace(out_info, view_meta_sequence=None)
+            runtime_safe_view_meta_sequence = (
+                None
+                if out_info.view_meta_sequence is None
+                else out_info.view_meta_sequence.make_runtime_safe()
+            )
+            # make_runtime_safe only returns the original object or None, so
+            # identity comparison is enough here and avoids __eq__(None) quirks.
+            if runtime_safe_view_meta_sequence is not out_info.view_meta_sequence:
+                self.output_info[i] = replace(
+                    out_info, view_meta_sequence=runtime_safe_view_meta_sequence
+                )
 
     @property
     def tensors_saved_for_backwards_slice(self) -> slice:


### PR DESCRIPTION
Fixes #184002 

Compiled DTensor view outputs no longer fall back to unsupported `as_strided`. Added test to cover both generic wrapper subclass case and DTensor compile path