### PR TITLE
[inductor]: support reinplace pass to handle in-place mutations on views of graph input

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -283,9 +283,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
 
         x1 = torch.randn(3, device=device)
         gm = make_fx(f, tracing_mode="fake")(x1)
-        print(gm.graph)
         reinplace_inplaceable_ops_core(gm.graph)
-        print(gm.graph)
 
         self.assertEqual(self.get_not_inplaced_count(gm.graph), 1)
 

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -283,7 +283,9 @@ class TestReinplacingPassCorrectness(InductorTestCase):
 
         x1 = torch.randn(3, device=device)
         gm = make_fx(f, tracing_mode="fake")(x1)
+        print(gm.graph)
         reinplace_inplaceable_ops_core(gm.graph)
+        print(gm.graph)
 
         self.assertEqual(self.get_not_inplaced_count(gm.graph), 1)
 
@@ -784,6 +786,22 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         finally:
             if my_wait_functional._opoverload in inplaceable_ops:
                 del inplaceable_ops[my_wait_functional._opoverload]
+
+    def test_reinplace_view_of_input(self):
+        """View of placeholder is inplace-mutated; copy_ back should be eliminated."""
+
+        def f(buf, indices, values):
+            buf_flat = buf.view(-1)
+            buf_flat[indices] = values
+            return buf
+
+        buf = torch.zeros(32, 32, device=device)
+        indices = torch.arange(8, device=device, dtype=torch.long)
+        values = torch.ones(8, device=device)
+        compiled_f = torch.compile(f, fullgraph=True)
+        expected = f(buf.clone(), indices, values)
+        result = compiled_f(buf.clone(), indices, values)
+        self.assertEqual(result, expected)
 
 
 instantiate_parametrized_tests(TestReinplacingPassCorrectness)

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -415,7 +415,7 @@ META_ONLY_OPS = OrderedSet(
 
 def _is_node_reachable_from(target: torch.fx.Node, source: torch.fx.Node) -> bool:
     """Check if target is reachable from source through view ops."""
-    visited: set[torch.fx.Node] = set()
+    visited: OrderedSet[torch.fx.Node] = OrderedSet()
     queue = [source]
     while queue:
         current = queue.pop()
@@ -728,7 +728,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                     copy_node = copy_args_to_copy_nodes.get((mutated_arg, node))
                     if copy_node is not None:
                         replace_dict[copy_node] = copy_node.args[0]
-                    else:
+                    elif isinstance(mutated_arg, torch.fx.Node):
                         # mutated_arg is a view of a placeholder; eliminate the
                         # base's copy_ epilogue since the inplace op already
                         # mutates the storage through the view.

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -548,10 +548,27 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
             # This should never happen in auto_functionalize_v2 non-inference mode,
             # since all mutated_arg are bases.
 
-            # If mutated arg is view of any of the inputs of the graph,
-            # do not allow for inplacing.
-            # This would require more sophisticated algorithm to handle
-            return False
+            # mutated_arg is not a placeholder itself, but shares storage with one.
+            # Allow inplacing if there is exactly one base placeholder with a copy_
+            # epilogue, and no conflicting uses of views between the op and the copy_.
+            base_placeholders = [
+                v for v in shared_view_nodes if v.op in ("placeholder", "get_attr")
+            ]
+
+            if len(base_placeholders) != 1:
+                return False
+            base = base_placeholders[0]
+
+            copy_node = copy_nodes.get(base)
+            if copy_node is None:
+                return False
+
+            if any_use_of_views_after_node(
+                node, shared_view_nodes, copy_node=copy_node, mutated_arg=base
+            ):
+                return False
+
+            return True
         else:
             return not any_use_of_views_after_node(
                 node, shared_view_nodes, copy_node=None, mutated_arg=mutated_arg
@@ -694,6 +711,19 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                     copy_node = copy_args_to_copy_nodes.get((mutated_arg, node))
                     if copy_node is not None:
                         replace_dict[copy_node] = copy_node.args[0]
+                    else:
+                        # mutated_arg is a view of a placeholder; eliminate the
+                        # base's copy_ epilogue since the inplace op already
+                        # mutates the storage through the view.
+                        storage = get_node_storage(mutated_arg)
+                        for view in storage_to_nodes.get(storage, []):
+                            if view.op in ("placeholder", "get_attr"):
+                                base_copy = copy_nodes.get(view)
+                                if (
+                                    base_copy is not None
+                                    and get_node_storage(base_copy.args[1]) == storage
+                                ):
+                                    replace_dict[base_copy] = base_copy.args[0]
                 node.target = inplaceable_op.inplace_op
         elif node.target is torch.ops.higher_order.auto_functionalized_v2:
             _mutable_op = node.args[0]

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -413,6 +413,23 @@ META_ONLY_OPS = OrderedSet(
 )
 
 
+def _is_node_reachable_from(target: torch.fx.Node, source: torch.fx.Node) -> bool:
+    """Check if target is reachable from source through view ops."""
+    visited: set[torch.fx.Node] = set()
+    queue = [source]
+    while queue:
+        current = queue.pop()
+        if current is target:
+            return True
+        if current in visited:
+            continue
+        visited.add(current)
+        for user in current.users:
+            if _is_view_op(user.target) or user is target:
+                queue.append(user)
+    return False
+
+
 def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
     """
     Reinplaces in-placeable operations.
@@ -719,9 +736,12 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                         for view in storage_to_nodes.get(storage, []):
                             if view.op in ("placeholder", "get_attr"):
                                 base_copy = copy_nodes.get(view)
-                                if (
-                                    base_copy is not None
-                                    and get_node_storage(base_copy.args[1]) == storage
+                                # Verify copy_'s src is derived from this op's
+                                # result via view ops. Can't use storage comparison
+                                # because meta["val"] still reflects functional
+                                # semantics (new storage) before inplace conversion.
+                                if base_copy is not None and _is_node_reachable_from(
+                                    base_copy.args[1], node
                                 ):
                                     replace_dict[base_copy] = base_copy.args[0]
                 node.target = inplaceable_op.inplace_op


### PR DESCRIPTION
Fixes #184542
## Proposal

https://github.com/pytorch/pytorch/blob/81fa97792064b7a5cd0f2b48c05a5856ce160a3c/torch/_inductor/fx_passes/reinplace.py#L547-L554
The `elif` branch in can_inplace (where mutated_arg is not a placeholder but shares storage with one) previously returned False unconditionally. This PR enables reinplacing in this case when it is safe:

1. There is exactly one base placeholder sharing storage with mutated_arg
2. That base has a copy_ epilogue (caller expects to observe the mutation)
3. No conflicting uses of aliased views exist between the op and the copy_

Additionally, when the op is successfully reinplaced, the now-redundant copy_ epilogue is eliminated by finding the base placeholder's copy_ node (with a safety check that the copy_'s source shares storage with the mutated arg).

## Example
```python
import torch

ROWS, COLS = 1024, 1024


def store_original(values: torch.Tensor, buf: torch.Tensor, indices: torch.Tensor):
    buf_flat = buf.view(-1)
    buf_flat[indices] = values
    return buf


def main():
    buf = torch.zeros((ROWS, COLS), dtype=torch.uint8, device="cuda")
    indices = torch.arange(256, dtype=torch.long, device="cuda")
    values = torch.ones(256, dtype=torch.uint8, device="cuda")

    compiled = torch.compile(store_original, fullgraph=True)
    result = compiled(values, buf.clone(), indices)
    expected = store_original(values, buf.clone(), indices)
    assert torch.equal(result, expected), "Mismatch!"
    print("Correctness check passed.")


if __name__ == "__main__":
    main()
```
Before this PR:
```python
def call(self, args):
        arg0_1, arg1_1, arg2_1 = args
        args.clear()
        assert_size_stride(arg0_1, (1024, 1024), (1024, 1), 'input')
        with torch.cuda._DeviceGuard(0):
            torch.cuda.set_device(0)
            buf0 = empty_strided_cuda((1048576, ), (1, ), torch.uint8)
            # Topologically Sorted Source Nodes: [buf_flat, setitem], Original ATen: [aten.view, aten.index_put]
            raw_stream0 = get_raw_stream(0)
            triton_poi_fused_index_put_view_0.run(arg0_1, buf0, 1048576, stream=raw_stream0)
            assert_size_stride(arg1_1, (256, ), (1, ), 'input')
            assert_size_stride(arg2_1, (256, ), (1, ), 'input')
            arg1_1 = copy_if_misaligned(arg1_1)
            arg2_1 = copy_if_misaligned(arg2_1)
            # Topologically Sorted Source Nodes: [buf_flat, setitem], Original ATen: [aten.view, aten.index_put]
            raw_stream0 = get_raw_stream(0)
            triton_poi_fused_index_put_view_1.run(arg1_1, arg2_1, buf0, 256, stream=raw_stream0)
            del arg1_1
            del arg2_1
            # Topologically Sorted Source Nodes: [setitem], Original ATen: [aten.view, aten.copy_]
            raw_stream0 = get_raw_stream(0)
            triton_poi_fused_copy__view_2.run(buf0, arg0_1, 1048576, stream=raw_stream0)
            del buf0
        return (arg0_1, )
```
After this PR:
```python
def call(self, args):
        arg0_1, arg1_1, arg2_1 = args
        args.clear()
        assert_size_stride(arg1_1, (256, ), (1, ), 'input')
        assert_size_stride(arg2_1, (256, ), (1, ), 'input')
        assert_size_stride(arg0_1, (1024, 1024), (1024, 1), 'input')
        with torch.cuda._DeviceGuard(0):
            torch.cuda.set_device(0)
            arg1_1 = copy_if_misaligned(arg1_1)
            arg2_1 = copy_if_misaligned(arg2_1)
            # Topologically Sorted Source Nodes: [buf_flat, setitem], Original ATen: [aten.view, aten.index_put]
            raw_stream0 = get_raw_stream(0)
            triton_poi_fused_index_put_view_0.run(arg1_1, arg2_1, arg0_1, 256, stream=raw_stream0)
            del arg1_1
            del arg2_1
        return (arg0_1, )
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos