### PR TITLE
DTensor.to_local() drops the _is_param marker that nn.Parameter sets on custom-tensor i...

### DIFF
--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -8,6 +8,7 @@ import unittest
 from numpy.testing import assert_array_equal
 
 import torch
+import torch.nn as nn
 import torch.distributed as dist
 import torch.nn.functional as F
 from torch.distributed._functional_collectives import AsyncCollectiveTensor
@@ -529,6 +530,32 @@ class DTensorTest(DTensorTestBase):
                 raise AssertionError(
                     "Expected local_no_grad to be sharded_tensor._local_tensor"
                 )
+
+    @with_comms
+    def test_to_local_preserves_parameter(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/166156:
+        # nn.Parameter wrapping a DTensor must remain isinstance(nn.Parameter)
+        # after calling .to_local() (both with and without grad enabled).
+        device_mesh = self.build_device_mesh()
+        global_tensor = torch.randn(4 * self.world_size, 3, requires_grad=True)
+        dtensor_param = nn.Parameter(
+            distribute_tensor(global_tensor, device_mesh, [Shard(0)])
+        )
+        self.assertTrue(isinstance(dtensor_param, nn.Parameter))
+
+        local = dtensor_param.to_local()
+        self.assertTrue(isinstance(local, nn.Parameter))
+        # Internal storage must not be mutated into a Parameter.
+        self.assertFalse(getattr(dtensor_param._local_tensor, "_is_param", False))
+
+        with torch.no_grad():
+            local_no_grad = dtensor_param.to_local()
+        self.assertTrue(isinstance(local_no_grad, nn.Parameter))
+        self.assertFalse(getattr(dtensor_param._local_tensor, "_is_param", False))
+
+        # A plain DTensor (not a Parameter) must NOT become a Parameter.
+        plain = distribute_tensor(global_tensor, device_mesh, [Shard(0)])
+        self.assertFalse(isinstance(plain.to_local(), nn.Parameter))
 
     @with_comms
     def test_to_local_grad_hint(self):

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -8,8 +8,8 @@ import unittest
 from numpy.testing import assert_array_equal
 
 import torch
-import torch.nn as nn
 import torch.distributed as dist
+import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed._functional_collectives import AsyncCollectiveTensor
 from torch.distributed.device_mesh import init_device_mesh
@@ -535,7 +535,8 @@ class DTensorTest(DTensorTestBase):
     def test_to_local_preserves_parameter(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/166156:
         # nn.Parameter wrapping a DTensor must remain isinstance(nn.Parameter)
-        # after calling .to_local() (both with and without grad enabled).
+        # after calling .to_local() (both with and without grad enabled), and
+        # autograd must continue to flow back into the DTensor parameter.
         device_mesh = self.build_device_mesh()
         global_tensor = torch.randn(4 * self.world_size, 3, requires_grad=True)
         dtensor_param = nn.Parameter(
@@ -545,8 +546,15 @@ class DTensorTest(DTensorTestBase):
 
         local = dtensor_param.to_local()
         self.assertTrue(isinstance(local, nn.Parameter))
+        # requires_grad must follow the DTensor parameter.
+        self.assertTrue(local.requires_grad)
         # Internal storage must not be mutated into a Parameter.
         self.assertFalse(getattr(dtensor_param._local_tensor, "_is_param", False))
+
+        # Gradient must still propagate through the returned local Parameter
+        # back into the DTensor parameter (to_local is differentiable).
+        local.sum().backward()
+        self.assertIsNotNone(dtensor_param.grad)
 
         with torch.no_grad():
             local_no_grad = dtensor_param.to_local()

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -602,13 +602,28 @@ class DTensor(torch.Tensor):
             will depend on if the `DTensor` requires_grad or not.
         """
         if not torch.is_grad_enabled():
-            return self._local_tensor
+            result = self._local_tensor
+        else:
+            if grad_placements is not None and not isinstance(grad_placements, tuple):
+                grad_placements = tuple(grad_placements)
+            result = _ToTorchTensor.apply(
+                self, grad_placements
+            )  # pyre-ignore[16]: autograd func
 
-        if grad_placements is not None and not isinstance(grad_placements, tuple):
-            grad_placements = tuple(grad_placements)
-        return _ToTorchTensor.apply(
-            self, grad_placements
-        )  # pyre-ignore[16]: autograd func
+        # Preserve nn.Parameter-ness: if self is an nn.Parameter (i.e. has the
+        # _is_param flag, which is how Parameter is represented for custom
+        # tensor subclasses like DTensor), make the returned local tensor also
+        # satisfy isinstance(result, nn.Parameter).
+        if getattr(self, "_is_param", False) and not getattr(
+            result, "_is_param", False
+        ):
+            if result is self._local_tensor:
+                # Avoid mutating the internal storage of this DTensor by
+                # returning a fresh view to attach the flag to.
+                result = result.view_as(result)
+            result._is_param = True
+
+        return result
 
     def redistribute(
         self,

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -613,7 +613,15 @@ class DTensor(torch.Tensor):
         # Preserve nn.Parameter-ness: if self is an nn.Parameter (i.e. has the
         # _is_param flag, which is how Parameter is represented for custom
         # tensor subclasses like DTensor), make the returned local tensor also
-        # satisfy isinstance(result, nn.Parameter).
+        # satisfy isinstance(result, nn.Parameter). See gh-166156.
+        #
+        # BC: this branch only runs when self has `_is_param` set, i.e. self
+        # is already a Parameter(DTensor). All raw-DTensor call sites are
+        # byte-for-byte unchanged, including the historical identity guarantee
+        # `to_local() is self._local_tensor` in the no-grad path. The only
+        # observable change is the targeted bug fix: Parameter(DTensor) inputs
+        # no longer return a plain Tensor.
+        #
         # We probe `_is_param` via getattr rather than isinstance(self,
         # nn.Parameter) for two reasons: (1) it avoids importing torch.nn at
         # this layer, and (2) it matches the exact mechanism that

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -614,6 +614,11 @@ class DTensor(torch.Tensor):
         # _is_param flag, which is how Parameter is represented for custom
         # tensor subclasses like DTensor), make the returned local tensor also
         # satisfy isinstance(result, nn.Parameter).
+        # We probe `_is_param` via getattr rather than isinstance(self,
+        # nn.Parameter) for two reasons: (1) it avoids importing torch.nn at
+        # this layer, and (2) it matches the exact mechanism that
+        # nn.parameter._ParameterMeta.__instancecheck__ uses to recognize
+        # Parameter-ness on custom tensor subclasses.
         if getattr(self, "_is_param", False) and not getattr(
             result, "_is_param", False
         ):


### PR DESCRIPTION
## Agent Report
### Summary
`nn.Parameter(dtensor).to_local()` returned a plain `torch.Tensor` rather than
preserving the `nn.Parameter` identity. After the fix, `isinstance(local, nn.Parameter)`
correctly mirrors `isinstance(dtensor, nn.Parameter)` in both grad-enabled and
no-grad modes.

### Root Cause
`nn.Parameter` represents Parameter-ness for custom tensor subclasses (like
`DTensor`) by setting a `_is_param = True` flag on the instance.
`torch.nn.parameter._ParameterMeta.__instancecheck__` looks at that flag when it
decides whether `isinstance(x, nn.Parameter)` is True.

`DTensor.to_local()` in `torch/distributed/tensor/_api.py` returned either
`self._local_tensor` (no_grad path) or the result of `_ToTorchTensor.apply`
(grad path). Neither carries the `_is_param` flag from the wrapping DTensor, so
the returned tensor was treated as a plain `torch.Tensor`.

### Fix
`torch/distributed/tensor/_api.py`: after computing the local result, if the
DTensor itself is an `nn.Parameter` (has `_is_param`), stamp `_is_param = True`
on the returned tensor. In the no-grad branch the returned tensor IS the
DTensor's internal `_local_tensor`, so we first take a `view_as` (a fresh
tensor object that shares storage) and set the flag on the view — this keeps
the DTensor's internal storage from accidentally becoming a Parameter.

This mirrors the design of `nn.Parameter.__new__` for custom tensors, which
also sets `_is_param` on a fresh instance returned by `detach()`.

We probe `_is_param` via `getattr` rather than `isinstance(self, nn.Parameter)`
because (1) this layer of the stack should not need a `torch.nn` import, and
(2) `_ParameterMeta.__instancecheck__` itself uses the `_is_param` attribute to
decide Parameter-ness for custom tensor subclasses, so the two are equivalent
by construction.

### Repro
The repro script asserts the expected Parameter-ness on the returned local
tensor. Before the fix, the assertions raise and the script exits 1; after the
fix, the assertions pass and the script exits 0.
Run:

```bash
python repro_166156_generated.py
```

<details>
<summary>Repro Script</summary>

```python
"""
Repro for pytorch/pytorch#166156:
Parameter.to_local() will make parameter a normal tensor.

This script asserts that calling .to_local() on an nn.Parameter wrapping a
DTensor preserves its Parameter-ness. It exits non-zero when the bug is
present (before the fix) and exits 0 only when the fix is in place.
"""

import os
import sys
import torch
import torch.nn as nn
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed.tensor import distribute_tensor, Replicate


def main() -> int:
    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
    os.environ.setdefault("MASTER_PORT", "29501")
    os.environ.setdefault("WORLD_SIZE", "1")
    os.environ.setdefault("RANK", "0")
    torch.distributed.init_process_group(backend="gloo")
    try:
        mesh = init_device_mesh("cpu", (1,))
        t = torch.randn(4, 4, requires_grad=True)
        dt = distribute_tensor(t, mesh, [Replicate()])
        w = nn.Parameter(dt)

        print(
            "Before to_local: "
            f"type={type(w).__name__}, "
            f"isinstance Parameter: {isinstance(w, nn.Parameter)}"
        )
        # Sanity check: the wrapped DTensor IS a Parameter at this point.
        assert isinstance(w, nn.Parameter), (
            "Precondition failed: nn.Parameter(DTensor) should itself be an "
            "nn.Parameter."
        )

        local = w.to_local()
        print(
            "After to_local (grad enabled): "
            f"type={type(local).__name__}, "
            f"isinstance Parameter: {isinstance(local, nn.Parameter)}"
        )

        with torch.no_grad():
            local_nograd = w.to_local()
        print(
            "After to_local (no grad): "
            f"type={type(local_nograd).__name__}, "
            f"isinstance Parameter: {isinstance(local_nograd, nn.Parameter)}"
        )

        # These assertions encode the reported failure: before the fix in
        # torch/distributed/tensor/_api.py:DTensor.to_local, both of these
        # return a plain Tensor, not an nn.Parameter, and the assertions fail
        # (script exits non-zero). After the fix, both pass.
        assert isinstance(local, nn.Parameter), (
            "BUG #166156: nn.Parameter(DTensor).to_local() returned a "
            "non-Parameter tensor in grad-enabled mode."
        )
        assert isinstance(local_nograd, nn.Parameter), (
            "BUG #166156: nn.Parameter(DTensor).to_local() returned a "
            "non-Parameter tensor in no_grad mode."
        )

        print("OK: nn.Parameter-ness preserved by DTensor.to_local()")
        return 0
    finally:
        torch.distributed.destroy_process_group()


if __name__ == "__main__":
    sys.exit(main())
```

</details>

### Testing
`test_fix.py` (extended edge cases) all pass:

```
Replicate Parameter preserved: OK
Shard Parameter preserved: OK
Parameter(requires_grad=False) preserved: OK
Non-Parameter DTensor stays plain tensor: OK
Internal _local_tensor not mutated: OK
Gradient flow through to_local: OK

All checks passed.
```

A new regression test was added at
`test/distributed/tensor/test_dtensor.py::DTensorTest::test_to_local_preserves_parameter`.
The DTensor test harness defaults to NCCL on a host with CUDA but no NCCL
build (this sandbox), so the in-tree distributed test suite could not be run
in-place here. Logic of the test exactly mirrors the standalone checks above,
which all pass; the in-tree test should be exercised in CI before merge.

The in-tree regression test covers the autograd-related concerns flagged by
the reviewers:

- Asserts `local.requires_grad` is True for a grad-requiring Parameter.
- Calls `.sum().backward()` on the returned local Parameter and asserts
  `dtensor_param.grad is not None`, confirming autograd still flows back into
  the DTensor parameter after the `_is_param` marker is stamped on the
  non-leaf result of `_ToTorchTensor.apply`.
- Asserts the internal `_local_tensor` of the DTensor is NOT mutated into a
  Parameter in either path (the `view_as` guard for the no_grad branch).
- Negative case: a plain (non-Parameter) DTensor must NOT become a Parameter
  after `to_local()`.

### Existing assertion preserved
`test_dtensor_constructor` (same file) asserts that in the no-grad case the
returned local tensor IS `sharded_tensor._local_tensor`. That test wraps a raw
`DTensor` rather than an `nn.Parameter`, so the new `_is_param` branch does not
trigger and the identity-equals behavior remains unchanged.

### Lint
`spin fixlint torch/distributed/tensor/_api.py test/distributed/tensor/test_dtensor.py`
reports "No lint issues" on both lintrunner passes (RUFF/PYREFLY/... and
PYFMT/CODESPELL/FLAKE8/...).

## Files Changed
- `torch/distributed/tensor/_api.py`
- `test/distributed/tensor/test_dtensor.py`


Fixes #166156

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*