### PR TITLE
Fix ZeroTensor view with symbolic sizes

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2177,6 +2177,13 @@ Tensor _reshape_alias(
   return alias_with_sizes_and_strides(self, sizes, strides);
 }
 
+Tensor _reshape_alias_symint(
+    const Tensor& self,
+    c10::SymIntArrayRef sizes,
+    c10::SymIntArrayRef strides) {
+  return alias_with_sizes_and_strides(self, sizes, strides);
+}
+
 Tensor reshape_as(const Tensor& self, const Tensor& other) {
   return self.reshape_symint(other.sym_sizes());
 }
@@ -4102,6 +4109,20 @@ static inline Tensor view_impl(const Tensor& self, IntArrayRef size) {
   return alias_with_sizes_and_strides(self, inferred_size, *stride);
 }
 
+static inline Tensor view_impl_symint(
+    const Tensor& self,
+    c10::SymIntArrayRef size) {
+  c10::SymDimVector inferred_size = at::infer_size_dv(size, self.sym_numel());
+  auto stride = at::detail::computeStride(
+      self.sym_sizes(), self.sym_strides(), inferred_size);
+  TORCH_CHECK(
+      stride.has_value(),
+      "view size is "
+      "not compatible with input tensor's size and stride (at least one dimension"
+      " spans across two contiguous subspaces). Use .reshape(...) instead.");
+  return alias_with_sizes_and_strides(self, inferred_size, *stride);
+}
+
 Tensor _unsafe_view(const Tensor& self, IntArrayRef size) {
   return view_impl(self, size);
 }
@@ -4562,6 +4583,10 @@ Tensor adjoint(const Tensor& self) {
 
 Tensor view(const Tensor& self, at::IntArrayRef size) {
   return view_impl(self, size);
+}
+
+Tensor view_symint(const Tensor& self, c10::SymIntArrayRef size) {
+  return view_impl_symint(self, size);
 }
 
 Tensor alias(const Tensor& self) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5151,7 +5151,8 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    CPU, CUDA, Meta, QuantizedCPU, QuantizedCUDA, ZeroTensor, MPS, MTIA: _reshape_alias
+    CPU, CUDA, Meta, QuantizedCPU, QuantizedCUDA, MPS, MTIA: _reshape_alias
+    ZeroTensor: _reshape_alias_symint
     # We don't need to support mkldnn since this is handled explicitly by the reshape operator.
 
 - func: _mkldnn_reshape(Tensor self, int[] shape) -> Tensor
@@ -8413,7 +8414,8 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    ZeroTensor, Meta, CPU, CUDA, QuantizedCPU, QuantizedCUDA, MPS, MTIA: view
+    Meta, CPU, CUDA, QuantizedCPU, QuantizedCUDA, MPS, MTIA: view
+    ZeroTensor: view_symint
     MkldnnCPU: mkldnn_view
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA: view_nested
   tags: core

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -4927,6 +4927,30 @@ class CPUReproTests(TestCase):
         torch.testing.assert_close(weight_cmp.grad, weight_ref.grad)
         torch.testing.assert_close(bias_cmp.grad, bias_ref.grad)
 
+    def test_group_norm_torch_func_grad_dynamic(self):
+        avg_pool = nn.AvgPool2d(2)
+        layer_norm = nn.LayerNorm([5])
+        batch_norm = nn.BatchNorm2d(12).eval()
+        group_norm = nn.GroupNorm(12, 12).eval()
+
+        def fn(x):
+            x = avg_pool(x)
+            x = layer_norm(x)
+            x = batch_norm(x)
+            x = group_norm(x)
+            return x.abs().mean()
+
+        torch.manual_seed(0)
+        x = torch.randn([2, 12, 10, 10])
+
+        expected = torch.func.grad(fn)(x)
+
+        torch._dynamo.reset()
+        compiled = torch.compile(torch.func.grad(fn), backend="inductor", dynamic=True)
+        actual = compiled(x)
+
+        self.assertEqual(actual, expected)
+
     @torch._dynamo.config.patch(
         capture_scalar_outputs=True, capture_dynamic_output_shape_ops=True
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184651

Route ZeroTensor view metadata paths through SymInt-aware implementations so AOTAutograd can trace dynamic-shape group norm backward without concretizing sizes.

Fixes #181384

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos