### PR TITLE
Gate baddbmm expectedFailureDynamic on TEST_Z3

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -102,6 +102,7 @@ from torch.testing._internal.common_utils import (
     subtest,
     TEST_HPU,
     TEST_XPU,
+    TEST_Z3,
     wrapDeterministicFlagAPITest,
 )
 from torch.testing._internal.jit_utils import JitTestCase
@@ -7015,7 +7016,16 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             "addcmul_positional",
             "addcdiv",
             "addcdiv_positional",
-            subtest("baddbmm", decorators=[expectedFailureDynamic]),
+            # baddbmm under dynamic shapes only fails when Z3 translation
+            # validation is enabled (https://github.com/pytorch/pytorch/issues/162287);
+            # the dynamic_shapes test class enables translation_validation only
+            # when Z3 is available, so the test passes when Z3 is missing. Mark
+            # as expected-fail only when Z3 is present to avoid spurious
+            # unexpected-success failures in Z3-less environments.
+            subtest(
+                "baddbmm",
+                decorators=[expectedFailureDynamic] if TEST_Z3 else [],
+            ),
         ],
     )
     def test_scalar_arg_0d_tensor(self, op):


### PR DESCRIPTION
## Summary

The `baddbmm` subtest of `test_scalar_arg_0d_tensor` was added in #182660 marked `expectedFailureDynamic` to track a Z3 translation-validation gap (#162287).

However, the dynamic_shapes test class only enables `translation_validation` when Z3 is importable ([test/dynamo/test_dynamic_shapes.py:57](https://github.com/pytorch/pytorch/blob/main/test/dynamo/test_dynamic_shapes.py#L57)):

```python
(fx_config, "translation_validation", TEST_Z3),
```

So when Z3 is not installed, the dynamic-shapes variant of the `baddbmm` test actually passes, and `unittest.expectedFailure` (applied by the dynamic class generator via `xfail_prop="_expected_failure_dynamic"`) flips that into an "unexpected success" failure -- one that surfaced on a downstream CI environment where Z3 is not present.

This PR makes the `expectedFailureDynamic` marker conditional on `TEST_Z3`, so the test reports correctly in both Z3-enabled and Z3-less environments:

- Z3 available -> marker set -> dynamic variant wrapped with `expectedFailure` -> Z3 raises -> passes as expected fail.
- Z3 unavailable -> marker not set -> dynamic variant runs normally -> passes.

The underlying Z3 issue (#162287) is unchanged.

## Test plan

- `python test/dynamo/test_misc.py MiscTests.test_scalar_arg_0d_tensor_baddbmm` -- static-shapes path unchanged.
- `python test/dynamo/test_dynamic_shapes.py DynamicShapesMiscTests.test_scalar_arg_0d_tensor_baddbmm_dynamic_shapes` -- passes in both Z3-enabled (expected-fail) and Z3-missing (plain pass) environments.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @laithsakka @kshitij12345