### PR TITLE
[TMA] Refuse TMA for buffers recorded in V.graph.unaligned_buffers

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1684,6 +1684,17 @@ class TritonTensorDescriptorTestCUDA(BlockDescriptorTestBase):
         self.assertEqual(result, fn(x))
         self.assertIn("tl.load", code)
 
+    def test_slice_view_dtype_unaligned_buffer(self):
+        offset = 1
+
+        def f(x):
+            return x[2:].view(dtype=torch.float32) + 1
+
+        x = torch.randn((128 + offset) * 2, dtype=torch.bfloat16, device=GPU_TYPE)
+        expected = f(x)
+        actual = torch.compile(f)(x)
+        self.assertEqual(actual, expected)
+
 
 test_torchinductor.copy_tests(
     CommonTemplate,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -120,6 +120,7 @@ from .simd import (
 from .triton_utils import (
     config_of,
     equal_1_arg_indices,
+    is_unaligned_buffer_name,
     non_constexpr_signature,
     should_unwrap_unspec_arg,
     signature_to_meta,
@@ -2851,12 +2852,7 @@ class TMACompatibilityChecker:
         # When operations like slicing, as_strided, or view(dtype=...) are folded into
         # the kernel argument (for example, via reinterpret_tensor with a non-aligned
         # storage_offset), the resulting buffer's data_ptr may not be 16-byte aligned.
-        # Inductor tracks such buffers by adding their names to V.graph.unaligned_buffers.
-        # Here we reuse this information to check if the buffer is unaligned.
-        if (
-            self.buffer_name is not None
-            and self.buffer_name in V.graph.unaligned_buffers
-        ):
+        if self.buffer_name is not None and is_unaligned_buffer_name(self.buffer_name):
             log.debug(
                 "%s TMA descriptor base must be 16 byte aligned but buffer %s "
                 "is recorded as unaligned (e.g. produced by a sub-pointer "

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2737,6 +2737,8 @@ class TMACompatibilityChecker:
     dtype: torch.dtype
     for_store: bool
     force: bool
+    # Inductor buffer name being loaded from / stored to.
+    buffer_name: str | None = None
 
     def __post_init__(self):
         self.failed_debug_prefix = "Cannot use TMA descriptor for load / store since: "
@@ -2843,6 +2845,24 @@ class TMACompatibilityChecker:
                 self.failed_debug_prefix,
                 constant_offset_expr,
                 element_size,
+            )
+            return False
+
+        # When operations like slicing, as_strided, or view(dtype=...) are folded into
+        # the kernel argument (for example, via reinterpret_tensor with a non-aligned
+        # storage_offset), the resulting buffer's data_ptr may not be 16-byte aligned.
+        # Inductor tracks such buffers by adding their names to V.graph.unaligned_buffers.
+        # Here we reuse this information to check if the buffer is unaligned.
+        if (
+            self.buffer_name is not None
+            and self.buffer_name in V.graph.unaligned_buffers
+        ):
+            log.debug(
+                "%s TMA descriptor base must be 16 byte aligned but buffer %s "
+                "is recorded as unaligned (e.g. produced by a sub-pointer "
+                "view / reinterpret_tensor).",
+                self.failed_debug_prefix,
+                self.buffer_name,
             )
             return False
 
@@ -4056,6 +4076,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 dtype,
                 for_store=False,
                 force=getattr(self, "tma_load_for_template_epilogue", False),
+                buffer_name=name,
             ),
         )
 
@@ -4248,6 +4269,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 dtype,
                 for_store=True,
                 force=force,
+                buffer_name=name,
             )
         indexing = self.indexing(
             index,

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -177,8 +177,7 @@ def _get_buffer_layout(buf_name: str) -> "torch._inductor.ir.Layout":
     return layout
 
 
-def is_unaligned_buffer(arg: TensorArg):
-    buf_name = arg.buffer
+def is_unaligned_buffer_name(buf_name: str) -> bool:
     if buf_name in V.graph.unaligned_buffers:
         return True
 
@@ -197,6 +196,10 @@ def is_unaligned_buffer(arg: TensorArg):
         return not layout.maybe_guard_aligned()
     else:
         return False
+
+
+def is_unaligned_buffer(arg: TensorArg):
+    return is_unaligned_buffer_name(arg.buffer)
 
 
 def _arg_equals_1(arg: KernelArgType) -> bool:


### PR DESCRIPTION
Fixes: #184714

When the wrapper materialises a sub-pointer via reinterpret_tensor (e.g. view(dtype) after a slice), the kernel argument's data_ptr may not be 16-byte aligned even though constant_offset is 0. Inductor already tracks these buffers in V.graph.unaligned_buffers but TMACompatibilityChecker was not consulting this set.

Add a buffer_name field to TMACompatibilityChecker and reject TMA when the buffer is known-unaligned, falling back to plain tl.load/tl.store.

cc: @kshitij12345 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos