### PR TITLE
Make DTensor.local_map pytree-aware on in/out_placements

### DIFF
--- a/test/distributed/tensor/experimental/test_local_map.py
+++ b/test/distributed/tensor/experimental/test_local_map.py
@@ -384,6 +384,141 @@ class TestLocalMap(DTensorTestBase):
             )
             self.assertEqual(W_dt.grad.full_tensor(), W.grad)
 
+    @with_comms()
+    def test_local_map_with_nested_grad_placement(self):
+        """
+        Nested in_grad_placements (mirroring a nested args structure) must
+        flow to to_local(grad_placements=...) the same way as a flat tuple.
+        """
+        device_mesh = init_device_mesh(
+            device_type=self.device_type, mesh_shape=(self.world_size,)
+        )
+        torch.manual_seed(12)
+
+        X = torch.randn(4, 2, device=self.device_type, requires_grad=True)
+        W = torch.randn(2, 4, device=self.device_type, requires_grad=True)
+        X_dt = distribute_tensor(X, device_mesh, row_wise)
+        W_dt = distribute_tensor(W, device_mesh, replicate)
+
+        def mm_pair(pair):
+            return torch.mm(pair[0], pair[1])
+
+        # Single positional arg is a list of two DTensors -- 2 flat leaves.
+        # in_placements / in_grad_placements mirror that nested structure.
+        nested_in_grad = ([Shard(0)], [Partial()])
+        local_mm_pair = local_map(
+            mm_pair,
+            out_placements=[Shard(0)],
+            in_placements=([row_wise, replicate],),
+            in_grad_placements=(nested_in_grad,),
+            device_mesh=device_mesh,
+        )
+        Y_dt = local_mm_pair([X_dt, W_dt])
+        loss = Y_dt.to_local().sum()
+        loss.backward()
+
+        # Without input redistribution, in_grad_placements feeds directly
+        # into to_local(grad_placements=...) and the input grad placements
+        # match the nested spec we passed in.
+        self.assertEqual(X_dt.grad.placements, tuple(nested_in_grad[0]))
+        self.assertEqual(W_dt.grad.placements, tuple(nested_in_grad[1]))
+
+        # Mismatched length on in_grad_placements raises the expected error.
+        bad_grad_fn = local_map(
+            mm_pair,
+            out_placements=[Shard(0)],
+            in_placements=([row_wise, replicate],),
+            in_grad_placements=([Shard(0)],),
+            device_mesh=device_mesh,
+            redistribute_inputs=True,
+        )
+        with self.assertRaisesRegex(
+            AssertionError, "in_grad_placements length 1 does not match"
+        ):
+            bad_grad_fn([X_dt, W_dt])
+
+    @with_comms
+    def test_nested_in_out_placements(self):
+        """
+        in_placements and out_placements may either be flat (matching the
+        pytree-flattened args/output 1:1) or mirror the args/output structure.
+        Both forms must accept the same set of placement specs at the leaves.
+        """
+        device_mesh = init_device_mesh(
+            device_type=self.device_type, mesh_shape=(self.world_size,)
+        )
+
+        X = torch.randn(16, 8, device=self.device_type, requires_grad=False)
+        W = torch.randn(16, 8, device=self.device_type, requires_grad=False)
+        X_dt = distribute_tensor(X, device_mesh, row_wise)
+        W_dt = distribute_tensor(W, device_mesh, row_wise)
+
+        def add_pair(pair):
+            return pair[0] + pair[1]
+
+        def split_pair(pair):
+            return [pair[0] * 2.0, pair[1] * 3.0]
+
+        # Nested in_placements mirrors the input tree, single-leaf output.
+        nested_in_fn = local_map(
+            add_pair,
+            out_placements=row_wise,
+            in_placements=([row_wise, row_wise],),
+            device_mesh=device_mesh,
+        )
+        result = nested_in_fn([X_dt, W_dt])
+        self.assertEqual(result.placements, tuple(row_wise))
+        self.assertEqual(result.full_tensor(), X + W)
+
+        # Nested out_placements mirrors a list-shaped output.
+        nested_out_fn = local_map(
+            split_pair,
+            out_placements=[row_wise, row_wise],
+            in_placements=([row_wise, row_wise],),
+            device_mesh=device_mesh,
+        )
+        outs = nested_out_fn([X_dt, W_dt])
+        self.assertIsInstance(outs, list)
+        self.assertEqual(len(outs), 2)
+        for d in outs:
+            self.assertEqual(d.placements, tuple(row_wise))
+
+        # Flat forms still work alongside nested ones (backward compat).
+        flat_fn = local_map(
+            split_pair,
+            out_placements=(row_wise, row_wise),
+            in_placements=(row_wise, row_wise),
+            device_mesh=device_mesh,
+        )
+        flat_outs = flat_fn([X_dt, W_dt])
+        for d in flat_outs:
+            self.assertEqual(d.placements, tuple(row_wise))
+
+        # Dict-shaped args with dict-shaped in_placements.
+        def dict_fn(d):
+            return d["a"] + d["b"]
+
+        dict_fn_wrapped = local_map(
+            dict_fn,
+            out_placements=row_wise,
+            in_placements=({"a": row_wise, "b": row_wise},),
+            device_mesh=device_mesh,
+        )
+        result = dict_fn_wrapped({"a": X_dt, "b": W_dt})
+        self.assertEqual(result.placements, tuple(row_wise))
+
+        # Mismatched length still raises a helpful error.
+        bad_fn = local_map(
+            add_pair,
+            out_placements=row_wise,
+            in_placements=(row_wise,),
+            device_mesh=device_mesh,
+        )
+        with self.assertRaisesRegex(
+            AssertionError, "in_placements length 1 does not match"
+        ):
+            bad_fn([X_dt, W_dt])
+
     @skip_if_lt_x_gpu(4)
     @with_comms
     def test_multi_mesh_inputs(self):

--- a/torch/distributed/tensor/experimental/_func_map.py
+++ b/torch/distributed/tensor/experimental/_func_map.py
@@ -22,6 +22,58 @@ InputPlacements = tuple[PlacementType, ...] | None
 OutputPlacements = PlacementType | tuple[PlacementType, ...]
 
 
+def _is_placement_spec(x):
+    """Return ``True`` if ``x`` is a ``PlacementType`` leaf.
+
+    A placement spec leaf is either ``None`` or a non-empty list/tuple whose
+    elements are all :class:`Placement` instances. This is used as the
+    ``is_leaf`` callback when pytree-flattening placement structures so that
+    a placement spec for a single tensor is never recursed into.
+    """
+    if x is None:
+        return True
+    if isinstance(x, (list, tuple)) and len(x) > 0:
+        return all(isinstance(p, Placement) for p in x)
+    return False
+
+
+def _flatten_input_placements(placements, num_flat_args, label):
+    """Flatten an input placement structure into a list of ``PlacementType``.
+
+    ``placements`` may either be a flat tuple matching the pytree-flattened
+    args (the original behavior) or a nested tuple/list mirroring the
+    structure of ``args`` -- in both cases the leaves (each
+    ``PlacementType``) are matched 1:1 with the flattened args.
+    """
+    if placements is None:
+        return None
+    flat, _ = pytree.tree_flatten(placements, is_leaf=_is_placement_spec)
+    if len(flat) != num_flat_args:
+        raise AssertionError(
+            f"{label} length {len(flat)} does not match the number of "
+            f"input args {num_flat_args}!"
+        )
+    return flat
+
+
+def _flatten_output_placements(out_placements, num_flat_out):
+    """Flatten an ``out_placements`` structure into a list of ``PlacementType``.
+
+    Accepts a single ``PlacementType`` for a single-leaf output (preserving
+    the existing shorthand), a flat tuple matching the pytree-flattened
+    output, or a nested structure mirroring the output's tree. In all cases
+    each leaf is a ``PlacementType``.
+    """
+    flat, _ = pytree.tree_flatten(out_placements, is_leaf=_is_placement_spec)
+    if len(flat) != num_flat_out:
+        raise AssertionError(
+            "local_map requires one PlacementType be provided for each "
+            f"output value, received {len(flat)} out_placements but "
+            f"{num_flat_out} is expected!"
+        )
+    return flat
+
+
 def local_map(
     func: Callable | None = None,
     out_placements: OutputPlacements = None,
@@ -41,20 +93,26 @@ def local_map(
         func (Callable): the function to be applied on each local shard of
             :class:`DTensor` s.
         out_placements (Union[`PlacementType`, Tuple[`PlacementType`, ...]]):
-            the desired placements of the :class:`DTensor` s in ``func``'s flattened output.
-            If the flattened ``output`` is a single value, the ``out_placements`` should be
-            of type `PlacementType`. Otherwise if the flattened ``output`` has multiple
-            values, the ``out_placements`` should be a tuple of `PlacementType` values 1:1
-            mapping to the flattened ``output``.
-            Besides, for :class:`Tensor` output, we use `PlacementType` as its
-            placements (a `Tuple[Placement]` value). For non-Tensor output, the `PlacementType`
+            the desired placements of the :class:`DTensor` s in ``func``'s pytree-flattened
+            output. ``out_placements`` may either be a single `PlacementType` (when the
+            flattened output is a single value), a flat tuple of `PlacementType` values
+            matching the flattened output 1:1, or a nested structure mirroring the
+            output's pytree whose leaves are each a `PlacementType`. In all cases the
+            leaves are paired with the pytree-flattened output values.
+            For :class:`Tensor` output, we use `PlacementType` as its placements
+            (a `Tuple[Placement]` value). For non-Tensor output, the `PlacementType`
             should be `None`.
             Note that the only exception is when no :class:`DTensor` argument is passed
             in. In this case, even if `out_placements` is not `None`, the result function
             should ignore the desired placements because the function is not running with
             :class:`DTensor` s.
         in_placements (Tuple[`PlacementType`, ...], optional):
-            the required placements of the :class:`DTensor` s in the flattened inputs of ``func``.
+            the required placements of the :class:`DTensor` s in the pytree-flattened inputs
+            of ``func``. ``in_placements`` may either be a flat tuple of `PlacementType`
+            values matching the flattened inputs 1:1, or a nested tuple/list mirroring
+            the structure of the positional arguments whose leaves are each a
+            `PlacementType`. In both cases the leaves are paired with the
+            pytree-flattened input values.
             If ``in_placements`` is specified, :meth:`local_map` would examine whether the
             placements of each :class:`DTensor` argument is the same as the required
             placements or not. If the placements are not the same and
@@ -169,12 +227,12 @@ def _local_map_wrapped(
 ):
     # process input args
     flat_args, args_spec = pytree.tree_flatten(args)
-    if in_placements is not None:
-        if len(in_placements) != len(flat_args):
-            raise AssertionError(
-                f"in_placements length {len(in_placements)} does not match the number "
-                f"of input args {len(flat_args)}!"
-            )
+    flat_in_placements = _flatten_input_placements(
+        in_placements, len(flat_args), "in_placements"
+    )
+    flat_in_grad_placements = _flatten_input_placements(
+        in_grad_placements, len(flat_args), "in_grad_placements"
+    )
 
     # we assume every DTensor object is placed on the same device mesh
     flat_local_args = []
@@ -190,8 +248,8 @@ def _local_map_wrapped(
             # this function is applied to at least one DTensor argument
             seen_dtensor_arg = True
 
-            if in_placements is not None:
-                spec = in_placements[idx]
+            if flat_in_placements is not None:
+                spec = flat_in_placements[idx]
                 if spec is None:
                     raise AssertionError(
                         f"DTensor input {arg} expects placements but received {spec}!"
@@ -213,8 +271,8 @@ def _local_map_wrapped(
                             "redistribute_inputs=True to local_map."
                         )
 
-            if in_grad_placements is not None:
-                spec = in_grad_placements[idx]
+            if flat_in_grad_placements is not None:
+                spec = flat_in_grad_placements[idx]
                 if spec is None:
                     raise AssertionError(
                         f"DTensor input {arg} expects in grad placements but received {spec}!"
@@ -231,8 +289,8 @@ def _local_map_wrapped(
             flat_local_args.append(local_arg)
         else:
             # Non-Tensor input must have None in `in_placements`
-            if in_placements is not None and not isinstance(arg, torch.Tensor):
-                spec = in_placements[idx]
+            if flat_in_placements is not None and not isinstance(arg, torch.Tensor):
+                spec = flat_in_placements[idx]
                 if spec is not None:
                     raise AssertionError(
                         f"Non-Tensor input {arg} expects None placements "
@@ -249,18 +307,10 @@ def _local_map_wrapped(
     if seen_dtensor_arg:
         # process output to be DTensor if we've seen DTensor inputs
         flat_out, out_spec = pytree.tree_flatten(out)
+        flat_out_placements = _flatten_output_placements(out_placements, len(flat_out))
 
         flat_dist_out = []
-        out_placements_tuple = (
-            out_placements if isinstance(out_placements, tuple) else (out_placements,)
-        )
-        if len(flat_out) != len(out_placements_tuple):
-            raise AssertionError(
-                "local_map requires one PlacementType be provided for each output value,"
-                f" received {len(out_placements_tuple)} out_placements but"
-                f" {len(flat_out)} is expected!"
-            )
-        for out, spec in zip(flat_out, out_placements_tuple):
+        for out, spec in zip(flat_out, flat_out_placements):
             if isinstance(out, torch.Tensor):
                 if isinstance(out, DTensor):
                     raise AssertionError(


### PR DESCRIPTION
## Agent Report
### Summary
`torch.distributed.tensor.experimental.local_map` pytree-flattens its
positional arguments via `pytree.tree_flatten(args)`, but it then treats
`in_placements`, `in_grad_placements`, and `out_placements` as flat sequences
to be compared by length against the flattened args/output. This is the
"worst of both worlds" called out in the issue: callers who pass nested
structures (e.g., a list of DTensors as a single positional argument) cannot
mirror that structure in the placements; they must mentally flatten the
structure themselves.

### Root Cause
In `_local_map_wrapped` in
`torch/distributed/tensor/experimental/_func_map.py`:

1. Args were pytree-flattened to `flat_args` and the loop indexed
 `in_placements[idx]` with that flattened index.
2. The output path normalized `out_placements` only with `(... if
 isinstance(... , tuple) else (... ,))`, never recursing into nested
 structures.

So nested args produced more flat leaves than the user-natural per-arg
`in_placements` tuple, leading to errors like
`in_placements length 1 does not match the number of input args 2!`.

### Fix
Make all three placement structures pytree-aware with `is_leaf` detection of
a `PlacementType` (`None` or a non-empty `Sequence[Placement]`):

- `_is_placement_spec(x)` returns `True` for `None` or a non-empty list/tuple
 whose elements are all `Placement` instances.
- `_flatten_input_placements(placements, num_flat_args, label)` pytree-flattens
 `in_placements` / `in_grad_placements` using that `is_leaf` and verifies the
 resulting flat-leaf count matches `len(flat_args)`.
- `_flatten_output_placements(out_placements, num_flat_out)` does the same for
 `out_placements`, naturally handling both the single-leaf shorthand
 (`out_placements=[Shard(0)]`) and tuples of placement specs.

Existing flat usages remain valid because each top-level placement spec
(`None` or `[Shard(0)]`, `[Replicate()]`, etc.) is itself a leaf under the
`is_leaf` rule, so flattening is a no-op for them. The new behavior accepts
nested structures such as `in_placements=([row_wise, row_wise],)` or
`in_placements=({"a": row_wise, "b": row_wise},)`, which mirror the args
pytree. The docstring is updated to describe both forms.

The change is in pure Python; no rebuild is required.

### Repro
Run:

```bash
python repro_182031_generated.py
```

<details>
<summary>Repro Script</summary>

```python
"""
Repro for issue #182031: DTensor.local_map inconsistently handles pytree on
input versus placements.

The bug: `local_map` pytree-flattens its positional arguments but then expects
in_placements (and out_placements) to be a flat tuple matching the length of
the flattened args. So a user who passes a nested structure (e.g., a list of
DTensors) cannot use a nested placements spec that mirrors the arg structure;
they are forced to mentally flatten the structure first.

After the fix, in_placements and out_placements may either be flat (the old
behavior, preserved) OR may mirror the pytree structure of the args/output.
Both flatten to the same set of leaves, paired 1:1 with the pytree-flattened
args/output values. A leaf is a `PlacementType`: `None` or a `Sequence` of
`Placement`.
"""

import os
import sys
import traceback

import torch
import torch.distributed as dist
from torch.distributed.tensor import distribute_tensor, Replicate, Shard
from torch.distributed.tensor.experimental import local_map


def main():
 os.environ.setdefault("MASTER_ADDR", "localhost")
 os.environ.setdefault("MASTER_PORT", "29555")
 os.environ.setdefault("RANK", "0")
 os.environ.setdefault("WORLD_SIZE", "1")

 dist.init_process_group(backend="gloo")
 try:
 device_mesh = dist.device_mesh.init_device_mesh("cpu", (1,))

 row_wise = [Shard(0)]
 replicate = [Replicate()]

 X = torch.randn(8, 8)
 Y = torch.randn(8, 8)
 X_dt = distribute_tensor(X, device_mesh, row_wise)
 Y_dt = distribute_tensor(Y, device_mesh, row_wise)

 def add_pair(pair):
 # pair is [t1, t2]; return their sum as a single tensor.
 return pair[0] + pair[1]

 def split_pair(pair):
 # pair is [t1, t2]; return a list (nested output).
 return [pair[0] * 2.0, pair[1] * 3.0]

 # Test 1: flat in_placements still works (backward compat).
 flat_fn = local_map(
 add_pair,
 out_placements=row_wise,
 in_placements=(row_wise, row_wise), # flat
 device_mesh=device_mesh,
 )
 r1 = flat_fn([X_dt, Y_dt])
 print("flat in_placements works.")
 assert r1.placements == tuple(row_wise)

 # Test 2: nested in_placements mirroring the args structure.
 nested_fn = local_map(
 add_pair,
 out_placements=row_wise,
 in_placements=([row_wise, row_wise],), # mirror args=([t,t],)
 device_mesh=device_mesh,
 )
 r2 = nested_fn([X_dt, Y_dt])
 print("nested in_placements mirroring args works.")
 assert r2.placements == tuple(row_wise)

 # Test 3: nested output with nested out_placements.
 nested_out_fn = local_map(
 split_pair,
 out_placements=[row_wise, row_wise], # mirror output=[t,t]
 in_placements=([row_wise, row_wise],),
 device_mesh=device_mesh,
 )
 out3 = nested_out_fn([X_dt, Y_dt])
 assert isinstance(out3, list) and len(out3) == 2
 for d in out3:
 assert d.placements == tuple(row_wise)
 print("nested output with nested out_placements works.")

 # Test 4: flat out_placements still works (backward compat).
 flat_out_fn = local_map(
 split_pair,
 out_placements=(row_wise, row_wise), # flat
 in_placements=(row_wise, row_wise),
 device_mesh=device_mesh,
 )
 out4 = flat_out_fn([X_dt, Y_dt])
 assert isinstance(out4, list) and len(out4) == 2
 for d in out4:
 assert d.placements == tuple(row_wise)
 print("flat out_placements still works.")

 # Test 5: mismatched length still raises a helpful error.
 bad_fn = local_map(
 add_pair,
 out_placements=row_wise,
 in_placements=(row_wise,), # too few specs for [t,t]
 device_mesh=device_mesh,
 )
 try:
 bad_fn([X_dt, Y_dt])
 except AssertionError as e:
 assert "in_placements length 1" in str(e)
 print("Mismatched length correctly errors:", e)
 else:
 print("BUG: mismatched length did not error.")
 sys.exit(1)

 # Test 6: dict-shaped args with dict-shaped placements.
 def dict_fn(d):
 return d["a"] + d["b"]

 dict_local = local_map(
 dict_fn,
 out_placements=row_wise,
 in_placements=({"a": row_wise, "b": row_wise},),
 device_mesh=device_mesh,
 )
 r6 = dict_local({"a": X_dt, "b": Y_dt})
 assert r6.placements == tuple(row_wise)
 print("dict-shaped args with dict-shaped placements works.")

 # Test 7: nested in_grad_placements mirroring a nested args tree.
 X_req = torch.randn(8, 8, requires_grad=True)
 Y_req = torch.randn(8, 8, requires_grad=True)
 Xr_dt = distribute_tensor(X_req, device_mesh, row_wise)
 Yr_dt = distribute_tensor(Y_req, device_mesh, row_wise)

 nested_grad_fn = local_map(
 add_pair,
 out_placements=row_wise,
 in_placements=([row_wise, row_wise],),
 in_grad_placements=([row_wise, row_wise],),
 device_mesh=device_mesh,
 redistribute_inputs=True,
 )
 out7 = nested_grad_fn([Xr_dt, Yr_dt])
 out7.to_local().sum().backward()
 assert Xr_dt.grad.placements == tuple(row_wise)
 assert Yr_dt.grad.placements == tuple(row_wise)
 print("nested in_grad_placements works.")

 print()
 print("All repro tests passed: local_map now handles pytree on")
 print("inputs and placements consistently.")
 sys.exit(0)
 finally:
 dist.destroy_process_group()


if __name__ == "__main__":
 try:
 main()
 except SystemExit:
 raise
 except Exception:
 traceback.print_exc()
 sys.exit(2)
```

</details>

### Testing
- `repro_182031_generated.py` exits 0 (all 7 user-facing tests pass).
- `python test/distributed/tensor/experimental/test_local_map.py` -> 8/8
 passed (6 pre-existing tests plus `test_nested_in_out_placements` and
 `test_local_map_with_nested_grad_placement`).
- `spin fixlint torch/distributed/tensor/experimental/_func_map.py
 test/distributed/tensor/experimental/test_local_map.py` -> no lint issues.

## Files Changed
- `torch/distributed/tensor/experimental/_func_map.py`
- `test/distributed/tensor/experimental/test_local_map.py`


Fixes #182031

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*