### PR TITLE
Load OSS slow-test metadata in Sandcastle (#184584)

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -338,6 +338,15 @@ DEFAULT_SLOW_TESTS_FILE = 'slow_tests.json'
 disabled_tests_dict = {}
 slow_tests_dict = {}
 
+
+def resolve_sandcastle_slow_tests_file() -> str:
+    if not IS_SANDCASTLE:
+        return ""
+
+    filename = torch._utils_internal.get_file_path("test", DEFAULT_SLOW_TESTS_FILE)
+    return filename if os.path.isfile(filename) else ""
+
+
 def maybe_load_json(filename):
     if os.path.isfile(filename):
         with open(filename) as fp:
@@ -346,8 +355,10 @@ def maybe_load_json(filename):
     return {}
 
 # set them here in case the tests are running in a subprocess that doesn't call run_tests
-if os.getenv("SLOW_TESTS_FILE", ""):
-    slow_tests_dict = maybe_load_json(os.getenv("SLOW_TESTS_FILE", ""))
+slow_tests_file = os.getenv("SLOW_TESTS_FILE", "") or resolve_sandcastle_slow_tests_file()
+if slow_tests_file:
+    slow_tests_dict = maybe_load_json(slow_tests_file)
+    os.environ["SLOW_TESTS_FILE"] = slow_tests_file
 if os.getenv("DISABLED_TESTS_FILE", ""):
     disabled_tests_dict = maybe_load_json(os.getenv("DISABLED_TESTS_FILE", ""))
 


### PR DESCRIPTION
Summary:

Sandcastle Buck `python_unittest` targets do not go through `test/run_test.py`, so they do not get `SLOW_TESTS_FILE` and can run tests that OSS marks slow. Package `test/slow_tests.json` as a resource of `//caffe2:test-lib` and, when `common_utils` detects Sandcastle, resolve it through `torch._utils_internal.get_file_path` so the existing `TestCase.setUp()` slow-test skip path applies to direct Buck targets and subprocesses inherit `SLOW_TESTS_FILE`. Authored by Codex.

Test Plan: `buck2 cquery fbcode//caffe2:test-lib --output-attribute resources`; `buck2 cquery fbcode//caffe2/test/inductor:torchinductor_codegen_dynamic_shapes_cpu --output-attribute deps --output-attribute env`; Not run: lint (`spin` is not available in this environment and no nearby `.venv` exists).

Reviewed By: JacobSzwejbka

Differential Revision: D105858113


