### PR TITLE
[ROCm] Fix test_origami autotune comparison after PR #181617 cap

### DIFF
--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -191,7 +191,7 @@ class TestOrigami(TestCase):
         # InductorTestCase caps test_configs.max_mm_configs=2, which would
         # collapse both branches to 0 benchmark calls; restore the unlimited
         # default so the differential comparison is meaningful.
-        with config.patch("test_configs.max_mm_configs", None):
+        with config.patch({"test_configs.max_mm_configs": None}):
             for op_name in ("mm", "addmm", "bmm"):
                 with self.subTest(op_name=op_name):
                     origami_case = self._compile_with_config(

--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -188,25 +188,29 @@ class TestOrigami(TestCase):
         Uses benchmark_gpu_calls count instead of wall-clock timing to avoid flakiness
         on shared CI runners and sequencing bias (origami runs first and pays import cost).
         """
-        for op_name in ("mm", "addmm", "bmm"):
-            with self.subTest(op_name=op_name):
-                origami_case = self._compile_with_config(
-                    op_name,
-                    self._origami_default_config(ORIGAMI_COMPILE_TOPK),
-                    size=256,
-                )
-                max_autotune_case = self._compile_with_config(
-                    op_name,
-                    self._max_autotune_default_config(),
-                    size=256,
-                )
-                # Origami with topk should benchmark fewer configs than full max_autotune
-                self.assertLess(
-                    origami_case["benchmark_gpu_calls"],
-                    max_autotune_case["benchmark_gpu_calls"],
-                    msg=f"Origami ({origami_case['benchmark_gpu_calls']} calls) should have fewer "
-                    f"GPU benchmarks than max_autotune ({max_autotune_case['benchmark_gpu_calls']} calls)",
-                )
+        # InductorTestCase caps test_configs.max_mm_configs=2, which would
+        # collapse both branches to 0 benchmark calls; restore the unlimited
+        # default so the differential comparison is meaningful.
+        with config.patch("test_configs.max_mm_configs", None):
+            for op_name in ("mm", "addmm", "bmm"):
+                with self.subTest(op_name=op_name):
+                    origami_case = self._compile_with_config(
+                        op_name,
+                        self._origami_default_config(ORIGAMI_COMPILE_TOPK),
+                        size=256,
+                    )
+                    max_autotune_case = self._compile_with_config(
+                        op_name,
+                        self._max_autotune_default_config(),
+                        size=256,
+                    )
+                    # Origami with topk should benchmark fewer configs than full max_autotune
+                    self.assertLess(
+                        origami_case["benchmark_gpu_calls"],
+                        max_autotune_case["benchmark_gpu_calls"],
+                        msg=f"Origami ({origami_case['benchmark_gpu_calls']} calls) should have fewer "
+                        f"GPU benchmarks than max_autotune ({max_autotune_case['benchmark_gpu_calls']} calls)",
+                    )
 
     @unittest.skipIf(
         not DO_PERF_TEST,


### PR DESCRIPTION
PR #181617 added a global test_configs.max_mm_configs=2 cap in InductorTestCase. test_origami_reduces_compile_work_vs_regular_max_autotune compares benchmark_gpu_calls between origami (topk-limited) and regular max_autotune; with both paths capped at 2 candidates the autotuner short-circuits in both branches and produces 0 vs 0, failing assertLess.

Only the linux-noble-rocm-py3.12-mi355 workflow surfaces this since it is the only runner with the origami package installed; everywhere else HAS_ORIGAMI=False and the class is skipped.

Restore unlimited max_mm_configs for this test via config.patch so the differential comparison is meaningful again.

Authored with Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben