### PR TITLE
Fix index ops on expanded tensors in Inductor

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10693,6 +10693,38 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         x = torch.randn(1, 2048, dtype=torch.float32)
         self.common(fn, (x,))
 
+    def test_index_ops_on_expanded_tensor(self):
+        def make_input(src):
+            return torch.zeros(1, src.size(1), device=src.device).expand(
+                src.size(0) + 1, -1
+            )
+
+        def check(fn):
+            idx = torch.tensor([0, 1, 0], device=self.device)
+            src = torch.ones(3, 8, device=self.device)
+            self.common(fn, (idx, src), check_lowp=False)
+
+        check(lambda idx, src: make_input(src).index_add(0, idx, src))
+        check(lambda idx, src: make_input(src).index_copy(0, idx[:2], src[:2]))
+        check(lambda idx, src: make_input(src).index_fill(0, idx[:2], 1.0))
+        check(lambda idx, src: make_input(src).index_put((idx,), src, accumulate=True))
+        check(
+            lambda idx, src: make_input(src).index_put(
+                (idx[:2],), src[:2], accumulate=False
+            )
+        )
+
+    def test_index_ops_on_expanded_tensor_dim1(self):
+        def fn(idx, src):
+            x = torch.zeros(src.size(0), 1, device=src.device).expand(
+                -1, src.size(1) + 5
+            )
+            return x.index_add(1, idx, src)
+
+        idx = torch.tensor([0, 2, 0], device=self.device)
+        src = torch.ones(4, 3, device=self.device)
+        self.common(fn, (idx, src), check_lowp=False)
+
     def test_adding_tensor_offsets(self):
         @torch.compile(fullgraph=True)
         def fn(x):

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -946,6 +946,9 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
         if get_node_storage(mutated_arg) is None:
             return False
 
+        if torch._debug_has_internal_overlap(mutated_arg.meta["val"]) == 1:
+            return False
+
         shared_view_nodes = storage_to_nodes[get_node_storage(mutated_arg)]
 
         # Only keep tensor that might overlap with mutated_arg.


### PR DESCRIPTION

Fixes #183986.

## What

This fixes silent wrong results for `torch.compile(..., backend="inductor")` when `index_add`, `index_copy`, `index_fill`, or `index_put` writes into an expanded tensor with internal overlap, such as a stride-0 dimension from `.expand()`.

## Why

Inductor's reinplace pass can turn functional indexed writes into in-place indexed writes when it decides the mutation is not observable. That is unsafe for expanded tensors with internal overlap: distinct logical indices can alias the same physical storage, so writes that should target different logical rows collide.

For example, writing into `torch.zeros(1, 8).expand(4, -1)` can incorrectly accumulate into the shared backing row and then expose that value through every expanded row.

`index_fill` also tried to preserve the input strides after lowering through `index_copy`. For overlapping expanded inputs, eager returns a materialized non-overlapping result instead, so preserving the stride-0 layout is not correct.

## How

The fix has two parts:

1. Prevent the Inductor reinplace pass from reinplacing an operation when the candidate mutated argument has definite internal overlap.
2. Update the `index_fill` reference decomposition so it only preserves strides for non-overlapping inputs.

Regression tests cover expanded tensor destinations for:
- `index_add`
- `index_copy`
- `index_fill`
- `index_put(..., accumulate=True)`
- `index_put(..., accumulate=False)`

They also include an `index_add` case indexing along a non-expanded dimension while the destination still contains a stride-0 expanded dimension.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos