### PR TITLE
[inductor] Fix test_origami imports for template_heuristics -> heuristics/template move

### DIFF
--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -448,7 +448,7 @@ class TestOrigami(TestCase):
                     fresh_cache(),
                     config.patch(patch_config),
                     mock.patch(
-                        "torch._inductor.template_heuristics.triton.origami",
+                        "torch._inductor.heuristics.template.triton.origami",
                         None,
                     ),
                 ):
@@ -478,7 +478,7 @@ class TestOrigami(TestCase):
         snippet = (
             "import os, torch\n"
             "from torch._inductor import config\n"
-            "from torch._inductor.template_heuristics import triton as th\n"
+            "from torch._inductor.heuristics.template import triton as th\n"
             "assert os.environ.get('TORCHINDUCTOR_ORIGAMI') != '1', 'env var leaked'\n"
             "assert th.origami is None, f'expected None, got {th.origami!r}'\n"
             "# Even after flipping the config knob mid-process, origami stays None\n"


### PR DESCRIPTION
## Summary

PR #183275 moved `torch/_inductor/template_heuristics/` -> `torch/_inductor/heuristics/template/` but missed updating two stale references in `test/inductor/test_origami.py`:

- **line 451** — `mock.patch` target string in `test_origami_fallback_when_disabled`
- **line 481** — subprocess `import` string in `test_origami_module_gate_when_env_var_unset`

The second one produces a hard failure in CI (tracked in disable issue #184658):

```
ModuleNotFoundError: No module named 'torch._inductor.template_heuristics'
```

The subprocess starts a fresh Python interpreter where the old package name no longer exists, so the gate test fails consistently. `mock.patch` on the stale string in the first call site would also raise `ModuleNotFoundError` when the `with` block is entered.

## Fix

Two-line update of the dotted-path strings to the new module location. The `origami = None` binding still lives in the moved `triton.py` (`heuristics/template/triton.py:77`, `:83`), so the existing `th.origami is None` assertions remain valid against the new path — no semantic change to what the tests verify.

After this lands, close #184658 to re-enable `test_origami_module_gate_when_env_var_unset`.

## Test plan

- [ ] `python test/inductor/test_origami.py -k test_origami_module_gate_when_env_var_unset` (ROCm; subprocess test no longer raises `ModuleNotFoundError` on import)
- [ ] `python test/inductor/test_origami.py -k test_origami_fallback_when_disabled` (ROCm; `mock.patch` resolves the new path)
- [ ] `inductor-rocm-mi355` workflow runs on this PR (via `ciflow/inductor-rocm-mi355` label)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jithunnair-amd @jeffdaily