### PR TITLE
[Test] Make test_testing.py device-agnostic for out-of-tree accelerators

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -457,8 +457,8 @@ if __name__ == '__main__':
             dynamic_dispatch = opinfo.utils.dtypes_dispatch_hint(dynamic_dtypes)
             if self.device_type == 'cpu':
                 dtypes = op.dtypes
-            else:  # device_type ='cuda'
-                dtypes = op.dtypesIfCUDA
+            else:
+                dtypes = op.supported_dtypes(self.device_type)
 
             self.assertTrue(set(dtypes) == set(dynamic_dtypes))
             self.assertTrue(set(dtypes) == set(dynamic_dispatch.dispatch_fn()))
@@ -990,7 +990,9 @@ class TestAssertCloseMultiDevice(TestCase):
                 fn(check_device=False)
 
 
-instantiate_device_type_tests(TestAssertCloseMultiDevice, globals(), only_for="cuda")
+instantiate_device_type_tests(
+    TestAssertCloseMultiDevice, globals(), except_for=["cpu"], allow_xpu=True
+)
 
 
 class TestAssertCloseErrorMessage(TestCase):


### PR DESCRIPTION
## Summary

This PR removes CUDA-specific assumptions from `test/test_testing.py` to enable out-of-tree accelerator backends to run these tests.

**Changes:**

1. **`test_get_supported_dtypes`**: The `else` branch previously hardcoded `op.dtypesIfCUDA`, which would return incorrect dtypes for any non-CUDA accelerator. Replaced with `op.supported_dtypes(self.device_type)`, the canonical device-agnostic API that routes through the OpInfo `dtypesIf` dict.

2. **`TestAssertCloseMultiDevice`**: Changed `instantiate_device_type_tests` from `only_for="cuda"` to `except_for=["cpu"], allow_xpu=True`. The class body is already fully device-generic (uses `@deviceCountAtLeast(1)` + `itertools.permutations` over `("cpu", *devices)`), so the only CUDA coupling was the instantiation filter.

**What stays unchanged:**
- The 3 `@onlyCUDA` CUDA-assert subprocess tests remain CUDA-only - they test CUDA/ROCm-specific error handling (device-side assert triggered) and are not generalizable.
- `@onlyNativeDeviceTypes` decorators are kept - `NATIVE_DEVICES` already includes PrivateUse1, so OOT backends run these automatically.

## Test plan
- [x] `test_get_supported_dtypes` passes on CPU and CUDA
- [x] `TestAssertCloseMultiDevice` (2 tests) passes on CUDA
- [x] Full test suite: 86 passed, 7 expected skips, no regressions

cc @albanD @fffrog @jbschlosser @mansiag05 