### PR TITLE
Linux py 3.15 wheel builds

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -306,7 +306,16 @@ WHEEL_CONTAINER_IMAGES = {
 RELEASE = "release"
 DEBUG = "debug"
 
-FULL_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+FULL_PYTHON_VERSIONS = [
+    "3.10",
+    "3.11",
+    "3.12",
+    "3.13",
+    "3.14",
+    "3.14t",
+    "3.15",
+    "3.15t",
+]
 
 
 def translate_desired_cuda(gpu_arch_type: str, gpu_arch_version: str) -> str:
@@ -418,6 +427,20 @@ def generate_wheels_matrix(
                 "macos-arm64",
                 "windows",
             ] and (python_version == "3.14" or python_version == "3.14t"):
+                continue
+
+            # TODO: Enable python 3.15 on non linux OSes
+            if os not in ["linux", "linux-aarch64"] and (
+                python_version == "3.15" or python_version == "3.15t"
+            ):
+                continue
+
+            # TODO: Re-enable ROCm for python 3.15 once composable_kernel's
+            # ck_tile/01_fmha/generate.py is updated; it still uses
+            # importlib.abc.Loader.load_module() which was removed in 3.15.
+            if arch_version in ROCM_ARCHES and (
+                python_version == "3.15" or python_version == "3.15t"
+            ):
                 continue
 
             # cuda linux wheels require PYTORCH_EXTRA_INSTALL_REQUIREMENTS to install

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -63,7 +63,7 @@ jobs:
       GPU_ARCH_TYPE: cpu-aarch64
       DOCKER_IMAGE: pytorch/manylinux2_28_aarch64-builder:cpu-aarch64
       SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t"
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
       BUILD_NAME_SUFFIX: "-cpu-aarch64"
     steps:
@@ -121,6 +121,16 @@ jobs:
           name: manywheel-py3_14t-cpu-aarch64
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-cpu-aarch64
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-cpu-aarch64
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cpu-aarch64/*
 
   manywheel-cuda-aarch64-cu126-build:
     name: manywheel-cuda-aarch64-cu126-build
@@ -138,7 +148,7 @@ jobs:
       GPU_ARCH_TYPE: cuda-aarch64
       DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cuda12.6
       SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t"
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
       BUILD_NAME_SUFFIX: "-cuda-aarch64-12_6"
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==12.6.3; platform_system == 'Linux' | cuda-bindings>=12.9.4,<13; platform_system == 'Linux' | nvidia-cudnn-cu12==9.10.2.21; platform_system == 'Linux' | nvidia-cusparselt-cu12==0.7.1; platform_system == 'Linux' | nvidia-nccl-cu12==2.29.3; platform_system == 'Linux' | nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux'"
@@ -197,6 +207,16 @@ jobs:
           name: manywheel-py3_14t-cuda-aarch64-12_6
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda-aarch64-12_6/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-cuda-aarch64-12_6
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda-aarch64-12_6/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-cuda-aarch64-12_6
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-12_6/*
 
   manywheel-cuda-aarch64-cu130-build:
     name: manywheel-cuda-aarch64-cu130-build
@@ -214,7 +234,7 @@ jobs:
       GPU_ARCH_TYPE: cuda-aarch64
       DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cuda13.0
       SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t"
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
       BUILD_NAME_SUFFIX: "-cuda-aarch64-13_0"
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cufile,nvjitlink,nvtx]==13.0.2; platform_system == 'Linux' | nvidia-cublas>=13.1.0.3,<=13.1.1.3; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
@@ -273,6 +293,16 @@ jobs:
           name: manywheel-py3_14t-cuda-aarch64-13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda-aarch64-13_0/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-cuda-aarch64-13_0
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda-aarch64-13_0/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-cuda-aarch64-13_0
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-13_0/*
 
   manywheel-cuda-aarch64-cu132-build:
     name: manywheel-cuda-aarch64-cu132-build
@@ -290,7 +320,7 @@ jobs:
       GPU_ARCH_TYPE: cuda-aarch64
       DOCKER_IMAGE: pytorch/manylinuxaarch64-builder:cuda13.2
       SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t"
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
       BUILD_NAME_SUFFIX: "-cuda-aarch64-13_2"
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
@@ -349,6 +379,16 @@ jobs:
           name: manywheel-py3_14t-cuda-aarch64-13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda-aarch64-13_2/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-cuda-aarch64-13_2
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda-aarch64-13_2/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-cuda-aarch64-13_2
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-13_2/*
 
   manywheel-test:
     name: ${{ matrix.build_name }}-test
@@ -551,6 +591,70 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14t-cuda-aarch64-13_2"
             runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.15"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_15-cpu-aarch64"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.15"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15-cuda-aarch64-12_6"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.15"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15-cuda-aarch64-13_0"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.15"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15-cuda-aarch64-13_2"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.15t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_15t-cpu-aarch64"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.15t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15t-cuda-aarch64-12_6"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.15t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15t-cuda-aarch64-13_0"
+            runs_on: "linux.arm64.2xlarge"
+          - desired_python: "3.15t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15t-cuda-aarch64-13_2"
+            runs_on: "linux.arm64.2xlarge"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -749,6 +853,62 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14t-cuda-aarch64-13_2"
+          - desired_python: "3.15"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_15-cpu-aarch64"
+          - desired_python: "3.15"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15-cuda-aarch64-12_6"
+          - desired_python: "3.15"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15-cuda-aarch64-13_0"
+          - desired_python: "3.15"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15-cuda-aarch64-13_2"
+          - desired_python: "3.15t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu-aarch64"
+            docker_image: "manylinux2_28_aarch64-builder"
+            docker_image_tag_prefix: "cpu-aarch64"
+            build_name: "manywheel-py3_15t-cpu-aarch64"
+          - desired_python: "3.15t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15t-cuda-aarch64-12_6"
+          - desired_python: "3.15t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15t-cuda-aarch64-13_0"
+          - desired_python: "3.15t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2-aarch64"
+            gpu_arch_type: "cuda-aarch64"
+            docker_image: "manylinuxaarch64-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15t-cuda-aarch64-13_2"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -64,7 +64,7 @@ jobs:
       GPU_ARCH_TYPE: cpu
       DOCKER_IMAGE: pytorch/manylinux2_28-builder:cpu
       SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t"
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
       BUILD_NAME_SUFFIX: "-cpu"
     steps:
@@ -122,6 +122,16 @@ jobs:
           name: manywheel-py3_14t-cpu
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-cpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-cpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cpu/*
 
   manywheel-cuda-cu126-build:
     name: manywheel-cuda-cu126-build
@@ -139,7 +149,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/manylinux2_28-builder:cuda12.6
       SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t"
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
       BUILD_NAME_SUFFIX: "-cuda12_6"
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==12.6.3; platform_system == 'Linux' | cuda-bindings>=12.9.4,<13; platform_system == 'Linux' | nvidia-cudnn-cu12==9.10.2.21; platform_system == 'Linux' | nvidia-cusparselt-cu12==0.7.1; platform_system == 'Linux' | nvidia-nccl-cu12==2.29.3; platform_system == 'Linux' | nvidia-nvshmem-cu12==3.4.5; platform_system == 'Linux'"
@@ -198,6 +208,16 @@ jobs:
           name: manywheel-py3_14t-cuda12_6
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda12_6/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-cuda12_6
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda12_6/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-cuda12_6
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda12_6/*
 
   manywheel-cuda-cu130-build:
     name: manywheel-cuda-cu130-build
@@ -215,7 +235,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/manylinux2_28-builder:cuda13.0
       SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t"
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
       BUILD_NAME_SUFFIX: "-cuda13_0"
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cufile,nvjitlink,nvtx]==13.0.2; platform_system == 'Linux' | nvidia-cublas>=13.1.0.3,<=13.1.1.3; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
@@ -274,6 +294,16 @@ jobs:
           name: manywheel-py3_14t-cuda13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda13_0/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-cuda13_0
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda13_0/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-cuda13_0
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_0/*
 
   manywheel-cuda-cu132-build:
     name: manywheel-cuda-cu132-build
@@ -291,7 +321,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/manylinux2_28-builder:cuda13.2
       SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t"
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       BUILD_NAME_PREFIX: "manywheel-py"
       BUILD_NAME_SUFFIX: "-cuda13_2"
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
@@ -350,6 +380,16 @@ jobs:
           name: manywheel-py3_14t-cuda13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda13_2/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-cuda13_2
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda13_2/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-cuda13_2
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_2/*
 
   manywheel-build:
     name: ${{ matrix.build_name }}-build
@@ -520,6 +560,24 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu"
             build_name: "manywheel-py3_14t-xpu"
+            timeout_minutes: 240
+            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0"
+          - desired_python: "3.15"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_15-xpu"
+            timeout_minutes: 240
+            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0"
+          - desired_python: "3.15t"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_15t-xpu"
             timeout_minutes: 240
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0"
     with:
@@ -743,6 +801,70 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14t-cuda13_2"
             runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.15"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_15-cpu"
+            runs_on: "linux.4xlarge"
+          - desired_python: "3.15"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15-cuda12_6"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.15"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15-cuda13_0"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.15"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15-cuda13_2"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.15t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_15t-cpu"
+            runs_on: "linux.4xlarge"
+          - desired_python: "3.15t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15t-cuda12_6"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.15t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15t-cuda13_0"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+          - desired_python: "3.15t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15t-cuda13_2"
+            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -910,6 +1032,18 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu"
             build_name: "manywheel-py3_14t-xpu"
+          - desired_python: "3.15"
+            desired_cuda: "xpu"
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_15-xpu"
+          - desired_python: "3.15t"
+            desired_cuda: "xpu"
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_15t-xpu"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1226,6 +1360,76 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu"
             build_name: "manywheel-py3_14t-xpu"
+          - desired_python: "3.15"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_15-cpu"
+          - desired_python: "3.15"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15-cuda12_6"
+          - desired_python: "3.15"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15-cuda13_0"
+          - desired_python: "3.15"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15-cuda13_2"
+          - desired_python: "3.15"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_15-xpu"
+          - desired_python: "3.15t"
+            desired_cuda: "cpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "cpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cpu"
+            build_name: "manywheel-py3_15t-cpu"
+          - desired_python: "3.15t"
+            desired_cuda: "cu126"
+            gpu_arch_version: "12.6"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda12.6"
+            build_name: "manywheel-py3_15t-cuda12_6"
+          - desired_python: "3.15t"
+            desired_cuda: "cu130"
+            gpu_arch_version: "13.0"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.0"
+            build_name: "manywheel-py3_15t-cuda13_0"
+          - desired_python: "3.15t"
+            desired_cuda: "cu132"
+            gpu_arch_version: "13.2"
+            gpu_arch_type: "cuda"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "cuda13.2"
+            build_name: "manywheel-py3_15t-cuda13_2"
+          - desired_python: "3.15t"
+            desired_cuda: "xpu"
+            gpu_arch_version: ""
+            gpu_arch_type: "xpu"
+            docker_image: "manylinux2_28-builder"
+            docker_image_tag_prefix: "xpu"
+            build_name: "manywheel-py3_15t-xpu"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel


### PR DESCRIPTION
## Summary
Adds Python 3.15 and 3.15t (free-threaded) to the Linux manywheel nightly build matrix, mirroring #157559 which enabled 3.14.

Related to Python 3.15 support tracking.

## Test plan
- [ ] `ciflow/binaries` triggers manywheel Linux 3.15 / 3.15t builds successfully

Authored by Claude.