### PR TITLE
[xpu] graphs must not use get_nodes() if empty() is available

### DIFF
--- a/aten/src/ATen/xpu/XPUGraph.cpp
+++ b/aten/src/ATen/xpu/XPUGraph.cpp
@@ -126,8 +126,15 @@ void XPUGraphImpl::capture_end() {
     wholegraph_increments = generator_state->capture_epilogue();
   }
 
-  size_t num_xpu_graph_nodes = graph_->get_nodes().size();
-  if (num_xpu_graph_nodes == 0) {
+  // When SYCL_COMPILER_VERSION meets the threshold, use empty(); If empty()
+  // method is available, graphs must not use get_nodes(). Otherwise use "the
+  // old method", via get_nodes().
+#if SYCL_COMPILER_VERSION >= 20260101
+  const bool graph_is_empty = graph_->empty();
+#else
+  const bool graph_is_empty = (graph_->get_nodes().size() == 0);
+#endif
+  if (graph_is_empty) {
     TORCH_WARN(
         "The XPU Graph is empty. This usually means that the graph was ",
         "attempted to be captured on wrong device or stream.");


### PR DESCRIPTION
# Motivation
We'd like to use empty() method on graphs, instead of relaying on `get_nodes()`. When SYCL will switch to new implementation - native L0 graphs - the `get_nodes()` method won't work.
`empty()` method, on the other hand, does work for both types of graphs.
Please see: https://github.com/intel/llvm/pull/21554