### PR TITLE
[ROCm][CI] Remove test-matrix from pull workflow ROCm build

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -510,12 +510,6 @@ jobs:
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       # TODO (huydhn): Add this back once other workflow migrates
       # sync-tag: rocm-build
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.mi210.1" },
-        ]}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
     secrets: inherit


### PR DESCRIPTION
## Summary

Remove the unused `test-matrix` from `linux-jammy-rocm-py3_10-build` in `pull.yml`. That workflow only runs the ROCm build; there is no pull test job that consumes the matrix output.

## Test plan

- [x] CI validates workflow YAML on this PR
- [x] Confirm `linux-jammy-rocm-py3.10` build still runs on PRs when triggered. See here: https://github.com/pytorch/pytorch/actions/runs/26171839359/job/76995261205?pr=184557


Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang