### PR TITLE
Fix NotImplementedError for float16 and bfloat16 in torch.trace on CPU

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1336,7 +1336,7 @@ Tensor trace_cpu(const Tensor& self) {
   // is set to true
   ScalarType dtype = get_dtype_from_self(self, std::nullopt, true);
   result = at::empty({}, self.options().dtype(dtype));
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX(self.scalar_type(), "trace", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(self.scalar_type(), at::ScalarType::Half, at::ScalarType::BFloat16, "trace", [&] {
     using accscalar_t = at::acc_type<scalar_t, false>;
     accscalar_t sum = 0;
     const auto* t_data = self.const_data_ptr<scalar_t>();


### PR DESCRIPTION
## Description
Fixes a bug where `torch.trace` on CPU throws a `NotImplementedError` for `float16` (Half) and `bfloat16` tensors, despite these types being fully supported on other backends like CUDA and MPS.

**Root cause:**
The CPU backend for `torch.trace` uses a custom implementation (`trace_cpu`) for performance reasons rather than delegating to `.diagonal().sum()`. This loop used the `AT_DISPATCH_ALL_TYPES_AND_COMPLEX` macro, which explicitly excludes reduced-precision floating-point types (`Half` and `BFloat16`). 

**Fix:**
Changed the dispatch macro in `aten/src/ATen/native/ReduceOps.cpp` to `AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2`, passing in `at::ScalarType::Half` and `at::ScalarType::BFloat16`. 

The underlying `acc_type` correctly promotes both dtypes to `float32` for accumulation, which means this dispatch change enables them while safely preventing early overflow during the summation step.

## Test Plan
- Manually validated that `torch.trace(x)` successfully returns the correct trace for 2D `float16` and `bfloat16` tensors on the `cpu` device, matching NumPy's behavior.
