### PR TITLE
[Inductor] Fix stale backed-symbol references in AOTI deferred runtime asserts (#184624)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6531,6 +6531,38 @@ class AOTInductorTestsTemplate:
         with config.patch({"scalar_asserts": False}):
             AOTIRunnerUtil.run_multiple(model, [example_inputs, unexpected_inputs])
 
+    def test_multi_input_nonzero_slice_shared_dim(self):
+        # Regression: when multiple inputs share a dynamic batch dim and are
+        # sliced with the same nonzero result, the generated C++ guard code
+        # referenced symbolic variables that were replaced during constraint
+        # solving but never defined in the wrapper.
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(4, 4)
+
+            def forward(self, x, a, b, mask):
+                n = torch.nonzero(mask).shape[0]
+                return self.linear(x[n:]) + a[n:] + b[n:]
+
+        B = Dim("B", min=1, max=1024)
+        dynamic_shapes = {
+            "x": {0: B},
+            "a": {0: B},
+            "b": {0: B},
+            "mask": {0: B},
+        }
+        example_inputs = (
+            torch.randn(8, 4, device=self.device),
+            torch.randn(8, 4, device=self.device),
+            torch.randn(8, 4, device=self.device),
+            torch.tensor(
+                [True, True, False, True, False, False, True, True],
+                device=self.device,
+            ),
+        )
+        self.check_model(Model(), example_inputs, dynamic_shapes=dynamic_shapes)
+
     def test_none_args_aot_codegen(self):
         if self.device != GPU_TYPE:
             raise unittest.SkipTest("requires GPU")

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -573,12 +573,13 @@ class CppWrapperCpu(PythonWrapperCodegen):
     ):
         self.prefix.writeline(f"""{info_kind}[{idx}].name = "{name}";""")
 
-    def codegen_input_symbol_assignment(
+    def codegen_input_symbol_assignment(  # type: ignore[override]
         self,
         name: str,
         value: ir.TensorBox,
         bound_vars: OrderedSet[sympy.Symbol],
     ):
+        """Assign symbolic shapes to C++ locals, with replacement aliases."""
         code = self.prefix
 
         @functools.cache
@@ -591,6 +592,26 @@ class CppWrapperCpu(PythonWrapperCodegen):
             self.codegen_input_stride_var_decl(code, name)
             return f"{name}_stride"
 
+        def maybe_emit_replacement_aliases(sym: sympy.Symbol) -> None:
+            # Deferred runtime asserts reference pre-replacement backed
+            # symbols (e.g. s77) that were replaced to this canonical
+            # symbol (s31) during constraint solving. Emit aliases so
+            # the asserts compile. Skip unbacked symbols — they are
+            # defined separately by the unbacked symbol codegen path.
+            from torch.utils._sympy.symbol import symbol_is_type, SymT
+
+            for src, tgt in V.graph.sizevars.shape_env.replacements.items():
+                if (
+                    tgt == sym
+                    and isinstance(src, sympy.Symbol)
+                    and src not in bound_vars
+                    and not symbol_is_type(
+                        src, (SymT.UNBACKED_INT, SymT.UNBACKED_FLOAT)
+                    )
+                ):
+                    code.writeline(f"int64_t {src} = {sym};")
+                    bound_vars.add(src)
+
         def codegen_symbol(
             sym_or_exp: sympy.Symbol | sympy.Expr,
             base_name: str,
@@ -602,6 +623,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     return
                 code.writeline(f"int64_t {sym_or_exp} = {name_fn(base_name)}[{dim}];")
                 bound_vars.add(sym_or_exp)
+                maybe_emit_replacement_aliases(sym_or_exp)
             elif isinstance(sym_or_exp, sympy.Expr):
                 undefined_symbols = [
                     sym for sym in sym_or_exp.free_symbols if sym not in bound_vars
@@ -639,6 +661,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 raise AssertionError("Unexpected symbol type")
             code.writeline(f"{decl} {value} = {name};")
             bound_vars.add(value)
+            maybe_emit_replacement_aliases(value)
         elif isinstance(value, ir.TensorBox):
             for dim, size in enumerate(value.get_size()):
                 codegen_symbol(size, name, sizeof, dim)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -2366,16 +2366,38 @@ class PythonWrapperCodegen(CodeGen):
             code.writeline(f"{name}_stride = {name}.stride()")
             return f"{name}_stride"
 
+        def maybe_emit_replacement_aliases(sym: sympy.Symbol) -> None:
+            # Deferred runtime asserts reference pre-replacement backed
+            # symbols (e.g. s77) that were replaced to this canonical
+            # symbol (s31) during constraint solving. Emit aliases so
+            # the asserts compile. Skip unbacked symbols — they are
+            # defined separately by the unbacked symbol codegen path.
+            from torch.utils._sympy.symbol import symbol_is_type, SymT
+
+            for src, tgt in V.graph.sizevars.shape_env.replacements.items():
+                if (
+                    tgt == sym
+                    and isinstance(src, sympy.Symbol)
+                    and src not in bound_vars
+                    and not symbol_is_type(
+                        src, (SymT.UNBACKED_INT, SymT.UNBACKED_FLOAT)
+                    )
+                ):
+                    code.writeline(f"{src} = {sym}")
+                    bound_vars.add(src)
+
         if isinstance(value, sympy.Expr):
             if not isinstance(value, sympy.Symbol) or value in bound_vars:
                 return
             code.writeline(f"{value} = {name}")
             bound_vars.add(value)
+            maybe_emit_replacement_aliases(value)
         elif isinstance(value, ir.TensorBox):
             for dim, size in enumerate(value.get_size()):
                 if isinstance(size, sympy.Symbol) and size not in bound_vars:
                     code.writeline(f"{size} = {sizeof(name)}[{dim}]")
                     bound_vars.add(size)
+                    maybe_emit_replacement_aliases(size)
             for dim, stride in enumerate(value.get_stride()):
                 if isinstance(stride, sympy.Symbol) and stride not in bound_vars:
                     code.writeline(f"{stride} = {strideof(name)}[{dim}]")

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -107,7 +107,6 @@ from .runtime import autotune_cache
 from .runtime.autotune_cache import AutotuneCacheBundler
 from .sizevars import SizeVarAllocator
 from .utils import (
-    convert_shape_to_inductor,
     gather_origins,
     get_cloned_parameter_buffer_name,
     get_donated_idxs,
@@ -592,7 +591,7 @@ class GraphLowering(torch.fx.Interpreter):
     def freeze_runtime_asserts(self) -> None:
         self._shape_env.freeze_runtime_asserts()
 
-    def symbolic_sizes_strides(
+    def get_placeholder_sizes_strides(
         self, ex: torch.Tensor
     ) -> tuple[Sequence[int | Expr], Sequence[int | Expr]]:
         sizes, strides, _ = self.symbolic_sizes_strides_storage_offset(ex)
@@ -607,14 +606,8 @@ class GraphLowering(torch.fx.Interpreter):
         have the same size they get assigned the same symbolic variable.
         """
         if self.reuse_shape_env:
+            size, stride = ex.size(), ex.stride()
             storage_offset = ex.storage_offset()
-            return (
-                convert_shape_to_inductor(ex.size()),
-                convert_shape_to_inductor(ex.stride()),
-                storage_offset.node.expr
-                if isinstance(storage_offset, torch.SymInt)
-                else sympy.sympify(storage_offset),
-            )
         else:
             from torch._dynamo.source import ConstantSource
 
@@ -638,8 +631,8 @@ class GraphLowering(torch.fx.Interpreter):
                 source,
             )
 
-        r_size = [i.node.expr if isinstance(i, torch.SymInt) else i for i in size]
-        r_stride = [i.node.expr if isinstance(i, torch.SymInt) else i for i in stride]
+        r_size = [sympy.sympify(i) for i in size]
+        r_stride = [sympy.sympify(i) for i in stride]
         r_storage_offset = (
             storage_offset.node.expr
             if isinstance(storage_offset, torch.SymInt)

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -2005,11 +2005,16 @@ class MetaConverter(Generic[_TensorT]):
                     s = t.storage
                     if s is None:
                         raise AssertionError("t.storage must not be None")
+                    from torch.fx.experimental.symbolic_shapes import (
+                        guard_or_false,
+                        sym_eq,
+                    )
+
                     if s.id not in self.storage_memo and (
                         r.is_nested
                         or (
-                            r.stride() == strides
-                            and r.storage_offset() == storage_offset
+                            guard_or_false(sym_eq(r.stride(), strides))
+                            and guard_or_false(r.storage_offset() == storage_offset)
                         )
                     ):
                         # You're normal and happy, install the fresh storage into the memo


### PR DESCRIPTION
Summary:

## Problem

When multiple inputs share the same dynamic batch dimension (via `dynamic_shapes`) and are sliced with the same `nonzero().shape[0]` result, AOTI compilation fails with C++ errors like `use of undeclared identifier 's77'`.

## Root Cause

During `torch.export`, ShapeEnv creates a separate backed symbol for each input's batch dimension (e.g., `s77` for `x.size()[0]`, `s97` for `a.size()[0]`). The constraint solver then discovers they're all equal (shared dim `B`) and records replacements: `s77 -> s31`, `s97 -> s31`, etc.

After constraint solving, `codegen_input_symbol_assignment` uses `i.node.expr` (which applies `shape_env.replace()`) and defines only the canonical symbol `s31`. However, `deferred_runtime_asserts` were created before constraint solving and still reference pre-replacement symbols like `s77`. When these are emitted as `AssertScalar` IR nodes, the generated C++ references undefined variables.

## Fix

Three changes:

1. `graph.py`: Rename `symbolic_sizes_strides` to `get_placeholder_sizes_strides` and use `_get_placeholder_expr(i.node)` to declare input sizes/strides with the raw pre-replacement symbol (e.g., `s77` from `._expr`) instead of the post-replacement canonical (e.g., `s31` from `.expr`). This ensures codegen defines all symbols that deferred runtime asserts reference. A backward-mode guard preserves the existing `.expr` behavior as a workaround for https://github.com/pytorch/pytorch/issues/155468.

2. `meta_utils.py`: Use `guard_or_false(sym_eq(...))` for stride/offset comparison in `from_tensor()` to avoid `GuardOnDataDependentSymNode` crash when FakeTensors have unbacked SymInts from `nonzero()`.

3. `test_aot_inductor.py`: New regression test `test_multi_input_nonzero_slice_shared_dim` covering the shared-dynamic-dim + nonzero scenario.

Test Plan:
All tests pass locally on devgpu (A100):

**GPU ABI-compatible (new regression test):**
```
buck2 run fbcode//mode/opt -c 'fbcode.nvcc_arch=a100,h100' fbcode//caffe2/test/inductor:test_aot_inductor -- -r test_multi_input_nonzero_slice_shared_dim
```
Ran 3, OK (skipped=1).

**CPU arrayref (stack_allocation + minimal_arrayref_interface):**
```
buck2 run fbcode//mode/opt fbcode//caffe2/test/inductor:aot_inductor_arrayref_cpu -- -r test_multi_input_nonzero_slice_shared_dim
```
Ran 2, OK.

**Existing unbacked symint tests (GPU+CPU):**
```
buck2 run fbcode//mode/opt -c 'fbcode.nvcc_arch=a100,h100' fbcode//caffe2/test/inductor:test_aot_inductor -- -r test_unbacked
```
Ran 30, OK (skipped=18).

**Runtime assert tests (verifies unbacked symbol assertions still fire):**
```
buck2 run fbcode//mode/opt fbcode//caffe2/test:dynamic_shapes -- -r test_post_specialize_runtime_assert1
```
Ran 2, OK.

Reviewed By: kqfu, desertfire

Differential Revision: D105336317




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo