### PR TITLE
Raise ValueError early when strategy="forward-mode" used without vectorize=True

### DIFF
--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -714,6 +714,14 @@ class TestAutogradFunctional(TestCase):
         self._assert_interleaved_struct(res, foo(*inp), inp)
 
     @base_and_logging_tensor
+    def test_jacobian_forward_mode_requires_vectorize(self, ctors):
+        inp = ctors.rand(4)
+        with self.assertRaisesRegex(
+            ValueError, 'strategy="forward-mode" requires vectorize=True'
+        ):
+            autogradF.jacobian(torch.tanh, inp, strategy="forward-mode")
+
+    @base_and_logging_tensor
     def test_jacobian_err_check_strict(self, ctors):
         def foo(a):
             return a.detach()
@@ -1073,6 +1081,17 @@ class TestAutogradFunctional(TestCase):
 
         res = autogradF.hessian(foo, inp, vectorize=vectorize)
         self._assert_interleaved_struct(res, inp, inp)
+
+    @base_and_logging_tensor
+    def test_hessian_forward_mode_requires_vectorize(self, ctors):
+        inp = ctors.rand(4)
+        with self.assertRaisesRegex(
+            ValueError,
+            'outer_jacobian_strategy="forward-mode" requires vectorize=True',
+        ):
+            autogradF.hessian(
+                lambda a: a.sum(), inp, outer_jacobian_strategy="forward-mode"
+            )
 
     @base_and_logging_tensor
     def test_hessian_err_check_strict(self, ctors):

--- a/torch/autograd/functional.py
+++ b/torch/autograd/functional.py
@@ -621,7 +621,7 @@ def jacobian(
             more information.
         strategy (str, optional): Set to ``"forward-mode"`` or ``"reverse-mode"`` to
             determine whether the Jacobian will be computed with forward or reverse
-            mode AD. Currently, ``"forward-mode"`` requires ``vectorized=True``.
+            mode AD. Currently, ``"forward-mode"`` requires ``vectorize=True``.
             Defaults to ``"reverse-mode"``. If ``func`` has more outputs than
             inputs, ``"forward-mode"`` tends to be more performant. Otherwise,
             prefer to use ``"reverse-mode"``.
@@ -684,6 +684,12 @@ def jacobian(
             'Otherwise, prefer to use "reverse-mode".'
         )
     if strategy == "forward-mode":
+        if not vectorize:
+            raise ValueError(
+                'strategy="forward-mode" requires vectorize=True. '
+                "Please either set `vectorize=True` or "
+                '`strategy="reverse-mode"`.'
+            )
         if create_graph:
             raise NotImplementedError(
                 "torch.autograd.functional.jacobian: `create_graph=True` "
@@ -893,7 +899,7 @@ def hessian(
             computed in reverse-mode AD. Setting strategy to ``"forward-mode"``
             or ``"reverse-mode"`` determines whether the outer Jacobian will be
             computed with forward or reverse mode AD. Currently, computing the outer
-            Jacobian in ``"forward-mode"`` requires ``vectorized=True``. Defaults
+            Jacobian in ``"forward-mode"`` requires ``vectorize=True``. Defaults
             to ``"reverse-mode"``.
 
     Returns:
@@ -953,6 +959,12 @@ def hessian(
     ):
         raise AssertionError(
             'Expected strategy to be either "forward-mode" or "reverse-mode".'
+        )
+    if outer_jacobian_strategy == "forward-mode" and not vectorize:
+        raise ValueError(
+            'outer_jacobian_strategy="forward-mode" requires vectorize=True. '
+            "Please either set `vectorize=True` or "
+            '`outer_jacobian_strategy="reverse-mode"`.'
         )
 
     def ensure_single_output_function(*inp):


### PR DESCRIPTION
`jacobian()` and `hessian()` accept `strategy="forward-mode"` with `vectorize=False` (the default) at call time but then raise `NotImplementedError` deep inside `_jacfwd` at execution time. This moves the check to argument validation so users get a clear `ValueError` with actionable guidance immediately.

Also fixes docstring typos: `vectorized=True` → `vectorize=True` in both `jacobian` and `hessian` parameter descriptions.

Closes: #184842

## Test Plan

Added two new test cases in `test/autograd/test_functional.py`:
- `test_jacobian_forward_mode_requires_vectorize`
- `test_hessian_forward_mode_requires_vectorize`

Verified with standalone script that:
- `jacobian(..., strategy="forward-mode")` now raises `ValueError` immediately
- `hessian(..., outer_jacobian_strategy="forward-mode")` now raises `ValueError` immediately
- All valid combinations (`vectorize=True`, `reverse-mode`) still work correctly

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6)