### PR TITLE
Fix int64 index expressions in Triton codegen

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7927,8 +7927,8 @@ class CommonTemplate:
                 )
 
             # test broadcasted shape bail
-            fn = lambda x: x + torch.zeros(  # noqa: E731
-                [256, 256, 256], dtype=lowp_dtype, device=self.device
+            fn = lambda x: (  # noqa: E731
+                x + torch.zeros([256, 256, 256], dtype=lowp_dtype, device=self.device)
             )
             out, source_codes = run_and_get_code(foo_opt, inps[0], inps[1], fn)
             self.assertEqual(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3343,6 +3343,20 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(14),))
 
+    @skip_if_triton_cpu
+    @skip_if_cpu
+    def test_arange_int64_mul_overflow(self):
+        def fn(x):
+            return torch.arange(
+                0, 9, device=x.device, dtype=torch.int64
+            ) * torch.tensor(
+                [1500000000],
+                dtype=torch.int64,
+                device=x.device,
+            )
+
+        self.common(fn, (torch.zeros(1),))
+
     def test_arange4(self):
         def fn(x):
             return x - torch.arange(512, -512, -1.0, device=x.device)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1071,7 +1071,9 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
             )
         )
 
-    def index_to_str(self, index: sympy.Expr) -> str:
+    def index_to_str(
+        self, index: sympy.Expr | list[sympy.Expr], dtype: torch.dtype | None = None
+    ) -> str:
         """
         Convert an index expr to a string that can be used in output code.
         e.g. a sympy expression "s2" may actually appear as "ks1" in the generated kernel.
@@ -1081,7 +1083,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         new parameters to the function signature.
         """
         if isinstance(index, list):
-            return f"[{', '.join(map(self.index_to_str, index))}]"
+            return f"[{', '.join(self.index_to_str(i, dtype=dtype) for i in index)}]"
         return self.kexpr(self.rename_indexing(index))  # type: ignore[call-arg]
 
     def prepare_indexing(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1118,6 +1118,18 @@ class TritonPrinter(PythonPrinter):  # noqa: docstring_linter
 texpr = TritonPrinter().doprint
 
 
+class TritonIndexExprPrinter(TritonPrinter):
+    def __init__(self, integer_dtype: str) -> None:
+        super().__init__()
+        self.integer_dtype = integer_dtype
+
+    def _print_Symbol(self, expr: sympy.Expr) -> str:
+        result = super()._print_Symbol(expr)  # pyrefly: ignore [missing-attribute]
+        if expr.is_integer:
+            return f"({result}).to({self.integer_dtype})"
+        return result
+
+
 def triton_compute_type(dtype: torch.dtype) -> str:
     """Convert torch.dtype to triton type and upcast [b]float16 to float32"""
     return triton_type(upcast_compute_type(dtype))
@@ -2342,7 +2354,10 @@ class TritonKernelOverrides(TritonOverrides):
     def index_expr(cls, expr, dtype):
         expr = _materialize_trunc_to_float_expr(expr, dtype)
         indexing = V.kernel.indexing(
-            expr, block_ptr=False, tma_compatibility_checker=None
+            expr,
+            expr_dtype=dtype,
+            block_ptr=False,
+            tma_compatibility_checker=None,
         )
         assert isinstance(indexing, IndexingOptions)
 
@@ -2351,11 +2366,6 @@ class TritonKernelOverrides(TritonOverrides):
             shape = indexing.expand_shape
         else:
             shape = TritonSymbols.get_block_shape(indexing.index)
-
-        # Our sympy expr printing casts to the current kernel index dtype.
-        # we only respect non int32-int64 dtypes and otherwise use current kernel indexing dtype
-        index_dtype = V.kernel.get_index_dtype_as_torch_dtype()
-        dtype = dtype if dtype not in (torch.int32, torch.int64) else index_dtype
 
         # after we emit this var we cast it to the correct dtype
         orig = config.test_configs.runtime_triton_dtype_assert
@@ -2371,6 +2381,7 @@ class TritonKernelOverrides(TritonOverrides):
         finally:
             config.test_configs.runtime_triton_dtype_assert = orig
 
+        # Use the requested dtype for value-producing index expressions.
         if dtype not in (torch.int32, torch.int64):
             var = V.kernel.cse.generate(
                 V.kernel.compute,
@@ -2380,23 +2391,32 @@ class TritonKernelOverrides(TritonOverrides):
             )
         else:
             # TODO: we are not always consistent in enforcing that the output of the index expr printing
-            # results in the indexing dtype. So if we detect that we have an input which might type promote
-            # to a dtype other than indexing dtype, add a cast.
-            # Trying to avoid
-            dtype = index_dtype
+            # results in the requested dtype. So if we detect that we have an input which might type promote
+            # to a dtype other than requested dtype, add a cast.
+            actual_dtype = dtype
             for index_var in expr.free_symbols:
                 if symbol_is_type(index_var, SymT.TMP):
-                    dtype = torch.promote_types(
-                        dtype, V.kernel.cse.varname_map[index_var.name].dtype
+                    actual_dtype = torch.promote_types(
+                        actual_dtype, V.kernel.cse.varname_map[index_var.name].dtype
                     )
 
-            if dtype != index_dtype:
+            if actual_dtype != dtype:
                 var = V.kernel.cse.generate(
                     V.kernel.compute,
-                    cls.to_dtype(var, index_dtype),
-                    dtype=index_dtype,
+                    cls.to_dtype(var, dtype),
+                    dtype=dtype,
                     shape=var.shape,
                 )
+
+        if dtype in (torch.int32, torch.int64) and var.dtype != dtype:
+            # CSE keys do not include dtype, so the same printed expression can
+            # reuse an earlier variable recorded with the kernel index dtype.
+            var = V.kernel.cse.generate(
+                V.kernel.compute,
+                cls.to_dtype(var, dtype),
+                dtype=dtype,
+                shape=var.shape,
+            )
 
         var.mask_vars = indexing.mask_vars
         return var
@@ -3026,6 +3046,18 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     )
     transpose_discontiguous_tensor_descriptors_override: bool | None = None
 
+    def index_to_str(self, index: sympy.Expr, dtype: torch.dtype | None = None) -> str:
+        if isinstance(index, list):
+            return f"[{', '.join(self.index_to_str(i, dtype=dtype) for i in index)}]"
+
+        renamed = self.rename_indexing(index)
+        if dtype is not None and (
+            dtype in (torch.int32, torch.int64)
+            and dtype != self.get_index_dtype_as_torch_dtype()
+        ):
+            return TritonIndexExprPrinter(triton_type(dtype)).doprint(renamed)
+        return self.kexpr(renamed)  # type: ignore[arg-type]
+
     def __init__(
         self,
         tiling: dict[str, sympy.Expr],
@@ -3270,6 +3302,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         copy_shape: str | tuple[str] | None = None,
         dense_indexing=False,
         override_mask=None,
+        expr_dtype: torch.dtype | None = None,
         block_ptr=False,
         tma_compatibility_checker: TMACompatibilityChecker | None = None,
         mask_constant_index=False,
@@ -3613,7 +3646,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 return options
         expand_str = None
         expand_shape: BlockShapeType = None
-        index_str = self.index_to_str(index)
+        index_str = self.index_to_str(index, dtype=expr_dtype)
+        if expr_dtype is not None and expr_dtype in (torch.int32, torch.int64):
+            index_str_dtype = triton_type(expr_dtype)
+        else:
+            index_str_dtype = "tl.int32"
 
         def _get_expand_str():
             if copy_shape:
@@ -3642,7 +3679,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 expand_str = str([1] * len(self.dense_size_list()))
                 expand_shape = tuple([1] * len(self.dense_size_list()))
 
-            index_str = f"tl.full({expand_str}, {index_str}, tl.int32)"
+            index_str = f"tl.full({expand_str}, {index_str}, {index_str_dtype})"
             if self.fixed_config or self.is_combo_kernel or mask_constant_index:
                 mask_vars = OrderedSet(
                     tree.mask_name()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1126,6 +1126,8 @@ class TritonIndexExprPrinter(TritonPrinter):
     def _print_Symbol(self, expr: sympy.Expr) -> str:
         result = super()._print_Symbol(expr)  # pyrefly: ignore [missing-attribute]
         if expr.is_integer:
+            # Cast integer leaves before arithmetic so requested int64 math
+            # does not overflow in the kernel's default index dtype.
             return f"({result}).to({self.integer_dtype})"
         return result
 
@@ -3046,16 +3048,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     )
     transpose_discontiguous_tensor_descriptors_override: bool | None = None
 
-    def index_to_str(self, index: sympy.Expr, dtype: torch.dtype | None = None) -> str:
+    def index_to_str(
+        self, index: sympy.Expr | list[sympy.Expr], dtype: torch.dtype | None = None
+    ) -> str:
         if isinstance(index, list):
             return f"[{', '.join(self.index_to_str(i, dtype=dtype) for i in index)}]"
 
         renamed = self.rename_indexing(index)
-        if dtype is not None and (
-            dtype in (torch.int32, torch.int64)
-            and dtype != self.get_index_dtype_as_torch_dtype()
-        ):
-            return TritonIndexExprPrinter(triton_type(dtype)).doprint(renamed)
+        if dtype in (torch.int32, torch.int64):
+            if dtype != self.get_index_dtype_as_torch_dtype():
+                return TritonIndexExprPrinter(triton_type(dtype)).doprint(renamed)
         return self.kexpr(renamed)  # type: ignore[arg-type]
 
     def __init__(

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -240,14 +240,7 @@ class DtypePropagationOpsHandler:
 
     @staticmethod
     def index_expr(expr: sympy.Expr, dtype: torch.dtype) -> torch.dtype:
-        # TODO - TODO - rationalize index_expr. The dtype is not always used and we are inconsistent about int32 or int64
-        # in lowerings. cpp just uses the dtype
-        if dtype not in (torch.int32, torch.int64) or not hasattr(
-            V.kernel, "index_dtype"
-        ):
-            return upcast_compute_type(dtype)
-
-        return V.kernel.get_index_dtype_as_torch_dtype()
+        return upcast_compute_type(dtype)
 
     @staticmethod
     def to_dtype(

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1658,6 +1658,7 @@ class TritonTemplateKernel(TritonKernel):
         dense_indexing=False,
         copy_shape=None,
         override_mask=None,
+        expr_dtype: torch.dtype | None = None,
         block_ptr=False,
         tma_compatibility_checker: TMACompatibilityChecker | None = None,
         mask_constant_index=False,
@@ -1673,6 +1674,7 @@ class TritonTemplateKernel(TritonKernel):
             # the mask might be broadcast to the output shape
             copy_shape=self.template_out_shape,
             override_mask=self.template_mask,
+            expr_dtype=expr_dtype,
             block_ptr=block_ptr,
             tma_compatibility_checker=tma_compatibility_checker,
             mask_constant_index=mask_constant_index,


### PR DESCRIPTION
Fixes #183901.
**Why**

`torch.compile` could silently produce wrong CUDA results for `int64` arange expressions. In the issue repro, `torch.arange(..., dtype=torch.int64) * 1500000000` compiled through Inductor/Triton overflowed as if the multiplication happened in `int32`, even though eager correctly computed `int64` values.

**How**

Inductor’s Triton codegen was treating value-producing `index_expr`s with `int32`/`int64` dtype as the kernel index dtype. For small kernels that index dtype is often `int32`, so the generated expression became int32 arithmetic before being stored to an int64 tensor.

This change preserves the requested dtype for value-producing Triton `index_expr`s. When an expression is requested as `int64`, integer symbols are cast before arithmetic so operations like the large multiply execute in `tl.int64`.

**What**

- Fixes Triton codegen for value-producing `int64` index expressions.
- Updates `index_expr` dtype propagation to return the requested compute dtype.
- Adds a CUDA regression test for #183901 covering int64 arange multiplied by a large int64 constant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos