### PR TITLE
[fake_tensor] Check select index bounds

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -18723,6 +18723,18 @@ def forward(self, x, mask):
             """\
 def forward(self, x, y):
     item = torch.ops.aten.item.default(y);  y = None
+    ge_3 = item >= -3
+    _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge_3, "Runtime assertion failed for expression u0 >= -3 on node 'ge_3'");  ge_3 = _assert_scalar_default = None
+    le_1 = item <= 2
+    _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(le_1, "Runtime assertion failed for expression u0 <= 2 on node 'le_1'");  le_1 = _assert_scalar_default_1 = None
+    lt_1 = item < 3
+    add_2 = 3 + item
+    ge_4 = add_2 >= 0
+    and__1 = lt_1 & ge_4;  ge_4 = None
+    _assert_scalar_default_2 = torch.ops.aten._assert_scalar.default(and__1, "Runtime assertion failed for expression (u0 < 3) & (0 <= u0 + 3) on node 'and__1'");  and__1 = _assert_scalar_default_2 = None
+    ge_1 = add_2 >= 0;  add_2 = None
+    and_ = lt_1 & ge_1;  lt_1 = ge_1 = None
+    _assert_scalar_2 = torch.ops.aten._assert_scalar.default(and_, "Runtime assertion failed for expression (u0 < 3) & (0 <= u0 + 3) on node 'and_'");  and_ = _assert_scalar_2 = None
     select = torch.ops.aten.select.int(x, 0, item);  x = item = None
     return (select,)""",
             ignore_empty_lines=True,

--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -1533,6 +1533,42 @@ class TestSplitCatFxPasses(TestCase):
             )
             counters.clear()
 
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "normalization_aten_pass": {},
+            "select_cat_aten_pass": {},
+            "unbind_stack_aten_pass": {},
+        },
+        post_grad_fusion_options={},
+    )
+    def test_select_unsqueeze_cat_out_of_bounds(self):
+        counters.clear()
+
+        def fn(x):
+            slice0 = torch.select(x, dim=1, index=0)
+            slice1 = torch.select(x, dim=1, index=1)
+            slice2 = torch.select(x, dim=1, index=2)
+            return torch.cat(
+                [
+                    torch.unsqueeze(slice0, dim=1),
+                    torch.unsqueeze(slice1, dim=1),
+                    torch.unsqueeze(slice2, dim=1),
+                ],
+                dim=1,
+            )
+
+        x = torch.randn(4, 1, 10, 16)
+
+        with self.assertRaisesRegex(IndexError, r"select\(\): index 1 out of range"):
+            fn(x)
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.TorchRuntimeError,
+            r"select\(\): index 1 out of range",
+        ):
+            torch.compile(fn)(x)
+        self.assertEqual(counters["inductor"]["unbind_stack_aten_pass"], 0)
+        counters.clear()
+
     def test_numpy_compat_normalization(self):
         def fn(x, y):
             a = torch.stack([x, y], axis=1)

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4513,6 +4513,11 @@ def forward(self, arg0_1: "i64[2][1]cpu", arg1_1: "Sym(u2)", arg2_1: "Sym(u3)", 
             output,
             """\
         _local_scalar_dense: "Sym(u0)" = torch.ops.aten._local_scalar_dense.default(arg0_1);  arg0_1 = None
+        lt: "Sym(u0 < s77)" = _local_scalar_dense < arg1_1
+        sym_sum: "Sym(s77 + u0)" = torch.sym_sum((_local_scalar_dense, arg1_1));  arg1_1 = None
+        ge: "Sym(s77 + u0 >= 0)" = sym_sum >= 0;  sym_sum = None
+        and_: "Sym((u0 < s77) & (s77 + u0 >= 0))" = lt & ge;  lt = ge = None
+        _assert_scalar = torch.ops.aten._assert_scalar.default(and_, "Runtime assertion failed for expression (u0 < s77) & (0 <= s77 + u0) on node 'and_'");  and_ = _assert_scalar = None
         select: "f32[s77, s77][s77, 1]cpu" = torch.ops.aten.select.int(arg2_1, 0, _local_scalar_dense)
         select_1: "f32[s77, s77][s77**2, 1]cpu" = torch.ops.aten.select.int(arg2_1, 1, _local_scalar_dense)
         select_2: "f32[s77, s77][s77**2, s77]cpu" = torch.ops.aten.select.int(arg2_1, 2, _local_scalar_dense);  arg2_1 = _local_scalar_dense = None

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -144,6 +144,18 @@ class FakeTensorTest(TestCase):
             self.assertEqual(z.device, torch.device("cpu"))
             self.assertTrue(isinstance(z, FakeTensor))
 
+    def test_select_bounds_check(self):
+        with FakeTensorMode() as mode:
+            x = mode.from_tensor(torch.empty(4, 1, 10, 16))
+            self.assertEqual(x.select(1, 0).shape, (4, 10, 16))
+            self.assertEqual(x.select(1, -1).shape, (4, 10, 16))
+
+            for index in (1, -2):
+                with self.assertRaisesRegex(
+                    IndexError, rf"select\(\): index {index} out of range"
+                ):
+                    x.select(1, index)
+
     def test_custom_op_fallback(self):
         from torch.library import _scoped_library, impl
 

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -477,7 +477,7 @@ def meta_select(
     dim: int,
     index: IntLikeType,
 ) -> FakeTensor:
-    from torch.fx.experimental.symbolic_shapes import guard_or_false
+    from torch.fx.experimental.symbolic_shapes import guard_or_false, sym_and
 
     if self.is_sparse:
         return NotImplemented
@@ -488,8 +488,15 @@ def meta_select(
         lambda: "select() cannot be applied to a 0-dim tensor.",
     )
 
-    dim = dim if dim >= 0 else dim + ndim
+    dim = canonicalize_dim(ndim, dim)
     size = self.size(dim)
+    torch._check_index(
+        sym_and(index >= -size, index < size),
+        lambda: (
+            f"select(): index {index} out of range for tensor of size "
+            f"{list(self.size())} at dimension {dim}"
+        ),
+    )
 
     new_size = list(self.size())
     new_stride = list(self.stride())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184686

Validate FakeTensor select indices to match eager/meta behavior and keep PT2 from tracing invalid select views. Update regression coverage for fake tensors, export/dynamic unbacked index assertions, and the select-unsqueeze-cat compile path.

Fixes #178881

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo