### PR TITLE
Fix Dynamo dict copy GC tracking semantics

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -3,6 +3,7 @@
 
 import copy
 import enum
+import gc
 import itertools
 import operator
 import types
@@ -2638,6 +2639,60 @@ class DictMethodsTests(torch._dynamo.test_case.TestCase):
 
         # Test invalid usage
         self.assertRaises(TypeError, d.copy, 1)
+
+    def test_copy_maintains_gc_tracking(self):
+        class A:
+            pass
+
+        key = A()
+
+        def fn():
+            result = []
+            for d in ({}, {"a": 1}, {key: "val"}):
+                d2 = d.copy()
+                result.append((gc.is_tracked(d), gc.is_tracked(d2)))
+            return result
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(), opt_fn())
+
+    def test_gc_is_tracked_mutated_dict_graph_breaks(self):
+        def fn():
+            d = {"a": []}
+            d["a"] = 1
+            return gc.is_tracked(d)
+
+        self.assertTrue(fn())
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        with self.assertRaisesRegex(Unsupported, "mutated dict"):
+            opt_fn()
+
+    def test_gc_is_tracked_source_backed_history_sensitive_dict_graph_breaks(self):
+        def fn(d):
+            return gc.is_tracked(d)
+
+        d = {"a": []}
+        d["a"] = 1
+        self.assertTrue(gc.is_tracked(d))
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        with self.assertRaisesRegex(Unsupported, "source-backed dict"):
+            opt_fn(d)
+
+    def test_gc_is_tracked_source_backed_history_sensitive_dict_copy_graph_breaks(
+        self,
+    ):
+        def fn(d):
+            d2 = d.copy()
+            return gc.is_tracked(d2)
+
+        d = {"a": []}
+        d["a"] = 1
+        self.assertTrue(fn(d))
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        with self.assertRaisesRegex(Unsupported, "unknown tracking state"):
+            opt_fn(d)
 
     @make_dynamo_test
     def test_fromkeys(self):

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -25,6 +25,7 @@ import contextlib
 import copy
 import dataclasses
 import functools
+import gc
 import importlib
 import inspect
 import linecache
@@ -3231,6 +3232,7 @@ def _builtin_function_ids() -> dict[int, str]:
         }
     )
     rv[id(builtins.__build_class__)] = "builtins.__build_class__"
+    rv[id(gc.is_tracked)] = "gc.is_tracked"
     return rv
 
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -23,6 +23,7 @@ import ast
 import builtins
 import contextlib
 import functools
+import gc
 import inspect
 import itertools
 import logging
@@ -2781,6 +2782,72 @@ class BuiltinVariable(BaseBuiltinVariable):
             return VariableTracker.build(tx, real_id)
 
         return FakeIdVariable(id(arg))
+
+    def call_is_tracked(
+        self, tx: "InstructionTranslator", obj: VariableTracker
+    ) -> VariableTracker:
+        if self.fn is not gc.is_tracked:
+            return super().call_function(tx, [obj], {})
+
+        if isinstance(obj, ConstDictVariable):
+            if obj.user_cls is not dict:
+                return ConstantVariable.create(True)
+            if obj.source is not None:
+                unimplemented(
+                    gb_type="gc.is_tracked() on source-backed dict",
+                    context=f"gc.is_tracked({obj})",
+                    explanation=(
+                        "Dynamo does not model pre-existing "
+                        "history-sensitive CPython dict GC tracking state."
+                    ),
+                    hints=[*graph_break_hints.SUPPORTABLE],
+                )
+            if obj.gc_tracking_unknown:
+                unimplemented(
+                    gb_type="gc.is_tracked() on dict with unknown tracking state",
+                    context=f"gc.is_tracked({obj})",
+                    explanation=(
+                        "Dynamo does not model history-sensitive CPython dict "
+                        "GC tracking state carried through dict.copy()."
+                    ),
+                    hints=[*graph_break_hints.SUPPORTABLE],
+                )
+            if obj.was_mutated:
+                unimplemented(
+                    gb_type="gc.is_tracked() on mutated dict",
+                    context=f"gc.is_tracked({obj})",
+                    explanation=(
+                        "Dynamo does not model history-sensitive CPython "
+                        "dict GC tracking state after mutation."
+                    ),
+                    hints=[*graph_break_hints.SUPPORTABLE],
+                )
+
+            concrete = {}
+            for key, value in obj.items.items():
+                if not isinstance(key, HashableTracker):
+                    raise AssertionError(f"expected HashableTracker key, got {key}")
+                concrete_key = key.vt.get_real_python_backed_value()
+                concrete_value = value.get_real_python_backed_value()
+                if concrete_key is NO_SUCH_SUBOBJ or concrete_value is NO_SUCH_SUBOBJ:
+                    unimplemented(
+                        gb_type="gc.is_tracked() on dict with symbolic contents",
+                        context=f"gc.is_tracked({obj})",
+                        explanation=(
+                            "Dynamo only supports gc.is_tracked() on "
+                            "dictionaries with Python-backed contents."
+                        ),
+                        hints=[*graph_break_hints.SUPPORTABLE],
+                    )
+                concrete[concrete_key] = concrete_value
+            return ConstantVariable.create(gc.is_tracked(concrete))
+
+        unimplemented(
+            gb_type="unsupported gc.is_tracked() argument",
+            context=f"gc.is_tracked({obj})",
+            explanation="Dynamo only supports gc.is_tracked() on dictionaries.",
+            hints=[*graph_break_hints.SUPPORTABLE],
+        )
 
     def call_deepcopy(
         self, tx: "InstructionTranslator", x: VariableTracker

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -96,7 +96,9 @@ class ConstDictVariable(VariableTracker):
     NOT_CONTAINS_GUARD = GuardBuilder.DICT_NOT_CONTAINS
 
     _nonvar_fields = {
+        "gc_tracking_unknown",
         "user_cls",
+        "was_mutated",
         *VariableTracker._nonvar_fields,
     }
 
@@ -112,6 +114,8 @@ class ConstDictVariable(VariableTracker):
             kwargs.pop("original_items")
         if "should_reconstruct_all" in kwargs:
             kwargs.pop("should_reconstruct_all")
+        gc_tracking_unknown = kwargs.pop("gc_tracking_unknown", False)
+        was_mutated = kwargs.pop("was_mutated", False)
 
         super().__init__(**kwargs)
 
@@ -142,6 +146,8 @@ class ConstDictVariable(VariableTracker):
         )
         self.original_items = items.copy()
         self.user_cls = user_cls
+        self.gc_tracking_unknown = gc_tracking_unknown
+        self.was_mutated = was_mutated
 
     def _get_dict_cls_from_user_cls(self, user_cls: type) -> type:
         accepted_dict_types = (dict, collections.OrderedDict, collections.defaultdict)
@@ -627,6 +633,7 @@ class ConstDictVariable(VariableTracker):
             temp_dict_vt = DictBuiltinVariable.call_custom_dict(
                 tx, dict, *args, **kwargs
             )
+            self.was_mutated = True
             tx.output.side_effects.mutation(self)
             self.items.update(temp_dict_vt.items)  # type: ignore[attr-defined]
             return ConstantVariable.create(None)
@@ -677,7 +684,12 @@ class ConstDictVariable(VariableTracker):
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             return self.clone(
-                items=self.items.copy(), mutation_type=ValueMutationNew(), source=None
+                items=self.items.copy(),
+                gc_tracking_unknown=self.gc_tracking_unknown
+                or (self.user_cls is dict and self.source is not None)
+                or self.was_mutated,
+                mutation_type=ValueMutationNew(),
+                source=None,
             )
         elif name == "__setitem__" and self.is_mutable():
             self.install_dict_keys_match_guard()
@@ -688,6 +700,7 @@ class ConstDictVariable(VariableTracker):
                     "2 args and 0 kwargs",
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
+            self.was_mutated = True
             tx.output.side_effects.mutation(self)
             self.items[Hashable(args[0])] = args[1]
             return ConstantVariable.create(None)
@@ -696,6 +709,7 @@ class ConstDictVariable(VariableTracker):
             if arg_hashable:
                 self.install_dict_keys_match_guard()
                 self.should_reconstruct_all = True
+                self.was_mutated = True
                 tx.output.side_effects.mutation(self)
                 self.items.__delitem__(Hashable(args[0]))
                 return ConstantVariable.create(None)
@@ -726,6 +740,7 @@ class ConstDictVariable(VariableTracker):
                 return args[1]
 
             self.should_reconstruct_all = True
+            self.was_mutated = True
             tx.output.side_effects.mutation(self)
             return self.items.pop(Hashable(args[0]))
         elif name == "popitem" and self.is_mutable():
@@ -745,6 +760,7 @@ class ConstDictVariable(VariableTracker):
 
             k, v = self.items.popitem()
             self.should_reconstruct_all = True
+            self.was_mutated = True
             tx.output.side_effects.mutation(self)
 
             return variables.TupleVariable([k.vt, v])
@@ -757,6 +773,7 @@ class ConstDictVariable(VariableTracker):
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
             self.should_reconstruct_all = True
+            self.was_mutated = True
             tx.output.side_effects.mutation(self)
             self.items.clear()
             return ConstantVariable.create(None)
@@ -770,6 +787,7 @@ class ConstDictVariable(VariableTracker):
             has_kwargs = len(kwargs) > 0
             if has_arg or has_kwargs or not args:
                 if has_arg or has_kwargs:
+                    self.was_mutated = True
                     tx.output.side_effects.mutation(self)
                 if has_arg:
                     from .object_protocol import generic_getiter, vt_getitem
@@ -842,6 +860,7 @@ class ConstDictVariable(VariableTracker):
                     x = ConstantVariable.create(None)
                 else:
                     x = args[1]
+                self.was_mutated = True
                 tx.output.side_effects.mutation(self)
                 self.items[Hashable(args[0])] = x
                 return x


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184674
* #184673
* #184672
* #184671
* #184670
* #184669
* #184635
* #184766
* #184765
* #184764
* __->__ #184763
* #184762
* #184761
* #184760
* #184759
* #184758
* #184757
* #184756
* #184755
* #184754
* #184753
* #184645
* #184627
* #184622
* #184617
* #184616
* #184605
* #184634

Add narrow Dynamo support for gc.is_tracked on fresh exact dicts and dict copies while graph-breaking for source-backed, mutated, or otherwise unknown history-sensitive dict tracking state.

This fixes the CPython dict copy tracking gate without attempting to model arbitrary CPython GC tracking history.

Authored by Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98