### PR TITLE
[PyTorch][AOTI] Refactor AOTInductorModelContainer to use ConstantBufferSet

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <condition_variable>
 #include <deque>
 #include <mutex>
@@ -37,20 +38,71 @@ inline std::string toStringConstantState(ConstantState state) {
   }
 }
 
+struct ConstantBufferSet {
+  RAIIDataPtr blob;
+  RAIIDataPtr aux_cpu_blob;
+  std::shared_ptr<ConstantMap> map;
+  std::shared_ptr<std::vector<ConstantHandle>> array;
+  ConstantState fold_state{ConstantState::NONE};
+
+  void* ensure_blob(size_t blob_size) {
+    if (!blob) {
+#if defined(USE_CUDA) || defined(USE_XPU) || defined(USE_MPS)
+      blob = RAII_gpuMalloc(blob_size);
+#else
+      blob = RAII_cpuMalloc(blob_size);
+#endif
+    }
+    return blob.get();
+  }
+
+  void* ensure_aux_cpu_blob(size_t aux_cpu_blob_size) {
+    if (!aux_cpu_blob) {
+      aux_cpu_blob = RAII_cpuMalloc(aux_cpu_blob_size);
+    }
+    return aux_cpu_blob.get();
+  }
+
+  void update_array(AOTInductorModel* model) {
+    auto num_constants = model->num_constants();
+    for (size_t idx = 0; idx < num_constants; idx++) {
+      auto it = map->find(model->constant_name(static_cast<int64_t>(idx)));
+      if (it != map->end()) {
+        array->at(idx) = ConstantHandle(it->second);
+      }
+    }
+  }
+
+  void reset(AOTInductorModel* model) {
+    fold_state = ConstantState::NONE;
+    blob.reset();
+    aux_cpu_blob.reset();
+    int num_constants = static_cast<int>(model->num_constants());
+    for (int i = 0; i < num_constants; i++) {
+      if (model->constant_from_folded(i)) {
+        auto it = map->find(model->constant_name(i));
+        if (it != map->end()) {
+          it->second.reset();
+        }
+      }
+    }
+  }
+};
+
 class AOTInductorModelContainer {
  public:
   AOTInductorModelContainer(
       size_t num_models,
       const std::string& device_str,
       const std::optional<std::string>& cubin_dir = std::nullopt) {
-    constants_map_ = std::make_shared<ConstantMap>();
-    constants_array_ = std::make_shared<std::vector<ConstantHandle>>();
+    buffers_[0].map = std::make_shared<ConstantMap>();
+    buffers_[0].array = std::make_shared<std::vector<ConstantHandle>>();
 
     models_.reserve(num_models);
     available_models_.reserve(num_models);
     for (size_t i = 0; i < num_models; ++i) {
       models_.push_back(AOTInductorModel::Create(
-          constants_map_, constants_array_, device_str, cubin_dir));
+          buffers_[0].map, buffers_[0].array, device_str, cubin_dir));
       available_models_.push_back(models_.back().get());
     }
 
@@ -75,8 +127,8 @@ class AOTInductorModelContainer {
       output_names_.emplace_back(model->output_name(static_cast<int64_t>(i)));
     }
     model->load_constants();
-    constant_blob_ = model->release_constant_blob();
-    aux_cpu_constant_blob_ = model->release_aux_cpu_constant_blob();
+    buffers_[0].blob = model->release_constant_blob();
+    buffers_[0].aux_cpu_blob = model->release_aux_cpu_constant_blob();
     constants_internal_offset_.resize(
         model->num_constants() - model->num_folded_constants());
     aux_cpu_constants_internal_offset_.resize(
@@ -86,11 +138,15 @@ class AOTInductorModelContainer {
         constants_internal_offset_,
         aux_cpu_blob_size_,
         aux_cpu_constants_internal_offset_);
-    constant_folded_ = ConstantState::INITIALIZED;
+    buffers_[0].fold_state = ConstantState::INITIALIZED;
 
-    for (auto& model : models_) {
-      model->update_constants_map(constants_map_);
+    for (auto& m : models_) {
+      m->update_constants_map(buffers_[0].map);
     }
+
+    buffers_[1].map = std::make_shared<ConstantMap>();
+    buffers_[1].array =
+        std::make_shared<std::vector<ConstantHandle>>(model->num_constants());
 
     in_spec_ = model->get_in_spec();
     out_spec_ = model->get_out_spec();
@@ -108,8 +164,7 @@ class AOTInductorModelContainer {
       AOTIProxyExecutorHandle proxy_executor) {
     std::shared_lock model_lk(model_exec_mutex_);
 
-    ConstantState& const_folded =
-        use_secondary_ ? constant_folded_secondary_ : constant_folded_;
+    auto& const_folded = active().fold_state;
     if (const_folded == ConstantState::INITIALIZED) {
       // Do NOT call get_available_model() before upgrading to exclusive lock.
       // Holding a model across the upgrade causes a deadlock when another
@@ -137,7 +192,7 @@ class AOTInductorModelContainer {
       model_lk.lock();
     } else if (const_folded != ConstantState::FOLDED) {
       throw std::runtime_error(
-          "Unknown constant state: " + toStringConstantState(constant_folded_));
+          "Unknown constant state: " + toStringConstantState(const_folded));
     }
 
     auto* model = get_available_model();
@@ -171,8 +226,7 @@ class AOTInductorModelContainer {
       AOTIProxyExecutorHandle proxy_executor) {
     auto* model = available_models_[0];
 
-    ConstantState& const_folded =
-        use_secondary_ ? constant_folded_secondary_ : constant_folded_;
+    auto& const_folded = active().fold_state;
     if (const_folded == ConstantState::INITIALIZED) {
       auto folded_const_map = model->run_const_fold(
           stream, proxy_executor, /* initialization = */ true);
@@ -196,11 +250,7 @@ class AOTInductorModelContainer {
     std::unordered_map<std::string, AtenTensorHandle> ret;
     ret.reserve(n_consts);
 
-    std::shared_ptr<ConstantMap> extract_map = constants_map_;
-    // Essentially a XOR
-    if (use_inactive != use_secondary_) {
-      extract_map = constants_map_secondary_;
-    }
+    const auto& extract_map = use_inactive ? inactive().map : active().map;
     for (size_t idx = 0; idx < n_consts; idx++) {
       if (this->constant_from_folded(idx)) {
         continue;
@@ -289,9 +339,8 @@ class AOTInductorModelContainer {
       DeviceStreamType stream,
       AOTIProxyExecutorHandle proxy_executor) {
     AOTInductorModel* model;
-    ConstantState& const_folded = inactive_buffer == use_secondary_
-        ? constant_folded_
-        : constant_folded_secondary_;
+    auto& const_folded =
+        inactive_buffer ? inactive().fold_state : active().fold_state;
     if (!inactive_buffer) {
       // We would need to acquire a unique lock if we want to run constant
       // folding on the active buffer.
@@ -315,13 +364,13 @@ class AOTInductorModelContainer {
 
       // We swap the constant mapping to the inactive buffer in the model to run
       // const run.
-      auto constants_map = get_constants_map(/* get_inactive= */ true);
-      auto constants_array = get_constants_array(/* get_inactive= */ true);
+      auto inactive_map = inactive().map;
+      auto inactive_array = inactive().array;
 
       try {
         model->update_constants_map(
-            constants_map, /* remap_constants_array= */ false);
-        model->update_constants_array(constants_array);
+            inactive_map, /* remap_constants_array= */ false);
+        model->update_constants_array(inactive_array);
 
         auto folded_const_map = model->run_const_fold(stream, proxy_executor);
         update_constant_buffer(
@@ -330,11 +379,11 @@ class AOTInductorModelContainer {
             /* validate_full_update = */ false);
 
         // Swap back the model's constants mapping
-        constants_map = get_constants_map(/* get_inactive= */ false);
-        constants_array = get_constants_array(/* get_inactive= */ false);
+        auto active_map = active().map;
+        auto active_array = active().array;
         model->update_constants_map(
-            constants_map, /* remap_constants_array= */ false);
-        model->update_constants_array(constants_array);
+            active_map, /* remap_constants_array= */ false);
+        model->update_constants_array(active_array);
         const_folded = ConstantState::FOLDED;
       } catch (...) {
         std::lock_guard lk(models_mutex_);
@@ -417,13 +466,9 @@ class AOTInductorModelContainer {
       assert_all_constants(constants_map);
     }
 
-    ConstantState& const_folded = use_inactive == use_secondary_
-        ? constant_folded_
-        : constant_folded_secondary_;
-    const_folded = ConstantState::INITIALIZED;
-
-    auto original_constants_map = get_constants_map(!use_inactive);
-    auto constants_map_to_update = get_constants_map(use_inactive);
+    auto& target = use_inactive ? inactive() : active();
+    auto& source = use_inactive ? active() : inactive();
+    target.fold_state = ConstantState::INITIALIZED;
 
     auto num_constants = models_[0]->num_constants();
     for (size_t idx = 0; idx < num_constants; idx++) {
@@ -438,17 +483,14 @@ class AOTInductorModelContainer {
       AtenTensorHandle tensor;
       if (it == constants_map.end()) {
         aoti_torch_clone(
-            original_constants_map->find(constant_name)->second.get(), &tensor);
+            source.map->find(constant_name)->second.get(), &tensor);
       } else {
         tensor = it->second;
       }
 
-      constants_map_to_update->insert_or_assign(
-          constant_name, RAIIAtenTensorHandle(tensor));
+      target.map->insert_or_assign(constant_name, RAIIAtenTensorHandle(tensor));
     }
-    // Update the inactive constant array.
-    update_array_from_map(
-        get_constants_array(use_inactive), constants_map_to_update);
+    target.update_array(models_[0].get());
   }
 
   // This function updates the buffer for storing constants.
@@ -494,10 +536,6 @@ class AOTInductorModelContainer {
       if (tensor_device_type != expected_const_device_type) {
 #ifndef USE_MPS
         if (allow_h2d_copy && tensor_device_type == cpu_device_type) {
-          // CPU input -> non-CPU expected device. The main-blob memcpy path
-          // (e.g. cudaMemcpyDefault, SYCL queue.memcpy) handles the
-          // direction. MPS is excluded: aoti_torch_mps_copy_buffer expects
-          // an MTLBuffer source, not a host pointer.
           continue;
         }
 #endif
@@ -511,13 +549,9 @@ class AOTInductorModelContainer {
 
     int32_t model_device_type = models_[0]->get_device_type();
 
-    ConstantState& const_folded = use_inactive == use_secondary_
-        ? constant_folded_
-        : constant_folded_secondary_;
-    const_folded = ConstantState::INITIALIZED;
-
-    auto original_constants_map = get_constants_map(!use_inactive);
-    auto constants_map_to_update = get_constants_map(use_inactive);
+    auto& target = use_inactive ? inactive() : active();
+    auto& source = use_inactive ? active() : inactive();
+    target.fold_state = ConstantState::INITIALIZED;
 
     // Running indices into constants_internal_offset_ and
     // aux_cpu_constants_internal_offset_, which hold per-blob offsets
@@ -553,7 +587,7 @@ class AOTInductorModelContainer {
 
       AtenTensorHandle tensor;
       if (it == constants_map.end()) {
-        tensor = original_constants_map->find(constant_name)->second.get();
+        tensor = source.map->find(constant_name)->second.get();
       } else {
         tensor = it->second;
       }
@@ -561,7 +595,7 @@ class AOTInductorModelContainer {
       if (user_managed) {
         // If user managed, we pass in the pointer directly, and skip the
         // copy.
-        constants_map_to_update->insert_or_assign(
+        target.map->insert_or_assign(
             constant_name,
             MaybeOwningAtenTensorHandle(tensor, /* user_managed = */ true));
         continue;
@@ -584,8 +618,8 @@ class AOTInductorModelContainer {
         // CPU constant in a mixed-device model. Write into the container's
         // auxiliary CPU blob at the pre-computed offset, mirroring how the
         // primary blob is managed.
-        auto* aux_blob_ptr =
-            static_cast<uint8_t*>(get_aux_cpu_constant_blob_ptr(use_inactive));
+        auto* aux_blob_ptr = static_cast<uint8_t*>(
+            target.ensure_aux_cpu_blob(aux_cpu_blob_size_));
         uint8_t* internal_constants_ptr =
             aux_blob_ptr + aux_cpu_constants_internal_offset_[this_aux_cpu_idx];
         memcpy(internal_constants_ptr, user_constant_ptr, constant_size);
@@ -601,7 +635,7 @@ class AOTInductorModelContainer {
             &tensor_handle));
       } else {
         auto* constants_blob_ptr =
-            static_cast<uint8_t*>(get_constant_blob_ptr(use_inactive));
+            static_cast<uint8_t*>(target.ensure_blob(blob_size_));
 
         // Move the data to container handled blob.
         uint8_t* internal_constants_ptr =
@@ -654,67 +688,26 @@ class AOTInductorModelContainer {
 
       // Now place the tensor to constants_map. Note at this point the
       // ownership of the tensor_handle will be taken over.
-      constants_map_to_update->insert_or_assign(
+      target.map->insert_or_assign(
           constant_name, RAIIAtenTensorHandle(tensor_handle));
     }
-    // Update the inactive constant array.
-    update_array_from_map(
-        get_constants_array(use_inactive), constants_map_to_update);
-  }
-
-  void update_array_from_map(
-      const std::shared_ptr<std::vector<ConstantHandle>>& constants_array,
-      const std::shared_ptr<ConstantMap>& constants_map) {
-    auto num_constants = models_[0]->num_constants();
-    for (size_t idx = 0; idx < num_constants; idx++) {
-      if (constants_map->find(models_[0]->constant_name(
-              static_cast<int64_t>(idx))) != constants_map->end()) {
-        constants_array->at(idx) = ConstantHandle(
-            constants_map
-                ->find(models_[0]->constant_name(static_cast<int64_t>(idx)))
-                ->second);
-      }
-    }
+    target.update_array(models_[0].get());
   }
 
   void swap_constant_buffer() {
     std::lock_guard unique_lk(model_exec_mutex_);
 
-    auto constants_map = get_constants_map(/* get_inactive= */ true);
-    auto constants_array = get_constants_array(/* get_inactive= */ true);
+    active_idx_ = 1 - active_idx_;
 
     for (auto& model : models_) {
       model->update_constants_map(
-          constants_map, /* remap_constants_array = */ false);
-      model->update_constants_array(constants_array);
+          active().map, /* remap_constants_array = */ false);
+      model->update_constants_array(active().array);
     }
-
-    use_secondary_ = !use_secondary_;
   }
 
   void free_inactive_constant_buffer() {
-    if (use_secondary_) {
-      constant_folded_ = ConstantState::NONE;
-      constant_blob_.reset();
-      aux_cpu_constant_blob_.reset();
-    } else {
-      constant_folded_secondary_ = ConstantState::NONE;
-      constant_blob_secondary_.reset();
-      aux_cpu_constant_blob_secondary_.reset();
-    }
-    // Free the internally held constants
-    int num_constants = static_cast<int>(models_[0]->num_constants());
-    std::shared_ptr<ConstantMap> to_free_map =
-        use_secondary_ ? constants_map_ : constants_map_secondary_;
-
-    for (int i = 0; i < num_constants; i++) {
-      if (models_[0]->constant_from_folded(i)) {
-        auto it = to_free_map->find(models_[0]->constant_name(i));
-        if (it != to_free_map->end()) {
-          it->second.reset();
-        }
-      }
-    }
+    inactive().reset(models_[0].get());
   }
 
   size_t num_inputs() const {
@@ -751,43 +744,13 @@ class AOTInductorModelContainer {
   const char* in_spec_;
   const char* out_spec_;
 
-  // Holds the blob storage for constants' at::Tensor within the container.
-  // This blob of memory will be managed by the container.
-  RAIIDataPtr constant_blob_;
-  RAIIDataPtr constant_blob_secondary_;
-
-  // Auxiliary CPU blob used for constants whose device_type differs from the
-  // model's primary device (only populated in mixed-device models, e.g. a
-  // CUDA model with some CPU-pinned constants). Unused when the model's
-  // primary device is already CPU. Parallels constant_blob_{,_secondary_}
-  // for double-buffering.
-  RAIIDataPtr aux_cpu_constant_blob_;
-  RAIIDataPtr aux_cpu_constant_blob_secondary_;
+  std::array<ConstantBufferSet, 2> buffers_;
+  int active_idx_{0};
 
   size_t blob_size_;
   std::vector<size_t> constants_internal_offset_;
   size_t aux_cpu_blob_size_;
   std::vector<size_t> aux_cpu_constants_internal_offset_;
-
-  // Determine which constants is being used for the model.
-  // If true,
-  // constants_map_secondary/constant_blob_secondary/constants_array_secondary
-  // is being used.
-  bool use_secondary_{false};
-
-  // Determine whether we have ran constant folding
-  ConstantState constant_folded_{ConstantState::NONE};
-  ConstantState constant_folded_secondary_{ConstantState::NONE};
-
-  // Holds the mapping of constants to at::Tensor.
-  // The underlying data of at::Tensor is in either constant_blob_ (for CUDA).
-  // or _binary_constants_bin_start (for CPU).
-  std::shared_ptr<ConstantMap> constants_map_;
-  std::shared_ptr<ConstantMap> constants_map_secondary_;
-
-  // Holds the indexed array of constant for faster lookup during runtime.
-  std::shared_ptr<std::vector<ConstantHandle>> constants_array_;
-  std::shared_ptr<std::vector<ConstantHandle>> constants_array_secondary_;
 
   // Holds all the AOTInductorModel instances owned by this container.
   std::vector<std::unique_ptr<AOTInductorModel>> models_;
@@ -806,6 +769,19 @@ class AOTInductorModelContainer {
   // Notified whenever a model is placed onto pending_models_.
   std::condition_variable pending_models_available_;
 
+  ConstantBufferSet& active() {
+    return buffers_[active_idx_];
+  }
+  ConstantBufferSet& inactive() {
+    return buffers_[1 - active_idx_];
+  }
+  const ConstantBufferSet& active() const {
+    return buffers_[active_idx_];
+  }
+  const ConstantBufferSet& inactive() const {
+    return buffers_[1 - active_idx_];
+  }
+
   AOTInductorModel* get_available_model() {
     std::unique_lock lk(models_mutex_);
     if (available_models_.empty()) {
@@ -822,71 +798,6 @@ class AOTInductorModelContainer {
   // model. One such case is when we want to do a weight swapping. We want to
   // make sure no one is executing the model.
   std::shared_mutex model_exec_mutex_;
-
-  RAIIDataPtr allocate_constant_blob() {
-#if defined(USE_CUDA) || defined(USE_XPU) || defined(USE_MPS)
-    return RAII_gpuMalloc(blob_size_);
-#else
-    return RAII_cpuMalloc(blob_size_);
-#endif // USE_CUDA
-  }
-
-  void* get_constant_blob_ptr(bool get_inactive) {
-    if ((get_inactive && use_secondary_) ||
-        (!get_inactive && !use_secondary_)) {
-      if (!constant_blob_) {
-        constant_blob_ = allocate_constant_blob();
-      }
-      return constant_blob_.get();
-    } else {
-      if (!constant_blob_secondary_) {
-        constant_blob_secondary_ = allocate_constant_blob();
-      }
-      return constant_blob_secondary_.get();
-    }
-  }
-
-  void* get_aux_cpu_constant_blob_ptr(bool get_inactive) {
-    if ((get_inactive && use_secondary_) ||
-        (!get_inactive && !use_secondary_)) {
-      if (!aux_cpu_constant_blob_) {
-        aux_cpu_constant_blob_ = RAII_cpuMalloc(aux_cpu_blob_size_);
-      }
-      return aux_cpu_constant_blob_.get();
-    } else {
-      if (!aux_cpu_constant_blob_secondary_) {
-        aux_cpu_constant_blob_secondary_ = RAII_cpuMalloc(aux_cpu_blob_size_);
-      }
-      return aux_cpu_constant_blob_secondary_.get();
-    }
-  }
-
-  std::shared_ptr<ConstantMap> get_constants_map(bool get_inactive) {
-    if ((get_inactive && use_secondary_) ||
-        (!get_inactive && !use_secondary_)) {
-      return constants_map_;
-    } else {
-      if (!constants_map_secondary_) {
-        constants_map_secondary_ = std::make_shared<ConstantMap>();
-      }
-      return constants_map_secondary_;
-    }
-  }
-
-  std::shared_ptr<std::vector<ConstantHandle>> get_constants_array(
-      bool get_inactive) {
-    if ((get_inactive && use_secondary_) ||
-        (!get_inactive && !use_secondary_)) {
-      return constants_array_;
-    } else {
-      if (!constants_array_secondary_) {
-        constants_array_secondary_ =
-            std::make_shared<std::vector<ConstantHandle>>(
-                models_[0]->num_constants());
-      }
-      return constants_array_secondary_;
-    }
-  }
 
   void reclaim_finished_models(std::unique_lock<std::mutex>& lk) {
 #ifdef __aarch64__


### PR DESCRIPTION
Summary:
The double-buffered constant management in AOTInductorModelContainer used 8 parallel _secondary_ fields, a use_secondary_ toggle, and XOR-based routing helpers to determine which buffer set was active. This was error-prone and hard to follow.

This diff extracts all per-buffer state (blob, aux_cpu_blob, map, array, fold_state) into a ConstantBufferSet struct and replaces the parallel fields with a std::array<ConstantBufferSet, 2> indexed by active_idx_. The struct owns its own helper methods (ensure_blob, ensure_aux_cpu_blob, update_array, reset), and the container uses active()/inactive() accessors instead of XOR routing.

Removed from container: 10 _secondary_ fields, use_secondary_ flag, 6 private helper methods (get_constants_map, get_constants_array, get_constant_blob_ptr, get_aux_cpu_constant_blob_ptr, allocate_constant_blob, update_array_from_map). Swap is now a single index flip + model pointer update.

Test Plan:
buck2 build mode/opt fbcode//caffe2:_libtorch
(clean build, 22276 actions, BUILD SUCCEEDED)

Reviewed By: desertfire

Differential Revision: D105888717


