### PR TITLE
dynamo: round-trip torch.cuda.stream ctx mgr across graph breaks

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -3,6 +3,7 @@ import gc
 import re
 import unittest
 import weakref
+from typing import Any
 from unittest.mock import patch
 
 import torch
@@ -265,6 +266,27 @@ class <lambda>(torch.nn.Module):
             f"inside 'with torch.cuda.stream(s):', got {len(fw_graphs)} "
             f"-- the post-break body was likely dropped",
         )
+
+        # Both halves of the round-trip should carry a stream annotation
+        # referring to the one and only stream `s` entered via
+        # `with torch.cuda.stream(s):`.  We do not pin the exact index, only
+        # that both adds are annotated with the same stream (i.e. `s`).
+        def add_node_stream(gm) -> int:
+            adds: list[torch.fx.Node] = [
+                n
+                for n in gm.graph.nodes
+                if n.op == "call_function"
+                and n.target is torch.ops.aten.add.Tensor
+            ]
+            self.assertEqual(len(adds), 1)
+            custom: dict[str, Any] = adds[0].meta.get("custom", {})
+            self.assertIn("stream", custom)
+            return custom["stream"]
+
+        pre_break_stream = add_node_stream(fw_graphs[0])
+        post_break_stream = add_node_stream(fw_graphs[1])
+        # The same stream `s` annotates the add on both sides of the break.
+        self.assertEqual(pre_break_stream, post_break_stream)
 
     @requires_cuda
     def test_stream_input(self):

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -210,6 +210,39 @@ class <lambda>(torch.nn.Module):
         self.assertExpectedInline(print_graph(fw_graphs[1]), """""")
 
     @requires_cuda
+    def test_target_values_dict_round_trips_through_graph_break(self):
+
+        # Regression test for a dict-vs-tuple issue interpreting
+        # `target_values`. This was initially a tuple and got repurposed as a
+        # dict, but some oft-unexecuted paths still assumed it was a tuple.
+        # Here we ensure that an in-use stream gets properly reconstructed on
+        # the other side of a graph break.
+        def fn(x):
+            s = torch.cuda.Stream()
+            with torch.cuda.stream(s):
+                z = x + 1
+                torch._dynamo.graph_break()
+                z = z + 2
+            return z
+
+        inp = (torch.ones(2, 2, device="cuda"),)
+        expected = fn(*inp)
+        actual, _, fw_graphs, _ = extract_graph(fn, *inp)
+        self.assertEqual(expected, actual)
+        # A graceful graph break inside with torch.cuda.stream(s):
+        # should split into two graph fragments.  Without the fix the
+        # post-break code is dropped and only the pre-break fragment is
+        # captured (or the whole frame falls back to eager and zero are
+        # captured).
+        self.assertEqual(
+            len(fw_graphs),
+            2,
+            f"expected 2 graph fragments after a graceful graph break "
+            f"inside 'with torch.cuda.stream(s):', got {len(fw_graphs)} "
+            f"-- the post-break body was likely dropped",
+        )
+
+    @requires_cuda
     def test_stream_input(self):
         def fn(x, y, s):
             z = torch.add(x, y)

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -181,7 +181,6 @@ class <lambda>(torch.nn.Module):
         )
 
     @requires_cuda
-    @unittest.skip("Needs graph break support with annotation context")
     def test_stream_context_graph_break(self):
         def fn(x, y):
             s2 = torch.Stream()
@@ -206,8 +205,33 @@ class <lambda>(torch.nn.Module):
         ) = extract_graph(fn, *inp)
         self.assertEqual(expected, actual)
         self.assertEqual(len(fw_graphs), 2)
-        self.assertExpectedInline(print_graph(fw_graphs[0]), """""")
-        self.assertExpectedInline(print_graph(fw_graphs[1]), """""")
+        self.assertExpectedInline(
+            print_graph(fw_graphs[0]),
+            """\
+class <lambda>(torch.nn.Module):
+    def forward(self, arg0_1: "f32[2, 2]", arg1_1: "f32[2, 2]"):
+        # Annotation: {'stream': 2}
+        add: "f32[2, 2]" = torch.ops.aten.add.Tensor(arg0_1, arg1_1)
+
+        # Annotation: {'stream': 1}
+        add_1: "f32[2, 2]" = torch.ops.aten.add.Tensor(arg0_1, arg1_1);  arg0_1 = arg1_1 = None
+
+        # Annotation: {'stream': 1}
+        add_2: "f32[2, 2]" = torch.ops.aten.add.Tensor(add_1, 2);  add_1 = None
+        add_3: "f32[2, 2]" = torch.ops.aten.add.Tensor(add_2, add);  add_2 = add = None
+        return (add_3,)
+""",
+        )
+        self.assertExpectedInline(
+            print_graph(fw_graphs[1]),
+            """\
+class <lambda>(torch.nn.Module):
+    def forward(self, arg0_1: "f32[2, 2]"):
+        # Annotation: {'stream': 1}
+        add: "f32[2, 2]" = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+        return (add,)
+""",
+        )
 
     @requires_cuda
     def test_target_values_dict_round_trips_through_graph_break(self):

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -236,7 +236,6 @@ class <lambda>(torch.nn.Module):
 
     @requires_cuda
     def test_target_values_dict_round_trips_through_graph_break(self):
-
         # Regression test for a dict-vs-tuple issue interpreting
         # `target_values`. This was initially a tuple and got repurposed as a
         # dict, but some oft-unexecuted paths still assumed it was a tuple.
@@ -275,8 +274,7 @@ class <lambda>(torch.nn.Module):
             adds: list[torch.fx.Node] = [
                 n
                 for n in gm.graph.nodes
-                if n.op == "call_function"
-                and n.target is torch.ops.aten.add.Tensor
+                if n.op == "call_function" and n.target is torch.ops.aten.add.Tensor
             ]
             self.assertEqual(len(adds), 1)
             custom: dict[str, Any] = adds[0].meta.get("custom", {})

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -352,7 +352,8 @@ class StreamContextVariable(ContextWrappingVariable):
 
         # annotate + preserve_node_meta: this ensures the captured
         # nodes have appropriate node.meta["custom"]["stream"] annotations.
-        assert strm.user_object_index is not None, "stream not registered"
+        if strm.user_object_index is None:
+            raise AssertionError("stream not registered")
         stream_idx: int = strm.user_object_index
         annotation: dict[str, Any] = {"stream": stream_idx}
         stack = contextlib.ExitStack()

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -381,29 +381,9 @@ class StreamContextVariable(ContextWrappingVariable):
         # to access "torch._C.fn_name()" which does not exist. Unfortunately we
         # cannot just directly reference the stream in the generated code.
         #
-        # Instead, push a 0-arg callable that returns the ctx mgr value
-        # at runtime: functools.partial(torch.cuda.stream, <Stream>).
-        # The partial is installed as a global on the compiled function
-        # so the resume prologue can LOAD_GLOBAL it.  The standard
-        # ContextWrappingVariable.reconstruct contract then emits
-        # CALL 0 (target_values is empty), invoking the partial to
-        # produce a fresh StreamContext just in time for the prologue's
-        # BEFORE_WITH.
-        #
-        # functools.partial (rather than a freshly-defined closure)
-        # is critical: dynamo retraces the resume prologue and a
-        # closure defined inside torch/_dynamo would be classified as
-        # MOD_SKIPLIST'd and refuse-to-trace, breaking the prologue.
-        # functools.partial is a builtin that dynamo handles
-        # natively, and the wrapped target is the plainly-traceable
-        # torch.cuda.stream(<Stream>) call.
-        #
-        # Using install_global_by_id (rather than the user-object
-        # table via register_graph_created_object) keeps the value
-        # indirection in user-visible Python globals: dynamo retraces
-        # the prologue and sees LOAD_GLOBAL ; CALL 0 to a partial,
-        # which lowers cleanly without any torch/_dynamo internal
-        # functions on the call path -- no ResumePrologueTracingError.
+        # Instead, we push a 0-arg callable that returns the ctx mgr value
+        # at runtime.  The partial is installed as a global on the compiled
+        # function so the resume prologue can LOAD_GLOBAL it.
         import functools
 
         # self.stream is None when we're really a StreamVariable

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -404,9 +404,7 @@ class StreamContextVariable(ContextWrappingVariable):
             )
 
         thunk = functools.partial(torch.cuda.stream, stream_value)
-        name = codegen.tx.output.install_global_by_id(
-            "_stream_ctx_thunk", thunk
-        )
+        name = codegen.tx.output.install_global_by_id("_stream_ctx_thunk", thunk)
         codegen.append_output(codegen.create_load_global(name, add=True))
 
     def get_stream(self) -> "StreamVariable":

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -21,7 +21,7 @@ from ..graph_bytecode_inputs import (
 from ..source import CurrentStreamSource
 from .base import VariableTracker
 from .constant import ConstantVariable
-from .ctx_manager import FxTracebackAnnotateVariable
+from .ctx_manager import ContextWrappingVariable
 from .lazy import LazyVariableTracker
 
 
@@ -320,7 +320,7 @@ class SymbolicStreamState:
         return id(stream.value)
 
 
-class StreamContextVariable(FxTracebackAnnotateVariable):
+class StreamContextVariable(ContextWrappingVariable):
     """This represents torch.cuda.StreamContext"""
 
     @staticmethod
@@ -351,12 +351,8 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
         # we are entering the target, and leaving the initial stream
         tx.symbolic_stream_state.enter_stream(strm)
 
-        # Eagerly annotate + preserve_node_meta; this ensures the captured
+        # annotate + preserve_node_meta: this ensures the captured
         # nodes have appropriate node.meta["custom"]["stream"] annotations.
-        # We inlined this part of FxTracebackAnnotateVariable because
-        # FxTracebackAnnotateVariable uses self.target_values for the
-        # annotation and for us target_values is a tuple of args---and it must
-        # remain a tuple of args for reconstruct_type.
         assert strm.user_object_index is not None, "stream not registered"
         stream_idx: int = strm.user_object_index
         annotation: dict[str, Any] = {"stream": stream_idx}
@@ -381,12 +377,9 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
         return True
 
     def reconstruct_type(self, codegen: "PyCodegen") -> None:
-        # Bypass FxTracebackAnnotateVariable.reconstruct_type's
-        # unconditional Unsupported("annotate escaped from compiled
-        # region") raise (it would otherwise fire via
-        # WithExitFunctionVariable.reconstruct -> self.ctx.reconstruct_type
-        # on every graph break inside with torch.cuda.stream(s): and
-        # silently drop the post-break body).
+        # Override our parent's reconstruct_type, as that implementation tries
+        # to access "torch._C.fn_name()" which does not exist. Unfortunately we
+        # cannot just directly reference the stream in the generated code.
         #
         # Instead, push a 0-arg callable that returns the ctx mgr value
         # at runtime: functools.partial(torch.cuda.stream, <Stream>).

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -336,7 +336,6 @@ class StreamContextVariable(ContextWrappingVariable):
 
     def __init__(self, stream: Optional["StreamVariable"], **kwargs: Any) -> None:
         self.stream = stream
-        stream_idx = self.get_stream().user_object_index
         super().__init__(
             target_values=(),
             initial_values=None,

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -357,6 +357,7 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
         # FxTracebackAnnotateVariable uses self.target_values for the
         # annotation and for us target_values is a tuple of args---and it must
         # remain a tuple of args for reconstruct_type.
+        assert strm.user_object_index is not None, "stream not registered"
         stream_idx: int = strm.user_object_index
         annotation: dict[str, Any] = {"stream": stream_idx}
         stack = contextlib.ExitStack()

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -337,13 +337,6 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
     def __init__(self, stream: Optional["StreamVariable"], **kwargs: Any) -> None:
         self.stream = stream
         stream_idx = self.get_stream().user_object_index
-        # self.annotation is the dict consumed by
-        # torch.fx.traceback.annotate at enter() time; it carries the
-        # "stream" -> stream-user-object-index pair that inductor reads
-        # off node.meta["custom"] for stream-affinity scheduling.
-        # Stored on a dedicated attribute so target_values (the
-        # positional rebuild-args tuple) does not have to do double duty.
-        self.annotation = {"stream": stream_idx}
         super().__init__(
             target_values=(),
             initial_values=None,
@@ -353,17 +346,21 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
     def enter(
         self, tx: "InstructionTranslatorBase", *args: VariableTracker
     ) -> VariableTracker:
+        strm: StreamVariable = self.get_stream()
         # to stream, from stream is the order of the arguments
         # we are entering the target, and leaving the initial stream
-        tx.symbolic_stream_state.enter_stream(self.get_stream())
+        tx.symbolic_stream_state.enter_stream(strm)
+
         # Eagerly annotate + preserve_node_meta; this ensures the captured
         # nodes have appropriate node.meta["custom"]["stream"] annotations.
         # We inlined this part of FxTracebackAnnotateVariable because
         # FxTracebackAnnotateVariable uses self.target_values for the
         # annotation and for us target_values is a tuple of args---and it must
         # remain a tuple of args for reconstruct_type.
+        stream_idx: int = strm.user_object_index
+        annotation: dict[str, Any] = {"stream": stream_idx}
         stack = contextlib.ExitStack()
-        stack.enter_context(torch.fx.traceback.annotate(self.annotation))
+        stack.enter_context(torch.fx.traceback.annotate(annotation))
         stack.enter_context(torch.fx.traceback.preserve_node_meta())
         self.set_cleanup_hook(tx, lambda: stack.close())
         return ConstantVariable.create(None)

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 from collections.abc import Callable
 from typing import Any, Optional
 
@@ -335,8 +336,16 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
 
     def __init__(self, stream: Optional["StreamVariable"], **kwargs: Any) -> None:
         self.stream = stream
+        stream_idx = self.get_stream().user_object_index
+        # self.annotation is the dict consumed by
+        # torch.fx.traceback.annotate at enter() time; it carries the
+        # "stream" -> stream-user-object-index pair that inductor reads
+        # off node.meta["custom"] for stream-affinity scheduling.
+        # Stored on a dedicated attribute so target_values (the
+        # positional rebuild-args tuple) does not have to do double duty.
+        self.annotation = {"stream": stream_idx}
         super().__init__(
-            target_values={"stream": self.get_stream().user_object_index},
+            target_values=(),
             initial_values=None,
             **kwargs,
         )
@@ -347,7 +356,17 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
         # to stream, from stream is the order of the arguments
         # we are entering the target, and leaving the initial stream
         tx.symbolic_stream_state.enter_stream(self.get_stream())
-        return super().enter(tx)
+        # Eagerly annotate + preserve_node_meta; this ensures the captured
+        # nodes have appropriate node.meta["custom"]["stream"] annotations.
+        # We inlined this part of FxTracebackAnnotateVariable because
+        # FxTracebackAnnotateVariable uses self.target_values for the
+        # annotation and for us target_values is a tuple of args---and it must
+        # remain a tuple of args for reconstruct_type.
+        stack = contextlib.ExitStack()
+        stack.enter_context(torch.fx.traceback.annotate(self.annotation))
+        stack.enter_context(torch.fx.traceback.preserve_node_meta())
+        self.set_cleanup_hook(tx, lambda: stack.close())
+        return ConstantVariable.create(None)
 
     def exit(
         self, tx: "InstructionTranslatorBase", *args: VariableTracker
@@ -362,6 +381,62 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
 
     def supports_graph_breaks(self) -> bool:
         return True
+
+    def reconstruct_type(self, codegen: "PyCodegen") -> None:
+        # Bypass FxTracebackAnnotateVariable.reconstruct_type's
+        # unconditional Unsupported("annotate escaped from compiled
+        # region") raise (it would otherwise fire via
+        # WithExitFunctionVariable.reconstruct -> self.ctx.reconstruct_type
+        # on every graph break inside with torch.cuda.stream(s): and
+        # silently drop the post-break body).
+        #
+        # Instead, push a 0-arg callable that returns the ctx mgr value
+        # at runtime: functools.partial(torch.cuda.stream, <Stream>).
+        # The partial is installed as a global on the compiled function
+        # so the resume prologue can LOAD_GLOBAL it.  The standard
+        # ContextWrappingVariable.reconstruct contract then emits
+        # CALL 0 (target_values is empty), invoking the partial to
+        # produce a fresh StreamContext just in time for the prologue's
+        # BEFORE_WITH.
+        #
+        # functools.partial (rather than a freshly-defined closure)
+        # is critical: dynamo retraces the resume prologue and a
+        # closure defined inside torch/_dynamo would be classified as
+        # MOD_SKIPLIST'd and refuse-to-trace, breaking the prologue.
+        # functools.partial is a builtin that dynamo handles
+        # natively, and the wrapped target is the plainly-traceable
+        # torch.cuda.stream(<Stream>) call.
+        #
+        # Using install_global_by_id (rather than the user-object
+        # table via register_graph_created_object) keeps the value
+        # indirection in user-visible Python globals: dynamo retraces
+        # the prologue and sees LOAD_GLOBAL ; CALL 0 to a partial,
+        # which lowers cleanly without any torch/_dynamo internal
+        # functions on the call path -- no ResumePrologueTracingError.
+        import functools
+
+        # self.stream is None when we're really a StreamVariable
+        # entering itself as a ctx mgr (with foo: where foo is a
+        # bare Stream), in which case self IS the stream and
+        # self.value holds it.  Otherwise we're a true
+        # StreamContextVariable wrapping someone else's StreamVariable
+        # and the value lives on the wrapped stream.
+        if self.stream is not None:
+            stream_value = self.stream.value
+        else:
+            stream_value = getattr(self, "value", None)
+        if stream_value is None:
+            raise AssertionError(
+                "StreamContextVariable.reconstruct_type called without a "
+                "stream value to rebuild; this should be impossible for "
+                "a properly-constructed ctx manager."
+            )
+
+        thunk = functools.partial(torch.cuda.stream, stream_value)
+        name = codegen.tx.output.install_global_by_id(
+            "_stream_ctx_thunk", thunk
+        )
+        codegen.append_output(codegen.create_load_global(name, add=True))
 
     def get_stream(self) -> "StreamVariable":
         if not self.stream:

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -1,5 +1,6 @@
 import collections
 import contextlib
+import functools
 from collections.abc import Callable
 from typing import Any, Optional
 
@@ -384,7 +385,6 @@ class StreamContextVariable(ContextWrappingVariable):
         # Instead, we push a 0-arg callable that returns the ctx mgr value
         # at runtime.  The partial is installed as a global on the compiled
         # function so the resume prologue can LOAD_GLOBAL it.
-        import functools
 
         # self.stream is None when we're really a StreamVariable
         # entering itself as a ctx mgr (with foo: where foo is a


### PR DESCRIPTION
Upstream #166472 ('[user-streams] Switch to fx annotations at trace time') changed `StreamContextVariable.target_values` from a positional list [stream_var] to a dict {"stream": idx} so that StreamContextVariable.enter() (inherited from FxTracebackAnnotateVariable.enter) could feed it to torch.fx.traceback.annotate.  That broke three other consumers of target_values -- output_graph.py's stack_ctx_args / locals_ctx_args population, the base
ContextWrappingVariable.reconstruct, and
BlockStackEntry.resume_fn -> ReenterWith.try_finally -- all of which iterate it as a positional tuple.  tuple({"stream": 3}) flattens to ("stream",): the int index is silently dropped and the rebuild call ends up as e.g. torch.cuda.stream("stream"), which fails with a confusing device-string parse error.

The breakage has been latent since #166472 because FxTracebackAnnotateVariable.reconstruct_type raises Unsupported("torch.fx.traceback.annotate escaped from compiled region") unconditionally, short-circuiting the rebuild before the dict-vs-positional mismatch can surface.  The visible symptom is a silent ungraceful graph break that drops the post-break body when a graph break occurs inside with torch.cuda.stream(s):.

This fix structurally separates the two purposes of target_values:

  * self.annotation = {"stream": idx} is a new dedicated field that enter() passes to torch.fx.traceback.annotate.
  * target_values = () keeps the positional rebuild contract happy.

Then StreamContextVariable.reconstruct_type is overridden to push a 0-arg callable -- functools.partial(torch.cuda.stream, <Stream>) -- installed as a global on the compiled function via OutputGraph.install_global_by_id.  The base
ContextWrappingVariable.reconstruct appends CALL 0 (target_values is empty), invoking the partial to produce a fresh StreamContext just in time for the resume prologue's BEFORE_WITH.

functools.partial (rather than a freshly-defined closure) is critical: dynamo retraces the resume prologue, and a closure defined inside torch/_dynamo would be classified as MOD_SKIPLIST'd and refuse-to-trace, breaking the prologue.  functools.partial is a builtin that dynamo handles natively, and the wrapped target (torch.cuda.stream) is plainly traceable.

enter() is also inlined (rather than inherited from FxTracebackAnnotateVariable.enter) because the parent passes self.target_values to annotate, but target_values is now the positional rebuild-args tuple; the annotation dict lives on self.annotation.  reconstruct_type is overridden alongside to bypass FxTracebackAnnotateVariable.reconstruct_type's unconditional Unsupported raise.

Regression test added at
test/dynamo/test_streams.py::test_target_values_dict_round_trips_through_graph_break: graph break inside with torch.cuda.stream(s):, asserts two graph fragments are captured (rather than the post-break body being silently dropped to eager).  Whole test_streams.py suite: 68 pass, 7 platform-skipped, no regressions.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98