### PR TITLE
Enable Armv9-A target support for torch.compile on AArch64

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2400,6 +2400,49 @@ class CPUReproTests(TestCase):
     def test_timed_cpu_only(self):
         timed(lambda: torch.randn(10), ())
 
+    def test_complex_memory_overlap(self):
+        dense = torch.zeros(64, 32)
+        self.assertFalse(complex_memory_overlap(dense))
+        self.assertFalse(complex_memory_overlap(dense.t()))
+
+        strided = dense.split(4, dim=1)
+        self.assertFalse(complex_memory_overlap(strided[0]))
+        self.assertFalse(complex_memory_overlap(strided[0].t()))
+
+        unsqueezed = dense.unsqueeze(1)
+        self.assertFalse(complex_memory_overlap(unsqueezed))
+        self.assertFalse(complex_memory_overlap(unsqueezed.permute(1, 2, 0)))
+
+        gathered = dense.index_select(0, torch.IntTensor([1, 0, 1]))
+        self.assertFalse(complex_memory_overlap(gathered))
+        self.assertFalse(complex_memory_overlap(gathered.t()))
+
+    def test_vec_sve_armv9_arch_flags(self):
+        # VecSVE256 should emit Armv9-A specific flags when SVE2 is available.#
+
+        isa = cpu_vec_isa.VecSVE256()
+
+        # Armv9-A + SVE2 path should switch to the Armv9 flag set with bf16/i8mm
+        with patch(
+            "torch.cpu.get_capabilities",
+            return_value={"sve": True, "sve2": True},
+        ):
+            isa._armv9a_supported = None
+            flags = isa.build_arch_flags()
+            self.assertIn("+sve2", flags)
+            self.assertIn("+bf16", flags)
+            self.assertIn("+i8mm", flags)
+            self.assertIn("-msve-vector-bits=256", flags)
+
+        # SVE-only path should stick to the base flags
+        with patch(
+            "torch.cpu.get_capabilities",
+            return_value={"sve": True, "sve2": False},
+        ):
+            isa._armv9a_supported = None
+            flags = isa.build_arch_flags()
+            self.assertEqual(flags, isa._arch_flags)
+
     @requires_vectorization
     def test_vec_dynamic_shapes(self):
         def fn(x):

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2400,48 +2400,65 @@ class CPUReproTests(TestCase):
     def test_timed_cpu_only(self):
         timed(lambda: torch.randn(10), ())
 
-    def test_complex_memory_overlap(self):
-        dense = torch.zeros(64, 32)
-        self.assertFalse(complex_memory_overlap(dense))
-        self.assertFalse(complex_memory_overlap(dense.t()))
-
-        strided = dense.split(4, dim=1)
-        self.assertFalse(complex_memory_overlap(strided[0]))
-        self.assertFalse(complex_memory_overlap(strided[0].t()))
-
-        unsqueezed = dense.unsqueeze(1)
-        self.assertFalse(complex_memory_overlap(unsqueezed))
-        self.assertFalse(complex_memory_overlap(unsqueezed.permute(1, 2, 0)))
-
-        gathered = dense.index_select(0, torch.IntTensor([1, 0, 1]))
-        self.assertFalse(complex_memory_overlap(gathered))
-        self.assertFalse(complex_memory_overlap(gathered.t()))
-
     def test_vec_sve_armv9_arch_flags(self):
-        # VecSVE256 should emit Armv9-A specific flags when SVE2 is available.#
-
-        isa = cpu_vec_isa.VecSVE256()
-
-        # Armv9-A + SVE2 path should switch to the Armv9 flag set with bf16/i8mm
-        with patch(
-            "torch.cpu.get_capabilities",
-            return_value={"sve": True, "sve2": True},
+        for isa_cls, vector_bits in (
+            (cpu_vec_isa.VecSVE128, 128),
+            (cpu_vec_isa.VecSVE256, 256),
         ):
-            isa._armv9a_supported = None
-            flags = isa.build_arch_flags()
-            self.assertIn("+sve2", flags)
-            self.assertIn("+bf16", flags)
-            self.assertIn("+i8mm", flags)
-            self.assertIn("-msve-vector-bits=256", flags)
+            isa = isa_cls()
 
-        # SVE-only path should stick to the base flags
-        with patch(
-            "torch.cpu.get_capabilities",
-            return_value={"sve": True, "sve2": False},
-        ):
-            isa._armv9a_supported = None
-            flags = isa.build_arch_flags()
-            self.assertEqual(flags, isa._arch_flags)
+            # Armv9-A + SVE2 path should switch to the Armv9 flag set with bf16/i8mm
+            with patch(
+                "torch.cpu.get_capabilities",
+                return_value={
+                    "sve": True,
+                    "sve2": True,
+                    "sve_max_length": vector_bits,
+                },
+            ):
+                isa._armv9a_supported = None
+                flags = isa.build_arch_flags()
+                self.assertIn("+sve2", flags)
+                self.assertIn("+bf16", flags)
+                self.assertIn("+i8mm", flags)
+                self.assertIn(f"-msve-vector-bits={vector_bits}", flags)
+
+            # SVE-only path should stick to the base flags
+            with patch(
+                "torch.cpu.get_capabilities",
+                return_value={
+                    "sve": True,
+                    "sve2": False,
+                    "sve_max_length": vector_bits,
+                },
+            ):
+                isa._armv9a_supported = None
+                flags = isa.build_arch_flags()
+                self.assertEqual(flags, isa._arch_flags)
+
+        try:
+            for isa_cls, vector_bits in (
+                (cpu_vec_isa.VecSVE128, 128),
+                (cpu_vec_isa.VecSVE256, 256),
+            ):
+                cpu_vec_isa.valid_vec_isa_list.cache_clear()
+                with (
+                    patch("sys.platform", "linux"),
+                    patch("platform.machine", return_value="aarch64"),
+                    patch(
+                        "torch.cpu.get_capabilities",
+                        return_value={
+                            "sve": True,
+                            "sve2": True,
+                            "sve_max_length": vector_bits,
+                        },
+                    ),
+                ):
+                    selected_isa = cpu_vec_isa.valid_vec_isa_list()[0]
+                    self.assertIsInstance(selected_isa, isa_cls)
+                    self.assertEqual(selected_isa.bit_width(), vector_bits)
+        finally:
+            cpu_vec_isa.valid_vec_isa_list.cache_clear()
 
     @requires_vectorization
     def test_vec_dynamic_shapes(self):

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2401,16 +2401,14 @@ class CPUReproTests(TestCase):
         timed(lambda: torch.randn(10), ())
 
     def test_vec_sve_armv9_arch_flags(self):
-        for isa_cls, vector_bits in (
-            (cpu_vec_isa.VecSVE128, 128),
-            (cpu_vec_isa.VecSVE256, 256),
-        ):
-            isa = isa_cls()
+        for vector_bits in (128, 256):
+            isa = cpu_vec_isa.VecSVE(vector_bits)
 
             # Armv9-A + SVE2 path should switch to the Armv9 flag set with bf16/i8mm
             with patch(
                 "torch.cpu.get_capabilities",
                 return_value={
+                    "bf16": True,
                     "sve": True,
                     "sve2": True,
                     "sve_max_length": vector_bits,
@@ -2427,6 +2425,7 @@ class CPUReproTests(TestCase):
             with patch(
                 "torch.cpu.get_capabilities",
                 return_value={
+                    "bf16": True,
                     "sve": True,
                     "sve2": False,
                     "sve_max_length": vector_bits,
@@ -2437,26 +2436,35 @@ class CPUReproTests(TestCase):
                 self.assertEqual(flags, isa._arch_flags)
 
         try:
-            for isa_cls, vector_bits in (
-                (cpu_vec_isa.VecSVE128, 128),
-                (cpu_vec_isa.VecSVE256, 256),
+            for sve2 in (False, True):
+                for vector_bits in (128, 256):
+                    cpu_vec_isa.valid_vec_isa_list.cache_clear()
+                    with (
+                        patch("sys.platform", "linux"),
+                        patch("platform.machine", return_value="aarch64"),
+                        patch(
+                            "torch.cpu.get_capabilities",
+                            return_value={
+                                "bf16": True,
+                                "sve": True,
+                                "sve2": sve2,
+                                "sve_max_length": vector_bits,
+                            },
+                        ),
+                    ):
+                        selected_isa = cpu_vec_isa.valid_vec_isa_list()[0]
+                        self.assertIsInstance(selected_isa, cpu_vec_isa.VecSVE)
+                        self.assertEqual(selected_isa.bit_width(), vector_bits)
+
+            cpu_vec_isa.valid_vec_isa_list.cache_clear()
+            with (
+                patch("sys.platform", "linux"),
+                patch("platform.machine", return_value="aarch64"),
+                patch("torch.cpu.get_capabilities", return_value={}),
             ):
-                cpu_vec_isa.valid_vec_isa_list.cache_clear()
-                with (
-                    patch("sys.platform", "linux"),
-                    patch("platform.machine", return_value="aarch64"),
-                    patch(
-                        "torch.cpu.get_capabilities",
-                        return_value={
-                            "sve": True,
-                            "sve2": True,
-                            "sve_max_length": vector_bits,
-                        },
-                    ),
-                ):
-                    selected_isa = cpu_vec_isa.valid_vec_isa_list()[0]
-                    self.assertIsInstance(selected_isa, isa_cls)
-                    self.assertEqual(selected_isa.bit_width(), vector_bits)
+                self.assertIsInstance(
+                    cpu_vec_isa.valid_vec_isa_list()[0], cpu_vec_isa.VecNEON
+                )
         finally:
             cpu_vec_isa.valid_vec_isa_list.cache_clear()
 

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -16,7 +16,7 @@ from ..cpu_vec_isa import (
     VecAVX512VNNI,
     VecISA,
     VecNEON,
-    VecSVE256,
+    VecSVE,
 )
 from ..utils import IndentedBuffer, parallel_num_threads
 from ..virtualized import V
@@ -426,7 +426,7 @@ def do_not_use_with_small_m_for_int8_woq(config, m, n, k, alpha, num_threads, **
         compute_dtype=torch.float,
     ),
     *generate_gemm_config(
-        VecSVE256,
+        VecSVE,
         [(4, 24, 1), (4, 16, 1), (8, 8, 1)],
         input_dtype=torch.float,
         input2_dtype=torch.float,

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -238,7 +238,7 @@ class VecNEON(VecISA):
 
 @dataclasses.dataclass
 class VecSVE256(VecISA):
-    # this function can be repurposed for SVE with variable vec length
+    # Repurposable for SVE targets with variable vector length.
     _bit_width = 256
     _macro = [
         "CPU_CAPABILITY_SVE",
@@ -247,13 +247,32 @@ class VecSVE256(VecISA):
         "__ARM_FEATURE_BF16",
     ]
     _arch_flags = "-march=armv8-a+sve+bf16 -msve-vector-bits=256"
+    _armv9a_arch_flags = (
+        "-march=armv9-a+sve2+fp16fml+sha3+bf16+i8mm -msve-vector-bits=256"
+    )
 
     _dtype_nelements = {torch.float: 8, torch.bfloat16: 16, torch.float16: 16}
+    _armv9a_supported: bool | None = None
 
     def __str__(self) -> str:
         if config.is_fbcode():
             return "neon"
         return "asimd"
+
+    def _has_armv9a(self) -> bool:
+        # Return True when torch.cpu.get_capabilities() reports
+        # Armv9-A + SVE2 support.
+        if self._armv9a_supported is None:
+            try:
+                self._armv9a_supported = bool(torch.cpu.get_capabilities()["sve2"])
+            except Exception:
+                self._armv9a_supported = False
+        return self._armv9a_supported
+
+    def build_arch_flags(self) -> str:
+        if self._has_armv9a():
+            return self._armv9a_arch_flags
+        return self._arch_flags
 
     __hash__: Callable[[VecISA], Any] = VecISA.__hash__  # type: ignore[assignment]
 
@@ -591,7 +610,8 @@ def valid_vec_isa_list() -> list[VecISA]:
     elif arch == "ppc64le":
         isa_list.append(VecVSX())
     elif arch == "aarch64":
-        if torch.backends.cpu.get_cpu_capability() == "SVE256":
+        caps = torch.cpu.get_capabilities()
+        if caps["sve2"] or caps["sve"]:
             isa_list.append(VecSVE256())
         else:
             isa_list.append(VecNEON())

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -237,62 +237,33 @@ class VecNEON(VecISA):
 
 
 @dataclasses.dataclass
-class VecSVE256(VecISA):
-    # Repurposable for SVE targets with variable vector length.
-    _bit_width = 256
-    _macro = [
-        "CPU_CAPABILITY_SVE",
-        "CPU_CAPABILITY_SVE256",
-        "AT_BUILD_ARM_VEC256_WITH_SLEEF",
-        "__ARM_FEATURE_BF16",
-    ]
-    _arch_flags = "-march=armv8-a+sve+bf16 -msve-vector-bits=256"
-    _armv9a_arch_flags = (
-        "-march=armv9-a+sve2+fp16fml+sha3+bf16+i8mm -msve-vector-bits=256"
+class VecSVE(VecISA):
+    _bit_width: int = 256
+    _armv9a_supported: bool | None = dataclasses.field(
+        default=None, init=False, compare=False
     )
 
-    _dtype_nelements = {torch.float: 8, torch.bfloat16: 16, torch.float16: 16}
-    _armv9a_supported: bool | None = None
-
-    def __str__(self) -> str:
-        if config.is_fbcode():
-            return "neon"
-        return "asimd"
-
-    def _has_armv9a(self) -> bool:
-        # Return True when torch.cpu.get_capabilities() reports
-        # Armv9-A + SVE2 support.
-        if self._armv9a_supported is None:
-            try:
-                self._armv9a_supported = bool(torch.cpu.get_capabilities()["sve2"])
-            except Exception:
-                self._armv9a_supported = False
-        return self._armv9a_supported
-
-    def build_arch_flags(self) -> str:
-        if self._has_armv9a():
-            return self._armv9a_arch_flags
-        return self._arch_flags
-
-    __hash__: Callable[[VecISA], Any] = VecISA.__hash__  # type: ignore[assignment]
-
-
-@dataclasses.dataclass
-class VecSVE128(VecISA):
-    _bit_width = 128
-    _macro = [
-        "CPU_CAPABILITY_SVE",
-        "CPU_CAPABILITY_SVE128",
-        "AT_BUILD_ARM_VEC256_WITH_SLEEF",
-        "__ARM_FEATURE_BF16",
-    ]
-    _arch_flags = "-march=armv8-a+sve+bf16 -msve-vector-bits=128"
-    _armv9a_arch_flags = (
-        "-march=armv9-a+sve2+fp16fml+sha3+bf16+i8mm -msve-vector-bits=128"
-    )
-
-    _dtype_nelements = {torch.float: 4, torch.bfloat16: 8, torch.float16: 8}
-    _armv9a_supported: bool | None = None
+    def __post_init__(self) -> None:
+        assert self._bit_width in (128, 256)
+        nelements = self._bit_width // 32
+        self._macro = [
+            "CPU_CAPABILITY_SVE",
+            f"CPU_CAPABILITY_SVE{self._bit_width}",
+            "AT_BUILD_ARM_VEC256_WITH_SLEEF",
+            "__ARM_FEATURE_BF16",
+        ]
+        self._arch_flags = (
+            f"-march=armv8-a+sve+bf16 -msve-vector-bits={self._bit_width}"
+        )
+        self._armv9a_arch_flags = (
+            "-march=armv9-a+sve2+fp16fml+sha3+bf16+i8mm "
+            f"-msve-vector-bits={self._bit_width}"
+        )
+        self._dtype_nelements = {
+            torch.float: nelements,
+            torch.bfloat16: nelements * 2,
+            torch.float16: nelements * 2,
+        }
 
     def __str__(self) -> str:
         if config.is_fbcode():
@@ -302,7 +273,9 @@ class VecSVE128(VecISA):
     def _has_armv9a(self) -> bool:
         if self._armv9a_supported is None:
             try:
-                self._armv9a_supported = bool(torch.cpu.get_capabilities()["sve2"])
+                self._armv9a_supported = bool(
+                    torch.cpu.get_capabilities().get("sve2", False)
+                )
             except Exception:
                 self._armv9a_supported = False
         return self._armv9a_supported
@@ -585,8 +558,7 @@ supported_vec_isa_list = [
     VecAVX512(),
     VecAVX2(),
     VecNEON(),
-    VecSVE256(),
-    VecSVE128(),
+    VecSVE(256),
 ]
 
 
@@ -650,11 +622,13 @@ def valid_vec_isa_list() -> list[VecISA]:
         isa_list.append(VecVSX())
     elif arch == "aarch64":
         caps = torch.cpu.get_capabilities()
-        if caps["sve2"] or caps["sve"]:
+        if (caps.get("sve2", False) or caps.get("sve", False)) and caps.get(
+            "bf16", False
+        ):
             if caps.get("sve_max_length") == 128:
-                isa_list.append(VecSVE128())
+                isa_list.append(VecSVE(128))
             else:
-                isa_list.append(VecSVE256())
+                isa_list.append(VecSVE(256))
         else:
             isa_list.append(VecNEON())
 

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -180,7 +180,7 @@ cdll.LoadLibrary("__lib_path__")
         key, input_path = write(
             code,
             "cpp",
-            extra=_get_isa_dry_compile_fingerprint(self._arch_flags),
+            extra=_get_isa_dry_compile_fingerprint(self.build_arch_flags()),
         )
         from torch.utils._filelock import FileLock
 
@@ -262,6 +262,44 @@ class VecSVE256(VecISA):
     def _has_armv9a(self) -> bool:
         # Return True when torch.cpu.get_capabilities() reports
         # Armv9-A + SVE2 support.
+        if self._armv9a_supported is None:
+            try:
+                self._armv9a_supported = bool(torch.cpu.get_capabilities()["sve2"])
+            except Exception:
+                self._armv9a_supported = False
+        return self._armv9a_supported
+
+    def build_arch_flags(self) -> str:
+        if self._has_armv9a():
+            return self._armv9a_arch_flags
+        return self._arch_flags
+
+    __hash__: Callable[[VecISA], Any] = VecISA.__hash__  # type: ignore[assignment]
+
+
+@dataclasses.dataclass
+class VecSVE128(VecISA):
+    _bit_width = 128
+    _macro = [
+        "CPU_CAPABILITY_SVE",
+        "CPU_CAPABILITY_SVE128",
+        "AT_BUILD_ARM_VEC256_WITH_SLEEF",
+        "__ARM_FEATURE_BF16",
+    ]
+    _arch_flags = "-march=armv8-a+sve+bf16 -msve-vector-bits=128"
+    _armv9a_arch_flags = (
+        "-march=armv9-a+sve2+fp16fml+sha3+bf16+i8mm -msve-vector-bits=128"
+    )
+
+    _dtype_nelements = {torch.float: 4, torch.bfloat16: 8, torch.float16: 8}
+    _armv9a_supported: bool | None = None
+
+    def __str__(self) -> str:
+        if config.is_fbcode():
+            return "neon"
+        return "asimd"
+
+    def _has_armv9a(self) -> bool:
         if self._armv9a_supported is None:
             try:
                 self._armv9a_supported = bool(torch.cpu.get_capabilities()["sve2"])
@@ -548,6 +586,7 @@ supported_vec_isa_list = [
     VecAVX2(),
     VecNEON(),
     VecSVE256(),
+    VecSVE128(),
 ]
 
 
@@ -612,7 +651,10 @@ def valid_vec_isa_list() -> list[VecISA]:
     elif arch == "aarch64":
         caps = torch.cpu.get_capabilities()
         if caps["sve2"] or caps["sve"]:
-            isa_list.append(VecSVE256())
+            if caps.get("sve_max_length") == 128:
+                isa_list.append(VecSVE128())
+            else:
+                isa_list.append(VecSVE256())
         else:
             isa_list.append(VecNEON())
 

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -38,7 +38,8 @@
 
 #if defined(CPU_CAPABILITY_AVX512) || defined(CPU_CAPABILITY_AVX2) ||  \
     defined(CPU_CAPABILITY_ZVECTOR) || defined(CPU_CAPABILITY_NEON) || \
-    defined(CPU_CAPABILITY_VSX) || defined(CPU_CAPABILITY_SVE256)
+    defined(CPU_CAPABILITY_VSX) || defined(CPU_CAPABILITY_SVE256) ||   \
+    defined(CPU_CAPABILITY_SVE128)
 #define INDUCTOR_USE_VECTOR_TYPES() 1
 #else
 #define INDUCTOR_USE_VECTOR_TYPES() 0


### PR DESCRIPTION
## Summary
This PR enables Armv9-A as a supported target for torch.compile on AArch64 platforms. It extends the existing AArch64 backend configuration to recognize and properly generate code for Armv9-A CPUs. This PR replaces #175326 in favour of recent support of SVE 128.

## Implementation
+ Extend architecture detection logic for AArch64 to add Armv9-A to supported `-march` mappings
+ Ensure Inductor codegen correctly propagates the target triple and feature set
+ Preserve default behavior for non-Armv9-A environments
+ No behavior change for x86 or other architectures
+ 128-bit and 256-bit SVE support

## Testing
AArch64 Armv9-A hardware (Neoverse V2)
Verified:
+ `torch.compile` succeeds
+ Inductor-generated kernels compile without error

cc: @aditew01 @robert-hardwick @nikhil-arm 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo