### PR TITLE
Fix deterministic selection for extern callers

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -80,6 +80,41 @@ def patches(fn):
     return wrapped
 
 
+class TestAlgorithmSelectorChoiceTypes(TestCase):
+    def _extern_kernel_caller(self, name):
+        choice = ExternKernelChoice.lookup(name)
+        if choice is None:
+            self.fail(f"missing extern kernel choice: {name}")
+        return choice.bind(input_nodes=[], layout=None)
+
+    def test_pick_deterministic_choice_prefers_extern_kernel_caller(self):
+        first_choice = select_algorithm.ChoiceCaller("not_extern", [], None, "")
+        extern_choice = self._extern_kernel_caller("mm")
+
+        picked = select_algorithm.AlgorithmSelectorCache().pick_deterministic_choice(
+            [first_choice, extern_choice]
+        )
+
+        self.assertIs(picked, extern_choice)
+
+    def test_classify_kernel_operation_uses_extern_kernel_caller_name(self):
+        cases = (
+            ("mm", "mm"),
+            ("addmm", "mm"),
+            ("convolution", "conv"),
+        )
+        for choice_name, expected in cases:
+            with self.subTest(choice_name=choice_name):
+                extern_choice = self._extern_kernel_caller(choice_name)
+
+                self.assertEqual(
+                    select_algorithm._classify_kernel_operation(
+                        "unclassified_name", [extern_choice], []
+                    ),
+                    expected,
+                )
+
+
 class TestSelectAlgorithm(TestCase):
     def setUp(self):
         super().setUp()

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3647,7 +3647,7 @@ def _classify_kernel_operation(
                 elif template_name.startswith("flex_"):
                     return "flex"
 
-            elif isinstance(choice, ExternKernelChoice):
+            elif isinstance(choice, ExternKernelCaller):
                 # Check extern kernel names
                 choice_name = choice.name
                 if choice_name in (
@@ -3771,7 +3771,7 @@ class AlgorithmSelectorCache(PersistentCache):
     def pick_deterministic_choice(self, choices: list[ChoiceCaller]) -> ChoiceCaller:
         assert len(choices) >= 2
         externs = [
-            choice for choice in choices if isinstance(choice, ExternKernelChoice)
+            choice for choice in choices if isinstance(choice, ExternKernelCaller)
         ]
         if len(externs) > 0:
             return externs[0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184493

Use ExternKernelCaller when detecting bound extern choices in Inductor's deterministic selector and kernel classifier.

Fixes #184416

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo