### PR TITLE
Inline view replay tracking in runtime wrapper codegen

### DIFF
--- a/test/functorch/test_codegen_runtime_wrapper.py
+++ b/test/functorch/test_codegen_runtime_wrapper.py
@@ -52,7 +52,7 @@ class TestCodegenRuntimeWrapper(TestCase):
     def test_training_simple(self):
         """
         Simple training path: no mutations. Generated code should use
-        the training path (enable_grad + force_view_tracking).
+        the training path (enable_grad + view replay tracking).
         """
         with capture_codegen_source("runtime_wrapper_orchestration") as captured:
 
@@ -69,7 +69,8 @@ class TestCodegenRuntimeWrapper(TestCase):
 
         self.assertEqual(len(captured), 1)
         source = captured[0]
-        self.assertIn("_force_view_tracking_", source)
+        self.assertIn("torch._C._set_view_replay_enabled(True)", source)
+        self.assertIn("if not prev_view_replay_enabled:", source)
         self.assertIn("torch.enable_grad()", source)
 
     def test_training_with_detach_indices(self):
@@ -96,7 +97,7 @@ class TestCodegenRuntimeWrapper(TestCase):
         self.assertEqual(len(captured), 1)
         source = captured[0]
         self.assertIn(".detach()", source)
-        self.assertIn("_force_view_tracking_", source)
+        self.assertIn("torch._C._set_view_replay_enabled(True)", source)
 
     def test_inference_with_mutation(self):
         """
@@ -305,7 +306,7 @@ class TestCodegenRuntimeWrapper(TestCase):
     def test_training_disable_amp(self):
         """
         Training path with autocast active at compile time. Generated code
-        should use _DisableAutocast_ alongside force_view_tracking and
+        should use _DisableAutocast_ alongside view replay tracking and
         enable_grad.
         """
         with capture_codegen_source("runtime_wrapper_orchestration") as captured:
@@ -323,7 +324,7 @@ class TestCodegenRuntimeWrapper(TestCase):
         self.assertEqual(len(captured), 1)
         source = captured[0]
         self.assertIn("_DisableAutocast_", source)
-        self.assertIn("_force_view_tracking_", source)
+        self.assertIn("torch._C._set_view_replay_enabled(True)", source)
 
     def test_dynamic_dims(self):
         """

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -522,17 +522,21 @@ class _RuntimeCompiledFnInvoker:
                 # It's possible to have trace_joint inside user specified with no_grad() region,
                 # if there is a nested with enable_grad(), that forces some outputs to require gradients.
                 # Therefore, we unconditionally turn on enable_grad() for compiled_fn execution.
-                with (
-                    torch.autograd._force_original_view_tracking(True),
-                    torch.enable_grad(),
-                ):
-                    on_before_call()
-                    return call_func_at_runtime_with_args(
-                        self.compiled_fn,
-                        args_,
-                        disable_amp=self.disable_amp,
-                        steal_args=True,
-                    )
+                prev_view_replay_enabled = torch._C._is_view_replay_enabled()
+                try:
+                    if not prev_view_replay_enabled:
+                        torch._C._set_view_replay_enabled(True)
+                    with torch.enable_grad():
+                        on_before_call()
+                        return call_func_at_runtime_with_args(
+                            self.compiled_fn,
+                            args_,
+                            disable_amp=self.disable_amp,
+                            steal_args=True,
+                        )
+                finally:
+                    if torch._C._is_view_replay_enabled() != prev_view_replay_enabled:
+                        torch._C._set_view_replay_enabled(prev_view_replay_enabled)
 
             # When we have an inference graph, we run with grad disabled.
             # It's possible to get an inference graph with inputs that require grad,
@@ -804,21 +808,29 @@ def _codegen_compiled_fn_invocation(
                 f"        if isinstance(args_[{idx}], torch.Tensor): "
                 f"args_[{idx}] = args_[{idx}].detach()"
             )
-        rw_globals["_force_view_tracking_"] = (
-            torch.autograd._force_original_view_tracking
-        )
         rw_lines.append(
-            "        with _force_view_tracking_(True), torch.enable_grad():"
+            "        prev_view_replay_enabled = torch._C._is_view_replay_enabled()"
         )
-        rw_lines.append("            _on_before_call_()")
+        rw_lines.append("        try:")
+        rw_lines.append("            if not prev_view_replay_enabled:")
+        rw_lines.append("                torch._C._set_view_replay_enabled(True)")
+        rw_lines.append("            with torch.enable_grad():")
+        rw_lines.append("                _on_before_call_()")
         if disable_amp:
             rw_globals["_DisableAutocast_"] = torch._C._DisableAutocast
-            rw_lines.append("            with _DisableAutocast_():")
+            rw_lines.append("                with _DisableAutocast_():")
+            rw_lines.append("                    all_outs = _compiled_fn_(args_)")
+            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=5)
+        else:
             rw_lines.append("                all_outs = _compiled_fn_(args_)")
             _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=4)
-        else:
-            rw_lines.append("            all_outs = _compiled_fn_(args_)")
-            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=3)
+        rw_lines.append("        finally:")
+        rw_lines.append(
+            "            if torch._C._is_view_replay_enabled() != prev_view_replay_enabled:"
+        )
+        rw_lines.append(
+            "                torch._C._set_view_replay_enabled(prev_view_replay_enabled)"
+        )
     else:
         rw_lines.append("        grad_enabled = torch.is_grad_enabled()")
         rw_lines.append("        try:")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

