### PR TITLE
Capturable param in optimizers restored using custom vts and cleanup hooks

### DIFF
--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -1077,6 +1077,25 @@ class CompiledOptimizerTests(TestCase):
         for param, param_ref in zip(params, params_ref):
             self.assertEqual(param, param_ref)
 
+    def test_capturable_does_not_leak_to_param_groups(self, device="cpu"):
+        if device == GPU_TYPE and not HAS_GPU:
+            self.skipTest("requires GPU")
+        m = torch.nn.Linear(2, 2, device=device)
+        opt = AdamW(m.parameters(), lr=0.01)
+        m(torch.randn(2, 2, device=device)).sum().backward()
+        opt.step()
+
+        original_capturable = opt.param_groups[0]["capturable"]
+
+        def fn():
+            opt.param_groups[0]["lr"] = 5.0
+            sd = deepcopy(opt.state_dict())
+            opt.param_groups[0]["lr"] = 0.01
+            return sd
+
+        torch._dynamo.optimize("eager_noexcept", nopython=False)(fn)()
+        self.assertEqual(opt.param_groups[0]["capturable"], original_capturable)
+
 
 @skipIfRocm(msg="ROCm may have different numerical behavior")
 @requires_gpu_and_triton

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -51,6 +51,7 @@ from .user_defined import UserDefinedObjectVariable
 
 
 if TYPE_CHECKING:
+    from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
 
 
@@ -220,7 +221,12 @@ class OptimizerVariable(UserDefinedObjectVariable):
         )
         for param_group_vt in param_groups_vt.items:
             key = HashableTracker(ConstantVariable.create("capturable"))
-            param_group_vt.items[key] = ConstantVariable.create(True)
+            orig_vt = param_group_vt.items.get(key)
+            if orig_vt is None or isinstance(orig_vt, OptimizerCapturableVariable):
+                continue
+            param_group_vt.items[key] = OptimizerCapturableVariable(
+                value=True, orig_value=orig_vt.as_python_constant()
+            )
 
     def get_python_args(
         self, *args: Any, **kwargs: Any
@@ -433,3 +439,24 @@ class OptimizerVariable(UserDefinedObjectVariable):
             weakref.finalize(value, clear_static_tensor_refs)
 
         tx.output.add_graph_finalizer(init_finalizer)
+
+
+class OptimizerCapturableVariable(VariableTracker):
+    """Reconstructs as the original capturable value, preventing side-effect leaks.
+    Dynamo never needs to statically evaluate 'if capturable:' itself,
+    so this VT intentionally does NOT expose as_python_constant/is_python_constant.
+    The codegen path therefore uses reconstruct() which emits the true original value.
+    """
+
+    _nonvar_fields = {"orig_value", *VariableTracker._nonvar_fields}
+
+    def __init__(self, value: bool, orig_value: bool, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.value = value
+        self.orig_value = orig_value
+
+    def python_type(self) -> type:
+        return bool
+
+    def reconstruct(self, codegen: "PyCodegen") -> None:
+        codegen(ConstantVariable.create(self.orig_value))


### PR DESCRIPTION
Fixes #182706 

Optimizers capturable Params are intentionally set to true for optimization however they are never restored. There are 2 places where the restoration is to happen:

1. ConstantVariableTracker which always have this value to be 1.  I have created Custom Vt which will do restoration to original val.
2. There is also dictionary of group params being set to True always. I am restoring those original values using add_cleanup_hook function as it is not necessary for every optimizer init_group is being called. Also, we cannot do the change in graph finalizer as that is when gc is called.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98