### PR TITLE
drop stale FIXME comments in ATen and tests

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -744,7 +744,6 @@ Tensor special_ndtr(const Tensor& self) {
   return calc_ndtr(self);
 }
 
-// FIXME: remove const_cast once unary_op_impl_out is updated
 TORCH_IMPL_FUNC(sgn_out) (const Tensor& self, const Tensor& result) {
   if (self.is_complex()) {
     sgn_stub(device_type(), *this);

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1794,7 +1794,6 @@ torch.cuda.synchronize()
         if adaptive:
             cls_name = f"AdaptiveMaxPool{num_dim}d"
         else:
-            # FIXME(#105716): Test fails when using f-string
             cls_name = f"MaxPool{num_dim}d"
         module_cls = getattr(nn, cls_name)
         module = module_cls(2, return_indices=True).to(device, dtype=dtype)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -13095,8 +13095,8 @@ class TestAdvancedIndexing(TestCaseMPS):
             y_cpu = x_cpu[1:4, [1, 2]]
             y_mps = x_mps[1:4, [1, 2]]
             self.assertEqual(y_cpu, y_mps, str(dtype))
-        # FIXME: use supported_dtypes once uint8 is fixed
-        [helper(dtype) for dtype in [torch.float32, torch.float16, torch.int64, torch.int32, torch.int16]]
+        for dtype in self.supported_dtypes:
+            helper(dtype)
 
     def test_boolean_array_indexing(self):
         def helper(dtype):

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -443,7 +443,6 @@ class TestFFT(TestCase):
          allowed_dtypes=[torch.float, torch.cfloat])
     def test_fftn_invalid(self, device, dtype, op):
         a = torch.rand(10, 10, 10, device=device, dtype=dtype)
-        # FIXME: https://github.com/pytorch/pytorch/issues/108205
         errMsg = "dims must be unique"
         with self.assertRaisesRegex(RuntimeError, errMsg):
             op(a, dim=(0, 1, 0))


### PR DESCRIPTION
Drops 4 FIXME comments that no longer apply: closed/resolved issues (#105716, #108205), code already updated, MPS uint8 advanced indexing now works.