### PR TITLE
[Inductor] Fix acc_type for fp8 dtypes in mm autotuning

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -368,5 +368,25 @@ class TestFP4Support(TestCase):
         self.assertTrue(t.is_cuda)
 
 
+class TestTritonTypeMapping(TestCase):
+    """Tests for acc_type() dtype conversions."""
+
+    def test_acc_type(self):
+        from torch._inductor.kernel.mm_common import acc_type
+
+        cases = {
+            "half promotes to float32": (torch.float16, "tl.float32"),
+            "bfloat16 promotes to float32": (torch.bfloat16, "tl.float32"),
+            "float32 passthrough": (torch.float32, "tl.float32"),
+            "fp8 e4m3fn promotes to float32": (torch.float8_e4m3fn, "tl.float32"),
+            "fp8 e5m2 promotes to float32": (torch.float8_e5m2, "tl.float32"),
+            "fp8 e4m3fnuz promotes to float32": (torch.float8_e4m3fnuz, "tl.float32"),
+            "fp8 e5m2fnuz promotes to float32": (torch.float8_e5m2fnuz, "tl.float32"),
+        }
+        for desc, (dtype, expected) in cases.items():
+            with self.subTest(desc=desc, dtype=dtype):
+                self.assertEqual(acc_type(dtype), expected)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -14,7 +14,7 @@ from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
 from .. import config
 from ..codegen.wrapper import PythonWrapperCodegen
 from ..ir import _IntLike, Layout, TensorBox
-from ..utils import load_template
+from ..utils import load_template, triton_type
 
 
 log = logging.getLogger(__name__)
@@ -47,7 +47,9 @@ def persistent_grouped_mm_grid(*args):
 def acc_type(dtype):
     if dtype in (torch.float16, torch.bfloat16):
         return "tl.float32"
-    return f"tl.{dtype}".replace("torch.", "")
+    if dtype.is_floating_point and dtype.itemsize == 1:  # fp8 dtypes
+        return "tl.float32"
+    return triton_type(dtype)
 
 
 def mm_args(


### PR DESCRIPTION
acc_type() in mm_common.py used a naive string replacement (f"tl.{dtype}".replace("torch.", "")) to convert torch dtypes to triton type names. This produced invalid triton names for fp8 dtypes (e.g.,
tl.float8_e4m3fn instead of tl.float8e4nv), causing AttributeError during AOT Inductor autotuning on ROCm.

Fix this by using the existing triton_type() utility which has the correct mappings, and promote fp8 dtypes to float32 for accumulation — accumulating matmul partial products in fp8 precision is numerically unsound.
  
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo