### PR TITLE
Add adaptive_max_pool2d/3d decompositions for ONNX export

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -34,6 +34,10 @@ aten::acos_
 aten::acosh
 aten::acosh.out
 aten::acosh_
+aten::adaptive_max_pool2d
+aten::adaptive_max_pool2d.out
+aten::adaptive_max_pool3d
+aten::adaptive_max_pool3d.out
 aten::add.Scalar
 aten::add.Scalar_out
 aten::add.Tensor

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -688,12 +688,8 @@ aten::adaptive_avg_pool1d.out
 aten::adaptive_avg_pool2d.out
 aten::adaptive_avg_pool3d.out
 aten::adaptive_avg_pool3d_backward.grad_input
-aten::adaptive_max_pool2d
-aten::adaptive_max_pool2d.out
 aten::adaptive_max_pool2d_backward
 aten::adaptive_max_pool2d_backward.grad_input
-aten::adaptive_max_pool3d
-aten::adaptive_max_pool3d.out
 aten::adaptive_max_pool3d_backward
 aten::adaptive_max_pool3d_backward.grad_input
 aten::addbmm

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -915,6 +915,19 @@ class DynamoExporterTest(common_utils.TestCase, _WithExport):
         onnx_program = self.export(Model(), (x,))
         onnx_testing.assert_onnx_program(onnx_program)
 
+    def test_adaptive_max_pool1d_evenly_divisible(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = torch.nn.AdaptiveMaxPool1d(2)
+
+            def forward(self, x):
+                return self.pool(x)
+
+        x = torch.randn(1, 3, 4)
+        onnx_program = self.export(Model(), (x,))
+        onnx_testing.assert_onnx_program(onnx_program)
+
 
 @common_utils.instantiate_parametrized_tests
 class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):

--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -850,6 +850,71 @@ class DynamoExporterTest(common_utils.TestCase, _WithExport):
         onnx_program = self.export(ComplexInitModel(), (x,))
         onnx_testing.assert_onnx_program(onnx_program)
 
+    def test_adaptive_max_pool2d_global_pooling(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = torch.nn.AdaptiveMaxPool2d((1, 1))
+
+            def forward(self, x):
+                return self.pool(x)
+
+        x = torch.randn(1, 3, 8, 8)
+        onnx_program = self.export(Model(), (x,))
+        onnx_testing.assert_onnx_program(onnx_program)
+
+    def test_adaptive_max_pool2d_evenly_divisible(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = torch.nn.AdaptiveMaxPool2d((2, 2))
+
+            def forward(self, x):
+                return self.pool(x)
+
+        x = torch.randn(1, 3, 4, 4)
+        onnx_program = self.export(Model(), (x,))
+        onnx_testing.assert_onnx_program(onnx_program)
+
+    def test_adaptive_max_pool3d_global_pooling(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = torch.nn.AdaptiveMaxPool3d((1, 1, 1))
+
+            def forward(self, x):
+                return self.pool(x)
+
+        x = torch.randn(1, 3, 4, 4, 4)
+        onnx_program = self.export(Model(), (x,))
+        onnx_testing.assert_onnx_program(onnx_program)
+
+    def test_adaptive_max_pool3d_evenly_divisible(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = torch.nn.AdaptiveMaxPool3d((2, 2, 2))
+
+            def forward(self, x):
+                return self.pool(x)
+
+        x = torch.randn(1, 3, 4, 4, 4)
+        onnx_program = self.export(Model(), (x,))
+        onnx_testing.assert_onnx_program(onnx_program)
+
+    def test_adaptive_max_pool1d_global_pooling(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = torch.nn.AdaptiveMaxPool1d(1)
+
+            def forward(self, x):
+                return self.pool(x)
+
+        x = torch.randn(1, 3, 8)
+        onnx_program = self.export(Model(), (x,))
+        onnx_testing.assert_onnx_program(onnx_program)
+
 
 @common_utils.instantiate_parametrized_tests
 class DynamoExporterNewOpsetsTest(common_utils.TestCase, _WithExport):

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -431,6 +431,11 @@ CROSS_REF_EXCLUDE_SET = {
         None,
         "bernoulli",
     ),  # bernoulli is a function of randomness, so couldn't do cross-reference.
+    # Decomposition is intentionally partial: returns NotImplemented for
+    # non-evenly-divisible output sizes.
+    (None, None, "nn.functional.adaptive_max_pool1d"),
+    (None, None, "nn.functional.adaptive_max_pool2d"),
+    (None, None, "nn.functional.adaptive_max_pool3d"),
 }
 
 CROSS_REF_BACKWARD_EXCLUDE_SET = {

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3051,11 +3051,13 @@ def adaptive_max_pool2d(
         ndim in (3, 4),
         lambda: f"adaptive_max_pool2d(): Expected 3D or 4D tensor, but got {ndim}D",
     )
-    for d in input.shape[-2:]:
+    for i in range(1, ndim):
         torch._check(
-            d != 0,
-            lambda: "adaptive_max_pool2d(): Expected input to have non-zero size "
-            f"for non-batch dimensions, but input has shape {tuple(input.shape)}",
+            input.size(i) > 0,
+            lambda: (
+                "adaptive_max_pool2d(): Expected input to have non-zero size for non-batch dimensions, "
+                f"but input has sizes {input.shape} with dimension {i} being empty"
+            ),
         )
 
     h_in = input.shape[-2]

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3040,6 +3040,107 @@ def max_pool3d_with_indices(
     )
 
 
+@register_decomposition(aten.adaptive_max_pool2d)
+@out_wrapper("out", "indices")
+def adaptive_max_pool2d(
+    input: Tensor,
+    output_size: tuple[int, int],
+) -> tuple[Tensor, Tensor]:
+    ndim = input.ndim
+    torch._check(
+        ndim in (3, 4),
+        lambda: f"adaptive_max_pool2d(): Expected 3D or 4D tensor, but got {ndim}D",
+    )
+    for d in input.shape[-2:]:
+        torch._check(
+            d != 0,
+            lambda: "adaptive_max_pool2d(): Expected input to have non-zero size "
+            f"for non-batch dimensions, but input has shape {tuple(input.shape)}",
+        )
+
+    h_in = input.shape[-2]
+    w_in = input.shape[-1]
+    h_out, w_out = output_size
+
+    # Case 1: empty output
+    if h_out == 0 or w_out == 0:
+        output_shape = list(input.shape[:-2]) + [h_out, w_out]
+        return (
+            input.new_empty(output_shape),
+            input.new_empty(output_shape, dtype=torch.int64),
+        )
+
+    # Case 2: global pooling (output_size == (1, 1))
+    # Equivalent to amax over spatial dims. argmax on the flattened spatial
+    # plane produces flat indices encoded as ih*W+iw.
+    if h_out == 1 and w_out == 1:
+        values = torch.amax(input, dim=(-2, -1), keepdim=True)
+        indices = torch.argmax(input.flatten(-2), dim=-1).unsqueeze(-1).unsqueeze(-1)
+        return values, indices
+
+    # Case 3: evenly divisible -- delegate to max_pool2d_with_indices
+    if h_in % h_out == 0 and w_in % w_out == 0:
+        kernel_size = [h_in // h_out, w_in // w_out]
+        return aten.max_pool2d_with_indices(input, kernel_size)
+
+    # Case 4: general (non-evenly-divisible, output_size > 1)
+    return NotImplemented
+
+
+@register_decomposition(aten.adaptive_max_pool3d)
+@out_wrapper("out", "indices")
+def adaptive_max_pool3d(
+    input: Tensor,
+    output_size: tuple[int, int, int],
+) -> tuple[Tensor, Tensor]:
+    ndim = input.ndim
+    torch._check(
+        ndim in (4, 5),
+        lambda: f"adaptive_max_pool3d(): Expected 4D or 5D tensor, but got {ndim}D",
+    )
+    for d in input.shape[-3:]:
+        torch._check(
+            d != 0,
+            lambda: "adaptive_max_pool3d(): Expected input to have non-zero size "
+            f"for non-batch dimensions, but input has shape {tuple(input.shape)}",
+        )
+
+    d_in = input.shape[-3]
+    h_in = input.shape[-2]
+    w_in = input.shape[-1]
+    d_out, h_out, w_out = output_size
+
+    # Case 1: empty output
+    if d_out == 0 or h_out == 0 or w_out == 0:
+        output_shape = list(input.shape[:-3]) + [d_out, h_out, w_out]
+        return (
+            input.new_empty(output_shape),
+            input.new_empty(output_shape, dtype=torch.int64),
+        )
+
+    # Case 2: global pooling (output_size == (1, 1, 1))
+    # Equivalent to amax over spatial dims. argmax on the flattened spatial
+    # volume produces flat indices encoded as
+    # id*H*W + ih*W + iw.
+    if d_out == 1 and h_out == 1 and w_out == 1:
+        values = torch.amax(input, dim=(-3, -2, -1), keepdim=True)
+        indices = (
+            torch.argmax(input.flatten(-3), dim=-1)
+            .unsqueeze(-1)
+            .unsqueeze(-1)
+            .unsqueeze(-1)
+        )
+        return values, indices
+
+    # Case 3: evenly divisible -- delegate to max_pool3d_with_indices
+    if d_in % d_out == 0 and h_in % h_out == 0 and w_in % w_out == 0:
+        kernel_size = [d_in // d_out, h_in // h_out, w_in // w_out]
+        return aten.max_pool3d_with_indices(input, kernel_size)
+
+    # Case 4: general (non-evenly-divisible, output_size > 1)
+    return NotImplemented
+
+
 def _max_unpoolnd(
     self: TensorLike, indices: TensorLike, output_size: list[int], dim: int
 ):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3100,11 +3100,13 @@ def adaptive_max_pool3d(
         ndim in (4, 5),
         lambda: f"adaptive_max_pool3d(): Expected 4D or 5D tensor, but got {ndim}D",
     )
-    for d in input.shape[-3:]:
+    for i in range(1, ndim):
         torch._check(
-            d != 0,
-            lambda: "adaptive_max_pool3d(): Expected input to have non-zero size "
-            f"for non-batch dimensions, but input has shape {tuple(input.shape)}",
+            input.size(i) > 0,
+            lambda: (
+                "adaptive_max_pool3d(): Expected input to have non-zero size for non-batch dimensions, "
+                f"but input has sizes {input.shape} with dimension {i} being empty"
+            ),
         )
 
     d_in = input.shape[-3]

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -62,6 +62,7 @@ inductor_decompositions = get_decompositions(
     [
         aten._adaptive_avg_pool2d_backward,
         aten.adaptive_max_pool2d,
+        aten.adaptive_max_pool3d,
         aten.index_select,
         aten.addmv,
         aten.arange,

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -61,6 +61,7 @@ quantized_decomposed = torch.ops.quantized_decomposed
 inductor_decompositions = get_decompositions(
     [
         aten._adaptive_avg_pool2d_backward,
+        aten.adaptive_max_pool2d,
         aten.index_select,
         aten.addmv,
         aten.arange,
@@ -1205,24 +1206,6 @@ def max_pool3d_with_indices(
     return _max_pool_with_indices(
         x, kernel_size, stride, padding, dilation, ceil_mode, dim=3
     )
-
-
-@register_decomposition(aten.adaptive_max_pool2d)
-def adaptive_max_pool2d(
-    x: torch.Tensor, output_size: list[int]
-) -> tuple[torch.Tensor, torch.Tensor]:
-    *batch, h_in, w_in = x.shape
-    h_out, w_out = output_size
-
-    if h_out == 0 or w_out == 0:
-        o_size = [*batch, h_out, w_out]
-        return x.new_empty(o_size), x.new_empty(o_size, dtype=torch.int64)
-
-    if h_in % h_out == 0 and w_in % w_out == 0:
-        kernel_size = [h_in // h_out, w_in // w_out]
-        return aten.max_pool2d_with_indices(x, kernel_size)
-
-    return NotImplemented
 
 
 @register_decomposition(aten.searchsorted.Scalar)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3461,6 +3461,7 @@ def sdpa_constraint(fx_node, *args, **kwargs):
 
 # WIP
 make_fallback(aten._adaptive_avg_pool3d)  # @isuruf
+make_fallback(aten.adaptive_max_pool3d, override_decomp=True)
 make_fallback(aten._scaled_dot_product_attention_math_for_mps)  # @malfet
 
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3461,7 +3461,6 @@ def sdpa_constraint(fx_node, *args, **kwargs):
 
 # WIP
 make_fallback(aten._adaptive_avg_pool3d)  # @isuruf
-make_fallback(aten.adaptive_max_pool3d)  # @isuruf
 make_fallback(aten._scaled_dot_product_attention_math_for_mps)  # @malfet
 
 


### PR DESCRIPTION
Fixes #183439

The dynamo-based ONNX exporter fails on models using `adaptive_max_pool2d` or `adaptive_max_pool3d` because these ops have no decomposition registered in `global_decomposition_table["post_autograd"]`. Without a decomposition, the ops remain in the FX graph as opaque nodes with no ONNX function mapping.

This PR adds decompositions for both ops. Each handles three cases:

1. **Empty output** (output_size contains 0): returns empty tensors
2. **Global pooling** (output_size all 1s): decomposes to `amax` + `argmax`
3. **Evenly divisible**: delegates to `max_pool{2,3}d_with_indices`

Non-evenly-divisible output sizes return `NotImplemented`, falling back to the native C++ kernel. ONNX itself has no adaptive pooling op for output size > 1, so the evenly-divisible case is the practical upper bound.

`adaptive_max_pool1d` is covered for free: its C++ implementation (CIA dispatch) delegates to `adaptive_max_pool2d`, so the decomposition applies transitively.

**Inductor changes:**

The shared decomposition in `torch/_decomp/decompositions.py` replaces the Inductor-specific copy that previously lived in `torch/_inductor/decomposition.py`. This avoids maintaining two duplicate decompositions and gives Inductor the global pooling optimization (output_size=1).

- **adaptive_max_pool2d:** Deleted the Inductor-specific decomposition and added `aten.adaptive_max_pool2d` to the `inductor_decompositions` list so Inductor picks up the shared version. The existing custom lowering in `lowering.py` handles non-evenly-divisible cases (Triton kernel for small windows, eager fallback for large windows).
- **adaptive_max_pool3d:** Added `make_fallback(aten.adaptive_max_pool3d, override_decomp=True)` since there is no custom lowering for 3d.  The decomposition handles cases it can; the fallback runs eager for the rest.

**Test changes:**
- Removed `adaptive_max_pool2d` and `adaptive_max_pool3d` (forward only) from `HasDecompTest` expect file
- Added all three ops to `CROSS_REF_EXCLUDE_SET` since the decomposition is intentionally partial (`NotImplemented` for non-divisible cases)
- Added 5 ONNX end-to-end export tests covering global pooling and evenly-divisible cases for 1d, 2d, and 3d


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo