### PR TITLE
[Test] Add has_sufficient_memory() hook to DeviceTypeTestBase

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -455,6 +455,18 @@ class DeviceTypeTestBase(TestCase):
         return dist.get_default_backend_for_device(cls.device_type)
 
     @classmethod
+    def get_available_memory(cls) -> int:
+        """
+        Returns available memory in bytes for this device type.
+
+        Device-specific test bases may override this to support
+        memory-aware tests.
+        """
+        raise NotImplementedError(
+            f"{cls.__name__}.get_available_memory() is not implemented"
+        )
+
+    @classmethod
     def _get_test_exclusions(cls, test_class_name):
         test_exclusions = getattr(cls, "test_exclusions", None)
         if test_exclusions is not None and test_class_name in test_exclusions:
@@ -738,6 +750,12 @@ class DeviceTypeTestBase(TestCase):
 class CPUTestBase(DeviceTypeTestBase):
     device_type = "cpu"
 
+    @classmethod
+    def get_available_memory(cls) -> int:
+        if not HAS_PSUTIL:
+            raise unittest.SkipTest("Need psutil to query available system memory")
+        return psutil.virtual_memory().available
+
     # No critical error should stop CPU test suite
     def _should_stop_test_suite(self):
         return False
@@ -772,6 +790,14 @@ class CUDATestBase(DeviceTypeTestBase):
             if idx != primary_device_idx
         ]
         return [prim_device] + non_primary_devices
+
+    @classmethod
+    def get_available_memory(cls) -> int:
+        device = torch.device(cls.device_type, 0)
+        return int(
+            torch.cuda.memory.mem_get_info(device)[0]
+            * torch.cuda.memory.get_per_process_memory_fraction(device)
+        )
 
     @classmethod
     def setUpClass(cls):
@@ -825,6 +851,12 @@ class MPSTestBase(DeviceTypeTestBase):
         return [prim_device]
 
     @classmethod
+    def get_available_memory(cls) -> int:
+        if not HAS_PSUTIL:
+            raise unittest.SkipTest("Need psutil to query available system memory")
+        return psutil.virtual_memory().available
+
+    @classmethod
     def setUpClass(cls):
         cls.primary_device = "mps:0"
 
@@ -854,6 +886,11 @@ class XPUTestBase(DeviceTypeTestBase):
             if idx != primary_device_idx
         ]
         return [prim_device] + non_primary_devices
+
+    @classmethod
+    def get_available_memory(cls) -> int:
+        device = torch.device(cls.device_type, 0)
+        return torch.xpu.memory.mem_get_info(device)[0]
 
     @classmethod
     def setUpClass(cls):
@@ -1597,7 +1634,34 @@ class skipPRIVATEUSE1If(skipIf):
         super().__init__(dep, reason, device_type=device_type)
 
 
-def _has_sufficient_memory(device, size):
+def _has_sufficient_memory(device, size, self=None):
+    # Some callers use _has_sufficient_memory() directly, while others go
+    # through largeTensorTest. Not all tests run as device-specific test
+    # classes, so some test instances may not expose get_available_memory().
+    # Prefer the device-type hook when available; once all relevant tests use
+    # device-specific test classes, the legacy device-specific logic below can
+    # be removed.
+    get_available_memory = getattr(self, "get_available_memory", None)
+    if callable(get_available_memory):
+        try:
+            required_size = size
+            if torch.device(self.device_type).type in ["cpu", "mps"]:
+                # The sanitizers have significant memory overheads
+                if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
+                    required_size *= 10
+
+                # don't try using all RAM on s390x, leave some for service processes
+                if IS_S390X:
+                    required_size *= 2
+
+            available = get_available_memory()
+            if available < required_size:
+                gc.collect()
+                available = get_available_memory()
+            return available >= required_size
+        except NotImplementedError:
+            pass
+
     device_ = torch.device(device)
     device_type = device_.type
     if device_type in ["cuda", "xpu", "mtia"]:
@@ -1701,7 +1765,7 @@ def largeTensorTest(size, device=None, inductor=TEST_WITH_TORCHINDUCTOR):
             # an additional array of the same size as the input.
             if inductor and torch._inductor.config.cpp_wrapper and _device != "cpu":
                 size_bytes *= 2
-            if not _has_sufficient_memory(_device, size_bytes):
+            if not _has_sufficient_memory(_device, size_bytes, self=self):
                 raise unittest.SkipTest(f"Insufficient {_device} memory")
 
             return fn(self, *args, **kwargs)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -806,12 +806,17 @@ class CUDATestBase(DeviceTypeTestBase):
     @classmethod
     def has_sufficient_memory(cls, size: int) -> bool:
         device = torch.cuda.current_device()
-        gc.collect()
-        torch.cuda.empty_cache()
         available = int(
             torch.cuda.memory.mem_get_info(device)[0]
             * torch.cuda.memory.get_per_process_memory_fraction(device)
         )
+        if available < size:
+            gc.collect()
+            torch.cuda.empty_cache()
+            available = int(
+                torch.cuda.memory.mem_get_info(device)[0]
+                * torch.cuda.memory.get_per_process_memory_fraction(device)
+            )
         return available >= size
 
     @classmethod
@@ -912,9 +917,11 @@ class XPUTestBase(DeviceTypeTestBase):
     @classmethod
     def has_sufficient_memory(cls, size: int) -> bool:
         device = torch.xpu.current_device()
-        gc.collect()
-        torch.xpu.empty_cache()
         available = torch.xpu.memory.mem_get_info(device)[0]
+        if available < size:
+            gc.collect()
+            torch.xpu.empty_cache()
+            available = torch.xpu.memory.mem_get_info(device)[0]
         return available >= size
 
     @classmethod

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -455,15 +455,15 @@ class DeviceTypeTestBase(TestCase):
         return dist.get_default_backend_for_device(cls.device_type)
 
     @classmethod
-    def get_available_memory(cls) -> int:
+    def has_sufficient_memory(cls, size: int) -> bool:
         """
-        Returns available memory in bytes for this device type.
+        Returns True if there is sufficient memory available for the given size.
 
         Device-specific test bases may override this to support
         memory-aware tests.
         """
         raise NotImplementedError(
-            f"{cls.__name__}.get_available_memory() is not implemented"
+            f"{cls.__name__}.has_sufficient_memory() is not implemented"
         )
 
     @classmethod
@@ -751,10 +751,22 @@ class CPUTestBase(DeviceTypeTestBase):
     device_type = "cpu"
 
     @classmethod
-    def get_available_memory(cls) -> int:
+    def has_sufficient_memory(cls, size: int) -> bool:
         if not HAS_PSUTIL:
             raise unittest.SkipTest("Need psutil to query available system memory")
-        return psutil.virtual_memory().available
+
+        # The sanitizers have significant memory overheads
+        if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
+            size *= 10
+
+        # don't try using all RAM on s390x, leave some for service processes
+        if IS_S390X:
+            size *= 2
+
+        available = psutil.virtual_memory().available
+        if available < size:
+            gc.collect()
+        return psutil.virtual_memory().available >= size
 
     # No critical error should stop CPU test suite
     def _should_stop_test_suite(self):
@@ -792,12 +804,15 @@ class CUDATestBase(DeviceTypeTestBase):
         return [prim_device] + non_primary_devices
 
     @classmethod
-    def get_available_memory(cls) -> int:
+    def has_sufficient_memory(cls, size: int) -> bool:
         device = torch.cuda.current_device()
-        return int(
+        gc.collect()
+        torch.cuda.empty_cache()
+        available = int(
             torch.cuda.memory.mem_get_info(device)[0]
             * torch.cuda.memory.get_per_process_memory_fraction(device)
         )
+        return available >= size
 
     @classmethod
     def setUpClass(cls):
@@ -851,10 +866,17 @@ class MPSTestBase(DeviceTypeTestBase):
         return [prim_device]
 
     @classmethod
-    def get_available_memory(cls) -> int:
+    def has_sufficient_memory(cls, size: int) -> bool:
         if not HAS_PSUTIL:
             raise unittest.SkipTest("Need psutil to query available system memory")
-        return psutil.virtual_memory().available
+        if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
+            size *= 10
+        if IS_S390X:
+            size *= 2
+        available = psutil.virtual_memory().available
+        if available < size:
+            gc.collect()
+        return psutil.virtual_memory().available >= size
 
     @classmethod
     def setUpClass(cls):
@@ -888,9 +910,12 @@ class XPUTestBase(DeviceTypeTestBase):
         return [prim_device] + non_primary_devices
 
     @classmethod
-    def get_available_memory(cls) -> int:
+    def has_sufficient_memory(cls, size: int) -> bool:
         device = torch.xpu.current_device()
-        return torch.xpu.memory.mem_get_info(device)[0]
+        gc.collect()
+        torch.xpu.empty_cache()
+        available = torch.xpu.memory.mem_get_info(device)[0]
+        return available >= size
 
     @classmethod
     def setUpClass(cls):
@@ -1634,46 +1659,7 @@ class skipPRIVATEUSE1If(skipIf):
         super().__init__(dep, reason, device_type=device_type)
 
 
-def _has_sufficient_memory(device, size, test_instance=None):
-    # Some callers use _has_sufficient_memory() directly, while others go
-    # through largeTensorTest. Not all tests run as device-specific test
-    # classes, so some test instances may not expose get_available_memory().
-    # Prefer the device-type hook when available; once all relevant tests use
-    # device-specific test classes, the legacy device-specific logic below can
-    # be removed.
-    device_ = torch.device(device)
-    device_type = device_.type
-
-    instance_device_type = (
-        torch.device(test_instance.device_type).type
-        if test_instance is not None and hasattr(test_instance, "device_type")
-        else None
-    )
-
-    get_available_memory = getattr(test_instance, "get_available_memory", None)
-    if callable(get_available_memory) and instance_device_type == device_type:
-        try:
-            required_size = size
-            if device_type in ["cpu", "mps"]:
-                # The sanitizers have significant memory overheads
-                if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
-                    required_size *= 10
-
-                # don't try using all RAM on s390x, leave some for service processes
-                if IS_S390X:
-                    required_size *= 2
-
-            available = get_available_memory()
-            if available < required_size:
-                gc.collect()
-                acc = torch.accelerator.current_accelerator()
-                if acc is not None and acc.type == device_type:
-                    torch.accelerator.empty_cache()
-                available = get_available_memory()
-            return available >= required_size
-        except NotImplementedError:
-            pass
-
+def _has_sufficient_memory(device, size):
     device_ = torch.device(device)
     device_type = device_.type
     if device_type in ["cuda", "xpu", "mtia"]:
@@ -1777,7 +1763,12 @@ def largeTensorTest(size, device=None, inductor=TEST_WITH_TORCHINDUCTOR):
             # an additional array of the same size as the input.
             if inductor and torch._inductor.config.cpp_wrapper and _device != "cpu":
                 size_bytes *= 2
-            if not _has_sufficient_memory(_device, size_bytes, test_instance=self):
+            # Prefer DeviceTypeTestBase.has_sufficient_memory hook when available.
+            has_sufficient_memory = getattr(self, "has_sufficient_memory", None)
+            if callable(has_sufficient_memory):
+                if not has_sufficient_memory(size_bytes):
+                    raise unittest.SkipTest(f"Insufficient {_device} memory")
+            elif not _has_sufficient_memory(_device, size_bytes):
                 raise unittest.SkipTest(f"Insufficient {_device} memory")
 
             return fn(self, *args, **kwargs)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -882,6 +882,9 @@ class MPSTestBase(DeviceTypeTestBase):
         available = psutil.virtual_memory().available
         if available < size:
             gc.collect()
+            # Sync and cleanup MPS memory before checking available memory
+            torch.mps.synchronize()
+            torch.mps.empty_cache()
         return psutil.virtual_memory().available >= size
 
     @classmethod

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -793,7 +793,7 @@ class CUDATestBase(DeviceTypeTestBase):
 
     @classmethod
     def get_available_memory(cls) -> int:
-        device = torch.device(cls.device_type, 0)
+        device = torch.cuda.current_device()
         return int(
             torch.cuda.memory.mem_get_info(device)[0]
             * torch.cuda.memory.get_per_process_memory_fraction(device)
@@ -889,7 +889,7 @@ class XPUTestBase(DeviceTypeTestBase):
 
     @classmethod
     def get_available_memory(cls) -> int:
-        device = torch.device(cls.device_type, 0)
+        device = torch.xpu.current_device()
         return torch.xpu.memory.mem_get_info(device)[0]
 
     @classmethod
@@ -1634,7 +1634,7 @@ class skipPRIVATEUSE1If(skipIf):
         super().__init__(dep, reason, device_type=device_type)
 
 
-def _has_sufficient_memory(device, size, self=None):
+def _has_sufficient_memory(device, size, test_instance=None):
     # Some callers use _has_sufficient_memory() directly, while others go
     # through largeTensorTest. Not all tests run as device-specific test
     # classes, so some test instances may not expose get_available_memory().
@@ -1644,14 +1644,14 @@ def _has_sufficient_memory(device, size, self=None):
     device_ = torch.device(device)
     device_type = device_.type
 
-    self_device_type = (
-        torch.device(self.device_type).type
-        if self is not None and hasattr(self, "device_type")
+    instance_device_type = (
+        torch.device(test_instance.device_type).type
+        if test_instance is not None and hasattr(test_instance, "device_type")
         else None
     )
 
-    get_available_memory = getattr(self, "get_available_memory", None)
-    if callable(get_available_memory) and self_device_type == device_type:
+    get_available_memory = getattr(test_instance, "get_available_memory", None)
+    if callable(get_available_memory) and instance_device_type == device_type:
         try:
             required_size = size
             if device_type in ["cpu", "mps"]:

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1771,12 +1771,20 @@ def largeTensorTest(size, device=None, inductor=TEST_WITH_TORCHINDUCTOR):
             # an additional array of the same size as the input.
             if inductor and torch._inductor.config.cpp_wrapper and _device != "cpu":
                 size_bytes *= 2
-            # Prefer DeviceTypeTestBase.has_sufficient_memory hook when available.
-            has_sufficient_memory = getattr(self, "has_sufficient_memory", None)
-            if callable(has_sufficient_memory):
-                if not has_sufficient_memory(size_bytes):
-                    raise unittest.SkipTest(f"Insufficient {_device} memory")
-            elif not _has_sufficient_memory(_device, size_bytes):
+            # When device is explicitly given for a *different* device type
+            # (e.g. device="cpu" on a CUDA test class), skip the class hook
+            # and use the generic helper directly.
+            if device is not None and device != getattr(self, "device_type", None):
+                ok = _has_sufficient_memory(_device, size_bytes)
+            else:
+                # Try the class hook first (e.g. CUDATestBase.has_sufficient_memory),
+                # falling back to the generic _has_sufficient_memory helper.
+                check_fn = getattr(self, "has_sufficient_memory", None)
+                if callable(check_fn):
+                    ok = check_fn(size_bytes)
+                else:
+                    ok = _has_sufficient_memory(_device, size_bytes)
+            if not ok:
                 raise unittest.SkipTest(f"Insufficient {_device} memory")
 
             return fn(self, *args, **kwargs)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1777,7 +1777,7 @@ def largeTensorTest(size, device=None, inductor=TEST_WITH_TORCHINDUCTOR):
             # an additional array of the same size as the input.
             if inductor and torch._inductor.config.cpp_wrapper and _device != "cpu":
                 size_bytes *= 2
-            if not _has_sufficient_memory(_device, size_bytes, self=self):
+            if not _has_sufficient_memory(_device, size_bytes, test_instance=self):
                 raise unittest.SkipTest(f"Insufficient {_device} memory")
 
             return fn(self, *args, **kwargs)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1641,11 +1641,20 @@ def _has_sufficient_memory(device, size, self=None):
     # Prefer the device-type hook when available; once all relevant tests use
     # device-specific test classes, the legacy device-specific logic below can
     # be removed.
+    device_ = torch.device(device)
+    device_type = device_.type
+
+    self_device_type = (
+        torch.device(self.device_type).type
+        if self is not None and hasattr(self, "device_type")
+        else None
+    )
+
     get_available_memory = getattr(self, "get_available_memory", None)
-    if callable(get_available_memory):
+    if callable(get_available_memory) and self_device_type == device_type:
         try:
             required_size = size
-            if torch.device(self.device_type).type in ["cpu", "mps"]:
+            if device_type in ["cpu", "mps"]:
                 # The sanitizers have significant memory overheads
                 if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
                     required_size *= 10
@@ -1657,6 +1666,9 @@ def _has_sufficient_memory(device, size, self=None):
             available = get_available_memory()
             if available < required_size:
                 gc.collect()
+                acc = torch.accelerator.current_accelerator()
+                if acc is not None and acc.type == device_type:
+                    torch.accelerator.empty_cache()
                 available = get_available_memory()
             return available >= required_size
         except NotImplementedError:

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -460,10 +460,10 @@ class DeviceTypeTestBase(TestCase):
         Returns True if there is sufficient memory available for the given size.
 
         Device-specific test bases should override this to support
-        memory-aware tests. The default implementation skips the test
+        memory-aware tests. The default implementation raises an error
         for device types that do not implement this hook.
         """
-        raise unittest.SkipTest(
+        raise NotImplementedError(
             f"{cls.__name__}.has_sufficient_memory() is not implemented"
         )
 
@@ -754,7 +754,7 @@ class CPUTestBase(DeviceTypeTestBase):
     @classmethod
     def has_sufficient_memory(cls, size: int) -> bool:
         if not HAS_PSUTIL:
-            raise unittest.SkipTest("Need psutil to query available system memory")
+            raise RuntimeError("Need psutil to query available system memory")
 
         # The sanitizers have significant memory overheads
         if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
@@ -874,7 +874,7 @@ class MPSTestBase(DeviceTypeTestBase):
     @classmethod
     def has_sufficient_memory(cls, size: int) -> bool:
         if not HAS_PSUTIL:
-            raise unittest.SkipTest("Need psutil to query available system memory")
+            raise RuntimeError("Need psutil to query available system memory")
         if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
             size *= 10
         if IS_S390X:

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -459,10 +459,11 @@ class DeviceTypeTestBase(TestCase):
         """
         Returns True if there is sufficient memory available for the given size.
 
-        Device-specific test bases may override this to support
-        memory-aware tests.
+        Device-specific test bases should override this to support
+        memory-aware tests. The default implementation skips the test
+        for device types that do not implement this hook.
         """
-        raise NotImplementedError(
+        raise unittest.SkipTest(
             f"{cls.__name__}.has_sufficient_memory() is not implemented"
         )
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -458,10 +458,11 @@ class DeviceTypeTestBase(TestCase):
         """
         Returns True if there is sufficient memory available for the given size.
 
-        Device-specific test bases may override this to support
-        memory-aware tests.
+        Device-specific test bases should override this to support
+        memory-aware tests. The default implementation skips the test
+        for device types that do not implement this hook.
         """
-        raise NotImplementedError(
+        raise unittest.SkipTest(
             f"{cls.__name__}.has_sufficient_memory() is not implemented"
         )
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1765,7 +1765,7 @@ def largeTensorTest(size, device=None, inductor=TEST_WITH_TORCHINDUCTOR):
             # an additional array of the same size as the input.
             if inductor and torch._inductor.config.cpp_wrapper and _device != "cpu":
                 size_bytes *= 2
-            if not _has_sufficient_memory(_device, size_bytes, self=self):
+            if not _has_sufficient_memory(_device, size_bytes, test_instance=self):
                 raise unittest.SkipTest(f"Insufficient {_device} memory")
 
             return fn(self, *args, **kwargs)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -454,6 +454,18 @@ class DeviceTypeTestBase(TestCase):
         return dist.get_default_backend_for_device(cls.device_type)
 
     @classmethod
+    def get_available_memory(cls) -> int:
+        """
+        Returns available memory in bytes for this device type.
+
+        Device-specific test bases may override this to support
+        memory-aware tests.
+        """
+        raise NotImplementedError(
+            f"{cls.__name__}.get_available_memory() is not implemented"
+        )
+
+    @classmethod
     def _get_test_exclusions(cls, test_class_name):
         test_exclusions = getattr(cls, "test_exclusions", None)
         if test_exclusions is not None and test_class_name in test_exclusions:
@@ -736,6 +748,12 @@ class DeviceTypeTestBase(TestCase):
 class CPUTestBase(DeviceTypeTestBase):
     device_type = "cpu"
 
+    @classmethod
+    def get_available_memory(cls) -> int:
+        if not HAS_PSUTIL:
+            raise unittest.SkipTest("Need psutil to query available system memory")
+        return psutil.virtual_memory().available
+
     # No critical error should stop CPU test suite
     def _should_stop_test_suite(self):
         return False
@@ -770,6 +788,14 @@ class CUDATestBase(DeviceTypeTestBase):
             if idx != primary_device_idx
         ]
         return [prim_device] + non_primary_devices
+
+    @classmethod
+    def get_available_memory(cls) -> int:
+        device = torch.device(cls.device_type, 0)
+        return int(
+            torch.cuda.memory.mem_get_info(device)[0]
+            * torch.cuda.memory.get_per_process_memory_fraction(device)
+        )
 
     @classmethod
     def setUpClass(cls):
@@ -823,6 +849,12 @@ class MPSTestBase(DeviceTypeTestBase):
         return [prim_device]
 
     @classmethod
+    def get_available_memory(cls) -> int:
+        if not HAS_PSUTIL:
+            raise unittest.SkipTest("Need psutil to query available system memory")
+        return psutil.virtual_memory().available
+
+    @classmethod
     def setUpClass(cls):
         cls.primary_device = "mps:0"
 
@@ -852,6 +884,11 @@ class XPUTestBase(DeviceTypeTestBase):
             if idx != primary_device_idx
         ]
         return [prim_device] + non_primary_devices
+
+    @classmethod
+    def get_available_memory(cls) -> int:
+        device = torch.device(cls.device_type, 0)
+        return torch.xpu.memory.mem_get_info(device)[0]
 
     @classmethod
     def setUpClass(cls):
@@ -1595,7 +1632,34 @@ class skipPRIVATEUSE1If(skipIf):
         super().__init__(dep, reason, device_type=device_type)
 
 
-def _has_sufficient_memory(device, size):
+def _has_sufficient_memory(device, size, self=None):
+    # Some callers use _has_sufficient_memory() directly, while others go
+    # through largeTensorTest. Not all tests run as device-specific test
+    # classes, so some test instances may not expose get_available_memory().
+    # Prefer the device-type hook when available; once all relevant tests use
+    # device-specific test classes, the legacy device-specific logic below can
+    # be removed.
+    get_available_memory = getattr(self, "get_available_memory", None)
+    if callable(get_available_memory):
+        try:
+            required_size = size
+            if torch.device(self.device_type).type in ["cpu", "mps"]:
+                # The sanitizers have significant memory overheads
+                if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
+                    required_size *= 10
+
+                # don't try using all RAM on s390x, leave some for service processes
+                if IS_S390X:
+                    required_size *= 2
+
+            available = get_available_memory()
+            if available < required_size:
+                gc.collect()
+                available = get_available_memory()
+            return available >= required_size
+        except NotImplementedError:
+            pass
+
     device_ = torch.device(device)
     device_type = device_.type
     if device_type in ["cuda", "xpu", "mtia"]:
@@ -1689,7 +1753,7 @@ def largeTensorTest(size, device=None, inductor=TEST_WITH_TORCHINDUCTOR):
             # an additional array of the same size as the input.
             if inductor and torch._inductor.config.cpp_wrapper and _device != "cpu":
                 size_bytes *= 2
-            if not _has_sufficient_memory(_device, size_bytes):
+            if not _has_sufficient_memory(_device, size_bytes, self=self):
                 raise unittest.SkipTest(f"Insufficient {_device} memory")
 
             return fn(self, *args, **kwargs)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -791,7 +791,7 @@ class CUDATestBase(DeviceTypeTestBase):
 
     @classmethod
     def get_available_memory(cls) -> int:
-        device = torch.device(cls.device_type, 0)
+        device = torch.cuda.current_device()
         return int(
             torch.cuda.memory.mem_get_info(device)[0]
             * torch.cuda.memory.get_per_process_memory_fraction(device)
@@ -887,7 +887,7 @@ class XPUTestBase(DeviceTypeTestBase):
 
     @classmethod
     def get_available_memory(cls) -> int:
-        device = torch.device(cls.device_type, 0)
+        device = torch.xpu.current_device()
         return torch.xpu.memory.mem_get_info(device)[0]
 
     @classmethod
@@ -1632,7 +1632,7 @@ class skipPRIVATEUSE1If(skipIf):
         super().__init__(dep, reason, device_type=device_type)
 
 
-def _has_sufficient_memory(device, size, self=None):
+def _has_sufficient_memory(device, size, test_instance=None):
     # Some callers use _has_sufficient_memory() directly, while others go
     # through largeTensorTest. Not all tests run as device-specific test
     # classes, so some test instances may not expose get_available_memory().
@@ -1642,14 +1642,14 @@ def _has_sufficient_memory(device, size, self=None):
     device_ = torch.device(device)
     device_type = device_.type
 
-    self_device_type = (
-        torch.device(self.device_type).type
-        if self is not None and hasattr(self, "device_type")
+    instance_device_type = (
+        torch.device(test_instance.device_type).type
+        if test_instance is not None and hasattr(test_instance, "device_type")
         else None
     )
 
-    get_available_memory = getattr(self, "get_available_memory", None)
-    if callable(get_available_memory) and self_device_type == device_type:
+    get_available_memory = getattr(test_instance, "get_available_memory", None)
+    if callable(get_available_memory) and instance_device_type == device_type:
         try:
             required_size = size
             if device_type in ["cpu", "mps"]:

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -459,10 +459,10 @@ class DeviceTypeTestBase(TestCase):
         Returns True if there is sufficient memory available for the given size.
 
         Device-specific test bases should override this to support
-        memory-aware tests. The default implementation skips the test
+        memory-aware tests. The default implementation raises an error
         for device types that do not implement this hook.
         """
-        raise unittest.SkipTest(
+        raise NotImplementedError(
             f"{cls.__name__}.has_sufficient_memory() is not implemented"
         )
 
@@ -752,7 +752,7 @@ class CPUTestBase(DeviceTypeTestBase):
     @classmethod
     def has_sufficient_memory(cls, size: int) -> bool:
         if not HAS_PSUTIL:
-            raise unittest.SkipTest("Need psutil to query available system memory")
+            raise RuntimeError("Need psutil to query available system memory")
 
         # The sanitizers have significant memory overheads
         if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
@@ -872,7 +872,7 @@ class MPSTestBase(DeviceTypeTestBase):
     @classmethod
     def has_sufficient_memory(cls, size: int) -> bool:
         if not HAS_PSUTIL:
-            raise unittest.SkipTest("Need psutil to query available system memory")
+            raise RuntimeError("Need psutil to query available system memory")
         if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
             size *= 10
         if IS_S390X:

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -804,12 +804,17 @@ class CUDATestBase(DeviceTypeTestBase):
     @classmethod
     def has_sufficient_memory(cls, size: int) -> bool:
         device = torch.cuda.current_device()
-        gc.collect()
-        torch.cuda.empty_cache()
         available = int(
             torch.cuda.memory.mem_get_info(device)[0]
             * torch.cuda.memory.get_per_process_memory_fraction(device)
         )
+        if available < size:
+            gc.collect()
+            torch.cuda.empty_cache()
+            available = int(
+                torch.cuda.memory.mem_get_info(device)[0]
+                * torch.cuda.memory.get_per_process_memory_fraction(device)
+            )
         return available >= size
 
     @classmethod
@@ -910,9 +915,11 @@ class XPUTestBase(DeviceTypeTestBase):
     @classmethod
     def has_sufficient_memory(cls, size: int) -> bool:
         device = torch.xpu.current_device()
-        gc.collect()
-        torch.xpu.empty_cache()
         available = torch.xpu.memory.mem_get_info(device)[0]
+        if available < size:
+            gc.collect()
+            torch.xpu.empty_cache()
+            available = torch.xpu.memory.mem_get_info(device)[0]
         return available >= size
 
     @classmethod

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1759,12 +1759,20 @@ def largeTensorTest(size, device=None, inductor=TEST_WITH_TORCHINDUCTOR):
             # an additional array of the same size as the input.
             if inductor and torch._inductor.config.cpp_wrapper and _device != "cpu":
                 size_bytes *= 2
-            # Prefer DeviceTypeTestBase.has_sufficient_memory hook when available.
-            has_sufficient_memory = getattr(self, "has_sufficient_memory", None)
-            if callable(has_sufficient_memory):
-                if not has_sufficient_memory(size_bytes):
-                    raise unittest.SkipTest(f"Insufficient {_device} memory")
-            elif not _has_sufficient_memory(_device, size_bytes):
+            # When device is explicitly given for a *different* device type
+            # (e.g. device="cpu" on a CUDA test class), skip the class hook
+            # and use the generic helper directly.
+            if device is not None and device != getattr(self, "device_type", None):
+                ok = _has_sufficient_memory(_device, size_bytes)
+            else:
+                # Try the class hook first (e.g. CUDATestBase.has_sufficient_memory),
+                # falling back to the generic _has_sufficient_memory helper.
+                check_fn = getattr(self, "has_sufficient_memory", None)
+                if callable(check_fn):
+                    ok = check_fn(size_bytes)
+                else:
+                    ok = _has_sufficient_memory(_device, size_bytes)
+            if not ok:
                 raise unittest.SkipTest(f"Insufficient {_device} memory")
 
             return fn(self, *args, **kwargs)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -454,15 +454,15 @@ class DeviceTypeTestBase(TestCase):
         return dist.get_default_backend_for_device(cls.device_type)
 
     @classmethod
-    def get_available_memory(cls) -> int:
+    def has_sufficient_memory(cls, size: int) -> bool:
         """
-        Returns available memory in bytes for this device type.
+        Returns True if there is sufficient memory available for the given size.
 
         Device-specific test bases may override this to support
         memory-aware tests.
         """
         raise NotImplementedError(
-            f"{cls.__name__}.get_available_memory() is not implemented"
+            f"{cls.__name__}.has_sufficient_memory() is not implemented"
         )
 
     @classmethod
@@ -749,10 +749,22 @@ class CPUTestBase(DeviceTypeTestBase):
     device_type = "cpu"
 
     @classmethod
-    def get_available_memory(cls) -> int:
+    def has_sufficient_memory(cls, size: int) -> bool:
         if not HAS_PSUTIL:
             raise unittest.SkipTest("Need psutil to query available system memory")
-        return psutil.virtual_memory().available
+
+        # The sanitizers have significant memory overheads
+        if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
+            size *= 10
+
+        # don't try using all RAM on s390x, leave some for service processes
+        if IS_S390X:
+            size *= 2
+
+        available = psutil.virtual_memory().available
+        if available < size:
+            gc.collect()
+        return psutil.virtual_memory().available >= size
 
     # No critical error should stop CPU test suite
     def _should_stop_test_suite(self):
@@ -790,12 +802,15 @@ class CUDATestBase(DeviceTypeTestBase):
         return [prim_device] + non_primary_devices
 
     @classmethod
-    def get_available_memory(cls) -> int:
+    def has_sufficient_memory(cls, size: int) -> bool:
         device = torch.cuda.current_device()
-        return int(
+        gc.collect()
+        torch.cuda.empty_cache()
+        available = int(
             torch.cuda.memory.mem_get_info(device)[0]
             * torch.cuda.memory.get_per_process_memory_fraction(device)
         )
+        return available >= size
 
     @classmethod
     def setUpClass(cls):
@@ -849,10 +864,17 @@ class MPSTestBase(DeviceTypeTestBase):
         return [prim_device]
 
     @classmethod
-    def get_available_memory(cls) -> int:
+    def has_sufficient_memory(cls, size: int) -> bool:
         if not HAS_PSUTIL:
             raise unittest.SkipTest("Need psutil to query available system memory")
-        return psutil.virtual_memory().available
+        if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
+            size *= 10
+        if IS_S390X:
+            size *= 2
+        available = psutil.virtual_memory().available
+        if available < size:
+            gc.collect()
+        return psutil.virtual_memory().available >= size
 
     @classmethod
     def setUpClass(cls):
@@ -886,9 +908,12 @@ class XPUTestBase(DeviceTypeTestBase):
         return [prim_device] + non_primary_devices
 
     @classmethod
-    def get_available_memory(cls) -> int:
+    def has_sufficient_memory(cls, size: int) -> bool:
         device = torch.xpu.current_device()
-        return torch.xpu.memory.mem_get_info(device)[0]
+        gc.collect()
+        torch.xpu.empty_cache()
+        available = torch.xpu.memory.mem_get_info(device)[0]
+        return available >= size
 
     @classmethod
     def setUpClass(cls):
@@ -1632,46 +1657,7 @@ class skipPRIVATEUSE1If(skipIf):
         super().__init__(dep, reason, device_type=device_type)
 
 
-def _has_sufficient_memory(device, size, test_instance=None):
-    # Some callers use _has_sufficient_memory() directly, while others go
-    # through largeTensorTest. Not all tests run as device-specific test
-    # classes, so some test instances may not expose get_available_memory().
-    # Prefer the device-type hook when available; once all relevant tests use
-    # device-specific test classes, the legacy device-specific logic below can
-    # be removed.
-    device_ = torch.device(device)
-    device_type = device_.type
-
-    instance_device_type = (
-        torch.device(test_instance.device_type).type
-        if test_instance is not None and hasattr(test_instance, "device_type")
-        else None
-    )
-
-    get_available_memory = getattr(test_instance, "get_available_memory", None)
-    if callable(get_available_memory) and instance_device_type == device_type:
-        try:
-            required_size = size
-            if device_type in ["cpu", "mps"]:
-                # The sanitizers have significant memory overheads
-                if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
-                    required_size *= 10
-
-                # don't try using all RAM on s390x, leave some for service processes
-                if IS_S390X:
-                    required_size *= 2
-
-            available = get_available_memory()
-            if available < required_size:
-                gc.collect()
-                acc = torch.accelerator.current_accelerator()
-                if acc is not None and acc.type == device_type:
-                    torch.accelerator.empty_cache()
-                available = get_available_memory()
-            return available >= required_size
-        except NotImplementedError:
-            pass
-
+def _has_sufficient_memory(device, size):
     device_ = torch.device(device)
     device_type = device_.type
     if device_type in ["cuda", "xpu", "mtia"]:
@@ -1765,7 +1751,12 @@ def largeTensorTest(size, device=None, inductor=TEST_WITH_TORCHINDUCTOR):
             # an additional array of the same size as the input.
             if inductor and torch._inductor.config.cpp_wrapper and _device != "cpu":
                 size_bytes *= 2
-            if not _has_sufficient_memory(_device, size_bytes, test_instance=self):
+            # Prefer DeviceTypeTestBase.has_sufficient_memory hook when available.
+            has_sufficient_memory = getattr(self, "has_sufficient_memory", None)
+            if callable(has_sufficient_memory):
+                if not has_sufficient_memory(size_bytes):
+                    raise unittest.SkipTest(f"Insufficient {_device} memory")
+            elif not _has_sufficient_memory(_device, size_bytes):
                 raise unittest.SkipTest(f"Insufficient {_device} memory")
 
             return fn(self, *args, **kwargs)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1639,11 +1639,20 @@ def _has_sufficient_memory(device, size, self=None):
     # Prefer the device-type hook when available; once all relevant tests use
     # device-specific test classes, the legacy device-specific logic below can
     # be removed.
+    device_ = torch.device(device)
+    device_type = device_.type
+
+    self_device_type = (
+        torch.device(self.device_type).type
+        if self is not None and hasattr(self, "device_type")
+        else None
+    )
+
     get_available_memory = getattr(self, "get_available_memory", None)
-    if callable(get_available_memory):
+    if callable(get_available_memory) and self_device_type == device_type:
         try:
             required_size = size
-            if torch.device(self.device_type).type in ["cpu", "mps"]:
+            if device_type in ["cpu", "mps"]:
                 # The sanitizers have significant memory overheads
                 if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
                     required_size *= 10
@@ -1655,6 +1664,9 @@ def _has_sufficient_memory(device, size, self=None):
             available = get_available_memory()
             if available < required_size:
                 gc.collect()
+                acc = torch.accelerator.current_accelerator()
+                if acc is not None and acc.type == device_type:
+                    torch.accelerator.empty_cache()
                 available = get_available_memory()
             return available >= required_size
         except NotImplementedError:


### PR DESCRIPTION
## Summary

This PR adds a `has_sufficient_memory()` hook to `DeviceTypeTestBase` and updates `largeTensorTest()` to use it when available.

## Motivation

`largeTensorTest()` currently relies on `_has_sufficient_memory()` to determine whether a device has enough available memory for a requested allocation size. 
`_has_sufficient_memory()` currently contains hardcoded backend-specific memory queries for built-in device types such as CUDA/XPU/MPS/CPU.

Available memory querying is fundamentally a device-level capability and is useful for device-generic testing infrastructure. 

This PR introduces a reusable `has_sufficient_memory()` hook on `DeviceTypeTestBase` so device-specific test bases can customize memory reporting behavior.

## Changes

- Add  `has_sufficient_memory()` hook to `DeviceTypeTestBase`
- Implement the hook for CPU/CUDA/MPS/XPU test bases.
- Update `largeTensorTest()` to use the hook when available while preserving the existing fallback logic for compatibility.


## Test Plan

- Draft PR to run the full test suite.
- Verified `test/nn/test_pooling.py` on CUDA, which contains tests using `@largeTensorTest()`:
  - `pytest test/nn/test_pooling.py -vvv`
  - Before: 210 passed, 59 skipped in 32.59s
  - After: 210 passed, 59 skipped in 32.29s