### PR TITLE
Materialize lazy modules fully on load_state_dict instead of leaving them in a partially initialized state.

### DIFF
--- a/test/nn/test_lazy_modules.py
+++ b/test/nn/test_lazy_modules.py
@@ -156,12 +156,11 @@ class TestLazyModules(TestCase):
         module = nn.Linear(5, 10)
         lazy_module = nn.LazyLinear(10)
         lazy_module.load_state_dict(module.state_dict())
-        # Parameters have been initialized but the module won't become a full
-        # Linear one until the first iteration. This is due to
-        # limitations on the state_dict loading logic
-        self.assertFalse(lazy_module.has_uninitialized_params())
+        self.assertIsInstance(lazy_module, nn.Linear)
+        self.assertNotIsInstance(lazy_module, nn.LazyLinear)
         self.assertTrue(lazy_module.weight.shape == (10, 5))
         self.assertTrue(lazy_module.bias.shape == (10,))
+        self.assertEqual(lazy_module.in_features, 5)
 
         module = nn.Linear(5, 10)
         lazy_module = nn.LazyLinear(10)
@@ -173,15 +172,12 @@ class TestLazyModules(TestCase):
         module = nn.Linear(5, 10)
         lazy_module = nn.LazyLinear(10)
         lazy_module.load_state_dict(module.state_dict())
-        # Parameters have been initialized but the module won't become a full
-        # Linear one until the first iteration. This is due to
-        # limitations on the state_dict loading logic
-        self.assertFalse(lazy_module.has_uninitialized_params())
-        self.assertTrue(isinstance(lazy_module, nn.LazyLinear))
+        self.assertIsInstance(lazy_module, nn.Linear)
+        self.assertNotIsInstance(lazy_module, nn.LazyLinear)
+        self.assertEqual(lazy_module.in_features, 5)
 
         input = torch.randn(5, 5)
         lazy_module(input)
-        self.assertFalse(isinstance(lazy_module, nn.LazyLinear))
         self.assertTrue(lazy_module.in_features == 5)
 
     def _check_lazy_conv(
@@ -245,11 +241,9 @@ class TestLazyModules(TestCase):
         module = gen_module()
         lazy_module = gen_lazy_module()
         lazy_module.load_state_dict(module.state_dict())
-        # Parameters have been initialized but the module won't become a full
-        # Conv one until the first iteration. This is due to
-        # limitations on the state_dict loading logic
-        self.assertFalse(lazy_module.has_uninitialized_params())
+        self.assertIsInstance(lazy_module, module.__class__)
         self.assertEqual(lazy_module.weight.shape, expected_weight_shape)
+        self.assertEqual(lazy_module.in_channels, module.in_channels)
         if lazy_module.bias is not None:
             self.assertEqual(lazy_module.bias.shape, expected_bias_shape)
 
@@ -353,6 +347,30 @@ class TestLazyModules(TestCase):
             (32, 16, 2, 2),
             (32,),
         )
+
+    @suppress_warnings
+    def test_lazy_conv2d_state_and_forward(self):
+        module = nn.Conv2d(3, 16, 3, padding=1)
+        lazy_module = nn.LazyConv2d(16, 3, padding=1)
+        lazy_module.load_state_dict(module.state_dict())
+        self.assertIsInstance(lazy_module, nn.Conv2d)
+        self.assertNotIsInstance(lazy_module, nn.LazyConv2d)
+        self.assertEqual(lazy_module.in_channels, 3)
+
+        x = torch.randn(1, 3, 8, 8)
+        self.assertTrue(torch.equal(lazy_module(x), module(x)))
+
+    @suppress_warnings
+    def test_lazy_conv_transpose2d_state_and_forward(self):
+        module = nn.ConvTranspose2d(3, 16, 3, padding=1)
+        lazy_module = nn.LazyConvTranspose2d(16, 3, padding=1)
+        lazy_module.load_state_dict(module.state_dict())
+        self.assertIsInstance(lazy_module, nn.ConvTranspose2d)
+        self.assertNotIsInstance(lazy_module, nn.LazyConvTranspose2d)
+        self.assertEqual(lazy_module.in_channels, 3)
+
+        x = torch.randn(1, 3, 8, 8)
+        self.assertTrue(torch.equal(lazy_module(x), module(x)))
 
     @suppress_warnings
     def test_lazy_conv3d(self):
@@ -605,10 +623,8 @@ class TestLazyModules(TestCase):
         module = cls(10)
         lazy_module = lazy_cls(affine=True, track_running_stats=True)
         lazy_module.load_state_dict(module.state_dict())
-        # Parameters have been initialized but the module won't become a full
-        # Conv one until the first iteration. This is due to
-        # limitations on the state_dict loading logic
-        self.assertFalse(lazy_module.has_uninitialized_params())
+        self.assertIsInstance(lazy_module, cls)
+        self.assertEqual(lazy_module.num_features, 10)
         self.assertEqual(lazy_module.weight.shape, (10,))
         self.assertEqual(lazy_module.bias.shape, (10,))
         self.assertEqual(lazy_module.running_mean.shape, (10,))
@@ -627,10 +643,9 @@ class TestLazyModules(TestCase):
                     affine=affine, track_running_stats=track_running_stats
                 )
                 lazy_module.load_state_dict(module.state_dict())
-                # Parameters have been initialized but the module won't become a full
-                # InstanceNorm one until the first iteration. This is due to
-                # limitations on the state_dict loading logic
-                self.assertFalse(lazy_module.has_uninitialized_params())
+                self.assertIsInstance(lazy_module, cls)
+                if affine or track_running_stats:
+                    self.assertEqual(lazy_module.num_features, 10)
                 if affine:
                     self.assertEqual(lazy_module.weight.shape, (10,))
                     self.assertEqual(lazy_module.bias.shape, (10,))
@@ -676,6 +691,19 @@ class TestLazyModules(TestCase):
     def test_lazy_batchnorm2d_state(self):
         self._check_lazy_batchnorm_state(nn.BatchNorm2d, nn.LazyBatchNorm2d)
         self._check_lazy_batchnorm_state(nn.BatchNorm2d, nn.LazyBatchNorm2d)
+
+    def test_lazy_batchnorm2d_state_and_forward(self):
+        module = nn.BatchNorm2d(16)
+        module.eval()
+        lazy_module = nn.LazyBatchNorm2d()
+        lazy_module.load_state_dict(module.state_dict())
+        lazy_module.eval()
+        self.assertIsInstance(lazy_module, nn.BatchNorm2d)
+        self.assertNotIsInstance(lazy_module, nn.LazyBatchNorm2d)
+        self.assertEqual(lazy_module.num_features, 16)
+
+        x = torch.randn(2, 16, 4, 4)
+        self.assertTrue(torch.allclose(lazy_module(x), module(x)))
 
     def test_lazy_batchnorm3d(self):
         self._check_lazy_norm(nn.BatchNorm3d, nn.LazyBatchNorm3d, (16, 3, 6, 7, 8))

--- a/test/nn/test_lazy_modules.py
+++ b/test/nn/test_lazy_modules.py
@@ -643,9 +643,11 @@ class TestLazyModules(TestCase):
                     affine=affine, track_running_stats=track_running_stats
                 )
                 lazy_module.load_state_dict(module.state_dict())
-                self.assertIsInstance(lazy_module, cls)
                 if affine or track_running_stats:
+                    self.assertIsInstance(lazy_module, cls)
                     self.assertEqual(lazy_module.num_features, 10)
+                else:
+                    self.assertIsInstance(lazy_module, lazy_cls)
                 if affine:
                     self.assertEqual(lazy_module.weight.shape, (10,))
                     self.assertEqual(lazy_module.bias.shape, (10,))
@@ -740,6 +742,17 @@ class TestLazyModules(TestCase):
     def test_lazy_instancenorm2d_state(self):
         self._check_lazy_instancenorm_state(nn.InstanceNorm2d, nn.LazyInstanceNorm2d)
         self._check_lazy_instancenorm_state(nn.InstanceNorm2d, nn.LazyInstanceNorm2d)
+
+    def test_lazy_instancenorm2d_stateless_load(self):
+        module = nn.InstanceNorm2d(10, affine=False, track_running_stats=False)
+        lazy_module = nn.LazyInstanceNorm2d(affine=False, track_running_stats=False)
+        lazy_module.load_state_dict(module.state_dict())
+        self.assertIsInstance(lazy_module, nn.LazyInstanceNorm2d)
+
+        x = torch.randn(2, 10, 4, 4)
+        lazy_module(x)
+        self.assertIsInstance(lazy_module, nn.InstanceNorm2d)
+        self.assertNotIsInstance(lazy_module, nn.LazyInstanceNorm2d)
 
     def test_lazy_instancenorm3d(self):
         self._check_lazy_norm(

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -277,6 +277,13 @@ class _LazyNormBase(LazyModuleMixin, _NormBase):
         if not self.has_uninitialized_params() and self.num_features != 0:
             super().reset_parameters()
 
+    def _lazy_load_pre_materialize_hook(self):
+        if self.num_features == 0:
+            if self.affine and isinstance(self.weight, torch.Tensor):
+                self.num_features = self.weight.shape[0]
+            elif self.track_running_stats and isinstance(self.running_mean, torch.Tensor):
+                self.num_features = self.running_mean.shape[0]
+
     def initialize_parameters(self, input) -> None:  # type: ignore[override]
         # pyrefly: ignore [bad-argument-type]
         if self.has_uninitialized_params():

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -1469,6 +1469,13 @@ class _LazyConvXdMixin(LazyModuleMixin):
                 self.bias.materialize((self.out_channels,))
             self.reset_parameters()
 
+    def _lazy_load_pre_materialize_hook(self):
+        if self.in_channels == 0 and isinstance(self.weight, Tensor):
+            if self.transposed:
+                self.in_channels = self.weight.shape[0]
+            else:
+                self.in_channels = self.weight.shape[1] * self.groups
+
     # Function to extract in_channels from first input.
     def _get_in_channels(self, input: Tensor) -> int:
         num_spatial_dims = self._get_num_spatial_dims()

--- a/torch/nn/modules/lazy.py
+++ b/torch/nn/modules/lazy.py
@@ -34,6 +34,14 @@ class _LazyProtocol(Protocol):
 
     def _infer_parameters(self, module, input): ...
 
+    def _lazy_load_pre_materialize_hook(self): ...
+
+    def _materialize(self): ...
+
+    def has_uninitialized_params(self): ...
+
+    cls_to_become: type[Any] | None
+
     @property
     def _parameters(self): ...
 
@@ -226,6 +234,29 @@ class LazyModuleMixin:
                         with torch.no_grad():
                             param.materialize(input_param.shape)
 
+        # _materialize removes hooks, but only for future calls; the current load completes normally.
+        if not self.has_uninitialized_params():
+            self._lazy_load_pre_materialize_hook()
+            self._materialize()
+
+    def _lazy_load_pre_materialize_hook(self: _LazyProtocol):
+        """Called before ``_materialize`` during ``load_state_dict``.
+
+        Override in subclasses to set module-specific attributes (e.g.
+        ``in_features``, ``in_channels``) from the already-loaded parameters,
+        since ``initialize_parameters`` is not called on the load path.
+        """
+        pass
+
+    def _materialize(self: _LazyProtocol):
+        """Remove lazy hooks and, if ``cls_to_become`` is set, mutate ``__class__`` to the concrete type."""
+        self._initialize_hook.remove()
+        self._load_hook.remove()
+        delattr(self, '_initialize_hook')
+        delattr(self, '_load_hook')
+        if self.cls_to_become is not None:
+            self.__class__ = self.cls_to_become
+
     def initialize_parameters(self: _LazyProtocol, *args, **kwargs):
         r"""Initialize parameters according to the input batch properties.
 
@@ -263,12 +294,7 @@ class LazyModuleMixin:
         module.initialize_parameters(*args, **kwargs)
         if module.has_uninitialized_params():
             raise RuntimeError(f'module {self._get_name()} has not been fully initialized')
-        module._initialize_hook.remove()
-        module._load_hook.remove()
-        delattr(module, '_initialize_hook')
-        delattr(module, '_load_hook')
-        if module.cls_to_become is not None:
-            module.__class__ = module.cls_to_become
+        module._materialize()
     # fmt: on
 
     def _replicate_for_data_parallel(self: _LazyProtocol):

--- a/torch/nn/modules/lazy.py
+++ b/torch/nn/modules/lazy.py
@@ -221,6 +221,7 @@ class LazyModuleMixin:
         See comment in ``torch.nn.Module._register_load_state_dict_pre_hook``
         for the details of the hook specification.
         """
+        had_lazy = False
         for name, param in itertools.chain(
             self._parameters.items(), self._buffers.items()
         ):
@@ -233,9 +234,10 @@ class LazyModuleMixin:
                     if not is_lazy(input_param):
                         with torch.no_grad():
                             param.materialize(input_param.shape)
+                        had_lazy = True
 
         # _materialize removes hooks, but only for future calls; the current load completes normally.
-        if not self.has_uninitialized_params():
+        if had_lazy and not self.has_uninitialized_params():
             self._lazy_load_pre_materialize_hook()
             self._materialize()
 
@@ -246,14 +248,13 @@ class LazyModuleMixin:
         ``in_features``, ``in_channels``) from the already-loaded parameters,
         since ``initialize_parameters`` is not called on the load path.
         """
-        pass
 
     def _materialize(self: _LazyProtocol):
         """Remove lazy hooks and, if ``cls_to_become`` is set, mutate ``__class__`` to the concrete type."""
         self._initialize_hook.remove()
         self._load_hook.remove()
-        delattr(self, '_initialize_hook')
-        delattr(self, '_load_hook')
+        delattr(self, "_initialize_hook")
+        delattr(self, "_load_hook")
         if self.cls_to_become is not None:
             self.__class__ = self.cls_to_become
 

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -334,5 +334,9 @@ class LazyLinear(LazyModuleMixin, Linear):
                 )
             self.in_features = input.shape[-1]
 
+    def _lazy_load_pre_materialize_hook(self):
+        if self.in_features == 0 and isinstance(self.weight, Tensor):
+            self.in_features = self.weight.shape[-1]
+
 
 # TODO: PartialLinear - maybe in sparse?


### PR DESCRIPTION
Materialize lazy modules fully on load_state_dict instead of leaving them in a partially initialized state, covering all 13 built-in lazy module types.(Fixes #73009)
- Factoring finalization into reusable _materialize() on LazyModuleMixin.
- Added _lazy_load_pre_materialize_hook() for subclasses to set metadata (in_features, in_channels, num_features) on the load path.
- Updated tests to assert immediate finalization; added forward-after-load tests.

**Note:** Changes _infer_parameters body, which torchrec tests for consistency.
