### PR TITLE
[MPS] Fix sort returning out-of-bounds indices for bool/int-max/NaN inputs

### DIFF
--- a/aten/src/ATen/native/mps/kernels/SortMerge.h
+++ b/aten/src/ATen/native/mps/kernels/SortMerge.h
@@ -40,21 +40,14 @@ inline bool bitonic_lt(T vi, IdxT ii, T vp, IdxT ip, bool /*i_am_low*/, bool des
 }
 
 template <bool STABLE, typename T, typename IdxT, ::metal::enable_if_t<!STABLE, bool> = true>
-inline bool bitonic_lt(T vi, IdxT ii, T vp, IdxT ip, bool i_am_low, bool desc) {
-  // padding slots in sort_block carry the sentinel index. When real values
-  // tie with the dtype extremum used for padding init like NaN, INT_MAX or True for bool.
-  // push padding to the "later" position so its out of range index doesn't
-  // leak into the output
+inline bool bitonic_lt(T vi, IdxT ii, T vp, IdxT ip, bool /*i_am_low*/, bool desc) {
+  // Tie-break by index: padding's sentinel ~0 (the largest index) sorts last,
+  // so its out-of-range index never leaks into the output.
   if (sort_compare(vi, vp, desc))
     return true;
   if (sort_compare(vp, vi, desc))
     return false;
-  constexpr IdxT sentinel = ~IdxT(0);
-  if (ii != sentinel && ip == sentinel)
-    return true;
-  if (ii == sentinel && ip != sentinel)
-    return false;
-  return i_am_low;
+  return ii < ip;
 }
 
 // Padding value for out-of-range slots. Chosen to sort to the end of the

--- a/aten/src/ATen/native/mps/kernels/SortMerge.h
+++ b/aten/src/ATen/native/mps/kernels/SortMerge.h
@@ -40,8 +40,21 @@ inline bool bitonic_lt(T vi, IdxT ii, T vp, IdxT ip, bool /*i_am_low*/, bool des
 }
 
 template <bool STABLE, typename T, typename IdxT, ::metal::enable_if_t<!STABLE, bool> = true>
-inline bool bitonic_lt(T vi, IdxT /*ii*/, T vp, IdxT /*ip*/, bool i_am_low, bool desc) {
-  return sort_compare(vi, vp, desc) || (!sort_compare(vp, vi, desc) && i_am_low);
+inline bool bitonic_lt(T vi, IdxT ii, T vp, IdxT ip, bool i_am_low, bool desc) {
+  // padding slots in sort_block carry the sentinel index. When real values
+  // tie with the dtype extremum used for padding init like NaN, INT_MAX or True for bool.
+  // push padding to the "later" position so its out of range index doesn't
+  // leak into the output
+  if (sort_compare(vi, vp, desc))
+    return true;
+  if (sort_compare(vp, vi, desc))
+    return false;
+  constexpr IdxT sentinel = ~IdxT(0);
+  if (ii != sentinel && ip == sentinel)
+    return true;
+  if (ii == sentinel && ip != sentinel)
+    return false;
+  return i_am_low;
 }
 
 // Padding value for out-of-range slots. Chosen to sort to the end of the
@@ -342,7 +355,7 @@ kernel void sort_block(const device T* inp [[buffer(0)]],
   long base_out = long(tid.y) * long(size);
   for (int i = lid.x; i < ELEMS_PER_TG; i += TPTG) {
     tgv[i] = i < size ? inp[base_in + i * stride_sort] : init;
-    tgi[i] = i;
+    tgi[i] = i < size ? uint(i) : ~uint(0);
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
   block_merge_sort<T, uint, TPTG, TN, STABLE>(tgv, tgi, lid.x, desc);
@@ -386,7 +399,7 @@ kernel void mb_sort_block(const device T* inp [[buffer(0)]],
   for (int i = lid.x; i < ELEMS_PER_TG; i += TPTG) {
     int g = blk + i;
     tgv[i] = g < size ? inp[seg + g * stride_sort] : init;
-    tgi[i] = IdxT(g);
+    tgi[i] = g < size ? IdxT(g) : ~IdxT(0);
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
   block_merge_sort<T, IdxT, TPTG, TN, STABLE>(tgv, tgi, lid.x, desc);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6349,6 +6349,22 @@ class TestMPS(TestCaseMPS):
             sorted_mi, _ = torch.sort(mi, dim=-1)
             self.assertEqual(sorted_mi.cpu(), torch.arange(mi.size(-1)).expand_as(mi))
 
+    def test_sort_padding_extremum_indices(self):
+        # Regression: bitonic-sort padding slots in the Metal kernel hold the
+        # dtype-extremum (True for bool asc, INT_MAX for int asc, NaN for float
+        # asc). Real inputs equal to that extremum tie with padding, unstable
+        # tie-breaks used to let padding's out-of-range index leak into the
+        # output. Every output index must be in [0, size).
+        cases = [
+            torch.tensor([True, False, True, False, True], device="mps"),
+            torch.tensor([1, torch.iinfo(torch.int32).max, 2], dtype=torch.int32, device="mps"),
+            torch.tensor([1.0, float('nan'), 2.0, float('nan'), 3.0], device="mps"),
+        ]
+        for t in cases:
+            _, idx = torch.sort(t)
+            self.assertLess(idx.max().item(), t.numel())
+            self.assertEqual(torch.gather(t, 0, idx), torch.sort(t.cpu())[0])
+
     @parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16, torch.int32, torch.int64])
     @parametrize("descending", [False, True])
     @parametrize("stable", [True, False])


### PR DESCRIPTION
Bitonic sort pads to power-of-2 with the dtype extremum (NaN/INT_MAX/True). Real values(from the array we give to sort) that equal the padding tied in the comparator, letting padding's out-of-range indices leak into the output.

This PR tags padding slots with a sentinel index (~IdxT(0), out of any real input's range) and the comparator  then prefers real slots over padding on value ties.

Reproducer:
```
import torch

cases = [
    ("bool",   torch.tensor([True, False, True, False, True], device="mps")),
    ("float-nan", torch.tensor([1.0, float('nan'), 2.0, float('nan'), 3.0], device="mps")),
    ("int-max", torch.tensor([1, torch.iinfo(torch.int32).max, 2], dtype=torch.int32, device="mps")),
]
for name, t in cases:
    _, idx = torch.sort(t)
    print(f"{name:12} idx={idx.tolist()}  max={idx.max().item()}  size={t.numel()}")
```

Performance, small regression:
## float32
| case | shape | before-fix (ms) | after-fix (ms) | after/before |
|---|---|---:|---:|---:|
| b1_sort4k | 1x4096 | 0.0290 | 0.0311 | 1.075x |
| b1_sort8k | 1x8192 | 0.0358 | 0.0381 | 1.062x |
| b1_sort16k | 1x16384 | 0.0565 | 0.0596 | 1.056x |
| b1_vocab32k | 1x32000 | 0.0659 | 0.0694 | 1.052x |
| b4_vocab32k | 4x32000 | 0.1103 | 0.1172 | 1.062x |

## bf16 (single-block merge path)

| case | shape | before-fix (ms) | after-fix (ms) | after/before |
|---|---|---:|---:|---:|
| bf16m_8x1024 | 8x1024 | 0.0237 | 0.0260 | 1.097x |
| bf16m_256x2048 | 256x2048 | 0.2499 | 0.2823 | 1.130x |
| bf16m_16x4096 | 16x4096 | 0.0421 | 0.0455 | 1.081x |

different shapes because the above shapes(float32 ones) dispatch to radix for bfloat16