### PR TITLE
Add 3.15 triton wheel build

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -50,9 +50,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py_vers: [ "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        py_vers: [ "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t" ]
         device: ["cuda", "rocm", "xpu", "aarch64"]
         docker-image: ["pytorch/manylinux2_28-builder:cpu"]
+        exclude:
+          # XPU builds for Python 3.15 are currently broken; skip until fixed.
+          - py_vers: "3.15"
+            device: "xpu"
+          - py_vers: "3.15t"
+            device: "xpu"
         include:
           - device: "rocm"
             rocm_version: "7.2"
@@ -125,6 +131,12 @@ jobs:
             ;;
           3.14t)
             PYTHON_EXECUTABLE=/opt/python/cp314-cp314t/bin/python
+            ;;
+          3.15)
+            PYTHON_EXECUTABLE=/opt/python/cp315-cp315/bin/python
+            ;;
+          3.15t)
+            PYTHON_EXECUTABLE=/opt/python/cp315-cp315t/bin/python
             ;;
           *)
             echo "Unsupported python version ${PY_VERS}"


### PR DESCRIPTION
Summary:
Adds Python 3.15 and 3.15t (free-threaded) to the triton wheel build matrix for both Linux and Windows, mirroring PR #159261 which added 3.14 and 3.14t. Includes the corresponding PYTHON_EXECUTABLE case branches pointing at /opt/python/cp315-cp315 and /opt/python/cp315-cp315t.

Test Plan: Triggered by `.github/workflows/build-triton-wheel.yml` via PR / nightly schedule.