### PR TITLE
Fix use-after-free in functionalization ViewMeta serialization

### DIFF
--- a/aten/src/ATen/FunctionalStorageImpl.h
+++ b/aten/src/ATen/FunctionalStorageImpl.h
@@ -2,6 +2,8 @@
 
 #include <ATen/Tensor.h>
 
+#include <tuple>
+#include <type_traits>
 #include <utility>
 
 namespace at::functionalization {
@@ -26,8 +28,22 @@ enum class InverseReturnMode {
     return #TYPE;                             \
   }
 
-#define FUNCTIONALIZATION_VIEWMETA_SERIALIZABLE_TUPLE(...) \
-  using SerializableTuple = std::tuple<__VA_ARGS__>
+template <class T>
+struct tuple_elements_are_owning;
+
+template <class... Ts>
+struct tuple_elements_are_owning<std::tuple<Ts...>>
+    : std::bool_constant<(std::is_same_v<std::decay_t<Ts>, Ts> && ...)> {};
+
+#define FUNCTIONALIZATION_VIEWMETA_SERIALIZABLE_TUPLE(...)                \
+  using SerializableTuple = std::tuple<__VA_ARGS__>;                      \
+  static_assert(                                                          \
+      ::at::functionalization::tuple_elements_are_owning<                 \
+          SerializableTuple>::value,                                      \
+      "FUNCTIONALIZATION_VIEWMETA_SERIALIZABLE_TUPLE elements must be "   \
+      "owning value types (no references or cv-qualifiers); a reference " \
+      "element would dangle in to_serializable_tuple() and in the data "  \
+      "member it initializes.")
 
 // ViewMeta is a class used by the functionalization pass to navigate between
 // a base tensor and a view tensor.
@@ -39,7 +55,7 @@ enum class InverseReturnMode {
 //   FUNCTIONALIZATION_VIEWMETA_NAME(view1_ViewMeta);
 //   FUNCTIONALIZATION_VIEWMETA_SERIALIZABLE_TUPLE(
 //       bool /* reapply_views */,
-//       const std::vector<int64_t>&);
+//       std::vector<int64_t>);
 //
 //   view1_ViewMeta(const SerializableTuple& tpl)
 //       : view1_ViewMeta(std::get<0>(tpl), std::get<1>(tpl)) {}

--- a/aten/src/ATen/FunctionalizeFallbackKernel.h
+++ b/aten/src/ATen/FunctionalizeFallbackKernel.h
@@ -9,7 +9,7 @@ struct TORCH_API resize__ViewMeta : public ViewMeta {
   FUNCTIONALIZATION_VIEWMETA_NAME(resize__ViewMeta)
   FUNCTIONALIZATION_VIEWMETA_SERIALIZABLE_TUPLE(
       bool /* reapply_views */,
-      const std::vector<int64_t>&);
+      std::vector<int64_t>);
 
   resize__ViewMeta(const SerializableTuple& tpl)
       : resize__ViewMeta(std::get<0>(tpl), std::get<1>(tpl)) {}
@@ -35,7 +35,7 @@ struct TORCH_API _unsafe_view_ViewMeta : public ViewMeta {
   FUNCTIONALIZATION_VIEWMETA_NAME(_unsafe_view_ViewMeta)
   FUNCTIONALIZATION_VIEWMETA_SERIALIZABLE_TUPLE(
       bool /* has_symbolic_inputs */,
-      const std::vector<c10::SymInt>&);
+      std::vector<c10::SymInt>);
 
   _unsafe_view_ViewMeta(const SerializableTuple& tpl)
       : _unsafe_view_ViewMeta(std::get<0>(tpl), std::get<1>(tpl)) {}

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: codegen"]
 # ruff: noqa: F841
 
+import pickle
 import unittest
 from contextlib import nullcontext
 
@@ -2322,6 +2323,94 @@ def forward(self, arg0_1):
 )
 class TestCrossRefFunctionalization(TestFunctionalization):
     crossref = True
+
+
+class TestViewMetaSerialization(TestCase):
+    # Exercise to_serializable_tuple() via as_tuple() and pickle, covering each
+    # element kind that used to be a dangling reference: std::vector (resize_/
+    # _unsafe_view_), const at::Tensor& (_make_dual), and const
+    # std::optional<at::Tensor>& (_nested_view_from_jagged). Deterministic UAF
+    # under ASAN before the fix; the tensor cases segfault even without ASAN.
+
+    def _make_dual_view_meta(self, tangent, level=0):
+        # _make_dual_ViewMeta's SerializableTuple is (has_symbolic_inputs,
+        # reapply_views, inverse_return_mode, tangent, level); the tangent
+        # element is the `const at::Tensor&` reference that used to dangle.
+        return torch._C._functionalization._make_dual_ViewMeta(
+            (
+                False,
+                True,
+                torch._C._functionalization.InverseReturnMode.AlwaysView,
+                tangent,
+                level,
+            )
+        )
+
+    def _nested_jagged_view_meta(self, offsets, lengths):
+        # _nested_view_from_jagged_ViewMeta's SerializableTuple is
+        # (has_symbolic_inputs, reapply_views, inverse_return_mode, offsets,
+        # dummy, lengths, ragged_idx, min_seqlen, max_seqlen). lengths/min_seqlen/
+        # max_seqlen are `const std::optional<at::Tensor>&` elements; this covers
+        # the optional<Tensor> decay path (min_seqlen/max_seqlen left as None).
+        return torch._C._functionalization._nested_view_from_jagged_ViewMeta(
+            (
+                False,
+                True,
+                torch._C._functionalization.InverseReturnMode.AlwaysView,
+                offsets,
+                torch.zeros(offsets.shape[0] - 1),
+                lengths,
+                1,
+                None,
+                None,
+            )
+        )
+
+    def test_resize_view_meta_as_tuple(self):
+        view_meta = torch._C._functionalization.resize__ViewMeta((True, [3, 4, 5]))
+        reapply_views, size = view_meta.as_tuple()
+        self.assertEqual(reapply_views, True)
+        self.assertEqual(size, [3, 4, 5])
+
+    def test_unsafe_view_meta_as_tuple(self):
+        view_meta = torch._C._functionalization._unsafe_view_ViewMeta((False, [2, 6]))
+        has_symbolic_inputs, size = view_meta.as_tuple()
+        self.assertEqual(has_symbolic_inputs, False)
+        self.assertEqual(size, [2, 6])
+
+    def test_make_dual_view_meta_tensor_element_as_tuple(self):
+        tangent = torch.arange(6.0).reshape(2, 3)
+        view_meta = self._make_dual_view_meta(tangent, level=0)
+        has_symbolic_inputs, reapply_views, _, restored_tangent, level = (
+            view_meta.as_tuple()
+        )
+        self.assertEqual(has_symbolic_inputs, False)
+        self.assertEqual(reapply_views, True)
+        self.assertEqual(level, 0)
+        self.assertEqual(restored_tangent, tangent)
+
+    def test_nested_jagged_view_meta_optional_tensor_elements_as_tuple(self):
+        offsets = torch.tensor([0, 2, 4])
+        lengths = torch.tensor([2, 2])
+        view_meta = self._nested_jagged_view_meta(offsets, lengths)
+        restored = view_meta.as_tuple()
+        self.assertEqual(restored[3], offsets)
+        # present optional<Tensor> round-trips, absent ones stay None
+        self.assertEqual(restored[5], lengths)
+        self.assertEqual(restored[7], None)
+        self.assertEqual(restored[8], None)
+
+    def test_view_meta_pickle_roundtrip(self):
+        for view_meta in (
+            torch._C._functionalization.resize__ViewMeta((True, [3, 4, 5])),
+            torch._C._functionalization._unsafe_view_ViewMeta((False, [2, 6])),
+            self._make_dual_view_meta(torch.arange(6.0).reshape(2, 3)),
+            self._nested_jagged_view_meta(
+                torch.tensor([0, 2, 4]), torch.tensor([2, 2])
+            ),
+        ):
+            restored = pickle.loads(pickle.dumps(view_meta))
+            self.assertEqual(restored.as_tuple(), view_meta.as_tuple())
 
 
 if __name__ == "__main__":

--- a/torchgen/api/cpp.py
+++ b/torchgen/api/cpp.py
@@ -128,7 +128,7 @@ def valuetype_type(
 
 # Translation of types occurring in JIT arguments to a C++ argument type.
 # If remove_non_owning_ref_types is set, we'll guarantee that the output CType is not a non-owning reference type.
-# For example, we'll return std::vector<int> instead of IntArrayRef.
+# For example, we'll return std::vector<int> instead of IntArrayRef, and at::Tensor instead of const at::Tensor&.
 # See Note [translation from C++ reference to value types]
 def argumenttype_type(
     t: Type,
@@ -152,9 +152,13 @@ def argumenttype_type(
         if t.name == BaseTy.Tensor:
             if mutable and not local.use_const_ref_for_mutable_tensors():
                 return NamedCType(binds, MutRefCType(BaseCType(tensorT)))
+            elif remove_non_owning_ref_types:
+                return NamedCType(binds, BaseCType(tensorT))
             else:
                 return NamedCType(binds, ConstRefCType(BaseCType(tensorT)))
         elif t.name == BaseTy.Scalar:
+            if remove_non_owning_ref_types:
+                return NamedCType(binds, BaseCType(scalarT))
             return NamedCType(binds, ConstRefCType(BaseCType(scalarT)))
         else:
             raise AssertionError(f"base type should have been value type {t}")
@@ -164,11 +168,15 @@ def argumenttype_type(
                 return NamedCType(
                     binds, MutRefCType(BaseCType(tensorT))
                 )  # TODO: fix this discrepancy
+            elif remove_non_owning_ref_types:
+                return NamedCType(binds, OptionalCType(BaseCType(tensorT)))
             else:
                 return NamedCType(
                     binds, ConstRefCType(OptionalCType(BaseCType(tensorT)))
                 )
         elif str(t.elem) == "Scalar":
+            if remove_non_owning_ref_types:
+                return NamedCType(binds, OptionalCType(BaseCType(scalarT)))
             return NamedCType(binds, ConstRefCType(OptionalCType(BaseCType(scalarT))))
         elif isinstance(t.elem, ListType) and str(t.elem.elem) == "int":
             return NamedCType(binds, BaseCType(optionalIntArrayRefT))

--- a/torchgen/api/translate.py
+++ b/torchgen/api/translate.py
@@ -400,6 +400,16 @@ Check this module for more information.
                 symIntArrayRef_ctype = NamedCType(goal.name, BaseCType(symIntArrayRefT))
                 argname = direct_solve(symIntArrayRef_ctype)
                 return f"{argname}.vec()"
+            if goal.type == BaseCType(tensorT):
+                const_ref_tensor_ctype = NamedCType(
+                    goal.name, ConstRefCType(BaseCType(tensorT))
+                )
+                return direct_solve(const_ref_tensor_ctype)
+            if goal.type == OptionalCType(BaseCType(tensorT)):
+                const_ref_optional_tensor_ctype = NamedCType(
+                    goal.name, ConstRefCType(OptionalCType(BaseCType(tensorT)))
+                )
+                return direct_solve(const_ref_optional_tensor_ctype)
             elif goal.type == OptionalCType(VectorCType(BaseCType(longT))):
                 optionalIntArrayRef_ctype = NamedCType(
                     goal.name, BaseCType(optionalIntArrayRefT)


### PR DESCRIPTION
ViewMeta subclasses spelled their `SerializableTuple` elements and data members as references (`const std::vector<...>&`, `const at::Tensor&`). Those bound to temporaries -- the `std::make_tuple` result in `to_serializable_tuple()`, and the tuple argument the constructor is built from -- and dangled once the call returned, so `as_tuple()`/pickle read freed memory.

This change:

1. Makes `remove_non_owning_ref_types` decay `const T&` to an owning value type (it already decayed `ArrayRef` -> `std::vector`), so codegen'd ViewMeta members and tuples own their data.
2. Adds a `static_assert` that every `SerializableTuple` element is owning, so a future reference spelling fails to compile instead of dangling.

The new tests fail under ASAN without the fix; the generated tensor-element case segfaults even without ASAN.

Test Plan:
```
python test/test_functionalization.py -k TestViewMetaSerialization
```