### PR TITLE
Avoid repr in Dynamo ID_MATCH guard text

### DIFF
--- a/test/dynamo/test_check_type_id.py
+++ b/test/dynamo/test_check_type_id.py
@@ -81,6 +81,54 @@ class TestCheckTypeId(torch._dynamo.test_case.TestCase):
         )
         self.assertIn(expected_second_part, second_part)
 
+    def test_id_match_guard_text_does_not_call_repr(self):
+        class ReprMeta(type):
+            repr_calls = 0
+
+            def __repr__(cls):
+                ReprMeta.repr_calls += 1
+                return "<expensive class repr>"
+
+        class Config(metaclass=ReprMeta):
+            multiplier = 2
+
+        class ReprCounter:
+            repr_calls = 0
+
+            def __repr__(self):
+                ReprCounter.repr_calls += 1
+                return "<expensive instance repr>"
+
+        obj = ReprCounter()
+
+        def fn(x, o):
+            if id(o) == id(obj):
+                return x + Config.multiplier
+            return x + 3
+
+        torch._dynamo.reset()
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+
+        x = torch.ones(1)
+        self.assertTrue(torch.allclose(opt_fn(x, obj), x + 2))
+        self.assertEqual(ReprCounter.repr_calls, 0)
+        self.assertEqual(ReprMeta.repr_calls, 0)
+
+        cache_entries = _debug_get_cache_entry_list(fn.__code__)
+        self.assertEqual(len(cache_entries), 1)
+
+        guard_str = str(cache_entries[0].guard_manager)
+        self.assertNotIn("<expensive", guard_str)
+
+        matches = self._find_guard_lines(guard_str, "ID_MATCH")
+        object_guard = next(line for line in matches if "L['o']" in line)
+        class_guard = next(line for line in matches if "Config" in line)
+
+        self.assertIn("type=<class '", object_guard)
+        self.assertIn("ReprCounter'>", object_guard)
+        self.assertIn("type=<class '", class_guard)
+        self.assertIn("Config'>", class_guard)
+
     def test_type_match_with_custom_classes(self):
         """
         Test TYPE_MATCH guard with custom class instances.

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -798,6 +798,10 @@ def _ast_unparse(node: ast.AST) -> str:
 strip_function_call = torch._C._dynamo.strip_function_call
 
 
+def _safe_type_repr(t: type[Any]) -> str:
+    return type.__repr__(t)
+
+
 def get_verbose_code_part(code_part: str, guard: Guard | None) -> str:
     extra = ""
     if guard is not None:
@@ -2208,7 +2212,7 @@ class GuardBuilder(GuardBuilderBase):
             guard._unserializable = True
 
         obj_id = self.id_ref(t, f"type({guard.name})")
-        type_repr = repr(t)
+        type_repr = _safe_type_repr(t)
         code = f"___check_type_id({self.arg_ref(guard)}, {obj_id}), type={type_repr}"
         self._set_guard_export_info(guard, [code])
 
@@ -2244,7 +2248,7 @@ class GuardBuilder(GuardBuilderBase):
             guard._unserializable = True
 
         obj_id = self.id_ref(t, f"type({guard.name})")
-        type_repr = repr(t)
+        type_repr = _safe_type_repr(t)
         code = f"___check_fake_script_type({self.arg_ref(guard)}, {obj_id}), type={type_repr}"
         self._set_guard_export_info(guard, [code])
 
@@ -2423,12 +2427,7 @@ class GuardBuilder(GuardBuilderBase):
         ref = self.arg_ref(guard)
         val = self.get(guard)
         id_val = self.id_ref(val, guard.name)
-        try:
-            type_repr = repr(val)
-        except Exception:
-            # During deepcopy reconstruction or other state transitions,
-            # objects may be in an incomplete state where repr() fails
-            type_repr = f"<{type(val).__name__}>"
+        type_repr = _safe_type_repr(val if inspect.isclass(val) else type(val))
         code = f"___check_obj_id({ref}, {id_val}), type={type_repr}"
         self._set_guard_export_info(guard, [code], provided_func_name="ID_MATCH")
         self.get_guard_manager(guard).add_id_match_guard(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184796

ID_MATCH guards used repr(val) while building diagnostic guard text. That repr result is not part of guard correctness, but it can execute arbitrary or expensive __repr__ implementations, including tensor repr paths that materialize profiler-visible work.

Use type.__repr__ on the guarded value's class, or directly on a class object, so the diagnostic string still carries a useful type name without dispatching to instance repr or metaclass repr. TYPE_MATCH and FAKE_SCRIPT_TYPE_MATCH now share the same helper for consistent type text.

An alternative would be to catch more repr failures or special-case tensors, but that would still execute user repr code for many values. Avoiding value repr entirely fixes the root cause for all ID_MATCH diagnostics.

Fixes #176129

Generated by my agent

Test Plan:

python test/dynamo/test_check_type_id.py TestCheckTypeId.test_id_match_guard_text_does_not_call_repr

python test/dynamo/test_check_type_id.py

python test/dynamo/test_id.py

lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos