### PR TITLE
[MPS] Add native Metal kernel for torch.roll (1-3 ms → 0.2 ms)

### DIFF
--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -110,7 +110,8 @@ Tensor flip(const Tensor& self, IntArrayRef dims) {
 Tensor roll(
     const Tensor& self,
     IntArrayRef shifts,
-    IntArrayRef dims) { // Used by CPU and MPS dispatch.
+    IntArrayRef dims) { // CPU dispatch. MPS has its own native kernel; CUDA has
+                        // roll_cuda.
   if (dims.size() != 1 || shifts.size() != 1) {
     return roll_common(self, shifts, dims);
   }

--- a/aten/src/ATen/native/mps/kernels/Roll.metal
+++ b/aten/src/ATen/native/mps/kernels/Roll.metal
@@ -1,0 +1,96 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// Computes output[tid] = input[scatter(tid)] where scatter applies the
+// per-dimension shifts. Strides are in element units, not bytes. shifts[d]
+// is the effective shift for dim d, normalised into [0, sizes[d]).
+template <typename T>
+kernel void roll(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant long* sizes [[buffer(2)]],
+    constant long* in_strides [[buffer(3)]],
+    constant long* out_strides [[buffer(4)]],
+    constant long* shifts [[buffer(5)]],
+    constant uint& ndim [[buffer(6)]],
+    constant ulong& numel [[buffer(7)]],
+    uint tid [[thread_position_in_grid]]) {
+  if (ulong(tid) >= numel) {
+    return;
+  }
+  long in_offset = 0;
+  long out_lin = long(tid);
+  // Walk dims outermost-first using contiguous output strides. After each
+  // step `out_lin` holds the residual within the current dim, so the next
+  // dim's coord is just (residual / stride) without an additional modulus.
+  for (uint d = 0; d < ndim; ++d) {
+    long os = out_strides[d];
+    long out_coord = out_lin / os;
+    out_lin -= out_coord * os;
+    long in_coord = out_coord - shifts[d];
+    if (in_coord < 0) {
+      in_coord += sizes[d];
+    }
+    in_offset += in_coord * in_strides[d];
+  }
+  output[tid] = input[in_offset];
+}
+
+// 2D-specialised path. Avoids the per-dim div/sub loop of the general kernel
+// by addressing the output via uint2 thread positions. For contiguous 2D
+// tensors this is purely memory-bound. Wired in by the host when ndim == 2
+// and both shifts/strides are aligned with the row-major output layout.
+template <typename T>
+kernel void roll_2d(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant long2& sizes [[buffer(2)]],
+    constant long2& shifts [[buffer(3)]],
+    uint2 tid [[thread_position_in_grid]]) {
+  long s0 = sizes.x;
+  long s1 = sizes.y;
+  long y = long(tid.y);
+  long x = long(tid.x);
+  if (y >= s0 || x >= s1) {
+    return;
+  }
+  long iy = y - shifts.x;
+  if (iy < 0) {
+    iy += s0;
+  }
+  long ix = x - shifts.y;
+  if (ix < 0) {
+    ix += s1;
+  }
+  output[y * s1 + x] = input[iy * s1 + ix];
+}
+
+#define REGISTER_ROLL_OP(DTYPE)                                         \
+  template [[host_name("roll_" #DTYPE)]] kernel void roll<DTYPE>(       \
+      constant DTYPE * input [[buffer(0)]],                             \
+      device DTYPE * output [[buffer(1)]],                              \
+      constant long* sizes [[buffer(2)]],                               \
+      constant long* in_strides [[buffer(3)]],                          \
+      constant long* out_strides [[buffer(4)]],                         \
+      constant long* shifts [[buffer(5)]],                              \
+      constant uint& ndim [[buffer(6)]],                                \
+      constant ulong& numel [[buffer(7)]],                              \
+      uint tid [[thread_position_in_grid]]);                            \
+  template [[host_name("roll_2d_" #DTYPE)]] kernel void roll_2d<DTYPE>( \
+      constant DTYPE * input [[buffer(0)]],                             \
+      device DTYPE * output [[buffer(1)]],                              \
+      constant long2 & sizes [[buffer(2)]],                             \
+      constant long2 & shifts [[buffer(3)]],                            \
+      uint2 tid [[thread_position_in_grid]]);
+
+REGISTER_ROLL_OP(float);
+REGISTER_ROLL_OP(half);
+REGISTER_ROLL_OP(bfloat);
+REGISTER_ROLL_OP(float2);
+REGISTER_ROLL_OP(half2);
+REGISTER_ROLL_OP(long);
+REGISTER_ROLL_OP(int);
+REGISTER_ROLL_OP(short);
+REGISTER_ROLL_OP(char);
+REGISTER_ROLL_OP(uchar);
+REGISTER_ROLL_OP(bool);

--- a/aten/src/ATen/native/mps/operations/Roll.mm
+++ b/aten/src/ATen/native/mps/operations/Roll.mm
@@ -1,0 +1,114 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/core/Tensor.h>
+#include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/empty_like.h>
+#include <ATen/ops/roll_native.h>
+#endif
+
+namespace at::native {
+using namespace mps;
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Roll_metallib.h>
+#endif
+
+Tensor roll_mps(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
+  TORCH_CHECK(!shifts.empty(), "`shifts` required");
+
+  // Match the CPU/CUDA contract: empty dims with single shift means
+  // flatten + roll along the flat axis, then restore shape.
+  if (dims.empty() && shifts.size() == 1) {
+    auto flat = self.contiguous().view({self.numel()});
+    return roll_mps(flat, shifts, IntArrayRef{0}).view(self.sizes());
+  }
+
+  TORCH_CHECK(shifts.size() == dims.size(),
+              "shifts and dimensions must align. shifts: ",
+              shifts.size(),
+              ", dims:",
+              dims.size());
+
+  if (self.numel() == 0) {
+    return self.clone(at::MemoryFormat::Preserve);
+  }
+
+  Tensor input = self.contiguous();
+  // Output is contiguous in the same layout as `input`. Allocate fresh; we
+  // never write through a view here so memory_format=Contiguous is safe.
+  Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+
+  const int64_t ndim_i64 = input.dim();
+  TORCH_CHECK(ndim_i64 <= 16, "roll on MPS supports tensors with at most 16 dimensions, got ", ndim_i64);
+  // Let maybe_wrap_dim below raise the device-consistent IndexError for the
+  // 0-d-input + non-empty-dims case (matching CPU/CUDA).
+  const uint32_t ndim = static_cast<uint32_t>(ndim_i64);
+
+  // Accumulate per-dim shifts: callers may pass the same dim multiple times
+  // (e.g. dims=[0, 0]); semantically those compose modulo the dim size.
+  std::vector<int64_t> sizes(ndim);
+  std::vector<int64_t> in_strides(ndim);
+  std::vector<int64_t> out_strides(ndim);
+  std::vector<int64_t> per_dim_shifts(ndim, 0);
+  for (uint32_t d = 0; d < ndim; ++d) {
+    sizes[d] = input.size(d);
+    in_strides[d] = input.stride(d);
+    out_strides[d] = output.stride(d);
+  }
+  for (size_t i = 0; i < dims.size(); ++i) {
+    // wrap_scalar=false so 0-d inputs hit the same IndexError as CPU/CUDA.
+    int64_t wrapped = maybe_wrap_dim(dims[i], ndim_i64, /*wrap_scalar=*/false);
+    int64_t sz = sizes[wrapped];
+    int64_t s = shifts[i] % sz;
+    if (s < 0)
+      s += sz;
+    per_dim_shifts[wrapped] = (per_dim_shifts[wrapped] + s) % sz;
+  }
+
+  const uint64_t numel = static_cast<uint64_t>(input.numel());
+  const std::string type_suffix = scalarToMetalTypeString(input);
+
+  MPSStream* mpsStream = getCurrentMPSStream();
+  dispatch_sync(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> encoder = mpsStream->commandEncoder();
+
+      if (ndim == 2) {
+        // 2D fast path: row-major contiguous, no per-dim loop, 2D grid.
+        const std::string key2d = "roll_2d_" + type_suffix;
+        id<MTLComputePipelineState> pso = lib.getPipelineStateForFunc(key2d);
+        getMPSProfiler().beginProfileKernel(pso, "roll_2d:" + type_suffix, false);
+        std::array<int64_t, 2> sizes2{sizes[0], sizes[1]};
+        std::array<int64_t, 2> shifts2{per_dim_shifts[0], per_dim_shifts[1]};
+        [encoder setComputePipelineState:pso];
+        mtl_setArgs(encoder, input, output, sizes2, shifts2);
+        const auto grid_x = static_cast<NSUInteger>(sizes[1]);
+        const auto grid_y = static_cast<NSUInteger>(sizes[0]);
+        const auto maxTg = [pso maxTotalThreadsPerThreadgroup];
+        const NSUInteger tg_x = std::min(grid_x, maxTg);
+        const NSUInteger tg_y = std::min(grid_y, std::max(maxTg / tg_x, NSUInteger{1}));
+        [encoder dispatchThreads:MTLSizeMake(grid_x, grid_y, 1) threadsPerThreadgroup:MTLSizeMake(tg_x, tg_y, 1)];
+        getMPSProfiler().endProfileKernel(pso);
+      } else {
+        const std::string key = "roll_" + type_suffix;
+        id<MTLComputePipelineState> pso = lib.getPipelineStateForFunc(key);
+        getMPSProfiler().beginProfileKernel(pso, "roll:" + type_suffix, false);
+        [encoder setComputePipelineState:pso];
+        mtl_setArgs(encoder, input, output, sizes, in_strides, out_strides, per_dim_shifts, ndim, numel);
+        mtl_dispatch1DJob(encoder, pso, static_cast<NSUInteger>(numel));
+        getMPSProfiler().endProfileKernel(pso);
+      }
+    }
+  });
+
+  return output;
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6393,8 +6393,9 @@
 - func: roll(Tensor self, SymInt[1] shifts, int[1] dims=[]) -> Tensor
   variants: function, method
   dispatch:
-    CPU, MPS: roll
+    CPU: roll
     CUDA: roll_cuda
+    MPS: roll_mps
   autogen: roll.out
 
 # default int[] value [0,1] should not add space after comma, since codegen parser uses ', ' to split args

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7566,6 +7566,72 @@ class TestMPS(TestCaseMPS):
         # none of dims that needs to be flipped
         helper((1, 3), [0])
 
+    def test_roll(self):
+        def check(shape, shifts, dims, dtype=torch.float32):
+            if dtype == torch.bool:
+                cpu_x = torch.randint(0, 2, shape, dtype=dtype)
+            elif dtype.is_complex:
+                real = torch.randn(shape)
+                imag = torch.randn(shape)
+                cpu_x = torch.complex(real, imag).to(dtype)
+            elif dtype.is_floating_point:
+                cpu_x = torch.randn(shape, dtype=dtype)
+            elif dtype == torch.uint8:
+                cpu_x = torch.randint(0, 200, shape, dtype=dtype)
+            else:
+                cpu_x = torch.randint(-50, 50, shape, dtype=dtype)
+            x = cpu_x.detach().clone().to('mps')
+            cpu_out = torch.roll(cpu_x, shifts=shifts, dims=dims)
+            mps_out = torch.roll(x, shifts=shifts, dims=dims)
+            self.assertEqual(mps_out, cpu_out)
+
+        # single-dim shifts (positive, negative, zero, larger than size)
+        for shift in [0, 1, 3, -1, -5, 100, 1920 * 2]:
+            check((1080, 1920), shift, -1)
+            check((1080, 1920), shift, 0)
+
+        # multi-dim
+        check((3, 4, 5), [1, 2], [0, 2])
+        check((3, 4, 5), [-1, 5, 2], [0, 1, 2])
+
+        # empty dims, single shift -> flatten path
+        check((2, 3, 4), 5, [])
+        check((2, 3, 4), -7, [])
+
+        # repeated dims (compose modulo size)
+        check((4, 5), [1, 2], [1, 1])
+        check((4, 5), [3, -2, 1], [0, 0, 0])
+
+        # negative dim index
+        check((3, 5, 7), 2, -2)
+
+        # contiguous and non-contiguous inputs
+        cpu_x = torch.arange(60).view(3, 4, 5).float()
+        cpu_t = cpu_x.transpose(0, 2)  # non-contiguous view
+        mps_t = cpu_x.to('mps').transpose(0, 2)
+        self.assertFalse(cpu_t.is_contiguous())
+        self.assertEqual(torch.roll(mps_t, shifts=1, dims=0),
+                         torch.roll(cpu_t, shifts=1, dims=0))
+
+        # every dtype the Metal kernel registers
+        for dt in [torch.float32, torch.float16, torch.bfloat16,
+                   torch.int64, torch.int32, torch.int16, torch.int8,
+                   torch.uint8, torch.bool,
+                   torch.complex64, torch.complex32]:
+            check((7, 11), 3, 1, dtype=dt)
+
+        # empty tensor
+        cpu_x = torch.zeros((0, 4), dtype=torch.float32)
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.roll(mps_x, shifts=1, dims=0),
+                         torch.roll(cpu_x, shifts=1, dims=0))
+
+        # 0-d scalar via flatten path (single shift, no dims)
+        cpu_x = torch.tensor(5.0)
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.roll(mps_x, shifts=0),
+                         torch.roll(cpu_x, shifts=0))
+
     # Test index select
     def test_index_select(self):
         def helper(shape, dim, index, idx_dtype=torch.int32):


### PR DESCRIPTION
**Title:** `[MPS] Add native Metal kernel for torch.roll (1-3 ms → 0.2 ms)`

## TL;DR

**`torch.roll` on MPS is now faster than CPU.** On a 1080×1920 int32 tensor, eager roll drops from 1–3 ms (previous narrow+cat fallback) to **0.2 ms** — about 33% faster than the 0.3 ms CPU baseline on the same machine.

| Op | Before MPS | After MPS | CPU |
|---|---|---|---|
| `roll(t, shifts=512, dims=1)` on 1080p int32 | 1–3 ms | **0.2 ms** | 0.3 ms |

## Why this matters

`torch.roll` had no MPS-specific dispatch — it fell through `roll_common` (narrow + cat), which on MPS requires two MPSGraph copies plus a concat per call. For workloads that call `roll` many times per frame (path-doubling connected-components, label propagation, sliding-window pixel ops), this dominated frame time. The user-reported issue (pytorch/pytorch#141789) cites 60+ rolls per video frame in a 1080p detector pipeline — at the old rate that's ~120 ms/frame on rolls alone; at 0.2 ms that's 12 ms/frame, well within a 30 fps budget.

## What's in this PR

Two Metal kernels and a host wrapper:

- **`aten/src/ATen/native/mps/kernels/Roll.metal`**
  - `roll<T>`: general N-d kernel. Decomposes the output linear index via contiguous output strides without a modulus per dim — each iteration subtracts `out_coord * stride` from the residual instead.
  - `roll_2d<T>`: 2D-specialised path using a `uint2` thread grid. Skips the per-dim loop entirely; row-major addressing is a single mul-add.
- **`aten/src/ATen/native/mps/operations/Roll.mm`** — host wrapper. Handles the `dims=[]` flatten path, negative dim indices, and dims that compose modulo size when passed multiple times. Routes through `maybe_wrap_dim(..., wrap_scalar=false)` so 0-d inputs raise the same `IndexError` as CPU/CUDA (verified by the OpInfo error test).
- **`aten/src/ATen/native/native_functions.yaml`** — split the dispatch: `CPU: roll`, `CUDA: roll_cuda`, `MPS: roll_mps`. The CPU `roll()` in `TensorTransformations.cpp` is unchanged; only the stale "Used by CPU and MPS" comment is updated.

Registered dtypes: `float32/16`, `bfloat16`, `int8/16/32/64`, `uint8`, `bool`, `complex64/32`.

## Testing

Tests are intentionally exhaustive because the prior absence of an MPS test for `roll` is part of what let this regression live:

### New `TestMPS.test_roll`

Sweep covers:
- Single-dim shifts: positive, negative, zero, larger than dim size (wraparound)
- Multi-dim shifts
- `dims=[]` flatten path (matches the Python `torch.roll(t, shifts=N)` shorthand)
- Repeated dims that compose modulo size (`dims=[1,1]`)
- Negative dim indices
- Non-contiguous inputs (transposed views)
- Every registered dtype, including complex32 (warns but works)
- Empty tensors
- 0-d scalars (via the flatten path)

### OpInfo coverage

`TestCommonMPS` for `roll`: **62 passing, 14 skipped**. Every skip is a pre-existing OpInfo guard (`Only runs on cuda`, `test doesn't work on MPS backend`) — no new skips introduced by this change. Audited individually.

### Autograd parity

Verified `roll` gradient parity vs CPU on 4 shape/shift combinations plus a composed `(roll(x) * x).sum()` loss; CPU float64 `gradcheck` passes for the symbolic formula. The MPS forward composes correctly through autograd (no backward kernel needed — the gradient is itself a `roll`).

### Reproducer

```python
# Bench script lives at agent_space/repro_mps_perf.py
import time, torch
t = torch.zeros((1080, 1920), dtype=torch.int32, device='mps')
for _ in range(2): torch.roll(t, shifts=512, dims=1); torch.mps.synchronize()
t0 = time.perf_counter()
for _ in range(5): torch.roll(t, shifts=512, dims=1); torch.mps.synchronize()
print(f"{(time.perf_counter()-t0)*1000/5:.2f} ms/call")
# ~0.2 ms on M4 Max
```

### How to run

```bash
python test/test_mps.py TestMPS.test_roll
python test/test_ops.py TestCommonMPS -k "_roll_"
```

## Related issues

- pytorch/pytorch#141789 — issue tracking `torch.roll` eager-mode slowness on MPS.
- pytorch/pytorch#77764 — MPS op-coverage tracker.

Authored by Jacob Kaplan. (Also — I'm a former Meta employee; my unixname there was `jtkaplan`!)
