### PR TITLE
Avoid fp32 materialization in checkpoint recompute

### DIFF
--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -368,6 +368,51 @@ class NumBytesMetricTests(TestCase):
 
         self.assertLessEqual(deferred_bytes, eager_bytes)
 
+    @requires_gpu_and_triton
+    @skipIfXpu(msg="CUDA-specific generated allocation check")
+    @unittest.skipIf(TEST_WITH_ROCM, "CUDA-specific generated allocation check")
+    def test_checkpoint_recompute_upcast_avoids_fp32_materialization(self):
+        from torch.utils.checkpoint import checkpoint
+
+        class Layer(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.mods = torch.nn.Sequential(
+                    torch.nn.Linear(dim, dim),
+                    torch.nn.LayerNorm([dim]),
+                    torch.nn.GELU(),
+                )
+
+            def forward(self, x):
+                return checkpoint(self.mods, x, use_reentrant=False)
+
+        def fwd_bwd(mod, inp):
+            for p in mod.parameters():
+                p.grad = None
+            mod(inp).sum().backward()
+            return tuple(p.grad for p in mod.parameters())
+
+        batch, dim = 64, 128
+        mod = Layer(dim).to(device=GPU_TYPE, dtype=torch.bfloat16)
+        inp = torch.randn(batch, dim, device=GPU_TYPE, dtype=torch.bfloat16)
+
+        _, wrapper_codes = run_and_get_code(
+            fwd_bwd, torch.compile(mod, fullgraph=True), inp
+        )
+        self.assertEqual(len(wrapper_codes), 2)
+        backward_code = wrapper_codes[-1]
+
+        full_size_fp32_allocs = re.findall(
+            rf"= empty_strided_{GPU_TYPE}\(\({batch}, {dim}\), "
+            rf"\({dim}, 1\), torch\.float32\)",
+            backward_code,
+        )
+        self.assertEqual(
+            full_size_fp32_allocs,
+            [],
+            f"Unexpected full-size fp32 buffers in backward:\n{backward_code}",
+        )
+
 
 class FusionTests(TestCase):
     """

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -54,6 +54,7 @@ from torch.fx.passes.reinplace import _is_view_op
 from torch.utils._mode_utils import no_dispatch
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.numbers import int_oo
+from torch.utils.checkpoint import CheckpointPolicy
 
 from . import config, ir, metrics
 from .codegen.common import (
@@ -111,6 +112,7 @@ from .utils import (
     gather_origins,
     get_cloned_parameter_buffer_name,
     get_donated_idxs,
+    get_dtype_size,
     get_sympy_Expr_dtype,
     GraphPartitionMap,
     is_same_tensor,
@@ -119,6 +121,7 @@ from .utils import (
     should_assume_input_aligned,
     should_fallback_by_default,
     SUPPORTED_MKLDNN_DEVICES,
+    sympy_product,
     ValueWithLineMap,
 )
 from .virtualized import NullHandler, V
@@ -362,6 +365,8 @@ def is_mkldnn_conv(node: Node) -> bool:
 
 
 class GraphLowering(torch.fx.Interpreter):
+    """Lower an FX graph into Inductor IR and generated code."""
+
     graph_outputs: list[ir.IRNode]
 
     def __init__(
@@ -1801,6 +1806,37 @@ class GraphLowering(torch.fx.Interpreter):
             if isinstance(ir_value, ir.TensorBox):
                 ir_value.realize()
 
+    def should_realize_for_recompute_broadcast_or_upcast(
+        self, producer: torch.fx.Node, user: torch.fx.Node
+    ) -> bool:
+        """Avoid materializing a checkpoint recompute value after it grows."""
+        if producer.meta.get("recompute") not in (
+            CheckpointPolicy.MUST_RECOMPUTE,
+            CheckpointPolicy.PREFER_RECOMPUTE,
+        ):
+            return False
+
+        producer_val = producer.meta.get("val")
+        user_val = user.meta.get("val")
+        if not isinstance(producer_val, torch.Tensor) or not isinstance(
+            user_val, torch.Tensor
+        ):
+            return False
+
+        if (
+            user.target is torch.ops.prims.convert_element_type.default
+            and get_dtype_size(user_val.dtype) > get_dtype_size(producer_val.dtype)
+        ):
+            return True
+
+        tags = getattr(user.target, "tags", ())
+        if torch.Tag.pointwise not in tags:
+            return False
+
+        producer_numel = sympy_product(convert_shape_to_inductor(producer_val.shape))
+        user_numel = sympy_product(convert_shape_to_inductor(user_val.shape))
+        return self.sizevars.statically_known_gt(user_numel, producer_numel)
+
     def run_node(self, n: torch.fx.Node) -> object:
         """Lower and execute a single FX node into Inductor IR."""
 
@@ -2022,6 +2058,12 @@ class GraphLowering(torch.fx.Interpreter):
             # Realize if (1) any user need inputs realized, or (2) there is
             # already too many reads and rematerializing can be bad.
             num_users = len(OrderedSet(n.users))
+            if isinstance(result, TensorBox):
+                for user in n.users:
+                    if self.should_realize_for_recompute_broadcast_or_upcast(n, user):
+                        result.realize()
+                        break
+
             if num_users > 1 and isinstance(result, TensorBox):
                 for user in n.users:
                     if user.target in needs_realized_inputs:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184380

Realize checkpoint recompute producers before they feed larger pointwise broadcasts or dtype upcasts. This keeps Inductor from materializing full-size fp32 intermediates in checkpoint backward graphs while leaving normal fusion behavior unchanged.

Fixes #120381

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos