### PR TITLE
[xpu] Refactor OneDNN C API to C++ API

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/DnnlExt.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/DnnlExt.h
@@ -6,8 +6,8 @@
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
 
-#include <oneapi/dnnl/dnnl.h>
 #include <oneapi/dnnl/dnnl.hpp>
+#include <oneapi/dnnl/dnnl_sycl.hpp>
 
 namespace std {
 
@@ -29,219 +29,95 @@ using namespace dnnl;
 namespace at::native::onednn {
 
 class primitive_ext : public primitive {
-  static constexpr int max_args = 12;
-
  public:
-  primitive_ext(const primitive& base) : primitive(base) {}
-  primitive_ext(primitive&& base) : primitive(std::move(base)) {}
+  primitive_ext(primitive&& base)
+      : primitive(std::move(base)),
+        pd_(const_cast<dnnl_primitive_desc_t>(this->get_primitive_desc())) {}
 
-  /// Returns a memory descriptor.
-  ///
-  /// @note
-  ///     There are also convenience methods
-  ///     #dnnl::primitive_desc_base::src_desc(),
-  ///     #dnnl::primitive_desc_base::dst_desc(), and others.
-  ///
-  /// @param what The kind of parameter to query; can be
-  ///     #dnnl::query::src_md, #dnnl::query::dst_md, etc.
-  /// @param idx Index of the parameter. For example, convolution bias can
-  ///     be queried with what = #dnnl::query::weights_md and idx = 1.
-  /// @returns The requested memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     parameter of the specified kind or index.
-  const_dnnl_memory_desc_t query_md(query what, int idx = 0) const {
-    std::vector<query> valid_q{
-        query::src_md,
-        query::diff_src_md,
-        query::weights_md,
-        query::diff_weights_md,
-        query::dst_md,
-        query::diff_dst_md,
-        query::workspace_md,
-        query::scratchpad_md,
-        query::exec_arg_md};
-    if (!std::any_of(valid_q.cbegin(), valid_q.cend(), [=](query q) {
-          return what == q;
-        }))
-      DNNL_THROW_ERROR(
-          dnnl_invalid_arguments, "memory descriptor query is invalid");
-
-    const_dnnl_memory_desc_t cdesc = dnnl_primitive_desc_query_md(
-        this->get_primitive_desc(), dnnl::convert_to_c(what), idx);
-
-    return cdesc ? cdesc : nullptr;
+  memory::desc query_md(query what, int idx = 0) const {
+    return pd_.query_md(what, idx);
   }
 
-  /// Returns a source memory descriptor.
-  /// @param idx Source index.
-  /// @returns Source memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     source parameter with index @p idx.
-  const_dnnl_memory_desc_t src_desc(int idx) const {
+  memory::desc src_desc(int idx) const {
     return query_md(query::src_md, idx);
   }
 
-  /// Returns a destination memory descriptor.
-  /// @param idx Destination index.
-  /// @returns Destination memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     destination parameter with index @p idx.
-  const_dnnl_memory_desc_t dst_desc(int idx) const {
+  memory::desc dst_desc(int idx) const {
     return query_md(query::dst_md, idx);
   }
 
-  /// Returns a weights memory descriptor.
-  /// @param idx Weights index.
-  /// @returns Weights memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     weights parameter with index @p idx.
-  const_dnnl_memory_desc_t weights_desc(int idx) const {
+  memory::desc weights_desc(int idx) const {
     return query_md(query::weights_md, idx);
   }
 
-  /// Returns a diff source memory descriptor.
-  /// @param idx Diff source index.
-  /// @returns Diff source memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     diff source parameter with index @p idx.
-  const_dnnl_memory_desc_t diff_src_desc(int idx) const {
+  memory::desc diff_src_desc(int idx) const {
     return query_md(query::diff_src_md, idx);
   }
 
-  /// Returns a diff destination memory descriptor.
-  /// @param idx Diff destination index.
-  /// @returns Diff destination memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     diff destination parameter with index @p idx.
-  const_dnnl_memory_desc_t diff_dst_desc(int idx) const {
+  memory::desc diff_dst_desc(int idx) const {
     return query_md(query::diff_dst_md, idx);
   }
 
-  /// Returns a diff weights memory descriptor.
-  /// @param idx Diff weights index.
-  /// @returns Diff weights memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     diff weights parameter with index @p idx.
-  const_dnnl_memory_desc_t diff_weights_desc(int idx) const {
+  memory::desc diff_weights_desc(int idx) const {
     return query_md(query::diff_weights_md, idx);
   }
 
-  const_dnnl_memory_desc_t exec_arg_desc(int idx) const {
+  memory::desc exec_arg_desc(int idx) const {
     return query_md(query::exec_arg_md, idx);
   }
 
-  // Separate versions without the index argument for documentation
-  // purposes.
-
-  /// Returns a source memory descriptor.
-  /// @returns Source memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     source parameter.
-  const_dnnl_memory_desc_t src_desc() const {
+  memory::desc src_desc() const {
     return src_desc(0);
   }
-
-  /// Returns a destination memory descriptor.
-  /// @returns Destination memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     destination parameter.
-  const_dnnl_memory_desc_t dst_desc() const {
+  memory::desc dst_desc() const {
     return dst_desc(0);
   }
-
-  /// Returns a weights memory descriptor.
-  /// @returns Weights memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     weights parameter.
-  const_dnnl_memory_desc_t weights_desc() const {
+  memory::desc weights_desc() const {
     return weights_desc(0);
   }
-
-  /// Returns a diff source memory descriptor.
-  /// @returns Diff source memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     diff source memory with.
-  const_dnnl_memory_desc_t diff_src_desc() const {
+  memory::desc diff_src_desc() const {
     return diff_src_desc(0);
   }
-
-  /// Returns a diff destination memory descriptor.
-  /// @returns Diff destination memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     diff destination parameter.
-  const_dnnl_memory_desc_t diff_dst_desc() const {
+  memory::desc diff_dst_desc() const {
     return diff_dst_desc(0);
   }
-
-  /// Returns a diff weights memory descriptor.
-  /// @returns Diff weights memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not have a
-  ///     diff weights parameter.
-  const_dnnl_memory_desc_t diff_weights_desc() const {
+  memory::desc diff_weights_desc() const {
     return diff_weights_desc(0);
   }
-
-  /// Returns the workspace memory descriptor.
-  /// @returns Workspace memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not require
-  ///     workspace parameter.
-  const_dnnl_memory_desc_t workspace_desc() const {
+  memory::desc workspace_desc() const {
     return query_md(query::workspace_md, 0);
   }
-
-  /// Returns the scratchpad memory descriptor.
-  /// @returns scratchpad memory descriptor.
-  /// @returns A zero memory descriptor if the primitive does not require
-  ///     scratchpad parameter.
-  /// @sa @ref dev_guide_attributes_scratchpad
-  const_dnnl_memory_desc_t scratchpad_desc() const {
+  memory::desc scratchpad_desc() const {
     return query_md(query::scratchpad_md, 0);
   }
 
-  inline memory make_memory(
-      const_dnnl_memory_desc_t md_t,
-      const engine& aengine,
-      void* handle = DNNL_MEMORY_ALLOCATE) const {
-    sycl_interop::memory_kind kind = dnnl::sycl_interop::memory_kind::usm;
-    dnnl_memory_t c_memory;
-    error::wrap_c_api(
-        dnnl_sycl_interop_memory_create(
-            &c_memory, md_t, aengine.get(), convert_to_c(kind), handle),
-        "could not create a memory");
-    return memory(c_memory);
+  memory make_src(engine& aengine, void* handle = DNNL_MEMORY_ALLOCATE) const {
+    return make_onednn_memory(src_desc(), aengine, handle);
   }
 
-  memory make_src(const engine& aengine, void* handle = DNNL_MEMORY_ALLOCATE)
+  memory make_weight(engine& aengine, void* handle = DNNL_MEMORY_ALLOCATE)
       const {
-    return make_memory(src_desc(), aengine, handle);
+    return make_onednn_memory(weights_desc(), aengine, handle);
   }
 
-  memory make_weight(const engine& aengine, void* handle = DNNL_MEMORY_ALLOCATE)
+  memory make_bias(engine& aengine, void* handle = DNNL_MEMORY_ALLOCATE) const {
+    return make_onednn_memory(weights_desc(1), aengine, handle);
+  }
+
+  memory make_dst(engine& aengine, void* handle = DNNL_MEMORY_ALLOCATE) const {
+    return make_onednn_memory(dst_desc(), aengine, handle);
+  }
+
+  memory make_scratchpad(engine& aengine, void* handle = DNNL_MEMORY_ALLOCATE)
       const {
-    return make_memory(weights_desc(), aengine, handle);
-  }
-
-  memory make_bias(const engine& aengine, void* handle = DNNL_MEMORY_ALLOCATE)
-      const {
-    return make_memory(weights_desc(1), aengine, handle);
-  }
-
-  memory make_dst(const engine& aengine, void* handle = DNNL_MEMORY_ALLOCATE)
-      const {
-    return make_memory(dst_desc(), aengine, handle);
-  }
-
-  memory make_scratchpad(
-      const engine& aengine,
-      void* handle = DNNL_MEMORY_ALLOCATE) const {
-    return make_memory(scratchpad_desc(), aengine, handle);
+    return make_onednn_memory(scratchpad_desc(), aengine, handle);
   }
 
   size_t get_scratchpad_size() const {
-    return dnnl_memory_desc_get_size(scratchpad_desc());
+    return scratchpad_desc().get_size();
   }
 
-  memory make_args(int arg_class, const engine& aengine, void* handle) const {
+  memory make_args(int arg_class, engine& aengine, void* handle) const {
     switch (arg_class) {
       case DNNL_ARG_SRC:
         return make_src(aengine, handle);
@@ -260,46 +136,31 @@ class primitive_ext : public primitive {
   }
 
   template <typename M>
-  void set_attribute(int slot, int arg_class, void* handle, M constructor) {
-    if (mem_arg_cache[slot])
-      mem_arg_cache[slot].set_data_handle(handle);
-    else {
-      mem_arg_cache[slot] = constructor();
-      c_args[slot].arg = arg_class;
-      c_args[slot].memory = mem_arg_cache[slot].get();
-    }
+  void set_attribute(int arg_class, void* handle, M constructor) {
+    auto it = args_cache_.find(arg_class);
+    if (it != args_cache_.end())
+      it->second.set_data_handle(handle);
+    else
+      args_cache_[arg_class] = constructor();
   }
 
   sycl::event execute(
       const stream& astream,
-      const engine& aengine,
-      std::vector<std::pair<int, void*>>&& handles,
-      int slot_off = 2) {
-    auto off = slot_off;
+      engine& aengine,
+      std::vector<std::pair<int, void*>>&& handles) {
     for (const auto& p : handles) {
-      auto& m_arg = mem_arg_cache[off];
-      if (m_arg)
-        m_arg.set_data_handle(p.second);
-      else {
-        m_arg = make_args(p.first, aengine, p.second);
-        c_args[off].arg = p.first;
-        c_args[off].memory = m_arg.get();
-      }
-      ++off;
+      auto it = args_cache_.find(p.first);
+      if (it != args_cache_.end())
+        it->second.set_data_handle(p.second);
+      else
+        args_cache_[p.first] = make_args(p.first, aengine, p.second);
     }
-
-    sycl::event return_event;
-    std::vector<sycl::event> deps{};
-    error::wrap_c_api(
-        dnnl_sycl_interop_primitive_execute(
-            this->get(), astream.get(), off, c_args, &deps, &return_event),
-        "could not execute a primitive");
-    return return_event;
+    return dnnl::sycl_interop::execute(*this, astream, args_cache_);
   }
 
  private:
-  memory mem_arg_cache[max_args];
-  dnnl_exec_arg_t c_args[max_args];
+  dnnl::matmul::primitive_desc pd_;
+  std::unordered_map<int, memory> args_cache_;
 };
 
 // Specifies the combined data types of input and weight tensors.

--- a/aten/src/ATen/native/mkldnn/xpu/detail/WoQMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/WoQMatmul.cpp
@@ -257,23 +257,16 @@ void woq_matmul_int4_impl_cache(
 
   auto& engine = GpuEngineManager::Instance().get_engine();
 
-  int arg_off = 0;
   // set scale and zero point for matmul args
   matmul_ext.set_attribute(
-      arg_off++,
-      DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS,
-      scale.data_ptr(),
-      [&]() {
+      DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, scale.data_ptr(), [&]() {
         return make_onednn_memory(
             get_onednn_md(scale), engine, scale.data_ptr());
       });
 
   // set zp_md for asymmetric quantization
   matmul_ext.set_attribute(
-      arg_off++,
-      DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS,
-      zp.data_ptr(),
-      [&]() {
+      DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, zp.data_ptr(), [&]() {
         int num_groups = k / group_size;
         memory zp_usr_m(
             {{num_groups, n}, memory::data_type::s8, {n, 1}},
@@ -297,7 +290,7 @@ void woq_matmul_int4_impl_cache(
 
   auto& strm = GpuStreamManager::Instance().get_stream();
   auto qint4_matmul_event =
-      matmul_ext.execute(strm, engine, std::move(arg_handles), arg_off);
+      matmul_ext.execute(strm, engine, std::move(arg_handles));
 }
 
 void woq_matmul_int4(


### PR DESCRIPTION
### Summary
Replace oneDNN C API calls in `DnnlExt.h` (and update the callsite in `WoQMatmul.cpp`) with their C++ API equivalents for a consistent programming style across the XPU oneDNN integration layer.

### Motivation
The existing code mixed oneDNN C API (`dnnl_*` functions, `dnnl_exec_arg_t`, `const_dnnl_memory_desc_t`, etc.) with the C++ API (`dnnl::memory::desc`, `dnnl::matmul::primitive_desc`, etc.) within the same file. This inconsistency made the code harder to read and maintain.

The C++ API also provides RAII semantics — destructors automatically handle resource cleanup (e.g., `memory::desc`, `memory`, `primitive_desc` are all properly destroyed on scope exit), eliminating the need for manual `destroy` calls and reducing the risk of resource leaks.

### Changes

**`DnnlExt.h` — `primitive_ext` class rewrite:**

| Before (C API) | After (C++ API) |
|---|---|
| `dnnl_primitive_desc_query_md()` | `matmul::primitive_desc::query_md()` |
| `dnnl_sycl_interop_memory_create()` | `make_onednn_memory()` (wraps `dnnl::sycl_interop::make_memory()`) |
| `dnnl_memory_desc_get_size()` | `memory::desc::get_size()` |
| `dnnl_sycl_interop_primitive_execute()` | `dnnl::sycl_interop::execute()` |
| `dnnl_exec_arg_t c_args[]` (C struct array) | `std::unordered_map<int, memory>` |
| `const_dnnl_memory_desc_t` return types | `memory::desc` return types |
| `#include <oneapi/dnnl/dnnl.h>` (C header) | `#include <oneapi/dnnl/dnnl_sycl.hpp>` (C++ header) |

Key design change: `primitive_ext` now reconstructs a `matmul::primitive_desc` from the underlying primitive via `get_primitive_desc()`, enabling pure C++ `query_md()` calls.

**`WoQMatmul.cpp` — callsite update:**
- `set_attribute()`: removed the manual slot index parameter; arguments are now keyed by `arg_class` in the internal map.
- `execute()`: removed the `slot_off` parameter.

### Test

Verified with WoQ (weight-only quantization) INT4 inference on Phi-3-mini-4k-instruct (FP16, XPU). Functional correctness and performance unchanged on BMG.

|  | No Primitive Cache | Primitive Cache (before) | Primitive Cache (after PR)|
| -- | -- | -- | -- |
| Next Token Latency (s) | baseline | -16.3% | -14.9% |


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01