### PR TITLE
[MPS] Materialize neg bit in copy_kernel_mps

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -10,6 +10,7 @@
 #include <ATen/ops/real.h>
 #include <ATen/ops/view_as_real.h>
 #include <ATen/ops/zeros_like.h>
+#include <fmt/format.h>
 
 namespace at::native {
 namespace mps {
@@ -47,8 +48,9 @@ static void copy_cast_mps(at::Tensor& dst,
 
   @autoreleasepool {
     const bool needs_conj = src.is_conj() != dst.is_conj();
-    std::string key = "copy_cast_mps" + getTensorsStringKey({src, dst}, true, /*exclude_shape*/ true) + ":" +
-        std::to_string(needs_conj);
+    const bool needs_neg = src.is_neg() != dst.is_neg();
+    std::string key = fmt::format(
+        "copy_cast_mps{}:{}:{}", getTensorsStringKey({src, dst}, true, /*exclude_shape*/ true), needs_conj, needs_neg);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, srcDType);
       auto outputTensor = inputTensor;
@@ -60,6 +62,9 @@ static void copy_cast_mps(at::Tensor& dst,
       }
       if (needs_conj) {
         outputTensor = [mpsGraph conjugateWithTensor:outputTensor name:nil];
+      }
+      if (needs_neg) {
+        outputTensor = [mpsGraph negativeWithTensor:outputTensor name:nil];
       }
 
       newCachedGraph->inputTensor_ = inputTensor;
@@ -238,12 +243,15 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, boo
   auto dst_byte_offset = dst_.storage_offset() * dst_.itemsize();
 
   // If dst is contiguous and there is no byte offset, we can save directly the result of
-  // gather into dst. This reduces the overhead of doing an additional blit for most cases
-  bool returnGatherOutput = dst_.is_contiguous();
+  // gather into dst. This reduces the overhead of doing an additional blit for most cases.
+  // Skip this shortcut when src has an unresolved neg bit, since the gather kernel does
+  // not apply negation (only conjugation) and we need the cast path below to materialize it.
+  bool returnGatherOutput = dst_.is_contiguous() && src_.is_neg() == dst_.is_neg();
   Tensor src;
   auto sameMemFormat =
       src_.is_contiguous(dst_.suggest_memory_format()) && dst_.is_contiguous(dst_.suggest_memory_format());
-  const bool sameDataType = src_.dtype() == dst_.dtype() && src_.is_conj() == dst_.is_conj();
+  const bool sameDataType =
+      src_.dtype() == dst_.dtype() && src_.is_conj() == dst_.is_conj() && src_.is_neg() == dst_.is_neg();
 
   if ((!src_.is_contiguous(MemoryFormat::Contiguous) && !sameMemFormat) ||
       // the copy_cast path requires storage_offset to be applied before casting

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -244,9 +244,7 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, boo
 
   // If dst is contiguous and there is no byte offset, we can save directly the result of
   // gather into dst. This reduces the overhead of doing an additional blit for most cases.
-  // Skip this shortcut when src has an unresolved neg bit, since the gather kernel does
-  // not apply negation (only conjugation) and we need the cast path below to materialize it.
-  bool returnGatherOutput = dst_.is_contiguous() && src_.is_neg() == dst_.is_neg();
+  bool returnGatherOutput = dst_.is_contiguous();
   Tensor src;
   auto sameMemFormat =
       src_.is_contiguous(dst_.suggest_memory_format()) && dst_.is_contiguous(dst_.suggest_memory_format());

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -42,28 +42,37 @@ static std::string getGatherScatterFunctionName(ScalarType scalarType, int64_t d
   return kernelName + "_kernel_" + (dim < 5 ? std::to_string(dim == 0 ? 1 : dim) : "n");
 }
 
-static std::string genScatterGatherCvtFunc(const std::string& dtypeSrc, const std::string& dtypeDst, bool needsConj) {
+static std::string genScatterGatherCvtFunc(const std::string& dtypeSrc,
+                                           const std::string& dtypeDst,
+                                           bool needsConj,
+                                           bool needsNeg) {
   const bool srcComplex = dtypeSrc[dtypeSrc.size() - 1] == '2';
   const bool dstComplex = dtypeDst[dtypeDst.size() - 1] == '2';
+  const std::string sign = needsNeg ? "-" : "";
   if (dstComplex) {
     // TODO: Document why explicit cast is needed only for bfloat types
     if (dtypeSrc == "bfloat") {
-      return dtypeDst + "(float(x), 0.0)";
+      return dtypeDst + "(" + sign + "float(x), 0.0)";
     }
-    return dtypeDst + (srcComplex ? needsConj ? "(x.x, -x.y)" : "(x.x, x.y)" : "(x,  0.0)");
+    if (srcComplex) {
+      // conj negates imag; neg negates both. Combined: real negated, imag kept.
+      const std::string imag = (needsConj != needsNeg) ? "-x.y" : "x.y";
+      return dtypeDst + "(" + sign + "x.x, " + imag + ")";
+    }
+    return dtypeDst + "(" + sign + "x, 0.0)";
   }
   if (srcComplex) {
     // TODO: Document why explicit cast is needed only for bfloat types
     if (dtypeDst == "bfloat") {
-      return "bfloat(x.x)";
+      return "bfloat(" + sign + "x.x)";
     }
-    return "x.x";
+    return sign + "x.x";
   }
   // TODO: Document why explicit cast is needed only for bfloat types
   if (dtypeDst == "bfloat") {
-    return "bfloat(x)";
+    return "bfloat(" + sign + "x)";
   }
-  return dtypeSrc == "bfloat" ? dtypeDst + "(x)" : "(x)";
+  return dtypeSrc == "bfloat" ? dtypeDst + "(" + sign + "x)" : "(" + sign + "x)";
 }
 
 static MetalShaderLibrary scatterLib(SCATTER_OPS_TEMPLATE, 3);
@@ -73,8 +82,9 @@ static id<MTLComputePipelineState> getPipelineState(const std::string& kernel,
                                                     const std::string& dtypeSrc,
                                                     const std::string& dtypeDst,
                                                     bool needsScatter,
-                                                    bool needsConj) {
-  auto cvtFunc = genScatterGatherCvtFunc(dtypeSrc, dtypeDst, needsConj);
+                                                    bool needsConj,
+                                                    bool needsNeg) {
+  auto cvtFunc = genScatterGatherCvtFunc(dtypeSrc, dtypeDst, needsConj, needsNeg);
   return (needsScatter ? scatterLib : gatherLib).getPipelineStateForFunc(kernel, {dtypeSrc, dtypeDst, cvtFunc});
 }
 
@@ -123,7 +133,8 @@ Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst) {
                                                              scalarToMetalTypeString(src),
                                                              scalarToMetalTypeString(output),
                                                              /*needsScatter=*/false,
-                                                             src.is_conj() != dst.is_conj());
+                                                             src.is_conj() != dst.is_conj(),
+                                                             src.is_neg() != dst.is_neg());
 
     // this function call is a no-op if MPS Profiler is not enabled
     getMPSProfiler().beginProfileKernel(gatherPSO, functionName, {src, output});
@@ -176,7 +187,8 @@ Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output) {
                                                                 scalarToMetalTypeString(src),
                                                                 scalarToMetalTypeString(output),
                                                                 /*needsScatter=*/true,
-                                                                src.is_conj() != output.is_conj());
+                                                                src.is_conj() != output.is_conj(),
+                                                                src.is_neg() != output.is_neg());
 
       getMPSProfiler().beginProfileKernel(scatterPSO, functionName, {src, output});
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6903,7 +6903,6 @@ class CommonTemplate:
 
         self.common(fn, (x,))
 
-    @xfail_if_mps
     def test_complex_real_imag_conj(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/171665
         # Tests that extracting real/imag from conjugated tensors works when compiled.

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14677,16 +14677,32 @@ class TestComplex(TestCase):
         x = torch.tensor([1 + 2j, 3 - 4j], device="mps")
         self.assertEqual(x.conj().imag.cpu(), x.cpu().conj().imag)
 
-    def test_neg_bit_materialized_by_clone(self):
+    def test_neg_bit(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/184379
-        # clone() must materialize the neg bit on MPS so downstream consumers
-        # (the math-bit fallback, .cpu() via _to_copy, etc.) see negated data.
-        y = torch.tensor([1.0, 2.0, 3.0], device="mps")._neg_view()
-        self.assertTrue(y.is_neg())
-        expected = torch.tensor([-1.0, -2.0, -3.0])
-        self.assertEqual(y.clone(), expected)
-        self.assertEqual(y.resolve_neg(), expected)
-        self.assertEqual(y.cpu(), expected)
+        # MPS copy paths (the direct blit, the cast path, and the gather/scatter
+        # kernels) must all materialize the neg bit -- previously only the conj
+        # bit was honored, so `.imag` of a conjugate view, clone, .cpu(), and
+        # copy_ into/out-of non-contiguous tensors silently returned un-negated
+        # data.
+        xforms = [(lambda t: t, "contig"), (lambda t: t.T, "T")]
+        torch.manual_seed(0)
+        v_cpu = torch.randn(4, 4)
+        v = v_cpu.to("mps")
+        for src_xform, src_label in xforms:
+            for dst_xform, dst_label in xforms:
+                src_mps = src_xform(v)._neg_view()
+                src_cpu = src_xform(v_cpu)._neg_view()
+                expected = src_cpu.clone()
+                dst_mps = dst_xform(torch.empty(4, 4, device="mps"))
+                dst_cpu = dst_xform(torch.empty(4, 4))
+                dst_mps.copy_(src_mps)
+                dst_cpu.copy_(src_cpu)
+                with self.subTest(src=src_label, dst=dst_label, op="clone"):
+                    self.assertEqual(src_mps.clone().cpu(), expected)
+                with self.subTest(src=src_label, dst=dst_label, op="cpu"):
+                    self.assertEqual(src_mps.cpu(), expected)
+                with self.subTest(src=src_label, dst=dst_label, op="copy_"):
+                    self.assertEqual(dst_mps.cpu(), dst_cpu)
 
     def test_tensor_scalar_binops(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/119088

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -14670,6 +14670,24 @@ class TestErrorInputs(TestCase):
 
 
 class TestComplex(TestCase):
+    def test_conj_imag(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/184379
+        # MPS copy ignored the neg bit, so `.imag` on a conjugate view returned
+        # the original imaginary values instead of their negation.
+        x = torch.tensor([1 + 2j, 3 - 4j], device="mps")
+        self.assertEqual(x.conj().imag.cpu(), x.cpu().conj().imag)
+
+    def test_neg_bit_materialized_by_clone(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/184379
+        # clone() must materialize the neg bit on MPS so downstream consumers
+        # (the math-bit fallback, .cpu() via _to_copy, etc.) see negated data.
+        y = torch.tensor([1.0, 2.0, 3.0], device="mps")._neg_view()
+        self.assertTrue(y.is_neg())
+        expected = torch.tensor([-1.0, -2.0, -3.0])
+        self.assertEqual(y.clone(), expected)
+        self.assertEqual(y.resolve_neg(), expected)
+        self.assertEqual(y.cpu(), expected)
+
     def test_tensor_scalar_binops(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/119088
         def to_cpu(x):

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -11,7 +11,6 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfMPS,
-    expectedFailureMPS,
     instantiate_device_type_tests,
     onlyCPU,
     onlyNativeDeviceTypes,
@@ -527,8 +526,8 @@ class TestViewOps(TestCase):
         self.assertEqual(a[5:].imag, a.imag[5:])
 
     @onlyNativeDeviceTypes
-    @expectedFailureMPS
     @dtypes(*complex_types())
+    @dtypesIfMPS(torch.cfloat)
     def test_conj_imag_view(self, device, dtype) -> None:
         t = _make_tensor((4, 5), dtype, device)
         t_numpy_conj = torch.from_numpy(t.cpu().numpy().conj()).to(device=device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #184403

MPS copy kernel handles is_conj but not is_neg, so cloning or printing a tensor with the negative bit set (`x.conj().imag` for example) returns the un-negated underlying data.

Fix by mirroring existing conjugation handling logic
Fixes https://github.com/pytorch/pytorch/issues/184379

Authored with Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo