### PR TITLE
[Reland] Port D104346887/PR 182675 for index_add fast path (#184824)

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1178,6 +1178,35 @@ void index_add_cuda_impl(const Tensor& self, int64_t dim, const Tensor& index, c
 
   const int mpc = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
 
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+  // Fast path: index_add_(0, idx, src) with alpha == 1 is equivalent to
+  // self.scatter_add_(0, idx.view({n, 1, ...}).expand_as(src), src). Delegate
+  // so scatter_add's own TMA/vectorized eligibility check + dispatch is the
+  // single source of truth (see PR #182675). Pattern from
+  // pytorch/pytorch#180430.
+  // Gated on CUDA >= 12.8: pre-12.8 builds compile out the TMA branch in
+  // scatter_add and fall back to its vectorized atomicAdd path, which
+  // regresses skewed/high-contention workloads vs indexFunc{Small,Large}Index
+  // (warp-per-entry scheduling concentrates atomic contention on hot rows).
+  // Older builds therefore stay on the existing indexFunc dispatch.
+  // index_add supports {complex64, complex128, ComplexHalf, Bool} that
+  // scatter_add does not, so exclude those and let them use indexFunc.
+  // The dtype check is ordered FIRST so short-circuit evaluation skips
+  // alpha.equal(1) for complex `self`, where alpha may itself be a
+  // complex Scalar and the equality comparison would be ill-defined.
+  const auto stype = self_.scalar_type();
+  const bool dtype_supported_by_scatter_add =
+      !c10::isComplexType(stype) && stype != at::kBool;
+  if (dtype_supported_by_scatter_add && dim == 0 &&
+      alpha.equal(1) && numIndex > 0 &&
+      index.dim() <= 1 && indContig) {
+    std::vector<int64_t> idx_shape(source_.dim(), 1);
+    idx_shape[0] = static_cast<int64_t>(numIndex);
+    self_.scatter_add_(0, index.view(idx_shape).expand_as(source_), source_);
+    return;
+  }
+#endif
+
 #define SMALL_INDEX(TENSOR_TYPE, INDICES_TYPE, TYPE, SELF_DIM, SOURCE_DIM, IDX_DIM)     \
   indexFuncSmallIndex<TENSOR_TYPE, INDICES_TYPE, TYPE, SELF_DIM, SOURCE_DIM, IDX_DIM>   \
     <<<smallIndexGrid, smallIndexBlock, 0, stream>>>(                                   \

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -21,10 +21,13 @@ from torch.testing._internal.common_device_type import (
     expectedFailureMPS,
     instantiate_device_type_tests,
     onlyCPU,
+    onlyCUDA,
     onlyNativeDeviceTypes,
     onlyOn,
     skipXLA,
     skipXPUIf,
+    tol,
+    toleranceOverride,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,
@@ -2041,6 +2044,142 @@ class TestIndexing(TestCase):
                 for _ in range(3):
                     y_nd = torch.index_add(x, dim, index, src, alpha=alpha)
                     self.assertEqual(y_nd, y0, atol=1e-3, rtol=1e-5)
+
+    @serialTest()
+    @onlyCUDA
+    @toleranceOverride(
+        {
+            torch.float32: tol(atol=1e-5, rtol=1e-3),
+            torch.float64: tol(atol=1e-5, rtol=1e-3),
+            torch.half: tol(atol=5e-2, rtol=5e-2),
+            torch.bfloat16: tol(atol=0.5, rtol=0.5),
+        }
+    )
+    @dtypes(torch.float32, torch.float64, torch.half, torch.bfloat16)
+    def test_index_add_fast_path(self, device, dtype):
+        # Coverage for the index_add_ TMA fast path: one eligible case + five
+        # fallback predicates per shape, asserted against a CPU reference.
+        # Shapes keep n/m <= 1 so atomicAdd-order noise on bf16/half stays
+        # within tolerance; (4096, 1024, 1024) crosses the TMA chunk_elems
+        # boundary (D > one chunk).
+        def check(out, dim, idx, src, alpha=1.0):
+            expected = (
+                out.cpu().clone().index_add_(dim, idx.cpu(), src.cpu(), alpha=alpha)
+            )
+            out.index_add_(dim, idx, src, alpha=alpha)
+            self.assertEqual(out.cpu(), expected)
+
+        for m, n, D in [(1024, 512, 128), (4096, 3072, 128), (4096, 1024, 1024)]:
+            torch.cuda.empty_cache()
+            for idx_dtype in (torch.int32, torch.int64):
+                src = make_tensor((n, D), device=device, dtype=dtype)
+                idx = torch.randint(m, (n,), device=device, dtype=idx_dtype)
+
+                # 1) Eligible -> fast path.
+                check(torch.zeros(m, D, device=device, dtype=dtype), 0, idx, src)
+                # 2) alpha != 1 -> fallback.
+                check(
+                    torch.zeros(m, D, device=device, dtype=dtype),
+                    0,
+                    idx,
+                    src,
+                    alpha=2.5,
+                )
+                # 3) Discontiguous src -> fallback.
+                src_strided = torch.empty(n, 2 * D, device=device, dtype=dtype)[
+                    :, ::2
+                ].copy_(src)
+                check(
+                    torch.zeros(m, D, device=device, dtype=dtype), 0, idx, src_strided
+                )
+                # 4) Misaligned self (one-element pointer offset) -> fallback.
+                self_mis = (
+                    torch.empty(m * D + 1, device=device, dtype=dtype)[1:]
+                    .view(m, D)
+                    .zero_()
+                )
+                check(self_mis, 0, idx, src)
+                # 5) dim != 0 -> fallback.
+                check(
+                    torch.zeros(D, m, device=device, dtype=dtype),
+                    1,
+                    idx,
+                    make_tensor((D, n), device=device, dtype=dtype),
+                )
+                # 6) Sliced inner dim (not is_contiguous) -> fallback.
+                sl = slice(64, 192)
+                check(
+                    torch.zeros(m, 256, device=device, dtype=dtype)[:, sl],
+                    0,
+                    idx,
+                    make_tensor((n, 256), device=device, dtype=dtype)[:, sl],
+                )
+
+        # 7) Empty index is a no-op.
+        out = torch.randn(8, 128, device=device, dtype=dtype)
+        expected = out.clone()
+        out.index_add_(
+            0,
+            torch.empty(0, device=device, dtype=torch.int64),
+            torch.empty(0, 128, device=device, dtype=dtype),
+        )
+        self.assertEqual(out, expected)
+
+    @serialTest()
+    @onlyCUDA
+    @toleranceOverride(
+        {
+            # Tolerances follow test_index_add_fast_path: this shape does
+            # ~n/m atomic adds per row (~670 here with m=13), and bf16's
+            # 7-bit mantissa accumulates noise quickly under non-
+            # deterministic atomicAdd ordering. fp32 stays tight.
+            torch.float32: tol(atol=1e-4, rtol=1e-3),
+            torch.bfloat16: tol(atol=20.0, rtol=0.5),
+        }
+    )
+    @dtypes(torch.float32, torch.bfloat16)
+    def test_index_add_smem_stage_alignment_regression(self, device, dtype):
+        # Regression for SEV S664741: the original D104669063 was reverted
+        # when this delegation surfaced a latent scatter_add TMA smem
+        # stage-alignment bug -- chunk_bytes < 128 (or not a multiple of
+        # 128) plus multi-iter-per-CTA (M_src > grid_x cap of sm*64) wrote
+        # stage 1 of the 2-stage pipeline buffer at a non-128-aligned smem
+        # offset, faulting in cp.async.bulk. Fixed in PR #184554 by
+        # rounding the stage stride to 128 bytes. This test pins the
+        # prod shape (small D + high M_src) at the index_add layer so a
+        # future refactor of the delegation re-exposing the same shape
+        # class is caught here, not in prod.
+        sm = torch.cuda.get_device_properties(0).multi_processor_count
+        # D=8 fp32 -> chunk_bytes=32 (< 128). M_src > sm*64 forces every
+        # CTA into >= 2 iterations -> stage 1 used. Prod fault was at
+        # sm*64=8448 (H100); sm*64 + 256 exposes the regime on any GPU.
+        m, n, D = 13, sm * 64 + 256, 8
+        src = make_tensor((n, D), device=device, dtype=dtype)
+        idx = torch.randint(m, (n,), device=device, dtype=torch.int64)
+        out = torch.zeros(m, D, device=device, dtype=dtype)
+        expected = out.cpu().clone().index_add_(0, idx.cpu(), src.cpu())
+        out.index_add_(0, idx, src)
+        self.assertEqual(out.cpu(), expected)
+
+    @serialTest()
+    @onlyCUDA
+    @dtypes(torch.complex64, torch.complex128, torch.bool)
+    def test_index_add_excluded_dtypes(self, device, dtype):
+        # scatter_add_'s CUDA dispatch covers neither complex nor bool, so the
+        # fast-path delegation in index_add_cuda_impl excludes these dtypes
+        # and lets them fall through to indexFunc{Small,Large}Index. Regression
+        # test that an eligible-shape (dim=0, alpha=1, contiguous, aligned)
+        # call still produces correct results for these dtypes.
+        m, n, D = 1024, 512, 128
+        if dtype == torch.bool:
+            src = torch.randint(0, 2, (n, D), device=device, dtype=dtype)
+        else:
+            src = make_tensor((n, D), device=device, dtype=dtype)
+        out = torch.zeros(m, D, device=device, dtype=dtype)
+        idx = torch.randint(m, (n,), device=device, dtype=torch.int64)
+        expected = out.cpu().clone().index_add_(0, idx.cpu(), src.cpu())
+        out.index_add_(0, idx, src)
+        self.assertEqual(out.cpu(), expected)
 
     @onlyNativeDeviceTypes
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/1973")


### PR DESCRIPTION
Summary:

Reland of D104669063, which was reverted following SEV S664741. The underlying TMA smem stage-alignment bug in scatter_add's CuTeDSL override has since been fixed in PR #184554 (sibling commit in this stack); this diff re-applies the `index_add -> scatter_add` delegation unchanged from the original, with one minor follow-up (see "Follow-ups from D104669063 review" below).


Adopts the vectorized scatter_add(dim=0) kernel from D104346887 / PR #182675 as a fast path for `index_add_` on CUDA. `index_add_(0, idx, src)` is mathematically equivalent to `self.scatter_add_(0, idx.unsqueeze(-1).expand_as(src), src)` when `alpha == 1`, so we delegate so scatter_add's own TMA/vectorized eligibility check + dispatch is the single source of truth.

Eligibility (all required to enter the fast path):
- `dim == 0`
- `alpha == 1`
- dtype supported by scatter_add (excludes complex + bool)
- `index.dim() <= 1` and contiguous, `numIndex > 0`
- scatter_add gates internally per-dtype: TMA sm_90+; vec-scatter sm_60+/sm_70+/sm_90+ for fp32/fp16/bf16
- CUDA 12.8+ at compile time

Outside the eligible regime, falls through to the existing `indexFunc{Small,Large}Index` dispatch (untouched).

## Why this reland is safe

The original revert was triggered by an IFR MTML embedding-backward job. Diagnostic logs surfaced a latent bug in scatter_add's CuTeDSL TMA path: the 2-stage pipeline buffer is laid out column-major in smem, so stage 1 sits at offset `chunk_bytes` from stage 0's 128B-aligned base. `cp.async.bulk` requires 128B-aligned smem destinations. When `chunk_bytes` is not a multiple of 128 (e.g. fp32 D=8 -> chunk_bytes=32, or fp32 D=36 -> chunk_bytes=144), AND a CTA does more than one iteration (M_src > grid_x cap of sm*64), the kernel writes stage 1 at a misaligned smem address and faults with `cudaErrorMisalignedAddress`.

Prod repro: src shape `(104280, 8)` fp32 stride `(568, 1)`, self shape `(13, 8)`. chunk_bytes = 8 * 4 = 32 (< 128), M_src = 104280 > sm * 64 = 8448 -> fault. Confirmed by a local unit-test reproducer at the exact prod call shape.

PR #184554 (parent of this diff in the stack) fixes the kernel by padding the 2-stage pipeline buffer's stage stride to a multiple of 128 bytes:
```
stage_stride_elems = _round_up(chunk_elems, 128 // elem_bytes)
sBuf = smem.allocate_tensor(
    dtype,
    cute.make_layout((chunk_elems, 2), stride=(1, stage_stride_elems)),
    128,
)
```

With that fix in place, every shape this delegation can produce runs through the TMA fast path correctly. PR #184554 ships kernel-level regression tests (`test_smem_stage_alignment_multi_iter`, parametrized over both `chunk_bytes < 128` and `chunk_bytes in (128, 512) not multiple of 128` cases). This diff adds `test_index_add_smem_stage_alignment_regression` in `test_indexing.py` to pin the same regime through the `index_add` public-API path, so a future refactor of the delegation re-exposing the same shape class is caught here rather than in prod.

## Benchmarks

Kernel-side perf is unchanged from D104669063 (the delegation forwards to the same scatter_add kernel, now with PR #184554's smem padding). See D104669063 summary for full B200 and H100 benchmark tables. Highlights:
- Real workloads: B200 4.52x (bf16) / 2.74x (fp32); H100 2.97x (bf16) / 1.42x (fp32).
- bf16 sweeps up to 7.40x on B200; zipf high-contention is neutral on both arches (atomic-contention-bound, not bandwidth-bound).

PR #184554's stage-stride padding is a one-extra-smem-byte change in the worst case (chunk_bytes already padded for chunk_bytes >= 128), so no measurable perf delta from the parent commit.

Test Plan:
Re-running the original D104669063 test suite plus the new small-D + high-M_src regression added in this diff:

```
buck2 test fbcode//mode/opt -c fbcode.enable_gpu_sections=true \
    -c fbcode.platform010_cuda_version=12.8 -c fbcode.nvcc_arch=h100a \
    fbcode//caffe2/test:test_others_cuda -- \
    --regex 'test_index_add_fast_path|test_index_add_excluded_dtypes|test_index_add_smem_stage_alignment_regression'
```

Expected: pass on all parametrized variants (fp32 / fp64 / half / bf16 across 3 shapes x 2 index dtypes for `test_index_add_fast_path`; complex64 / complex128 / bool for `test_index_add_excluded_dtypes`; fp32 / bf16 for the new regression).

`test_index_add_smem_stage_alignment_regression` specifically reproduces the SEV-class shape (D=8, M_src = sm * 64 + 256 so every CTA enters stage 1) and asserts numerical equality against a CPU reference. Without PR #184554 in the same build, this test crashes with `cudaErrorMisalignedAddress`; with the parent commit present, it passes cleanly.

No regressions in existing `index_add` tests.

https://www.internalfb.com/mlhub/pipelines/runs/mast/mvai-training-online-2122147583-mrs_cog-test-3bd717?job_attempt=0&version=0&tab=logs&env=PRODUCTION


f1085796899

mvai-training-online-2122002363-mrs_cog-test-a767bb

Reviewed By: slayton58

Differential Revision: D105959759


