### PR TITLE
Fix Dynamo frozenset copy identity semantics

### DIFF
--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -781,6 +781,12 @@ class _SetBase(_FrozensetBase):
 class FrozensetTests(_FrozensetBase, _BaseSetTests):
     thetype = frozenset
 
+    @make_dynamo_test
+    def test_copy_preserves_identity(self):
+        p = frozenset("abc")
+        self.assertTrue(id(p) == id(p.copy()))
+        self.assertTrue(id(p) == id(frozenset.copy(p)))
+
 
 class SetTests(_SetBase, _BaseSetTests):
     thetype = set
@@ -807,6 +813,17 @@ class UserDefinedFrozensetTests(_FrozensetBase, _BaseSetTests):
         pass
 
     thetype = CustomFrozenset
+
+    @make_dynamo_test
+    def test_copy_returns_base_frozenset(self):
+        p = self.thetype("abc")
+        result = p.copy()
+        self.assertTrue(type(result) is frozenset)
+        self.assertTrue(id(result) != id(p))
+
+        result = frozenset.copy(p)
+        self.assertTrue(type(result) is frozenset)
+        self.assertTrue(id(result) != id(p))
 
     def test_in_frozenset(self):
         super().test_in_frozenset()

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -587,7 +587,17 @@ class SetVariable(VariableTracker):
         if not pyanyset_check(self_) or not pyanyset_check(other_):
             return ConstantVariable.create(NotImplemented)
 
-        result = self_.call_method(tx, "copy", [], {})
+        if isinstance(self_, variables.UserDefinedSetVariable):
+            result_source = self_._base_vt
+            if result_source is None:
+                raise AssertionError("_base_vt must not be None")
+        else:
+            result_source = self_
+        result = result_source.clone(
+            items=result_source.items.copy(),  # type: ignore[missing-attribute]
+            mutation_type=ValueMutationNew(),
+            source=None,
+        )
         if self_ is other_:
             return result
         result.items.update(other_.items)  # type: ignore[missing-attribute]
@@ -613,7 +623,17 @@ class SetVariable(VariableTracker):
         if not pyanyset_check(self_) or not pyanyset_check(other_):
             return ConstantVariable.create(NotImplemented)
 
-        result = self_.call_method(tx, "copy", [], {})
+        if isinstance(self_, variables.UserDefinedSetVariable):
+            result_source = self_._base_vt
+            if result_source is None:
+                raise AssertionError("_base_vt must not be None")
+        else:
+            result_source = self_
+        result = result_source.clone(
+            items=result_source.items.copy(),  # type: ignore[missing-attribute]
+            mutation_type=ValueMutationNew(),
+            source=None,
+        )
         for k in list(other_.items.keys()):  # type: ignore[missing-attribute]
             result.items.pop(k, None)  # type: ignore[missing-attribute]
         return result
@@ -857,8 +877,23 @@ class FrozensetVariable(SetVariable):
         elif name == "__init__":
             # frozenset is immutable. Calling __init__ again shouldn't have any effect
             return ConstantVariable.create(None)
+        elif name == "copy":
+            if args or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
+            if (
+                self.source is not None
+                and type(tx.output.resolve_source_value(self.source)) is not frozenset
+            ):
+                return FrozensetVariable(
+                    self.items.copy(), mutation_type=ValueMutationNew(), source=None
+                )
+            return self
         elif name in (
-            "copy",
             "difference",
             "intersection",
             "symmetric_difference",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184674
* #184673
* #184672
* #184671
* #184670
* #184669
* #184635
* #184766
* #184765
* #184764
* #184763
* #184762
* #184761
* #184760
* #184759
* #184758
* #184757
* #184756
* #184755
* #184754
* __->__ #184753
* #184645
* #184627
* #184622
* #184617
* #184616
* #184605
* #184634

Exact frozenset.copy now preserves identity, while frozenset subclass copies still produce a distinct base frozenset. Internal set binary operations clone base storage directly so they do not depend on user-visible copy semantics.

Authored by Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98