### PR TITLE
[inductor][refactor] Extract lazy scratch allocation as a util function

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -421,18 +421,10 @@ class DeferredTritonCallWrapper:
             prefix.splice(
                 maybe_hipify_code_wrapper(
                     f"""\
-                {device_ptr_type} {var} = 0;
+                int64_t {var}_numel = {size_expr} * {grid_extent};
                 RAIIAtenTensorHandle {var}_tensor;
-                if ({size_expr} > 0) {{
-                    int64_t {var}_size[] = {{{size_expr} * {grid_extent}}};
-                    int64_t {var}_stride[] = {{1}};
-                    AtenTensorHandle {var}_handle;
-                    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_empty_strided(
-                        1, {var}_size, {var}_stride, {dtype_str},
-                        {device_type}, device_idx_, &{var}_handle));
-                    {var}_tensor = RAIIAtenTensorHandle({var}_handle);
-                    {var} = reinterpret_cast<{device_ptr_type}>({var}_tensor.data_ptr());
-                }}
+                {device_ptr_type} {var} = allocate_scratch_tensor<{device_ptr_type}>(
+                    {var}_numel, {dtype_str}, {device_type}, device_idx_, {var}_tensor);
             """
                 )
             )

--- a/torch/csrc/inductor/aoti_runtime/utils.h
+++ b/torch/csrc/inductor/aoti_runtime/utils.h
@@ -407,6 +407,32 @@ inline RAIIAtenTensorHandle wrap_with_raii_handle_if_needed(
   return RAIIAtenTensorHandle(handle);
 }
 
+template <typename DevicePtr>
+inline DevicePtr allocate_scratch_tensor(
+    int64_t numel,
+    int32_t dtype,
+    int32_t device_type,
+    int32_t device_index,
+    RAIIAtenTensorHandle& scratch_tensor) {
+  DevicePtr scratch_ptr = 0;
+  if (numel > 0) {
+    int64_t scratch_size[] = {numel};
+    int64_t scratch_stride[] = {1};
+    AtenTensorHandle scratch_handle;
+    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_empty_strided(
+        1,
+        scratch_size,
+        scratch_stride,
+        dtype,
+        device_type,
+        device_index,
+        &scratch_handle));
+    scratch_tensor = RAIIAtenTensorHandle(scratch_handle);
+    scratch_ptr = reinterpret_cast<DevicePtr>(scratch_tensor.data_ptr());
+  }
+  return scratch_ptr;
+}
+
 class ConstantHandle {
  public:
   ConstantHandle() = default;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184729
* #184728
* #184727
* #183784
* __->__ #184726

Route lazy Triton scratch allocation through a runtime helper instead of emitting the allocation call directly in generated wrapper source. This keeps source-count checks focused on model allocations while preserving scratch allocation for kernels that need it.

Authored with Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo