### PR TITLE
Decompose supported aten._trilinear in Inductor

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4299,6 +4299,102 @@ class CommonTemplate:
         with torch.no_grad():
             self.assertEqual(cfn(input, mat, vec), fn(input, mat, vec))
 
+    def test_trilinear_decomposition(self):
+        if self.device == "mps":
+            raise unittest.SkipTest("MPS does not exercise Inductor trilinear codegen")
+
+        def fn(i1, i2, i3):
+            y = torch._trilinear(i1, i2, i3, [1, 3], [0], [1, 2], [2, 3])
+            return torch.cos(torch.sin(y) + 1)
+
+        inputs = (
+            torch.randn(4, 3, device=self.device),
+            torch.randn(5, 3, 6, device=self.device),
+            torch.randn(4, 6, device=self.device),
+        )
+
+        expected = fn(*inputs)
+        torch._inductor.metrics.reset()
+        actual, codes = run_and_get_code(
+            torch.compile(fn, fullgraph=True),
+            *inputs,
+        )
+
+        self.assertEqual(actual, expected, atol=1e-5, rtol=1e-5)
+        code = "\n".join(codes)
+        (
+            FileCheck()
+            .check_not("torch.ops.aten._trilinear.default(")
+            .check_not("aten::_trilinear")
+            .run(code)
+        )
+        if self.device == "cuda":
+            self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
+        def unsupported_unroll_fn(i1, i2, i3):
+            return torch._trilinear(i1, i2, i3, [0], [], [1], [], 0)
+
+        unsupported_inputs = (
+            torch.randn(2, 3, device=self.device),
+            torch.randn(4, 2, 3, device=self.device),
+            torch.randn(2, 3, device=self.device),
+        )
+        expected = unsupported_unroll_fn(*unsupported_inputs)
+        actual, _ = run_and_get_code(
+            torch.compile(unsupported_unroll_fn, fullgraph=True),
+            *unsupported_inputs,
+        )
+        self.assertEqual(actual, expected, atol=1e-5, rtol=1e-5)
+
+        if self.device == "cpu":
+
+            def int_fn(i1, i2, i3):
+                return torch._trilinear(i1, i2, i3, [1, 3], [0], [1, 2], [2, 3])
+
+            int_inputs = (
+                torch.randint(-3, 3, (4, 3), dtype=torch.int8),
+                torch.randint(-3, 3, (5, 3, 6), dtype=torch.int8),
+                torch.randint(-3, 3, (4, 6), dtype=torch.int8),
+            )
+            expected = int_fn(*int_inputs)
+            actual, _ = run_and_get_code(
+                torch.compile(int_fn, fullgraph=True),
+                *int_inputs,
+            )
+            self.assertEqual(actual.dtype, expected.dtype)
+            self.assertEqual(actual, expected)
+
+        mixed_inputs = (
+            torch.randn(4, 3, device=self.device),
+            torch.randn(5, 3, 6, device=self.device, dtype=torch.float64),
+            torch.randn(4, 6, device=self.device),
+        )
+        with self.assertRaisesRegex(Exception, "expected scalar type"):
+            torch.compile(fn, fullgraph=True)(*mixed_inputs)
+
+        bool_inputs = (
+            torch.randint(0, 2, (4, 3), device=self.device, dtype=torch.bool),
+            torch.randint(0, 2, (5, 3, 6), device=self.device, dtype=torch.bool),
+            torch.randint(0, 2, (4, 6), device=self.device, dtype=torch.bool),
+        )
+        with self.assertRaisesRegex(NotImplementedError, "not implemented"):
+            torch.compile(fn, fullgraph=True)(*bool_inputs)
+
+        if hasattr(torch, "float8_e4m3fn"):
+
+            def float8_fn(i1, i2, i3):
+                return torch._trilinear(i1, i2, i3, [1, 3], [0], [1, 2], [2, 3])
+
+            float8_inputs = tuple(x.to(torch.float8_e4m3fn) for x in inputs)
+            with self.assertRaisesRegex(NotImplementedError, "not implemented"):
+                torch.compile(float8_fn, fullgraph=True)(*float8_inputs)
+
+        def duplicate_dim_fn(i1, i2, i3):
+            return torch._trilinear(i1, i2, i3, [1, 1], [0], [1, 2], [2, 3])
+
+        with self.assertRaisesRegex(Exception, "appears multiple times"):
+            torch.compile(duplicate_dim_fn, fullgraph=True)(*inputs)
+
     # https://github.com/pytorch/pytorch/issues/98979
     @skipCUDAIf(True, "cuda failed for float64 linear")
     @skipIfXpu(msg="Double and complex datatype matmul is not supported in oneDNN")

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -4,7 +4,7 @@ import logging
 import math
 import operator
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, TypeAlias, TypeVar
 from typing_extensions import ParamSpec
 
@@ -37,6 +37,7 @@ from torch._prims_common import (
 )
 from torch._refs import native_layer_norm as decomp_native_layer_norm
 from torch.fx.experimental.symbolic_shapes import guard_or_false, statically_known_true
+from torch.utils._ordered_set import OrderedSet
 
 from . import config, inductor_prims
 from .utils import (
@@ -152,6 +153,117 @@ def register_decomposition(
         if op in decompositions:
             log.warning("duplicate decomp: %s", ops)
     return decomp.register_decomposition(ops, decompositions)
+
+
+def _trilinear_canonicalize_dims(
+    dims: Sequence[int], total_dim: int
+) -> tuple[int, ...]:
+    canonical_dims = utils.canonicalize_dims(total_dim, dims)
+    seen: OrderedSet[int] = OrderedSet()
+    for dim in canonical_dims:
+        if dim in seen:
+            raise RuntimeError(f"dim {dim} appears multiple times in the list of dims")
+        seen.add(dim)
+    return canonical_dims
+
+
+def _trilinear_unsqueeze(
+    input: torch.Tensor, dims: Sequence[int], total_dim: int
+) -> torch.Tensor:
+    for dim in sorted(dims):
+        input = input.unsqueeze(dim)
+    return input
+
+
+def _trilinear_size_eq(lhs, rhs) -> bool:
+    return guard_or_false(lhs == rhs)
+
+
+def _trilinear_is_float8_dtype(dtype: torch.dtype) -> bool:
+    return dtype in (
+        torch.float8_e4m3fn,
+        torch.float8_e5m2,
+        torch.float8_e4m3fnuz,
+        torch.float8_e5m2fnuz,
+        torch.float8_e8m0fnu,
+    )
+
+
+def _trilinear_supported_shapes(
+    inputs: Sequence[torch.Tensor],
+    expands: Sequence[tuple[int, ...]],
+    total_dim: int,
+    unroll_dim: int,
+) -> bool:
+    unroll_sizes = [
+        input.size(unroll_dim - sum(dim < unroll_dim for dim in expand))
+        for input, expand in zip(inputs, expands)
+        if unroll_dim not in expand
+    ]
+    if not unroll_sizes:
+        return False
+    unroll_size = unroll_sizes[-1]
+    if any(not _trilinear_size_eq(size, unroll_size) for size in unroll_sizes[:-1]):
+        return False
+
+    expanded_inputs = [
+        _trilinear_unsqueeze(input, expand, total_dim)
+        for input, expand in zip(inputs, expands)
+    ]
+    for dim in range(total_dim):
+        dim_sizes = [input.size(dim) for input in expanded_inputs]
+        non_broadcast_sizes = [
+            size for size in dim_sizes if not statically_known_true(size == 1)
+        ]
+        if non_broadcast_sizes and any(
+            not _trilinear_size_eq(size, non_broadcast_sizes[0])
+            for size in non_broadcast_sizes[1:]
+        ):
+            return False
+    return True
+
+
+@register_decomposition(aten._trilinear.default)
+def _trilinear(
+    i1: torch.Tensor,
+    i2: torch.Tensor,
+    i3: torch.Tensor,
+    expand1: list[int],
+    expand2: list[int],
+    expand3: list[int],
+    sumdim: list[int],
+    unroll_dim: int = 1,
+) -> torch.Tensor:
+    total_dim = i1.dim() + len(expand1)
+    torch._check(
+        unroll_dim >= 0 and unroll_dim < total_dim,
+        lambda: f"unroll_dim must be in [0,{total_dim - 1}]",
+    )
+
+    expand_dims = (
+        _trilinear_canonicalize_dims(expand1, total_dim),
+        _trilinear_canonicalize_dims(expand2, total_dim),
+        _trilinear_canonicalize_dims(expand3, total_dim),
+    )
+    sum_dims = _trilinear_canonicalize_dims(sumdim, total_dim)
+
+    if i1.dtype != i2.dtype or i1.dtype != i3.dtype:
+        return NotImplemented
+    if i1.dtype == torch.bool or not (i1.is_floating_point() or i1.dtype.is_complex):
+        return NotImplemented
+    if _trilinear_is_float8_dtype(i1.dtype):
+        return NotImplemented
+    if not _trilinear_supported_shapes(
+        (i1, i2, i3), expand_dims, total_dim, unroll_dim
+    ):
+        return NotImplemented
+
+    result = (
+        _trilinear_unsqueeze(i1, expand_dims[0], total_dim)
+        * _trilinear_unsqueeze(i2, expand_dims[1], total_dim)
+        * _trilinear_unsqueeze(i3, expand_dims[2], total_dim)
+    )
+    return result.sum(sum_dims) if sum_dims else result
 
 
 @register_decomposition([aten.lerp.Scalar])

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3404,8 +3404,7 @@ make_fallback(aten._cdist_forward)  # p=2 should be feasible
 make_fallback(aten._cdist_backward)
 
 # 2) Medium
-make_fallback(aten._trilinear)
-
+make_fallback(aten._trilinear, warn=False, override_decomp=True)
 
 # 3) Difficult
 # Scans


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184459

Add an Inductor-only conditional decomposition for aten._trilinear so broadcast-compatible floating and complex cases can fuse, while unsupported dtype and shape cases continue through the native fallback path.

Fixes #105560

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo