### PR TITLE
[compile] fix addcmul_ and addcdiv_ backward

### DIFF
--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -602,6 +602,37 @@ class TestDynamoDecompositionsNumerics(TestCase):
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_addcmul__backward(self, device):
+        """Compiled addcmul_ backward matches eager backward."""
+
+        def fn(x, tensor1, tensor2, value):
+            y = x.clone()
+            y.addcmul_(tensor1, tensor2, value=value)
+            return y.sum()
+
+        def make_inputs():
+            torch.manual_seed(42)
+            x = torch.randn(4, 4, device=device, requires_grad=True)
+            tensor1 = torch.randn(4, 4, device=device, requires_grad=True)
+            tensor2 = torch.randn(4, 4, device=device, requires_grad=True)
+            return x, tensor1, tensor2
+
+        x1, t1e, t2e = make_inputs()
+        expected = fn(x1, t1e, t2e, 0.5).backward()
+        expected_grads = (x1.grad, t1e.grad, t2e.grad)
+
+        for backend in ["aot_eager", "eager", "inductor"]:
+            torch._dynamo.reset()
+            x2, t1a, t2a = make_inputs()
+            actual = torch.compile(fn, backend=backend, fullgraph=True)(
+                x2, t1a, t2a, 0.5
+            ).backward()
+            actual_grads = (x2.grad, t1a.grad, t2a.grad)
+            for exp, act in zip(expected_grads, actual_grads):
+                self.assertEqual(exp, act)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     def test_addcdiv_tensor_value_numerics(self, device):
         """Compiled addcdiv_ with tensor value matches eager."""
 
@@ -616,6 +647,37 @@ class TestDynamoDecompositionsNumerics(TestCase):
         expected = fn(x.clone(), tensor1, tensor2, value)
         actual = torch.compile(fn, fullgraph=True)(x.clone(), tensor1, tensor2, value)
         self.assertEqual(expected, actual)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_addcdiv__backward(self, device):
+        """Compiled addcdiv_ backward matches eager backward."""
+
+        def fn(x, tensor1, tensor2, value):
+            y = x.clone()
+            y.addcdiv_(tensor1, tensor2, value=value)
+            return y.sum()
+
+        def make_inputs():
+            torch.manual_seed(42)
+            x = torch.randn(4, 4, device=device, requires_grad=True)
+            tensor1 = torch.randn(4, 4, device=device, requires_grad=True)
+            tensor2 = torch.randn(4, 4, device=device, requires_grad=True) + 0.1
+            return x, tensor1, tensor2
+
+        x1, t1e, t2e = make_inputs()
+        expected = fn(x1, t1e, t2e, 0.5).backward()
+        expected_grads = (x1.grad, t1e.grad, t2e.grad)
+
+        for backend in ["aot_eager", "eager", "inductor"]:
+            torch._dynamo.reset()
+            x2, t1a, t2a = make_inputs()
+            actual = torch.compile(fn, backend=backend, fullgraph=True)(
+                x2, t1a, t2a, 0.5
+            ).backward()
+            actual_grads = (x2.grad, t1a.grad, t2a.grad)
+            for exp, act in zip(expected_grads, actual_grads):
+                self.assertEqual(exp, act)
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)

--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -605,9 +605,9 @@ class TestDynamoDecompositionsNumerics(TestCase):
     def test_addcmul__backward(self, device):
         """Compiled addcmul_ backward matches eager backward."""
 
-        def fn(x, tensor1, tensor2, value):
+        def fn(x, tensor1, tensor2):
             y = x.clone()
-            y.addcmul_(tensor1, tensor2, value=value)
+            y.addcmul_(tensor1, tensor2, value=0.5)
             return y.sum()
 
         def make_inputs():
@@ -618,14 +618,44 @@ class TestDynamoDecompositionsNumerics(TestCase):
             return x, tensor1, tensor2
 
         x1, t1e, t2e = make_inputs()
-        expected = fn(x1, t1e, t2e, 0.5).backward()
+        fn(x1, t1e, t2e).backward()
         expected_grads = (x1.grad, t1e.grad, t2e.grad)
 
         for backend in ["aot_eager", "eager", "inductor"]:
             torch._dynamo.reset()
             x2, t1a, t2a = make_inputs()
-            actual = torch.compile(fn, backend=backend, fullgraph=True)(
-                x2, t1a, t2a, 0.5
+            torch.compile(fn, backend=backend, fullgraph=True)(x2, t1a, t2a).backward()
+            actual_grads = (x2.grad, t1a.grad, t2a.grad)
+            for exp, act in zip(expected_grads, actual_grads):
+                self.assertEqual(exp, act)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_addcmul__tensor_value_backward(self, device):
+        """Compiled addcmul_ backward with tensor value matches eager backward."""
+
+        def fn(x, tensor1, tensor2, value):
+            y = x.clone()
+            y.addcmul_(tensor1, tensor2, value=value)
+            return y.sum()
+
+        def make_inputs():
+            torch.manual_seed(42)
+            x = torch.randn(4, 4, device=device, requires_grad=True)
+            tensor1 = torch.randn(4, 4, device=device, requires_grad=True)
+            tensor2 = torch.randn(4, 4, device=device, requires_grad=True)
+            value = torch.tensor(0.5, device=device)
+            return x, tensor1, tensor2, value
+
+        x1, t1e, t2e, v1 = make_inputs()
+        fn(x1, t1e, t2e, v1).backward()
+        expected_grads = (x1.grad, t1e.grad, t2e.grad)
+
+        for backend in ["aot_eager", "eager", "inductor"]:
+            torch._dynamo.reset()
+            x2, t1a, t2a, v2 = make_inputs()
+            torch.compile(fn, backend=backend, fullgraph=True)(
+                x2, t1a, t2a, v2
             ).backward()
             actual_grads = (x2.grad, t1a.grad, t2a.grad)
             for exp, act in zip(expected_grads, actual_grads):
@@ -653,9 +683,9 @@ class TestDynamoDecompositionsNumerics(TestCase):
     def test_addcdiv__backward(self, device):
         """Compiled addcdiv_ backward matches eager backward."""
 
-        def fn(x, tensor1, tensor2, value):
+        def fn(x, tensor1, tensor2):
             y = x.clone()
-            y.addcdiv_(tensor1, tensor2, value=value)
+            y.addcdiv_(tensor1, tensor2, value=0.5)
             return y.sum()
 
         def make_inputs():
@@ -666,14 +696,44 @@ class TestDynamoDecompositionsNumerics(TestCase):
             return x, tensor1, tensor2
 
         x1, t1e, t2e = make_inputs()
-        expected = fn(x1, t1e, t2e, 0.5).backward()
+        fn(x1, t1e, t2e).backward()
         expected_grads = (x1.grad, t1e.grad, t2e.grad)
 
         for backend in ["aot_eager", "eager", "inductor"]:
             torch._dynamo.reset()
             x2, t1a, t2a = make_inputs()
-            actual = torch.compile(fn, backend=backend, fullgraph=True)(
-                x2, t1a, t2a, 0.5
+            torch.compile(fn, backend=backend, fullgraph=True)(x2, t1a, t2a).backward()
+            actual_grads = (x2.grad, t1a.grad, t2a.grad)
+            for exp, act in zip(expected_grads, actual_grads):
+                self.assertEqual(exp, act)
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_addcdiv__tensor_value_backward(self, device):
+        """Compiled addcdiv_ backward with tensor value matches eager backward."""
+
+        def fn(x, tensor1, tensor2, value):
+            y = x.clone()
+            y.addcdiv_(tensor1, tensor2, value=value)
+            return y.sum()
+
+        def make_inputs():
+            torch.manual_seed(42)
+            x = torch.randn(4, 4, device=device, requires_grad=True)
+            tensor1 = torch.randn(4, 4, device=device, requires_grad=True)
+            tensor2 = torch.randn(4, 4, device=device, requires_grad=True) + 0.1
+            value = torch.tensor(0.5, device=device)
+            return x, tensor1, tensor2, value
+
+        x1, t1e, t2e, v1 = make_inputs()
+        fn(x1, t1e, t2e, v1).backward()
+        expected_grads = (x1.grad, t1e.grad, t2e.grad)
+
+        for backend in ["aot_eager", "eager", "inductor"]:
+            torch._dynamo.reset()
+            x2, t1a, t2a, v2 = make_inputs()
+            torch.compile(fn, backend=backend, fullgraph=True)(
+                x2, t1a, t2a, v2
             ).backward()
             actual_grads = (x2.grad, t1a.grad, t2a.grad)
             for exp, act in zip(expected_grads, actual_grads):

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -211,6 +211,44 @@ fma = make_prim(
     tags=(torch.Tag.pointwise,),
 )
 
+
+def _fma_setup_context(ctx, inputs, output):
+    a, b, c = inputs
+    ctx.a_shape = a.shape
+    ctx.b_is_tensor = isinstance(b, Tensor)
+    if ctx.b_is_tensor:
+        ctx.b_shape = b.shape
+        ctx.save_for_backward(a, b)
+    else:
+        ctx.b = b
+        ctx.save_for_backward(a)
+    ctx.c_shape = c.shape
+
+
+def _fma_backward(ctx, grad):
+    if ctx.b_is_tensor:
+        a, b = ctx.saved_tensors
+    else:
+        (a,) = ctx.saved_tensors
+        b = ctx.b
+
+    grad_a = (grad * b).sum_to_size(ctx.a_shape) if ctx.needs_input_grad[0] else None
+    grad_b = (
+        (grad * a).sum_to_size(ctx.b_shape)
+        if ctx.b_is_tensor and ctx.needs_input_grad[1]
+        else None
+    )
+    grad_c = grad.sum_to_size(ctx.c_shape) if ctx.needs_input_grad[2] else None
+    return grad_a, grad_b, grad_c
+
+
+torch.library.register_autograd(
+    fma,
+    _fma_backward,
+    setup_context=_fma_setup_context,
+)
+
+
 # Register DTensor sharding strategies for inductor prims ops.
 # This must happen here (not in _pointwise_ops.py) because the ops
 # don't exist until make_prim() is called above.


### PR DESCRIPTION
Fixes: #183987

addcmul_ /addcdiv_ is defined in [_dynamo/variables/tensor.py](https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/variables/tensor.py#L1712), is decomposed into `inductor_prims.fma`.  `fma`'s are built via [make_prims](https://github.com/pytorch/pytorch/blob/main/torch/_inductor/inductor_prims.py#L21), which is built using [_prims._make_prim](https://github.com/pytorch/pytorch/blob/main/torch/_prims/__init__.py#L280), which itself uses `torch.library.custom_op` internally. conventionally prims does not support backward. in order to support gradients in `addcmul_`/`addcdiv_`, i registered the backward for `fma` using `torch.library.custom_op`. This is my understanding from reading various files, please correct me if anything is inaccurate. Thanks!

Also, thanks to this incredible post on [custom ops under torch.compile](https://dev-discuss.pytorch.org/t/custom-ops-under-torch-compile-autograd-function-vs-torch-library-custom-op/3338) by Alban!

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98