### PR TITLE
[xpu][fix] Fix reflection/replication pad output memory format to match eager behavior

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5217,12 +5217,12 @@ def _reflection_or_replication_pad(
     # produce non-standard strides — so suggest_memory_format(result) may
     # not reflect the desired output format.
     #
-    # CPU vs CUDA eager behavior differs:
+    # CPU vs CUDA/XPU/MPS eager behavior differs:
     #   CPU:  allocates output via at::empty_like with suggest_memory_format,
     #         preserving the input's format (e.g. channels_last).
-    #   CUDA: kernel writes to a flat contiguous buffer with linear indexing,
+    #   CUDA/XPU/MPS: kernel writes to a flat contiguous buffer with linear indexing,
     #         always producing contiguous output regardless of input format.
-    if a.device.type in ("cuda", "mps"):
+    if a.device.type in ("cuda", "mps", "xpu"):
         memory_format = torch.contiguous_format
     else:
         memory_format = utils.suggest_memory_format(a)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #184567
* #184499
* __->__ #184484
# Motivation
fix https://github.com/pytorch/pytorch/issues/184468

