### PR TITLE
Allow functorch grad fake propagation in Dynamo

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -3911,6 +3911,26 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
+    def test_vmap_hessian_aot_eager(self):
+        def fn(x):
+            return (x**4).sum()
+
+        def wrapper_fn(x):
+            return torch.vmap(torch.func.hessian(fn))(x)
+
+        devices = ["cpu"]
+        if torch.cuda.is_available():
+            devices.append("cuda")
+
+        for device in devices:
+            with self.subTest(device=device):
+                x = torch.randn(4, 8, device=device, dtype=torch.float64)
+                actual = torch.compile(wrapper_fn, fullgraph=True, backend="aot_eager")(
+                    x
+                )
+                expected = torch.diag_embed(12 * x.square())
+                self.assertEqual(actual, expected)
+
     def test_hessian_argnums(self):
         counters.clear()
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -3096,15 +3096,32 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             if tx.fake_mode and tx.fake_mode.shape_env:
                 ctx = tx.fake_mode.shape_env.ignore_fresh_unbacked_symbols
 
-        with ctx():
-            tensor_variable = wrap_fx_proxy(
-                tx=tx,
-                proxy=tx.output.create_proxy(
-                    "call_function",
-                    fn_,
-                    *proxy_args_kwargs(args, kwargs),
-                ),
-            )
+        patched_fake_mode = (
+            tx.fake_mode
+            if fn_ is torch._functorch.eager_transforms._autograd_grad
+            else None
+        )
+        old_allow_non_fake_inputs = False
+        if patched_fake_mode is not None:
+            # Functorch wrappers can contain FakeTensors without being FakeTensors
+            # themselves.  CUDA autograd may run this fake propagation in engine
+            # worker threads, so patch the mode object instead of Python TLS.
+            old_allow_non_fake_inputs = patched_fake_mode.allow_non_fake_inputs
+            patched_fake_mode.allow_non_fake_inputs = True
+
+        try:
+            with ctx():
+                tensor_variable = wrap_fx_proxy(
+                    tx=tx,
+                    proxy=tx.output.create_proxy(
+                        "call_function",
+                        fn_,
+                        *proxy_args_kwargs(args, kwargs),
+                    ),
+                )
+        finally:
+            if patched_fake_mode is not None:
+                patched_fake_mode.allow_non_fake_inputs = old_allow_non_fake_inputs
 
         # Handle e.g., `torch.ones(10, requires_grad=True)`
         if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184595

Temporarily allow non-fake functorch wrapper tensors while fake-propagating _autograd_grad so compiled vmap(hessian) works across CPU and CUDA.

Fixes #183015

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos