### PR TITLE
[Test]Make test_scatter_gather_ops.py device generic

### DIFF
--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -96,7 +96,7 @@ class TestScatterGather(TestCase):
                 res = torch.gather(src, dim=dim, index=ind)
                 ref = src[ind0] if dim == 0 else src[:, ind0]
                 self.assertEqual(res, ref, atol=0, rtol=0)
-                if res.device.type == "cuda":
+                if device != 'cpu':
                     ref_cpu = src.cpu()[ind0.cpu()] if dim == 0 else src.cpu()[:, ind0.cpu()]
                     self.assertEqual(res.cpu(), ref_cpu, atol=0, rtol=0)
                 res = torch.gather(src, dim=dim, index=ind_discontig)
@@ -125,7 +125,7 @@ class TestScatterGather(TestCase):
         src = make_tensor((16, 2, 16), device=device, dtype=dtype)
         ind = torch.randint(2, (16, 1), device=device).view(16, 1, 1).expand(16, 1, 16)
         res = torch.gather(src, dim=1, index=ind)
-        if res.device.type == "cuda":
+        if device != 'cpu':
             ref_cpu = torch.gather(src.cpu(), dim=1, index=ind.cpu())
             self.assertEqual(res.cpu(), ref_cpu, atol=0, rtol=0)
 


### PR DESCRIPTION
Replace `if res.device.type == "cuda":` with `if device != 'cpu':` in test_gather_large to enable CPU cross-validation for all accelerators (CUDA, XPU, MPS, etc.), not just CUDA.

  This change makes the test more robust by validating accelerator results against CPU
  reference implementation for any accelerator device.

  Changes:
  - test/test_scatter_gather_ops.py:99 - Make CPU cross-validation accelerator-generic
  - test/test_scatter_gather_ops.py:128 - Make CPU cross-validation accelerator-generic

  Testing:
  All tests pass.
  TEST_CONFIG=cpu python test/test_scatter_gather_ops.py TestScatterGatherCPU -v
  TEST_CONFIG=cuda python test/test_scatter_gather_ops.py TestScatterGatherCUDA -v
  
  CC: @fffrog @albanD 