### PR TITLE
[MPS] Fix additive mask scaling in prefill attention

### DIFF
--- a/aten/src/ATen/native/mps/kernels/PrefillAttention.h
+++ b/aten/src/ATen/native/mps/kernels/PrefillAttention.h
@@ -825,13 +825,14 @@ prefill_attention(
               row_pos_in_seq,
               col_pos_in_seq);
 
+          constexpr selem_t kLog2E = selem_t(1.44269504089f);
           PREFILL_PRAGMA_UNROLL
           for (short jj = 0; jj < stile_t::MMAFrag_t::kElemsPerFrag; jj++) {
             if IF_CONSTEXPR (is_bool) {
               Stile.frag_at(i, j)[jj] =
                   mfrag[jj] ? Stile.frag_at(i, j)[jj] : neg_inf;
             } else {
-              Stile.frag_at(i, j)[jj] += selem_t(mfrag[jj]);
+              Stile.frag_at(i, j)[jj] += selem_t(mfrag[jj]) * kLog2E;
             }
           }
         }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11328,8 +11328,10 @@ class TestSDPA(TestCaseMPS):
             attn_mask = torch.ones(B, NH_q, qL, kL, dtype=torch.bool, device="mps")
             attn_mask[..., kL // 2:] = False
         elif variant == "float_mask":
+            # Use a moderate negative value: -1e4 saturates exp() to 0 and
+            # hides scaling bugs in the softmax (e.g. missing log2(e) factor).
             attn_mask = torch.zeros(B, NH_q, qL, kL, dtype=dtype, device="mps")
-            attn_mask[..., kL // 2:] = -1e4
+            attn_mask[..., kL // 2:] = -3.0
         self._run_prefill_test(q, k, v, attn_mask=attn_mask, is_causal=is_causal)
 
     @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
@@ -11371,7 +11373,7 @@ class TestSDPA(TestCaseMPS):
             mask[..., kL // 2:] = False
         elif mask_layout == "sliced":
             mask_full = torch.zeros(B, NH, qL, kL * 2 + 1, dtype=dtype, device="mps")
-            mask_full[..., 1 + kL // 2:1 + kL] = -1e4
+            mask_full[..., 1 + kL // 2:1 + kL] = -3.0
             mask = mask_full[..., 1:kL + 1]
         else:
             raise ValueError(f"Unknown mask_layout: {mask_layout}")


### PR DESCRIPTION
Prefill softmax runs in log2 space due to exp2 being faster than exp, due to this additive float masks must be multiplied by `log2(e)` to match the score scaling.

Existing test used -1e4 which saturated exp() and hid the bug, switched to -3.0.
Reproducer:
```
import math
import torch
import torch.nn.functional as F

torch.manual_seed(0)
q = torch.randn(1, 2, 64, 64)
k = torch.randn(1, 2, 64, 64)
v = torch.randn(1, 2, 64, 64)
m = torch.zeros(1, 2, 64, 64)
m[..., ::8] = -3.0

ok  = F.scaled_dot_product_attention(q, k, v, attn_mask=m)
mps = F.scaled_dot_product_attention(q.to("mps"), k.to("mps"), v.to("mps"), attn_mask=m.to("mps")).cpu()
print((ok  - mps).abs().max().item())
```