### PR TITLE
[Native DSL] Add cutedsl 4.5.0 and 4.5.1 to known-good versions

### DIFF
--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -30,6 +30,8 @@ _CUTEDSL_REQUIRED_VERSIONS: set[Version] = {
     #                   but > v26 of packaging.
     Version(f"{4}.{4}.{1}"),
     Version(f"{4}.{4}.{2}"),
+    Version(f"{4}.{5}.{0}"),
+    Version(f"{4}.{5}.{1}"),
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184579

Extends _CUTEDSL_REQUIRED_VERSIONS in torch/_native/cutedsl_utils.py with
Version("4.5.0") and Version("4.5.1"). Both releases were validated against
the in-tree cuteDSL test surface on a Blackwell (B200) host.

Tests run (per version, with the corresponding nvidia-cutlass-dsl installed):

    TORCH_NATIVE_SKIP_VERSION_CHECK=1 python test/python_native/test_cutedsl_smoketest.py
    TORCH_NATIVE_SKIP_VERSION_CHECK=1 python test/python_native/test_native_dsl_ops.py
    TORCH_NATIVE_SKIP_VERSION_CHECK=1 python test/python_native/test_dsl_registry.py
    TORCH_NATIVE_SKIP_VERSION_CHECK=1 python test/inductor/test_cutedsl_template.py
    TORCH_NATIVE_SKIP_VERSION_CHECK=1 python test/inductor/test_cutedsl_grouped_mm.py
    TORCH_NATIVE_SKIP_VERSION_CHECK=1 python test/test_scatter_gather_ops.py \
        TestScatterAddOverrideConds TestScatterAddOverrideCorrectness

Results (identical for 4.5.0 and 4.5.1, 142/142 passed each):

    test_cutedsl_smoketest                              4/4
    test_native_dsl_ops                                17/17
    test_dsl_registry                                  15/15
    test/inductor/test_cutedsl_template                21/21
    test/inductor/test_cutedsl_grouped_mm (Blackwell)  24/24
    test_scatter_gather_ops (override conds + corr.)   61/61

The grouped_mm run surfaces DeprecationWarnings from inside cutlass-dsl
(make_trivial_tiled_mma ab_dtype overload, struct.scalar as pointer);
these are upstream cleanup items, not test failures.

Authored by Claude.