### PR TITLE
Fold pytree.tree_map_only into a single unflatten pass

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -641,6 +641,16 @@ class TestGenericPytree(TestCase):
         )
 
     @parametrize_pytree_module
+    def test_tree_map_only_returns_fresh_tree_when_no_match(self, pytree):
+        tree = {"a": [1, 2], "b": ("x", "y")}
+        out_type = pytree.tree_map_only(float, lambda x: x, tree)
+        self.assertEqual(out_type, tree)
+        self.assertIsNot(out_type, tree)
+        out_pred = pytree.tree_map_only(lambda _: False, lambda x: x, tree)
+        self.assertEqual(out_pred, tree)
+        self.assertIsNot(out_pred, tree)
+
+    @parametrize_pytree_module
     def test_tree_all_any(self, pytree):
         self.assertTrue(pytree.tree_all(lambda x: x % 2, [1, 3]))
         self.assertFalse(pytree.tree_all(lambda x: x % 2, [0, 1]))

--- a/torch/_inductor/kernel/flex/common.py
+++ b/torch/_inductor/kernel/flex/common.py
@@ -12,7 +12,7 @@ import sympy
 import torch
 from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._pytree import tree_map, tree_map_only
+from torch.utils._pytree import tree_leaves, tree_map, tree_map_only
 
 
 if TYPE_CHECKING:
@@ -243,7 +243,7 @@ def realize_captures_for_cutedsl(buffers):
     buffers = tree_map(_realize, buffers)
     freeze_irnodes(buffers)
 
-    for buf in tree_map_only(IRNode, lambda x: x, buffers) if buffers else []:
+    for buf in tree_leaves(buffers or []):
         if isinstance(buf, IRNode) and (name := buf.maybe_get_name()):
             V.graph._cutedsl_capture_nodes[name] = buf
     # Keep the original view nodes for call-site reinterpret_tensor emission.

--- a/torch/utils/_cxx_pytree.py
+++ b/torch/utils/_cxx_pytree.py
@@ -24,6 +24,7 @@ from typing_extensions import deprecated, Self, TypeIs
 import torch.utils._pytree as python_pytree
 from torch.torch_version import TorchVersion as _TorchVersion
 from torch.utils._pytree import (
+    _make_pred,
     Context,
     DumpableContext,
     FlattenFn,
@@ -36,6 +37,7 @@ from torch.utils._pytree import (
     is_structseq_class,
     is_structseq_instance,
     KeyPath,
+    map_only,
     PyTree,
     ToDumpableContextFn,
     UnflattenFn,
@@ -81,6 +83,7 @@ __all__ = [
     "tree_map",
     "tree_map_with_path",
     "tree_map_",
+    "map_only",
     "tree_map_only",
     "tree_map_only_",
     "tree_all",
@@ -627,76 +630,6 @@ FnAny = Callable[[Any], R]
 MapOnlyFn = Callable[[T], Callable[[Any], Any]]
 
 
-# These specializations help with type inference on the lambda passed to this
-# function
-@overload
-def map_only(type_or_types_or_pred: type[T], /) -> MapOnlyFn[Fn[T, Any]]: ...
-
-
-@overload
-def map_only(type_or_types_or_pred: Type2[T, S], /) -> MapOnlyFn[Fn2[T, S, Any]]: ...
-
-
-@overload
-def map_only(
-    type_or_types_or_pred: Type3[T, S, U], /
-) -> MapOnlyFn[Fn3[T, S, U, Any]]: ...
-
-
-# This specialization is needed for the implementations below that call
-@overload
-def map_only(type_or_types_or_pred: TypeAny, /) -> MapOnlyFn[FnAny[Any]]: ...
-
-
-@overload
-def map_only(
-    type_or_types_or_pred: Callable[[Any], bool], /
-) -> MapOnlyFn[FnAny[Any]]: ...
-
-
-def map_only(
-    type_or_types_or_pred: TypeAny | Callable[[Any], bool], /
-) -> MapOnlyFn[FnAny[Any]]:
-    """
-    Suppose you are writing a tree_map over tensors, leaving everything
-    else unchanged.  Ordinarily you would have to write:
-
-        def go(t):
-            if isinstance(t, Tensor):
-                return ...
-            else:
-                return t
-
-    With this function, you only need to write:
-
-        @map_only(Tensor)
-        def go(t):
-            return ...
-
-    You can also directly use 'tree_map_only'
-    """
-    if isinstance(type_or_types_or_pred, (type, tuple, types.UnionType)):
-
-        def pred(x: Any) -> bool:
-            return isinstance(x, type_or_types_or_pred)  # type: ignore[arg-type]
-
-    elif callable(type_or_types_or_pred):
-        pred = type_or_types_or_pred  # type: ignore[assignment]
-    else:
-        raise TypeError("Argument must be a type, a tuple of types, or a callable.")
-
-    def wrapper(func: Callable[[T], Any]) -> Callable[[Any], Any]:
-        @functools.wraps(func)
-        def wrapped(x: T) -> Any:
-            if pred(x):
-                return func(x)
-            return x
-
-        return wrapped
-
-    return wrapper
-
-
 @overload
 def tree_map_only(
     type_or_types_or_pred: type[T],
@@ -754,7 +687,11 @@ def tree_map_only(
     tree: PyTree,
     is_leaf: Callable[[PyTree], bool] | None = None,
 ) -> PyTree:
-    return tree_map(map_only(type_or_types_or_pred)(func), tree, is_leaf=is_leaf)
+    pred = _make_pred(type_or_types_or_pred)
+    leaves, treespec = tree_flatten(tree, is_leaf=is_leaf)
+    if not any(pred(leaf) for leaf in leaves):
+        return treespec.unflatten(leaves)
+    return treespec.unflatten(func(leaf) if pred(leaf) else leaf for leaf in leaves)
 
 
 @overload

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -1651,6 +1651,17 @@ def map_only(
 ) -> MapOnlyFn[FnAny[Any]]: ...
 
 
+def _make_pred(
+    type_or_types_or_pred: TypeAny | Callable[[Any], bool],
+) -> Callable[[Any], bool]:
+    if isinstance(type_or_types_or_pred, (type, tuple, types.UnionType)):
+        types_arg: TypeAny = type_or_types_or_pred
+        return lambda x: isinstance(x, types_arg)
+    if callable(type_or_types_or_pred):
+        return type_or_types_or_pred
+    raise TypeError("Argument must be a type, a tuple of types, or a callable.")
+
+
 def map_only(
     type_or_types_or_pred: TypeAny | Callable[[Any], bool], /
 ) -> MapOnlyFn[FnAny[Any]]:
@@ -1672,15 +1683,7 @@ def map_only(
 
     You can also directly use 'tree_map_only'
     """
-    if isinstance(type_or_types_or_pred, (type, tuple, types.UnionType)):
-
-        def pred(x: Any) -> bool:
-            return isinstance(x, type_or_types_or_pred)  # type: ignore[arg-type]
-
-    elif callable(type_or_types_or_pred):
-        pred = type_or_types_or_pred  # type: ignore[assignment]
-    else:
-        raise TypeError("Argument must be a type, a tuple of types, or a callable.")
+    pred = _make_pred(type_or_types_or_pred)
 
     def wrapper(func: Callable[[T], Any]) -> Callable[[Any], Any]:
         @functools.wraps(func)
@@ -1751,7 +1754,11 @@ def tree_map_only(
     tree: PyTree,
     is_leaf: Callable[[PyTree], bool] | None = None,
 ) -> PyTree:
-    return tree_map(map_only(type_or_types_or_pred)(func), tree, is_leaf=is_leaf)
+    pred = _make_pred(type_or_types_or_pred)
+    leaves, treespec = tree_flatten(tree, is_leaf=is_leaf)
+    if not any(pred(leaf) for leaf in leaves):
+        return treespec.unflatten(leaves)
+    return treespec.unflatten(func(leaf) if pred(leaf) else leaf for leaf in leaves)
 
 
 @overload


### PR DESCRIPTION
`tree_map_only` went through `tree_map` with a `map_only(...)` wrapper,
adding a per-leaf closure indirection on every leaf. Flatten once, apply
pred and func inline, and unflatten once; the result is still a fresh tree
when nothing matches.

Also factor the type/predicate dispatch into a shared `_make_pred`, drop
the duplicate `map_only` in `_cxx_pytree`, and swap a
`tree_map_only(IRNode, lambda x: x, ...)` misuse in `flex/common.py` for
`tree_leaves`.

Test Plan:
```
pytest test/test_pytree.py -k tree_map_only
```
