### PR TITLE
Fix Dynamo tensor subclass constructor side effects

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1422,6 +1422,58 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(res, ref)
         self.assertEqual(res[0].bar, ref[0].bar)
 
+    def test_tensor_subclass_from_module_attr_data_assignment(self):
+        class CustomTensor(torch.Tensor):
+            def __init__(self, data):
+                super().__init__()
+                self.custom_metadata = "custom_tensor_data"
+
+            @classmethod
+            def __torch_function__(cls, func, types, args=(), kwargs=None):
+                return super().__torch_function__(func, types, args, kwargs or {})
+
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer = torch.nn.Linear(4, 4)
+                self.custom_weights = None
+
+            def forward(self, x):
+                self.custom_weights = CustomTensor(self.layer.weight.data)
+                return self.layer(x)
+
+        mod = Mod().eval()
+        opt_mod = torch.compile(mod, backend="eager", fullgraph=True)
+        inp = torch.randn(2, 4)
+        expected = mod.layer(inp)
+
+        with torch.no_grad():
+            result = opt_mod(inp)
+
+        self.assertEqual(result, expected)
+        self.assertIsInstance(mod.custom_weights, CustomTensor)
+        self.assertEqual(mod.custom_weights.custom_metadata, "custom_tensor_data")
+
+    def test_tensor_subclass_unpack_attr_mutation(self):
+        class MySubclass(torch.Tensor):
+            @classmethod
+            def __torch_function__(cls, func, types, args=(), kwargs=None):
+                return super().__torch_function__(func, types, args, kwargs or {})
+
+        def f(x):
+            a, b = x
+            a.foo = 3
+            return a + b, a.foo
+
+        opt_f = compile_full_eager(f)
+
+        x = torch.ones(2, 3).as_subclass(MySubclass)
+        res = f(x)
+        ref = opt_f(x)
+
+        self.assertEqual(res, ref)
+        self.assertIsInstance(ref[0], MySubclass)
+
     def test_as_subclass_attr_mutation(self):
         # Make sure the attribute mutation for newly constructed tensor subclass
         # object (from as_subclass call) is handled both during Dynamo tracing

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2799,7 +2799,11 @@ class TensorSubclassVariable(UserDefinedClassVariable):
                 # Simulate `torch.Tensor.__new__` as shallow-copying the input
                 # tensor data with a new type. TODO polyfill?
                 var = TensorWithTFOverrideVariable.from_tensor_var(
-                    tx, data, self.value, self.source
+                    tx,
+                    data,
+                    self.value,
+                    self.source,
+                    inherit_tensor_var_attrs=False,
                 )
             else:
                 unimplemented(
@@ -2819,17 +2823,18 @@ class TensorSubclassVariable(UserDefinedClassVariable):
             )
         if var is None:
             raise AssertionError("__new__ must return a non-None variable")
-        # Let Dynamo trace through custom `__init__`
-        init_func = self.value.__init__
-        # TODO builder should be able to handle `torch.Tensor.__init__`,
-        # which is `object.__init__`, so that we can remove this check.
-        if init_func is not torch.Tensor.__init__:
-            VariableTracker.build(tx, init_func).call_function(tx, [var], kwargs)
 
         # See NOTE [Side effect tracking for newly constructed tensor]
         tx.output.side_effects._track_obj(
             object(), var, mutation_type_cls=AttributeMutationNew
         )
+
+        # Let Dynamo trace through custom `__init__`
+        init_func = self.value.__init__
+        # TODO builder should be able to handle `torch.Tensor.__init__`,
+        # which is `object.__init__`, so that we can remove this check.
+        if init_func is not torch.Tensor.__init__:
+            VariableTracker.build(tx, init_func).call_function(tx, [var, *args], kwargs)
         return var
 
     def as_python_constant(self) -> type:

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -598,6 +598,8 @@ class TensorWithTFOverrideVariable(TensorVariable):
         tensor_var: VariableTracker,
         class_type: type,
         cls_source: Source | None,
+        *,
+        inherit_tensor_var_attrs: bool = True,
     ) -> "TensorWithTFOverrideVariable":
         # [Note: __torch_function__] coerce `tensor_var` into a
         # TensorWithTFOverrideVariable. In eager, this is just a type change.
@@ -607,6 +609,12 @@ class TensorWithTFOverrideVariable(TensorVariable):
         # This simulates shallow-copying the tensor object.
         kwargs = dict(tensor_var.__dict__)
         input_tensor_type = kwargs.pop("class_type")
+        if not inherit_tensor_var_attrs:
+            # The subclass constructor creates a new Python object, not another
+            # source for the wrapped tensor variable.
+            kwargs.pop("source", None)
+            kwargs.pop("source_location", None)
+            kwargs.pop("mutation_type", None)
         if not (
             input_tensor_type in (torch.Tensor, torch.nn.Parameter)
             or issubclass(input_tensor_type, torch.Tensor)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184709

Treat tensor subclass construction from an existing tensor as a fresh Python wrapper, track it before tracing custom __init__, and forward constructor arguments so __init__ side effects are replayed correctly. Add coverage for module attribute assignment and preserved non-constructor wrapper mutation.

Fixes #178388

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos