### PR TITLE
Cache invoke_subgraph functionalization schemas

### DIFF
--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -1493,6 +1493,58 @@ def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals
         self.assertEqual(out_loss, ref_loss)
         self.assertEqual(out_grad, ref_grad)
 
+    def test_invoke_subgraph_functionalize_schema_cache(self):
+        from torch._guards import InvokeSubgraphCache
+        from torch._higher_order_ops.invoke_subgraph import InvokeSubgraphHOP
+
+        orig_gen_schema = InvokeSubgraphHOP.gen_schema
+        orig_get_schema = InvokeSubgraphCache.get_functionalize_schema_entry
+        orig_add_schema = InvokeSubgraphCache.add_functionalize_schema_entry
+
+        def run(disable_cache):
+            gen_schema_calls = 0
+
+            def counted_gen_schema(self, *args, **kwargs):
+                nonlocal gen_schema_calls
+                gen_schema_calls += 1
+                return orig_gen_schema(self, *args, **kwargs)
+
+            @torch.compiler.nested_compile_region
+            def gn(x):
+                return torch.sin(x) + 1
+
+            def fn(x):
+                out = x
+                for _ in range(4):
+                    out = gn(out)
+                return out.sum()
+
+            try:
+                torch._dynamo.reset()
+                InvokeSubgraphHOP.gen_schema = counted_gen_schema
+                if disable_cache:
+                    InvokeSubgraphCache.get_functionalize_schema_entry = (
+                        lambda self, key: None
+                    )
+                    InvokeSubgraphCache.add_functionalize_schema_entry = (
+                        lambda self, key, schema: None
+                    )
+                x = torch.randn(8, requires_grad=True)
+                opt_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", UserWarning)
+                    opt_fn(x).backward()
+                return gen_schema_calls
+            finally:
+                torch._dynamo.reset()
+                InvokeSubgraphHOP.gen_schema = orig_gen_schema
+                InvokeSubgraphCache.get_functionalize_schema_entry = orig_get_schema
+                InvokeSubgraphCache.add_functionalize_schema_entry = orig_add_schema
+
+        cached_calls = run(disable_cache=False)
+        uncached_calls = run(disable_cache=True)
+        self.assertLess(cached_calls, uncached_calls)
+
     def test_refcounts(self):
         """Tests that activations can be cleared before the end of graph"""
 

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -766,6 +766,16 @@ class HopSubgraphCache:
     def get_proxy_dispatch_entry(self, identifier: str) -> Callable | None: ...
 
     @abstractmethod
+    def add_functionalize_schema_entry(
+        self, key: object, schema: torch._C.FunctionSchema
+    ) -> None: ...
+
+    @abstractmethod
+    def get_functionalize_schema_entry(
+        self, key: object
+    ) -> torch._C.FunctionSchema | None: ...
+
+    @abstractmethod
     def add_lazy_bwd_entry(
         self,
         identifier: str,
@@ -836,6 +846,7 @@ class InvokeSubgraphCache(HopSubgraphCache):
     def __init__(self) -> None:
         self.autograd_cache: dict[str, Callable] = {}
         self.proxy_dispatch_cache: dict[str, Callable] = {}
+        self.functionalize_schema_cache: dict[object, torch._C.FunctionSchema] = {}
         self.dynamo_installed_submodules: dict[CodeType, list[str]] = defaultdict(list)
         self.lazy_bwd_cache: dict[
             str, dict[tuple[object], tuple[torch.fx.GraphModule, int]]
@@ -874,6 +885,16 @@ class InvokeSubgraphCache(HopSubgraphCache):
 
     def get_proxy_dispatch_entry(self, identifier: str) -> Callable | None:
         return self.proxy_dispatch_cache.get(identifier, None)
+
+    def add_functionalize_schema_entry(
+        self, key: object, schema: torch._C.FunctionSchema
+    ) -> None:
+        self.functionalize_schema_cache[key] = schema
+
+    def get_functionalize_schema_entry(
+        self, key: object
+    ) -> torch._C.FunctionSchema | None:
+        return self.functionalize_schema_cache.get(key, None)
 
     def add_lazy_bwd_entry(
         self,

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -1027,7 +1027,29 @@ def _(ctx, subgraph, identifier, *operands):
 
     unwrapped_operands = ctx.unwrap_tensors(operands)
 
-    hop_instance = HopInstance.create(invoke_subgraph, subgraph, identifier, *operands)
+    functionalize_schema = None
+    schema_cache_key = None
+    if invoke_subgraph_cache:
+        schema_cache_key = (
+            id(subgraph),
+            identifier,
+            tuple(type(operand) for operand in operands),
+        )
+        functionalize_schema = invoke_subgraph_cache.get_functionalize_schema_entry(
+            schema_cache_key
+        )
+
+    if functionalize_schema is None:
+        hop_instance = HopInstance.create(
+            invoke_subgraph, subgraph, identifier, *operands
+        )
+        if invoke_subgraph_cache and schema_cache_key is not None:
+            invoke_subgraph_cache.add_functionalize_schema_entry(
+                schema_cache_key, hop_instance._schema
+            )
+    else:
+        hop_instance = HopInstance(invoke_subgraph, functionalize_schema)
+
     if can_auto_functionalize(hop_instance):
         # NOTE: [auto_functionalize x invoke_subgraph caching]
         # We call auto_functionalized_v2 to support input mutation of invoke_subgraph.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184646

Repeated nested_compile_region calls were rebuilding the invoke_subgraph functionalization schema during AOTAutograd metadata collection and graph capture. Keep the schema in the per-compile InvokeSubgraphCache so repeated calls can reuse the materialized schema instead of retracing the same subgraph for can_auto_functionalize. The cache stays scoped to the current tracing context, and the regression test compares schema generation with and without the cache.

Testing:
```bash
lintrunner -a
python -m py_compile torch/_guards.py torch/_higher_order_ops/invoke_subgraph.py test/dynamo/test_regional_inductor.py
python test/dynamo/test_regional_inductor.py -k RegionalInductorInvokeSubgraphTests.test_invoke_subgraph_functionalize_schema_cache
python test/dynamo/test_regional_inductor.py -k RegionalInductorTests.test_invoke_subgraph
python test/dynamo/test_regional_inductor.py -k RegionalInductorInvokeSubgraphTests.test_nested_compile_region_multi_invocation
python test/dynamo/test_aot_autograd_cache.py -k AOTAutogradCacheTests.test_invoke_subgraph
rm -rf /tmp/torchinductor_anijain agent_space/auraflow_nested_final_trace agent_space/auraflow_nested_final_tlp agent_space/auraflow_nested_final_run.log
/usr/bin/time -v env TORCH_TRACE=$PWD/agent_space/auraflow_nested_final_trace CUDA_VISIBLE_DEVICES=0 python benchmarks/diffusion/compile_benchmark.py --model auroflow --mode full > agent_space/auraflow_nested_final_run.log 2>&1
tlparse agent_space/auraflow_nested_final_trace -o agent_space/auraflow_nested_final_tlp --overwrite >> agent_space/auraflow_nested_final_run.log 2>&1
```

Authored by Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98