### PR TITLE
Fix RNN docstring 'Efficient implementation' example breaking on backward

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -503,27 +503,27 @@ class RNN(RNNBase):
         # Efficient implementation equivalent to the following with bidirectional=False
         rnn = nn.RNN(input_size, hidden_size, num_layers)
         params = dict(rnn.named_parameters())
-        def forward(x, hx=None, batch_first=False):
+        def forward(x, h_t_minus_1=None, batch_first=False):
             if batch_first:
                 x = x.transpose(0, 1)
             seq_len, batch_size, _ = x.size()
-            if hx is None:
-                hx = torch.zeros(rnn.num_layers, batch_size, rnn.hidden_size)
-            h_t_minus_1 = hx.clone()
-            h_t = hx.clone()
+            if h_t_minus_1 is None:
+                h_t_minus_1 = torch.zeros(rnn.num_layers, batch_size, rnn.hidden_size)
             output = []
             for t in range(seq_len):
+                h_t = []
                 for layer in range(rnn.num_layers):
                     input_t = x[t] if layer == 0 else h_t[layer - 1]
-                    h_t[layer] = torch.tanh(
+                    h_t.append(torch.tanh(
                         input_t @ params[f"weight_ih_l{layer}"].T
                         + h_t_minus_1[layer] @ params[f"weight_hh_l{layer}"].T
                         + params[f"bias_hh_l{layer}"]
                         + params[f"bias_ih_l{layer}"]
-                    )
-                output.append(h_t[-1].clone())
-                h_t_minus_1 = h_t.clone()
+                    ))
+                output.append(h_t[-1])
+                h_t_minus_1 = h_t
             output = torch.stack(output)
+            h_t = torch.stack(h_t)
             if batch_first:
                 output = output.transpose(0, 1)
             return output, h_t


### PR DESCRIPTION
## Summary

Fixes #165621.

The `RNN` class docstring has an "Efficient implementation" code block intended to show users the equivalent Python loop for an `nn.RNN` forward pass. The current version assigns into `h_t[layer]` in place and rebinds `h_t_minus_1 = h_t.clone()` after writing through the same storage, so the result has no usable autograd graph and `.backward()` fails as documented in the issue.

This patch swaps the in-place writes for an append-only Python list rebuilt each timestep, matching the autograd-compatible variant proposed in the issue body. The math is unchanged: each layer still consumes the previous timestep's hidden state via `h_t_minus_1`, and the current timestep's stack of layer hidden states is exposed to the next layer via `h_t`. At the end of each timestep, `h_t` becomes `h_t_minus_1` for the next step (a plain reference rebind, no clone needed since the list of fresh tensors is never mutated).

## Test plan

- [x] Ran the new docstring example end-to-end against `torch 2.11.0`: `forward` produces output, `CrossEntropyLoss(output, target).backward()` completes, and `weight_ih_l*` / `weight_hh_l*` / `bias_*` parameters all receive non-zero gradients.
- [x] Confirmed the example block is a `.. code-block:: python` directive (not a `>>>` doctest), so it is documentation-only and not executed by xdoctest. No behavior change to `nn.RNN` itself.
- [x] `git diff` is scoped to the example inside the `RNN` class docstring in `torch/nn/modules/rnn.py`.