### PR TITLE
[inductor] Enable loop ordering for nested reduction tests

### DIFF
--- a/test/inductor/test_nested_reduction.py
+++ b/test/inductor/test_nested_reduction.py
@@ -50,7 +50,10 @@ class TestBase(TestCase):
         metrics.reset()
         torch._dynamo.utils.clear_compilation_metrics()
         self._nested_reduction_ctx = inductor_config.patch(
-            "triton.nested_reduction", True
+            {
+                "triton.nested_reduction": True,
+                "loop_ordering_after_fusion": True,
+            }
         )
         self._nested_reduction_ctx.__enter__()
         self._choices_ctx = _choices_context(self.force_persistent_outer_reduction)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184821

Run the nested-reduction test fixture with loop ordering after fusion enabled, matching the dependency form required by the generated-code expectations without changing the fbcode production default.

Differential Revision: [D106019891](https://our.internmc.facebook.com/intern/diff/D106019891/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo