### PR TITLE
Add a switch to control KernelContext object

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6080,12 +6080,11 @@ class AOTInductorTestsTemplate:
             )
             shim_fn_codes = f'RAIIAtenRecordFunctionHandle .*\\("{kernel_calls}"'
             if enable_kernel_profile:
-                file_check = FileCheck().check_regex(shim_fn_codes)
                 if enable_kernel_context_guard:
-                    file_check.check("KernelContextGuard")
+                    FileCheck().check("KernelContextGuard").run(code)
                 else:
-                    file_check.check_not("KernelContextGuard")
-                file_check.run(code)
+                    FileCheck().check_not("KernelContextGuard").run(code)
+                FileCheck().check_regex(shim_fn_codes).run(code)
             else:
                 FileCheck().check_not("RAIIAtenRecordFunctionHandle").check_not(
                     "KernelContextGuard"

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6041,9 +6041,7 @@ class AOTInductorTestsTemplate:
     )
     @common_utils.parametrize("enable_kernel_profile", (True, False))
     @common_utils.parametrize("enable_kernel_context_guard", (True, False))
-    def test_aoti_profiler(
-        self, enable_kernel_context_guard, enable_kernel_profile
-    ):
+    def test_aoti_profiler(self, enable_kernel_context_guard, enable_kernel_profile):
         # basic addmm model
         class Model(torch.nn.Module):
             def __init__(self, n, k, device):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6040,7 +6040,10 @@ class AOTInductorTestsTemplate:
         config.triton.native_matmul, "different kernel name when native matmul"
     )
     @common_utils.parametrize("enable_kernel_profile", (True, False))
-    def test_aoti_profiler(self, enable_kernel_profile):
+    @common_utils.parametrize("enable_kernel_context_guard", (True, False))
+    def test_aoti_profiler(
+        self, enable_kernel_context_guard, enable_kernel_profile
+    ):
         # basic addmm model
         class Model(torch.nn.Module):
             def __init__(self, n, k, device):
@@ -6068,15 +6071,27 @@ class AOTInductorTestsTemplate:
             if self.device == GPU_TYPE
             else "aoti_torch_cpu_addmm_out"
         )
-        with config.patch({"cpp.enable_kernel_profile": enable_kernel_profile}):
+        with config.patch(
+            {
+                "cpp.enable_kernel_profile": enable_kernel_profile,
+                "cpp.enable_kernel_context_guard": enable_kernel_context_guard,
+            }
+        ):
             _, code = run_and_get_cpp_code(
                 AOTIRunnerUtil.compile, model, example_inputs
             )
             shim_fn_codes = f'RAIIAtenRecordFunctionHandle .*\\("{kernel_calls}"'
             if enable_kernel_profile:
-                FileCheck().check_regex(shim_fn_codes).run(code)
+                file_check = FileCheck().check_regex(shim_fn_codes)
+                if enable_kernel_context_guard:
+                    file_check.check("KernelContextGuard")
+                else:
+                    file_check.check_not("KernelContextGuard")
+                file_check.run(code)
             else:
-                FileCheck().check_not("RAIIAtenRecordFunctionHandle").run(code)
+                FileCheck().check_not("RAIIAtenRecordFunctionHandle").check_not(
+                    "KernelContextGuard"
+                ).run(code)
 
             self.check_model(Model(N, K, self.device), example_inputs)
 

--- a/test/inductor/test_provenance_tracing.py
+++ b/test/inductor/test_provenance_tracing.py
@@ -939,11 +939,38 @@ class ProvenanceTracingKernelContextTemplate:
         _, code = run_and_get_cpp_code(torch._inductor.aoti_compile_and_package, ep)
 
         self.assertTrue("KernelContextGuard" not in code)
+        FileCheck().check_not(
+            "#include <torch/csrc/inductor/aoti_runtime/kernel_context_tls.h>"
+        ).check_not("thread_local KernelContext* tls_kernel_context = nullptr;").run(
+            code
+        )
 
         with config.patch(
             {
                 "trace.provenance_tracking_level": 1,
                 "cpp.enable_kernel_profile": True,
+                "cpp.enable_kernel_context_guard": False,
+            }
+        ):
+            package_path, code = run_and_get_cpp_code(
+                torch._inductor.aoti_compile_and_package, ep
+            )
+
+            FileCheck().check_not(
+                "#include <torch/csrc/inductor/aoti_runtime/kernel_context_tls.h>"
+            ).check_not(
+                "thread_local KernelContext* tls_kernel_context = nullptr;"
+            ).check_not("KernelContextGuard").run(code)
+
+            compiled_model = torch._inductor.aoti_load_package(package_path)
+            result = compiled_model(*example_inputs)
+            self.assertEqual(result, model(*example_inputs))
+
+        with config.patch(
+            {
+                "trace.provenance_tracking_level": 1,
+                "cpp.enable_kernel_profile": True,
+                "cpp.enable_kernel_context_guard": True,
             }
         ):
             package_path, code = run_and_get_cpp_code(

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5710,6 +5710,10 @@ class CppScheduling(BaseScheduling):
             self.codegen_comment(self.kernel_group.scheduled_nodes, kernel_name)
             if config.cpp.enable_kernel_profile:
                 V.graph.wrapper_code.write_kernel_context_guard_begin()
+            if (
+                config.cpp.enable_kernel_profile
+                and config.cpp.enable_kernel_context_guard
+            ):
                 V.graph.wrapper_code.write_kernel_context_guard(
                     kernel_name,
                     self.kernel_group.scheduled_nodes,  # type: ignore[arg-type]

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -515,10 +515,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         if V.graph.aot_mode:
             self._write_aoti_interface_header()
 
-        if (
-            config.cpp.enable_kernel_profile
-            and config.cpp.enable_kernel_context_guard
-        ):
+        if config.cpp.enable_kernel_profile and config.cpp.enable_kernel_context_guard:
             self.header.splice(
                 "#include <torch/csrc/inductor/aoti_runtime/kernel_context_tls.h>"
             )

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -515,7 +515,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
         if V.graph.aot_mode:
             self._write_aoti_interface_header()
 
-        if config.cpp.enable_kernel_profile:
+        if (
+            config.cpp.enable_kernel_profile
+            and config.cpp.enable_kernel_context_guard
+        ):
             self.header.splice(
                 "#include <torch/csrc/inductor/aoti_runtime/kernel_context_tls.h>"
             )
@@ -1724,27 +1727,35 @@ class CppWrapperCpu(PythonWrapperCodegen):
             "linux",
             "win32",
         ]
+        enable_kernel_context_guard = (
+            enable_kernel_profile and config.cpp.enable_kernel_context_guard
+        )
         with debug_printer_manager:
             shim_fn = self.get_c_shim_func_name(kernel, device)
             shim_fn_codes = [
                 f"AOTI_TORCH_ERROR_CODE_CHECK({shim_fn}({', '.join(args)}));"
             ]
             if enable_kernel_profile:
-                stack_trace_str = 'R"('
-                if stack_traces:
-                    for stack_trace in stack_traces:
-                        for line in stack_trace.split("\n"):
-                            stack_trace_str += f"\n{line}"
-                        stack_trace_str += "\n"
-                stack_trace_str += ')"'
-
-                shim_fn_codes = [
-                    "{",
-                    f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});""",
-                    f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
-                    shim_fn_codes[0],
-                    "}",
-                ]
+                call_code = shim_fn_codes[0]
+                shim_fn_codes = ["{"]
+                if enable_kernel_context_guard:
+                    stack_trace_str = 'R"('
+                    if stack_traces:
+                        for stack_trace in stack_traces:
+                            for line in stack_trace.split("\n"):
+                                stack_trace_str += f"\n{line}"
+                            stack_trace_str += "\n"
+                    stack_trace_str += ')"'
+                    shim_fn_codes.append(
+                        f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+                    )
+                shim_fn_codes.extend(
+                    [
+                        f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
+                        call_code,
+                        "}",
+                    ]
+                )
             self.writelines(shim_fn_codes)
 
     def generate_c_shim_extern_kernel_alloc(

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -3118,10 +3118,7 @@ class SIMDScheduling(BaseScheduling):
         self.codegen_comment(base_scheduler_nodes, kernel.kernel_name)
         if config.cpp.enable_kernel_profile:
             V.graph.wrapper_code.write_kernel_context_guard_begin()
-        if (
-            config.cpp.enable_kernel_profile
-            and config.cpp.enable_kernel_context_guard
-        ):
+        if config.cpp.enable_kernel_profile and config.cpp.enable_kernel_context_guard:
             V.graph.wrapper_code.write_kernel_context_guard(
                 kernel.kernel_name,
                 base_scheduler_nodes,

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -3118,6 +3118,10 @@ class SIMDScheduling(BaseScheduling):
         self.codegen_comment(base_scheduler_nodes, kernel.kernel_name)
         if config.cpp.enable_kernel_profile:
             V.graph.wrapper_code.write_kernel_context_guard_begin()
+        if (
+            config.cpp.enable_kernel_profile
+            and config.cpp.enable_kernel_context_guard
+        ):
             V.graph.wrapper_code.write_kernel_context_guard(
                 kernel.kernel_name,
                 base_scheduler_nodes,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1701,6 +1701,11 @@ class cpp:
         os.environ.get("TORCHINDUCTOR_CPP_ENABLE_KERNEL_PROFILE", "0") == "1"
     )
 
+    # Allow emitting KernelContextGuard metadata alongside kernel profiling.
+    enable_kernel_context_guard = (
+        os.environ.get("TORCHINDUCTOR_CPP_ENABLE_KERNEL_CONTEXT_GUARD", "0") == "1"
+    )
+
     # enable weight prepacking to get a better performance; may lead to large memory footprint
     weight_prepack = os.environ.get("TORCHINDUCTOR_CPP_WEIGHT_PREPACK", "1") == "1"
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1702,6 +1702,7 @@ class cpp:
     )
 
     # Allow emitting KernelContextGuard metadata alongside kernel profiling.
+    # This switch only works when enable_kernel_profile is set to 1.
     enable_kernel_context_guard = (
         os.environ.get("TORCHINDUCTOR_CPP_ENABLE_KERNEL_CONTEXT_GUARD", "0") == "1"
     )


### PR DESCRIPTION
KernelContext object added in #160539 introduced extra overhead and generated an excessively long and hard-to-read tracing stack text in some case. This PR add a switch to control the object. 



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo