### PR TITLE
[distributed] Handle empty inputs and kwargs in _to_kwargs

### DIFF
--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 from torch import distributed as dist
 from torch.distributed.fsdp._common_utils import _get_param_to_fqns
-from torch.distributed.utils import _apply_to_tensors, _replace_by_prefix
+from torch.distributed.utils import _apply_to_tensors, _replace_by_prefix, _to_kwargs
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
@@ -45,6 +45,15 @@ else:
 
 
 class TestUtils(TestCase):
+    def test_to_kwargs_empty_inputs_and_kwargs(self):
+        moved_inputs, moved_kwargs = _to_kwargs((), None, torch.device("cpu"), False)
+        self.assertEqual(moved_inputs, ((),))
+        self.assertEqual(moved_kwargs, ({},))
+
+        moved_inputs, moved_kwargs = _to_kwargs((), {}, torch.device("cpu"), False)
+        self.assertEqual(moved_inputs, ((),))
+        self.assertEqual(moved_kwargs, ({},))
+
     @parametrize(
         "device_list",
         [

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -264,12 +264,12 @@ def _to_kwargs(
     moved_inputs = (
         _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies)
         if inputs
-        else []
+        else [()]
     )
     moved_kwargs = (
         _recursive_to(kwargs, target_device, use_side_stream_for_tensor_copies)
         if kwargs
-        else []
+        else [{}]
     )
     if len(moved_inputs) < len(moved_kwargs):
         moved_inputs.extend([() for _ in range(len(moved_kwargs) - len(inputs))])


### PR DESCRIPTION
Summary:
Fix `_to_kwargs` so modules with no positional inputs and no keyword inputs still get a single empty call entry instead of empty input/kwarg lists.

Review:
@rohan-varma @weifengpy, would you mind taking a look when you have a chance? Your guidance on the distributed/FSDP input handling here would be greatly appreciated.
