### PR TITLE
Fix pow(-0.0, +/-0.5) sign on sqrt/rsqrt shortcut

### DIFF
--- a/aten/src/ATen/native/cpu/PowKernel.cpp
+++ b/aten/src/ATen/native/cpu/PowKernel.cpp
@@ -94,12 +94,35 @@ static void pow_tensor_scalar_kernel(
 
   if (dtype == ScalarType::Float || dtype == ScalarType::Double ||
       dtype == kBFloat16 || isComplexType(dtype)) {
-    // Dispatch to fast specialization for sqrt, rsqrt and reciprocal
+    // Adding zero before sqrt/rsqrt cancels the sign of -0.0 so
+    // pow(-0.0, +/-0.5) returns a positive result per IEEE-754.
     if (exp_scalar.equal(.5)) {
-      sqrt_kernel(iter);
+      if (isComplexType(dtype)) {
+        sqrt_kernel(iter);
+      } else {
+        AT_DISPATCH_FLOATING_TYPES_AND(kBFloat16, dtype, "pow_half", [&]() {
+          using Vec = Vectorized<scalar_t>;
+          cpu_kernel_vec(iter,
+              [](scalar_t base) -> scalar_t {
+                return std::sqrt(base + scalar_t(0));
+              },
+              [](Vec base) -> Vec { return (base + Vec(scalar_t(0))).sqrt(); });
+        });
+      }
       return;
     } else if (exp_scalar.equal(-0.5)) {
-      rsqrt_kernel(iter);
+      if (isComplexType(dtype)) {
+        rsqrt_kernel(iter);
+      } else {
+        AT_DISPATCH_FLOATING_TYPES_AND(kBFloat16, dtype, "pow_neg_half", [&]() {
+          using Vec = Vectorized<scalar_t>;
+          cpu_kernel_vec(iter,
+              [](scalar_t base) __ubsan_ignore_float_divide_by_zero__ -> scalar_t {
+                return scalar_t(1) / std::sqrt(base + scalar_t(0));
+              },
+              [](Vec base) -> Vec { return (base + Vec(scalar_t(0))).rsqrt(); });
+        });
+      }
       return;
     } else if (exp_scalar.equal(-1.0)) {
       reciprocal_kernel(iter);

--- a/aten/src/ATen/native/cuda/PowKernel.cu
+++ b/aten/src/ATen/native/cuda/PowKernel.cu
@@ -168,12 +168,32 @@ void pow_tensor_scalar_kernel_impl(TensorIteratorBase& iter,
 }
 
 void pow_tensor_scalar_kernel(TensorIteratorBase& iter, const Scalar& exp_scalar) {
-  // Dispatch to fast specialization for sqrt, rsqrt and reciprocal
+  // Adding zero before sqrt/rsqrt cancels the sign of -0.0 so
+  // pow(-0.0, +/-0.5) returns a positive result per IEEE-754.
   if (!exp_scalar.isComplex()) {
+    const auto common_dtype = iter.common_dtype();
     if (exp_scalar.equal(.5)) {
-      return sqrt_kernel_cuda(iter);
+      if (isComplexType(common_dtype)) {
+        return sqrt_kernel_cuda(iter);
+      }
+      AT_DISPATCH_FLOATING_TYPES_AND2(
+          ScalarType::Half, ScalarType::BFloat16, common_dtype, "pow_half_cuda", [&]() {
+            gpu_kernel(iter, []GPU_LAMBDA(scalar_t base) -> scalar_t {
+              return std::sqrt(base + scalar_t(0));
+            });
+          });
+      return;
     } else if (exp_scalar.equal(-0.5)) {
-      return rsqrt_kernel_cuda(iter);
+      if (isComplexType(common_dtype)) {
+        return rsqrt_kernel_cuda(iter);
+      }
+      AT_DISPATCH_FLOATING_TYPES_AND2(
+          ScalarType::Half, ScalarType::BFloat16, common_dtype, "pow_neg_half_cuda", [&]() {
+            gpu_kernel(iter, []GPU_LAMBDA(scalar_t base) -> scalar_t {
+              return ::rsqrt(base + scalar_t(0));
+            });
+          });
+      return;
     } else if (exp_scalar.equal(-1.0)) {
       return reciprocal_kernel_cuda(iter);
     }

--- a/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
@@ -580,6 +580,22 @@ struct rsqrt_functor {
   }
 };
 
+// x + T(0) cancels the sign of -0.0 so pow(-0.0, 0.5) returns +0.0.
+struct pow_half_functor {
+  template <typename T>
+  inline enable_if_t<is_scalar_floating_point_v<T>, T> operator()(const T x) {
+    return T(::precise::sqrt(x + T(0)));
+  }
+};
+
+// x + T(0) cancels the sign of -0.0 so pow(-0.0, -0.5) returns +inf.
+struct pow_neg_half_functor {
+  template <typename T>
+  inline enable_if_t<is_scalar_floating_point_v<T>, T> operator()(const T x) {
+    return T(::precise::rsqrt(x + T(0)));
+  }
+};
+
 struct neg_functor {
   template <typename T>
   inline T operator()(const T x) {
@@ -716,6 +732,13 @@ INSTANTIATE_UNARY_KERNELS2(float, char);
 INSTANTIATE_UNARY_KERNELS2(float, short);
 INSTANTIATE_UNARY_KERNELS2(float, int);
 INSTANTIATE_UNARY_KERNELS2(float, long);
+
+REGISTER_UNARY_OP(pow_half, float, float);
+REGISTER_UNARY_OP(pow_half, half, half);
+REGISTER_UNARY_OP(pow_half, bfloat, bfloat);
+REGISTER_UNARY_OP(pow_neg_half, float, float);
+REGISTER_UNARY_OP(pow_neg_half, half, half);
+REGISTER_UNARY_OP(pow_neg_half, bfloat, bfloat);
 
 #define INSTANTIATE_UNARY_KERNELS_VEC2(DTYPE)        \
   REGISTER_UNARY_OP(angle, DTYPE##2, DTYPE##2);      \

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -36,11 +36,19 @@ static void pow_tensor_scalar_kernel(TensorIteratorBase& iter, const Scalar& exp
   if (!exp_scalar.isComplex() && exp_scalar.to<float>() == -1.0) {
     return lib.exec_unary_kernel(iter, "reciprocal");
   }
+  // Route +/-0.5 through pow_half / pow_neg_half so pow(-0.0, +/-0.5)
+  // returns a positive result.
   if (!exp_scalar.isComplex() && exp_scalar.to<float>() == -.5) {
-    return lib.exec_unary_kernel(iter, "rsqrt");
+    if (c10::isComplexType(iter.common_dtype())) {
+      return lib.exec_unary_kernel(iter, "rsqrt");
+    }
+    return lib.exec_unary_kernel(iter, "pow_neg_half");
   }
   if (!exp_scalar.isComplex() && exp_scalar.to<float>() == .5) {
-    return lib.exec_unary_kernel(iter, "sqrt");
+    if (c10::isComplexType(iter.common_dtype())) {
+      return lib.exec_unary_kernel(iter, "sqrt");
+    }
+    return lib.exec_unary_kernel(iter, "pow_half");
   }
   if (exp_scalar.isComplex() || c10::isComplexType(iter.common_dtype())) {
     return lib.exec_unary_kernel(iter, "pow_scalar", exp_scalar, ScalarType::ComplexFloat);

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -22,6 +22,7 @@ from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfCPU,
     dtypesIfCUDA,
+    dtypesIfMPS,
     dtypesIfXPU,
     expectedFailureMeta,
     instantiate_device_type_tests,
@@ -1623,6 +1624,36 @@ class TestBinaryUfuncs(TestCase):
         for base, exponent in test_inputs:
             regex = "doesn't match the broadcast shape"
             self.assertRaisesRegex(RuntimeError, regex, base.pow_, exponent)
+
+    @dtypes(torch.float32, torch.float64, torch.float16, torch.bfloat16)
+    @dtypesIfMPS(torch.float32, torch.float16, torch.bfloat16)
+    def test_pow_neg_zero(self, device, dtype):
+        neg_zero = torch.tensor([0.0, -0.0], dtype=dtype, device=device)
+
+        res_half = torch.pow(neg_zero, 0.5)
+        self.assertEqual(res_half.tolist(), [0.0, 0.0])
+        self.assertFalse(torch.signbit(res_half).any().item())
+
+        res_neg_half = torch.pow(neg_zero, -0.5)
+        self.assertEqual(res_neg_half.tolist(), [inf, inf])
+        self.assertFalse(torch.signbit(res_neg_half).any().item())
+
+        positive = torch.tensor([1.0, 4.0, 9.0, 16.0], dtype=dtype, device=device)
+        self.assertEqual(torch.pow(positive, 0.5), torch.sqrt(positive))
+        self.assertEqual(torch.pow(positive, -0.5), torch.rsqrt(positive))
+
+        nan_t = torch.tensor([nan], dtype=dtype, device=device)
+        self.assertTrue(torch.isnan(torch.pow(nan_t, 0.5)).item())
+        self.assertTrue(torch.isnan(torch.pow(nan_t, -0.5)).item())
+
+        pos_inf = torch.tensor([inf], dtype=dtype, device=device)
+        self.assertEqual(torch.pow(pos_inf, 0.5).item(), inf)
+        self.assertEqual(torch.pow(pos_inf, -0.5).item(), 0.0)
+        self.assertFalse(torch.signbit(torch.pow(pos_inf, -0.5)).item())
+
+        neg_finite = torch.tensor([-2.0], dtype=dtype, device=device)
+        self.assertTrue(torch.isnan(torch.pow(neg_finite, 0.5)).item())
+        self.assertTrue(torch.isnan(torch.pow(neg_finite, -0.5)).item())
 
     def test_int_tensor_pow_neg_ints(self, device):
         ints = [

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7045,7 +7045,8 @@ def pow(a, b):
     if isinstance(b, float) and b.is_integer():
         return pow(a, int(b))
     elif isinstance(b, float) and b == 0.5:
-        return sqrt(a)
+        # Cancel the sign of -0.0 so pow(-0.0, 0.5) is +0.0.
+        return sqrt(add(a, 0.0))
     elif isinstance(b, int) and b == 1:
         return clone(a)
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1344,7 +1344,8 @@ def pow(
         elif statically_known_true(b == 2.0):
             return a * a  # type: ignore[return-value]
         elif statically_known_true(b == 0.5):
-            return torch.sqrt(a)  # type: ignore[arg-type]
+            # Cancel the sign of -0.0 so pow(-0.0, 0.5) is +0.0.
+            return torch.sqrt(a + 0)  # type: ignore[arg-type,operator]
     elif isinstance(a, Number):
         if statically_known_true(a == 1.0):
             return torch.fill(b, True)


### PR DESCRIPTION
Fixes #127163

`pow(x, +/-0.5)` routed through the sqrt / rsqrt fast path preserved the sign of `-0.0`, so `pow(-0.0, 0.5)` returned `-0.0` and `pow(-0.0, -0.5)` returned `-inf`. 

According to IEEE-754 / Array API both should be positive. 

Fix: `kernel(x + 0.0)`. `-0.0 + 0.0 == +0.0` canonicalizes the sign; every other finite input is bit-identical.

Applied at CPU `PowKernel.cpp`, CUDA `PowKernel.cu`, MPS `UnaryKernel.metal` + `.mm` (new `pow_half` / `pow_neg_half` kernels), `_refs.pow`, and the Inductor `aten.pow` lowering. Complex base still routes through the existing `sqrt_kernel` / `rsqrt_kernel`.

## Repro

```python
import torch
x = torch.tensor([0.0, -0.0])
print(torch.pow(x, 0.5), torch.pow(x, -0.5))
```

Before: `tensor([0., -0.]) tensor([inf, -inf])`
After:  `tensor([0., 0.])  tensor([inf, inf])`

## Perf

Median ns/call. CPU = Apple M5, single-threaded. Baseline = torch 2.11.0 on the same machine.

CPU fp32:

| Shape   | sqrt   | pow(0.5) main  | pow(0.5) PR    | pow(-0.5) main | pow(-0.5) PR   |
| ---     | ---    | ---            | ---            | ---            | ---            |
| 1024    | 458    | 667 (1.46x)    | 667 (1.46x)    | 708 (1.42x)    | 750 (1.39x)    |
| 65536   | 8167   | 8500 (1.05x)   | 8167 (1.00x)   | 11875 (1.03x)  | 11875 (1.02x)  |
| 1048576 | 119417 | 120229 (1.01x) | 115750 (0.97x) | 174833 (1.00x) | 174875 (1.00x) |

The added `+ 0` is offset by inlining the kernel instead of going through the `sqrt_kernel(iter)` stub. No measurable CPU regression.

CUDA RTX 4090 (sm_8.9), this PR:
(Pre-PR not in table but the diff results were identical to CPU's)
| Shape   | dtype | sqrt  | pow(0.5)      | rsqrt | pow(-0.5)     |
| ---     | ---   | ---   | ---           | ---   | ---           |
| 65536   | fp32  | 13540 | 15730 (1.16x) | 13230 | 15870 (1.20x) |
| 65536   | fp64  | 14145 | 15850 (1.12x) | 13385 | 15880 (1.19x) |
| 65536   | fp16  | 13425 | 15686 (1.17x) | 13155 | 15535 (1.18x) |
| 65536   | bf16  | 13380 | 15590 (1.17x) | 13190 | 15490 (1.17x) |
| 1048576 | fp32  | 13160 | 15440 (1.17x) | 13155 | 15995 (1.22x) |
| 1048576 | fp64  | 25510 | 29360 (1.15x) | 20190 | 24140 (1.20x) |
| 1048576 | fp16  | 13455 | 15830 (1.18x) | 13135 | 15540 (1.18x) |
| 1048576 | bf16  | 13400 | 24300 (1.81x) | 13305 | 15630 (1.17x) |

The 1.12-1.22x is `aten.pow.Tensor_Scalar` wrapper overhead vs `aten.sqrt`, present on main too (main also routes `pow(0.5)` to `sqrt_kernel_cuda` via the same wrapper). bf16 1048576 1.81x is a cold-load outlier.

Validated locally with `test_pow_neg_zero` (4 dtypes), full `pow` / `sqrt` / `_pow_` OpInfo suites (1536 tests), `test_mps.py -k test_pow`, an Inductor smoke test, and a CUDA RTX 4090 run; all green.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo