### PR TITLE
Un-xfail test_sdpa_rewriter_14_cpu on ARM64 SVE256

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -1805,8 +1805,7 @@ if HAS_CPU:
         test_sdpa_rewriter_13_cpu = functools.partialmethod(
             TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_13, dtype=torch.float32
         )
-        # see https://github.com/pytorch/pytorch/issues/177244
-        test_sdpa_rewriter_14_cpu = xfailIf(IS_ARM64 and IS_CPU_CAPABILITY_SVE256)(
+        test_sdpa_rewriter_14_cpu = (
             TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_14
         )
         test_sdpa_rewriter_15_cpu = functools.partialmethod(

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -1783,8 +1783,7 @@ if HAS_CPU:
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_reuse
         )
         test_sdpa_rewriter_2_cpu = TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_2
-        # see https://github.com/pytorch/pytorch/issues/177244
-        test_sdpa_rewriter_5_cpu = xfailIf(IS_ARM64 and IS_CPU_CAPABILITY_SVE256)(
+        test_sdpa_rewriter_5_cpu = (
             TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_5
         )
         test_pattern_fails_with_tensor_factor_cpu = (

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -17,11 +17,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FUSED_ATTENTION,
     SM80OrLater,
 )
-from torch.testing._internal.common_utils import (
-    IS_LINUX,
-    skipIfXpu,
-    TEST_WITH_ROCM,
-)
+from torch.testing._internal.common_utils import IS_LINUX, skipIfXpu, TEST_WITH_ROCM
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CPU,

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -18,12 +18,9 @@ from torch.testing._internal.common_cuda import (
     SM80OrLater,
 )
 from torch.testing._internal.common_utils import (
-    IS_ARM64,
-    IS_CPU_CAPABILITY_SVE256,
     IS_LINUX,
     skipIfXpu,
     TEST_WITH_ROCM,
-    xfailIf,
 )
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
@@ -1783,9 +1780,7 @@ if HAS_CPU:
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_reuse
         )
         test_sdpa_rewriter_2_cpu = TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_2
-        test_sdpa_rewriter_5_cpu = (
-            TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_5
-        )
+        test_sdpa_rewriter_5_cpu = TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_5
         test_pattern_fails_with_tensor_factor_cpu = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_tensor_factor
         )


### PR DESCRIPTION
## Summary

Remove `xfailIf(IS_ARM64 and IS_CPU_CAPABILITY_SVE256)` from `test_sdpa_rewriter_14_cpu` in `test/inductor/test_fused_attention.py`.

The new OSDC aarch64 runner (`mt-l-arm64g3-16-62`, enabled trunk-wide via #183482) reports `IS_CPU_CAPABILITY_SVE256=True` but does not reproduce the numerical mismatch from #177244. The decorator now flips passing runs to `FAILED CONSISTENTLY` via "Unexpected success" whenever target determination pulls the file into the shard.

Failure first surfaced at `07734446eb` on `trunk / linux-jammy-aarch64-py3.10 / test-osdc (default, 4, 5, mt-l-arm64g3-16-62)` and has been consistent across every subsequent main commit whose TD scope selected `test_fused_attention.py`.

Closes #177244 (if the issue still applies to the older `m7g.4xlarge` runner family, we can re-narrow the gate later).

## Test plan

- [ ] `pull / trunk` aarch64 OSDC test-osdc shard 4/5 turns green on this branch.
- [ ] No regressions on x86 or other aarch64 shards.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo