### PR TITLE
Fix GroupNorm validation for non-positive num-groups

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9411,6 +9411,16 @@ class TestNNDeviceType(NNTestCase):
         x = torch.rand(10)[None, :, None]
         with self.assertRaises(ValueError):
             torch.nn.GroupNorm(10, 10)(x).to(device)
+    
+    def test_GroupNorm_raises_error_for_non_positive_num_groups(self,device):
+        with self.assertRaisesRegex(ValueError,
+            "num_groups \(.+\) must be a positive integer"
+        ):
+            torch.nn.GroupNorm(0,4)
+        with self.assertRaisesRegex(ValueError,
+            "num_groups \(.+\) must be a positive integer"
+        ):
+            torch.nn.GroupNorm(-1,4)
 
     def test_GroupNorm_empty(self, device):
         mod = torch.nn.GroupNorm(2, 4).to(device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9421,6 +9421,10 @@ class TestNNDeviceType(NNTestCase):
             "must be a positive integer"
         ):
             torch.nn.GroupNorm(-1, 4)
+        with self.assertRaisesRegex(ValueError,
+            "must be a positive integer"
+        ):
+            torch.nn.GroupNorm(0, 0)
 
     def test_GroupNorm_empty(self, device):
         mod = torch.nn.GroupNorm(2, 4).to(device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9412,15 +9412,15 @@ class TestNNDeviceType(NNTestCase):
         with self.assertRaises(ValueError):
             torch.nn.GroupNorm(10, 10)(x).to(device)
     
-    def test_GroupNorm_raises_error_for_non_positive_num_groups(self,device):
+    def test_GroupNorm_raises_error_for_non_positive_num_groups(self, device):
         with self.assertRaisesRegex(ValueError,
-            "num_groups \(.+\) must be a positive integer"
+            "must be a positive integer"
         ):
-            torch.nn.GroupNorm(0,4)
+            torch.nn.GroupNorm(0, 4)
         with self.assertRaisesRegex(ValueError,
-            "num_groups \(.+\) must be a positive integer"
+            "must be a positive integer"
         ):
-            torch.nn.GroupNorm(-1,4)
+            torch.nn.GroupNorm(-1, 4)
 
     def test_GroupNorm_empty(self, device):
         mod = torch.nn.GroupNorm(2, 4).to(device)

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -302,7 +302,11 @@ class GroupNorm(Module):
         bias: bool = True,
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__()
+        super().__init__()  
+        if num_groups <= 0:
+            raise ValueError(
+                f"num_groups ({num_groups}) must be a positive integer"
+            )  
         if num_channels % num_groups != 0:
             raise ValueError(
                 f"num_channels ({num_channels}) must be divisible by num_groups ({num_groups})"

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -302,11 +302,11 @@ class GroupNorm(Module):
         bias: bool = True,
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__()  
+        super().__init__()
         if num_groups <= 0:
             raise ValueError(
                 f"num_groups ({num_groups}) must be a positive integer"
-            )  
+            )
         if num_channels % num_groups != 0:
             raise ValueError(
                 f"num_channels ({num_channels}) must be divisible by num_groups ({num_groups})"


### PR DESCRIPTION
### Summary

Adds explicit value logic for `num_groups <= 0` in `torch.nn.GroupNorm` to avoid triggering a `ZeroDivisionError`.

New raise:
`ValueError: num_groups must be a positive integer`

Instead.

Also adds tests covering `num_groups=0` and negative values.

Fixes #184280