### PR TITLE
Forward CXX compiler to nvcc as host compiler for GCC too

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -47,10 +47,10 @@ endif()
 
 # Enable CUDA language support
 set(CUDAToolkit_ROOT "${CUDA_TOOLKIT_ROOT_DIR}")
-# Pass clang as host compiler, which according to the docs
+# Pass clang or g++ as host compiler, which according to the docs
 # Must be done before CUDA language is enabled, see
 # https://cmake.org/cmake/help/v3.15/variable/CMAKE_CUDA_HOST_COMPILER.html
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang|GNU")
   set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}")
 endif()
 enable_language(CUDA)


### PR DESCRIPTION
cuda.cmake sets CMAKE_CUDA_HOST_COMPILER to CMAKE_CXX_COMPILER only when the C++ compiler is Clang. With GCC, nvcc was left to its default and picks up bare `g++`, which in my case was GCC 10 even though CXX=g++-14 was set to override it.

CUDA 13's CCCL headers (cuda::std::optional and friends) break on GCC 10 with "internal compiler error: in tsubst_pack_expansion".

Extend the existing clause to also match GNU, so that nvcc will use the same host compiler as the rest of the build.