### PR TITLE
Inductor Lowering of Trunc Div should use div_rn

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4105,6 +4105,41 @@ for dtype in (torch.int32, torch.int64):
         b = torch.tensor([0.0], dtype=torch.bfloat16, device=self.device)
         self.common(fn, (a, b))
 
+    def test_truncdiv_float_accuracy(self):
+        # Reproducer for https://github.com/pytorch/pytorch/issues/184408
+        def fn(a, b):
+            return torch.div(a, b, rounding_mode="trunc")
+
+        # Near-integer quotients: approximate division can push past the
+        # boundary, making trunc overshoot by +1.
+        a = torch.tensor([14.999999, 26.999999, 13.999999], device=self.device)
+        b = torch.tensor([3.0, 3.0, 7.0], device=self.device)
+        self.common(fn, (a, b))
+
+        # Exact integer quotients: approximate division can undershoot,
+        # making trunc return one less than the true value.
+        a = torch.tensor([148.0, 1073.0, 2112.0], device=self.device)
+        b = torch.tensor([37.0, 37.0, 33.0], device=self.device)
+        self.common(fn, (a, b))
+
+        # Negative operands / mixed signs
+        for dtype in [torch.float16, torch.float32]:
+            for a_val, b_val in [
+                (7.0, 2.0),
+                (7.0, -2.0),
+                (-7.0, 2.0),
+                (-7.0, -2.0),
+                (6.0, 3.0),
+                (0.0, 5.0),
+                (0.0, -5.0),
+                (-14.999999, 3.0),
+                (14.999999, -3.0),
+            ]:
+                a = torch.full((8,), a_val, dtype=dtype, device=self.device)
+                b = torch.full((8,), b_val, dtype=dtype, device=self.device)
+                self.common(fn, (a, b))
+
+
     def test_div_precision(self):
         # Reproducer for https://github.com/pytorch/pytorch/issues/101039
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7540,7 +7540,11 @@ def div_mode(a, b, rounding_mode=None):
             raise AssertionError(
                 "truncdiv operands can not be boolean at the same time"
             )
-        return truncdiv(a, b) if both_integer else trunc(div(a, b))
+        # Use div_rn (IEEE round-to-nearest) instead of truediv here because
+        # Triton's default division uses an approximate reciprocal, which can
+        # nudge the quotient past an integer boundary and cause trunc() to
+        # return the wrong integer.
+        return truncdiv(a, b) if both_integer else trunc(_div_rn(a, b))
     return div(a, b)
 
 


### PR DESCRIPTION
Fixes: #184408 

Use div_rn (IEEE round-to-nearest) instead of truediv here because Triton's default division uses an approximate reciprocal, which can nudge the quotient past an integer boundary and cause trunc() to return the wrong  integer.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo