### PR TITLE
[inductor] Improve Triton launcher arg mismatch error and its reporting. Included some basic optimizations

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -1291,7 +1291,10 @@ class TestCheckLauncherCallArgs(TestCase):
     def test_error_message_includes_kernel_name(self):
         """The TypeError message should include the kernel name from inductor_meta."""
         args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
-        args["inductor_meta"] = {"kernel_name": "my_custom_kernel", "grid_type": "Grid1D"}
+        args["inductor_meta"] = {
+            "kernel_name": "my_custom_kernel",
+            "grid_type": "Grid1D",
+        }
         autotuner = CachingAutotuner(**args)
         launcher = self._make_launcher(n_positional=2)
         with self.assertRaises(TypeError) as cm:

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -26,6 +26,7 @@ from torch.testing._internal.inductor_utils import (
     requires_gpu_with_enough_memory,
 )
 
+
 try:
     import triton  # @manual
     import triton.language as tl  # @manual

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -1246,6 +1246,95 @@ class TestDynamicScaleRblockCacheInteraction(TestCase):
         mock_precompile.assert_called_once_with(dynamic_cfg)
 
 
+class TestCheckLauncherCallArgs(TestCase):
+    """Unit tests for CachingAutotuner._check_launcher_call_args.
+
+    These tests are pure-Python (no GPU / Triton compilation) and guard
+    against regressions in the improved arg-mismatch error path.
+    """
+
+    def _make_autotuner(self):
+        """Return a CachingAutotuner configured with the cos kernel fixture."""
+        args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
+        return CachingAutotuner(**args)
+
+    def _make_launcher(self, n_positional: int):
+        """Return a minimal callable that looks like a generated launcher.
+
+        The only attribute _check_launcher_call_args inspects is
+        ``_expected_positional_count``, so we don't need real Triton machinery.
+        """
+
+        def launcher(*args, stream=None):
+            pass
+
+        launcher._expected_positional_count = n_positional
+        return launcher
+
+    def test_correct_arg_count_passes_silently(self):
+        """No exception when args exactly matches _expected_positional_count."""
+        autotuner = self._make_autotuner()
+        launcher = self._make_launcher(n_positional=3)
+        # Pass exactly 3 positional args — should be a no-op.
+        autotuner._check_launcher_call_args(launcher, (1, 2, 3))
+
+    def test_too_many_args_raises_type_error(self):
+        """TypeError with a helpful message when too many positional args are passed."""
+        autotuner = self._make_autotuner()
+        launcher = self._make_launcher(n_positional=3)
+        # Simulate the 'stream' being passed positionally (4 args, expected 3).
+        with self.assertRaises(TypeError) as cm:
+            autotuner._check_launcher_call_args(launcher, (1, 2, 3, 4))
+        self.assertIn("stream", str(cm.exception).lower())
+        self.assertIn("keyword", str(cm.exception).lower())
+
+    def test_error_message_includes_kernel_name(self):
+        """The TypeError message should include the kernel name from inductor_meta."""
+        args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
+        args["inductor_meta"] = {"kernel_name": "my_custom_kernel", "grid_type": "Grid1D"}
+        autotuner = CachingAutotuner(**args)
+        launcher = self._make_launcher(n_positional=2)
+        with self.assertRaises(TypeError) as cm:
+            autotuner._check_launcher_call_args(launcher, (1, 2, 3))
+        self.assertIn("my_custom_kernel", str(cm.exception))
+
+    def test_check_runs_only_once_per_launcher(self):
+        """Second call with the same launcher is a no-op (fast-path via set)."""
+        autotuner = self._make_autotuner()
+        launcher = self._make_launcher(n_positional=3)
+
+        # First call: too many args → raises.
+        with self.assertRaises(TypeError):
+            autotuner._check_launcher_call_args(launcher, (1, 2, 3, 4))
+
+        # Second call with the same launcher: already in checked set → no raise.
+        autotuner._check_launcher_call_args(launcher, (1, 2, 3, 4))
+
+    def test_launcher_without_expected_count_is_skipped(self):
+        """Launchers not produced by _gen_launcher_code lack the attribute; skip gracefully."""
+
+        def raw_launcher(*args, stream=None):
+            pass
+
+        # No _expected_positional_count attribute set.
+        autotuner = self._make_autotuner()
+        # Should not raise, even with many args.
+        autotuner._check_launcher_call_args(raw_launcher, (1, 2, 3, 4, 5))
+
+    def test_checked_set_cleared_on_restore_after_unpickle(self):
+        """_launcher_arg_count_checked is reset by restore_after_unpickle."""
+        autotuner = self._make_autotuner()
+        launcher = self._make_launcher(n_positional=3)
+
+        # Populate the checked set.
+        autotuner._check_launcher_call_args(launcher, (1, 2, 3))
+        self.assertIn(id(launcher), autotuner._launcher_arg_count_checked)
+
+        # After restore_after_unpickle the set must be empty.
+        autotuner.restore_after_unpickle(None)
+        self.assertEqual(autotuner._launcher_arg_count_checked, set())
+
+
 if __name__ == "__main__":
     if IS_LINUX and HAS_GPU:
         run_tests()

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -25,6 +25,7 @@ from torch.testing._internal.inductor_utils import (
     HAS_GPU_AND_TRITON,
     requires_gpu_with_enough_memory,
 )
