### PR TITLE
Make LocalTensorMode work with compile_on_one_rank functional collectives and runtime mesh coordinates

### DIFF
--- a/test/distributed/test_local_tensor.py
+++ b/test/distributed/test_local_tensor.py
@@ -667,6 +667,125 @@ class TestLocalTensorWorld4(LocalTensorWorldTest):
             result = my_func(lt)
             self.assertEqual(result.shape, torch.Size([8, 3]))
 
+    def test_functional_all_gather_with_pg_compile_on_one_rank(self):
+        # Under compile_on_one_rank=True, _group_or_group_name passes the
+        # ProcessGroup straight through to the functional collective op, so the
+        # LocalTensorMode implementations must accept either a string group
+        # name or a ProcessGroup. See pytorch/pytorch#184746.
+        import torch.distributed.config as dist_config
+
+        fake_pg = dist.distributed_c10d._get_default_group()
+        different_tensors = {
+            r: torch.full((2, 3), float(r)) for r in range(self.world_size)
+        }
+        with (
+            LocalTensorMode(self.world_size),
+            dist_config.patch(compile_on_one_rank=True),
+        ):
+            lt = LocalTensor(different_tensors)
+            result = all_gather_tensor(lt, gather_dim=0, group=fake_pg)
+            if hasattr(result, "wait"):
+                result = result.wait()
+            self.assertIsInstance(result, LocalTensor)
+            self.assertEqual(result.shape, torch.Size([2 * self.world_size, 3]))
+            for r in range(self.world_size):
+                expected = torch.cat(
+                    [different_tensors[i] for i in range(self.world_size)], dim=0
+                )
+                self.assertEqual(result._local_tensors[r], expected)
+
+    def test_functional_reduce_scatter_with_pg_compile_on_one_rank(self):
+        # Same compile_on_one_rank gap as the all_gather test, but covers the
+        # reduce_scatter handler. See pytorch/pytorch#184746.
+        import torch.distributed.config as dist_config
+        from torch.distributed._functional_collectives import reduce_scatter_tensor
+
+        fake_pg = dist.distributed_c10d._get_default_group()
+        # Each rank contributes the same input so the reduction sum is
+        # deterministic regardless of which rank "ran" the op.
+        ws = self.world_size
+        input_tensor = torch.arange(2 * ws * 3, dtype=torch.float32).reshape(2 * ws, 3)
+        per_rank = {r: input_tensor.clone() for r in range(ws)}
+        with (
+            LocalTensorMode(ws),
+            dist_config.patch(compile_on_one_rank=True),
+        ):
+            lt = LocalTensor(per_rank)
+            result = reduce_scatter_tensor(lt, "sum", scatter_dim=0, group=fake_pg)
+            if hasattr(result, "wait"):
+                result = result.wait()
+            self.assertIsInstance(result, LocalTensor)
+            self.assertEqual(result.shape, torch.Size([2, 3]))
+            chunks = input_tensor.chunk(ws, dim=0)
+            for r in range(ws):
+                self.assertEqual(result._local_tensors[r], chunks[r] * ws)
+
+    def test_functional_all_to_all_single_with_pg_compile_on_one_rank(self):
+        # Same compile_on_one_rank gap, exercising all_to_all_single. See
+        # pytorch/pytorch#184746.
+        import torch.distributed.config as dist_config
+        from torch.distributed._functional_collectives import all_to_all_single
+
+        fake_pg = dist.distributed_c10d._get_default_group()
+        ws = self.world_size
+        # Each rank's input row r is "rank * world + r"; after all-to-all,
+        # rank r should see contributions from every other rank stacked.
+        per_rank = {
+            r: torch.tensor([float(r * ws + i) for i in range(ws)]).reshape(ws, 1)
+            for r in range(ws)
+        }
+        with (
+            LocalTensorMode(ws),
+            dist_config.patch(compile_on_one_rank=True),
+        ):
+            lt = LocalTensor(per_rank)
+            result = all_to_all_single(lt, None, None, group=fake_pg)
+            if hasattr(result, "wait"):
+                result = result.wait()
+            self.assertIsInstance(result, LocalTensor)
+            self.assertEqual(result.shape, torch.Size([ws, 1]))
+            for r in range(ws):
+                expected = torch.tensor(
+                    [float(sender * ws + r) for sender in range(ws)]
+                ).reshape(ws, 1)
+                self.assertEqual(result._local_tensors[r], expected)
+
+    def test_runtime_compute_coordinate_on_dim_per_rank(self):
+        # Under LocalTensorMode the device_mesh op must return per-rank
+        # coordinates wrapped in a LocalIntNode-backed SymInt, instead of
+        # falling back to dist.get_rank() (which is always 0 under the fake
+        # backend). See pytorch/pytorch#184746.
+        from torch.distributed._ops import device_mesh as _dm_ops  # noqa: F401
+
+        with LocalTensorMode(self.world_size):
+            mesh = self.build_device_mesh()
+            full_mesh = mesh._layout.remap_to_tensor(mesh._rank_map)
+            coord = torch.ops.device_mesh._runtime_compute_coordinate_on_dim(
+                full_mesh, 0
+            )
+
+        self.assertIsInstance(coord, torch.SymInt)
+        self.assertIsInstance(coord.node, LocalIntNode)
+        expected = {r: r for r in range(self.world_size)}
+        self.assertEqual(coord.node._local_ints, expected)
+
+    def test_runtime_compute_coordinate_on_dim_kwargs(self):
+        # The LocalTensorMode override must also work when the op is called
+        # with keyword arguments, not just positional ones.
+        from torch.distributed._ops import device_mesh as _dm_ops  # noqa: F401
+
+        with LocalTensorMode(self.world_size):
+            mesh = self.build_device_mesh()
+            full_mesh = mesh._layout.remap_to_tensor(mesh._rank_map)
+            coord = torch.ops.device_mesh._runtime_compute_coordinate_on_dim(
+                full_mesh=full_mesh, index=0
+            )
+
+        self.assertIsInstance(coord, torch.SymInt)
+        self.assertIsInstance(coord.node, LocalIntNode)
+        expected = {r: r for r in range(self.world_size)}
+        self.assertEqual(coord.node._local_ints, expected)
+
 
 class TestLocalTensorWorld8(LocalTensorWorldTest):
     world_size = 8

--- a/test/distributed/test_local_tensor.py
+++ b/test/distributed/test_local_tensor.py
@@ -673,12 +673,15 @@ class TestLocalTensorWorld4(LocalTensorWorldTest):
             result = my_func(lt)
             self.assertEqual(result.shape, torch.Size([8, 3]))
 
-    @parametrize("op_name", ["all_gather", "reduce_scatter", "all_to_all_single"])
+    @parametrize(
+        "op_name",
+        ["all_gather", "reduce_scatter", "all_to_all_single", "shard_dim_alltoall"],
+    )
     def test_functional_collective_with_pg_compile_on_one_rank(self, op_name):
         # Under compile_on_one_rank=True, _group_or_group_name passes the
         # ProcessGroup straight through to the functional collective op, so the
         # LocalTensorMode implementations must accept either a string group
-        # name or a ProcessGroup. Covers the three handlers that share the
+        # name or a ProcessGroup. Covers the four handlers that share the
         # widened group-name signature. See pytorch/pytorch#184746.
         import torch.distributed.config as dist_config
         from torch.distributed._functional_collectives import (
@@ -724,6 +727,26 @@ class TestLocalTensorWorld4(LocalTensorWorldTest):
                 for r in range(ws)
             }
             run = lambda lt: all_to_all_single(lt, None, None, group=fake_pg)  # noqa: E731
+        elif op_name == "shard_dim_alltoall":
+            # shard_dim_alltoall is reachable with a live ProcessGroup under
+            # compile_on_one_rank=True via DTensor redistribute (see
+            # torch/distributed/tensor/_collective_utils.py: shard_dim_alltoall
+            # forwards funcol._group_or_group_name(group) into the op). Each
+            # rank contributes a (1, ws) row; after gather along dim 0 and
+            # shard along dim 1, rank r should receive the r-th column of the
+            # (ws, ws) gathered matrix as a (ws, 1) shard.
+            per_rank = {
+                r: torch.arange(ws, dtype=torch.float32).reshape(1, ws) * 100 + r
+                for r in range(ws)
+            }
+            expected_shape = torch.Size([ws, 1])
+            expected_per_rank = {
+                r: (torch.arange(ws, dtype=torch.float32) + 100 * r).reshape(ws, 1)
+                for r in range(ws)
+            }
+            run = lambda lt: torch.ops._dtensor.shard_dim_alltoall(  # noqa: E731
+                lt, 0, 1, fake_pg
+            )
         else:
             raise ValueError(f"Unknown op_name: {op_name}")
 

--- a/test/distributed/test_local_tensor.py
+++ b/test/distributed/test_local_tensor.py
@@ -25,7 +25,12 @@ from torch.distributed.tensor import (
     Shard,
     zeros,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import reduce_local_int
 
 
@@ -637,6 +642,7 @@ class TestLocalTensorWorld3(LocalTensorWorldTest):
             self.assertEqual(lt_output_tensor, expected_output)
 
 
+@instantiate_parametrized_tests
 class TestLocalTensorWorld4(LocalTensorWorldTest):
     world_size = 4
 
@@ -667,87 +673,101 @@ class TestLocalTensorWorld4(LocalTensorWorldTest):
             result = my_func(lt)
             self.assertEqual(result.shape, torch.Size([8, 3]))
 
-    def test_functional_all_gather_with_pg_compile_on_one_rank(self):
+    @parametrize("op_name", ["all_gather", "reduce_scatter", "all_to_all_single"])
+    def test_functional_collective_with_pg_compile_on_one_rank(self, op_name):
         # Under compile_on_one_rank=True, _group_or_group_name passes the
         # ProcessGroup straight through to the functional collective op, so the
         # LocalTensorMode implementations must accept either a string group
-        # name or a ProcessGroup. See pytorch/pytorch#184746.
+        # name or a ProcessGroup. Covers the three handlers that share the
+        # widened group-name signature. See pytorch/pytorch#184746.
         import torch.distributed.config as dist_config
+        from torch.distributed._functional_collectives import (
+            all_to_all_single,
+            reduce_scatter_tensor,
+        )
 
         fake_pg = dist.distributed_c10d._get_default_group()
-        different_tensors = {
-            r: torch.full((2, 3), float(r)) for r in range(self.world_size)
-        }
-        with (
-            LocalTensorMode(self.world_size),
-            dist_config.patch(compile_on_one_rank=True),
-        ):
-            lt = LocalTensor(different_tensors)
-            result = all_gather_tensor(lt, gather_dim=0, group=fake_pg)
-            if hasattr(result, "wait"):
-                result = result.wait()
-            self.assertIsInstance(result, LocalTensor)
-            self.assertEqual(result.shape, torch.Size([2 * self.world_size, 3]))
-            for r in range(self.world_size):
-                expected = torch.cat(
-                    [different_tensors[i] for i in range(self.world_size)], dim=0
-                )
-                self.assertEqual(result._local_tensors[r], expected)
-
-    def test_functional_reduce_scatter_with_pg_compile_on_one_rank(self):
-        # Same compile_on_one_rank gap as the all_gather test, but covers the
-        # reduce_scatter handler. See pytorch/pytorch#184746.
-        import torch.distributed.config as dist_config
-        from torch.distributed._functional_collectives import reduce_scatter_tensor
-
-        fake_pg = dist.distributed_c10d._get_default_group()
-        # Each rank contributes the same input so the reduction sum is
-        # deterministic regardless of which rank "ran" the op.
         ws = self.world_size
-        input_tensor = torch.arange(2 * ws * 3, dtype=torch.float32).reshape(2 * ws, 3)
-        per_rank = {r: input_tensor.clone() for r in range(ws)}
-        with (
-            LocalTensorMode(ws),
-            dist_config.patch(compile_on_one_rank=True),
-        ):
-            lt = LocalTensor(per_rank)
-            result = reduce_scatter_tensor(lt, "sum", scatter_dim=0, group=fake_pg)
-            if hasattr(result, "wait"):
-                result = result.wait()
-            self.assertIsInstance(result, LocalTensor)
-            self.assertEqual(result.shape, torch.Size([2, 3]))
+
+        if op_name == "all_gather":
+            per_rank = {r: torch.full((2, 3), float(r)) for r in range(ws)}
+            expected_shape = torch.Size([2 * ws, 3])
+            expected_per_rank = {
+                r: torch.cat([per_rank[i] for i in range(ws)], dim=0) for r in range(ws)
+            }
+            run = lambda lt: all_gather_tensor(lt, gather_dim=0, group=fake_pg)  # noqa: E731
+        elif op_name == "reduce_scatter":
+            # Each rank contributes the same input so the reduction sum is
+            # deterministic regardless of which rank ran the op.
+            input_tensor = torch.arange(2 * ws * 3, dtype=torch.float32).reshape(
+                2 * ws, 3
+            )
+            per_rank = {r: input_tensor.clone() for r in range(ws)}
             chunks = input_tensor.chunk(ws, dim=0)
-            for r in range(ws):
-                self.assertEqual(result._local_tensors[r], chunks[r] * ws)
-
-    def test_functional_all_to_all_single_with_pg_compile_on_one_rank(self):
-        # Same compile_on_one_rank gap, exercising all_to_all_single. See
-        # pytorch/pytorch#184746.
-        import torch.distributed.config as dist_config
-        from torch.distributed._functional_collectives import all_to_all_single
-
-        fake_pg = dist.distributed_c10d._get_default_group()
-        ws = self.world_size
-        # Each rank's input row r is "rank * world + r"; after all-to-all,
-        # rank r should see contributions from every other rank stacked.
-        per_rank = {
-            r: torch.tensor([float(r * ws + i) for i in range(ws)]).reshape(ws, 1)
-            for r in range(ws)
-        }
-        with (
-            LocalTensorMode(ws),
-            dist_config.patch(compile_on_one_rank=True),
-        ):
-            lt = LocalTensor(per_rank)
-            result = all_to_all_single(lt, None, None, group=fake_pg)
-            if hasattr(result, "wait"):
-                result = result.wait()
-            self.assertIsInstance(result, LocalTensor)
-            self.assertEqual(result.shape, torch.Size([ws, 1]))
-            for r in range(ws):
-                expected = torch.tensor(
+            expected_shape = torch.Size([2, 3])
+            expected_per_rank = {r: chunks[r] * ws for r in range(ws)}
+            run = lambda lt: reduce_scatter_tensor(  # noqa: E731
+                lt, "sum", scatter_dim=0, group=fake_pg
+            )
+        elif op_name == "all_to_all_single":
+            # Each rank's input row r is "rank * world + r"; after all-to-all,
+            # rank r should see contributions from every other rank stacked.
+            per_rank = {
+                r: torch.tensor([float(r * ws + i) for i in range(ws)]).reshape(ws, 1)
+                for r in range(ws)
+            }
+            expected_shape = torch.Size([ws, 1])
+            expected_per_rank = {
+                r: torch.tensor(
                     [float(sender * ws + r) for sender in range(ws)]
                 ).reshape(ws, 1)
+                for r in range(ws)
+            }
+            run = lambda lt: all_to_all_single(lt, None, None, group=fake_pg)  # noqa: E731
+        else:
+            raise ValueError(f"Unknown op_name: {op_name}")
+
+        with (
+            LocalTensorMode(ws),
+            dist_config.patch(compile_on_one_rank=True),
+        ):
+            lt = LocalTensor(per_rank)
+            result = run(lt)
+            if hasattr(result, "wait"):
+                result = result.wait()
+            self.assertIsInstance(result, LocalTensor)
+            self.assertEqual(result.shape, expected_shape)
+            for r in range(ws):
+                self.assertEqual(result._local_tensors[r], expected_per_rank[r])
+
+    def test_compile_on_one_rank_e2e_torch_compile(self):
+        # End-to-end coverage: under LocalTensorMode + compile_on_one_rank=True,
+        # a torch.compile'd graph that issues a functional collective should
+        # both (a) survive the ProcessGroup-as-group_name path through
+        # LocalTensorMode's _local_functional_* handlers and (b) return a
+        # LocalTensor whose per-rank shards are the correct concatenation.
+        import torch.distributed.config as dist_config
+
+        fake_pg = dist.distributed_c10d._get_default_group()
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            return all_gather_tensor(x, gather_dim=0, group=fake_pg)
+
+        ws = self.world_size
+        per_rank = {r: torch.full((2, 3), float(r)) for r in range(ws)}
+        with (
+            LocalTensorMode(ws),
+            dist_config.patch(compile_on_one_rank=True),
+        ):
+            lt = LocalTensor(per_rank)
+            result = f(lt)
+            if hasattr(result, "wait"):
+                result = result.wait()
+            self.assertIsInstance(result, LocalTensor)
+            self.assertEqual(result.shape, torch.Size([2 * ws, 3]))
+            expected = torch.cat([per_rank[i] for i in range(ws)], dim=0)
+            for r in range(ws):
                 self.assertEqual(result._local_tensors[r], expected)
 
     def test_runtime_compute_coordinate_on_dim_per_rank(self):

--- a/test/distributed/test_local_tensor.py
+++ b/test/distributed/test_local_tensor.py
@@ -770,36 +770,26 @@ class TestLocalTensorWorld4(LocalTensorWorldTest):
             for r in range(ws):
                 self.assertEqual(result._local_tensors[r], expected)
 
-    def test_runtime_compute_coordinate_on_dim_per_rank(self):
+    @parametrize("call_style", ["positional", "kwargs"])
+    def test_runtime_compute_coordinate_on_dim_per_rank(self, call_style):
         # Under LocalTensorMode the device_mesh op must return per-rank
         # coordinates wrapped in a LocalIntNode-backed SymInt, instead of
         # falling back to dist.get_rank() (which is always 0 under the fake
-        # backend). See pytorch/pytorch#184746.
+        # backend). The override binds arguments via the op schema so it must
+        # also accept keyword call sites. See pytorch/pytorch#184746.
         from torch.distributed._ops import device_mesh as _dm_ops  # noqa: F401
 
         with LocalTensorMode(self.world_size):
             mesh = self.build_device_mesh()
             full_mesh = mesh._layout.remap_to_tensor(mesh._rank_map)
-            coord = torch.ops.device_mesh._runtime_compute_coordinate_on_dim(
-                full_mesh, 0
-            )
-
-        self.assertIsInstance(coord, torch.SymInt)
-        self.assertIsInstance(coord.node, LocalIntNode)
-        expected = {r: r for r in range(self.world_size)}
-        self.assertEqual(coord.node._local_ints, expected)
-
-    def test_runtime_compute_coordinate_on_dim_kwargs(self):
-        # The LocalTensorMode override must also work when the op is called
-        # with keyword arguments, not just positional ones.
-        from torch.distributed._ops import device_mesh as _dm_ops  # noqa: F401
-
-        with LocalTensorMode(self.world_size):
-            mesh = self.build_device_mesh()
-            full_mesh = mesh._layout.remap_to_tensor(mesh._rank_map)
-            coord = torch.ops.device_mesh._runtime_compute_coordinate_on_dim(
-                full_mesh=full_mesh, index=0
-            )
+            if call_style == "positional":
+                coord = torch.ops.device_mesh._runtime_compute_coordinate_on_dim(
+                    full_mesh, 0
+                )
+            else:
+                coord = torch.ops.device_mesh._runtime_compute_coordinate_on_dim(
+                    full_mesh=full_mesh, index=0
+                )
 
         self.assertIsInstance(coord, torch.SymInt)
         self.assertIsInstance(coord.node, LocalIntNode)

--- a/test/distributed/test_local_tensor.py
+++ b/test/distributed/test_local_tensor.py
@@ -728,13 +728,6 @@ class TestLocalTensorWorld4(LocalTensorWorldTest):
             }
             run = lambda lt: all_to_all_single(lt, None, None, group=fake_pg)  # noqa: E731
         elif op_name == "shard_dim_alltoall":
-            # shard_dim_alltoall is reachable with a live ProcessGroup under
-            # compile_on_one_rank=True via DTensor redistribute (see
-            # torch/distributed/tensor/_collective_utils.py: shard_dim_alltoall
-            # forwards funcol._group_or_group_name(group) into the op). Each
-            # rank contributes a (1, ws) row; after gather along dim 0 and
-            # shard along dim 1, rank r should receive the r-th column of the
-            # (ws, ws) gathered matrix as a (ws, 1) shard.
             per_rank = {
                 r: torch.arange(ws, dtype=torch.float32).reshape(1, ws) * 100 + r
                 for r in range(ws)

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1324,6 +1324,38 @@ class LocalTensorMode(TorchDispatchMode):
             )
             return NotImplemented
 
+        # device_mesh::_runtime_compute_coordinate_on_dim is checked before the
+        # no-LocalTensor early return because compile-on-one-rank calls it with
+        # only a plain mesh-tensor argument, but the result must still vary per
+        # simulated rank under LocalTensorMode.
+        if (
+            not self._disable
+            and func.namespace == "device_mesh"
+            and func.overloadpacket.__name__ == "_runtime_compute_coordinate_on_dim"
+        ):
+            # Schema is "(Tensor full_mesh, int index) -> SymInt" so we accept
+            # both positional and keyword forms by looking up names from the
+            # op's schema. This avoids silently mis-unpacking if a caller
+            # passes either argument as a kwarg.
+            schema_args = func._schema.arguments
+            bound = dict(zip((a.name for a in schema_args), args))
+            bound.update(kwargs)
+            full_mesh = bound["full_mesh"]
+            index = bound["index"]
+            rank_results: dict[int, int] = {}
+            for r in self.ranks:
+                mesh_tensor = DeviceMesh._get_mesh_tensor_from_full_mesh(
+                    full_mesh, current_rank=r
+                )
+                mesh_coords = DeviceMesh._compute_coordinates_from_mesh(mesh_tensor, r)
+                if mesh_coords is None:
+                    raise AssertionError(
+                        f"Rank {r} not found in mesh tensor for "
+                        "_runtime_compute_coordinate_on_dim"
+                    )
+                rank_results[r] = mesh_coords[index]
+            return _combine_int_rank_results(rank_results)
+
         # Factory functions convert into LocalTensor, so we don't have to
         # transmute a Tensor into a LocalTensor if mutation happens...
         # But if you do an operation on a Tensor, do NOT wrap it into a

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1333,15 +1333,21 @@ class LocalTensorMode(TorchDispatchMode):
             and func.namespace == "device_mesh"
             and func.overloadpacket.__name__ == "_runtime_compute_coordinate_on_dim"
         ):
-            # Schema is "(Tensor full_mesh, int index) -> SymInt" so we accept
-            # both positional and keyword forms by looking up names from the
-            # op's schema. This avoids silently mis-unpacking if a caller
-            # passes either argument as a kwarg.
-            schema_args = func._schema.arguments
-            bound = dict(zip((a.name for a in schema_args), args))
-            bound.update(kwargs)
-            full_mesh = bound["full_mesh"]
-            index = bound["index"]
+            from torch.fx.operator_schemas import normalize_function
+
+            normalized = normalize_function(
+                func,
+                args,
+                kwargs,
+                normalize_to_only_use_kwargs=True,
+            )
+            if normalized is None:
+                raise AssertionError(
+                    "LocalTensorMode could not normalize arguments for "
+                    "device_mesh::_runtime_compute_coordinate_on_dim"
+                )
+            full_mesh = normalized.kwargs["full_mesh"]
+            index = normalized.kwargs["index"]
             rank_results: dict[int, int] = {}
             for r in self.ranks:
                 mesh_tensor = DeviceMesh._get_mesh_tensor_from_full_mesh(

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1331,7 +1331,7 @@ class LocalTensorMode(TorchDispatchMode):
         if (
             not self._disable
             and func.namespace == "device_mesh"
-            and func.overloadpacket.__name__ == "_runtime_compute_coordinate_on_dim"
+            and func is torch.ops.device_mesh._runtime_compute_coordinate_on_dim.default
         ):
             from torch.fx.operator_schemas import normalize_function
 
@@ -1355,7 +1355,7 @@ class LocalTensorMode(TorchDispatchMode):
                 )
                 mesh_coords = DeviceMesh._compute_coordinates_from_mesh(mesh_tensor, r)
                 if mesh_coords is None:
-                    raise AssertionError(
+                    raise RuntimeError(
                         f"Rank {r} not found in mesh tensor for "
                         "_runtime_compute_coordinate_on_dim"
                     )

--- a/torch/distributed/_local_tensor/_c10d.py
+++ b/torch/distributed/_local_tensor/_c10d.py
@@ -74,6 +74,20 @@ def _indices_to_layout(indices: list[int]) -> tuple[tuple[int, ...], tuple[int, 
     return final_shapes, final_strides
 
 
+def _resolve_pg_or_name(
+    group: ScriptObject | ProcessGroup | str | GroupName,
+) -> ScriptObject | ProcessGroup:
+    """Accept any of the group reps that may reach a functional collective.
+
+    Under ``compile_on_one_rank=True`` the functional collective ops receive
+    the live ``ProcessGroup`` instead of a string group name, so we cannot
+    unconditionally call ``_resolve_process_group``.
+    """
+    if isinstance(group, (ProcessGroup, ScriptObject)):
+        return group
+    return _resolve_process_group(group)
+
+
 def _prepare_collective_groups(
     process_group_so: ScriptObject | ProcessGroup,
 ) -> tuple[list[int], list[int], int]:
@@ -107,13 +121,15 @@ def _prepare_collective_groups(
 # work object). Functional collectives expect the implementation to allocate outputs, accept
 # process group name that must be resolved and do not support async ops (return output).
 def _local_functional_all_gather_into_tensor(
-    tensor: torch.Tensor, group_size: int, group_name: GroupName
+    tensor: torch.Tensor,
+    group_size: int,
+    group_name: GroupName | ProcessGroup,
 ) -> torch.Tensor:
     # "all_gather_into_tensor(Tensor input, int group_size, str group_name) -> Tensor"
     from . import LocalTensor
 
     ranks, group_offsets, offset = _prepare_collective_groups(
-        _resolve_process_group(group_name)
+        _resolve_pg_or_name(group_name)
     )
 
     if not isinstance(tensor, LocalTensor):
@@ -142,13 +158,16 @@ def _local_functional_all_gather_into_tensor(
 
 
 def _local_functional_reduce_scatter_tensor(
-    tensor: torch.Tensor, reduce_op: str, group_size: int, group_name: GroupName
+    tensor: torch.Tensor,
+    reduce_op: str,
+    group_size: int,
+    group_name: GroupName | ProcessGroup,
 ) -> torch.Tensor:
     #  "reduce_scatter_tensor(Tensor input, str reduce_op, int group_size, str group_name) -> Tensor"
     from . import _zero_sized_like, LocalTensor
 
     ranks, group_offsets, offset = _prepare_collective_groups(
-        _resolve_process_group(group_name)
+        _resolve_pg_or_name(group_name)
     )
 
     if not isinstance(tensor, LocalTensor):
@@ -186,13 +205,16 @@ def _local_functional_reduce_scatter_tensor(
 
 
 def _local_functional_shard_dim_alltoall(
-    tensor: torch.Tensor, gather_dim: int, shard_dim: int, group_name: GroupName
+    tensor: torch.Tensor,
+    gather_dim: int,
+    shard_dim: int,
+    group_name: GroupName | ProcessGroup,
 ) -> torch.Tensor:
     # "shard_dim_alltoall(Tensor input, int gather_dim, int shard_dim, str group_name) -> Tensor"
     from . import _zero_sized_like, LocalTensor
 
     ranks, group_offsets, offset = _prepare_collective_groups(
-        _resolve_process_group(group_name)
+        _resolve_pg_or_name(group_name)
     )
 
     if not isinstance(tensor, LocalTensor):
@@ -235,13 +257,13 @@ def _local_functional_all_to_all_single(
     tensor: torch.Tensor,
     output_split_sizes: list[torch.SymInt],
     input_split_sizes: list[torch.SymInt],
-    group_name: GroupName,
+    group_name: GroupName | ProcessGroup,
 ) -> torch.Tensor:
     # "all_to_all_single(Tensor input, SymInt[] output_split_sizes, SymInt[] input_split_sizes, str group_name) -> Tensor"
     from . import LocalIntNode, LocalTensor
 
     ranks, group_offsets, offset = _prepare_collective_groups(
-        _resolve_process_group(group_name)
+        _resolve_pg_or_name(group_name)
     )
 
     if not isinstance(tensor, LocalTensor):

--- a/torch/distributed/_local_tensor/_c10d.py
+++ b/torch/distributed/_local_tensor/_c10d.py
@@ -85,7 +85,7 @@ def _resolve_pg_or_name(
     """
     if isinstance(group, (ProcessGroup, ScriptObject)):
         return group
-    return _resolve_process_group(group)
+    return _resolve_process_group(GroupName(group))
 
 
 def _prepare_collective_groups(

--- a/torch/distributed/_local_tensor/_c10d.py
+++ b/torch/distributed/_local_tensor/_c10d.py
@@ -85,6 +85,9 @@ def _resolve_pg_or_name(
     """
     if isinstance(group, (ProcessGroup, ScriptObject)):
         return group
+    # ``GroupName`` is ``NewType("GroupName", str)``, so wrapping ``group`` here
+    # is a runtime no-op. The cast exists purely so pyrefly accepts the
+    # narrowed ``str | GroupName`` argument against the declared parameter type.
     return _resolve_process_group(GroupName(group))
 
 


### PR DESCRIPTION
## Agent Report
### Summary
`LocalTensorMode` is used by autoparallel's compile-on-one-rank flow to
simulate a multi-rank execution from a single process backed by the fake PG.
Two upstream gaps prevented this from working:

1. **Functional collectives reject `ProcessGroup` arguments.** When
 `torch.distributed.config.compile_on_one_rank=True`, the helper
 `torch.distributed._functional_collectives._group_or_group_name` passes the
 live `ProcessGroup` straight through (instead of `pg.group_name`) to ops
 like `torch.ops._c10d_functional.all_gather_into_tensor`. Under
 `LocalTensorMode` those ops are intercepted by
 `_local_functional_all_gather_into_tensor` (and siblings) in
 `torch/distributed/_local_tensor/_c10d.py`, which unconditionally called
 `_resolve_process_group(group_name)` — a C++ binding that only accepts
 `str`. The result was `TypeError: _resolve_process_group(): incompatible
 function arguments`.
2. **`_runtime_compute_coordinate_on_dim` always returns the rank-0 coord.**
 `torch.ops.device_mesh._runtime_compute_coordinate_on_dim`'s
 `CompositeExplicitAutograd` impl calls `torch.distributed.get_rank()`,
 which under the fake PG returns 0 on every simulated rank. When this op is
 invoked inside `LocalTensorMode` (e.g. by graphs produced by autoparallel's
 compile-on-one-rank flow) it falls through to `_for_each_rank_run_func`,
 but the args are plain tensors / ints so we recurse and every simulated
 rank ends up with the rank-0 coordinate.

### Repro
Run:

```bash
python repro_184746_generated.py
```

<details>
<summary>Repro Script</summary>

```python
"""
Reproducer for https://github.com/pytorch/pytorch/issues/184746

Two gaps in LocalTensorMode when combined with compile_on_one_rank=True:

1) Functional collectives receive ProcessGroup objects (not string group names)
 because _group_or_group_name() passes the PG through when compile_on_one_rank
 is enabled. The LocalTensorMode implementations only know how to handle a
 string name (they call _resolve_process_group() on it) so they currently
 blow up with a type error.

2) device_mesh::_runtime_compute_coordinate_on_dim falls back to
 torch.distributed.get_rank() which is always 0 under the fake backend used
 with LocalTensorMode, so every simulated rank gets the rank-0 coordinate.
"""

from __future__ import annotations

import sys
import traceback

import torch
import torch.distributed as dist
import torch.distributed.config as dist_config
from torch.distributed._functional_collectives import all_gather_tensor
from torch.distributed._local_tensor import (
 LocalIntNode,
 LocalTensor,
 LocalTensorMode,
)
from torch.distributed.tensor import init_device_mesh


WORLD_SIZE = 4


def _setup_fake_pg():
 if dist.is_initialized():
 dist.destroy_process_group()
 dist.init_process_group("fake", rank=0, world_size=WORLD_SIZE)


def _make_local_tensor():
 shards = {r: torch.tensor([float(r)] * 4) for r in range(WORLD_SIZE)}
 return LocalTensor(shards)


def case_functional_collective_with_pg() -> bool:
 """Returns True if the bug reproduces (the call fails)."""
 print("\n=== Case 1: functional collective gets ProcessGroup ===")
 _setup_fake_pg()

 pg = dist.distributed_c10d._get_default_group()
 lt = _make_local_tensor()

 try:
 with LocalTensorMode(WORLD_SIZE), dist_config.patch(compile_on_one_rank=True):
 out = all_gather_tensor(lt, gather_dim=0, group=pg)
 # Force materialization.
 if hasattr(out, "wait"):
 out = out.wait()
 print(f"all_gather_tensor returned: {type(out).__name__}")
 return False
 except Exception as exc:
 print("FAILED:", type(exc).__name__, str(exc).splitlines()[0])
 traceback.print_exc(limit=4)
 return True


def case_runtime_compute_coordinate() -> bool:
 """Returns True if the bug reproduces (coordinates are wrong)."""
 print("\n=== Case 2: _runtime_compute_coordinate_on_dim under LocalTensorMode ===")
 _setup_fake_pg()

 with LocalTensorMode(WORLD_SIZE):
 mesh = init_device_mesh("cpu", (WORLD_SIZE,), mesh_dim_names=("dp",))

 rank_map_list = mesh._rank_map.tolist()
 rank_map = torch.tensor(rank_map_list, device="cpu", dtype=torch.int)
 full_mesh = mesh._layout.remap_to_tensor(rank_map)

 # Ensure ops are registered.
 from torch.distributed._ops import device_mesh as _dm_ops # noqa: F401

 coord = torch.ops.device_mesh._runtime_compute_coordinate_on_dim(full_mesh, 0)

 print(f"coord = {coord!r}")
 if isinstance(coord, torch.SymInt) and isinstance(coord.node, LocalIntNode):
 per_rank = coord.node._local_ints
 expected = {r: r for r in range(WORLD_SIZE)}
 print(f"per-rank coords: {per_rank}")
 if per_rank != expected:
 print(f"WRONG: expected {expected}")
 return True
 return False
 print("WRONG: expected a LocalIntNode-wrapped SymInt")
 return True


if __name__ == "__main__":
 bug1 = case_functional_collective_with_pg()
 bug2 = case_runtime_compute_coordinate()

 print("\n=== Summary ===")
 print(f"case 1 (PG to functional collective) bug reproduced: {bug1}")
 print(f"case 2 (runtime coord uses dist.get_rank) bug reproduced: {bug2}")

 sys.exit(0 if not (bug1 or bug2) else 1)
```

</details>

### Testing
Added regression tests under `TestLocalTensorWorld4` in
`test/distributed/test_local_tensor.py` (class decorated with
`@instantiate_parametrized_tests`):

- `test_functional_collective_with_pg_compile_on_one_rank` —
 `@parametrize("op_name", ["all_gather", "reduce_scatter",
 "all_to_all_single"])` exercises each functional collective handler that
 was widened by `_resolve_pg_or_name`, by calling
 `{all_gather_tensor, reduce_scatter_tensor, all_to_all_single}(...,
 group=fake_pg)` inside
 `LocalTensorMode + dist_config.patch(compile_on_one_rank=True)` and
 verifying the per-rank LocalTensor shards match the expected output for
 that op.
- `test_compile_on_one_rank_e2e_torch_compile` — end-to-end test that wraps
 an `all_gather_tensor(group=fake_pg)` call in `torch.compile(backend=
 "eager", fullgraph=True)` and runs it under
 `LocalTensorMode + compile_on_one_rank=True`, verifying the per-rank
 LocalTensor shards match the expected concatenation.
- `test_runtime_compute_coordinate_on_dim_per_rank` —
 `@parametrize("call_style", ["positional", "kwargs"])` covers both call
 shapes for `torch.ops.device_mesh._runtime_compute_coordinate_on_dim`:
 the positional `(full_mesh, 0)` form and the kwargs-only
 `(full_mesh=..., index=0)` form. Both run under `LocalTensorMode(4)` and
 assert the result is a `SymInt` backed by
 `LocalIntNode({0: 0, 1: 1, 2: 2, 3: 3})`, locking in the
 `normalize_function`-based arg bind inside the dispatch-mode override.

Each test was verified to catch the corresponding bug by stashing the
relevant source fix and re-running with the tests in place:

- Without `_resolve_pg_or_name`: all three parametrized functional-collective
 variants raise
 `TypeError: _resolve_process_group(): incompatible function arguments`.
- Without the dispatch-mode special case: both runtime-coord tests fail with
 `AssertionError: 0 is not an instance of <class 'torch.SymInt'>`.

## Files Changed
- `torch/distributed/_local_tensor/_c10d.py`
- `torch/distributed/_local_tensor/__init__.py`
- `test/distributed/test_local_tensor.py`


Fixes #184746

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*