### PR TITLE
[profiler] Allowlist channel / channel_type in trace metadata parity test (#184701)

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4708,6 +4708,13 @@ class TestProfilerEventsParity(TestCase):
             "ptr",
             "src",
             "dst",
+            # Preemptive: an upcoming kineto change will start emitting
+            # CUPTI's channel / channel_type on kernel-launch, memcpy, memset,
+            # and p2p activities. The matching EventMetadata fields already
+            # exist; the _EVENT_METADATA_KEYS mapping lands alongside the
+            # kineto pin update.
+            "channel",
+            "channel_type",
         }
         supported_trace_keys = set(_EVENT_METADATA_KEYS).union(
             allowed_non_structured_trace_keys


### PR DESCRIPTION
Summary:

A follow-up kineto release adds `channel` and `channel_type` to the
per-event metadata JSON for kernel-launch, memcpy, memset, and p2p
activities. The matching `EventMetadata` fields already exist; the
`_EVENT_METADATA_KEYS` wiring follows in a separate change. Allowlist
the keys in `test_structured_metadata_matches_chrome_trace` so the
parity test stays green in the window between the kineto update
landing and the wiring landing.

Test Plan:
re-ran `test_structured_metadata_matches_chrome_trace`
against a kineto build that emits the new keys: fails without the
allowlist entries, passes with them.

Reviewed By: scotts

Differential Revision: D105950441


