### PR TITLE
Add boundary checks  in set_storage_quantized_

### DIFF
--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -79,6 +79,17 @@ inline c10::SymInt maybe_convert_symint(c10::SymInt x) { return x; }
 template <>
 inline int64_t maybe_convert_symint(c10::SymInt x) { return x.guard_int(__FILE__, __LINE__); }
 
+// Sub-byte quantized dtypes (QUInt4x2, QUInt2x4) pack multiple logical
+// elements per storage byte. Itemsize is still 1, so the standard
+// element*itemsize formula over-counts; divide by this packing factor.
+inline int64_t subByteElementPerByte(const caffe2::TypeMeta& data_type) {
+  switch (c10::typeMetaToScalarType(data_type)) {
+    case c10::ScalarType::QUInt4x2: return 2;
+    case c10::ScalarType::QUInt2x4: return 4;
+    default: return 1;
+  }
+}
+
 template <typename T>
 inline void checkInBoundsForStorage(
     ArrayRef<T> size,
@@ -97,6 +108,13 @@ inline void checkInBoundsForStorage(
         at::detail::computeStorageNbytesContiguous(size, data_type.itemsize());
     storage_size_plus_offset_bytes = at::detail::computeStorageNbytesContiguous(
         size, data_type.itemsize(), storage_offset);
+  }
+  const int64_t element_per_byte = subByteElementPerByte(data_type);
+  if (element_per_byte > 1) {
+    storage_size_bytes =
+        (storage_size_bytes + element_per_byte - 1) / element_per_byte;
+    storage_size_plus_offset_bytes =
+        (storage_size_plus_offset_bytes + element_per_byte - 1) / element_per_byte;
   }
   // It's ok to always evaluate to False for this early return for SymInts because
   // (1) maybe_convert_symint below only installs guard for int64_t case

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
+#include <ATen/native/Resize.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/quantized/cpu/QuantUtils.h>
 #include <ATen/quantized/QTensorImpl.h>
@@ -174,8 +175,10 @@ Tensor& set_storage_quantized_(
     int64_t storage_offset,
     IntArrayRef sizes,
     IntArrayRef strides) {
+  checkSetStorage(self, storage, storage_offset, sizes, strides);
+  checkInBoundsForStorage(
+      sizes, strides, storage_offset, self.dtype(), self.storage());
   auto* self_ = self.unsafeGetTensorImpl();
-  self_->set_storage_keep_dtype(std::move(storage));
   self_->set_storage_offset(storage_offset);
   self_->set_sizes_and_strides(sizes, strides);
   return self;

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -175,7 +175,7 @@ Tensor& set_storage_quantized_(
     int64_t storage_offset,
     IntArrayRef sizes,
     IntArrayRef strides) {
-  checkSetStorage(self, storage, storage_offset, sizes, strides);
+  checkSetStorage(self, std::move(storage), storage_offset, sizes, strides);
   checkInBoundsForStorage(
       sizes, strides, storage_offset, self.dtype(), self.storage());
   auto* self_ = self.unsafeGetTensorImpl();

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4981,11 +4981,26 @@ class TestSerialization(TestCase, SerializationMixin):
         with self.assertRaisesRegex(RuntimeError, "out of bounds for storage"):
             qx.set_(torch.UntypedStorage(12), 0, (3, 4), (2 ** 17, 1))
 
+        # Stride is fine but storage_offset alone pushes the layout out of
+        # the storage — exercises the offset branch of the bounds formula
+        # (storage_offset + max_element_offset) * itemsize > storage.nbytes.
+        with self.assertRaisesRegex(RuntimeError, "out of bounds for storage"):
+            _rebuild_qtensor(
+                make_storage(12), 999, (3, 4), (4, 1),
+                per_channel_params, False, None,
+            )
+
         # Per-channel axis out of range / scales length mismatch
         with self.assertRaisesRegex(ValueError, "axis .* out of range"):
             _rebuild_qtensor(
                 make_storage(12), 0, (3, 4), (4, 1),
                 (torch.per_channel_affine, scales, zero_points, 5),
+                False, None,
+            )
+        with self.assertRaisesRegex(ValueError, "axis .* out of range"):
+            _rebuild_qtensor(
+                make_storage(12), 0, (3, 4), (4, 1),
+                (torch.per_channel_affine, scales, zero_points, -1),
                 False, None,
             )
         with self.assertRaisesRegex(ValueError, "scales/zero_points length"):

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4948,6 +4948,55 @@ class TestSerialization(TestCase, SerializationMixin):
             for key in state_dict:
                 self.assertTrue(torch.equal(state_dict[key], loaded_cpu2[key]))
 
+    def test_rebuild_qtensor_bounds(self):
+        from torch._utils import _rebuild_qtensor
+        from torch.storage import TypedStorage
+
+        def make_storage(nbytes, dtype=torch.quint8):
+            return TypedStorage(
+                wrap_storage=torch.UntypedStorage(nbytes),
+                dtype=dtype,
+                _internal=True,
+            )
+
+        scales = torch.tensor([0.1, 0.2, 0.3], dtype=torch.double)
+        zero_points = torch.tensor([0, 1, 2], dtype=torch.long)
+        per_channel_params = (torch.per_channel_affine, scales, zero_points, 0)
+
+        # _rebuild_qtensor with stride that overruns the storage
+        # The bound check is in C++, so RuntimeError.
+        with self.assertRaisesRegex(RuntimeError, "out of bounds for storage"):
+            _rebuild_qtensor(
+                make_storage(12), 0, (3, 4), (2 ** 17, 1),
+                per_channel_params, False, None,
+            )
+
+        # Direct quantized-tensor set_() with an OOB stride must also be
+        # rejected (TorchScript deserialization and user-issued set_ go
+        # through this path without ever touching _rebuild_qtensor).
+        x = torch.randn(3, 4)
+        qx = torch.quantize_per_channel(
+            x, scales, zero_points, axis=0, dtype=torch.qint8,
+        )
+        with self.assertRaisesRegex(RuntimeError, "out of bounds for storage"):
+            qx.set_(torch.UntypedStorage(12), 0, (3, 4), (2 ** 17, 1))
+
+        # Per-channel axis out of range / scales length mismatch
+        with self.assertRaisesRegex(ValueError, "axis .* out of range"):
+            _rebuild_qtensor(
+                make_storage(12), 0, (3, 4), (4, 1),
+                (torch.per_channel_affine, scales, zero_points, 5),
+                False, None,
+            )
+        with self.assertRaisesRegex(ValueError, "scales/zero_points length"):
+            _rebuild_qtensor(
+                make_storage(12), 0, (3, 4), (4, 1),
+                (torch.per_channel_affine,
+                 torch.zeros(99, dtype=torch.double),
+                 torch.zeros(99, dtype=torch.long), 0),
+                False, None,
+            )
+
     def run(self, *args, **kwargs):
         with serialization_method(use_zip=True):
             return super().run(*args, **kwargs)

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -456,6 +456,24 @@ def _rebuild_qtensor(
         )
     elif qscheme in (torch.per_channel_affine, torch.per_channel_affine_float_qparams):
         _, scales, zero_points, axis = quantizer_params
+        # The C++ constructor does not bound-check axis or the
+        # scales/zero_points length against size; values arriving from an
+        # untrusted weights_only checkpoint can otherwise be arbitrary.
+        if not 0 <= axis < len(size):
+            raise ValueError(
+                f"_rebuild_qtensor: per_channel axis {axis} out of range for size {tuple(size)}"
+            )
+        expected_len = int(size[axis])
+        scales_len = len(scales) if isinstance(scales, list) else scales.numel()
+        zero_points_len = (
+            len(zero_points) if isinstance(zero_points, list) else zero_points.numel()
+        )
+        if scales_len != expected_len or zero_points_len != expected_len:
+            raise ValueError(
+                "_rebuild_qtensor: per_channel scales/zero_points length must equal "
+                f"size[axis]={expected_len}, got scales={scales_len}, "
+                f"zero_points={zero_points_len}"
+            )
         if type(scales) is list and type(zero_points) is list:
             if qscheme == torch.per_channel_affine:
                 scales = torch.tensor(scales, dtype=torch.double, device=storage.device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #184561

`set_storage_quantized` assigns storage, offset, sizes and strides directly without validating that they fit the storage. Route through `checkSetStorage`/`checkInBoundsForStorage` so the quantized path matches the validation `set_` already performs. 

Tighten `_rebuild_qtensor`'s per_channel branch: the C++ quantizer constructor does not bound-check axis against len(size) nor scales/zero_points length against size[axis], so validate both before constructing the tensor.

Adds test_weights_only_rebuild_qtensor_bounds covering both the _rebuild_qtensor entry point and a direct q_tensor.set_(...) call.

Authored with Claude.

TODO:
 - Change `TORCH_CHECK` to `TORCH_CHECK_VALUE` in `checkSetStorage`