### PR TITLE
[profiler] Add channel / channel_type dummy fields to EventMetadata

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -589,6 +589,11 @@ class EventMetadata(NamedTuple):
     dst_rank: int | None
     seq: int | None
     is_async: bool | None
+    # CUPTI channel and channel type for the activity, when surfaced by
+    # kineto's per-event metadata. Optional so events that don't carry
+    # them deserialize without error.
+    channel: int | None = None
+    channel_type: int | None = None
 
 
 def _to_str(v: str) -> str:


### PR DESCRIPTION
Summary:
Adds two new optional fields, `channel: int | None = None` and `channel_type: int | None = None`, to `EventMetadata` in `torch/autograd/profiler_util.py`. They surface the CUPTI channel and channel type for an activity when kineto's per-event metadata includes them, and stay `None` for events that don't carry them.

The fields are appended at the end of the NamedTuple because NamedTuples require trailing fields to be defaulted, and defaulting the existing intermediate fields would be larger-scope churn.

Test Plan: CI

Reviewed By: scotts

Differential Revision: D105842750


