### PR TITLE
Use custom Min Max in Inductor symbolic indexing

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -32,6 +32,8 @@ from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
 from torch.utils._sympy.functions import (
     FloorDiv,
     Identity,
+    Max,
+    Min,
     Mod,
     ModularIndexing,
     PythonMod,
@@ -796,6 +798,33 @@ class ExprPrinterTests(InductorTestCase):
                 if sys.platform in ["darwin", "win32"]
                 else f"std::{s}<int64_t>({{x, 2L*x, 3L*x}})",
             )
+
+    def test_print_custom_Min_Max(self):
+        from torch._inductor.codegen.mps import MetalExprPrinter
+        from torch._inductor.codegen.pallas import pallas_pexpr
+
+        x, y, z = sympy.symbols("x y z", integer=True)
+
+        self.assertEqual(
+            pallas_pexpr(Min(x, y, z)), "jnp.minimum(jnp.minimum(x, y), z)"
+        )
+        self.assertEqual(
+            pallas_pexpr(Max(x, y, z)), "jnp.maximum(jnp.maximum(x, y), z)"
+        )
+
+        metal_printer = MetalExprPrinter()
+        self.assertIn("metal::min", metal_printer.doprint(Min(x, y, z)))
+        self.assertIn("metal::max", metal_printer.doprint(Max(x, y, z)))
+
+    def test_index_propagation_uses_custom_Min_Max(self):
+        from torch._inductor.index_propagation import SymPyOps, TypedExpr
+
+        x, y = sympy.symbols("x y", integer=True)
+        x_expr = TypedExpr(x, torch.int64)
+        y_expr = TypedExpr(y, torch.int64)
+
+        self.assertIsInstance(SymPyOps.minimum(x_expr, y_expr).expr, Min)
+        self.assertIsInstance(SymPyOps.maximum(x_expr, y_expr).expr, Max)
 
 
 instantiate_parametrized_tests(ExprPrinterTests)

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -94,22 +94,22 @@ class MetalExprPrinter(ExprPrinter_):
         return f"({x}) % ({mod})"
 
     def _print_Min(self, expr: sympy.Expr) -> str:
-        if len(expr.args) != 2:
-            raise RuntimeError("metal::min only supported for 2 args")
-        # pyrefly: ignore [missing-attribute]
-        a, b = map(self._print, expr.args)
-        typecast_a = f"static_cast<decltype({a}+{b})>({a})"
-        typecast_b = f"static_cast<decltype({a}+{b})>({b})"
-        return f"metal::min({typecast_a}, {typecast_b})"
+        return self._print_min_max(expr, "min")
 
     def _print_Max(self, expr: sympy.Expr) -> str:
-        if len(expr.args) != 2:
-            raise RuntimeError("metal::max only supported for 2 args")
+        return self._print_min_max(expr, "max")
+
+    def _print_min_max(self, expr: sympy.Expr, op: str) -> str:
+        if len(expr.args) < 2:
+            raise RuntimeError(f"metal::{op} requires at least 2 args")
         # pyrefly: ignore [missing-attribute]
-        a, b = map(self._print, expr.args)
-        typecast_a = f"static_cast<decltype({a}+{b})>({a})"
-        typecast_b = f"static_cast<decltype({a}+{b})>({b})"
-        return f"metal::max({typecast_a}, {typecast_b})"
+        result = self._print(expr.args[0])
+        for arg in expr.args[1:]:
+            next_arg = self._print(arg)
+            typecast_result = f"static_cast<decltype({result}+{next_arg})>({result})"
+            typecast_next = f"static_cast<decltype({result}+{next_arg})>({next_arg})"
+            result = f"metal::{op}({typecast_result}, {typecast_next})"
+        return result
 
     def _print_Abs(self, expr: sympy.Expr) -> str:
         assert len(expr.args) == 1

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -11,7 +11,7 @@ import sympy
 
 import torch
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._sympy.functions import ModularIndexing
+from torch.utils._sympy.functions import Max, Min, ModularIndexing
 
 from .. import config
 from ..runtime.runtime_utils import torch_dtype_to_jax
@@ -2392,7 +2392,12 @@ class PallasKernel(SIMDKernel):
             self.has_flatten_indexing = True
             self.flatten_indexed_buffers.add(name)
             # Flatten then index for non-contiguous access (gather operation)
-            has_minmax = index.has(sympy.Min) or index.has(sympy.Max)
+            has_minmax = (
+                index.has(sympy.Min)
+                or index.has(sympy.Max)
+                or index.has(Min)
+                or index.has(Max)
+            )
             idx_dtype = "jnp.int32" if self.is_tpu else "jnp.int64"
             idx = (
                 f"({indexing.index_str}).astype({idx_dtype})"

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -30,7 +30,7 @@ import sympy
 
 import torch
 from torch._prims_common import dtype_to_type, is_integer_dtype
-from torch.utils._sympy.functions import FloorDiv, ModularIndexing, Where
+from torch.utils._sympy.functions import FloorDiv, Max, Min, ModularIndexing, Where
 from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
 
 from .ops_handler import DefaultHandler
@@ -172,12 +172,12 @@ class SymPyOps:
     @staticmethod
     def minimum(x: TypedExpr, y: TypedExpr) -> TypedExpr:
         result_type = torch.promote_types(x.dtype, y.dtype)
-        return TypedExpr(sympy.Min(x.expr, y.expr), result_type)
+        return TypedExpr(Min(x.expr, y.expr), result_type)
 
     @staticmethod
     def maximum(x: TypedExpr, y: TypedExpr) -> TypedExpr:
         result_type = torch.promote_types(x.dtype, y.dtype)
-        return TypedExpr(sympy.Max(x.expr, y.expr), result_type)
+        return TypedExpr(Max(x.expr, y.expr), result_type)
 
 
 @dataclass

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -52,6 +52,8 @@ from torch.utils._sympy.functions import (
     CeilDiv,
     FloorDiv,
     Identity,
+    Max,
+    Min,
     Mod,
     ModularIndexing,
 )
@@ -1492,10 +1494,10 @@ def slice_(x, dim=0, start=0, end=sys.maxsize, step=1, clamp=True):
             return 0
         elif fn(sympy.Ge(index, 0)):
             # If index >= 0, the resolved index is at most min(index, size).
-            return sympy.Min(index, size)
+            return Min(index, size)
         elif fn(sympy.Lt(index, 0)):
             # If index < 0, wrap and clamp: the resolved index is at least 0.
-            return sympy.Max(index + size, 0)
+            return Max(index + size, 0)
         return None
 
     start_index, end_index = None, None
@@ -6287,10 +6289,10 @@ def _avg_poolnd(
             divide_factors = []
             for i in range(dim):
                 hstart = bh[i] * stride[i] - padding[i]
-                hend = sympy.Min(hstart + kernel_size[i], h[i] + padding[i])
+                hend = Min(hstart + kernel_size[i], h[i] + padding[i])
                 if not count_include_pad:
-                    hstart = sympy.Max(hstart, 0)
-                    hend = sympy.Min(hend, h[i])
+                    hstart = Max(hstart, 0)
+                    hend = Min(hend, h[i])
                 factor = ops.index_expr(hend - hstart, torch.int32)
                 divide_factors.append(factor)
             return functools.reduce(ops.mul, divide_factors)
@@ -6860,7 +6862,7 @@ def var_mean_sum_(x, axis, correction, keepdim, return_mean):
 
     denom = sympy_product(size[i] for i in axis)
     if correction:
-        denom = sympy.Max(denom - correction, 0)
+        denom = Max(denom - correction, 0)
     denom = ir.IndexingConstant(index=denom, dtype=x.get_dtype(), device=x.get_device())
     denom = ExpandView.create(denom, list(sum_result.get_size()))
     x_var = div(sum_result, denom)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #184811
* #184810

Route focused Inductor lowering and index-propagation paths through torch's custom symbolic Min and Max so existing simplification support applies. Update Pallas and MPS printing for the resulting expressions.\n\nAuthored by Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo