### PR TITLE
[inductor] Avoid data-dependent guards in mix-order reduction checks

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -773,7 +773,6 @@ class MixOrderReductionTest(TestBase):
         from torch._inductor.scheduler import BaseSchedulerNode
         from torch._inductor.virtualized import V
         from torch.fx.experimental.proxy_tensor import make_fx
-        from torch.fx.experimental.symbolic_shapes import GuardOnDataDependentSymNode
 
         mock_node_1 = mock.create_autospec(BaseSchedulerNode)
         mock_node_2 = mock.create_autospec(BaseSchedulerNode)
@@ -812,8 +811,6 @@ class MixOrderReductionTest(TestBase):
                 {"triton.mix_order_reduction_non_strict_mode": False}
             ),
         ):
-            with self.assertRaises(GuardOnDataDependentSymNode):
-                graph.sizevars.guard_or_true(nrow * ncol >= 5 * 2**20)
             self.assertFalse(MixOrderReduction.can_fuse(mock_node_1, mock_node_2))
 
     @inductor_config.patch({"triton.mix_order_reduction_non_strict_mode": True})

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -756,6 +756,66 @@ class MixOrderReductionTest(TestBase):
         ):
             self.assertTrue(MixOrderReduction.can_fuse(mock_node_1, mock_node_2))
 
+    @patch("torch._inductor.scheduler.MixOrderReduction.is_split_reduction")
+    @patch("torch._inductor.scheduler.MixOrderReduction.get_numel_rnumel")
+    @patch("torch._inductor.scheduler.MixOrderReduction.get_common_read")
+    @patch("torch._inductor.scheduler.MixOrderReduction.has_mix_reduction_orders")
+    def test_mix_order_reduction_data_dependent_checks_skip_fusion(
+        self,
+        mock_has_mix_reduction_orders: mock.Mock,
+        mock_get_common_read: mock.Mock,
+        mock_get_numel_rnumel: mock.Mock,
+        mock_is_split_reduction: mock.Mock,
+    ):
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        from torch._inductor.scheduler import BaseSchedulerNode
+        from torch._inductor.virtualized import V
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch.fx.experimental.symbolic_shapes import GuardOnDataDependentSymNode
+
+        mock_node_1 = mock.create_autospec(BaseSchedulerNode)
+        mock_node_2 = mock.create_autospec(BaseSchedulerNode)
+
+        mock_node_1.is_gpu.return_value = True
+        mock_node_2.is_gpu.return_value = True
+        mock_node_1.get_device.return_value.type = "cuda"
+        mock_node_1.is_reduction.return_value = True
+        mock_node_2.is_reduction.return_value = True
+
+        from torch._inductor.utils import OrderedSet
+
+        mock_node_1.ancestors = OrderedSet()
+        mock_node_2.ancestors = OrderedSet()
+        mock_node_1.get_operation_names.return_value = OrderedSet()
+        mock_node_2.get_operation_names.return_value = OrderedSet()
+
+        mock_has_mix_reduction_orders.return_value = True
+        mock_get_common_read.return_value = ["common_read"]
+        mock_is_split_reduction.return_value = False
+
+        mock_node_1.read_writes = mock.Mock()
+        mock_node_1.read_writes.reads = []
+
+        from torch._inductor.graph import GraphLowering
+
+        gm = make_fx(lambda: torch.zeros(2, 3))()
+        graph = GraphLowering(gm)
+        nrow = graph.sizevars.shape_env.create_unbacked_symint().node.expr
+        ncol = graph.sizevars.shape_env.create_unbacked_symint().node.expr
+        mock_get_numel_rnumel.return_value = (nrow, ncol)
+
+        with (
+            V.set_graph_handler(graph),
+            inductor_config.patch(
+                {"triton.mix_order_reduction_non_strict_mode": False}
+            ),
+        ):
+            with self.assertRaises(GuardOnDataDependentSymNode):
+                graph.sizevars.guard_or_true(nrow * ncol >= 5 * 2**20)
+            self.assertFalse(MixOrderReduction.can_fuse(mock_node_1, mock_node_2))
+
     @inductor_config.patch({"triton.mix_order_reduction_non_strict_mode": True})
     def test_no_recompile(self):
         if not inductor_config.triton.mix_order_reduction:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -384,19 +384,31 @@ class MixOrderReduction:
             # Call evaluate_expr rather than statically_known_geq since nrow can
             # have dynamic shape in real models.
             # Don't use hint directly since hint can be non-representative.
-            if not V.graph.sizevars.guard_or_true(sympy.Ge(nrow * ncol, size_thres)):
+            if not V.graph.sizevars.evaluate_expr(
+                sympy.Ge(nrow * ncol, size_thres),
+                size_oblivious=True,
+                fallback_value=False,
+            ):
                 return False
 
             # We require more more row than columns since
             # 1, we prefer doing persistent reduction for each row
             # 2, we will split the reduction across the rows
-            if not V.graph.sizevars.guard_or_true(sympy.Ge(nrow, ncol * 2)):
+            if not V.graph.sizevars.evaluate_expr(
+                sympy.Ge(nrow, ncol * 2),
+                size_oblivious=True,
+                fallback_value=False,
+            ):
                 return False
 
             # When nrow is small, ncol should also be small (due to the check
             # above). Thus the entire tensor should be well cached in L2.
             # Mix order reduction is less beneficial.
-            if not V.graph.sizevars.guard_or_true(sympy.Ge(nrow, 4096)):
+            if not V.graph.sizevars.evaluate_expr(
+                sympy.Ge(nrow, 4096),
+                size_oblivious=True,
+                fallback_value=False,
+            ):
                 return False
 
         # Make sure a persistent reduction will be generated


### PR DESCRIPTION
Summary:
Make mixed-order reduction profitability checks use size-oblivious symbolic evaluation with a conservative false fallback. This avoids installing data-dependent guards when symbolic conditions cannot be proven.

Review:
@eellison, would you mind taking a look when you have a chance? Your guidance on the Inductor scheduler/reduction behavior here would be greatly appreciated.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos