### PR TITLE
Fix hardcoded CUDA device in OSSProxyExecutor

### DIFF
--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -119,7 +119,7 @@ consider rebuild your model with the latest AOTInductor.");
 
   if (c10::filesystem::exists(json_filename)) {
     proxy_executor_ = std::make_unique<torch::aot_inductor::OSSProxyExecutor>(
-        json_filename, device_str == "cpu", std::nullopt, device_str);
+        json_filename, device_str);
     proxy_executor_handle_ =
         reinterpret_cast<AOTIProxyExecutorHandle>(proxy_executor_.get());
   } else {

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -119,7 +119,7 @@ consider rebuild your model with the latest AOTInductor.");
 
   if (c10::filesystem::exists(json_filename)) {
     proxy_executor_ = std::make_unique<torch::aot_inductor::OSSProxyExecutor>(
-        json_filename, device_str == "cpu");
+        json_filename, device_str == "cpu", std::nullopt, device_str);
     proxy_executor_handle_ =
         reinterpret_cast<AOTIProxyExecutorHandle>(proxy_executor_.get());
   } else {

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -615,18 +615,9 @@ std::unique_ptr<OSSCallTorchBindKernel> OSSProxyExecutor::
 
 OSSProxyExecutor::OSSProxyExecutor(
     const std::string& json_path,
-    bool is_cpu,
-    std::optional<std::unordered_map<std::string, c10::IValue>> custom_objs,
-    const std::string& device_str) {
-  if (is_cpu) {
-    device_ = std::make_unique<c10::Device>(c10::DeviceType::CPU);
-  } else if (!device_str.empty()) {
-    device_ = std::make_unique<c10::Device>(device_str);
-  } else {
-    // Legacy fallback: assume CUDA for backward compatibility
-    int device_idx = -1;
-    device_ = std::make_unique<c10::Device>(c10::DeviceType::CUDA, device_idx);
-  }
+    const std::string& device_str,
+    std::optional<std::unordered_map<std::string, c10::IValue>> custom_objs) {
+  device_ = std::make_unique<c10::Device>(device_str);
 
   // If custom_objs is provided, use it instead of loading from
   // custom_objs_config.json If custom_objs is not provided, try to load from

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -616,10 +616,14 @@ std::unique_ptr<OSSCallTorchBindKernel> OSSProxyExecutor::
 OSSProxyExecutor::OSSProxyExecutor(
     const std::string& json_path,
     bool is_cpu,
-    std::optional<std::unordered_map<std::string, c10::IValue>> custom_objs) {
+    std::optional<std::unordered_map<std::string, c10::IValue>> custom_objs,
+    const std::string& device_str) {
   if (is_cpu) {
     device_ = std::make_unique<c10::Device>(c10::DeviceType::CPU);
+  } else if (!device_str.empty()) {
+    device_ = std::make_unique<c10::Device>(device_str);
   } else {
+    // Legacy fallback: assume CUDA for backward compatibility
     int device_idx = -1;
     device_ = std::make_unique<c10::Device>(c10::DeviceType::CUDA, device_idx);
   }

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -211,9 +211,8 @@ void OSSProxyExecutor::prefill_stack_with_static_arguments(
       std::string device_string = serialized_arg_val["type"].get<std::string>();
       if (serialized_arg_val.contains("index") &&
           serialized_arg_val["index"].is_number()) {
-        auto index = serialized_arg_val["index"].get<int>();
-        device_string += ":" + std::to_string(index);
-        device_->set_index(static_cast<int8_t>(index));
+        device_string +=
+            ":" + std::to_string(serialized_arg_val["index"].get<int>());
       }
 
       c10::Device device(device_string);

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
@@ -113,10 +113,9 @@ class OSSProxyExecutor : public ProxyExecutor {
  public:
   explicit OSSProxyExecutor(
       const std::string& json_path,
-      bool is_cpu,
+      const std::string& device_str,
       std::optional<std::unordered_map<std::string, c10::IValue>> custom_objs =
-          std::nullopt,
-      const std::string& device_str = "");
+          std::nullopt);
 
   void call_function(
       int extern_node_index,

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
@@ -115,7 +115,8 @@ class OSSProxyExecutor : public ProxyExecutor {
       const std::string& json_path,
       bool is_cpu,
       std::optional<std::unordered_map<std::string, c10::IValue>> custom_objs =
-          std::nullopt);
+          std::nullopt,
+      const std::string& device_str = "");
 
   void call_function(
       int extern_node_index,

--- a/torch/nativert/executor/DelegateExecutor.h
+++ b/torch/nativert/executor/DelegateExecutor.h
@@ -16,7 +16,7 @@ std::string extractToTemporaryFolder(
 using MakeProxyExecutorFn =
     std::function<std::unique_ptr<torch::aot_inductor::ProxyExecutor>(
         const std::string&,
-        bool,
+        const std::string&,
         std::optional<std::unordered_map<std::string, c10::IValue>>)>;
 
 // This is the extension point for delegation backends.

--- a/torch/nativert/kernels/KernelHandlerRegistry.cpp
+++ b/torch/nativert/kernels/KernelHandlerRegistry.cpp
@@ -44,10 +44,10 @@ void updateNodeTargetIfNeeded(Node& node) {
 
 std::unique_ptr<torch::aot_inductor::ProxyExecutor> make_proxy_executor(
     const std::string& filename,
-    bool is_cpu,
+    const std::string& device_str,
     std::optional<std::unordered_map<std::string, c10::IValue>> custom_objs) {
   return std::make_unique<torch::aot_inductor::OSSProxyExecutor>(
-      filename, is_cpu, std::move(custom_objs));
+      filename, device_str, std::move(custom_objs));
 }
 } // namespace
 


### PR DESCRIPTION
Replace old aoti `OSSProxyExecutor` logic, that checked if `device_str == "cpu"` and based on that used either CPU or hardcoded `"CUDA:-1",` with just passing `device_str` to `OSSProxyExecutor` instead of `is_cpu`. This makes it device agnostic and work with device indexes for CUDA. All relevant call sites and typedefs have been updated.

Fixes: https://github.com/intel/torch-xpu-ops/issues/3723

cc: @EikanWang @guangyey 