### PR TITLE
[AOTI] Shape Logging (#184399)

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -1541,6 +1541,38 @@ TorchDynamo attempted to trace the following frames: [
         self.assertIn("non-infra torch dispatch mode present", msg)
         self.assertIn("fn", msg)
 
+    @requires_gpu
+    @torch._inductor.config.patch("force_disable_caches", True)
+    @make_logging_test(autotuning_inputs=True)
+    def test_autotuning_inputs(self, records):
+        @torch.compile(mode="max-autotune")
+        def f(x):
+            return (x * 2.0 + 1.0).sum(dim=1)
+
+        f(torch.randn(2048, 4096, device=device_type))
+
+        autotune_records = [r for r in records if ".__autotuning_inputs" in r.name]
+        self.assertGreater(len(autotune_records), 0)
+        msg = "\n".join(r.getMessage() for r in autotune_records)
+        self.assertIn("Autotuning inputs for kernel", msg)
+        self.assertIn("shape=(", msg)
+        self.assertIn("dtype=torch.float32", msg)
+        self.assertIn("stride=(", msg)
+
+    @requires_gpu
+    @torch._inductor.config.patch("force_disable_caches", True)
+    @make_logging_test(inductor=logging.DEBUG)
+    def test_autotuning_inputs_off_by_default(self, records):
+        # off_by_default: must stay silent even with the parent inductor log at DEBUG
+        @torch.compile(mode="max-autotune")
+        def f(x):
+            return (x * 2.0 + 1.0).sum(dim=1)
+
+        f(torch.randn(2048, 4096, device=device_type))
+        self.assertEqual(
+            len([r for r in records if ".__autotuning_inputs" in r.name]), 0
+        )
+
 
 # non single record tests
 exclusions = {
@@ -1588,6 +1620,7 @@ exclusions = {
     "loop_tiling",
     "auto_chunker",
     "autotuning",
+    "autotuning_inputs",
     "incremental",
     "graph_region_expansion",
     "hierarchical_compile",

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -141,6 +141,7 @@ if get_args(_KernelType) != _T.__constraints__:
     raise AssertionError("_KernelType args must match _T type constraints")
 
 log = logging.getLogger(__name__)
+autotuning_inputs_log = torch._logging.getArtifactLogger(__name__, "autotuning_inputs")
 
 triton_name_sub = re.compile(r"^def [^(]+\(")
 
@@ -1571,6 +1572,79 @@ class CachingAutotuner(KernelInterface):
                         close()
             self.compile_results = keep_results
 
+    def _log_autotune_inputs(self, args, kwargs) -> None:
+        """Log input tensor shapes/dtypes and scalar values for autotuning."""
+        kernel_name = self.inductor_meta.get("kernel_name", self.fn.__name__)
+        signature = self.triton_meta.get("signature", {})
+        arg_names = list(signature.keys())
+
+        autotuning_inputs_log.debug("=" * 60)
+        autotuning_inputs_log.debug("Autotuning inputs for kernel: %s", kernel_name)
+        autotuning_inputs_log.debug("=" * 60)
+        autotuning_inputs_log.debug("  Heuristic type: %s", self.heuristic_type)
+        autotuning_inputs_log.debug("  Size hints: %s", self.size_hints)
+        autotuning_inputs_log.debug(
+            "  Num configs to benchmark: %d", len(self.launchers)
+        )
+        autotuning_inputs_log.debug(
+            "  Device: %s (index=%s)", self.device_props.type, self.device_props.index
+        )
+        autotuning_inputs_log.debug("-" * 60)
+        autotuning_inputs_log.debug("Arguments:")
+
+        for i, arg in enumerate(args):
+            arg_name = arg_names[i] if i < len(arg_names) else f"arg_{i}"
+            arg_signature = signature.get(arg_name, "unknown")
+            if isinstance(arg, torch.Tensor):
+                autotuning_inputs_log.debug(
+                    "  [%d] %s (%s): Tensor(shape=%s, dtype=%s, device=%s, stride=%s, contiguous=%s)",
+                    i,
+                    arg_name,
+                    arg_signature,
+                    tuple(arg.shape),
+                    arg.dtype,
+                    arg.device,
+                    arg.stride(),
+                    arg.is_contiguous(),
+                )
+            elif isinstance(arg, (int, float, bool)):
+                autotuning_inputs_log.debug(
+                    "  [%d] %s (%s): %s (type=%s)",
+                    i,
+                    arg_name,
+                    arg_signature,
+                    arg,
+                    type(arg).__name__,
+                )
+            else:
+                autotuning_inputs_log.debug(
+                    "  [%d] %s (%s): %s (type=%s)",
+                    i,
+                    arg_name,
+                    arg_signature,
+                    repr(arg)[:100],
+                    type(arg).__name__,
+                )
+
+        if kwargs:
+            autotuning_inputs_log.debug("-" * 60)
+            autotuning_inputs_log.debug("Keyword arguments:")
+            for k, v in kwargs.items():
+                if isinstance(v, torch.Tensor):
+                    autotuning_inputs_log.debug(
+                        "  %s: Tensor(shape=%s, dtype=%s, device=%s)",
+                        k,
+                        tuple(v.shape),
+                        v.dtype,
+                        v.device,
+                    )
+                else:
+                    autotuning_inputs_log.debug(
+                        "  %s: %s (type=%s)", k, v, type(v).__name__
+                    )
+
+        autotuning_inputs_log.debug("=" * 60)
+
     def benchmark_all_configs(self, *args, **kwargs):
         with (
             dynamo_timed(
@@ -1635,7 +1709,10 @@ class CachingAutotuner(KernelInterface):
             return timings
 
     def autotune_to_one_config(self, *args, **kwargs):
-        """Do the actual autotuning"""
+        """Execute autotuning to select the optimal kernel configuration."""
+        if autotuning_inputs_log.isEnabledFor(logging.DEBUG):
+            self._log_autotune_inputs(args, kwargs)
+
         start_time = time.time_ns()
         timings = self.benchmark_all_configs(*args, **kwargs)
         benchmark_time_taken_ns = time.time_ns() - start_time

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -258,6 +258,7 @@ def set_logs(
     cudagraph_static_inputs: bool = False,
     benchmarking: bool = False,
     autotuning: bool = False,
+    autotuning_inputs: bool = False,
     incremental: bool = False,
     graph_region_expansion: bool = False,
     inductor_metrics: bool = False,
@@ -459,6 +460,9 @@ def set_logs(
         autotuning (:class:`bool`):
             Autotuning choice logs, such as kernel source, perf, and tuning parameters. Default: ``False``
 
+        autotuning_inputs (:class:`bool`):
+            Per-kernel input tensor shapes/dtypes/strides logged during autotuning. Default: ``False``
+
         incremental (:class:`bool`):
             Incremental autotuning logs. Default: ``False``
 
@@ -590,6 +594,7 @@ def set_logs(
         cudagraph_static_inputs=cudagraph_static_inputs,
         benchmarking=benchmarking,
         autotuning=autotuning,
+        autotuning_inputs=autotuning_inputs,
         incremental=incremental,
         graph_region_expansion=graph_region_expansion,
         inductor_metrics=inductor_metrics,

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -257,6 +257,11 @@ register_artifact(
     off_by_default=True,
 )
 register_artifact(
+    "autotuning_inputs",
+    "Per-kernel input tensor shapes/dtypes/strides logged during autotuning.",
+    off_by_default=True,
+)
+register_artifact(
     "graph_region_expansion",
     "Logs detailed steps of the duplicate graph region tracker expansion algorithm",
     off_by_default=True,


### PR DESCRIPTION
Summary:

Add verbose autotuning input logs (see example below), emitted when the `autotuning_inputs` log artifact is enabled via `TORCH_LOGS=autotuning_inputs`. For each Triton kernel about to be autotuned, this dumps the input tensor shapes/dtypes/strides and scalar argument values. The artifact is off-by-default and independent of `+inductor`, so these verbose per-kernel logs stay out of the general inductor channel and can be combined with other settings as needed (e.g. `TORCH_LOGS=+inductor,autotuning_inputs`). Example output for `triton_red_fused_sum_3` kernel:
```
Autotuning inputs for kernel: triton_red_fused_sum_3
============================================================
  Heuristic type: HeuristicType.REDUCTION
  Size hints: {'x': 1, 'r0_': 2}
  Num configs to benchmark: 3
  Device: cuda (index=0)
------------------------------------------------------------
Arguments:
  [0] in_ptr0 (*i32): Tensor(shape=(2,), dtype=torch.int32, device=cuda:0, stride=(1,), contiguous=True)
  [1] out_ptr0 (*i64): Tensor(shape=(), dtype=torch.int64, device=cuda:0, stride=(), contiguous=True)
  [2] xnumel (constexpr): 1 (type=int)
  [3] r0_numel (i32): 2 (type=int)
============================================================
```

Test Plan:
## New Testing
### 06-22-2026
- Reworked the gating: dropped the `log_autotune_inputs` config flag in favor of a dedicated, off-by-default `TORCH_LOGS` artifact, `autotuning_inputs`. Enable with `TORCH_LOGS=autotuning_inputs`; it is independent of `+inductor` and composable, e.g. `TORCH_LOGS=+inductor,autotuning_inputs`.
- Added two artifact tests in `test_logging.py` using the standard `make_logging_test` harness so they exercise the real enablement paths (both the `TORCH_LOGS` env var and the `torch._logging.set_logs(...)` API) and assert on captured log records:
    - `test_autotuning_inputs` compiles `(x * 2.0 + 1.0).sum(dim=1)` under `mode="max-autotune"` (caches disabled) and asserts the `autotuning_inputs` records contain the dump header and the rendered tensor metadata (`Autotuning inputs for kernel`, `shape=(`, `dtype=torch.float32`, `stride=(`).
    - `test_autotuning_inputs_off_by_default` enables the parent `inductor` log at DEBUG and asserts that zero `autotuning_inputs` records are emitted, proving the artifact stays off unless explicitly named.
- Ran on a real GPU (non-ASAN `fbcode//mode/dev-nosan`) via a temporary remote-GPU target for `test_logging.py` (removed after verifying):
```
# Result: Pass 2, Fail 0.
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/dynamo:<tmp_target> -- --regex 'test_autotuning_inputs'
```
- The autotuned kernel was `triton_red_fused_add_mul_sum_0`; representative captured dump:
```
Autotuning inputs for kernel: triton_red_fused_add_mul_sum_0
============================================================
  Heuristic type: HeuristicType.REDUCTION
  Size hints: {'x': 2048, 'r0_': 4096}
  Num configs to benchmark: 6
  Device: cuda (index=0)
------------------------------------------------------------
Arguments:
  [0] in_ptr0 (*fp32): Tensor(shape=(2048, 4096), dtype=torch.float32, device=cuda:0, stride=(4096, 1), contiguous=True)
  [1] out_ptr0 (*fp32): Tensor(shape=(2048,), dtype=torch.float32, device=cuda:0, stride=(1,), contiguous=True)
  [2] xnumel (i32): 2048 (type=int)
  [3] r0_numel (i32): 4096 (type=int)
============================================================
```
- The logger qualified name was `torch._inductor.runtime.triton_heuristics.__autotuning_inputs`, confirming it routes through the dedicated artifact and not the shared `autotuning` channel.
___

Reviewed By: Indicator, angelayi

Differential Revision: D91361678




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98