### PR TITLE
[custom_op] Redispatch past ADInplaceOrView for non-view mutable ops

### DIFF
--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -802,36 +802,28 @@ class CustomOpDef:
     def _register_mutation_version_bump(self, schema: _C.FunctionSchema) -> None:
         mutated_idxs, mutated_keys = utils.mutated_args_kwargs(schema)
 
-        if schema._is_view_op():
-            # View ops need the C++ fallback for aliasing tracking
+        is_view = schema._is_view_op()
+        if is_view:
             original_kernel = torch._C._dispatch_get_computed_kernel_for_dispatch_key(
                 f"{self._lib.ns}::{self._name}", "ADInplaceOrView"
             )
-
-            def adinplaceorview_impl(keyset, *args, **kwargs):
-                all_args, all_kwargs = utils.fill_defaults(schema, args, kwargs)
-
-                for idx in mutated_idxs:
-                    increment_version(all_args[idx])
-                for key in mutated_keys:
-                    increment_version(all_kwargs[key])
-                return original_kernel.call_boxed(keyset, *args, **kwargs)
         else:
-            # Non-view mutable ops: increment_version is sufficient,
-            # redispatch directly past ADInplaceOrView to the backend.
             op = self._opoverload
             after_ADInplaceOrView_keyset = _C._after_ADInplaceOrView_keyset
 
-            def adinplaceorview_impl(keyset, *args, **kwargs):
-                all_args, all_kwargs = utils.fill_defaults(schema, args, kwargs)
+        def adinplaceorview_impl(keyset, *args, **kwargs):
+            all_args, all_kwargs = utils.fill_defaults(schema, args, kwargs)
 
-                for idx in mutated_idxs:
-                    increment_version(all_args[idx])
-                for key in mutated_keys:
-                    increment_version(all_kwargs[key])
-                return op.redispatch(
-                    keyset & after_ADInplaceOrView_keyset, *args, **kwargs
-                )
+            for idx in mutated_idxs:
+                increment_version(all_args[idx])
+            for key in mutated_keys:
+                increment_version(all_kwargs[key])
+            if is_view:
+                # View ops need the C++ fallback for aliasing tracking
+                return original_kernel.call_boxed(keyset, *args, **kwargs)
+            # Non-view mutable ops: increment_version is sufficient,
+            # redispatch directly past ADInplaceOrView to the backend.
+            return op.redispatch(keyset & after_ADInplaceOrView_keyset, *args, **kwargs)
 
         with warnings.catch_warnings():
             warnings.filterwarnings(

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -802,20 +802,36 @@ class CustomOpDef:
     def _register_mutation_version_bump(self, schema: _C.FunctionSchema) -> None:
         mutated_idxs, mutated_keys = utils.mutated_args_kwargs(schema)
 
-        original_kernel = torch._C._dispatch_get_computed_kernel_for_dispatch_key(
-            f"{self._lib.ns}::{self._name}", "ADInplaceOrView"
-        )
+        if schema._is_view_op():
+            # View ops need the C++ fallback for aliasing tracking
+            original_kernel = torch._C._dispatch_get_computed_kernel_for_dispatch_key(
+                f"{self._lib.ns}::{self._name}", "ADInplaceOrView"
+            )
 
-        def adinplaceorview_impl(keyset, *args, **kwargs):
-            # Handle the mutated idx the user gave us explicitly
-            all_args, all_kwargs = utils.fill_defaults(schema, args, kwargs)
+            def adinplaceorview_impl(keyset, *args, **kwargs):
+                all_args, all_kwargs = utils.fill_defaults(schema, args, kwargs)
 
-            for idx in mutated_idxs:
-                increment_version(all_args[idx])
-            for key in mutated_keys:
-                increment_version(all_kwargs[key])
-            # Handle view + mutation that are in the schema
-            return original_kernel.call_boxed(keyset, *args, **kwargs)
+                for idx in mutated_idxs:
+                    increment_version(all_args[idx])
+                for key in mutated_keys:
+                    increment_version(all_kwargs[key])
+                return original_kernel.call_boxed(keyset, *args, **kwargs)
+        else:
+            # Non-view mutable ops: increment_version is sufficient,
+            # redispatch directly past ADInplaceOrView to the backend.
+            op = self._opoverload
+            after_ADInplaceOrView_keyset = _C._after_ADInplaceOrView_keyset
+
+            def adinplaceorview_impl(keyset, *args, **kwargs):
+                all_args, all_kwargs = utils.fill_defaults(schema, args, kwargs)
+
+                for idx in mutated_idxs:
+                    increment_version(all_args[idx])
+                for key in mutated_keys:
+                    increment_version(all_kwargs[key])
+                return op.redispatch(
+                    keyset & after_ADInplaceOrView_keyset, *args, **kwargs
+                )
 
         with warnings.catch_warnings():
             warnings.filterwarnings(


### PR DESCRIPTION
Split `_register_mutation_version_bump` on `schema._is_view_op()`. Non-view mutable custom ops now call `op.redispatch(keyset & after_ADInplaceOrView_keyset, ...)` after bumping version counters, matching the generated `ADInplaceOrViewType_*.cpp` kernels. View ops keep the existing `call_boxed` path into the C++ fallback for alias tracking.

Previously all custom ops called `original_kernel.call_boxed(keyset, ...)` which re-enters the C++ ADInplaceOrView boxed fallback with the full (unmasked) keyset. The fallback only adds value for view ops; for non-view mutable ops, `increment_version` in Python is sufficient.

Split out from #183508 per review feedback. cc @zou3519

## Test plan

No additional tests.

```bash
python -m pytest test/test_custom_ops.py -x -q -k "mutate or version or inplace"
```

34 tests pass. Pre-existing failure in `test_incorrect_schema_types` reproduces on main.