### PR TITLE
Make DTensor local tensor contiguous after uneven Shard->Replicate redistribute

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -644,6 +644,27 @@ class RedistributeTest(DTensorContinuousTestBase):
         reshard_tensor = shard_tensor.redistribute(device_mesh, shard_minus_spec)
         self.assertEqual(reshard_tensor.placements[0].dim, 1)
 
+    def test_uneven_shard_to_replicate_contiguous_local(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/173041
+        # After all-gathering an uneven Shard(dim>0) back to Replicate the
+        # unpad step does a narrow on a non-leading dim, which would otherwise
+        # leave the local tensor non-contiguous and break downstream view ops
+        # (e.g. inside parallelized nn.Linear).
+        device_mesh = self.build_device_mesh()
+
+        for shard_dim in range(1, 3):
+            shape = [2, 2, 2]
+            # Make the sharded dim uneven across the mesh.
+            shape[shard_dim] = self.world_size * 2 + 1
+            input_tensor = torch.randn(*shape, device=self.device_type)
+
+            sharded = distribute_tensor(input_tensor, device_mesh, [Shard(shard_dim)])
+            replicated = sharded.redistribute(device_mesh, [Replicate()])
+
+            self.assertTrue(replicated.is_contiguous())
+            self.assertTrue(replicated.to_local().is_contiguous())
+            self.assertEqual(replicated.to_local(), input_tensor)
+
     def test_redistribute_uneven_sharding(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size).reshape(2, 2))
         data_to_test = [

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -644,26 +644,39 @@ class RedistributeTest(DTensorContinuousTestBase):
         reshard_tensor = shard_tensor.redistribute(device_mesh, shard_minus_spec)
         self.assertEqual(reshard_tensor.placements[0].dim, 1)
 
-    def test_uneven_shard_to_replicate_contiguous_local(self):
-        # Regression test for https://github.com/pytorch/pytorch/issues/173041
-        # After all-gathering an uneven Shard(dim>0) back to Replicate the
-        # unpad step does a narrow on a non-leading dim, which would otherwise
-        # leave the local tensor non-contiguous and break downstream view ops
-        # (e.g. inside parallelized nn.Linear).
+    def test_shard_to_replicate_local_tensor_contiguous(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/173041.
+        # When the sharded dim is not evenly divisible by world_size the unpad
+        # step in Shard._to_replicate_tensor uses narrow(), which on a non-leading
+        # dim produces a non-contiguous view. The resulting local tensor then
+        # breaks downstream view ops (e.g. inside parallelized nn.Linear).
         device_mesh = self.build_device_mesh()
 
-        for shard_dim in range(1, 3):
-            shape = [2, 2, 2]
-            # Make the sharded dim uneven across the mesh.
-            shape[shard_dim] = self.world_size * 2 + 1
-            input_tensor = torch.randn(*shape, device=self.device_type)
+        # world_size=4 here, so sizes like 13/14/15/31 are uneven on the sharded dim.
+        test_cases = [
+            # (shape, shard_dim)
+            ((4, 13, 8), 1),
+            ((4, 14, 8), 1),
+            ((4, 15, 8), 1),
+            ((3, 31, 10), 1),  # shape from the original issue repro
+            ((4, 8, 13), 2),
+            ((13, 8), 0),
+            ((8, 13), 1),
+        ]
 
-            sharded = distribute_tensor(input_tensor, device_mesh, [Shard(shard_dim)])
-            replicated = sharded.redistribute(device_mesh, [Replicate()])
+        for shape, shard_dim in test_cases:
+            full_tensor = torch.randn(shape, device=self.device_type)
+            dt_rep = distribute_tensor(full_tensor, device_mesh, [Replicate()])
+            dt_shard = dt_rep.redistribute(device_mesh, [Shard(shard_dim)])
+            dt_back_rep = dt_shard.redistribute(device_mesh, [Replicate()])
 
-            self.assertTrue(replicated.is_contiguous())
-            self.assertTrue(replicated.to_local().is_contiguous())
-            self.assertEqual(replicated.to_local(), input_tensor)
+            self.assertTrue(
+                dt_back_rep._local_tensor.is_contiguous(),
+                f"Local tensor should be contiguous after Shard({shard_dim})->Replicate "
+                f"for shape {shape}. Got stride {dt_back_rep._local_tensor.stride()}",
+            )
+            self.assertTrue(dt_back_rep.is_contiguous())
+            self.assertEqual(dt_back_rep.to_local(), full_tensor)
 
     def test_redistribute_uneven_sharding(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size).reshape(2, 2))

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -452,8 +452,9 @@ class Shard(torch._C._distributed.Shard):
         # narrow/unpad on a non-leading dim leaves the tensor non-contiguous,
         # which leaks out to callers that expect a Replicate() result to have
         # a contiguous local tensor (e.g. downstream view ops in TP linear).
-        if not local_tensor.is_contiguous():
-            local_tensor = local_tensor.contiguous()
+        # Use unconditional .contiguous() to avoid guarding on symbolic strides
+        # under torch.compile with unbacked symints.
+        local_tensor = local_tensor.contiguous()
 
         return local_tensor
 

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -449,6 +449,12 @@ class Shard(torch._C._distributed.Shard):
                     f"{orig_size} -> {local_tensor.size(self.dim)}"
                 )
 
