### PR TITLE
Add pytorch/crcr-test to L2 allowlist

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -36,7 +36,9 @@
 #   - org4/downstream-repo4: @oncall1,oncall2
 
 L1:
-  # Canonical test repo for CRCR.
-  - pytorch/crcr-test
   - Ascend/pytorch
   - riseproject-dev/pytorch-ci
+
+L2:
+  # Canonical test repo for CRCR.
+  - pytorch/crcr-test


### PR DESCRIPTION
Promote the canonical CRCR test repo from L1 to L2 so downstream CI results are reported to HUD. This supports end-to-end testing of the L2 relay (pytorch/test-infra#7967) and OOT HUD pipeline (pytorch/test-infra#8069).