### PR TITLE
[inductor] Wire torch.cond and torch.while_loop into AOTI dual-wrapper

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -2668,11 +2668,11 @@ class AOTInductorTestsTemplate:
         model = CondModelWithViewAndLinear().to(device=self.device)
         exported_program = torch.export.export(model, example_input)
         program = exported_program.run_decompositions()
-        gm = ReplaceViewOpsWithViewCopyOpsPass()(program.graph_module).graph_module
+        program = program._transform_do_not_use(ReplaceViewOpsWithViewCopyOpsPass())
         with config.patch(
             {"max_autotune": True, "max_autotune_gemm_backends": "TRITON,ATEN"}
         ):
-            _ = torch._inductor.aot_compile(gm, example_input)
+            torch._inductor.aoti_compile_and_package(program)
 
     def test_cond_with_multiple_outputs(self):
         inputs = (
@@ -9049,73 +9049,6 @@ copy_tests(
 # Lazy-autotune-mode-specific failures go here. Inherits regular GPU failures.
 GPU_LAZY_AUTOTUNE_TEST_FAILURES = {
     **GPU_TEST_FAILURES,
-    # torch.cond and torch.while_loop dual-wrapper-mode support is not yet
-    # implemented; skip these tests until the follow-up fix lands.
-    "test_cond_simple": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_cond_nested": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_cond_with_parameters": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_cond_with_reinterpret_view_inputs_outputs": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_cond_with_replace_view_ops": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_cond_with_multiple_outputs": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_cond_with_outer_code_before_after": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_cond_use_buffers_from_outer_scope": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_cond_non_tensor_predicates_dynamic_False": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_cond_non_tensor_predicates_dynamic_True": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_cond_unbacked_symint_closure_dynamic_False": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_cond_unbacked_symint_closure_dynamic_True": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_cond_mismatched_branch_output_dynamic_False": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_cond_mismatched_branch_output_dynamic_True": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_cond_symint_input": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_cond_symint_input_disable_one_pass": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_cond_cpu_predicate_cuda_operands_max_autotune_False": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_cond_cpu_predicate_cuda_operands_max_autotune_True": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_cond_share_predicate": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_cond_predicate_on_cpu": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_custom_op_in_subgraph": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_while_loop_simple": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_while_loop_nested": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_while_loop_with_outer_code": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_while_loop_with_parameters": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_while_loop_with_outer_buffers": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_while_loop_with_pytree_inputs": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_while_loop_with_unbacked_symint_closure_dynamic_False": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_while_loop_with_unbacked_symint_closure_dynamic_True": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_while_loop_with_mixed_device_dynamic_False": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_while_loop_with_mixed_device_dynamic_True": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_while_loop_with_sym_expr_cond_dynamic_False": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_while_loop_with_sym_expr_cond_dynamic_True": fail_gpu(
-        ("cuda", "xpu"), is_skip=True
-    ),
-    "test_while_loop_with_conv_dynamic_False": fail_gpu(("cuda", "xpu"), is_skip=True),
-    "test_while_loop_with_conv_dynamic_True": fail_gpu(("cuda", "xpu"), is_skip=True),
 }
 
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -304,6 +304,51 @@ class CppWrapperCpu(PythonWrapperCodegen):
         self.codegen_int_array_var_cache = {}
         self.needs_vec_isa = self.device == "cpu"
 
+    @contextlib.contextmanager
+    def _preserve_device_guard_state(self):
+        last_seen_device_guard_index = self.last_seen_device_guard_index
+        try:
+            yield
+        finally:
+            self.last_seen_device_guard_index = last_seen_device_guard_index
+
+    @contextlib.contextmanager
+    def _preserve_codegen_state(self, graphs):
+        wrapper_state = (
+            OrderedSet(self.allocated),
+            OrderedSet(self.freed),
+            dict(self.reuses),
+            dict(self.allocated_workspaces),
+            OrderedSet(self.declared_int_array_vars),
+            dict(self.codegen_int_array_var_cache),
+            OrderedSet(self.kernel_numel_expr),
+            OrderedSet(self.used_cond_predicate),
+        )
+        subgraph_state = [
+            (
+                graph,
+                OrderedSet(graph.removed_buffers),
+                OrderedSet(graph.inplaced_to_remove),
+            )
+            for graph in graphs
+        ]
+        try:
+            yield
+        finally:
+            (
+                self.allocated,
+                self.freed,
+                self.reuses,
+                self.allocated_workspaces,
+                self.declared_int_array_vars,
+                self.codegen_int_array_var_cache,
+                self.kernel_numel_expr,
+                self.used_cond_predicate,
+            ) = wrapper_state
+            for graph, removed_buffers, inplaced_to_remove in subgraph_state:
+                graph.removed_buffers = removed_buffers
+                graph.inplaced_to_remove = inplaced_to_remove
+
     @staticmethod
     def create(
         is_subgraph: bool,
@@ -2554,6 +2599,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         )
 
     def codegen_conditional(self, conditional):
+        """Emit ABI-compatible C++ for a higher-order conditional."""
         outer_inputs = [f"{buf.codegen_reference()}" for buf in conditional.operands]
         outer_outputs = []
         for out in conditional.outputs:
@@ -2577,15 +2623,65 @@ class CppWrapperCpu(PythonWrapperCodegen):
             # the predicate is not a Tensor: SymBool or Python bool
             predicate = conditional.predicate.codegen_reference()
 
-        self.writeline(f"if ({predicate}) {{")
-        self.writeline(EnterSubgraphLine(self, conditional.true_subgraph.graph))
-        self.codegen_subgraph(conditional.true_subgraph, outer_inputs, outer_outputs)
-        self.writeline(ExitSubgraphLine(self))
-        self.writeline("} else {")
-        self.writeline(EnterSubgraphLine(self, conditional.false_subgraph.graph))
-        self.codegen_subgraph(conditional.false_subgraph, outer_inputs, outer_outputs)
-        self.writeline(ExitSubgraphLine(self))
-        self.writeline("}")
+        def codegen_original_conditional() -> None:
+            self.writeline(f"if ({predicate}) {{")
+            with self._preserve_device_guard_state():
+                self.writeline(EnterSubgraphLine(self, conditional.true_subgraph.graph))
+                self.codegen_subgraph(
+                    conditional.true_subgraph, outer_inputs, outer_outputs
+                )
+                self.writeline(ExitSubgraphLine(self))
+            self.writeline("} else {")
+            with self._preserve_device_guard_state():
+                self.writeline(
+                    EnterSubgraphLine(self, conditional.false_subgraph.graph)
+                )
+                self.codegen_subgraph(
+                    conditional.false_subgraph, outer_inputs, outer_outputs
+                )
+                self.writeline(ExitSubgraphLine(self))
+            self.writeline("}")
+
+        if not V.graph.is_dual_wrapper_mode:
+            return codegen_original_conditional()
+
+        graphs = (
+            conditional.true_subgraph.graph,
+            conditional.false_subgraph.graph,
+        )
+        jit_code = DualIndentedBuffer(initial_indent=self.wrapper_call._indent)
+        with (
+            self._preserve_codegen_state(graphs),
+            self._target_buf("wrapper_call", jit_code),
+            self.set_writeline(jit_code, jit_code.writeline_jit),
+        ):
+            self.writeline("{")
+            with self._preserve_device_guard_state():
+                self.writeline(EnterSubgraphLine(self, conditional.true_subgraph.graph))
+                self.codegen_subgraph(
+                    conditional.true_subgraph, outer_inputs, outer_outputs
+                )
+                self.writeline(ExitSubgraphLine(self))
+            self.writeline("}")
+            self.writeline("{")
+            with self._preserve_device_guard_state():
+                self.writeline(
+                    EnterSubgraphLine(self, conditional.false_subgraph.graph)
+                )
+                self.codegen_subgraph(
+                    conditional.false_subgraph, outer_inputs, outer_outputs
+                )
+                self.writeline(ExitSubgraphLine(self))
+            self.writeline("}")
+
+        aot_code = DualIndentedBuffer(initial_indent=self.wrapper_call._indent)
+        with (
+            self._target_buf("wrapper_call", aot_code),
+            self.set_writeline(aot_code, aot_code.writeline_aot),
+        ):
+            codegen_original_conditional()
+
+        self.writeline(DualWrapperCodeLine(jit_code, aot_code))
 
     def codegen_subgraph(self, subgraph, outer_inputs, outer_outputs):
         # TODO (desertfire) - This function is the old way of supporting
@@ -2607,6 +2703,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
             self.pop_codegened_graph()
 
     def codegen_while_loop(self, while_loop, stack_output=False):
+        """Emit ABI-compatible C++ for a higher-order while_loop.
+
+        In dual-wrapper mode, keep the real loop on the AOTI side while making
+        the JIT first pass visit the condition and body once for lazy autotune.
+        """
         if stack_output:
             raise NotImplementedError("NYI cpp wrapper for while_loop_stack_output")
         is_bool_pred = isinstance(
@@ -2647,26 +2748,64 @@ class CppWrapperCpu(PythonWrapperCodegen):
         body_outer_inputs = list(cond_outer_inputs)
         body_outer_outputs = body_outer_inputs[: len(outer_carried_inputs)]
 
-        self.writeline("while (1) {")
-        self.writeline(EnterSubgraphLine(self, while_loop.cond_subgraph.graph))
-        self.codegen_subgraph(
-            while_loop.cond_subgraph, cond_outer_inputs, cond_outer_outputs
-        )
+        def codegen_original_while_loop() -> None:
+            self.writeline("while (1) {")
+            with self._preserve_device_guard_state():
+                self.writeline(EnterSubgraphLine(self, while_loop.cond_subgraph.graph))
+                self.codegen_subgraph(
+                    while_loop.cond_subgraph, cond_outer_inputs, cond_outer_outputs
+                )
 
-        if is_bool_pred:
-            cond_result = f"{cond_result_name}"
-        else:
-            cond_result = f"{cond_result_name}_scalar"
-            self.codegen_tensor_item(torch.bool, cond_result_name, cond_result)
-        self.writeline(f"if (!{cond_result}) break;")
+                if is_bool_pred:
+                    cond_result = f"{cond_result_name}"
+                else:
+                    cond_result = f"{cond_result_name}_scalar"
+                    self.codegen_tensor_item(torch.bool, cond_result_name, cond_result)
+                self.writeline(f"if (!{cond_result}) break;")
 
-        self.writeline(ExitSubgraphLine(self))
-        self.writeline(EnterSubgraphLine(self, while_loop.body_subgraph.graph))
-        self.codegen_subgraph(
-            while_loop.body_subgraph, body_outer_inputs, body_outer_outputs
+                self.writeline(ExitSubgraphLine(self))
+                self.writeline(EnterSubgraphLine(self, while_loop.body_subgraph.graph))
+                self.codegen_subgraph(
+                    while_loop.body_subgraph, body_outer_inputs, body_outer_outputs
+                )
+                self.writeline(ExitSubgraphLine(self))
+                self.writeline("}")
+
+        if not V.graph.is_dual_wrapper_mode:
+            return codegen_original_while_loop()
+
+        graphs = (
+            while_loop.cond_subgraph.graph,
+            while_loop.body_subgraph.graph,
         )
-        self.writeline(ExitSubgraphLine(self))
-        self.writeline("}")
+        jit_code = DualIndentedBuffer(initial_indent=self.wrapper_call._indent)
+        with (
+            self._preserve_codegen_state(graphs),
+            self._target_buf("wrapper_call", jit_code),
+            self.set_writeline(jit_code, jit_code.writeline_jit),
+        ):
+            self.writeline("{")
+            with self._preserve_device_guard_state():
+                self.writeline(EnterSubgraphLine(self, while_loop.cond_subgraph.graph))
+                self.codegen_subgraph(
+                    while_loop.cond_subgraph, cond_outer_inputs, cond_outer_outputs
+                )
+                self.writeline(ExitSubgraphLine(self))
+                self.writeline(EnterSubgraphLine(self, while_loop.body_subgraph.graph))
+                self.codegen_subgraph(
+                    while_loop.body_subgraph, body_outer_inputs, body_outer_outputs
+                )
+                self.writeline(ExitSubgraphLine(self))
+            self.writeline("}")
+
+        aot_code = DualIndentedBuffer(initial_indent=self.wrapper_call._indent)
+        with (
+            self._target_buf("wrapper_call", aot_code),
+            self.set_writeline(aot_code, aot_code.writeline_aot),
+        ):
+            codegen_original_while_loop()
+
+        self.writeline(DualWrapperCodeLine(jit_code, aot_code))
 
     def generate_extern_kernel_args_decl_if_needed(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184729
* #184728
* #184727
* #184732
* #184731

Emit cond and while_loop as DualWrapperCodeLine entries so the dual-wrapper codegen can route the predicate-guarded body to the AOTI side while running the JIT first pass through both branches (cond) or both subgraphs once (while_loop) for lazy autotune. Introduce _preserve_codegen_state and _preserve_device_guard_state so wrapper bookkeeping is restored between the JIT and AOTI passes over the same subgraphs.

Update test_cond_with_replace_view_ops to use aoti_compile_and_package, and drop the cond/while_loop skips from AOTInductorTestDualWrapper now that the dual-wrapper path supports them.

Authored with Codex.