+from torch.utils._ordered_set import OrderedSet
 
 
 try:
@@ -1275,7 +1276,7 @@ class TestCheckLauncherCallArgs(TestCase):
         """No exception when args exactly matches _expected_positional_count."""
         autotuner = self._make_autotuner()
         launcher = self._make_launcher(n_positional=3)
-        # Pass exactly 3 positional args — should be a no-op.
+        # Pass exactly 3 positional args - should be a no-op.
         autotuner._check_launcher_call_args(launcher, (1, 2, 3))
 
     def test_too_many_args_raises_type_error(self):
@@ -1306,15 +1307,16 @@ class TestCheckLauncherCallArgs(TestCase):
         autotuner = self._make_autotuner()
         launcher = self._make_launcher(n_positional=3)
 
-        # First call: too many args → raises.
+        # First call: too many args raises.
         with self.assertRaises(TypeError):
             autotuner._check_launcher_call_args(launcher, (1, 2, 3, 4))
 
-        # Second call with the same launcher: already in checked set → no raise.
-        autotuner._check_launcher_call_args(launcher, (1, 2, 3, 4))
+        # Failed validations are not cached, so the improved error is stable.
+        with self.assertRaises(TypeError):
+            autotuner._check_launcher_call_args(launcher, (1, 2, 3, 4))
 
     def test_launcher_without_expected_count_is_skipped(self):
-        """Launchers not produced by _gen_launcher_code lack the attribute; skip gracefully."""
+        """Launchers without the generated metadata are skipped gracefully."""
 
         def raw_launcher(*args, stream=None):
             pass
@@ -1335,7 +1337,7 @@ class TestCheckLauncherCallArgs(TestCase):
 
         # After restore_after_unpickle the set must be empty.
         autotuner.restore_after_unpickle(None)
-        self.assertEqual(autotuner._launcher_arg_count_checked, set())
+        self.assertEqual(autotuner._launcher_arg_count_checked, OrderedSet())
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -25,7 +25,6 @@ from torch.testing._internal.inductor_utils import (
     HAS_GPU_AND_TRITON,
     requires_gpu_with_enough_memory,
 )
-from torch.utils._ordered_set import OrderedSet
 
 
 try:
@@ -1302,19 +1301,6 @@ class TestCheckLauncherCallArgs(TestCase):
             autotuner._check_launcher_call_args(launcher, (1, 2, 3))
         self.assertIn("my_custom_kernel", str(cm.exception))
 
-    def test_check_runs_only_once_per_launcher(self):
-        """Second call with the same launcher is a no-op (fast-path via set)."""
-        autotuner = self._make_autotuner()
-        launcher = self._make_launcher(n_positional=3)
-
-        # First call: too many args raises.
-        with self.assertRaises(TypeError):
-            autotuner._check_launcher_call_args(launcher, (1, 2, 3, 4))
-
-        # Failed validations are not cached, so the improved error is stable.
-        with self.assertRaises(TypeError):
-            autotuner._check_launcher_call_args(launcher, (1, 2, 3, 4))
-
     def test_launcher_without_expected_count_is_skipped(self):
         """Launchers without the generated metadata are skipped gracefully."""
 
@@ -1325,19 +1311,6 @@ class TestCheckLauncherCallArgs(TestCase):
         autotuner = self._make_autotuner()
         # Should not raise, even with many args.
         autotuner._check_launcher_call_args(raw_launcher, (1, 2, 3, 4, 5))
-
-    def test_checked_set_cleared_on_restore_after_unpickle(self):
-        """_launcher_arg_count_checked is reset by restore_after_unpickle."""
-        autotuner = self._make_autotuner()
-        launcher = self._make_launcher(n_positional=3)
-
-        # Populate the checked set.
-        autotuner._check_launcher_call_args(launcher, (1, 2, 3))
-        self.assertIn(id(launcher), autotuner._launcher_arg_count_checked)
-
-        # After restore_after_unpickle the set must be empty.
-        autotuner.restore_after_unpickle(None)
-        self.assertEqual(autotuner._launcher_arg_count_checked, OrderedSet())
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -26,7 +26,6 @@ from torch.testing._internal.inductor_utils import (
     requires_gpu_with_enough_memory,
 )
 
-
 try:
     import triton  # @manual
     import triton.language as tl  # @manual

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -553,6 +553,9 @@ class CachingAutotuner(KernelInterface):
             and not self.dump_launch_params
             and not self.dump_launch_tensors
         )
+        # Tracks which launchers (by id) have already passed
+        # _check_launcher_call_args so the check only runs once per launcher.
+        self._launcher_arg_count_checked: set[int] = set()
 
         self._plugins = get_caching_autotuner_plugins(self)
 
@@ -897,12 +900,14 @@ class CachingAutotuner(KernelInterface):
         self.fn.repr = _ConstRepr(self.fn.repr(self.fn))
         self.launchers = []
         self._cached_launcher = None
+        self._launcher_arg_count_checked = set()
         self.benchmark_failure_reasons = {}
         self.fn._hash_lock = None
         return old_values
 
     def restore_after_unpickle(self, old_values: tuple[Any, ...] | None) -> None:
         self._cached_launcher = None
+        self._launcher_arg_count_checked = set()
         if old_values:
             (
                 self.fn.fn,
@@ -1262,13 +1267,7 @@ class CachingAutotuner(KernelInterface):
             )
             # reset to zero before evaluating any config
             self.reset_to_zero_args(*args, **kwargs)
-            kernel_name = self.inductor_meta.get("kernel_name", "triton kernel")
-            self._check_launcher_call_args(
-                launcher,
-                cloned_args,
-                ("stream",),
-                kernel_name=kernel_name,
-            )
+            self._check_launcher_call_args(launcher, cloned_args)
             if autograd_profiler._is_profiler_enabled:
                 profiler_kwargs = self.get_profiler_kwargs(stream, launcher)
                 with torch._C._profiler._RecordFunctionFast(
@@ -2120,13 +2119,7 @@ class CachingAutotuner(KernelInterface):
 
         try:
             self._pre_launch(launcher, *args, stream=stream, **kwargs)
-            kernel_name = self.inductor_meta.get("kernel_name", "triton kernel")
-            self._check_launcher_call_args(
-                launcher,
-                args,
-                ("stream",),
-                kernel_name=kernel_name,
-            )
+            self._check_launcher_call_args(launcher, args)
             result = launcher(*args, **kwargs, stream=stream)
         finally:
             self._post_launch()
@@ -2144,6 +2137,35 @@ class CachingAutotuner(KernelInterface):
         ):
             self._cached_launcher = self._build_fast_launcher(launcher) or launcher
         return result
+
+    def _check_launcher_call_args(
+        self,
+        launcher: LauncherType,
+        args: tuple[Any, ...],
+    ) -> None:
+        """Raise TypeError with a helpful message when stream is passed positionally."""
+        # Fast path: we've already validated this launcher on a prior call.
+        # Cache the result on self (keyed by launcher id) so we never mutate
+        # the launcher function object and never silently swallow errors.
+        if id(launcher) in self._launcher_arg_count_checked:
+            return
+        self._launcher_arg_count_checked.add(id(launcher))
+
+        # _expected_positional_count is stashed by _gen_launcher_code at
+        # code-generation time, so no inspect.signature() call is needed.
+        expected = getattr(launcher, "_expected_positional_count", None)
+        if expected is None:
+            # Launcher was not produced by _gen_launcher_code (e.g. a test
+            # double).  Skip the check rather than falling back to inspection.
+            return
+
+        if len(args) > expected:
+            kernel_name = self.inductor_meta.get("kernel_name", "triton kernel")
+            raise TypeError(
+                f"{kernel_name}: too many positional arguments — "
+                f"expected {expected}, got {len(args)}. "
+                "'stream' must be passed as a keyword argument."
+            )
 
     def _build_fast_launcher(self, launcher: LauncherType) -> LauncherType | None:
         """Try to build a _FastCudaLauncher-backed version of the launcher.
@@ -2315,7 +2337,11 @@ class CompileResult(Generic[_T]):
         ]
         launcher_code = "\n".join(lines)
         exec(launcher_code, scope)
-        return scope["launcher"]
+        launcher = scope["launcher"]
+        # Stash expected positional arg count at codegen time so
+        # _check_launcher_call_args can validate without inspect.signature().
+        launcher._expected_positional_count = len(def_args)
+        return launcher
 
     def _get_arg_lists(
         self, arg_names, constexprs

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -554,8 +554,7 @@ class CachingAutotuner(KernelInterface):
             and not self.dump_launch_tensors
         )
         # Tracks which launchers (by id) have already passed
-        # _check_launcher_call_args so the check only runs once per launcher.
-        self._launcher_arg_count_checked: OrderedSet[int] = OrderedSet()
+        # _check_launcher_call_args can validate without inspect.signature().
 
         self._plugins = get_caching_autotuner_plugins(self)
 
@@ -900,14 +899,12 @@ class CachingAutotuner(KernelInterface):
         self.fn.repr = _ConstRepr(self.fn.repr(self.fn))
         self.launchers = []
         self._cached_launcher = None
-        self._launcher_arg_count_checked = OrderedSet()
         self.benchmark_failure_reasons = {}
         self.fn._hash_lock = None
         return old_values
 
     def restore_after_unpickle(self, old_values: tuple[Any, ...] | None) -> None:
         self._cached_launcher = None
-        self._launcher_arg_count_checked = OrderedSet()
         if old_values:
             (
                 self.fn.fn,
@@ -1197,7 +1194,6 @@ class CachingAutotuner(KernelInterface):
             kernel_name = self.inductor_meta.get("kernel_name", "triton kernel")
             # reset to zero before evaluating any config
             self.reset_to_zero_args(*args, **kwargs)
-            self._check_launcher_call_args(launcher, cloned_args)
             if autograd_profiler._is_profiler_enabled:
                 profiler_kwargs = self.get_profiler_kwargs(stream, launcher)
                 with torch._C._profiler._RecordFunctionFast(
@@ -1211,7 +1207,9 @@ class CachingAutotuner(KernelInterface):
                             **cloned_kwargs,
                             stream=stream,
                         )
-                    except Exception:
+                    except Exception as e:
+                        if isinstance(e, TypeError):
+                            self._check_launcher_call_args(launcher, cloned_args)
                         log.error(
                             "Failed during launch %s with config: %s (num_warps=%s, num_stages=%s, kwargs=%s)",
                             kernel_name,
@@ -1229,7 +1227,9 @@ class CachingAutotuner(KernelInterface):
                         **cloned_kwargs,
                         stream=stream,
                     )
-                except Exception:
+                except Exception as e:
+                    if isinstance(e, TypeError):
+                        self._check_launcher_call_args(launcher, cloned_args)
                     log.error(
                         "Failed during launch %s with config: %s (num_warps=%s, num_stages=%s, kwargs=%s)",
                         kernel_name,
@@ -2049,8 +2049,12 @@ class CachingAutotuner(KernelInterface):
 
         try:
             self._pre_launch(launcher, *args, stream=stream, **kwargs)
-            self._check_launcher_call_args(launcher, args)
-            result = launcher(*args, **kwargs, stream=stream)
+            try:
+                result = launcher(*args, **kwargs, stream=stream)
+            except Exception as e:
+                if isinstance(e, TypeError):
+                    self._check_launcher_call_args(launcher, args)
+                raise
         finally:
             self._post_launch()
 
@@ -2074,18 +2078,8 @@ class CachingAutotuner(KernelInterface):
         args: tuple[Any, ...],
     ) -> None:
         """Raise TypeError with a helpful message when stream is passed positionally."""
-        # Fast path: this launcher has already passed validation.
-        # Cache successful validations on self (keyed by launcher id) so we
-        # never mutate the launcher function object.
-        if id(launcher) in self._launcher_arg_count_checked:
-            return
-
-        # _expected_positional_count is stashed by _gen_launcher_code at
-        # code-generation time, so no inspect.signature() call is needed.
         expected = getattr(launcher, "_expected_positional_count", None)
         if expected is None:
-            # Launcher was not produced by _gen_launcher_code (e.g. a test
-            # double).  Skip the check rather than falling back to inspection.
             return
 
         if len(args) > expected:
@@ -2095,7 +2089,6 @@ class CachingAutotuner(KernelInterface):
                 f"expected {expected}, got {len(args)}. "
                 "'stream' must be passed as a keyword argument."
             )
-        self._launcher_arg_count_checked.add(id(launcher))
 
     def _build_fast_launcher(self, launcher: LauncherType) -> LauncherType | None:
         """Try to build a _FastCudaLauncher-backed version of the launcher.

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -555,7 +555,7 @@ class CachingAutotuner(KernelInterface):
         )
         # Tracks which launchers (by id) have already passed
         # _check_launcher_call_args so the check only runs once per launcher.
-        self._launcher_arg_count_checked: set[int] = set()
+        self._launcher_arg_count_checked: OrderedSet[int] = OrderedSet()
 
         self._plugins = get_caching_autotuner_plugins(self)
 
@@ -900,14 +900,14 @@ class CachingAutotuner(KernelInterface):
         self.fn.repr = _ConstRepr(self.fn.repr(self.fn))
         self.launchers = []
         self._cached_launcher = None
-        self._launcher_arg_count_checked = set()
+        self._launcher_arg_count_checked = OrderedSet()
         self.benchmark_failure_reasons = {}
         self.fn._hash_lock = None
         return old_values
 
     def restore_after_unpickle(self, old_values: tuple[Any, ...] | None) -> None:
         self._cached_launcher = None
-        self._launcher_arg_count_checked = set()
+        self._launcher_arg_count_checked = OrderedSet()
         if old_values:
             (
                 self.fn.fn,
@@ -1162,76 +1162,6 @@ class CachingAutotuner(KernelInterface):
 
         return TritonCompileResult(binary, cfg, compile_meta, self.inductor_meta)
 
-    def _check_launcher_call_args(
-        self,
-        launcher: LauncherType,
-        args: tuple[Any, ...],
-        kwarg_names: tuple[str, ...],
-        *,
-        kernel_name: str,
-    ) -> None:
-        """
-        A clearer error when too many positional args would bind to a kwarg.
-
-        If a generated Triton launcher has a fixed Python signature passing too many positional
-        args will start binding them to later parameters. If we also pass that parameter by keyword,
-        the runtime error becomes "got multiple values for argument ...", which
-        is hard to diagnose. Detect that scenario and raise a clear message.
-        """
-        cache_key = "_inductor_launcher_positional_limits"
-        cached = getattr(launcher, cache_key, None)
-        if cached is None:
-            try:
-                sig = inspect.signature(launcher)
-            except (TypeError, ValueError):
-                return
-
-            params = list(sig.parameters.values())
-            if any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params):
-                # Can't reason about positional binding if *args is present.
-                return
-
-            positional_params = [
-                p
-                for p in params
-                if p.kind
-                in (
-                    inspect.Parameter.POSITIONAL_ONLY,
-                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                )
-            ]
-            name_to_pos_index = {p.name: i for i, p in enumerate(positional_params)}
-            cached = name_to_pos_index
-            try:
-                setattr(launcher, cache_key, cached)
-            except Exception:
-                pass
-
-        if not isinstance(cached, dict):
-            return
-
-        positional_limit = None
-        conflict_param = None
-        for kw_name in kwarg_names:
-            idx = cached.get(kw_name)
-            if idx is None:
-                continue
-            if positional_limit is None or idx < positional_limit:
-                positional_limit = idx
-                conflict_param = kw_name
-
-        if positional_limit is None:
-            return
-
-        if len(args) > positional_limit:
-            raise TypeError(
-                f"{kernel_name} launcher expected at most {positional_limit} positional "
-                f"arguments (got {len(args)}); extra positional arguments would bind to "
-                f"'{conflict_param}', which is also passed by keyword. This usually "
-                "means the Triton kernel has fewer parameters than the call site is "
-                "passing (e.g. signature changed or constexpr/None-arg filtering "
-                "mismatched)."
-            )
 
     def bench(self, launcher, *args, with_profiler=False, **kwargs):
         """Measure the performance of a given launcher."""
@@ -1265,6 +1195,7 @@ class CachingAutotuner(KernelInterface):
             cloned_args, cloned_kwargs = self.maybe_clone_args(
                 cpu_copies, *args, **kwargs
             )
+            kernel_name = self.inductor_meta.get("kernel_name", "triton kernel")
             # reset to zero before evaluating any config
             self.reset_to_zero_args(*args, **kwargs)
             self._check_launcher_call_args(launcher, cloned_args)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2075,12 +2075,11 @@ class CachingAutotuner(KernelInterface):
         args: tuple[Any, ...],
     ) -> None:
         """Raise TypeError with a helpful message when stream is passed positionally."""
-        # Fast path: we've already validated this launcher on a prior call.
-        # Cache the result on self (keyed by launcher id) so we never mutate
-        # the launcher function object and never silently swallow errors.
+        # Fast path: this launcher has already passed validation.
+        # Cache successful validations on self (keyed by launcher id) so we
+        # never mutate the launcher function object.
         if id(launcher) in self._launcher_arg_count_checked:
             return
-        self._launcher_arg_count_checked.add(id(launcher))
 
         # _expected_positional_count is stashed by _gen_launcher_code at
         # code-generation time, so no inspect.signature() call is needed.
@@ -2093,10 +2092,11 @@ class CachingAutotuner(KernelInterface):
         if len(args) > expected:
             kernel_name = self.inductor_meta.get("kernel_name", "triton kernel")
             raise TypeError(
-                f"{kernel_name}: too many positional arguments — "
+                f"{kernel_name}: too many positional arguments - "
                 f"expected {expected}, got {len(args)}. "
                 "'stream' must be passed as a keyword argument."
             )
+        self._launcher_arg_count_checked.add(id(launcher))
 
     def _build_fast_launcher(self, launcher: LauncherType) -> LauncherType | None:
         """Try to build a _FastCudaLauncher-backed version of the launcher.
@@ -2167,6 +2167,7 @@ class CachingAutotuner(KernelInterface):
                 "cache_hash",
                 "store_cubin",
                 "_is_static",
+                "_expected_positional_count",
             ):
                 val = getattr(launcher, attr, None)
                 if val is not None:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1162,7 +1162,6 @@ class CachingAutotuner(KernelInterface):
 
         return TritonCompileResult(binary, cfg, compile_meta, self.inductor_meta)
 
-
     def bench(self, launcher, *args, with_profiler=False, **kwargs):
         """Measure the performance of a given launcher."""
         # we don't skip configs with spilled registers when auto-tuning custom

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1157,6 +1157,79 @@ class CachingAutotuner(KernelInterface):
 
         return TritonCompileResult(binary, cfg, compile_meta, self.inductor_meta)
 
+    def _check_launcher_call_args(
+        self,
+        launcher: LauncherType,
+        args: tuple[Any, ...],
+        kwarg_names: tuple[str, ...],
+        *,
+        kernel_name: str,
+    ) -> None:
+        """
+        Emit a clearer error when too many positional args would bind to a kwarg.
+
+        If a generated Triton launcher has a fixed Python signature (e.g.
+        `def launcher(arg0, arg1, ..., stream):`), passing too many positional
+        args will start binding them to later parameters (like `stream`, or `grid`
+        in older launcher variants). If we also pass that parameter by keyword,
+        the runtime error becomes "got multiple values for argument ...", which
+        is hard to diagnose. Detect that scenario and raise a direct message.
+        """
+        cache_key = "_inductor_launcher_positional_limits"
+        cached = getattr(launcher, cache_key, None)
+        if cached is None:
+            try:
+                sig = inspect.signature(launcher)
+            except (TypeError, ValueError):
+                return
+
+            params = list(sig.parameters.values())
+            if any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params):
+                # Can't reason about positional binding if *args is present.
+                return
+
+            positional_params = [
+                p
+                for p in params
+                if p.kind
+                in (
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                )
+            ]
+            name_to_pos_index = {p.name: i for i, p in enumerate(positional_params)}
+            cached = name_to_pos_index
+            try:
+                setattr(launcher, cache_key, cached)
+            except Exception:
+                pass
+
+        if not isinstance(cached, dict):
+            return
+
+        positional_limit = None
+        conflict_param = None
+        for kw_name in kwarg_names:
+            idx = cached.get(kw_name)
+            if idx is None:
+                continue
+            if positional_limit is None or idx < positional_limit:
+                positional_limit = idx
+                conflict_param = kw_name
+
+        if positional_limit is None:
+            return
+
+        if len(args) > positional_limit:
+            raise TypeError(
+                f"{kernel_name} launcher expected at most {positional_limit} positional "
+                f"arguments (got {len(args)}); extra positional arguments would bind to "
+                f"'{conflict_param}', which is also passed by keyword. This usually "
+                "means the Triton kernel has fewer parameters than the call site is "
+                "passing (e.g. signature changed or constexpr/None-arg filtering "
+                "mismatched)."
+            )
+
     def bench(self, launcher, *args, with_profiler=False, **kwargs):
         """Measure the performance of a given launcher."""
         # we don't skip configs with spilled registers when auto-tuning custom
@@ -1192,6 +1265,12 @@ class CachingAutotuner(KernelInterface):
             # reset to zero before evaluating any config
             self.reset_to_zero_args(*args, **kwargs)
             kernel_name = self.inductor_meta.get("kernel_name", "triton kernel")
+            self._check_launcher_call_args(
+                launcher,
+                cloned_args,
+                ("stream",),
+                kernel_name=kernel_name,
+            )
             if autograd_profiler._is_profiler_enabled:
                 profiler_kwargs = self.get_profiler_kwargs(stream, launcher)
                 with torch._C._profiler._RecordFunctionFast(
@@ -2043,6 +2122,13 @@ class CachingAutotuner(KernelInterface):
 
         try:
             self._pre_launch(launcher, *args, stream=stream, **kwargs)
+            kernel_name = self.inductor_meta.get("kernel_name", "triton kernel")
+            self._check_launcher_call_args(
+                launcher,
+                args,
+                ("stream",),
+                kernel_name=kernel_name,
+            )
             result = launcher(*args, **kwargs, stream=stream)
         finally:
             self._post_launch()

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -553,8 +553,6 @@ class CachingAutotuner(KernelInterface):
             and not self.dump_launch_params
             and not self.dump_launch_tensors
         )
-        # Tracks which launchers (by id) have already passed
-        # _check_launcher_call_args can validate without inspect.signature().
 
         self._plugins = get_caching_autotuner_plugins(self)
 
@@ -2088,7 +2086,7 @@ class CachingAutotuner(KernelInterface):
                 f"{kernel_name}: too many positional arguments - "
                 f"expected {expected}, got {len(args)}. "
                 "'stream' must be passed as a keyword argument."
-            )
+            ) from None
 
     def _build_fast_launcher(self, launcher: LauncherType) -> LauncherType | None:
         """Try to build a _FastCudaLauncher-backed version of the launcher.

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1166,14 +1166,12 @@ class CachingAutotuner(KernelInterface):
         kernel_name: str,
     ) -> None:
         """
-        Emit a clearer error when too many positional args would bind to a kwarg.
+        A clearer error when too many positional args would bind to a kwarg.
 
-        If a generated Triton launcher has a fixed Python signature (e.g.
-        `def launcher(arg0, arg1, ..., stream):`), passing too many positional
-        args will start binding them to later parameters (like `stream`, or `grid`
-        in older launcher variants). If we also pass that parameter by keyword,
+        If a generated Triton launcher has a fixed Python signature passing too many positional
+        args will start binding them to later parameters. If we also pass that parameter by keyword,
         the runtime error becomes "got multiple values for argument ...", which
-        is hard to diagnose. Detect that scenario and raise a direct message.
+        is hard to diagnose. Detect that scenario and raise a clear message.
         """
         cache_key = "_inductor_launcher_positional_limits"
         cached = getattr(launcher, cache_key, None)


### PR DESCRIPTION
### **PROBLEM**
When Inductor generates a Triton kernel and its corresponding launcher, a mismatch in arguments (e.g., due to signature changes, or a mismatch in filtering `constexpr` / `None` args) results in passing too many positional arguments at the call site. Because generated launcher functions append explicit parameters at the end (like `stream`), Python binds the excess positional arguments to these trailing parameters. Since `stream` is also explicitly passed via keyword argument during the launch, this results in a highly cryptic and confusing runtime error: `TypeError: got multiple values for argument 'stream'`.
### **SOLUTION**
This PR introduces a lightweight, cached preflight check (`_check_launcher_call_args`) inside `CachingAutotuner`. 
By caching positional limits using `inspect.signature` on the generated launcher, we can detect exactly when the number of positional arguments exceeds the parameter limit before it conflicts with keyword arguments like `stream`. 
Instead of an opaque multiple-values error, this check intercepts the launch and raises a highly descriptive `TypeError`:
> `...launcher expected at most X positional arguments (got Y); extra positional arguments would bind to 'stream', which is also passed by keyword. This usually means the Triton kernel has fewer parameters than the call site is passing...`
This significantly improves the debuggability of Inductor's custom kernel code generation. The check is executed during both benchmarking (`bench`) and standard runtime launches.
## **TESTING**
- The preflight check safely bails out with no-op overhead during standard, correctly formed kernel executions. 
- Properly catches and emits the improved error message when a mismatched parameter count occurs.

##** this was created by me, Noah Zach- I am an CS engineering major learning and trying to do something useful for my community.  My linkedin, insta and github are all open. You can freely reach out to me anytime for anything.**

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos