### PR TITLE
Replace deprecated std::aligned_storage in group/layer norm CUDA kernels

### DIFF
--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -61,11 +61,12 @@ __global__ void RowwiseMomentsCUDAKernel(
   if (blockDim.x <= C10_WARP_SIZE) {
     val = cuda_utils::WarpReduce(val, welford_op);
   } else {
-    // There will be a warning if we declare a __shared__ WelfordType array.
-    // https://github.com/pytorch/pytorch/pull/13967
-    __shared__ std::aligned_storage_t<
-        sizeof(WelfordType),
-        alignof(WelfordType)> val_shared[C10_WARP_SIZE_UPPER_BOUND];
+    // Use a byte array with alignas instead of a __shared__ WelfordType array
+    // directly, because nvcc warns on non-trivial constructors in __shared__.
+    // alignas must precede __shared__; HIP's clang rejects it placed between
+    // __shared__ and the type.
+    alignas(WelfordType) __shared__
+        char val_shared[sizeof(WelfordType) * C10_WARP_SIZE_UPPER_BOUND];
     WelfordType* val_shared_ptr = reinterpret_cast<WelfordType*>(val_shared);
     val = cuda_utils::BlockReduce(
         val,

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -63,8 +63,8 @@ __global__ void RowwiseMomentsCUDAKernel(
   using WelfordOp =
       WelfordOps<T_ACC, T_ACC, int64_t, std::pair<T_ACC, T_ACC>>;
 
-  __shared__ std::aligned_storage_t<sizeof(WelfordType), alignof(WelfordType)>
-      val_shared[C10_WARP_SIZE_UPPER_BOUND];
+  alignas(WelfordType) __shared__
+      char val_shared[sizeof(WelfordType) * C10_WARP_SIZE_UPPER_BOUND];
   WelfordType* val_shared_ptr = reinterpret_cast<WelfordType*>(val_shared);
 
   const int64_t i = blockIdx.x;


### PR DESCRIPTION
This PR replaces deprecated std::aligned_storage with alignas in CUDA kernels.
Authored by Claude.