### PR TITLE
Set is_compiling flag for the whole torch.compile session

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1669,6 +1669,14 @@ def _compile(
         code: CodeType, one_graph: bool, hooks: Hooks
     ) -> tuple[ConvertFrameReturn, DynamoTracerOutput | None]:
         with contextlib.ExitStack() as stack:
+            # Hold _is_compiling_flag True for the duration of compilation so
+            # torch.compiler.is_compiling() is observable in code that runs
+            # during the compile session but is not directly Dynamo-traced
+            # (wrapper-subclass __torch_dispatch__ invoked by AOTAutograd,
+            # make_fx invoked from a custom backend, etc.). Export sets the
+            # flag itself via _compiling_state_context, so skip there.
+            if not export:
+                stack.enter_context(torch.compiler._compile_session_context())
             stack.enter_context(
                 torch._dynamo.callback_handler.install_callbacks(
                     CallbackTrigger.DYNAMO, str(CompileContext.current_compile_id())

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -4179,7 +4179,10 @@ class SubgraphTracer(fx.Tracer):
             #
             # Also see NOTE: [Export inputs must be explicitly passed in]
             is_strict_export = self.is_export
-            is_non_strict_export = torch.compiler.is_compiling()
+            # Use is_exporting() (not is_compiling()) to detect non-strict
+            # export. is_compiling() is now also True during regular
+            # torch.compile sessions, but only export sets is_exporting().
+            is_non_strict_export = torch.compiler.is_exporting()
             if not is_strict_export and not is_non_strict_export:
                 if isinstance(example_value, torch.Tensor):
                     self._lift_basic_symbols(example_value, source)

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -198,7 +198,7 @@ def cond(
     if isinstance(pred, (bool, int, float)):
         # This is the non-strict export case. Strict export and torch.compile are
         # handled above in dynamo.
-        if torch.compiler.is_compiling():
+        if torch.compiler.is_exporting():
             warnings.warn(
                 "Pred is a Python constant. When used with torch.cond, it specializes on one of the branches."
                 " If you want torch.cond to preserve two branches, please make the predicate a boolean tensor or a SymBool.",

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -390,7 +390,7 @@ def invoke_subgraph_placeholder(func, *args, **kwargs):
         # This is just a placeholder for Dynamo to replace with invoke_subgraph
         raise RuntimeError("invoke_subgraph should not be called directly in Dynamo")
 
-    if torch.compiler.is_compiling():
+    if torch.compiler.is_exporting():
         # For non-strict export tracing, we still want to go through Dynamo
 
         def _invoke_subgraph_placeholder_wrapper(func, args, kwargs):

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -514,6 +514,20 @@ def _non_strict_tracing_context():
 
 
 @contextlib.contextmanager
+def _compile_session_context():
+    """Context manager that sets _is_compiling_flag for the duration of a
+    torch.compile session.
+    """
+    global _is_compiling_flag
+    old = _is_compiling_flag
+    try:
+        _is_compiling_flag = True
+        yield
+    finally:
+        _is_compiling_flag = old
+
+
+@contextlib.contextmanager
 def _patch_autograd_grad():
     """Patch autograd.grad for non-strict make_fx tracing.
 


### PR DESCRIPTION

torch.compiler.is_compiling depends on a Dynamo trace-time bytecode intercept, so any code that runs inside a compile session but is not directly Dynamo-traced (wrapper subclass __torch_dispatch__ methods invoked by AOTAutograd, custom backends, make_fx called from inside the session) observes the underlying flag as False. The runtime _is_compiling_flag is only ever set by the torch.export entry point, so under torch.compile those callers see False even though they are clearly part of a compile session. This change wraps OptimizeContext with a small context manager that holds _is_compiling_flag True for the duration of the session, gated to non-export so the existing export entry point stays the sole flag setter there. Validated locally with a wrapper subclass repro that observes True both inside a custom backend and inside make_fx invoked from a compile body, and confirmed the flag still resets to False after the session exits and across nested torch.compile calls. Fixes #184547.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98