### PR TITLE
[ROCm] Remove stale skips in test_native_multihead_self_attention

### DIFF
--- a/test/test_native_mha.py
+++ b/test/test_native_mha.py
@@ -12,7 +12,7 @@ from torch.testing._internal.common_device_type import (
     skipMeta,
     skipXPUIf,
 )
-from torch.testing._internal.common_utils import parametrize, run_tests, TestCase, TEST_WITH_ROCM
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
 from torch.nn.attention import SDPBackend
 
 class TestMHADeviceType(TestCase):
@@ -283,11 +283,6 @@ class TestMHADeviceType(TestCase):
     @torch.no_grad()
     def test_native_multihead_self_attention(self, device, dtype, use_nt,
                                              need_weights, average_attn_weights, use_padding, pad_all, fused):
-        if TEST_WITH_ROCM:
-            if use_nt and use_padding and pad_all:
-                self.skipTest("Large numerical errors on ROCM to investigate.")
-            if use_padding and not pad_all and fused:
-                self.skipTest("Large numerical errors on ROCM to investigate.")
         for need_weights in (False, not pad_all):
             with self.subTest(use_padding=use_padding, pad_all=pad_all,
                               use_nt=use_nt, need_weights=need_weights,


### PR DESCRIPTION
FIXES #168782
FIXES #168783

### Investigation summary

### Testing environment
-- PyTorch version: `2.13.0a0+gitf6f4e17`
-- Hip version: `7.2.53211`
-- GPU 0 name: AMD Instinct MI300X (also verified on a machine with MI210, same behaviour is observed)

### Command to reproduce
`$ PYTORCH_TEST_WITH_ROCM=1 pytest test/test_native_mha.py -k "test_native_multihead_self_attention and not CPU" -v
`
Test results before fix:
```
$ PYTORCH_TEST_WITH_ROCM=1 pytest test/test_native_mha.py -k "test_native_multihead_self_attention and not CPU" -v | tail -2
================ 32 passed, 16 skipped, 34 deselected in 1.47s =================
```

Test results after removing the ROCm-specific skips:
```
$ for seed in 0 1 2 3 4 5 6 7 8 9; do
  PYTORCH_SEED=$seed PYTORCH_TEST_WITH_ROCM=1 pytest test/test_native_mha.py \
    -k "test_native_multihead_self_attention and not CPU" --tb=line -q 2>&1 | tail -2
done
................................................                         [100%]
48 passed, 34 deselected in 1.51s
................................................                         [100%]
48 passed, 34 deselected in 1.51s
................................................                         [100%]
48 passed, 34 deselected in 1.53s
................................................                         [100%]
48 passed, 34 deselected in 1.55s
................................................                         [100%]
48 passed, 34 deselected in 1.51s
................................................                         [100%]
48 passed, 34 deselected in 1.51s
................................................                         [100%]
48 passed, 34 deselected in 1.51s
................................................                         [100%]
48 passed, 34 deselected in 1.51s
................................................                         [100%]
48 passed, 34 deselected in 1.51s
................................................                         [100%]
48 passed, 34 deselected in 1.52s
```

### Conclusion
Git archaeology shows that the two skips in this case were first introduced in PR #135869 for enabling `AOTriton 0.7b`. The first skip was then modified to in PR #140172 for enabling `AOTriton 0.8b` and marked "to investigate". However, as of my testing today (May, 2026) by re-running with the tests with the current PyTorch / ROCm / AOTriton stack, all 48 parameterizations -- including previously skipped cases, now pass on MI300X. The underlying numerical issues in the masked/padded fused MHA path have been resolved by subsequent AOTriton updates.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang