### PR TITLE
Annotate Dynamo variable tx arguments

### DIFF
--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -646,39 +646,6 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def unpack_var_sequence(self, tx: Any) -> list[VariableTracker]:
         raise NotImplementedError
 
-    def force_unpack_var_sequence(self, tx: Any) -> list[VariableTracker]:
-        # like unpack_var_sequence, but should only be used when it is
-        # safe to eagerly (vs. lazily) unpack this variable.
-        # e.g. map(f, x) is normally evaluated lazily but sometimes
-        # we want to force eager unpacking, e.g. when converting to a list.
-        # NOTE: this method is allowed to mutate the VariableTracker, so
-        # it should only be called once.
-        return self.unpack_var_sequence(tx)
-
-    def has_unpack_var_sequence(self, tx: Any) -> bool:
-        try:
-            self.unpack_var_sequence(tx)
-            return True
-        except NotImplementedError:
-            return False
-
-    # NB: don't call force_unpack_var_sequence, especially if it mutates!
-    def has_force_unpack_var_sequence(self, tx: Any) -> bool:
-        return self.has_unpack_var_sequence(tx)
-
-    # Forces unpacking the var sequence while also applying a function to each element.
-    # Only use when it is safe to eagerly unpack this variable (like force_unpack_var_sequence).
-    # INVARIANT: variable must satisfy has_force_unpack_var_sequence() == True!
-    def force_apply_to_var_sequence(
-        self, tx: Any, fn: Callable[[VariableTracker], Any]
-    ) -> None:
-        if not self.has_force_unpack_var_sequence(tx):
-            raise AssertionError(
-                "force_apply_to_var_sequence requires has_force_unpack_var_sequence(tx) == True"
-            )
-        for v in self.unpack_var_sequence(tx):
-            fn(v)
-
     def call_obj_hasattr(
         self, tx: InstructionTranslatorBase, name: str
     ) -> ConstantVariable:

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -643,12 +643,10 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def reconstruct_pycode(self, codegen: PyCodegen) -> str:
         raise NotImplementedError(f"reconstruct_pycode not implemented for {self}")
 
-    def unpack_var_sequence(self, tx: InstructionTranslator) -> list[VariableTracker]:
+    def unpack_var_sequence(self, tx: Any) -> list[VariableTracker]:
         raise NotImplementedError
 
-    def force_unpack_var_sequence(
-        self, tx: InstructionTranslatorBase
-    ) -> list[VariableTracker]:
+    def force_unpack_var_sequence(self, tx: Any) -> list[VariableTracker]:
         # like unpack_var_sequence, but should only be used when it is
         # safe to eagerly (vs. lazily) unpack this variable.
         # e.g. map(f, x) is normally evaluated lazily but sometimes
@@ -657,7 +655,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         # it should only be called once.
         return self.unpack_var_sequence(tx)
 
-    def has_unpack_var_sequence(self, tx: InstructionTranslatorBase) -> bool:
+    def has_unpack_var_sequence(self, tx: Any) -> bool:
         try:
             self.unpack_var_sequence(tx)
             return True
@@ -665,14 +663,14 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             return False
 
     # NB: don't call force_unpack_var_sequence, especially if it mutates!
-    def has_force_unpack_var_sequence(self, tx: InstructionTranslatorBase) -> bool:
+    def has_force_unpack_var_sequence(self, tx: Any) -> bool:
         return self.has_unpack_var_sequence(tx)
 
     # Forces unpacking the var sequence while also applying a function to each element.
     # Only use when it is safe to eagerly unpack this variable (like force_unpack_var_sequence).
     # INVARIANT: variable must satisfy has_force_unpack_var_sequence() == True!
     def force_apply_to_var_sequence(
-        self, tx: InstructionTranslatorBase, fn: Callable[[VariableTracker], Any]
+        self, tx: Any, fn: Callable[[VariableTracker], Any]
     ) -> None:
         if not self.has_force_unpack_var_sequence(tx):
             raise AssertionError(
@@ -711,7 +709,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_function(
         self,
-        tx: InstructionTranslatorBase,
+        tx: Any,
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
@@ -737,7 +735,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             ],
         )
 
-    def sq_length(self, tx: InstructionTranslator) -> VariableTracker:
+    def sq_length(self, tx: Any) -> VariableTracker:
         """Called when sq_length is not implemented."""
         raise_observed_exception(
             TypeError,
@@ -745,7 +743,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             args=[f"object of type '{self.python_type_name()}' has no len()"],
         )
 
-    def mp_length(self, tx: InstructionTranslator) -> VariableTracker:
+    def mp_length(self, tx: Any) -> VariableTracker:
         """Called when mp_length is not implemented."""
         raise_observed_exception(
             TypeError,
@@ -784,9 +782,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             hints=[],
         )
 
-    def sq_contains(
-        self, tx: InstructionTranslator, item: VariableTracker
-    ) -> VariableTracker:
+    def sq_contains(self, tx: Any, item: VariableTracker) -> VariableTracker:
         """Called when sq_contains is not implemented."""
         unimplemented(
             gb_type="missing sq_contains",
@@ -849,7 +845,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_method(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         name: str,
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
@@ -1110,7 +1106,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_tree_map(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1143,7 +1139,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_tree_map_branch(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1160,7 +1156,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def _tree_map_fallback(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1182,7 +1178,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_tree_map_with_path(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1221,7 +1217,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_tree_map_with_path_branch(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1236,7 +1232,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def _tree_map_with_path_fallback(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1276,7 +1272,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         """Used by LazyVariableTracker to indicate an unrealized node"""
         return True
 
-    def tp_iternext_impl(self, tx: InstructionTranslator) -> VariableTracker:
+    def tp_iternext_impl(self, tx: Any) -> VariableTracker:
         """
         Implements tp_iternext slot semantics.
         Subclasses override this to support next(). Reaching this base is a
@@ -1292,10 +1288,10 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             hints=[*graph_break_hints.SUPPORTABLE],
         )
 
-    def next_variable(self, tx: InstructionTranslator) -> VariableTracker:
+    def next_variable(self, tx: Any) -> VariableTracker:
         return self.tp_iternext_impl(tx)
 
-    def is_strict_mode(self, tx: InstructionTranslator) -> bool:
+    def is_strict_mode(self, tx: Any) -> bool:
         return bool(tx.strict_checks_fn and tx.strict_checks_fn(self))
 
     def is_mutable(self) -> bool:
@@ -1308,7 +1304,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     @staticmethod
     def build(
-        tx: InstructionTranslator,
+        tx: Any,
         value: Any,
         source: Source | None = None,
         realize: bool = False,
@@ -1358,7 +1354,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_index_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
     ) -> VariableTracker:
         """Mirrors CPython's PyNumber_Index / nb_index slot.
 
@@ -1412,7 +1408,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_int_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
     ) -> VariableTracker:
         """Mirrors CPython's tp_as_number->nb_int slot.
 
@@ -1429,7 +1425,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_float_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
     ) -> VariableTracker:
         """Mirrors CPython's tp_as_number->nb_float slot.
 
@@ -1459,7 +1455,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_lshift_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -1472,7 +1468,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_inplace_lshift_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         other: VariableTracker,
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_lshift slot. Default: returns NotImplemented."""
@@ -1480,7 +1476,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_rshift_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -1493,7 +1489,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_inplace_rshift_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         other: VariableTracker,
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_rshift slot. Default: returns NotImplemented."""
@@ -1704,7 +1700,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_or_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -1717,7 +1713,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_inplace_or_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         other: VariableTracker,
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_or slot. Default: returns NotImplemented."""
@@ -1725,7 +1721,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_negative_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
     ) -> VariableTracker:
         """Mirrors CPython's tp_as_number->nb_negative slot.
 
@@ -1742,7 +1738,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_positive_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
     ) -> VariableTracker:
         """Mirrors CPython's tp_as_number->nb_positive slot.
 
@@ -1759,7 +1755,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_add_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -1773,7 +1769,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_inplace_add_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         other: VariableTracker,
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_add slot. Default: graph break."""
@@ -1782,7 +1778,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_subtract_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -1795,7 +1791,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_inplace_subtract_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
         other: VariableTracker,
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_subtract slot. Default: graph break."""
@@ -1803,7 +1799,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_absolute_impl(
         self,
-        tx: InstructionTranslator,
+        tx: Any,
     ) -> VariableTracker:
         """Mirrors CPython's tp_as_number->nb_absolute slot.
 

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -643,8 +643,43 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     def reconstruct_pycode(self, codegen: PyCodegen) -> str:
         raise NotImplementedError(f"reconstruct_pycode not implemented for {self}")
 
-    def unpack_var_sequence(self, tx: Any) -> list[VariableTracker]:
+    def unpack_var_sequence(self, tx: InstructionTranslator) -> list[VariableTracker]:
         raise NotImplementedError
+
+    def force_unpack_var_sequence(
+        self, tx: InstructionTranslatorBase
+    ) -> list[VariableTracker]:
+        # like unpack_var_sequence, but should only be used when it is
+        # safe to eagerly (vs. lazily) unpack this variable.
+        # e.g. map(f, x) is normally evaluated lazily but sometimes
+        # we want to force eager unpacking, e.g. when converting to a list.
+        # NOTE: this method is allowed to mutate the VariableTracker, so
+        # it should only be called once.
+        return self.unpack_var_sequence(tx)
+
+    def has_unpack_var_sequence(self, tx: InstructionTranslatorBase) -> bool:
+        try:
+            self.unpack_var_sequence(tx)
+            return True
+        except NotImplementedError:
+            return False
+
+    # NB: don't call force_unpack_var_sequence, especially if it mutates!
+    def has_force_unpack_var_sequence(self, tx: InstructionTranslatorBase) -> bool:
+        return self.has_unpack_var_sequence(tx)
+
+    # Forces unpacking the var sequence while also applying a function to each element.
+    # Only use when it is safe to eagerly unpack this variable (like force_unpack_var_sequence).
+    # INVARIANT: variable must satisfy has_force_unpack_var_sequence() == True!
+    def force_apply_to_var_sequence(
+        self, tx: InstructionTranslatorBase, fn: Callable[[VariableTracker], Any]
+    ) -> None:
+        if not self.has_force_unpack_var_sequence(tx):
+            raise AssertionError(
+                "force_apply_to_var_sequence requires has_force_unpack_var_sequence(tx) == True"
+            )
+        for v in self.unpack_var_sequence(tx):
+            fn(v)
 
     def call_obj_hasattr(
         self, tx: InstructionTranslatorBase, name: str
@@ -676,7 +711,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_function(
         self,
-        tx: Any,
+        tx: InstructionTranslatorBase,
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
@@ -702,7 +737,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             ],
         )
 
-    def sq_length(self, tx: Any) -> VariableTracker:
+    def sq_length(self, tx: InstructionTranslator) -> VariableTracker:
         """Called when sq_length is not implemented."""
         raise_observed_exception(
             TypeError,
@@ -710,7 +745,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             args=[f"object of type '{self.python_type_name()}' has no len()"],
         )
 
-    def mp_length(self, tx: Any) -> VariableTracker:
+    def mp_length(self, tx: InstructionTranslator) -> VariableTracker:
         """Called when mp_length is not implemented."""
         raise_observed_exception(
             TypeError,
@@ -749,7 +784,9 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             hints=[],
         )
 
-    def sq_contains(self, tx: Any, item: VariableTracker) -> VariableTracker:
+    def sq_contains(
+        self, tx: InstructionTranslator, item: VariableTracker
+    ) -> VariableTracker:
         """Called when sq_contains is not implemented."""
         unimplemented(
             gb_type="missing sq_contains",
@@ -812,7 +849,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_method(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         name: str,
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
@@ -1073,7 +1110,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_tree_map(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1106,7 +1143,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_tree_map_branch(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1123,7 +1160,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def _tree_map_fallback(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1145,7 +1182,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_tree_map_with_path(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1184,7 +1221,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def call_tree_map_with_path_branch(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1199,7 +1236,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def _tree_map_with_path_fallback(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         tree_map_fn: UserFunctionVariable,
         map_fn: VariableTracker,
         rest: list[VariableTracker],
@@ -1239,7 +1276,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         """Used by LazyVariableTracker to indicate an unrealized node"""
         return True
 
-    def tp_iternext_impl(self, tx: Any) -> VariableTracker:
+    def tp_iternext_impl(self, tx: InstructionTranslator) -> VariableTracker:
         """
         Implements tp_iternext slot semantics.
         Subclasses override this to support next(). Reaching this base is a
@@ -1255,10 +1292,10 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             hints=[*graph_break_hints.SUPPORTABLE],
         )
 
-    def next_variable(self, tx: Any) -> VariableTracker:
+    def next_variable(self, tx: InstructionTranslator) -> VariableTracker:
         return self.tp_iternext_impl(tx)
 
-    def is_strict_mode(self, tx: Any) -> bool:
+    def is_strict_mode(self, tx: InstructionTranslator) -> bool:
         return bool(tx.strict_checks_fn and tx.strict_checks_fn(self))
 
     def is_mutable(self) -> bool:
@@ -1271,7 +1308,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     @staticmethod
     def build(
-        tx: Any,
+        tx: InstructionTranslator,
         value: Any,
         source: Source | None = None,
         realize: bool = False,
@@ -1321,7 +1358,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_index_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         """Mirrors CPython's PyNumber_Index / nb_index slot.
 
@@ -1375,7 +1412,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_int_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         """Mirrors CPython's tp_as_number->nb_int slot.
 
@@ -1392,7 +1429,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_float_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         """Mirrors CPython's tp_as_number->nb_float slot.
 
@@ -1422,7 +1459,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_lshift_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -1435,7 +1472,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_inplace_lshift_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_lshift slot. Default: returns NotImplemented."""
@@ -1443,7 +1480,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_rshift_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -1456,7 +1493,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_inplace_rshift_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_rshift slot. Default: returns NotImplemented."""
@@ -1667,7 +1704,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_or_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -1680,7 +1717,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_inplace_or_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_or slot. Default: returns NotImplemented."""
@@ -1688,7 +1725,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_negative_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         """Mirrors CPython's tp_as_number->nb_negative slot.
 
@@ -1705,7 +1742,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_positive_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         """Mirrors CPython's tp_as_number->nb_positive slot.
 
@@ -1722,7 +1759,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_add_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -1736,7 +1773,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_inplace_add_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_add slot. Default: graph break."""
@@ -1745,7 +1782,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_subtract_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -1758,7 +1795,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_inplace_subtract_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
     ) -> VariableTracker:
         """tp_as_number->nb_inplace_subtract slot. Default: graph break."""
@@ -1766,7 +1803,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def nb_absolute_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         """Mirrors CPython's tp_as_number->nb_absolute slot.
 

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -473,7 +473,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_index_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         # CPython: int and bool define nb_index (returns self for int,
         # int(self) for bool). All other constant types do not.
@@ -485,7 +485,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_int_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         # CPython: int defines nb_int (long_long, returns copy).
         # bool inherits nb_int from int via slot inheritance.
@@ -494,7 +494,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_float_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         # CPython: float defines nb_float (float_float, returns copy).
         # int defines nb_float (long_float, converts to float).
@@ -529,7 +529,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_lshift_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -543,7 +543,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_rshift_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -642,7 +642,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_or_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -659,7 +659,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_subtract_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -753,7 +753,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_negative_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         # int: https://github.com/python/cpython/blob/v3.13.0/Objects/longobject.c#L5179-L5189
         # float: https://github.com/python/cpython/blob/v3.13.0/Objects/floatobject.c#L839-L849
@@ -763,7 +763,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_positive_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         # int: https://github.com/python/cpython/blob/v3.13.0/Objects/longobject.c#L5619 (long_long)
         # float: https://github.com/python/cpython/blob/v3.13.0/Objects/floatobject.c#L1114 (float_float)
@@ -773,7 +773,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_add_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -838,7 +838,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_absolute_impl(
         self,
-        tx: Any,
+        tx: InstructionTranslator,
     ) -> VariableTracker:
         # int: https://github.com/python/cpython/blob/v3.13.0/Objects/longobject.c#L5184-L5190
         # float: https://github.com/python/cpython/blob/v3.13.0/Objects/floatobject.c#L847-L850
@@ -906,7 +906,7 @@ class FakeIdVariable(VariableTracker):
     def python_type(self) -> type:
         return int
 
-    def hash_impl(self, tx: Any) -> tuple[int, bool]:
+    def hash_impl(self, tx: InstructionTranslator) -> tuple[int, bool]:
         return hash(self.value), True
 
     def richcompare_impl(

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -473,7 +473,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_index_impl(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
     ) -> VariableTracker:
         # CPython: int and bool define nb_index (returns self for int,
         # int(self) for bool). All other constant types do not.
@@ -485,7 +485,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_int_impl(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
     ) -> VariableTracker:
         # CPython: int defines nb_int (long_long, returns copy).
         # bool inherits nb_int from int via slot inheritance.
@@ -494,7 +494,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_float_impl(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
     ) -> VariableTracker:
         # CPython: float defines nb_float (float_float, returns copy).
         # int defines nb_float (long_float, converts to float).
@@ -529,7 +529,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_lshift_impl(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -543,7 +543,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_rshift_impl(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -642,7 +642,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_or_impl(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -659,7 +659,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_subtract_impl(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -753,7 +753,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_negative_impl(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
     ) -> VariableTracker:
         # int: https://github.com/python/cpython/blob/v3.13.0/Objects/longobject.c#L5179-L5189
         # float: https://github.com/python/cpython/blob/v3.13.0/Objects/floatobject.c#L839-L849
@@ -763,7 +763,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_positive_impl(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
     ) -> VariableTracker:
         # int: https://github.com/python/cpython/blob/v3.13.0/Objects/longobject.c#L5619 (long_long)
         # float: https://github.com/python/cpython/blob/v3.13.0/Objects/floatobject.c#L1114 (float_float)
@@ -773,7 +773,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_add_impl(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -838,7 +838,7 @@ class ConstantVariable(VariableTracker):
 
     def nb_absolute_impl(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
     ) -> VariableTracker:
         # int: https://github.com/python/cpython/blob/v3.13.0/Objects/longobject.c#L5184-L5190
         # float: https://github.com/python/cpython/blob/v3.13.0/Objects/floatobject.c#L847-L850
@@ -906,7 +906,7 @@ class FakeIdVariable(VariableTracker):
     def python_type(self) -> type:
         return int
 
-    def hash_impl(self, tx: InstructionTranslator) -> tuple[int, bool]:
+    def hash_impl(self, tx: InstructionTranslatorBase) -> tuple[int, bool]:
         return hash(self.value), True
 
     def richcompare_impl(

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -770,7 +770,7 @@ class ConstDictVariable(VariableTracker):
 
     def nb_or_impl(
         self,
-        tx: "InstructionTranslator",
+        tx: "InstructionTranslatorBase",
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -784,7 +784,7 @@ class ConstDictVariable(VariableTracker):
 
     def nb_inplace_or_impl(
         self,
-        tx: "InstructionTranslator",
+        tx: "InstructionTranslatorBase",
         other: VariableTracker,
     ) -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/3.13/Objects/dictobject.c#L4660-L4667

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -770,7 +770,7 @@ class ConstDictVariable(VariableTracker):
 
     def nb_or_impl(
         self,
-        tx: Any,
+        tx: "InstructionTranslator",
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
@@ -784,7 +784,7 @@ class ConstDictVariable(VariableTracker):
 
     def nb_inplace_or_impl(
         self,
-        tx: Any,
+        tx: "InstructionTranslator",
         other: VariableTracker,
     ) -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/3.13/Objects/dictobject.c#L4660-L4667

--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -70,7 +70,7 @@ class DistributedVariable(VariableTracker):
         # check if the distributed package is available or not
         return torch.distributed.is_available()
 
-    def hash_impl(self, tx: Any) -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
         return hash(self.value), False
 
     def richcompare_impl(self, tx, other, op):

--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -70,7 +70,7 @@ class DistributedVariable(VariableTracker):
         # check if the distributed package is available or not
         return torch.distributed.is_available()
 
-    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         return hash(self.value), False
 
     def richcompare_impl(self, tx, other, op):

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1650,7 +1650,7 @@ class UserMethodVariable(UserFunctionVariable):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.fn}, {self.obj})"
 
-    def hash_impl(self, tx: Any) -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
         # CPython method_hash: hash(self) ^ hash(func)
         # https://github.com/python/cpython/blob/e76aa128fe/Objects/classobject.c#L304
         if self.source:
@@ -4073,7 +4073,7 @@ class MethodWrapperVariable(VariableTracker):
         codegen(self.obj)
         codegen.extend_output(codegen.create_load_attrs(self.descriptor.__name__))
 
-    def hash_impl(self, tx: Any) -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
         try:
             # CPython wrapper_hash:
             # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L1347

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1650,7 +1650,7 @@ class UserMethodVariable(UserFunctionVariable):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.fn}, {self.obj})"
 
-    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         # CPython method_hash: hash(self) ^ hash(func)
         # https://github.com/python/cpython/blob/e76aa128fe/Objects/classobject.c#L304
         if self.source:
@@ -4073,7 +4073,7 @@ class MethodWrapperVariable(VariableTracker):
         codegen(self.obj)
         codegen.extend_output(codegen.create_load_attrs(self.descriptor.__name__))
 
-    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         try:
             # CPython wrapper_hash:
             # https://github.com/python/cpython/blob/3.13/Objects/descrobject.c#L1347

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1482,7 +1482,7 @@ class GetAttrVariable(VariableTracker):
         except AttributeError:
             raise NotImplementedError(f"{self} is not a constant") from None
 
-    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         # GetAttrVariable can wrap various types (bound methods, descriptors,
         # etc.) with different C tp_hash.  Resolve to the actual value and hash.
         try:
@@ -1717,7 +1717,7 @@ class TypingVariable(VariableTracker):
     def as_python_constant(self) -> Any:
         return self.value
 
-    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         return hash(self.value), False
 
     def get_real_python_backed_value(self) -> Any:
@@ -2643,7 +2643,7 @@ class WeakRefVariable(VariableTracker):
         codegen(self.callback_vt)
         codegen.extend_output(create_call_function(2, False))
 
-    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         # CPython weakref_hash: hash(referent)
         # https://github.com/python/cpython/blob/e76aa128fe/Objects/weakrefobject.c#L186
         from .object_protocol import generic_hash_impl

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1482,7 +1482,7 @@ class GetAttrVariable(VariableTracker):
         except AttributeError:
             raise NotImplementedError(f"{self} is not a constant") from None
 
-    def hash_impl(self, tx: Any) -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
         # GetAttrVariable can wrap various types (bound methods, descriptors,
         # etc.) with different C tp_hash.  Resolve to the actual value and hash.
         try:
@@ -1717,7 +1717,7 @@ class TypingVariable(VariableTracker):
     def as_python_constant(self) -> Any:
         return self.value
 
-    def hash_impl(self, tx: Any) -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
         return hash(self.value), False
 
     def get_real_python_backed_value(self) -> Any:
@@ -2643,7 +2643,7 @@ class WeakRefVariable(VariableTracker):
         codegen(self.callback_vt)
         codegen.extend_output(create_call_function(2, False))
 
-    def hash_impl(self, tx: Any) -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
         # CPython weakref_hash: hash(referent)
         # https://github.com/python/cpython/blob/e76aa128fe/Objects/weakrefobject.c#L186
         from .object_protocol import generic_hash_impl

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -107,7 +107,7 @@ class OpaqueObjectClassVariable(UserDefinedVariable):
         # allowing for proper validation and error handling
         return False
 
-    def hash_impl(self, tx: Any) -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
         # OpaqueObjectClassVariable wraps the CLASS, not an instance.
         # Classes are always hashable in CPython (type.__hash__ = object.__hash__).
         return hash(self.value), False
@@ -574,7 +574,7 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
             return self.value
         return super().as_python_constant()
 
-    def hash_impl(self, tx: Any) -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
         from ..exc import raise_type_error
 
         real_obj = self.as_python_constant()

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -107,7 +107,7 @@ class OpaqueObjectClassVariable(UserDefinedVariable):
         # allowing for proper validation and error handling
         return False
 
-    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         # OpaqueObjectClassVariable wraps the CLASS, not an instance.
         # Classes are always hashable in CPython (type.__hash__ = object.__hash__).
         return hash(self.value), False
@@ -574,7 +574,7 @@ class TorchScriptObjectVariable(UserDefinedObjectVariable):
             return self.value
         return super().as_python_constant()
 
-    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         from ..exc import raise_type_error
 
         real_obj = self.as_python_constant()

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -603,7 +603,7 @@ class BaseTorchVariable(VariableTracker):
             return VariableTracker.build(tx, NotImplemented)
         return VariableTracker.build(tx, result)
 
-    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
         return hash(self.value), False
 
     def richcompare_impl(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -603,7 +603,7 @@ class BaseTorchVariable(VariableTracker):
             return VariableTracker.build(tx, NotImplemented)
         return VariableTracker.build(tx, result)
 
-    def hash_impl(self, tx: Any) -> tuple[int, bool]:
+    def hash_impl(self, tx: "InstructionTranslator") -> tuple[int, bool]:
         return hash(self.value), False
 
     def richcompare_impl(


### PR DESCRIPTION
Summary:
- Replace the remaining `tx: Any` annotations in `torch/_dynamo/variables/` with `InstructionTranslator` annotations.
- Keep the change scoped to the affected Dynamo variable tracker method signatures.

Root cause problem:
- A partial migration left several `tx` parameters typed as `Any`, even though these methods receive Dynamo's instruction translator.

Proposed fix:
- Annotate those `tx` parameters as `InstructionTranslator`, following the existing type import pattern in the touched modules.

Why this is the right long term fix:
- `tx` is the shared translator context throughout Dynamo variable tracking, so using the concrete translator type improves static analysis without changing runtime behavior.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98