### PR TITLE
Make profiler resilient to duplicate flow start IDs

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1550,6 +1550,9 @@ test_libtorch_profiler() {
 
   # Run all other tests
   python test/run_test.py --cpp --verbose -i cpp/test_privateuse1_profiler -k "not EndToEndProfiling"
+
+  # Tests for torch/csrc/profiler/collection.cpp.
+  python test/run_test.py --cpp --verbose -i cpp/test_profiler_collection
 }
 
 test_libtorch_api() {

--- a/test/cpp/profiler/CMakeLists.txt
+++ b/test/cpp/profiler/CMakeLists.txt
@@ -1,7 +1,7 @@
-# Test for PrivateUse1 profiler registration
-
 if(USE_KINETO)
   set(PROFILER_TEST_ROOT ${TORCH_ROOT}/test/cpp/profiler)
+
+  set(PROFILER_TEST_DEPENDENCIES torch gtest_main fmt::fmt-header-only)
 
   add_executable(test_privateuse1_profiler
     ${TORCH_ROOT}/test/cpp/common/main.cpp
@@ -9,8 +9,6 @@ if(USE_KINETO)
   )
 
   target_compile_definitions(test_privateuse1_profiler PRIVATE USE_GTEST USE_KINETO)
-
-  set(PROFILER_TEST_DEPENDENCIES torch gtest_main fmt::fmt-header-only)
 
   target_link_libraries(test_privateuse1_profiler PRIVATE ${PROFILER_TEST_DEPENDENCIES})
   target_include_directories(test_privateuse1_profiler PRIVATE
@@ -21,6 +19,27 @@ if(USE_KINETO)
   if(INSTALL_TEST)
     set_target_properties(test_privateuse1_profiler PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${_rpath_portable_origin}/../lib")
     install(TARGETS test_privateuse1_profiler DESTINATION bin)
+  endif()
+
+  add_executable(test_profiler_collection
+    ${TORCH_ROOT}/test/cpp/common/main.cpp
+    ${PROFILER_TEST_ROOT}/test_profiler_collection.cpp
+  )
+
+  target_compile_definitions(test_profiler_collection PRIVATE USE_GTEST USE_KINETO)
+
+  # Link libkineto explicitly. The test calls libkineto::api() and uses
+  # libkineto::GenericTraceActivity as a value type (which references its
+  # vtable, including GenericTraceActivity::log). Needed for Windows.
+  target_link_libraries(test_profiler_collection PRIVATE ${PROFILER_TEST_DEPENDENCIES} kineto)
+  target_include_directories(test_profiler_collection PRIVATE
+    ${ATen_CPU_INCLUDE}
+    ${KINETO_SOURCE_DIR}/include
+  )
+
+  if(INSTALL_TEST)
+    set_target_properties(test_profiler_collection PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${_rpath_portable_origin}/../lib")
+    install(TARGETS test_profiler_collection DESTINATION bin)
   endif()
 
   if(USE_DISTRIBUTED)

--- a/test/cpp/profiler/test_profiler_collection.cpp
+++ b/test/cpp/profiler/test_profiler_collection.cpp
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Tests for torch/csrc/profiler/collection.cpp. The PrivateUse1 profiler
+// machinery is used here only as a vehicle for injecting synthetic kineto
+// activities into a real profiling session.
+//
+// To add new tests in this file:
+//   - Register child profilers via libkineto::api().registerProfilerFactory()
+//     directly. PrivateUse1ProfilerRegistry::registerFactory() is one-shot
+//     (it forwards to libkineto on first call only), so it cannot layer
+//     additional mocks on top of whatever a prior test already installed.
+//   - Wrap assertions on TORCH_WARN_ONCE output in c10::WarningUtils::
+//     WarnAlways(true) to defeat per-process rate limiting.
+//   - Capture warnings with CapturingWarningHandler under a
+//     WarningHandlerGuard for isolated capture.
+//   - Assert what your test PRODUCES, not what is ABSENT. Activities from
+//     prior tests' child profilers will still flow through setParents.
+//
+// If a future test genuinely needs a pristine Kineto state (e.g., asserts a
+// negative, or relies on TORCH_WARN_ONCE rate limiting being in effect),
+// split it out in .ci/pytorch/test.sh with a -k filter — same pattern that
+// isolates EndToEndProfiling in test_privateuse1_profiler.
+
+#ifdef USE_KINETO
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <c10/util/Exception.h>
+#include <torch/csrc/autograd/profiler_kineto.h>
+#include <torch/csrc/profiler/standalone/privateuse1_profiler.h>
+
+#include <GenericTraceActivity.h>
+#include <IActivityProfiler.h>
+#include <libkineto.h>
+#include <output_base.h>
+
+namespace {
+
+// Mock session that emits two CUDA_RUNTIME activities sharing the same
+// async-CPU-GPU flow start ID. Drives the duplicate-flow path in
+// TransferEvents::setParents().
+class DuplicateFlowMockSession : public libkineto::IActivityProfilerSession {
+ public:
+  DuplicateFlowMockSession() {
+    span_ = libkineto::TraceSpan{0, 0, "duplicate_flow_span"};
+    for (int i = 0; i < 2; ++i) {
+      libkineto::GenericTraceActivity a(
+          span_,
+          libkineto::ActivityType::CUDA_RUNTIME,
+          "duplicate_flow_launch");
+      a.startTime = 100 + i;
+      a.endTime = 200 + i;
+      a.id = i; // distinct correlation IDs
+      a.flow.id = 42; // identical flow ID across both activities
+      a.flow.type = libkineto::kLinkAsyncCpuGpu;
+      a.flow.start = 1; // both are flow starts
+      activities_.push_back(std::move(a));
+    }
+  }
+
+  void start() override {
+    status_ = libkineto::TraceStatus::RECORDING;
+  }
+  void stop() override {
+    status_ = libkineto::TraceStatus::PROCESSING;
+  }
+  std::vector<std::string> errors() override {
+    return {};
+  }
+
+  // Push the duplicate-flow activities into the logger so they reach the
+  // MemoryTraceLogger's activities_ list, which is what TransferEvents
+  // consumes via ActivityTrace::activities().
+  void processTrace(libkineto::ActivityLogger& logger) override {
+    for (const auto& a : activities_) {
+      logger.handleGenericActivity(a);
+    }
+  }
+
+  std::unique_ptr<libkineto::DeviceInfo> getDeviceInfo() override {
+    return std::make_unique<libkineto::DeviceInfo>(
+        /*id=*/1,
+        /*sortIndex=*/1,
+        /*name=*/"DuplicateFlowMockDevice",
+        /*label=*/"duplicate_flow_mock_device");
+  }
+
+  std::vector<libkineto::ResourceInfo> getResourceInfos() override {
+    return {};
+  }
+
+  std::unique_ptr<libkineto::CpuTraceBuffer> getTraceBuffer() override {
+    return nullptr;
+  }
+
+ private:
+  libkineto::TraceSpan span_{0, 0, ""};
+  std::vector<libkineto::GenericTraceActivity> activities_;
+};
+
+class DuplicateFlowMockProfiler : public libkineto::IActivityProfiler {
+ public:
+  const std::string& name() const override {
+    return name_;
+  }
+
+  const std::set<libkineto::ActivityType>& availableActivities()
+      const override {
+    return activities_;
+  }
+
+  std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      [[maybe_unused]] const std::set<libkineto::ActivityType>& activity_types,
+      [[maybe_unused]] const libkineto::Config& config) override {
+    return std::make_unique<DuplicateFlowMockSession>();
+  }
+
+  std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      [[maybe_unused]] int64_t ts_ms,
+      [[maybe_unused]] int64_t duration_ms,
+      const std::set<libkineto::ActivityType>& activity_types,
+      const libkineto::Config& config) override {
+    return configure(activity_types, config);
+  }
+
+ private:
+  std::string name_{"duplicate_flow_mock"};
+  std::set<libkineto::ActivityType> activities_{
+      libkineto::ActivityType::CUDA_RUNTIME};
+};
+
+// Minimal IActivityProfiler used to ensure PrivateUse1ProfilerRegistry has
+// a factory so libkineto initializes. Emits no activities.
+class NoopPrivateUse1Profiler : public libkineto::IActivityProfiler {
+ public:
+  const std::string& name() const override {
+    return name_;
+  }
+  const std::set<libkineto::ActivityType>& availableActivities()
+      const override {
+    return activities_;
+  }
+  std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      [[maybe_unused]] const std::set<libkineto::ActivityType>& activity_types,
+      [[maybe_unused]] const libkineto::Config& config) override {
+    class Session : public libkineto::IActivityProfilerSession {
+     public:
+      void start() override {
+        status_ = libkineto::TraceStatus::RECORDING;
+      }
+      void stop() override {
+        status_ = libkineto::TraceStatus::PROCESSING;
+      }
+      std::vector<std::string> errors() override {
+        return {};
+      }
+      void processTrace(
+          [[maybe_unused]] libkineto::ActivityLogger& logger) override {}
+      std::unique_ptr<libkineto::DeviceInfo> getDeviceInfo() override {
+        return nullptr;
+      }
+      std::vector<libkineto::ResourceInfo> getResourceInfos() override {
+        return {};
+      }
+      std::unique_ptr<libkineto::CpuTraceBuffer> getTraceBuffer() override {
+        return nullptr;
+      }
+    };
+    return std::make_unique<Session>();
+  }
+  std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      [[maybe_unused]] int64_t ts_ms,
+      [[maybe_unused]] int64_t duration_ms,
+      const std::set<libkineto::ActivityType>& activity_types,
+      const libkineto::Config& config) override {
+    return configure(activity_types, config);
+  }
+
+ private:
+  std::string name_{"noop_privateuse1"};
+  std::set<libkineto::ActivityType> activities_{
+      libkineto::ActivityType::CPU_OP};
+};
+
+class CapturingWarningHandler : public c10::WarningHandler {
+ public:
+  void process(const c10::Warning& warning) override {
+    messages_.push_back(warning.msg());
+  }
+  const std::vector<std::string>& messages() const {
+    return messages_;
+  }
+
+ private:
+  std::vector<std::string> messages_;
+};
+
+} // namespace
+
+// A backend producing duplicate async-CPU-GPU flow start IDs must be handled
+// gracefully.
+TEST(ProfilerCollectionTest, DuplicateFlowIdHandledGracefully) {
+  using namespace torch::autograd::profiler;
+  using namespace torch::profiler::impl;
+
+  // Capture warnings so the new diagnostic can be asserted. TORCH_WARN_ONCE
+  // is rate-limited per process; force every WARN_ONCE to behave like WARN
+  // for the duration of this test.
+  CapturingWarningHandler handler;
+  c10::WarningUtils::WarningHandlerGuard handler_guard(&handler);
+  c10::WarningUtils::WarnAlways warn_always_guard(true);
+
+  // Register a child profiler directly with libkineto. The session it
+  // returns is what injects duplicate flow IDs into the trace.
+  libkineto::api().registerProfilerFactory(
+      []() { return std::make_unique<DuplicateFlowMockProfiler>(); });
+
+  // The PrivateUse1 registry needs a factory so prepareProfiler triggers
+  // libkineto init, which in turn materializes the factory registered above.
+  if (!PrivateUse1ProfilerRegistry::instance().hasFactory()) {
+    PrivateUse1ProfilerRegistry::instance().registerFactory(
+        []() { return std::make_unique<NoopPrivateUse1Profiler>(); });
+  }
+
+  ProfilerConfig config(
+      ProfilerState::KINETO_PRIVATEUSE1,
+      /*report_input_shapes=*/false,
+      /*profile_memory=*/false,
+      /*with_stack=*/false,
+      /*with_flops=*/false,
+      /*with_modules=*/false);
+
+  std::set<ActivityType> activities{ActivityType::CPU};
+
+  prepareProfiler(config, activities);
+  enableProfiler(config, activities, {at::RecordScope::FUNCTION});
+  auto result = disableProfiler();
+  EXPECT_NE(result, nullptr);
+
+  bool saw_per_id_warning = false;
+  bool saw_summary_warning = false;
+  for (const auto& msg : handler.messages()) {
+    if (msg.find("Profiler produced duplicate flow start") !=
+        std::string::npos) {
+      saw_per_id_warning = true;
+    }
+    if (msg.find("duplicate flow start ID") != std::string::npos &&
+        msg.find("Profiler observed") != std::string::npos) {
+      saw_summary_warning = true;
+    }
+  }
+  EXPECT_TRUE(saw_per_id_warning);
+  EXPECT_TRUE(saw_summary_warning);
+}
+
+#endif // USE_KINETO

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -1169,20 +1169,30 @@ class TransferEvents {
   void setParents() {
     // First pass: Collect start events and set parent to linked event.
     ska::flat_hash_map<uint32_t, std::shared_ptr<Result>> flow_map;
+    uint64_t dropped_flow_count = 0;
     for (auto& e : results_.get()) {
       TORCH_INTERNAL_ASSERT(e != nullptr);
       e->visit(c10::overloaded(
           [&](const ExtraFields<EventType::Kineto>& i) {
             if (i.flow.type == libkineto::kLinkAsyncCpuGpu && i.flow.start) {
               auto inserted = flow_map.insert({i.flow.id, e});
-#ifdef USE_ROCM
-              if (inserted.second) {
+              if (!inserted.second) {
+                // Two flow start events arrived with the same ID, so the
+                // active backend produced a non-unique correlation ID.
+                // Nothing in the colliding pair tells us which start (if
+                // either) is the true owner of this ID, so attaching the
+                // matching flow end to the first inserter would risk
+                // linking it to an unrelated CPU op. Poison the slot so
+                // the colliding flow end skips the flow lookup and falls
+                // back to its linked_activity_ parent set in the first
+                // pass: an approximate runtime-correlation link, but never
+                // a wrong one. Any legitimate flow-based link for either
+                // start is forfeited as a result.
                 TORCH_WARN_ONCE(
-                    "ROCTracer produced duplicate flow start: ", i.flow.id);
+                    "Profiler produced duplicate flow start: ", i.flow.id);
+                ++dropped_flow_count;
+                inserted.first->second.reset();
               }
-#else // USE_ROCM
-              TORCH_INTERNAL_ASSERT(inserted.second);
-#endif // USE_ROCM
             }
             TORCH_INTERNAL_ASSERT(e->parent_.expired());
             e->parent_ = i.linked_activity_;
@@ -1194,9 +1204,10 @@ class TransferEvents {
     for (auto& e : results_.get()) {
       e->visit(c10::overloaded(
           [&](const ExtraFields<EventType::Kineto>& i) {
-            // Flow takes priority over linked event.
+            // Flow takes priority over linked event. Skip poisoned slots
+            // (set to null when a duplicate flow start ID was detected).
             const auto it = flow_map.find(i.flow.id);
-            if (it != flow_map.end() &&
+            if (it != flow_map.end() && it->second &&
                 i.flow.type == libkineto::kLinkAsyncCpuGpu && !i.flow.start) {
               e->parent_ = it->second;
             }
@@ -1209,6 +1220,15 @@ class TransferEvents {
             }
           },
           [](const auto&) {}));
+    }
+
+    if (dropped_flow_count > 0) {
+      TORCH_WARN(
+          "Profiler observed ",
+          dropped_flow_count,
+          " duplicate flow start ID(s); affected events were linked via "
+          "runtime correlation instead. This indicates a flow ID collision "
+          "in the active backend's profiler.");
     }
 
     // Set TIDs now that we have established lineage.


### PR DESCRIPTION
Summary:
**Problem**
The PyTorch profiler crashes when an active backend produces duplicate async-flow correlation IDs. `TransferEvents::setParents()` asserts on collisions outside ROCm builds, so workloads abort instead of completing.

**Why**
The assert was originally added in PR #102424 to defend against a libkineto segfault class that is independent of `flow_map`. `flow_map` only affects parent-tree linkage in the PyTorch event tree; a duplicate ID can produce wrong CPU-op attribution for a GPU kernel in `key_averages()` / tree views but never a memory-safety issue. Crashing is disproportionate.

**Fix**
On collision, poison the `flow_map` slot (set to null) so the second-pass lookup produces no override. The colliding flow end then retains its kineto runtime-correlation parent set earlier in the first pass — approximate but never wrong. The change also removes the `#ifdef USE_ROCM` gate so all backends benefit. Count dropped links and emit a single summary `TORCH_WARN` so the symptom is discoverable beyond the rate-limited `TORCH_WARN_ONCE`.

**Test**
A new `test_profiler_collection.cpp` covers the duplicate-flow path. It uses
the PrivateUse1 machinery to mock the profiler. We can put new unit tests for
`collection.cpp` in this file.

Reviewed By: aaronenyeshi, NicolasHug

Differential Revision: D105979688


