### PR TITLE
Switch lookup-only std::map/std::set to unordered variants

### DIFF
--- a/aten/src/ATen/native/mkldnn/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/Utils.cpp
@@ -142,8 +142,8 @@ static AttrFunction attr_func_hardsigmoid =
       return attr;
     };
 
-const std::map<std::string_view, AttrFunction>& fusion_unary_attr_map() {
-  static const std::map<std::string_view, AttrFunction> fusion_attr_map{
+const std::unordered_map<std::string_view, AttrFunction>& fusion_unary_attr_map() {
+  static const std::unordered_map<std::string_view, AttrFunction> fusion_attr_map{
       {"relu", ATTR_FUNC(relu)},
       {"sigmoid", ATTR_FUNC(sigmoid)},
       {"tanh", ATTR_FUNC(tanh)},
@@ -157,15 +157,15 @@ const std::map<std::string_view, AttrFunction>& fusion_unary_attr_map() {
   return fusion_attr_map;
 }
 
-const std::map<std::string_view, ideep::algorithm>& fusion_unary_alg_map() {
-  static const std::map<std::string_view, ideep::algorithm> fusion_attr_map{
+const std::unordered_map<std::string_view, ideep::algorithm>& fusion_unary_alg_map() {
+  static const std::unordered_map<std::string_view, ideep::algorithm> fusion_attr_map{
       {"relu", {ideep::algorithm::eltwise_relu}},
   };
   return fusion_attr_map;
 }
 
-const std::map<std::string_view, ideep::algorithm>& fusion_binary_alg_map() {
-  static const std::map<std::string_view, ideep::algorithm> fusion_attr_map{
+const std::unordered_map<std::string_view, ideep::algorithm>& fusion_binary_alg_map() {
+  static const std::unordered_map<std::string_view, ideep::algorithm> fusion_attr_map{
       {"add", {ideep::algorithm::binary_add}},
       {"sub", {ideep::algorithm::binary_sub}},
       {"mul", {ideep::algorithm::binary_mul}},

--- a/aten/src/ATen/native/mkldnn/Utils.h
+++ b/aten/src/ATen/native/mkldnn/Utils.h
@@ -5,6 +5,7 @@
 #include <ATen/core/Tensor.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/strides.h>
+#include <unordered_map>
 #if !defined(__s390x__) && !defined(__powerpc__)
 #include <cpuinfo.h>
 #endif
@@ -76,11 +77,11 @@ using AttrFunction = std::function<ideep::attr_t(
     torch::List<std::optional<at::Scalar>>,
     std::optional<std::string_view>)>;
 
-const std::map<std::string_view, AttrFunction>& fusion_unary_attr_map();
+const std::unordered_map<std::string_view, AttrFunction>& fusion_unary_attr_map();
 
-const std::map<std::string_view, ideep::algorithm>& fusion_unary_alg_map();
+const std::unordered_map<std::string_view, ideep::algorithm>& fusion_unary_alg_map();
 
-const std::map<std::string_view, ideep::algorithm>& fusion_binary_alg_map();
+const std::unordered_map<std::string_view, ideep::algorithm>& fusion_binary_alg_map();
 
 #endif // AT_MKLDNN_ENABLED()
 }

--- a/aten/src/ATen/native/mkldnn/xpu/FusionUtils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/FusionUtils.cpp
@@ -1,5 +1,7 @@
 #include <ATen/native/mkldnn/xpu/FusionUtils.h>
 
+#include <unordered_set>
+
 using namespace at::native::onednn;
 
 namespace at::native::xpu {
@@ -121,17 +123,17 @@ onednn::Attr& construct_unary_attr(
   // Category `need_algorithm`: require algorithm specification, only gelu now.
   // If further unary operations required, they can be added to these sets or
   // add new sets according to their new categories.
-  static const std::set<std::string_view> argument_less = {
+  static const std::unordered_set<std::string_view> argument_less = {
       "none", "relu", "sigmoid", "tanh", "hardswish", "swish", "hardsigmoid"};
-  static const std::set<std::string_view> need_scalars = {
+  static const std::unordered_set<std::string_view> need_scalars = {
       "leaky_relu", "hardtanh"};
-  static const std::set<std::string_view> need_algorithm = {"gelu"};
+  static const std::unordered_set<std::string_view> need_algorithm = {"gelu"};
 
-  if (argument_less.find(unary) != argument_less.end()) {
+  if (argument_less.contains(unary)) {
     return handle_argument_less(unary, attr);
-  } else if (need_scalars.find(unary) != need_scalars.end()) {
+  } else if (need_scalars.contains(unary)) {
     return handle_need_sclars(unary, attr, scalars);
-  } else if (need_algorithm.find(unary) != need_algorithm.end()) {
+  } else if (need_algorithm.contains(unary)) {
     return handle_need_algorithm(unary, attr, algorithm);
   } else {
     TORCH_CHECK(

--- a/aten/src/ATen/native/vulkan/ops/Mean.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mean.cpp
@@ -120,7 +120,7 @@ Tensor mean_dim_IntList(
           "], but got ",
           d);
       int64_t dim_normalized = utils::normalize(d, self.dim());
-      if (dims_set.find(dim_normalized) != dims_set.end()) {
+      if (dims_set.contains(dim_normalized)) {
         TORCH_CHECK(
             false,
             "dim ",

--- a/aten/src/ATen/native/vulkan/ops/Sum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Sum.cpp
@@ -112,7 +112,7 @@ Tensor sum_dim_IntList(
           dim);
       // Normalize dim into range [0, self.dim() - 1]
       int64_t dim_normalized = utils::normalize(dim, self.dim());
-      if (dims_set.find(dim_normalized) != dims_set.end()) {
+      if (dims_set.contains(dim_normalized)) {
         TORCH_CHECK(
             false,
             "dim ",
@@ -134,6 +134,7 @@ Tensor sum_dim_IntList(
 
 Tensor sum(const Tensor& self, const std::optional<ScalarType> dtype) {
   std::vector<int64_t> dims;
+  dims.reserve(self.dim());
   for (int64_t d = 0; d < self.dim(); d++) {
     // If any dimension has zero elements, we will shortcut to a zero-dim.
     if (self.size(d) == 0) {

--- a/aten/src/ATen/native/vulkan/ops/Var.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Var.cpp
@@ -2,6 +2,8 @@
 #include <ATen/native/vulkan/ops/Utils.h>
 #include <torch/library.h>
 
+#include <unordered_set>
+
 namespace at {
 namespace native {
 namespace vulkan {
@@ -24,7 +26,7 @@ Tensor var_dim_IntList(
 
   const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
 
-  std::set<int64_t> dims_set;
+  std::unordered_set<int64_t> dims_set;
   if (opt_dim.has_value()) {
     int sample_size = 1;
     auto dims = opt_dim.value();
@@ -33,7 +35,7 @@ Tensor var_dim_IntList(
       TORCH_CHECK(d >= -self.dim() || d < self.dim(), "Dimension out of range");
 
       int64_t dim_normalized = utils::normalize(d, self.dim());
-      if (dims_set.find(dim_normalized) != dims_set.end()) {
+      if (dims_set.contains(dim_normalized)) {
         TORCH_CHECK(
             false,
             "dim ",

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -5,6 +5,8 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
+#include <unordered_set>
+
 #include <torch/csrc/distributed/c10d/PrefixStore.hpp>
 
 namespace c10d {
@@ -166,7 +168,7 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
   TORCH_CHECK(
       ranks.size() <= static_cast<size_t>(size_),
       "the split group's size should be no larger than the world_size set by init_process_group");
-  std::set<int> ranks_set(ranks.begin(), ranks.end());
+  std::unordered_set<int> ranks_set(ranks.begin(), ranks.end());
   TORCH_CHECK(
       ranks_set.size() == ranks.size(),
       "Split ranks should not have duplicates. Please provide a list of unique ranks to split the group.");

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/distributed/c10d/default_comm_hooks.hpp>
 
 #include <functional>
+#include <unordered_set>
 
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>
@@ -134,7 +135,7 @@ Reducer::Reducer(
   }
   // Check whether the module is multi_device_module
   {
-    std::set<int> unique_devices;
+    std::unordered_set<int> unique_devices;
     for (const auto& v : params_) {
       auto device_idx = static_cast<int>(v.device().index());
       auto [_, inserted] = unique_devices.emplace(device_idx);

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -7,6 +7,9 @@
 #include <cstdlib>
 #include <limits>
 #include <map>
+#include <unordered_map>
+
+#include <c10/util/hash.h>
 #include <memory>
 #include <optional>
 #include <type_traits>
@@ -1104,16 +1107,14 @@ inline std::tuple<std::shared_ptr<int64_t[]>, int> _get_factors(
 }
 
 inline std::tuple<std::shared_ptr<int64_t[]>, int> get_factors(int64_t number) {
-  thread_local std::map<int64_t, std::tuple<std::shared_ptr<int64_t[]>, int>>
-      cache;
-  auto it = cache.find(number);
-  if (it != cache.end()) {
-    return it->second;
-  } else {
-    auto factors = _get_factors(number);
-    cache[number] = factors;
-    return factors;
+  thread_local std::
+      unordered_map<int64_t, std::tuple<std::shared_ptr<int64_t[]>, int>>
+          cache;
+  auto [it, inserted] = cache.try_emplace(number);
+  if (inserted) {
+    it->second = _get_factors(number);
   }
+  return it->second;
 }
 // NOLINTEND(*-avoid-c-arrays)
 
@@ -1226,20 +1227,19 @@ inline void mm_get_thread_blocking(
     int64_t& Mt,
     int64_t& Nt,
     int64_t& Kt) {
-  thread_local std::map<
-      std::
-          tuple<int, int, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>,
-      std::tuple<int64_t, int64_t, int64_t>>
-      cache;
+  using Key = std::
+      tuple<int, int, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>;
+  thread_local std::
+      unordered_map<Key, std::tuple<int64_t, int64_t, int64_t>, c10::hash<Key>>
+          cache;
   auto key = std::make_tuple(num_threads, max_k_slices, M, N, K, Mr, Nr, Kr);
-  auto it = cache.find(key);
-  if (it != cache.end()) {
-    std::tie(Mt, Nt, Kt) = it->second;
-    return;
-  } else {
+  auto [it, inserted] = cache.try_emplace(key);
+  if (inserted) {
     _mm_get_thread_blocking(
         num_threads, max_k_slices, M, N, K, Mr, Nr, Kr, Mt, Nt, Kt);
-    cache[key] = std::make_tuple(Mt, Nt, Kt);
+    it->second = std::make_tuple(Mt, Nt, Kt);
+  } else {
+    std::tie(Mt, Nt, Kt) = it->second;
   }
 }
 
@@ -1321,22 +1321,22 @@ void mm_get_cache_blocking(
     int64_t& Kc_blocks,
     uint32_t L1_cache_size,
     uint32_t L2_cache_size) {
-  thread_local std::map<
-      std::tuple<
-          int,
-          int64_t,
-          int64_t,
-          int64_t,
-          int64_t,
-          int64_t,
-          int64_t,
-          int64_t,
-          int64_t,
-          int64_t,
-          int64_t,
-          int64_t>,
-      std::tuple<int64_t, int64_t, int64_t>>
-      cache;
+  using Key = std::tuple<
+      int,
+      int64_t,
+      int64_t,
+      int64_t,
+      int64_t,
+      int64_t,
+      int64_t,
+      int64_t,
+      int64_t,
+      int64_t,
+      int64_t,
+      int64_t>;
+  thread_local std::
+      unordered_map<Key, std::tuple<int64_t, int64_t, int64_t>, c10::hash<Key>>
+          cache;
   auto key = std::make_tuple(
       num_threads,
       M,
@@ -1350,11 +1350,8 @@ void mm_get_cache_blocking(
       Kt_blocks,
       L1_cache_size,
       L2_cache_size);
-  auto it = cache.find(key);
-  if (it != cache.end()) {
-    std::tie(Mc_blocks, Nc_blocks, Kc_blocks) = it->second;
-    return;
-  } else {
+  auto [it, inserted] = cache.try_emplace(key);
+  if (inserted) {
     _mm_get_cache_blocking<X_t, W_t>(
         num_threads,
         M,
@@ -1371,7 +1368,9 @@ void mm_get_cache_blocking(
         Kc_blocks,
         L1_cache_size,
         L2_cache_size);
-    cache[key] = std::make_tuple(Mc_blocks, Nc_blocks, Kc_blocks);
+    it->second = std::make_tuple(Mc_blocks, Nc_blocks, Kc_blocks);
+  } else {
+    std::tie(Mc_blocks, Nc_blocks, Kc_blocks) = it->second;
   }
 }
 

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <sstream>
 #include <stack>
+#include <unordered_map>
 #include <vector>
 
 #include <ATen/core/TensorBody.h>
@@ -109,11 +110,11 @@ struct TORCH_API ExecutionTraceObserver { // NOLINT
   using ID = size_t;
 
   // Mapping of each thread to its own operator stack
-  std::map<size_t, std::stack<ID>> opStack;
+  std::unordered_map<size_t, std::stack<ID>> opStack;
   // Uses the underlying TensorImpl object pointer as the key and map to its
   // unique id.
 
-  std::map<const void*, ID> objectId;
+  std::unordered_map<const void*, ID> objectId;
   // Observer run state.
   enum class RunState { uninitialized, disabled, enabled };
 
@@ -381,13 +382,10 @@ static ExecutionTraceObserver::ID getObjectID(
     const void* t) {
   const std::lock_guard<std::recursive_mutex> lock(ob.gMutex);
 
-  auto iter = ob.objectId.find(t);
-  if (iter == ob.objectId.end()) {
-    ExecutionTraceObserver::ID objectId = ob.getNewID();
-    ob.objectId[t] = objectId;
-    return objectId;
+  auto [iter, inserted] = ob.objectId.try_emplace(t);
+  if (inserted) {
+    iter->second = ob.getNewID();
   }
-
   return iter->second;
 }
 


### PR DESCRIPTION
Convert lookup-only std::map/std::set to unordered variants.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01