### PR TITLE
[Test]Make test/nn/test_parametrization.py device generic

### DIFF
--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1917,8 +1917,7 @@ class TestNNParametrizationDevice(NNTestCase):
             self.assertEqual(m(input), expected_output)
 
 
-only_for = ("cpu", "cuda")
-instantiate_device_type_tests(TestNNParametrizationDevice, globals(), only_for=only_for)
+instantiate_device_type_tests(TestNNParametrizationDevice, globals())
 instantiate_parametrized_tests(TestNNParametrization)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove only_for=("cpu", "cuda") restriction from
  TestNNParametrizationDevice to enable tests on all accelerator devices.

  test_weight_norm_parametrization uses only device-agnostic operations:
  - torch.randn(..., device=device)
  - nn.Linear(..., device=device)
  - torch.nn.utils.parametrizations.weight_norm()

  This allows the test to run on any registered accelerator device
  (XPU, PrivateUse1, etc.), not just CPU and CUDA.

**Test Plan:**
(cuda_torch_build) [root@88fde2b2e6e0 pytorch]# TEST_CONFIG=cpu python test/nn/test_parametrization.py TestNNParametrizationDeviceCUDA -v :
test_weight_norm_parametrization_swap_False_cuda (__main__.TestNNParametrizationDeviceCUDA.test_weight_norm_parametrization_swap_False_cuda) ... ok
test_weight_norm_parametrization_swap_True_cuda (__main__.TestNNParametrizationDeviceCUDA.test_weight_norm_parametrization_swap_True_cuda) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.192s

OK
(cuda_torch_build) [root@88fde2b2e6e0 pytorch]# TEST_CONFIG=cuda python test/nn/test_parametrization.py TestNNParametrizationDeviceCUDA -v :
test_weight_norm_parametrization_swap_False_cuda (__main__.TestNNParametrizationDeviceCUDA.test_weight_norm_parametrization_swap_False_cuda) ... ok
test_weight_norm_parametrization_swap_True_cuda (__main__.TestNNParametrizationDeviceCUDA.test_weight_norm_parametrization_swap_True_cuda) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.191s

OK


CC: @fffrog @albanD @jbschlosser 