### PR TITLE
Reset Dynamo around combo kernel benchmark tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,9 @@ changes. Instead, if the PR is large, explain the order to review changes
 (e.g., the logical progression), or if it's short just omit the bullet list
 entirely.
 
+When describing the testing strategy in a commit message, include the literal
+commands that were run in fenced Markdown code blocks.
+
 Disclose that the PR was authored with an AI assistant. Do this informally in
 the commit body (e.g., "Authored by Claude." or a similar attribution for
 whichever assistant was used). NEVER add a `Co-authored-by:` trailer

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -789,6 +789,7 @@ class ComboKernelBenchmarkTests(TestCase):
 
     def setUp(self):
         super().setUp()
+        torch._dynamo.reset()
         torch._inductor.metrics.reset()
         self._test_stack = contextlib.ExitStack()
         self._test_stack.enter_context(
@@ -806,6 +807,7 @@ class ComboKernelBenchmarkTests(TestCase):
 
     def tearDown(self):
         self._test_stack.close()
+        torch._dynamo.reset()
         torch._inductor.metrics.reset()
         super().tearDown()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184556

ComboKernelBenchmarkTests and its per-subkernel-blocks subclass run inherited test methods in the same Python process. The base variant can leave a Dynamo cache entry behind, so the subclass may reuse compiled work generated under the previous combo_kernel_per_subkernel_blocks setting. That makes generated_kernel_count stay at zero even though the test expects fresh benchmark compilation.

Reset Dynamo in setUp and tearDown for this benchmark class so each inherited variant observes the config it installs before compiling. Also document that commit-message testing strategies should include literal commands in fenced Markdown blocks.

Testing strategy:

First reproduced the failure by running the base benchmark test immediately before the per-subkernel-blocks variant in one process with a clean Inductor cache:

```bash
rm -rf agent_space/inductor-cache-ordered && mkdir -p agent_space/inductor-cache-ordered && TORCHINDUCTOR_CACHE_DIR=$PWD/agent_space/inductor-cache-ordered PYTORCH_PRINT_REPRO_ON_FAILURE=0 python test/inductor/test_combo_kernels.py ComboKernelBenchmarkTests.test_round_robin_dispatch ComboKernelBenchmarkTestsPerSubkernelBlocks.test_round_robin_dispatch
```

Then verified the fix with the three Sandcastle failures in the same ordered base-then-subclass shape:

```bash
rm -rf agent_space/inductor-cache-clean-three-final && mkdir -p agent_space/inductor-cache-clean-three-final && TORCHINDUCTOR_CACHE_DIR=$PWD/agent_space/inductor-cache-clean-three-final PYTORCH_PRINT_REPRO_ON_FAILURE=0 python test/inductor/test_combo_kernels.py ComboKernelBenchmarkTests.test_persistent_reduction_no_x_dim ComboKernelBenchmarkTests.test_reduce_benchmark ComboKernelBenchmarkTests.test_round_robin_dispatch ComboKernelBenchmarkTestsPerSubkernelBlocks.test_persistent_reduction_no_x_dim ComboKernelBenchmarkTestsPerSubkernelBlocks.test_reduce_benchmark ComboKernelBenchmarkTestsPerSubkernelBlocks.test_round_robin_dispatch
```

Finally ran the full benchmark class pair together:

```bash
rm -rf agent_space/inductor-cache-clean-allbench && mkdir -p agent_space/inductor-cache-clean-allbench && TORCHINDUCTOR_CACHE_DIR=$PWD/agent_space/inductor-cache-clean-allbench PYTORCH_PRINT_REPRO_ON_FAILURE=0 python test/inductor/test_combo_kernels.py ComboKernelBenchmarkTests ComboKernelBenchmarkTestsPerSubkernelBlocks
```

Before amending, ran lint:

```bash
lintrunner -a
```

Authored by Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo