### PR TITLE
Use c10::make_scope_exit to avoid exception leaks

### DIFF
--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -14,6 +14,7 @@
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
 #include <torch/csrc/copy_utils.h>
 
+#include <c10/util/ScopeExit.h>
 #include <c10/util/intrusive_ptr.h>
 #include <fmt/format.h>
 
@@ -264,6 +265,8 @@ static PyObject* THPStorage_fromBuffer(
 
   if (PyObject_GetBuffer(obj, &buffer, PyBUF_SIMPLE) < 0)
     return nullptr;
+  auto buffer_guard =
+      c10::make_scope_exit([&buffer]() { PyBuffer_Release(&buffer); });
 
   if (offset < 0 || offset > buffer.len) {
     PyErr_SetString(
@@ -272,7 +275,6 @@ static PyObject* THPStorage_fromBuffer(
             "offset must be non-negative and no greater than buffer length ({}) , but got {}",
             offset,
             buffer.len));
-    PyBuffer_Release(&buffer);
     return nullptr;
   }
 
@@ -285,7 +287,6 @@ static PyObject* THPStorage_fromBuffer(
               "buffer size ({}) must be a multiple of element size ({})",
               buffer.len,
               element_size));
-      PyBuffer_Release(&buffer);
       return nullptr;
     }
     size_bytes = buffer.len - offset;
@@ -302,7 +303,6 @@ static PyObject* THPStorage_fromBuffer(
             buffer.len - offset,
             offset,
             count));
-    PyBuffer_Release(&buffer);
     return nullptr;
   }
 
@@ -346,7 +346,6 @@ static PyObject* THPStorage_fromBuffer(
     }
   }
 
