### PR TITLE
Fix CUDA fake mul strides for promoted tensors

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1655,6 +1655,32 @@ class CommonTemplate:
             msg=f"Expected complex add with strided inputs to fall back to extern kernels, got:\n{code}",
         )
 
+    @skipCPUIf(True, "requires CUDA")
+    @requires_cuda_and_triton
+    def test_complex_abs_angle_backward_permuted_stride(self):
+        if not self.is_dtype_supported(torch.complex64):
+            raise unittest.SkipTest("complex64 not supported on device")
+
+        def check(fn, dynamic):
+            x = torch.randn(
+                4,
+                8,
+                dtype=torch.complex64,
+                device=self.device,
+                requires_grad=True,
+            )
+            eager_x = x.detach().clone().requires_grad_(True)
+
+            fn(eager_x).backward()
+            torch.compile(fn, backend="inductor", dynamic=dynamic)(x).backward()
+
+            self.assertEqual(x.grad, eager_x.grad)
+
+        for dynamic in (False, True):
+            check(lambda x: x.T.abs().sum(), dynamic)
+            check(lambda x: x.T.angle().sum(), dynamic)
+            check(lambda x: (x.T * 1).abs().sum(), dynamic)
+
     def test_add_complex5(self):
         def fn(a, b, alpha):
             return torch.add(a, b, alpha=alpha)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -273,6 +273,60 @@ class FakeTensorTest(TestCase):
         eager_out = model.forward(x, w, b)
         self.assertEqual(fake_out.stride(), eager_out.stride())
 
+    def test_mul_complex_expanded_scalar_transposed_strides(self):
+        devices = ["cpu"]
+        if RUN_CUDA:
+            devices.append("cuda")
+
+        for device in devices:
+            x = torch.empty_strided(
+                (8, 4), (1, 8), dtype=torch.complex64, device=device
+            )
+            scalar = torch.empty_strided((), (), dtype=torch.float32, device=device)
+            exp = torch.as_strided(scalar, (8, 4), (0, 0))
+            broadcast = torch.empty_strided(
+                (1, 4), (4, 1), dtype=torch.float32, device=device
+            )
+            real_x = torch.empty_strided(
+                (8, 4), (1, 8), dtype=torch.float32, device=device
+            )
+            real_scalar = torch.empty_strided(
+                (), (), dtype=torch.float16, device=device
+            )
+            real_exp = torch.as_strided(real_scalar, (8, 4), (0, 0))
+            eager_out = exp * x
+            eager_scalar_out = x * 1
+            eager_broadcast_out = broadcast * x
+            eager_real_out = real_exp * real_x
+
+            with FakeTensorMode():
+                fake_x = torch.empty_strided(
+                    (8, 4), (1, 8), dtype=torch.complex64, device=device
+                )
+                fake_scalar = torch.empty_strided(
+                    (), (), dtype=torch.float32, device=device
+                )
+                fake_exp = torch.as_strided(fake_scalar, (8, 4), (0, 0))
+                fake_broadcast = torch.empty_strided(
+                    (1, 4), (4, 1), dtype=torch.float32, device=device
+                )
+                fake_real_x = torch.empty_strided(
+                    (8, 4), (1, 8), dtype=torch.float32, device=device
+                )
+                fake_real_scalar = torch.empty_strided(
+                    (), (), dtype=torch.float16, device=device
+                )
+                fake_real_exp = torch.as_strided(fake_real_scalar, (8, 4), (0, 0))
+                fake_out = fake_exp * fake_x
+                fake_scalar_out = fake_x * 1
+                fake_broadcast_out = fake_broadcast * fake_x
+                fake_real_out = fake_real_exp * fake_real_x
+
+            self.assertEqual(fake_out.stride(), eager_out.stride())
+            self.assertEqual(fake_scalar_out.stride(), eager_scalar_out.stride())
+            self.assertEqual(fake_broadcast_out.stride(), eager_broadcast_out.stride())
+            self.assertEqual(fake_real_out.stride(), eager_real_out.stride())
+
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_zero_dim(self):
         with FakeTensorMode() as mode:

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -79,20 +79,33 @@ def register_meta(op) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
 def elementwise_meta(
     *args,
     type_promotion: ELEMENTWISE_TYPE_PROMOTION_KIND,
+    _use_original_input_strides: bool = False,
 ):
     # Perform type promotion, as this is expected from prim_metafunction
     _, result_dtype = utils.elementwise_dtypes(
         *args,
         type_promotion_kind=type_promotion,
     )
-    args = [_maybe_convert_to_dtype(x, result_dtype) for x in args]
 
-    # Broadcast
-    args = _maybe_broadcast(*args)
+    args_with_fixed_dtypes = None
+    if _use_original_input_strides:
+        # CUDA TensorIterator computes the output layout from the original
+        # broadcasted operands before promoted temporaries are materialized.
+        args_with_fixed_dtypes = _maybe_broadcast(*args)
+        args = [
+            _maybe_convert_to_dtype(x, result_dtype) for x in args_with_fixed_dtypes
+        ]
+    else:
+        # CPU TensorIterator observes promoted temporaries during layout
+        # selection, so keep the normal convert-then-broadcast ordering.
+        args = [_maybe_convert_to_dtype(x, result_dtype) for x in args]
+        args = _maybe_broadcast(*args)
 
     # Perform prim checks
     return _prim_elementwise_meta(
-        *args, type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT
+        *args,
+        type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+        args_with_fixed_dtypes=args_with_fixed_dtypes,
     )
 
 
@@ -4635,6 +4648,13 @@ def meta_binop_inplace_alpha(self, other, alpha=1):
     ],
 )
 def meta_binop_alpha(self, other, alpha=1):
+    return elementwise_meta(
+        self, other, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
+    )
+
+
+@register_meta(aten.mul.Tensor)
+def meta_mul(self, other):
     return elementwise_meta(
         self, other, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
     )

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -346,6 +346,41 @@ def workaround_stride_incorrect_op(
     raise UnsupportedOperatorException(func)
 
 
+@register_op_impl(aten.mul.Tensor)
+def mul_tensor(
+    fake_mode: FakeTensorMode,
+    _func: OpOverload,
+    self: Any,
+    other: Any,
+) -> Any:
+    from torch._meta_registrations import elementwise_meta
+
+    if not isinstance(self, torch.Tensor) or not isinstance(other, torch.Tensor):
+        return NotImplemented
+
+    if self.layout != torch.strided or other.layout != torch.strided:
+        return NotImplemented
+
+    _, result_dtype = elementwise_dtypes(
+        self, other, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
+    )
+    has_cuda_tensor = (
+        self.device.type == "cuda" and not utils.is_cpu_scalar_tensor(self)
+    ) or (other.device.type == "cuda" and not utils.is_cpu_scalar_tensor(other))
+    if (
+        self.dtype == result_dtype and other.dtype == result_dtype
+    ) or not has_cuda_tensor:
+        return NotImplemented
+
+    with fake_mode:
+        return elementwise_meta(
+            self,
+            other,
+            type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+            _use_original_input_strides=True,
+        )
+
+
 # Dont default to default device handling,
 # since the device of `the_template` is ignored
 @register_op_impl(aten.resize_as_.default)
@@ -1880,15 +1915,22 @@ def fast_detach(
 def get_fast_op_impls() -> dict[OpOverload, Callable[..., Any]]:
     import torch._refs
 
+    fast_mul_impl = make_fast_binary_impl(torch._refs.mul)
+
+    def fast_mul_tensor(mode: FakeTensorMode, *args: Any, **kwargs: Any) -> FakeTensor:
+        if not kwargs and len(args) == 2:
+            out = mul_tensor(mode, aten.mul.Tensor, args[0], args[1])
+            if out is not NotImplemented:
+                return out
+        return fast_mul_impl(mode, *args, **kwargs)
+
     register_fast_op_impl(torch.ops.aten.add.Tensor)(
         make_fast_binary_impl(torch._refs.add)
     )
     register_fast_op_impl(torch.ops.aten.sub.Tensor)(
         make_fast_binary_impl(torch._refs.sub)
     )
-    register_fast_op_impl(torch.ops.aten.mul.Tensor)(
-        make_fast_binary_impl(torch._refs.mul)
-    )  # type: ignore[has-type]
+    register_fast_op_impl(torch.ops.aten.mul.Tensor)(fast_mul_tensor)
     register_fast_op_impl(torch.ops.aten.div.Tensor)(
         make_fast_binary_impl(
             torch._refs.div,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184515

Match FakeTensor stride propagation to CUDA TensorIterator for promoted aten.mul.Tensor inputs so Inductor fallback assertions agree with runtime layouts for transposed complex tensors.

Fixes #184101

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos