### PR TITLE
[Inductor] Fix `torch.cond` subgraph buffer reuse with per-scope `EfficientPeakEstimate`

### DIFF
--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -817,6 +817,39 @@ class CondTests(TestCase):
             dynamic=True,
         )
 
+    @requires_gpu
+    @parametrize("device", ["cpu", GPU_TYPE])
+    def test_cond_buffer_reuse_with_large_subgraph(self, device):
+        # Regression test: torch.cond subgraph with more buffers than main
+        # graph scheduler nodes caused segmented_tree OOB in memory planning.
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList(
+                    [torch.nn.Linear(64, 64) for _ in range(10)]
+                )
+
+            def forward(self, p, x):
+                def true_fn(inp):
+                    h = inp
+                    for layer in self.layers:
+                        h = torch.relu(layer(h))
+                    return h.clone()
+
+                def false_fn(inp):
+                    return inp.new_zeros(inp.shape[0], 64)
+
+                return torch.cond(p, true_fn, false_fn, (x,))
+
+        model = Model().to(device)
+        inputs = (torch.randn(8, 64),)
+        self._run_test(
+            model=model,
+            inputs=inputs,
+            device=device,
+            dynamic=True,
+        )
+
 
 class WhileLoopModels:
     class Simple(torch.nn.Module):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2259,14 +2259,21 @@ class PythonWrapperCodegen(CodeGen):
         # codegen allocations in two passes
         planning_states = [MemoryPlanningState()]
         past_planning_states = []
+        peak_estimate_stack: list[EfficientPeakEstimate] = []
         for i in range(len(self.lines)):
             line = self.lines[i]
             if isinstance(line, MemoryPlanningLine):
                 self.lines[i] = line.plan(planning_states[-1])
             elif isinstance(line, EnterSubgraphLine):
                 planning_states.append(MemoryPlanningState())
+                if config.allow_buffer_reuse:
+                    peak_estimate_stack.append(self.estimate_peak)
+                    with V.set_graph_handler(line.graph):
+                        self.estimate_peak = EfficientPeakEstimate()
             elif isinstance(line, ExitSubgraphLine):
                 past_planning_states.append(planning_states.pop())
+                if config.allow_buffer_reuse:
+                    self.estimate_peak = peak_estimate_stack.pop()
         past_planning_states.append(planning_states.pop())
         assert len(planning_states) == 0
 


### PR DESCRIPTION
Summary:
When `torch.cond` subgraphs are inlined during AOT codegen, their `AllocateLine`s carry `scheduler_node_index` values from the subgraph's scheduler, but `memory_plan_reuse()` uses a single `EfficientPeakEstimate` built from the main graph's scheduler. If the subgraph has more scheduler nodes than the main graph, querying the segmented tree causes an OOB crash. Even when indices happen to be in-bounds, the peak data is for the wrong scheduler node.

Fix this by scoping `EfficientPeakEstimate` per subgraph: push/pop `self.estimate_peak` at `EnterSubgraphLine`/`ExitSubgraphLine` markers in `memory_plan_reuse()`, constructing a new `EfficientPeakEstimate` from the subgraph's `GraphLowering` (available on `EnterSubgraphLine.graph`). This gives each scope its own correctly-sized segmented tree with correct peak memory data, matching what the non-AOT lifted path already does implicitly.

Test Plan: `buck2 test fbcode//caffe2/test/inductor:control_flow -- -r test_cond_buffer_reuse_with_large_subgraph` — added regression test with a `torch.cond` model where the true branch has 10 linear layers (more subgraph scheduler nodes than main graph nodes). Passes on CPU; GPU skipped in ASAN build.

Reviewed By: desertfire, rmiao

Differential Revision: D105883677




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo