### PR TITLE
Fix memory leak in Dynamo guard manager (skip under ASAN/TSAN)

### DIFF
--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1,7 +1,11 @@
 # Owner(s): ["module: dynamo"]
 import abc
 import functools
+import gc
 import inspect
+import os
+import sys
+import unittest
 import weakref
 
 import torch
@@ -11,7 +15,11 @@ from torch._C._dynamo import guards
 from torch._dynamo.convert_frame import GlobalStateGuard
 from torch._dynamo.eval_frame import _debug_get_cache_entry_list
 from torch._library.fake_class_registry import FakeScriptObject
-from torch.testing._internal.common_utils import set_default_dtype
+from torch.testing._internal.common_utils import (
+    set_default_dtype,
+    TEST_WITH_ASAN,
+    TEST_WITH_TSAN,
+)
 
 
 RootGuardManager = guards.RootGuardManager
@@ -2094,6 +2102,42 @@ class GuardCheckSpecTests(torch._dynamo.test_case.TestCase):
             handler.eval_fn(types.MappingProxyType({"a": 10, "b": 20}), expected)
         )
         self.assertFalse(handler.eval_fn(types.MappingProxyType({"x": 1}), expected))
+
+    @unittest.skipIf(
+        sys.platform != "linux",
+        "Only support mem leak checking on Linux.",
+    )
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN,
+        "RSS-based leak detection is unreliable under sanitizers.",
+    )
+    def test_clone_manager_memory_leak(self):
+        def get_mem():
+            with open("/proc/self/statm") as f:
+                return int(f.read().split()[1]) * os.sysconf("SC_PAGE_SIZE")
+
+        def clone_filter(mgr):
+            return True
+
+        root = RootGuardManager()
+
+        # Warmup
+        for _ in range(100):
+            root.clone_manager(clone_filter)
+        gc.collect()
+
+        # Iterate to make the leak larger
+        initial_mem = get_mem()
+        for _ in range(100000):
+            root.clone_manager(clone_filter)
+        gc.collect()
+        final_mem = get_mem()
+        delta = final_mem - initial_mem
+
+        # Only fail if the leak is larger than 2MB.
+        self.assertLessEqual(
+            delta, 2 * 1024 * 1024, f"Memory leaked: {delta / 1024 / 1024:.2f} MB"
+        )
 
     def test_dict_keys_match(self):
         from torch._dynamo.guards import GuardBuilder

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2128,15 +2128,15 @@ class GuardCheckSpecTests(torch._dynamo.test_case.TestCase):
 
         # Iterate to make the leak larger
         initial_mem = get_mem()
-        for _ in range(100000):
+        for _ in range(10000):
             root.clone_manager(clone_filter)
         gc.collect()
         final_mem = get_mem()
         delta = final_mem - initial_mem
 
-        # Only fail if the leak is larger than 2MB.
+        # Only fail if the leak is larger than 1MB.
         self.assertLessEqual(
-            delta, 2 * 1024 * 1024, f"Memory leaked: {delta / 1024 / 1024:.2f} MB"
+            delta, 1 * 1024 * 1024, f"Memory leaked: {delta / 1024 / 1024:.2f} MB"
         )
 
     def test_dict_keys_match(self):

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -4284,13 +4284,15 @@ class RootGuardManager : public GuardManager {
   }
 
   // See note on [Ownership with cloning]
-  RootGuardManager* clone_manager(const py::function& clone_filter_fn) {
+  std::unique_ptr<RootGuardManager> clone_manager(
+      const py::function& clone_filter_fn) {
     // Use clone_filter_fn
     if (!py::cast<bool>(clone_filter_fn(this))) {
       return nullptr;
     }
-    RootGuardManager* cloned_root = new RootGuardManager();
-    clone_common(cloned_root, cloned_root, clone_filter_fn);
+    std::unique_ptr<RootGuardManager> cloned_root =
+        std::make_unique<RootGuardManager>();
+    clone_common(cloned_root.get(), cloned_root.get(), clone_filter_fn);
     for (const auto& guard : _epilogue_lambda_guards) {
       cloned_root->_epilogue_lambda_guards.emplace_back(guard);
     }
@@ -8476,10 +8478,7 @@ PyObject* torch_c_dynamo_guards_init() {
       .def("check", &RootGuardManager::check)
       .def("check_verbose", &RootGuardManager::check_verbose)
       .def("attach_compile_id", &RootGuardManager::attach_compile_id)
-      .def(
-          "clone_manager",
-          &RootGuardManager::clone_manager,
-          py::return_value_policy::reference)
+      .def("clone_manager", &RootGuardManager::clone_manager)
       // return by reference because GuardManager has the ownership of leaf
       // guards
       .def(


### PR DESCRIPTION
This PR fixes a memory leak in `RootGuardManager::clone_manager`. The leak occurred because `clone_manager` returned a raw C++ pointer combined with `py::return_value_policy::reference`, which told pybind11 that C++
retained ownership of the cloned manager. In practice, no one on the C++ side actually held the pointer, so each cloned `RootGuardManager` was never released and resulting in a steady leak on every clone call.

The fix returns `std::unique_ptr<RootGuardManager>` instead, whichtransfers ownership to Python via pybind11's standard `unique_ptr` return semantics so that each cloned manager is now correctly destroyed when its Python reference count drops to zero.

The PR also adds a unit test to reproduce the leak. The test fails before the fix and succeeds with the fix.

Adds skip for the leak detection test under ASAN/TSAN where RSS-based measurement is unreliable due to sanitizer overhead.

Original fix by @haifeng-jin in #180603. As instructed by @haifeng-jin, I am creating a new PR to continue to work on this.

Co-authored-by: Haifeng Jin haifeng-jin@users.noreply.github.com

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98