### PR TITLE
Fix check for `aiohttp` in tests

### DIFF
--- a/test/distributed/test_debug.py
+++ b/test/distributed/test_debug.py
@@ -31,6 +31,8 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 try:
+    import aiohttp  # noqa: F401  # type: ignore[import]
+
     from torch.distributed.debug._frontend import fetch_aiohttp
 
     HAS_AIOHTTP = True


### PR DESCRIPTION
The check was supposed to try importing `aiohttp` but doesn't. So tests will be run even when the package is not installed.