### PR TITLE
[Build] Fix torch_version generation

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -65,7 +65,7 @@ def regenerate_version():
         "tools.generate_torch_version",
         "--is-debug=false",
     ]
-    spin.util.run(cmd, cwd=CWD)
+    spin.util.run(cmd)
 
 
 TYPE_STUBS = [

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -65,7 +65,7 @@ def regenerate_version():
         "tools.generate_torch_version",
         "--is-debug=false",
     ]
-    spin.util.run(cmd)
+    spin.util.run(cmd, cwd=CWD)
 
 
 TYPE_STUBS = [

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -480,7 +480,7 @@ endif()
 
 add_custom_target(
   gen_torch_version ALL
-  "${Python_EXECUTABLE}" "${TOOLS_PATH}/generate_torch_version.py"
+  "${Python_EXECUTABLE}" -m tools.generate_torch_version
     --is-debug=${TORCH_VERSION_DEBUG}
     --cuda-version=${CUDA_VERSION}
     --hip-version=${HIP_VERSION_CLEAN}


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pulls/182120 introduced the problem by adding `from tools.strtobool import strtobool`, which fails whenever rebuild is invoked from say `build` folder
```
[1/190] Regenerating version file...
FAILED: [code=1] caffe2/torch/CMakeFiles/gen_torch_version /Users/nshulga/git/pytorch/pytorch/torch/version.py /Users/nshulga/git/pytorch/pytorch/build/caffe2/torch/CMakeFiles/gen_torch_version 
cd /Users/nshulga/git/pytorch/pytorch && /Users/nshulga/py3.14-local/bin/python /Users/nshulga/git/pytorch/pytorch/torch/../tools/generate_torch_version.py --is-debug=0 --cuda-version= --hip-version= --rocm-version= --xpu-version=
Traceback (most recent call last):
  File "/Users/nshulga/git/pytorch/pytorch/torch/../tools/generate_torch_version.py", line 117, in <module>
    from tools.strtobool import strtobool
ModuleNotFoundError: No module named 'tools'
```

Fixed by invoking generate_torch_version.py the same way from spin and from `torch/CMakeLists.txt`

Fixes https://github.com/pytorch/pytorch/issues/184687