### PR TITLE
[tcomms-shim] Tests for torchcomms backed cuda symm mem

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -27,6 +27,7 @@ from torch.distributed._symmetric_memory import (
     restride_A_for_fused_matmul_reduce_scatter,
     restride_A_shard_for_fused_all_gather_matmul,
 )
+from torch.distributed.distributed_c10d import _TORCHCOMM_AVAILABLE
 from torch.testing._internal.common_cuda import (
     SM100OrLater,
     SM89OrLater,
@@ -39,6 +40,8 @@ from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     PLATFORM_SUPPORTS_SYMM_MEM,
     requires_multicast_support,
+    requires_nccl,
+    setup_torchcomms_pg,
     skip_if_lt_x_gpu,
     skip_if_rocm_multiprocess,
     skip_if_rocm_ver_lessthan_multiprocess,
@@ -1937,6 +1940,59 @@ class SymmMemPoolTest(MultiProcContinuousTest):
         y = torch.ops.symm_mem.one_shot_all_reduce(y, "sum", group_name)
         expected = torch.mm(x, w) * self.world_size
         self.assertEqual(y, expected)
+
+
+@instantiate_parametrized_tests
+@requires_cuda_p2p_access()
+class TorchCommsCudaSymmMemTest(MultiProcContinuousTest):
+    """CUDA symm_mem rendezvous against a torchcomms-backed PG.
+
+    Builds a torchcomms comm, wraps it in _BackendWrapper, registers it as
+    the NCCL backend on a bare ProcessGroup, and exercises symm_mem on the
+    CUDA backend (cuMemMap/IPC).
+    """
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    @requires_nccl()
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skipIf(not _TORCHCOMM_AVAILABLE, "torchcomms not installed")
+    @skipIf(TEST_WITH_ROCM, "torchcomms nccl backend not available on ROCm")
+    @skip_if_lt_x_gpu(2)
+    @parametrize("use_pg_for_rendezvous", [True, False])
+    def test_cuda_symm_mem_rendezvous_nccl(self, use_pg_for_rendezvous: bool) -> None:
+        torch.cuda.set_device(self.device)
+        suffix = f"usepg_{use_pg_for_rendezvous}"
+        group_name = f"torchcomms_cuda_symm_mem_nccl_{suffix}"
+        store_path = os.environ.get(
+            "TORCHCOMM_STORE_PATH",
+            f"/tmp/test_torchcomms_cuda_symm_mem_"
+            f"{os.environ.get('MASTER_PORT', '0')}_{suffix}",
+        )
+        pg = setup_torchcomms_pg(
+            backend="nccl",
+            rank=self.rank,
+            world_size=self.world_size,
+            device=self.device,
+            store_path=store_path,
+            group_name=group_name,
+        )
+        pg.use_pg_for_symm_mem_rendezvous = use_pg_for_rendezvous
+
+        t = symm_mem.empty(64, dtype=torch.float32, device=self.device).fill_(self.rank)
+        symm_mem_hdl = symm_mem.rendezvous(t, group=group_name)
+        self.assertEqual(symm_mem_hdl.rank, self.rank)
+        self.assertEqual(symm_mem_hdl.world_size, self.world_size)
+
+        symm_mem_hdl.barrier()
+        for peer in range(self.world_size):
+            buf = symm_mem_hdl.get_buffer(peer, (64,), torch.float32)
+            self.assertTrue(buf.eq(peer).all())
+        symm_mem_hdl.barrier()
 
 
 if __name__ == "__main__":

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -78,6 +78,73 @@ if _TORCHCOMM_AVAILABLE:
         if torchcomms.is_backend_built(_backend):
             globals()[_flag] = True
 
+
+def setup_torchcomms_pg(
+    backend: str,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    store_path: str,
+    group_name: str,
+) -> c10d.ProcessGroup:
+    """Build a bare ProcessGroup whose backend is a torchcomms _BackendWrapper.
+
+    Creates a torchcomms comm of the requested ``backend`` (e.g. ``nccl``,
+    ``ncclx``) and wraps it in ``_BackendWrapper``, then registers it as the
+    NCCL backend on a fresh ``ProcessGroup`` and publishes the group into
+    ``c10d._world`` so name-based lookups (e.g. ``symm_mem.rendezvous(...,
+    group=group_name)``) resolve to it.
+
+    Callers are responsible for choosing a ``group_name`` (and matching
+    ``store_path``) that is unique within the process — duplicates trip
+    ``_register_pg_in_world`` and the underlying FileStore.
+    """
+    from torch.distributed.distributed_c10d import (
+        _BackendWrapper,
+        _register_pg_in_world,
+    )
+
+    file_store = c10d.FileStore(store_path, world_size)
+
+    os.environ["TORCHCOMM_RANK"] = str(rank)
+    os.environ["TORCHCOMM_SIZE"] = str(world_size)
+
+    tc_comm = torchcomms.new_comm(
+        backend,
+        device,
+        name=f"{group_name}_comm",
+        store=c10d.PrefixStore(f"{group_name}_tc/", file_store),
+        hints={"persistent_store": "true"},
+    )
+
+    pg = c10d.ProcessGroup(
+        c10d.PrefixStore(f"{group_name}_pg/", file_store),
+        tc_comm.get_rank(),
+        tc_comm.get_size(),
+    )
+    pg._register_backend(
+        tc_comm.get_device(),
+        c10d.ProcessGroup.BackendType.NCCL,
+        _BackendWrapper(tc_comm),
+    )
+    # _register_backend only updates the per-device map; backendType_ stays
+    # UNDEFINED. getDefaultBackend()-dependent setters (including
+    # use_pg_for_symm_mem_rendezvous) fail without this.
+    pg._set_default_backend(c10d.ProcessGroup.BackendType.NCCL)
+
+    pg._set_group_name(group_name)
+    _register_pg_in_world(
+        pg,
+        backend_name=backend,
+        store=file_store,
+        group_name=group_name,
+        backend_config=backend,
+        rank_mapping={r: r for r in range(world_size)},
+    )
+
+    return pg
+
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
Adds coverage for `CUDASymmetricMemory` rendezvous on a `ProcessGroup` whose backend is provided by torchcomms via `_BackendWrapper`, validating the shim path that lets symm_mem work without  `ProcessGroupNCCL`.

Two variants are parametrized:

- `use_pg_for_symm_mem_rendezvous=True` — metadata allgather flows through the torchcomms-backed PG.
- `use_pg_for_symm_mem_rendezvous=False` — metadata exchange falls back to  the default TCPStore path.

In both cases the test allocates a symm_mem buffer, rendezvouses on the PG, and verifies each rank reads its peers' buffers.

**NOTE:** Also, serves as an example of using _BackendWrapper torchcomms shim with cuda symm mem

**Test Plan:** `pytest test/distributed/test_symmetric_memory.py::TorchCommsCudaSymmMemTest -v -s`
