### PR TITLE
[MPS] Handle NaNs properly in cholesky

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -360,7 +360,7 @@ kernel void factorDiagonalBlock(
 
     if (linear_tid == 0) {
       float diagVal = tile[kk][kk] - diagElt;
-      if (diagVal <= 0.0f) {
+      if (!(diagVal > 0.0f)) {
         info[bid.x] = kk + 1;
         return;
       }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6491,6 +6491,10 @@ class TestMPS(TestCaseMPS):
         ], device="mps")
         with self.assertRaisesRegex(RuntimeError, r'leading minor of order 2 is not positive-definite'):
             torch.linalg.cholesky_ex(A, check_errors=True)
+        # NaN on the diagonal must fail
+        A_nan = torch.eye(3, device="mps")
+        A_nan[0, 0] = float('nan')
+        self.assertEqual(torch.linalg.cholesky_ex(A_nan).info.item(), 1)
 
     def test_upsample_nearest2d(self):
         def helper(N, C, H, W, memory_format):


### PR DESCRIPTION
Handle nans properly in cholesky, before info would be 0 if it encountered Nan due to `diagVal <= 0.0f` returning False