### PR TITLE
[inductor] Roll back invalid CPU loop split

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -4805,6 +4805,25 @@ class CPUReproTests(TestCase):
                         "__at_align__ std::array", 0, exactly=True
                     ).run(code)
 
+    def test_loop_split_rollback_mismatched_groups(self):
+        # https://github.com/pytorch/pytorch/issues/183370
+        torch.manual_seed(31)
+        in2d = nn.InstanceNorm2d(7)
+        rrelu = nn.RReLU().eval()
+        bn1 = nn.BatchNorm1d(63).eval()
+        x = torch.randn([8, 7, 3, 3])
+
+        def model():
+            t = in2d(x)
+            t = rrelu(t)
+            t = torch.flatten(t, start_dim=1)
+            t = torch.exp(torch.clamp(t, max=10))
+            return bn1(t)
+
+        expected = model()
+        actual = torch.compile(model, backend="inductor")()
+        torch.testing.assert_close(actual, expected)
+
     @requires_vectorization
     @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
     def test_group_norm_sum_conv1d_tail_reduction_store(self):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5182,6 +5182,8 @@ class CppScheduling(BaseScheduling):
                 (new_index_vars, reduce_vars),
             )
 
+        snapshots = [(node, node.snapshot_loop_state()) for node in nodes]
+
         # Here decide the final loop order
         for node in nodes:
             if node == matched_node:
@@ -5192,6 +5194,13 @@ class CppScheduling(BaseScheduling):
                     extra_indexing_constraints=extra_indexing_constraints,
                     recompute_sizes_body_func=loop_split,
                 )
+
+        # codegen_functions() requires same-sized pointwise fused nodes to use
+        # identical loop groups. If splitting cannot preserve that invariant,
+        # keep the original fused loops instead of generating an invalid kernel.
+        if any(node.group[1] != nodes[0].group[1] for node in nodes[1:]):
+            for node, state in reversed(snapshots):
+                node.restore_loop_state(state)
 
         return nodes
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184576

Restore scheduler node loop state when CPU loop splitting leaves fused pointwise nodes with mismatched groups, avoiding invalid C++ codegen after speculative splitting. Adds a regression test for the InstanceNorm/RReLU/BatchNorm compile crash.

Fixes #183370
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos