### PR TITLE
Fix torch.compile addmm failure with beta=0 nonbroadcastable bias

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4259,6 +4259,24 @@ class CommonTemplate:
             ),
         )
 
+    def test_addmm_beta_zero_nonbroadcastable_bias(self):
+        if self.device != GPU_TYPE:
+            raise unittest.SkipTest(f"{GPU_TYPE} only test")
+
+        def fn(bias, x, weight):
+            return torch.addmm(bias, x, weight.t(), beta=0.0, alpha=0.25)
+
+        x = torch.randn(3, 7, device=self.device)
+        weight = torch.randn(11, 7, device=self.device)
+        bias = torch.zeros(7, device=self.device)
+        eager_out = fn(bias, x, weight)
+        compiled_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+        compiled_out = compiled_fn(bias, x, weight)
+
+        self.assertEqual(eager_out.shape, compiled_out.shape)
+        self.assertEqual(eager_out.shape, torch.Size([3, 11]))
+        torch.testing.assert_close(eager_out, compiled_out)
+
     def test_addmv(self):
         def fn(a, b, c):
             return torch.addmv(a, b, c)

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -201,6 +201,9 @@ def addmm_pattern(
 
 def should_pad_addmm(match: Match) -> bool:
     mat1, mat2, input = fetch_fake_tensors(match, ("mat1", "mat2", "input"))
+    beta = match.kwargs.get("beta", 1.0)
+    if beta == 0:
+        return False
     return should_pad(match, mat1, mat2, torch.ops.aten.addmm, input=input)
 
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -624,6 +624,12 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
 
         return lowerings[aten.add](arg1, arg2)
 
+    if beta == 0:
+        result = tuned_mm(mat1, mat2, layout=layout)
+        if alpha != 1:
+            result = lowerings[aten.mul](alpha, result)
+        return result
+
     # TODO(coconutruben): integrate into MMKernelInputs when all callsites use that
     m, n, k, layout, mat1, mat2, inp_expanded = mm_args(mat1, mat2, inp, layout=layout)
     static_shape, is_nonzero = _is_static_problem(layout)


### PR DESCRIPTION
Fixes #183899 
Fixes torch compile addmm failure when beta = 0 and bias shape is not broadcastable to output. When beta = 0 bias is ignored (multiplied by 0). So my fix skips bias shape validation in both pattern matching and the lowering paths. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos