### PR TITLE
Fix Dynamo defaultdict shallow copy semantics

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
 
+import copy
 import enum
 import itertools
 import operator
@@ -45,6 +46,11 @@ class FakeMapping:
 
     def __getitem__(self, key: str) -> Any:
         return self._value
+
+
+class CopyableNonDefaultDict:
+    def __copy__(self):
+        return "wrong"
 
 
 class DictTests(torch._dynamo.test_case.TestCase):
@@ -1435,6 +1441,45 @@ class DictTests(torch._dynamo.test_case.TestCase):
                 list(d),
                 d[4],
             )
+
+        opt_f = torch.compile(f, backend="eager", fullgraph=True)
+        self.assertEqual(f(), opt_f())
+
+    def test_defaultdict_shallow_copy_preserves_factory(self):
+        def f(x):
+            d1 = defaultdict(int, {1: x})
+            d2 = copy.copy(d1)
+            d1.default_factory = list
+            d3 = copy.copy(d1)
+            d2[2] = x + 1
+            return (
+                type(d2) is defaultdict,
+                d2.default_factory is int,
+                d2[1],
+                d2[2],
+                d1.default_factory is list,
+                2 in d1,
+                d3.default_factory is list,
+                d3[1],
+            )
+
+        x = torch.ones(2)
+        ref = f(x)
+        res = torch.compile(f, backend="eager", fullgraph=True)(x)
+
+        self.assertEqual(ref, res)
+
+    def test_defaultdict_unbound_copy_rejects_unrelated_receiver(self):
+        def f():
+            try:
+                result = defaultdict.__copy__(CopyableNonDefaultDict())
+            except TypeError as e:
+                return (
+                    "TypeError",
+                    "__copy__" in str(e),
+                    "CopyableNonDefaultDict" in str(e),
+                )
+            return ("wrong", result)
 
         opt_f = torch.compile(f, backend="eager", fullgraph=True)
         self.assertEqual(f(), opt_f())

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -983,6 +983,27 @@ class UserDefinedClassVariable(UserDefinedVariable):
             return variables.DictBuiltinVariable.call_custom_dict_fromkeys(
                 tx, self, *args, **kwargs
             )
+        elif self.value is collections.defaultdict and name == "__copy__":
+            if not args:
+                raise_type_error(
+                    tx,
+                    "unbound method defaultdict.__copy__() needs an argument",
+                )
+            try:
+                receiver_type = args[0].python_type()
+            except NotImplementedError:
+                raise_type_error(
+                    tx,
+                    "descriptor '__copy__' for 'collections.defaultdict' "
+                    "objects doesn't apply to this object",
+                )
+            if not issubclass(receiver_type, collections.defaultdict):
+                raise_type_error(
+                    tx,
+                    "descriptor '__copy__' for 'collections.defaultdict' "
+                    f"objects doesn't apply to a '{receiver_type.__name__}' object",
+                )
+            return args[0].call_method(tx, name, args[1:], kwargs)
         elif self.value is collections.OrderedDict and name == "move_to_end":
             return args[0].call_method(tx, name, [*args[1:]], kwargs)
         elif name == "__len__" and len(args) == 1 and not kwargs:
@@ -4537,11 +4558,18 @@ class DefaultDictVariable(UserDefinedDictVariable):
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return self.nb_inplace_or_impl(tx, args[0])
-        elif name == "copy":
+        elif name in ("copy", "__copy__"):
             # defaultdict.copy() creates a new defaultdict with same factory
             # https://github.com/python/cpython/blob/v3.13.3/Modules/_collectionsmodule.c#L2282
             from .builder import SourcelessBuilder
 
+            if args or kwargs:
+                raise_args_mismatch(
+                    tx,
+                    name,
+                    "0 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
+                )
             if self._base_vt is None:
                 raise AssertionError("_base_vt must not be None in copy")
             new_dd = tx.output.side_effects.track_new_user_defined_object(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184674
* #184673
* #184672
* #184671
* #184670
* #184669
* #184635
* #184766
* #184765
* #184764
* #184763
* #184762
* #184761
* #184760
* #184759
* __->__ #184758
* #184757
* #184756
* #184755
* #184754
* #184753
* #184645
* #184627
* #184622
* #184617
* #184616
* #184605
* #184634

Teach Dynamo to route defaultdict.__copy__ through the defaultdict variable implementation, preserving default_factory while enforcing descriptor receiver checks. Add focused regression coverage for shallow copy independence and invalid unbound receivers.

Authored by Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98