### PR TITLE
[inductor] Add fast_optimization_hint config for faster template config generation (#184805)

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -531,6 +531,8 @@ incremental_autotune: bool | None = get_tristate_env(
     "TORCHINDUCTOR_INCREMENTAL_AUTOTUNE", default=False
 )
 
+fast_optimization_hint = os.environ.get("TORCHINDUCTOR_FAST_OPTIMIZATION_HINT") == "1"
+
 inductor_default_autotune_warmup = int(
     os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_WARMUP", 25)
 )

--- a/torch/fx/experimental/_size_hinting.py
+++ b/torch/fx/experimental/_size_hinting.py
@@ -350,6 +350,46 @@ def _optimization_hint_base(
 
         fallback = unbacked_symint_fallback
 
+    from torch._inductor.config import fast_optimization_hint
+
+    if fast_optimization_hint:
+        result = _maybe_realize_expr(expr, fallback)
+        if result is not None:
+            return result
+
+        if isinstance(expr, sympy.Expr):
+            expr = _sympy_subs(expr, precomputed_replacements)
+            expr = _sympy_subs(expr, shape_env.backed_var_to_val)
+            expr = _sympy_subs(expr, shape_env.var_to_hint_override)
+
+        result = _maybe_realize_expr(expr, fallback)
+        if result is not None:
+            return result
+
+        if not isinstance(expr, sympy.Expr):
+            return fallback if fallback is not None else 0
+
+        size_dict = {}
+        for s in expr.free_symbols:
+            sym_fallback = fallback
+            vr = shape_env.var_to_range.get(s, None)
+            if vr is not None:
+                if isinstance(vr.lower, (int, sympy.Integer)):
+                    sym_fallback = max(sym_fallback, int(vr.lower))
+                if isinstance(vr.upper, (int, sympy.Integer)):
+                    sym_fallback = min(sym_fallback, int(vr.upper))
+            size_dict[s] = sym_fallback
+
+        try:
+            final_result = expr.subs(size_dict)
+        except ZeroDivisionError:
+            return fallback if fallback is not None else 0
+
+        final_result = _maybe_realize_expr(final_result, fallback)
+        if final_result is None:
+            return fallback if fallback is not None else 0
+        return final_result
+
     # to have expanded (Identity free) expr stored in original
     if isinstance(expr, sympy.Expr):
         expr = expr.expand(identity=True)


### PR DESCRIPTION
Summary:

When enabled, optimization_hint skips expensive sympy.factor() and
_sub_unbacked_exprs() for unbacked symbol expressions. Instead uses
simple backed-var substitution with var_to_range-bounded fallback.

This restores the performance characteristics of the old size_hint API
for template config generation during AOTI lowering. Models with many
unbacked symbolic dimensions (e.g. iterative decoding with 30+ steps)
see 40x+ speedup in the FX-to-IR lowering phase.

Default is False (no behavior change for existing models).

Test Plan:
```
cd ~/fbsource/fbcode && fbpkg build ien.lower.mvai --build-remote
```

https://www.internalfb.com/intern/servicelab/build/979791643

- product side model e2e testing in D105249373



- local debug run with more detailed logging: https://www.internalfb.com/mlhub/pipelines/runs/mast/fire-chriszheng-20260514-1328-f3a4f4ed?job_attempt=1&version=0&tab=summary&env=PRODUCTION

Reviewed By: laithsakka

Differential Revision: D105238089


