### PR TITLE
[MPS] Enable NDHWC+DHWIO fast path for Conv3d on channels_last_3d

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -330,6 +330,15 @@ MPSShape* getMPSShape(IntArrayRef sizes, c10::MemoryFormat memory_format) {
     const NSUInteger W = sizes[3];
     return @[ @(N), @(H), @(W), @(C) ];
   }
+  if (memory_format == MemoryFormat::ChannelsLast3d) {
+    TORCH_INTERNAL_ASSERT(sizes.size() == 5, "ChannelsLast3d memory format must have 5 dimensions!");
+    const NSUInteger N = sizes[0];
+    const NSUInteger C = sizes[1];
+    const NSUInteger D = sizes[2];
+    const NSUInteger H = sizes[3];
+    const NSUInteger W = sizes[4];
+    return @[ @(N), @(D), @(H), @(W), @(C) ];
+  }
   const int sz = sizes.size();
   const int sz_ = (sz > 0) ? sz : 1;
 

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -631,9 +631,7 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
                                                                forwardConvolutionDescriptor:conv3dDescriptor_
                                                                                        name:nil];
         if (use_dhwio) {
-          gradWeightTensor = [mpsGraph transposeTensor:gradWeightTensor
-                                           permutation:@[ @4, @3, @0, @1, @2 ]
-                                                  name:nil];
+          gradWeightTensor = [mpsGraph transposeTensor:gradWeightTensor permutation:@[ @4, @3, @0, @1, @2 ] name:nil];
         }
       } else if (isDepthwiseConv) {
         MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -10,7 +10,8 @@
 
 namespace at::native {
 
-// Create 3D convolution descriptor
+// `memory_format` selects NDHWC vs NCDHW; `use_dhwio` selects DHWIO vs OIDHW
+// (caller must insert the matching in-graph weight transpose).
 static void fill_conv3d_desc(MPSGraphConvolution3DOpDescriptor* descriptor_,
                              NSUInteger strideInX,
                              NSUInteger strideInY,
@@ -21,6 +22,8 @@ static void fill_conv3d_desc(MPSGraphConvolution3DOpDescriptor* descriptor_,
                              NSUInteger paddingHorizontal,
                              NSUInteger paddingVertical,
                              NSUInteger paddingDepth,
+                             c10::MemoryFormat memory_format,
+                             bool use_dhwio,
                              NSUInteger groups) {
   descriptor_.strideInX = strideInX;
   descriptor_.strideInY = strideInY;
@@ -39,11 +42,51 @@ static void fill_conv3d_desc(MPSGraphConvolution3DOpDescriptor* descriptor_,
   descriptor_.paddingFront = paddingDepth;
   descriptor_.paddingBack = paddingDepth;
 
-  descriptor_.dataLayout = MPSGraphTensorNamedDataLayoutNCDHW;
-
-  descriptor_.weightsLayout = MPSGraphTensorNamedDataLayoutOIDHW;
+  descriptor_.dataLayout = (memory_format == at::MemoryFormat::ChannelsLast3d) ? MPSGraphTensorNamedDataLayoutNDHWC
+                                                                               : MPSGraphTensorNamedDataLayoutNCDHW;
+  descriptor_.weightsLayout = use_dhwio ? MPSGraphTensorNamedDataLayoutDHWIO : MPSGraphTensorNamedDataLayoutOIDHW;
 
   descriptor_.groups = groups; // not yet tested in Xcode/C++
+}
+
+// Exact-stride match: a sliced view of CL3d has CL-like strides but isn't
+// NHWC-packed; the raw-buffer NDHWC path would misread it (#180984).
+static bool is_packed_channels_last_3d(const Tensor& t) {
+  return t.dim() == 5 &&
+      t.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == at::MemoryFormat::ChannelsLast3d;
+}
+
+// DHWIO costs one in-graph weight transpose per call; only worth it when
+// Cin/groups is large enough and the kernel is not factorized.
+static bool conv3d_dhwio_is_beneficial(IntArrayRef weight_size) {
+  constexpr int64_t kMinCinPerGroup = 4; // skip first-layer Cin=3, depthwise Cin/g=1.
+  constexpr int64_t kMinKernelDim = 2; // skip 1x3x3, 3x1x1, 1x1x1.
+  return weight_size.size() == 5 && weight_size[1] >= kMinCinPerGroup && weight_size[2] >= kMinKernelDim &&
+      weight_size[3] >= kMinKernelDim && weight_size[4] >= kMinKernelDim;
+}
+
+// Force the tensor's stride pattern to match `desc_layout`; MPSGraph's 3D
+// conv path takes a slow strided route otherwise. 4D tensors pass through.
+static Tensor materialize_for_conv(const Tensor& t, c10::MemoryFormat desc_layout) {
+  if (desc_layout == at::MemoryFormat::ChannelsLast3d) {
+    return t.contiguous(at::MemoryFormat::ChannelsLast3d);
+  }
+  if (t.dim() == 5) {
+    return t.contiguous();
+  }
+  return t;
+}
+
+// CL3d needs the NDArray path for explicit NDHWC ordering; NCDHW takes the
+// tensor-direct Placeholder. Caller must materialize_for_conv first.
+static at::native::mps::Placeholder make_conv_placeholder(MPSGraphTensor* graphTensor,
+                                                          const at::Tensor& t,
+                                                          c10::MemoryFormat desc_layout) {
+  if (desc_layout == at::MemoryFormat::Contiguous) {
+    return at::native::mps::Placeholder(graphTensor, t);
+  }
+  return at::native::mps::Placeholder(graphTensor,
+                                      at::native::mps::getMPSNDArray(t, at::native::mps::getMPSShape(t, desc_layout)));
 }
 
 static void fill_depthwise_conv_desc(MPSGraphDepthwiseConvolution3DOpDescriptor* descriptor_,
@@ -110,16 +153,18 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
                                     int64_t groups,
                                     std::optional<IntArrayRef> input_shape) {
   constexpr auto kChannelsLast = MemoryFormat::ChannelsLast;
+  constexpr auto kChannelsLast3d = MemoryFormat::ChannelsLast3d;
   constexpr auto kContiguous = MemoryFormat::Contiguous;
   const bool is_macos_15_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
 
   const bool is3DConv = input_t.dim() == 5;
-  // Use exact-match: a channel-slice of a channels-last tensor has CL-like
-  // strides but is not NHWC-packed, so the raw-buffer NHWC path would misread
-  // it. See https://github.com/pytorch/pytorch/issues/180984
   const auto memory_format = input_t.suggest_memory_format(/*channels_last_strides_exact_match=*/true);
-  const auto input_suggested_layout = memory_format == kChannelsLast && is_macos_15_plus ? kChannelsLast : kContiguous;
-  const bool is_channels_last = mps_conv_use_channels_last(input_t, weight_t) && !is3DConv;
+  const bool is_cl_input =
+      is_macos_15_plus && (is3DConv ? is_packed_channels_last_3d(input_t) : memory_format == kChannelsLast);
+  const auto input_suggested_layout = is_cl_input ? (is3DConv ? kChannelsLast3d : kChannelsLast) : kContiguous;
+  const bool use_dhwio = is3DConv && is_cl_input && conv3d_dhwio_is_beneficial(weight_t.sizes());
+  // Allocate output in the user-requested layout regardless of fast-path gate.
+  const bool is_channels_last = mps_conv_use_channels_last(input_t, weight_t);
   const bool bias_defined = bias_opt ? bias_opt->defined() : false;
 
   TORCH_CHECK(isFloatingType(input_t.scalar_type()), "Convolution is supported only for Floating types");
@@ -137,7 +182,7 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
                 std::nullopt,
                 kMPS,
                 std::nullopt,
-                is_channels_last ? kChannelsLast : kContiguous);
+                is_channels_last ? (is3DConv ? kChannelsLast3d : kChannelsLast) : kContiguous);
   if (output_t.numel() == 0) {
     return output_t;
   }
@@ -181,19 +226,19 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
       bias_shape_key = "nobias";
     }
 
-    std::string key = fmt::format("mps_{}convolution:{}:{}:{}:{}:{}:{}:{}:{}",
+    std::string key = fmt::format("mps_{}convolution:{}:{}:{}:{}:{}:{}:{}:{}:{}",
                                   is3DConv ? "3d_" : "",
                                   getArrayRefString(stride),
                                   getArrayRefString(dilation),
                                   getArrayRefString(padding),
                                   groups,
-                                  input_suggested_layout == kChannelsLast,
+                                  is_cl_input,
+                                  use_dhwio,
                                   mps::getTensorsStringKey({input_t, weight_t}),
                                   bias_defined,
                                   bias_shape_key);
 
     auto inputShape = mps::getMPSShape(input_t, input_suggested_layout);
-    auto outputShape = mps::getMPSShape(output_t, input_suggested_layout);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       bool isDepthwiseConv =
           (groups > 1 && weight_t.size(1) == 1) && input_t.dim() >= 4 && weight_t.dim() >= 4 && !is_channels_last;
@@ -213,10 +258,15 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
                          padding[2],
                          padding[1],
                          padding[0],
+                         input_suggested_layout,
+                         use_dhwio,
                          groups);
 
+        MPSGraphTensor* conv3dWeightTensor = use_dhwio
+            ? [mpsGraph transposeTensor:weightTensor permutation:@[ @2, @3, @4, @1, @0 ] name:nil]
+            : weightTensor;
         outputTensor = [mpsGraph convolution3DWithSourceTensor:inputTensor
-                                                 weightsTensor:weightTensor
+                                                 weightsTensor:conv3dWeightTensor
                                                     descriptor:conv3dDescriptor_
                                                           name:nil];
       } else if (isDepthwiseConv) {
@@ -261,23 +311,26 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
       newCachedGraph->outputTensor_ = outputTensor;
     });
 
-    auto inputPlaceholder = input_suggested_layout == kContiguous
-        ? Placeholder(cachedGraph->inputTensor_, output_c || is3DConv ? input_t.contiguous() : input_t)
-        : Placeholder(cachedGraph->inputTensor_, getMPSNDArray(input_t, inputShape));
-    auto outputPlaceholder = input_suggested_layout == kContiguous
-        ? Placeholder(cachedGraph->outputTensor_, output_c ? *output_c : output_t)
-        : Placeholder(cachedGraph->outputTensor_, getMPSNDArray(output_t, outputShape));
+    const auto input_for_graph =
+        output_c ? input_t.contiguous() : materialize_for_conv(input_t, input_suggested_layout);
+    auto inputPlaceholder = make_conv_placeholder(cachedGraph->inputTensor_, input_for_graph, input_suggested_layout);
+    auto outputPlaceholder = output_c
+        ? Placeholder(cachedGraph->outputTensor_, *output_c)
+        : make_conv_placeholder(cachedGraph->outputTensor_, output_t, input_suggested_layout);
     auto weightsPlaceholder = Placeholder(cachedGraph->weightTensor_, output_c ? weight_t.contiguous() : weight_t);
     auto biasPlaceholder = Placeholder();
     // Reshape the bias to be broadcastable with output of conv2d or conv3d
     if (bias_defined) {
+      const int64_t C = bias_shape[0];
+      std::vector<int64_t> bias_view;
       if (is3DConv) {
-        biasPlaceholder = Placeholder(cachedGraph->biasTensor_, bias_opt->view({1, bias_shape[0], 1, 1, 1}));
-      } else if (input_suggested_layout == kChannelsLast) {
-        biasPlaceholder = Placeholder(cachedGraph->biasTensor_, bias_opt->view({1, 1, 1, bias_shape[0]}));
+        bias_view = input_suggested_layout == kChannelsLast3d ? std::vector<int64_t>{1, 1, 1, 1, C}
+                                                              : std::vector<int64_t>{1, C, 1, 1, 1};
       } else {
-        biasPlaceholder = Placeholder(cachedGraph->biasTensor_, bias_opt->view({1, bias_shape[0], 1, 1}));
+        bias_view = input_suggested_layout == kChannelsLast ? std::vector<int64_t>{1, 1, 1, C}
+                                                            : std::vector<int64_t>{1, C, 1, 1};
       }
+      biasPlaceholder = Placeholder(cachedGraph->biasTensor_, bias_opt->view(bias_view));
     }
 
     auto feeds = [[[NSMutableDictionary alloc] initWithCapacity:3] autorelease];
@@ -331,17 +384,31 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
   checkAllSameType(c, {grad_output, weight});
   checkAllSameGPU(c, {grad_output, weight});
   constexpr auto kChannelsLast = at::MemoryFormat::ChannelsLast;
-  bool is_channels_last = mps_conv_use_channels_last(grad_output_t, weight_t) && !is3DConv;
+  constexpr auto kChannelsLast3d = at::MemoryFormat::ChannelsLast3d;
+  constexpr auto kContiguous = at::MemoryFormat::Contiguous;
+  const bool is_macos_15_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
+  // Backward uses NDHWC+DHWIO only when the full fast path is beneficial; for
+  // factorized kernels / small Cin / depthwise the NCDHW+OIDHW fallback wins.
+  const bool use_dhwio = is3DConv && is_macos_15_plus && is_packed_channels_last_3d(grad_output_t) &&
+      conv3d_dhwio_is_beneficial(weight_t.sizes());
+  const auto desc_layout = use_dhwio ? kChannelsLast3d : kContiguous;
+  // Allocate grad_input in the user-requested layout. The fast path writes
+  // directly; the NCDHW fallback writes via a contig scratch + copy below.
+  const bool is_channels_last = mps_conv_use_channels_last(grad_output_t, weight_t);
   auto grad_input_t =
-      at::empty(input_size, grad_output_t.options(), is_channels_last ? std::optional(kChannelsLast) : std::nullopt);
+      at::empty(input_size,
+                grad_output_t.options(),
+                is_channels_last ? std::optional(is3DConv ? kChannelsLast3d : kChannelsLast) : std::nullopt);
 
   // Avoid "grad_input" when this is being used as transposed convolution
   TensorArg grad_input{grad_input_t, "result", 0};
   convolution_shape_check(c, grad_input, weight, grad_output, padding, stride, dilation, groups);
 
-  // TODO: Remove me when MacOS-14 is no longer supported
+  // Contig scratch when graph emits NCDHW but grad_input is CL3d -- covers
+  // the macOS-14 fallback and the 3D NCDHW fallback on macOS 15+.
   std::optional<Tensor> grad_input_c;
-  if (!is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) && is_channels_last) {
+  const bool needs_contig_scratch = is_channels_last && (!is_macos_15_plus || (is3DConv && !use_dhwio));
+  if (needs_contig_scratch) {
     grad_input_c = at::empty_like(grad_input_t, grad_input_t.options().memory_format(MemoryFormat::Contiguous));
   }
 
@@ -356,17 +423,19 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
   // Add backward with input
   @autoreleasepool {
     MPSStream* stream = getCurrentMPSStream();
-    MPSShape* mps_input_shape = getMPSShape(input_size);
-    std::string key = fmt::format("mps_{}_convolution_backward_input:{}:{}:{}:{}:{}:{}",
+    MPSShape* mps_input_shape = getMPSShape(input_size, desc_layout);
+    std::string key = fmt::format("mps_{}_convolution_backward_input:{}:{}:{}:{}:{}:{}:{}",
                                   is3DConv ? "3d_" : "",
                                   getArrayRefString(stride),
                                   getArrayRefString(dilation),
                                   getArrayRefString(padding),
                                   groups,
                                   is_channels_last,
+                                  use_dhwio,
                                   getTensorsStringKey({grad_output_t, weight_t}));
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      auto gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output_t);
+      auto gradOutputShape = getMPSShape(grad_output_t, desc_layout);
+      auto gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output_t), gradOutputShape);
       auto weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight_t);
 
       MPSGraphTensor* gradInputTensor;
@@ -387,9 +456,14 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
                          padding[2],
                          padding[1],
                          padding[0],
+                         desc_layout,
+                         use_dhwio,
                          groups);
+        MPSGraphTensor* convWeightTensor = use_dhwio
+            ? [mpsGraph transposeTensor:weightTensor permutation:@[ @2, @3, @4, @1, @0 ] name:nil]
+            : weightTensor;
         gradInputTensor = [mpsGraph convolution3DDataGradientWithIncomingGradientTensor:gradOutputTensor
-                                                                          weightsTensor:weightTensor
+                                                                          weightsTensor:convWeightTensor
                                                                             outputShape:mps_input_shape
                                                            forwardConvolutionDescriptor:conv3dDescriptor_
                                                                                    name:nil];
@@ -432,10 +506,13 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
       newCachedGraph->gradInputTensor_ = gradInputTensor;
     });
 
-    auto gradOutputPlaceholder =
-        Placeholder(cachedGraph->gradOutputTensor_, grad_input_c ? grad_output_t.contiguous() : grad_output_t);
+    const auto grad_out_for_graph =
+        grad_input_c ? grad_output_t.contiguous() : materialize_for_conv(grad_output_t, desc_layout);
+    auto gradOutputPlaceholder = make_conv_placeholder(cachedGraph->gradOutputTensor_, grad_out_for_graph, desc_layout);
     auto weightsPlaceholder = Placeholder(cachedGraph->weightTensor_, grad_input_c ? weight_t.contiguous() : weight_t);
-    auto outputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input_c ? *grad_input_c : grad_input_t);
+    auto outputPlaceholder = grad_input_c
+        ? Placeholder(cachedGraph->gradInputTensor_, *grad_input_c)
+        : make_conv_placeholder(cachedGraph->gradInputTensor_, grad_input_t, desc_layout);
 
     auto feeds = dictionaryFromPlaceholders(gradOutputPlaceholder, weightsPlaceholder);
     runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
@@ -460,7 +537,19 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");
   CheckedFrom c = "mps_convolution_backward_weights";
   constexpr auto kChannelsLast = at::MemoryFormat::ChannelsLast;
-  bool is_channels_last = mps_conv_use_channels_last(input_t, grad_output_t) && !is3DConv;
+  constexpr auto kChannelsLast3d = at::MemoryFormat::ChannelsLast3d;
+  constexpr auto kContiguous = at::MemoryFormat::Contiguous;
+  const bool is_macos_15_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
+  // Half-precision WG regresses on NDHWC+DHWIO; force NCDHW+OIDHW.
+  const bool half_precision_wg =
+      grad_output_t.scalar_type() == at::kBFloat16 || grad_output_t.scalar_type() == at::kHalf;
+  // Require BOTH inputs CL3d-packed; otherwise we'd permute the non-packed one each call.
+  const bool use_dhwio = is3DConv && is_macos_15_plus && !half_precision_wg && is_packed_channels_last_3d(input_t) &&
+      is_packed_channels_last_3d(grad_output_t) && conv3d_dhwio_is_beneficial(weight_size);
+  const auto desc_layout = use_dhwio ? kChannelsLast3d : kContiguous;
+  // grad_weight allocation: 2D follows the standard CL convention; 3D always
+  // stays contiguous OIDHW (the graph already transposes DHWIO -> OIDHW).
+  const bool allocate_grad_weight_cl = mps_conv_use_channels_last(input_t, grad_output_t) && !is3DConv;
 
   // For uniformity with everything else, although it seems grad_weight
   // would be unambiguous too.
@@ -470,8 +559,8 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
   checkAllSameType(c, {grad_output, input});
   checkAllSameGPU(c, {grad_output, input});
 
-  auto grad_weight_t =
-      at::empty(weight_size, grad_output_t.options(), is_channels_last ? std::optional(kChannelsLast) : std::nullopt);
+  auto grad_weight_t = at::empty(
+      weight_size, grad_output_t.options(), allocate_grad_weight_cl ? std::optional(kChannelsLast) : std::nullopt);
 
   TensorArg grad_weight{grad_weight_t, "result", 0};
 
@@ -487,29 +576,38 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
 
   // TODO: Remove me when MacOS-14 is no longer supported
   std::optional<Tensor> grad_weight_c;
-  if (!is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) && is_channels_last) {
+  if (!is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) && allocate_grad_weight_cl) {
     grad_weight_c = at::empty_like(grad_weight_t, grad_weight_t.options().memory_format(MemoryFormat::Contiguous));
   }
 
   @autoreleasepool {
     MPSStream* stream = getCurrentMPSStream();
 
-    MPSShape* mps_weight_shape = getMPSShape(weight_size);
-    std::string key = fmt::format("mps_{}convolution_backward_weights:{}:{}:{}:{}:{}:{}",
+    // Under DHWIO the graph emits weight grad in DHWIO order; the op output
+    // shape must match, and we transpose back to OIDHW after.
+    MPSShape* mps_weight_shape = use_dhwio
+        ? @[ @(weight_size[2]), @(weight_size[3]), @(weight_size[4]), @(weight_size[1]), @(weight_size[0]) ]
+        : getMPSShape(weight_size);
+    std::string key = fmt::format("mps_{}convolution_backward_weights:{}:{}:{}:{}:{}:{}:{}",
                                   is3DConv ? "3d_" : "",
                                   getArrayRefString(stride),
                                   getArrayRefString(dilation),
                                   getArrayRefString(padding),
                                   groups,
-                                  is_channels_last,
+                                  allocate_grad_weight_cl,
+                                  use_dhwio,
                                   getTensorsStringKey({grad_output_t, input_t, grad_weight_t}));
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSShape* inputShape = getMPSShape(input_t);
-      bool isDepthwiseConv =
-          ((groups > 1 && (mps_weight_shape[1].intValue == 1)) && inputShape.count >= 4 && mps_weight_shape.count >= 4);
+      MPSShape* inputShape = getMPSShape(input_t, desc_layout);
+      MPSShape* gradOutputShape = getMPSShape(grad_output_t, desc_layout);
+      // For the non-CL path the depthwise heuristic inspects the OIHW weight shape.
+      MPSShape* weight_shape_OIDHW = getMPSShape(weight_size);
+      bool isDepthwiseConv = ((groups > 1 && (weight_shape_OIDHW[1].intValue == 1)) && inputShape.count >= 4 &&
+                              weight_shape_OIDHW.count >= 4);
 
-      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output_t);
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+      MPSGraphTensor* gradOutputTensor =
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(grad_output_t), gradOutputShape);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(input_t), inputShape);
 
       MPSGraphTensor* gradWeightTensor;
       if (is3DConv) {
@@ -524,12 +622,19 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
                          padding[2],
                          padding[1],
                          padding[0],
+                         desc_layout,
+                         use_dhwio,
                          groups);
         gradWeightTensor = [mpsGraph convolution3DWeightsGradientWithIncomingGradientTensor:gradOutputTensor
                                                                                sourceTensor:inputTensor
                                                                                 outputShape:mps_weight_shape
                                                                forwardConvolutionDescriptor:conv3dDescriptor_
                                                                                        name:nil];
+        if (use_dhwio) {
+          gradWeightTensor = [mpsGraph transposeTensor:gradWeightTensor
+                                           permutation:@[ @4, @3, @0, @1, @2 ]
+                                                  name:nil];
+        }
       } else if (isDepthwiseConv) {
         MPSGraphDepthwiseConvolution3DOpDescriptor* depthWiseConv3dDescriptor_ =
             [[MPSGraphDepthwiseConvolution3DOpDescriptor new] autorelease];
@@ -568,9 +673,11 @@ static Tensor mps_convolution_backward_weights(IntArrayRef weight_size,
       newCachedGraph->gradWeightTensor_ = gradWeightTensor;
     });
 
-    auto gradOutputPlaceholder =
-        Placeholder(cachedGraph->gradOutputTensor_, grad_weight_c ? grad_output_t.contiguous() : grad_output_t);
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, grad_weight_c ? input_t.contiguous() : input_t);
+    const auto grad_out_for_graph =
+        grad_weight_c ? grad_output_t.contiguous() : materialize_for_conv(grad_output_t, desc_layout);
+    const auto input_for_graph = grad_weight_c ? input_t.contiguous() : materialize_for_conv(input_t, desc_layout);
+    auto gradOutputPlaceholder = make_conv_placeholder(cachedGraph->gradOutputTensor_, grad_out_for_graph, desc_layout);
+    auto inputPlaceholder = make_conv_placeholder(cachedGraph->inputTensor_, input_for_graph, desc_layout);
     auto outputPlaceholder =
         Placeholder(cachedGraph->gradWeightTensor_, grad_weight_c ? *grad_weight_c : grad_weight_t);
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10486,6 +10486,97 @@ class TestPad(TestCaseMPS):
         gi_ref = torch.ops.aten.replication_pad1d_backward(go.cpu(), x.cpu(), (1, 1))
         self.assertEqual(gi.cpu(), gi_ref)
 
+class TestConv3dChannelsLast3dMPS(NNTestCase):
+    def _run_conv3d_cl3d(self, *, input_shape, Cin, Cout, k, pad, with_bias, dtype, groups=1):
+        torch.manual_seed(0)
+        m_cpu = nn.Conv3d(Cin, Cout, k, stride=1, padding=pad, bias=with_bias,
+                          groups=groups, device="cpu")
+        x_cpu = torch.randn(*input_shape, device="cpu", requires_grad=True)
+
+        m_mps_cont = copy.deepcopy(m_cpu).to(device="mps", dtype=dtype)
+        x_mps_cont = x_cpu.detach().to(device="mps", dtype=dtype).requires_grad_(True)
+
+        m_mps_cl = copy.deepcopy(m_cpu).to(device="mps", dtype=dtype)
+        x_mps_cl = (x_cpu.detach().to(device="mps", dtype=dtype)
+                    .contiguous(memory_format=torch.channels_last_3d)
+                    .requires_grad_(True))
+
+        y_cpu = m_cpu(x_cpu)
+        y_mps_cont = m_mps_cont(x_mps_cont)
+        y_mps_cl = m_mps_cl(x_mps_cl)
+
+        # Fast-path invariant: CL output must match contiguous in same dtype.
+        cl_vs_cont = dict(atol=1e-5, rtol=1e-5) if dtype == torch.float32 else dict(atol=1e-3, rtol=1e-3)
+        self.assertEqual(y_mps_cont, y_mps_cl, **cl_vs_cont)
+        self.assertTrue(y_mps_cl.is_contiguous(memory_format=torch.channels_last_3d))
+        if dtype == torch.float32:
+            self.assertEqual(y_cpu, y_mps_cl.cpu(), atol=1e-4, rtol=1e-4)
+
+        grad_out_cpu = torch.randn_like(y_cpu)
+        grad_out_mps = grad_out_cpu.to(device="mps", dtype=dtype)
+        y_cpu.backward(grad_out_cpu)
+        y_mps_cont.backward(grad_out_mps)
+        y_mps_cl.backward(grad_out_mps.contiguous(memory_format=torch.channels_last_3d))
+
+        self.assertEqual(x_mps_cont.grad, x_mps_cl.grad, **cl_vs_cont)
+        self.assertTrue(x_mps_cl.grad.is_contiguous(memory_format=torch.channels_last_3d))
+        self.assertEqual(m_mps_cont.weight.grad, m_mps_cl.weight.grad, **cl_vs_cont)
+        if with_bias:
+            self.assertEqual(m_mps_cont.bias.grad, m_mps_cl.bias.grad, **cl_vs_cont)
+        if dtype == torch.float32:
+            self.assertEqual(x_cpu.grad, x_mps_cl.grad.cpu(), atol=1e-4, rtol=1e-4)
+            self.assertEqual(m_cpu.weight.grad, m_mps_cl.weight.grad.cpu(), atol=1e-4, rtol=1e-4)
+            if with_bias:
+                self.assertEqual(m_cpu.bias.grad, m_mps_cl.bias.grad.cpu(), atol=1e-4, rtol=1e-4)
+
+    # `factorized` (1,3,3) trips the DHWIO gate off; exercises the fallback.
+    @parametrize("with_bias", [True, False])
+    @parametrize("shape_kind", ["small", "production", "factorized"])
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_conv3d_channels_last_3d_fwd_bwd(self, dtype, shape_kind, with_bias):
+        if shape_kind == "small":
+            cfg = dict(input_shape=(2, 4, 8, 8, 8), Cin=4, Cout=8, k=3, pad=1)
+        elif shape_kind == "production":
+            # Reduced from issue's [4,32,64,64,64] for test runtime.
+            cfg = dict(input_shape=(2, 32, 16, 16, 16), Cin=32, Cout=64, k=3, pad=1)
+        else:
+            cfg = dict(input_shape=(2, 16, 8, 16, 16), Cin=16, Cout=32, k=(1, 3, 3), pad=(0, 1, 1))
+        self._run_conv3d_cl3d(**cfg, with_bias=with_bias, dtype=dtype)
+
+    # groups=2, Cin/groups=4: hits the DHWIO fast path.
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_conv3d_channels_last_3d_grouped(self, dtype):
+        self._run_conv3d_cl3d(input_shape=(2, 8, 8, 8, 8), Cin=8, Cout=16,
+                              k=3, pad=1, groups=2, with_bias=True, dtype=dtype)
+
+    # Depthwise (Cin/groups=1): gate bypasses DHWIO, exercises NCDHW fallback.
+    def test_conv3d_channels_last_3d_depthwise(self):
+        self._run_conv3d_cl3d(input_shape=(2, 4, 8, 8, 8), Cin=4, Cout=4,
+                              k=3, pad=1, groups=4, with_bias=True, dtype=torch.float32)
+
+    # ConvTranspose3d routes through _mps_convolution_impl; fp32 only since
+    # the op rejects bf16/fp16 for 3D.
+    def test_conv_transpose3d_channels_last_3d(self):
+        torch.manual_seed(0)
+        m_cpu = nn.ConvTranspose3d(8, 4, 3, stride=1, padding=1, device="cpu")
+        x_cpu = torch.randn(2, 8, 8, 8, 8, device="cpu", requires_grad=True)
+
+        m_mps = copy.deepcopy(m_cpu).to("mps")
+        x_mps = (x_cpu.detach().clone().to("mps")
+                 .contiguous(memory_format=torch.channels_last_3d)
+                 .requires_grad_(True))
+
+        y_cpu = m_cpu(x_cpu)
+        y_mps = m_mps(x_mps)
+        self.assertEqual(y_cpu, y_mps.cpu(), atol=1e-4, rtol=1e-4)
+
+        grad_out = torch.randn_like(y_cpu)
+        y_cpu.backward(grad_out)
+        y_mps.backward(grad_out.to("mps"))
+        self.assertEqual(x_cpu.grad, x_mps.grad.cpu(), atol=1e-4, rtol=1e-4)
+        self.assertEqual(m_cpu.weight.grad, m_mps.weight.grad.cpu(), atol=1e-4, rtol=1e-4)
+
+
 class TestLinalgMPS(TestCaseMPS):
     def _test_addmm_addmv(self, f, t, m, v, *, alpha=None, beta=None, transpose_out=False):
         dtype = t.dtype
@@ -15280,6 +15371,7 @@ instantiate_parametrized_tests(TestMPS)
 instantiate_parametrized_tests(TestSDPA)
 instantiate_parametrized_tests(TestSmoothL1Loss)
 instantiate_parametrized_tests(TestMetalLibrary)
+instantiate_parametrized_tests(TestConv3dChannelsLast3dMPS)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Fixes #182823.

This PR drops the `&& !is3DConv` guard so 3D convs with `channels_last_3d` input take the MPSGraph NDHWC data layout. It also adds an in-graph OIDHW<->DHWIO weight transpose gated by a beneficial-shape heuristic (Cin/groups >= 4, all kernel dims >= 2).  Forward, backward-input, and backward-weights all honor the layout-propagation contract after these changes.

For bf16/fp16 the underlying kernel for weight gradient computations is underperformant and it shows up especially with the more recent GPU generations. This is why the fp16/bf16 weight-grad computation is gated to take place in NCDHW+OIDHW until there is a kernel side fix to avoid regressing the perf.

Benchmarking this with M2 Max and M5 Max sweeping across some commonly encountered shapes using the CL3d now that it is respected for the computation

```
  ┌──────────────────────────────┬─────────────────────────────────────┬───────┬────────────┬─────────────┬────────────────┬────────────────┐
  │            Sweep             │                range                │ dtype │ M2 Max fwd │ M5 Max fwd  │ M2 Max fwd+bwd │ M5 Max fwd+bwd │
  ├──────────────────────────────┼─────────────────────────────────────┼───────┼────────────┼─────────────┼────────────────┼────────────────┤
  │ Spatial (Cin=32, Cout=64)    │ S ∈ {8, 16, 24, 32, 48, 64}         │ fp32  │ 1.30–1.43x │ 0.94–1.28x  │ 1.05–1.18x     │ 0.88–1.07x     │
  ├──────────────────────────────┼─────────────────────────────────────┼───────┼────────────┼─────────────┼────────────────┼────────────────┤
  │                              │                                     │ fp16  │ 1.10–1.25x │ 0.86–1.13x  │ 1.02–1.06x     │ 0.99–1.04x     │
  ├──────────────────────────────┼─────────────────────────────────────┼───────┼────────────┼─────────────┼────────────────┼────────────────┤
  │                              │                                     │ bf16  │ 1.09–1.25x │ 0.83–1.16x  │ 1.02–1.07x     │ 0.88–1.04x     │
  ├──────────────────────────────┼─────────────────────────────────────┼───────┼────────────┼─────────────┼────────────────┼────────────────┤
  │ Channel (S=32)               │ C=Cin=Cout ∈ {16, 32, 64, 128, 256} │ fp32  │ 1.04–1.38x │ 1.00–1.28x  │ 0.87–1.26x     │ 0.81–1.18x     │
  ├──────────────────────────────┼─────────────────────────────────────┼───────┼────────────┼─────────────┼────────────────┼────────────────┤
  │                              │                                     │ fp16  │ 1.02–1.32x │ 0.97–1.18x  │ 0.99–1.15x     │ 0.98–1.10x     │
  ├──────────────────────────────┼─────────────────────────────────────┼───────┼────────────┼─────────────┼────────────────┼────────────────┤
  │                              │                                     │ bf16  │ 1.04–1.35x │ 0.99–1.13x  │ 0.99–1.15x     │ 0.99–1.05x     │
  ├──────────────────────────────┼─────────────────────────────────────┼───────┼────────────┼─────────────┼────────────────┼────────────────┤
  │ First-layer (Cin=3, Cout=32) │ S ∈ {64, 96, 128}                   │ all   │ ~1.00x     │ ~1.00–1.02x │ 0.92–0.97x     │ 0.90–0.96x     │
  └──────────────────────────────┴─────────────────────────────────────┴───────┴────────────┴─────────────┴────────────────┴────────────────┘
```

So the story is somewhat mixed: Forward pass universally benefits from the change. The full fwd+bw pass sometimes benefits and sometimes not. The issue is more prevalent with the wider GPUs where the insufficiently exposed parallelism becomes an issue dropping the GPU util and with half types, while smaller GPUs are kept busy enough regardless to have a lesser impact. However once the faulty weight gradient kernel is tuned there should be a second uplift. This is the remaining gap mentioned in #182823 

The reasoning for accepting that downside is that now the conv3d op respects the channels last layout wishes from the caller by returning its outputs as channels last as well possibly helping with downstream usage. This did not use to be case. Also I tried to avoid baking in too much complexity on choosing when to respect the CL3d for the computation and when not to just to work around the current quirks of the underlying kernel.

One last note on the discrepancy of the NDHWC + DHWIO result in the follow-up comment of #182823: The test presented there does not account for pytorch weights being stored as OIDHW. So while the computation objectively will benefit from DHWIO used in conjunction with CL3d we will need to pay the cost of manipulating the weights as well as the gradients to them to align with their storage. This means that in reality the permutations will eat some of the perf benefits that the standalone test expected due to its optimistic setup.