### PR TITLE
[Autograd][Pri vateUse1] Expose backend name as alias in DeviceType for PrivateUse1

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_misc.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_misc.py
@@ -28,6 +28,16 @@ class TestBackendModule(TestCase):
         self.assertEqual(str(ProfilerActivity.OPENREG), "ProfilerActivity.OPENREG")
         self.assertEqual(ProfilerActivity.OPENREG.name, "OPENREG")
 
+    def test_device_type_alias(self):
+        """Test DeviceType exposes device-specific alias for PrivateUse1"""
+        from torch._C._autograd import DeviceType
+
+        self.assertTrue(hasattr(DeviceType, "OPENREG"))
+        self.assertEqual(DeviceType.OPENREG, DeviceType.PrivateUse1)
+        self.assertEqual(repr(DeviceType.OPENREG), "<DeviceType.OPENREG: 20>")
+        self.assertEqual(str(DeviceType.OPENREG), "DeviceType.OPENREG")
+        self.assertEqual(DeviceType.OPENREG.name, "OPENREG")
+
     def test_backend_module_registration(self):
         """Test backend module registration error handling"""
 

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -46,6 +46,33 @@ def _rename_profiler_activity(backend_name: str) -> None:
     )
 
 
+def _rename_device_type(backend_name: str) -> None:
+    from torch._C._autograd import DeviceType
+
+    alias = backend_name.upper()
+    setattr(DeviceType, alias, DeviceType.PrivateUse1)
+
+    pu1 = DeviceType.PrivateUse1
+    original_repr = DeviceType.__repr__
+    original_str = DeviceType.__str__
+
+    def custom_repr(self):
+        if self == pu1:
+            return f"<DeviceType.{alias}: {pu1.value}>"
+        return original_repr(self)
+
+    def custom_str(self):
+        if self == pu1:
+            return f"DeviceType.{alias}"
+        return original_str(self)
+
+    DeviceType.__repr__ = custom_repr
+    DeviceType.__str__ = custom_str
+    DeviceType.name = property(  # type: ignore[assignment]
+        lambda self: alias if self == pu1 else original_str(self).split(".")[-1]
+    )
+
+
 def rename_privateuse1_backend(backend_name: str) -> None:
     r"""
     Rename the privateuse1 backend device to make it more convenient to use as a device name within PyTorch APIs.
@@ -109,6 +136,7 @@ def rename_privateuse1_backend(backend_name: str) -> None:
     global _privateuse1_backend_name
     _privateuse1_backend_name = backend_name
     _rename_profiler_activity(backend_name)
+    _rename_device_type(backend_name)
 
 
 def _check_register_once(module, attr) -> None:


### PR DESCRIPTION
## Summary

Add renamed backend aliases for `torch._C._autograd.DeviceType.PrivateUse1`.

This allows PrivateUse1-based backends to use:
```python
DeviceType.<backend_name>
```
instead of:
```python
DeviceType.PrivateUse1
```