### PR TITLE
[inductor][autotuning] add incremental autotune foundation

### DIFF
--- a/test/inductor/test_incremental_autotune.py
+++ b/test/inductor/test_incremental_autotune.py
@@ -1,0 +1,1533 @@
+# Owner(s): ["module: inductor"]
+
+import gc
+import queue
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+from torch._inductor.runtime.incremental._launcher import Launcher
+from torch._inductor.runtime.incremental._state import IncrementalAutotuneState
+from torch._inductor.runtime.incremental.config import (
+    LauncherTimingAggregation,
+    max_timings_per_launcher,
+    min_timings_before_filter,
+)
+from torch._inductor.test_case import run_tests, TestCase
+
+
+def _wait_until(predicate, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def _make_launcher(name: str = "launcher") -> Launcher:
+    fn = MagicMock()
+    fn.return_value = f"result_{name}"
+    fn.config = f"config:{name}"
+    fn.cache_hash = f"hash:{name}"
+    launcher = Launcher(raw_launcher=fn)
+    # Production keeps fn alive via CachingAutotuner.launchers; tests stash
+    # it on the launcher so the weakref doesn't die immediately.
+    launcher._raw_launcher_keepalive = fn  # pyrefly: ignore
+    return launcher
+
+
+def _make_state(
+    launchers: list[Launcher], **kwargs: object
+) -> IncrementalAutotuneState:
+    """Create an IncrementalAutotuneState seeded with launchers."""
+    state = IncrementalAutotuneState(**kwargs)
+    for launcher in launchers:
+        # Tests use the launcher's own raw as the autotuner-side raw.
+        raw = launcher.get_raw_launcher()
+        state.add_launcher(launcher, raw)
+    return state
+
+
+def _force_total_timings(launcher: Launcher, n: int) -> None:
+    """Force ``num_total_timings`` to ``n`` by stuffing the in-flight counter."""
+    with launcher._lock:
+        launcher._num_timings_in_flight = n - len(launcher._timings)
+
+
+def _set_in_flight(launcher: Launcher, n: int) -> None:
+    with launcher._lock:
+        launcher._num_timings_in_flight = n
+
+
+def _discard(state: IncrementalAutotuneState, launcher: Launcher) -> list:
+    """Test helper: invoke ``state._discard`` under the state lock and
+    return the deferred discard list. Mirrors how production callers
+    (``add_launcher`` / ``_next_launcher``) wrap the call."""
+    pending: list = []
+    with state._lock:
+        state._discard(launcher, pending)
+    if state._on_discard_fn is not None:
+        for entry in pending:
+            # _discard appends (launcher, raw) tuples.
+            state._on_discard_fn(*entry)
+    return pending
+
+
+class _PicklableRaw:
+    """Module-level raw launcher used in pickle round-trip tests."""
+
+    def __init__(self, config: object = "cfg", cache_hash: str = "h") -> None:
+        self.config = config
+        self.cache_hash = cache_hash
+
+    def __call__(self, *_a: object, **_kw: object) -> str:
+        return "ok"
+
+
+class LauncherTest(TestCase):
+    def test_timing_empty(self):
+        launcher = _make_launcher()
+        self.assertEqual(launcher.timing, float("inf"))
+
+    def test_call_delegates_to_raw_launcher(self):
+        launcher = _make_launcher("test")
+        result = launcher(1, 2, stream=0)
+        self.assertEqual(result, "result_test")
+        launcher._raw_launcher_keepalive.assert_called_once_with(1, 2, stream=0)
+
+    def test_call_raises_when_raw_launcher_garbage_collected(self):
+        """raw_launcher is held weakly; once the only strong ref drops,
+        __call__ asserts."""
+
+        class _Callable:
+            def __call__(self) -> str:
+                return "ok"
+
+        fn = _Callable()
+        launcher = Launcher(raw_launcher=fn)
+        del fn
+        gc.collect()
+        with self.assertRaises(AssertionError):
+            launcher(stream=0)
+
+    def test_set_raw_launcher_replaces_and_resets_warm(self):
+        """set_raw_launcher attaches a fresh raw to a previously-dormant
+        Launcher (or replaces a dead one) and resets the warm flag."""
+        original = MagicMock(return_value="orig")
+        launcher = Launcher(raw_launcher=original)
+        launcher._raw_launcher_keepalive_orig = original  # pyrefly: ignore
+        launcher(stream=0)
+        self.assertTrue(launcher._warm)
+
+        replacement = MagicMock(return_value="new")
+        launcher.set_raw_launcher(replacement)
+        launcher._raw_launcher_keepalive_repl = replacement  # pyrefly: ignore
+        self.assertFalse(launcher._warm)
+        self.assertEqual(launcher(stream=0), "new")
+
+    def test_set_raw_launcher_preserves_timings(self):
+        """set_raw_launcher assumes the new raw is interchangeable, so
+        accumulated timings must not be cleared."""
+        launcher = _make_launcher()
+        launcher.add_timing(1.0)
+        launcher.add_timing(2.0)
+        new_fn = MagicMock(return_value="new")
+        launcher.set_raw_launcher(new_fn)
+        launcher._raw_launcher_keepalive = new_fn  # pyrefly: ignore
+        self.assertEqual(launcher.num_available_timings, 2)
+        self.assertAlmostEqual(launcher.timing, 1.5)
+
+    def test_first_call_sets_warm(self):
+        launcher = _make_launcher()
+        self.assertFalse(launcher._warm)
+        launcher(stream=0)
+        self.assertTrue(launcher._warm)
+
+    def test_untimed_call_does_not_track_timing(self):
+        launcher = _make_launcher()
+        launcher(stream=0)
+        launcher(stream=0)
+        self.assertEqual(launcher.num_in_flight_timings, 0)
+        self.assertEqual(launcher.num_available_timings, 0)
+        self.assertEqual(launcher.num_total_timings, 0)
+
+    def test_timed_call_increments_in_flight_and_submits_event(self):
+        launcher = _make_launcher()
+        # Warm the launcher so the next time_if_warm=True call actually times.
+        launcher(stream=0)
+        start_event = MagicMock()
+        end_event = MagicMock()
+        events = iter([start_event, end_event])
+        with (
+            patch("torch.cuda.Event", side_effect=lambda **_: next(events)),
+            patch(
+                "torch._inductor.runtime.incremental._launcher.submit_event"
+            ) as mock_submit,
+        ):
+            launcher(stream=0, time_if_warm=True)
+            self.assertEqual(launcher.num_in_flight_timings, 1)
+            mock_submit.assert_called_once_with(
+                launcher.add_timing, start_event, end_event
+            )
+
+    def test_time_if_warm_false_when_not_yet_warm(self):
+        """time_if_warm=True on a cold launcher does NOT time — the
+        launcher's internal _warm gate prevents measuring a cold dispatch.
+        """
+        launcher = _make_launcher()
+        with patch(
+            "torch._inductor.runtime.incremental._launcher.submit_event"
+        ) as mock_submit:
+            launcher(stream=0, time_if_warm=True)
+            self.assertEqual(launcher.num_in_flight_timings, 0)
+            mock_submit.assert_not_called()
+        # Now warm; subsequent time_if_warm=True does time.
+        with patch("torch.cuda.Event", return_value=MagicMock()), patch(
+            "torch._inductor.runtime.incremental._launcher.submit_event"
+        ) as mock_submit:
+            launcher(stream=0, time_if_warm=True)
+            self.assertEqual(launcher.num_in_flight_timings, 1)
+            mock_submit.assert_called_once()
+
+    def test_add_timing_appends_to_available(self):
+        launcher = _make_launcher()
+        _set_in_flight(launcher, 2)
+        launcher.add_timing(1.0)
+        self.assertEqual(launcher.num_in_flight_timings, 1)
+        self.assertEqual(launcher.num_available_timings, 1)
+        launcher.add_timing(2.0)
+        self.assertEqual(launcher.num_in_flight_timings, 0)
+        self.assertEqual(launcher.num_available_timings, 2)
+
+    def test_num_total_timings_sums_in_flight_and_available(self):
+        launcher = _make_launcher()
+        _set_in_flight(launcher, 3)
+        self.assertEqual(launcher.num_total_timings, 3)
+        launcher.add_timing(1.0)
+        self.assertEqual(launcher.num_total_timings, 3)
+
+    def test_concurrent_add_timing_is_thread_safe(self):
+        """add_timing is called from the resolver thread; the lock must
+        protect _timings and _num_timings_in_flight against the main
+        thread's concurrent reads/writes.
+        """
+        launcher = _make_launcher()
+        n_threads = 4
+        per_thread = 250
+        total = n_threads * per_thread
+        with launcher._lock:
+            launcher._num_timings_in_flight = total
+
+        def worker() -> None:
+            for _ in range(per_thread):
+                launcher.add_timing(1.0)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(launcher.num_available_timings, total)
+        self.assertEqual(launcher.num_in_flight_timings, 0)
+
+    def test_timing_median_odd(self):
+        launcher = _make_launcher()
+        for v in [5.0, 1.0, 3.0]:
+            launcher.add_timing(v)
+        self.assertAlmostEqual(launcher.timing, 3.0)
+
+    def test_timing_median_even(self):
+        launcher = _make_launcher()
+        for v in [4.0, 2.0]:
+            launcher.add_timing(v)
+        self.assertAlmostEqual(launcher.timing, 3.0)
+
+    def test_timing_median_ignores_outliers(self):
+        launcher = _make_launcher()
+        for v in [1.0, 2.0, 3.0, 4.0, 100.0]:
+            launcher.add_timing(v)
+        self.assertAlmostEqual(launcher.timing, 3.0)
+
+    def test_timing_uses_mean_when_configured(self):
+        launcher = _make_launcher()
+        for v in [1.0, 2.0, 3.0, 4.0, 100.0]:
+            launcher.add_timing(v)
+        with patch(
+            "torch._inductor.runtime.incremental._launcher.launcher_timing_aggregation",
+            LauncherTimingAggregation.MEAN,
+        ):
+            self.assertAlmostEqual(launcher.timing, 22.0)
+
+    def test_on_timing_update_callback_receives_self_old_and_new(self):
+        # WeakMethod requires a bound method whose owning instance supports
+        # weakref, so we use a small recorder class instead of list.append.
+        class _Recorder:
+            def __init__(self) -> None:
+                self.calls: list[tuple[Launcher, float, float]] = []
+
+            def record(
+                self, launcher: Launcher, old_timing: float, new_timing: float
+            ) -> None:
+                self.calls.append((launcher, old_timing, new_timing))
+
+        launcher = _make_launcher()
+        rec = _Recorder()
+        launcher.add_on_timing_update_fn(rec.record)
+        launcher.add_timing(1.0)  # median: inf -> 1.0
+        launcher.add_timing(2.0)  # median: 1.0 -> 1.5
+        self.assertEqual(len(rec.calls), 2)
+        self.assertIs(rec.calls[0][0], launcher)
+        self.assertEqual(rec.calls[0][1], float("inf"))
+        self.assertEqual(rec.calls[0][2], 1.0)
+        self.assertIs(rec.calls[1][0], launcher)
+        self.assertEqual(rec.calls[1][1], 1.0)
+        self.assertEqual(rec.calls[1][2], 1.5)
+
+    def test_on_timing_update_subscription_cancel_stops_future_fires(self):
+        class _Counter:
+            def __init__(self) -> None:
+                self.n = 0
+
+            def bump(self, _l: Launcher, _o: float, _n: float) -> None:
+                self.n += 1
+
+        launcher = _make_launcher()
+        counter = _Counter()
+        sub = launcher.add_on_timing_update_fn(counter.bump)
+        launcher.add_timing(1.0)
+        sub.cancel()
+        launcher.add_timing(2.0)
+        self.assertEqual(counter.n, 1)
+
+    def test_on_timing_update_subscription_cancel_removes_from_registry(self):
+        """``cancel()`` must physically remove the sub from the parent
+        Launcher's ``_on_timing_update_subs`` so subsequent ``add_timing``
+        iterations don't pay for dead subs (and so the deterministic-
+        cleanup contract from the docstring holds without relying on a
+        future ``add_timing`` call to prune)."""
+
+        class _Counter:
+            def __init__(self) -> None:
+                self.n = 0
+
+            def bump(self, _l: Launcher, _o: float, _n: float) -> None:
+                self.n += 1
+
+        launcher = _make_launcher()
+        counter = _Counter()
+        sub = launcher.add_on_timing_update_fn(counter.bump)
+        self.assertEqual(len(launcher._on_timing_update_subs), 1)
+        sub.cancel()
+        self.assertEqual(len(launcher._on_timing_update_subs), 0)
+        # Idempotent.
+        sub.cancel()
+        self.assertEqual(len(launcher._on_timing_update_subs), 0)
+
+    def test_on_timing_update_subscription_cancel_is_idempotent(self):
+        class _Counter:
+            def __init__(self) -> None:
+                self.n = 0
+
+            def bump(self, _l: Launcher, _o: float, _n: float) -> None:
+                self.n += 1
+
+        launcher = _make_launcher()
+        sub = launcher.add_on_timing_update_fn(_Counter().bump)
+        sub.cancel()
+        sub.cancel()  # second cancel should no-op, not raise
+
+    def test_on_timing_update_subscription_cancel_waits_for_in_flight(self):
+        """``cancel()`` must block until any in-flight call completes,
+        so the caller can rely on the callback being retired by the
+        time ``cancel`` returns.
+        """
+
+        class _SlowCallback:
+            def __init__(self) -> None:
+                self.entered = threading.Event()
+                self.may_return = threading.Event()
+                self.calls = 0
+
+            def slow(self, _l: Launcher, _o: float, _n: float) -> None:
+                self.calls += 1
+                self.entered.set()
+                # Block until the test releases us.
+                self.may_return.wait(timeout=5.0)
+
+        launcher = _make_launcher()
+        slow = _SlowCallback()
+        sub = launcher.add_on_timing_update_fn(slow.slow)
+
+        # Fire add_timing on a background thread so the callback runs
+        # there; we can race ``cancel`` against the in-flight callback.
+        fire_thread = threading.Thread(target=launcher.add_timing, args=(1.0,))
+        fire_thread.start()
+        self.assertTrue(slow.entered.wait(timeout=5.0))
+
+        # Now the callback is mid-execution; ``cancel`` must wait.
+        cancel_thread = threading.Thread(target=sub.cancel)
+        cancel_thread.start()
+        # Cancel shouldn't have returned yet because the callback is blocked.
+        cancel_thread.join(timeout=0.05)
+        self.assertTrue(cancel_thread.is_alive())
+
+        # Release the callback; both threads should now finish, and any
+        # subsequent add_timing must NOT call the callback.
+        slow.may_return.set()
+        cancel_thread.join(timeout=5.0)
+        fire_thread.join(timeout=5.0)
+        self.assertFalse(cancel_thread.is_alive())
+        self.assertFalse(fire_thread.is_alive())
+
+        launcher.add_timing(2.0)
+        self.assertEqual(slow.calls, 1)
+
+    def test_on_timing_update_callbacks_multiple_owners(self):
+        """A Launcher shared across owners fires every registered callback."""
+
+        class _Counter:
+            def __init__(self) -> None:
+                self.n = 0
+
+            def bump(self, _l: Launcher, _o: float, _n: float) -> None:
+                self.n += 1
+
+        launcher = _make_launcher()
+        a, b = _Counter(), _Counter()
+        launcher.add_on_timing_update_fn(a.bump)
+        launcher.add_on_timing_update_fn(b.bump)
+        launcher.add_timing(1.0)
+        self.assertEqual((a.n, b.n), (1, 1))
+
+    def test_on_timing_update_callback_pruned_when_owner_gced(self):
+        """Owners that go away should auto-prune their callbacks."""
+
+        class _Counter:
+            def __init__(self) -> None:
+                self.n = 0
+
+            def bump(self, _l: Launcher, _o: float, _n: float) -> None:
+                self.n += 1
+
+        launcher = _make_launcher()
+        survivor = _Counter()
+        ephemeral = _Counter()
+        launcher.add_on_timing_update_fn(survivor.bump)
+        launcher.add_on_timing_update_fn(ephemeral.bump)
+        del ephemeral
+        gc.collect()
+        launcher.add_timing(1.0)
+        self.assertEqual(survivor.n, 1)
+        # The ephemeral callback's WeakMethod was pruned in place.
+        self.assertEqual(len(launcher._on_timing_update_subs), 1)
+
+
+class IncrementalAutotuneStateTest(TestCase):
+    def test_add_launcher_queue(self):
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state = _make_state([a, b])
+        self.assertIs(state._queue[0], a)
+        self.assertIs(state._queue[1], b)
+        self.assertEqual(len(state._queue), 2)
+
+    def test_next_launcher_skips_when_in_flight_exhausts_budget(self):
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state = _make_state([a, b])
+        _force_total_timings(a, 999)
+        self.assertIs(state._next_launcher(), b)
+        # Skipped (not filtered), so a remains in the active set.
+        self.assertIn(a, state._queue)
+
+    def test_next_launcher_returns_none_when_all_skipped(self):
+        a = _make_launcher("a")
+        state = _make_state([a])
+        _force_total_timings(a, 999)
+        self.assertIsNone(state._next_launcher())
+        self.assertIn(a, state._queue)
+
+    def test_next_launcher_promotes_first_done_to_best(self):
+        a = _make_launcher("a")
+        state = _make_state([a])
+        for _ in range(max_timings_per_launcher):
+            a.add_timing(1.0)
+        self.assertIsNone(state._next_launcher())
+        self.assertIs(state._certified_launcher, a)
+
+    def test_next_launcher_replaces_best_with_faster_done(self):
+        dropped: list[Launcher] = []
+        old_certified = _make_launcher("old")
+        new_certified = _make_launcher("new")
+        for _ in range(max_timings_per_launcher):
+            old_certified.add_timing(5.0)
+            new_certified.add_timing(1.0)
+        state = IncrementalAutotuneState(on_discard_fn=lambda launcher, _raw: dropped.append(launcher))
+        state._certified_launcher = old_certified
+        state._queue.append(new_certified)
+        self.assertIsNone(state._next_launcher())
+        self.assertIs(state._certified_launcher, new_certified)
+        self.assertIn(old_certified, dropped)
+
+    def test_next_launcher_discards_slower_done(self):
+        dropped: list[Launcher] = []
+        cached = _make_launcher("cached")
+        loser = _make_launcher("loser")
+        for _ in range(max_timings_per_launcher):
+            cached.add_timing(1.0)
+            loser.add_timing(5.0)
+        state = IncrementalAutotuneState(on_discard_fn=lambda launcher, _raw: dropped.append(launcher))
+        state._certified_launcher = cached
+        state._queue.append(loser)
+        self.assertIsNone(state._next_launcher())
+        self.assertIs(state._certified_launcher, cached)
+        self.assertIn(loser, dropped)
+
+    def test_next_launcher_threshold_discards_slow_candidate(self):
+        dropped: list[Launcher] = []
+        best = _make_launcher("best")
+        slow = _make_launcher("slow")
+        for _ in range(max_timings_per_launcher):
+            best.add_timing(1.0)
+        state = IncrementalAutotuneState(on_discard_fn=lambda launcher, _raw: dropped.append(launcher))
+        state._certified_launcher = best
+        state._queue.append(slow)
+        for _ in range(min_timings_before_filter):
+            slow.add_timing(10.0)
+        # Direct setup bypasses add_launcher, so seed the temp-best cache.
+        state._recompute_provisional()
+        self.assertIsNone(state._next_launcher())
+        self.assertIn(slow, dropped)
+
+    def test_next_launcher_threshold_silent_when_launcher_is_provisional(self):
+        a = _make_launcher("a")
+        state = _make_state([a])
+        for _ in range(min_timings_before_filter):
+            a.add_timing(100.0)
+        # ``a`` is its own provisional → threshold check skipped, dispatch ``a``.
+        self.assertIs(state._next_launcher(), a)
+
+    def test_next_launcher_threshold_uses_provisional_from_queue(self):
+        """provisional can come from the queue, not just the cached
+        _certified_launcher.
+
+        Order matters: provisional (fast) is at the back so the loop
+        hits slow1 and slow2 first and discards them against fast's
+        timing. After both losers are discarded, the queue is down to
+        just fast — ``_maybe_converge_early`` (triggered from
+        ``_discard``) then promotes fast to certified, so
+        ``_next_launcher`` returns None (the caller's fallback path
+        uses the certified launcher) rather than dispatching fast for
+        more tuning.
+        """
+        dropped: list[Launcher] = []
+        fast = _make_launcher("fast")
+        slow1 = _make_launcher("slow1")
+        slow2 = _make_launcher("slow2")
+        state = IncrementalAutotuneState(on_discard_fn=lambda launcher, _raw: dropped.append(launcher))
+        state.add_launcher(slow1, slow1.get_raw_launcher())
+        state.add_launcher(slow2, slow2.get_raw_launcher())
+        state.add_launcher(fast, fast.get_raw_launcher())
+        for _ in range(min_timings_before_filter):
+            fast.add_timing(1.0)
+            slow1.add_timing(10.0)
+            slow2.add_timing(10.0)
+        self.assertIsNone(state._next_launcher())
+        self.assertIs(state._certified_launcher, fast)
+        self.assertIn(slow1, dropped)
+        self.assertIn(slow2, dropped)
+
+    def test_next_launcher_threshold_relaxed_when_best_has_few_samples(self):
+        dropped: list[Launcher] = []
+        best = _make_launcher("best")
+        candidate = _make_launcher("candidate")
+        # Best has only one sample → noisy, so we shouldn't discard a
+        # candidate that's only modestly slower despite the threshold.
+        best.add_timing(1.0)
+        state = IncrementalAutotuneState(on_discard_fn=lambda launcher, _raw: dropped.append(launcher))
+        state._certified_launcher = best
+        state._queue.append(candidate)
+        for _ in range(min_timings_before_filter):
+            candidate.add_timing(2.0)
+        # Direct setup bypasses add_launcher, so seed the temp-best cache.
+        state._recompute_provisional()
+        self.assertIs(state._next_launcher(), candidate)
+        self.assertNotIn(candidate, dropped)
+
+    def test_converged_reflects_queue_state(self):
+        state = IncrementalAutotuneState()
+        self.assertTrue(state.converged)
+        state._queue.append(_make_launcher())
+        self.assertFalse(state.converged)
+
+    def test_discard_promotes_last_survivor_without_max_samples(self):
+        """When threshold-discards leave a single queued launcher and
+        no certified launcher yet, the survivor wins by elimination
+        and is promoted to certified immediately — no need to keep
+        sampling against nobody. Mirrors how ``_next_launcher`` drives
+        the flow: popleft the launcher first, then ``_discard`` it.
+        """
+        a = _make_launcher("a")
+        survivor = _make_launcher("survivor")
+        state = _make_state([a, survivor])
+        self.assertFalse(state.converged)
+        self.assertIsNone(state._certified_launcher)
+        state._queue.popleft()  # ``_next_launcher`` pops before discarding
+        _discard(state, a)
+        self.assertTrue(state.converged)
+        self.assertIs(state._certified_launcher, survivor)
+        self.assertEqual(len(state._queue), 0)
+        # Survivor's timing budget was never touched.
+        self.assertEqual(survivor.num_available_timings, 0)
+
+    def test_discard_does_not_early_promote_when_certified_exists(self):
+        """If a certified launcher already exists, a discard that
+        leaves one queued launcher must NOT short-circuit — the queued
+        one needs samples to fairly compete with the certified one."""
+        certified = _make_launcher("certified")
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state = _make_state([a, b])
+        state._certified_launcher = certified
+        state._queue.popleft()
+        _discard(state, a)
+        self.assertFalse(state.converged)
+        self.assertIs(state._certified_launcher, certified)
+        self.assertIs(state._queue[0], b)
+
+    def test_discard_does_not_early_promote_when_queue_emptied(self):
+        """If a discard empties the queue entirely with no certified,
+        the assertion in the converged dispatch path will fire later
+        — early-promote must not silently certify nothing."""
+        a = _make_launcher("a")
+        state = _make_state([a])
+        state._queue.popleft()
+        _discard(state, a)
+        self.assertTrue(state.converged)
+        self.assertIsNone(state._certified_launcher)
+
+    def test_certified_launcher_returns_cached_when_converged(self):
+        state = IncrementalAutotuneState()
+        # Empty queue → converged.
+        self.assertIsNone(state.certified_launcher)
+        a = _make_launcher("a")
+        state._certified_launcher = a
+        self.assertIs(state.certified_launcher, a)
+
+    def test_certified_launcher_asserts_when_not_converged(self):
+        state = _make_state([_make_launcher()])
+        with self.assertRaises(AssertionError):
+            _ = state.certified_launcher
+        with self.assertRaises(AssertionError):
+            _ = state.certified_timing
+
+    def test_recompute_provisional_picks_min_across_queue_and_cached(self):
+        state = IncrementalAutotuneState()
+        cached = _make_launcher("cached")
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        cached.add_timing(2.0)
+        a.add_timing(5.0)
+        b.add_timing(1.0)
+        state._queue.append(a)
+        state._queue.append(b)
+        state._certified_launcher = cached
+        state._recompute_provisional()
+        self.assertIs(state._provisional_launcher, b)
+
+    def test_add_launcher_seeds_provisional(self):
+        state = IncrementalAutotuneState()
+        a = _make_launcher("a")
+        state.add_launcher(a, a.get_raw_launcher())
+        self.assertIs(state._provisional_launcher, a)
+
+    def test_provisional_updates_on_timing_callback(self):
+        state = IncrementalAutotuneState()
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state.add_launcher(a, a.get_raw_launcher())
+        state.add_launcher(b, b.get_raw_launcher())
+        # Both launchers register the timing-update callback, so the first
+        # finite timing on ``b`` should immediately make it the temp best.
+        b.add_timing(1.0)
+        self.assertIs(state._provisional_launcher, b)
+        # A faster timing on ``a`` should now displace ``b``.
+        a.add_timing(0.5)
+        self.assertIs(state._provisional_launcher, a)
+        # A slower timing on ``b`` doesn't change anything.
+        b.add_timing(10.0)
+        self.assertIs(state._provisional_launcher, a)
+
+    def test_discard_provisional_triggers_recompute(self):
+        dropped: list[Launcher] = []
+        state = IncrementalAutotuneState(on_discard_fn=lambda launcher, _raw: dropped.append(launcher))
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state.add_launcher(a, a.get_raw_launcher())
+        state.add_launcher(b, b.get_raw_launcher())
+        a.add_timing(1.0)
+        b.add_timing(5.0)
+        self.assertIs(state._provisional_launcher, a)
+        # Discard contract: caller has already popped the launcher off the queue.
+        state._queue.remove(a)
+        _discard(state, a)
+        self.assertIs(state._provisional_launcher, b)
+
+    def test_discard_clears_launcher_callback(self):
+        state = IncrementalAutotuneState()
+        a = _make_launcher("a")
+        state.add_launcher(a, a.get_raw_launcher())
+        self.assertEqual(len(a._on_timing_update_subs), 1)
+        _discard(state, a)
+        self.assertEqual(len(a._on_timing_update_subs), 0)
+
+    def test_convergence_clears_callback_on_certified_launcher(self):
+        state = IncrementalAutotuneState(
+            on_convergence_fn=lambda _state: None,
+        )
+        a = _make_launcher("a")
+        state.add_launcher(a, a.get_raw_launcher())
+        for _ in range(max_timings_per_launcher):
+            a.add_timing(1.0)
+        # Drive a to converged: _next_launcher promotes it to _certified_launcher.
+        state._next_launcher()
+        self.assertTrue(state.converged)
+        self.assertEqual(len(a._on_timing_update_subs), 1)
+        # The converged branch of __call__ clears the callback before the
+        # convergence hook fires; trigger that path with a no-op fn ref.
+        a._raw_launcher_keepalive = MagicMock(return_value=None)  # pyrefly: ignore
+        a.set_raw_launcher(a._raw_launcher_keepalive)
+        state(stream=0)
+        self.assertEqual(len(a._on_timing_update_subs), 0)
+
+    def test_add_launcher_multiple(self):
+        launchers = [_make_launcher(f"l{i}") for i in range(3)]
+        state = _make_state(launchers)
+        self.assertEqual(len(state._queue), 3)
+
+    def test_unsaturated_then_saturate_loser_no_orphan_sub(self):
+        """A launcher arrives unsaturated (sub registered via
+        ``add_launcher``), accumulates timings, becomes saturated, is
+        popped via ``_next_launcher`` and loses ``_maybe_promote``
+        (cert is faster) → ``_register_provisional_sub`` is no-op
+        (idempotent) and ``_discard``'s ``cancel()`` removes the
+        original sub. No leak."""
+        cert = _make_launcher("cert")
+        loser = _make_launcher("loser")
+        state = IncrementalAutotuneState()
+        # Cert: saturated and fast. Pre-populate timings + add.
+        for _ in range(max_timings_per_launcher):
+            cert.add_timing(1.0)
+        state.add_launcher(cert, cert.get_raw_launcher())
+        # Loser: unsaturated, will saturate later.
+        state.add_launcher(loser, loser.get_raw_launcher())
+        self.assertEqual(len(loser._on_timing_update_subs), 1)
+        # Saturate loser with slower timings.
+        for _ in range(max_timings_per_launcher):
+            loser.add_timing(10.0)
+        # Pop loser via _next_launcher → _maybe_promote → loser loses
+        # → _discard. The cert had auto-promoted on add_launcher, so
+        # cert is _certified_launcher already.
+        self.assertIs(state._certified_launcher, cert)
+        # _next_launcher walks queue; finds loser saturated → promote
+        # against cert → discard loser.
+        state._next_launcher()
+        # loser's sub was cancelled and removed from its registry.
+        self.assertEqual(len(loser._on_timing_update_subs), 0)
+        # Loser is not in state's tracking anymore.
+        self.assertNotIn(loser, state._provisional_subs)
+        self.assertNotIn(loser, state._per_launcher_raw)
+
+    def test_dispatch_round_robin_and_convergence(self):
+        """__call__ iterates launchers round-robin and calls on_convergence when done."""
+        converged = threading.Event()
+        converged_launcher: list[Launcher | None] = [None]
+
+        def on_convergence(state: IncrementalAutotuneState) -> None:
+            converged_launcher[0] = state.certified_launcher
+            converged.set()
+
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        # Make b reliably slower so it gets filtered.
+        a._raw_launcher_keepalive.return_value = "result_a"
+        state = _make_state([a, b], on_convergence_fn=on_convergence)
+
+        timing_for: dict[int, float] = {id(a): 1.0, id(b): 10.0}
+
+        def fake_submit(
+            callback: object,
+            _start: object,
+            _end: object,
+        ) -> None:
+            launcher = callback.__self__  # bound method → owning launcher
+            callback(timing_for[id(launcher)])
+
+        with (
+            patch("torch._inductor.runtime.incremental._state.timed_sampling_rate", 1),
+            patch("torch.cuda.Event", return_value=MagicMock()),
+            patch(
+                "torch._inductor.runtime.incremental._launcher.submit_event"
+            ) as mock_submit,
+        ):
+            mock_submit.side_effect = fake_submit
+            for _ in range(100):
+                state(stream=0)
+                if converged.is_set():
+                    break
+
+        self.assertTrue(converged.is_set())
+        self.assertIs(converged_launcher[0], a)
+
+    def test_first_dispatch_per_launcher_is_untimed_warmup(self):
+        """A cold launcher gets one untimed warmup dispatch before timing."""
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state = _make_state([a, b])
+
+        with (
+            patch("torch.cuda.Event", return_value=MagicMock()),
+            patch(
+                "torch._inductor.runtime.incremental._launcher.submit_event"
+            ) as mock_submit,
+        ):
+            # First dispatch per launcher: untimed warmup; _warm becomes True.
+            state(stream=0)
+            state(stream=0)
+            self.assertEqual(mock_submit.call_count, 0)
+            self.assertTrue(a._warm)
+            self.assertTrue(b._warm)
+            # Subsequent dispatches: timed.
+            state(stream=0)
+            state(stream=0)
+            self.assertEqual(mock_submit.call_count, 2)
+
+    def test_dispatch_drops_invalid_config_and_retries(self):
+        """RuntimeError("invalid configuration ...") prunes the launcher and retries."""
+        bad = _make_launcher("bad")
+        good = _make_launcher("good")
+        bad._raw_launcher_keepalive.side_effect = RuntimeError(
+            "invalid configuration argument from CUDA launch"
+        )
+        state = _make_state([bad, good])
+
+        with (
+            patch("torch.cuda.Event", return_value=MagicMock()),
+            patch("torch._inductor.runtime.incremental._launcher.submit_event"),
+        ):
+            result = state(stream=0)
+
+        self.assertEqual(result, "result_good")
+        self.assertNotIn(bad, state._queue)
+
+    def test_on_discard_fn_invoked_on_discard_and_invalid_config(self):
+        dropped: list[Launcher] = []
+        bad = _make_launcher("bad")
+        good = _make_launcher("good")
+        bad._raw_launcher_keepalive.side_effect = RuntimeError(
+            "invalid configuration argument from CUDA launch"
+        )
+        state = IncrementalAutotuneState(on_discard_fn=lambda launcher, _raw: dropped.append(launcher))
+        state.add_launcher(bad, bad.get_raw_launcher())
+        state.add_launcher(good, good.get_raw_launcher())
+
+        with (
+            patch("torch.cuda.Event", return_value=MagicMock()),
+            patch("torch._inductor.runtime.incremental._launcher.submit_event"),
+        ):
+            state(stream=0)
+        self.assertIn(bad, dropped)
+
+
+class StreamingCompileTest(TestCase):
+    """Tests for the streaming-compile primitives on
+    ``IncrementalAutotuneState``: pending-compile counter, blocking
+    first dispatch, and the all-initial-failed failure mode."""
+
+    def test_pending_blocks_convergence_with_empty_queue(self):
+        state = IncrementalAutotuneState()
+        self.assertTrue(state.converged)
+        state.register_pending_compilations(2)
+        self.assertFalse(state.converged)
+
+    def test_register_pending_asserts_on_non_positive(self):
+        state = IncrementalAutotuneState()
+        with self.assertRaises(AssertionError):
+            state.register_pending_compilations(0)
+        with self.assertRaises(AssertionError):
+            state.register_pending_compilations(-3)
+
+    def test_note_compilation_failed_decrements(self):
+        state = IncrementalAutotuneState()
+        state.register_pending_compilations(2)
+        state.note_compilation_failed()
+        self.assertEqual(state._pending_compilations, 1)
+        self.assertFalse(state.converged)
+        state.note_compilation_failed()
+        self.assertEqual(state._pending_compilations, 0)
+        self.assertTrue(state.converged)
+
+    def test_add_launcher_decrements_pending(self):
+        state = IncrementalAutotuneState()
+        state.register_pending_compilations(1)
+        a = _make_launcher("a")
+        state.add_launcher(a, a.get_raw_launcher())
+        self.assertEqual(state._pending_compilations, 0)
+
+    def test_add_launcher_without_pending_is_fine(self):
+        """Direct adds (no prior register_pending) still work — counter
+        stays at zero."""
+        state = IncrementalAutotuneState()
+        a = _make_launcher("a")
+        state.add_launcher(a, a.get_raw_launcher())
+        self.assertEqual(state._pending_compilations, 0)
+        self.assertIs(state._queue[0], a)
+
+    def test_maybe_converge_early_does_not_fire_with_pending(self):
+        """A discard that leaves one queued launcher must NOT
+        early-promote if compiles are still in flight (the in-flight
+        one might be faster)."""
+        a = _make_launcher("a")
+        survivor = _make_launcher("survivor")
+        state = _make_state([a, survivor])
+        state.register_pending_compilations(1)
+        state._queue.popleft()
+        _discard(state, a)
+        self.assertFalse(state.converged)
+        self.assertIsNone(state._certified_launcher)
+        self.assertIs(state._queue[0], survivor)
+
+    def test_call_raises_when_all_initial_compiles_fail(self):
+        """If every pending compile resolves via
+        ``note_compilation_failed`` with no launcher ever added, the
+        first dispatch surfaces ``NoTritonConfigsError`` — matching the
+        normal-path failure mode."""
+        from torch._inductor.runtime.triton_heuristics import (
+            NoTritonConfigsError,
+        )
+
+        state = IncrementalAutotuneState()
+        state.register_pending_compilations(2)
+
+        def fail_all() -> None:
+            state.note_compilation_failed()
+            state.note_compilation_failed()
+
+        threading.Thread(target=fail_all, daemon=True).start()
+        with self.assertRaises(NoTritonConfigsError):
+            state(stream=0)
+
+    def test_call_blocks_until_first_launcher_arrives(self):
+        """First dispatch waits for a streaming-compile worker to add a
+        launcher, then dispatches it."""
+        state = IncrementalAutotuneState()
+        state.register_pending_compilations(1)
+        launcher = _make_launcher("a")
+        dispatched_event = threading.Event()
+        result_holder: list[object] = []
+
+        def caller() -> None:
+            result_holder.append(state(stream=0))
+            dispatched_event.set()
+
+        caller_thread = threading.Thread(target=caller, daemon=True)
+        caller_thread.start()
+
+        # Caller must be blocked: no launcher has arrived yet.
+        self.assertFalse(dispatched_event.wait(timeout=0.05))
+
+        state.add_launcher(launcher, launcher.get_raw_launcher())
+        self.assertTrue(dispatched_event.wait(timeout=5.0))
+        caller_thread.join(timeout=5.0)
+        self.assertEqual(result_holder, ["result_a"])
+
+    def test_convergence_callback_fires_per_generation(self):
+        """The convergence callback re-arms when new work arrives
+        (add_launcher or register_pending_compilations) so a
+        multi-generation flow can chain through it."""
+        fire_count = [0]
+
+        def on_conv(_state: IncrementalAutotuneState) -> None:
+            fire_count[0] += 1
+
+        a = _make_launcher("a")
+        for _ in range(max_timings_per_launcher):
+            a.add_timing(1.0)
+        state = IncrementalAutotuneState(on_convergence_fn=on_conv)
+        state.add_launcher(a, a.get_raw_launcher())
+        self.assertTrue(state.converged)
+
+        # First dispatch fires the callback once.
+        a._raw_launcher_keepalive = MagicMock(return_value="r")
+        a.set_raw_launcher(a._raw_launcher_keepalive)
+        state(stream=0)
+        self.assertEqual(fire_count[0], 1)
+
+        # Subsequent dispatches in the same converged generation do
+        # not re-fire.
+        state(stream=0)
+        self.assertEqual(fire_count[0], 1)
+
+        # New work arriving re-arms the callback. Once that work
+        # converges (here: register-and-fail to keep the test simple),
+        # the callback fires again.
+        state.register_pending_compilations(1)
+        self.assertFalse(state.converged)
+        state.note_compilation_failed()
+        self.assertTrue(state.converged)
+        state(stream=0)
+        self.assertEqual(fire_count[0], 2)
+
+
+class ResolverTest(TestCase):
+    def setUp(self):
+        from torch._inductor.runtime.incremental import _resolver
+
+        self._resolver = _resolver
+        # Short idle timeout so the daemon exits quickly between tests.
+        self._timeout_patcher = patch.object(_resolver, "_RESOLVER_IDLE_TIMEOUT_S", 0.05)
+        self._timeout_patcher.start()
+        _wait_until(self._daemon_stopped, timeout=10.0)
+
+    def tearDown(self):
+        while not self._resolver._global_event_queue.empty():
+            try:
+                self._resolver._global_event_queue.get_nowait()
+            except queue.Empty:
+                break
+        _wait_until(self._daemon_stopped, timeout=10.0)
+        self._timeout_patcher.stop()
+
+    def _daemon_stopped(self) -> bool:
+        with self._resolver._global_resolver_lock:
+            return self._resolver._global_resolver_thread is None
+
+    def test_submit_event_puts_then_ensures_daemon(self):
+        """Put-then-ensure ordering: item is visible when daemon checks empty()."""
+        with (
+            patch.object(self._resolver, "_ensure_daemon") as mock_ensure,
+            patch.object(self._resolver._global_event_queue, "put") as mock_put,
+        ):
+            call_order = []
+            mock_put.side_effect = lambda *a, **k: call_order.append("put")
+            mock_ensure.side_effect = lambda: call_order.append("ensure")
+
+            self._resolver.submit_event(MagicMock(), MagicMock(), MagicMock())
+
+        self.assertEqual(call_order, ["put", "ensure"])
+
+    def test_daemon_processes_event_and_invokes_callback(self):
+        """Submitted events are synchronized and the callback receives elapsed_ms."""
+        done = threading.Event()
+        received: list[float] = []
+
+        def callback(elapsed_ms: float) -> None:
+            received.append(elapsed_ms)
+            done.set()
+
+        start_event = MagicMock()
+        end_event = MagicMock()
+        start_event.elapsed_time.return_value = 42.0
+
+        self._resolver.submit_event(callback, start_event, end_event)
+
+        self.assertTrue(done.wait(timeout=5.0))
+        self.assertEqual(received, [42.0])
+        end_event.synchronize.assert_called_once()
+        start_event.elapsed_time.assert_called_once_with(end_event)
+
+    def test_daemon_idles_out_after_processing(self):
+        """After processing all events, the daemon exits and clears the global slot."""
+        done = threading.Event()
+        start_event = MagicMock()
+        start_event.elapsed_time.return_value = 1.0
+        self._resolver.submit_event(lambda _: done.set(), start_event, MagicMock())
+        self.assertTrue(done.wait(timeout=5.0))
+
+        self.assertTrue(_wait_until(self._daemon_stopped, timeout=5.0))
+
+    def test_daemon_restarts_after_idle_exit(self):
+        """A second submit_event after idle-out is processed by a fresh daemon."""
+        done1 = threading.Event()
+        ev_a = MagicMock()
+        ev_a.elapsed_time.return_value = 1.0
+        self._resolver.submit_event(lambda _: done1.set(), ev_a, MagicMock())
+        self.assertTrue(done1.wait(timeout=5.0))
+        self.assertTrue(_wait_until(self._daemon_stopped, timeout=5.0))
+
+        done2 = threading.Event()
+        ev_b = MagicMock()
+        ev_b.elapsed_time.return_value = 2.0
+        self._resolver.submit_event(lambda _: done2.set(), ev_b, MagicMock())
+        self.assertTrue(done2.wait(timeout=5.0))
+
+
+class CacheTest(TestCase):
+    def setUp(self):
+        from torch._inductor.runtime.incremental import _launcher
+
+        self._cache = _launcher
+        # Snapshot and clear so each test starts with an empty registry,
+        # regardless of bleed-through from earlier modules.
+        self._original_registry = _launcher._caching_autotuner_launcher_registry.copy()
+        _launcher._caching_autotuner_launcher_registry.clear()
+
+    def tearDown(self):
+        self._cache._caching_autotuner_launcher_registry.clear()
+        self._cache._caching_autotuner_launcher_registry.update(self._original_registry)
+
+    @staticmethod
+    def _make_autotuner_mock(name="triton_kernel", src="def triton_kernel():..."):
+        """Build a minimal CachingAutotuner-shaped mock for cache key tests."""
+        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+        autotuner = MagicMock(spec=CachingAutotuner)
+        autotuner.fn = MagicMock()
+        autotuner.fn.__name__ = name
+        autotuner.fn.src = src
+        autotuner.inductor_meta = {"a": 1}
+        autotuner.triton_meta = {"b": 2}
+        # Attributes required by ``_caching_autotuner_instance_key``
+        # that aren't reflected in inductor_meta / triton_meta.
+        autotuner.size_hints = {"x": 16}
+        autotuner.heuristic_type = "POINTWISE"
+        autotuner.custom_kernel = False
+        autotuner.mutated_arg_names = []
+        autotuner.reset_to_zero_arg_names = []
+        autotuner.optimize_mem = True
+        return autotuner
+
+    # Share a single config object per x_block across raw launchers so
+    # raws produced for the same kernel/config compare equal — mirroring
+    # how Triton's Config implements __eq__ over its fields, and what
+    # the cache-hit assert in _get_or_create_launchers expects.
+    _shared_configs: dict[int, MagicMock] = {}
+
+    @classmethod
+    def _make_raw_launcher(cls, x_block: int, cache_hash: str | None = None):
+        if x_block not in cls._shared_configs:
+            cls._shared_configs[x_block] = MagicMock(
+                kwargs={"X": x_block}, num_warps=4, num_stages=1
+            )
+        raw = MagicMock()
+        raw.config = cls._shared_configs[x_block]
+        raw.cache_hash = cache_hash if cache_hash is not None else f"hash:{x_block}"
+        return raw
+
+    def test_kernel_key_raises_when_fn_has_no_src(self):
+        autotuner = self._make_autotuner_mock()
+        # Build a fn mock without ``src`` from the start so the absence is
+        # structural, not the result of a deferred ``del`` on a MagicMock.
+        autotuner.fn = MagicMock(spec=["__name__"])
+        autotuner.fn.__name__ = "triton_kernel"
+        with self.assertRaises(ValueError):
+            self._cache._caching_autotuner_instance_key(autotuner)
+
+    def test_kernel_key_normalizes_kernel_name(self):
+        """Two autotuners with different kernel names but identical structure share a key."""
+        a = self._make_autotuner_mock(name="triton_a", src="def triton_a():\n    pass")
+        b = self._make_autotuner_mock(name="triton_b", src="def triton_b():\n    pass")
+        self.assertEqual(
+            self._cache._caching_autotuner_instance_key(a),
+            self._cache._caching_autotuner_instance_key(b),
+        )
+
+    def test_kernel_key_distinguishes_distinct_kernels(self):
+        """Distinct (src, inductor, triton) triples must produce distinct keys
+        even when their concatenated bytes happen to align — guards against
+        the without-delimiters hash-collision class.
+        """
+        a = self._make_autotuner_mock(src="def triton_kernel(): a")
+        a.inductor_meta = {}
+        a.triton_meta = {}
+
+        b = self._make_autotuner_mock(src="def triton_kernel():")
+        b.inductor_meta = {"a": ""}
+        b.triton_meta = {}
+
+        self.assertNotEqual(
+            self._cache._caching_autotuner_instance_key(a),
+            self._cache._caching_autotuner_instance_key(b),
+        )
+
+    def test_get_or_create_launcher_reuses_existing_for_same_autotuner(self):
+        autotuner = self._make_autotuner_mock()
+        raw = self._make_raw_launcher(x_block=16)
+        first, _ = self._cache.get_or_create_launcher(autotuner, raw)
+        second, _ = self._cache.get_or_create_launcher(autotuner, raw)
+        self.assertIs(first, second)
+
+    def test_get_or_create_launcher_shared_across_identical_autotuners(self):
+        """Two autotuners with the same kernel content share Launchers per config."""
+        a = self._make_autotuner_mock()
+        b = self._make_autotuner_mock()
+        raw = self._make_raw_launcher(x_block=16)
+        launcher_a, _ = self._cache.get_or_create_launcher(a, raw)
+        launcher_b, _ = self._cache.get_or_create_launcher(b, raw)
+        self.assertIs(launcher_a, launcher_b)
+        self.assertEqual(len(self._cache._caching_autotuner_launcher_registry), 1)
+
+    def test_get_or_create_launcher_distinct_for_distinct_config(self):
+        autotuner = self._make_autotuner_mock()
+        a, _ = self._cache.get_or_create_launcher(
+            autotuner, self._make_raw_launcher(x_block=16)
+        )
+        b, _ = self._cache.get_or_create_launcher(
+            autotuner, self._make_raw_launcher(x_block=32)
+        )
+        self.assertIsNot(a, b)
+
+    def test_get_or_create_launcher_case_1_share_live_raw(self):
+        """Case 1: pool already has a live raw → second autotuner gets a
+        view onto that raw (not the new raw it just created)."""
+        a = self._make_autotuner_mock()
+        b = self._make_autotuner_mock()
+        raw_a = self._make_raw_launcher(x_block=16, cache_hash="hash_a")
+        raw_b = self._make_raw_launcher(x_block=16, cache_hash="hash_b")
+
+        # Hold strong ref to raw_a so its weakref doesn't die.
+        keepalive: list[object] = [raw_a]
+
+        launcher_a, chosen_a = self._cache.get_or_create_launcher(a, raw_a)
+        launcher_b, chosen_b = self._cache.get_or_create_launcher(b, raw_b)
+        self.assertIs(launcher_a, launcher_b)
+        # Case 1: second autotuner's chosen is a view, not the new raw.
+        self.assertIsInstance(chosen_b, self._cache.RawLauncherView)
+        # The view delegates dispatch to raw_a but exposes b's cache_hash.
+        self.assertEqual(chosen_b.cache_hash, "hash_b")
+        self.assertEqual(chosen_b.config, raw_a.config)
+        # Sanity: keepalive prevents GC.
+        del keepalive
+
+    def test_get_or_create_launcher_case_3_set_when_raw_dead(self):
+        """Case 3: pool has a Launcher with timing data but its raw is
+        dead → attach the new raw (not a view)."""
+        a = self._make_autotuner_mock()
+        raw_a = self._make_raw_launcher(x_block=16, cache_hash="hash_a")
+        launcher_a, chosen_a = self._cache.get_or_create_launcher(a, raw_a)
+        # First go-round attaches raw_a directly (pool miss).
+        self.assertIs(chosen_a, raw_a)
+
+        # Drop raw_a; the Launcher's weakref dies.
+        del raw_a
+        del chosen_a
+        gc.collect()
+        self.assertIsNone(launcher_a.get_raw_launcher())
+
+        # Second autotuner shows up; pool finds the dormant Launcher and
+        # case 3 attaches the new raw.
+        b = self._make_autotuner_mock()
+        raw_b = self._make_raw_launcher(x_block=16, cache_hash="hash_b")
+        launcher_b, chosen_b = self._cache.get_or_create_launcher(b, raw_b)
+        self.assertIs(launcher_a, launcher_b)
+        # Case 3: chosen is the new raw itself, not a view.
+        self.assertIs(chosen_b, raw_b)
+
+    def test_get_or_create_launcher_raises_when_obj_not_autotuner(self):
+        """For unrecognized obj, get_or_create_launcher raises ValueError."""
+        raw = self._make_raw_launcher(x_block=16)
+        with self.assertRaises(ValueError):
+            self._cache.get_or_create_launcher("not an autotuner", raw)
+        self.assertEqual(len(self._cache._caching_autotuner_launcher_registry), 0)
+
+    def test_get_or_create_launcher_view_exposes_per_autotuner_cache_hash(self):
+        """The view wrapper overrides cache_hash so each sharing
+        autotuner sees its own value, while delegating other attrs to
+        the underlying real raw."""
+        a = self._make_autotuner_mock()
+        b = self._make_autotuner_mock()
+        raw_a = self._make_raw_launcher(x_block=16, cache_hash="hash_a")
+        raw_b = self._make_raw_launcher(x_block=16, cache_hash="hash_b")
+        keepalive: list[object] = [raw_a]
+
+        _, chosen_a = self._cache.get_or_create_launcher(a, raw_a)
+        _, chosen_b = self._cache.get_or_create_launcher(b, raw_b)
+
+        # First autotuner gets the real raw.
+        self.assertIs(chosen_a, raw_a)
+        self.assertEqual(chosen_a.cache_hash, "hash_a")
+        # Second gets a view with its own cache_hash but real_raw's config.
+        self.assertIsInstance(chosen_b, self._cache.RawLauncherView)
+        self.assertEqual(chosen_b.cache_hash, "hash_b")
+        self.assertEqual(chosen_b.config, raw_a.config)
+        del keepalive
+
+    def test_raw_launcher_view_pickle_round_trip(self):
+        """``RawLauncherView`` must survive pickle round-trip with its
+        per-autotuner ``cache_hash`` and ``found_by_coordesc`` overrides
+        intact. Without ``__reduce__``/``__setstate__``, pickle would
+        route through ``__getattr__`` to ``_real_raw`` and silently
+        drop the overrides."""
+        import pickle
+        from torch._inductor.runtime.incremental._launcher import (
+            RawLauncherView,
+        )
+
+        view = RawLauncherView(
+            _PicklableRaw(config="cfg", cache_hash="underlying_hash"),
+            cache_hash="my_hash",
+        )
+        view.found_by_coordesc = True
+
+        restored = pickle.loads(pickle.dumps(view))
+        self.assertIsInstance(restored, RawLauncherView)
+        self.assertEqual(restored.cache_hash, "my_hash")
+        self.assertTrue(restored.found_by_coordesc)
+        self.assertEqual(restored.config, "cfg")
+        # Dispatch still works.
+        self.assertEqual(restored(), "ok")
+
+    def test_get_or_create_launcher_thread_safe(self):
+        """Concurrent get_or_create_launcher calls must produce exactly one
+        Launcher per (kernel, config), not one per thread.
+        """
+        autotuner = self._make_autotuner_mock()
+        raw = self._make_raw_launcher(x_block=16)
+
+        n_threads = 8
+        results: list[object] = []
+        results_lock = threading.Lock()
+        barrier = threading.Barrier(n_threads)
+
+        def worker() -> None:
+            barrier.wait()
+            launcher, _ = self._cache.get_or_create_launcher(autotuner, raw)
+            with results_lock:
+                results.append(launcher)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(len(results), n_threads)
+        self.assertTrue(all(r is results[0] for r in results))
+
+    def test_lookup_launcher_miss_returns_none(self):
+        autotuner = self._make_autotuner_mock()
+        raw = self._make_raw_launcher(x_block=16)
+        self.assertIsNone(self._cache.lookup_launcher(autotuner, raw.config))
+
+    def test_lookup_launcher_hit_returns_existing(self):
+        autotuner = self._make_autotuner_mock()
+        raw = self._make_raw_launcher(x_block=16)
+        launcher, _ = self._cache.get_or_create_launcher(autotuner, raw)
+        # Sharing autotuner sees the same Launcher via lookup.
+        other = self._make_autotuner_mock()
+        looked_up = self._cache.lookup_launcher(other, raw.config)
+        self.assertIs(looked_up, launcher)
+
+    def test_lookup_launcher_returns_none_for_unrecognized_obj(self):
+        raw = self._make_raw_launcher(x_block=16)
+        self.assertIsNone(
+            self._cache.lookup_launcher("not an autotuner", raw.config)
+        )
+
+    def test_lookup_launcher_does_not_mutate_pool(self):
+        autotuner = self._make_autotuner_mock()
+        raw = self._make_raw_launcher(x_block=16)
+        self._cache.lookup_launcher(autotuner, raw.config)
+        # Pool entry was created lazily for the autotuner key but no
+        # Launcher was registered. The inner per-config dict is empty.
+        from torch._inductor.runtime.incremental._launcher import (
+            _caching_autotuner_instance_key,
+        )
+        key = _caching_autotuner_instance_key(autotuner)
+        self.assertEqual(
+            self._cache._caching_autotuner_launcher_registry.get(key, {}), {}
+        )
+
+
+class _CachingAutotunerInstanceKeyTest(TestCase):
+    """Test stability of the per-kernel pool key across pickle and across
+    attribute permutations. The key MUST be deterministic for the
+    parent / worker / post-pickle instances of the same kernel to find
+    the same pool entry; otherwise per-kernel ``Launcher`` sharing
+    misses across autotuner reincarnations."""
+
+    @staticmethod
+    def _make_autotuner_mock(**overrides):
+        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+        autotuner = MagicMock(spec=CachingAutotuner)
+        autotuner.fn = MagicMock()
+        autotuner.fn.__name__ = "triton_kernel"
+        autotuner.fn.src = "def triton_kernel():..."
+        autotuner.inductor_meta = {"a": 1}
+        autotuner.triton_meta = {"b": 2}
+        autotuner.size_hints = {"x": 16}
+        autotuner.heuristic_type = "POINTWISE"
+        autotuner.custom_kernel = False
+        autotuner.mutated_arg_names = []
+        autotuner.reset_to_zero_arg_names = []
+        autotuner.optimize_mem = True
+        for k, v in overrides.items():
+            setattr(autotuner, k, v)
+        return autotuner
+
+    def test_key_distinguishes_size_hints(self):
+        from torch._inductor.runtime.incremental._launcher import (
+            _caching_autotuner_instance_key,
+        )
+
+        a = self._make_autotuner_mock(size_hints={"x": 16})
+        b = self._make_autotuner_mock(size_hints={"x": 32})
+        self.assertNotEqual(
+            _caching_autotuner_instance_key(a),
+            _caching_autotuner_instance_key(b),
+        )
+
+    def test_key_distinguishes_heuristic_type(self):
+        from torch._inductor.runtime.incremental._launcher import (
+            _caching_autotuner_instance_key,
+        )
+
+        a = self._make_autotuner_mock(heuristic_type="POINTWISE")
+        b = self._make_autotuner_mock(heuristic_type="REDUCTION")
+        self.assertNotEqual(
+            _caching_autotuner_instance_key(a),
+            _caching_autotuner_instance_key(b),
+        )
+
+    def test_key_distinguishes_custom_kernel(self):
+        from torch._inductor.runtime.incremental._launcher import (
+            _caching_autotuner_instance_key,
+        )
+
+        a = self._make_autotuner_mock(custom_kernel=False)
+        b = self._make_autotuner_mock(custom_kernel=True)
+        self.assertNotEqual(
+            _caching_autotuner_instance_key(a),
+            _caching_autotuner_instance_key(b),
+        )
+
+    def test_key_distinguishes_mutated_arg_names(self):
+        from torch._inductor.runtime.incremental._launcher import (
+            _caching_autotuner_instance_key,
+        )
+
+        a = self._make_autotuner_mock(mutated_arg_names=[])
+        b = self._make_autotuner_mock(mutated_arg_names=["x"])
+        self.assertNotEqual(
+            _caching_autotuner_instance_key(a),
+            _caching_autotuner_instance_key(b),
+        )
+
+    def test_key_distinguishes_reset_to_zero_arg_names(self):
+        from torch._inductor.runtime.incremental._launcher import (
+            _caching_autotuner_instance_key,
+        )
+
+        a = self._make_autotuner_mock(reset_to_zero_arg_names=[])
+        b = self._make_autotuner_mock(reset_to_zero_arg_names=["x"])
+        self.assertNotEqual(
+            _caching_autotuner_instance_key(a),
+            _caching_autotuner_instance_key(b),
+        )
+
+    def test_key_distinguishes_optimize_mem(self):
+        from torch._inductor.runtime.incremental._launcher import (
+            _caching_autotuner_instance_key,
+        )
+
+        a = self._make_autotuner_mock(optimize_mem=True)
+        b = self._make_autotuner_mock(optimize_mem=False)
+        self.assertNotEqual(
+            _caching_autotuner_instance_key(a),
+            _caching_autotuner_instance_key(b),
+        )
+
+    def test_key_stable_across_two_equivalent_instances(self):
+        """Two distinct autotuner objects with identical content
+        produce the same key — required for stage-2 stash drain to
+        work across the parent → worker → post-pickle plugin instance
+        boundary."""
+        from torch._inductor.runtime.incremental._launcher import (
+            _caching_autotuner_instance_key,
+        )
+
+        a = self._make_autotuner_mock()
+        b = self._make_autotuner_mock()
+        self.assertEqual(
+            _caching_autotuner_instance_key(a),
+            _caching_autotuner_instance_key(b),
+        )
+
+
+class _StateLifecycleTest(TestCase):
+    """Cover hooks (pre_launch, post_launch) and resolver-thread
+    exception handling that aren't exercised by the unit tests."""
+
+    def test_pre_launch_and_post_launch_hooks_fire_in_order(self):
+        order: list[str] = []
+
+        def pre(launcher, *args, stream, **kwargs):
+            order.append("pre")
+
+        def post():
+            order.append("post")
+
+        launcher = _make_launcher("a")
+        state = IncrementalAutotuneState(pre_launch_fn=pre, post_launch_fn=post)
+        state.add_launcher(launcher, launcher.get_raw_launcher())
+        # Drive a dispatch via the converged-fallback path: set cert
+        # and call once.
+        state._certified_launcher = launcher
+        # Drain the queue so converged is True.
+        state._queue.clear()
+        state._provisional_subs.pop(launcher, None)
+        state._convergence_callback_fired = True  # skip cb fire path
+        state(stream=0)
+        self.assertEqual(order, ["pre", "post"])
+
+    def test_post_launch_fires_even_when_launcher_raises(self):
+        order: list[str] = []
+
+        def pre(launcher, *args, stream, **kwargs):
+            order.append("pre")
+
+        def post():
+            order.append("post")
+
+        # Launcher whose underlying raw raises.
+        fn = MagicMock(side_effect=RuntimeError("boom"))
+        launcher = Launcher(raw_launcher=fn)
+        launcher._raw_launcher_keepalive = fn  # pyrefly: ignore
+        state = IncrementalAutotuneState(pre_launch_fn=pre, post_launch_fn=post)
+        state.add_launcher(launcher, launcher.get_raw_launcher())
+        state._certified_launcher = launcher
+        state._queue.clear()
+        state._provisional_subs.pop(launcher, None)
+        state._convergence_callback_fired = True
+        with self.assertRaises(RuntimeError):
+            state(stream=0)
+        # post still fired despite the exception.
+        self.assertEqual(order, ["pre", "post"])
+
+    def test_invalid_configuration_loops_not_recurses(self):
+        """Many launchers all raising 'invalid configuration' should
+        loop (not recurse) so the stack doesn't blow up."""
+        n = 200
+        launchers = [_make_launcher(f"l{i}") for i in range(n)]
+        for l in launchers:
+            l._raw_launcher_keepalive.side_effect = RuntimeError(
+                "invalid configuration"
+            )
+        # Use one good launcher at the end so we eventually return.
+        good = _make_launcher("good")
+        good._raw_launcher_keepalive.return_value = "ok"
+        all_launchers = launchers + [good]
+        state = IncrementalAutotuneState()
+        for l in all_launchers:
+            state.add_launcher(l, l.get_raw_launcher())
+        # Set provisional manually so case-2 doesn't trigger
+        # threshold-discards on every launcher pre-dispatch.
+        # (n+1 launchers, all unsaturated, no threshold triggers.)
+        result = state(stream=0)
+        self.assertEqual(result, "ok")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -1,10 +1,18 @@
 # Owner(s): ["module: inductor"]
 
 import functools
+import io
 import os
+import pickle
+import queue
+import socket
+import stat
 import sys
 import tempfile
+import threading
+import time
 import unittest
+from concurrent.futures import Future
 from unittest import skipUnless
 from unittest.mock import MagicMock, patch
 
@@ -594,6 +602,629 @@ class TestCachingAutotunerPlugin(TestCase):
         revived = CachingAutotuner.__new__(CachingAutotuner)
         revived.__setstate__(state)
         self.assertEqual(revived._plugins, [])
+
+
+class TestPipelineCachingAutotunerPlugin(TestCase):
+    """Synchronization between ``_bg_drain_kernel`` and the plugin's
+    ``pre_dispatch`` hook on multi-config, single-config, overlap, and
+    error paths."""
+
+    device_type = GPU_TYPE
+
+    @staticmethod
+    def _make_handle(
+        *,
+        num_configs,
+        drain_done=True,
+        drain_exc=None,
+        push_launcher_end=True,
+    ):
+        """Build a ``PipelineCachingAutotunerHandle`` with the drain
+        future pre-resolved per the simulation knobs."""
+        from torch._inductor.async_compile import (
+            _LAUNCHER_END,
+            PipelineCachingAutotunerHandle,
+        )
+
+        drain_fut: Future = Future()
+        if drain_exc is not None:
+            drain_fut.set_exception(drain_exc)
+        elif drain_done:
+            drain_fut.set_result(None)
+        launcher_q: queue.Queue = queue.Queue()
+        if push_launcher_end:
+            launcher_q.put(_LAUNCHER_END)
+        return PipelineCachingAutotunerHandle(
+            launcher_q=launcher_q,
+            drain_future=drain_fut,
+            num_configs=num_configs,
+            kernel_name="test_kernel",
+        )
+
+    def _make_autotuner(self):
+        args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
+        args["inductor_meta"] = {**args["inductor_meta"], "grid_type": "Grid1D"}
+        return CachingAutotuner(**args)
+
+    def _make_plugin(self):
+        from torch._inductor.async_compile import (
+            _make_pipeline_caching_autotuner_plugin,
+        )
+
+        return _make_pipeline_caching_autotuner_plugin()
+
+    def test_pre_dispatch_no_op_without_handle(self):
+        """No stashed handle → ``pre_dispatch`` is a no-op (returns
+        ``DEFER``)."""
+        from torch._inductor.runtime.triton_heuristics import DEFER
+
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        result = plugin.pre_dispatch(autotuner, stream=0)
+        self.assertIs(result, DEFER)
+
+    def test_pre_dispatch_single_config_waits_for_drain_no_bench(self):
+        """Single-config kernel: plugin awaits ``drain_future`` and
+        proceeds without bench. ``run()``'s standard flow then sees
+        ``len(launchers) == 1`` and skips autotune."""
+        from torch._inductor.runtime.triton_heuristics import DEFER
+
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        launcher = MagicMock()
+        autotuner.launchers = [launcher]
+        autotuner.compile_results = [MagicMock()]
+        autotuner._pipeline_caching_autotuner_handle = self._make_handle(
+            num_configs=1
+        )
+        autotuner.bench = MagicMock()
+
+        result = plugin.pre_dispatch(autotuner, stream=0)
+
+        self.assertIs(result, DEFER)
+        autotuner.bench.assert_not_called()
+        self.assertEqual(autotuner.launchers, [launcher])
+        self.assertIsNone(autotuner._pipeline_caching_autotuner_handle)
+
+    def test_pre_dispatch_multi_config_drains_launcher_q_picks_winner(self):
+        """Multi-config kernel: plugin pulls launchers from
+        ``handle.launcher_q``, benches each via ``_bench_launchers``,
+        and ``_finalize_autotune_winner`` reduces ``autotuner.launchers``
+        to ``[winner]``."""
+        from torch._inductor.runtime.triton_heuristics import DEFER
+
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        launcher_fast, launcher_slow = MagicMock(), MagicMock()
+        launcher_fast.cache_hash = "lf"
+        launcher_slow.cache_hash = "ls"
+        autotuner.launchers = [launcher_fast, launcher_slow]
+        autotuner.compile_results = [MagicMock(), MagicMock()]
+        handle = self._make_handle(num_configs=2)
+        for launcher in (launcher_fast, launcher_slow):
+            # Insert before the LAUNCHER_END that _make_handle pushed.
+            handle.launcher_q.queue.insert(-1, launcher)
+        autotuner._pipeline_caching_autotuner_handle = handle
+        autotuner.bench = MagicMock(side_effect=[1.0, 5.0])
+        autotuner.coordesc_tuner = MagicMock()
+        autotuner.save_cache_hook = None
+        autotuner.get_device_interface = MagicMock()
+
+        with patch("torch._dynamo.device_interface.DeviceGuard"):
+            result = plugin.pre_dispatch(autotuner, stream=0)
+
+        self.assertIs(result, DEFER)
+        self.assertEqual(autotuner.bench.call_count, 2)
+        self.assertEqual(autotuner.launchers, [launcher_fast])
+        self.assertIsNone(autotuner._pipeline_caching_autotuner_handle)
+
+    def test_pre_dispatch_multi_config_overlaps_with_bg_drain(self):
+        """Plugin consumes ``launcher_q`` blocking-style — it begins
+        benching as soon as the FIRST launcher arrives, without waiting
+        for the bg drain to finish making all of them."""
+        from torch._inductor.async_compile import _LAUNCHER_END
+        from torch._inductor.runtime.triton_heuristics import DEFER
+
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        launcher_a, launcher_b = MagicMock(), MagicMock()
+        launcher_a.cache_hash = "la"
+        launcher_b.cache_hash = "lb"
+        autotuner.launchers = [launcher_a, launcher_b]
+        autotuner.compile_results = [MagicMock(), MagicMock()]
+        handle = self._make_handle(num_configs=2, push_launcher_end=False)
+        autotuner._pipeline_caching_autotuner_handle = handle
+        autotuner.coordesc_tuner = MagicMock()
+        autotuner.save_cache_hook = None
+        autotuner.get_device_interface = MagicMock()
+
+        bench_results = [1.0, 5.0]
+        bench_call_observed = threading.Event()
+
+        def bench_side_effect(*args, **kwargs):
+            bench_call_observed.set()
+            return bench_results.pop(0)
+
+        autotuner.bench = MagicMock(side_effect=bench_side_effect)
+
+        def pusher():
+            handle.launcher_q.put(launcher_a)
+            # Wait until the plugin has actually started benching
+            # launcher_a before we push launcher_b — proves the plugin
+            # didn't block waiting for all launchers up-front.
+            bench_call_observed.wait(timeout=2.0)
+            handle.launcher_q.put(launcher_b)
+            handle.launcher_q.put(_LAUNCHER_END)
+
+        t = threading.Thread(target=pusher, daemon=True)
+        t.start()
+
+        with patch("torch._dynamo.device_interface.DeviceGuard"):
+            result = plugin.pre_dispatch(autotuner, stream=0)
+        t.join(timeout=2.0)
+
+        self.assertIs(result, DEFER)
+        self.assertEqual(autotuner.bench.call_count, 2)
+        self.assertEqual(autotuner.launchers, [launcher_a])
+
+    def test_pre_dispatch_reraises_drain_exception(self):
+        """If the bg drainer caught an exception, ``drain_future`` is
+        resolved with it (and ``_LAUNCHER_END`` is pushed so the plugin's
+        bench loop terminates). The plugin re-raises via
+        ``drain_future.result()`` so the user sees the failure."""
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        autotuner.launchers = []
+        autotuner.compile_results = []
+        autotuner._pipeline_caching_autotuner_handle = self._make_handle(
+            num_configs=1, drain_exc=RuntimeError("boom")
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            plugin.pre_dispatch(autotuner, stream=0)
+
+    def test_pre_dispatch_raises_when_zero_results_streamed(self):
+        """Worker-side total-failure surfaces ``NoTritonConfigsError``
+        when the bg drainer ends with no compile_results AND no launchers."""
+        from torch._inductor.runtime.triton_heuristics import (
+            NoTritonConfigsError,
+        )
+
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        autotuner.launchers = []
+        autotuner.compile_results = []
+        autotuner._pipeline_caching_autotuner_handle = self._make_handle(
+            num_configs=1
+        )
+
+        with self.assertRaises(NoTritonConfigsError):
+            plugin.pre_dispatch(autotuner, stream=0)
+
+
+class TestStreamingPickler(TestCase):
+    """Wire-format coverage for ``_StreamingPickler`` /
+    ``_StreamingUnpickler``: every object the persistent_id callback
+    substitutes must round-trip to ``None`` on the parent side, and
+    everything else must pass through untouched."""
+
+    @staticmethod
+    def _round_trip(obj):
+        from torch._inductor.runtime.compile_tasks import (
+            _StreamingPickler,
+            _StreamingUnpickler,
+        )
+
+        buf = io.BytesIO()
+        _StreamingPickler(buf, protocol=pickle.HIGHEST_PROTOCOL).dump(obj)
+        buf.seek(0)
+        return _StreamingUnpickler(buf).load()
+
+    def test_rlock_substituted_with_none(self):
+        loaded = self._round_trip({"lock": threading.RLock(), "value": 42})
+        self.assertIsNone(loaded["lock"])
+        self.assertEqual(loaded["value"], 42)
+
+    def test_module_substituted_with_none(self):
+        loaded = self._round_trip({"mod": os, "name": "hello"})
+        self.assertIsNone(loaded["mod"])
+        self.assertEqual(loaded["name"], "hello")
+
+    def test_dyn_module_function_substituted_with_none(self):
+        from types import ModuleType
+
+        from torch._inductor.runtime.compile_tasks import (
+            _DYN_KERNEL_MODULE_PREFIX,
+        )
+
+        fake_mod_name = f"{_DYN_KERNEL_MODULE_PREFIX}fake_test_kernel"
+        fake_mod = ModuleType(fake_mod_name)
+        sys.modules[fake_mod_name] = fake_mod
+        try:
+            exec("def fake_kernel(): pass", fake_mod.__dict__)
+            loaded = self._round_trip({"fn": fake_mod.fake_kernel, "value": "x"})
+            self.assertIsNone(loaded["fn"])
+            self.assertEqual(loaded["value"], "x")
+        finally:
+            del sys.modules[fake_mod_name]
+
+    def test_normal_function_preserved(self):
+        # math.sqrt is a builtin, importable on the parent.
+        import math
+
+        loaded = self._round_trip({"fn": math.sqrt, "value": 9})
+        self.assertIs(loaded["fn"], math.sqrt)
+        self.assertEqual(loaded["value"], 9)
+
+    def test_unknown_persistent_id_raises(self):
+        from torch._inductor.runtime.compile_tasks import _StreamingUnpickler
+
+        class BadPickler(pickle.Pickler):
+            def persistent_id(self, obj):
+                if isinstance(obj, list):
+                    return ("bogus_id",)
+                return None
+
+        buf = io.BytesIO()
+        BadPickler(buf, protocol=pickle.HIGHEST_PROTOCOL).dump({"data": [1, 2]})
+        buf.seek(0)
+        with self.assertRaises(pickle.UnpicklingError):
+            _StreamingUnpickler(buf).load()
+
+
+class TestStreamingTransport(TestCase):
+    """Process-wide shared AF_UNIX listener: worker connects, sends per-kernel
+    id to identify itself to the dispatcher, streams the wire protocol
+    (_Kernel / _Success / _Failure / _Done). Same-UID trust model -- id is
+    identification only, not authentication."""
+
+    @staticmethod
+    def _fake_worker(sock_path, kernel_id, messages):
+        """Mimics _stream_compile_triton: connect + send kernel id + send each
+        wire-protocol message via _streaming_send."""
+        from multiprocessing.connection import Connection
+
+        from torch._inductor.runtime.compile_tasks import _streaming_send
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(sock_path)
+        sock.sendall(kernel_id)
+        conn = Connection(sock.detach())
+        try:
+            for m in messages:
+                _streaming_send(conn, m)
+        finally:
+            conn.close()
+
+    def test_listener_round_trip(self):
+        """Register a kernel, connect a fake worker that sends id +
+        _Kernel + 2 _Success + _Done. Parent reads them through
+        _streaming_decode and dispatches."""
+        from multiprocessing.connection import Connection
+
+        from torch._inductor.async_compile import _setup_streaming_listener
+        from torch._inductor.runtime.compile_tasks import (
+            _Done,
+            _Kernel,
+            _streaming_decode,
+            _Success,
+        )
+
+        sock_path, kernel_id, conn_future = _setup_streaming_listener("k")
+        outgoing = [
+            _Kernel("fake-kernel-payload"),
+            _Success("result-1"),
+            _Success("result-2"),
+            _Done(),
+        ]
+        t = threading.Thread(
+            target=self._fake_worker,
+            args=(sock_path, kernel_id, outgoing),
+            daemon=True,
+        )
+        t.start()
+        conn_sock = conn_future.result(timeout=10.0)
+        parent = Connection(conn_sock.detach())
+        try:
+            seen = []
+            while True:
+                msg = _streaming_decode(parent.recv_bytes())
+                seen.append(msg)
+                if isinstance(msg, _Done):
+                    break
+            self.assertIsInstance(seen[0], _Kernel)
+            self.assertEqual(seen[0].kernel, "fake-kernel-payload")
+            self.assertEqual(
+                [m.result for m in seen[1:-1] if isinstance(m, _Success)],
+                ["result-1", "result-2"],
+            )
+            self.assertIsInstance(seen[-1], _Done)
+        finally:
+            parent.close()
+        t.join(timeout=2.0)
+
+    def test_setup_streaming_listener_unique_per_kernel_state(self):
+        """Each call shares the same listener path but returns a unique id
+        and Future. Listener path is owner-only (0600)."""
+        from torch._inductor.async_compile import (
+            _setup_streaming_listener,
+            _STREAMING_KERNEL_ID_SIZE,
+        )
+
+        path1, id1, fut1 = _setup_streaming_listener("k1")
+        path2, id2, fut2 = _setup_streaming_listener("k2")
+        self.assertEqual(path1, path2)  # shared listener
+        self.assertNotEqual(id1, id2)
+        self.assertEqual(len(id1), _STREAMING_KERNEL_ID_SIZE)
+        self.assertIsNot(fut1, fut2)
+        self.assertEqual(stat.S_IMODE(os.stat(path1).st_mode), 0o600)
+
+    def test_unknown_kernel_id_dropped(self):
+        """Connecting with an id not in the registry: dispatcher silently
+        drops the connection (no kernel waiting)."""
+        from torch._inductor.async_compile import (
+            _ensure_shared_listener,
+            _STREAMING_KERNEL_ID_SIZE,
+        )
+
+        sock_path = _ensure_shared_listener()
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(sock_path)
+        sock.sendall(b"\x00" * _STREAMING_KERNEL_ID_SIZE)  # never registered
+        # Dispatcher closes the connection; reading should hit EOF.
+        sock.settimeout(5.0)
+        data = sock.recv(1)
+        self.assertEqual(data, b"")
+        sock.close()
+
+    def test_short_read_on_kernel_id_dropped(self):
+        """Worker connects but sends fewer than ``_STREAMING_KERNEL_ID_SIZE``
+        bytes then closes. Dispatcher drops the connection without crashing
+        and continues serving subsequent connections normally."""
+        from torch._inductor.async_compile import (
+            _ensure_shared_listener,
+            _setup_streaming_listener,
+            _STREAMING_KERNEL_ID_SIZE,
+        )
+
+        sock_path = _ensure_shared_listener()
+        # Send a half-sized id then close. The dispatcher's recv loop sees
+        # the EOF mid-read and raises OSError("short read on kernel id"),
+        # which the loop catches + closes the conn.
+        bad = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        bad.connect(sock_path)
+        bad.sendall(b"\xab" * (_STREAMING_KERNEL_ID_SIZE // 2))
+        bad.close()
+
+        # A subsequent valid registration must still dispatch end-to-end.
+        _, kernel_id, conn_future = _setup_streaming_listener("k_after_short")
+        t = threading.Thread(
+            target=self._fake_worker,
+            args=(sock_path, kernel_id, ["only-payload"]),
+            daemon=True,
+        )
+        t.start()
+        conn_sock = conn_future.result(timeout=10.0)
+        try:
+            self.assertIsNotNone(conn_sock)
+        finally:
+            conn_sock.close()
+        t.join(timeout=2.0)
+
+    def test_drop_streaming_registration_removes_id(self):
+        """``_drop_streaming_registration`` must actually pop the id from
+        the registry so the kernel-id space doesn't leak."""
+        from torch._inductor.async_compile import (
+            _drop_streaming_registration,
+            _setup_streaming_listener,
+            _SHARED_REGISTRY,
+            _STREAMING_KERNEL_ID_STRUCT,
+        )
+
+        _, kernel_id, _ = _setup_streaming_listener("k_drop")
+        (parsed_id,) = _STREAMING_KERNEL_ID_STRUCT.unpack(kernel_id)
+        self.assertIn(parsed_id, _SHARED_REGISTRY)
+        _drop_streaming_registration(kernel_id)
+        self.assertNotIn(parsed_id, _SHARED_REGISTRY)
+        # Idempotent: dropping a second time must not raise.
+        _drop_streaming_registration(kernel_id)
+
+    @staticmethod
+    def _make_fake_kernel(make_launcher_returns=None):
+        """Minimal fake satisfying the bg drain's CachingAutotuner interface.
+        ``make_launcher_returns`` is a callable ``result -> (launcher, exc)``;
+        defaults to wrapping the result string as the launcher."""
+        if make_launcher_returns is None:
+            make_launcher_returns = lambda r: (f"launcher_for_{r}", None)  # noqa: E731
+
+        class _FakeKernel:
+            def __init__(self):
+                self._last_compile_exception = None
+                self.fn = type("F", (), {"__name__": "fake_kernel"})()
+                self.triton_meta = {"device": 0}
+                self.compile_results: list = []
+                self.launchers: list = []
+                self.configs: list = []
+                self._dynamic_scale_called = False
+
+            def get_device_interface(self):
+                return MagicMock()
+
+            def _maybe_put_static_autotuner(self, key):
+                pass
+
+            def _bundle_compile_result(self, result):
+                pass
+
+            def _make_launcher(self, result):
+                return make_launcher_returns(result)
+
+            def _all_failed_fallback(self, exc):
+                pass
+
+            def _dynamic_scale_rblock(self, on_launcher=None):
+                self._dynamic_scale_called = True
+
+        return _FakeKernel()
+
+    @staticmethod
+    def _bg_drain_with_noop_device_guard(kernel, conn, handle, key):
+        """Run ``_bg_drain_kernel`` with DeviceGuard patched to a no-op so the
+        test doesn't need a real device."""
+        import contextlib
+        from unittest.mock import patch
+
+        from torch._inductor.async_compile import _bg_drain_kernel
+
+        @contextlib.contextmanager
+        def _noop_guard(*_a, **_k):
+            yield
+
+        with patch(
+            "torch._dynamo.device_interface.DeviceGuard", _noop_guard
+        ):
+            _bg_drain_kernel(kernel, conn, handle, key)
+
+    def test_garbage_payload_propagates_to_drain(self):
+        """Worker sends a valid id then non-zlib bytes. The drain's
+        ``_recv_msg`` raises ``zlib.error``; ``_bg_drain_kernel`` forwards
+        that to ``handle.drain_future`` and pushes ``_LAUNCHER_END``."""
+        from concurrent.futures import Future as _Fut
+        from multiprocessing.connection import Connection
+
+        from torch._inductor.async_compile import (
+            _LAUNCHER_END,
+            _setup_streaming_listener,
+            PipelineCachingAutotunerHandle,
+        )
+
+        sock_path, kernel_id, conn_future = _setup_streaming_listener("k_garbage")
+
+        def _bad_worker():
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.connect(sock_path)
+            s.sendall(kernel_id)
+            payload = b"not-zlib-data"
+            s.sendall(len(payload).to_bytes(4, "big") + payload)
+            s.close()
+
+        threading.Thread(target=_bad_worker, daemon=True).start()
+        conn_sock = conn_future.result(timeout=10.0)
+        conn = Connection(conn_sock.detach())
+
+        handle = PipelineCachingAutotunerHandle(
+            launcher_q=__import__("queue").Queue(),
+            drain_future=_Fut(),
+            num_configs=1,
+            kernel_name="k_garbage",
+        )
+        self._bg_drain_with_noop_device_guard(
+            self._make_fake_kernel(), conn, handle, None
+        )
+
+        with self.assertRaises(BaseException):
+            handle.drain_future.result(timeout=2.0)
+        self.assertIs(handle.launcher_q.get(timeout=2.0), _LAUNCHER_END)
+
+    def test_eof_without_done_is_anomaly(self):
+        """Worker sends a valid kernel id then closes the socket without ever
+        sending a ``_Done``. The drain raises rather than silently treating
+        the empty stream as a successful completion."""
+        from concurrent.futures import Future as _Fut
+        from multiprocessing.connection import Connection
+
+        from torch._inductor.async_compile import (
+            _LAUNCHER_END,
+            _setup_streaming_listener,
+            PipelineCachingAutotunerHandle,
+        )
+
+        sock_path, kernel_id, conn_future = _setup_streaming_listener("k_eof")
+
+        def _silent_worker():
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.connect(sock_path)
+            s.sendall(kernel_id)
+            s.close()  # no _Done, no anything
+
+        threading.Thread(target=_silent_worker, daemon=True).start()
+        conn_sock = conn_future.result(timeout=10.0)
+        conn = Connection(conn_sock.detach())
+
+        handle = PipelineCachingAutotunerHandle(
+            launcher_q=__import__("queue").Queue(),
+            drain_future=_Fut(),
+            num_configs=1,
+            kernel_name="k_eof",
+        )
+        self._bg_drain_with_noop_device_guard(
+            self._make_fake_kernel(), conn, handle, None
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "without sending _Done"):
+            handle.drain_future.result(timeout=2.0)
+        self.assertIs(handle.launcher_q.get(timeout=2.0), _LAUNCHER_END)
+
+    def test_failure_messages_track_last_on_kernel(self):
+        """Worker sends valid kernel id, then two ``_Failure`` messages, then
+        ``_Done``. The drain must NOT build any launchers (no _Success), must
+        set ``kernel._last_compile_exception`` to a RuntimeError carrying the
+        last failure, and must complete the drain_future successfully."""
+        from concurrent.futures import Future as _Fut
+        from multiprocessing.connection import Connection
+
+        from torch._inductor.async_compile import (
+            _LAUNCHER_END,
+            _setup_streaming_listener,
+            PipelineCachingAutotunerHandle,
+        )
+        from torch._inductor.runtime.compile_tasks import (
+            _Done,
+            _Failure,
+            _streaming_send,
+        )
+
+        sock_path, kernel_id, conn_future = _setup_streaming_listener("k_fail")
+
+        def _all_fail_worker():
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.connect(sock_path)
+            s.sendall(kernel_id)
+            wconn = Connection(s.detach())
+            try:
+                _streaming_send(wconn, _Failure("OOM", "first", "tb1"))
+                _streaming_send(wconn, _Failure("OOM", "second", "tb2"))
+                _streaming_send(wconn, _Done())
+            finally:
+                wconn.close()
+
+        threading.Thread(target=_all_fail_worker, daemon=True).start()
+        conn_sock = conn_future.result(timeout=10.0)
+        conn = Connection(conn_sock.detach())
+
+        kernel = self._make_fake_kernel()
+        handle = PipelineCachingAutotunerHandle(
+            launcher_q=__import__("queue").Queue(),
+            drain_future=_Fut(),
+            num_configs=2,
+            kernel_name="k_fail",
+        )
+        self._bg_drain_with_noop_device_guard(kernel, conn, handle, None)
+
+        # No _Success -> nothing built.
+        self.assertEqual(kernel.launchers, [])
+        # drain_future completes cleanly (per-config _Failure is not fatal).
+        self.assertIsNone(handle.drain_future.result(timeout=2.0))
+        # Last failure stashed on the kernel for the all-failed message.
+        last = kernel._last_compile_exception
+        self.assertIsInstance(last, RuntimeError)
+        self.assertIn("OOM", str(last))
+        self.assertIn("second", str(last))
+        # bg drain no longer calls _dynamic_scale_rblock -- the plugin's
+        # pre_dispatch does, after the drain finishes.
+        self.assertFalse(kernel._dynamic_scale_called)
+        # EOF sentinel pushed.
+        self.assertIs(handle.launcher_q.get(timeout=2.0), _LAUNCHER_END)
 
 
 class TestArgumentCloneAndRestore(TestCase):

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -3,21 +3,31 @@ from __future__ import annotations
 
 import atexit
 import functools
+import itertools
 import json
 import logging
 import multiprocessing
 import os
+import queue as _queue
 import re
+import shutil
+import socket
+import struct
 import sys
+import tempfile
+import threading
 from concurrent.futures import (
     Future,
+    InvalidStateError,
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
 )
 from concurrent.futures.process import BrokenProcessPool
+from dataclasses import dataclass
 from functools import partial
+from multiprocessing.connection import Connection
 from time import time, time_ns
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 
 import torch
 from torch._dynamo.device_interface import get_registered_device_interfaces
@@ -52,9 +62,20 @@ from torch._inductor.compile_worker.tracked_process_pool import (
 )
 from torch._inductor.compile_worker.utils import _async_compile_initializer
 from torch._inductor.runtime.compile_tasks import (
+    _Done,
+    _Failure,
+    _Kernel,
     _set_triton_libdevice_path,
     _set_triton_ptxas_path,
+    _streaming_decode,
+    _Success,
+    _try_set_sock_buf,
     _worker_compile_triton,
+)
+from torch._inductor.runtime.triton_heuristics import (
+    CachingAutotunerPlugin,
+    DEFER,
+    NoTritonConfigsError,
 )
 from torch._inductor.utils import clear_on_fresh_cache
 from torch._inductor.virtualized import V
@@ -65,7 +86,7 @@ from torch.utils._triton import has_triton_package
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     from torch._inductor.runtime.hints import HalideMeta
     from torch._inductor.runtime.triton_heuristics import CachingAutotuner
@@ -80,9 +101,419 @@ log = logging.getLogger(__name__)
 
 _triton_kernel_metrics: dict[str, dict[str, Any]] | None = None
 
+# EOF marker on ``launcher_q`` (single producer: ``_bg_drain_kernel``).
+_LAUNCHER_END = object()
+
+
+def _try_set_exception(fut: "Future[Any]", exc: BaseException) -> bool:
+    """Race-tolerant ``Future.set_exception``. Returns True iff the future
+    was actually transitioned to the exception state."""
+    try:
+        fut.set_exception(exc)
+        return True
+    except InvalidStateError:
+        return False
+
+
+def _try_set_result(fut: "Future[Any]", value: Any) -> bool:
+    """Race-tolerant ``Future.set_result``. Returns True iff the future was
+    actually transitioned to the result state. Callers handing off ownership
+    of a resource (e.g. a socket) should release ownership only on True; on
+    False they retain ownership and must clean up themselves."""
+    try:
+        fut.set_result(value)
+        return True
+    except InvalidStateError:
+        return False
+
+
 size_hints_regex = re.compile(
     r"size_hints=(\{.*?\})",
 )
+
+
+@dataclass
+class PipelineCachingAutotunerHandle:
+    """Per-kernel state shared between ``_bg_drain_kernel`` (writer) and
+    ``PipelineCachingAutotunerPlugin.pre_dispatch`` (reader). EOF on
+    ``launcher_q`` is ``_LAUNCHER_END``. ``bg_drain_wait_ns`` is
+    happens-before-published via ``drain_future`` resolution.
+    """
+
+    launcher_q: _queue.Queue[object]
+    drain_future: Future[None]
+    num_configs: int
+    kernel_name: str
+    bg_drain_wait_ns: int = 0
+
+
+# One process-wide tmpdir for the shared streaming-compile AF_UNIX listener,
+# lazy-created.
+_STREAMING_SOCK_DIR: str | None = None
+_STREAMING_SOCK_DIR_LOCK = threading.Lock()
+
+# 10 minutes. Bounds both kernel-handshake wait and recv_bytes() (per-config
+# compile). Picked to be far above any realistic compile time so that only a
+# wedged worker trips it.
+_STREAMING_TIMEOUT_S = 600.0
+
+# Kernel-id read timeout in the shared accept loop. Workers send the id
+# microseconds after connect; a few seconds is plenty and bounds the head-of-
+# line blocking caused by a slow worker.
+_STREAMING_KERNEL_ID_READ_TIMEOUT_S = 5.0
+
+# 8-byte big-endian uint64 wire format for the kernel id. Same-UID trust
+# model -- this is identification only, not authentication.
+_STREAMING_KERNEL_ID_STRUCT = struct.Struct(">Q")
+_STREAMING_KERNEL_ID_SIZE = _STREAMING_KERNEL_ID_STRUCT.size
+
+# Monotonic kernel-id source. Wraps after 2**64 kernels in a single process,
+# which is unreachable in practice.
+_STREAMING_KERNEL_ID_COUNTER = itertools.count(1)
+
+# Send/recv buffer size for streaming-compile sockets. CompileResult payloads
+# observed at p95 ~640 KiB and max ~665 KiB; 4 MiB gives the worker headroom
+# for several pending messages without blocking in send() when the drain
+# thread is briefly busy. Capped by net.core.{w,r}mem_max (typically 20 MiB).
+_STREAMING_SOCK_BUF = 4 * 1024 * 1024
+
+
+# One process-wide AF_UNIX listener (shared listener). Workers all connect
+# here; an accept loop reads a per-kernel id from each incoming connection
+# and dispatches it to the registered Future. Saves the per-kernel
+# bind/listen/inode that the original per-kernel-listener design paid.
+_SHARED_LISTENER: socket.socket | None = None
+_SHARED_LISTENER_PATH: str | None = None
+_SHARED_LISTENER_LOCK = threading.Lock()
+_SHARED_REGISTRY: dict[int, "Future[socket.socket]"] = {}
+_SHARED_REGISTRY_LOCK = threading.Lock()
+
+# Process-wide thread pool for ``_bg_drain_kernel`` execution. Sized to match
+# the compile-worker pool: at most ``compile_threads`` kernels can be in
+# flight at once, so we never over-provision drain threads. Reusing threads
+# across kernels saves ~150 us/kernel of pthread_create + Python startup vs.
+# the prior per-kernel ``threading.Thread().start()``.
+_DRAIN_POOL: ThreadPoolExecutor | None = None
+_DRAIN_POOL_LOCK = threading.Lock()
+
+
+def _get_drain_pool() -> ThreadPoolExecutor:
+    global _DRAIN_POOL
+    if _DRAIN_POOL is not None:
+        return _DRAIN_POOL
+    with _DRAIN_POOL_LOCK:
+        if _DRAIN_POOL is None:
+            n = max(1, get_compile_threads())
+            _DRAIN_POOL = ThreadPoolExecutor(
+                max_workers=n, thread_name_prefix="inductor-stream-drain"
+            )
+    return _DRAIN_POOL
+
+
+def _get_streaming_sock_dir() -> str:
+    global _STREAMING_SOCK_DIR
+    if _STREAMING_SOCK_DIR is None:
+        with _STREAMING_SOCK_DIR_LOCK:
+            if _STREAMING_SOCK_DIR is None:
+                d = tempfile.mkdtemp(prefix="inductor_stream_")
+                # Best-effort cleanup: atexit doesn't run on SIGKILL or hard
+                # crash, so /tmp/inductor_stream_* may accumulate.
+                atexit.register(shutil.rmtree, d, ignore_errors=True)
+                _STREAMING_SOCK_DIR = d
+    return _STREAMING_SOCK_DIR
+
+
+def _ensure_shared_listener() -> str:
+    """Lazy-bind the process-wide AF_UNIX listener and start the accept loop.
+    Idempotent. Returns the sock path."""
+    global _SHARED_LISTENER, _SHARED_LISTENER_PATH
+    if _SHARED_LISTENER is not None:
+        assert _SHARED_LISTENER_PATH is not None
+        return _SHARED_LISTENER_PATH
+    with _SHARED_LISTENER_LOCK:
+        if _SHARED_LISTENER is not None:
+            assert _SHARED_LISTENER_PATH is not None
+            return _SHARED_LISTENER_PATH
+        path = os.path.join(_get_streaming_sock_dir(), "shared.sock")
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(path)
+        # Don't trust the caller's umask: bind() inherits it. 0700 parent dir
+        # already blocks cross-UID, but explicit chmod survives anyone changing
+        # the parent path later.
+        os.chmod(path, 0o600)
+        sock.listen(128)
+        threading.Thread(
+            target=_shared_accept_loop,
+            args=(sock,),
+            name="inductor-stream-accept",
+            daemon=True,
+        ).start()
+        _SHARED_LISTENER = sock
+        _SHARED_LISTENER_PATH = path
+    return path
+
+
+def _shared_accept_loop(listener: socket.socket) -> None:
+    """Forever-loop: accept a connection, read the per-kernel id, dispatch to
+    the kernel's pending Future. A short id-read timeout bounds head-of-line
+    blocking from a slow worker.
+    """
+    while True:
+        try:
+            conn_sock, _ = listener.accept()
+        except OSError:
+            return  # listener closed; daemon thread exits
+        _try_set_sock_buf(conn_sock, socket.SO_RCVBUF, _STREAMING_SOCK_BUF)
+        try:
+            conn_sock.settimeout(_STREAMING_KERNEL_ID_READ_TIMEOUT_S)
+            buf = bytearray()
+            while len(buf) < _STREAMING_KERNEL_ID_SIZE:
+                chunk = conn_sock.recv(_STREAMING_KERNEL_ID_SIZE - len(buf))
+                if not chunk:
+                    raise OSError("short read on kernel id")
+                buf.extend(chunk)
+            conn_sock.settimeout(None)
+            (kernel_id,) = _STREAMING_KERNEL_ID_STRUCT.unpack(bytes(buf))
+        except OSError:
+            try:
+                conn_sock.close()
+            except OSError:
+                pass
+            continue
+        with _SHARED_REGISTRY_LOCK:
+            future = _SHARED_REGISTRY.pop(kernel_id, None)
+        if future is None or not _try_set_result(future, conn_sock):
+            # Unknown id (stale entry) or future was already cancelled: drop
+            # the connection.
+            try:
+                conn_sock.close()
+            except OSError:
+                pass
+
+
+def _setup_streaming_listener(
+    kernel_name: str,
+) -> tuple[str, bytes, "Future[socket.socket]"]:
+    """Register a kernel with the shared streaming listener. Returns
+    ``(shared_sock_path, kernel_id_bytes, conn_future)``. The worker connects
+    to ``shared_sock_path`` and sends the 8-byte ``kernel_id_bytes`` so the
+    parent's accept loop can route the socket to ``conn_future``.
+
+    Trust model: same UID, our own subprocess. The kernel id is identification
+    only -- not authentication.
+    """
+    path = _ensure_shared_listener()
+    kernel_id = next(_STREAMING_KERNEL_ID_COUNTER)
+    kernel_id_bytes = _STREAMING_KERNEL_ID_STRUCT.pack(kernel_id)
+    conn_future: Future[socket.socket] = Future()
+    with _SHARED_REGISTRY_LOCK:
+        _SHARED_REGISTRY[kernel_id] = conn_future
+    return path, kernel_id_bytes, conn_future
+
+
+def _drop_streaming_registration(kernel_id_bytes: bytes) -> None:
+    """Remove a kernel's registration from the shared registry. Safe to call
+    even if the id has already been dispatched."""
+    (kernel_id,) = _STREAMING_KERNEL_ID_STRUCT.unpack(kernel_id_bytes)
+    with _SHARED_REGISTRY_LOCK:
+        _SHARED_REGISTRY.pop(kernel_id, None)
+
+
+def _bg_drain_kernel(
+    kernel: Any,
+    conn: Connection,
+    handle: PipelineCachingAutotunerHandle,
+    static_triton_bundle_key: str | None,
+) -> None:
+    """Per-kernel daemon. Reads the streaming wire protocol off ``conn``,
+    builds launchers in the parent process, and feeds them into
+    ``handle.launcher_q`` for ``PipelineCachingAutotunerPlugin.pre_dispatch``
+    to bench. EOF without a preceding ``_Done`` is a worker-died-mid-stream
+    anomaly and surfaces as the drain's exception. Parent-side
+    ``_dynamic_scale_rblock`` runs in the plugin's ``pre_dispatch`` after the
+    drain completes -- not here -- so this thread doesn't have to know about
+    it.
+    """
+    from torch._dynamo.device_interface import DeviceGuard
+
+    def _recv_msg() -> Any:
+        # ``recv_bytes()`` blocks waiting on the worker; that wait is the
+        # parent-side cost the plugin folds into compile_time_us.
+        tq0 = time_ns()
+        if not conn.poll(_STREAMING_TIMEOUT_S):
+            raise TimeoutError(
+                f"streaming worker for {handle.kernel_name} sent no data "
+                f"for {_STREAMING_TIMEOUT_S:.0f}s"
+            )
+        try:
+            payload = conn.recv_bytes()
+        except EOFError:
+            raise RuntimeError(
+                f"streaming worker for {handle.kernel_name} closed pipe "
+                f"without sending _Done (worker died mid-stream)"
+            ) from None
+        handle.bg_drain_wait_ns += time_ns() - tq0
+        return _streaming_decode(payload)
+
+    try:
+        kernel._maybe_put_static_autotuner(static_triton_bundle_key)
+        with DeviceGuard(
+            kernel.get_device_interface(), kernel.triton_meta["device"]
+        ):
+            # Drain worker: build a launcher per _Success, stash per-config
+            # failures on the kernel for the all-failed message.
+            while True:
+                msg = _recv_msg()
+                if isinstance(msg, _Done):
+                    break
+                if isinstance(msg, _Failure):
+                    kernel._last_compile_exception = msg.as_runtime_error()
+                    continue
+                if not isinstance(msg, _Success):
+                    raise RuntimeError(
+                        f"streaming worker for {handle.kernel_name} sent "
+                        f"unknown message type {type(msg).__name__}"
+                    )
+                kernel.compile_results.append(msg.result)
+                kernel._bundle_compile_result(msg.result)
+                launcher, _exc = kernel._make_launcher(msg.result)
+                if launcher is not None:
+                    kernel.launchers.append(launcher)
+                    handle.launcher_q.put(launcher)
+            # Mirror ``_precompile_worker`` post-condition.
+            kernel.configs = None
+            # All-failed fallback (e.g., OOM with pipelining=on -> retry
+            # with pipelining off). Pushes its result into self.launchers.
+            if not kernel.launchers and kernel.compile_results:
+                kernel._all_failed_fallback(kernel._last_compile_exception)
+                if kernel.launchers:
+                    handle.launcher_q.put(kernel.launchers[-1])
+    except BaseException as e:
+        # Only log when we actually transition the future; otherwise the
+        # plugin already saw the exception (or doesn't care anymore).
+        if _try_set_exception(handle.drain_future, e):
+            log.exception("background drain failed for %s", kernel.fn.__name__)
+    else:
+        _try_set_result(handle.drain_future, None)
+    finally:
+        handle.launcher_q.put(_LAUNCHER_END)
+        try:
+            conn.close()
+        except OSError:
+            pass
+
+
+# Sentinel returned by ``PipelineCachingAutotunerPlugin.pre_compile`` to tell
+# ``CachingAutotuner.precompile`` to do nothing. Identity-only -- value is
+# never read, only checked against ``DEFER``.
+_PIPELINE_PRECOMPILE_OWNED = object()
+
+
+class PipelineCachingAutotunerPlugin(CachingAutotunerPlugin):
+    """When a streaming handle is attached: ``pre_compile`` returns non-DEFER
+    so the standard ``precompile()`` body skips entirely (the bg drain is
+    doing compile + launcher-build in the background). At first ``run()``:
+    ``pre_dispatch`` drains ``launcher_q`` (multi-config) or waits on
+    ``drain_future`` (single-config), benches, finalizes, and returns
+    ``DEFER`` so the standard dispatch path runs with
+    ``self.launchers == [winner]``.
+    """
+
+    def pre_compile(self, autotuner: object) -> object:
+        # Streaming: bg drain owns compile + launcher-build. No-op precompile.
+        if autotuner._pipeline_caching_autotuner_handle is not None:
+            return _PIPELINE_PRECOMPILE_OWNED
+        return DEFER
+
+    def pre_dispatch(
+        self,
+        autotuner: object,
+        *args: object,
+        stream: object,
+        **kwargs: object,
+    ) -> object:
+        from torch._dynamo.device_interface import DeviceGuard
+
+        handle = autotuner._pipeline_caching_autotuner_handle
+        if handle is None:
+            return DEFER
+        autotuner._pipeline_caching_autotuner_handle = None
+
+        plugin_wait_ns = 0
+        bench_ns = 0
+        timings: dict[Any, float] = {}
+
+        with DeviceGuard(
+            autotuner.get_device_interface(), autotuner.triton_meta["device"]
+        ):
+            if handle.num_configs > 1:
+                # Bench worker-streamed launchers as they arrive.
+                def _drain_launchers() -> "Iterable[Any]":
+                    nonlocal plugin_wait_ns
+                    while True:
+                        tq0 = time_ns()
+                        launcher = handle.launcher_q.get()
+                        plugin_wait_ns += time_ns() - tq0
+                        if launcher is _LAUNCHER_END:
+                            return
+                        yield launcher
+
+                timings, bench_ns = autotuner._bench_launchers(
+                    _drain_launchers(), *args, **kwargs
+                )
+            else:
+                # Single-config: nothing to compare against, just wait for
+                # the drain to push EOF.
+                tq0 = time_ns()
+                while handle.launcher_q.get() is not _LAUNCHER_END:
+                    pass
+                plugin_wait_ns += time_ns() - tq0
+
+            # Surface drain exceptions (sentinel was pushed in finally).
+            handle.drain_future.result()
+
+            # Parent-side rblock-scale: generate + compile new candidates and
+            # build their launchers. Then bench the new launchers (those
+            # appended after the count we just had) and merge into timings.
+            pre_rblock = len(autotuner.launchers)
+            autotuner._dynamic_scale_rblock()
+            new_launchers = autotuner.launchers[pre_rblock:]
+            if new_launchers:
+                rblock_timings, rblock_bench_ns = autotuner._bench_launchers(
+                    new_launchers, *args, **kwargs
+                )
+                timings.update(rblock_timings)
+                bench_ns += rblock_bench_ns
+
+        if not autotuner.launchers and not autotuner.compile_results:
+            last = autotuner._last_compile_exception
+            suffix = f" Last per-config failure: {last}" if last else ""
+            raise NoTritonConfigsError(
+                f"Pipelined autotuner produced 0 results for "
+                f"{autotuner.fn.__name__}.{suffix}"
+            )
+
+        # compile_time_us for pipelined kernels is the parent's blocking
+        # time only (drain wait + plugin wait); the worker's wall time
+        # overlaps with parent codegen for OTHER kernels and is intentionally
+        # not added here to avoid double-counting.
+        parent_wait_ns = handle.bg_drain_wait_ns + plugin_wait_ns
+
+        if timings:
+            autotuner._finalize_autotune_winner(
+                timings,
+                autotune_time_taken_ns=parent_wait_ns + bench_ns,
+            )
+
+        _emit_triton_kernel_compile_metric(
+            autotuner, handle.kernel_name, parent_wait_ns // 1000
+        )
+        return DEFER
+
+
+def _make_pipeline_caching_autotuner_plugin() -> CachingAutotunerPlugin:
+    """Singleton-style factory used by ``get_caching_autotuner_plugins``."""
+    return PipelineCachingAutotunerPlugin()
 
 
 def pre_fork_setup():
@@ -150,6 +581,9 @@ def _emit_triton_kernel_compile_metric(
 ) -> None:
     """Emit per-kernel ``compile_time_us`` to both the dynamo
     ``_triton_kernel_metrics`` map and the ``MetricsContext`` top-N.
+
+    Used by both the standard ``AsyncCompile.triton`` path and the
+    ``PipelineCachingAutotunerPlugin``.
 
     Note: ``kernel.autotune_cache_info`` is only mutated in place when
     non-empty; when ``None`` or ``{}`` the metric still reaches
@@ -464,18 +898,104 @@ class AsyncCompile:
                         fn_hash: torch._inductor.config.autotune_lookup_table[fn_hash]
                     }
 
-            task = self.process_pool().submit(
-                _worker_compile_triton,
-                load_kernel,
-                extra_env,
-                extra_config,
-            )
+            if config.pipeline_caching_autotuner:
+                sock_path, kernel_id, conn_future = _setup_streaming_listener(
+                    kernel_name
+                )
+            else:
+                sock_path = None
+                kernel_id = None
+                conn_future = None
+
+            try:
+                task = self.process_pool().submit(
+                    _worker_compile_triton,
+                    load_kernel,
+                    extra_env,
+                    extra_config,
+                    streaming_address=sock_path,
+                    streaming_kernel_id=kernel_id,
+                )
+            except BaseException:
+                # Synchronous submit failure (pool shutdown, queue overflow):
+                # nothing will ever consume the registry entry. Drop it so we
+                # don't leak.
+                if kernel_id is not None:
+                    _drop_streaming_registration(kernel_id)
+                raise
+
+            if config.pipeline_caching_autotuner:
+                # If the worker dies before connecting, conn_future would
+                # block forever. Surface the worker exception via the future
+                # and clean up the registry entry.
+                assert conn_future is not None and kernel_id is not None
+                _captured_kernel_id = kernel_id
+                _captured_future = conn_future
+
+                def _on_task_fail_propagate(future: Future) -> None:
+                    exc = future.exception()
+                    if exc is not None:
+                        _try_set_exception(_captured_future, exc)
+                        _drop_streaming_registration(_captured_kernel_id)
+
+                task.add_done_callback(_on_task_fail_propagate)
 
             def get_result() -> CachingAutotuner:
-                try:
-                    kernel, elapsed_us = task.result()
-                except SubprocException as e:
-                    raise e.with_name(kernel_name) from e
+                elapsed_us: int | None = None
+                if config.pipeline_caching_autotuner:
+                    assert conn_future is not None and kernel_id is not None
+                    try:
+                        conn_sock = conn_future.result(
+                            timeout=_STREAMING_TIMEOUT_S
+                        )
+                    except FuturesTimeoutError:
+                        _drop_streaming_registration(kernel_id)
+                        try:
+                            task.result()
+                        except SubprocException as e:
+                            raise e.with_name(kernel_name) from e
+                        raise RuntimeError(
+                            f"streaming worker for {kernel_name} did not "
+                            f"connect within {_STREAMING_TIMEOUT_S:.0f}s"
+                        )
+                    except SubprocException as e:
+                        # _on_task_fail_propagate forwarded the worker exception.
+                        raise e.with_name(kernel_name) from e
+                    conn = Connection(conn_sock.detach())
+                    # Same-UID trust model: the kernel id is identification
+                    # only. No authentication round trip after accept.
+                    if not conn.poll(_STREAMING_TIMEOUT_S):
+                        raise TimeoutError(
+                            f"streaming worker for {kernel_name} sent no kernel "
+                            f"for {_STREAMING_TIMEOUT_S:.0f}s"
+                        )
+                    try:
+                        kernel_bytes = conn.recv_bytes()
+                    except EOFError:
+                        try:
+                            task.result()
+                        except SubprocException as e:
+                            raise e.with_name(kernel_name) from e
+                        raise RuntimeError(
+                            f"worker for {kernel_name} closed pipe before sending kernel"
+                        )
+                    msg = _streaming_decode(kernel_bytes)
+                    if not isinstance(msg, _Kernel):
+                        raise RuntimeError(
+                            f"worker for {kernel_name} sent {type(msg).__name__} "
+                            f"as first message; expected _Kernel"
+                        )
+                    kernel = cast("CachingAutotuner", msg.kernel)
+                else:
+                    try:
+                        result = task.result()
+                    except SubprocException as e:
+                        raise e.with_name(kernel_name) from e
+                    kernel_or_none, elapsed_us = result
+                    assert kernel_or_none is not None, (
+                        "non-streaming worker must return a kernel"
+                    )
+                    kernel = kernel_or_none
 
                 # Now that we've compiled, we should clear the future
                 # so it can't be used again
@@ -484,12 +1004,40 @@ class AsyncCompile:
 
                 kernel.restore_after_unpickle(old_values=None)
 
+                if config.pipeline_caching_autotuner:
+                    # Attach the streaming handle and kick off the bg drain.
+                    # The drain owns compile + launcher-build; the plugin's
+                    # ``pre_compile`` will short-circuit ``precompile()``
+                    # below when it sees the handle.
+                    # Unbounded queue: bg drain produces at most
+                    # ``num_configs`` launchers (small per kernel) before
+                    # pushing _LAUNCHER_END.
+                    handle = PipelineCachingAutotunerHandle(
+                        launcher_q=_queue.Queue(),
+                        drain_future=Future(),
+                        num_configs=len(kernel.configs or []),
+                        kernel_name=kernel_name,
+                    )
+                    kernel._pipeline_caching_autotuner_handle = handle
+                    _get_drain_pool().submit(
+                        _bg_drain_kernel,
+                        kernel,
+                        conn,
+                        handle,
+                        CompiledTritonKernels.key(source_code),
+                    )
+                # Always call precompile; the streaming-plugin's pre_compile
+                # makes it a no-op when a handle is attached.
                 kernel.precompile(
                     warm_cache_only=False,
                     reload_kernel=reload_kernel_in_parent,
                     static_triton_bundle_key=CompiledTritonKernels.key(source_code),
                 )
-                _emit_triton_kernel_compile_metric(kernel, kernel_name, elapsed_us)
+                if not config.pipeline_caching_autotuner:
+                    assert elapsed_us is not None
+                    _emit_triton_kernel_compile_metric(
+                        kernel, kernel_name, elapsed_us
+                    )
                 return kernel
 
             future = LambdaFuture(get_result, future=task)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -531,6 +531,13 @@ incremental_autotune: bool | None = get_tristate_env(
     "TORCHINDUCTOR_INCREMENTAL_AUTOTUNE", default=False
 )
 
+# Pipeline the CachingAutotuner: overlap triton compile, make_launcher, and benchmarking.
+pipeline_caching_autotuner: bool = Config(
+    default=False,
+    env_name_force="TORCHINDUCTOR_PIPELINE_CACHING_AUTOTUNER",
+    justknob="pytorch/inductor:pipeline_caching_autotuner",
+)
+
 inductor_default_autotune_warmup = int(
     os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_WARMUP", 25)
 )

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 import functools
+import io
 import linecache
 import os
+import pickle
+import socket
 import sys
+import threading
 import time
+import traceback
 import warnings
+import zlib
+from dataclasses import dataclass
+from multiprocessing.connection import Connection
 from pathlib import Path
-from types import ModuleType
+from types import FunctionType, ModuleType
 from typing import Any, TYPE_CHECKING
 
 from torch._utils_internal import log_triton_builds
@@ -118,7 +126,19 @@ def _worker_compile_triton(
     load_kernel: Callable[[], CachingAutotuner],
     extra_env: dict[str, str],
     extra_config: dict[str, Any],
-) -> tuple[CachingAutotuner, int]:
+    streaming_address: str | None = None,
+    streaming_kernel_id: bytes | None = None,
+) -> tuple[CachingAutotuner | None, int]:
+    """Worker entry point for ``AsyncCompile.triton``. Two flows:
+
+    - Streaming (``streaming_address`` non-None): connect to the parent's
+      shared listener, send ``streaming_kernel_id`` so the dispatcher routes
+      this connection to the right Future, send the kernel, then stream each
+      ``CompileResult``. Returns ``(None, elapsed_us)``.
+    - Blocking (None): ``precompile(warm_cache_only=True)`` runs every
+      config, kernel is pickled back with ``compile_results`` populated.
+      Returns ``(kernel, elapsed_us)``.
+    """
     _set_triton_ptxas_path()
     os.environ.update(extra_env)
     # Set libdevice path if passed via env from main process
@@ -137,6 +157,18 @@ def _worker_compile_triton(
         try:
             start_ns = time.time_ns()
             kernel = load_kernel()
+            if streaming_address is not None:
+                assert streaming_kernel_id is not None
+                _stream_compile_triton(
+                    kernel,
+                    streaming_address,
+                    streaming_kernel_id,
+                )
+                elapsed_ns = time.time_ns() - start_ns
+                # Kernel was streamed back already; nothing left to
+                # return via the future payload.
+                linecache.clearcache()
+                return None, elapsed_ns // 1000
             kernel.precompile(warm_cache_only=True)
             elapsed_ns = time.time_ns() - start_ns
             kernel.prepare_for_pickle()
@@ -148,3 +180,214 @@ def _worker_compile_triton(
             raise
         finally:
             log_triton_builds(fail=fail)
+
+
+_DYN_KERNEL_MODULE_PREFIX = "torch._inductor.runtime.compile_tasks."
+
+# RLock's type isn't directly importable; capture once via type(RLock()).
+# _streaming_persistent_id checks this on every traversed pickle object.
+_RLOCK_TYPE = type(threading.RLock())
+
+
+# Wire sentinel for the worker->parent streaming connection. Round-trips as
+# an ``is``-identical singleton through ``_streaming_persistent_id`` /
+# ``_streaming_persistent_load``. If you add a second sentinel, update both
+# functions in lockstep.
+_STREAMING_SKIP = object()
+
+
+def _streaming_persistent_id(obj: Any) -> object | None:
+    """Substitute ``_STREAMING_SKIP`` for things that don't survive pickle to
+    the parent. All resolve to ``None`` on the parent; downstream consumers
+    either don't read them or handle ``None`` defensively.
+
+    - ``RLock``: pickle refuses these outright.
+    - ``ModuleType``: the dyn kernel module isn't in the parent's
+      ``sys.modules``; uniform substitution is the simplest correct policy.
+    - Raw functions in a dyn kernel module (e.g. ``@triton.jit`` bodies):
+      pickle-by-name fails on the parent. Restricted to ``FunctionType``
+      so we don't catch ``JITFunction``, which inherits the same
+      ``__module__`` but pickles fine via its own class.
+    """
+    if isinstance(obj, _RLOCK_TYPE):
+        return _STREAMING_SKIP
+    if isinstance(obj, ModuleType):
+        return _STREAMING_SKIP
+    if isinstance(obj, FunctionType):
+        mod = obj.__module__
+        if isinstance(mod, str) and mod.startswith(_DYN_KERNEL_MODULE_PREFIX):
+            return _STREAMING_SKIP
+    return None
+
+
+def _streaming_persistent_load(pid: object) -> object:
+    """Resolve ids from ``_streaming_persistent_id`` to ``None``;
+    raise on anything else (wire format divergence)."""
+    if pid is _STREAMING_SKIP:
+        return None
+    raise pickle.UnpicklingError(f"unsupported persistent id: {pid!r}")
+
+
+class _StreamingPickler(pickle.Pickler):
+    """Pickler honoring ``_streaming_persistent_id`` substitutions."""
+
+    persistent_id = staticmethod(_streaming_persistent_id)
+
+
+class _StreamingUnpickler(pickle.Unpickler):
+    """Parent-side companion to ``_StreamingPickler``.
+
+    Trust model: this unpickler accepts arbitrary classes from the worker.
+    That is safe only because the worker is part of our trust domain
+    (same UID, our own subprocess); pickle deserialization from an
+    untrusted peer would be a remote-code-execution risk.
+    """
+
+    persistent_load = staticmethod(_streaming_persistent_load)
+
+
+# Kernel-emit cubin/asm payloads pickle to ~28 KiB median, ~640 KiB p95;
+# zlib level 1 cuts those by ~3-5x at <100 MB/s on the worker, paying for
+# itself many times over against the 5+ second aggregate socket-flow-control
+# wait observed without compression.
+_STREAMING_ZLIB_LEVEL = 1
+
+
+def _streaming_send(conn: Any, obj: Any) -> None:
+    """Pickle ``obj`` via ``_StreamingPickler``, zlib-compress, send_bytes.
+    Bypasses ``conn.send``, which would use ``ForkingPickler``. The parent
+    is the only reader and uses :func:`_streaming_decode` symmetrically."""
+    buf = io.BytesIO()
+    _StreamingPickler(buf, protocol=pickle.HIGHEST_PROTOCOL).dump(obj)
+    conn.send_bytes(zlib.compress(buf.getvalue(), _STREAMING_ZLIB_LEVEL))
+
+
+def _streaming_decode(payload: bytes) -> Any:
+    """Inverse of :func:`_streaming_send`: zlib-decompress + unpickle. Kept
+    here so the wire format (compression level, framing) lives in one file.
+    """
+    return _StreamingUnpickler(io.BytesIO(zlib.decompress(payload))).load()
+
+
+def _try_set_sock_buf(sock: socket.socket, opt: int, size: int) -> None:
+    """setsockopt that tolerates sandbox/seccomp denials. The kernel silently
+    clamps size to the system-wide max."""
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, opt, size)
+    except OSError:
+        pass
+
+
+# ----------------------------------------------------------------------------
+# Streaming wire-protocol message types.
+#
+# Every message sent over the streaming socket is one of:
+#   _Kernel(kernel)       -- first message; the worker's CachingAutotuner
+#   _Success(result)      -- a successful CompileResult
+#   _Failure(...)         -- a per-config compile failure (mirrors what the
+#                            non-streaming worker stores on
+#                            ``kernel._last_compile_exception``); not fatal
+#   _Done()               -- explicit end-of-stream marker
+#
+# EOF on the socket without a preceding _Done is treated as an anomaly
+# (worker died mid-stream). Adding a new variant requires updating the
+# parent's dispatch in ``_bg_drain_kernel._iter_results``.
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Kernel:
+    kernel: Any  # CachingAutotuner
+
+
+@dataclass(frozen=True)
+class _Success:
+    result: Any  # CompileResult
+
+
+@dataclass(frozen=True)
+class _Failure:
+    """Per-config compile failure. Carries the exception type+message+
+    traceback as strings so that exceptions whose ``__reduce__`` is fragile
+    (or whose constructor signature has drifted) still survive the wire."""
+
+    exc_type: str
+    exc_msg: str
+    traceback: str
+
+    @classmethod
+    def from_exc(cls, exc: BaseException) -> _Failure:
+        # ``traceback.format_exc()`` only reflects the current except-block;
+        # we may be called outside one. Use the exception's own __traceback__.
+        tb_str = "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        )
+        return cls(
+            exc_type=type(exc).__name__,
+            exc_msg=str(exc),
+            traceback=tb_str,
+        )
+
+    def as_runtime_error(self) -> RuntimeError:
+        """Reconstruct as a ``RuntimeError`` for storage on the parent's
+        ``kernel._last_compile_exception`` slot."""
+        return RuntimeError(f"{self.exc_type}: {self.exc_msg}\n{self.traceback}")
+
+
+class _Done:
+    """End-of-stream marker. Pickled as a class instance; the parent uses
+    ``isinstance(msg, _Done)`` so each unpickled instance is fine."""
+
+
+def _stream_compile_triton(
+    kernel: CachingAutotuner,
+    streaming_address: str,
+    streaming_kernel_id: bytes,
+) -> None:
+    """Connect to the parent's shared streaming listener at
+    ``streaming_address``, send the 8-byte ``streaming_kernel_id`` so the
+    parent's dispatcher can route this connection to the right Future. Send
+    a ``_Kernel`` as the first message (so the parent can dispatch before
+    any compile finishes), then stream each per-config result as a
+    ``_Success`` or ``_Failure``, then ``_Done``. ``_StreamingPickler``
+    substitutes unpicklable bits per-send so we never mutate the live
+    JITFunction (other in-flight compiles in this worker still need it).
+    """
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.connect(streaming_address)
+        # Bump SNDBUF to mirror the parent's RCVBUF so the worker can write
+        # several CompileResult messages without blocking when the drain
+        # thread is briefly busy.
+        _try_set_sock_buf(sock, socket.SO_SNDBUF, 4 * 1024 * 1024)
+        # Identify ourselves to the parent's dispatcher. ID is fixed-size so
+        # the parent reads exactly that many bytes and routes us.
+        view = memoryview(streaming_kernel_id)
+        while view:
+            sent = sock.send(view)
+            if sent == 0:
+                raise OSError("short write on streaming kernel id")
+            view = view[sent:]
+        conn = Connection(sock.detach())
+    except Exception:
+        try:
+            sock.close()
+        except OSError:
+            pass
+        raise
+    try:
+        # No in-flight compiles yet; mutating kernel is safe.
+        old_values = kernel.prepare_for_pickle()
+        try:
+            _streaming_send(conn, _Kernel(kernel))
+        finally:
+            kernel.restore_after_unpickle(old_values)
+
+        for _cfg, result, exc in kernel._iter_compile_results_tagged(parallel=True):
+            if exc is None:
+                _streaming_send(conn, _Success(result))
+            else:
+                _streaming_send(conn, _Failure.from_exc(exc))
+        _streaming_send(conn, _Done())
+    finally:
+        conn.close()

--- a/torch/_inductor/runtime/incremental/__init__.py
+++ b/torch/_inductor/runtime/incremental/__init__.py
@@ -1,0 +1,8 @@
+from . import config
+from ._plugin import IncrementalAutotunePlugin
+
+
+__all__ = [
+    "IncrementalAutotunePlugin",
+    "config",
+]

--- a/torch/_inductor/runtime/incremental/_launcher.py
+++ b/torch/_inductor/runtime/incremental/_launcher.py
@@ -1,0 +1,655 @@
+from __future__ import annotations
+
+import bisect
+import hashlib
+import json
+import re
+import threading
+import weakref
+from collections.abc import Hashable, Iterable
+from typing import cast, Protocol, TYPE_CHECKING
+
+import torch
+
+from torch._inductor.runtime.runtime_utils import triton_config_to_hashable
+from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+from ._resolver import submit_event
+from .config import (
+    max_timings_per_launcher,
+    launcher_timing_aggregation,
+    LauncherTimingAggregation,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class RawLauncher(Protocol):
+    """Structural shape of an entry in ``CachingAutotuner.launchers``.
+
+    The ``CachingAutotuner`` does not export a typed launcher class;
+    the raw launchers are anonymous callables annotated by
+    ``triton_heuristics`` with ``config``, ``cache_hash`` and friends
+    after construction. This Protocol pins down the attributes the
+    incremental autotuner actually relies on. ``RawLauncherView``
+    structurally satisfies it.
+    """
+
+    config: object
+    cache_hash: str | None
+    # ``found_by_coordesc`` is set by ``_finalize`` on the chosen raw
+    # (or its view) so the autotuner's post-dispatch coordesc gate
+    # skips on subsequent dispatches.
+    found_by_coordesc: bool
+
+    def __call__(self, *args: object, **kwargs: object) -> object: ...
+
+
+class RawLauncherView:
+    """Per-autotuner view of a (possibly shared) raw launcher.
+
+    When two ``CachingAutotuner`` instances autotune the same
+    kernel/config they share the same compiled binary (the
+    ``RawLauncher``) — but each autotuner has its own ``cache_hash``
+    (per-binary identifier from its own compile, since the same source
+    can hash differently across binaries even when the kernel content
+    is equivalent). The view wraps the real raw, overrides
+    ``cache_hash`` with the per-autotuner value, and delegates
+    everything else to the underlying raw.
+
+    ``cache_hash`` may be ``None`` when stage-1 sharing skipped this
+    autotuner's compile entirely (the view was created directly from
+    a cached pool entry, with no fresh compile to derive a per-autotuner
+    cache_hash from). The plugin's ``_finalize`` detects ``None`` and
+    compiles on-demand to resolve it before ``save_cache_hook``.
+
+    Holds a strong reference to the real raw so it stays alive for as
+    long as any view (i.e., any sharing autotuner's ``launchers`` list)
+    references it.
+    """
+
+    def __init__(
+        self,
+        real_raw: RawLauncher,
+        cache_hash: str | None,
+    ) -> None:
+        self._real_raw = real_raw
+        self.cache_hash = cache_hash
+        # ``found_by_coordesc`` is per-autotuner: two sharing autotuners
+        # may discover the same launcher via different paths (initial set
+        # vs coordesc neighbor). Default False; ``_finalize`` flips it to
+        # True for autotuners whose coordesc applied.
+        self.found_by_coordesc: bool = False
+
+    def __getattr__(self, name: str) -> object:
+        # Any attribute not explicitly overridden falls through to the
+        # real raw — config, n_regs, n_spills, shared, store_cubin,
+        # _is_static, etc.
+        return getattr(self._real_raw, name)
+
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        return self._real_raw(*args, **kwargs)
+
+    def __reduce__(self) -> tuple[object, ...]:
+        # Without an explicit ``__reduce__``, pickle would route
+        # ``__getstate__`` / ``__reduce_ex__`` introspection through
+        # our ``__getattr__`` to ``_real_raw``, silently dropping the
+        # per-autotuner ``cache_hash`` and ``found_by_coordesc``
+        # overrides. Re-create the view explicitly. Note this still
+        # requires ``_real_raw`` to be picklable; that's the same
+        # constraint as pickling the underlying raw directly, which
+        # ``CachingAutotuner.prepare_for_pickle`` already deals with.
+        return (
+            self.__class__,
+            (self._real_raw, self.cache_hash),
+            {"found_by_coordesc": self.found_by_coordesc},
+        )
+
+    def __setstate__(self, state: dict) -> None:
+        self.found_by_coordesc = state.get("found_by_coordesc", False)
+
+
+class OnTimingUpdateSubscription:
+    """Handle returned by ``Launcher.add_on_timing_update_fn``.
+
+    Owns the lifecycle of a single registered timing-update callback.
+    The callback fires under ``_in_flight``, so at most one invocation
+    of this callback is ever active. ``cancel()`` takes the same lock
+    to set ``_active=False``: if a fire is in progress when ``cancel``
+    is called, ``cancel`` blocks until it completes; once ``cancel``
+    returns, the callback is guaranteed not to fire again. ``cancel``
+    also physically removes the subscription from the parent
+    Launcher's registry so future ``add_timing`` calls don't even
+    iterate over it. Idempotent.
+
+    Also held via :class:`weakref.WeakMethod`, so an owning instance
+    that is garbage-collected without explicit ``cancel()`` still
+    causes the subscription to fall dormant — ``is_alive()`` returns
+    False and the next ``add_timing`` prunes it from the registry.
+    """
+
+    def __init__(
+        self,
+        fn: Callable[[Launcher, float, float], None],
+        launcher: Launcher,
+    ) -> None:
+        self._weak_method: weakref.WeakMethod[
+            Callable[[Launcher, float, float], None]
+        ] = weakref.WeakMethod(fn)
+        self._active: bool = True
+        self._in_flight: threading.Lock = threading.Lock()
+        # Weak back-ref so cancel() can remove this sub from the
+        # Launcher's registry without keeping the Launcher alive.
+        self._launcher_ref: weakref.ref[Launcher] = weakref.ref(launcher)
+
+    def is_alive(self) -> bool:
+        return self._active and self._weak_method() is not None
+
+    def fire(self, launcher: Launcher, old_timing: float, new_timing: float) -> None:
+        with self._in_flight:
+            if not self._active:
+                return
+            cb = self._weak_method()
+            if cb is None:
+                return
+            cb(launcher, old_timing, new_timing)
+
+    def cancel(self) -> None:
+        """Block until any in-flight invocation completes, prevent
+        future invocations, AND remove this subscription from the
+        parent Launcher's registry. Idempotent.
+        """
+        with self._in_flight:
+            self._active = False
+        launcher = self._launcher_ref()
+        if launcher is not None:
+            launcher.remove_subscription(self)
+
+
+class Launcher:
+    """A timing-collecting wrapper around a single raw kernel launcher.
+
+    Holds a single weak reference to its current raw launcher (the
+    front-of-queue model is gone — see the per-kernel pool docs for
+    why). Strong ownership of the raw lives in
+    ``CachingAutotuner.launchers`` (or in a ``RawLauncherView`` held by
+    a sharing autotuner's ``launchers``). When the raw dies, the
+    Launcher is "dormant": its accumulated timing samples remain valid
+    but it can't dispatch until a fresh raw is attached via
+    :func:`get_or_create_launcher`.
+
+    Sharing model:
+      Two ``IncrementalAutotuneState`` instances autotuning the same
+      kernel/config share a single Launcher via the per-kernel pool.
+      The pool stores Launchers; per-state strong refs to the raw live
+      in ``autotuner.launchers`` (possibly via a per-autotuner
+      ``RawLauncherView`` that overrides ``cache_hash``).
+
+    Threading: ``__call__`` is the only method guaranteed to run on
+    the main (dispatch) thread; every other public method on Launcher
+    is fair game to be called from any thread (the resolver daemon
+    fires ``add_timing`` and arbitrary owners may register/remove
+    callbacks or query ``timing``). All shared state — ``_raw_ref``,
+    ``_warm``, ``_timings``, ``_num_timings_in_flight``,
+    ``_on_timing_update_subs`` — is protected by ``_lock``. ``__call__``
+    takes the lock briefly to snapshot the current raw and flip
+    ``_warm``, but releases it before the actual kernel dispatch so
+    concurrent callers aren't blocked behind a long-running launch.
+    """
+
+    def __init__(self, raw_launcher: RawLauncher) -> None:
+        self._raw_ref: weakref.ref[RawLauncher] | None = weakref.ref(raw_launcher)
+        self._timings: list[float] = []
+        self._num_timings_in_flight: int = 0
+        self._warm: bool = False
+        self._lock: threading.Lock = threading.Lock()
+        self._on_timing_update_subs: list[OnTimingUpdateSubscription] = []
+
+    def remove_subscription(self, sub: OnTimingUpdateSubscription) -> None:
+        """Drop ``sub`` from this Launcher's registry. Idempotent —
+        already-pruned subscriptions are a no-op.
+        """
+        with self._lock:
+            try:
+                self._on_timing_update_subs.remove(sub)
+            except ValueError:
+                pass
+
+    def add_on_timing_update_fn(
+        self, fn: Callable[[Launcher, float, float], None]
+    ) -> OnTimingUpdateSubscription:
+        """Register a bound-method callback fired after every ``add_timing``
+        and return a ``OnTimingUpdateSubscription`` handle.
+
+        The callback receives ``(self, old_timing, new_timing)``: the
+        aggregated timing immediately before and after the new sample
+        landed. Subscribers can use the diff to detect slow-downs (e.g.,
+        a tracker that rescans only when ``new_timing > old_timing``).
+
+        ``fn`` is held via :class:`weakref.WeakMethod`, so it is pruned
+        automatically once its owning instance is garbage-collected.
+        For deterministic cleanup (e.g., on ``_discard`` / convergence),
+        call ``sub.cancel()`` on the returned subscription: cancel waits
+        for any in-flight invocation to finish before returning, so the
+        callback is provably retired when ``cancel`` returns.
+
+        ``fn`` must be a bound method (``WeakMethod`` requires it).
+        """
+        sub = OnTimingUpdateSubscription(fn, self)
+        with self._lock:
+            self._on_timing_update_subs.append(sub)
+        return sub
+
+    def set_raw_launcher(self, raw_launcher: RawLauncher) -> None:
+        """Attach a fresh raw to a previously-dormant Launcher.
+
+        Used by :func:`get_or_create_launcher` when the pool's existing
+        Launcher has lost its raw (autotuner that owned it filtered or
+        was GC'd) and a new autotuner shows up with a fresh raw.
+        Resets ``_warm`` because the new raw hasn't been dispatched
+        through this Launcher yet.
+        """
+        with self._lock:
+            self._raw_ref = weakref.ref(raw_launcher)
+            self._warm = False
+
+    def get_raw_launcher(self) -> RawLauncher | None:
+        """Return the live raw launcher, or ``None`` if it's been collected."""
+        with self._lock:
+            if self._raw_ref is None:
+                return None
+            return self._raw_ref()
+
+    def __call__(
+        self,
+        *args: object,
+        time_if_warm: bool = False,
+        **kwargs: object,
+    ) -> object:
+        """Dispatch the kernel.
+
+        When ``time_if_warm`` is True and the raw is currently warm
+        (has already been dispatched at least once via this Launcher),
+        perform a CUDA-event-timed dispatch; otherwise dispatch
+        untimed. ``_warm`` flips to True after the dispatch so the next
+        ``time_if_warm=True`` call can actually time.
+
+        The "is the raw warm?" decision is made inside ``self._lock``
+        and after the strong reference to the raw is captured — that
+        way the decision is consistent with the raw we actually
+        dispatch on, even if other threads are racing on the launcher.
+        Letting the Launcher gate timing internally (rather than
+        exposing a warm-flag for callers to inspect and act on
+        non-atomically) closes the read-then-dispatch window.
+        """
+        raw_launcher = self.get_raw_launcher()
+        assert raw_launcher is not None, (
+            "Launcher's raw launcher has been garbage-collected"
+        )
+        with self._lock:
+            timed = time_if_warm and self._warm
+            self._warm = True
+        if not timed:
+            return raw_launcher(*args, **kwargs)
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        # Two failure modes for the raw launcher under timed dispatch:
+        #   A) Launch failure (e.g., invalid configuration argument):
+        #      raises synchronously here, before we increment
+        #      _num_timings_in_flight, so the counter stays consistent
+        #      and the caller observes the error normally.
+        #   B) Execution failure (e.g., illegal memory access): is
+        #      asynchronous and only surfaces on the next device
+        #      sync (typically far away, on a different code path). We
+        #      don't reconcile the counter for this case — such failures
+        #      are assumed fatal to the entire program, so a small
+        #      bookkeeping desync on a Launcher that is about to be
+        #      discarded is moot.
+        result = raw_launcher(*args, **kwargs)
+        end_event.record()
+        with self._lock:
+            self._num_timings_in_flight += 1
+        submit_event(self.add_timing, start_event, end_event)
+        return result
+
+    def add_timing(self, elapsed_ms: float) -> None:
+        """Record a timing sample, decrement the in-flight counter, and fire
+        every live on-timing-update subscription with ``(self, old_timing,
+        new_timing)``. Cancelled subscriptions and subscriptions whose
+        owning instance has been garbage-collected are pruned in place.
+        """
+        with self._lock:
+            old_timing = self._aggregate_timings()
+            bisect.insort(self._timings, elapsed_ms)
+            self._num_timings_in_flight -= 1
+            new_timing = self._aggregate_timings()
+            live = self._get_live_subs()
+        # Fire outside the launcher lock — each subscription's ``fire``
+        # takes its own ``_in_flight`` lock around the actual callback,
+        # which guarantees that ``cancel()`` returns only after this
+        # invocation completes (and prevents any future invocations).
+        for sub in live:
+            sub.fire(self, old_timing, new_timing)
+
+    def _get_live_subs(self) -> list[OnTimingUpdateSubscription]:
+        """Return a snapshot of live on-timing-update subscriptions,
+        dropping cancelled or owner-collected entries from the registry
+        as a side effect.
+
+        Caller must hold ``self._lock`` — this both reads and rebuilds
+        ``self._on_timing_update_subs``. The returned list is a
+        separate copy so concurrent ``add_on_timing_update_fn`` calls
+        (which append to the registry under the lock) don't appear
+        partway through the snapshot.
+        """
+        live: list[OnTimingUpdateSubscription] = [
+            sub for sub in self._on_timing_update_subs if sub.is_alive()
+        ]
+        self._on_timing_update_subs = list(live)
+        return live
+
+    @property
+    def num_available_timings(self) -> int:
+        with self._lock:
+            return len(self._timings)
+
+    @property
+    def num_in_flight_timings(self) -> int:
+        with self._lock:
+            return self._num_timings_in_flight
+
+    @property
+    def num_total_timings(self) -> int:
+        with self._lock:
+            return len(self._timings) + self._num_timings_in_flight
+
+    def _aggregate_timings(self) -> float:
+        """Return the aggregated timing per the configured strategy.
+
+        Caller must hold ``self._lock``. Returns ``inf`` when no samples
+        have landed yet (so a fresh launcher compares as worst).
+        """
+        if not self._timings:
+            return float("inf")
+        match launcher_timing_aggregation:
+            case LauncherTimingAggregation.MEAN:
+                return sum(self._timings) / len(self._timings)
+            case LauncherTimingAggregation.MEDIAN:
+                n = len(self._timings)
+                mid = n // 2
+                if n % 2 == 1:
+                    return self._timings[mid]
+                return (self._timings[mid - 1] + self._timings[mid]) / 2
+            case _:
+                # Defensive: LauncherTimingAggregation is exhaustively matched
+                # above so this branch is currently unreachable. Keep it
+                # so that adding a new LauncherTimingAggregation member without
+                # a matching case fails loudly instead of silently
+                # returning the wrong aggregation.
+                raise ValueError(f"Unknown timing aggregation: {launcher_timing_aggregation!r}")
+
+    @property
+    def timing(self) -> float:
+        """Representative timing aggregated per the configured strategy."""
+        with self._lock:
+            return self._aggregate_timings()
+
+
+# --------------------------------------------------------------------------
+# Per-kernel Launcher dedup. Two ``IncrementalAutotuneState`` instances that
+# compile the same kernel/config pair share a single Launcher (and its
+# accumulated timings) via the registry below.
+# --------------------------------------------------------------------------
+
+
+# Per-kernel pool of Launcher instances, keyed by a content hash of the
+# CachingAutotuner (see :func:`_caching_autotuner_instance_key`) and then
+# by the Triton config (a ``Hashable`` produced by
+# ``triton_config_to_hashable``). Two CachingAutotuner instances whose
+# kernels hash to the same key share the same inner dict, so two
+# autotuners compiling the same kernel reuse Launchers (and their
+# accumulated timings) per matching config.
+#
+# This dict is the only persistent strong reference to Launcher objects
+# across the lifetime of the program. That's intentional and cheap:
+# Launcher only weakrefs the underlying raw launcher, so the device
+# memory pinned by raw launchers is not held here. Lifetime of those raw
+# launchers is owned by ``CachingAutotuner.launchers`` (directly, or via
+# a ``RawLauncherView`` for sharing autotuners).
+_caching_autotuner_launcher_registry: dict[str, dict[Hashable, Launcher]] = {}
+
+# Single lock guarding all reads/writes of every registry in this module.
+# Today the only registry is ``_caching_autotuner_launcher_registry``; if
+# we add more in the future they should share this lock so callers don't
+# have to reason about a per-registry locking matrix.
+_registry_lock: threading.Lock = threading.Lock()
+
+
+def _caching_autotuner_instance_key(autotuner: CachingAutotuner) -> str:
+    """Return a content hash that identifies ``autotuner``'s kernel.
+
+    Two CachingAutotuner instances with matching keys are considered to
+    have equivalent underlying kernels — so a Launcher built for one can
+    safely be reused for the other (when their Triton configs also
+    match).
+
+    Raises ``ValueError`` when ``autotuner`` is missing one of the
+    attributes we hash over. We want such cases to fail loudly so they
+    can be investigated and fixed rather than silently dropping the
+    autotuner out of the shared pool.
+    """
+    fn = autotuner.fn
+    # Attributes hashed below. Several of these (``size_hints``,
+    # ``heuristic_type``, ``custom_kernel``, ``mutated_arg_names``,
+    # ``reset_to_zero_arg_names``, ``optimize_mem``) are NOT in
+    # ``inductor_meta`` / ``triton_meta`` at runtime — ``cached_autotune``
+    # pops them out before constructing the autotuner. They still
+    # affect autotune correctness (compile-result selection, benchmark
+    # arg cloning / zeroing, register-spill filtering), so we include
+    # them in the key explicitly.
+    missing = [
+        attr
+        for obj, attr in (
+            (fn, "src"),
+            (fn, "__name__"),
+            (autotuner, "inductor_meta"),
+            (autotuner, "triton_meta"),
+            (autotuner, "size_hints"),
+            (autotuner, "heuristic_type"),
+            (autotuner, "custom_kernel"),
+            (autotuner, "mutated_arg_names"),
+            (autotuner, "reset_to_zero_arg_names"),
+            (autotuner, "optimize_mem"),
+        )
+        if not hasattr(obj, attr)
+    ]
+    if missing:
+        raise ValueError(
+            f"CachingAutotuner instance is missing required attributes: {missing}"
+        )
+
+    # Inductor mangles each generated kernel's name with an incrementing
+    # suffix (``triton_foo_0``, ``triton_foo_1``, ...) so symbol names
+    # don't collide. Two structurally-identical kernels would therefore
+    # hash differently if we kept the names. Normalize every occurrence
+    # of the kernel name in ``fn.src`` (and in the inductor metadata,
+    # which embeds the same name) to a fixed sentinel so the resulting
+    # hash depends only on kernel content. Whole-word matching avoids
+    # clobbering substrings of unrelated identifiers that happen to
+    # contain the kernel name.
+    name: str = fn.__name__
+    name_re = re.compile(rf"\b{re.escape(name)}\b")
+    normalized_src = name_re.sub("triton_", fn.src)
+    normalized_inductor = name_re.sub(
+        "triton_",
+        json.dumps(autotuner.inductor_meta, sort_keys=True, default=repr),
+    )
+    # ``triton_meta`` does not embed the kernel name, so it goes in
+    # as-is.
+    raw_triton = json.dumps(autotuner.triton_meta, sort_keys=True, default=repr)
+    # Extra attributes that aren't reflected in inductor_meta /
+    # triton_meta but affect autotune correctness.
+    extra_attrs = json.dumps(
+        {
+            "size_hints": autotuner.size_hints,
+            "heuristic_type": repr(autotuner.heuristic_type),
+            "custom_kernel": autotuner.custom_kernel,
+            "mutated_arg_names": list(autotuner.mutated_arg_names),
+            "reset_to_zero_arg_names": list(autotuner.reset_to_zero_arg_names),
+            "optimize_mem": autotuner.optimize_mem,
+        },
+        sort_keys=True,
+        default=repr,
+    )
+
+    # Length-prefix each chunk so two distinct (src, inductor, triton, extra)
+    # tuples whose concatenated bytes would otherwise align cannot collide.
+    hasher = hashlib.sha256()
+    for chunk in (normalized_src, normalized_inductor, raw_triton, extra_attrs):
+        encoded = chunk.encode("utf-8")
+        hasher.update(len(encoded).to_bytes(8, "big"))
+        hasher.update(encoded)
+    return hasher.hexdigest()
+
+
+def _get_autotuner_specific_registry(
+    autotuner: object,
+) -> dict[Hashable, Launcher]:
+    """Return the ``config -> Launcher`` pool for ``autotuner``.
+
+    ``autotuner`` is typed as ``object`` so additional autotuner types
+    can be plugged in later without touching the call sites; today only
+    ``CachingAutotuner`` is recognized. Any other type raises
+    ``ValueError`` (we'd rather hear about an unsupported caller than
+    silently bypass the pool). ``CachingAutotuner`` instances that are
+    missing the attributes needed for content-keying (see
+    :func:`_caching_autotuner_instance_key`) also raise ``ValueError``.
+    """
+    if isinstance(autotuner, CachingAutotuner):
+        key = _caching_autotuner_instance_key(autotuner)
+        return _caching_autotuner_launcher_registry.setdefault(key, {})
+    raise ValueError(
+        f"Unsupported autotuner type {type(autotuner).__name__}; "
+        "only CachingAutotuner is recognized today."
+    )
+
+
+def _get_or_create_launchers(
+    autotuner: object,
+    raw_launchers: Iterable[RawLauncher],
+) -> list[tuple[Launcher, RawLauncher | RawLauncherView]]:
+    """Unlocked worker shared by :func:`get_or_create_launcher` and
+    :func:`get_or_create_launchers`.
+
+    For each input raw launcher, returns a tuple
+    ``(Launcher, raw_or_view)``. The second element is what should be
+    placed in ``autotuner.launchers``:
+
+    * A new ``RawLauncher`` (the one passed in) if this autotuner is
+      the sole / first owner of the Launcher (pool miss, or pool hit
+      with a dead raw).
+    * A ``RawLauncherView`` wrapping another autotuner's raw if a live
+      raw was already attached to this Launcher in the pool (sharing).
+
+    Caller is responsible for holding ``_registry_lock``.
+    """
+    if not isinstance(autotuner, CachingAutotuner):
+        raise ValueError(
+            f"Unsupported autotuner type {type(autotuner).__name__}; "
+            "only CachingAutotuner is recognized today."
+        )
+    pool = _get_autotuner_specific_registry(autotuner)
+    result: list[tuple[Launcher, RawLauncher | RawLauncherView]] = []
+    for raw_launcher in raw_launchers:
+        new_raw = cast(RawLauncher, raw_launcher)
+        cfg_key = triton_config_to_hashable(new_raw.config)
+        existing = pool.get(cfg_key)
+        if existing is None:
+            # Pool miss — this autotuner is the first to register a
+            # Launcher for this config. Use the new raw as-is.
+            launcher = Launcher(raw_launcher=new_raw)
+            pool[cfg_key] = launcher
+            chosen: RawLauncher | RawLauncherView = new_raw
+        else:
+            launcher = existing
+            live_raw = launcher.get_raw_launcher()
+            if live_raw is not None:
+                # Sharing path. Reuse the existing live raw via a
+                # per-autotuner view so this autotuner's ``cache_hash``
+                # is preserved for cache persistence.
+                chosen = RawLauncherView(
+                    cast(RawLauncher, live_raw),
+                    new_raw.cache_hash,
+                )
+            else:
+                # Pool hit but the prior raw is gone. Attach the new
+                # raw and use it.
+                launcher.set_raw_launcher(new_raw)
+                chosen = new_raw
+        result.append((launcher, chosen))
+    return result
+
+
+def get_or_create_launcher(
+    autotuner: object,
+    raw_launcher: RawLauncher,
+) -> tuple[Launcher, RawLauncher | RawLauncherView]:
+    """Return ``(Launcher, raw_to_register)`` for ``raw_launcher``.
+
+    The Launcher is fetched from (or registered into) the shared
+    per-kernel pool so two autotuners with the same kernel and
+    overlapping configs share Launchers and accumulated timings. The
+    second element of the returned tuple is the raw (or view) that the
+    caller should place in ``autotuner.launchers`` — see
+    :func:`_get_or_create_launchers` for the case dispatch.
+
+    Raises ``ValueError`` when ``autotuner`` isn't a recognized type or
+    when its kernel can't be content-keyed (see
+    :func:`_get_autotuner_specific_registry`).
+    """
+    with _registry_lock:
+        return _get_or_create_launchers(autotuner, [raw_launcher])[0]
+
+
+def get_or_create_launchers(
+    autotuner: object,
+    raw_launchers: Iterable[RawLauncher],
+) -> list[tuple[Launcher, RawLauncher | RawLauncherView]]:
+    """Batch form of :func:`get_or_create_launcher`.
+
+    Acquires ``_registry_lock`` once for the whole batch instead of once
+    per launcher. Same contract as :func:`get_or_create_launcher` for
+    each ``(autotuner, raw_launcher)`` pair.
+    """
+    with _registry_lock:
+        return _get_or_create_launchers(autotuner, raw_launchers)
+
+
+def lookup_launcher(
+    autotuner: object, config: object
+) -> Launcher | None:
+    """Return the existing pool ``Launcher`` for ``(autotuner-kernel,
+    config)``, or ``None`` if none is registered.
+
+    Read-only — does not mutate the pool, does not create a Launcher,
+    does not attach a raw. Used by the plugin's post-convergence
+    kick-off paths to skip submitting compiles for configs whose
+    Launchers are already in the pool from prior autotuners (stage 1
+    cache-hit).
+
+    Returns ``None`` for unrecognized autotuner types or for configs
+    that ``triton_config_to_hashable`` can't hash (best-effort lookup —
+    a non-hashable config just means "no cache hit, please compile").
+    """
+    if not isinstance(autotuner, CachingAutotuner):
+        return None
+    try:
+        cfg_key = triton_config_to_hashable(config)
+    except (AttributeError, TypeError):
+        return None
+    with _registry_lock:
+        pool = _get_autotuner_specific_registry(autotuner)
+        return pool.get(cfg_key)

--- a/torch/_inductor/runtime/incremental/_plugin.py
+++ b/torch/_inductor/runtime/incremental/_plugin.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import hashlib
+import threading
+from typing import TYPE_CHECKING
+
+from torch._inductor.config import triton as inductor_triton_config
+from torch._inductor.runtime.runtime_utils import triton_config_to_hashable
+from torch._inductor.runtime.triton_heuristics import CachingAutotunerPlugin, DEFER
+
+from ._launcher import get_or_create_launcher
+from ._state import IncrementalAutotuneState
+from ._utils import jk_passes, log
+from .config import should_include
+
+
+if TYPE_CHECKING:
+    from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+    from ._launcher import Launcher, RawLauncher, RawLauncherView
+
+
+# Cross-recompilation registry: when two recompilations produce identical
+# kernels (differing only in the generated name suffix), the second
+# recompilation reuses the same ``IncrementalAutotuneState`` -- whether
+# converged or still in progress. Keyed by a content hash strong enough
+# that matching keys produce binary-identical launchers.
+_shared_autotuner_registry: dict[str, IncrementalAutotuneState] = {}
+
+
+def _kernel_content_key(autotuner: CachingAutotuner) -> str:
+    """SHA-256 over normalized source, inductor/Triton metadata, and configs.
+
+    Including ``triton_meta`` guarantees identical compiled binaries, so
+    launchers from a matching shared state are directly interchangeable.
+    """
+    fn = autotuner.fn
+    name = fn.__name__
+    normalized_src = fn.src.replace(name, "triton_")
+    normalized_inductor = str(sorted(autotuner.inductor_meta.items())).replace(
+        name, "triton_"
+    )
+    normalized_triton = str(sorted(autotuner.triton_meta.items())).replace(
+        name, "triton_"
+    )
+    config_keys = sorted(
+        triton_config_to_hashable(launcher.config) for launcher in autotuner.launchers
+    )
+
+    hasher = hashlib.sha256()
+    hasher.update(normalized_src.encode("utf-8"))
+    hasher.update(normalized_inductor.encode("utf-8"))
+    hasher.update(normalized_triton.encode("utf-8"))
+    hasher.update(str(config_keys).encode("utf-8"))
+    return hasher.hexdigest()
+
+
+class IncrementalAutotunePlugin(CachingAutotunerPlugin):
+    """Spread autotuning across real kernel invocations instead of blocking up
+    front. Two cooperation modes:
+
+    - Standalone: standard precompile populates ``autotuner.launchers``;
+      ``pre_autotune`` snapshots them and initializes an
+      ``IncrementalAutotuneState``. Subsequent dispatches go through the
+      state until convergence; once converged the autotuner's launchers
+      collapse to the single best launcher and the standard fast-path
+      takes over.
+    - Pipelining + incremental: ``pre_compile`` sees the streaming handle
+      attached by ``AsyncCompile.triton`` and initializes the state up
+      front. A background drain reads launchers off ``handle.launcher_q``
+      as the worker streams them and feeds them into the state via
+      ``register_compile``, so the dispatch path can start tuning before
+      all configs have compiled.
+
+    In either mode an existing ``IncrementalAutotuneState`` may be joined
+    from the cross-recompilation registry: if it has already converged,
+    the autotuner skips straight to the winner; otherwise it tags along
+    and dispatches through the in-progress state.
+    """
+
+    def __init__(self) -> None:
+        self._state: IncrementalAutotuneState | None = None
+        self._is_shared: bool = False
+        self._drain_thread: threading.Thread | None = None
+
+    def pre_compile(self, autotuner) -> object:
+        """Streaming combo entry point. If the pipelining plugin attached a
+        handle to the autotuner, initialize the incremental state here and
+        spawn a drain thread that feeds it from the handle's launcher_q.
+        Otherwise DEFER -- the standalone path runs in ``pre_autotune``
+        after standard precompile.
+        """
+        handle = getattr(autotuner, "_pipeline_caching_autotuner_handle", None)
+        if handle is None:
+            return DEFER
+        if not self._should_apply(autotuner):
+            return DEFER
+        self._initialize_for_streaming(autotuner, handle)
+        return DEFER
+
+    def pre_autotune(self, autotuner, *args, stream, **kwargs):
+        """Standalone entry point. Standard precompile has populated
+        ``autotuner.launchers``; snapshot them into a fresh state, then
+        dispatch this call through it. In the streaming combo the state
+        is already initialized by ``pre_compile`` -- just dispatch.
+        """
+        if self._state is not None:
+            return self._state(*args, stream=stream, **kwargs)
+        if not self._should_apply(autotuner):
+            return DEFER
+        self._initialize_standard(autotuner)
+        if self._state is None:
+            return DEFER
+        return self._state(*args, stream=stream, **kwargs)
+
+    def pre_dispatch(self, autotuner, *args, stream, **kwargs):
+        """Route dispatch through the active state, or DEFER if none.
+
+        When the active state is one we joined from the registry and it
+        converged on another autotuner, finalize locally (set the single
+        launcher + write to the cache hook) and DEFER so the autotuner's
+        standard single-launcher dispatch path runs.
+        """
+        if self._state is None:
+            return DEFER
+        if self._is_shared and self._state.converged:
+            self._finalize_shared(autotuner)
+            return DEFER
+        return self._state(*args, stream=stream, **kwargs)
+
+    @staticmethod
+    def _should_apply(autotuner) -> bool:
+        if not autotuner.inductor_meta.get("incremental_autotune", False):
+            return False
+        if inductor_triton_config.autotune_at_compile_time:
+            log.warning(
+                "Incremental autotune: skipping %s - autotune_at_compile_time=True",
+                autotuner.fn.__name__,
+            )
+            return False
+        if inductor_triton_config.cudagraphs:
+            log.warning(
+                "Incremental autotune: skipping %s - cudagraphs=True",
+                autotuner.fn.__name__,
+            )
+            return False
+        if not jk_passes():
+            log.warning(
+                "Incremental autotune: skipping %s - JK gate blocked",
+                autotuner.fn.__name__,
+            )
+            return False
+        if not should_include(autotuner.heuristic_type):
+            log.debug(
+                "Incremental autotune: skipping %s - heuristic_type %s not included",
+                autotuner.fn.__name__,
+                autotuner.heuristic_type,
+            )
+            return False
+        log.debug("Incremental autotune: enabled for %s", autotuner.fn.__name__)
+        return True
+
+    def _make_callbacks(self, autotuner):
+        """Build the (on_convergence, on_discard) pair for a state owning
+        ``autotuner``. Convergence: collapse ``autotuner.launchers`` to the
+        winner and fire ``save_cache_hook``. Discard: remove the chosen
+        entry from ``autotuner.launchers``.
+        """
+
+        def on_convergence(state):
+            launcher = state.current_certified
+            assert launcher is not None
+            chosen = state.chosen_for(launcher)
+            assert chosen is not None
+            with autotuner.lock:
+                autotuner.launchers = [chosen]
+                self._state = None
+            log.info(
+                "Incremental autotune converged for %s: %s (timing=%.3f ms)",
+                autotuner.fn.__name__,
+                chosen.config,
+                launcher.timing,
+            )
+            if autotuner.save_cache_hook:
+                autotuner.save_cache_hook(
+                    chosen.config,
+                    0,
+                    found_by_coordesc=getattr(chosen, "found_by_coordesc", False),
+                    triton_cache_hash=chosen.cache_hash,
+                )
+
+        def on_discard(launcher, raw):
+            with autotuner.lock:
+                try:
+                    autotuner.launchers.remove(raw)
+                except ValueError:
+                    pass
+
+        return on_convergence, on_discard
+
+    def _try_join_shared(self, autotuner, content_key) -> bool:
+        """If a shared state exists for ``content_key``, adopt it and return
+        True (caller skips state creation). Converged shared states collapse
+        ``autotuner.launchers`` to the winner; in-progress ones leave them
+        empty and route dispatch through the shared state.
+        """
+        shared = _shared_autotuner_registry.get(content_key)
+        if shared is None:
+            return False
+        if shared.converged:
+            launcher = shared.current_certified
+            assert launcher is not None
+            chosen = shared.chosen_for(launcher)
+            assert chosen is not None
+            autotuner.launchers = [chosen]
+            log.info(
+                "Incremental autotune: %s using converged shared state id=%d "
+                "(config=%s, timing=%.3f ms)",
+                autotuner.fn.__name__,
+                id(shared),
+                chosen.config,
+                launcher.timing,
+            )
+            return True
+        autotuner.launchers = []
+        self._state = shared
+        self._is_shared = True
+        log.info(
+            "Incremental autotune: %s joining shared state id=%d (in progress)",
+            autotuner.fn.__name__,
+            id(shared),
+        )
+        return True
+
+    def _initialize_standard(self, autotuner) -> None:
+        """Standalone path: snapshot ``autotuner.launchers`` into a fresh
+        state. Adopts a shared state when one is registered for this kernel.
+        """
+        content_key = (
+            _kernel_content_key(autotuner) if hasattr(autotuner.fn, "src") else None
+        )
+        if content_key is not None and self._try_join_shared(autotuner, content_key):
+            return
+
+        raws = list(autotuner.launchers)
+        autotuner.launchers = []
+
+        on_convergence, on_discard = self._make_callbacks(autotuner)
+        self._state = IncrementalAutotuneState(
+            pre_launch_fn=autotuner._pre_launch,
+            post_launch_fn=autotuner._post_launch,
+            on_convergence_fn=on_convergence,
+            on_discard_fn=on_discard,
+        )
+        for raw in raws:
+            self._state.register_compile(autotuner, raw)
+        log.info(
+            "Incremental autotune: initializing %s with %d launchers (state id=%d)",
+            autotuner.fn.__name__,
+            len(raws),
+            id(self._state),
+        )
+        if content_key is not None:
+            _shared_autotuner_registry[content_key] = self._state
+
+    def _initialize_for_streaming(self, autotuner, handle) -> None:
+        """Pipelining combo path: bg drain is already feeding launchers into
+        ``handle.launcher_q``. Set up a state expecting ``handle.num_configs``
+        compiles and spawn a thread that drains the queue, registering each
+        launcher (and counting failures as the END sentinel is reached).
+        """
+        # Bg drain also appends each launcher to ``autotuner.launchers``;
+        # clear that so ``register_compile`` is the sole writer.
+        with autotuner.lock:
+            autotuner.launchers = []
+
+        on_convergence, on_discard = self._make_callbacks(autotuner)
+        self._state = IncrementalAutotuneState(
+            pre_launch_fn=autotuner._pre_launch,
+            post_launch_fn=autotuner._post_launch,
+            on_convergence_fn=on_convergence,
+            on_discard_fn=on_discard,
+        )
+        self._state.register_pending_compilations(handle.num_configs)
+        log.info(
+            "Incremental autotune: initializing %s for streaming with "
+            "%d pending compilations (state id=%d)",
+            autotuner.fn.__name__,
+            handle.num_configs,
+            id(self._state),
+        )
+        self._drain_thread = threading.Thread(
+            target=self._drain_loop,
+            args=(autotuner, handle),
+            daemon=True,
+            name="inductor-incremental-drain",
+        )
+        self._drain_thread.start()
+
+    def _drain_loop(self, autotuner, handle) -> None:
+        """Read launchers off ``handle.launcher_q`` until the END sentinel,
+        feeding each into the state. Any compiles that didn't surface as a
+        launcher are charged as failures so the state's pending counter
+        drains to zero.
+        """
+        from torch._inductor.async_compile import _LAUNCHER_END
+
+        state = self._state
+        assert state is not None
+        seen = 0
+        try:
+            while True:
+                item = handle.launcher_q.get()
+                if item is _LAUNCHER_END:
+                    break
+                state.register_compile(autotuner, item)
+                seen += 1
+        finally:
+            # Either the bg drain finished normally (END sentinel) or it
+            # crashed (drain_future has the exception). Either way: any
+            # pending compilations we didn't see must be accounted for so
+            # the state can converge.
+            remaining = max(0, handle.num_configs - seen)
+            for _ in range(remaining):
+                state.note_compilation_failed()
+
+    def _finalize_shared(self, autotuner) -> None:
+        """Take ownership of the converged shared state's winner without
+        mutating the shared state -- other autotuners may still be
+        dispatching through it.
+        """
+        state = self._state
+        assert state is not None and state.converged
+        launcher = state.current_certified
+        assert launcher is not None
+        chosen = state.chosen_for(launcher)
+        assert chosen is not None
+        with autotuner.lock:
+            autotuner.launchers = [chosen]
+            self._state = None
+            self._is_shared = False
+        log.debug(
+            "Incremental autotune: %s finalized from shared state "
+            "(config=%s, timing=%.3f ms)",
+            autotuner.fn.__name__,
+            chosen.config,
+            launcher.timing,
+        )
+        if autotuner.save_cache_hook:
+            autotuner.save_cache_hook(
+                chosen.config,
+                0,
+                found_by_coordesc=getattr(chosen, "found_by_coordesc", False),
+                triton_cache_hash=chosen.cache_hash,
+            )

--- a/torch/_inductor/runtime/incremental/_resolver.py
+++ b/torch/_inductor/runtime/incremental/_resolver.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import queue
+import threading
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from ._utils import log
+from .config import _RESOLVER_IDLE_TIMEOUT_S
+
+
+if TYPE_CHECKING:
+    import torch
+
+
+TimingCallback = Callable[[float], None]
+
+_QueueItem = tuple[TimingCallback, "torch.cuda.Event", "torch.cuda.Event"]
+
+_global_event_queue: queue.Queue[_QueueItem] = queue.Queue()
+_global_resolver_lock: threading.Lock = threading.Lock()
+_global_resolver_thread: threading.Thread | None = None
+
+
+def submit_event(
+    callback: TimingCallback,
+    start_event: torch.cuda.Event,
+    end_event: torch.cuda.Event,
+) -> None:
+    """Enqueue a CUDA event pair for async timing resolution.
+
+    The daemon synchronizes on ``end_event``, computes elapsed time, and
+    invokes ``callback(elapsed_ms)``. Starts the global resolver daemon
+    if it is not already running.
+    """
+    # Put-then-ensure ordering closes a termination race: if we ensured first
+    # and a daemon was idling out concurrently, it could exit between our
+    # ensure and our put, leaving the item orphaned. Putting first guarantees
+    # the daemon's empty()-check (also under _global_resolver_lock) sees it.
+    _global_event_queue.put((callback, start_event, end_event))
+    _ensure_daemon()
+
+
+def _ensure_daemon() -> None:
+    global _global_resolver_thread
+    with _global_resolver_lock:
+        if _global_resolver_thread is not None:
+            return
+        t = threading.Thread(
+            target=_global_event_resolver_loop,
+            daemon=True,
+            name="autotune-event-resolver",
+        )
+        t.start()
+        _global_resolver_thread = t
+        log.info(
+            "Incremental autotune event resolver started (thread id=%d)",
+            t.ident,
+        )
+
+
+def _global_event_resolver_loop() -> None:
+    global _global_resolver_thread
+
+    while True:
+        try:
+            item = _global_event_queue.get(timeout=_RESOLVER_IDLE_TIMEOUT_S)
+        except queue.Empty:
+            # Consumer side of the put-then-ensure race close: a producer may
+            # have called put() between our get() raising Empty and our
+            # acquiring the lock. Re-check empty() under the lock so we don't
+            # exit while an item is sitting in the queue.
+            with _global_resolver_lock:
+                if _global_event_queue.empty():
+                    _global_resolver_thread = None
+                    log.info(
+                        "Incremental autotune event resolver stopped (idle timeout)"
+                    )
+                    return
+                continue
+
+        callback, start_event, end_event = item
+        try:
+            end_event.synchronize()
+            elapsed_ms: float = start_event.elapsed_time(end_event)
+            callback(elapsed_ms)
+        except Exception:
+            # Silently drop. We assume any underlying CUDA fault will
+            # resurface on the main thread's next CUDA op (e.g.
+            # ``torch.cuda.synchronize``) and would rather not surface it
+            # twice from a background thread with no clear ownership.
+            log.debug(
+                "Incremental autotune: timing resolution failed",
+                exc_info=True,
+            )

--- a/torch/_inductor/runtime/incremental/_state.py
+++ b/torch/_inductor/runtime/incremental/_state.py
@@ -1,0 +1,770 @@
+from __future__ import annotations
+
+import contextlib
+import threading
+from collections import deque
+from typing import TYPE_CHECKING
+
+from torch.utils._ordered_set import OrderedSet
+
+from .config import (
+    filter_threshold_decay_exp,
+    force_timing_if_lt_n_timings,
+    initial_filter_threshold,
+    max_timings_per_launcher,
+    min_timings_before_filter,
+    timed_sampling_rate,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+    from ._launcher import (
+        Launcher,
+        OnTimingUpdateSubscription,
+        RawLauncher,
+        RawLauncherView,
+    )
+
+
+# Precomputed threshold scale factors for sample counts 1..max_timings_per_launcher.
+# Index i corresponds to sample_count == i+1.  Avoids repeated pow() calls.
+_THRESHOLD_MULTIPLIERS: tuple[float, ...] = tuple(
+    1.0 - ((n - 1) / (max_timings_per_launcher - 1)) ** filter_threshold_decay_exp
+    for n in range(1, max_timings_per_launcher + 1)
+)
+
+
+class IncrementalAutotuneState:
+    """Drives incremental autotuning across a set of ``Launcher`` candidates.
+
+    Call the instance to dispatch one kernel invocation; over many calls
+    the state collects timings, discards underperformers, and converges
+    on a single best launcher.
+
+    Threading model:
+      * The dispatch thread (single, the user's thread that calls into
+        the autotuner) runs ``__call__`` and the queue-walk inside
+        ``_next_launcher``.
+      * Worker threads run ``add_launcher`` /
+        ``note_compilation_failed`` from ``AsyncCompile``'s pool or the
+        streaming-compile reader. ``register_pending_compilations`` is
+        called from the dispatch thread (plugin's ``_kick_off_*``).
+      * The global resolver daemon (single thread, see
+        ``_resolver.py``) fires per-launcher timing-update callbacks
+        sequentially.
+
+      ``self._lock`` guards every mutation of ``_queue``,
+      ``_certified_launcher``, ``_provisional_subs``,
+      ``_pending_compilations``, and ``_convergence_callback_fired``.
+
+      Lock ordering: ``state.lock → launcher.lock``. The reverse path
+      ``autotuner.lock → state.lock`` exists in
+      ``CachingAutotuner.precompile`` (it calls ``plugin.pre_compile``,
+      which calls ``register_pending_compilations``), so anything that
+      takes ``autotuner.lock`` while holding ``state.lock`` would
+      deadlock — namely user callbacks ``on_discard_fn`` and
+      ``on_convergence_fn``. Both are deferred out of the locked
+      region: ``_discard`` / ``_maybe_promote`` accept a
+      ``pending_discards`` list to append to, and the ``_mutation``
+      context manager fires them after releasing the lock; the
+      convergence callback is fired in ``__call__`` after the locked
+      check-and-pop.
+
+      ``_provisional_launcher`` is intentionally lock-free: it's only
+      a heuristic threshold reference, mutated by
+      ``_maybe_update_provisional`` (which fires from the resolver
+      thread without the state lock). Stale reads / racy writes
+      self-correct on the next timing event.
+    """
+
+    def __init__(
+        self,
+        pre_launch_fn: Callable | None = None,
+        post_launch_fn: Callable[[], None] | None = None,
+        on_discard_fn: Callable[
+            [Launcher, "RawLauncher | RawLauncherView"], None
+        ]
+        | None = None,
+        on_convergence_fn: Callable[[IncrementalAutotuneState], None] | None = None,
+    ) -> None:
+        # Queue holds launchers that either still need timing runs or have
+        # launched enough but are waiting for in-flight timings to land.
+        # ``_certified_launcher`` is set once a launcher has reached its
+        # full sample budget — its timing is the stable answer used at
+        # convergence and as a threshold-check baseline.
+        self._queue: deque[Launcher] = deque()
+        self._certified_launcher: Launcher | None = None
+        # Lowest-timing launcher across the queue and ``_certified_launcher``,
+        # i.e. the best candidate so far whose timing hasn't yet been
+        # certified by reaching the sample budget. Maintained incrementally
+        # via the per-launcher timing-update callback; rescanned only when
+        # its current holder is discarded.
+        self._provisional_launcher: Launcher | None = None
+
+        self._pre_launch_fn = pre_launch_fn
+        self._post_launch_fn = post_launch_fn
+        self._on_discard_fn = on_discard_fn
+        self._on_convergence_fn = on_convergence_fn
+
+        self._dispatch_count: int = 0
+
+        # Per-launcher subscription handles, so we can deterministically
+        # cancel callbacks on discard / convergence rather than relying
+        # on GC alone. Keyed by launcher identity (Launcher uses default
+        # object identity hashing).
+        self._provisional_subs: dict[
+            Launcher, OnTimingUpdateSubscription
+        ] = {}
+
+        # Per-launcher autotuner-side raw (or view). Looked up at
+        # discard time so ``on_discard_fn`` can remove the right entry
+        # from ``autotuner.launchers`` without scanning. Keyed by
+        # Launcher identity.
+        self._per_launcher_raw: dict[
+            Launcher, "RawLauncher | RawLauncherView"
+        ] = {}
+
+        # Streaming-compile coordination. Producers (worker threads
+        # compiling kernels) call ``register_pending_compilations(n)``
+        # to declare that ``n`` more launchers are on the way, then
+        # call ``add_launcher`` (success) or ``note_compilation_failed``
+        # (failure) to satisfy each pending entry. Convergence is gated
+        # on ``_pending_compilations == 0`` so the state can't pre-converge
+        # while compiles are still in flight. ``_compile_signal`` lets
+        # ``_next_launcher`` block efficiently for the first launcher.
+        self._lock: threading.Lock = threading.Lock()
+        self._pending_compilations: int = 0
+        self._compile_signal: threading.Event = threading.Event()
+        # ``on_convergence_fn`` is fired once per converged generation. The
+        # flag is re-armed whenever new work arrives (add_launcher or
+        # register_pending_compilations) so a multi-generation flow
+        # (initial → rblock → coordesc → done) re-fires the callback at
+        # each convergence point.
+        self._convergence_callback_fired: bool = False
+
+    # -- Lock helpers ------------------------------------------------------
+
+    @contextlib.contextmanager
+    def _mutation(
+        self,
+    ) -> Iterator[list[tuple[Launcher, "RawLauncher | RawLauncherView"]]]:
+        """Acquire ``self._lock`` for a state-mutation block; on exit,
+        release the lock and fire ``on_discard_fn`` for any launchers
+        accumulated in the yielded list.
+
+        The yielded list is the deferral channel: ``_discard`` /
+        ``_maybe_promote`` append ``(launcher, raw)`` tuples, and the
+        callbacks are fired outside the lock so they don't AB/BA against
+        ``autotuner.lock`` (the reverse path exists in
+        ``CachingAutotuner.precompile`` ⇒ ``plugin.pre_compile`` ⇒
+        ``register_pending_compilations``). Doing the firing in
+        ``__exit__`` (rather than releasing mid-mutation) keeps the
+        lock continuously held across the full state mutation, avoiding
+        any window where another thread can swap state out from under
+        us.
+
+        ``raw`` is the autotuner-side raw (or view) that was registered
+        via ``add_launcher`` — passed through to ``on_discard_fn`` so
+        it can remove the right entry from ``autotuner.launchers``
+        without re-deriving it.
+        """
+        pending: list[tuple[Launcher, "RawLauncher | RawLauncherView"]] = []
+        with self._lock:
+            yield pending
+        on_discard_fn = self._on_discard_fn
+        if on_discard_fn is not None:
+            for launcher, raw in pending:
+                on_discard_fn(launcher, raw)
+
+    # -- Producer API (worker threads) -------------------------------------
+
+    def register_pending_compilations(self, n: int) -> None:
+        """Declare that ``n`` more launchers are about to arrive.
+
+        Called by the producer (e.g., the plugin's async-compile
+        scheduler) before submitting compiles. Each pending entry must
+        eventually be satisfied by either ``add_launcher`` (success) or
+        ``note_compilation_failed`` (failure). Until all pending entries
+        are satisfied, ``converged`` returns False so we don't terminate
+        prematurely.
+        """
+        assert n > 0, f"register_pending_compilations requires n > 0, got {n}"
+        with self._lock:
+            self._pending_compilations += n
+            self._convergence_callback_fired = False
+
+    def note_compilation_failed(self) -> None:
+        """Record that a previously-registered compilation failed.
+
+        Decrements the pending counter without adding a launcher. Only
+        signals the first-launcher waiter when the counter hits zero,
+        since that's the transition the waiter cares about (it surfaces
+        ``NoTritonConfigsError``); intermediate decrements leave the
+        wait condition unchanged.
+        """
+        with self._lock:
+            assert self._pending_compilations > 0, (
+                "note_compilation_failed called with no pending compilations"
+            )
+            self._pending_compilations -= 1
+            should_signal = self._pending_compilations == 0
+        if should_signal:
+            self._compile_signal.set()
+
+    def add_launcher(
+        self,
+        launcher: Launcher,
+        raw: "RawLauncher | RawLauncherView",
+    ) -> None:
+        """Register ``launcher`` as a candidate.
+
+        If ``launcher`` already has a full sample budget (e.g., it came
+        from the shared per-kernel pool with timings inherited from a
+        prior autotuner), promote it directly against the cached best
+        instead of queueing — so a state initialized with all-saturated
+        launchers immediately converges without dispatching anything.
+
+        ``raw`` is the autotuner-side raw / view that was placed in
+        ``autotuner.launchers``. Stashed in ``_per_launcher_raw`` so
+        ``on_discard_fn`` can find it later.
+
+        Queue/promote happens *before* the pending-counter decrement
+        under a single lock, so observers (``converged``,
+        ``_next_launcher``'s outer block-or-return) can never see
+        ``_pending_compilations == 0`` with the launcher missing from
+        ``_queue`` / ``_certified_launcher``.
+        """
+        with self._mutation() as pending_discards:
+            self._per_launcher_raw[launcher] = raw
+            if launcher.num_available_timings >= max_timings_per_launcher:
+                self._maybe_promote(launcher, pending_discards)
+            else:
+                self._queue.append(launcher)
+                # Register the timing-update sub now (not just for
+                # saturated launchers via ``_maybe_promote``) so the
+                # provisional reflects this launcher as soon as its
+                # first timing lands. Without this, the threshold-based
+                # early-discard branch in ``_next_launcher`` has no
+                # provisional reference during the formative-samples
+                # window.
+                self._register_provisional_sub(launcher)
+            if self._pending_compilations > 0:
+                self._pending_compilations -= 1
+            self._convergence_callback_fired = False
+        self._compile_signal.set()
+
+    def register_compile(
+        self,
+        autotuner: CachingAutotuner,
+        raw: RawLauncher,
+        *,
+        found_by_coordesc: bool = False,
+    ) -> Launcher:
+        """High-level registration: look up / create the shared
+        ``Launcher`` for ``raw``, attach the chosen entry to
+        ``autotuner.launchers``, and register with this state.
+
+        Bundles the three-step dance (pool lookup → autotuner.launchers
+        append → ``add_launcher``) so callers don't have to thread the
+        per-autotuner ``chosen`` (raw or view) through manually.
+        Returns the shared ``Launcher`` for further reference if
+        needed.
+        """
+        from ._launcher import get_or_create_launcher
+
+        launcher, chosen = get_or_create_launcher(autotuner, raw)
+        if found_by_coordesc:
+            chosen.found_by_coordesc = True
+        with autotuner.lock:
+            autotuner.launchers.append(chosen)
+        self.add_launcher(launcher, chosen)
+        return launcher
+
+    # -- Internal mutation helpers (caller holds self._lock) ---------------
+
+    def _maybe_promote(
+        self,
+        launcher: Launcher,
+        pending_discards: list[
+            tuple[Launcher, "RawLauncher | RawLauncherView"]
+        ],
+    ) -> None:
+        """Compare a fully-sampled ``launcher`` against the cached best;
+        the slower of the two is discarded.
+
+        Caller must hold ``self._lock`` so the cert check-and-set is
+        atomic — without it, two concurrent ``_maybe_promote`` calls
+        could both see ``_certified_launcher is None`` and orphan one
+        of the launchers.
+
+        Appends ``(launcher, raw)`` for any discarded launchers to
+        ``pending_discards`` for the caller to fire ``on_discard_fn``
+        on after releasing the lock.
+        """
+        if self._certified_launcher is None:
+            self._certified_launcher = launcher
+            self._register_provisional_sub(launcher)
+        elif launcher.timing < self._certified_launcher.timing:
+            old_certified = self._certified_launcher
+            self._certified_launcher = launcher
+            self._discard(old_certified, pending_discards)
+            self._register_provisional_sub(launcher)
+        else:
+            # ``launcher`` is the loser; ``_discard`` cleans it up and
+            # we do NOT register a sub for it. (A sub registered here
+            # would fire ``_maybe_update_provisional`` for an already-
+            # discarded launcher, which can install it as
+            # ``_provisional_launcher`` and leak through dispatch.)
+            self._discard(launcher, pending_discards)
+
+    def _register_provisional_sub(self, launcher: Launcher) -> None:
+        """Caller must hold ``self._lock``. Wires
+        ``_maybe_update_provisional`` as a timing-update callback on
+        ``launcher`` and seeds the provisional with the launcher's
+        current timing snapshot.
+
+        No-op if a sub is already registered for this launcher in this
+        state (e.g., the launcher was added unsaturated via
+        ``add_launcher`` — which registers a sub — and later saturates
+        via ``_next_launcher → _maybe_promote`` — which also tries to
+        register one).
+
+        Seeding with ``inf`` for a fresh launcher with no timings is
+        intentional: ``_provisional_launcher`` becomes the launcher
+        even though its representative timing is meaningless, but the
+        threshold-discard branch in ``_next_launcher`` is gated on
+        ``provisional.num_available_timings >= 1`` so an inf-timing
+        provisional is filtered out from threshold checks until a real
+        sample lands. The seed exists so subsequent timing updates
+        compare against ``inf`` and immediately install a meaningful
+        value.
+        """
+        if launcher in self._provisional_subs:
+            return
+        self._provisional_subs[launcher] = launcher.add_on_timing_update_fn(
+            self._maybe_update_provisional
+        )
+        # No actual timing change here — pass the same value for old/new
+        # so the rescan-on-slowdown branch isn't tripped on registration.
+        current = launcher.timing
+        self._maybe_update_provisional(launcher, current, current)
+
+    def _discard(
+        self,
+        launcher: Launcher,
+        pending_discards: list[
+            tuple[Launcher, "RawLauncher | RawLauncherView"]
+        ],
+    ) -> None:
+        """Drop ``launcher`` from tracking and queue an ``on_discard_fn``
+        notification.
+
+        Caller must hold ``self._lock``. Cancels the subscription
+        synchronously: ``cancel()`` blocks until any in-flight
+        ``_maybe_update_provisional`` invocation for this launcher
+        completes (the callback doesn't take ``self._lock``, so this
+        wait is safe under our lock).
+
+        Appends ``(launcher, raw)`` to ``pending_discards`` instead of
+        calling ``on_discard_fn`` directly, so the callback fires
+        outside the lock — necessary because ``on_discard_fn`` takes
+        ``autotuner.lock`` and the reverse direction
+        ``autotuner.lock → self._lock`` exists in
+        ``CachingAutotuner.precompile``.
+        """
+        sub = self._provisional_subs.pop(launcher, None)
+        if sub is not None:
+            sub.cancel()
+        if launcher is self._provisional_launcher:
+            self._recompute_provisional()
+        self._maybe_converge_early()
+        # ``pop`` (rather than ``get``) so the side-map shrinks as
+        # launchers leave the state. Returns None if launcher was never
+        # registered with a raw (defensive) or already popped.
+        raw = self._per_launcher_raw.pop(launcher, None)
+        if self._on_discard_fn is not None:
+            pending_discards.append((launcher, raw))
+
+    def _maybe_converge_early(self) -> None:
+        """Promote the queue's last survivor as certified without
+        waiting for ``max_timings_per_launcher``.
+
+        Caller must hold ``self._lock``. Triggered after a discard: if
+        the queue is down to a single launcher, no certified one
+        exists, and no compiles are pending to bring more candidates,
+        the survivor wins by process of elimination and we can skip
+        the remaining confirmation dispatches.
+
+        Triggers only from threshold-driven discards. The other
+        ``_discard`` call site is inside ``_maybe_promote``, which has
+        already set ``_certified_launcher`` before discarding the
+        loser, so the ``is None`` guard is false and this is a no-op
+        in that path. The pending-compilations guard prevents an early
+        promote during streaming where another candidate is about to
+        arrive.
+        """
+        if (
+            self._certified_launcher is None
+            and len(self._queue) == 1
+            and self._pending_compilations == 0
+        ):
+            self._certified_launcher = self._queue.popleft()
+
+    def _maybe_update_provisional(
+        self, launcher: Launcher, old_timing: float, new_timing: float
+    ) -> None:
+        """Update ``_provisional_launcher`` in response to a timing change.
+
+        Wired in as the per-launcher timing-update callback. Three cases:
+
+        1. ``launcher`` is the current provisional and got slower
+           (``new_timing > old_timing``): the provisional may no longer
+           be the actual minimum, so rescan the queue and the certified
+           launcher to refresh it.
+        2. ``launcher`` is now strictly faster than the current
+           provisional (or there is no provisional): take over.
+        3. Otherwise: nothing to do.
+
+        Together with ``_recompute_provisional`` on discard, this keeps
+        ``_provisional_launcher`` in sync with the actual fastest
+        launcher we know about at any point in time.
+
+        Lock-free: called from the resolver thread without
+        ``self._lock`` (and synchronously from ``_maybe_promote`` with
+        the lock held). Reads/writes of ``_provisional_launcher`` race
+        between the two — heuristic, self-correcting on the next event.
+        """
+        if launcher is self._provisional_launcher and new_timing > old_timing:
+            self._recompute_provisional()
+            return
+        if (
+            self._provisional_launcher is None
+            or new_timing < self._provisional_launcher.timing
+        ):
+            self._provisional_launcher = launcher
+
+    def _recompute_provisional(self) -> None:
+        """Re-scan candidates and refresh ``_provisional_launcher``. O(n).
+
+        Lock-free for the same reason as ``_maybe_update_provisional``:
+        the snapshot of ``_queue`` / ``_certified_launcher`` may be
+        stale, but the result is heuristic and corrects on the next
+        event.
+        """
+        candidates: list[Launcher] = list(self._queue)
+        if self._certified_launcher is not None:
+            candidates.append(self._certified_launcher)
+        self._provisional_launcher = (
+            min(candidates, key=lambda l: l.timing) if candidates else None
+        )
+
+    # -- Read-only views ---------------------------------------------------
+
+    @property
+    def certified_launcher(self) -> Launcher | None:
+        # Only meaningful at convergence: the stable, definitively best
+        # launcher. Use ``current_certified`` for mid-autotune reads
+        # (e.g., from a convergence callback).
+        assert self.converged, "certified_launcher is only valid while converged"
+        return self._certified_launcher
+
+    @property
+    def certified_timing(self) -> float:
+        assert self.converged, "certified_timing is only valid while converged"
+        if self._certified_launcher is None:
+            return float("inf")
+        return self._certified_launcher.timing
+
+    @property
+    def current_certified(self) -> Launcher | None:
+        """Current certified launcher, without the converged-only
+        assertion of ``certified_launcher``. Intended for use inside
+        ``on_convergence_fn`` (where the state is mid-mutation between
+        generations) and other in-progress reads."""
+        return self._certified_launcher
+
+    def chosen_for(
+        self, launcher: Launcher
+    ) -> "RawLauncher | RawLauncherView | None":
+        """Return the autotuner-side raw / view registered for
+        ``launcher`` via ``add_launcher``, or ``None`` if there's no
+        entry (launcher was discarded or never registered)."""
+        return self._per_launcher_raw.get(launcher)
+
+    def replace_chosen(
+        self,
+        launcher: Launcher,
+        raw: "RawLauncher | RawLauncherView",
+    ) -> None:
+        """Update the autotuner-side raw / view recorded for
+        ``launcher``. Used by callers that swap a placeholder view for
+        a freshly-compiled raw (e.g., the plugin's compile-on-finalize
+        path)."""
+        self._per_launcher_raw[launcher] = raw
+
+    @property
+    def converged(self) -> bool:
+        # The queue drains as launchers either become best or get
+        # discarded; ``_pending_compilations`` blocks convergence while
+        # producers (the plugin's async-compile scheduler) still have
+        # launchers in flight that haven't been added yet.
+        return not self._queue and self._pending_compilations == 0
+
+    # -- Dispatch ----------------------------------------------------------
+
+    def _next_launcher(self) -> Launcher | None:
+        """Pop the next launcher to dispatch, blocking when streaming
+        compiles are still in flight and no fallback is available.
+
+        Returns the next launcher for tuning mode, or ``None`` if the
+        caller should fall back to ``_certified_launcher`` /
+        ``_provisional_launcher``. Raises ``NoTritonConfigsError`` when
+        there's nothing to dispatch and nothing more is coming
+        (initial-set all-failed) — the unique state shape
+        ``(_queue=[], _certified_launcher=None,
+        _provisional_launcher=None, _pending_compilations=0)`` is only
+        reachable that way, since every other path keeps at least one
+        of cert / provisional set.
+
+        Per-iteration locking: each queue-walk iteration takes
+        ``self._lock`` (via ``_mutation``) so worker ``add_launcher``
+        calls can squeeze in between iterations. The lock is released
+        between iterations, including across ``_compile_signal.wait``.
+        """
+        seen_waiting: OrderedSet[int] = OrderedSet()
+        # Track the queue size at the last "all-waiting" tally point so
+        # we can detect worker-side ``add_launcher`` calls that grew
+        # the queue between iterations and reset cycle detection
+        # accordingly (otherwise we'd return None after cycling through
+        # the originally-queued waiters even though new ready launchers
+        # are sitting behind them).
+        last_seen_queue_size: int = 0
+        # Snapshot provisional once for stable threshold reference
+        # across the walk (matches the prior unlocked design).
+        with self._lock:
+            provisional = self._provisional_launcher
+        while True:
+            wait_after = False
+            with self._mutation() as pending_discards:
+                if not self._queue:
+                    if (
+                        self._certified_launcher is not None
+                        or self._provisional_launcher is not None
+                    ):
+                        return None
+                    if self._pending_compilations == 0:
+                        # Lazy import to avoid the circular dep with
+                        # triton_heuristics.
+                        from torch._inductor.runtime.triton_heuristics import (
+                            NoTritonConfigsError,
+                        )
+
+                        raise NoTritonConfigsError(
+                            "Incremental autotune: all initial configs "
+                            "failed to compile"
+                        )
+                    wait_after = True
+                else:
+                    # Queue grew since our last cycle-detect bookkeeping
+                    # — worker added new launchers we haven't examined.
+                    # Reset seen_waiting so we don't bail before walking
+                    # the new entries.
+                    if len(self._queue) > last_seen_queue_size:
+                        seen_waiting = OrderedSet()
+                    launcher = self._queue.popleft()
+                    available = launcher.num_available_timings
+
+                    # 1) Done — promote against the cached best, discard the loser.
+                    if available >= max_timings_per_launcher:
+                        self._maybe_promote(launcher, pending_discards)
+                        continue
+
+                    # 2) Threshold-based early discard against the snapshotted
+                    # temp best. Each side gets its own permissiveness based on
+                    # its sample count; we multiply so a noisy candidate or a
+                    # noisy baseline both relax the bar. Skip the baseline
+                    # itself so we never discard our reference point, and
+                    # require at least one sample on the baseline so the
+                    # multiplier index is in range.
+                    if (
+                        provisional is not None
+                        and launcher is not provisional
+                        and available >= min_timings_before_filter
+                        and provisional.num_available_timings >= 1
+                    ):
+                        cand_mult = max(
+                            1.0,
+                            1.0
+                            + (initial_filter_threshold - 1.0)
+                            * _THRESHOLD_MULTIPLIERS[available - 1],
+                        )
+                        provisional_mult = max(
+                            1.0,
+                            1.0
+                            + (initial_filter_threshold - 1.0)
+                            * _THRESHOLD_MULTIPLIERS[
+                                provisional.num_available_timings - 1
+                            ],
+                        )
+                        if (
+                            launcher.timing
+                            > cand_mult * provisional_mult * provisional.timing
+                        ):
+                            self._discard(launcher, pending_discards)
+                            continue
+
+                    # 3) Waiting — launched enough but not all resolved yet.
+                    if launcher.num_total_timings >= max_timings_per_launcher:
+                        if id(launcher) in seen_waiting:
+                            self._queue.append(launcher)
+                            return None
+                        seen_waiting.add(id(launcher))
+                        self._queue.append(launcher)
+                        last_seen_queue_size = len(self._queue)
+                        continue
+
+                    # 4) Ready to dispatch.
+                    return launcher
+            # Only reachable for the wait case. Lock released; pending
+            # discards (none in this branch) fired in __exit__.
+            if wait_after:
+                self._compile_signal.wait(timeout=1.0)
+                self._compile_signal.clear()
+
+    def __call__(self, *args: object, stream: object, **kwargs: object) -> object:
+        # Converged path: fire the convergence callback once per
+        # generation (re-armed by ``add_launcher`` /
+        # ``register_pending_compilations``) and dispatch the certified
+        # launcher.
+        sub_to_cancel = None
+        should_fire = False
+        with self._lock:
+            if (
+                self.converged
+                and self._certified_launcher is not None
+                and not self._convergence_callback_fired
+                and self._on_convergence_fn is not None
+            ):
+                self._convergence_callback_fired = True
+                should_fire = True
+                sub_to_cancel = self._provisional_subs.pop(
+                    self._certified_launcher, None
+                )
+
+        if should_fire:
+            # Cancel our timing-update subscription on the surviving
+            # launcher so we don't keep this state alive via the global
+            # pool. Then fire the convergence callback (which may queue
+            # more compiles and re-arm ``_convergence_callback_fired``).
+            # Both run with the lock released — ``cancel()`` blocks on
+            # the subscription's ``_in_flight`` lock, and
+            # ``on_convergence_fn`` calls back into
+            # ``register_pending_compilations``, which takes
+            # ``self._lock``.
+            if sub_to_cancel is not None:
+                sub_to_cancel.cancel()
+            assert self._on_convergence_fn is not None
+            self._on_convergence_fn(self)
+
+        # ``_certified_launcher`` is never re-nulled, so the unlocked
+        # read here is safe; the converged check below detects the case
+        # where the callback added more work.
+        if self.converged and self._certified_launcher is not None:
+            return self._launch(
+                self._certified_launcher,
+                *args,
+                stream=stream,
+                time_if_warm=False,
+                requeue=False,
+                **kwargs,
+            )
+
+        # Tuning path. ``_next_launcher`` blocks if needed and raises
+        # ``NoTritonConfigsError`` if everything failed. The loop
+        # handles "invalid configuration" RuntimeErrors by discarding
+        # the offending launcher and trying the next one, without
+        # recursing (which would blow the stack on many invalid
+        # configs in a row).
+        while (launcher := self._next_launcher()) is not None:
+            self._dispatch_count += 1
+            # We *want* to time iff we're still inside the forced-timing
+            # window for this launcher OR this dispatch lands on a
+            # sampling beat. The Launcher additionally gates on its own
+            # warm state inside its lock, so a freshly-switched front
+            # never gets timed against on its first call. Either way we
+            # requeue: more timings may still be needed and
+            # ``_next_launcher`` will pull the launcher back out when
+            # it's done.
+            time_if_warm = (
+                launcher.num_total_timings < force_timing_if_lt_n_timings
+                or self._dispatch_count % timed_sampling_rate == 0
+            )
+            try:
+                return self._launch(
+                    launcher,
+                    *args,
+                    stream=stream,
+                    time_if_warm=time_if_warm,
+                    requeue=True,
+                    **kwargs,
+                )
+            except RuntimeError as e:
+                # Triton surfaces invalid kernel configs (e.g. requested
+                # block size exceeds device limits) as a RuntimeError with
+                # "invalid configuration" in the message. Drop the launcher
+                # and try the next.
+                if "invalid configuration" not in str(e).lower():
+                    raise
+                with self._mutation() as pending_discards:
+                    self._discard(launcher, pending_discards)
+                # Loop and try the next ready launcher.
+
+        # ``_next_launcher`` returned None, so cert or provisional is
+        # non-None (otherwise it would have raised).
+        if self._certified_launcher is not None:
+            return self._launch(
+                self._certified_launcher,
+                *args,
+                stream=stream,
+                time_if_warm=False,
+                requeue=False,
+                **kwargs,
+            )
+        return self._launch(
+            self._provisional_launcher,
+            *args,
+            stream=stream,
+            time_if_warm=False,
+            requeue=False,
+            **kwargs,
+        )
+
+    def _launch(
+        self,
+        launcher: Launcher | None,
+        *args: object,
+        stream: object,
+        time_if_warm: bool,
+        requeue: bool,
+        **kwargs: object,
+    ) -> object:
+        """Run ``launcher`` (timed only if it's warm and ``time_if_warm``
+        is set), optionally re-queueing it."""
+        assert launcher is not None
+        try:
+            if self._pre_launch_fn is not None:
+                self._pre_launch_fn(launcher, *args, stream=stream, **kwargs)
+            result = launcher(
+                *args, stream=stream, time_if_warm=time_if_warm, **kwargs
+            )
+        finally:
+            if self._post_launch_fn is not None:
+                self._post_launch_fn()
+        if requeue:
+            with self._lock:
+                self._queue.append(launcher)
+        return result

--- a/torch/_inductor/runtime/incremental/_utils.py
+++ b/torch/_inductor/runtime/incremental/_utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+import torch._utils_internal
+
+from torch._logging import getArtifactLogger
+
+from .config import _INCREMENTAL_AUTOTUNE_VERSION
+
+
+if TYPE_CHECKING:
+    import logging
+
+
+log: logging.Logger = getArtifactLogger(__name__, "incremental")
+
+
+@functools.cache
+def jk_passes() -> bool:
+    """Return True if the JK gate allows incremental autotuning."""
+    try:
+        val = torch._utils_internal.justknobs_getval_int(
+            "pytorch/inductor:incremental_autotune_version"
+        )
+    except AttributeError:
+        return True
+    return _INCREMENTAL_AUTOTUNE_VERSION >= val

--- a/torch/_inductor/runtime/incremental/config.py
+++ b/torch/_inductor/runtime/incremental/config.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+from enum import Enum
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from torch._inductor.runtime.hints import HeuristicType
+
+
+# Bump this to enable incremental autotuning for users who have
+# config.incremental_autotune = True (or the env var set to "1"). The JK
+# "pytorch/inductor:incremental_autotune_version" must be <= this value
+# for the feature to activate.
+_INCREMENTAL_AUTOTUNE_VERSION: int = 1
+
+# How long the timing-resolution background thread waits for new work
+# before exiting (it restarts on demand). Higher = stays alive longer
+# between sparse autotuning workloads; lower = releases its
+# background-thread slot sooner.
+_RESOLVER_IDLE_TIMEOUT_S: int = 600
+
+
+class LauncherTimingAggregation(str, Enum):
+    """How a launcher reduces its sample list to a single
+    representative timing."""
+
+    MEAN = "MEAN"
+    MEDIAN = "MEDIAN"
+
+
+# How a launcher's accumulated timing samples are reduced to a single
+# representative value used for all comparisons. MEDIAN is robust
+# against single-iteration outliers; MEAN is simpler and slightly
+# cheaper.
+launcher_timing_aggregation: LauncherTimingAggregation = LauncherTimingAggregation(
+    os.environ.get("TORCHINDUCTOR_INCREMENTAL_TIMING_AGGREGATION", "MEDIAN").upper()
+)
+
+
+# Minimum number of timings a launcher must accumulate before it's
+# eligible to be filtered out as too-slow. Too low risks discarding
+# launchers whose first few samples were unrepresentatively slow;
+# too high delays filtering and wastes dispatches on obvious losers.
+min_timings_before_filter: int = int(
+    os.environ.get("TORCHINDUCTOR_INCREMENTAL_MIN_SAMPLES_BEFORE_FILTER", "3")
+)
+
+# Maximum number of timings collected per launcher before it's
+# considered fully measured and eligible for promotion to the
+# certified winner. Bigger = more confident timing at the cost of
+# more dispatches before convergence.
+max_timings_per_launcher: int = int(
+    os.environ.get("TORCHINDUCTOR_INCREMENTAL_MAX_SAMPLES_PER_LAUNCHER", "25")
+)
+
+# Force a timed dispatch on every call until the launcher has at
+# least this many timings; afterwards only ``timed_sampling_rate``
+# of dispatches are timed. Ensures enough early samples to make
+# filter decisions before falling back to the lower sampling rate.
+force_timing_if_lt_n_timings: int = int(
+    os.environ.get("TORCHINDUCTOR_INCREMENTAL_FORCED_TIMING_ROUNDS", "3")
+)
+
+# Once past the forced-timing window, time only one in N dispatches.
+# Higher = less benchmarking overhead in steady state, slower
+# convergence to the per-launcher cap.
+timed_sampling_rate: int = int(
+    os.environ.get("TORCHINDUCTOR_INCREMENTAL_SAMPLING_RATE", "5")
+)
+
+# Initial multiplier for the filter check: a candidate launcher is
+# discarded when its timing exceeds this factor times the
+# best-so-far timing. 1.0 = exact comparison (any slower → discard);
+# higher = more tolerance for noise early on.
+initial_filter_threshold: float = float(
+    os.environ.get("TORCHINDUCTOR_INCREMENTAL_INITIAL_THRESHOLD", "2.5")
+)
+
+# Controls how fast the per-launcher filter tolerance tightens as
+# more samples accumulate. Lower (closer to 0) = stays relaxed
+# longer; higher = tightens faster.
+filter_threshold_decay_exp: float = float(
+    os.environ.get("TORCHINDUCTOR_INCREMENTAL_THRESHOLD_DECAY_EXP", "0.1")
+)
+
+# Per-config async-compile timeout. If a single config doesn't
+# compile within this many seconds it's recorded as a failed
+# compilation; the underlying compile may still finish in the
+# background but its result is discarded.
+compile_timeout_s: float = float(
+    os.environ.get("TORCHINDUCTOR_INCREMENTAL_COMPILE_TIMEOUT_S", "60")
+)
+
+
+# Kernel heuristic types to include in incremental autotuning. Default is all
+# HeuristicType members. Override via the
+# ``TORCHINDUCTOR_INCREMENTAL_AUTOTUNE_INCLUDE`` env var as a comma-separated
+# list of ``HeuristicType`` names (case-insensitive), e.g.
+# ``"pointwise,template"``. Empty string = no types enabled (incremental
+# autotune effectively off); unset = default (all).
+def _compute_included_heuristic_types() -> frozenset[HeuristicType]:
+    from torch._inductor.runtime.hints import HeuristicType
+
+    raw = os.environ.get("TORCHINDUCTOR_INCREMENTAL_AUTOTUNE_INCLUDE")
+    if raw is None:
+        return frozenset(HeuristicType)
+    if not raw:
+        return frozenset()
+    return frozenset(
+        HeuristicType[name.strip().upper()] for name in raw.split(",") if name.strip()
+    )
+
+
+_INCLUDED_HEURISTIC_TYPES: frozenset[HeuristicType] = (
+    _compute_included_heuristic_types()
+)
+
+
+def should_include(heuristic_type: HeuristicType) -> bool:
+    """Return True if ``heuristic_type`` participates in incremental autotuning."""
+    return heuristic_type in _INCLUDED_HEURISTIC_TYPES

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -626,7 +626,7 @@ class CachingAutotuner(KernelInterface):
             self._precompile_worker()
             if static_triton_bundle_key is not None and self.is_statically_launchable():
                 TritonBundler.put_static_autotuner(static_triton_bundle_key, self)
-            self._make_launchers()
+            self._make_launchers(self.compile_results)
             self._dynamic_scale_rblock()
 
     def _precompile_worker(self):
@@ -782,9 +782,12 @@ class CachingAutotuner(KernelInterface):
             return
         if not self._could_rblock_scale:
             return
+        new_results = []
         for new_config in self._iter_rblock_scale_candidates():
-            self.compile_results.append(self._precompile_config(new_config))  # noqa: B909
-        self._make_launchers()
+            result = self._precompile_config(new_config)
+            self.compile_results.append(result)  # noqa: B909
+            new_results.append(result)
+        self._make_launchers(new_results)
 
     def compile_by_disabling_pipelining(self, config):
         self._ensure_kernel_loaded()
@@ -814,8 +817,12 @@ class CachingAutotuner(KernelInterface):
         ) as e:
             return None, e
 
-    def _make_launchers(self):
-        if len(self.launchers) == len(self.compile_results):
+    def _make_launchers(self, compile_results):
+        """Wrap each result in ``compile_results`` into a launcher and
+        append the survivors to ``self.launchers``. Fires the all-failed
+        fallback only when ``self.launchers`` is empty AND no new launcher
+        survived this call."""
+        if not compile_results:
             return
 
         from torch._dynamo.device_interface import DeviceGuard
@@ -825,12 +832,12 @@ class CachingAutotuner(KernelInterface):
         exc = None
         # DeviceGuard ensures each launcher's binary loads onto the right device.
         with DeviceGuard(device_interface, self.triton_meta["device"]):
-            for result in self.compile_results:
+            for result in compile_results:
                 launcher, exc = self._make_launcher(result)
                 if launcher is not None:
                     launchers.append(launcher)
-            if len(launchers) == 0:
-                result = self.compile_results[-1]
+            if not self.launchers and not launchers:
+                result = compile_results[-1]
                 config = result.config
                 if (
                     isinstance(exc, (OutOfResources, torch.cuda.OutOfMemoryError))
@@ -844,7 +851,7 @@ class CachingAutotuner(KernelInterface):
                 raise RuntimeError(
                     f"No valid triton configs. {type(exc).__name__}: {exc}"
                 )
-        self.launchers = launchers
+        self.launchers.extend(launchers)
 
     def _ensure_kernel_loaded(self) -> None:
         """Reload the kernel in the parent process if needed.

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -406,12 +406,9 @@ def get_caching_autotuner_plugins(
 
     plugins: list[CachingAutotunerPlugin] = []
     if autotuner.inductor_meta.get("incremental_autotune", False):
-        try:
-            from .fb.incremental import IncrementalAutotunePlugin
+        from .incremental import IncrementalAutotunePlugin
 
-            plugins.append(IncrementalAutotunePlugin())
-        except ImportError:
-            pass
+        plugins.append(IncrementalAutotunePlugin())
     if config.pipeline_caching_autotuner:
         # Lazy import: the plugin lives in ``async_compile`` (alongside
         # the streaming setup helpers), and importing

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -402,6 +402,8 @@ def get_caching_autotuner_plugins(
     Each plugin adds an entry here, gated on its own config flag, with
     imports kept inside the relevant branch.
     """
+    from torch._inductor import config
+
     plugins: list[CachingAutotunerPlugin] = []
     if autotuner.inductor_meta.get("incremental_autotune", False):
         try:
@@ -410,6 +412,16 @@ def get_caching_autotuner_plugins(
             plugins.append(IncrementalAutotunePlugin())
         except ImportError:
             pass
+    if config.pipeline_caching_autotuner:
+        # Lazy import: the plugin lives in ``async_compile`` (alongside
+        # the streaming setup helpers), and importing
+        # ``async_compile`` at module-load time would create an upward
+        # dependency from runtime/ into _inductor/.
+        from torch._inductor.async_compile import (
+            _make_pipeline_caching_autotuner_plugin,
+        )
+
+        plugins.append(_make_pipeline_caching_autotuner_plugin())
     return plugins
 
 
@@ -548,6 +560,14 @@ class CachingAutotuner(KernelInterface):
         # consulted by ``_precompile_worker`` to enrich the "all configs failed"
         # error message.
         self._last_compile_exception: BaseException | None = None
+
+        # Set by ``AsyncCompile.triton`` when the pipelined-autotuner path
+        # is active; consumed and reset to None by
+        # ``PipelineCachingAutotunerPlugin.pre_dispatch`` on first ``run()``.
+        # Typed as Any to dodge a forward-ref to ``async_compile``.
+        # TODO: side-channel; should flow through the plugin protocol
+        # (pre_compile/pre_dispatch arg) instead of a kernel attribute.
+        self._pipeline_caching_autotuner_handle: Any = None
 
         self._plugins = get_caching_autotuner_plugins(self)
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -113,7 +113,7 @@ class NoTritonConfigsError(RuntimeError):
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Container, Hashable
+    from collections.abc import Callable, Container, Generator, Hashable
 
     from torch._C._profiler import _RecordFunctionFast
     from torch._guards import CompileId
@@ -539,6 +539,11 @@ class CachingAutotuner(KernelInterface):
             and not self.dump_launch_tensors
         )
 
+        # Last per-config compile exception caught by ``_iter_compile_results``;
+        # consulted by ``_precompile_worker`` to enrich the "all configs failed"
+        # error message.
+        self._last_compile_exception: BaseException | None = None
+
         self._plugins = get_caching_autotuner_plugins(self)
 
         # Compile-time info included in runtime logginging
@@ -637,19 +642,77 @@ class CachingAutotuner(KernelInterface):
         if not self.configs:
             raise NoTritonConfigsError("No triton configs are available")
 
-        compile_results = []
-        exc = None
-        for c in self.configs:
-            try:
-                compile_results.append(self._precompile_config(c))
-            except (OutOfResources, PTXASError, IntelGPUError) as e:
-                exc = e
-        if len(compile_results) == 0:
-            raise NoTritonConfigsError(
-                f"No valid triton configs. {type(exc).__name__}: {exc}"
+        self.compile_results = list(self._iter_compile_results())
+        if not self.compile_results:
+            last_exc = self._last_compile_exception
+            exc_str = (
+                f" {type(last_exc).__name__}: {last_exc}"
+                if last_exc is not None
+                else ""
             )
-        self.compile_results = compile_results
+            raise NoTritonConfigsError(
+                f"No valid triton configs compiled for {self.fn.__name__}.{exc_str}"
+            )
         self.configs = None
+
+    def _iter_compile_results(
+        self, parallel: bool = False
+    ) -> Generator[CompileResult, None, None]:
+        """Yield successful ``CompileResult``s. OOM / PTXAS / IntelGPU
+        failures are dropped; the last one is kept on
+        ``self._last_compile_exception`` for the all-failed error.
+        ``parallel`` thread-pools the compile, sized to ``len(configs)``.
+        """
+        self._last_compile_exception = None
+        for _cfg, result, exc in self._iter_compile_results_tagged(parallel=parallel):
+            if exc is None:
+                yield result
+            else:
+                self._last_compile_exception = exc
+
+    def _iter_compile_results_tagged(
+        self, parallel: bool = False
+    ) -> Generator[
+        tuple[Config, CompileResult | None, BaseException | None], None, None
+    ]:
+        """Yield ``(config, result, exc)`` for every config:
+        ``exc is None`` -> ``result`` is a successful ``CompileResult``;
+        otherwise ``exc`` is an OOM / PTXAS / IntelGPU per-config failure
+        and ``result`` is None. The standard ``_iter_compile_results``
+        adapter discards failures and just stashes the last on
+        ``self._last_compile_exception``.
+        """
+        configs = list(self.configs or [])
+        if not configs:
+            return
+
+        # Skip the executor when there's nothing to parallelize: a single config
+        # gains nothing from a thread pool but pays the executor setup/teardown
+        # cost (matters per-kernel on graphs with many single-config kernels).
+        if parallel and len(configs) > 1:
+            from concurrent.futures import as_completed, ThreadPoolExecutor
+
+            # No upper bound on max_workers: Triton AST visit holds the GIL
+            # so extra threads above ~CPU-count add scheduler overhead, but
+            # ptxas / native compile releases the GIL and benefits from
+            # additional parallelism. Per-kernel config counts are small in
+            # practice (max_autotune_* tops out at a few dozen).
+            with ThreadPoolExecutor(max_workers=len(configs)) as executor:
+                fut_to_cfg = {
+                    executor.submit(self._precompile_config, c): c for c in configs
+                }
+                for fut in as_completed(fut_to_cfg):
+                    cfg = fut_to_cfg[fut]
+                    try:
+                        yield cfg, fut.result(), None
+                    except (OutOfResources, PTXASError, IntelGPUError) as e:
+                        yield cfg, None, e
+        else:
+            for c in configs:
+                try:
+                    yield c, self._precompile_config(c), None
+                except (OutOfResources, PTXASError, IntelGPUError) as e:
+                    yield c, None, e
 
     @functools.cached_property
     def _could_rblock_scale(self) -> bool:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
-import builtins
 import copy
 import dataclasses
 import enum
@@ -113,7 +112,13 @@ class NoTritonConfigsError(RuntimeError):
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Container, Generator, Hashable
+    from collections.abc import (
+        Callable,
+        Container,
+        Generator,
+        Hashable,
+        Iterable,
+    )
 
     from torch._C._profiler import _RecordFunctionFast
     from torch._guards import CompileId
@@ -929,6 +934,49 @@ class CachingAutotuner(KernelInterface):
         if static_triton_bundle_key is not None and self.is_statically_launchable():
             TritonBundler.put_static_autotuner(static_triton_bundle_key, self)
 
+    def _bench_launchers(
+        self,
+        launchers: Iterable[LauncherType],
+        *args: object,
+        **kwargs: object,
+    ) -> tuple[dict[LauncherType, float], int]:
+        """Bench each launcher and feed the coordesc cache. Returns
+        ``(timings, bench_ns)``; caller decides on the winner.
+        """
+        timings: dict[LauncherType, float] = {}
+        bench_ns = 0
+        for launcher in launchers:
+            t0 = time.time_ns()
+            timings[launcher] = self.bench(launcher, *args, **kwargs)
+            bench_ns += time.time_ns() - t0
+            self.coordesc_tuner.cache_benchmark_result(
+                launcher.config, timings[launcher]
+            )
+        return timings, bench_ns
+
+    def _finalize_autotune_winner(
+        self,
+        timings: dict[LauncherType, float],
+        autotune_time_taken_ns: int,
+    ) -> None:
+        """Pick the lowest-timing launcher as the sole survivor, register it
+        with ``TritonBundler.put_winner``, notify ``save_cache_hook``, and
+        record ``self.autotune_time_taken_ns``.
+        """
+        self.autotune_time_taken_ns = autotune_time_taken_ns
+        best_launcher = min(timings, key=timings.get)  # type: ignore[arg-type]
+        self.launchers = [best_launcher]
+        TritonBundler.put_winner(best_launcher.cache_hash)
+        if self.save_cache_hook:
+            self.save_cache_hook(
+                best_launcher.config,
+                self.autotune_time_taken_ns,
+                found_by_coordesc=self.inductor_meta.get(
+                    "coordinate_descent_tuning", False
+                ),
+                triton_cache_hash=best_launcher.cache_hash,
+            )
+
     def _ensure_kernel_loaded(self) -> None:
         """Reload the kernel in the parent process if needed.
 
@@ -1550,9 +1598,11 @@ class CachingAutotuner(KernelInterface):
                     best_time,
                 )
 
-        self.launchers = [builtins.min(timings, key=timings.get)]
-        self.autotune_time_taken_ns = (
-            self.precompile_time_taken_ns + benchmark_time_taken_ns
+        self._finalize_autotune_winner(
+            timings,
+            autotune_time_taken_ns=(
+                self.precompile_time_taken_ns + benchmark_time_taken_ns
+            ),
         )
 
         # log the best config
@@ -1566,18 +1616,6 @@ class CachingAutotuner(KernelInterface):
             launcher.n_spills,
             launcher.shared,
         )
-
-        TritonBundler.put_winner(launcher.cache_hash)
-
-        if self.save_cache_hook:
-            self.save_cache_hook(
-                launcher.config,
-                self.autotune_time_taken_ns,
-                found_by_coordesc=self.inductor_meta.get(
-                    "coordinate_descent_tuning", False
-                ),
-                triton_cache_hash=launcher.cache_hash,
-            )
 
     def _combo_sequential_autotune(self, launcher, *args, **kwargs):
         """

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -624,18 +624,14 @@ class CachingAutotuner(KernelInterface):
                 if plugin.pre_compile(self) is not DEFER:
                     return
             self._precompile_worker()
-            if static_triton_bundle_key is not None and self.is_statically_launchable():
-                TritonBundler.put_static_autotuner(static_triton_bundle_key, self)
+            self._maybe_put_static_autotuner(static_triton_bundle_key)
             self._make_launchers(self.compile_results)
             self._dynamic_scale_rblock()
 
     def _precompile_worker(self):
         if self.compile_results:
             for result in self.compile_results:
-                TritonBundler.put(
-                    triton_hash_to_path_key(result.kernel.hash),  # type: ignore[attr-defined]
-                    self.triton_meta.get("device", 0),
-                )
+                self._bundle_compile_result(result)
             return
         assert not self.launchers
         if not self.configs:
@@ -837,21 +833,38 @@ class CachingAutotuner(KernelInterface):
                 if launcher is not None:
                     launchers.append(launcher)
             if not self.launchers and not launchers:
-                result = compile_results[-1]
-                config = result.config
-                if (
-                    isinstance(exc, (OutOfResources, torch.cuda.OutOfMemoryError))
-                    and (
-                        config.num_stages > 1 or config.kwargs.get("NUM_STAGES", 1) > 1
-                    )
-                    and self.inductor_meta.get("dynamic_disable_pipelining", True)
-                ):
-                    self.launchers = [self.compile_by_disabling_pipelining(config)]
-                    return
-                raise RuntimeError(
-                    f"No valid triton configs. {type(exc).__name__}: {exc}"
-                )
+                self._all_failed_fallback(exc)
+                return
         self.launchers.extend(launchers)
+
+    def _bundle_compile_result(self, result: CompileResult[_KernelType]) -> None:
+        """Parent-side ``TritonBundler.put`` for one CompileResult."""
+        TritonBundler.put(
+            triton_hash_to_path_key(result.kernel.hash),  # type: ignore[attr-defined]
+            self.triton_meta.get("device", 0),
+        )
+
+    def _all_failed_fallback(self, exc: BaseException | None) -> None:
+        """If the last failure was OOM on a pipelined config, retry with
+        pipelining disabled; otherwise raise. Caller holds the DeviceGuard.
+        Mutates self.launchers and self.compile_results on the OOM-retry path.
+        """
+        result = self.compile_results[-1]
+        config = result.config
+        if (
+            isinstance(exc, (OutOfResources, torch.cuda.OutOfMemoryError))
+            and (config.num_stages > 1 or config.kwargs.get("NUM_STAGES", 1) > 1)
+            and self.inductor_meta.get("dynamic_disable_pipelining", True)
+        ):
+            self.launchers = [self.compile_by_disabling_pipelining(config)]
+            return
+        raise RuntimeError(f"No valid triton configs. {type(exc).__name__}: {exc}")
+
+    def _maybe_put_static_autotuner(
+        self, static_triton_bundle_key: str | None
+    ) -> None:
+        if static_triton_bundle_key is not None and self.is_statically_launchable():
+            TritonBundler.put_static_autotuner(static_triton_bundle_key, self)
 
     def _ensure_kernel_loaded(self) -> None:
         """Reload the kernel in the parent process if needed.


### PR DESCRIPTION
Summary:
Adds the standalone subsystems that the incremental autotune plugin builds
on, with no plugin engagement yet:

- incremental/_resolver.py: background daemon that waits on CUDA timing
  events and dispatches per-launcher callbacks.
- incremental/_launcher.py: Launcher (timed-dispatch wrapper with
  weak-ref'd raw + sliding sample window + on-update subscriptions),
  RawLauncherView for cross-autotuner sharing, content-keyed per-kernel
  Launcher pool.
- incremental/_state.py: IncrementalAutotuneState — queue, threshold-based
  filter, promote/discard, callbacks, dispatch entry point used by the
  plugin in the next commit.
- incremental/__init__.py / config.py / _utils.py: package surface, env
  knobs (max_timings_per_launcher, force_timing_if_lt_n_timings,
  initial_filter_threshold, etc.), helpers.
- torch/_inductor/config.py: incremental_autotune flag (default off).
- torch/_logging/_internal.py + _registrations.py: incremental log
  channel.

Plus full unit-test coverage for each subsystem (LauncherTest,
IncrementalAutotuneStateTest, StreamingCompileTest, ResolverTest,
CacheTest, _CachingAutotunerInstanceKeyTest, _StateLifecycleTest).

No behavior change at runtime: nothing in the inductor dispatch path
imports these modules yet. The plugin that wires them in lands in the
next commit.

Differential Revision: D105735815




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo