### PR TITLE
[ROCM][Inductor]Fixing the path in the tests to the triton template in test_origami.

### DIFF
--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -448,7 +448,7 @@ class TestOrigami(TestCase):
                     fresh_cache(),
                     config.patch(patch_config),
                     mock.patch(
-                        "torch._inductor.template_heuristics.triton.origami",
+                        "torch._inductor.heuristics.template.triton.origami",
                         None,
                     ),
                 ):
@@ -478,7 +478,7 @@ class TestOrigami(TestCase):
         snippet = (
             "import os, torch\n"
             "from torch._inductor import config\n"
-            "from torch._inductor.template_heuristics import triton as th\n"
+            "from torch._inductor.heuristics.template import triton as th\n"
             "assert os.environ.get('TORCHINDUCTOR_ORIGAMI') != '1', 'env var leaked'\n"
             "assert th.origami is None, f'expected None, got {th.origami!r}'\n"
             "# Even after flipping the config knob mid-process, origami stays None\n"


### PR DESCRIPTION
Fixes #184658 #184660

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben