### PR TITLE
Fix CPU vectorized logit clamp priority

### DIFF
--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -168,7 +168,11 @@ static void logit_kernel(TensorIteratorBase& iter, const Scalar& eps_scalar) {
                     : std::log(x / (scalar_t(1) - x));
               },
               [kOneVec, lo_vec, hi_vec](Vectorized<scalar_t> x_vec) {
-                x_vec = vec::clamp(x_vec, lo_vec, hi_vec);
+                // Match the scalar clamp priority when lo > hi.
+                x_vec = Vectorized<scalar_t>::blendv(
+                    Vectorized<scalar_t>::blendv(x_vec, hi_vec, x_vec > hi_vec),
+                    lo_vec,
+                    x_vec < lo_vec);
                 return (x_vec / (kOneVec - x_vec)).log();
               });
         }

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -43,6 +43,7 @@ from torch.testing._internal.common_utils import (
     gradcheck,
     is_iterable_of_tensors,
     numpy_to_torch_dtype_dict,
+    parametrize,
     run_tests,
     skipIfNoSciPy,
     slowTest,
@@ -1937,6 +1938,29 @@ class TestUnaryUfuncs(TestCase):
         y = x.to(torch.float8_e5m2)
         ref = x.cpu().float().to(torch.float8_e5m2)
         self.assertEqual(y.cpu().view(torch.uint8), ref.view(torch.uint8))
+
+    @onlyCPU
+    @dtypes(torch.float32, torch.float64, torch.float16, torch.bfloat16)
+    @parametrize("eps", [0.51, 0.9])
+    @parametrize("shape", [(4, 32), (8, 64)])
+    def test_logit_vectorized_matches_scalar(self, device, dtype, eps, shape):
+        # Regression test for https://github.com/pytorch/pytorch/issues/177839.
+        # Non-contiguous input bypasses the contiguous MKL fast path and covers
+        # the vectorized TensorIterator kernel.
+        torch.manual_seed(0)
+        rows, cols = shape
+        base = torch.rand((rows, cols + 2), dtype=dtype, device=device) * 2 - 0.5
+        x = base[:, :cols]
+        self.assertFalse(x.is_contiguous())
+
+        actual = torch.special.logit(x, eps=eps)
+        ref = torch.empty_like(actual)
+        x_flat = x.flatten()
+        ref_flat = ref.view(-1)
+        for i in range(x_flat.numel()):
+            ref_flat[i] = torch.special.logit(x_flat[i : i + 1], eps=eps)
+
+        self.assertEqual(actual, ref)
 
 
 instantiate_device_type_tests(TestUnaryUfuncs, globals())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

The CPU vectorized logit kernel used vec::clamp, which gives the upper bound priority when eps > 0.5 and diverges from the scalar/MKL path. Match the scalar clamp order with nested blendv and add a non-contiguous CPU regression test. Prior abandoned attempts include #177853 and #181297.

Fixes #177839

Generated by my agent

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01