### PR TITLE
Remove coordinate cache in LocalDeviceMesh

### DIFF
--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1261,10 +1261,6 @@ class LocalTensorMode(TorchDispatchMode):
         self._per_rank_rng_states: dict[
             int, tuple[torch.Tensor, dict[int, torch.Tensor]]
         ] = {}
-        # Cache for get_coordinate results, keyed by mesh id
-        # Protected by _coordinate_cache_lock for thread safety in MPMD contexts
-        self._coordinate_cache: dict[int, list[SymInt]] = {}
-        self._coordinate_cache_lock = threading.Lock()
 
     def __enter__(self) -> "LocalTensorMode":
         get_local_tensor_mode_list().append(self)
@@ -1594,36 +1590,23 @@ class _LocalDeviceMesh:
         if lm is None:
             raise AssertionError("Unexpectedly not in LocalTensorMode")
 
-        # Check cache first (fast path without lock)
-        mesh_id = id(self)
-        if mesh_id in lm._coordinate_cache:
-            return lm._coordinate_cache[mesh_id]
+        coords: list[dict[int, int]] = [{} for _ in range(self.ndim)]
+        # Clone rank_map to avoid "Cannot set version_counter for inference tensor"
+        # error when running under torch.inference_mode()
+        rank_map = self._rank_map.clone()
+        for r in lm.ranks:
+            rank_tensor = self._layout.remap_to_tensor(rank_map)
+            rank_coords = (rank_tensor == r).nonzero().tolist()
+            if len(rank_coords) != 1:
+                raise AssertionError
+            for d, c in enumerate(rank_coords[0][1:]):
+                coords[d][r] = c
 
-        # Acquire lock for thread safety in MPMD contexts
-        with lm._coordinate_cache_lock:
-            # Double-check after acquiring lock
-            if mesh_id in lm._coordinate_cache:
-                return lm._coordinate_cache[mesh_id]
-
-            coords: list[dict[int, int]] = [{} for _ in range(self.ndim)]
-            # Clone rank_map to avoid "Cannot set version_counter for inference tensor"
-            # error when running under torch.inference_mode()
-            rank_map = self._rank_map.clone()
-            for r in lm.ranks:
-                rank_tensor = self._layout.remap_to_tensor(rank_map)
-                rank_coords = (rank_tensor == r).nonzero().tolist()
-                if len(rank_coords) != 1:
-                    raise AssertionError
-                for d, c in enumerate(rank_coords[0][1:]):
-                    coords[d][r] = c
-
-            out = [torch.SymInt(LocalIntNode(c)) for c in coords]
-            # Cache the result
-            lm._coordinate_cache[mesh_id] = out
-            # The output contains coordinates for each of the ranks with respect to
-            # their meshes formed from root mesh and selecting the same dimensions
-            # as the current mesh.
-            return out  # type: ignore[return-value]
+        out = [torch.SymInt(LocalIntNode(c)) for c in coords]
+        # The output contains coordinates for each of the ranks with respect to
+        # their meshes formed from root mesh and selecting the same dimensions
+        # as the current mesh.
+        return out  # type: ignore[return-value]
 
     @staticmethod
     def _is_current_rank_part_of_mesh(self: DeviceMesh) -> bool:


### PR DESCRIPTION
The cache uses the `id` of the Mesh as the key which is not unique over the lifetime of the `LocalTensorMode` instance:
When the mesh is destroyed its slot may be reused leading to silently wrong, indeterministic results.
E.g.:
```
        mesh_dim0_local_rank = mesh_2d["dim0"].get_local_rank(mesh_dim=0)
        mesh_dim1_local_rank = mesh_2d["dim1"].get_local_rank(mesh_dim=0)
```
The values for both might be the same as the 2nd could use the cached coords from the first submesh, which is a temporary that gets immediately destroyed.

Mostly a revert of https://github.com/pytorch/pytorch/pull/173836

Fixes #184526