### PR TITLE
[inductor][refactor] Extract profiled Triton launch emission

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -690,139 +690,158 @@ class DeferredTritonCallWrapper:
             "win32",
         ]
         if enable_kernel_profile:
-            normalized_kernel_name = re.sub(r"[^a-zA-Z0-9_]", "_", f"{kernel_var_name}")
-            prefix.writeline("{")
-            with prefix.indent():
+            self.generate_profiled_launch_kernel(
+                prefix,
+                kernel_var_name,
+                call_args,
+                arg_types,
+                arg_signatures,
+                launch_kernel_args,
+            )
+        else:
+            prefix.writeline(f"launchKernel({', '.join(launch_kernel_args)});")
+
+    def generate_profiled_launch_kernel(
+        self,
+        prefix: IndentedBuffer,
+        kernel_var_name: str,
+        call_args: list[str],
+        arg_types: list[Any],
+        arg_signatures: list[str | None],
+        launch_kernel_args: list[str],
+    ) -> None:
+        """Wrap a kernel launch in an AOTI record_function profiling scope."""
+        normalized_kernel_name = re.sub(r"[^a-zA-Z0-9_]", "_", f"{kernel_var_name}")
+        prefix.writeline("{")
+        with prefix.indent():
+            prefix.writelines(
+                [
+                    f"std::unordered_map<std::string, C10IValueHandle> kwargs_{normalized_kernel_name};",
+                    "",
+                ]
+            )
+            # Add launch args info
+            record_launch_kernel_args = [
+                ("grid_0", "grid_0"),
+                ("grid_1", "grid_1"),
+                ("grid_2", "grid_2"),
+                ("num_warps", launch_kernel_args[4]),
+                ("shared_mem", launch_kernel_args[5]),
+            ]
+            for k, v in record_launch_kernel_args:
+                arg_name = f"{normalized_kernel_name}_{k}"
                 prefix.writelines(
                     [
-                        f"std::unordered_map<std::string, C10IValueHandle> kwargs_{normalized_kernel_name};",
-                        "",
+                        f"// Create c10::IValue for {k}",
+                        f"C10IValueHandle tmp_{arg_name};",
+                        f"aoti_torch_int64_to_ivalue({v}, &tmp_{arg_name});",
+                        f"RAIIC10IValueHandle RAII_{arg_name}(tmp_{arg_name});",
+                        f'kwargs_{normalized_kernel_name}.emplace("{k}", RAII_{arg_name});',
                     ]
                 )
-                # Add launch args info
-                record_launch_kernel_args = [
-                    ("grid_0", "grid_0"),
-                    ("grid_1", "grid_1"),
-                    ("grid_2", "grid_2"),
-                    ("num_warps", str(params["num_warps"])),
-                    ("shared_mem", str(params["shared_mem"])),
-                ]
-                for k, v in record_launch_kernel_args:
-                    arg_name = f"{normalized_kernel_name}_{k}"
-                    prefix.writelines(
-                        [
-                            f"// Create c10::IValue for {k}",
-                            f"C10IValueHandle tmp_{arg_name};",
-                            f"aoti_torch_int64_to_ivalue({v}, &tmp_{arg_name});",
-                            f"RAIIC10IValueHandle RAII_{arg_name}(tmp_{arg_name});",
-                            f'kwargs_{normalized_kernel_name}.emplace("{k}", RAII_{arg_name});',
-                        ]
-                    )
 
-                # Add input info (This copies the logic from args_decl)
-                curr_arg_id = -1
-                total_args = []
-                ordered_argsname = []
+            # Add input info (This copies the logic from args_decl)
+            curr_arg_id = -1
+            total_args = []
+            ordered_argsname = []
 
-                def write_dummy_scalar_ivalue(arg_name):
-                    # We only care about the shape, therefore we create a dummy scalar here.
+            def write_dummy_scalar_ivalue(arg_name):
+                # We only care about the shape, therefore we create a dummy scalar here.
+                prefix.writelines(
+                    [
+                        f"// Create c10::IValue for arg_{curr_arg_id}",
+                        f"C10IValueHandle tmp_{arg_name};",
+                        f"aoti_torch_int64_to_ivalue(0, &tmp_{arg_name});",
+                        f"RAIIC10IValueHandle RAII_{arg_name}(tmp_{arg_name});",
+                    ]
+                )
+                # pyrefly: ignore [bad-argument-type]
+                total_args.append(f"tmp_{arg_name}")
+
+            def process_args_for_input_shape(arg, arg_type, arg_signature=None):
+                nonlocal curr_arg_id
+                curr_arg_id += 1
+                arg_name = f"{normalized_kernel_name}_arg_{curr_arg_id}"
+                # ignore tma descriptors, as host-side TMA descriptors need
+                # to be passed to the compiled Triton kernel by value
+                if isinstance(arg_type, UnwrapUnspecArg) and not signature_is_tma_desc(
+                    arg_signature
+                ):
+                    write_dummy_scalar_ivalue(arg_name)
+                elif isinstance(arg_type, torch_dtype) and not signature_is_tma_desc(
+                    arg_signature
+                ):
+                    # This is an at::Tensor.
                     prefix.writelines(
                         [
                             f"// Create c10::IValue for arg_{curr_arg_id}",
                             f"C10IValueHandle tmp_{arg_name};",
-                            f"aoti_torch_int64_to_ivalue(0, &tmp_{arg_name});",
+                            f"aoti_torch_tensor_to_ivalue({arg}, &tmp_{arg_name});",
                             f"RAIIC10IValueHandle RAII_{arg_name}(tmp_{arg_name});",
                         ]
                     )
                     # pyrefly: ignore [bad-argument-type]
                     total_args.append(f"tmp_{arg_name}")
+                elif (
+                    isinstance(arg_type, type(SymbolicCallArg))
+                    and arg_signature is not None
+                    and arg_signature in TRITON_SIGNATURE_TO_CPP
+                ) or arg_type in (sympy.Integer, int, sympy.Float, float):
+                    write_dummy_scalar_ivalue(arg_name)
+                elif arg_signature and arg_signature.startswith("tensordesc<"):
+                    # Skip tma related args
+                    pass
+                else:
+                    write_dummy_scalar_ivalue(arg_name)
 
-                def process_args_for_input_shape(arg, arg_type, arg_signature=None):
-                    nonlocal curr_arg_id
-                    curr_arg_id += 1
-                    arg_name = f"{normalized_kernel_name}_arg_{curr_arg_id}"
-                    # ignore tma descriptors, as host-side TMA descriptors need
-                    # to be passed to the compiled Triton kernel by value
-                    if isinstance(
-                        arg_type, UnwrapUnspecArg
-                    ) and not signature_is_tma_desc(arg_signature):
-                        write_dummy_scalar_ivalue(arg_name)
-                    elif isinstance(
-                        arg_type, torch_dtype
-                    ) and not signature_is_tma_desc(arg_signature):
-                        # This is an at::Tensor.
-                        prefix.writelines(
-                            [
-                                f"// Create c10::IValue for arg_{curr_arg_id}",
-                                f"C10IValueHandle tmp_{arg_name};",
-                                f"aoti_torch_tensor_to_ivalue({arg}, &tmp_{arg_name});",
-                                f"RAIIC10IValueHandle RAII_{arg_name}(tmp_{arg_name});",
-                            ]
-                        )
-                        # pyrefly: ignore [bad-argument-type]
-                        total_args.append(f"tmp_{arg_name}")
-                    elif (
-                        isinstance(arg_type, type(SymbolicCallArg))
-                        and arg_signature is not None
-                        and arg_signature in TRITON_SIGNATURE_TO_CPP
-                    ) or arg_type in (sympy.Integer, int, sympy.Float, float):
-                        write_dummy_scalar_ivalue(arg_name)
-                    elif arg_signature and arg_signature.startswith("tensordesc<"):
-                        # Skip tma related args
-                        pass
-                    else:
-                        write_dummy_scalar_ivalue(arg_name)
+            # Add input name and shape information
+            for arg, arg_type, arg_signature in zip_longest(
+                call_args, arg_types, arg_signatures
+            ):
+                # pyrefly: ignore [bad-argument-type]
+                ordered_argsname.append(f'"{arg}"')
+                process_args_for_input_shape(arg, arg_type, arg_signature)
 
-                # Add input name and shape information
-                for arg, arg_type, arg_signature in zip_longest(
-                    call_args, arg_types, arg_signatures
-                ):
-                    # pyrefly: ignore [bad-argument-type]
-                    ordered_argsname.append(f'"{arg}"')
-                    process_args_for_input_shape(arg, arg_type, arg_signature)
+            # Add input name into kwargs
+            name_var = f"{normalized_kernel_name}_input_names"
+            prefix.writelines(
+                [
+                    "// Create c10::IValue for input names",
+                    f"C10IValueHandle tmp_{name_var};",
+                    f"std::vector<const char*> {name_var}({{{', '.join(ordered_argsname)}}});",
+                    f"aoti_torch_strlist_to_ivalue({name_var}.data(), {len(ordered_argsname)}, &tmp_{name_var});",
+                    f"RAIIC10IValueHandle RAII_{name_var}(tmp_{name_var});",
+                    f'kwargs_{normalized_kernel_name}.emplace("Input Args", RAII_{name_var});',
+                ]
+            )
 
-                # Add input name into kwargs
-                name_var = f"{normalized_kernel_name}_input_names"
-                prefix.writelines(
-                    [
-                        "// Create c10::IValue for input names",
-                        f"C10IValueHandle tmp_{name_var};",
-                        f"std::vector<const char*> {name_var}({{{', '.join(ordered_argsname)}}});",
-                        f"aoti_torch_strlist_to_ivalue({name_var}.data(), {len(ordered_argsname)}, &tmp_{name_var});",
-                        f"RAIIC10IValueHandle RAII_{name_var}(tmp_{name_var});",
-                        f'kwargs_{normalized_kernel_name}.emplace("Input Args", RAII_{name_var});',
-                    ]
-                )
+            inputs_info_ = f"{normalized_kernel_name}_inputs_info_"
+            # We pass in the non-RAII handles, since C10 doesn't automatically free them.
+            # The RAII will make sure they get freed when they are out of scope.
+            tmp_args = ",".join(total_args)
+            prefix.writelines(
+                [
+                    "// Aggregate all c10::IValue for inputs",
+                    f"std::vector<C10IValueHandle> {inputs_info_}({{{tmp_args}}});",
+                ]
+            )
 
-                inputs_info_ = f"{normalized_kernel_name}_inputs_info_"
-                # We pass in the non-RAII handles, since C10 doesn't automatically free them.
-                # The RAII will make sure they get freed when they are out of scope.
-                tmp_args = ",".join(total_args)
-                prefix.writelines(
-                    [
-                        "// Aggregate all c10::IValue for inputs",
-                        f"std::vector<C10IValueHandle> {inputs_info_}({{{tmp_args}}});",
-                    ]
-                )
-
-                # Start recording Function
-                prefix.writelines(
-                    [
-                        "",
-                        (
-                            "torch::aot_inductor::RAIIAtenRecordFunctionHandle "
-                            f"record_{normalized_kernel_name}_"
-                            f'("{kernel_var_name}", '
-                            f"reinterpret_cast<IValueMapHandle>(&kwargs_{normalized_kernel_name}), "
-                            f"{inputs_info_});"
-                        ),
-                        "",
-                        f"launchKernel({', '.join(launch_kernel_args)});",
-                    ]
-                )
-            prefix.writeline("}")
-        else:
-            prefix.writeline(f"launchKernel({', '.join(launch_kernel_args)});")
+            # Start recording Function
+            prefix.writelines(
+                [
+                    "",
+                    (
+                        "torch::aot_inductor::RAIIAtenRecordFunctionHandle "
+                        f"record_{normalized_kernel_name}_"
+                        f'("{kernel_var_name}", '
+                        f"reinterpret_cast<IValueMapHandle>(&kwargs_{normalized_kernel_name}), "
+                        f"{inputs_info_});"
+                    ),
+                    "",
+                    f"launchKernel({', '.join(launch_kernel_args)});",
+                ]
+            )
+        prefix.writeline("}")
 
 
 class CppWrapperGpu(CppWrapperCpu):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184729
* #184728
* __->__ #184727
* #184732
* #184731

Move the AOTI record_function profiling wrapper for Triton launches into a helper so the regular launch path and lazy launch path can share it without duplicating the profiling block.

Authored with Codex.