### PR TITLE
Speed up inductor test infrastructure (~4x collection, ~1.7x execution)

### DIFF
--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -111,6 +111,8 @@ def aot_eager_regional_inductor(
 @skipIfTorchDynamo("Not a suitable dynamo wrapped test")
 @instantiate_parametrized_tests
 class RegionalInductorTests(torch._inductor.test_case.TestCase):
+    _max_mm_configs = None
+
     @parametrize("serialize", [False, True])
     def test_simple(self, serialize):
         def fn(x, y):
@@ -588,6 +590,8 @@ class RegionalInductorTests(torch._inductor.test_case.TestCase):
 @torch._dynamo.config.patch("enable_invoke_subgraph_regional_compile", True)
 @instantiate_parametrized_tests
 class RegionalInductorInvokeSubgraphTests(torch._inductor.test_case.TestCase):
+    _max_mm_configs = None
+
     def test_custom_decomposition(self):
         # Test that custom decompositions are applied to the subgraph.
 

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -333,6 +333,8 @@ if not torch._library.opaque_object.is_opaque_type(_CyclicOpaque):
 
 
 class TestPyCodeCache(TestCase):
+    _share_triton_cache = False
+
     def test_linemaps_empty(self):
         src = """import torch"""
         (key, path) = PyCodeCache.write(src, "")
@@ -440,6 +442,7 @@ class TestPyCodeCache(TestCase):
 @instantiate_parametrized_tests
 class TestFxGraphCache(TestCase):
     device_type = GPU_TYPE
+    _share_triton_cache = False
 
     def setUp(self):
         super().setUp()
@@ -2113,6 +2116,8 @@ class TestFxGraphCache(TestCase):
 
 @instantiate_parametrized_tests
 class TestStandaloneCompile(TestCase):
+    _share_triton_cache = False
+
     def setUp(self):
         super().setUp()
         counters.clear()
@@ -2764,6 +2769,8 @@ class TestCustomPartitionerFn(CustomPartitionerFn):
 
 
 class TestFxGraphCacheHashing(TestCase):
+    _share_triton_cache = False
+
     @unittest.skipIf(not torch.backends.mkldnn.is_available(), "requires MKLDNN")
     def test_cacheability_validator_checks_mkldnn_constant(self):
         graph = torch.fx.Graph()
@@ -3622,6 +3629,8 @@ class TestFxGraphCacheHashing(TestCase):
 
 
 class TestCudaCompileCommand(TestCase):
+    _share_triton_cache = False
+
     @requires_cuda_and_triton
     def test_cuda_compile_command(self):
         cmd_no_extra_args: str = cuda_compile_command(
@@ -3664,6 +3673,8 @@ class TestCudaCompileCommand(TestCase):
 
 @instantiate_parametrized_tests
 class TestAutotuneCache(TestCase):
+    _share_triton_cache = False
+
     device_type = GPU_TYPE
 
     def setUp(self):
@@ -4063,6 +4074,8 @@ class TestAutotuneCache(TestCase):
 
 
 class TestRemoteAOTAutogradCache(TestCase):
+    _share_triton_cache = False
+
     @requires_gpu()
     @unittest.skipIf(not HAS_XPU_AND_TRITON and not SM80OrLater, "Requires SM80+")
     @config.patch({"fx_graph_cache": False})
@@ -4153,6 +4166,8 @@ class TestRemoteAOTAutogradCache(TestCase):
 
 
 class TestUtils(TestCase):
+    _share_triton_cache = False
+
     @config.patch({"fx_graph_remote_cache": False})
     def test_fresh_cache(self):
         def fn(x, y):
@@ -4195,6 +4210,8 @@ class TestUtils(TestCase):
 
 
 class TestCompilationEventLogging(TestCase):
+    _share_triton_cache = False
+
     def reset(self):
         DynamoCache.clear()
         PrecompileContext.clear()
@@ -4385,6 +4402,8 @@ class TestCompilationEventLogging(TestCase):
 
 
 class TestAutotuneCacheExtraOptions(TestCase):
+    _share_triton_cache = False
+
     """
     Unit tests for extra_options preservation in _load_cached_autotuning().
 

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -81,6 +81,8 @@ def patches(fn):
 
 
 class TestSelectAlgorithm(TestCase):
+    _max_mm_configs = None
+
     def setUp(self):
         super().setUp()
         if not is_big_gpu():

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2829,6 +2829,7 @@ class test_configs:
     force_no_impl_grouping: bool = False
 
     max_mm_configs: int | None = None
+    max_flex_configs: int | None = None
 
     runtime_triton_dtype_assert = False
     runtime_triton_shape_assert = False

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -124,17 +124,24 @@ cdll.LoadLibrary("__lib_path__")
                 if not os.path.isfile(output_path):
                     x86_isa_help_builder.build()
 
-                # Check build result
-                subprocess.check_call(
-                    [
-                        sys.executable,
-                        "-c",
-                        VecISA._avx_py_load.replace("__lib_path__", output_path),
-                    ],
-                    cwd=output_dir,
-                    stderr=subprocess.DEVNULL,
-                    env=python_subprocess_env(),
-                )
+                # Use a marker file to cache the subprocess load-check result.
+                # The subprocess spawns a full Python process that imports torch
+                # just to verify the .so can be loaded, which takes ~2s each.
+                # Caching the result avoids this on subsequent runs.
+                load_ok_marker = output_path + ".load_ok"
+                if not os.path.isfile(load_ok_marker):
+                    subprocess.check_call(
+                        [
+                            sys.executable,
+                            "-c",
+                            VecISA._avx_py_load.replace("__lib_path__", output_path),
+                        ],
+                        cwd=output_dir,
+                        stderr=subprocess.DEVNULL,
+                        env=python_subprocess_env(),
+                    )
+                    with open(load_ok_marker, "w") as f:
+                        f.write("")
             except Exception:
                 return False
 

--- a/torch/_inductor/kernel/flex/flex_flash_attention.py
+++ b/torch/_inductor/kernel/flex/flex_flash_attention.py
@@ -67,9 +67,13 @@ def _get_flex_flash_fwd_configs(
         return [FlexFlashConfig(score_mod_vec_size=1)]
     if not torch._inductor.config.max_autotune:
         return [FlexFlashConfig()]
-    return [
+    configs = [
         FlexFlashConfig(score_mod_vec_size=v) for v in (1, 2, 4, 8, 16, 32, 64, 128)
     ]
+    max_configs = torch._inductor.config.test_configs.max_flex_configs
+    if max_configs is not None and len(configs) > max_configs:
+        configs = configs[:max_configs]
+    return configs
 
 
 def _select_aux_score_mod_vec_size(

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1163,12 +1163,18 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         ]
 
     # Flex attn helpers
+    def _limit_flex_configs(self, configs: list) -> list:
+        max_configs = config.test_configs.max_flex_configs
+        if max_configs is not None and len(configs) > max_configs:
+            return configs[:max_configs]
+        return configs
+
     def get_flex_attn_fwd_configs(self, head_dim: int, dtype: Any) -> list[FlexConfig]:
         flex_attn_fwd_configs: list[FlexConfig] = []
 
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_attn_fwd_configs
+                return self._limit_flex_configs(self.exhaustive_flex_attn_fwd_configs)
             flex_attn_fwd_configs += self.flex_attn_fwd_autotune_configs
 
         if head_dim <= 256:
@@ -1185,7 +1191,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         if default_config not in flex_attn_fwd_configs:
             flex_attn_fwd_configs.append(default_config)
 
-        return flex_attn_fwd_configs
+        return self._limit_flex_configs(flex_attn_fwd_configs)
 
     def get_flex_attn_bwd_configs(
         self, head_dim: int, dtype: Any
@@ -1194,7 +1200,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
 
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_attn_bwd_configs
+                return self._limit_flex_configs(self.exhaustive_flex_attn_bwd_configs)
             flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs
 
         default_config = FlexBwDConfig(16, 16, 16, 16, 1, 4)
@@ -1202,7 +1208,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         if default_config not in flex_attn_bwd_configs:
             flex_attn_bwd_configs.append(default_config)
 
-        return flex_attn_bwd_configs
+        return self._limit_flex_configs(flex_attn_bwd_configs)
 
     def get_flex_decode_configs(
         self, head_dim: int, dtype: Any
@@ -1211,7 +1217,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
 
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_decode_configs
+                return self._limit_flex_configs(self.exhaustive_flex_decode_configs)
             flex_decode_configs += self.flex_decode_autotune_configs
 
         default_config = FlexDecodeConfig(block_n=64, num_stages=1, num_warps=2)
@@ -1219,7 +1225,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
         if default_config not in flex_decode_configs:
             flex_decode_configs.append(default_config)
 
-        return flex_decode_configs
+        return self._limit_flex_configs(flex_decode_configs)
 
 
 class CPUConfigHeuristic(BaseConfigHeuristic):
@@ -1378,7 +1384,7 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
 
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_attn_fwd_configs
+                return self._limit_flex_configs(self.exhaustive_flex_attn_fwd_configs)
             flex_attn_fwd_configs += self.flex_attn_fwd_autotune_configs
 
         if head_dim <= 256:
@@ -1412,7 +1418,7 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
         if default_config not in flex_attn_fwd_configs:
             flex_attn_fwd_configs.append(default_config)
 
-        return flex_attn_fwd_configs
+        return self._limit_flex_configs(flex_attn_fwd_configs)
 
     def get_flex_attn_bwd_configs(
         self, head_dim: int, dtype: Any
@@ -1421,7 +1427,7 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
         flex_attn_bwd_configs: list[FlexBwDConfig] = []
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_attn_bwd_configs
+                return self._limit_flex_configs(self.exhaustive_flex_attn_bwd_configs)
             flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs
 
         major, minor = capability
@@ -1486,7 +1492,7 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
         if default_config not in flex_attn_bwd_configs:
             flex_attn_bwd_configs.append(default_config)
 
-        return flex_attn_bwd_configs
+        return self._limit_flex_configs(flex_attn_bwd_configs)
 
     def get_flex_decode_configs(
         self, head_dim: int, dtype: Any
@@ -1499,7 +1505,7 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
 
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_decode_configs
+                return self._limit_flex_configs(self.exhaustive_flex_decode_configs)
             flex_decode_configs += self.flex_decode_autotune_configs
 
         if capability in [(9, 0), (10, 0), (10, 3)]:  # sm_90, sm_100, sm_103
@@ -1515,7 +1521,7 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
         if default_config not in flex_decode_configs:
             flex_decode_configs.append(default_config)
 
-        return flex_decode_configs
+        return self._limit_flex_configs(flex_decode_configs)
 
 
 class ROCmConfigHeuristic(BaseConfigHeuristic):
@@ -1815,7 +1821,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
 
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_attn_fwd_configs
+                return self._limit_flex_configs(self.exhaustive_flex_attn_fwd_configs)
             flex_attn_fwd_configs += self.flex_attn_fwd_autotune_configs
 
         capability = torch.cuda.get_device_capability()
@@ -1843,7 +1849,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
         if default_config not in flex_attn_fwd_configs:
             flex_attn_fwd_configs.append(default_config)
 
-        return flex_attn_fwd_configs
+        return self._limit_flex_configs(flex_attn_fwd_configs)
 
     def get_flex_attn_bwd_configs(
         self, head_dim: int, dtype: Any
@@ -1852,7 +1858,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
 
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_attn_bwd_configs
+                return self._limit_flex_configs(self.exhaustive_flex_attn_bwd_configs)
             flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs
 
         default_kpack = get_default_kpack()
@@ -1881,7 +1887,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
         if default_config not in flex_attn_bwd_configs:
             flex_attn_bwd_configs.append(default_config)
 
-        return flex_attn_bwd_configs
+        return self._limit_flex_configs(flex_attn_bwd_configs)
 
     def get_flex_decode_configs(
         self, head_dim: int, dtype: Any
@@ -1890,7 +1896,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
 
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_decode_configs
+                return self._limit_flex_configs(self.exhaustive_flex_decode_configs)
             flex_decode_configs += self.flex_decode_autotune_configs
 
         default_kpack = get_default_kpack()
@@ -1899,7 +1905,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
         if default_config not in flex_decode_configs:
             flex_decode_configs.append(default_config)
 
-        return flex_decode_configs
+        return self._limit_flex_configs(flex_decode_configs)
 
 
 class XPUConfigHeuristic(BaseConfigHeuristic):
@@ -1963,7 +1969,7 @@ class XPUConfigHeuristic(BaseConfigHeuristic):
 
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_attn_fwd_configs
+                return self._limit_flex_configs(self.exhaustive_flex_attn_fwd_configs)
             flex_attn_fwd_configs += self.flex_attn_fwd_autotune_configs
 
         if head_dim <= 256:
@@ -1983,7 +1989,7 @@ class XPUConfigHeuristic(BaseConfigHeuristic):
         if default_config not in flex_attn_fwd_configs:
             flex_attn_fwd_configs.append(default_config)
 
-        return flex_attn_fwd_configs
+        return self._limit_flex_configs(flex_attn_fwd_configs)
 
     def get_flex_attn_bwd_configs(
         self, head_dim: int, dtype: Any
@@ -1992,7 +1998,7 @@ class XPUConfigHeuristic(BaseConfigHeuristic):
 
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_attn_bwd_configs
+                return self._limit_flex_configs(self.exhaustive_flex_attn_bwd_configs)
             flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs
 
         if dtype == torch.float32:
@@ -2010,7 +2016,7 @@ class XPUConfigHeuristic(BaseConfigHeuristic):
         if default_config not in flex_attn_bwd_configs:
             flex_attn_bwd_configs.append(default_config)
 
-        return flex_attn_bwd_configs
+        return self._limit_flex_configs(flex_attn_bwd_configs)
 
     def get_flex_decode_configs(
         self, head_dim: int, dtype: Any
@@ -2019,7 +2025,7 @@ class XPUConfigHeuristic(BaseConfigHeuristic):
 
         if config.max_autotune:
             if config.max_autotune_flex_search_space == "EXHAUSTIVE":
-                return self.exhaustive_flex_decode_configs
+                return self._limit_flex_configs(self.exhaustive_flex_decode_configs)
             flex_decode_configs += self.flex_decode_autotune_configs
 
         default_config = FlexDecodeConfig(64, 1, 2)
@@ -2027,7 +2033,7 @@ class XPUConfigHeuristic(BaseConfigHeuristic):
         if default_config not in flex_decode_configs:
             flex_decode_configs.append(default_config)
 
-        return flex_decode_configs
+        return self._limit_flex_configs(flex_decode_configs)
 
     def _prune_exhaustive_configs(
         self,

--- a/torch/_inductor/test_case.py
+++ b/torch/_inductor/test_case.py
@@ -51,11 +51,17 @@ class TestCase(DynamoTestCase):
                 config.patch({"fx_graph_cache": True})
             )
 
-        if config.test_configs.max_mm_configs is None and self._max_mm_configs is not None:
+        if (
+            config.test_configs.max_mm_configs is None
+            and self._max_mm_configs is not None
+        ):
             self._inductor_test_stack.enter_context(
                 config.patch({"test_configs.max_mm_configs": self._max_mm_configs})
             )
-        if config.test_configs.max_flex_configs is None and self._max_flex_configs is not None:
+        if (
+            config.test_configs.max_flex_configs is None
+            and self._max_flex_configs is not None
+        ):
             self._inductor_test_stack.enter_context(
                 config.patch({"test_configs.max_flex_configs": self._max_flex_configs})
             )

--- a/torch/_inductor/test_case.py
+++ b/torch/_inductor/test_case.py
@@ -20,6 +20,18 @@ class TestCase(DynamoTestCase):
     the cache directory for each test.
     """
 
+    # Share Triton compilation cache across tests by default. Triton
+    # compilation is a pure function of the kernel source so reusing
+    # compiled kernels is safe and avoids redundant compilation.
+    # Subclasses that explicitly delete or inspect the Triton cache
+    # directory should set this to False.
+    _share_triton_cache = True
+
+    # Cap the number of autotune configs in tests to speed up compilation.
+    # Set to None in subclasses that need the full config space.
+    _max_mm_configs: int | None = 2
+    _max_flex_configs: int | None = 2
+
     def setUp(self) -> None:
         super().setUp()
         self._inductor_test_stack = contextlib.ExitStack()
@@ -39,11 +51,22 @@ class TestCase(DynamoTestCase):
                 config.patch({"fx_graph_cache": True})
             )
 
+        if config.test_configs.max_mm_configs is None and self._max_mm_configs is not None:
+            self._inductor_test_stack.enter_context(
+                config.patch({"test_configs.max_mm_configs": self._max_mm_configs})
+            )
+        if config.test_configs.max_flex_configs is None and self._max_flex_configs is not None:
+            self._inductor_test_stack.enter_context(
+                config.patch({"test_configs.max_flex_configs": self._max_flex_configs})
+            )
+
         if (
             os.environ.get("INDUCTOR_TEST_DISABLE_FRESH_CACHE") != "1"
             and os.environ.get("TORCH_COMPILE_DEBUG") != "1"
         ):
-            self._inductor_test_stack.enter_context(fresh_cache())
+            self._inductor_test_stack.enter_context(
+                fresh_cache(share_triton=self._share_triton_cache)
+            )
 
     def tearDown(self) -> None:
         super().tearDown()

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1366,24 +1366,36 @@ def fresh_cache(
     cache_entries: dict[str, Any] | None = None,
     dir: str | None = None,
     delete: bool = True,
+    share_triton: bool = False,
 ) -> Iterator[None]:
     """
     Contextmanager that provides a clean tmp cachedir for pt2 caches.
 
     Optionally, pass a dict as 'cache_entries' to get a list of filenames and sizes
     generated with this cache instance.
+
+    When share_triton=True, the Triton compilation cache is placed in a
+    persistent shared directory rather than inside the per-test temp dir.
+    Triton compilation is a pure function of the kernel source, so sharing
+    compiled kernels across tests is safe and avoids redundant compilation.
     """
     clear_caches()
 
     from torch._inductor.cpp_builder import normalize_path_separator
+    from torch._inductor.runtime.cache_dir_utils import default_cache_dir
 
     inductor_cache_dir = normalize_path_separator(tempfile.mkdtemp(dir=dir))
     try:
         with _set_env("TORCHINDUCTOR_CACHE_DIR", inductor_cache_dir):
             log.debug("Using inductor cache dir %s", inductor_cache_dir)
-            triton_cache_dir = normalize_path_separator(
-                os.path.join(inductor_cache_dir, "triton")
-            )
+            if share_triton:
+                triton_cache_dir = normalize_path_separator(
+                    os.path.join(default_cache_dir(), "triton")
+                )
+            else:
+                triton_cache_dir = normalize_path_separator(
+                    os.path.join(inductor_cache_dir, "triton")
+                )
             with _set_env("TRITON_CACHE_DIR", triton_cache_dir):
                 yield
                 if isinstance(cache_entries, dict):

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -10,21 +10,7 @@ import unittest
 from subprocess import CalledProcessError
 
 import torch
-import torch._inductor.async_compile
 import torch._inductor.config as config
-from torch._inductor.codecache import CppCodeCache
-from torch._inductor.codegen.common import (
-    get_custom_backend_config_for_device,
-    get_custom_backend_pass_for_device,
-    get_scheduling_for_device,
-    get_wrapper_codegen_for_device,
-    init_backend_registration,
-    register_backend_for_device,
-)
-from torch._inductor.codegen.wrapper import PythonWrapperCodegen
-from torch._inductor.compile_fx import shape_env_from_inputs
-from torch._inductor.custom_graph_pass import CustomGraphModulePass, CustomGraphPass
-from torch._inductor.graph import GraphLowering
 from torch._inductor.utils import (
     get_gpu_shared_memory,
     get_gpu_type,
@@ -33,7 +19,6 @@ from torch._inductor.utils import (
     is_gpu,
     OrderedSet,
 )
-from torch.fx.experimental.proxy_tensor import make_fx
 from torch.utils._helion import has_helion
 from torch.utils._pallas import has_pallas_package, has_tpu_pallas
 from torch.utils._triton import has_triton
@@ -55,6 +40,8 @@ log: logging.Logger = logging.getLogger(__name__)
 
 def test_cpu():
     try:
+        from torch._inductor.codecache import CppCodeCache
+
         CppCodeCache.load("")
         return True
     except (
@@ -70,7 +57,7 @@ HAS_CPU = LazyVal(test_cpu)
 
 HAS_TRITON = has_triton()
 
-HAS_PALLAS = has_pallas_package()
+HAS_PALLAS = LazyVal(has_pallas_package)
 
 HAS_HELION = has_helion()
 
@@ -103,17 +90,24 @@ RUN_GPU = HAS_GPU and any(
     is_gpu(getattr(x, "device_type", "")) for x in _desired_test_bases
 )
 
-RUN_CPU = HAS_CPU and any(
-    getattr(x, "device_type", "") == "cpu" for x in _desired_test_bases
+RUN_CPU = LazyVal(
+    lambda: HAS_CPU
+    and any(getattr(x, "device_type", "") == "cpu" for x in _desired_test_bases)
 )
 
-HAS_TPU = has_tpu_pallas()
+HAS_TPU = LazyVal(has_tpu_pallas)
 # TPU is a privateuse1 backend that isn't in _desired_test_bases (it requires
 # runtime initialization before the test base is registered). Check the env var
 # directly, matching the same semantics as RUN_CPU/RUN_GPU: when the env var is
 # unset, run if the hardware is available; when set, only run if "tpu" is listed.
-_only_for = os.environ.get("PYTORCH_TESTING_DEVICE_ONLY_FOR", "")
-RUN_TPU = HAS_TPU and ("tpu" in _only_for.split(",") if _only_for else True)
+RUN_TPU = LazyVal(
+    lambda: HAS_TPU
+    and (
+        "tpu" in os.environ.get("PYTORCH_TESTING_DEVICE_ONLY_FOR", "").split(",")
+        if os.environ.get("PYTORCH_TESTING_DEVICE_ONLY_FOR", "")
+        else True
+    )
+)
 
 
 def _check_has_dynamic_shape(
@@ -212,11 +206,15 @@ IS_H100 = LazyVal(lambda: HAS_CUDA_AND_TRITON and get_gpu_shared_memory() == 232
 IS_BIG_GPU = LazyVal(lambda: HAS_GPU_AND_TRITON and is_big_gpu())
 
 
-def dummy_graph() -> GraphLowering:
+def dummy_graph():
     """
     Create a graph. This is useful for unit testing code which accesses
     V.graph.sizevars.
     """
+    from torch._inductor.compile_fx import shape_env_from_inputs
+    from torch._inductor.graph import GraphLowering
+    from torch.fx.experimental.proxy_tensor import make_fx
+
     example_inputs = [torch.randn(10) for _ in range(2)]
     gm = make_fx(torch.add, tracing_mode="fake")(*example_inputs)
     shape_env = shape_env_from_inputs(example_inputs)
@@ -379,7 +377,7 @@ def _quantize_blockwise(
     return x_fp8, inverse_scale
 
 
-class MockGraphHandler(GraphLowering):
+class MockGraphHandler:
     """Minimal mock graph handler for testing virtualized context."""
 
     def __init__(self, name_to_buffer=None):
@@ -399,6 +397,11 @@ class MockGraphHandler(GraphLowering):
 
 
 def has_cpp_wrapper_for_device(device: str) -> bool:
+    from torch._inductor.codegen.common import (
+        get_wrapper_codegen_for_device,
+        init_backend_registration,
+    )
+
     init_backend_registration()
     return get_wrapper_codegen_for_device(device, cpp_wrapper=True) is not None
 
@@ -406,13 +409,22 @@ def has_cpp_wrapper_for_device(device: str) -> bool:
 @contextlib.contextmanager
 def patch_inductor_backend(
     device: str,
-    python_wrapper_codegen: PythonWrapperCodegen = None,
-    custom_pass: CustomGraphModulePass = None,
+    python_wrapper_codegen=None,
+    custom_pass=None,
     custom_backend_config: ConfigModule = None,
 ):
     """
     Patch the inductor backend for a specific device.
     """
+    from torch._inductor.codegen.common import (
+        get_custom_backend_config_for_device,
+        get_custom_backend_pass_for_device,
+        get_scheduling_for_device,
+        get_wrapper_codegen_for_device,
+        init_backend_registration,
+        register_backend_for_device,
+    )
+
     # Make sure the backend is already registered
     init_backend_registration()
 
@@ -462,6 +474,8 @@ def patch_custom_fallback_pass(predicate: Callable[[torch.fx.Node], bool]) -> co
     we could provide a predicate which returns True for all aten.add.default nodes.
     Returns a context activating the pass.
     """
+    from torch._inductor.custom_graph_pass import CustomGraphPass
+
     class Pass(CustomGraphPass):
         def __call__(self, graph: torch.fx.Graph):
             for node in graph.nodes:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184607

Several independent optimizations to reduce inductor test overhead:

**ISA subprocess caching** (`cpu_vec_isa.py`): Cache the result of CPU vector ISA load-check subprocesses using `.load_ok` marker files. Each `check_build()` call spawns a Python subprocess that imports torch to verify a compiled .so can be loaded (~2s each, 6 checks per process). The compilation result was already cached on disk, but the load verification subprocess ran every time.

**Lazy evaluation** (`inductor_utils.py`): Defer expensive module-level computations -- `RUN_CPU` (triggers ISA checks), `HAS_PALLAS`/`HAS_TPU` (imports JAX), and heavy imports like `async_compile`, `codegen.wrapper`, `compile_fx`, `GraphLowering` -- until actually needed. Most test files only need simple constants like `HAS_GPU` and `RUN_GPU`.

**Shared Triton cache** (`utils.py`, `test_case.py`): Add `share_triton` parameter to `fresh_cache()`. When enabled, Triton compiled kernels are placed in a persistent shared directory instead of the per-test temp dir. Triton compilation is a pure function of the kernel source, so sharing is safe. `InductorTestCase` enables this by default; `test_codecache.py` classes that explicitly delete/inspect the Triton cache directory opt out via `_share_triton_cache = False`.

**Autotune config limits** (`config.py`, `triton.py`, `flex_flash_attention.py`): Add `test_configs.max_flex_configs` (similar to existing `max_mm_configs`) and set both to 2 in `InductorTestCase`. This limits the number of Triton kernel variants compiled during autotuning in tests (e.g., flex attention fwd goes from 6 to 2 configs, bwd from 28 to 2), without affecting production behavior. Tests that need the full config space (e.g., `TestSelectAlgorithm`, TLX templates) opt out via `_max_mm_configs = None`.

Originally landed as pytorch/pytorch#181617 but reverted due to internal test failures from the unconditional `max_mm_configs=2` cap. Fixed by making the cap opt-out via class attributes `_max_mm_configs` and `_max_flex_configs` on `InductorTestCase`.

Authored with Claude.

Differential Revision: [D105864477](https://our.internmc.facebook.com/intern/diff/D105864477/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98