### PR TITLE
[dynamo] Reject Parameter fill_value in torch.full

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -6067,6 +6067,82 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(result_a, torch.full((2,), 3.14, dtype=torch.float32))
         self.assertEqual(result_b, torch.full((2,), 2.71, dtype=torch.float32))
 
+    def test_full_with_parameter_fill_value_matches_eager_error(self):
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fill_value = torch.nn.Parameter(torch.tensor(1.0))
+
+            def forward(self, x):
+                return torch.full(
+                    (x.shape[0],),
+                    fill_value=self.fill_value,
+                    dtype=x.dtype,
+                    device=x.device,
+                )
+
+        mod = Mod()
+        x = torch.randn(2)
+
+        with self.assertRaisesRegex(TypeError, "full\\(\\) received an invalid"):
+            mod(x)
+
+        torch._dynamo.reset()
+        opt_mod = torch.compile(mod, backend="eager", fullgraph=True)
+        with self.assertRaisesRegex(
+            Unsupported, "TypeError when making fake tensor call"
+        ):
+            opt_mod(x)
+
+    def test_full_with_custom_parameter_fill_value_matches_eager_error(self):
+        class MyTensor(torch.Tensor):
+            pass
+
+        def fn(fill_value):
+            return torch.full((2,), fill_value, dtype=torch.float32)
+
+        fill_value = torch.nn.Parameter(
+            torch.Tensor._make_subclass(MyTensor, torch.tensor(1.0), False)
+        )
+
+        with self.assertRaisesRegex(TypeError, "full\\(\\) received an invalid"):
+            fn(fill_value)
+
+        torch._dynamo.reset()
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        with self.assertRaisesRegex(
+            Unsupported, "TypeError when making fake tensor call"
+        ):
+            opt_fn(fill_value)
+
+    def test_full_with_non_scalar_tensor_fill_value_matches_eager_error(self):
+        def fn(fill_value):
+            return torch.full((2,), fill_value, dtype=torch.float32)
+
+        fill_value = torch.tensor([1.0])
+
+        with self.assertRaisesRegex(TypeError, "full\\(\\) received an invalid"):
+            fn(fill_value)
+
+        torch._dynamo.reset()
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        with self.assertRaisesRegex(
+            Unsupported, "TypeError when making fake tensor call"
+        ):
+            opt_fn(fill_value)
+
+    def test_full_with_buffer_fill_value(self):
+        def fn(fill_value):
+            return torch.full((2,), fill_value, dtype=torch.float32)
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+
+        for fill_value in (
+            torch.nn.Buffer(torch.tensor(3.0)),
+            torch.nn.Buffer(torch.tensor(4.0)),
+        ):
+            self.assertEqual(opt_fn(fill_value), fn(fill_value))
+
 
 instantiate_parametrized_tests(FunctionTests)
 instantiate_parametrized_tests(DefaultsTests)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1535,15 +1535,20 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             fill_value: VariableTracker,
             **kwargs: VariableTracker,
         ) -> VariableTracker | None:
-            if fill_value.is_tensor():
-                # Decompose: create empty tensor and fill it
-                # This avoids the scalar extraction at compile time
-                empty_result = TorchInGraphFunctionVariable(torch.empty).call_function(
-                    tx, [size], kwargs
-                )
-                # Call fill_ method on the empty tensor
-                return empty_result.call_method(tx, "fill_", [fill_value], {})
-            return None
+            if not isinstance(fill_value, TensorVariable) or fill_value.ndim != 0:
+                return None
+
+            fill_value_example = fill_value.as_proxy().node.meta["example_value"]
+            if isinstance(fill_value_example, torch.nn.Parameter):
+                return None
+
+            # Decompose: create empty tensor and fill it.
+            # This avoids the scalar extraction at compile time.
+            empty_result = TorchInGraphFunctionVariable(torch.empty).call_function(
+                tx, [size], kwargs
+            )
+            # Call fill_ method on the empty tensor
+            return empty_result.call_method(tx, "fill_", [fill_value], {})
 
         @register(torch._foreach_lerp_)
         def handle_inplace_foreach_lerp_scalar(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184721

Dynamo decomposes scalar tensor fill_value for torch.full into empty plus fill_ to avoid specializing scalar values. Skip that decomposition for Parameter fill values so fake execution follows eager's invalid-argument TypeError, including custom tensor Parameters marked with _is_param. This revisits the stale approach from #178187 while preserving scalar tensor and Buffer behavior.

Fixes #178046

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98