### PR TITLE
[BE] Exclude `c10/metal` from HEADER_ONLY wraps

### DIFF
--- a/tools/wrap_headers.py
+++ b/tools/wrap_headers.py
@@ -18,6 +18,8 @@ EXCLUDE_PATTERNS = (
     "torch/csrc/stable/",
     "torch/csrc/inductor/aoti_torch/c/",
     "torch/csrc/inductor/aoti_torch/generated/",
+    # Metal headers are GPU only, so by defentions they are headeronly
+    "c10/metal/",
     # Third-party headers: not part of the torch stable API surface, and
     # wrapping them creates an incremental-build cycle because the install
     # step un-wraps them on every build (source content differs from the


### PR DESCRIPTION
StableABI protects only CPU code part, and headers when used are fully migrated into the compiled `metallib`