### PR TITLE
[inductor] In ExternKernel.get_read_writes(): recursively record IR reads inside nested constant_args and kwargs.

### DIFF
--- a/test/inductor/test_dependencies.py
+++ b/test/inductor/test_dependencies.py
@@ -4,7 +4,7 @@ import contextlib
 import torch
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
-from torch._inductor.ir import Buffer, FixedLayout, Pointwise
+from torch._inductor.ir import Buffer, ExternKernel, FixedLayout, Pointwise
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import sympy_index_symbol
 from torch._inductor.virtualized import ops, V
@@ -94,6 +94,23 @@ class TestDependencies(InductorTestCase):
         )
 
         self.assertEqual(len(pointwise.get_reads()), 2)
+
+    def test_extern_kernel_nested_ir_args_are_dependencies(self):
+        data = self._create_buffer("data", (4,))
+        index = self._create_buffer("index", (4,), torch.int64)
+        value = self._create_buffer("value", (4,))
+        out = self._create_buffer("out", (4,))
+
+        extern = ExternKernel(
+            name="extern",
+            layout=out.layout,
+            inputs=[data],
+            constant_args=([None, index],),
+            kwargs={"value": {"nested": value}},
+        )
+
+        reads = {dep.name for dep in extern.get_read_writes().reads}
+        self.assertEqual(reads, {"data", "index", "value"})
 
     def test_get_offset(self):
         x = sympy_index_symbol("x")

--- a/test/inductor/test_dependencies.py
+++ b/test/inductor/test_dependencies.py
@@ -4,7 +4,13 @@ import contextlib
 import torch
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
-from torch._inductor.ir import Buffer, ExternKernel, FixedLayout, Pointwise
+from torch._inductor.ir import (
+    Buffer,
+    ExternKernel,
+    FixedLayout,
+    Pointwise,
+    ShapeAsConstantBuffer,
+)
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import sympy_index_symbol
 from torch._inductor.virtualized import ops, V
@@ -100,13 +106,14 @@ class TestDependencies(InductorTestCase):
         index = self._create_buffer("index", (4,), torch.int64)
         value = self._create_buffer("value", (4,))
         out = self._create_buffer("out", (4,))
+        shape_arg = ShapeAsConstantBuffer(expr=sympy_index_symbol("nested_size"))
 
         extern = ExternKernel(
             name="extern",
             layout=out.layout,
             inputs=[data],
-            constant_args=([None, index],),
-            kwargs={"value": {"nested": value}},
+            constant_args=([None, index, shape_arg],),
+            kwargs={"value": {"nested": (value, shape_arg)}},
         )
 
         reads = {dep.name for dep in extern.get_read_writes().reads}

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6630,20 +6630,17 @@ class ExternKernel(InputsKernel):
     def get_read_writes(self) -> dependencies.ReadWrites:
         read_writes = super().get_read_writes()
 
-        def add_nested_ir_reads(value: Any) -> None:
+        def add_ir_read(value: Any) -> None:
             if isinstance(value, IRNode):
                 name = value.maybe_get_name()
                 if name is not None:
                     read_writes.reads.add(dependencies.StarDep(name))
-            elif isinstance(value, dict):
-                for nested_value in value.values():
-                    add_nested_ir_reads(nested_value)
-            elif isinstance(value, (list, tuple)):
-                for nested_value in value:
-                    add_nested_ir_reads(nested_value)
 
-        add_nested_ir_reads(self.constant_args)
-        add_nested_ir_reads(self.kwargs)
+        pytree.tree_map_(
+            add_ir_read,
+            (self.constant_args, self.kwargs),
+            is_leaf=lambda value: isinstance(value, IRNode),
+        )
         return read_writes
 
     def collect_arg_kwarg_properties(self) -> None:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6627,6 +6627,23 @@ class ExternKernel(InputsKernel):
     def get_unbacked_symbol_defs(self) -> OrderedSet[sympy.Symbol]:
         return OrderedSet()
 
+    def get_read_writes(self) -> dependencies.ReadWrites:
+        read_writes = super().get_read_writes()
+
+        def add_nested_ir_reads(value: Any) -> None:
+            if isinstance(value, IRNode):
+                read_writes.reads.add(dependencies.StarDep(value.get_name()))
+            elif isinstance(value, dict):
+                for nested_value in value.values():
+                    add_nested_ir_reads(nested_value)
+            elif isinstance(value, (list, tuple)):
+                for nested_value in value:
+                    add_nested_ir_reads(nested_value)
+
+        add_nested_ir_reads(self.constant_args)
+        add_nested_ir_reads(self.kwargs)
+        return read_writes
+
     def collect_arg_kwarg_properties(self) -> None:
         # if self.op_overload is torch._ops.OpOverload, we can use its schema to collect additional
         # information for args and kwargs, e.g. type and default value, to help with the cpp wrapper codegen

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6632,7 +6632,9 @@ class ExternKernel(InputsKernel):
 
         def add_nested_ir_reads(value: Any) -> None:
             if isinstance(value, IRNode):
-                read_writes.reads.add(dependencies.StarDep(value.get_name()))
+                name = value.maybe_get_name()
+                if name is not None:
+                    read_writes.reads.add(dependencies.StarDep(name))
             elif isinstance(value, dict):
                 for nested_value in value.values():
                     add_nested_ir_reads(nested_value)


### PR DESCRIPTION

The index producer was being DCE’d because aten.index_put.out carries its index tensor inside a nested argument list, and Inductor’s ExternKernel dependency scan only accounts for inputs, not IR nodes buried in constant/kwarg structures.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo