### PR TITLE
[ROCm] derive the hipcub compatible cccl version from 'HIPCUB_CCCL_VERSION'

### DIFF
--- a/aten/src/ATen/cuda/cub.cuh
+++ b/aten/src/ATen/cuda/cub.cuh
@@ -106,7 +106,11 @@ template<class Iter>
 auto cccl_make_reverse_iterator(Iter it) { return ::thrust::make_reverse_iterator(it); }
 #endif
 
-#if defined(USE_ROCM)
+// Pre ROCm 8.0 we require backporting of FpLimits specialization
+// for 'c10::BFloat16'. However, ROCm 8.0 lifts the compatible
+// CUB version to 3.x which uses libhipcxx and derives numerical
+// limits from there.
+#if defined(USE_ROCM) && CUB_VERSION < 300000
 
 // backport https://github.com/NVIDIA/cub/pull/306 for c10::BFloat16
 

--- a/aten/src/ATen/cuda/cub_definitions.cuh
+++ b/aten/src/ATen/cuda/cub_definitions.cuh
@@ -1,13 +1,20 @@
 #pragma once
 
 #if !defined(USE_ROCM)
-#include <cuda.h>  // for CUDA_VERSION
-#endif
-
-#if !defined(USE_ROCM)
+#include <cuda.h> // for CUDA_VERSION
 #include <cub/version.cuh>
 #else
+// Check if we can find HIPCUB_CCCL_VERSION. It is exposed
+// transitively by hipcub/config.hpp.
+#include <hipcub/config.hpp>
+// Older versions of hipCUB do not support the CUB V3 API.
+#if defined(HIPCUB_CCCL_VERSION) && HIPCUB_CCCL_VERSION >= 300000
+#define CUB_VERSION HIPCUB_CCCL_VERSION
+#else
+// If we cannot find a compatible CCCL version, fallback to
+// a very old version.
 #define CUB_VERSION 200001
+#endif
 #endif
 
 // cub support for CUB_WRAPPED_NAMESPACE is added to cub 1.13.1 in:
@@ -26,9 +33,11 @@
 #define CUB_V3_4_PLUS() true
 #define CUB_V3_PLUS() false
 #elif CUB_VERSION >= 200800
+// CCCL 2.8 introduced new CUB v3 API.
 #define CUB_V3_4_PLUS() false
 #define CUB_V3_PLUS() true
 #else
+// Pre CCCL 2.8.
 #define CUB_V3_4_PLUS() false
 #define CUB_V3_PLUS() false
 #endif

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -333,6 +333,9 @@ if(PYTORCH_FOUND_HIP)
 
   # Optional components.
   find_package_and_print_version(hipsparselt)  # Will be required when ready.
+  # ROCm 8.0 and later requires libhipcxx! This should be marked as
+  # 'REQUIRED' once minimal ROCm version is bumped to 8.0 or later.
+  find_package_and_print_version(libhipcxx)
 
   list(REMOVE_DUPLICATES ROCM_INCLUDE_DIRS)
 


### PR DESCRIPTION
# Context

hipCUB is targeting to be compatible with CCCL 3.0 (https://github.com/ROCm/rocm-libraries/pull/4079). This requires updating some of the CUB and hipCUB compatibility glue.

To help this transition hipCUB will be exposing `HIPCUB_CCCL_VERSION` in one of the following ROCm releases (>=7.14) (https://github.com/ROCm/rocm-libraries/pull/7632), which will be bumped once hipCUB reaches parity with CCCL 3.0 and beyond.

This PR is created in anticipation for this future changes.

# Implementation

- Introduce dependency on [`libhipcxx`](https://github.com/ROCm/libhipcxx).
- Guard `FpLimits` for `c10::BFloat16` backport to pre CCCL 3.x. Numeric limits are handled by libhipcxx.
- Extend `CUB_VERSION` derivation for hipCUB. Keep old fallback for backwards compatibility. Only enable CUB V3 API once hipCUB reaches parity with CCCL 3.x.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang