### PR TITLE
Fix TD failure under Python 3.9 from runtime PEP 604 union

### DIFF
--- a/tools/testing/target_determination/heuristics/utils.py
+++ b/tools/testing/target_determination/heuristics/utils.py
@@ -47,7 +47,7 @@ def _get_pr_info(pr_number: int) -> dict[str, object]:
 def _get_pr_merge_base(pr_info: dict[str, object]) -> str:
     base_info = cast(dict[str, object], pr_info["base"])
     base_ref = cast(str, base_info["ref"])
-    base_sha = cast(str | None, base_info.get("sha"))
+    base_sha = cast("str | None", base_info.get("sha"))
     last_error: Exception | None = None
 
     for base in (f"origin/{base_ref}", base_sha):
@@ -64,7 +64,7 @@ def _get_pr_merge_base(pr_info: dict[str, object]) -> str:
         _github_api_json(f"compare/{quote(base_ref, safe='')}...{head}"),
     )
     merge_base_commit = cast(dict[str, object], compare.get("merge_base_commit", {}))
-    merge_base = cast(str | None, merge_base_commit.get("sha"))
+    merge_base = cast("str | None", merge_base_commit.get("sha"))
     if merge_base:
         return merge_base
     if base_sha:


### PR DESCRIPTION
## Summary

Fixes #184441.

The `target-determination` workflow has no `actions/setup-python` step before the "Do TD" step, so on the self-hosted `linux.2xlarge` runner `python3` resolves to the system Python 3.9 (the boto3 install log in the failing job confirms this: `Requirement already satisfied: jmespath ... in /usr/lib/python3.9/site-packages`).

`tools/testing/target_determination/heuristics/utils.py` has `from __future__ import annotations`, which defers evaluation of annotations — but `cast()` is a regular function call, so its first argument is evaluated at runtime. PEP 604 union on `type` objects only works on Python 3.10+; on 3.9 `cast(str | None, ...)` raises `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`. That exception escapes `_get_pr_merge_base` and is caught by each heuristic's outer `try/except`, producing the observed cascade:

```
Error in EditedByPR: unsupported operand type(s) for |: 'type' and 'NoneType'
Error in HistoricalClassFailurCorrelation: ...
Error in CorrelatedWithHistoricalFailures: ...
Error in HistorialEditedFiles: ...
Error in Profiling: ...
Error in Filepath: ...
Error in PublicBindings: ...
```

The two offending runtime expressions landed in #182957 (2026-05-08), which is also when TD failures started becoming user-visible (lookup errors are no longer silently turned into empty heuristic results).

Quote the cast targets so the type expression is never evaluated. `typing.cast` ignores its first argument at runtime, so a forward-reference string works on every Python version.

## Test plan

- [ ] CI `target-determination` job runs without the `unsupported operand type(s) for |` errors.

Authored by Claude.