### PR TITLE
[Inductor][CPU] Fix assert message in cpp_micro_gemm.py

### DIFF
--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -1021,7 +1021,7 @@ class CppMicroGemmAVX512VNNI(CppMicroGemm):
                 break;
 {%- endfor %}
             default:
-                {{kernel.assert_function}}(false, "Unsupported M_TAIL: {}", M_TAIL);
+                {{kernel.assert_function}}(false, "Unsupported M_TAIL");
         } // switch M_TAIL
     } // if M_TAIL
 }

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -1659,7 +1659,7 @@ class CppMicroGemmWoQInt4Avx512(CppMicroGemmFP32Vec):
                     break;
                 {%- endfor %}
                 default:
-                    {{kernel.assert_function}}(false, "Unsupported block_m: ", block_m);
+                    {{kernel.assert_function}}(false, "Unsupported block_m");
                 }
             }
         }


### PR DESCRIPTION
`AOTI_TORCH_CHECK` does not support concatenation of multiple messages and will raise a build error during AOTI compilation of `CppMicroGemmAVX512VNNI` and `CppMicroGemmWoQInt4Avx512`. This PR fixes the issue in `torch/_inductor/codegen/cpp_micro_gemm.py`.
```python
# Before
{{kernel.assert_function}}(false, "Unsupported M_TAIL: {}", M_TAIL);
{{kernel.assert_function}}(false, "Unsupported block_m: ", block_m);
# After
{{kernel.assert_function}}(false, "Unsupported M_TAIL");
{{kernel.assert_function}}(false, "Unsupported block_m");
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo