### PR TITLE
Remove ONEDNN_SUPPORT_DETERMINISTIC compile-time guard for XPU oneDNN primitives

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
@@ -112,12 +112,10 @@ sycl::event convolution(
 
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-#if ONEDNN_SUPPORT_DETERMINISTIC
   if (at::globalContext().deterministicAlgorithms() ||
       at::globalContext().deterministicMkldnn()) {
     pattr.set_deterministic(true);
   }
-#endif
 
   at::native::onednn::apply_tf32_if_allowed(pattr);
 
@@ -204,12 +202,10 @@ sycl::event convolution_backward_weights(
   dnnl::memory::dims _dilation = compatible_dilation(dilation);
   dnnl::primitive_attr pattr;
 
-#if ONEDNN_SUPPORT_DETERMINISTIC
   if (at::globalContext().deterministicAlgorithms() ||
       at::globalContext().deterministicMkldnn()) {
     pattr.set_deterministic(true);
   }
-#endif
 
   at::native::onednn::apply_tf32_if_allowed(pattr);
 
@@ -307,12 +303,10 @@ sycl::event convolution_backward_data(
   // create fwd primitive desc hint
   dnnl::primitive_attr pattr;
 
-#if ONEDNN_SUPPORT_DETERMINISTIC
   if (at::globalContext().deterministicAlgorithms() ||
       at::globalContext().deterministicMkldnn()) {
     pattr.set_deterministic(true);
   }
-#endif
 
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
   dnnl::memory::dims _stride = stride.vec();

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
@@ -183,11 +183,9 @@ sycl::event deconvolution(
   dnnl::primitive_attr pattr;
   dnnl::post_ops po = attr.extract_post_ops(dst);
   pattr.set_post_ops(po);
-#if ONEDNN_SUPPORT_DETERMINISTIC
   if (at::globalContext().deterministicAlgorithms() ||
       at::globalContext().deterministicMkldnn())
     pattr.set_deterministic(true);
-#endif
 
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -268,11 +266,9 @@ sycl::event deconvolution_backward_data(
   // create fwd primitive desc hint
   dnnl::primitive_attr pattr;
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-#if ONEDNN_SUPPORT_DETERMINISTIC
   if (at::globalContext().deterministicAlgorithms() ||
       at::globalContext().deterministicMkldnn())
     pattr.set_deterministic(true);
-#endif
 
   dnnl::memory::dims _stride = stride.vec();
   dnnl::memory::dims _padding_l = padding.vec();
@@ -370,11 +366,9 @@ sycl::event deconvolution_backward_weights(
   dnnl::memory::dims _dilation = deconv_compatible_dilation(dilation);
   dnnl::primitive_attr pattr;
 
-#if ONEDNN_SUPPORT_DETERMINISTIC
   if (at::globalContext().deterministicAlgorithms() ||
       at::globalContext().deterministicMkldnn())
     pattr.set_deterministic(true);
-#endif
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
   auto deconv_fwd_pd = dnnl::deconvolution_forward::primitive_desc(
       engine,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -188,11 +188,9 @@ sycl::event matmul(
   dnnl::primitive_attr pattr;
   pattr.set_post_ops(po);
 
-#if ONEDNN_SUPPORT_DETERMINISTIC
   if (at::globalContext().deterministicAlgorithms() ||
       at::globalContext().deterministicMkldnn())
     pattr.set_deterministic(true);
-#endif
 
   // scratchpad
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -471,11 +471,9 @@ sycl::event scaled_matmul(
 
   dnnl::primitive_attr op_attr = dnnl::primitive_attr();
 
-#if ONEDNN_SUPPORT_DETERMINISTIC
   if (at::globalContext().deterministicAlgorithms() ||
       at::globalContext().deterministicMkldnn())
     op_attr.set_deterministic(true);
-#endif
 
   std::vector<int64_t> default_groups;
   op_attr.set_scales(

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -15,9 +15,6 @@
 
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
 
-#define ONEDNN_SUPPORT_DETERMINISTIC \
-  (DNNL_VERSION_MAJOR >= 3 && DNNL_VERSION_MINOR >= 4)
-
 namespace at::native::onednn {
 
 dnnl::memory::format_tag get_dnnl_default_format(

--- a/aten/src/ATen/native/mkldnn/xpu/detail/WoQMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/WoQMatmul.cpp
@@ -121,12 +121,10 @@ void woq_matmul_int4_impl(
 
   dnnl::primitive_attr pattr;
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-#if ONEDNN_SUPPORT_DETERMINISTIC
   if (at::globalContext().deterministicAlgorithms() ||
       at::globalContext().deterministicMkldnn()) {
     pattr.set_deterministic(true);
   }
-#endif
 
   // Set scales with multiple scales along K dimension and with groups along  K.
   pattr.set_scales(
@@ -230,12 +228,10 @@ void woq_matmul_int4_impl_cache(
 
     set_quant_primitive_attr(pattr, scale, zp, group_size);
 
-#if ONEDNN_SUPPORT_DETERMINISTIC
     if (at::globalContext().deterministicAlgorithms() ||
         at::globalContext().deterministicMkldnn()) {
       pattr.set_deterministic(true);
     }
-#endif
   };
 
   int64_t zp_group_size = group_size;


### PR DESCRIPTION
## Summary

Remove `#if ONEDNN_SUPPORT_DETERMINISTIC` / `#endif` compile-time guards around `pattr.set_deterministic(true)` calls in XPU oneDNN primitive setup code.

## Problem

`torch.use_deterministic_algorithms(True)` is silently ignored for XPU matmul/convolution/deconvolution operations when the `ONEDNN_SUPPORT_DETERMINISTIC` macro evaluates to 0. This produces non-reproducible results on Intel XPU GPUs, while the equivalent CUDA BLAS operations (CublasHandlePool.cpp:460) unconditionally enforce the deterministic contract.

Reproducer shows:
- **XPU**: `det=True` vs `det=False` produce different bitwise results (max diff 6.2e-06 float32, 1.5e-02 bfloat16)
- **CUDA**: bitwise-identical results regardless of the flag

## Root Cause

The guard `#if ONEDNN_SUPPORT_DETERMINISTIC` (defined as `DNNL_VERSION_MAJOR >= 3 && DNNL_VERSION_MINOR >= 4`) conditionally compiles out the `set_deterministic(true)` call. When built with oneDNN < 3.4, the deterministic algorithms flag becomes a no-op for all XPU BLAS operations.

## Fix

Since oneDNN >= 3.4 is the minimum supported version for Intel XPU builds (current systems use oneDNN 3.9+), the compile-time guard is unnecessary. Remove it so `set_deterministic(true)` is unconditionally called when `deterministicAlgorithms()` or `deterministicMkldnn()` is true.

**Files changed (6, -23 lines):**
- `aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp` — 1 guard removed
- `aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp` — 3 guards removed (fwd, bwd_weights, bwd_data)
- `aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp` — 3 guards removed (fwd, bwd_data, bwd_weights)
- `aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp` — 1 guard removed
- `aten/src/ATen/native/mkldnn/xpu/detail/WoQMatmul.cpp` — 2 guards removed
- `aten/src/ATen/native/mkldnn/xpu/detail/Utils.h` — dead macro definition removed

## CUDA Reference

`aten/src/ATen/cuda/CublasHandlePool.cpp:460` unconditionally checks `at::globalContext().deterministicAlgorithms()` at handle creation time — no compile-time gate prevents this check.

## Testing

- Reproducer script exercises `aten::mm`, `aten::addmm`, `aten::linear`, `aten::convolution` with float32 and bfloat16 on XPU
- Verifies self-consistency of `det=True` runs (same input → same output)
- Confirms CUDA produces bitwise-identical results as reference

Fixes: https://github.com/intel/torch-xpu-ops/issues/3216

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @intel/torch-xpu-ops-maintainers
