### PR TITLE
[MPS] Skip strided NDArray path in _mps_linear_nograph when inputs are contiguous

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -40,8 +40,9 @@ static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const
 
       const auto mpsDataType = getMPSDataType(weight.scalar_type());
 
-      auto inputNDArray = getMPSNDArray(input, input.sizes(), input.strides());
-      auto outNDArray = getMPSNDArray(output, output.sizes(), output.strides());
+      // input/output/bias are contiguous here; skip the strided NDArray path.
+      auto inputNDArray = getMPSNDArray(input, input.sizes());
+      auto outNDArray = getMPSNDArray(output, output.sizes());
 
       auto weightBuf = getMTLBufferStorage(weight);
       auto weightDesc = [MPSNDArrayDescriptor descriptorWithDataType:mpsDataType shape:getMPSShape(weight.sizes())];
@@ -52,7 +53,7 @@ static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const
                                                     descriptor:weightDesc] autorelease];
 
       if (is_bias_defined) {
-        auto biasNDArray = getMPSNDArray(bias, bias.sizes(), bias.strides());
+        auto biasNDArray = getMPSNDArray(bias, bias.sizes());
         auto cachedKernel = LookUpOrCreateCachedKernel<MPSCachedKernel>(key, [&]() {
           return [[[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device sourceCount:3] autorelease];
         });

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1433,6 +1433,49 @@ class TestMPS(TestCaseMPS):
         result_contig = torch.nn.functional.linear(input_s, weight_contiguous_equiv)
         self.assertEqual(result_contig, result_sliced)
 
+    def test_linear_strided_contiguous_view(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/181725:
+        # (1, L, D).transpose(0, 1) is is_contiguous()==True but has non-default
+        # strides, which used to force a redundant permuteNDArray per F.linear.
+        torch.manual_seed(0)
+        device = 'mps'
+        L, D, H = 32, 512, 8
+
+        # fp16 additionally covers the needs_nd_workaround flatten path on M5+.
+        for dtype in (torch.float32, torch.float16):
+            W = torch.randn(D, D, device=device, dtype=dtype)
+            b = torch.randn(D, device=device, dtype=dtype)
+            q = torch.randn(1, L, D, device=device, dtype=dtype)
+
+            x_view = q.transpose(0, 1)
+            x_ref = torch.empty_like(x_view, memory_format=torch.contiguous_format)
+            x_ref.copy_(x_view)
+            self.assertTrue(x_view.is_contiguous())
+            self.assertNotEqual(x_view.stride(), x_ref.stride())
+            self.assertTrue(torch.equal(F.linear(x_view, W, b), F.linear(x_ref, W, b)))
+
+        # nn.MultiheadAttention at B=1 vs the issue's hand-rolled SDPA reference.
+        mha = nn.MultiheadAttention(D, H, batch_first=True, device=device).eval()
+        x = torch.randn(1, L, D, device=device)
+        m = torch.randn(1, L, D, device=device)
+        with torch.no_grad():
+            Wq, Wk, Wv = (mha.in_proj_weight[:D],
+                          mha.in_proj_weight[D:2 * D],
+                          mha.in_proj_weight[2 * D:])
+            bq, bk, bv = (mha.in_proj_bias[:D],
+                          mha.in_proj_bias[D:2 * D],
+                          mha.in_proj_bias[2 * D:])
+            Wo, bo = mha.out_proj.weight, mha.out_proj.bias
+            hd = D // H
+
+            out_mha = mha(x, m, m, need_weights=False)[0]
+            Q = F.linear(x, Wq, bq).view(1, L, H, hd).transpose(1, 2)
+            K = F.linear(m, Wk, bk).view(1, L, H, hd).transpose(1, 2)
+            V = F.linear(m, Wv, bv).view(1, L, H, hd).transpose(1, 2)
+            attn = F.scaled_dot_product_attention(Q, K, V).transpose(1, 2).contiguous().view(1, L, D)
+            out_sdpa = F.linear(attn, Wo, bo)
+        self.assertTrue(torch.equal(out_mha, out_sdpa))
+
     def test_linear_backward_channels_last_grad(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/178222
         # Linear backward crashed when grad_output had channels_last strides,


### PR DESCRIPTION
## Summary

Fixes #181725.

`_mps_linear` only takes the no-graph path when input, weight, and bias are all contiguous (`Linear.mm:117`).

But `_mps_linear_nograph` still forwards `t.strides()` to `getMPSNDArray` for all three, pushing every `F.linear` down the strided `arrayViewWithShape:strides:` + `permuteNDArray` path. That's an extra Metal kernel per call that is pure overhead, since the inputs are already contiguous.

This is the issue's ~9x MHA-vs-SDPA gap: at `B=1`, `query.transpose(1, 0)` in `MultiheadAttention.forward` stays contiguous but picks up non-default strides on the size-1 batch dim, so every projection hits the slow path.

Fix: Drop the strides args at the three call sites. `MPSNDArrayMatrixMultiplication` is otherwise unchanged.

## Results

MHA vs hand-rolled SDPA (full script below). Numbers are the MHA÷SDPA time ratio (1.0 = parity). "Before" is from the issue (M4 Pro); "after" is this branch (M5) — ratios are comparable across hardware, absolute times are not, so only ratios are shown.

| Shape (B, Lq, Lkv, D, H) | before | after |
|---|---:|---:|
| 1, 32, 256, 512, 8 | 8.6x | 1.08x |
| 1, 64, 512, 512, 8 | 11.2x | 1.10x |
| 1, 128, 1024, 512, 8 | 9.0x | 1.07x |
| 1, 64, 64, 768, 12 | 6.2x | 1.01x |
| 4, 32, 256, 512, 8 | 1.3x | 1.12x |

The gap collapses to ~1x with bit-identical output (`max|diff| = 0` everywhere). The residual few percent is `MultiheadAttention.forward` wrapper overhead, out of scope.

## Test plan

New `test_linear_strided_contiguous_view` (MPS-only): `F.linear` on a strided-but-contiguous view matches the default-stride result, and `nn.MultiheadAttention` at `B=1` matches the SDPA reference — both via `torch.equal`, over fp32 and fp16.

- [x] `python test/test_mps.py -v -k linear` — 90 passed, pre-existing skips/xfails unchanged

<details>
<summary>Bench script</summary>

```python
import time, statistics, torch
import torch.nn as nn
import torch.nn.functional as F

torch.manual_seed(0)
device = "mps"

SHAPES = [
    # (B, Lq, Lkv, D, H, label)
    (1, 32,  256,  512,  8, "small cross"),
    (1, 64,  512,  512,  8, "medium cross"),
    (1, 128, 1024, 512,  8, "large cross"),
    (1, 64,  64,   768, 12, "BERT-base self"),
    (4, 32,  256,  512,  8, "B=4 cross"),
]

def bench(fn, iters=300, warmup=30):
    with torch.no_grad():
        for _ in range(warmup): fn()
        torch.mps.synchronize()
        t0 = time.perf_counter()
        for _ in range(iters): fn()
        torch.mps.synchronize()
    return (time.perf_counter() - t0) / iters * 1e6

print(f"{'shape':<22} {'MHA (us)':>10} {'SDPA (us)':>10} {'ratio':>7} {'max|diff|':>11}")
for B, Lq, Lkv, D, H, label in SHAPES:
    hd = D // H
    mha = nn.MultiheadAttention(D, H, batch_first=True).to(device).eval()
    q   = torch.randn(B, Lq, D, device=device)
    mem = torch.randn(B, Lkv, D, device=device)
    with torch.no_grad():
        Wq, Wk, Wv = mha.in_proj_weight[:D], mha.in_proj_weight[D:2*D], mha.in_proj_weight[2*D:]
        bq, bk, bv = mha.in_proj_bias[:D],   mha.in_proj_bias[D:2*D],   mha.in_proj_bias[2*D:]
        Wo, bo = mha.out_proj.weight, mha.out_proj.bias

    def via_mha():
        return mha(q, mem, mem, need_weights=False)[0]
    def via_sdpa():
        Q = F.linear(q,   Wq, bq).view(B, Lq,  H, hd).transpose(1, 2)
        K = F.linear(mem, Wk, bk).view(B, Lkv, H, hd).transpose(1, 2)
        V = F.linear(mem, Wv, bv).view(B, Lkv, H, hd).transpose(1, 2)
        out = F.scaled_dot_product_attention(Q, K, V).transpose(1, 2).contiguous().view(B, Lq, D)
        return F.linear(out, Wo, bo)

    with torch.no_grad():
        diff = (via_mha() - via_sdpa()).abs().max().item()
    t_mha  = statistics.median([bench(via_mha)  for _ in range(3)])
    t_sdpa = statistics.median([bench(via_sdpa) for _ in range(3)])
    print(f"{label:<22} {t_mha:>10.1f} {t_sdpa:>10.1f} {t_mha/t_sdpa:>6.2f}x {diff:>11.2e}")
```

</details>

