### PR TITLE
[ONNX] Fix _rotary_embedding_23_fake_impl stride drift for 3D and 4D inputs

### DIFF
--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -488,6 +488,34 @@ class NativeOnnxOpsTest(common_utils.TestCase):
             (input_data, cos_cache_data, sin_cache_data, position_ids_data),
         )
 
+    def test_rotary_embedding_opcheck_3d(self):
+        # 3D input path must also match the real impl's contiguous output stride.
+        input_data = torch.rand(2, 4, 24)
+        position_ids_data = torch.randint(0, 50, (2, 4)).long()
+        sin_cache_data = torch.rand(50, 4)
+        cos_cache_data = torch.rand(50, 4)
+
+        torch.library.opcheck(
+            _impl.rotary_embedding_23,
+            (input_data, cos_cache_data, sin_cache_data, position_ids_data),
+            kwargs=dict(num_heads=3),
+        )
+
+    def test_rotary_embedding_opcheck_non_contiguous(self):
+        # Non-contiguous inputs must not break fake/real stride alignment.
+        # transpose(1, 2) on a (B, S, H, D) tensor yields the (B, H, S, D)
+        # layout the op expects, with non-contiguous strides.
+        input_data = torch.rand(2, 4, 3, 8).transpose(1, 2)
+        self.assertFalse(input_data.is_contiguous())
+        position_ids_data = torch.randint(0, 50, (2, 4)).long()
+        sin_cache_data = torch.rand(50, 4)
+        cos_cache_data = torch.rand(50, 4)
+
+        torch.library.opcheck(
+            _impl.rotary_embedding_23,
+            (input_data, cos_cache_data, sin_cache_data, position_ids_data),
+        )
+
     def test_rotary_embedding(self):
         input_data = torch.rand(2, 3, 4, 8)
         position_ids_data = torch.randint(0, 50, (2, 4)).long()

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -60,7 +60,17 @@ def _rotary_embedding_23_fake_impl(
     rotary_embedding_dim: int = 0,
 ) -> torch.Tensor:
     """Fake implementation for RotaryEmbedding-23 for torch.compile purposes."""
-    return x.clone()
+    if x.dim() == 4:
+        # Real impl permutes (0,2,1,3), computes via cat (allocates fresh
+        # contiguous), then permutes back, yielding strides equivalent to
+        # empty_permuted with (0,2,1,3) regardless of input strides.
+        return torch.empty_permuted(
+            x.shape, (0, 2, 1, 3), dtype=x.dtype, device=x.device
+        )
+    # 3D path: real impl ends in torch.reshape(contiguous_output, input_shape),
+    # which always yields contiguous strides. Force contiguous here so the
+    # fake stays aligned even when the caller passes a non-contiguous input.
+    return torch.empty(x.shape, dtype=x.dtype, device=x.device)
 
 
 @_onnx_op("RotaryEmbedding", 23, _rotary_embedding_23_fake_impl)


### PR DESCRIPTION
`_rotary_embedding_23_fake_impl` returned `x.clone()`, so its strides followed the input. The real impl always ends with `permute(output, (0,2,1,3))` (4D) or `reshape(contiguous_output, input_shape)` (3D), yielding deterministic strides regardless of input layout. opcheck caught the 4D case (#183713); the 3D case is the same bug, latent for non-contiguous inputs.

Fix: `torch.empty_permuted(shape, (0,2,1,3))` for 4D, `torch.empty(shape)` for 3D — both match the real strides for any input layout. Adds opcheck coverage for 3D and for non-contiguous 4D.

Supersedes #183727 (which fixes only 4D).

Test: `pytest test/onnx/ops/test_ops.py -k rotary_embedding_opcheck`

Fixes #183713
