### PR TITLE
Narrow ExternKernel argument property typing

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -26,7 +26,15 @@ from typing import (
     TypeVar,
     Union,
 )
-from typing_extensions import assert_never, Never, override, ParamSpec, Self, TypeIs
+from typing_extensions import (
+    assert_never,
+    Never,
+    override,
+    ParamSpec,
+    Self,
+    TypedDict,
+    TypeIs,
+)
 from unittest.mock import patch
 
 import sympy
@@ -152,6 +160,13 @@ _IntLike: TypeAlias = int | Expr
 _NumLike: TypeAlias = int | float | Expr
 
 _OpOverloads: TypeAlias = torch._ops.OpOverload | torch._ops.HigherOrderOperator
+
+
+class ArgProperty(TypedDict, total=False):
+    name: str
+    type: torch.JitType
+    default_value: object
+
 
 log = logging.getLogger(__name__)
 indent = functools.partial(textwrap.indent, prefix="  ")
@@ -564,7 +579,7 @@ class IRNode:
     traceback: list[str] | None = dataclasses.field(init=False)
     origin_node: torch.fx.Node | None = dataclasses.field(init=False)
     # Annotations dict for storing metadata (e.g., KernelTemplateChoice)
-    annotations: dict[str, Any] = dataclasses.field(init=False)
+    annotations: dict[str, object] = dataclasses.field(init=False)
     # User-annotated stream index from FX node metadata (set during lowering)
     stream_idx: int | None = dataclasses.field(init=False)
 
@@ -5342,7 +5357,7 @@ class TemplateBuffer(OperationBuffer):
         self.name = V.graph.register_buffer(self)
         V.graph.register_operation(self)
         # Annotations dict for storing metadata (e.g., KernelTemplateChoice)
-        self.annotations: dict[str, Any] = {}
+        self.annotations: dict[str, object] = {}
 
         # Output buffer names eligible for epilogue fusion.
         # Maps buffer name → kernel parameter name (e.g. "buf3" → "result").
@@ -5639,11 +5654,11 @@ class ChoiceCaller:
         # A place to store annotations that can be read post benchmarking
         # Use this to shuttle information between ChoieCaller generation
         # and the end of benchmarking
-        self.annotations: dict[Any, Any] = {}
+        self.annotations: dict[str, object] = {}
         # Subclass-overridden attributes for subgraph-based choices
         self.gm: torch.fx.GraphModule | None = None
         self.decomposition: Callable[..., Any] | None = None
-        self.decomposition_kwargs: dict[str, Any] = {}
+        self.decomposition_kwargs: dict[str, object] = {}
         self.config_patches: dict[str, Any] = {}
 
     def benchmark(self, *args: Any, out: torch.Tensor) -> float:
@@ -6292,11 +6307,11 @@ class ExternKernel(InputsKernel):
         default_factory=list
     )
     op_overload: _OpOverloads | None = None
-    arg_properties: list[dict[str, Any]] | None = None
-    allarg_properties: dict[str, dict[str, Any]] = dataclasses.field(
+    arg_properties: list[ArgProperty] | None = None
+    allarg_properties: dict[str, ArgProperty] = dataclasses.field(
         default_factory=dict
     )
-    kwarg_properties: dict[str, dict[str, Any]] | None = None
+    kwarg_properties: dict[str, ArgProperty] | None = None
     unbacked_bindings: dict[sympy.Symbol, pytree.KeyPath] = dataclasses.field(
         default_factory=dict
     )
@@ -6332,7 +6347,7 @@ class ExternKernel(InputsKernel):
         self.mutation_outputs = []
         self.fx_node = V.graph.current_node
         # Annotations dict for storing metadata (e.g., KernelTemplateChoice)
-        self.annotations: dict[str, Any] = {}
+        self.annotations: dict[str, object] = {}
 
     def get_outputs(self) -> list[Buffer]:
         return [self, *self.mutation_outputs]
@@ -7057,8 +7072,10 @@ class ExternKernel(InputsKernel):
                 assert len(self.constant_args) == len(names), (
                     "names passed to codegen_const_args does not match self.constant_args"
                 )
-                name_to_arg_properties = {
-                    arg.get("name"): arg for arg in self.arg_properties
+                name_to_arg_properties: dict[str, ArgProperty] = {
+                    name: arg
+                    for arg in self.arg_properties
+                    if (name := arg.get("name")) is not None
                 }
 
             for i, x in enumerate(self.constant_args):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6308,9 +6308,7 @@ class ExternKernel(InputsKernel):
     )
     op_overload: _OpOverloads | None = None
     arg_properties: list[ArgProperty] | None = None
-    allarg_properties: dict[str, ArgProperty] = dataclasses.field(
-        default_factory=dict
-    )
+    allarg_properties: dict[str, ArgProperty] = dataclasses.field(default_factory=dict)
     kwarg_properties: dict[str, ArgProperty] | None = None
     unbacked_bindings: dict[sympy.Symbol, pytree.KeyPath] = dataclasses.field(
         default_factory=dict
@@ -7067,12 +7065,12 @@ class ExternKernel(InputsKernel):
             # in which case the following 'len(self.inputs) + i' logic works. But this
             # may not be true for other ops, and if that is the case, caller needs to
             # pass in a list of const arg names for arg_properties lookup.
-            name_to_arg_properties = None
+            name_to_arg_properties: dict[str, ArgProperty] | None = None
             if names and self.arg_properties:
                 assert len(self.constant_args) == len(names), (
                     "names passed to codegen_const_args does not match self.constant_args"
                 )
-                name_to_arg_properties: dict[str, ArgProperty] = {
+                name_to_arg_properties = {
                     name: arg
                     for arg in self.arg_properties
                     if (name := arg.get("name")) is not None


### PR DESCRIPTION
Summary:
- Add an `ArgProperty` `TypedDict` for `ExternKernel` schema-derived argument metadata.
- Use the typed property dict for positional, all-argument, and keyword property maps.
- Narrow related annotation and decomposition kwargs containers from `Any` values to `object`.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo