### PR TITLE
[distributed] Route _set_pg_timeout to ProcessGroupXCCL on xpu PGs

### DIFF
--- a/test/distributed/test_c10d_xccl.py
+++ b/test/distributed/test_c10d_xccl.py
@@ -1,7 +1,6 @@
 # Owner(s): ["module: distributed"]
 
 import os
-import socket
 import sys
 import warnings
 from datetime import timedelta
@@ -19,19 +18,16 @@ from torch.testing._internal.common_distributed import (
     requires_accelerator_dist_backend,
 )
 from torch.testing._internal.common_utils import (
+    find_free_port,
+    retry_on_connect_failures,
     run_tests,
     TestCase,
 )
 
 
-def _free_port() -> str:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return str(s.getsockname()[1])
-
-
 class ProcessGroupXCCLTest(TestCase):
     @requires_accelerator_dist_backend(["xccl"])
+    @retry_on_connect_failures
     def test_xccl_set_pg_timeout_api(self):
         """
         Test _set_pg_timeout API for XCCL backend.
@@ -51,7 +47,7 @@ class ProcessGroupXCCLTest(TestCase):
             self.skipTest("requires Intel XPU")
 
         os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
-        os.environ.setdefault("MASTER_PORT", _free_port())
+        os.environ.setdefault("MASTER_PORT", str(find_free_port()))
         os.environ["WORLD_SIZE"] = "1"
         os.environ["RANK"] = "0"
         torch.xpu.set_device(0)
@@ -81,7 +77,7 @@ class ProcessGroupXCCLTest(TestCase):
                 unsupported_warnings,
                 [],
                 "_set_pg_timeout on an xccl PG should not emit the "
-                "'only supported for nccl or gloo' warning",
+                "'only supported for nccl, gloo, and xccl' warning",
             )
             self.assertEqual(
                 backend.options._timeout, timedelta(milliseconds=1)

--- a/test/distributed/test_c10d_xccl.py
+++ b/test/distributed/test_c10d_xccl.py
@@ -1,0 +1,94 @@
+# Owner(s): ["module: distributed"]
+
+import os
+import socket
+import sys
+import warnings
+from datetime import timedelta
+
+import torch
+import torch.distributed as c10d
+
+
+if not c10d.is_available() or not c10d.is_xccl_available():
+    print("c10d XCCL not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+import torch.distributed as dist
+from torch.testing._internal.common_distributed import (
+    requires_accelerator_dist_backend,
+)
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TestCase,
+)
+
+
+def _free_port() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return str(s.getsockname()[1])
+
+
+class ProcessGroupXCCLTest(TestCase):
+    @requires_accelerator_dist_backend(["xccl"])
+    def test_xccl_set_pg_timeout_api(self):
+        """
+        Test _set_pg_timeout API for XCCL backend.
+
+        Prior to this fix, ``_set_pg_timeout`` had device-conditional
+        branches only for cpu (gloo) and cuda (nccl/gloo/torchcomms);
+        an xpu/xccl process group fell through to the "Set timeout is
+        now only supported for either nccl or gloo." warning and the
+        per-PG timeout was silently never propagated to the backend.
+
+        This test verifies:
+        1. ``_set_pg_timeout`` on an xccl PG does NOT emit the warning;
+        2. the call reaches ``ProcessGroupXCCL.set_timeout`` and
+           updates ``backend.options._timeout`` to the new value.
+        """
+        if not torch.xpu.is_available():
+            self.skipTest("requires Intel XPU")
+
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", _free_port())
+        os.environ["WORLD_SIZE"] = "1"
+        os.environ["RANK"] = "0"
+        torch.xpu.set_device(0)
+
+        dist.init_process_group(
+            backend="xccl",
+            init_method="env://",
+            timeout=timedelta(seconds=50),
+        )
+        try:
+            pg = dist.distributed_c10d._get_default_group()
+            backend = pg._get_backend(torch.device("xpu"))
+            self.assertEqual(backend.options._timeout, timedelta(seconds=50))
+
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                c10d.distributed_c10d._set_pg_timeout(
+                    timedelta(milliseconds=1), pg
+                )
+
+            unsupported_warnings = [
+                w
+                for w in caught
+                if "Set timeout is now only supported" in str(w.message)
+            ]
+            self.assertEqual(
+                unsupported_warnings,
+                [],
+                "_set_pg_timeout on an xccl PG should not emit the "
+                "'only supported for nccl or gloo' warning",
+            )
+            self.assertEqual(
+                backend.options._timeout, timedelta(milliseconds=1)
+            )
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1654,21 +1654,22 @@ def _set_pg_timeout(timeout: timedelta, group: ProcessGroup | None = None) -> No
     # XCCL exposes the public Backend API method ``set_timeout`` rather
     # than the private ``_set_default_timeout`` alias NCCL uses, so it
     # cannot share the ``backends`` set above (which is drained via
-    # ``_set_default_timeout``). Route xpu PGs through ``set_timeout``
-    # directly.
-    xccl_backends: set[Backend] = set()
+    # ``_set_default_timeout``). An xpu PG resolves to a single xccl
+    # backend, so a single optional binding suffices here.
+    xccl_backend: ProcessGroupXCCL | None = None
     if torch.device("xpu") in devices and is_xccl_available():
         backend = group._get_backend(torch.device("xpu"))
         if isinstance(backend, ProcessGroupXCCL):
-            xccl_backends.add(backend)
-    if len(backends) == 0 and len(xccl_backends) == 0:
+            xccl_backend = backend
+    if len(backends) == 0 and xccl_backend is None:
         warnings.warn(
-            "Set timeout is now only supported for either nccl or gloo.", stacklevel=2
+            "Set timeout is now only supported for nccl, gloo, and xccl.",
+            stacklevel=2,
         )
     for backend in backends:
         backend._set_default_timeout(timeout)
-    for backend in xccl_backends:
-        backend.set_timeout(timeout)
+    if xccl_backend is not None:
+        xccl_backend.set_timeout(timeout)
 
 
 @_exception_logger

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1651,12 +1651,24 @@ def _set_pg_timeout(timeout: timedelta, group: ProcessGroup | None = None) -> No
             backends.add(backend)  # type: ignore[arg-type]
         elif _use_torchcomms_enabled() and isinstance(backend, _BackendWrapper):
             backends.add(backend)  # type: ignore[arg-type]
-    if len(backends) == 0:
+    # XCCL exposes the public Backend API method ``set_timeout`` rather
+    # than the private ``_set_default_timeout`` alias NCCL uses, so it
+    # cannot share the ``backends`` set above (which is drained via
+    # ``_set_default_timeout``). Route xpu PGs through ``set_timeout``
+    # directly.
+    xccl_backends: set[Backend] = set()
+    if torch.device("xpu") in devices and is_xccl_available():
+        backend = group._get_backend(torch.device("xpu"))
+        if isinstance(backend, ProcessGroupXCCL):
+            xccl_backends.add(backend)
+    if len(backends) == 0 and len(xccl_backends) == 0:
         warnings.warn(
             "Set timeout is now only supported for either nccl or gloo.", stacklevel=2
         )
     for backend in backends:
         backend._set_default_timeout(timeout)
+    for backend in xccl_backends:
+        backend.set_timeout(timeout)
 
 
 @_exception_logger


### PR DESCRIPTION
# [distributed] Route `_set_pg_timeout` to `ProcessGroupXCCL` on xpu PGs

## Summary

`torch.distributed.distributed_c10d._set_pg_timeout` currently has
device-conditional branches for **cpu** (gloo) and **cuda**
(nccl/gloo/torchcomms) — but **no `torch.device("xpu")` branch**. On
an xccl-backed process group the existing loop adds no backends,
emits the warning

```
UserWarning: Set timeout is now only supported for either nccl or gloo.
```

and `_set_default_timeout` is never called. The per-PG timeout
(e.g. `CommConfig.train_timeout_seconds` in torchtitan, or any user
who later wants to call `_set_pg_timeout` directly) silently no-ops on
every Intel XPU run.

`ProcessGroupXCCL` already exposes the public `Backend.set_timeout`
method; the only gap is the Python dispatch. This PR adds an `xpu`
branch that mirrors the existing `cuda` branch and routes xccl PGs
through `backend.set_timeout(timeout)`. (XCCL doesn't expose
`_set_default_timeout` the way `ProcessGroupNCCL` does, so it can't
share the existing `backends` set, which is drained via
`_set_default_timeout` at the end of the function.)

After this patch, calling `_set_pg_timeout` on an xccl PG:
- does **not** emit the "only supported for nccl or gloo" warning;
- routes through `ProcessGroupXCCL.set_timeout(timeout)`;
- updates `backend.options._timeout` (the same field
  [`test_gloo_set_pg_timeout_api`](test/distributed/test_c10d_gloo.py)
  asserts on for gloo).

## Diff

```diff
@@ inside _set_pg_timeout, after the cuda branch @@
+    # XCCL exposes the public Backend API method ``set_timeout`` rather
+    # than the private ``_set_default_timeout`` alias NCCL uses, so it
+    # cannot share the ``backends`` set above (which is drained via
+    # ``_set_default_timeout``). Route xpu PGs through ``set_timeout``
+    # directly.
+    xccl_backends: set[Backend] = set()
+    if torch.device("xpu") in devices and is_xccl_available():
+        backend = group._get_backend(torch.device("xpu"))
+        if isinstance(backend, ProcessGroupXCCL):
+            xccl_backends.add(backend)
-    if len(backends) == 0:
+    if len(backends) == 0 and len(xccl_backends) == 0:
         warnings.warn(
             "Set timeout is now only supported for either nccl or gloo.", stacklevel=2
         )
     for backend in backends:
         backend._set_default_timeout(timeout)
+    for backend in xccl_backends:
+        backend.set_timeout(timeout)
```

## Test plan

Adds `test/distributed/test_c10d_xccl.py::ProcessGroupXCCLTest::test_xccl_set_pg_timeout_api`,
modeled on the existing `test_gloo_set_pg_timeout_api`. The new test:

1. Initialises a single-rank xccl PG with `timeout=timedelta(seconds=50)`.
2. Asserts `backend.options._timeout == timedelta(seconds=50)`.
3. Calls `c10d.distributed_c10d._set_pg_timeout(timedelta(milliseconds=1), pg)`
   inside `warnings.catch_warnings(record=True)`.
4. Asserts no "Set timeout is now only supported..." warning fired.
5. Asserts `backend.options._timeout == timedelta(milliseconds=1)`.

The test gates on `@requires_accelerator_dist_backend(["xccl"])` and
skips when XPU is not available, matching the convention used by
other xccl tests under `test/distributed/`.

### Empirical verification (out-of-tree)

Verified on 12 ranks of an Intel XPU (Sunspot, 1 node × 12 tiles) with
torch `2.13.0.dev` from the same `distributed_c10d.py`, patched and
unpatched:

| State    | Warning fires | `ProcessGroupXCCL.set_timeout` called | `options._timeout` after |
|----------|:-------------:|:-------------------------------------:|:-------------------------:|
| Unpatched | yes           | no                                    | unchanged                 |
| Patched   | no            | yes (recorded via monkey-patched class-method spy) | updated to new value |

Side observation: xccl's C++ `set_timeout` **does** propagate the
value into `options._timeout`. Whether that timeout is then
**enforced** by a watchdog (and `ccl_abort`-equivalent fires when
collectives exceed the deadline) is a separate question and is **out
of scope for this PR**. This PR only fixes the Python dispatch gap so
the value actually reaches the backend; an enforcement PR — which
needs to land changes in `ProcessGroupXCCL.{hpp,cpp}` and likely a
watchdog thread analogous to NCCL's — would follow.

## Risk

Minimal. Behavior for cpu / cuda / torchcomms users is unchanged. For
xccl users, the previous behavior was a no-op + warning; the new
behavior calls `backend.set_timeout` and suppresses the warning. The
only failure mode is if `ProcessGroupXCCL.set_timeout` itself raises —
in which case the user would have been getting the warning today and
the timeout would have been silently ignored, so this surfaces an
otherwise-hidden error.

## Related

This is a prerequisite for proper per-collective timeout handling on
Intel XPU. Downstream context (a hung MoE training run that consumed
its full PBS walltime instead of aborting at the configured 100s
deadline, because `_set_pg_timeout` had silently no-op'd) is described
in [this writeup](https://github.com/saforem2/torchtitan/blob/ezpz/torchtitan/experiments/ezpz/docs/upstream-issues/train_timeout_xpu_silent_noop.md).
The downstream torchtitan workaround in
[`saforem2/torchtitan@22847fcb`](https://github.com/saforem2/torchtitan/commit/22847fcb3)
walks each PG and calls `ProcessGroupXCCL.set_timeout` directly; this
PR makes that workaround unnecessary.

cc @gujinghui @fengyuan14 @jbschlosser
