### PR TITLE
Avoid CSE for auto-functionalized bases

### DIFF
--- a/test/functorch/test_memory_efficient_fusion.py
+++ b/test/functorch/test_memory_efficient_fusion.py
@@ -18,6 +18,21 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 HAS_CUDA = torch.cuda.is_available()
 
 
+@torch.library.custom_op("_cse_reinplacing::foo", mutates_args={})
+def cse_foo(x: torch.Tensor) -> torch.Tensor:
+    return x.clone()
+
+
+@cse_foo.register_fake
+def _(x):
+    return x.clone()
+
+
+@torch.library.custom_op("_cse_reinplacing::sin", mutates_args={"result"})
+def cse_sin(x: torch.Tensor, result: torch.Tensor) -> None:
+    result.copy_(x.sin())
+
+
 def _num_args(fn: Callable):
     return len(inspect.signature(fn).parameters)
 
@@ -258,6 +273,62 @@ class NoChangeTestCase(TestCase):
 
         t = torch.randn(2, 2)
         check(f, t, 0)
+
+    def test_auto_functionalized_v2_bases_not_csed(self):
+        def f(x):
+            out0 = cse_foo(x)
+            _, new_out0 = torch.ops.higher_order.auto_functionalized_v2(
+                cse_sin._opoverload,
+                x=x,
+                _result_base_index=0,
+                _result_size=(3,),
+                _result_stride=(1,),
+                _result_storage_offset=0,
+                _all_bases=[out0],
+            )
+            out1 = cse_foo(x)
+            _, new_out1 = torch.ops.higher_order.auto_functionalized_v2(
+                cse_sin._opoverload,
+                x=new_out0,
+                _result_base_index=0,
+                _result_size=(3,),
+                _result_stride=(1,),
+                _result_storage_offset=0,
+                _all_bases=[out1],
+            )
+            return new_out0, new_out1
+
+        t = torch.randn(3)
+        fx_g = make_fx(f, tracing_mode="fake")(t)
+        new_graph = fx_graph_cse(fx_g.graph)
+        self.assertEqual(
+            sum(n.target is cse_foo._opoverload for n in new_graph.nodes),
+            2,
+        )
+
+    def test_auto_functionalized_bases_not_csed(self):
+        def f(x):
+            out0 = cse_foo(x)
+            _, new_out0 = torch.ops.higher_order.auto_functionalized(
+                cse_sin._opoverload,
+                x=x,
+                result=out0,
+            )
+            out1 = cse_foo(x)
+            _, new_out1 = torch.ops.higher_order.auto_functionalized(
+                cse_sin._opoverload,
+                x=new_out0,
+                result=out1,
+            )
+            return new_out0, new_out1
+
+        t = torch.randn(3)
+        fx_g = make_fx(f, tracing_mode="fake")(t)
+        new_graph = fx_graph_cse(fx_g.graph)
+        self.assertEqual(
+            sum(n.target is cse_foo._opoverload for n in new_graph.nodes),
+            2,
+        )
 
     def test_rand_like(self):
         def f(x):

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -43,6 +43,16 @@ def sin(x: torch.Tensor, result: torch.Tensor) -> None:
     result.copy_(x.sin())
 
 
+@torch.library.custom_op("_reinplacing::foo", mutates_args={})
+def foo(x: torch.Tensor) -> torch.Tensor:
+    return x.clone()
+
+
+@foo.register_fake
+def _(x):
+    return x.clone()
+
+
 @torch.library.custom_op("_reinplacing::sin_cos", mutates_args={"out_sin", "out_cos"})
 def sin_cos(x: torch.Tensor, out_sin: torch.Tensor, out_cos: torch.Tensor) -> None:
     out_sin.copy_(x.sin())
@@ -478,6 +488,31 @@ class TestReinplacingPassCorrectness(InductorTestCase):
 
         x = torch.randn(3, requires_grad=True, device=device)
         f(x)
+        self.assertEqual(num_reinplacing_failures(), 0)
+
+    def test_partitioner_recomputes_custom_factory(self):
+        class MySin(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                out = foo(x)
+                sin(x, out)
+                ctx.save_for_backward(x, out)
+                return out
+
+            @staticmethod
+            def backward(ctx, grad):
+                x, saved = ctx.saved_tensors
+                out = foo(x)
+                sin(saved, out)
+                return out
+
+        @torch.compile(backend="inductor")
+        def f(x):
+            return MySin.apply(x)
+
+        x = torch.randn(3, requires_grad=True, device=device)
+        result = f(x)
+        self.assertEqual(result, x.sin())
         self.assertEqual(num_reinplacing_failures(), 0)
 
     def test_with_effects_reinplace(self):

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -74,28 +74,63 @@ def fx_graph_cse(fx_g: torch.fx.graph.Graph) -> fx.Graph:
             f"expected output_node.op to be 'output', got '{output_node.op}'"
         )
 
-    def checkable_node(node: fx.Node) -> bool:
-        """We can evaluate only nodes that represent tensors with defined storage."""
-        if "val" not in node.meta or not isinstance(node.meta["val"], torch.Tensor):
-            return False
+    def get_node_storages(node: fx.Node) -> set[StorageWeakRef]:
+        """Returns all defined tensor storages in node metadata."""
+        if "val" not in node.meta:
+            return set()
 
-        try:
-            node.meta["val"].untyped_storage()
-        except NotImplementedError:
-            return False
+        storages = set()
+        for value in pytree.tree_leaves(node.meta["val"]):
+            if not isinstance(value, torch.Tensor):
+                continue
 
-        return True
+            try:
+                storages.add(StorageWeakRef(value.untyped_storage()))
+            except NotImplementedError:
+                continue
+
+        return storages
 
     output_storages = {
-        StorageWeakRef(n.meta["val"].untyped_storage())
-        for n in output_node.all_input_nodes
-        if checkable_node(n)
+        storage for n in output_node.all_input_nodes for storage in get_node_storages(n)
     }
     nodes_that_alias_outputs = {
+        n for n in fx_g.nodes if get_node_storages(n) & output_storages
+    }
+
+    # These bases are potential write targets for Inductor reinplacing. CSEing
+    # them, or producers that alias them, can create artificial later uses.
+    def collect_auto_functionalized_base_nodes() -> set[fx.Node]:
+        base_nodes = set()
+
+        def add_nodes(value: Any) -> None:
+            for leaf in pytree.tree_leaves(value):
+                if isinstance(leaf, fx.Node):
+                    base_nodes.add(leaf)
+
+        for node in fx_g.nodes:
+            if node.target is torch.ops.higher_order.auto_functionalized_v2:
+                add_nodes(node.kwargs.get("_all_bases", ()))
+            elif node.target is torch.ops.higher_order.auto_functionalized:
+                from torch._higher_order_ops.auto_functionalize import get_mutable_args
+
+                mutable_arg_names, _ = get_mutable_args(node.args[0])
+                for arg_name in mutable_arg_names:
+                    add_nodes(node.kwargs.get(arg_name))
+
+        return base_nodes
+
+    auto_functionalized_base_nodes = collect_auto_functionalized_base_nodes()
+    auto_functionalized_base_storages = {
+        storage
+        for node in auto_functionalized_base_nodes
+        for storage in get_node_storages(node)
+    }
+    nodes_that_alias_auto_functionalized_bases = {
         n
         for n in fx_g.nodes
-        if checkable_node(n)
-        and StorageWeakRef(n.meta["val"].untyped_storage()) in output_storages
+        if n in auto_functionalized_base_nodes
+        or get_node_storages(n) & auto_functionalized_base_storages
     }
 
     for n in fx_g.nodes:
@@ -111,6 +146,7 @@ def fx_graph_cse(fx_g: torch.fx.graph.Graph) -> fx.Graph:
             # so it's not worth CSEing.
             or get_aten_target(n) is aten.empty
             or n in nodes_that_alias_outputs
+            or n in nodes_that_alias_auto_functionalized_bases
             # This CSE pass currently doesn't handle re-propagation of unbacked
             # meta where it'll sometimes eliminate a _local_scalar_dense but not
             # replace the meta of downstream users. eg. one bug we've seen is:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184446

AOTAutograd CSE could merge pure factory calls that later serve as mutable auto-functionalized bases, causing Inductor reinplacing to see artificial later uses. Skip CSE for those bases and their storage aliases so each mutable call keeps its own write target.

Fixes #132865
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo