### PR TITLE
[inductor] Fix scan accumulator default for unsigned integer types (#184514)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3217,6 +3217,14 @@ class CommonTemplate:
                 inp = torch.full((2, n), float("inf"), device=self.device, dtype=_dtype)
                 self.assertEqual(cfn(inp), fn(inp))
 
+    def test_cumsum_uint8(self):
+        def fn(x):
+            return x.cumsum(-1)
+
+        cfn = torch.compile(fn)
+        inp = torch.randint(0, 10, (8, 16), dtype=torch.uint8, device=self.device)
+        self.assertEqual(cfn(inp), fn(inp))
+
     @xfail_if_triton_cpu
     def test_logcumsumexp(self):
         def fn(x):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5601,7 +5601,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 accumulator = self.cse.newvar(dtype=dtype, shape=reduced_size)
                 reduced_size_str = f"[{', '.join(reduced_size)}]"
 
-                default = "float('nan')" if dtype.is_floating_point else "-1"
+                default = "float('nan')" if dtype.is_floating_point else "0"
                 self.body.writeline(
                     f"{accumulator} = tl.full({reduced_size_str}, {default}, {acc_type})"
                 )


### PR DESCRIPTION
Summary:

Issue: Cumulative reduction ops (`cumsum`, `cummax`, `cummin`, `cumprod`) with unsigned integer inputs (e.g., `torch.uint8`) fail during Triton compilation with `get_uint8(): incompatible function arguments`. The same issue affects `uint16` and `uint32`.

Root cause: The Inductor codegen at `triton.py:5056` uses `-1` as the default accumulator value for non-persistent integer scans: `default = "float('nan')" if dtype.is_floating_point else "-1"`. This generates `tl.full([...], -1, tl.uint8)`, which calls `builder.get_uint8(-1)` in Triton's IR builder. The `get_uint8` pybind11 binding takes `uint64_t`, so pybind11 rejects `-1` as an invalid unsigned value. This is the same behavior in upstream Triton — `tl.full(..., -1, tl.uint8)` is not valid Triton code on any backend.

Fix: Changed the default accumulator value from `-1` to `0` in the Inductor codegen. The accumulator is a dead value on the first iteration — it is overwritten before being read (the `tl.where(roffset > 0, ...)` guard at line 5115 selects `partial_scan` on the first iteration, ignoring the accumulator). Changing from `-1` to `0` has no correctness impact.

This fixes the issue at the source (Inductor codegen) rather than working around it in Triton's pybind11 bindings, which would diverge from upstream Triton where `get_uint{8,16,32}` also takes `uint64_t`.

Test Plan:
1) Unit test (regression for the codegen path):

test_cumsum_uint8_no_crash

Result: PASS

2) OSS test (regression for cumsum with uint8 dtype):

  buck2 test fbcode//caffe2/test/inductor:test_inductor -- --regex test_cumsum_uint8

Before fix: FAIL with get_uint8(): incompatible function arguments
After fix: PASS

3) Opinfo compile tests 
After fix : Done. 6 compiled, 0 errors.

4) These 6 cases are added to
   
   so the chronos job will catch any future regression.

Reviewed By: nandesuka

Differential Revision: D104972179


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo