### PR TITLE
[DTensor] add  sharding strategy for group norm backward

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -2069,6 +2069,24 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(dt_b.grad.full_tensor(), ref_b.grad)
         self.assertEqual(dt_b.grad.placements, (Partial("sum"),))
 
+        # group_norm backward with weight=None, bias=None (affine=False)
+        ref_inp_na = inp_bwd.clone().detach().requires_grad_(True)
+        dt_inp_na = distribute_tensor(
+            inp_bwd.clone().detach().requires_grad_(True), device_mesh, [Shard(0)]
+        )
+
+        ref_out_na = F.group_norm(ref_inp_na, num_groups)
+        ref_out_na.sum().backward()
+
+        with CommDebugMode() as comm_mode:
+            dt_out_na = F.group_norm(dt_inp_na, num_groups)
+            dt_out_na.sum().backward()
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+
+        self.assertEqual(dt_out_na.full_tensor(), ref_out_na)
+        self.assertEqual(dt_inp_na.grad.full_tensor(), ref_inp_na.grad)
+        self.assertTrue(dt_inp_na.grad.placements[0].is_shard(0))
+
 
 DistMathOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistMathOpsTest,

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -2034,58 +2034,51 @@ class DistMathOpsTest(DTensorTestBase):
         N_bwd = self.world_size * 2
         inp_bwd = torch.randn(N_bwd, C, H, W, device=self.device_type)
 
-        ref_inp = inp_bwd.clone().detach().requires_grad_(True)
-        ref_w = weight.clone().detach().requires_grad_(True)
-        ref_b = bias.clone().detach().requires_grad_(True)
-        dt_inp_bwd = distribute_tensor(
-            inp_bwd.clone().detach().requires_grad_(True), device_mesh, [Shard(0)]
-        )
-        dt_w = distribute_tensor(
-            weight.clone().detach().requires_grad_(True), device_mesh, replicate
-        )
-        dt_b = distribute_tensor(
-            bias.clone().detach().requires_grad_(True), device_mesh, replicate
-        )
+        for elementwise_affine in [True, False]:
+            w = (
+                weight.clone().detach().requires_grad_(True)
+                if elementwise_affine
+                else None
+            )
+            b = (
+                bias.clone().detach().requires_grad_(True)
+                if elementwise_affine
+                else None
+            )
 
-        ref_out = F.group_norm(ref_inp, num_groups, ref_w, ref_b)
-        ref_out.sum().backward()
+            ref_inp = inp_bwd.clone().detach().requires_grad_(True)
+            dt_inp = distribute_tensor(
+                inp_bwd.clone().detach().requires_grad_(True), device_mesh, [Shard(0)]
+            )
+            dt_w = (
+                distribute_tensor(w, device_mesh, replicate) if w is not None else None
+            )
+            dt_b = (
+                distribute_tensor(b, device_mesh, replicate) if b is not None else None
+            )
 
-        comm_mode = CommDebugMode()
-        with comm_mode:
-            dt_out = F.group_norm(dt_inp_bwd, num_groups, dt_w, dt_b)
-            dt_out.sum().backward()
-        self.assertEqual(
-            comm_mode.get_total_counts(),
-            0,
-            "Unexpected communication in group_norm forward/backward",
-        )
+            ref_out = F.group_norm(ref_inp, num_groups, w, b)
+            ref_out.sum().backward()
 
-        self.assertEqual(dt_out.full_tensor(), ref_out)
-        self.assertTrue(dt_out.placements[0].is_shard(0))
-        self.assertEqual(dt_inp_bwd.grad.full_tensor(), ref_inp.grad)
-        self.assertTrue(dt_inp_bwd.grad.placements[0].is_shard(0))
-        self.assertEqual(dt_w.grad.full_tensor(), ref_w.grad)
-        self.assertEqual(dt_w.grad.placements, (Partial("sum"),))
-        self.assertEqual(dt_b.grad.full_tensor(), ref_b.grad)
-        self.assertEqual(dt_b.grad.placements, (Partial("sum"),))
+            with CommDebugMode() as comm_mode:
+                dt_out = F.group_norm(dt_inp, num_groups, dt_w, dt_b)
+                dt_out.sum().backward()
+            self.assertEqual(
+                comm_mode.get_total_counts(),
+                0,
+                f"Unexpected comm in group_norm bwd (affine={elementwise_affine})",
+            )
 
-        # group_norm backward with weight=None, bias=None (affine=False)
-        ref_inp_na = inp_bwd.clone().detach().requires_grad_(True)
-        dt_inp_na = distribute_tensor(
-            inp_bwd.clone().detach().requires_grad_(True), device_mesh, [Shard(0)]
-        )
+            self.assertEqual(dt_out.full_tensor(), ref_out)
+            self.assertTrue(dt_out.placements[0].is_shard(0))
+            self.assertEqual(dt_inp.grad.full_tensor(), ref_inp.grad)
+            self.assertTrue(dt_inp.grad.placements[0].is_shard(0))
 
-        ref_out_na = F.group_norm(ref_inp_na, num_groups)
-        ref_out_na.sum().backward()
-
-        with CommDebugMode() as comm_mode:
-            dt_out_na = F.group_norm(dt_inp_na, num_groups)
-            dt_out_na.sum().backward()
-        self.assertEqual(comm_mode.get_total_counts(), 0)
-
-        self.assertEqual(dt_out_na.full_tensor(), ref_out_na)
-        self.assertEqual(dt_inp_na.grad.full_tensor(), ref_inp_na.grad)
-        self.assertTrue(dt_inp_na.grad.placements[0].is_shard(0))
+            if elementwise_affine:
+                self.assertEqual(dt_w.grad.full_tensor(), w.grad)
+                self.assertEqual(dt_w.grad.placements, (Partial("sum"),))
+                self.assertEqual(dt_b.grad.full_tensor(), b.grad)
+                self.assertEqual(dt_b.grad.placements, (Partial("sum"),))
 
 
 DistMathOpsTestWithLocalTensor = create_local_tensor_test_class(

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -2030,6 +2030,45 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(result_no_affine.full_tensor(), expected_no_affine)
         self.assertTrue(result_no_affine.placements[0].is_shard(0))
 
+        # group_norm with batch-dim sharding -- forward + backward
+        N_bwd = self.world_size * 2
+        inp_bwd = torch.randn(N_bwd, C, H, W, device=self.device_type)
+
+        ref_inp = inp_bwd.clone().detach().requires_grad_(True)
+        ref_w = weight.clone().detach().requires_grad_(True)
+        ref_b = bias.clone().detach().requires_grad_(True)
+        dt_inp_bwd = distribute_tensor(
+            inp_bwd.clone().detach().requires_grad_(True), device_mesh, [Shard(0)]
+        )
+        dt_w = distribute_tensor(
+            weight.clone().detach().requires_grad_(True), device_mesh, replicate
+        )
+        dt_b = distribute_tensor(
+            bias.clone().detach().requires_grad_(True), device_mesh, replicate
+        )
+
+        ref_out = F.group_norm(ref_inp, num_groups, ref_w, ref_b)
+        ref_out.sum().backward()
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            dt_out = F.group_norm(dt_inp_bwd, num_groups, dt_w, dt_b)
+            dt_out.sum().backward()
+        self.assertEqual(
+            comm_mode.get_total_counts(),
+            0,
+            "Unexpected communication in group_norm forward/backward",
+        )
+
+        self.assertEqual(dt_out.full_tensor(), ref_out)
+        self.assertTrue(dt_out.placements[0].is_shard(0))
+        self.assertEqual(dt_inp_bwd.grad.full_tensor(), ref_inp.grad)
+        self.assertTrue(dt_inp_bwd.grad.placements[0].is_shard(0))
+        self.assertEqual(dt_w.grad.full_tensor(), ref_w.grad)
+        self.assertEqual(dt_w.grad.placements, (Partial("sum"),))
+        self.assertEqual(dt_b.grad.full_tensor(), ref_b.grad)
+        self.assertEqual(dt_b.grad.placements, (Partial("sum"),))
+
 
 DistMathOpsTestWithLocalTensor = create_local_tensor_test_class(
     DistMathOpsTest,

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1909,11 +1909,11 @@ def grid_sampler_backward_strategy(
 def _adjust_group_norm_scalars(
     input_specs: list[DTensorSpec], schema: OpSchema
 ) -> OpSchema:
-    """Adjust N, C, HxW scalar args in native_group_norm to local values.
+    """Adjust N, C, HxW scalar args to local values for group_norm forward/backward.
 
-    native_group_norm(input, weight?, bias?, N, C, HxW, group, eps)
-    The scalar args are derived from the global input shape by the Python frontend.
-    When the input is sharded, we recompute them from the local input shape.
+    Shared by native_group_norm and native_group_norm_backward. Both have
+    tensor args followed by N, C, HxW scalars. The scalars are derived from
+    the global input shape; we recompute them from the local shape when sharded.
     """
     input_spec = input_specs[0]
     if input_spec.tensor_meta is None:
@@ -2033,11 +2033,41 @@ def group_norm_strategy(
     return [placements]
 
 
-# Register scalar shape adjuster for group_norm so the sharding propagator
-# rewrites the N/C/HxW args to local values when the input is sharded.
+@register_single_dim_strategy(
+    [aten.native_group_norm_backward.default],
+    schema_info=RuntimeSchemaInfo(1),
+)
+def group_norm_backward_strategy(
+    op: torch._ops.OpOverload,
+    args_schema: tuple[Any, ...],
+    kwargs_schema: dict[str, Any],
+) -> list[list[Placement | _ShardingPlaceholder]]:
+    # native_group_norm_backward(grad_out, input, mean, rstd, weight?, N, C, HxW, group, output_mask)
+    #   -> (grad_input, grad_weight, grad_bias)
+    # Batch-dim sharding: each sample is independent for grad_input, but
+    # grad_weight/grad_bias reduce over batch, so they need Partial().
+    num_tensor_inputs = sum(isinstance(a, TensorMeta) for a in args_schema)
+    placements: list[Placement | _ShardingPlaceholder] = [
+        _ShardingPlaceholder(0),  # grad_input [N,C,*]
+        Partial("sum"),  # grad_weight [C] -- reduce over batch
+        Partial("sum"),  # grad_bias [C] -- reduce over batch
+        _ShardingPlaceholder(0),  # grad_out [N,C,*]
+        _ShardingPlaceholder(0),  # input [N,C,*]
+        _ShardingPlaceholder(0),  # mean [N,groups]
+        _ShardingPlaceholder(0),  # rstd [N,groups]
+    ]
+    # weight (if present) must be Replicate
+    placements.extend([Replicate()] * (num_tensor_inputs - 4))
+    return [placements]
+
+
+# Register scalar adjuster for both forward and backward.
 from torch.distributed.tensor._api import DTensor
 
 
 DTensor._op_dispatcher.sharding_propagator.op_to_scalar_shape_adjuster[
     aten.native_group_norm.default
+] = _adjust_group_norm_scalars
+DTensor._op_dispatcher.sharding_propagator.op_to_scalar_shape_adjuster[
+    aten.native_group_norm_backward.default
 ] = _adjust_group_norm_scalars

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -2041,23 +2041,21 @@ def group_norm_backward_strategy(
     op: torch._ops.OpOverload,
     args_schema: tuple[Any, ...],
     kwargs_schema: dict[str, Any],
-) -> list[list[Placement | _ShardingPlaceholder]]:
+) -> list[list[Placement | _ShardingPlaceholder | None]]:
     # native_group_norm_backward(grad_out, input, mean, rstd, weight?, N, C, HxW, group, output_mask)
     #   -> (grad_input, grad_weight, grad_bias)
-    # Batch-dim sharding: each sample is independent for grad_input, but
-    # grad_weight/grad_bias reduce over batch, so they need Partial().
-    num_tensor_inputs = sum(isinstance(a, TensorMeta) for a in args_schema)
-    placements: list[Placement | _ShardingPlaceholder] = [
+    weight_meta = args_schema[4]
+    placements: list[Placement | _ShardingPlaceholder | None] = [
         _ShardingPlaceholder(0),  # grad_input [N,C,*]
-        Partial("sum"),  # grad_weight [C] -- reduce over batch
-        Partial("sum"),  # grad_bias [C] -- reduce over batch
+        Partial("sum") if weight_meta is not None else None,  # grad_weight [C]
+        Partial("sum") if weight_meta is not None else None,  # grad_bias [C]
         _ShardingPlaceholder(0),  # grad_out [N,C,*]
         _ShardingPlaceholder(0),  # input [N,C,*]
         _ShardingPlaceholder(0),  # mean [N,groups]
         _ShardingPlaceholder(0),  # rstd [N,groups]
     ]
-    # weight (if present) must be Replicate
-    placements.extend([Replicate()] * (num_tensor_inputs - 4))
+    if weight_meta is not None:
+        placements.append(Replicate())
     return [placements]
 
 


### PR DESCRIPTION
Register a single-dim strategy for aten.native_group_norm_backward.default that enables batch-dim (Shard(0)) sharding. Each sample is independent for grad_input; grad_weight and grad_bias reduce over batch via Partial("sum").

Also register the scalar shape adjuster for the backward op so N/C/HxW arguments are rewritten to local-shard values during sharding propagation.

Authored with Claude.