-  PyBuffer_Release(&buffer);
   return THPStorage_Wrap(storage);
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -1100,20 +1100,26 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
 
 void unregister_gc_callback() {
   PyGILState_STATE gstate = PyGILState_Ensure();
+  auto gil_guard =
+      c10::make_scope_exit([gstate]() { PyGILState_Release(gstate); });
+
   PyObject* gc_module = PyImport_ImportModule("gc");
   if (!gc_module) {
     PyErr_Print();
-    PyGILState_Release(gstate);
     return;
   }
+  auto module_guard =
+      c10::make_scope_exit([gc_module]() { Py_DECREF(gc_module); });
+
   PyObject* callbacks = PyObject_GetAttrString(gc_module, "callbacks");
   if (!callbacks || !PyList_Check(callbacks)) {
     PyErr_Print();
-    Py_XDECREF(gc_module);
     Py_XDECREF(callbacks);
-    PyGILState_Release(gstate);
     return;
   }
+  auto callbacks_guard =
+      c10::make_scope_exit([callbacks]() { Py_DECREF(callbacks); });
+
   Py_ssize_t idx = PySequence_Index(callbacks, py_gc_callback);
   if (idx >= 0) {
     PySequence_DelItem(callbacks, idx);
@@ -1121,29 +1127,32 @@ void unregister_gc_callback() {
     // Not found, maybe already removed
     PyErr_Clear();
   }
-  Py_DECREF(callbacks);
-  Py_DECREF(gc_module);
   Py_XDECREF(py_gc_callback);
   py_gc_callback = nullptr;
-  PyGILState_Release(gstate);
 }
 
 void PythonTracer::register_gc_callback() {
   PyGILState_STATE gstate = PyGILState_Ensure();
+  auto gil_guard =
+      c10::make_scope_exit([gstate]() { PyGILState_Release(gstate); });
+
   PyObject* gc_module = PyImport_ImportModule("gc");
   if (!gc_module) {
     PyErr_Print();
-    PyGILState_Release(gstate);
     return;
   }
+  auto module_guard =
+      c10::make_scope_exit([gc_module]() { Py_DECREF(gc_module); });
+
   PyObject* callbacks = PyObject_GetAttrString(gc_module, "callbacks");
   if (!callbacks || !PyList_Check(callbacks)) {
     PyErr_Print();
-    Py_XDECREF(gc_module);
     Py_XDECREF(callbacks);
-    PyGILState_Release(gstate);
     return;
   }
+  auto callbacks_guard =
+      c10::make_scope_exit([callbacks]() { Py_DECREF(callbacks); });
+
   static PyMethodDef method_def = {
       "gc_event_callback",
       (PyCFunction)gc_event_callback,
@@ -1156,9 +1165,6 @@ void PythonTracer::register_gc_callback() {
     PyErr_Print();
   }
   gc_callback_registered_ = true;
-  Py_DECREF(callbacks);
-  Py_DECREF(gc_module);
-  PyGILState_Release(gstate);
 }
 
 void PythonTracer::stop() {

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -1,5 +1,6 @@
 #if !defined(C10_MOBILE) && !defined(ANDROID)
 #include <ATen/DynamicLibrary.h>
+#include <c10/util/ScopeExit.h>
 
 #include <torch/csrc/inductor/aoti_runner/model_container_runner.h>
 #include <torch/csrc/inductor/aoti_torch/oss_proxy_executor.h>
@@ -358,14 +359,14 @@ void AOTIModelContainerRunner::update_constant_buffer_from_blob(
   if (hMapping == NULL) {
     TORCH_CHECK(false, "CreateFileMapping failed");
   }
+  auto mapping_guard =
+      c10::make_scope_exit([hMapping]() { CloseHandle(hMapping); });
 
   uint8_t* ptr = static_cast<uint8_t*>(
       MapViewOfFile(hMapping, FILE_MAP_READ, 0, 0, weights_size));
 
-  if (ptr == NULL) {
-    CloseHandle(hMapping);
-    TORCH_CHECK(false, "MapViewOfFile failed");
-  }
+  TORCH_CHECK(ptr != NULL, "MapViewOfFile failed");
+  auto view_guard = c10::make_scope_exit([ptr]() { UnmapViewOfFile(ptr); });
 
 #else
   // Unix/Linux implementation
@@ -377,19 +378,11 @@ void AOTIModelContainerRunner::update_constant_buffer_from_blob(
 
   close(fd);
   TORCH_CHECK(ptr != MAP_FAILED, "mmap() failed");
+  auto mmap_guard = c10::make_scope_exit(
+      [ptr, weights_size]() { munmap(ptr, weights_size); });
 #endif
   AOTI_RUNTIME_ERROR_CODE_CHECK(
       update_constants_from_blob_func_(container_handle_, ptr));
-
-  // After update_constants_from_blob_func_ returns, the model has copied
-  // all the data from the mmap'd memory to its own internal storage,
-  // so we can safely unmap the memory now.
-#ifdef _WIN32
-  UnmapViewOfFile(ptr);
-  CloseHandle(hMapping);
-#else
-  munmap(ptr, weights_size);
-#endif
 }
 
 void AOTIModelContainerRunner::update_inactive_constant_buffer(

--- a/torch/csrc/profiler/unwind/mem_file.h
+++ b/torch/csrc/profiler/unwind/mem_file.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <c10/util/ScopeExit.h>
 #include <c10/util/error.h>
 #include <elf.h>
 #include <fcntl.h>
@@ -46,27 +47,26 @@ struct MemFile {
         "failed to open {}: {}",
         filename_,
         c10::utils::str_error(errno));
+    auto fd_guard = c10::make_scope_exit([this]() { close(fd_); });
+
     struct stat s{};
-    if (-1 == fstat(fd_, &s)) {
-      close(fd_); // destructors don't run during exceptions
-      UNWIND_CHECK(
-          false,
-          "failed to stat {}: {}",
-          filename_,
-          c10::utils::str_error(errno));
-    }
+    UNWIND_CHECK(
+        -1 != fstat(fd_, &s),
+        "failed to stat {}: {}",
+        filename_,
+        c10::utils::str_error(errno));
     n_bytes_ = s.st_size;
     UNWIND_CHECK(
         n_bytes_ > sizeof(Elf64_Ehdr), "empty shared library: {}", filename_);
     mem_ = (char*)mmap(nullptr, n_bytes_, PROT_READ, MAP_SHARED, fd_, 0);
-    if (MAP_FAILED == mem_) {
-      close(fd_);
-      UNWIND_CHECK(
-          false,
-          "failed to mmap {}: {}",
-          filename_,
-          c10::utils::str_error(errno));
-    }
+    UNWIND_CHECK(
+        MAP_FAILED != mem_,
+        "failed to mmap {}: {}",
+        filename_,
+        c10::utils::str_error(errno));
+    auto mem_guard =
+        c10::make_scope_exit([this]() { munmap((void*)mem_, n_bytes_); });
+
     ehdr_ = (Elf64_Ehdr*)mem_;
 #define ELF_CHECK(cond) UNWIND_CHECK(cond, "not an ELF file: {}", filename_)
     ELF_CHECK(ehdr_->e_ident[EI_MAG0] == ELFMAG0);
@@ -89,6 +89,8 @@ struct MemFile {
         ehdr_->e_shstrndx < ehdr_->e_shnum, "invalid strtab section offset");
     auto& strtab_hdr = shdr_[ehdr_->e_shstrndx];
     strtab_ = getSection(strtab_hdr);
+    mem_guard.release();
+    fd_guard.release();
   }
 
   MemFile(const MemFile&) = delete;


### PR DESCRIPTION
This PR uses `c10::make_scope_exit` to implement C API resource RAII.