### PR TITLE
Improve Dynamo output graph metadata typing

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -50,7 +50,7 @@ import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from types import CellType, CodeType, FunctionType, ModuleType
-from typing import Any, NoReturn, TypeVar
+from typing import Any, cast, NoReturn, TypeVar
 from typing_extensions import ParamSpec
 from weakref import ReferenceType
 
@@ -134,7 +134,7 @@ from .guards import (
     GuardedCode,
 )
 from .hooks import Hooks
-from .output_graph import DynamoTracerOutput, OutputGraphCommon
+from .output_graph import CodeOptions, DynamoTracerOutput, OutputGraphCommon
 from .pgo import (
     _log_size_mismatch_recompile,
     log_frame_dynamic_whitelist,
@@ -896,7 +896,7 @@ def trace_frame(
     one_graph: bool,
     speculation_log: SpeculationLog,
     instructions: list[Instruction],
-    code_options: dict[str, object],
+    code_options: CodeOptions,
     *,
     export: bool = False,
     export_constraints: Any | None = None,
@@ -1547,7 +1547,7 @@ def compile_frame(  # type: ignore[return]
     speculation_log = SpeculationLog()
 
     def transform(
-        instructions: list[Instruction], code_options: dict[str, object]
+        instructions: list[Instruction], code_options: dict[str, Any]
     ) -> DynamoTracerOutput:
         tf_mode_stack: list[torch.overrides.TorchFunctionMode] = list(
             torch_function_mode_stack_state_mgr.stack
@@ -1563,7 +1563,7 @@ def compile_frame(  # type: ignore[return]
             one_graph,
             speculation_log,
             instructions,
-            code_options,
+            cast(CodeOptions, code_options),
             export=export,
             export_constraints=export_constraints,
             frame_state=frame_state,

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -6,8 +6,7 @@ import sys
 import traceback
 import types
 from collections import namedtuple
-from collections.abc import Callable, Iterable, Sequence
-from typing import Any, cast, Optional, TYPE_CHECKING, TypeVar
+from typing import Any, cast, TYPE_CHECKING, TypeVar
 
 import sympy
 
@@ -22,19 +21,21 @@ from torch._dynamo.utils import dynamo_timed, get_metrics_context
 from torch._export.utils import _compiling_state_context
 from torch._guards import TracingContext
 from torch.export.dynamic_shapes import _RelaxedConstraint, Constraint
-from torch.fx import Node
 from torch.fx.experimental.symbolic_shapes import (
     ConstraintViolationError,
     DimDynamic,
     StatelessSymbolicContext,
 )
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
-from torch.fx.node import Argument, Target
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+
     from torch._dynamo.output_graph import OutputReturnInfo
     from torch._subclasses.fake_tensor import FakeTensorMode
+    from torch.fx import Node
+    from torch.fx.node import Argument, Target
 
 T = TypeVar("T")
 log = logging.getLogger(__name__)
@@ -225,7 +226,7 @@ class ModuleToTrace(torch.nn.Module):
         self._export_root = foo
         self.in_spec = in_spec
 
-    def forward(self, *flat_args: Any) -> "ExportTracerOutput":
+    def forward(self, *flat_args: Any) -> ExportTracerOutput:
         args, kwargs = pytree.tree_unflatten(flat_args, self.in_spec)
         res = self._export_root(*args, **kwargs)
         out_flat, out_spec = pytree.tree_flatten(res)
@@ -433,7 +434,7 @@ class DynamoGraphTransformer(torch.fx.Transformer):
 def _suggest_or_raise_constraint_violation(
     module_to_trace: torch.nn.Module,
     orig_callable: Callable[..., Any],
-    fake_mode: Optional["FakeTensorMode"],
+    fake_mode: FakeTensorMode | None,
     graph_capture_output: CaptureOutput,
     args: Any,
     kwargs: Any,

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import logging
 import sys
@@ -5,7 +7,7 @@ import traceback
 import types
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Optional, TYPE_CHECKING, TypeVar
+from typing import Any, cast, Optional, TYPE_CHECKING, TypeVar
 
 import sympy
 
@@ -31,6 +33,7 @@ from torch.fx.node import Argument, Target
 
 
 if TYPE_CHECKING:
+    from torch._dynamo.output_graph import OutputReturnInfo
     from torch._subclasses.fake_tensor import FakeTensorMode
 
 T = TypeVar("T")
@@ -242,7 +245,7 @@ class DynamoGraphTransformer(torch.fx.Transformer):
         flat_inputs: list[Any],
         flat_args_dynamic_dims: list[set[int]],
         graph_input_order: dict[int, int],
-        graph_output_map: dict[int, tuple[str, Any]],
+        graph_output_map: dict[int, OutputReturnInfo],
         fake_mode: Any | None = None,
         graph_inputs: dict[int, Any] | None = None,
     ) -> None:
@@ -377,9 +380,9 @@ class DynamoGraphTransformer(torch.fx.Transformer):
             output_type, val = self.graph_output_map[i]
 
             if output_type == "graph_out":
-                new_outputs.append(original_outputs[val])
+                new_outputs.append(original_outputs[cast(int, val)])
             elif output_type == "input":
-                input_idx = val.index
+                input_idx = cast(Any, val).index
                 new_outputs.append(self.new_input_nodes[input_idx])
             elif output_type == "constant":
                 new_outputs.append(val)

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -17,6 +17,7 @@ from torch._dynamo.convert_frame import CaptureOutput, fullgraph_capture, get_tr
 from torch._dynamo.decorators import disable as dynamo_disable
 from torch._dynamo.eval_frame import argument_names, check_user_input_output
 from torch._dynamo.exc import UserErrorType
+from torch._dynamo.source import GetItemSource
 from torch._dynamo.utils import dynamo_timed, get_metrics_context
 from torch._export.utils import _compiling_state_context
 from torch._guards import TracingContext
@@ -353,7 +354,7 @@ class DynamoGraphTransformer(torch.fx.Transformer):
             placeholder_idx = self.placeholders.index(self.current_node)
             if placeholder_idx in self.graph_inputs:
                 source = self.graph_inputs[placeholder_idx]
-                if not isinstance(source, torch._dynamo.source.GetItemSource):
+                if not isinstance(source, GetItemSource):
                     example_val = self.current_node.meta.get(
                         "val"
                     ) or self.current_node.meta.get("example_value")
@@ -383,7 +384,7 @@ class DynamoGraphTransformer(torch.fx.Transformer):
             if output_type == "graph_out":
                 new_outputs.append(original_outputs[cast(int, val)])
             elif output_type == "input":
-                input_idx = cast(Any, val).index
+                input_idx = cast(GetItemSource, val).index
                 new_outputs.append(self.new_input_nodes[input_idx])
             elif output_type == "constant":
                 new_outputs.append(val)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -885,7 +885,7 @@ def convert_int_to_concrete_values(dim: Any) -> int | None:
         return dim.node.maybe_as_int()
 
 
-def convert_to_concrete_values(size_or_stride: list[Any]) -> list[int | None]:
+def convert_to_concrete_values(size_or_stride: Sequence[Any]) -> list[int | None]:
     return [convert_int_to_concrete_values(dim) for dim in size_or_stride]
 
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -38,8 +38,17 @@ import weakref
 from collections.abc import Callable, Generator, Sequence
 from dataclasses import dataclass, field as dc_field
 from types import CodeType
-from typing import Any, cast, Optional, TYPE_CHECKING, Union
-from typing_extensions import ParamSpec, TypeVar
+from typing import (
+    Any,
+    cast,
+    Literal,
+    NamedTuple,
+    Optional,
+    TYPE_CHECKING,
+    TypedDict,
+    Union,
+)
+from typing_extensions import NotRequired, ParamSpec, TypeVar
 
 import sympy
 
@@ -190,6 +199,43 @@ graph_sizes_log = torch._logging.getArtifactLogger(__name__, "graph_sizes")
 trace_call_log = torch._logging.getArtifactLogger(__name__, "trace_call")
 
 RootGuardManager = guards.RootGuardManager
+
+TensorMetadataDim = int | torch.SymInt | None
+TensorMetadataSequence = Sequence[TensorMetadataDim]
+OutputReturnKind = Literal["graph_out", "input", "constant"]
+
+
+class SizesStridesInfo(TypedDict):
+    size: TensorMetadataSequence
+    stride: TensorMetadataSequence
+    values_size: NotRequired[TensorMetadataSequence]
+    values_stride: NotRequired[TensorMetadataSequence]
+
+
+class CodeOptions(TypedDict):
+    co_argcount: int
+    co_posonlyargcount: int
+    co_kwonlyargcount: int
+    co_nlocals: int
+    co_stacksize: int
+    co_flags: int
+    co_code: bytes
+    co_consts: tuple[object, ...]
+    co_names: tuple[str, ...]
+    co_varnames: tuple[str, ...]
+    co_filename: str
+    co_name: str
+    co_qualname: NotRequired[str]
+    co_firstlineno: int
+    co_linetable: bytes
+    co_exceptiontable: NotRequired[bytes]
+    co_freevars: tuple[str, ...]
+    co_cellvars: tuple[str, ...]
+
+
+class OutputReturnInfo(NamedTuple):
+    kind: OutputReturnKind
+    value: object
 
 
 # Capture fn pointer at import time
@@ -403,7 +449,7 @@ class OutputGraphGuardsState:
     torch_function_mode_stack: list[torch.overrides.TorchFunctionMode]
     guard_on_key_order: set[Source]
     # Map from graph input's `Source` to sizes / strides metadata
-    input_source_to_sizes_strides: dict[Source, dict[str, Any]]
+    input_source_to_sizes_strides: dict[Source, SizesStridesInfo]
     dual_level: int
     functorch_layers: list[torch._functorch.pyfunctorch.FuncTorchInterpreter]
     current_device: torch.device | None
@@ -463,9 +509,13 @@ class StackLocalsMetadata:
     )  # order of locals codegen'd to the stack
     stack_null_idxes: list[int] = dc_field(default_factory=list)
     locals_null_keys: list[str] = dc_field(default_factory=list)
-    stack_ctx_args: list[tuple[int, tuple[Any, ...]]] = dc_field(default_factory=list)
+    stack_ctx_args: list[tuple[int, tuple[object, ...]]] = dc_field(
+        default_factory=list
+    )
     stack_ctx_idxes_orig: list[int] = dc_field(default_factory=list)
-    locals_ctx_args: list[tuple[str, tuple[Any, ...]]] = dc_field(default_factory=list)
+    locals_ctx_args: list[tuple[str, tuple[object, ...]]] = dc_field(
+        default_factory=list
+    )
 
 
 # TODO we should expand this to make it work for atribtrary in/out
@@ -481,7 +531,7 @@ class ExportMetaData:
     # 1) graph out
     # 2) user input
     # 3) constants
-    output_return_type: dict[int, tuple[str, Any]] = dc_field(default_factory=dict)
+    output_return_type: dict[int, OutputReturnInfo] = dc_field(default_factory=dict)
     # output spec of the traced function
     out_spec: torch.utils._pytree.TreeSpec | torch.utils._pytree.LeafSpec = (
         torch.utils._pytree._LEAF_SPEC
@@ -602,7 +652,7 @@ class OutputGraph(OutputGraphCommon):
 
     def __init__(
         self,
-        code_options: dict[str, Any],
+        code_options: CodeOptions,
         compiler_fn: CompilerFn | None,
         root_tx: "InstructionTranslatorBase",
         export: bool,
@@ -739,7 +789,7 @@ class OutputGraph(OutputGraphCommon):
         # Cache for inspect.signature results: function -> VariableTracker
         self.signature_cache: dict[Any, VariableTracker] = {}
         self.unique_var_id = itertools.count()
-        self.code_options: dict[str, Any] = dict(code_options)
+        self.code_options: CodeOptions = cast(CodeOptions, dict(code_options))
         self.output_instructions: list[Instruction] = []
         self.output_pycode: list[list[str] | None] = []
         # used to track nodes that are added between calls of copy_graphstate
@@ -2124,25 +2174,23 @@ class OutputGraph(OutputGraphCommon):
                         variable: VariableTracker = value.variable
                         vt_to_graph_out_idx[variable] = value.index
 
+                    output_return_type = self.export_metadata.output_return_type
                     for idx, vt in enumerate(flat_returns.items):
                         if vt in vt_to_graph_out_idx:
-                            self.export_metadata.output_return_type[idx] = (
-                                "graph_out",
-                                vt_to_graph_out_idx[vt],
+                            output_return_type[idx] = OutputReturnInfo(
+                                "graph_out", vt_to_graph_out_idx[vt]
                             )
                         elif (
                             vt.source is not None
                             and (source := getattr(vt.source, "base", None))  # type: ignore[assignment]
                             and getattr(source, "is_input", False)
                         ):
-                            self.export_metadata.output_return_type[idx] = (
-                                "input",
-                                vt.source,
+                            output_return_type[idx] = OutputReturnInfo(
+                                "input", vt.source
                             )
                         elif vt.is_python_constant():
-                            self.export_metadata.output_return_type[idx] = (
-                                "constant",
-                                vt.as_python_constant(),
+                            output_return_type[idx] = OutputReturnInfo(
+                                "constant", vt.as_python_constant()
                             )
                         else:
                             raise AssertionError(

--- a/torch/_dynamo/replay_record.py
+++ b/torch/_dynamo/replay_record.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Python execution state recording and replay functionality.
 
@@ -17,10 +19,14 @@ import dataclasses
 from dataclasses import field
 from io import BufferedReader, BufferedWriter
 from types import CellType, CodeType, ModuleType
-from typing import Any, IO
+from typing import Any, cast, IO, TYPE_CHECKING
 from typing_extensions import Self
 
 from torch.utils._import_utils import import_dill
+
+
+if TYPE_CHECKING:
+    from .output_graph import CodeOptions
 
 
 dill = import_dill()
@@ -50,7 +56,7 @@ class ExecutionRecord:
     globals: dict[str, Any] = field(default_factory=dict)
     locals: dict[str, Any] = field(default_factory=dict)
     builtins: dict[str, Any] = field(default_factory=dict)
-    code_options: dict[str, Any] = field(default_factory=dict)
+    code_options: CodeOptions = field(default_factory=lambda: cast("CodeOptions", {}))
 
     def dump(self, f: IO[str] | BufferedWriter) -> None:
         if dill is None:
@@ -73,7 +79,7 @@ class ExecutionRecorder:
     globals: dict[str, Any] = field(default_factory=dict)
     locals: dict[str, Any] = field(default_factory=dict)
     builtins: dict[str, Any] = field(default_factory=dict)
-    code_options: dict[str, Any] = field(default_factory=dict)
+    code_options: CodeOptions = field(default_factory=lambda: cast("CodeOptions", {}))
     name_to_modrec: dict[str, ModuleRecord] = field(default_factory=dict)
 
     def add_local_var(self, name: str, var: Any) -> None:

--- a/torch/_dynamo/replay_record.py
+++ b/torch/_dynamo/replay_record.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+
 """
 Python execution state recording and replay functionality.
 
@@ -17,7 +18,6 @@ and recreate specific program states.
 
 import dataclasses
 from dataclasses import field
-from io import BufferedReader, BufferedWriter
 from types import CellType, CodeType, ModuleType
 from typing import Any, cast, IO, TYPE_CHECKING
 from typing_extensions import Self
@@ -26,6 +26,8 @@ from torch.utils._import_utils import import_dill
 
 
 if TYPE_CHECKING:
+    from io import BufferedReader, BufferedWriter
+
     from .output_graph import CodeOptions
 
 
@@ -56,6 +58,7 @@ class ExecutionRecord:
     globals: dict[str, Any] = field(default_factory=dict)
     locals: dict[str, Any] = field(default_factory=dict)
     builtins: dict[str, Any] = field(default_factory=dict)
+    # The replay record starts empty and gets populated by the translator before use.
     code_options: CodeOptions = field(default_factory=lambda: cast("CodeOptions", {}))
 
     def dump(self, f: IO[str] | BufferedWriter) -> None:
@@ -79,6 +82,7 @@ class ExecutionRecorder:
     globals: dict[str, Any] = field(default_factory=dict)
     locals: dict[str, Any] = field(default_factory=dict)
     builtins: dict[str, Any] = field(default_factory=dict)
+    # The recorder starts empty and gets populated by the translator before use.
     code_options: CodeOptions = field(default_factory=lambda: cast("CodeOptions", {}))
     name_to_modrec: dict[str, ModuleRecord] = field(default_factory=dict)
 

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -18,9 +18,6 @@ from __future__ import annotations
 import copy
 import dataclasses
 import sys
-import types
-from collections.abc import Callable, Iterable
-from contextlib import AbstractContextManager
 from typing import Any, cast, TYPE_CHECKING
 
 from .bytecode_transformation import (
@@ -40,6 +37,10 @@ from .bytecode_transformation import (
 from .utils import ExactWeakKeyDictionary
 
 if TYPE_CHECKING:
+    import types
+    from collections.abc import Callable, Iterable
+    from contextlib import AbstractContextManager
+
     from .output_graph import CodeOptions
 
 

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -36,6 +36,7 @@ from .bytecode_transformation import (
 )
 from .utils import ExactWeakKeyDictionary
 
+
 if TYPE_CHECKING:
     import types
     from collections.abc import Callable, Iterable

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -13,13 +13,15 @@ The module is critical for PyTorch Dynamo's ability to optimize code while prese
 Python semantics and execution state.
 """
 
+from __future__ import annotations
+
 import copy
 import dataclasses
 import sys
 import types
 from collections.abc import Callable, Iterable
 from contextlib import AbstractContextManager
-from typing import Any, cast
+from typing import Any, cast, TYPE_CHECKING
 
 from .bytecode_transformation import (
     add_push_null,
@@ -36,6 +38,9 @@ from .bytecode_transformation import (
     unique_id,
 )
 from .utils import ExactWeakKeyDictionary
+
+if TYPE_CHECKING:
+    from .output_graph import CodeOptions
 
 
 # taken from code.h in cpython
@@ -123,7 +128,7 @@ class ReenterWith:
     target_values: tuple[Any, ...] | None = None
 
     def try_except_torch_function_mode(
-        self, code_options: dict[str, Any], cleanup: list[Instruction]
+        self, code_options: CodeOptions, cleanup: list[Instruction]
     ) -> list[Instruction]:
         """
         Codegen based off of:
@@ -144,7 +149,7 @@ class ReenterWith:
     # If we do not want to destroy the stack, we can do the same thing as a
     # `SETUP_WITH` block, only that we store the context manager in a local_symbol
     def try_finally(
-        self, code_options: dict[str, Any], cleanup: list[Instruction]
+        self, code_options: CodeOptions, cleanup: list[Instruction]
     ) -> list[Instruction]:
         """
         Codegen based off of:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5091,7 +5091,9 @@ class InstructionTranslatorBase(
         # Execution record for replaying errors
         if closure is not None and config.replay_record_enabled:
             self.exec_recorder = ExecutionRecorder(
-                code=f_code, closure=closure, code_options=code_options
+                code=f_code,
+                closure=closure,
+                code_options=cast(dict[str, Any], code_options),
             )
         else:
             self.exec_recorder = None
@@ -5878,17 +5880,19 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         if cached is not None:
             instructions = cached.instructions
             indexof = cached.indexof
-            code_options = cached.code_options
+            code_options = cast(CodeOptions, cached.code_options)
         else:
             instructions = cleaned_instructions(code)
             propagate_line_nums(instructions)
             indexof = get_indexof(instructions)
-            code_options = {k: getattr(code, k) for k in get_code_keys()}
+            code_options = cast(
+                CodeOptions, {k: getattr(code, k) for k in get_code_keys()}
+            )
             if tracing_ctx:
                 tracing_ctx.inlined_code_cache[code] = InlinedCodeCache(
                     instructions=instructions,
                     indexof=indexof,
-                    code_options=code_options,
+                    code_options=cast(dict[str, Any], code_options),
                 )
 
         super().__init__(

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5093,7 +5093,7 @@ class InstructionTranslatorBase(
             self.exec_recorder = ExecutionRecorder(
                 code=f_code,
                 closure=closure,
-                code_options=cast(dict[str, Any], code_options),
+                code_options=code_options,
             )
         else:
             self.exec_recorder = None

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5880,7 +5880,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         if cached is not None:
             instructions = cached.instructions
             indexof = cached.indexof
-            code_options = cast(CodeOptions, cached.code_options)
+            code_options = cached.code_options
         else:
             instructions = cleaned_instructions(code)
             propagate_line_nums(instructions)
@@ -5892,7 +5892,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 tracing_ctx.inlined_code_cache[code] = InlinedCodeCache(
                     instructions=instructions,
                     indexof=indexof,
-                    code_options=cast(dict[str, Any], code_options),
+                    code_options=code_options,
                 )
 
         super().__init__(

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5020,7 +5020,7 @@ class InstructionTranslatorBase(
         f_locals: dict[str, Any],
         f_globals: dict[str, Any],
         f_builtins: dict[str, Any],
-        code_options: dict[str, Any],
+        code_options: CodeOptions,
         symbolic_locals: dict[str, VariableTracker],
         symbolic_globals: dict[str, VariableTracker],
         symbolic_torch_function_state: SymbolicTorchFunctionState,
@@ -5084,7 +5084,7 @@ class InstructionTranslatorBase(
         )
         self.f_globals: dict[str, Any] = f_globals
         self.f_builtins: dict[str, Any] = f_builtins
-        self.code_options: CodeOptions = cast(CodeOptions, code_options)
+        self.code_options: CodeOptions = code_options
         self.f_code: types.CodeType = f_code
         self.closure = closure
 
@@ -5177,7 +5177,7 @@ class InstructionTranslator(InstructionTranslatorBase):
         f_builtins: dict[str, Any],
         closure: tuple[Any, ...] | None,
         torch_function_mode_stack: Any,
-        code_options: dict[str, Any],
+        code_options: CodeOptions,
         compiler_fn: Any,
         one_graph: bool,
         export: bool,
@@ -5194,7 +5194,7 @@ class InstructionTranslator(InstructionTranslatorBase):
         )
         super().__init__(
             output=OutputGraph(
-                cast(CodeOptions, code_options),
+                code_options,
                 compiler_fn,
                 self,
                 export,

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1391,7 +1391,7 @@ class InstructionTranslatorBase(
         """Return the most recently generated pycode varname for the given prefix."""
         return self._pycode_last_varname[prefix]
 
-    def cell_and_freevars(self) -> list[str]:
+    def cell_and_freevars(self) -> tuple[str, ...]:
         if not hasattr(self, "_cell_and_freevars"):
             self._cell_and_freevars = self.cellvars() + self.freevars()
         return self._cell_and_freevars

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -105,7 +105,12 @@ from .exc import (
 )
 from .funcname_cache import get_funcname
 from .guards import GuardBuilder, install_guard
-from .output_graph import GraphCompileReason, OutputGraph, StackLocalsMetadata
+from .output_graph import (
+    CodeOptions,
+    GraphCompileReason,
+    OutputGraph,
+    StackLocalsMetadata,
+)
 from .polyfills import (
     impl_IS_MAPPING,
     impl_MATCH_CLASS,
@@ -1367,10 +1372,10 @@ class InstructionTranslatorBase(
             cur_tx = cur_tx.parent
         return False
 
-    def cellvars(self) -> list[str]:
+    def cellvars(self) -> tuple[str, ...]:
         return self.code_options["co_cellvars"]
 
-    def freevars(self) -> list[str]:
+    def freevars(self) -> tuple[str, ...]:
         return self.code_options["co_freevars"]
 
     def new_pycode_varname(self, prefix: str) -> str:
@@ -4308,6 +4313,8 @@ class InstructionTranslatorBase(
         pass
 
     def KW_NAMES(self, inst: Instruction) -> None:
+        if inst.arg is None:
+            raise AssertionError("expected inst.arg is not None to be true")
         kw_names = self.code_options["co_consts"][inst.arg]
         if not isinstance(kw_names, tuple):
             raise AssertionError("expected isinstance(kw_names, tuple) to be true")
@@ -4880,7 +4887,7 @@ class InstructionTranslatorBase(
 
     def log_graph_break(
         self,
-        code_options: dict[str, Any],
+        code_options: CodeOptions,
         reason: str,
         exc: Unsupported | UserError | StepUnsupported,
     ) -> None:
@@ -5077,7 +5084,7 @@ class InstructionTranslatorBase(
         )
         self.f_globals: dict[str, Any] = f_globals
         self.f_builtins: dict[str, Any] = f_builtins
-        self.code_options: dict[str, Any] = code_options
+        self.code_options: CodeOptions = cast(CodeOptions, code_options)
         self.f_code: types.CodeType = f_code
         self.closure = closure
 
@@ -5187,7 +5194,7 @@ class InstructionTranslator(InstructionTranslatorBase):
         )
         super().__init__(
             output=OutputGraph(
-                code_options,
+                cast(CodeOptions, code_options),
                 compiler_fn,
                 self,
                 export,

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -24,14 +24,14 @@ import sys
 import types
 import unittest
 from collections.abc import Callable, Generator, Sequence
-from typing import Any, overload, TypeVar
+from typing import Any, cast, overload, TypeVar
 from typing_extensions import ParamSpec
 from unittest.mock import patch
 
 import torch
 from torch import fx
 from torch._dynamo.backends.debugging import aot_eager
-from torch._dynamo.output_graph import OutputGraph
+from torch._dynamo.output_graph import CodeOptions, OutputGraph
 
 from . import config, eval_frame, optimize_assert, reset
 from .bytecode_transformation import (
@@ -208,7 +208,7 @@ def debug_insert_nops(
         debug_checks(frame.f_code)
         code, _ = transform_code_object(frame.f_code, insert_nops)
         graph = OutputGraph(
-            code_options={},
+            code_options=cast(CodeOptions, {}),
             compiler_fn=None,
             root_tx=None,  # type: ignore[arg-type]
             export=False,

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -24,14 +24,14 @@ import sys
 import types
 import unittest
 from collections.abc import Callable, Generator, Sequence
-from typing import Any, cast, overload, TypeVar
+from typing import Any, overload, TypeVar
 from typing_extensions import ParamSpec
 from unittest.mock import patch
 
 import torch
 from torch import fx
 from torch._dynamo.backends.debugging import aot_eager
-from torch._dynamo.output_graph import CodeOptions, OutputGraph
+from torch._dynamo.output_graph import OutputGraph
 
 from . import config, eval_frame, optimize_assert, reset
 from .bytecode_transformation import (
@@ -208,7 +208,8 @@ def debug_insert_nops(
         debug_checks(frame.f_code)
         code, _ = transform_code_object(frame.f_code, insert_nops)
         graph = OutputGraph(
-            code_options=cast(CodeOptions, {}),
+            # The nop-insertion path does not inspect code object attributes.
+            code_options={},  # type: ignore[arg-type]
             compiler_fn=None,
             root_tx=None,  # type: ignore[arg-type]
             export=False,

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from torch._dynamo.backends.distributed import DDPOptimizerContext
     from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.guards import GuardCheckSpec
+    from torch._dynamo.output_graph import CodeOptions
     from torch._functorch._aot_autograd.schemas import ViewAndMutationMeta
     from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
     from torch._subclasses.fake_tensor import FakeTensorMode
@@ -1047,7 +1048,7 @@ class InlinedCodeCache:
 
     instructions: list[Any]
     indexof: dict[Any, int]
-    code_options: dict[str, Any]
+    code_options: CodeOptions
 
 
 class TracingContext:


### PR DESCRIPTION
Summary:
- Add TypedDict/NamedTuple schemas for Dynamo output graph metadata.
- Type code object options and context-manager metadata without broad Any containers.
- Widen guard concrete-value conversion to accept the sequence types stored for size/stride metadata.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98