### PR TITLE
[inductor] Fix exposed_delta calculation bug in sink_waits_iterative

### DIFF
--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -1958,19 +1958,21 @@ def _sink_waits_iterative_internal(
                     c_runtime = runtimes[candidate]
 
                     if c_runtime > 0 and len(group_colls) > 0:
-                        # Advantage for current Wait to do the Swap
                         # pyrefly: ignore[no-matching-overload]
-                        exposed_delta = max(
-                            0,
-                            info.comm_time - info.comp_time,
+                        exposed_before = max(0, info.comm_time - info.comp_time)
+                        # pyrefly: ignore[no-matching-overload]
+                        exposed_after = max(
+                            0, info.comm_time - info.comp_time - c_runtime
                         )
-                        # pyrefly: ignore[no-matching-overload]
-                        -max(0, info.comm_time - info.comp_time - c_runtime)
+                        exposed_delta = exposed_after - exposed_before
                         for gc_comm_time, gc_comp_time in group_colls.values():
                             # pyrefly: ignore [no-matching-overload]
-                            exposed_delta += max(0, gc_comm_time - gc_comp_time) - max(
+                            gc_exposed_before = max(0, gc_comm_time - gc_comp_time)
+                            # pyrefly: ignore [no-matching-overload]
+                            gc_exposed_after = max(
                                 0, gc_comm_time - gc_comp_time + c_runtime
                             )
+                            exposed_delta += gc_exposed_after - gc_exposed_before
                         if exposed_delta > 0:
                             info.limiting_factor = (
                                 f"candidate has compute {c_runtime}, group contains collectives,"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184558

Summary: Fix two bugs in the `exposed_delta` calculation in `_sink_waits_iterative_internal` that caused the pass to stop prematurely when `sink_waits_iterative_swap_with_collectives=True` and `sink_iterative_use_runtime_estimations=True`.

**Bug 1 (line 1968):** A standalone expression `-max(0, comm_time - comp_time - c_runtime)` computed a value and discarded it instead of being subtracted from `exposed_delta`. This set `exposed_delta` to the full exposed time (always positive) instead of the improvement delta.

**Bug 2 (lines 1971-1973):** The loop accumulating grouped collectives' cost used `exposed_before - exposed_after` (negative, representing "improvement" to the grouped collective) instead of `exposed_after - exposed_before` (positive, representing cost/worsening), which is the opposite sign from the analogous code in the reorder pass (lines 1035-1049).

**Combined effect:** `exposed_delta` always started positive and stayed positive, so `if exposed_delta > 0: break` fired immediately at the first compute node whenever the group contained collectives. This completely prevented waits from being sunk past compute when grouped collectives were present -- exactly the scenario enabled by `sink_waits_iterative_swap_with_collectives=True`.

**Impact:** In an ADS model (dhn_arch, 10 layers), this caused 8 of 24 reduce_scatter GPU kernels to have 0% overlap with compute. Exposed FSDP comm: 41ms (simple_fsdp) vs 22ms (baseline FSDP). The fix mirrors the correct pattern from `_reorder_communication_preserving_peak_memory_internal`.

Authored by Claude.

Test Plan: - Verified lintrunner passes on torch/_inductor/comms.py
- Audited all exposed_delta calculations in both reorder and sink_waits passes for similar patterns -- none found
- Verified sign conventions match between reorder pass (lines 1035-1049) and sink_waits pass (lines 1960-1975)
- TODO: Run test/distributed/test_inductor_collectives.py::TestCollectivesInductor::test_reorder_peak_memory_bucketed
- TODO: Verify with FakePG simulation on ADS model fx_runnable

Reviewers:

Subscribers:

Tasks:

Tags:

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo