### PR TITLE
Add Sphinx redirects for renamed autosummary Stream/stream pages

### DIFF
--- a/docs/source/redirects.py
+++ b/docs/source/redirects.py
@@ -159,4 +159,17 @@ redirects = {
         "user_guide/torch_compiler/compile/"
         "programming_model.where_to_apply_compile.html"
     ),
+    # Redirects for autosummary pages renamed via autosummary_filename_map in
+    # conf.py. Stream/stream classes and context-manager functions for each
+    # accelerator backend were renamed to *_class.html / *_function.html to
+    # disambiguate case-only collisions, which broke incoming links to the
+    # previous URLs (see #173318).
+    "generated/torch.cuda.Stream": "torch.cuda.Stream_class.html",
+    "generated/torch.cuda.stream": "torch.cuda.stream_function.html",
+    "generated/torch.cpu.Stream": "torch.cpu.Stream_class.html",
+    "generated/torch.cpu.stream": "torch.cpu.stream_function.html",
+    "generated/torch.mtia.Stream": "torch.mtia.Stream_class.html",
+    "generated/torch.mtia.stream": "torch.mtia.stream_function.html",
+    "generated/torch.xpu.Stream": "torch.xpu.Stream_class.html",
+    "generated/torch.xpu.stream": "torch.xpu.stream_function.html",
 }


### PR DESCRIPTION
## Summary

Fixes #173318.

`autosummary_filename_map` in `docs/source/conf.py` (introduced by #164901) renames `torch.{cuda,cpu,mtia,xpu}.Stream` and the lowercase `stream` context manager pages to `*_class.html` / `*_function.html` to disambiguate case-only collisions. The rename leaves the original `generated/*.html` URLs as 404s on 2.10+, breaking the heavily-linked `torch.cuda.Stream` docs (and the analogous pages for the other accelerator backends).

This PR registers `sphinx-reredirects` entries in `docs/source/redirects.py` for the renamed Stream/stream pages on all four backends so that existing inbound links from external docs, tutorials, and search results continue to resolve.

Confirmed broken on current docs:

| URL | Status |
| --- | --- |
| `docs/main/generated/torch.cuda.Stream.html` | 404 |
| `docs/main/generated/torch.cuda.stream.html` | 404 |
| `docs/main/generated/torch.cpu.Stream.html` | 404 |
| `docs/main/generated/torch.cpu.stream.html` | 404 |
| `docs/main/generated/torch.mtia.Stream.html` | 404 |
| `docs/main/generated/torch.mtia.stream.html` | 404 |
| `docs/main/generated/torch.xpu.Stream.html` | 404 |
| `docs/main/generated/torch.xpu.stream.html` | 404 |

The corresponding `*_class.html` / `*_function.html` targets all return 200.

## Notes

- `torch.cuda.Event` is intentionally **not** included: it is not in `autosummary_filename_map`, and `generated/torch.cuda.Event.html` currently resolves with a 200, so adding a redirect would overwrite the working page.
- The partial fix in pytorch/docs#67 only handled the published 2.10/ tree for `torch.cuda.Stream`; this fix is at the source so it applies to every future build, all four backends, and the lowercase function pages too.
- Pure docs change. No code changes.

## Test plan

- [x] `python3 -c "from redirects import redirects"` imports cleanly with all 71 entries.
- [x] `python3 -m py_compile docs/source/redirects.py` passes.
- [x] `python3 -m ruff check docs/source/redirects.py` passes.
- [x] `python3 -m ruff format --check docs/source/redirects.py` reports already formatted.
- [ ] After build/deploy, verify `generated/torch.cuda.Stream.html` etc. produce a meta-refresh to the `*_class.html` / `*_function.html` page.

cc @sekyondaMeta @malfet @svekars