### PR TITLE
Fix test_cpp_warnings_have_python_context

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -830,6 +830,7 @@ class TestTorchDeviceType(TestCase):
         s = ".+Triggered internally at.+RangeFactories.+"
         # nvfuser deprecation warning filter
         warnings.filterwarnings("ignore", "torch::jit::fuser::cuda", UserWarning)
+        warnings.filterwarnings("ignore", "`torch.jit.script`", DeprecationWarning)
 
         def cpp_warn_fn():
             out = torch.empty((5,))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -828,9 +828,6 @@ class TestTorchDeviceType(TestCase):
     def test_cpp_warnings_have_python_context(self, device):
         # Creates long string in advance to avoid a too-long Python line
         s = ".+Triggered internally at.+RangeFactories.+"
-        # nvfuser deprecation warning filter
-        warnings.filterwarnings("ignore", "torch::jit::fuser::cuda", UserWarning)
-        warnings.filterwarnings("ignore", "`torch.jit.script`", DeprecationWarning)
 
         def cpp_warn_fn():
             out = torch.empty((5,))
@@ -839,6 +836,8 @@ class TestTorchDeviceType(TestCase):
 
         # Checks eager-mode cpp warning
         with warnings.catch_warnings(record=True) as w:
+            # nvfuser deprecation warning filter
+            warnings.filterwarnings("ignore", "torch::jit::fuser::cuda", UserWarning)
             cpp_warn_fn()
             frameinfo = inspect.getframeinfo(inspect.currentframe())
             warning = w[0]
@@ -850,11 +849,15 @@ class TestTorchDeviceType(TestCase):
             # Checks the Python features of the warning
             # Note: the eager mode warning refers to the line in the function
             # that throws the warning.
-            self.assertEqual(frameinfo.lineno - 6, warning.lineno)
+            self.assertEqual(frameinfo.lineno - 8, warning.lineno)
             self.assertEqual(len(w), 1)
 
         # Checks jitted cpp warning
         with warnings.catch_warnings(record=True) as w:
+            # nvfuser deprecation warning filter
+            warnings.filterwarnings("ignore", "torch::jit::fuser::cuda", UserWarning)
+            # ignore all deprecation warnings
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
             scripted_cpp_warn_fn = torch.jit.script(cpp_warn_fn)
             scripted_cpp_warn_fn()
             warning = w[0]
@@ -875,6 +878,10 @@ class TestTorchDeviceType(TestCase):
 
         # The jit mimics an eager-mode Python warning in this case
         with warnings.catch_warnings(record=True) as w:
+            # nvfuser deprecation warning filter
+            warnings.filterwarnings("ignore", "torch::jit::fuser::cuda", UserWarning)
+            # ignore all deprecation warnings
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
             scripted_warn_fn = torch.jit.script(warn_fn)
             scripted_warn_fn()
             frameinfo = inspect.getframeinfo(inspect.currentframe())
@@ -883,7 +890,7 @@ class TestTorchDeviceType(TestCase):
             self.assertTrue(re.search('Warning!', str(warning.message)) is not None)
 
             # Checks the Python features of the warning
-            self.assertEqual(frameinfo.lineno - 6, warning.lineno)
+            self.assertEqual(frameinfo.lineno - 10, warning.lineno)
             self.assertEqual(len(w), 1)
 
     # FIXME: move to test_testing


### PR DESCRIPTION
This PR fixes:
- test_torch.py::TestTorchDeviceTypeCUDA::test_cpp_warnings_have_python_context_cuda
- test_torch.py::TestTorchDeviceTypeCPU::test_cpp_warnings_have_python_context_cpu

The test expects only one UserWarning about tensor shape but also captures another DeprecationWarning about using `torch.jit.script` in depth of Pytorch.
The fix configures a filter to ignore `DeprecationWarning` (which the `torch.jit.script` warning falls under) in the affected blocks.

All `filterwarnings` were moved inside the `catch_warnings` blocks to avoid global filter leak

Fixes https://github.com/pytorch/pytorch/issues/38135
