### PR TITLE
Fix Dynamo frozenset dict-key hashing semantics

### DIFF
--- a/test/dynamo/test_tp_hash.py
+++ b/test/dynamo/test_tp_hash.py
@@ -320,6 +320,93 @@ class TpHashTests(torch._dynamo.test_case.TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, 99)
 
+    def test_hash_int_subclass_base_descriptor_preserves_dict_key_hashes(self):
+        class HashCountingInt(int):
+            def __init__(self, *args):
+                self.hash_count = 0
+
+            def __hash__(self):
+                self.hash_count += 1
+                return int.__hash__(self)
+
+        def fn(x):
+            d = dict.fromkeys(map(HashCountingInt, range(4)))
+            after_dict = sum(elem.hash_count for elem in d)
+            s = frozenset(d)
+            after_frozenset = sum(elem.hash_count for elem in d)
+            s.difference(d)
+            after_difference = sum(elem.hash_count for elem in d)
+            if hasattr(s, "symmetric_difference_update"):
+                s.symmetric_difference_update(d)
+            after_hasattr = sum(elem.hash_count for elem in d)
+            dict.fromkeys(set(d))
+            after_set_fromkeys = sum(elem.hash_count for elem in d)
+            dict.fromkeys(frozenset(d), 123)
+            after_frozenset_fromkeys = sum(elem.hash_count for elem in d)
+            keys = d.keys()
+            set(keys)
+            after_keys_set = sum(elem.hash_count for elem in d)
+            frozenset(keys)
+            after_keys_frozenset = sum(elem.hash_count for elem in d)
+            dict.fromkeys(keys)
+            after_keys_fromkeys = sum(elem.hash_count for elem in d)
+            frozenset(keys).difference(keys)
+            after_keys_difference = sum(elem.hash_count for elem in d)
+            return (
+                after_dict,
+                after_frozenset,
+                after_difference,
+                after_hasattr,
+                after_set_fromkeys,
+                after_frozenset_fromkeys,
+                after_keys_set,
+                after_keys_frozenset,
+                after_keys_fromkeys,
+                after_keys_difference,
+            )
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
+        self.assertEqual(result, (4, 4, 4, 4, 4, 4, 4, 4, 4, 4))
+
+    def test_hash_object_descriptor_uses_identity_hash(self):
+        value = 1
+        nan_value = float("nan")
+        expected = (object.__hash__(value), object.__hash__(nan_value))
+
+        def fn(x):
+            return object.__hash__(value), object.__hash__(nan_value)
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
+        self.assertEqual(result, expected)
+
+    def test_hash_object_descriptor_singleton_receiver(self):
+        expected = object.__hash__(None)
+
+        def fn(x):
+            return object.__hash__(None)
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
+        self.assertEqual(result, expected)
+
+    def test_hash_object_descriptor_guards_dynamic_receiver_identity(self):
+        class C:
+            pass
+
+        def fn(o, x):
+            return x + object.__hash__(o)
+
+        counter = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=counter)
+        x = torch.tensor(0, dtype=torch.int64)
+        o1 = C()
+        o2 = C()
+
+        self.assertEqual(opt_fn(o1, x), fn(o1, x))
+        self.assertEqual(opt_fn(o2, x), fn(o2, x))
+        self.assertEqual(counter.frame_count, 2)
+        self.assertEqual(opt_fn(o2, x), fn(o2, x))
+        self.assertEqual(counter.frame_count, 2)
+
     def test_hash_user_class_unhashable(self):
         """Class with __hash__ = None raises TypeError."""
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1675,6 +1675,56 @@ class BuiltinVariable(BaseBuiltinVariable):
                     tx, getattr(float, name)(args[0].as_python_constant())
                 )
 
+        if (
+            isinstance(self.fn, type)
+            and name == "__hash__"
+            and len(args) == 1
+            and not kwargs
+        ):
+            descriptor = getattr(self.fn, name, None)
+            descriptor_owner = getattr(descriptor, "__objclass__", self.fn)
+            try:
+                receiver_type = args[0].python_type()
+            except NotImplementedError:
+                return super().call_method(tx, name, args, kwargs)
+            if not issubclass(receiver_type, descriptor_owner):
+                raise_type_error(
+                    tx,
+                    f"descriptor '__hash__' requires a '{descriptor_owner.__name__}' "
+                    f"object but received a '{receiver_type.__name__}'",
+                )
+            if self.fn is object:
+                real_id = args[0].get_id(tx)
+                if real_id is not None:
+                    guard_type = args[0].get_id_guard_type()
+                    if args[0].source and guard_type is not None:
+                        install_guard(args[0].source.make_guard(guard_type))
+                    real_value = args[0].get_real_python_backed_value()
+                    if real_value is NO_SUCH_SUBOBJ and args[0].source:
+                        real_value = tx.output.resolve_source_value(args[0].source)
+                    if real_value is not NO_SUCH_SUBOBJ:
+                        return ConstantVariable.create(object.__hash__(real_value))
+                if args[0].source:
+                    guard_type = args[0].get_id_guard_type()
+                    if guard_type is not None:
+                        install_guard(args[0].source.make_guard(guard_type))
+                    return ConstantVariable.create(
+                        object.__hash__(tx.output.resolve_source_value(args[0].source))
+                    )
+                return FakeIdVariable(id(args[0]))
+            elif (
+                isinstance(args[0], UserDefinedObjectVariable)
+                and args[0]._base_vt is not None
+                and args[0]._base_methods is not None
+                and descriptor in args[0]._base_methods
+            ):
+                h, is_fake = args[0]._base_vt.hash_impl(tx)
+            else:
+                h, is_fake = args[0].hash_impl(tx)
+            if is_fake:
+                return FakeIdVariable(h)
+            return ConstantVariable.create(h)
+
         if name == "__len__" and len(args) == 1 and not kwargs:
             # type.__len__(instance) → len(instance)
             # e.g. list.__len__(my_list) → len(my_list)
@@ -2302,6 +2352,14 @@ class BuiltinVariable(BaseBuiltinVariable):
         arg = args[0]
         if istype(arg, variables.SetVariable):
             return arg.clone(mutation_type=ValueMutationNew())
+        elif isinstance(arg, (ConstDictVariable, DictKeysVariable)):
+            if isinstance(arg, ConstDictVariable):
+                arg.install_dict_keys_match_guard()
+                items = arg.items.keys()
+            else:
+                arg.dv_dict.install_dict_keys_match_guard()
+                items = arg.view_items
+            return SetVariable(items, mutation_type=ValueMutationNew())
         elif arg.has_force_unpack_var_sequence(tx):
             items = arg.force_unpack_var_sequence(tx)
             return SetVariable(items, mutation_type=ValueMutationNew())
@@ -2344,6 +2402,16 @@ class BuiltinVariable(BaseBuiltinVariable):
         if istype(arg, variables.FrozensetVariable):
             # CPython: frozenset(existing_frozenset) returns the same object.
             return arg
+        elif isinstance(arg, SetVariable):
+            return FrozensetVariable(arg.items.keys())
+        elif isinstance(arg, (ConstDictVariable, DictKeysVariable)):
+            if isinstance(arg, ConstDictVariable):
+                arg.install_dict_keys_match_guard()
+                items = arg.items.keys()
+            else:
+                arg.dv_dict.install_dict_keys_match_guard()
+                items = arg.view_items
+            return FrozensetVariable(items)
         elif arg.has_force_unpack_var_sequence(tx):
             items = arg.force_unpack_var_sequence(tx)
             return FrozensetVariable(items)
@@ -3225,6 +3293,18 @@ class DictBuiltinVariable(BaseBuiltinVariable):
                 return ConstDictVariable(const_items, mutation_type=ValueMutationNew())
 
         items: dict[HashableTracker, VariableTracker] = {}
+        if isinstance(arg, (ConstDictVariable, DictKeysVariable)):
+            if isinstance(arg, ConstDictVariable):
+                arg.install_dict_keys_match_guard()
+                keys = arg.items.keys()
+            else:
+                arg.dv_dict.install_dict_keys_match_guard()
+                keys = arg.view_items
+            items.update(dict.fromkeys(keys, value))
+            return _make_result(items)
+        if isinstance(arg, SetVariable):
+            items.update(dict.fromkeys(arg.items.keys(), value))
+            return _make_result(items)
         iterator = generic_getiter(tx, arg)
         while True:
             try:

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -195,7 +195,7 @@ class SetVariable(VariableTracker):
     def call_obj_hasattr(
         self, tx: "InstructionTranslator", name: str
     ) -> ConstantVariable:
-        return VariableTracker.build(tx, hasattr(set, name))
+        return VariableTracker.build(tx, hasattr(self.python_type(), name))
 
     def install_set_contains_guard(
         self, tx: "InstructionTranslator", args: list[VariableTracker]
@@ -274,14 +274,14 @@ class SetVariable(VariableTracker):
                 "difference",
                 "symmetric_difference",
             )
-            and check_constant_args(args, kwargs)
             and self.python_type() is set
+            and check_constant_args(args, kwargs)
         ):
             py_type = self.python_type()
             return self._fast_set_method(tx, getattr(py_type, name), args, kwargs)
 
         # Lazy imports to avoid circular dependencies
-        from .dicts import DictItemsVariable, DictKeysVariable
+        from .dicts import ConstDictVariable, DictItemsVariable, DictKeysVariable
 
         if name == "__init__":
             temp_set_vt = SourcelessBuilder.create(tx, set).call_set(
@@ -360,6 +360,29 @@ class SetVariable(VariableTracker):
                 raise_args_mismatch(
                     tx, name, f"Expect: 0 kwargs, Actual: {len(kwargs)} kwargs"
                 )
+            if all(
+                isinstance(x, (SetVariable, ConstDictVariable, DictKeysVariable))
+                for x in args
+            ):
+                result = self.clone(
+                    items=self.items.copy(),
+                    mutation_type=ValueMutationNew(),
+                    source=None,
+                )
+                for other in args:
+                    if isinstance(other, ConstDictVariable):
+                        other.install_dict_keys_match_guard()
+                        other_items = other.items.keys()
+                    elif isinstance(other, DictKeysVariable):
+                        other.dv_dict.install_dict_keys_match_guard()
+                        other_items = other.view_items
+                    elif isinstance(other, SetVariable):
+                        other_items = other.items.keys()
+                    else:
+                        raise AssertionError("unreachable")
+                    for item in other_items:
+                        result.items.pop(item, None)  # type: ignore[attr-defined]
+                return result
             return SourcelessBuilder.create(tx, polyfills.set_difference).call_function(
                 tx,
                 [self, *args],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184674
* #184673
* #184672
* #184671
* #184670
* #184669
* #184635
* #184766
* #184765
* #184764
* #184763
* #184762
* #184761
* #184760
* __->__ #184759
* #184758
* #184757
* #184756
* #184755
* #184754
* #184753
* #184645
* #184627
* #184622
* #184617
* #184616
* #184605
* #184634

Preserve tracked dict-key and set hash entries through set, frozenset, dict.fromkeys, and difference paths, and handle builtin hash descriptor calls without rehashing or unsafely reusing object identity hashes.

Authored by Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98