### PR TITLE
optim: use _get_closed_form_lr in normal step when get_lr not overridden

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -30,7 +30,8 @@ from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import run_tests, skipIfRocm
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
-    DTensorTestBase,
+    DTensorOpTestBase,
+    LocalDTensorOpTestBase,
     map_local_for_rank,
     skip_unless_torch_gpu,
     with_comms,
@@ -40,7 +41,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 funcol = torch.ops.c10d_functional
 
 
-class DistMathOpsTest(DTensorTestBase):
+class DistMathOpsTest(DTensorOpTestBase):
     def _check_module(self, m1, m2, check_grad=False):
         named_parameters = dict(m1.named_parameters())
         for name, param_m2 in m2.named_parameters():
@@ -1063,6 +1064,7 @@ class DistMathOpsTest(DTensorTestBase):
     def test_cumsum(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
+        torch.manual_seed(42)
         inp = torch.rand(3, 5, device=self.device_type)
 
         shard_dim = 0
@@ -1091,6 +1093,7 @@ class DistMathOpsTest(DTensorTestBase):
     def test_scan_ops(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
+        torch.manual_seed(42)
         inp = torch.rand(3, 5, device=self.device_type)
 
         shard_dim = 0
@@ -1113,6 +1116,7 @@ class DistMathOpsTest(DTensorTestBase):
     def test_scan_ops_with_indices(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
+        torch.manual_seed(42)
         inp = torch.rand(12, 8, device=self.device_type)
 
         shard_dim = 0
@@ -1277,6 +1281,7 @@ class DistMathOpsTest(DTensorTestBase):
     def test_logsumexp(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
+        torch.manual_seed(42)
         inp = torch.rand(3, 5, device=self.device_type)
 
         shard_dim = 0
@@ -1830,7 +1835,7 @@ class DistMathOpsTest(DTensorTestBase):
 
 
 DistMathOpsTestWithLocalTensor = create_local_tensor_test_class(
-    DistMathOpsTest,
+    DistMathOpsTest, base_class=LocalDTensorOpTestBase
 )
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -38,7 +38,8 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
-    DTensorTestBase,
+    DTensorOpTestBase,
+    LocalDTensorOpTestBase,
     skip_unless_torch_gpu,
     with_comms,
 )
@@ -61,7 +62,7 @@ def scale_for_fp8(
     return t_fp8.flatten(end_dim=1).flatten(start_dim=-2), scale.view(scale_shape)
 
 
-class DistMatrixOpsTest(DTensorTestBase):
+class DistMatrixOpsTest(DTensorOpTestBase):
     @with_comms
     def test_addmm(self):
         """
@@ -1136,7 +1137,7 @@ class DistMatrixOpsTest(DTensorTestBase):
 instantiate_parametrized_tests(DistMatrixOpsTest)
 
 DistMatrixOpsTestWithLocalTensor = create_local_tensor_test_class(
-    DistMatrixOpsTest,
+    DistMatrixOpsTest, base_class=LocalDTensorOpTestBase
 )
 
 if __name__ == "__main__":

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2664,6 +2664,20 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
+    def test_closed_form_lr_only_subclass(self):
+        # Subclass implementing only _get_closed_form_lr (no get_lr) should
+        # initialize without NotImplementedError.
+        class ClosedFormOnlyScheduler(LRScheduler):
+            def _get_closed_form_lr(self):
+                return [base_lr * 0.5**self.last_epoch for base_lr in self.base_lrs]
+
+        model = torch.nn.Linear(3, 3)
+        optim = SGD(model.parameters(), lr=0.1)
+        sch = ClosedFormOnlyScheduler(optim)
+        self.assertAlmostEqual(sch.get_last_lr()[0], 0.05)
+        sch.step()
+        self.assertAlmostEqual(sch.get_last_lr()[0], 0.025)
+
     def test_lr_scheduler_checkpoint_on_plateau(self):
         model = torch.nn.Linear(3, 3)
         optim = torch.optim.AdamW(model.parameters())

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -285,7 +285,10 @@ class LRScheduler:
         with _enable_get_lr_call(self):
             if epoch is None:
                 self.last_epoch += 1
-                values = self.get_lr()
+                if hasattr(self, "_get_closed_form_lr") and type(self).get_lr is LRScheduler.get_lr:
+                    values = cast(list[float | Tensor], self._get_closed_form_lr())
+                else:
+                    values = self.get_lr()
             else:
                 self.last_epoch = epoch
                 if hasattr(self, "_get_closed_form_lr"):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -285,7 +285,10 @@ class LRScheduler:
         with _enable_get_lr_call(self):
             if epoch is None:
                 self.last_epoch += 1
-                if hasattr(self, "_get_closed_form_lr") and type(self).get_lr is LRScheduler.get_lr:
+                if (
+                    hasattr(self, "_get_closed_form_lr")
+                    and type(self).get_lr is LRScheduler.get_lr
+                ):
                     values = cast(list[float | Tensor], self._get_closed_form_lr())
                 else:
                     values = self.get_lr()


### PR DESCRIPTION
## Description

A subclass that implements only `_get_closed_form_lr` (without overriding `get_lr`) fails at construction time with `NotImplementedError`. This is because `__init__` calls `_initial_step()` → `step()` → `_update_lr(epoch=None)`, which always calls `get_lr()`.

The `epoch is not None` path already prefers `_get_closed_form_lr` when available, but the `epoch is None` path does not.

## Fix

In `_update_lr`, when `epoch is None`, also check for `_get_closed_form_lr` if the subclass has not overridden `get_lr`. This mirrors the existing `epoch is not None` logic and preserves all existing behavior (built-in schedulers all override `get_lr`).

## Test

Added `test_closed_form_lr_only_subclass` in `test/optim/test_lrscheduler.py` that defines a minimal scheduler with only `_get_closed_form_lr`, verifies it initializes without error, and checks the LR values are correct.

Fixes #184517.