### PR TITLE
Skip test_emulate_precision_casts_sets_libdevice_path in fbcode (#184799)

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import unittest
 from threading import Event
 
 import torch._inductor.config as config
@@ -15,7 +16,7 @@ from torch._inductor.compile_worker.subproc_pool import (
 )
 from torch._inductor.compile_worker.timer import Timer
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import skipIfWindows
+from torch.testing._internal.common_utils import IS_FBCODE, skipIfWindows
 from torch.testing._internal.inductor_utils import HAS_CPU
 
 
@@ -214,6 +215,11 @@ class TestTimer(TestCase):
 
 
 class TestSetTritonLibdevicePath(TestCase):
+    @unittest.skipIf(
+        IS_FBCODE,
+        "knobs.nvidia.libdevice_path mismatch in fbcode CI environment; "
+        "matches sibling test_libdevice_path_* disables",
+    )
     @config.patch({"compile_threads": 1, "emulate_precision_casts": True})
     def test_emulate_precision_casts_sets_libdevice_path(self):
         """Test eager numerics mode sets libdevice path for CUDA libdevice calls."""


### PR DESCRIPTION
Summary:

The new test `test_emulate_precision_casts_sets_libdevice_path` added in D105887699 (PR #184022) fails in fbcode CI with a `knobs.nvidia.libdevice_path` mismatch. The two sibling tests in `TestSetTritonLibdevicePath` that share the identical `_test_libdevice_path_with_compilation()` body (`test_libdevice_path_no_subprocess` and `test_libdevice_path_default_threads`) are already auto-disabled in the same TestX runs for the same reason, but the new test was added without a matching disable entry, so it failed 11/13 runs on D105887699.

Add an `IS_FBCODE` skip to mirror the disabled state of the sibling tests until the underlying environment mismatch is resolved. The test continues to run normally in OSS GitHub CI.

Test Plan: CI

Reviewed By: izaitsevfb

Differential Revision: D105996604


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo