### PR TITLE
[TMA] Check constant_offset alignment in TMACompatibilityChecker

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1670,6 +1670,17 @@ class TritonTensorDescriptorTestCUDA(BlockDescriptorTestBase):
         actual = compiled_fn(t)
         self.assertTrue((actual == 4).all())
 
+    def test_slice_constant_offset_disables_tma(self):
+        """TMA requires 16-byte aligned base; x[1:] with float32 yields 4-byte offset."""
+
+        def fn(x):
+            return x[1:] + 1
+
+        x = torch.randn(1025, device=GPU_TYPE)
+        result, (code,) = run_and_get_code(torch.compile(fn), x)
+        self.assertEqual(result, fn(x))
+        self.assertIn("tl.load", code)
+
 
 test_torchinductor.copy_tests(
     CommonTemplate,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2654,6 +2654,7 @@ class TMACompatibilityChecker:
     def are_block_parameters_compatible(
         self,
         block_params: BlockParameters,
+        constant_offset: sympy.Expr | int = 0,
     ) -> bool:
         """
         Check if the block parameters are valid for TMA.
@@ -2665,8 +2666,12 @@ class TMACompatibilityChecker:
                 V.graph.sizevars.replace_backed_symbols_with_hints(st)
                 for st in block_params.strides
             ]
+            constant_offset_expr = V.graph.sizevars.replace_backed_symbols_with_hints(
+                sympy.sympify(constant_offset)
+            )
         else:
             strides = block_params.strides
+            constant_offset_expr = sympy.sympify(constant_offset)
 
         # The TMA API requires that the innermost stride is 1
         # and that the outer strides are 16 byte aligned
@@ -2691,6 +2696,26 @@ class TMACompatibilityChecker:
                     strides,
                 )
                 return False
+
+        # Ensure the TMA descriptor base pointer maintains 16-byte alignment.
+        # The actual kernel-side base pointer is computed as `in_ptr + constant_offset`.
+        # While `in_ptr` is handled to be 16-byte aligned (see assume_aligned_inputs and copy_if_misaligned),
+        # adding a constant element offset may break that alignment requirement.
+        # We must verify that the resulting address remains 16-byte aligned after applying constant_offset.
+        if not V.graph.sizevars.statically_known_equals(
+            ModularIndexing(
+                constant_offset_expr * element_size, 1, sympy.Integer(16)
+            ),
+            sympy.Integer(0),
+        ):
+            log.debug(
+                "%s TMA descriptor base must be 16 byte aligned but constant_offset=%s "
+                "with %d-byte dtype yields a non-16-byte aligned base.",
+                self.failed_debug_prefix,
+                constant_offset_expr,
+                element_size,
+            )
+            return False
 
         # Now compute the minimum value of the block type that is used
         # in the innermost block size that can guarantee that 16 bytes of data
@@ -3447,7 +3472,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         TMACompatibilityChecker, tma_compatibility_checker
                     )
                     if not tma_compatibility_checker.are_block_parameters_compatible(
-                        options.params
+                        options.params,
+                        constant_offset=options.constant_offset,
                     ):
                         return None
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2703,9 +2703,7 @@ class TMACompatibilityChecker:
         # adding a constant element offset may break that alignment requirement.
         # We must verify that the resulting address remains 16-byte aligned after applying constant_offset.
         if not V.graph.sizevars.statically_known_equals(
-            ModularIndexing(
-                constant_offset_expr * element_size, 1, sympy.Integer(16)
-            ),
+            ModularIndexing(constant_offset_expr * element_size, 1, sympy.Integer(16)),
             sympy.Integer(0),
         ):
             log.debug(


### PR DESCRIPTION
Fixes #184563

### Root cause
The wrapper calls copy_if_misaligned to guarantee the graph input pointer (arg0_1) is 16-byte aligned. However, the kernel-side descriptor base is in_ptr0 + constant_offset where the offset comes from the slice. 

For example:
```
@triton.jit
def triton_poi_fused_add_slice_0(in_ptr0, out_ptr0, xnumel, XBLOCK : tl.constexpr):
    xnumel = 1024
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.arange(0, XBLOCK)[:]
    xmask = xindex < xnumel
    x0 = xindex
    tmp0 = tl.make_tensor_descriptor(in_ptr0 + (1), shape=[1024], strides=[1],
                                    block_shape=[XBLOCK]).load([xoffset])
    # TMACompatibilityChecker checks in_ptr0 but not the in_ptr0 + (1)
  ...

# wrapper
def call(self, args):
  arg0_1, = args
  args.clear()
  assert_size_stride(arg0_1, (1025, ), (1, ))
  with torch.cuda._DeviceGuard(0):
      torch.cuda.set_device(0)
      arg0_1 = copy_if_misaligned(arg0_1)            # arg0_1 is 16-B aligned
      ...
      triton_poi_fused_add_slice_0.run(arg0_1, buf0, 1024, stream=stream0)
```

TMACompatibilityChecker checks stride alignment but never verifies that constant_offset * element_size is a multiple of 16, so it incorrectly approves TMA for this load.


### The fix
Add a `constant_offset` parameter for `are_block_parameters_compatible` and assert `(constant_offset * element_size) % 16 == 0` symbolically

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos