### PR TITLE
[inductor][autotuning] make incremental_autotune kernel selection an env-configurable include knob

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -531,6 +531,15 @@ incremental_autotune: bool | None = get_tristate_env(
     "TORCHINDUCTOR_INCREMENTAL_AUTOTUNE", default=False
 )
 
+# TORCHINDUCTOR_INCREMENTAL_AUTOTUNE_INCLUDE: comma-separated list of
+# HeuristicType names (case-insensitive) restricting which kernel heuristic
+# types participate in incremental autotuning. Empty string = none enabled;
+# unset (None here) = default (all). Parsing and resolution against
+# HeuristicType lives in torch._inductor.runtime.fb.incremental.config.
+incremental_autotune_include: str | None = os.environ.get(
+    "TORCHINDUCTOR_INCREMENTAL_AUTOTUNE_INCLUDE"
+)
+
 inductor_default_autotune_warmup = int(
     os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_WARMUP", 25)
 )


### PR DESCRIPTION
Summary:
Renames `incremental_autotune_exclude` to `incremental_autotune_include`
and inverts the semantics. The default is now all `HeuristicType` members
(previously: all except `REDUCTION`, `PERSISTENT_REDUCTION`, `SPLIT_SCAN`).
Users can restrict which kernel heuristic types participate in incremental
autotuning via the new env var `TORCHINDUCTOR_INCREMENTAL_AUTOTUNE_INCLUDE`,
which takes a comma-separated, case-insensitive list of `HeuristicType`
names — e.g. `TORCHINDUCTOR_INCREMENTAL_AUTOTUNE_INCLUDE="pointwise,template"`.
Setting the env var to the empty string disables incremental autotune for
all types; leaving it unset uses the default.

Test Plan: buck test fbcode//mode/opt caffe2/test/inductor:torchinductor

Reviewed By: MengjiaoZhou

Differential Revision: D103933877




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo