### PR TITLE
[Native DSL] Route diagnostics through TORCH_LOGS=native_dsl

### DIFF
--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -46,6 +46,7 @@ register_log("pp", ["torch.distributed.pipelining"])
 register_log("fsdp", ["torch.distributed.fsdp", "torch.distributed._composable.fsdp"])
 register_log("dtensor", ["torch.distributed._tensor", "torch.distributed.tensor"])
 register_log("onnx", "torch.onnx")
+register_log("native_dsl", "torch._native")
 register_log(
     "export",
     [

--- a/torch/_native/README.md
+++ b/torch/_native/README.md
@@ -250,6 +250,19 @@ def example_ordering_fn(op_symbol, dispatch_key, nodes):
     return out_nodes
 ```
 
+# Logging
+
+All modules under `torch._native` route through Python's standard `logging` and are wired into `TORCH_LOGS` under the `native_dsl` shorthand. Use it to surface registration-time diagnostics (missing optional deps, version mismatches, DSL availability checks) without spamming stderr on stock `import torch`.
+
+```
+# show INFO and above from torch._native
+TORCH_LOGS=+native_dsl python my_script.py
+```
+
+When adding new code under `torch/_native`, follow the existing pattern:
+* Use `log = logging.getLogger(__name__)` per module.
+* Default to `log.info(...)` for registration-time diagnostics that the average user does not need to see; reserve `log.warning(...)` for genuine misuse (e.g. user-supplied callbacks that fail).
+
 # Testing Native Ops
 
 Adding operators means that they should be tested. Given that we're dealing with overrides, which by definition change behavior, we need to be a little careful.

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -53,7 +53,11 @@ def _check_runtime_available() -> tuple[bool, Version | None]:
         available = True
         version = _available_version("nvidia_cutlass_dsl")
     else:
-        log.warning(
+        # info, not warning: missing optional deps is the common case on stock
+        # builds and we don't want to spam stderr on `import torch`. Surface
+        # it via TORCH_LOGS=+native_dsl when diagnosing why an override is
+        # silent.
+        log.info(
             "CuTeDSL operators require optional Python packages "
             "`nvidia-cutlass-dsl` and `apache-tvm-ffi`; "
             "%s",
@@ -80,7 +84,7 @@ def _version_is_ok() -> bool:
     if check_native_version_skip() or (version in _CUTEDSL_REQUIRED_VERSIONS):
         return True
 
-    log.warning(
+    log.info(
         "cutedsl version %s is not known-good (ok: %s); "
         "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
         version,

--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -1,17 +1,6 @@
-import functools
-import importlib.util
-
 import torch
 
 from ... import triton_utils as tu
-
-
-@functools.cache
-def _has_triton() -> bool:
-    try:
-        return importlib.util.find_spec("triton") is not None
-    except ModuleNotFoundError:
-        return False
 
 
 def _is_outer_product(a: torch.Tensor, b: torch.Tensor) -> bool:
@@ -46,8 +35,7 @@ def _bmm_outer_product_cond(
     a_is_cow = torch._C._is_cow_tensor(a)  # pyrefly: ignore[missing-attribute]
     b_is_cow = torch._C._is_cow_tensor(b)  # pyrefly: ignore[missing-attribute]
     if (
-        _has_triton()
-        and a.is_cuda
+        a.is_cuda
         and b.is_cuda
         and _is_outer_product(a, b)
         and not (a_is_cow or b_is_cow)
@@ -68,9 +56,6 @@ def _register_for_dispatch_key(dispatch_key: str) -> None:
 
 
 def register_to_dispatch() -> None:
-    if not _has_triton():
-        return
-
     _register_for_dispatch_key("CUDA")
     if torch.xpu._is_compiled():
         _register_for_dispatch_key("XPU")

--- a/torch/_native/ops/scatter_add/cutedsl_impl.py
+++ b/torch/_native/ops/scatter_add/cutedsl_impl.py
@@ -22,7 +22,6 @@ intercept the in-place method.
 """
 
 import functools
-import importlib.util
 import math
 
 import torch
@@ -32,17 +31,6 @@ from ...registry import _OpCondFn, _OpImplFn
 
 
 _SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
-
-
-@functools.cache
-def _has_cutedsl() -> bool:
-    try:
-        return (
-            importlib.util.find_spec("cutlass") is not None
-            and importlib.util.find_spec("tvm_ffi") is not None
-        )
-    except ModuleNotFoundError:
-        return False
 
 
 @functools.cache
@@ -70,7 +58,7 @@ def _any_cow(*tensors: torch.Tensor) -> bool:
 
 def _base_cond_ok(*tensors: torch.Tensor) -> bool:
     """Pre-checks shared by every path: env sanity, all CUDA, non-COW."""
-    if not _has_cutedsl() or _deterministic():
+    if _deterministic():
         return False
     if not all(t.is_cuda for t in tensors):
         return False
@@ -357,7 +345,5 @@ def _register_path(
 
 
 def register_to_dispatch() -> None:
-    if not _has_cutedsl():
-        return
     for path in _PATHS:
         _register_path("CUDA", *path)

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -48,7 +48,10 @@ def _check_runtime_available() -> tuple[bool, Version | None]:
         available = True
         version = _available_version("triton")
     else:
-        log.warning("triton native DSL ops require: `triton` %s", reason)
+        # info, not warning: see cutedsl_utils._check_runtime_available for
+        # rationale (missing optional deps is the common case; surface via
+        # TORCH_LOGS=+native_dsl when needed).
+        log.info("triton native DSL ops require: `triton` %s", reason)
         available = False
         version = None
     return available, version
@@ -78,7 +81,7 @@ def _version_is_sufficient() -> bool:
     if (major_ok and minor_ok) or check_native_version_skip():
         return True
 
-    log.warning(
+    log.info(
         "triton version %s is not sufficient (>= (%s.%s.*)); "
         "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
         version,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184381

Register `native_dsl` as a TORCH_LOGS shorthand for `torch._native`, and
downgrade dep-missing / version-mismatch messages from warnings to info
so `import torch` is silent. With the DSL utility's gate now quiet by
default, the per-op `_has_*()` short-circuits in `bmm_outer_product` and
`scatter_add` are redundant and removed.

Authored by Claude.