### PR TITLE
Use PyTorch Min/Max in Inductor index propagation

### DIFF
--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -93,23 +93,25 @@ class MetalExprPrinter(ExprPrinter_):
             return f"c10::metal::safe_mod({x}, {mod})"
         return f"({x}) % ({mod})"
 
-    def _print_Min(self, expr: sympy.Expr) -> str:
-        if len(expr.args) != 2:
-            raise RuntimeError("metal::min only supported for 2 args")
+    def _print_min_max(self, expr: sympy.Expr, fn: str) -> str:
         # pyrefly: ignore [missing-attribute]
-        a, b = map(self._print, expr.args)
+        args = list(map(self._print, expr.args))
+        result = args[0]
+        for arg in args[1:]:
+            result = self._print_binary_min_max(result, arg, fn)
+        return result
+
+    @staticmethod
+    def _print_binary_min_max(a: str, b: str, fn: str) -> str:
         typecast_a = f"static_cast<decltype({a}+{b})>({a})"
         typecast_b = f"static_cast<decltype({a}+{b})>({b})"
-        return f"metal::min({typecast_a}, {typecast_b})"
+        return f"metal::{fn}({typecast_a}, {typecast_b})"
+
+    def _print_Min(self, expr: sympy.Expr) -> str:
+        return self._print_min_max(expr, "min")
 
     def _print_Max(self, expr: sympy.Expr) -> str:
-        if len(expr.args) != 2:
-            raise RuntimeError("metal::max only supported for 2 args")
-        # pyrefly: ignore [missing-attribute]
-        a, b = map(self._print, expr.args)
-        typecast_a = f"static_cast<decltype({a}+{b})>({a})"
-        typecast_b = f"static_cast<decltype({a}+{b})>({b})"
-        return f"metal::max({typecast_a}, {typecast_b})"
+        return self._print_min_max(expr, "max")
 
     def _print_Abs(self, expr: sympy.Expr) -> str:
         assert len(expr.args) == 1

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -11,7 +11,11 @@ import sympy
 
 import torch
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._sympy.functions import ModularIndexing
+from torch.utils._sympy.functions import (
+    Max as TorchMax,
+    Min as TorchMin,
+    ModularIndexing,
+)
 
 from .. import config
 from ..runtime.runtime_utils import torch_dtype_to_jax
@@ -2392,7 +2396,7 @@ class PallasKernel(SIMDKernel):
             self.has_flatten_indexing = True
             self.flatten_indexed_buffers.add(name)
             # Flatten then index for non-contiguous access (gather operation)
-            has_minmax = index.has(sympy.Min) or index.has(sympy.Max)
+            has_minmax = index.has(sympy.Min, sympy.Max, TorchMin, TorchMax)
             idx_dtype = "jnp.int32" if self.is_tpu else "jnp.int64"
             idx = (
                 f"({indexing.index_str}).astype({idx_dtype})"

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -30,7 +30,7 @@ import sympy
 
 import torch
 from torch._prims_common import dtype_to_type, is_integer_dtype
-from torch.utils._sympy.functions import FloorDiv, ModularIndexing, Where
+from torch.utils._sympy.functions import FloorDiv, Max, Min, ModularIndexing, Where
 from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
 
 from .ops_handler import DefaultHandler
@@ -172,12 +172,12 @@ class SymPyOps:
     @staticmethod
     def minimum(x: TypedExpr, y: TypedExpr) -> TypedExpr:
         result_type = torch.promote_types(x.dtype, y.dtype)
-        return TypedExpr(sympy.Min(x.expr, y.expr), result_type)
+        return TypedExpr(Min(x.expr, y.expr), result_type)
 
     @staticmethod
     def maximum(x: TypedExpr, y: TypedExpr) -> TypedExpr:
         result_type = torch.promote_types(x.dtype, y.dtype)
-        return TypedExpr(sympy.Max(x.expr, y.expr), result_type)
+        return TypedExpr(Max(x.expr, y.expr), result_type)
 
 
 @dataclass

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -52,6 +52,8 @@ from torch.utils._sympy.functions import (
     CeilDiv,
     FloorDiv,
     Identity,
+    Max,
+    Min,
     Mod,
     ModularIndexing,
 )
@@ -6287,10 +6289,10 @@ def _avg_poolnd(
             divide_factors = []
             for i in range(dim):
                 hstart = bh[i] * stride[i] - padding[i]
-                hend = sympy.Min(hstart + kernel_size[i], h[i] + padding[i])
+                hend = Min(hstart + kernel_size[i], h[i] + padding[i])
                 if not count_include_pad:
-                    hstart = sympy.Max(hstart, 0)
-                    hend = sympy.Min(hend, h[i])
+                    hstart = Max(hstart, 0)
+                    hend = Min(hend, h[i])
                 factor = ops.index_expr(hend - hstart, torch.int32)
                 divide_factors.append(factor)
             return functools.reduce(ops.mul, divide_factors)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184592
* __->__ #184589

SymPy's builtin Min/Max constructors run generic pairwise dominance checks in _find_localzeros via _is_connected. For dynamic avg_pool3d_backward CPU codegen, index propagation builds many boundary expressions containing Max(0, x - 1) and Min(s, Max(...) + k). During CPU vector tiling analysis those expressions are repeatedly substituted and simplified, and the builtin SymPy Min/Max path dominates compile time.

Use torch.utils._sympy.functions.Min/Max for symbolic ops.minimum/maximum propagation, and for avg-pool divisor boundary construction. The PyTorch Min/Max implementation keeps the useful numeric 0/1 special cases but avoids the generic pairwise is-connected test.

Benchmarks on test/inductor/test_torchinductor_codegen_dynamic_shapes.py::DynamicShapesCodegenCpuTests::test_avg_pool3d_backward2_dynamic_shapes_cpu:

- Baseline OSS repro: 1 passed in 342.93s (pytest total 0:05:42).

- Fresh-cache timed reproduction: test body 337.347s, total 352.308s.

- Compile-time breakdown before: compile_inner 333.266s, GraphLowering.codegen 330.383s, Scheduler.codegen 313.728s, compile_file 1.583s.

- SymPy instrumentation before: Min._find_localzeros 140.7s total, Max._find_localzeros 125.6s total, with ~294k Max(2 args) and ~162k Min(2 args) calls.

- Global/custom Min/Max experiment: ~72s.

- After this patch: 1 passed in 75.52s (0:01:15).

Additional validation:

- python -m pytest test/inductor/test_torchinductor.py -k 'index_propagation and cpu' -q -s: 7 passed, 2558 deselected in 16.85s.

- python -m pytest test/inductor/test_torchinductor_codegen_dynamic_shapes.py -k 'avg_pool3d and dynamic_shapes_cpu' -q -s: 3 passed, 2370 deselected, 1 xfailed in 80.10s.

Authored by Codex

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo