### PR TITLE
[inductor] Support AOTI lazy autotune with dual wrappers

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -7748,6 +7748,11 @@ class AOTInductorTestsTemplate:
     def test_rocm_triton_autotuning(self):
         if self.device != GPU_TYPE:
             raise unittest.SkipTest("requires GPU")
+        if config.triton.autotune_at_compile_time is False:
+            raise unittest.SkipTest(
+                "Testing triton.autotune_with_sample_inputs, only works when "
+                "triton.autotune_at_compile_time is True"
+            )
 
         class Model(torch.nn.Module):
             def forward(self, x, y, m):
@@ -7789,6 +7794,11 @@ class AOTInductorTestsTemplate:
     def test_triton_autotuning(self):
         if self.device != GPU_TYPE:
             raise unittest.SkipTest("requires GPU")
+        if config.triton.autotune_at_compile_time is False:
+            raise unittest.SkipTest(
+                "Testing triton.autotune_with_sample_inputs, only works when "
+                "triton.autotune_at_compile_time is True"
+            )
 
         class Model(torch.nn.Module):
             def forward(self, x, y, m):
@@ -7836,6 +7846,11 @@ class AOTInductorTestsTemplate:
     def test_triton_mutated_autotuning(self):
         if self.device != GPU_TYPE:
             raise unittest.SkipTest("requires GPU")
+        if config.triton.autotune_at_compile_time is False:
+            raise unittest.SkipTest(
+                "Testing triton.autotune_with_sample_inputs, only works when "
+                "triton.autotune_at_compile_time is True"
+            )
 
         @triton.jit
         def add_one_kernel(X, Y, N):
@@ -7895,6 +7910,11 @@ class AOTInductorTestsTemplate:
     def test_triton_dynamic_launcher_grid(self):
         if self.device != GPU_TYPE:
             raise unittest.SkipTest("requires GPU")
+        if config.triton.autotune_at_compile_time is False:
+            raise unittest.SkipTest(
+                "Testing triton.autotune_with_sample_inputs, only works when "
+                "triton.autotune_at_compile_time is True"
+            )
 
         @triton.autotune(
             configs=[
@@ -7940,6 +7960,11 @@ class AOTInductorTestsTemplate:
     def test_triton_dynamic_launcher_grid_infer_from_tensor(self):
         if self.device != GPU_TYPE:
             raise unittest.SkipTest("requires GPU")
+        if config.triton.autotune_at_compile_time is False:
+            raise unittest.SkipTest(
+                "Testing triton.autotune_with_sample_inputs, only works when "
+                "triton.autotune_at_compile_time is True"
+            )
 
         @triton.autotune(
             configs=[
@@ -8554,6 +8579,11 @@ class AOTInductorTestsTemplate:
     def test_constant_int_kernel_input(self):
         if self.device != GPU_TYPE:
             raise unittest.SkipTest("requires GPU")
+        if config.triton.autotune_at_compile_time is False:
+            raise unittest.SkipTest(
+                "Testing triton.autotune_with_sample_inputs, only works when "
+                "triton.autotune_at_compile_time is True"
+            )
 
         class Model(torch.nn.Module):
             def forward(self, x):
@@ -9013,6 +9043,107 @@ copy_tests(
     AOTInductorTestABICompatibleGpu,
     GPU_TYPE,
     GPU_TEST_FAILURES,
+)
+
+
+# Lazy-autotune-mode-specific failures go here. Inherits regular GPU failures.
+GPU_LAZY_AUTOTUNE_TEST_FAILURES = {
+    **GPU_TEST_FAILURES,
+    # torch.cond and torch.while_loop dual-wrapper-mode support is not yet
+    # implemented; skip these tests until the follow-up fix lands.
+    "test_cond_simple": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_cond_nested": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_cond_with_parameters": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_cond_with_reinterpret_view_inputs_outputs": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cond_with_replace_view_ops": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_cond_with_multiple_outputs": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_cond_with_outer_code_before_after": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_cond_use_buffers_from_outer_scope": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_cond_non_tensor_predicates_dynamic_False": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cond_non_tensor_predicates_dynamic_True": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cond_unbacked_symint_closure_dynamic_False": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cond_unbacked_symint_closure_dynamic_True": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cond_mismatched_branch_output_dynamic_False": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cond_mismatched_branch_output_dynamic_True": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cond_symint_input": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_cond_symint_input_disable_one_pass": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_cond_cpu_predicate_cuda_operands_max_autotune_False": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cond_cpu_predicate_cuda_operands_max_autotune_True": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cond_share_predicate": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_cond_predicate_on_cpu": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_custom_op_in_subgraph": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_while_loop_simple": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_while_loop_nested": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_while_loop_with_outer_code": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_while_loop_with_parameters": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_while_loop_with_outer_buffers": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_while_loop_with_pytree_inputs": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_while_loop_with_unbacked_symint_closure_dynamic_False": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_while_loop_with_unbacked_symint_closure_dynamic_True": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_while_loop_with_mixed_device_dynamic_False": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_while_loop_with_mixed_device_dynamic_True": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_while_loop_with_sym_expr_cond_dynamic_False": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_while_loop_with_sym_expr_cond_dynamic_True": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_while_loop_with_conv_dynamic_False": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_while_loop_with_conv_dynamic_True": fail_gpu(("cuda", "xpu"), is_skip=True),
+}
+
+
+@unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")
+class AOTInductorTestDualWrapper(TestCase):
+    """Run AOTInductor tests with autotune_at_compile_time=False, exercising
+    the lazy Triton compile + dual-wrapper-mode codegen path."""
+
+    device = GPU_TYPE
+    device_type = GPU_TYPE
+    check_model = check_model
+    check_model_with_multiple_inputs = check_model_with_multiple_inputs
+    code_check_count = code_check_count
+    allow_stack_allocation = False
+    use_minimal_arrayref_interface = False
+
+    def setUp(self):
+        super().setUp()
+        ctx = torch._inductor.config.patch("triton.autotune_at_compile_time", False)
+        ctx.__enter__()
+        self.addCleanup(ctx.__exit__, None, None, None)
+
+
+copy_tests(
+    AOTInductorTestsTemplate,
+    AOTInductorTestDualWrapper,
+    GPU_TYPE,
+    GPU_LAZY_AUTOTUNE_TEST_FAILURES,
 )
 
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -27,7 +27,7 @@ from torch.utils._sympy.symbol import symbol_is_type, SymT
 
 from .. import config, cpp_builder, ir
 from ..ir import ExternKernel
-from ..utils import _align, make_codegen_buffer, normalize_name
+from ..utils import _align, DualIndentedBuffer, make_codegen_buffer, normalize_name
 from ..virtualized import V
 from .aoti_hipify_utils import maybe_hipify_code_wrapper
 from .common import get_device_op_overrides, IndentedBuffer, Kernel
@@ -39,6 +39,7 @@ from .wrapper import (
     HasWriteLine,
     PythonWrapperCodegen,
     SymbolicCallArg,
+    WrapperLine,
 )
 
 
@@ -51,6 +52,16 @@ if TYPE_CHECKING:
     _OUTPUT_ARGS_TYPE = list[str | None | list[str | None]]
 
     from ..scheduler import BaseSchedulerNode
+
+
+@dataclasses.dataclass
+class DualWrapperCodeLine(WrapperLine):
+    jit_code: IndentedBuffer
+    aot_code: IndentedBuffer
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        code.splice_jit(self.jit_code)
+        code.splice_aot(self.aot_code)
 
 
 @dataclasses.dataclass
@@ -468,11 +479,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
             with open(
                 os.path.join(os.path.dirname(__file__), "aoti_runtime", "interface.cpp")
             ) as f:
-                self.header.splice(f.read())
+                self.header.splice_aot(f.read())
         else:
             # we produce a separate model header for each model in static linkage
-            self.header.splice(f"""#include \"{self.model_class_name_suffix}.h\"""")
-        self.header.splice("\n")
+            self.header.splice_aot(f"""#include \"{self.model_class_name_suffix}.h\"""")
+        self.header.splice_aot("\n")
 
     def write_header(self):
         if V.graph.is_const_graph:
@@ -561,7 +572,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 """
             )
         if V.graph.aot_mode:
-            self.prefix.writeline("namespace torch::aot_inductor {")
+            self.prefix.writeline_aot("namespace torch::aot_inductor {")
         if not V.graph.is_const_graph:
             self.codegen_input_size_and_nan_asserts()
 
@@ -809,11 +820,14 @@ class CppWrapperCpu(PythonWrapperCodegen):
         self.codegen_additional_funcs()
 
         if V.graph.const_module:
-            self.header.splice(V.graph.const_module.wrapper_code.header)
-
+            # In dual-wrapper-mode, the const graph's JIT output is emitted separately,
+            # while its AOTI body is spliced below into the main AOTI source.
+            # Keep the const graph header out of the main output to avoid
+            # duplicate standalone header content.
+            if not V.graph.is_dual_wrapper_mode:
+                self.header.splice(V.graph.const_module.wrapper_code.header)
             assert V.graph.const_wrapper_code is not None
             self.prefix.splice_aot(V.graph.const_wrapper_code)
-
             assert V.graph.const_kernel_code is not None
             self.kernel_declarations.splice(V.graph.const_kernel_code)
 
@@ -860,10 +874,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
             self.generate_input_output_runtime_checks()
             self.prefix.splice_aot(run_impl_proto)
 
-    @staticmethod
-    def _write_jit_entry_point_signature(prefix):
+    def _write_jit_entry_point_signature(self):
         """Emit the JIT entry point: inductor_entry_impl free function."""
-        prefix.splice(
+        self.prefix.splice_jit(
             """
             void inductor_entry_impl(
                 AtenTensorHandle*
@@ -882,26 +895,28 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
         AOTI: AOTInductorModel::run_impl with stream and proxy_executor params.
         JIT: inductor_entry_impl free function.
+        Dual-wrapper-mode: both signatures, to their respective buffers.
         """
         if V.graph.aot_mode:
             self._write_aoti_entry_point_signature()
-        else:
-            self._write_jit_entry_point_signature(self.prefix)
+        self._write_jit_entry_point_signature()
 
     def _write_input_preamble(self):
         """Emit input stealing and (in JIT mode) GIL release."""
-        if V.graph.is_const_graph:
-            return
-        aoti_num_args = len(V.graph.graph_inputs)
         # Weights are promoted in the JIT mode
-        jit_num_args = aoti_num_args + len(V.graph.constants)
+        jit_num_args = len(V.graph.graph_inputs) + len(V.graph.constants)
+        # AOTI const graphs enter through _const_run_impl and have no
+        # input_handles. Their JIT entry point still receives constants as
+        # appended input handles.
+        if not V.graph.is_const_graph:
+            aoti_num_args = len(V.graph.graph_inputs)
+            self.prefix.splice_aot(
+                f"auto inputs = steal_from_raw_handles_to_raii_handles(input_handles, {aoti_num_args});"
+            )
         # release GIL to support multiple instances inference (in different threads of the same process)
         self.prefix.splice_jit("py::gil_scoped_release_simple release;")
         self.prefix.splice_jit(
             f"auto inputs = steal_from_raw_handles_to_raii_handles(input_handles, {jit_num_args});"
-        )
-        self.prefix.splice_aot(
-            f"auto inputs = steal_from_raw_handles_to_raii_handles(input_handles, {aoti_num_args});"
         )
 
     def _write_input_unpacking(self):
@@ -1361,11 +1376,16 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
     def finalize_prefix(self):
         prior = self.prefix
+
+        # Build AOTI model class into a temporary buffer (AOTI-only content).
+        # _codegen_aoti_model_class calls methods that write to self.prefix,
+        # so redirect self.prefix to the temporary buffer during the call.
         aot_mode_decls = IndentedBuffer()
         if V.graph.aot_mode and not V.graph.is_const_graph:
             with self._target_buf("prefix", aot_mode_decls):
                 self._codegen_aoti_model_class()
 
+        # Reset self.prefix and write shared cache decls + CPU triton content.
         self.prefix = make_codegen_buffer()
         for dtype in self.used_cached_dtypes:
             self.prefix.writeline(f"CACHE_TORCH_DTYPE({dtype});")
@@ -1386,8 +1406,8 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 self.prefix.writeline("\n")
                 wrapper.generate(self)
 
-        # aot_mode_decls is AOTI-only; splice_aot routes correctly across modes
-        # (no-op on plain IndentedBuffer in pure-JIT).
+        # aot_mode_decls is AOTI-only; splice_aot routes correctly across
+        # all three modes (no-op on plain IndentedBuffer in pure-JIT).
         self.prefix.splice_aot(aot_mode_decls)
         self.prefix.splice(prior)
 
@@ -1523,17 +1543,38 @@ class CppWrapperCpu(PythonWrapperCodegen):
         before the GIL is released. Default no-op."""
 
     def generate_before_suffix(self, result):
-        if not V.graph.is_const_graph:
-            if V.graph.aot_mode:
-                result.writeline(f"}} // {self.aoti_model_class_name}::run_impl")
-            else:
+        # Close the entry function. In dual-wrapper-mode `result` is the JIT side;
+        # the AOTI side close is emitted by _generate_end_aoti.
+        if V.graph.aot_mode:
+            if V.graph.is_dual_wrapper_mode:
                 result.writeline("} // inductor_entry_impl")
+            else:
+                entry = "_const_run_impl" if V.graph.is_const_graph else "run_impl"
+                result.writeline(f"}} // {self.aoti_model_class_name}::{entry}")
+        else:
+            result.writeline("} // inductor_entry_impl")
 
     def _generate_end_aoti(self, result):
-        """Close AOTI namespace (no-op for const_graph, which only has _const_run_impl)."""
-        if V.graph.is_const_graph:
-            result.writeline(f"}} // {self.aoti_model_class_name}::_const_run_impl")
-        else:
+        """Close AOTI namespace. In dual-wrapper-mode, also assemble the
+        AOTI source string from `.aot` buffers into self._aot_output; the
+        input `result` is the JIT side and is left untouched in that case.
+        """
+        if V.graph.is_dual_wrapper_mode:
+            assert isinstance(self.header, DualIndentedBuffer)
+            assert isinstance(self.prefix, DualIndentedBuffer)
+            assert isinstance(self.wrapper_call, DualIndentedBuffer)
+            aot_result = IndentedBuffer()
+            aot_result.splice(self.header.aot)
+            aot_result.splice(self.prefix.aot)
+            with aot_result.indent():
+                aot_result.splice(self.wrapper_call.aot)
+            entry = "_const_run_impl" if V.graph.is_const_graph else "run_impl"
+            aot_result.writeline(f"}} // {self.aoti_model_class_name}::{entry}")
+            aot_result.splice(self.suffix)
+            if not V.graph.is_const_graph:
+                aot_result.writeline("} // namespace torch::aot_inductor\n\n\n")
+            self._aot_output = aot_result.getvalue()
+        elif not V.graph.is_const_graph:
             result.writeline("} // namespace torch::aot_inductor\n\n\n")
 
     def _generate_end_jit(self, result):
@@ -1937,8 +1978,14 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def _codegen_assert_div_by_zero(
         self, code: IndentedBuffer, divisor_str: str, op_name: str
     ) -> None:
-        """Emit one div-by-zero AOTI check to `code` (replay-phase target)."""
-        code.writeline(
+        """Emit one div-by-zero AOTI check to `code` (replay-phase target).
+
+        Uses writeline_aot so the check is routed to the AOTI side only in
+        dual-wrapper mode; on plain buffers writeline_aot has the expected
+        single-stream behavior (AotOnlyBuffer delegates to writeline, plain
+        IndentedBuffer is a no-op).
+        """
+        code.writeline_aot(
             f'AOTI_TORCH_CHECK({divisor_str} != 0, "Integer {op_name} by zero");'
         )
 
@@ -2106,7 +2153,14 @@ class CppWrapperCpu(PythonWrapperCodegen):
             return
         stmt = f'assert_size_stride({name}, {size}, {stride}, "{op_name}");'
         if V.graph.aot_mode:
-            code.writeline(f"if (_check_aoti_runtime_check_inputs_env()) {{ {stmt} }}")
+            guarded = f"if (_check_aoti_runtime_check_inputs_env()) {{ {stmt} }}"
+            if V.graph.is_dual_wrapper_mode:
+                # _check_aoti_runtime_check_inputs_env() is AOTI-only; the JIT
+                # side gets the plain assert.
+                code.writeline_jit(stmt)
+                code.writeline_aot(guarded)
+            else:
+                code.writeline(guarded)
         else:
             code.writeline(stmt)
 
@@ -2209,6 +2263,12 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def make_allocation(
         self, name, device, dtype, shape, stride, allocation_shape=None, is_pinned=False
     ):
+        """Emit C++ to allocate a tensor handle via aoti_torch_empty_strided.
+
+        Returns the RAIIAtenTensorHandle binding string; if the allocation
+        shape differs from the logical shape, a follow-up aoti_torch_as_strided
+        is emitted to reinterpret the handle.
+        """
         if allocation_shape is None:
             allocation_shape = shape
 
@@ -2245,24 +2305,30 @@ class CppWrapperCpu(PythonWrapperCodegen):
             graph=self.get_codegened_graph(),
         )
         device_type, device_id = device_str.split(",")
-        device_idx = "this->device_idx_" if V.graph.aot_mode else device_id
-
         handle_name = f"{name}_handle"
-        args = [
-            str(len(shape)),
-            allocation_size_array_var,
-            stride_array_var,
-            dtype_code,
-            device_type,
-            device_idx,
-            f"&{handle_name}",
-        ]
-
         self.wrapper_call.writeline(f"AtenTensorHandle {handle_name};")
         pinned_str = "_pinned" if is_pinned else ""
-        self.wrapper_call.writeline(
-            f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_empty_strided{pinned_str}({', '.join(args)}));"
-        )
+
+        def _alloc_line(device_idx: str) -> str:
+            args = ", ".join(
+                [
+                    str(len(shape)),
+                    allocation_size_array_var,
+                    stride_array_var,
+                    dtype_code,
+                    device_type,
+                    device_idx,
+                    f"&{handle_name}",
+                ]
+            )
+            return f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_empty_strided{pinned_str}({args}));"
+
+        # AOTI side uses this->device_idx_ so the model honors runtime device
+        # assignment; JIT side (pure or dual mode's JIT) has no
+        # this->device_idx_ in scope, so use the concrete graph device id.
+        aoti_device_idx = "this->device_idx_" if V.graph.aot_mode else device_id
+        self.wrapper_call.writeline_aot(_alloc_line(aoti_device_idx))
+        self.wrapper_call.writeline_jit(_alloc_line(device_id))
 
         if allocation_size != size:
             old_handle_name, handle_name = handle_name, f"{name}_handle_restrided"
@@ -2856,6 +2922,37 @@ class CppWrapperCpu(PythonWrapperCodegen):
             output_args = output_name
 
         # In AOT mode, we use a ProxyExecutor to run fallback kernels.
+        if V.graph.aot_mode and V.graph.is_dual_wrapper_mode:
+            jit_code = DualIndentedBuffer(initial_indent=self.wrapper_call._indent)
+            with (
+                self._target_buf("wrapper_call", jit_code),
+                self.set_writeline(jit_code, jit_code.writeline_jit),
+            ):
+                self._generate_fallback_kernel_jit(
+                    buf_name,
+                    python_kernel_name,
+                    get_args,
+                    op_overload,
+                    raw_args,
+                    output_args,
+                    outputs,
+                )
+
+            aot_code = DualIndentedBuffer(initial_indent=self.wrapper_call._indent)
+            with (
+                self._target_buf("wrapper_call", aot_code),
+                self.set_writeline(aot_code, aot_code.writeline_aot),
+            ):
+                self.generate_fallback_kernel_with_runtime_lookup_aot(
+                    op_overload,
+                    raw_args,
+                    output_args,
+                    outputs,
+                )
+
+            self.writeline(DualWrapperCodeLine(jit_code, aot_code))
+            return
+
         if V.graph.aot_mode:
             self.generate_fallback_kernel_with_runtime_lookup_aot(
                 op_overload,
@@ -2863,17 +2960,17 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 output_args,
                 outputs,
             )
-            return
 
-        self._generate_fallback_kernel_jit(
-            buf_name,
-            python_kernel_name,
-            get_args,
-            op_overload,
-            raw_args,
-            output_args,
-            outputs,
-        )
+        if not V.graph.aot_mode:
+            self._generate_fallback_kernel_jit(
+                buf_name,
+                python_kernel_name,
+                get_args,
+                op_overload,
+                raw_args,
+                output_args,
+                outputs,
+            )
 
     def _generate_fallback_kernel_jit(
         self,
@@ -3488,10 +3585,13 @@ if (!custom_op_wrapper) {
         tmp_var_name = f"var_{next(self.arg_var_id)}"
         call_str = f"auto {tmp_var_name} = {handle};"
 
-        writer = writer if writer is not None else self
+        writer = (
+            writer if writer is not None else self
+        )  # pyrefly: ignore [bad-assignment]
         if isinstance(writer, list):
             writer.append(call_str)
         else:
+            # pyrefly: ignore [missing-attribute]
             writer.writeline(call_str)
 
         return tmp_var_name

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -60,6 +60,97 @@ def cpp_string_literal(s: str) -> str:
     return f'"{escaped}"'
 
 
+def generate_aoti_kernel_config_header(kernel_names: list[str]) -> str:
+    """Generate a C header defining macros for each lazy-compiled kernel.
+
+    Called after the JIT first-pass runs and populates CudaKernelParamCache.
+    The AOTI compilation includes this header so that LazyKernelCompileResult
+    structs get compile-time-initialized with the autotuned values.
+    """
+
+    def braced(values: list[int]) -> str:
+        return "{" + ", ".join(str(v) for v in values) + "}"
+
+    buf = IndentedBuffer()
+    buf.splice("""
+        #pragma once
+        // Auto-generated kernel configurations for AOTInductor lazy compile.
+    """)
+
+    for kernel_name in kernel_names:
+        params = CudaKernelParamCache.get(kernel_name)
+        assert params is not None, (
+            f"CudaKernelParamCache not populated for {kernel_name} "
+            "after first-pass execution"
+        )
+
+        macro_prefix = kernel_name.upper()
+        cubin_path = cpp_string_literal(params[get_cpp_wrapper_cubin_path_name()])
+        mangled_name = cpp_string_literal(params["mangled_name"])
+        num_warps = params["num_warps"]
+        shared_mem = params["shared_mem"]
+
+        # params["config"] is already a dict (from config_to_dict in CachingAutotuner)
+        config_dict = params.get("config") or {}
+
+        # For combo/foreach kernels, merge default_config
+        inductor_meta = params.get("inductor_meta") or {}
+        combo_grid_meta = inductor_meta.get("combo_grid_meta")
+        default_config = (
+            combo_grid_meta.get("default_config") if combo_grid_meta else None
+        )
+        if default_config:
+            config_dict = {**default_config, **config_dict}
+
+        config_index: int | None = None
+        grid_type = inductor_meta.get("grid_type")
+        if grid_type == "PrecomputedGrid":
+            precomputed_grids = inductor_meta.get("precomputed_grids", [])
+            for idx, entry in enumerate(precomputed_grids):
+                entry_config = entry.get("config", {})
+                if all(config_dict.get(k) == v for k, v in entry_config.items()):
+                    config_index = idx
+                    break
+
+        # Per-subkernel block sizes for combo kernels, or single-element lists.
+        num_kernels = combo_grid_meta.get("num_kernels", 1) if combo_grid_meta else 1
+        if num_kernels > 1 and "XBLOCK_0" in config_dict:
+            xblocks = [config_dict.get(f"XBLOCK_{i}", 128) for i in range(num_kernels)]
+            yblocks = [config_dict.get(f"YBLOCK_{i}", 1) for i in range(num_kernels)]
+            zblocks = [config_dict.get(f"ZBLOCK_{i}", 1) for i in range(num_kernels)]
+            r0blocks = [config_dict.get(f"R0_BLOCK_{i}", 1) for i in range(num_kernels)]
+        else:
+            xblocks = [config_dict.get("XBLOCK", 128)]
+            yblocks = [config_dict.get("YBLOCK", 1)]
+            zblocks = [config_dict.get("ZBLOCK", 1)]
+            r0blocks = [config_dict.get("R0_BLOCK", 1)]
+        rsplit = config_dict.get("RSPLIT", 1)
+        rsplit_size = config_dict.get("RSPLIT_SIZE", 1)
+        ci = config_index if config_index is not None else -1
+        gs = params.get("global_scratch", -1) or -1
+        ps = params.get("profile_scratch", -1) or -1
+
+        buf.writeline("")
+        buf.splice(f"""
+            // Kernel: {kernel_name}
+            #define {macro_prefix}_CUBIN_PATH {cubin_path}
+            #define {macro_prefix}_MANGLED_NAME {mangled_name}
+            #define {macro_prefix}_NUM_WARPS {num_warps}
+            #define {macro_prefix}_SHARED_MEM {shared_mem}
+            #define {macro_prefix}_XBLOCKS {braced(xblocks)}
+            #define {macro_prefix}_YBLOCKS {braced(yblocks)}
+            #define {macro_prefix}_ZBLOCKS {braced(zblocks)}
+            #define {macro_prefix}_R0BLOCKS {braced(r0blocks)}
+            #define {macro_prefix}_RSPLIT {rsplit}
+            #define {macro_prefix}_RSPLIT_SIZE {rsplit_size}
+            #define {macro_prefix}_CONFIG_INDEX {ci}
+            #define {macro_prefix}_GLOBAL_SCRATCH {gs}
+            #define {macro_prefix}_PROFILE_SCRATCH {ps}
+        """)
+
+    return buf.getvalue()
+
+
 TRITON_SIGNATURE_TO_CPP = {
     "i32": "int32_t",
     "i64": "int64_t",
@@ -220,7 +311,7 @@ class DeferredTritonCallWrapper:
 
         # Defer compilation to runtime if autotune_at_compile_time is False (JIT only).
         # AOTI lazy-compile emission is wired up later in the stack.
-        if not V.graph.aot_mode and config.triton.autotune_at_compile_time is False:
+        if config.triton.autotune_at_compile_time is False:
             return self.generate_lazy(wrapper)
 
         params = CudaKernelParamCache.get(self.kernel_name)
@@ -483,20 +574,60 @@ class DeferredTritonCallWrapper:
             f" {kernel_name}_result.shared_mem,"
             f" kernel_args_, stream_"
         )
+        launch_kernel_args = [
+            "grid_0",
+            "grid_1",
+            "grid_2",
+            f"{kernel_name}_result.num_warps",
+            f"{kernel_name}_result.shared_mem",
+        ]
 
-        prefix.writeline_jit(f"void* kernel_args_[] = {{{call_args_str}}};")
+        # kernel_args_ is consumed by both JIT and AOT launchKernel calls.
+        prefix.writeline(f"void* kernel_args_[] = {{{call_args_str}}};")
+        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
+            "linux",
+            "win32",
+        ]
         prefix.writeline_jit(f"launchKernel({kernel_name}, {common_launch_args});")
+        if enable_kernel_profile:
+            profile_arg_types = [arg_type_lookup.get(n) for n in kernel_arg_names]
+            profile_arg_sigs = [signature.get(n) for n in kernel_arg_names]
+            aot_profile = IndentedBuffer(initial_indent=prefix._indent)
+            self.generate_profiled_launch_kernel(
+                aot_profile,
+                f"kernels_.{kernel_name}",
+                kernel_arg_names,
+                profile_arg_types,
+                profile_arg_sigs,
+                [
+                    f"kernels_.{kernel_name}",
+                    *launch_kernel_args,
+                    "kernel_args_",
+                    "stream_",
+                ],
+            )
+            prefix.splice_aot(aot_profile)
+        else:
+            prefix.writeline_aot(
+                f"launchKernel(kernels_.{kernel_name}, {common_launch_args});"
+            )
 
     def generate_lazy(self, wrapper: CppWrapperGpu):
         """
-        Generate C++ code that embeds Triton source and compiles it at runtime.
+        Generate dual-wrapper-mode C++ code for lazy Triton kernel compilation.
 
-        Writes JIT-side content via writeline_jit/splice_jit; on a plain
-        IndentedBuffer those are equivalent to writeline/splice. AOTI-side
-        emission for dual-wrapper mode is added later in the stack.
+        DualIndentedBuffer routes lines into separate JIT and AOTI sources:
+        - JIT side: embeds Triton source, compiles at runtime, autotunes
+          with real inputs.
+        - AOTI side: uses a compile-time-initialized LazyKernelCompileResult
+          from a config header generated after the JIT first-pass.
+
+        Grid computation and kernel launch are shared between both sides
+        via the LazyKernelCompileResult struct.
         """
         prefix = wrapper.prefix
         kernel_name = self.kernel_name
+        macro_prefix = kernel_name.upper()
 
         # Track kernel names for parallel initialization (JIT only)
         wrapper._lazy_kernel_names.append(kernel_name)
@@ -518,11 +649,34 @@ class DeferredTritonCallWrapper:
             f"static const char* {kernel_name}_source = {kernel_body};"
         )
 
+        # LazyKernelCompileResult: JIT fills at runtime; AOTI uses compile-time
+        # init from the config header generated after the first pass.
         prefix.writeline_jit(f"static LazyKernelCompileResult {kernel_name}_result;")
+        prefix.splice_aot(
+            f"""\
+            static LazyKernelCompileResult {kernel_name}_result = {{
+                {macro_prefix}_CUBIN_PATH,
+                {macro_prefix}_MANGLED_NAME,
+                {macro_prefix}_NUM_WARPS,
+                {macro_prefix}_SHARED_MEM,
+                {macro_prefix}_XBLOCKS,
+                {macro_prefix}_YBLOCKS,
+                {macro_prefix}_ZBLOCKS,
+                {macro_prefix}_R0BLOCKS,
+                {macro_prefix}_RSPLIT,
+                {macro_prefix}_RSPLIT_SIZE,
+                {macro_prefix}_CONFIG_INDEX,
+                {macro_prefix}_GLOBAL_SCRATCH,
+                {macro_prefix}_PROFILE_SCRATCH,
+            }};
+            """
+        )
 
         wrapper_arg_names, kernel_arg_names = self._resolve_lazy_arg_names()
         signature = (self.triton_meta or {}).get("signature", {})
 
+        # kernels_type_/kernels_ are routed to the AOTI buffer; if prefix is a
+        # plain IndentedBuffer (pure JIT lazy compile) those writes are dropped.
         self._write_wrapper_signature(
             prefix,
             wrapper,
@@ -552,9 +706,11 @@ class DeferredTritonCallWrapper:
                 autotune_arg_list.append(name)
         autotune_args = ", ".join(autotune_arg_list)
 
-        # Lazy compile with autotuning on first invocation.
-        # Build into temp buffer to avoid DualIndentedBuffer dispatch.
         with prefix.indent():
+            # First-call initialization: JIT lazy compiles, AOTI loads cubin
+
+            # JIT: lazy compile with autotuning on first invocation.
+            # Build into temp buffer to avoid DualIndentedBuffer dispatch.
             jit_init = IndentedBuffer(initial_indent=prefix._indent)
             jit_init.writeline(f"if ({kernel_name} == nullptr) {{")
             with jit_init.indent():
@@ -579,6 +735,23 @@ class DeferredTritonCallWrapper:
             jit_init.writeline("}")
             prefix.splice_jit(jit_init)
 
+            # AOTI: load precompiled cubin from compile-time-initialized result.
+            aoti_init = IndentedBuffer(initial_indent=prefix._indent)
+            aoti_init.writeline(f"if (kernels_.{kernel_name} == nullptr) {{")
+            with aoti_init.indent():
+                aoti_init.splice(
+                    f"""\
+                    kernels_.{kernel_name} = loadKernel(
+                        {kernel_name}_result.cubin_path,
+                        {kernel_name}_result.mangled_name,
+                        {kernel_name}_result.shared_mem,
+                        cubin_dir_);
+                    """
+                )
+            aoti_init.writeline("}")
+            prefix.splice_aot(aoti_init)
+
+            # Shared: grid computation and launch using result struct
             self._generate_lazy_grid(prefix)
             self._generate_lazy_launch(
                 prefix,
@@ -878,8 +1051,9 @@ class CppWrapperGpu(CppWrapperCpu):
         super().write_header()
         kernel_driver = maybe_hipify_code_wrapper(self.device_codegen.kernel_driver())
         if V.graph.is_const_graph and V.graph.is_dual_wrapper_mode:
-            # const_graph's AOTI variant merges into main (which has its own
-            # kernel_driver) — JIT-only emission avoids the duplicate.
+            # For a dual-wrapper-mode const graph, only the standalone JIT
+            # output needs this header content. The AOTI const body is spliced
+            # into the main AOTI source, which has its own kernel driver.
             self.header.splice_jit(kernel_driver)
         else:
             self.header.splice(kernel_driver)
@@ -889,7 +1063,19 @@ class CppWrapperGpu(CppWrapperCpu):
         self.header.splice(self.device_codegen.tma_descriptor_helpers())
 
     def write_get_raw_stream(self, device_idx: int, graph_name: str) -> str:
+        # Pure AOTI receives the stream as a function parameter. JIT and
+        # dual-wrapper-mode code use an explicit stream variable so the shared kernel
+        # call arguments are valid for the JIT entry point.
+        if V.graph.aot_mode and not V.graph.is_dual_wrapper_mode:
+            return "stream"
+
         name = f"stream{device_idx}"
+        # In dual-wrapper mode, the JIT stream is declared at the entry function
+        # prologue (see _codegen_entry_impl_prologue) so it stays in scope
+        # across all kernel call sites.
+        if V.graph.is_dual_wrapper_mode:
+            return name
+
         self.writeline(
             maybe_hipify_code_wrapper(
                 f"{self.device_codegen.cpp_stream_type()} {name};"
@@ -966,11 +1152,29 @@ class CppWrapperGpu(CppWrapperCpu):
             return super().generate(is_inference)
 
     def _codegen_entry_impl_prologue(self):
-        self.prefix.writeline(
+        # ensure_triton_kernel_compiles_started() is JIT-only; AOTI has no
+        # Python-dependent lazy compile flow.
+        self.prefix.writeline_jit(
             _LazyTritonCompileKickoffLine(
                 self._lazy_kernel_names, "ensure_triton_kernel_compiles_started();"
             )
         )
+        # In dual-wrapper mode, hoist the JIT-side stream declaration to the entry
+        # function prologue. Kernel calls run inside KernelContextGuard
+        # scopes, so a per-call declaration would be scoped to the guard
+        # and unavailable to other kernel calls in the same function.
+        if V.graph.is_dual_wrapper_mode:
+            stream_type = maybe_hipify_code_wrapper(
+                self.device_codegen.cpp_stream_type()
+            )
+            get_stream = self.device_codegen.aoti_get_stream()
+            for device_idx in sorted(V.graph.device_idxs):
+                name = f"stream{device_idx}"
+                self.prefix.writeline_jit(f"{stream_type} {name};")
+                self.prefix.writeline_jit(
+                    f"AOTI_TORCH_ERROR_CODE_CHECK("
+                    f"{get_stream}({device_idx}, (void**)&{name}));"
+                )
 
     def finalize_prefix(self):
         """Define the triton kernels now that autotuning is finished"""
@@ -1279,11 +1483,7 @@ static inline void ensure_triton_kernel_compiles_started() {{
                 original_fxnode_name=original_fxnode_name,
             )
 
-        stream = (
-            "stream"
-            if V.graph.aot_mode
-            else self.write_get_raw_stream(device.index, graph_name)
-        )
+        stream = self.write_get_raw_stream(device.index, graph_name)
 
         if triton:
             call_args, arg_types = self.prepare_triton_wrapper_args(
@@ -1328,18 +1528,35 @@ static inline void ensure_triton_kernel_compiles_started() {{
                         torch.float32
                     )  # dtype doesn't matter, just need tensor type
 
-            device_idx = "this->device_idx_" if V.graph.aot_mode else str(device.index)
-            call_args.append(device_idx)
-            call_args.append(stream)
-            if V.graph.aot_mode:
-                call_args.append("kernels")
-                call_args.append("this->cubin_dir_")
+            # AOTI side uses this->device_idx_ so the model honors runtime device
+            # assignment; JIT side has no this->device_idx_ in scope, so use the
+            # concrete graph device index. Similarly, AOTI side always uses the
+            # `stream` function parameter of run_impl, while JIT side uses the
+            # locally-declared stream{idx} (see _codegen_entry_impl_prologue).
+            aoti_device_idx = (
+                "this->device_idx_" if V.graph.aot_mode else str(device.index)
+            )
+            jit_device_idx = str(device.index)
+            jit_call_args = [*call_args, jit_device_idx, stream]
+            aot_call_args = [*call_args, aoti_device_idx, "stream"]
             debug_printer_manager = V.graph.wrapper_code.debug_printer
             debug_printer_manager.set_printer_args(
-                call_args[: len(arg_types)], kernel_name, arg_types, None
+                jit_call_args[: len(arg_types)], kernel_name, arg_types, None
             )
-            with debug_printer_manager:
-                self.writeline(f"{wrapper_name}({', '.join(call_args)});")
+            # DebugPrinterManager is AOTI-only: route its writes through
+            # writeline_aot so they're dropped on the JIT side (no-op for the
+            # pure-JIT IndentedBuffer; AOT-only for DualIndentedBuffer). Without
+            # this, the JIT buffer would receive before/after-launch prints
+            # after the JIT launch, reporting post-launch state as pre-launch.
+            with self.set_writeline(self.wrapper_call, self.wrapper_call.writeline_aot):
+                with debug_printer_manager:
+                    self.wrapper_call.writeline_jit(
+                        f"{wrapper_name}({', '.join(jit_call_args)});"
+                    )
+                    self.wrapper_call.writeline_aot(
+                        f"{wrapper_name}({', '.join(aot_call_args)}, "
+                        f"kernels, this->cubin_dir_);"
+                    )
         else:
             casted = []
             # pyrefly: ignore [bad-argument-type, no-matching-overload]

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -575,25 +575,21 @@ class EnterDeviceContextManagerLine(WrapperLine):
     def codegen(self, code: IndentedBuffer) -> None:
         if V.graph.cpp_wrapper:
             code.writeline("\n")
-            if V.graph.aot_mode:
-                # In AOT mode, we have a stream provided as a param. A stream is
-                # associated with a device, so we never expect the device to change.
-                # CUDAStreamGuard sets the stream and the device.
-                if self.last_seen_device_guard_index is None:
-                    code.writeline(
-                        f"{V.graph.device_ops.cpp_aoti_stream_guard()} stream_guard(stream, this->device_idx_);"
-                    )
-                else:
+            # AOTI stream is bound to a device, so CUDAStreamGuard sets both
+            # stream and device, and the device cannot change later.
+            if self.last_seen_device_guard_index is None:
+                code.writeline_aot(
+                    f"{V.graph.device_ops.cpp_aoti_stream_guard()} stream_guard(stream, this->device_idx_);"
+                )
+                code.writeline_jit(
+                    f"{V.graph.device_ops.cpp_aoti_device_guard()} device_guard({self.device_idx});"
+                )
+            else:
+                if V.graph.aot_mode:
                     assert self.last_seen_device_guard_index == self.device_idx, (
                         "AOTInductor only supports running on one CUDA device"
                     )
-            else:
-                if self.last_seen_device_guard_index is None:
-                    code.writeline(
-                        f"{V.graph.device_ops.cpp_aoti_device_guard()} device_guard({self.device_idx});"
-                    )
-                else:
-                    code.writeline(f"device_guard.set_index({self.device_idx});")
+                code.writeline_jit(f"device_guard.set_index({self.device_idx});")
         else:
             # Note _DeviceGuard has less overhead than device, but only accepts
             # integers
@@ -2216,9 +2212,15 @@ class PythonWrapperCodegen(CodeGen):
         result.splice(self.imports)
         result.writeline("")
         result.splice(self.header)
-        # We do not want the cpp header for intermediate const graph. Headers would be
-        # rendered by the main module instead.
-        if V.graph.aot_mode and V.graph.cpp_wrapper and V.graph.is_const_graph:
+        # Intermediate const graphs normally use headers rendered by the main
+        # module. In dual-wrapper-mode, the const graph's JIT wrapper is emitted as
+        # standalone C++ and needs its own header.
+        if (
+            V.graph.aot_mode
+            and V.graph.cpp_wrapper
+            and V.graph.is_const_graph
+            and not V.graph.is_dual_wrapper_mode
+        ):
             result = IndentedBuffer()
 
         # Add subgraph definitions to the result

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -55,7 +55,7 @@ from torch.utils._mode_utils import no_dispatch
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.numbers import int_oo
 
-from . import config, ir, metrics
+from . import config, ir
 from .codegen.common import (
     BackendFeature,
     DeviceOpOverrides,
@@ -362,6 +362,16 @@ def is_mkldnn_conv(node: Node) -> bool:
 
 
 class GraphLowering(torch.fx.Interpreter):
+    """Lowers an FX graph to Inductor IR and drives backend code generation.
+
+    Walks the FX graph node-by-node, materializing inputs/outputs and
+    constants, dispatching each call to an Inductor lowering, and accumulating
+    the resulting IR nodes. Holds graph-wide state needed by lowerings and
+    codegen (sizevars, scheduler inputs, device/dtype tracking, wrapper code,
+    etc.) and orchestrates the call into `codegen()` to produce a wrapper +
+    kernel module via the configured backend (Python/C++ wrappers, AOTI).
+    """
+
     graph_outputs: list[ir.IRNode]
 
     def __init__(
@@ -2554,32 +2564,134 @@ class GraphLowering(torch.fx.Interpreter):
                 return self.codegen()
             else:
                 if not self.aot_mode:
-                    # Lazy kernel compilation does not require two passes
-                    # TODO: need to consolidate the logic between AOT and JIT
+                    # cpp_wrapper JIT does not require two passes
                     return self.codegen()
 
-                # first pass
-                self.cpp_wrapper = False
-                compiled = self.compile_to_module().call
+                # AOTI with lazy compile: single codegen pass producing
+                # two separate C++ files — JIT (for autotuning) and AOTI
+                # (for packaging) — via DualIndentedBuffer.
+                # wrapper_code is the JIT variant, AOTI variant is in
+                # self.wrapper_code._aot_output.
+                wrapper_code, kernel_code = self.codegen()
 
-                real_inputs = extract_real_inputs()
-                with torch.utils._python_dispatch._disable_current_modes():
-                    compiled(real_inputs)
-                del real_inputs
+                lazy_kernel_names = list(
+                    self.wrapper_code._lazy_kernel_names  # type: ignore[attr-defined]
+                )
+                if lazy_kernel_names:
+                    self._run_jit_variant_for_autotune(
+                        wrapper_code,
+                        kernel_code,
+                        extract_real_inputs,
+                        lazy_kernel_names,
+                    )
 
-                # second pass
-                self.cpp_wrapper = True
-                self.removed_buffers.clear()
-                self.removed_operations.clear()
-                self.inplaced_to_remove.clear()
-                V.graph.sizevars.precomputed_replacements.clear()
-                V.graph.sizevars.inv_precomputed_replacements.clear()
-                metrics.reset()
-                with config.patch({"triton.autotune_at_compile_time": False}):
-                    return self.codegen()
+                # Prepend config header with kernel compile results
+                # to the AOTI source for packaging.
+                from .codegen.cpp_wrapper_gpu import generate_aoti_kernel_config_header
+
+                config_header = generate_aoti_kernel_config_header(lazy_kernel_names)
+                aoti_wrapper = ValueWithLineMap(
+                    config_header + "\n" + self.wrapper_code._aot_output,  # type: ignore[attr-defined]
+                    wrapper_code.line_map,
+                )
+
+                return aoti_wrapper, kernel_code
         else:
             # cpu
             return self.codegen()
+
+    def _run_jit_variant_for_autotune(
+        self,
+        wrapper_code,
+        kernel_code,
+        extract_real_inputs,
+        kernel_names: list[str],
+    ) -> None:
+        """Compile dual-wrapper-mode C++ as JIT variant and run to autotune kernels.
+
+        Compiles the dual-wrapper-mode C++ source without -DAOT_INDUCTOR, which
+        activates the JIT path (inductor_entry_impl). Running this with
+        real inputs triggers lazy Triton compilation and autotuning,
+        populating CudaKernelParamCache for the AOTI packaging step.
+        """
+        from .codecache import (
+            CppWrapperCodeCache,
+            CudaKernelParamCache,
+            get_cpp_wrapper_cubin_path_name,
+            output_code_log,
+        )
+
+        cpp_source = wrapper_code.value
+        kernel_source = kernel_code.value if kernel_code else None
+
+        # The JIT wrapper keeps lazy kernel state in function-local statics.
+        # Compile a fresh wrapper for each first pass so autotuning always reruns.
+        cpp_source += f"\n// AOTI lazy autotune first pass: {id(self)}\n"
+        for name in kernel_names:
+            CudaKernelParamCache.cache.pop(name, None)
+
+        output_code_log.debug("AOTI lazy compile JIT wrapper code: \n%s", cpp_source)
+
+        # Prefer the GPU device for the JIT compile: the wrapper includes
+        # cpp_wrapper/<gpu>.h which transitively pulls in cuda_runtime.h.
+        # A "cpu" device would precompile cpp_wrapper/cpu.h, which does not
+        # include the CUDA headers needed to compile the kernel call sites.
+        device_type = next(
+            (d for d in self.device_types if d in ("cuda", "xpu")),
+            next((d for d in self.device_types if d != "meta"), "cpu"),
+        )
+
+        # This temporary Python-loaded wrapper can depend on libtorch even when
+        # the final packaged AOTI artifact is built with link_libtorch=False.
+        with config.patch("aot_inductor.link_libtorch", True):
+            compiled_fn = CppWrapperCodeCache.load_pybinding(
+                argtypes=["std::vector<AtenTensorHandle>"],
+                main_code=cpp_source,
+                device_type=device_type,
+                num_outputs=len(self.graph_outputs),
+                kernel_code=kernel_source,
+            )
+
+        real_inputs = extract_real_inputs()
+
+        def materialize_constant(name: str) -> torch.Tensor:
+            constant = self.constants[name]
+            if isinstance(constant, FakeTensor):
+                constant = defake(constant)
+            assert isinstance(constant, torch.Tensor), (
+                f"Expected tensor constant for {name}"
+            )
+            return constant
+
+        # Non-tensor scalars become 0-d CPU tensors; None and ints/floats
+        # that the graph specialized away aren't part of the C++ wrapper
+        # signature and must be skipped.
+        input_tensors: list[torch.Tensor] = []
+        for arg in real_inputs:
+            if arg is None:
+                continue
+            if isinstance(arg, torch.Tensor):
+                input_tensors.append(arg)
+            else:
+                input_tensors.append(torch.tensor(arg, device="cpu"))
+        input_tensors.extend(materialize_constant(name) for name in self.constants)
+        input_handles = torch._C._aoti.unsafe_alloc_void_ptrs_from_tensors(
+            input_tensors
+        )
+        del real_inputs, input_tensors
+
+        output_handles = compiled_fn(input_handles)
+        output_tensors = torch._C._aoti.alloc_tensors_by_stealing_from_void_ptrs(
+            output_handles
+        )
+        del output_tensors
+
+        # Collect cubin files produced by lazy compilation for AOTI packaging
+        cubin_path_name = get_cpp_wrapper_cubin_path_name()
+        for name in kernel_names:
+            params = CudaKernelParamCache.get(name)
+            if params and cubin_path_name in params:
+                self.wrapper_code.additional_files.append(params[cubin_path_name])
 
     def _update_scheduler(self) -> None:
         """

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2794,7 +2794,13 @@ class DebugAutotuner(CachingAutotuner):
             return
         else:
             possible_names = _find_names(self)
-            kernel_name = f"{max(possible_names, key=len)}"
+            if possible_names:
+                kernel_name = f"{max(possible_names, key=len)}"
+            else:
+                # In the AOTI lazy compile path, the CachingAutotuner is not
+                # bound to a module-level name, so _find_names returns empty.
+                # Fall back to the kernel name recorded in inductor_meta.
+                kernel_name = self.inductor_meta.get("kernel_name") or self.fn.__name__
             if not re.match(self.regex_filter, kernel_name):
                 return
             if len(self.launchers) != 1:

--- a/torch/_inductor/runtime/triton_lazy_compile.py
+++ b/torch/_inductor/runtime/triton_lazy_compile.py
@@ -170,6 +170,9 @@ def run_triton_kernel_with_autotune(
                 f"{key_name} not found in cached params for {kernel_name}"
             )
     cubin_path = cached_params[cubin_path_name]
+    assert isinstance(cubin_path, str)
+    runtime_bin_path = cached_params.get("runtime_bin_path", cubin_path)
+    assert isinstance(runtime_bin_path, str)
     mangled_name = cached_params["mangled_name"]
     num_warps = cached_params["num_warps"]
     shared_mem = cached_params["shared_mem"]
@@ -215,10 +218,12 @@ def run_triton_kernel_with_autotune(
     profile_scratch: int | None = cached_params.get("profile_scratch")
 
     log.debug(
-        "Successfully autotuned Triton kernel: cubin_path=%s, mangled_name=%s, "
+        "Successfully autotuned Triton kernel: cubin_path=%s, "
+        "runtime_bin_path=%s, mangled_name=%s, "
         "num_warps=%d, shared_mem=%d, xblocks=%s, yblocks=%s, zblocks=%s, r0blocks=%s, "
         "rsplit=%d, rsplit_size=%d, config_index=%s, global_scratch=%s, profile_scratch=%s",
         cubin_path,
+        runtime_bin_path,
         mangled_name,
         num_warps,
         shared_mem,
@@ -234,7 +239,7 @@ def run_triton_kernel_with_autotune(
     )
 
     result = TritonKernelCompileResult(
-        cubin_path=cubin_path,
+        cubin_path=runtime_bin_path,
         mangled_name=mangled_name,
         num_warps=num_warps,
         shared_mem=shared_mem,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1823,11 +1823,14 @@ class AotOnlyBuffer(IndentedBuffer):
 def make_codegen_buffer() -> IndentedBuffer:
     """Construct the IndentedBuffer subclass matching the current codegen mode.
 
+    Dual-wrapper mode -> DualIndentedBuffer (JIT and AOTI both active).
     Pure AOTI -> AotOnlyBuffer (writeline_aot writes; writeline_jit drops).
     Pure JIT  -> IndentedBuffer  (writeline_jit writes; writeline_aot drops).
     """
     from .virtualized import V
 
+    if V.graph.is_dual_wrapper_mode:
+        return DualIndentedBuffer()
     if V.graph.aot_mode:
         return AotOnlyBuffer()
     return IndentedBuffer()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184729
* __->__ #184728
* #184727
* #184732
* #184731

Switch the AOTI lazy-autotune path to emit separate JIT and AOTI C++ wrapper bodies in one codegen pass. The JIT body is compiled and run with real inputs to populate lazy Triton kernel metadata, then the generated AOTI source includes the captured kernel config for packaging.

Add test_aot_inductor variant that runs with triton.autotune_at_compile_time=False so this path is exercised. torch.cond and torch.while_loop are not yet wired up for the dual-wrapper path and are skipped in this variant; a follow-up commit adds support for them.

Authored with Codex.