### PR TITLE
[dynamo] Add support for record_function as a decorator + fix create(…

### DIFF
--- a/test/dynamo/test_profiler.py
+++ b/test/dynamo/test_profiler.py
@@ -7,6 +7,8 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch._dynamo.utils
 from torch._dynamo.utils import chromium_event_timed, ChromiumEventLogger, dynamo_timed
+from torch._dynamo.variables.constant import ConstantVariable
+from torch._dynamo.variables.ctx_manager import ProfilerRecordFunctionContextVariable
 from torch.profiler import record_function
 from torch.testing._internal.common_utils import TemporaryFileName
 
@@ -401,6 +403,54 @@ def forward(self, arg0_1):
                 "my_net2",
             ],
         )
+
+    @torch._dynamo.config.patch("capture_profiler_record_function", True)
+    def test_profiler_record_function_create_uses_record_args_and_kwargs(self):
+        ctx = ProfilerRecordFunctionContextVariable.create(
+            func=record_function,
+            record_args=[ConstantVariable.create("with_args")],
+            record_kwargs={"args": ConstantVariable.create("payload")},
+        )
+
+        self.assertEqual(ctx.target_values, ["with_args", "payload"])
+
+        ctx = ProfilerRecordFunctionContextVariable.create(
+            func=record_function,
+            record_args=[],
+            record_kwargs={
+                "name": ConstantVariable.create("with_kwargs"),
+                "args": ConstantVariable.create("kw_payload"),
+            },
+        )
+
+        self.assertEqual(ctx.target_values, ["with_kwargs", "kw_payload"])
+
+    @torch._dynamo.config.patch("capture_profiler_record_function", True)
+    def test_dynamo_preserve_record_func_decorator(self):
+        @record_function("my_net")
+        def fn(x):
+            a = x.sin()
+            return a + 2
+
+        backend = torch._dynamo.testing.AotEagerAndRecordGraphs()
+        fn_c = torch.compile(fn, backend=backend)
+        fn_c(torch.randn(10))
+        self.assertExpectedInline(
+            backend.graphs[0].code.strip(),
+            """\
+def forward(self, L_args_0_ : torch.Tensor):
+    l_args_0_ = L_args_0_
+    _record_function_enter_new = torch.ops.profiler._record_function_enter_new('my_net', None)
+    a = l_args_0_.sin();  l_args_0_ = None
+    add = a + 2;  a = None
+    _record_function_exit__record_function = torch.ops.profiler._record_function_exit._RecordFunction(_record_function_enter_new);  _record_function_enter_new = _record_function_exit__record_function = None
+    return (add,)""",
+        )
+        with torch.profiler.profile() as prof:
+            fn_c(torch.randn(10))
+
+        annotations = [e.name for e in prof.events() if "my_" in e.name]
+        self.assertEqual(annotations, ["my_net"])
 
     @torch._dynamo.config.patch("capture_profiler_record_function", True)
     def test_dynamo_preserve_record_func_with_graph_break(self):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1064,6 +1064,7 @@ class VariableBuilder:
                 return self.wrap_tensor(value)
 
         if isinstance(value, torch.profiler.record_function):
+            self.install_guards(GuardBuilder.ID_MATCH)
             return RecordFunctionVariable(value)
         if is_namedtuple(value):
             self.install_guards(GuardBuilder.SEQUENCE_LENGTH)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -212,6 +212,7 @@ from .ctx_manager import (
     ErrorOnGraphBreakVariable,
     NullContextVariable,
     PreserveVersionContextVariable,
+    RecordFunctionVariable,
 )
 from .dicts import ConstDictVariable, MappingProxyVariable, SetVariable
 from .distributed import WorldMetaClassVariable
@@ -1062,6 +1063,8 @@ class VariableBuilder:
             ):
                 return self.wrap_tensor(value)
 
+        if isinstance(value, torch.profiler.record_function):
+            return RecordFunctionVariable(value)
         if is_namedtuple(value):
             self.install_guards(GuardBuilder.SEQUENCE_LENGTH)
             output: list[VariableTracker] = [

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -216,6 +216,24 @@ class GenericContextWrappingVariable(UserDefinedObjectVariable):
         return True
 
 
+class RecordFunctionVariable(GenericContextWrappingVariable):
+    def __init__(self, cm_obj: torch.profiler.record_function, **kwargs: Any) -> None:
+        super().__init__(cm_obj, **kwargs)
+        args = [variables.ConstantVariable.create(cm_obj.name)]
+        record_kwargs = {}
+        if cm_obj.args:
+            record_kwargs["args"] = variables.ConstantVariable.create(cm_obj.args)
+        self.record_fn = variables.torch.ProfilerRecordFunctionContextVariable.create(
+            func=type(self.cm_obj), record_args=args, record_kwargs=record_kwargs
+        )
+
+    def enter(self, tx):
+        return self.record_fn.enter(tx)
+
+    def exit(self, tx, *args):
+        return self.record_fn.exit(tx, *args)
+
+
 class RepararametrizeModuleContextVariable(GenericContextWrappingVariable):
     def __init__(self, ctx_manager_vt: ContextWrappingVariable, mod: Any) -> None:
         self.cm_vt = ctx_manager_vt
@@ -1215,15 +1233,15 @@ class ProfilerRecordFunctionContextVariable(ContextWrappingVariable):
             name = (
                 record_args[0].as_python_constant()
                 if record_args
-                else kwargs.get(
+                else record_kwargs.get(
                     "name", variables.ConstantVariable.create("unknown")
                 ).as_python_constant()
             )
             record_args_const = None
             if len(record_args) > 1:
                 record_args_const = record_args[1].as_python_constant()
-            elif "args" in kwargs:
-                record_args_const = kwargs["args"].as_python_constant()
+            elif "args" in record_kwargs:
+                record_args_const = record_kwargs["args"].as_python_constant()
             target_values = [name, record_args_const]
         else:
             warning_once(log, "Profiler record function %s will be ignored", func)

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -228,9 +228,11 @@ class RecordFunctionVariable(GenericContextWrappingVariable):
         )
 
     def enter(self, tx):
+        tx.active_generic_context_managers.append(self)
         return self.record_fn.enter(tx)
 
     def exit(self, tx, *args):
+        tx.active_generic_context_managers.pop()
         return self.record_fn.exit(tx, *args)
 
 


### PR DESCRIPTION
…) method

- #167787 introduced support for record_function in Dynamo but only as a context manager. This PR extend the support to function decorators.
- The create() method was using args / kwargs instead of record_args / record_kwargs: fix this and add a test.

Jira-task: PYT-1518

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos