### PR TITLE
Improve Inductor index simplification

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -17,7 +17,11 @@ from torch._inductor.sizevars import (
     stride_at_vec_range,
 )
 from torch._inductor.test_case import TestCase as InductorTestCase
-from torch._inductor.utils import run_and_get_triton_code
+from torch._inductor.utils import (
+    fresh_inductor_cache,
+    run_and_get_code,
+    run_and_get_triton_code,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_MACOS,
@@ -193,7 +197,10 @@ class TestIndexingSimplification(InductorTestCase):
         # Nested modular indexing is correctly simplified
         var_ranges = {i1: 13, i2: 121}
         expr = ModularIndexing(ModularIndexing(121 * i1 + i2, 1, 784), 1, 28)
-        self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), expr)
+        self.assertEqual(
+            sizevars.simplify_with_ranges(expr, var_ranges),
+            ModularIndexing(121 * i1 + i2, 1, 28),
+        )
         expr = ModularIndexing(ModularIndexing(121 * i1 + i2, 1, 784) + 1, 1, 28)
         self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), expr)
         var_ranges = {i2: 784}
@@ -340,12 +347,79 @@ class TestIndexingSimplification(InductorTestCase):
         self.assertEqual(expr2, actual)
         self.assertNotEqual(ModularIndexing(x, 1, b), actual)
 
+    def test_nested_modular_indexing_simplification(self):
+        sizevars = SizeVarAllocator()
+        i0, i1 = sympy.symbols("i0 i1", integer=True)
+        expr = ModularIndexing(ModularIndexing(121 * i0 + i1, 1, 784), 1, 28)
+
+        self.assertEqual(
+            sizevars.simplify_with_ranges(expr, {i0: 13, i1: 121}),
+            ModularIndexing(121 * i0 + i1, 1, 28),
+        )
+
     def test_modular_indexing_positive(self):
         x = sympy.Symbol("x", integer=True, positive=True)
         expr = ModularIndexing(x, 1, 1024) - 1
         expr2 = abs(expr)
 
         self.assertNotEqual(expr2, expr)
+
+    def test_mod_less_than_modulus(self):
+        sizevars = SizeVarAllocator()
+        x = sympy.Symbol("x", integer=True, nonnegative=True)
+        y = sympy.Symbol("y", integer=True, positive=True)
+        z = sympy.Symbol("z", integer=True, positive=True)
+
+        self.assertTrue(sizevars.statically_known_true(sympy.Lt(Mod(x, y), y)))
+        self.assertTrue(
+            sizevars.statically_known_true(sympy.Lt(ModularIndexing(x, z, y), y))
+        )
+
+        unknown = sympy.Symbol("unknown", integer=True)
+        self.assertFalse(sizevars.statically_known_true(sympy.Lt(Mod(unknown, y), y)))
+        self.assertFalse(
+            sizevars.statically_known_true(sympy.Lt(ModularIndexing(unknown, z, y), y))
+        )
+
+    def test_mod_simplification_with_ranges(self):
+        sizevars = SizeVarAllocator()
+        i0, i1 = sympy.symbols("i0 i1", integer=True)
+        var_ranges = {i0: 4, i1: 5}
+
+        self.assertEqual(
+            sizevars.simplify_with_ranges(4 * FloorDiv(i0, 4) + Mod(i0, 4), {i0: 16}),
+            i0,
+        )
+        self.assertEqual(
+            sizevars.simplify_with_ranges(Mod(i0 + 4 * i1, 4), var_ranges),
+            i0,
+        )
+        self.assertEqual(
+            sizevars.simplify_with_ranges(
+                4 * FloorDiv(i0 + 4 * i1, 4) + Mod(i0 + 4 * i1, 4),
+                var_ranges,
+            ),
+            i0 + 4 * i1,
+        )
+
+    @unittest.skipUnless(HAS_GPU, "Need GPU for this test")
+    def test_mod_floordiv_shape_expr_simplifies_e2e(self):
+        def f(x):
+            n = x.shape[0]
+            return x + (4 * (n // 4) + n % 4)
+
+        x = torch.randn(13, device=GPU_TYPE)
+        torch._dynamo.mark_dynamic(x, 0)
+
+        with fresh_inductor_cache():
+            actual, source_codes = run_and_get_code(
+                torch.compile(f, fullgraph=True, dynamic=True), x
+            )
+
+        self.assertEqual(actual, f(x))
+        code = "\n".join(source_codes)
+        self.assertNotIn("// 4", code)
+        self.assertNotIn("% 4", code)
 
     def test_expand_floor_div_skipped(self):
         sizevars = SizeVarAllocator()
@@ -368,6 +442,19 @@ class TestIndexingSimplification(InductorTestCase):
         expected = FloorDiv(x * 15 + y, 3)
         self.assertEqual(expected, FloorDiv(actual, denominator))
 
+    def test_expand_floor_div_symbolic_coefficient(self):
+        sizevars = SizeVarAllocator()
+        s = sympy.Symbol("s", integer=True, positive=True)
+        x = sympy.Symbol("x", integer=True, positive=True)
+        y = sympy.Symbol("y", integer=True, positive=True)
+
+        expr = 2 * s * x + FloorDiv(y, 3)
+        self.assertFalse(sizevars.expand_floor_div(expr))
+
+        actual, denominator = sizevars.expand_floor_div(expr, (x, y))
+        expected = FloorDiv(6 * s * x + y, 3)
+        self.assertEqual(expected, FloorDiv(actual, denominator))
+
     @unittest.skipUnless(HAS_GPU, "Need GPU for this test")
     def test_int8_unpack(self):
         @torch.compile
@@ -388,6 +475,68 @@ class TestIndexingSimplification(InductorTestCase):
         if DO_PERF_TEST:
             ms = benchmarker.benchmark_gpu(lambda: f(x))
             print(f"{ms=:.03f}")
+
+    @unittest.skipUnless(HAS_GPU, "Need GPU for this test")
+    def test_expand_floor_div_symbolic_coefficient_e2e(self):
+        orig_expand_floor_div = SizeVarAllocator.expand_floor_div
+        records = []
+
+        def recording_expand_floor_div(sizevars, index, index_vars=None):
+            result = orig_expand_floor_div(sizevars, index, index_vars)
+            if index_vars is not None and result:
+                new_index, denominator = result
+                records.append((sizevars, index, index_vars, new_index, denominator))
+            return result
+
+        def has_symbolic_factor(index, index_vars):
+            index_var_set = set(index_vars)
+            terms = index.args if isinstance(index, sympy.Add) else (index,)
+            for term in terms:
+                if not isinstance(term, sympy.Mul):
+                    continue
+                term_index_vars = [
+                    arg
+                    for arg in term.args
+                    if isinstance(arg, sympy.Symbol) and arg in index_var_set
+                ]
+                if len(term_index_vars) != 1:
+                    continue
+                factor = sympy.cancel(term / term_index_vars[0])
+                if factor.free_symbols - index_var_set:
+                    return True
+            return False
+
+        def f(x):
+            n = x.size(0) // 2
+            m = x.size(1)
+            y = torch.as_strided(x, (n, m), (2 * m, 1))
+            z = y.unsqueeze(2).expand(n, m, 3).reshape(n, m * 3)
+            return z.t().contiguous() + 1
+
+        x = torch.randn((34, 31), device=GPU_TYPE)
+        torch._dynamo.mark_dynamic(x, 0)
+        torch._dynamo.mark_dynamic(x, 1)
+
+        SizeVarAllocator.expand_floor_div = recording_expand_floor_div
+        try:
+            with fresh_inductor_cache():
+                actual, _source_codes = run_and_get_code(
+                    torch.compile(f, fullgraph=True, dynamic=True), x
+                )
+        finally:
+            SizeVarAllocator.expand_floor_div = orig_expand_floor_div
+
+        self.assertEqual(actual, f(x))
+        self.assertTrue(
+            any(
+                index.has(FloorDiv)
+                and has_symbolic_factor(index, index_vars)
+                and denominator == 3
+                and not new_index.has(FloorDiv)
+                and not orig_expand_floor_div(sizevars, index)
+                for sizevars, index, index_vars, new_index, denominator in records
+            )
+        )
 
     @unittest.skipUnless(HAS_GPU, "Need GPU for this test")
     def test_floordiv_div_sympy_is_integer_bug(self):
@@ -654,10 +803,15 @@ instantiate_parametrized_tests(ExprPrinterTests)
 
 class TestEvaluateMinMax(InductorTestCase):
     def test_evaluate_min_multiple(self):
-        """min(u0, k*u0) resolves via GCD: gcd(u0, k*u0)=u0.
-        UNSOUND: if u0 < 0 (e.g. u0=-1) true min is 10*u0=-10, not -1."""
+        """min(u0, k*u0) is only valid when u0 is known non-negative."""
         sizevars = SizeVarAllocator()
         u0 = sizevars.shape_env.create_unbacked_symint().node.expr
+        with self.assertRaisesRegex(TypeError, "evaluate_min"):
+            sizevars.evaluate_min(u0, 10 * u0)
+        with self.assertRaisesRegex(TypeError, "evaluate_min"):
+            sizevars.evaluate_min(10 * u0, u0)
+
+        sizevars.check(sympy.Ge(u0, 0))
         self.assertEqual(sizevars.evaluate_min(u0, 10 * u0), u0)
         self.assertEqual(sizevars.evaluate_min(10 * u0, u0), u0)
         self.assertEqual(sizevars.evaluate_max(u0, 10 * u0), 10 * u0)
@@ -669,12 +823,12 @@ class TestEvaluateMinMax(InductorTestCase):
         self.assertEqual(sizevars.evaluate_min(-5, 3), -5)
 
     def test_evaluate_min_product_gcd(self):
-        """evaluate_min(u0, u0*u1) resolves via GCD fallback: gcd(u0, u0*u1)=u0.
-        UNSOUND: when u1=0 the true min is 0, not u0; when u0<0 ordering inverts."""
+        """evaluate_min(u0, u0*u1) needs sign and non-zero factor proof."""
         sizevars = SizeVarAllocator()
         u0 = sizevars.shape_env.create_unbacked_symint().node.expr
         u1 = sizevars.shape_env.create_unbacked_symint().node.expr
-        self.assertEqual(sizevars.evaluate_min(u0, u0 * u1), u0)
+        with self.assertRaisesRegex(TypeError, "evaluate_min"):
+            sizevars.evaluate_min(u0, u0 * u1)
 
     def test_evaluate_min_product_with_both_gt_gcd(self):
         """evaluate_min(u0, u0*u1) with u0>0, u1>0 resolves via GCD.

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -24,6 +24,7 @@ from torch.fx.experimental.sym_node import method_to_operator, SymNode, to_node
 from torch.fx.experimental.symbolic_shapes import (
     _constrain_range_for_size,
     _iterate_exprs,
+    constrain_range,
     DimConstraints,
     DimDynamic,
     expect_true,
@@ -1086,6 +1087,16 @@ def forward(self, x_1):
 
         self.assertTrue(shape_env.evaluate_expr(test1))
         self.assertTrue(shape_env.evaluate_expr(test2))
+
+    def test_mod_less_than_positive_modulus_static(self):
+        shape_env = ShapeEnv()
+        x = shape_env.create_unbacked_symint()
+        y = shape_env.create_unbacked_symint()
+        constrain_range(x, min=0, max=None)
+        constrain_range(y, min=1, max=None)
+
+        expr = sympy.Lt(Mod(x.node.expr, y.node.expr), y.node.expr)
+        self.assertEqual(shape_env._maybe_evaluate_static(expr), sympy.true)
 
     def test_sympy_optimized_add(self):
         shape_env = ShapeEnv()

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -734,7 +734,8 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
     def combine_contiguous_dims(
         self, index: sympy.Expr, tree: IterationRangesRoot
     ) -> sympy.Expr:
-        if expand_res := V.graph.sizevars.expand_floor_div(index):
+        index_vars, _sizes = tree.vars_and_sizes(index)
+        if expand_res := V.graph.sizevars.expand_floor_div(index, index_vars):
             new_index, denominator = expand_res  # type: ignore[misc]
             return FloorDiv(self._combine_contiguous_dims(new_index, tree), denominator)
         else:

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -211,6 +211,9 @@ def statically_known_true(
     if expr in (True, False):
         return bool(expr)
 
+    if _statically_known_modular_indexing_bound(shape_env, expr, axioms, var_to_range):
+        return True
+
     # Hint fast-path: if the current concrete hints make `expr` evaluate to
     # False, it cannot be universally True, so bail out without running the
     # much more expensive `_maybe_evaluate_static`. (A True hint doesn't let
@@ -234,6 +237,34 @@ def statically_known_true(
         log.debug("Could not simplify  %s", expr, exc_info=True)
 
     return False
+
+
+def _statically_known_modular_indexing_bound(
+    shape_env: ShapeEnv,
+    expr: sympy.Basic | bool,
+    axioms: tuple[sympy.Expr] | None,
+    var_to_range: tuple[tuple[sympy.Symbol, ValueRanges[Any]]] | None,
+) -> bool:
+    if not isinstance(expr, sympy.StrictLessThan):
+        return False
+
+    lhs, rhs = expr.args
+    if not isinstance(lhs, ModularIndexing):
+        return False
+
+    base, divisor, modulus = lhs.args
+    if modulus != rhs:
+        return False
+
+    constraints = (
+        sympy.Ge(base, 0),
+        sympy.Gt(divisor, 0),
+        sympy.Gt(modulus, 0),
+    )
+    return all(
+        statically_known_true(shape_env, constraint, axioms, var_to_range)
+        for constraint in constraints
+    )
 
 
 # This class is a little awkward, because ShapeEnv is doing most of the heavy
@@ -367,6 +398,40 @@ class SizeVarAllocator:
             )
             return bool(evaluated)
 
+        def join_mod_floor_terms(expr: Expr) -> Expr:
+            if not isinstance(expr, sympy.Add) or not expr.has(Mod, FloorDiv):
+                return expr
+
+            def split_scaled_floor_div(term: Expr):
+                if isinstance(term, FloorDiv):
+                    floor_div = term
+                    factor = sympy.S.One
+                elif isinstance(term, sympy.Mul):
+                    floor_divs = [arg for arg in term.args if isinstance(arg, FloorDiv)]
+                    if len(floor_divs) != 1:
+                        return None
+                    floor_div = floor_divs[0]
+                    factor = sympy.cancel(term / floor_div)
+                else:
+                    return None
+
+                base, divisor = floor_div.args
+                if not statically_known(sympy.Eq(factor, divisor)):
+                    return None
+                if not statically_known(base >= 0) or not statically_known(divisor > 0):
+                    return None
+                return base, divisor
+
+            for term1 in expr.args:
+                split = split_scaled_floor_div(term1)
+                if split is None:
+                    continue
+                base, divisor = split
+                for term2 in expr.args:
+                    if term1 != term2 and term2 == Mod(base, divisor):
+                        return join_mod_floor_terms(expr - term1 - term2 + base)
+            return expr
+
         def remove_zero_terms(base, divisor):
             """Symbols smaller than the divisor are zero"""
             if not statically_known(base >= 0):
@@ -384,6 +449,22 @@ class SizeVarAllocator:
                             base = m[rest]
             return base
 
+        def remove_modular_terms(base, modulus):
+            if not isinstance(base, sympy.Add):
+                return base
+            kept_terms = []
+            removed = False
+            for term in base.args:
+                if statically_known(sympy.Eq(Mod(term, modulus), 0)):
+                    removed = True
+                else:
+                    kept_terms.append(term)
+            if not removed:
+                return base
+            if not kept_terms:
+                return sympy.S.Zero
+            return sympy.Add(*kept_terms)
+
         def visit_indexing_div(base, divisor):
             base = remove_zero_terms(base, divisor)
             if statically_known(base >= 0) and statically_known(base < divisor):
@@ -398,6 +479,18 @@ class SizeVarAllocator:
         def visit_modular_indexing(base, divisor, modulus):
             base = remove_zero_terms(base, divisor)
 
+            if (
+                divisor == 1
+                and isinstance(base, ModularIndexing)
+                and statically_known(sympy.Eq(Mod(base.args[2], modulus), 0))
+                and statically_known(base.args[0] >= 0)
+                and statically_known(base.args[1] > 0)
+                and statically_known(base.args[2] > 0)
+                and statically_known(modulus > 0)
+            ):
+                inner_base, inner_divisor, _inner_modulus = base.args
+                return ModularIndexing(inner_base, inner_divisor, modulus)
+
             can_remove_mod = statically_known(base >= 0) and statically_known(
                 base < modulus * divisor
             )
@@ -405,6 +498,32 @@ class SizeVarAllocator:
             if can_remove_mod:
                 return FloorDiv(base, divisor)
             return ModularIndexing(base, divisor, modulus)
+
+        def visit_mod(base, modulus):
+            if statically_known(base >= 0) and statically_known(modulus > 0):
+                reduced = remove_modular_terms(base, modulus)
+                if reduced != base:
+                    if reduced == 0:
+                        return sympy.S.Zero
+                    if not statically_known(reduced >= 0):
+                        return Mod(base, modulus)
+                    if statically_known(reduced < modulus):
+                        return reduced
+                    return Mod(reduced, modulus)
+                if statically_known(base < modulus):
+                    return base
+            return Mod(base, modulus)
+
+        expr = join_mod_floor_terms(expr)
+
+        if expr.has(Mod):
+            expr = expr.replace(
+                Mod(
+                    sympy.Wild("base", integer=True),
+                    sympy.Wild("modulus", integer=True),
+                ),
+                visit_mod,
+            )
 
         if expr.has(ModularIndexing):
             expr = expr.replace(
@@ -913,19 +1032,27 @@ class SizeVarAllocator:
         if self.guard_or_false(sympy.Le(right, left)):
             return right
 
-        # GCD fallback: if gcd(a, b) == a then a divides b, implying a <= b.
-        #
-        # TODO: This is NOT always sound for unbacked symints.  It can
-        # produce wrong results when:
-        #   - inputs can be negative: gcd(u0, 10*u0) = u0, returns u0,
-        #     but if u0 < 0 then u0 > 10*u0 (e.g. u0=-1: min(-1,-10) = -10)
-        #   - a factor can be zero: gcd(u0, u0*u1) = u0, returns u0,
-        #     but if u1=0 then u0*u1=0 < u0 (e.g. u0=5,u1=0: min(5,0) = 0)
-        # TODO shall we add a runtime assertion at least.
+        def divides_and_orders(a: Expr, b: Expr) -> bool:
+            """Return True when `a` divides `b` and we can prove `a <= b`."""
+            try:
+                quotient = sympy.cancel(b / a)
+            except Exception:
+                return False
+            diff_factor = quotient - 1
+            return (
+                self.statically_known_geq(a, 0)
+                and self.statically_known_geq(diff_factor, 0)
+            ) or (
+                self.statically_known_leq(a, 0)
+                and self.statically_known_leq(diff_factor, 0)
+            )
+
+        # GCD fallback: if gcd(a, b) == a then a divides b, but that alone
+        # does not imply a <= b. Also prove the ordering before simplifying.
         gcd = sympy.gcd(left, right)
-        if left == gcd:
+        if left == gcd and divides_and_orders(left, right):
             return left
-        if right == gcd:
+        if right == gcd and divides_and_orders(right, left):
             return right
 
         # Min/Max fallback: we can prove Min(a, b) <= c when any arg <= c, but
@@ -1339,7 +1466,7 @@ class SizeVarAllocator:
         return index
 
     def expand_floor_div(
-        self, index: sympy.Expr
+        self, index: sympy.Expr, index_vars: Sequence[sympy.Symbol] | None = None
     ) -> bool | tuple[sympy.Expr, sympy.Expr]:
         """
         Expand the FloorDiv to the entire expression so that the expression may
@@ -1352,7 +1479,7 @@ class SizeVarAllocator:
         '(x1 * 2b + x2) // 2'. This transformation allows us to merge loops
         for the numerator!
 
-        Return false if this optimization can be applied;
+        Return false if this optimization cannot be applied;
         Return the new expression and the denominator otherwise.
         The original expression will be equivalent to 'new_expression // denominator'
         """
@@ -1365,23 +1492,63 @@ class SizeVarAllocator:
         floor_div_index = -1
         varlist = []
         factorlist = []
+        index_var_set = OrderedSet(index_vars) if index_vars is not None else None
+
+        def split_mul_term(
+            term: sympy.Mul,
+        ) -> tuple[sympy.Expr, sympy.Symbol] | None:
+            if index_var_set is None:
+                if len(term.args) != 2:
+                    return None
+                factor, var = term.args
+            else:
+                term_index_vars = [
+                    arg
+                    for arg in term.args
+                    if isinstance(arg, sympy.Symbol) and arg in index_var_set
+                ]
+                if len(term_index_vars) != 1:
+                    return None
+                var = term_index_vars[0]
+                factor = sympy.cancel(term / var)
+                if not isinstance(factor, sympy.Expr) or any(
+                    symbol in index_var_set for symbol in factor.free_symbols
+                ):
+                    return None
+
+            if not isinstance(var, sympy.Symbol):
+                return None
+            if not isinstance(factor, sympy.Integer) and factor.is_integer is not True:
+                return None
+            return factor, var
+
+        def split_symbol_term(
+            term: sympy.Symbol,
+        ) -> tuple[sympy.Expr, sympy.Symbol] | None:
+            if index_var_set is None or term in index_var_set:
+                return sympy.S.One, term
+            return None
+
         for idx, term in enumerate(terms):
             if isinstance(term, sympy.Mul):
-                # For dynamic shape, term like '2*s1*x1' has 3 child nodes.
-                # - A integer for 2
-                # - A symbol for s1
-                # - A symbol for x1
-                # Skip for now.
-                if len(term.args) != 2:
+                split = split_mul_term(term)
+                if split is None:
                     return False
-                factor, var = term.args
+                factor, var = split
                 varlist.append(var)
                 factorlist.append(factor)
-                if not isinstance(factor, sympy.Integer) or not isinstance(
-                    var, sympy.Symbol
-                ):
+                # It's easier to reason about the correctness of the transformation
+                # for non-negative integers.
+                if not self.statically_known_geq(var, 0):
                     return False
-                # It's easier to reason about the correceness of the transformation
+            elif isinstance(term, sympy.Symbol):
+                split = split_symbol_term(term)
+                if split is None:
+                    return False
+                factor, var = split
+                varlist.append(var)
+                factorlist.append(factor)
+                # It's easier to reason about the correctness of the transformation
                 # for non-negative integers.
                 if not self.statically_known_geq(var, 0):
                     return False

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -7084,6 +7084,30 @@ class ShapeEnv:
         expr = expr.xreplace(subst)
         # TODO: compute hint might have gotten broken here
 
+        if isinstance(expr, sympy.StrictLessThan):
+            lhs, rhs = expr.args
+            if isinstance(lhs, Mod):
+                base, modulus = lhs.args
+                if rhs == modulus and (
+                    self._maybe_evaluate_static(
+                        sympy.Ge(base, 0),
+                        unbacked_only=unbacked_only,
+                        size_oblivious=size_oblivious,
+                        axioms=axioms,
+                        var_to_range=var_to_range,
+                    )
+                    is sympy.true
+                    and self._maybe_evaluate_static(
+                        sympy.Gt(modulus, 0),
+                        unbacked_only=unbacked_only,
+                        size_oblivious=size_oblivious,
+                        axioms=axioms,
+                        var_to_range=var_to_range,
+                    )
+                    is sympy.true
+                ):
+                    return sympy.true
+
         fs = expr.free_symbols
 
         if not fs and (expr.is_number or expr.is_Boolean):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184813
* __->__ #184812

Teach SizeVar simplification a few guarded modular arithmetic identities used by dynamic-shape indexing, including mod/floordiv joins and symbolic-coefficient floor-div expansion through SIMD codegen. Also tighten evaluate_min's GCD fallback so divisibility alone is not treated as an ordering proof.\n\nAuthored by Codex.