### PR TITLE
Fix pad_mm getitem traversal

### DIFF
--- a/test/inductor/test_pad_mm_utils.py
+++ b/test/inductor/test_pad_mm_utils.py
@@ -1,0 +1,20 @@
+# Owner(s): ["module: inductor"]
+import operator
+
+import torch
+from torch._inductor.fx_passes.pad_mm import get_non_view_def
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class PadMMUtilsTest(TestCase):
+    def test_get_non_view_def_traverses_getitem(self):
+        graph = torch.fx.Graph()
+        arg = graph.placeholder("arg")
+        sort = graph.call_function(torch.ops.aten.sort.default, (arg,))
+        getitem = graph.call_function(operator.getitem, (sort, 0))
+
+        self.assertIs(get_non_view_def(getitem), sort)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -362,7 +362,7 @@ def should_pad_bench_key(
 
 
 def get_non_view_def(node: torch.fx.Node) -> torch.fx.Node:
-    if node.op is operator.getitem:
+    if node.op == "call_function" and node.target is operator.getitem:
         return get_non_view_def(node.args[0])  # type: ignore[arg-type]
 
     if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184495

Recognize FX getitem nodes by their call_function target so pad_mm traces through multi-output producers when deciding whether padding time can be excluded.

Fixes #184410

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos