### PR TITLE
[Triton] Map float8 acc type among torch and triton

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2403,7 +2403,12 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
         Get accumulator type for the given dtype.
         Moved from mm_common.acc_type.
         """
-        if dtype in (torch.float16, torch.bfloat16):
+        if dtype in (
+            torch.float16,
+            torch.bfloat16,
+            torch.float8_e4m3fnuz,
+            torch.float8_e4m3fn,
+        ):
             return "tl.float32"
         return self._dtype_to_triton(dtype)
 


### PR DESCRIPTION
Summary:
export: https://github.com/pytorch/pytorch/pull/184806

Base on the [mapping](https://www.internalfb.com/code/fbsource/[ff67fb62241f]/fbcode/deeplearning/fbgemm/fbgemm_gpu/experimental/gemm/triton_gemm/fp8_gemm.py?lines=77), set correct mapping among fp8 types among torch and triton for triton template ops, to solve latest-surfaced issue blocking max-autotune in MTS:
```
def triton_mm(arg_A, arg_B, in_ptr2, in_ptr3, in_ptr4, out_ptr0, ks0):
    EVEN_K : tl.constexpr = True
    USE_FAST_ACCUM : tl.constexpr = True
    ACC_TYPE : tl.constexpr = tl.float8_e4m3fn
...
AttributeError("module 'triton.language' has no attribute 'float8_e4m3fn'")
```

Test Plan: MTS [benchmark](https://www.internalfb.com/phabricator/paste/view/P2338612433) runs e2e as [logged](https://www.internalfb.com/intern/everpaste/?phabricator_paste_number=2338609059&handle=GB2pwSgaV2DJTykGACUru4e4H6IGbsIXAAAB) ~

Reviewed By: PaulZhang12

Differential Revision: D105454087


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo