### PR TITLE
[Inductor] add broader CuteDSL op overrides

### DIFF
--- a/test/inductor/test_cutedsl_template.py
+++ b/test/inductor/test_cutedsl_template.py
@@ -672,6 +672,66 @@ SCALE_FACTOR: cutlass.Constexpr = 1.5
                 result = CuteDSLOpOverrides.minimum(mock_cse_a, mock_cse_b)
                 self.assertIsInstance(result, CSEVariable)
 
+                # Unary math ops
+                result = CuteDSLOpOverrides.rsqrt(mock_cse_a)
+                self.assertIsInstance(result, CSEVariable)
+
+                result = CuteDSLOpOverrides.exp2(mock_cse_a)
+                self.assertIsInstance(result, CSEVariable)
+
+                result = CuteDSLOpOverrides.log2(mock_cse_a)
+                self.assertIsInstance(result, CSEVariable)
+
+                result = CuteDSLOpOverrides.log10(mock_cse_a)
+                self.assertIsInstance(result, CSEVariable)
+
+                result = CuteDSLOpOverrides.tan(mock_cse_a)
+                self.assertIsInstance(result, CSEVariable)
+
+                result = CuteDSLOpOverrides.acos(mock_cse_a)
+                self.assertIsInstance(result, CSEVariable)
+
+                result = CuteDSLOpOverrides.asin(mock_cse_a)
+                self.assertIsInstance(result, CSEVariable)
+
+                result = CuteDSLOpOverrides.atan(mock_cse_a)
+                self.assertIsInstance(result, CSEVariable)
+
+                result = CuteDSLOpOverrides.floor(mock_cse_a)
+                self.assertIsInstance(result, CSEVariable)
+
+                # Binary math ops
+                result = CuteDSLOpOverrides.atan2(mock_cse_a, mock_cse_b)
+                self.assertIsInstance(result, CSEVariable)
+
+                result = CuteDSLOpOverrides.logical_xor(mock_cse_a, mock_cse_b)
+                self.assertIsInstance(result, CSEVariable)
+
+            body = kernel.body.getvalue()
+
+            # Verify codegen strings for existing ops
+            self.assertIn("(tensor_a + tensor_b)", body)
+            self.assertIn("(tensor_a * tensor_b)", body)
+            self.assertIn("(tensor_a / tensor_b)", body)
+            self.assertIn("cute.math.sqrt(tensor_a)", body)
+
+            # Verify codegen strings for new unary math ops
+            self.assertIn("cute.math.rsqrt(tensor_a)", body)
+            self.assertIn("cute.math.exp2(tensor_a)", body)
+            self.assertIn("cute.math.log2(tensor_a)", body)
+            self.assertIn("cute.math.log10(tensor_a)", body)
+            self.assertIn("cute.math.tan(tensor_a)", body)
+            self.assertIn("cute.math.acos(tensor_a)", body)
+            self.assertIn("cute.math.asin(tensor_a)", body)
+            self.assertIn("cute.math.atan(tensor_a)", body)
+            self.assertIn("cute.math.floor(tensor_a)", body)
+
+            # Verify codegen strings for new binary math ops
+            self.assertIn("cute.math.atan2(tensor_a, tensor_b)", body)
+
+            # Verify codegen strings for logical op
+            self.assertIn("(tensor_a ^ tensor_b)", body)
+
         scalar_result = CuteDSLOpOverrides._ensure_tensor_ssa(
             "5.0", mock_cse_a, is_tensor=False
         )

--- a/test/inductor/test_cutedsl_template.py
+++ b/test/inductor/test_cutedsl_template.py
@@ -704,18 +704,19 @@ SCALE_FACTOR: cutlass.Constexpr = 1.5
                 result = CuteDSLOpOverrides.atan2(mock_cse_a, mock_cse_b)
                 self.assertIsInstance(result, CSEVariable)
 
+                # Logical ops
                 result = CuteDSLOpOverrides.logical_xor(mock_cse_a, mock_cse_b)
                 self.assertIsInstance(result, CSEVariable)
 
             body = kernel.body.getvalue()
 
-            # Verify codegen strings for existing ops
+            # Arithmetic ops
             self.assertIn("(tensor_a + tensor_b)", body)
             self.assertIn("(tensor_a * tensor_b)", body)
             self.assertIn("(tensor_a / tensor_b)", body)
-            self.assertIn("cute.math.sqrt(tensor_a)", body)
 
-            # Verify codegen strings for new unary math ops
+            # Unary math ops
+            self.assertIn("cute.math.sqrt(tensor_a)", body)
             self.assertIn("cute.math.rsqrt(tensor_a)", body)
             self.assertIn("cute.math.exp2(tensor_a)", body)
             self.assertIn("cute.math.log2(tensor_a)", body)
@@ -726,10 +727,10 @@ SCALE_FACTOR: cutlass.Constexpr = 1.5
             self.assertIn("cute.math.atan(tensor_a)", body)
             self.assertIn("cute.math.floor(tensor_a)", body)
 
-            # Verify codegen strings for new binary math ops
+            # Binary math ops
             self.assertIn("cute.math.atan2(tensor_a, tensor_b)", body)
 
-            # Verify codegen strings for logical op
+            # Logical ops
             self.assertIn("(tensor_a ^ tensor_b)", body)
 
         scalar_result = CuteDSLOpOverrides._ensure_tensor_ssa(

--- a/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
@@ -375,15 +375,35 @@ class CuteDSLOpOverrides(OpOverrides):
 
     @staticmethod
     # pyrefly: ignore [bad-override]
+    def exp2(x: CuteDSLArg) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.exp2({x})")
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
     def sqrt(x: CuteDSLArg) -> CuteDSLArg:
         """Square root using CuteDSL cute.math.sqrt function."""
         return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.sqrt({x})")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
+    def rsqrt(x: CuteDSLArg) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.rsqrt({x})")
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
     def log(x: CuteDSLArg) -> CuteDSLArg:
         """Natural logarithm using CuteDSL cute.math.log function."""
         return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.log({x})")
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def log2(x: CuteDSLArg) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.log2({x})")
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def log10(x: CuteDSLArg) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.log10({x})")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
@@ -396,6 +416,31 @@ class CuteDSLOpOverrides(OpOverrides):
     def sin(x: CuteDSLArg) -> CuteDSLArg:
         """Sine using CuteDSL cute.math.sin function."""
         return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.sin({x})")
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def tan(x: CuteDSLArg) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.tan({x})")
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def acos(x: CuteDSLArg) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.acos({x})")
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def asin(x: CuteDSLArg) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.asin({x})")
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def atan(x: CuteDSLArg) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.atan({x})")
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def atan2(a: CuteDSLArg, b: CuteDSLArg) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_binary_op(a, b, "cute.math.atan2({a}, {b})")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
@@ -537,6 +582,11 @@ class CuteDSLOpOverrides(OpOverrides):
 
     @staticmethod
     # pyrefly: ignore [bad-override]
+    def floor(x: CuteDSLArg) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.floor({x})")
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
     def abs(x: CuteDSLArg) -> CuteDSLArg:
         """Absolute value using CuteDSL cute.math.abs function."""
         if isinstance(x, CSEVariable):
@@ -615,6 +665,10 @@ class CuteDSLOpOverrides(OpOverrides):
     @staticmethod
     def logical_or(x0: CuteDSLArg, x1: CuteDSLArg) -> CuteDSLArg:
         return CuteDSLOpOverrides._apply_binary_op(x0, x1, "({a} | {b})")
+
+    @staticmethod
+    def logical_xor(x0: CuteDSLArg, x1: CuteDSLArg) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_binary_op(x0, x1, "({a} ^ {b})")
 
     # Bitwise operations (override parent class to properly CSE)
     @staticmethod


### PR DESCRIPTION
Add CuteDSL op overrides for common math intrinsics (`rsqrt`, `exp2`, `log2`, `log10`, `tan`, `acos`, `asin`, `atan`, `atan2`, `floor`) and `logical_xor`. These were missing from `CuteDSLOpOverrides`, meaning CuteDSL templates would fall through to decomposed fallbacks or fail for ops without decompositions. All map directly to `cute.math.*` intrinsics.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo