### PR TITLE
Fix BlockMask adjust sequence lengths

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -3087,6 +3087,38 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         self.assertEqual(block_mask_a.q_num_blocks, block_mask_b.q_num_blocks)
 
     @supported_platform
+    def test_block_mask_adjust_updates_seq_lengths(self, device):
+        def causal_mask(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        adjusted_q_len = 16
+        adjusted_kv_len = 16
+        block_mask = create_block_mask(
+            causal_mask,
+            B=None,
+            H=None,
+            Q_LEN=32,
+            KV_LEN=32,
+            device=device,
+        )
+        adjusted_block_mask = block_mask._adjust(adjusted_q_len, adjusted_kv_len)
+
+        self.assertEqual(
+            adjusted_block_mask.seq_lengths, (adjusted_q_len, adjusted_kv_len)
+        )
+        self.assertEqual(
+            adjusted_block_mask.shape, (1, 1, adjusted_q_len, adjusted_kv_len)
+        )
+
+        q = torch.randn((1, 1, adjusted_q_len, 32), device=device)
+        k = torch.randn((1, 1, adjusted_kv_len, 32), device=device)
+        v = torch.randn((1, 1, adjusted_kv_len, 32), device=device)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            out = flex_attention(q, k, v, block_mask=adjusted_block_mask)
+        self.assertEqual(out.shape, q.shape)
+
+    @supported_platform
     def test_mask_mod_combiners(self, device):
         def causal_mask(b, h, q, kv):
             return q >= kv

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1186,8 +1186,10 @@ class BlockMask:
             new_kv_indices,
             new_full_kv_num_blocks,
             new_full_kv_indices,
-            self.BLOCK_SIZE,
-            self.mask_mod,
+            BLOCK_SIZE=self.BLOCK_SIZE,
+            mask_mod=self.mask_mod,
+            seq_lengths=(new_q_len, new_kv_len),
+            compute_q_blocks=self.q_indices is not None,
         )
 
     def numel(self) -> int:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184807

BlockMask._adjust crops the sparse block metadata to match a requested query and key/value length, but it rebuilt the resulting BlockMask without passing those requested sequence lengths. BlockMask.from_kv_blocks then inferred lengths from the cropped block grid and block size, so adjusting a 32-token mask down to 16 tokens still produced shape metadata rounded up to a full sparse block.

Pass the requested seq_lengths through the rebuild step and preserve whether q-block metadata was present on the original mask. This keeps _adjust as a metadata-preserving crop rather than requiring callers to recreate the mask. The alternative would be to recompute the full mask at the target size, but that would change _adjust from a cheap crop into a different operation and would not match the existing API guidance.

The regression test checks that an adjusted BlockMask reports the cropped sequence lengths and can be passed to flex_attention at those adjusted shapes.

Fixes #175533
Generated by my agent

Test Plan:
python -m pytest test/inductor/test_flex_attention.py -k test_block_mask_adjust_updates_seq_lengths -q
lintrunner -a
git diff --cached --check

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo