### PR TITLE
[symbolic shapes] Avoid direct replacement cycles

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -734,6 +734,19 @@ def forward(self, x_1):
         # After expecting true, guards now resolve given the runtime assert
         bool(i0 == 0)
 
+    def test_set_replacement_skips_direct_cycles(self):
+        shape_env = ShapeEnv()
+        i0 = shape_env.create_unbacked_symint()
+        i1 = shape_env.create_unbacked_symint()
+        i0_sym = i0.node.expr
+        i1_sym = i1.node.expr
+
+        shape_env._set_replacement(i0_sym, i1_sym, "test")
+        shape_env._set_replacement(i1_sym, i0_sym, "test")
+
+        self.assertEqual(shape_env.replacements[i0_sym], i1_sym)
+        self.assertNotIn(i1_sym, shape_env.replacements)
+
     def test_expect_true_with_s0(self):
         shape_env = ShapeEnv()
         s0 = create_symint(shape_env, 5)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -7439,6 +7439,10 @@ class ShapeEnv:
         if tgt == self.replacements.get(a, None):
             return
 
+        # avoid direct cycle, find will reduce rank to 1
+        if a == self.replacements.get(tgt, None):
+            return
+
         if a in tgt.free_symbols:
             return
 


### PR DESCRIPTION
Summary:
Avoid adding a direct replacement cycle in `ShapeEnv._set_replacement` when the target symbol already maps back to the source. This keeps replacement tracking acyclic before union-find rank reduction.

Review:
@laithsakka, would you mind taking a look when you have a chance? Your guidance on the symbolic shapes behavior here would be greatly appreciated.
