### PR TITLE
Fix Dynamo list extend iterator semantics

### DIFF
--- a/test/dynamo/test_list.py
+++ b/test/dynamo/test_list.py
@@ -3,6 +3,8 @@
 # TODO: move set tests from test_functions.py/test_misc.py to this file
 
 
+import sys
+
 import torch
 import torch._dynamo.test_case
 from torch.testing._internal.common_utils import make_dynamo_test
@@ -19,6 +21,213 @@ class AlwaysEqualForListRemove:
 class NeverEqualForListRemove:
     def __eq__(self, other):
         return False
+
+
+class EmptyLengthHintIterator:
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise StopIteration
+
+    def __length_hint__(self):
+        return sys.maxsize
+
+
+class LengthObservingIterator:
+    def __init__(self, items):
+        self.items = items
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index == 2:
+            raise StopIteration
+        self.index += 1
+        return len(self.items)
+
+
+class IterSideEffectIterable:
+    def __init__(self):
+        self.iter_calls = 0
+        self.index = 0
+
+    def __iter__(self):
+        self.iter_calls += 1
+        self.index = 0
+        return self
+
+    def __next__(self):
+        if self.index == 1:
+            raise StopIteration
+        self.index += 1
+        return self.iter_calls
+
+
+class LengthHintSideEffectIterable:
+    def __init__(self):
+        self.hint_calls = 0
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __length_hint__(self):
+        self.hint_calls += 1
+        return 1
+
+    def __next__(self):
+        if self.index == 1:
+            raise StopIteration
+        self.index += 1
+        return self.hint_calls
+
+
+class BadLenGoodLengthHintIterable:
+    def __init__(self):
+        self.hint_calls = 0
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __len__(self):
+        return 1.5  # noqa: PLE0303
+
+    def __length_hint__(self):
+        self.hint_calls += 1
+        return 1
+
+    def __next__(self):
+        if self.index == 1:
+            raise StopIteration
+        self.index += 1
+        return self.hint_calls
+
+
+class LengthHintTypeErrorIterable:
+    def __init__(self):
+        self.hint_calls = 0
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __length_hint__(self):
+        self.hint_calls += 1
+        raise TypeError("bad hint")
+
+    def __next__(self):
+        if self.index == 1:
+            raise StopIteration
+        self.index += 1
+        return 3
+
+
+class NonCallableLengthHintIterable:
+    __length_hint__ = 1
+
+    def __init__(self):
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index == 1:
+            raise StopIteration
+        self.index += 1
+        return 4
+
+
+class TensorLengthHintIterable:
+    __length_hint__ = torch.tensor(1)
+
+    def __init__(self):
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index == 1:
+            raise StopIteration
+        self.index += 1
+        return 5
+
+
+class PropertyLengthHintIterable:
+    def __init__(self):
+        self.hint_calls = 0
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    @property
+    def __length_hint__(self):
+        self.hint_calls += 1
+        return 1
+
+    def __next__(self):
+        if self.index == 1:
+            raise StopIteration
+        self.index += 1
+        return self.hint_calls
+
+
+class TensorPropertyLengthHintIterable:
+    def __init__(self):
+        self.hint_calls = 0
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    @property
+    def __length_hint__(self):
+        self.hint_calls += 1
+        return torch.tensor(1)
+
+    def __next__(self):
+        if self.index == 1:
+            raise StopIteration
+        self.index += 1
+        return self.hint_calls
+
+
+class TensorReturnLengthHintIterable:
+    def __iter__(self):
+        return self
+
+    def __length_hint__(self):
+        return torch.tensor(1)
+
+    def __next__(self):
+        raise StopIteration
+
+
+class LengthHintOverflowIterable:
+    def __iter__(self):
+        return self
+
+    def __length_hint__(self):
+        return sys.maxsize + 1
+
+    def __next__(self):
+        raise StopIteration
+
+
+class LengthHintMutatingList(list):
+    def __len__(self):
+        self[0] = 7
+        return 1
+
+
+class NonIterable:
+    pass
 
 
 class TupleTests(torch._dynamo.test_case.TestCase):
@@ -254,6 +463,106 @@ class ListTests(TupleTests):
         # Wrong number of arguments
         self.assertRaises(TypeError, p.extend)
         self.assertRaises(TypeError, p.extend, 2, 3)
+
+    @make_dynamo_test
+    def test_extend_empty_user_defined_iterator(self):
+        p = self.thetype([1, 2, 3])
+        self.assertIsNone(p.extend(EmptyLengthHintIterator()))
+        self.assertEqual(p, self.thetype([1, 2, 3]))
+
+    @make_dynamo_test
+    def test_extend_user_defined_iterator_observes_mutation(self):
+        p = self.thetype([0])
+        self.assertIsNone(p.extend(LengthObservingIterator(p)))
+        self.assertEqual(p, self.thetype([0, 1, 2]))
+
+    @make_dynamo_test
+    def test_extend_user_defined_iter_called_once(self):
+        p = self.thetype([])
+        it = IterSideEffectIterable()
+        self.assertIsNone(p.extend(it))
+        self.assertEqual(p, self.thetype([1]))
+        self.assertEqual(it.iter_calls, 1)
+
+    @make_dynamo_test
+    def test_extend_user_defined_length_hint_side_effect(self):
+        p = self.thetype([])
+        it = LengthHintSideEffectIterable()
+        self.assertIsNone(p.extend(it))
+        self.assertEqual(p, self.thetype([1]))
+        self.assertEqual(it.hint_calls, 1)
+
+    @make_dynamo_test
+    def test_extend_bad_len_falls_back_to_length_hint(self):
+        p = self.thetype([])
+        it = BadLenGoodLengthHintIterable()
+        self.assertIsNone(p.extend(it))
+        self.assertEqual(p, self.thetype([1]))
+        self.assertEqual(it.hint_calls, 1)
+
+    @make_dynamo_test
+    def test_extend_length_hint_type_error_defaults(self):
+        p = self.thetype([])
+        it = LengthHintTypeErrorIterable()
+        self.assertIsNone(p.extend(it))
+        self.assertEqual(p, self.thetype([3]))
+        self.assertEqual(it.hint_calls, 1)
+
+    @make_dynamo_test
+    def test_extend_non_callable_length_hint_defaults(self):
+        p = self.thetype([])
+        self.assertIsNone(p.extend(NonCallableLengthHintIterable()))
+        self.assertEqual(p, self.thetype([4]))
+
+    @make_dynamo_test
+    def test_extend_tensor_length_hint_defaults(self):
+        p = self.thetype([])
+        self.assertIsNone(p.extend(TensorLengthHintIterable()))
+        self.assertEqual(p, self.thetype([5]))
+
+    @make_dynamo_test
+    def test_extend_property_length_hint_defaults(self):
+        p = self.thetype([])
+        it = PropertyLengthHintIterable()
+        self.assertIsNone(p.extend(it))
+        self.assertEqual(p, self.thetype([1]))
+        self.assertEqual(it.hint_calls, 1)
+
+    @make_dynamo_test
+    def test_extend_tensor_property_length_hint_defaults(self):
+        p = self.thetype([])
+        it = TensorPropertyLengthHintIterable()
+        self.assertIsNone(p.extend(it))
+        self.assertEqual(p, self.thetype([1]))
+        self.assertEqual(it.hint_calls, 1)
+
+    @make_dynamo_test
+    def test_extend_tensor_return_length_hint_type_error(self):
+        p = self.thetype([])
+        with self.assertRaisesRegex(
+            TypeError, "__length_hint__ must be an integer, not Tensor"
+        ):
+            p.extend(TensorReturnLengthHintIterable())
+
+    @make_dynamo_test
+    def test_extend_length_hint_overflow(self):
+        p = self.thetype([])
+        with self.assertRaises(OverflowError):
+            p.extend(LengthHintOverflowIterable())
+
+    @make_dynamo_test
+    def test_extend_list_subclass_len_before_inherited_iter(self):
+        p = self.thetype([])
+        it = LengthHintMutatingList([1])
+        self.assertIsNone(p.extend(it))
+        self.assertEqual(p, self.thetype([7]))
+        self.assertEqual(it, [7])
+
+    @make_dynamo_test
+    def test_extend_user_defined_non_iterable_type_error(self):
+        p = self.thetype([])
+        with self.assertRaisesRegex(TypeError, "'NonIterable' object is not iterable"):
+            p.extend(NonIterable())
 
     @make_dynamo_test
     def test_insert(self):

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -855,12 +855,13 @@ class CommonListMethodsVariable(BaseListVariable):
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
-            if not args[0].has_force_unpack_var_sequence(tx):
-                raise_observed_exception(
-                    TypeError, tx, args=[f"{type(args[0])} object is not iterable"]
-                )
-
             (arg,) = args
+            if not isinstance(arg, variables.UserDefinedObjectVariable):
+                if not arg.has_force_unpack_var_sequence(tx):
+                    raise_observed_exception(
+                        TypeError, tx, args=[f"{type(arg)} object is not iterable"]
+                    )
+
             arg.force_apply_to_var_sequence(
                 tx, lambda item: self.call_method(tx, "append", [item], {})
             )

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -108,7 +108,7 @@ from .base import (
 )
 from .dicts import ConstDictVariable, pydict_check
 from .hashable import HashableTracker
-from .object_protocol import is_nb_not_implemented, type_implements_nb_slot
+from .object_protocol import generic_len, is_nb_not_implemented, type_implements_nb_slot
 from .sets import SetVariable
 
 
@@ -2728,7 +2728,15 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         from .builder import SourcelessBuilder
 
         result = []
-        iter_ = SourcelessBuilder.create(tx, iter).call_function(tx, [self], {})
+        try:
+            iter_ = SourcelessBuilder.create(tx, iter).call_function(tx, [self], {})
+        except ObservedTypeError:
+            handle_observed_exception(tx)
+            raise_observed_exception(
+                TypeError,
+                tx,
+                args=[f"'{self.python_type_name()}' object is not iterable"],
+            )
 
         while True:
             try:
@@ -2738,6 +2746,132 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 handle_observed_exception(tx)
                 break
         return result
+
+    def validate_iterable_length_hint(
+        self,
+        tx: "InstructionTranslator",
+        result: VariableTracker,
+        source_name: str,
+    ) -> None:
+        if not result.is_python_constant():
+            try:
+                result_type = result.python_type()
+            except NotImplementedError:
+                result_type = None
+            if isinstance(result_type, type) and not issubclass(result_type, int):
+                if (
+                    source_name != "__len__"
+                    or inspect.getattr_static(result_type, "__index__", None) is None
+                ):
+                    if source_name == "__len__":
+                        msg = f"'{result_type.__name__}' object cannot be interpreted as an integer"
+                    else:
+                        msg = f"__length_hint__ must be an integer, not {result_type.__name__}"
+                    raise_observed_exception(
+                        TypeError,
+                        tx,
+                        args=[msg],
+                    )
+            unimplemented(
+                gb_type="Cannot trace user-defined __len__",
+                context=f"{self.python_type_name()}.__len__()",
+                explanation=(
+                    f"Dynamo cannot trace len() on {self.python_type_name()} because the __len__ "
+                    "method is either not traceable (e.g., defined in C or built-in) or returns a "
+                    "non-constant value."
+                ),
+                hints=[
+                    *graph_break_hints.SUPPORTABLE,
+                ],
+            )
+
+        value = result.as_python_constant()
+        if value is NotImplemented and source_name == "__length_hint__":
+            return
+        if not isinstance(value, int):
+            if source_name == "__len__":
+                msg = f"'{type(value).__name__}' object cannot be interpreted as an integer"
+            else:
+                msg = f"__length_hint__ must be an integer, not {type(value).__name__}"
+            raise_observed_exception(
+                TypeError,
+                tx,
+                args=[msg],
+            )
+        if value < 0:
+            msg = f"{source_name}() should return >= 0"
+            raise_observed_exception(ValueError, tx, args=[msg])
+        if value > sys.maxsize:
+            raise_observed_exception(
+                OverflowError,
+                tx,
+                args=["Python int too large to convert to C ssize_t"],
+            )
+
+    def apply_iterable_length_hint(self, tx: "InstructionTranslator") -> None:
+        try:
+            length = generic_len(tx, self)
+            self.validate_iterable_length_hint(tx, length, "__len__")
+        except ObservedTypeError:
+            handle_observed_exception(tx)
+        else:
+            return
+
+        type_attr = self.lookup_class_mro_attr("__length_hint__")
+        if type_attr is NO_SUCH_SUBOBJ or type_attr is None:
+            return
+        if (
+            not callable(type_attr)
+            and inspect.getattr_static(type(type_attr), "__get__", None) is None
+        ):
+            return
+
+        source = self.source and self.get_source_by_walking_mro(tx, "__length_hint__")
+        if isinstance(type_attr, property) and not self._is_c_defined_property(
+            type_attr
+        ):
+            method_var = variables.PropertyVariable(
+                type_attr, source=source
+            ).tp_descr_get_impl(tx, self, self.var_getattr(tx, "__class__"))
+        else:
+            method_var = self.resolve_type_attr(
+                tx, "__length_hint__", type_attr, source
+            )
+        if method_var.is_python_constant():
+            if not callable(method_var.as_python_constant()):
+                return
+        elif isinstance(method_var, UserDefinedVariable) and not callable(
+            method_var.value
+        ):
+            return
+        elif type(method_var).call_function is VariableTracker.call_function:
+            return
+        try:
+            length_hint = method_var.call_function(tx, [], {})
+        except ObservedTypeError:
+            handle_observed_exception(tx)
+            return
+        self.validate_iterable_length_hint(tx, length_hint, "__length_hint__")
+
+    def force_apply_to_var_sequence(
+        self, tx: "InstructionTranslator", fn: Callable[[VariableTracker], Any]
+    ) -> None:
+        from .builder import SourcelessBuilder
+
+        iter_ = SourcelessBuilder.create(tx, iter).call_function(tx, [self], {})
+        self.apply_iterable_length_hint(tx)
+
+        if self._base_vt is not None and self._base_methods is not None:
+            iter_method = self._maybe_get_baseclass_method("__iter__")
+            if iter_method is not None and iter_method in self._base_methods:
+                return self._base_vt.force_apply_to_var_sequence(tx, fn)
+
+        while True:
+            try:
+                fn(iter_.tp_iternext_impl(tx))
+            except ObservedUserStopIteration:
+                handle_observed_exception(tx)
+                break
 
     def is_supported_random(self) -> bool:
         try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184674
* #184673
* #184672
* #184671
* #184670
* #184669
* #184635
* #184766
* #184765
* #184764
* #184763
* __->__ #184762
* #184761
* #184760
* #184759
* #184758
* #184757
* #184756
* #184755
* #184754
* #184753
* #184645
* #184627
* #184622
* #184617
* #184616
* #184605
* #184634

Handle user-defined iterables in list.extend with CPython-style iterator consumption and observable length-hint behavior, including defaulting and validation edge cases for __length_hint__ results. Remove the now-passing CPython expected-failure sentinel and add focused Dynamo regressions.

Authored by Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98