+        # narrow/unpad on a non-leading dim leaves the tensor non-contiguous,
+        # which leaks out to callers that expect a Replicate() result to have
+        # a contiguous local tensor (e.g. downstream view ops in TP linear).
+        if not local_tensor.is_contiguous():
+            local_tensor = local_tensor.contiguous()
+
         return local_tensor
 
     def _to_replicate_tensor(


### PR DESCRIPTION
## Agent Report
### Summary
When a DTensor is redistributed from `Shard(dim>0)` to `Replicate()` with uneven
sharding (the sharded dim is not divisible by the mesh size), the resulting
local tensor is non-contiguous. Downstream code that calls `.view(...)` on the
local tensor (notably the reshape inside parallelized `nn.Linear` produced by
`ColwiseParallel` / `RowwiseParallel`) then fails with:

```
view size is not compatible with input tensor's size and stride
(at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```

Shard(0) is fine because narrowing the leading dim still yields a contiguous
tensor. The issue only manifests when `Shard(dim).dim > 0`.

The matching upstream maintainer comment in the issue
(`From claude:` quote by @wconstab) flagged this exact case as the real bug
and pointed at `_maybe_unpad_tensor`. Cases 1 and 4 from the issue (direct
`Shard(1)` input feeding TP linear) are expected behavior — the sequence
dimension can't be flattened into batch without redistribution — and they
already pass on this build.

### Root Cause
`torch/distributed/tensor/placement_types.py::Shard._to_replicate_tensor`
pads the local shard, all-gathers, then calls `_maybe_unpad_tensor`. The
unpad path does two `narrow` operations:

1. `unpad_tensor(t, dim, n)` → `t.narrow(dim, 0, size-n)` whenever the
   sharded dim was padded.
2. An additional `t.narrow(self.dim, 0, logical_dim_size)` to rebind
   derived symbolic sizes (e.g. `2*(s//2)`) back to the original symbol.

`narrow` on `dim != 0` produces a non-contiguous view. The companion path
`Shard._maybe_unpad_tensor_with_sizes` already takes a `make_contiguous`
flag and calls `.contiguous()` (see `_shard_tensor`/`_reduce_shard_tensor`
in the same file), but `_maybe_unpad_tensor` had no such fixup, so its
caller `_to_replicate_tensor` returned a non-contiguous local tensor for
`Shard(dim>0) -> Replicate()` redistribution.

### Fix
`torch/distributed/tensor/placement_types.py` — add a contiguity guard at
the end of `Shard._maybe_unpad_tensor` so the returned local tensor is
contiguous whenever the unpad / narrow above produced a non-contiguous view:

```python
if not local_tensor.is_contiguous():
    local_tensor = local_tensor.contiguous()
```

This is a no-op when the dim was 0 or no padding was needed (the existing
codepath that fast-returns the input already produces contiguous output).

I also added a regression test
`RedistributeTest.test_shard_to_replicate_local_tensor_contiguous` in
`test/distributed/tensor/test_redistribute.py` modeled on the example
referenced by @aditvenk on the draft PR (see PR #174134). It iterates
over a list of `(shape, shard_dim)` cases — including the issue's
`(3, 31, 10)` shape, plus uneven shards on dim 0, 1, and 2 — and for
each case it does `Replicate() -> Shard(dim) -> Replicate()` and asserts:
1. `_local_tensor.is_contiguous()` (the actual bug — error message
   reports the stride to help future debugging),
2. `DTensor.is_contiguous()`, and
3. round-trip equality with the original tensor.

The Replicate -> Shard -> Replicate path mirrors the failing Case 2 from
the issue repro exactly, so this test would have flagged the original
bug in CI.

### Repro
<details>
<summary>Repro Script</summary>

```python
Run:

```bash
python repro_173041_generated.py
```

<details>
<summary>Repro Script</summary>

```python
# torchrun --nproc_per_node=2 repro_173041_generated.py
# Mirror of issue's repro without the loguru dependency.
import torch
from torch import nn
from torch.distributed import init_process_group
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed._tensor import DTensor, distribute_tensor, Shard, Replicate
from torch.distributed.tensor.parallel import parallelize_module, ColwiseParallel

init_process_group()
torch.cuda.set_device(torch.distributed.get_rank())
device_mesh = init_device_mesh(
    device_type="cuda", mesh_shape=(2,), mesh_dim_names=("tp",)
)


def rank0_log(message):
    if torch.distributed.get_rank() == 0:
        print(message, flush=True)


def test_case(case_num, shard_dim=1):
    model = nn.Linear(10, 10).cuda()
    bs = 3
    n_token = 31

    if case_num == 1:
        inp_local = torch.randn(bs, n_token, 10, device="cuda", requires_grad=True)
        inp = DTensor.from_local(
            inp_local, device_mesh=device_mesh, placements=[Shard(shard_dim)]
        )

    elif case_num == 2:
        inp_local = torch.randn(bs, n_token, 10, device="cuda", requires_grad=True)
        inp = distribute_tensor(inp_local, device_mesh, [Replicate()])
        inp = inp.redistribute(placements=[Shard(shard_dim)])
        inp = inp.redistribute(placements=[Replicate()])

    elif case_num == 3:
        inp_local = torch.randn(bs, n_token, 10, device="cuda", requires_grad=True)
        inp = distribute_tensor(inp_local, device_mesh, [Replicate()])
        inp = inp.redistribute(placements=[Shard(shard_dim)])
        inp = inp.redistribute(placements=[Replicate()])
        inp._local_tensor = inp._local_tensor.contiguous()

    elif case_num == 4:
        inp_local = torch.randn(bs, n_token, 10, device="cuda", requires_grad=True)
        inp = DTensor.from_local(
            inp_local, device_mesh=device_mesh, placements=[Shard(shard_dim)]
        )
        inp._local_tensor = inp._local_tensor.contiguous()
    else:
        raise ValueError(f"Invalid case number: {case_num}")

    parallelize_module(model, device_mesh, ColwiseParallel(use_local_output=False))
    rank0_log(
        f"[Test {case_num} | Shard({shard_dim})]: {inp.placements=} "
        f"{inp.is_contiguous()=} {inp._local_tensor.is_contiguous()=}"
    )
    out = model(inp)
    return out


for shard_dim in (1, 0):
    for i in range(1, 5):
        try:
            test_case(i, shard_dim=shard_dim)
            rank0_log(f"[Test {i} | Shard({shard_dim})]: pass")
        except Exception as e:
            rank0_log(f"[Test {i} | Shard({shard_dim})]: failed: {e}")

if torch.distributed.is_initialized():
    torch.distributed.destroy_process_group()
```

</details>

### Testing
- `repro_173041_generated.py`: all 8 cases pass after the fix
  (Case 2 with `Shard(1)` previously failed with the view/stride error;
  cases 1/3/4 and all `Shard(0)` cases were already passing).
- Regression test
  `RedistributeTest.test_shard_to_replicate_local_tensor_contiguous`:
  PASS (also for `RedistributeTestWithLocalTensor` LocalTensor variant).
  Test rewritten per @aditvenk review to match the pattern from PR #174134
  (multiple `(shape, shard_dim)` cases, Replicate -> Shard -> Replicate
  redistribution path, descriptive error reporting the stride).
- Full `test/distributed/tensor/test_redistribute.py`:
  `Ran 114 tests in 146.171s — OK (skipped=22)`.
- `test/distributed/tensor/parallel/test_tp_style.py`:
  `Ran 22 tests in 50.086s — OK`.
- `test/distributed/tensor/parallel/test_parallelize_api.py`:
  `Ran 32 tests in 74.371s — OK (skipped=1)`.
- `spin fixlint torch/distributed/tensor/placement_types.py test/distributed/tensor/test_redistribute.py`:
  `ok No lint issues.`

## Files Changed
- `torch/distributed/tensor/placement_types.py`
- `test/distributed/tensor/test_redistribute.py`


Fixes #173041

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*