### PR TITLE
[dynamo] Preserve exception chaining in InternalTorchDynamoError rewrapping

### DIFF
--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -6,6 +6,7 @@ import pickle
 import re
 import sys
 import tempfile
+import traceback
 import unittest
 from typing import cast
 
@@ -16,6 +17,7 @@ import torch._dynamo.test_case
 from torch._dynamo.comptime import comptime
 from torch._dynamo.exc import (
     BackendCompilerFailed,
+    InternalTorchDynamoError,
     InvalidBackend,
     ResetRequired,
     ShortenTraceback,
@@ -238,6 +240,67 @@ from user code:
    File "test_exc.py", line N, in fn001
     comptime(f)""",
         )
+
+    @torch._dynamo.config.patch(suppress_errors=False)
+    def test_exception_chaining_preserved(self):
+        def fn001(x):
+            def f(ctx):
+                try:
+                    config = {}
+                    _ = config["missing_key"]
+                except KeyError as e:
+                    raise RuntimeError("failed to load config") from e
+
+            comptime(f)
+
+        with self.assertRaises(InternalTorchDynamoError) as cm:
+            torch.compile(fn001, backend="eager")(torch.randn(1))
+
+        e = cm.exception
+        self.assertIsNotNone(e.__cause__)
+        self.assertIsInstance(e.__cause__, RuntimeError)
+        self.assertIn("failed to load config", str(e.__cause__))
+        self.assertIsNotNone(e.__cause__.__cause__)
+        self.assertIsInstance(e.__cause__.__cause__, KeyError)
+        self.assertIn("missing_key", str(e.__cause__.__cause__))
+
+    @torch._dynamo.config.patch(verbose=True, suppress_errors=True)
+    @make_logging_test()
+    @unittest.skipIf(IS_FBCODE, "stack trace slightly different in fbcode")
+    def test_chain_false_consistent_with_exc_info(self, records):
+        def fn001(x):
+            def f(ctx):
+                try:
+                    {}["missing_key"]
+                except KeyError as e:
+                    raise RuntimeError("failed to load config") from e
+
+            comptime(f)
+
+        torch.compile(fn001, backend="eager")(torch.randn(1))
+
+        record = self.getRecord(records, "WON'T CONVERT")
+        self.assertNotIn("missing_key", record.getMessage())
+        self.assertExpectedInline(
+            munge_exc(record.getMessage()),
+            """\
+WON'T CONVERT fn001 test_exc.py line N
+========== TorchDynamo Stack Trace ==========
+Traceback (most recent call last):
+  File "test_exc.py", line N, in f
+    raise RuntimeError("failed to load config") from e
+torch._dynamo.exc.InternalTorchDynamoError: RuntimeError: failed to load config
+
+from user code:
+   File "test_exc.py", line N, in fn001
+    comptime(f)
+
+""",
+        )
+        self.assertIsNotNone(record.exc_info)
+        rendered = "".join(traceback.format_exception(*record.exc_info))
+        self.assertIn("missing_key", rendered)
+        self.assertIn("InternalTorchDynamoError", rendered)
 
     @torch._dynamo.config.patch(inject_BUILD_SET_unimplemented_TESTING_ONLY=True)
     @make_logging_test(graph_breaks=True)

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -2224,7 +2224,7 @@ def _compile(
                 # Rewrap for clarity
                 raise InternalTorchDynamoError(
                     f"{type(e).__qualname__}: {str(e)}"
-                ).with_traceback(e.__traceback__) from None
+                ).with_traceback(e.__traceback__) from e
         finally:
             # === WARNING WARNING WARNING ===
             # If you commit a bug here, it will suppress writing to

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -2181,7 +2181,7 @@ def _compile(
                 # Rewrap for clarity
                 raise InternalTorchDynamoError(
                     f"{type(e).__qualname__}: {str(e)}"
-                ).with_traceback(e.__traceback__) from None
+                ).with_traceback(e.__traceback__) from e
         finally:
             # === WARNING WARNING WARNING ===
             # If you commit a bug here, it will suppress writing to

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -62,7 +62,7 @@ import typing
 from enum import auto, Enum
 from functools import lru_cache
 from pathlib import Path
-from traceback import format_exc, format_list, FrameSummary, StackSummary
+from traceback import format_exception, format_list, FrameSummary, StackSummary
 from typing import Any, NoReturn, TYPE_CHECKING
 
 import torch._guards
@@ -1012,7 +1012,7 @@ def format_error_msg_verbose(
         f"WON'T CONVERT {code.co_name} {code.co_filename} line {code.co_firstlineno}\n"
     )
     msg += "=" * 10 + " TorchDynamo Stack Trace " + "=" * 10 + "\n"
-    msg += format_exc()
+    msg += "".join(format_exception(exc, chain=False))
     real_stack = get_real_stack(exc, frame)
     if real_stack is not None:
         msg += (
@@ -1060,4 +1060,4 @@ def format_error_msg(
     if config.verbose:
         return format_error_msg_verbose(exc, code, record_filename, frame)
     return f"WON'T CONVERT {code.co_name} {code.co_filename}\
- line {code.co_firstlineno} \ndue to: \n{format_exc()}"
+ line {code.co_firstlineno} \ndue to: \n{''.join(format_exception(exc, chain=False))}"

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -62,7 +62,7 @@ import typing
 from enum import auto, Enum
 from functools import lru_cache
 from pathlib import Path
-from traceback import format_exc, format_list, FrameSummary, StackSummary
+from traceback import format_exception, format_list, FrameSummary, StackSummary
 from typing import Any, NoReturn, TYPE_CHECKING
 
 import torch._guards
@@ -987,7 +987,7 @@ def format_error_msg_verbose(
         f"WON'T CONVERT {code.co_name} {code.co_filename} line {code.co_firstlineno}\n"
     )
     msg += "=" * 10 + " TorchDynamo Stack Trace " + "=" * 10 + "\n"
-    msg += format_exc()
+    msg += "".join(format_exception(exc, chain=False))
     real_stack = get_real_stack(exc, frame)
     if real_stack is not None:
         msg += (
@@ -1035,4 +1035,4 @@ def format_error_msg(
     if config.verbose:
         return format_error_msg_verbose(exc, code, record_filename, frame)
     return f"WON'T CONVERT {code.co_name} {code.co_filename}\
- line {code.co_firstlineno} \ndue to: \n{format_exc()}"
+ line {code.co_firstlineno} \ndue to: \n{''.join(format_exception(exc, chain=False))}"


### PR DESCRIPTION
When Dynamo catches an unexpected exception during compilation and rewraps it as `InternalTorchDynamoError`, the original `from None` suppressed the entire exception chain. If the original exception had a `__cause__` (e.g. a `RuntimeError` caused by a `KeyError`), that deeper chain was completely inaccessible — not in `__cause__`, not in `__context__`, not inspectable programmatically.

Change `from None` to `from e` so the original exception and its full cause chain are preserved as `__cause__` on the `InternalTorchDynamoError`. Also use `format_exception(exc, chain=False)` in `format_error_msg` / `format_error_msg_verbose` so the WON'T CONVERT log format is unchanged.

Fixes #113800

## Before/After

**Before:** Only `InternalTorchDynamoError` is visible. The root cause (`KeyError`) and intermediate exception (`RuntimeError`) are lost:

```
torch._dynamo.exc.InternalTorchDynamoError: RuntimeError: failed to load config

e.__cause__    → None   ← chain severed, root cause lost
```

**After:** The full cause chain is preserved and inspectable:

```
KeyError: 'missing_key'

The above exception was the direct cause of the following exception:

  ...
RuntimeError: failed to load config

The above exception was the direct cause of the following exception:

  ...
torch._dynamo.exc.InternalTorchDynamoError: RuntimeError: failed to load config

e.__cause__           → RuntimeError: failed to load config
e.__cause__.__cause__ → KeyError: 'missing_key'
```

<details>
<summary>Full before log</summary>

```
Traceback (most recent call last):
  File "demo.py", line 19, in <module>
    out = torch.compile(model, backend="eager")(torch.randn(4))
  File ".../convert_frame.py", line 2159, in _compile
    raise InternalTorchDynamoError(
  File ".../convert_frame.py", line 2094, in _compile
    guarded_code, tracer_output = compile_inner(code, one_graph, hooks)
  ...
  File "demo.py", line 10, in f
    raise RuntimeError("failed to load config") from e
torch._dynamo.exc.InternalTorchDynamoError: RuntimeError: failed to load config

from user code:
   File "demo.py", line 13, in model
    comptime(f)

e.__cause__    → None   ← chain severed, root cause lost
```

</details>

<details>
<summary>Full after log</summary>

```
Traceback (most recent call last):
  File "demo.py", line 8, in f
    val = config["missing_key"]
KeyError: 'missing_key'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File ".../convert_frame.py", line 2094, in _compile
    guarded_code, tracer_output = compile_inner(code, one_graph, hooks)
  ...
  File "demo.py", line 10, in f
    raise RuntimeError("failed to load config") from e
RuntimeError: failed to load config

from user code:
   File "demo.py", line 13, in model
    comptime(f)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "demo.py", line 19, in <module>
    out = torch.compile(model, backend="eager")(torch.randn(4))
  File ".../convert_frame.py", line 2159, in _compile
    raise InternalTorchDynamoError(
  ...
  File "demo.py", line 10, in f
    raise RuntimeError("failed to load config") from e
torch._dynamo.exc.InternalTorchDynamoError: RuntimeError: failed to load config

from user code:
   File "demo.py", line 13, in model
    comptime(f)

e.__cause__           → RuntimeError: failed to load config
e.__cause__.__cause__ → KeyError: 'missing_key'
```

</details>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98