### PR TITLE
[Torch] make AOTInductor's GPU memory deleter noexcept

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -322,16 +322,26 @@ RAIIDataPtr RAII_gpuMalloc(size_t num_bytes) {
   void* data_ptr = nullptr;
   AOTI_TORCH_ERROR_CODE_CHECK(
       aoti_torch_cuda_caching_allocator_raw_alloc(num_bytes, &data_ptr));
-  auto deleter = [](void* ptr) {
-    AOTI_TORCH_ERROR_CODE_CHECK(
-        aoti_torch_cuda_caching_allocator_raw_delete(ptr));
+  auto deleter = [](void* ptr) noexcept {
+    auto err = aoti_torch_cuda_caching_allocator_raw_delete(ptr);
+    if (err != AOTI_TORCH_SUCCESS) {
+      std::cerr
+          << "Failed to free GPU memory in AOTInductor model (caching allocator): error code "
+          << err << '\n';
+    }
   };
   return RAIIDataPtr(data_ptr, deleter);
 #else
   // Use cudaMalloc directly for allocating GPU memory
   void* data_ptr = nullptr;
   AOTI_RUNTIME_CUDA_CHECK(cudaMalloc((void**)&data_ptr, num_bytes));
-  auto deleter = [](void* ptr) { AOTI_RUNTIME_CUDA_CHECK(cudaFree(ptr)); };
+  auto deleter = [](void* ptr) noexcept {
+    auto code = cudaFree(ptr);
+    if (code != cudaSuccess) {
+      std::cerr << "Failed to free GPU memory in AOTInductor model: "
+                << cudaGetErrorString(code) << '\n';
+    }
+  };
   return RAIIDataPtr(data_ptr, deleter);
 #endif
 }


### PR DESCRIPTION
Summary:
The CUDA paths of RAII_gpuMalloc previously installed deleters that called AOTI_TORCH_ERROR_CODE_CHECK / AOTI_RUNTIME_CUDA_CHECK, both of which throw on a non-zero status. Because these deleters run from ~unique_ptr inside AOTInductor model destruction — frequently invoked during stack unwinding of an earlier exception (e.g. a poisoned CUDA context from a kernel failure) — a throw here re-enters unwinding, triggers std::terminate, and hides the original error.

The deleters are now marked noexcept, check the status manually, and on failure log to std::cerr (matching the existing pattern in ~AOTInductorModelBase for cudaEventDestroy) without throwing. This makes the original exception observable to callers instead of being replaced by an opaque terminate().

Test Plan: CI/CD

Differential Revision: D106021294


