### PR TITLE
Require clang 16 or newer in CMake configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,18 @@ if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.3)
   )
 endif()
 
+# --- [ Check that minimal clang version is 16+
+# Older clangs (e.g. clang-14) fail to compile C++20 ranges adaptors such as
+# `std::views::filter` over associative containers when paired with libstdc++,
+# see https://github.com/pytorch/pytorch/issues/184630. AppleClang uses its
+# own versioning scheme and is excluded from this check.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+  message(
+    FATAL_ERROR
+      "Clang-16 or newer is required to compile PyTorch, but found ${CMAKE_CXX_COMPILER_VERSION}"
+  )
+endif()
+
 # This define is needed to preserve behavior given anticpated changes to
 # cccl/thrust
 # https://nvidia.github.io/cccl/libcudacxx/standard_api/numerics_library/complex.html


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #184770

clang-14 and clang-15 fail to compile the C++20 `std::views::filter` pipeline introduced in #184309 when paired with
libstdc++, producing a confusing SFINAE error from `__adaptor_invocable`, see https://godbolt.org/z/zEjnoo8WP
Fail early at configure time with a clear message pointing at the minimum supported clang, matching the existing GCC-11.3 check.

Fixes https://github.com/pytorch/pytorch/issues/184630

Authored with Claude.