### PR TITLE
[Inductor] Scale test_bmm_large_batch_dynamic inputs to unskip it on ROCm

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1905,6 +1905,9 @@ class AOTInductorTestsTemplate:
         # Large batch exceeding CUDA grid.y limit of 65535
         large_batch = 70000
         list_example_inputs.append(make_inputs(large_batch))
+        # ROCm Triton fp16 BMM uses a different reduction order than eager BLAS,
+        # so a few elements diff by ~1 fp16 ULP; NVIDIA stays bit-equivalent.
+        tol = 1e-3 if TEST_WITH_ROCM else 1e-4
         self.check_model_with_multiple_inputs(
             model,
             list_example_inputs,
@@ -1913,7 +1916,7 @@ class AOTInductorTestsTemplate:
                 "max_autotune_gemm_backends": "TRITON",
             },
             dynamic_shapes=dynamic_shapes,
-            tol=1e-3,
+            tol=tol,
         )
 
     @skipIfWindows(msg="TODO: (xuhancn) confirm, Crash: access violation")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1913,6 +1913,7 @@ class AOTInductorTestsTemplate:
                 "max_autotune_gemm_backends": "TRITON",
             },
             dynamic_shapes=dynamic_shapes,
+            tol=1e-2,
         )
 
     @skipIfWindows(msg="TODO: (xuhancn) confirm, Crash: access violation")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1866,7 +1866,6 @@ class AOTInductorTestsTemplate:
             dynamic_shapes=dynamic_shapes,
         )
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179958")
     @unittest.skipIf(
         not IS_BIG_GPU, "Skipping triton backend only since not big GPU (not enough SM)"
     )
@@ -1906,7 +1905,7 @@ class AOTInductorTestsTemplate:
         large_batch = 70000
         list_example_inputs.append(make_inputs(large_batch))
         # ROCm Triton fp16 BMM uses a different reduction order than eager BLAS,
-        # so a few elements diff by ~1 fp16 ULP; NVIDIA stays bit-equivalent.
+        # so a few elements diff by ~1 fp16 ULP, regression would create x30 diff
         tol = 1e-3 if TEST_WITH_ROCM else 1e-4
         self.check_model_with_multiple_inputs(
             model,

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1913,7 +1913,7 @@ class AOTInductorTestsTemplate:
                 "max_autotune_gemm_backends": "TRITON",
             },
             dynamic_shapes=dynamic_shapes,
-            tol=1e-2,
+            tol=1e-3,
         )
 
     @skipIfWindows(msg="TODO: (xuhancn) confirm, Crash: access violation")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1941,13 +1941,14 @@ class AOTInductorTestsTemplate:
         model = Model()
 
         # Scale inputs so this grid-size test is not sensitive to FP16 BMM noise.
+        # Outputs stay under 0.125, where 1 fp16 ULP exceeds same()'s 1e-4 tolerance.
         def make_inputs(batch):
             return (
-                0.5
+                0.25
                 * random_matrix_with_scaled_reduction_dim(
                     M, K, batch, device=self.device, dtype=dtype, reduction_dim=-1
                 ),
-                0.5
+                0.25
                 * random_matrix_with_scaled_reduction_dim(
                     K, N, batch, device=self.device, dtype=dtype, reduction_dim=-2
                 ),
@@ -1963,9 +1964,6 @@ class AOTInductorTestsTemplate:
         # Large batch exceeding CUDA grid.y limit of 65535
         large_batch = 70000
         list_example_inputs.append(make_inputs(large_batch))
-        # ROCm Triton fp16 BMM uses a different reduction order than eager BLAS,
-        # so a few elements diff by ~1 fp16 ULP, regression would create x30 diff
-        tol = 1e-3 if TEST_WITH_ROCM else 1e-4
         self.check_model_with_multiple_inputs(
             model,
             list_example_inputs,
@@ -1974,7 +1972,6 @@ class AOTInductorTestsTemplate:
                 "max_autotune_gemm_backends": "TRITON",
             },
             dynamic_shapes=dynamic_shapes,
-            tol=tol,
         )
 
     @skipIfWindows(msg="TODO: (xuhancn) confirm, Crash: access violation")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1925,7 +1925,6 @@ class AOTInductorTestsTemplate:
             dynamic_shapes=dynamic_shapes,
         )
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179958")
     @unittest.skipIf(
         not IS_BIG_GPU, "Skipping triton backend only since not big GPU (not enough SM)"
     )
@@ -1965,7 +1964,7 @@ class AOTInductorTestsTemplate:
         large_batch = 70000
         list_example_inputs.append(make_inputs(large_batch))
         # ROCm Triton fp16 BMM uses a different reduction order than eager BLAS,
-        # so a few elements diff by ~1 fp16 ULP; NVIDIA stays bit-equivalent.
+        # so a few elements diff by ~1 fp16 ULP, regression would create x30 diff
         tol = 1e-3 if TEST_WITH_ROCM else 1e-4
         self.check_model_with_multiple_inputs(
             model,

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1972,6 +1972,7 @@ class AOTInductorTestsTemplate:
                 "max_autotune_gemm_backends": "TRITON",
             },
             dynamic_shapes=dynamic_shapes,
+            tol=1e-2,
         )
 
     @skipIfWindows(msg="TODO: (xuhancn) confirm, Crash: access violation")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1964,6 +1964,9 @@ class AOTInductorTestsTemplate:
         # Large batch exceeding CUDA grid.y limit of 65535
         large_batch = 70000
         list_example_inputs.append(make_inputs(large_batch))
+        # ROCm Triton fp16 BMM uses a different reduction order than eager BLAS,
+        # so a few elements diff by ~1 fp16 ULP; NVIDIA stays bit-equivalent.
+        tol = 1e-3 if TEST_WITH_ROCM else 1e-4
         self.check_model_with_multiple_inputs(
             model,
             list_example_inputs,
@@ -1972,7 +1975,7 @@ class AOTInductorTestsTemplate:
                 "max_autotune_gemm_backends": "TRITON",
             },
             dynamic_shapes=dynamic_shapes,
-            tol=1e-3,
+            tol=tol,
         )
 
     @skipIfWindows(msg="TODO: (xuhancn) confirm, Crash: access violation")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1972,7 +1972,7 @@ class AOTInductorTestsTemplate:
                 "max_autotune_gemm_backends": "TRITON",
             },
             dynamic_shapes=dynamic_shapes,
-            tol=1e-2,
+            tol=1e-3,
         )
 
     @skipIfWindows(msg="TODO: (xuhancn) confirm, Crash: access violation")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -85,7 +85,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     random_matrix_with_scaled_reduction_dim,
     runOnRocm,
-    skipIfRocm,
     skipIfRocmArch,
     skipIfWindows,
     skipIfWindowsXPU,

--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -265,6 +265,7 @@ def check_model_with_multiple_inputs(
     list_example_inputs,
     options=None,
     dynamic_shapes=None,
+    tol: float = 1e-4,
 ):
     with (
         torch.no_grad(),
@@ -286,7 +287,7 @@ def check_model_with_multiple_inputs(
             model, list_example_inputs, options, dynamic_shapes
         )
 
-    self.assertTrue(same(list_actual, list_expected))
+    self.assertTrue(same(list_actual, list_expected, tol=tol))
 
 
 def code_check_count(

--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -265,7 +265,6 @@ def check_model_with_multiple_inputs(
     list_example_inputs,
     options=None,
     dynamic_shapes=None,
-    tol: float = 1e-4,
 ):
     with (
         torch.no_grad(),
@@ -287,7 +286,7 @@ def check_model_with_multiple_inputs(
             model, list_example_inputs, options, dynamic_shapes
         )
 
-    self.assertTrue(same(list_actual, list_expected, tol=tol))
+    self.assertTrue(same(list_actual, list_expected))
 
 
 def code_check_count(


### PR DESCRIPTION
FIXES #179958

Following @jeffdaily's review, this drops the tolerance approach and extends the input scaling from #183630 instead: `make_inputs` scales by 0.25 rather than 0.5, and the ROCm skip is removed. There is no new tolerance parameter and no `TEST_WITH_ROCM` conditional, so `check_model_with_multiple_inputs` is left alone.

**Why the test fails.** `check_model_with_multiple_inputs` compares with `same()`, which is `allclose(atol=1e-4, rtol=1e-4)`. Once fp16 outputs reach 0.125, one ULP there (1.22e-4) is wider than that budget, so above that magnitude the check requires eager and Triton to round every element identically. At the 0.5 scale about 36k of the 287M outputs at `batch=70000` land above 0.125. NVIDIA happens to round them the same way, MI300 does not, because its Triton kernel chains two K=16 MFMAs in an order that doesn't match rocBLAS/hipBLASLt/CK. So main leaves less than one ULP of headroom at the top of the output distribution on every platform, which is the same fragility #183630 hit on RTX PRO 6000.

**Why 0.25.** Both factors are powers of two, so this halves every fp16 input exactly: outputs and diffs scale by exactly 1/4 while the 1e-4 atol floor stays where it is. The largest output moves to ~0.05, where 1 ULP is 3.05e-5 against a ~1.0e-4 budget. Measured on MI300X over 5 seeds at `batch=70000`:

| input scale | max output | outputs >= 0.125 | worst diff | elements over 1e-4 | min passing tol |
| --- | --- | --- | --- | --- | --- |
| 0.5 (main) | 0.209 | 35887 | 1.22e-4 (1 ULP) | 1-7 of 287M | 1.083e-4 |
| 0.25 (this PR) | 0.052 | 0 | 3.05e-5 (1 ULP) | 0 | 2.96e-5 |

**The test still covers what it is for.** `batch=70000` is unchanged, so the `grid.y` > 65535 path runs exactly as before and only the values differ. The round-off now being tolerated is unrelated to the batch splitting under test: its rate is flat across the boundary, 2.87e-4 below vs 2.84e-4 above (ratio 0.99). Injecting plausible `grid.y` regressions into the result still fails the comparison by a wide margin at the 0.25 scale: 515x for a tail that is never written, 650x for a tail that wraps to batch 0, 295x for a single zeroed batch, and 36x for a single zeroed element.

Verified on MI300X: fails on main with the skip removed, passes with this change.

@eqy flagging you since this extends the scaling you added in #183630.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben
