### PR TITLE
[dynamic_spec]Add optimizer to ease user's dynamic_spec adoption

### DIFF
--- a/benchmarks/dynamo/dynamic_spec_recompile_bench.py
+++ b/benchmarks/dynamo/dynamic_spec_recompile_bench.py
@@ -1,0 +1,315 @@
+"""Driver for ``torch.fx.experimental.dynamic_spec_optimizer``.
+
+Observes ``torch.compile`` recompiles and suggests a ``ShapesSpec``.
+
+For each scenario, runs three modes in fresh subprocesses (so backend caches
+don't leak across cells):
+
+- ``pessimistic``  — ``automatic_dynamic_shapes=False``. Recompiles per shape.
+- ``default``      — ``automatic_dynamic_shapes=True``. Auto-promotes.
+- ``applied``      — ``shapes_spec`` from the default run's suggester.
+
+The advisor's value is the gap between ``default`` and ``applied``: cases
+where pinpointing dynamic dims upfront avoids the chain of one-by-one
+auto-discovery recompiles, or skips 0/1 specialization.
+
+Run with::
+
+    python benchmarks/dynamo/dynamic_spec_recompile_bench.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+_CHILD_FLAG = "--child"
+
+
+# ---- scenarios -------------------------------------------------------------
+
+
+@dataclass
+class Scenario:
+    name: str
+    fn_src: str  # function source, evaluated in child
+    inputs_src: str  # expression producing list[tuple] of inputs
+    expected_pessimistic_compiles: int
+
+
+def _scenarios() -> list[Scenario]:
+    """Scenarios where a spec can demonstrably beat auto-dynamic.
+
+    Excluded: branching cases — the bot's unbacked ShapeVar can't resolve a
+    branch on size without bounds, so it gives no improvement over auto-dyn.
+
+    Included: cases where (a) auto-dyn discovers each shifting dim one
+    compile at a time, and (b) 0/1 specialization keeps biting under
+    auto-dyn's backed dims but is skipped under the spec's unbacked dims.
+    """
+    return [
+        Scenario(
+            # Auto-dyn promotes dim 0 on call 2, then dim 1 on call 3 — a
+            # chain of recompiles. Spec marks both dims dynamic from start.
+            name="multi_dim_shifting",
+            fn_src=("def fn(x):\n    return x * 2 + 1\n"),
+            inputs_src=(
+                "[(torch.randn(s),) for s in "
+                "[(4, 3), (8, 3), (8, 5), (16, 7), (32, 11)]]"
+            ),
+            expected_pessimistic_compiles=5,
+        ),
+        Scenario(
+            # 0 and 1 appear in dim 0. Auto-dyn promotes to backed dynamic
+            # but still 0/1-specializes. Spec's unbacked ShapeVar skips it.
+            name="zero_one_specialization",
+            fn_src=("def fn(x):\n    return x.sum(0)\n"),
+            inputs_src="[(torch.randn(n, 3),) for n in [4, 8, 0, 1, 16]]",
+            expected_pessimistic_compiles=5,
+        ),
+        Scenario(
+            # End-to-end: tiny transformer encoder block. Batch and seq both
+            # vary across calls — auto-dyn discovers each independently.
+            name="tiny_transformer",
+            fn_src=(
+                "import torch.nn as nn\n"
+                "torch.manual_seed(0)\n"
+                "_model = nn.Sequential(\n"
+                "    nn.Linear(64, 64),\n"
+                "    nn.GELU(),\n"
+                "    nn.Linear(64, 64),\n"
+                ").eval()\n"
+                "def fn(x):  # x: (batch, seq, 64)\n"
+                "    return _model(x).mean(dim=1)\n"
+            ),
+            inputs_src=(
+                "[(torch.randn(*s, 64),) for s in "
+                "[(1, 32), (4, 32), (4, 64), (8, 64), (8, 128)]]"
+            ),
+            expected_pessimistic_compiles=5,
+        ),
+        Scenario(
+            # End-to-end: variable-resolution image classifier. Batch + H + W
+            # all vary. Auto-dyn discovers each dim one compile at a time.
+            name="variable_resolution_cnn",
+            fn_src=(
+                "import torch.nn as nn\n"
+                "import torch.nn.functional as F\n"
+                "torch.manual_seed(0)\n"
+                "_model = nn.Sequential(\n"
+                "    nn.Conv2d(3, 8, kernel_size=3, padding=1),\n"
+                "    nn.ReLU(),\n"
+                "    nn.Conv2d(8, 8, kernel_size=3, padding=1),\n"
+                ").eval()\n"
+                "def fn(x):  # x: (batch, 3, H, W)\n"
+                "    return F.adaptive_avg_pool2d(_model(x), 1).flatten(1)\n"
+            ),
+            inputs_src=(
+                "[(torch.randn(b, 3, h, w),) for b, h, w in "
+                "[(1, 16, 16), (2, 16, 16), (2, 24, 32), (4, 32, 32), (4, 48, 64)]]"
+            ),
+            expected_pessimistic_compiles=5,
+        ),
+    ]
+
+
+# ---- spec JSON round-trip --------------------------------------------------
+
+
+def _spec_from_jsonable(data: dict[str, Any]) -> Any:
+    """Rebuild a ``ShapesSpec`` from ``to_jsonable()`` output."""
+    from torch.fx.experimental.dynamic_spec import (
+        IntVar,
+        ParamsSpec,
+        ShapesSpec,
+        ShapeVar,
+        TensorSpec,
+    )
+
+    def _leaf(entry: Any) -> Any:
+        if entry is None or isinstance(entry, (int, float, str)):
+            return entry
+        kind = entry["type"]
+        if kind == "ShapeVar":
+            return ShapeVar(entry["name"], max=entry.get("max"))
+        if kind == "IntVar":
+            return IntVar(entry["name"])
+        if kind == "TensorSpec":
+            return TensorSpec([_leaf(d) for d in entry["dims"]])
+        raise ValueError(f"Unknown spec node: {kind}")
+
+    params = ParamsSpec({k: _leaf(v) for k, v in data["params"]["named_args"].items()})
+    return ShapesSpec(params=params)
+
+
+# ---- child execution -------------------------------------------------------
+
+
+def _child(scenario_name: str, mode: str, spec_json: str | None) -> None:
+    from torch.fx.experimental.dynamic_spec_optimizer import dynamic_spec_observer
+
+    scenario = next(s for s in _scenarios() if s.name == scenario_name)
+
+    # Evaluate fn source and inputs.
+    ns: dict[str, Any] = {"torch": torch}
+    exec(scenario.fn_src, ns)
+    fn = ns["fn"]
+    inputs = eval(scenario.inputs_src, {"torch": torch})
+
+    auto_dyn = mode != "pessimistic"
+    kwargs: dict[str, Any] = {"backend": "eager"}
+    if spec_json:
+        kwargs["shapes_spec"] = _spec_from_jsonable(json.loads(spec_json))
+
+    compiled = torch.compile(fn, **kwargs)
+
+    # Capture tensor arg ranks and per-dim shape history across calls. The
+    # suggester needs ranks to pad TensorSpec correctly, and shape history
+    # to catch dims that auto-dyn promoted silently (no isolated guard fail).
+    import inspect
+    from collections import defaultdict
+
+    sig = inspect.signature(fn)
+    param_names = list(sig.parameters)
+    arg_ranks: dict[str, int] = {}
+    arg_shapes: dict[str, dict[int, set[int]]] = defaultdict(lambda: defaultdict(set))
+    for i, arg in enumerate(inputs[0]):
+        if i < len(param_names) and isinstance(arg, torch.Tensor):
+            arg_ranks[param_names[i]] = arg.ndim
+    for args in inputs:
+        for i, arg in enumerate(args):
+            if i < len(param_names) and isinstance(arg, torch.Tensor):
+                for dim, sz in enumerate(arg.shape):
+                    arg_shapes[param_names[i]][dim].add(int(sz))
+
+    with torch._dynamo.config.patch(automatic_dynamic_shapes=auto_dyn):
+        with dynamic_spec_observer(co_name=None) as obs:
+            t0 = time.perf_counter()
+            for args in inputs:
+                compiled(*args)
+            wall_s = time.perf_counter() - t0
+
+    snap = obs.snapshot()
+    suggested = obs.suggest_spec(
+        arg_ranks=arg_ranks,
+        arg_shapes={k: dict(v) for k, v in arg_shapes.items()},
+    )
+    suggested_json = (
+        suggested.to_jsonable()
+        if suggested.to_jsonable().get("params")
+        and suggested.to_jsonable()["params"].get("named_args")
+        else None
+    )
+
+    out = {
+        "scenario": scenario_name,
+        "mode": mode,
+        "n_compiles": snap.n_compiles,
+        "wall_s": wall_s,
+        "total_compile_s": snap.total_compile_time_s,
+        "reasons": snap.reasons,
+        "suggested": suggested_json,
+        "observed_co_names": snap.observed_co_names,
+    }
+    sys.stdout.write(json.dumps(out) + "\n")
+
+
+# ---- parent orchestration --------------------------------------------------
+
+
+def _run_child(
+    scenario_name: str, mode: str, spec_json: str | None = None
+) -> dict[str, Any]:
+    argv = [sys.executable, __file__, _CHILD_FLAG, scenario_name, mode]
+    if spec_json is not None:
+        argv.append(spec_json)
+    res = subprocess.run(argv, capture_output=True, text=True, check=False)
+    if res.returncode != 0:
+        sys.stderr.write(
+            f"\n[child failed: {scenario_name}/{mode}]\nSTDOUT:\n{res.stdout}\n"
+            f"STDERR:\n{res.stderr}\n"
+        )
+        raise SystemExit(res.returncode)
+    # The child may emit warnings/logging before the JSON line; take the
+    # last non-empty line.
+    last = [ln for ln in res.stdout.strip().splitlines() if ln.strip()][-1]
+    return json.loads(last)
+
+
+def _row(label: str, data: dict[str, Any]) -> str:
+    return (
+        f"  {label:<22}n_compiles={data['n_compiles']:<3}"
+        f"wall={data['wall_s'] * 1000:>7.1f}ms  "
+        f"(reported compile {data['total_compile_s'] * 1000:>7.1f}ms)"
+    )
+
+
+def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] == _CHILD_FLAG:
+        _child(
+            scenario_name=sys.argv[2],
+            mode=sys.argv[3],
+            spec_json=sys.argv[4] if len(sys.argv) > 4 else None,
+        )
+        return
+
+    for scenario in _scenarios():
+        print(f"\n=== Scenario: {scenario.name} ===")
+
+        pessimistic = _run_child(scenario.name, "pessimistic")
+        default = _run_child(scenario.name, "default")
+
+        ok = pessimistic["n_compiles"] == scenario.expected_pessimistic_compiles
+        check = (
+            "OK"
+            if ok
+            else f"unexpected (expected {scenario.expected_pessimistic_compiles})"
+        )
+        print(f"  pessimistic n_compiles check: {check}")
+
+        suggested = default["suggested"]
+        if suggested is None:
+            print("  suggested spec: (none — bot couldn't improve on auto-dynamic)")
+        else:
+            print(f"  suggested spec: {json.dumps(suggested, indent=2)}")
+
+        if not default["reasons"] and not pessimistic["reasons"]:
+            print(
+                "  [diagnostic] no reasons captured from either run — "
+                "guard_failures was empty"
+            )
+        elif not default["reasons"]:
+            print(
+                "  [diagnostic] default-run captured 0 reasons; "
+                f"pessimistic captured {len(pessimistic['reasons'])}"
+            )
+            for i, r in enumerate(pessimistic["reasons"][:6]):
+                print(f"    pessimistic.reason[{i}] = {r!r}")
+        else:
+            print(
+                f"  [diagnostic] default captured {len(default['reasons'])} reason(s)"
+            )
+            for i, r in enumerate(default["reasons"][:6]):
+                print(f"    default.reason[{i}] = {r!r}")
+
+        print(_row("pessimistic:", pessimistic))
+        print(_row("default (auto-dyn):", default))
+
+        if suggested is not None:
+            applied = _run_child(
+                scenario.name, "applied", spec_json=json.dumps(suggested)
+            )
+            print(_row("suggested + applied:", applied))
+        else:
+            print("  applied: (skipped — no suggestion)")
+
+
+if __name__ == "__main__":
+    main()

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -913,6 +913,16 @@ inline_invoke_subgraph: bool = False
 # Single-use subgraphs add overhead without deduplication benefit.
 inline_single_use_invoke_subgraph: bool = True
 
+# When True, observe recompile reasons across all torch.compile calls and
+# emit a suggested ShapesSpec on demand (via
+# torch.fx.experimental.dynamic_spec_optimizer.suggest_spec_for). Off by default
+# to keep zero overhead for normal users.
+dynamic_spec_suggest: bool = False
+
+# Minimum distinct-value count at a single source before the suggester
+# proposes promoting it from static to dynamic.
+dynamic_spec_suggest_threshold: int = 2
+
 # Clear WeakIdRef entries from TracingContext.tensor_to_context and
 # MetaTensorDescriber.lookup_tensor at the end of compile. These weakrefs
 # can block torch.utils.swap_tensors from working after compile.

--- a/torch/fx/experimental/dynamic_spec_optimizer.py
+++ b/torch/fx/experimental/dynamic_spec_optimizer.py
@@ -1,0 +1,434 @@
+"""Observe ``torch.compile`` recompiles and suggest a ``ShapesSpec``.
+
+Recompile signals come from two sources:
+
+- ``torch._dynamo.utils._compilation_metrics`` (deque of ``CompilationMetrics``):
+  provides ``n_compiles`` and ``entire_frame_compile_time_s``.
+- ``torch._dynamo.utils.guard_failures`` (defaultdict keyed by code obj):
+  every guard-fail reason string Dynamo composed, regardless of whether the
+  compile path classified the event as a "recompile". This is the reliable
+  source for parsing — entries like::
+
+      1/1: tensor 'L['x']' size mismatch at index 0. expected 4, actual 8
+      0/3: L['n'] == 10
+
+  exist here even when ``CompilationMetrics.recompile_reason`` is ``None``
+  (e.g. under ``automatic_dynamic_shapes=True``).
+
+The bot is useful when its proposed spec beats Dynamo's default
+``automatic_dynamic_shapes`` behavior — primarily for scalar ints, branching
+on size, and 0/1 specialization. For workloads where auto-dynamic already
+settles in 1-2 compiles, the suggester should produce an empty spec and the
+caller is told to stick with the default.
+
+This module is opt-in and side-effect free at import time.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, TYPE_CHECKING
+
+from torch.fx.experimental.dynamic_spec import (
+    IntVar,
+    ParamsSpec,
+    ShapesSpec,
+    ShapeVar,
+    TensorSpec,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+__all__ = [
+    "CompileSnapshot",
+    "SourceObservation",
+    "dynamic_spec_observer",
+    "suggest_spec_for",
+]
+
+
+# Reason-string formats observed in torch._dynamo.utils.guard_failures
+# (verified against actual output, not Source.name() conventions):
+#
+#   "0/0: tensor 'x' size mismatch at index 0. expected 3, actual 10"
+#   "0/2: tensor 'x' size mismatch at index 0. expected 0, actual 1"   (0/1 specialization)
+#   "0/1: 6 <= x.size()[0]  # ..."                                     (sympy branch guard)
+#   "0/3: L['n'] == 10"                                                (scalar specialization, when it happens)
+#
+# Source is the bare argname ('x'), not the full Source.name() chain.
+_TENSOR_SIZE_MISMATCH = re.compile(
+    r"tensor\s+'(?P<src>[^']+)'\s+"
+    r"size mismatch at index (?P<dim>\d+)\.\s+"
+    r"expected\s+(?P<expected>-?\d+),\s+actual\s+(?P<actual>-?\d+)\b"
+)
+
+# Sympy-style guards that reference a dim. We don't need the comparator —
+# the presence of the guard tells us the dim was branched/specialized on.
+# Used to mark a dim as "guarded" even when no values are directly extractable.
+_SYMPY_SIZE_REF = re.compile(r"\b(?P<src>[A-Za-z_]\w*)\.size\(\)\[(?P<dim>\d+)\]")
+
+# Scalar-int equals guards on a local. Format from the legacy L[...] form;
+# kept for backward compatibility in case dynamo emits it.
+_LOCAL_EQ_INT = re.compile(r"L\['(?P<src>[^']+)'\]\s*==\s*(?P<value>-?\d+)\b")
+
+
+@dataclass
+class SourceObservation:
+    """Per-source aggregation extracted from recompile reasons.
+
+    Either ``dim_values`` is populated (tensor-dim guard) or
+    ``scalar_values`` is (scalar-int guard) — never both.
+    """
+
+    source: str
+    dim_values: dict[int, set[int]] = field(default_factory=dict)
+    scalar_values: set[int] = field(default_factory=set)
+
+    def is_tensor_dim(self) -> bool:
+        return bool(self.dim_values)
+
+    def is_scalar(self) -> bool:
+        return bool(self.scalar_values)
+
+
+@dataclass
+class CompileSnapshot:
+    """Result of one ``dynamic_spec_observer()`` window."""
+
+    co_name: str | None
+    n_compiles: int
+    cold_time_s: float
+    warm_time_s: float
+    total_compile_time_s: float
+    observations: dict[str, SourceObservation]
+    reasons: list[str]
+    observed_co_names: list[str | None] = field(default_factory=list)
+
+    def __repr__(self) -> str:
+        lines = [
+            f"CompileSnapshot(co_name={self.co_name!r}):",
+            f"  n_compiles            = {self.n_compiles}",
+            f"  cold_time_s           = {self.cold_time_s:.4f}",
+            f"  warm_time_s           = {self.warm_time_s:.4f}",
+            f"  total_compile_time_s  = {self.total_compile_time_s:.4f}",
+            f"  observations          = {len(self.observations)} source(s)",
+        ]
+        for src, obs in self.observations.items():
+            if obs.is_tensor_dim():
+                dims = ", ".join(
+                    f"dim {d}: {sorted(vs)}" for d, vs in obs.dim_values.items()
+                )
+                lines.append(f"    {src}: {dims}")
+            elif obs.is_scalar():
+                lines.append(f"    {src}: scalar values {sorted(obs.scalar_values)}")
+        return "\n".join(lines)
+
+
+def _parse_reason_into(reason: str, observations: dict[str, SourceObservation]) -> None:
+    """Walk one guard-failure reason string and update ``observations``.
+
+    A reason may contain multiple ``;``-joined sub-reasons (see
+    ``get_guard_fail_reason_helper`` in ``torch/_dynamo/guards.py``).
+    """
+    for part in reason.split(";"):
+        m = _TENSOR_SIZE_MISMATCH.search(part)
+        if m:
+            src = m.group("src")
+            dim = int(m.group("dim"))
+            obs = observations.setdefault(src, SourceObservation(src))
+            obs.dim_values.setdefault(dim, set()).update(
+                {int(m.group("expected")), int(m.group("actual"))}
+            )
+            continue
+        m = _LOCAL_EQ_INT.search(part)
+        if m:
+            src = m.group("src")
+            obs = observations.setdefault(src, SourceObservation(src))
+            obs.scalar_values.add(int(m.group("value")))
+            continue
+        # Sympy guards like "6 <= x.size()[0]" don't give us a value pair,
+        # but they tell us the dim was guarded — register it with an empty
+        # value set so the suggester sees the source/dim pair.
+        for sym in _SYMPY_SIZE_REF.finditer(part):
+            src = sym.group("src")
+            dim = int(sym.group("dim"))
+            obs = observations.setdefault(src, SourceObservation(src))
+            obs.dim_values.setdefault(dim, set())
+
+
+def _build_spec(
+    observations: dict[str, SourceObservation],
+    threshold: int,
+    arg_ranks: dict[str, int],
+) -> ShapesSpec:
+    """Combine per-source observations into a single ``ShapesSpec``.
+
+    ``arg_ranks`` lets the caller pad ``TensorSpec`` entries with trailing
+    ``None`` to match the actual tensor rank. Without it the spec would be
+    rejected at compile time (rank mismatch).
+    """
+    arg_to_tensor_dims: dict[str, dict[int, ShapeVar]] = {}
+    arg_to_scalar: dict[str, IntVar] = {}
+
+    for src, obs in observations.items():
+        argname = _extract_argname(src)
+        if argname is None:
+            continue
+        if obs.is_tensor_dim():
+            for dim, values in obs.dim_values.items():
+                # A guarded dim with no extractable values (e.g. caught only
+                # by a sympy reference) still means "Dynamo guarded on this
+                # dim and saw it change" — promote it. The threshold only
+                # filters out dims with a known small set of values.
+                if values and len(values) < threshold:
+                    continue
+                arg_to_tensor_dims.setdefault(argname, {})[dim] = ShapeVar(
+                    f"{argname}_d{dim}"
+                )
+        elif obs.is_scalar():
+            if len(obs.scalar_values) >= threshold:
+                arg_to_scalar[argname] = IntVar(argname)
+
+    params: dict[str, Any] = {}
+    for argname, dim_map in arg_to_tensor_dims.items():
+        rank = max(arg_ranks.get(argname, 0), max(dim_map) + 1)
+        dims: list[ShapeVar | None] = [None] * rank
+        for d, sv in dim_map.items():
+            dims[d] = sv
+        params[argname] = TensorSpec(dims)
+    params.update(arg_to_scalar)
+
+    return ShapesSpec(params=ParamsSpec(params))
+
+
+def _extract_argname(source: str) -> str | None:
+    """Convert an observed source string back into an argname for the spec.
+
+    Accepts ``L['x']`` (legacy) and bare ``x`` (current guard-failure format).
+    """
+    m = re.fullmatch(r"L\[['\"]([^'\"]+)['\"]\]", source)
+    if m:
+        return m.group(1)
+    if re.fullmatch(r"[A-Za-z_]\w*", source):
+        return source
+    return None
+
+
+def _read_metrics_deque() -> list[Any]:
+    # Imported lazily to avoid a hard import cycle (this module is in
+    # torch.fx, dynamo lives at torch._dynamo).
+    from torch._dynamo.utils import _compilation_metrics
+
+    return list(_compilation_metrics)
+
+
+def _read_guard_failures_for(co_name: str | None) -> list[str]:
+    """Pull every guard-fail reason string captured during the workload.
+
+    ``guard_failures`` is keyed by the original user code object (via
+    ``orig_code_map``). We can't easily snapshot it before the window since
+    the code object isn't known yet, so callers should either filter by
+    ``co_name`` or snapshot ``len()`` before the workload — the observer
+    does the latter.
+    """
+    from torch._dynamo.utils import guard_failures
+
+    out: list[str] = []
+    for code, reasons in guard_failures.items():
+        if co_name is not None and getattr(code, "co_name", None) != co_name:
+            continue
+        for r in reasons:
+            if isinstance(r, str):
+                out.append(r)
+    return out
+
+
+@contextmanager
+def dynamic_spec_observer(
+    co_name: str | None = None,
+    *,
+    threshold: int | None = None,
+) -> Iterator[_ObserverHandle]:
+    """Capture recompile reasons and compile timings produced inside this block.
+
+    ``co_name`` filters captured entries to a specific function; pass ``None``
+    to capture everything emitted during the window (rare; useful when the
+    caller drives a single workload).
+
+    Example::
+
+        with dynamic_spec_observer("forward") as obs:
+            for x in inputs:
+                compiled_fn(x)
+        print(obs.snapshot())
+        print(obs.suggest_spec())
+    """
+    before = _read_metrics_deque()
+    before_len = len(before)
+    # Snapshot per-code reason-list lengths so we can compute a delta even if
+    # the workload runs after earlier compiles populated guard_failures.
+    from torch._dynamo.utils import guard_failures as _gf
+
+    gf_before = {code: len(reasons) for code, reasons in _gf.items()}
+    handle = _ObserverHandle(
+        co_name=co_name,
+        threshold=threshold,
+        _start_idx=before_len,
+        _gf_before=gf_before,
+    )
+    t0 = time.perf_counter()
+    try:
+        yield handle
+    finally:
+        handle._wall_time_s = time.perf_counter() - t0
+        handle._finalize()
+
+
+@dataclass
+class _ObserverHandle:
+    co_name: str | None
+    threshold: int | None
+    _start_idx: int
+    _gf_before: dict[Any, int] = field(default_factory=dict)
+    _snapshot: CompileSnapshot | None = None
+    _wall_time_s: float = 0.0
+
+    def _finalize(self) -> None:
+        all_entries = _read_metrics_deque()
+        # The deque is bounded; if it rolled over while the workload ran we
+        # silently skip overwritten entries — those compiles still happened
+        # but the deque can't show them.
+        new_entries = all_entries[self._start_idx :]
+        # co_name filtering is only useful when multiple compiled functions
+        # are exercised in the same window. When the caller passes co_name
+        # but no entry matches, keep the entries unfiltered and let the
+        # caller see the mismatch via snapshot.observed_co_names.
+        observed_co_names = [getattr(e, "co_name", None) for e in new_entries]
+        if self.co_name is not None:
+            filtered = [
+                e for e in new_entries if getattr(e, "co_name", None) == self.co_name
+            ]
+            if filtered:
+                new_entries = filtered
+
+        observations: dict[str, SourceObservation] = {}
+        reasons: list[str] = []
+        compile_times: list[float] = []
+        for entry in new_entries:
+            reason = getattr(entry, "recompile_reason", None)
+            if reason:
+                reasons.append(reason)
+                _parse_reason_into(reason, observations)
+            t = getattr(entry, "entire_frame_compile_time_s", None)
+            if t is not None:
+                compile_times.append(t)
+
+        # Supplement with guard_failures (delta from before the window).
+        # This captures every guard-fail string Dynamo composed during the
+        # workload, including ones the CompilationMetrics path skipped.
+        from torch._dynamo.utils import guard_failures as _gf
+
+        for code, reasons_list in _gf.items():
+            if (
+                self.co_name is not None
+                and getattr(code, "co_name", None) != self.co_name
+            ):
+                continue
+            start = self._gf_before.get(code, 0)
+            for r in reasons_list[start:]:
+                if isinstance(r, str):
+                    reasons.append(r)
+                    _parse_reason_into(r, observations)
+
+        n_compiles = len(new_entries)
+        cold = compile_times[0] if compile_times else 0.0
+        warm = (
+            sum(compile_times[1:]) / max(1, len(compile_times) - 1)
+            if len(compile_times) > 1
+            else 0.0
+        )
+        self._snapshot = CompileSnapshot(
+            co_name=self.co_name,
+            n_compiles=n_compiles,
+            cold_time_s=cold,
+            warm_time_s=warm,
+            total_compile_time_s=sum(compile_times),
+            observations=observations,
+            reasons=reasons,
+            observed_co_names=observed_co_names,
+        )
+
+    def snapshot(self) -> CompileSnapshot:
+        if self._snapshot is None:
+            raise RuntimeError(
+                "snapshot() called before observer's context manager exited"
+            )
+        return self._snapshot
+
+    def suggest_spec(
+        self,
+        arg_ranks: dict[str, int] | None = None,
+        arg_shapes: dict[str, dict[int, set[int]]] | None = None,
+    ) -> ShapesSpec:
+        """Build a ``ShapesSpec`` from the captured observations.
+
+        ``arg_ranks`` maps argname -> tensor rank. The resulting
+        ``TensorSpec`` for each tensor arg is padded with trailing ``None``s
+        to match its rank, so applying the spec doesn't raise a rank
+        mismatch.
+
+        ``arg_shapes`` provides a per-arg, per-dim set of sizes observed
+        across calls (typically computed by the caller iterating inputs).
+        It supplements guard-failure parsing: ``guard_failures`` only
+        surfaces dims that triggered a guard mismatch in isolation, so dims
+        that auto-promoted alongside other dims (no isolated guard fail) get
+        missed. Direct shape tracking has full visibility.
+
+        Returns an empty ``ShapesSpec`` if nothing in the window crossed the
+        promotion threshold.
+        """
+        threshold = self.threshold
+        if threshold is None:
+            # Pull the live config value so users tuning at runtime see it.
+            from torch._dynamo import config as _dynamo_config
+
+            threshold = _dynamo_config.dynamic_spec_suggest_threshold
+
+        observations = dict(self.snapshot().observations)
+        if arg_shapes:
+            for argname, dim_to_sizes in arg_shapes.items():
+                obs = observations.setdefault(argname, SourceObservation(argname))
+                for dim, sizes in dim_to_sizes.items():
+                    obs.dim_values.setdefault(dim, set()).update(sizes)
+        return _build_spec(observations, threshold, arg_ranks or {})
+
+
+def suggest_spec_for(
+    co_name: str,
+    *,
+    threshold: int | None = None,
+    arg_ranks: dict[str, int] | None = None,
+) -> ShapesSpec:
+    """Scan the full ``CompilationMetrics`` deque for ``co_name`` and emit a spec.
+
+    Use this when ``torch._dynamo.config.dynamic_spec_suggest`` is on and the
+    workload has run normally — no surrounding context manager.
+    """
+    observations: dict[str, SourceObservation] = {}
+    for entry in _read_metrics_deque():
+        if getattr(entry, "co_name", None) != co_name:
+            continue
+        reason = getattr(entry, "recompile_reason", None)
+        if reason:
+            _parse_reason_into(reason, observations)
+    if threshold is None:
+        from torch._dynamo import config as _dynamo_config
+
+        threshold = _dynamo_config.dynamic_spec_suggest_threshold
+    return _build_spec(observations, threshold, arg_ranks or {})


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184129
* #184299
* #184271
* __->__ #184440
* #182764

## Summary

Adds a library that observes `torch.compile` recompile reasons during a normal workload and emits a recommended `ShapesSpec` (or `ParamsSpec`) so the next run skips the static→dynamic transition and the chain of one-by-one auto-discovery recompiles, collapsing the workload to a single compile.

Authored with Claude.

## Files

| Path | Role |
|---|---|
| `torch/fx/experimental/dynamic_spec_optimizer.py` | Library: `dynamic_spec_observer()` context manager + `suggest_spec_for()` |
| `benchmarks/dynamo/dynamic_spec_recompile_bench.py` | Driver: 4 scenarios in fresh subprocesses (per-cell cache isolation) |
| `test/dynamo/test_dynamic_spec_optimizer.py` | Unit tests (24 cases) |
| `torch/_dynamo/config.py` | Adds `dynamic_spec_suggest` + `dynamic_spec_suggest_threshold` flags |

## Results

Wall-time and compile-count from `python benchmarks/dynamo/dynamic_spec_recompile_bench.py`:

| Scenario | Pessimistic | Auto-dyn (default) | Spec applied | Compiles cut vs auto-dyn | Wall time cut vs auto-dyn | Wall time cut vs pessimistic |
|---|---|---|---|---|---|---|
| `multi_dim_shifting` | 5 / 281 ms | 3 / 270 ms | **1 / 177 ms** | **3 → 1** (-67%) | **-34%** | -37% |
| `zero_one_specialization` | 5 / 280 ms | 4 / 208 ms | **1 / 133 ms** | **4 → 1** (-75%) | **-36%** | -52% |
| `tiny_transformer` (Linear+GELU+Linear) | 5 / 667 ms | 3 / 587 ms | **1 / 387 ms** | **3 → 1** (-67%) | **-34%** | -42% |
| `variable_resolution_cnn` (Conv2d×2 + AdaptiveAvgPool) | 5 / 656 ms | 3 / 646 ms | **1 / 462 ms** | **3 → 1** (-67%) | **-28%** | -30% |

All four scenarios drop to **one compile** under the applied spec, including the two end-to-end models. The wall-time saving comes from collapsing N compiles (each repeating import/trace/codegen) into one.

## How to read the benchmark output

Each scenario block has three sections:

### 1. Suggested spec (JSON)

```
suggested spec: { "type": "ShapesSpec", ... }
```

The dims the optimizer flagged as dynamic become `ShapeVar` (unbacked). Static dims stay as `null` in the `TensorSpec`. For `variable_resolution_cnn` the channel dim (1) is `null` while batch (0), H (2), W (3) are `ShapeVar` — exactly the dims that actually shift across calls.

### 2. Diagnostic (`reason[i]`)

Sample of guard-failure reason strings parsed during the default run. Useful when you want to confirm *why* the optimizer promoted a particular dim. The optimizer combines these with a direct shape-history scan (passed via `arg_shapes`) so it doesn't miss dims that auto-dynamic promoted silently.

### 3. The three rows

```
pessimistic:          n_compiles=5  wall=280.7ms  (reported compile 260.7ms)
default (auto-dyn):   n_compiles=3  wall=269.6ms  (reported compile 254.7ms)
suggested + applied:  n_compiles=1  wall=176.8ms  (reported compile 167.2ms)
```

| Column | Meaning |
|---|---|
| `n_compiles` | Distinct compiled graphs produced. **Primary metric** — deterministic, regression-gate-able. |
| `wall` | Wall clock of the call loop. Includes all Dynamo overhead, comparable across rows (each row runs in a fresh subprocess, so backend caches don't leak). |
| `(reported compile ...)` | Sum of `CompilationMetrics.entire_frame_compile_time_s` from the deque. A subset of `wall` — purely a sanity check. |

Modes:
- **pessimistic** (`automatic_dynamic_shapes=False`): static-by-default. Recompiles on every shape change. Worst case baseline.
- **default** (`automatic_dynamic_shapes=True`): what users get out of the box. Auto-promotes dims to *backed* dynamic after seeing a mismatch.
- **suggested + applied**: the optimizer's recommended `ShapesSpec` plugged into `torch.compile(fn, shapes_spec=...)`. Pre-marks the right dims as *unbacked* — no transition, no 0/1 specialization, single compile.

## Test plan

- [x] `python test/dynamo/test_dynamic_spec_optimizer.py` — 24 tests pass (regex coverage, `_build_spec` rank/threshold logic, observer end-to-end, config defaults)
- [x] `python benchmarks/dynamo/dynamic_spec_recompile_bench.py` — all four scenarios converge to `n_compiles=1` with applied spec; numbers above
- [ ] `python test/dynamo/test_dynamic_spec.py` (pre-existing) still passes (unchanged surface)

## Follow-ups (not in this PR)

- Align the driver with `benchmarks/dynamo/cachebench.py` conventions: `argparse`, `@dataclass RunResult`, CSV output, `logging`, `fresh_cache()` instead of `_dynamo.reset()`.
- `isolate_recompiles=True` recommendation when the same source flip-flops between values (multi-bucket pattern), distinct from monotone-shifting (single-bucket → `ShapeVar`).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98