### PR TITLE
Propagate graphed callable input mutations

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4096,6 +4096,63 @@ exit(2)
                 self.assertNotEqual(p.data_ptr(), pg.data_ptr())
                 self.assertNotEqual(p.grad.data_ptr(), pg.grad.data_ptr())
 
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_make_graphed_callables_propagates_input_mutation(self):
+        def fn(x, y):
+            x.add_(y)
+            return x * 2
+
+        sample_x = torch.zeros(4, device="cuda")
+        sample_y = torch.ones(4, device="cuda")
+        graphed_fn = torch.cuda.make_graphed_callables(
+            fn, (sample_x, sample_y), num_warmup_iters=1
+        )
+
+        x = torch.arange(4, device="cuda", dtype=torch.float)
+        y = torch.full_like(x, 3)
+        expected_x = x + y
+        x_version = x._version
+        y_version = y._version
+
+        out = graphed_fn(x, y)
+        torch.cuda.synchronize()
+
+        self.assertEqual(x, expected_x)
+        self.assertEqual(out, expected_x * 2)
+        self.assertGreater(x._version, x_version)
+        self.assertEqual(y._version, y_version)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_make_graphed_callables_rejects_grad_input_mutation(self):
+        def fn(x):
+            x.mul_(2)
+            return x * 3
+
+        base = torch.ones(4, device="cuda", requires_grad=True)
+        sample = base * 1
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "in-place mutations on user inputs that require grad",
+        ):
+            torch.cuda.make_graphed_callables(fn, (sample,), num_warmup_iters=1)
+
+        sample = torch.ones(4, device="cuda")
+        graphed_fn = torch.cuda.make_graphed_callables(
+            fn, (sample,), num_warmup_iters=1
+        )
+        live_base = torch.ones(4, device="cuda", requires_grad=True)
+        live = live_base * 1
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "in-place mutations on user inputs that require grad",
+        ):
+            graphed_fn(live)
+
     def test_cuda_graph_inference_mode(self):
         # This test is to verify that capturing a CUDAGraph in inference mode
         # doesn't create RNG State tensors as inference tensors which can't
@@ -4110,6 +4167,20 @@ exit(2)
             captured_fn = torch.cuda.make_graphed_callables(fn, (x,))
             inp = torch.ones(10, 10, device="cuda")
             self.assertEqual(captured_fn(inp), inp + 1)
+
+        with torch.inference_mode():
+            inference_x = torch.randn(10, 10, device="cuda")
+            captured_fn = torch.cuda.make_graphed_callables(fn, (inference_x,))
+
+        inp = torch.ones(10, 10, device="cuda")
+        expected_inp = inp.clone()
+        expected_out = expected_inp + 1
+        inp_version = inp._version
+        with torch.inference_mode():
+            out = captured_fn(inp)
+        self.assertEqual(out, expected_out)
+        self.assertEqual(inp, expected_inp)
+        self.assertEqual(inp._version, inp_version)
 
         torch.cuda.make_graphed_callables(fn, (x,))
         inp = torch.ones(10, 10, device="cuda") * 10

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -2562,6 +2562,73 @@ if __name__ == "__main__":
                 self.assertNotEqual(p.data_ptr(), pg.data_ptr())
                 self.assertNotEqual(p.grad.data_ptr(), pg.grad.data_ptr())
 
+    def test_graph_make_graphed_callables_propagates_input_mutation(self):
+        def fn(x, y):
+            x.add_(y)
+            return x * 2
+
+        sample_x = torch.zeros(4, device="xpu")
+        sample_y = torch.ones(4, device="xpu")
+        graphed_fn = torch.xpu.make_graphed_callables(
+            fn, (sample_x, sample_y), num_warmup_iters=1
+        )
+
+        x = torch.arange(4, device="xpu", dtype=torch.float)
+        y = torch.full_like(x, 3)
+        expected_x = x + y
+        x_version = x._version
+        y_version = y._version
+
+        out = graphed_fn(x, y)
+        torch.xpu.synchronize()
+
+        self.assertEqual(x, expected_x)
+        self.assertEqual(out, expected_x * 2)
+        self.assertGreater(x._version, x_version)
+        self.assertEqual(y._version, y_version)
+
+    def test_graph_make_graphed_callables_rejects_grad_input_mutation(self):
+        def fn(x):
+            x.mul_(2)
+            return x * 3
+
+        base = torch.ones(4, device="xpu", requires_grad=True)
+        sample = base * 1
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "in-place mutations on user inputs that require grad",
+        ):
+            torch.xpu.make_graphed_callables(fn, (sample,), num_warmup_iters=1)
+
+        sample = torch.ones(4, device="xpu")
+        graphed_fn = torch.xpu.make_graphed_callables(fn, (sample,), num_warmup_iters=1)
+        live_base = torch.ones(4, device="xpu", requires_grad=True)
+        live = live_base * 1
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "in-place mutations on user inputs that require grad",
+        ):
+            graphed_fn(live)
+
+    def test_xpu_graph_inference_mode_make_graphed_callables(self):
+        def fn(x):
+            return x + 1
+
+        with torch.inference_mode():
+            inference_x = torch.randn(10, 10, device="xpu")
+            captured_fn = torch.xpu.make_graphed_callables(fn, (inference_x,))
+
+        inp = torch.ones(10, 10, device="xpu")
+        expected_inp = inp.clone()
+        expected_out = expected_inp + 1
+        inp_version = inp._version
+        with torch.inference_mode():
+            out = captured_fn(inp)
+        self.assertEqual(out, expected_out)
+        self.assertEqual(inp, expected_inp)
+        self.assertEqual(inp._version, inp_version)
+
     def test_graph_optims_with_explicitly_capturable_param_groups(self):
         n_warmup, n_replay = 3, 2
         for optimizer, second_param_group_capturable in product(

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -527,6 +527,13 @@ def make_graphed_callables(
         they appeared in that callable's ``sample_args``.
 
     .. warning::
+        In-place mutations to user-provided inputs that do not require grad are copied back to the
+        runtime inputs after graph replay. In-place mutations to user-provided inputs that require
+        grad are not supported and raise an error during graphing or replay. In-place mutations
+        to user-provided inputs in ``sample_args`` that are inference tensors are not supported
+        because inference tensors do not track version counters.
+
+    .. warning::
         The automatic mixed precision is supported in :func:`~torch.cuda.make_graphed_callables` only with disabled
         caching. The context manager `torch.cuda.amp.autocast()` must have `cache_enabled=False`.
     """
@@ -622,14 +629,47 @@ def make_graphed_callables(
     # the safest approach is to capture all passes in the same order they'll run:
     # fwd 1, fwd 2, ... fwd N, then bwd N, bwd N-1, ... bwd 1.
 
+    # Inference tensors have no version counter, so their mutations are not detectable here.
+    def _version_or_none(t: Tensor) -> int | None:
+        if t.is_inference():
+            return None
+        return t._version
+
     # Capture forward graphs
     per_callable_static_outputs = []
     per_callable_output_unflatten_spec = []
-    for func, args, fwd_graph in zip(callables, _sample_args, fwd_graphs):
+    per_callable_mutated_user_inputs = []
+    for func, args, fwd_graph, static_input_surface, len_user_args in zip(
+        callables,
+        _sample_args,
+        fwd_graphs,
+        per_callable_static_input_surfaces,
+        per_callable_len_user_args,
+    ):
+        prior_user_input_versions = tuple(
+            _version_or_none(t) for t in static_input_surface[:len_user_args]
+        )
         with torch.cuda.graph(fwd_graph, pool=mempool):
             func_outputs = func(*args)
 
+        mutated_user_inputs = tuple(
+            prior_version is not None and _version_or_none(t) != prior_version
+            for t, prior_version in zip(
+                static_input_surface[:len_user_args], prior_user_input_versions
+            )
+        )
+        if any(
+            mutated and arg.requires_grad
+            for mutated, arg in zip(
+                mutated_user_inputs, static_input_surface[:len_user_args]
+            )
+        ):
+            raise RuntimeError(
+                "make_graphed_callables does not support in-place mutations "
+                "on user inputs that require grad"
+            )
         flatten_outputs, spec = torch.utils._pytree.tree_flatten(func_outputs)
+        per_callable_mutated_user_inputs.append(mutated_user_inputs)
         per_callable_static_outputs.append(tuple(flatten_outputs))
         per_callable_output_unflatten_spec.append(spec)
 
@@ -685,6 +725,7 @@ def make_graphed_callables(
         bwd_graph: CUDAGraph,
         module_params: tuple[torch.nn.Parameter, ...],
         len_user_args: int,
+        mutated_user_inputs: tuple[bool, ...],
         output_unflatten_spec: torch.utils._pytree.TreeSpec,
         static_input_surface: tuple[Tensor, ...],
         static_outputs: tuple[Tensor, ...],
@@ -697,9 +738,21 @@ def make_graphed_callables(
             def forward(ctx: object, *inputs: Tensor) -> tuple[Tensor, ...]:
                 # At this stage, only the user args may (potentially) be new tensors.
                 for i in range(len_user_args):
+                    if mutated_user_inputs[i] and inputs[i].requires_grad:
+                        raise RuntimeError(
+                            "make_graphed_callables does not support in-place mutations "
+                            "on user inputs that require grad"
+                        )
+                for i in range(len_user_args):
                     if static_input_surface[i].data_ptr() != inputs[i].data_ptr():
                         static_input_surface[i].copy_(inputs[i])
                 fwd_graph.replay()
+                for i in range(len_user_args):
+                    if (
+                        mutated_user_inputs[i]
+                        and static_input_surface[i].data_ptr() != inputs[i].data_ptr()
+                    ):
+                        inputs[i].copy_(static_input_surface[i])
                 if not isinstance(static_outputs, tuple):
                     raise AssertionError(
                         f"static_outputs must be tuple, got {type(static_outputs)}"
@@ -751,6 +804,7 @@ def make_graphed_callables(
             bwd_graphs[i],
             per_callable_module_params[i],
             per_callable_len_user_args[i],
+            per_callable_mutated_user_inputs[i],
             per_callable_output_unflatten_spec[i],
             per_callable_static_input_surfaces[i],
             per_callable_static_outputs[i],

--- a/torch/xpu/graphs.py
+++ b/torch/xpu/graphs.py
@@ -292,6 +292,13 @@ def make_graphed_callables(
         they appeared in that callable's ``sample_args``.
 
     .. warning::
+        In-place mutations to user-provided inputs that do not require grad are copied back to the
+        runtime inputs after graph replay. In-place mutations to user-provided inputs that require
+        grad are not supported and raise an error during graphing or replay. In-place mutations
+        to user-provided inputs in ``sample_args`` that are inference tensors are not supported
+        because inference tensors do not track version counters.
+
+    .. warning::
         The automatic mixed precision is supported in :func:`~torch.xpu.make_graphed_callables` only with disabled
         caching. The context manager `torch.amp.autocast()` must have `cache_enabled=False`.
     """
@@ -381,15 +388,48 @@ def make_graphed_callables(
 
     torch.xpu.synchronize()
 
+    # Inference tensors have no version counter, so their mutations are not detectable here.
+    def _version_or_none(t: Tensor) -> int | None:
+        if t.is_inference():
+            return None
+        return t._version
+
     # Capture forward graphs
     per_callable_static_outputs = []
     per_callable_output_unflatten_spec = []
-    for func, args, fwd_graph in zip(callables, _sample_args, fwd_graphs):
+    per_callable_mutated_user_inputs = []
+    for func, args, fwd_graph, static_input_surface, len_user_args in zip(
+        callables,
+        _sample_args,
+        fwd_graphs,
+        per_callable_static_input_surfaces,
+        per_callable_len_user_args,
+    ):
+        prior_user_input_versions = tuple(
+            _version_or_none(t) for t in static_input_surface[:len_user_args]
+        )
         # each graph uses the same mempool
         with torch.xpu.graph(fwd_graph, pool=mempool):
             func_outputs = func(*args)
 
+        mutated_user_inputs = tuple(
+            prior_version is not None and _version_or_none(t) != prior_version
+            for t, prior_version in zip(
+                static_input_surface[:len_user_args], prior_user_input_versions
+            )
+        )
+        if any(
+            mutated and arg.requires_grad
+            for mutated, arg in zip(
+                mutated_user_inputs, static_input_surface[:len_user_args]
+            )
+        ):
+            raise RuntimeError(
+                "make_graphed_callables does not support in-place mutations "
+                "on user inputs that require grad"
+            )
         flatten_outputs, spec = torch.utils._pytree.tree_flatten(func_outputs)
+        per_callable_mutated_user_inputs.append(mutated_user_inputs)
         per_callable_static_outputs.append(tuple(flatten_outputs))
         per_callable_output_unflatten_spec.append(spec)
 
@@ -439,6 +479,7 @@ def make_graphed_callables(
         bwd_graph: XPUGraph,
         module_params: tuple[torch.nn.Parameter, ...],
         len_user_args: int,
+        mutated_user_inputs: tuple[bool, ...],
         output_unflatten_spec: torch.utils._pytree.TreeSpec,
         static_input_surface: tuple[Tensor, ...],
         static_outputs: tuple[Tensor, ...],
@@ -451,9 +492,21 @@ def make_graphed_callables(
             def forward(ctx: object, *inputs: Tensor) -> tuple[Tensor, ...]:
                 # At this stage, only the user args may (potentially) be new tensors.
                 for i in range(len_user_args):
+                    if mutated_user_inputs[i] and inputs[i].requires_grad:
+                        raise RuntimeError(
+                            "make_graphed_callables does not support in-place mutations "
+                            "on user inputs that require grad"
+                        )
+                for i in range(len_user_args):
                     if static_input_surface[i].data_ptr() != inputs[i].data_ptr():
                         static_input_surface[i].copy_(inputs[i])
                 fwd_graph.replay()
+                for i in range(len_user_args):
+                    if (
+                        mutated_user_inputs[i]
+                        and static_input_surface[i].data_ptr() != inputs[i].data_ptr()
+                    ):
+                        inputs[i].copy_(static_input_surface[i])
                 if not isinstance(static_outputs, tuple):
                     raise RuntimeError("static_outputs must be a tuple")
                 return tuple(o.detach() for o in static_outputs)
@@ -493,6 +546,7 @@ def make_graphed_callables(
             bwd_graphs[i],
             per_callable_module_params[i],
             per_callable_len_user_args[i],
+            per_callable_mutated_user_inputs[i],
             per_callable_output_unflatten_spec[i],
             per_callable_static_input_surfaces[i],
             per_callable_static_outputs[i],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184699

Track user inputs mutated during make_graphed_callables capture and copy non-grad mutations back after replay. Reject mutated grad-tracked user inputs because their in-place history cannot be represented correctly in the caller's autograd graph.

Fixes #178586

Generated by my agent