### PR TITLE
Drop ^ anchor from check_nondeterministic_alert regex

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -4826,8 +4826,8 @@ class TestCase(expecttest.TestCase):
           fn (callable): Function to check for a nondeterministic alert
 
           caller_name (str): Name of the operation that produces the
-              nondeterministic alert. This name is expected to appear at the
-              beginning of the error/warning message.
+              nondeterministic alert. This name is expected to appear in
+              the error/warning message.
 
           should_alert (bool, optional): If True, then the check will only pass
               if calling `fn` produces a nondeterministic error/warning with the
@@ -4835,7 +4835,7 @@ class TestCase(expecttest.TestCase):
               calling `fn` does not produce an error. Default: `True`.
         '''
 
-        alert_message = '^' + caller_name + ' does not have a deterministic implementation, but you set'
+        alert_message = caller_name + ' does not have a deterministic implementation, but you set'
 
         # Check that errors are thrown correctly
         with DeterministicGuard(True):


### PR DESCRIPTION
Anchoring at the start breaks the helper under dynamo_wrapped mode (PYTORCH_TEST_WITH_DYNAMO=1): when an ATen deterministic check fires during fake tensor tracing, dynamo wraps the original RuntimeError in a TorchRuntimeError so the message is no longer at position 0.
Authored by Claude.