### PR TITLE
Respect flex attention backward block overrides

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2633,6 +2633,59 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             self.assertEqual(flex_output.dtype, torch.float16)
 
     @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @skip_on_rocm
+    @skipCUDAIf(not PLATFORM_SUPPORTS_BF16, "bf16 requires SM >= 80")
+    def test_backward_autocast_bfloat16_respects_kernel_options(self, device):
+        B, H, N, C = 1, 2, 64, 16
+        block_size = 32
+
+        def mask_mod(b, h, q, kv):
+            return q > kv
+
+        block_mask = create_block_mask(
+            mask_mod,
+            B=None,
+            H=None,
+            Q_LEN=N,
+            KV_LEN=N,
+            device=device,
+            BLOCK_SIZE=block_size,
+        )
+        kernel_options = {
+            "BLOCK_M": block_size,
+            "BLOCK_M1": block_size,
+            "BLOCK_M2": block_size,
+            "BLOCK_N": block_size,
+            "BLOCK_N1": block_size,
+            "BLOCK_N2": block_size,
+        }
+        linear = nn.Linear(C, 3 * C, device=device)
+        x = torch.randn(B, H, N, C, device=device, dtype=torch.float32)
+        x.requires_grad_()
+
+        @torch.compile
+        def forward(x, block_mask):
+            with torch.autocast(device_type=device, dtype=torch.bfloat16):
+                q, k, v = torch.chunk(linear(x), chunks=3, dim=-1)
+                q = torch.exp(q)
+                k = torch.exp(k)
+                return flex_attention(
+                    q,
+                    k,
+                    v,
+                    block_mask=block_mask,
+                    kernel_options=kernel_options,
+                ).mean()
+
+        loss = forward(x, block_mask)
+        self.assertEqual(loss.dtype, torch.bfloat16)
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertTrue(torch.isfinite(x.grad).all())
+
+    @supported_platform
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -920,14 +920,6 @@ def flex_attention_backward(*args, **kwargs):
     original_kernel_options = kernel_options.copy()
 
     for conf in configs:
-        if (
-            SPARSE_KV_BLOCK_SIZE % conf.block_n1 != 0
-            or SPARSE_Q_BLOCK_SIZE % conf.block_m1 != 0
-            or SPARSE_KV_BLOCK_SIZE % conf.block_n2 != 0
-            or SPARSE_Q_BLOCK_SIZE % conf.block_m2 != 0
-        ):
-            continue
-
         # Performance tuning
         # Triton heuristics
         cur_kernel_options = original_kernel_options.copy()
@@ -961,6 +953,14 @@ def flex_attention_backward(*args, **kwargs):
         # Blocksparse options
         cur_kernel_options.setdefault("SPARSE_Q_BLOCK_SIZE", SPARSE_Q_BLOCK_SIZE)
         cur_kernel_options.setdefault("SPARSE_KV_BLOCK_SIZE", SPARSE_KV_BLOCK_SIZE)
+
+        if (
+            SPARSE_KV_BLOCK_SIZE % cur_kernel_options["BLOCK_N1"] != 0
+            or SPARSE_Q_BLOCK_SIZE % cur_kernel_options["BLOCK_M1"] != 0
+            or SPARSE_KV_BLOCK_SIZE % cur_kernel_options["BLOCK_N2"] != 0
+            or SPARSE_Q_BLOCK_SIZE % cur_kernel_options["BLOCK_M2"] != 0
+        ):
+            continue
 
         # ROCm specific kernargs
         for attrib in ["kpack", "matrix_instr_nonkdim", "waves_per_eu"]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184797

flex_attention_backward builds candidate Triton choices from heuristic configs,
then applies user kernel_options such as BLOCK_M1/BLOCK_N1 and bwd_-prefixed
overrides. The sparse-block divisibility filter was running before those effective
options were applied, so a valid user override could still be rejected based on
the heuristic config. In CUDA autocast bf16 cases with small sparse block sizes,
that left the choice list empty and autotune_select_algorithm raised
NoValidChoicesError during backward compilation.

Move the divisibility filter after per-choice kernel options are normalized and
defaulted, so the filter checks the block sizes that will actually be passed to
the backward template. This preserves the existing skip for invalid effective
configs while allowing explicit valid backward tile overrides to participate.

Add a CUDA bf16 regression test matching the autocast pattern from the issue.
The test uses small dimensions to keep runtime focused while still exercising
the empty-choice failure mode.

Fixes #176025
Generated by my agent

Test Plan:
- python inline issue reproducer for BLOCK_SIZE=32, C=16, B=1, H=8, N=234: forward and backward pass after fix
- python inline issue matrix for BLOCK_SIZE in (32, 64, 128), C in (16, 32, 64, 128), B=1, H=8, N=234: all 12 combinations pass
- python test/inductor/test_flex_attention.py -k backward_autocast_bfloat16_respects_kernel_options: OK, 2 tests run, 1 skipped
- lintrunner -a: OK, no lint issues
- git diff --check: no output

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos