### PR TITLE
[scatter_add] Fix two alignment crashes in CuTeDSL override

### DIFF
--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -2,6 +2,7 @@
 
 import random
 import unittest
+from typing import NamedTuple
 
 import torch
 
@@ -15,7 +16,7 @@ from torch.testing._internal.common_device_type import \
 from torch.testing._internal.common_dtype import \
     (get_all_dtypes,)
 
-from torch.testing._internal.common_cuda import CDNA3OrLater
+from torch.testing._internal.common_cuda import CDNA3OrLater, SM90OrLater
 
 # Protects against includes accidentally setting the default dtype
 if torch.get_default_dtype() is not torch.float32:
@@ -589,6 +590,92 @@ def _override_tol(dtype):
     return 1e-4 if dtype == torch.float32 else 0.5
 
 
+def _misaligned_view(rows, cols, dtype):
+    """Allocate (rows*cols + 1) elements and slice from index 1, producing
+    a contiguous (rows, cols) view whose data_ptr is one element past a
+    16B-aligned base."""
+    t = torch.empty(rows * cols + 1, device="cuda", dtype=dtype)[1:].view(rows, cols)
+    # Sanity check: if the allocator ever hands us a base such that the
+    # +1-element slice is still 16B-aligned, the test silently passes
+    # without exercising the misalignment path.
+    assert t.data_ptr() % 16 != 0, (  # noqa: S101
+        f"test bug: data_ptr() should be misaligned, got {t.data_ptr() % 16=}"
+    )
+    return t
+
+
+def _outer_padded_view(rows, cols, dtype):
+    """Allocate (rows, cols + 1) zeros and slice the first `cols` columns,
+    producing a view with stride(0) == cols + 1 (not cols)."""
+    return torch.zeros(rows, cols + 1, device="cuda", dtype=dtype)[:, :cols]
+
+
+# Joint matrix for the data_ptr / row-stride alignment cond checks. Each
+# case names a misalignment site and what the cond should return. M_out /
+# M_src / D are fixed; D=128 -> row_bytes = 128 * elem_size, which is
+# 16B-aligned for fp32 and bf16, so any cond rejection here comes from
+# the new data_ptr / row-stride checks (not the row_bytes check).
+_M_OUT, _M_SRC, _D = 100, 50, 128
+
+
+class _AlignmentCase(NamedTuple):
+    name: str
+    # which buffer is misaligned: "self_dp", "src_dp", "both_dp",
+    # "self_rs", "src_rs"
+    site: str
+    dtype: torch.dtype
+    expected_tma: bool
+    expected_vec: bool
+
+    @property
+    def M_out(self):
+        return _M_OUT
+
+    @property
+    def M_src(self):
+        return _M_SRC
+
+    @property
+    def D(self):
+        return _D
+
+
+_ALIGNMENT_CASES = [
+    # data_ptr misalignment via storage_offset=1.
+    _AlignmentCase("fp32_self_dp", "self_dp", torch.float32, False, True),
+    _AlignmentCase("fp32_src_dp", "src_dp", torch.float32, False, False),
+    _AlignmentCase("fp32_both_dp", "both_dp", torch.float32, False, False),
+    _AlignmentCase("bf16_self_dp", "self_dp", torch.bfloat16, False, False),
+    # Outer row-stride misalignment via shape (D+1) slice.
+    _AlignmentCase("fp32_self_rs", "self_rs", torch.float32, False, True),
+    _AlignmentCase("fp32_src_rs", "src_rs", torch.float32, False, False),
+    _AlignmentCase("bf16_self_rs", "self_rs", torch.bfloat16, False, False),
+]
+
+
+def _build_alignment_case(case):
+    """Return (self, src) tensors for an alignment case."""
+    dtype = case.dtype
+    if case.site == "self_dp":
+        self_t = _misaligned_view(case.M_out, case.D, dtype).zero_()
+        src = torch.randn(case.M_src, case.D, device="cuda", dtype=dtype)
+    elif case.site == "src_dp":
+        self_t = torch.zeros(case.M_out, case.D, device="cuda", dtype=dtype)
+        src = _misaligned_view(case.M_src, case.D, dtype).normal_()
+    elif case.site == "both_dp":
+        self_t = _misaligned_view(case.M_out, case.D, dtype).zero_()
+        src = _misaligned_view(case.M_src, case.D, dtype).normal_()
+    elif case.site == "self_rs":
+        self_t = _outer_padded_view(case.M_out, case.D, dtype)
+        src = torch.randn(case.M_src, case.D, device="cuda", dtype=dtype)
+    elif case.site == "src_rs":
+        self_t = torch.zeros(case.M_out, case.D, device="cuda", dtype=dtype)
+        src = _outer_padded_view(case.M_src, case.D, dtype).normal_()
+    else:
+        raise ValueError(f"unknown site: {case.site}")
+    return self_t, src
+
+
 @unittest.skipUnless(TEST_CUDA, "needs CUDA")
 @skipIfNoCuteDSL
 class TestScatterAddOverrideConds(TestCase):
@@ -622,6 +709,67 @@ class TestScatterAddOverrideConds(TestCase):
         # 129 % 4 != 0 -> vec also rejects.
         self_t, idx, src, _ = _make_override_triple(100, 50, (129,))
         self.assertEqual(self._conds(self_t, idx, src), (False, False))
+
+    @parametrize("case", _ALIGNMENT_CASES, name_fn=lambda c: c.name)
+    def test_alignment_cond_matrix(self, case):
+        # Joint coverage of the data_ptr / row-stride alignment checks
+        # in `_alignment_contract_ok`. src always needs 16B alignment
+        # (LDG.128 / TMA load); self/dst needs 16B for TMA but only 4B
+        # for vec-scatter, so dtype changes the vec-scatter expectation
+        # whenever the dst misalignment is sub-4B (bf16 storage_offset=1
+        # is 2B-aligned; bf16 row-stride pad of 1 elem leaves a 2B
+        # remainder).
+        #
+        # bf16 cases require sm_90+: pre-sm_90 vec-scatter and TMA both
+        # gate bf16 unconditionally, which would mask the alignment cond
+        # under test (False return value would come from the SM gate,
+        # not _alignment_contract_ok).
+        if case.dtype is torch.bfloat16 and not SM90OrLater:
+            self.skipTest("bf16 alignment cond requires sm_90+")
+        torch.manual_seed(0)
+        self_t, src = _build_alignment_case(case)
+        idx = _expanded_idx(
+            torch.randint(0, case.M_out, (case.M_src,), device="cuda", dtype=torch.int64),
+            (case.D,),
+        )
+        self.assertEqual(
+            self._conds(self_t, idx, src), (case.expected_tma, case.expected_vec),
+            msg=f"{case.name}: expected (TMA={case.expected_tma}, vec={case.expected_vec})",
+        )
+
+    def test_out_cond_rejects_misaligned_out(self):
+        # The .out impl runs the kernel on ``out``, not ``self`` (see
+        # _make_impls.out_impl). A misaligned ``out`` with aligned
+        # ``self`` must be rejected -- otherwise the kernel runs on
+        # ``out``'s misaligned data_ptr and faults with
+        # cudaErrorMisalignedAddress (the exact bug this diff prevents,
+        # just on the .out variant).
+        M_out, M_src, D = 100, 50, 128
+        self_t = torch.zeros(M_out, D, device="cuda", dtype=torch.bfloat16)
+        src = torch.randn(M_src, D, device="cuda", dtype=torch.bfloat16)
+        # Misaligned out: one-element (2B) offset from a 16B boundary.
+        # bf16 -> 2B-aligned, which fails both the TMA 16B and the
+        # vec-scatter 4B destination alignment checks.
+        out_mis = (
+            torch.empty(M_out * D + 1, device="cuda", dtype=torch.bfloat16)[1:]
+            .view(M_out, D)
+        )
+        self.assertNotEqual(
+            out_mis.data_ptr() % 16, 0,
+            msg=f"test bug: out should be misaligned, got {out_mis.data_ptr() % 16=}",
+        )
+        idx = _expanded_idx(
+            torch.randint(0, M_out, (M_src,), device="cuda", dtype=torch.int64),
+            (D,),
+        )
+        self.assertFalse(
+            self.impl._tma_out_cond(self_t, 0, idx, src, out=out_mis),
+            msg=".out TMA cond accepted misaligned `out`",
+        )
+        self.assertFalse(
+            self.impl._vs_out_cond(self_t, 0, idx, src, out=out_mis),
+            msg=".out vec-scatter cond accepted misaligned `out`",
+        )
 
     def test_tma_accepts_row_not_chunk_multiple(self):
         # bf16 D=264 -> row_bytes=528, 16-aligned but not a multiple of
@@ -774,6 +922,105 @@ class TestScatterAddOverrideCorrectness(TestCase):
         with DeterministicGuard(True):
             got = torch.scatter_add(self_t, 0, idx, src)
         self.assertEqual(got, ref)
+
+    @parametrize("case", _ALIGNMENT_CASES, name_fn=lambda c: c.name)
+    def test_alignment_correctness(self, case):
+        # End-to-end regression for the SEV-class crash where a
+        # misaligned data_ptr / row stride bypassed the cond and faulted
+        # in the TMA / vec-scatter kernel (cudaErrorMisalignedAddress
+        # from cp.reduce.async.bulk or LDG.128). With the alignment cond
+        # in place, every case here either runs via vec-scatter (when
+        # the relaxed dst-only 4B contract is met -- expected_vec=True)
+        # or falls through to aten; both must produce correct numerics.
+        from torch._native.ops.scatter_add import cutedsl_impl
+
+        # See test_alignment_cond_matrix.
+        if case.dtype is torch.bfloat16 and not SM90OrLater:
+            self.skipTest("bf16 alignment cond requires sm_90+")
+        torch.manual_seed(0)
+        self_t, src = _build_alignment_case(case)
+        idx_1d = torch.randint(0, case.M_out, (case.M_src,), device="cuda", dtype=torch.int64)
+        idx = _expanded_idx(idx_1d, (case.D,))
+
+        # Confirm the cond observed in the unit test matches what the
+        # dispatch-layer cond returns end-to-end (no skew between
+        # eligibility check and kernel execution).
+        self.assertEqual(
+            cutedsl_impl._is_tma_supported(self_t, 0, idx, src), case.expected_tma,
+        )
+        self.assertEqual(
+            cutedsl_impl._is_vec_scatter_supported(self_t, 0, idx, src), case.expected_vec,
+        )
+
+        ref = _naive_scatter_add(self_t, idx_1d, src)
+        got = torch.scatter_add(self_t, 0, idx, src)
+        tol = _override_tol(case.dtype)
+        self.assertEqual(got, ref, atol=tol, rtol=tol, msg=case.name)
+
+    def test_misaligned_out_correctness(self):
+        # End-to-end regression for the .out variant: when ``out`` is
+        # misaligned the .out cond must reject so the call falls through
+        # to aten (the kernel runs on ``out``, so a misaligned ``out``
+        # would otherwise fault with cudaErrorMisalignedAddress -- same
+        # SEV-class bug as the functional path, just on .out).
+        torch.manual_seed(0)
+        M_out, M_src, D = 200, 100, 128
+        self_t = torch.zeros(M_out, D, device="cuda", dtype=torch.bfloat16)
+        src = torch.randn(M_src, D, device="cuda", dtype=torch.bfloat16)
+        # bf16 -> 2B-aligned data_ptr; fails both 16B (TMA) and 4B
+        # (vec-scatter) destination alignment.
+        out_mis = _misaligned_view(M_out, D, torch.bfloat16)
+        self.assertNotEqual(out_mis.data_ptr() % 16, 0)
+        idx_1d = torch.randint(0, M_out, (M_src,), device="cuda", dtype=torch.int64)
+        idx = _expanded_idx(idx_1d, (D,))
+
+        ref = _naive_scatter_add(self_t, idx_1d, src)
+        ret = torch.scatter_add(self_t, 0, idx, src, out=out_mis)
+        self.assertIs(ret, out_mis)
+        tol = _override_tol(torch.bfloat16)
+        self.assertEqual(out_mis, ref, atol=tol, rtol=tol)
+
+    @parametrize("dtype,N", [
+        # chunk_bytes < 128 (small D)
+        subtest((torch.float32, 8), name="fp32_N8_cb32"),
+        subtest((torch.float32, 16), name="fp32_N16_cb64"),
+        subtest((torch.bfloat16, 8), name="bf16_N8_cb16"),
+        subtest((torch.bfloat16, 16), name="bf16_N16_cb32"),
+        # 128 < chunk_bytes < 512 but not a multiple of 128 -- stage 1
+        # also misaligns here without the stage-stride padding.
+        subtest((torch.float32, 36), name="fp32_N36_cb144"),
+        subtest((torch.bfloat16, 72), name="bf16_N72_cb144"),
+    ])
+    @unittest.skipUnless(SM90OrLater, "TMA path requires sm_90+")
+    def test_smem_stage_alignment_multi_iter(self, dtype, N):
+        # Regression for TMA stage-1 smem misalignment: stage 1 of the
+        # 2-stage pipeline buffer lands at offset chunk_bytes, so any
+        # chunk_bytes that isn't 128B-aligned (small D < 128, or D's
+        # row_bytes not a multiple of 128) makes cp.async.bulk fault
+        # with cudaErrorMisalignedAddress the first time a CTA writes
+        # stage 1. Stage 1 is only reached when a CTA does >= 2
+        # iterations, i.e. M_src > grid_x. _plan_grid caps grid_x at
+        # sm*64, so M_src must exceed that to expose the bug.
+        from torch._native.ops.scatter_add import cutedsl_impl
+
+        torch.manual_seed(0)
+        sm = torch.cuda.get_device_properties(0).multi_processor_count
+        M_out, M_src = 1024, sm * 64 + 256
+        self_t, idx, src, idx_1d = _make_override_triple(
+            M_out, M_src, (N,), dtype=dtype
+        )
+        # Assert the TMA path is the one that actually runs -- otherwise
+        # the test would silently regress to vec-scatter (which has no
+        # smem stage stride and can't reproduce this bug).
+        self.assertTrue(
+            cutedsl_impl._is_tma_supported(self_t, 0, idx, src),
+            msg="test bug: TMA cond rejected; this test would not exercise the regressed path",
+        )
+        ref = _naive_scatter_add(self_t, idx_1d, src)
+        got = torch.scatter_add(self_t, 0, idx, src)
+        torch.cuda.synchronize()
+        tol = _override_tol(dtype)
+        self.assertEqual(got, ref, atol=tol, rtol=tol)
 
 
 

--- a/torch/_native/ops/scatter_add/cutedsl_impl.py
+++ b/torch/_native/ops/scatter_add/cutedsl_impl.py
@@ -33,6 +33,17 @@ from ...registry import _OpCondFn, _OpImplFn
 
 _SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
 
+# 16B alignment for `src.data_ptr()` and `src.stride(0) * elem`: required
+# for the LDG.128 / tile-mode TMA load of `src` and the row-start 16B
+# boundary that LDG.128 reads from. Applies to both paths.
+_SRC_ALIGN_BYTES = 16
+# Path-specific destination alignment. TMA: cp.reduce.async.bulk gmem
+# operand needs 16B base + stride. vec-scatter: scalar fp32 atomicAdd /
+# f16x2 / bf16x2 paired atomics need natural alignment of the 4B atomic
+# operand on both base and per-row stride.
+_TMA_DST_ALIGN_BYTES = 16
+_VEC_DST_ALIGN_BYTES = 4
+
 
 @functools.cache
 def _has_cutedsl() -> bool:
@@ -157,6 +168,37 @@ def _flatten_2d_view(t: torch.Tensor) -> torch.Tensor:
     return t.as_strided((t.shape[0], N), (t.stride(0), 1))
 
 
+def _alignment_contract_ok(
+    self: torch.Tensor, src: torch.Tensor, *, dst_ptr_align: int
+) -> bool:
+    """Alignment of effective ptrs and outer row strides.
+
+    The src side is always read via 16B-wide vector ops (LDG.128 /
+    tile-mode TMA load), so its data_ptr and per-row stride must be
+    16B-aligned. The dst side's requirement is path-specific:
+
+      - TMA: ``cp.reduce.async.bulk`` writes the gmem operand via a TMA
+        descriptor that requires 16B alignment of both base and stride.
+      - vec-scatter: writes via scalar fp32 atomicAdd / f16x2 / bf16x2
+        paired atomics, which need natural alignment of the 4B atomic
+        operand on both base address and per-row stride.
+
+    When this returns False the cond rejects and the call falls through
+    to aten, which has its own predicate and safe fallback to
+    ``vectorized_scatter_add_kernel_launch`` / ``indexFunc{Small,Large}Index``.
+    """
+    if src.data_ptr() % _SRC_ALIGN_BYTES:
+        return False
+    if self.data_ptr() % dst_ptr_align:
+        return False
+    elem = self.element_size()
+    if (src.stride(0) * elem) % _SRC_ALIGN_BYTES:
+        return False
+    if (self.stride(0) * elem) % dst_ptr_align:
+        return False
+    return True
+
+
 def _flatten_for_expanded_1d(
     self: torch.Tensor, index: torch.Tensor, src: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -193,6 +235,8 @@ def _is_tma_supported(
     N = _expanded_1d_inner_size(self, dim, index, src)
     if N is None:
         return False
+    if not _alignment_contract_ok(self, src, dst_ptr_align=_TMA_DST_ALIGN_BYTES):
+        return False
     # TMA transfer size is baked in at compile time (chunk_bytes =
     # min(row_bytes, 512)); row_bytes must evenly divide by chunk_bytes
     # and chunk_bytes must be 16-byte aligned.
@@ -210,6 +254,8 @@ def _is_vec_scatter_supported(
         return False
     N = _expanded_1d_inner_size(self, dim, index, src)
     if N is None:
+        return False
+    if not _alignment_contract_ok(self, src, dst_ptr_align=_VEC_DST_ALIGN_BYTES):
         return False
     # Each lane owns vec_elems consecutive elements; the loop is either
     # fully in-bounds or fully skipped per lane. Only requirement is
@@ -229,12 +275,18 @@ def _is_vec_scatter_supported(
 def _make_cond(
     support_check,
     *,
-    requires_out: bool = False,
+    out_dst_ptr_align: int | None = None,
 ) -> _OpCondFn:
     """Build a cond function that runs ``support_check`` behind the shared
     boilerplate (cutedsl availability, non-deterministic mode, CUDA tensors,
-    non-COW, dtype/shape match on ``out`` when present)."""
-    if requires_out:
+    non-COW, dtype/shape match on ``out`` when present).
+
+    ``out_dst_ptr_align`` is None for the functional / inplace variants.
+    For the ``.out`` variant it is the path-specific destination
+    alignment (TMA: 16, vec-scatter: 4) used to alignment-check ``out``,
+    which the ``.out`` impl runs the kernel on instead of ``self``.
+    """
+    if out_dst_ptr_align is not None:
 
         def _cond(self, dim, index, src, *, out):
             if not _base_cond_ok(self, index, src, out):
@@ -247,6 +299,15 @@ def _make_cond(
             # stride can differ from prod(shape[1:]) (same relaxation as
             # self/src). Inner dims must be packed for the 2D view.
             if not _inner_contiguous(out):
+                return False
+            # The .out impl runs the kernel on ``out``, not ``self``
+            # (see _make_impls.out_impl). ``support_check`` below
+            # validates self/src alignment via _alignment_contract_ok,
+            # but ``out`` may be a distinct buffer with different
+            # alignment from ``self`` -- check it explicitly here so a
+            # misaligned ``out`` falls through to aten instead of
+            # faulting in the kernel.
+            if not _alignment_contract_ok(out, src, dst_ptr_align=out_dst_ptr_align):
                 return False
             return support_check(self, dim, index, src)
 
@@ -310,9 +371,11 @@ _tma_impl, _tma_out_impl, _tma_inplace_impl = _make_impls(_tma_kernel)
 _vs_impl, _vs_out_impl, _vs_inplace_impl = _make_impls(_vs_kernel)
 
 _tma_cond = _make_cond(_is_tma_supported)
-_tma_out_cond = _make_cond(_is_tma_supported, requires_out=True)
+_tma_out_cond = _make_cond(_is_tma_supported, out_dst_ptr_align=_TMA_DST_ALIGN_BYTES)
 _vs_cond = _make_cond(_is_vec_scatter_supported)
-_vs_out_cond = _make_cond(_is_vec_scatter_supported, requires_out=True)
+_vs_out_cond = _make_cond(
+    _is_vec_scatter_supported, out_dst_ptr_align=_VEC_DST_ALIGN_BYTES
+)
 
 
 # ---------------------------------------------------------------------------

--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -171,7 +171,7 @@ def _make_kernel(
         sBuf = smem.allocate_tensor(
             dtype,
             cute.make_layout((chunk_elems, 2), stride=(1, stage_stride_elems)),
-            128,
+            _SMEM_ALIGN_BYTES,
         )
         mbar_storage = smem.allocate_array(cutlass.Uint64, num_elems=2 * 2)
 
@@ -244,9 +244,7 @@ def _make_kernel(
 
                     if pair_count > Int32(0):
                         pipe.consumer_wait(consumer_state)
-                        cbuf_ptr = sBuf.iterator + consumer_state.index * Int32(
-                            stage_stride_elems
-                        )
+                        cbuf_ptr = sBuf[None, consumer_state.index].iterator
 
                         # Partial-chunk handling: actual valid element
                         # count is min(chunk_elems, N - off). TMA
@@ -278,9 +276,7 @@ def _make_kernel(
         if tidx == Int32(0):
             if pair_count > Int32(0):
                 pipe.consumer_wait(consumer_state)
-                cbuf_ptr = sBuf.iterator + consumer_state.index * Int32(
-                    stage_stride_elems
-                )
+                cbuf_ptr = sBuf[None, consumer_state.index].iterator
 
                 off = prev_chunk_idx * Int32(chunk_elems)
                 cur_elems = Int32(N) - off

--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -66,6 +66,12 @@ from ._ptx import cvta_smem, make_bulk_reduce_add
 
 _MAX_CHUNK_BYTES = 512
 _THREADS_PER_CTA = 32  # one warp per CTA
+# cp.async.bulk requires 128B-aligned smem destinations.
+_SMEM_ALIGN_BYTES = 128
+
+
+def _round_up(x: int, m: int) -> int:
+    return (x + m - 1) // m * m
 
 
 _TORCH_TO_CUTE = {
@@ -121,6 +127,14 @@ def _make_kernel(
     # partial final chunk handled by TMA OOB clamp.
     num_chunks = (N + chunk_elems - 1) // chunk_elems
 
+    # 2-stage pipeline buffer is laid out column-major; stage i starts
+    # at offset i * stage_stride_elems * elem_bytes, so the stride must
+    # round chunk_bytes up to a multiple of _SMEM_ALIGN_BYTES. Otherwise
+    # stage 1 is misaligned and the kernel faults the first time a CTA
+    # writes it. Bites both chunk_bytes < 128 (small D) and chunk_bytes
+    # not a multiple of 128 (e.g. fp32 N=36 -> 144 B).
+    stage_stride_elems = _round_up(chunk_elems, _SMEM_ALIGN_BYTES // elem_bytes)
+
     @cute.kernel
     def _kernel(
         tma_atom: cute.CopyAtom,
@@ -156,7 +170,7 @@ def _make_kernel(
         smem = cutlass.utils.SmemAllocator()
         sBuf = smem.allocate_tensor(
             dtype,
-            cute.make_layout((chunk_elems, 2)),
+            cute.make_layout((chunk_elems, 2), stride=(1, stage_stride_elems)),
             128,
         )
         mbar_storage = smem.allocate_array(cutlass.Uint64, num_elems=2 * 2)
@@ -231,7 +245,7 @@ def _make_kernel(
                     if pair_count > Int32(0):
                         pipe.consumer_wait(consumer_state)
                         cbuf_ptr = sBuf.iterator + consumer_state.index * Int32(
-                            chunk_elems
+                            stage_stride_elems
                         )
 
                         # Partial-chunk handling: actual valid element
@@ -264,7 +278,9 @@ def _make_kernel(
         if tidx == Int32(0):
             if pair_count > Int32(0):
                 pipe.consumer_wait(consumer_state)
-                cbuf_ptr = sBuf.iterator + consumer_state.index * Int32(chunk_elems)
+                cbuf_ptr = sBuf.iterator + consumer_state.index * Int32(
+                    stage_stride_elems
+                )
 
                 off = prev_chunk_idx * Int32(chunk_elems)
                 cur_elems = Int32(N) - off


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184554

Subsumes #184257.

Two latent crashes on shapes the cond accepted but the kernel couldn't
safely run:

1. Gmem alignment. The cond didn't check `data_ptr()` or outer row
   stride alignment. Adds `_alignment_contract_ok` covering:
     - `src.data_ptr()`: 16B (LDG.128 / TMA load).
     - `self.data_ptr()` (kernel destination): 16B for TMA
       (`cp.reduce.async.bulk` gmem operand); 4B for vec-scatter
       (natural alignment of the fp32 atomicAdd / f16x2 / bf16x2 paired
       atomics). The 4B path lets fp32 storage_offset slices stay on
       the override fast path instead of falling through to aten.
     - row stride: 16B for both paths so each row of `src` starts on a
       16B boundary for the LDG.128 read.
   Wired into both `_is_*_supported` checks and the `out`-variant
   branch of `_make_cond` so a misaligned `out` (the kernel's actual
   destination on the `.out` impl) is also caught.

2. 128B smem alignment in the TMA kernel. The 2-stage pipeline buffer
   was a contiguous `(chunk_elems, 2)`, so stage 1 started at offset
   `chunk_bytes`. `cp.async.bulk` requires 128B-aligned smem
   destinations, so any chunk_bytes not a multiple of 128 (e.g. fp32
   D=8 -> 32 B, D=36 -> 144 B) produced a misaligned stage 1 and
   faulted as soon as M_src > grid_x. Pads the smem column stride up
   to 128 B.

Tests cover cond rejection (data_ptr / row stride / `out`),
fall-through correctness on misaligned inputs, the 4B vec-scatter
relaxation for fp32, and a stage-1 regression over D in {8, 16} for
fp32/bf16 with M_src = sm*64 + 256.

Authored with assistance from Claude.

Co-authored-by: Albert Chen <albertchen@meta.com>
Co-authored-by: @AlbertDachiChen <chendachimail@gmail.com>