### PR TITLE
[profiler] Propagate record_funtion_id from TorchOp ancestor to Kinet…

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -368,6 +368,19 @@ struct AddGenericMetadata : public MetadataBase {
     addMetadata("Total Reserved", std::to_string(alloc.total_reserved_));
   }
 
+  // - for Kineto events, write the propagated rf_id when the underlying
+  // activity is writable
+  // - CUPTI GPU kernel activities have kineto_activity_ == nullptr so
+  // addMetadata is a no-op for them
+  // - CUDA runtime activities (GenericTraceActivity) do have it
+  void operator()(const ExtraFields<EventType::Kineto>& kineto_event) {
+    if (kineto_event.record_function_id_ != 0) {
+      addMetadata(
+          "Record function id",
+          std::to_string(kineto_event.record_function_id_));
+    }
+  }
+
   template <typename T>
   void operator()(const T& /*unused*/) {}
 

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -973,6 +973,7 @@ class TransferEvents {
     reassociate();
     extractEventsFromTrace();
     setParents();
+    propagateRfIds();
   }
 
  private:
@@ -1218,6 +1219,31 @@ class TransferEvents {
       if (e->parent_.expired()) {
         setKinetoTID(e, nullptr);
       }
+    }
+  }
+
+  // Walk up the parent chain from Kineto GPU/runtime events to find the nearest
+  // TorchOp ancestor and copy its record_function_id.
+  void propagateRfIds() {
+    for (auto& e : results_.get()) {
+      e->visit(c10::overloaded(
+          [&](ExtraFields<EventType::Kineto>& i) {
+            auto parent = e->parent_.lock();
+            while (parent) {
+              bool found = false;
+              parent->visit(c10::overloaded(
+                  [&](const ExtraFields<EventType::TorchOp>& op) {
+                    i.record_function_id_ = op.record_function_id_;
+                    found = true;
+                  },
+                  [](const auto&) {}));
+              if (found) {
+                break;
+              }
+              parent = parent->parent_.lock();
+            }
+          },
+          [](auto&) {}));
     }
   }
 

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -366,6 +366,7 @@ struct ExtraFields<EventType::Kineto> {
   std::string name_;
   int64_t duration_ns_{0};
   uint64_t correlation_id_{0};
+  uint64_t record_function_id_{0};
   libkineto::ActivityType activity_type_;
   Flow flow;
   std::weak_ptr<Result> linked_activity_;


### PR DESCRIPTION
When profiling GPU workloads, Kineto GPU kernel and CUDA runtime activities do not carry any record_function_id, making it impossible to correlate them back to the originating TorchOp in the profiler output. This matters for tools that consume profiler traces and need to reconstruct the execution graph: without the rf_id on GPU activities, the link between a high-level operator (e.g. aten::mm) and the kernel it actually launched on device is lost, forcing consumers to rely on fragile heuristics or correlation IDs alone.

This adds a propagateRfIds() pass in TransferEvents that walks each Kineto event's parent chain to find the nearest TorchOp ancestor and copies its record_function_id. The id is then emitted as 'Record function id' metadata in AddGenericMetadata so it appears in the Kineto trace alongside the activity.