### PR TITLE
[Torch][AOTI] track and unload CUmodule handles to prevent GPU code object leaks (#184860)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -274,6 +274,33 @@ class AOTInductorTestsTemplate:
                 model, example_inputs, "AOTInductorModelRunMinimalArrayrefInterface(", 1
             )
 
+    @common_utils.parametrize("embed_kernel_binary", [False, True])
+    def test_loaded_modules_tracking(self, embed_kernel_binary):
+        # Verify that AOTI codegen on CUDA/HIP passes &kernels_.loaded_modules_
+        # to loadKernel so CUmodule handles are tracked and unloaded on
+        # destruction, preventing GPU code object leaks.
+        if self.device != "cuda":
+            raise unittest.SkipTest("requires CUDA/HIP")
+
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10)
+
+            def forward(self, x, y):
+                return x + self.linear(y)
+
+        example_inputs = (
+            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=self.device),
+        )
+        model = Model().to(self.device)
+        with config.patch({"aot_inductor.embed_kernel_binary": embed_kernel_binary}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            FileCheck().check("&kernels_.loaded_modules_").run(code)
+
     def test_triton_kernel_bool_param(self):
         if self.device != GPU_TYPE or self.device == "mps":
             raise unittest.SkipTest("requires GPU")

--- a/test/inductor/test_cpp_wrapper_hipify.py
+++ b/test/inductor/test_cpp_wrapper_hipify.py
@@ -61,7 +61,8 @@ class TestCppWrapperHipify(TestCase):
                     std::string filePath,
                     const std::string &funcName,
                     uint32_t sharedMemBytes,
-                    const std::optional<std::string> &cubinDir = std::nullopt) {
+                    const std::optional<std::string> &cubinDir = std::nullopt,
+                    std::vector<hipModule_t>* loaded_modules = nullptr) {
                 if (cubinDir) {
                     std::filesystem::path p1{*cubinDir};
                     std::filesystem::path p2{filePath};
@@ -71,6 +72,9 @@ class TestCppWrapperHipify(TestCase):
                 hipModule_t mod;
                 hipFunction_t func;
                 CUDA_DRIVER_CHECK(hipModuleLoad(&mod, filePath.c_str()));
+                if (loaded_modules) {
+                    loaded_modules->push_back(mod);
+                }
                 CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
                 if (sharedMemBytes > 0) {
                     CUDA_DRIVER_CHECK(hipFuncSetAttribute(
@@ -82,10 +86,17 @@ class TestCppWrapperHipify(TestCase):
                 return func;
             }
 
-            static inline hipFunction_t loadKernel(const void* start, const std::string &funcName, uint32_t sharedMemBytes) {
+            static inline hipFunction_t loadKernel(
+                    const void* start,
+                    const std::string &funcName,
+                    uint32_t sharedMemBytes,
+                    std::vector<hipModule_t>* loaded_modules = nullptr) {
                 hipModule_t mod;
                 hipFunction_t func;
                 CUDA_DRIVER_CHECK(hipModuleLoadData(&mod, start));
+                if (loaded_modules) {
+                    loaded_modules->push_back(mod);
+                }
                 CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
                 if (sharedMemBytes > 0) {
                     CUDA_DRIVER_CHECK(hipFuncSetAttribute(

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -637,6 +637,14 @@ class DeferredTritonCallWrapper:
                     "cubin_dir_",
                 ]
 
+            # In AOTI mode on CUDA/HIP, pass the loaded_modules_ vector so
+            # CUmodule handles are tracked and can be unloaded on destruction,
+            # preventing GPU code object leaks. XPU is excluded because its
+            # loadKernel returns std::unique_ptr<sycl::kernel> and manages
+            # cleanup via RAII.
+            if V.graph.aot_mode and V.graph.device_type != "xpu":
+                load_kernel_args = load_kernel_args + ["&kernels_.loaded_modules_"]
+
             prefix.writeline(
                 f"{kernel_var_name} = loadKernel({', '.join(load_kernel_args)}); "
             )

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -50,6 +50,8 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
         return source_codes
 
     def kernel_driver(self) -> str:
+        """Return C++ host-side helpers (loadKernel, launchKernel, CUDA_DRIVER_CHECK)
+        embedded in AOTI-generated wrapper code."""
         source_codes = """
             #define CUDA_DRIVER_CHECK(EXPR)                    \\
             do {                                               \\
@@ -72,7 +74,8 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                     std::string filePath,
                     const std::string &funcName,
                     uint32_t sharedMemBytes,
-                    const std::optional<std::string> &cubinDir = std::nullopt) {
+                    const std::optional<std::string> &cubinDir = std::nullopt,
+                    std::vector<CUmodule>* loaded_modules = nullptr) {
                 if (cubinDir) {
                     std::filesystem::path p1{*cubinDir};
                     std::filesystem::path p2{filePath};
@@ -82,6 +85,9 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                 CUmodule mod;
                 CUfunction func;
                 CUDA_DRIVER_CHECK(cuModuleLoad(&mod, filePath.c_str()));
+                if (loaded_modules) {
+                    loaded_modules->push_back(mod);
+                }
                 CUDA_DRIVER_CHECK(cuModuleGetFunction(&func, mod, funcName.c_str()));
                 if (sharedMemBytes > 0) {
                     CUDA_DRIVER_CHECK(cuFuncSetAttribute(
@@ -93,10 +99,17 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                 return func;
             }
 
-            static inline CUfunction loadKernel(const void* start, const std::string &funcName, uint32_t sharedMemBytes) {
+            static inline CUfunction loadKernel(
+                    const void* start,
+                    const std::string &funcName,
+                    uint32_t sharedMemBytes,
+                    std::vector<CUmodule>* loaded_modules = nullptr) {
                 CUmodule mod;
                 CUfunction func;
                 CUDA_DRIVER_CHECK(cuModuleLoadData(&mod, start));
+                if (loaded_modules) {
+                    loaded_modules->push_back(mod);
+                }
                 CUDA_DRIVER_CHECK(cuModuleGetFunction(&func, mod, funcName.c_str()));
                 if (sharedMemBytes > 0) {
                     CUDA_DRIVER_CHECK(cuFuncSetAttribute(

--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -1125,7 +1125,29 @@ class AOTInductorModelBase {
 // Codegen-ed classes can derive from this to keep pointers to loaded kernels.
 class AOTInductorModelKernelsBase {
  public:
-  virtual ~AOTInductorModelKernelsBase() = default;
+  // NOLINTNEXTLINE(modernize-use-equals-default)
+  virtual ~AOTInductorModelKernelsBase() {
+#ifdef USE_CUDA
+    for (auto mod : loaded_modules_) {
+      if (mod) {
+        auto err = cuModuleUnload(mod);
+        if (err != CUDA_SUCCESS) {
+          const char* msg = nullptr;
+          cuGetErrorString(err, &msg);
+          std::cerr << "Failed to unload CUDA module in AOTInductor model: "
+                    << (msg ? msg : "unknown error") << '\n';
+        }
+      }
+    }
+#endif // USE_CUDA
+  }
+
+#ifdef USE_CUDA
+  // Tracks CUmodule handles loaded by loadKernel() so they can be
+  // properly unloaded when the model is destroyed, preventing GPU
+  // code object leaks.
+  std::vector<CUmodule> loaded_modules_;
+#endif // USE_CUDA
 };
 
 } // namespace torch::aot_inductor


### PR DESCRIPTION
Summary:

### AOTInductor CUDA Kernel Module Management

 **Problem:**  
AOTInductor's generated code loads CUDA kernels using `cuModuleLoad` / `cuModuleLoadData` but does not unload them. Each loaded module pins a GPU code object, causing repeated `aoti_load_package` cycles (or destroying and recreating models) to steadily leak GPU memory until the process exits.

**Solution:**  
The fix tracks every `CUmodule` handle returned by `loadKernel` in a `std::vector<CUmodule> loaded_modules_` member on `AOTInductorModelKernelsBase`. The base class's destructor iterates over that vector and calls `cuModuleUnload` on each entry, logging (but not throwing) on failure so a single unload error cannot prevent the rest of the cleanup.

**Implementation Details:**  
  - To enable tracking, `loadKernel` receives a new optional trailing `std::vector<CUmodule>* loaded_modules` parameter (defaulted to `nullptr`, maintaining source compatibility for out-of-tree callers).
  - The cpp wrapper codegen appends `&kernels_.loaded_modules_` as an extra argument whenever in AOTI mode and the target device is not XPU.
  - XPU is excluded because its `loadKernel` returns `std::unique_ptr<sycl::kernel>` and handles cleanup via RAII.

**Summary:**  
This change ensures proper cleanup of CUDA kernel modules, preventing GPU memory leaks during repeated package loads or model recreation, while maintaining compatibility and robust error handling.

Test Plan:
```
buck2 test fbcode//caffe2/test/inductor:test_aot_inductor -- test_loaded_modules_tracking
```

Reviewed By: desertfire

Differential Revision: D100858474




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo