### PR TITLE
[bugfix] use input memory format for F.pad

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8451,6 +8451,25 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         template([1, 1, 8, 8], [2, 2, 0, -1])
         template([1, 1, 8, 8], [2, 2, -1, 0])
 
+    @parametrize("ndim", (2, 3))
+    def test_pad_memory_format_preservation(self, ndim):
+        padding = [2 for _ in range(2 * ndim)]
+        shape = list(range(2, ndim + 4))
+        memory_format = torch.channels_last if ndim == 2 else torch.channels_last_3d
+
+        def fn(x):
+            return F.pad(x, padding, mode="reflect")
+
+        x = torch.randn(shape).to(memory_format=memory_format)
+
+        eager_result = fn(x)
+        compiled_fn = torch.compile(fn)
+        compiled_result = compiled_fn(x.clone())
+
+        self.assertEqual(eager_result, compiled_result)
+        self.assertTrue(eager_result.is_contiguous(memory_format=memory_format))
+        self.assertTrue(compiled_result.is_contiguous(memory_format=memory_format))
+
     def test_grid_sampler_2d(self):
         def fn(a, b):
             return (

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5213,7 +5213,7 @@ def _reflection_or_replication_pad(
         result = aten._unsafe_index(result, idx)
 
     # convert output to correct memory format, if necessary
-    memory_format = utils.suggest_memory_format(result)
+    memory_format = utils.suggest_memory_format(a)
     result = result.contiguous(memory_format=memory_format)
     return result
 


### PR DESCRIPTION
fixes https://github.com/pytorch/pytorch/issues/183770

Updated torch compile decomp of  F.pad to match memory format of input tensor.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo