### PR TITLE
Upload docs preview from a workflow_run job, not the OSDC pod

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -343,22 +343,41 @@ jobs:
           pip install $(echo dist/*.whl)[opt-einsum]
           ./.ci/pytorch/${DOCS_TYPE}_doc_push_script.sh
 
-      - name: Install AWS CLI
-        if: ${{ steps.aws-creds.outcome == 'success' && steps.build-docs.outcome == 'success' }}
-        run: pip install awscli==1.29.40
-
-      - name: Upload Python Docs Preview
-        if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}
+      # The OSDC pod cannot upload to s3://doc-previews directly: fork PRs cannot
+      # authenticate via OIDC, and we don't want to grant the pod's IAM role
+      # write access. Stage the built docs as a GHA artifact and let the
+      # upload-docs-preview workflow (running via workflow_run in the base repo
+      # context) do the actual S3 upload.
+      - name: Stage docs preview artifact (PR)
+        if: ${{ github.event_name == 'pull_request' && steps.build-docs.outcome == 'success' }}
+        shell: bash
         run: |
-          aws s3 sync pytorch_docs/main/ s3://doc-previews/pytorch/pytorch/${{ github.event.pull_request.number }} --delete --quiet
+          set -ex
+          if [ "${{ matrix.docs_type }}" = "python" ]; then
+            src_dir="pytorch_docs/main"
+          else
+            src_dir="cppdocs"
+          fi
+          mkdir -p docs-preview-staging
+          cp -r "${src_dir}" docs-preview-staging/content
+          cat > docs-preview-staging/pr-metadata.txt <<EOF
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          DOCS_TYPE=${{ matrix.docs_type }}
+          SHA=${{ github.sha }}
+          EOF
 
-      - name: Upload C++ Docs Preview
-        if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
-        run: |
-          aws s3 sync cppdocs/ s3://doc-previews/pytorch/pytorch/${{ github.event.pull_request.number }}/cppdocs --delete --quiet
+      - name: Upload docs preview artifact (PR)
+        if: ${{ github.event_name == 'pull_request' && steps.build-docs.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-preview-osdc-${{ matrix.docs_type }}
+          path: docs-preview-staging
+          retention-days: 14
+          if-no-files-found: error
 
       - name: Post C++ Docs Coverage Comment
-        if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
+        # Skip on fork PRs since the GITHUB_TOKEN is read-only there.
+        if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -391,14 +410,10 @@ jobs:
 
           gh pr comment "$PR_NUM" --body "$body"
 
-      - name: Upload C++ Docs Preview (nightly dry-run)
-        if: ${{ steps.aws-creds.outcome == 'success' && !inputs.push && github.event_name != 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
-        run: |
-          # Unlike EC2 runners, the OSDC container doesn't have aws CLI pre-installed
-          pip install awscli==1.29.40
-          aws s3 cp cppdocs/ s3://doc-previews/pytorch/pytorch/nightly-${{ github.sha }}/cppdocs --recursive --quiet
-          echo "C++ docs preview available at:"
-          echo "https://docs-preview.pytorch.org/pytorch/pytorch/nightly-${{ github.sha }}/cppdocs/index.html"
+      # The nightly C++ dry-run preview is intentionally not produced from the
+      # OSDC path: the upload-docs-preview workflow_run uploader only handles
+      # PR events. If nightly OSDC previews are needed, extend that uploader
+      # to trigger on the corresponding workflow.
 
   memory-viz-tests:
     # Tests for torch memory visualizer

--- a/.github/workflows/upload-docs-preview.yml
+++ b/.github/workflows/upload-docs-preview.yml
@@ -73,11 +73,11 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
         run: |
-          aws s3 sync docs-preview-staging/content/ "s3://doc-previews/pytorch/pytorch/${PR_NUMBER}" --delete --quiet
+          aws s3 sync docs-preview-staging/content/ "s3://doc-previews/pytorch/pytorch/${PR_NUMBER}" --quiet
 
       - name: Upload C++ docs preview
         if: ${{ steps.download.outcome == 'success' && matrix.docs_type == 'cpp' }}
         env:
           PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
         run: |
-          aws s3 sync docs-preview-staging/content/ "s3://doc-previews/pytorch/pytorch/${PR_NUMBER}/cppdocs" --delete --quiet
+          aws s3 sync docs-preview-staging/content/ "s3://doc-previews/pytorch/pytorch/${PR_NUMBER}/cppdocs" --quiet

--- a/.github/workflows/upload-docs-preview.yml
+++ b/.github/workflows/upload-docs-preview.yml
@@ -1,0 +1,83 @@
+name: Upload docs preview
+
+# Runs in the base-repo context so it has the AWS credentials needed to write
+# to s3://doc-previews. This exists because OSDC docs builds run in a k8s pod
+# that does not (and should not) have S3 write permission, and fork PRs cannot
+# authenticate via OIDC from the build job itself. The pull.yml docs job stages
+# the built docs as a GHA artifact; this workflow downloads that artifact and
+# performs the actual S3 upload.
+
+on:
+  workflow_run:
+    workflows:
+      - pull
+    types:
+      - completed
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  upload-docs-preview:
+    if: >-
+      github.repository_owner == 'pytorch' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        docs_type: [python, cpp]
+    steps:
+      - name: Download docs preview artifact
+        id: download
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: docs-preview-osdc-${{ matrix.docs_type }}
+          path: docs-preview-staging
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        if: steps.download.outcome == 'success'
+        id: metadata
+        shell: bash
+        run: |
+          set -ex
+          if [ ! -f docs-preview-staging/pr-metadata.txt ]; then
+            echo "pr-metadata.txt missing from artifact, aborting."
+            exit 1
+          fi
+          # shellcheck disable=SC1091
+          source docs-preview-staging/pr-metadata.txt
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "PR_NUMBER is empty, aborting."
+            exit 1
+          fi
+          echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+          echo "docs_type=${DOCS_TYPE}" >> "${GITHUB_OUTPUT}"
+
+      - name: Configure AWS credentials
+        if: steps.download.outcome == 'success'
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/arc
+          aws-region: us-east-1
+          role-session-name: docs-preview-uploader
+
+      - name: Upload Python docs preview
+        if: ${{ steps.download.outcome == 'success' && matrix.docs_type == 'python' }}
+        env:
+          PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+        run: |
+          aws s3 sync docs-preview-staging/content/ "s3://doc-previews/pytorch/pytorch/${PR_NUMBER}" --delete --quiet
+
+      - name: Upload C++ docs preview
+        if: ${{ steps.download.outcome == 'success' && matrix.docs_type == 'cpp' }}
+        env:
+          PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+        run: |
+          aws s3 sync docs-preview-staging/content/ "s3://doc-previews/pytorch/pytorch/${PR_NUMBER}/cppdocs" --delete --quiet


### PR DESCRIPTION
## Summary

- The OSDC (k8s pod) docs build cannot upload docs previews to S3: fork PRs cannot authenticate via OIDC from the build job, and we don't want to grant the pod's IAM role S3 write access on `doc-previews/`.
- Move the upload out of the build pod. `build-docs-osdc` now stages the built docs as a GHA artifact (`docs-preview-osdc-<docs_type>`) along with a `pr-metadata.txt` that records the PR number.
- A new `upload-docs-preview` workflow is triggered by `workflow_run` on completion of the `pull` workflow. It runs in the base-repo context (full OIDC + secrets), downloads the staged artifact, and performs the `aws s3 sync` to `s3://doc-previews/pytorch/pytorch/<PR#>[/cppdocs]`. This works for fork PRs.
- The EC2 docs upload path (which uses the EC2 instance profile credentials) is unchanged.
- The C++ docs coverage PR comment stays in `_docs.yml` but is now gated on the PR being from a branch in the base repo, so the read-only fork `GITHUB_TOKEN` no longer causes spurious failures.
- The OSDC nightly C++ dry-run upload step is removed; if needed it can be restored later by extending the new uploader to trigger on additional workflows.

## Follow-ups (out of scope here)

- Update the trust policy of `arn:aws:iam::308535385114:role/arc` so it can be assumed from this `workflow_run` workflow (the OIDC subject points to the base repo, so this should already be compatible).
- Optionally drop S3 write to `doc-previews/` from the OSDC pod's IAM policy now that the pod no longer uploads.

## Test plan

- [ ] Open a same-repo PR after this lands; verify `docs-preview-osdc-python` and `docs-preview-osdc-cpp` artifacts are produced by `linux-docs`.
- [ ] Verify the `Upload docs preview` workflow_run job runs to completion and uploads to `s3://doc-previews/pytorch/pytorch/<PR#>/` and `<PR#>/cppdocs/`.
- [ ] Verify the preview URLs resolve: `https://docs-preview.pytorch.org/pytorch/pytorch/<PR#>/index.html` and `.../<PR#>/cppdocs/index.html`.
- [ ] Open a fork PR (or simulate one); confirm the artifacts upload and the workflow_run uploader still publishes the preview (previously the OSDC path silently no-op'd).
- [ ] Confirm the C++ coverage comment still posts on same-repo PRs touching `docs/cpp/`, and skips cleanly on fork PRs without producing a failed step.

Authored by Claude.