### PR TITLE
[inductor][ROCm] Fix sys.modules eviction in origami fallback test

### DIFF
--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -444,11 +444,17 @@ class TestOrigami(TestCase):
                 # Configuration with origami enabled, but we'll mock it to fail
                 patch_config = self._origami_default_config(ORIGAMI_COMPILE_TOPK)
 
-                # Mock origami module to be None (simulating import failure)
+                # Patch the cached origami binding directly. Avoid mock.patch.dict
+                # on sys.modules: its snapshot/restore evicts modules lazily imported
+                # inside the `with` (e.g. torch._dynamo.repro.after_dynamo), causing
+                # duplicate backend registration on the next subtest iteration.
                 with (
                     fresh_cache(),
                     config.patch(patch_config),
-                    mock.patch.dict("sys.modules", {"origami": None}),
+                    mock.patch(
+                        "torch._inductor.template_heuristics.triton.origami",
+                        None,
+                    ),
                 ):
                     compiled = torch.compile(fn, dynamic=False)
                     result = compiled(*args)


### PR DESCRIPTION
## Summary                                                                                                   
                                                                                                               
  `test_origami_fallback_when_disabled` failed on the 2nd/3rd subtest iterations with `AssertionError:         
  duplicate name: dynamo_minifier_backend`.                                                                    
                                                                                                               
  **Cause:** `mock.patch.dict("sys.modules", {"origami": None})` snapshots `sys.modules` on enter and restores 
  from snapshot on exit, evicting `torch._dynamo.repro.after_dynamo` (lazily imported by the 1st               
  `torch.compile`). The 2nd subtest re-imports it, re-running `@register_debug_backend` against the            
  already-populated `_COMPILER_FNS`.

  **Fix:** patch the cached binding directly —                                                                 
  `mock.patch("torch._inductor.template_heuristics.triton.origami", None)` — so `sys.modules` is left alone.
                                                                                                               
  ## Test plan    

  - [x] `HIP_VISIBLE_DEVICES=6 TORCHINDUCTOR_ORIGAMI=1 TORCHINDUCTOR_MAX_AUTOTUNE=1 python                     
  test/inductor/test_origami.py TestOrigami.test_origami_fallback_when_disabled -v` → `OK`
  - [x] `ruff check` / `ruff format --check` clean       

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben