### PR TITLE
Fix scan gradients for closed-over parameters with non-grad carries

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -2977,6 +2977,45 @@ class GraphModule(torch.nn.Module):
             self.assertEqual(grads, expected_grads)
             self.assertEqual(add_input_grads, expected_add_input_grads)
 
+    @parametrize("include_final_carry", [False, True])
+    def test_scan_closure_scalar_carry_grad(self, include_final_carry):
+        dtype = torch.float64
+        x = torch.tensor([0.11, -0.37, 0.23, 0.41, -0.19], dtype=dtype)
+        a = torch.tensor(0.7, dtype=dtype)
+        carry0 = torch.tensor(0.2, dtype=dtype)
+
+        def loop_recurrence(x, a, carry0):
+            carry = carry0
+            ys = []
+            for x_t in x:
+                carry = a * carry + x_t
+                ys.append(carry)
+            return carry, torch.stack(ys)
+
+        def scan_recurrence(x, a, carry0):
+            def step(carry, x_t):
+                carry_next = a * carry + x_t
+                return carry_next.clone(), carry_next.clone()
+
+            return scan(step, carry0, x, dim=0)
+
+        def value_and_grad(recurrence):
+            a_req_grad = a.detach().clone().requires_grad_()
+            carry, ys = recurrence(x, a_req_grad, carry0)
+            loss = ys.square().sum()
+            if include_final_carry:
+                loss = loss + carry.square()
+            (grad_a,) = torch.autograd.grad(loss, a_req_grad)
+            return loss.detach(), grad_a.detach(), carry.detach(), ys.detach()
+
+        scan_loss, scan_grad, scan_carry, scan_ys = value_and_grad(scan_recurrence)
+        loop_loss, loop_grad, loop_carry, loop_ys = value_and_grad(loop_recurrence)
+
+        self.assertEqual(scan_carry, loop_carry)
+        self.assertEqual(scan_ys, loop_ys)
+        self.assertEqual(scan_loss, loop_loss)
+        self.assertEqual(scan_grad, loop_grad)
+
     @unittest.skipIf(not SM70OrLater, "triton")
     @requires_cuda
     @parametrize("reverse", [False, True])

--- a/torch/_higher_order_ops/scan.py
+++ b/torch/_higher_order_ops/scan.py
@@ -814,13 +814,25 @@ class ScanAutogradImpl:
         )
 
 
+def _make_scan_carry_differentiable_for_tracing(carry: torch.Tensor) -> torch.Tensor:
+    sample_carry = carry.detach().clone()
+    if carry.dtype.is_floating_point or carry.dtype.is_complex:
+        sample_carry.requires_grad_(True)
+    return sample_carry
+
+
 @scan_op.py_autograd_impl
 def scan_autograd(combine_fn, init, xs, additional_inputs):
+    partitioner_args = (
+        *[_make_scan_carry_differentiable_for_tracing(t) for t in init],
+        *[x[0] for x in xs],
+        *additional_inputs,
+    )
     with disable_proxy_modes_tracing():
         hop_partitioned_graph: HopPartitionedGraph = (
             HopGraphMinCutPartitioner.create_partitioned_graph(
                 combine_fn,
-                (*init, *[x[0] for x in xs], *additional_inputs),
+                partitioner_args,
                 always_recompute_complex_exprs=True,
             )
         )

--- a/torch/_higher_order_ops/scan.py
+++ b/torch/_higher_order_ops/scan.py
@@ -540,6 +540,7 @@ class ScanAutogradImpl:
         self.saved_intermediates: list[Any] = []
         self.fw_spec = pytree.tree_flatten((init, xs, additional_inputs))[1]
         self._optimize_forward_intermediates()
+        self._break_bw_input_output_aliasing()
 
     def _insert_clone(
         self, need_copy_node: torch.fx.Node, output_node: torch.fx.Node
@@ -554,6 +555,39 @@ class ScanAutogradImpl:
                 need_copy_node.meta.copy() if hasattr(need_copy_node, "meta") else {}
             )
         return clone_node
+
+    def _break_bw_input_output_aliasing(self) -> None:
+        """
+        The min-cut partitioner can produce a ``bw_gm`` that returns an input
+        placeholder directly (for example when an input doesn't require grad
+        and its gradient is ``zeros_like(input)`` which the partitioner saved as
+        a forward intermediate).
+
+        When this ``bw_gm`` is later wrapped into the per-step backward used by
+        ``scan_op``, the resulting subgraph has an input that is returned as an
+        output, which violates ``scan_op``'s aliasing-free invariant and causes
+        ``UncapturedHigherOrderOpError`` under dynamo. To prevent this, clone
+        any ``bw_gm`` output that is a placeholder.
+        """
+        bw_gm = self.hop_partitioned_graph.bw_gm
+        bw_output_node = next(iter(bw_gm.graph.find_nodes(op="output")))
+        if len(bw_output_node.args) != 1:
+            raise AssertionError(
+                f"expected bw_gm output to have 1 arg, got {len(bw_output_node.args)}"
+            )
+        bw_outputs = bw_output_node.args[0]
+        new_bw_outputs = []
+        rewrote = False
+        for out in bw_outputs:
+            if isinstance(out, torch.fx.Node) and out.op == "placeholder":
+                new_bw_outputs.append(self._insert_clone(out, bw_output_node))
+                rewrote = True
+            else:
+                new_bw_outputs.append(out)
+        if rewrote:
+            bw_output_node.args = (tuple(new_bw_outputs),)
+            bw_gm.graph.lint()
+            bw_gm.recompile()
 
     def _optimize_forward_intermediates(self):
         """


### PR DESCRIPTION
Closes https://github.com/pytorch/pytorch/issues/184528

## Summary

Fixes `torch._higher_order_ops.scan` autograd so closed-over parameter gradients include indirect contributions through recurrent carry state, even when the initial carry tensor does not require grad.

`scan_autograd` previously built the single-step joint graph from the real initial carry tensors. If an initial carry had `requires_grad=False`, AOTAutograd traced the single-step backward with a zero carry gradient. The reverse scan then propagated zero carry cotangents across timesteps, causing closed-over parameters to miss part of their gradient.

This PR traces the partitioned scan backward graph with detached carry samples that require grad when their dtype is differentiable. The actual operands passed to `ScanAutogradOp.apply` are unchanged, so user-visible initial-carry gradient semantics are preserved.

Added a regression test comparing `scan` with a Python loop for a scalar recurrence where `a` is closed over by the scan body and `carry0.requires_grad=False`. The test checks forward carry, stacked outputs, loss, and `dloss / da` for both losses with and without the final carry.
