### PR TITLE
[MPS] Fix Inductor undeclared identifier in multi-pass welford reductions

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -222,6 +222,22 @@ class MPSBasicTests(TestCase):
         torch._dynamo.mark_dynamic(x, 1)
         self.assertEqual(fn(x), x.var(dim=-1))
 
+    def test_welford_multistage_sibling_redeclare(self):
+        # Regression test: BatchNorm2d-train emits two codegen passes on
+        # the same multistage reduction root (welford + running-stats
+        # update). Sibling indices (r0_1, r0_2) declared via the
+        # root_already_processed branch must be redeclared in the second
+        # loop scope; otherwise Metal compilation fails with
+        # "use of undeclared identifier 'r0_2'".
+        torch.manual_seed(0)
+        bn_ref = torch.nn.BatchNorm2d(8).train()
+        bn_mps = torch.nn.BatchNorm2d(8).to(self.device).train()
+        bn_mps.load_state_dict(bn_ref.state_dict())
+        x = torch.randn(4, 8, 32, 32)
+        y_ref = bn_ref(x)
+        y_mps = torch.compile(bn_mps)(x.to(self.device))
+        self.assertEqual(y_mps.cpu(), y_ref)
+
     def test_sdpa_split_qkv(self):
         # regression test for metal compiler bug where fused (x / A) % B
         # produces wrong results, causing incorrect reads from non-contiguous.

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -927,8 +927,11 @@ class MetalKernel(SIMDKernel):
                 )
             )
             # And loop codegen
-            while self.multistage_reduction_entry:
-                self.multistage_reduction_entry.pop().cache_clear()
+            roots = [e.root for e in self.multistage_reduction_entry]
+            self.multistage_reduction_entry.clear()
+            for node in self.range_tree_nodes.values():
+                if any(node.root is r for r in roots):
+                    node.cache_clear()
         else:
             self.body.splice(self.loads)
             self.body.splice(self.compute)


### PR DESCRIPTION
Sibling indices declared via the `root_already_processed` branch weren't being cache-cleared between codegen passes, so the second multistage loop on the same reduction root skipped their redeclaration

Reproducer:
```
import torch, torch.nn as nn
m = torch.compile(nn.BatchNorm2d(8).to("mps").train())
m(torch.randn(4, 8, 32, 32, device="mps"))
```

would fail with:
```
torch._inductor.exc.InductorError: SyntaxError: failed to compile #include <c10/metal/reduction_utils.h>
#include <c10/metal/utils.h>


    [[max_total_threads_per_threadgroup(1024)]]
    kernel void generated_kernel_0(
        device float* out_ptr0,
        device float* out_ptr2,
        device float* out_ptr4,
        device float* out_ptr6,
        device float* out_ptr7,
        constant float* in_ptr0,
        constant float* in_ptr1,
        constant float* in_ptr2,
        constant float* in_ptr3,
        constant float* in_ptr4,
        uint2 thread_pos [[thread_position_in_grid]],
        uint2 group_pos [[thread_position_in_threadgroup]]
    ) {
        auto xindex = thread_pos.x;
        auto r0_index = thread_pos.y;
        int x0 = xindex;
        threadgroup float3 tmp_acc_0[1024];
        tmp_acc_0[r0_index * 1] = 0.0;
        for(auto r0__cnt = 0; r0__cnt < 4; ++r0__cnt) {
            int r0__linear_idx = 4 * r0_index + r0__cnt;
            int r0_1 = (r0__linear_idx) % (1024);
            int r0_2 = c10::metal::floor_divide(r0__linear_idx, 1024);
            auto tmp0 = in_ptr0[r0_1 + 1024*x0 + 8192*r0_2];
            tmp_acc_0[r0_index * 1] = ::c10::metal::welford_combine(tmp_acc_0[r0_index * 1], float3(tmp0, 0.0, 1.0));
        }
        auto tmp1 = c10::metal::threadgroup_welford_combine(tmp_acc_0, 1024);
        if (r0_index == 0) out_ptr0[x0] = static_cast<float>(tmp1.x);
        auto tmp11 = in_ptr1[x0];
        auto tmp16 = in_ptr2[x0];
        auto tmp2 = 4096.0;
        auto tmp3 = tmp1.y / tmp2;
        auto tmp4 = 1e-05;
        auto tmp5 = tmp3 + tmp4;
        auto tmp6 = metal::precise::rsqrt(tmp5);
        auto tmp7 = 1.0002442002442002;
        auto tmp8 = tmp3 * tmp7;
        auto tmp9 = 0.1;
        auto tmp10 = tmp8 * tmp9;
        auto tmp12 = 0.9;
        auto tmp13 = tmp11 * tmp12;
        auto tmp14 = tmp10 + tmp13;
        auto tmp15 = tmp1.x * tmp9;
        auto tmp17 = tmp16 * tmp12;
        auto tmp18 = tmp15 + tmp17;
        out_ptr2[x0] = static_cast<float>(tmp6);
        out_ptr4[x0] = static_cast<float>(tmp14);
        out_ptr6[x0] = static_cast<float>(tmp18);
        for(auto r0__cnt = 0; r0__cnt < 4; ++r0__cnt) {
            int r0__linear_idx = 4 * r0_index + r0__cnt;
            int r0_1 = (r0__linear_idx) % (1024);
            auto tmp19 = in_ptr0[r0_1 + 1024*x0 + 8192*r0_2];
            auto tmp22 = in_ptr3[x0];
            auto tmp24 = in_ptr4[x0];
            auto tmp20 = tmp19 - tmp1.x;
            auto tmp21 = tmp20 * tmp6;
            auto tmp23 = tmp21 * tmp22;
            auto tmp25 = tmp23 + tmp24;
            out_ptr7[r0_1 + 1024*x0 + 8192*r0_2] = static_cast<float>(tmp25);
        }
    }




    kernel void generated_kernel_1(
        device long* out_ptr1,
        constant long* in_ptr0,
        uint xindex [[thread_position_in_grid]]
    ) {
        auto tmp0 = in_ptr0[0];
        auto tmp1 = 1;
        auto tmp2 = tmp0 + tmp1;
        out_ptr1[0] = static_cast<long>(tmp2);
    }

 with program_source:1081:56: error: use of undeclared identifier 'r0_2'; did you mean 'r0_1'?
            auto tmp19 = in_ptr0[r0_1 + 1024*x0 + 8192*r0_2];
                                                       ^~~~
                                                       r0_1
program_source:1080:17: note: 'r0_1' declared here
            int r0_1 = (r0__linear_idx) % (1024);
                ^
program_source:1088:44: error: use of undeclared identifier 'r0_2'; did you mean 'r0_1'?
            out_ptr7[r0_1 + 1024*x0 + 8192*r0_2] = static_cast<float>(tmp25);
                                           ^~~~
                                           r0_1
program_source:1080:17: note: 'r0_1' declared here
            int r0_1 = (r0__linear_idx) % (1024);
                ^


Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo