### PR TITLE
Fix compiled CELU zero alpha validation

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2306,6 +2306,70 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
             )
         )
 
+    @unittest.skipIf(
+        "inductor" not in torch._dynamo.list_backends(),
+        "inductor backend is not available",
+    )
+    def test_celu_zero_alpha_raises(self):
+        try:
+            import numpy as np
+        except ImportError:
+            np = None
+
+        zero_alphas = (0.0,)
+        if np is not None:
+            zero_alphas += (np.float64(0.0),)
+
+        for alpha, inplace in itertools.product(zero_alphas, (False, True)):
+            with self.subTest(alpha=alpha, inplace=inplace):
+
+                def fn(x):
+                    if inplace:
+                        return torch.celu_(x, alpha=alpha)
+                    return torch.celu(x, alpha=alpha)
+
+                with self.assertRaisesRegex(
+                    RuntimeError, "ZeroDivisionError: alpha cannot be 0 for CELU"
+                ):
+                    fn(torch.randn(8))
+
+                opt_fn = torch.compile(
+                    fn, backend="inductor", fullgraph=True, dynamic=True
+                )
+                with self.assertRaisesRegex(
+                    RuntimeError, "ZeroDivisionError: alpha cannot be 0 for CELU"
+                ):
+                    opt_fn(torch.randn(8))
+
+    @unittest.skipIf(
+        "inductor" not in torch._dynamo.list_backends(),
+        "inductor backend is not available",
+    )
+    def test_celu_numpy_alpha_matches_eager(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("NumPy is required for this test")
+
+        alpha = np.float64(1.5)
+        for inplace in (False, True):
+            with self.subTest(inplace=inplace):
+
+                def fn(x):
+                    if inplace:
+                        return torch.celu_(x, alpha=alpha)
+                    return torch.celu(x, alpha=alpha)
+
+                inp = torch.linspace(-2, 2, 17)
+                expected_inp = inp.clone()
+                actual_inp = inp.clone()
+                expected = fn(expected_inp)
+                opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+                actual = opt_fn(actual_inp)
+
+                self.assertEqual(actual, expected)
+                self.assertEqual(actual_inp, expected_inp)
+
     @patch.object(torch._dynamo.config, "skip_nnmodule_hook_guards", False)
     def test_hooks_outer(self):
         class TestModule(torch.nn.Module):

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -186,6 +186,13 @@ def celu(
 
     rhs: TensorLikeType
     if alpha is not None:
+        alpha_nonzero = alpha != 0
+        if not isinstance(alpha_nonzero, torch.SymBool):
+            alpha_nonzero = bool(alpha_nonzero)
+        torch._check(
+            alpha_nonzero,
+            lambda: "ZeroDivisionError: alpha cannot be 0 for CELU",
+        )
         python_type = utils.dtype_to_type(a.dtype)
         if not utils.is_weakly_lesser_type(type(alpha), python_type):
             msg = f"alpha argument of type {type(alpha)} cannot be safely cast to type {python_type}!"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184707

Add the eager CELU alpha=0 validation to the reference decomposition used by torch.compile, and cover the compiled out-of-place, in-place, and NumPy scalar alpha paths. This picks up the abandoned root-cause approach from #179375 while preserving NumPy scalar handling.

Fixes #178480

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos