### PR TITLE
[ROCm][Windows] Skip CK SDPA auto enable on ROCm on Windows

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -202,13 +202,13 @@ file(GLOB native_flash_attn_api_cpp CONFIGURE_DEPENDS "native/transformers/cuda/
 file(GLOB flash_attention_hip_hip CONFIGURE_DEPENDS "native/transformers/hip/flash_attn/*.hip")
 # if USE_FLASH_ATTENTION is set, ensure CK instances get generated
 if(USE_FLASH_ATTENTION)
-  # Now building CK by default
-  if(USE_ROCM)
+  # Now building CK by default (Linux only; USE_ROCM_CK_SDPA defaults OFF on WIN32)
+  if(USE_ROCM AND NOT WIN32)
     if(DEFINED ENV{USE_ROCM_CK_SDPA})
         if(ENV{USE_ROCM_CK_SDPA} EQUAL 1)
           caffe2_update_option(USE_ROCM_CK_SDPA ON)
         endif()
-    elseif(NOT WIN32)
+    else()
       caffe2_update_option(USE_ROCM_CK_SDPA ON)
     endif()
     # CK SDPA only supports gfx942/gfx950. Auto-disable when none of those archs


### PR DESCRIPTION
## Summary

On Windows ROCm builds with `USE_FLASH_ATTENTION=ON`, PyTorch configure can still force `USE_ROCM_CK_SDPA=ON` even though [#182733](https://github.com/pytorch/pytorch/pull/182733) already sets the CMake default to **OFF** on `WIN32`. This change aligns the flash-attention configure path in `aten/src/ATen/CMakeLists.txt` with that intent by skipping CK SDPA auto-enable on Windows.

## Problem

Two separate CMake mechanisms control `USE_ROCM_CK_SDPA`, and they disagreed on Windows.

### 1. Top-level default (correct after #182733)

In the repository root `CMakeLists.txt`, #182733 changed:

```cmake
cmake_dependent_option(USE_ROCM_CK_SDPA "Use ROCm Composable Kernel for SDPA"
  ON "USE_ROCM;NOT WIN32" OFF)
```

On Windows, the condition `USE_ROCM;NOT WIN32` is false, so the **initial default** for `USE_ROCM_CK_SDPA` is **OFF**. This matches the goal of not building CK SDPA on Windows (same pattern as `USE_ROCM_CK_GEMM`).

### 2. Flash-attention auto-enable (still ran on Windows)

Later in configure, `aten/src/ATen/CMakeLists.txt` runs under `if(USE_FLASH_ATTENTION)` ([#178310](https://github.com/pytorch/pytorch/pull/178310) — “Now building CK by default”):

```cmake
if(USE_ROCM)
  if(DEFINED ENV{USE_ROCM_CK_SDPA})
    if(ENV{USE_ROCM_CK_SDPA} EQUAL 1)
      caffe2_update_option(USE_ROCM_CK_SDPA ON)
    endif()
  else()
    caffe2_update_option(USE_ROCM_CK_SDPA ON)  # runs on WIN32 when env unset
  endif()
  ...
endif()
```

When `USE_ROCM_CK_SDPA` is **not** set in the environment, this calls `caffe2_update_option(USE_ROCM_CK_SDPA ON)` on **all** ROCm platforms, including Windows.

## Solution

Wrap the flash-attention CK SDPA configure block in aten/src/ATen/CMakeLists.txt with `NOT WIN32`, so it matches the top-level default from #182733:

```cmake
# Before
if(USE_ROCM)

# After
if(USE_ROCM AND NOT WIN32)
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang