### PR TITLE
Scope third-party install rules out of the wheel via CMake components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,12 @@ endif()
 
 set(CMAKE_INSTALL_MESSAGE NEVER)
 
+# Install components ("libtorch", "torch", "dev", "third_party") and the
+# pytorch_add_thirdparty_subdirectory() macro used below to scope vendored
+# subprojects' install rules out of the wheel. Must be included before any
+# install() calls or add_subdirectory(third_party/...) sites.
+include(cmake/InstallComponents.cmake)
+
 # check and set CMAKE_CXX_STANDARD
 string(FIND "${CMAKE_CXX_FLAGS}" "-std=c++" env_cxx_standard)
 if(env_cxx_standard GREATER -1)
@@ -1356,7 +1362,7 @@ if(USE_MIMALLOC)
   set(MI_BUILD_OBJECT OFF)
   set(MI_BUILD_TESTS OFF)
   add_definitions(-DUSE_MIMALLOC)
-  add_subdirectory(third_party/mimalloc)
+  pytorch_add_thirdparty_subdirectory(third_party/mimalloc)
   include_directories(third_party/mimalloc/include)
 endif()
 

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -807,7 +807,13 @@ if(NOT EMSCRIPTEN AND NOT INTERN_BUILD_MOBILE)
         set(DISABLE_SVE ON CACHE BOOL "Xcode's clang-12.5 crashes while trying to compile SVE code" FORCE)
       endif()
     endif()
-    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/sleef" ${CMAKE_BINARY_DIR}/sleef)
+    pytorch_add_thirdparty_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/sleef" ${CMAKE_BINARY_DIR}/sleef)
+    # sleef.h is generated at build time and is part of the libtorch public
+    # include surface (vec128_float_neon.h #includes <sleef.h>); re-stage it
+    # since sleef's own install rules were suppressed.
+    install(FILES "${CMAKE_BINARY_DIR}/sleef/include/sleef.h"
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+      COMPONENT libtorch)
     set_property(TARGET sleef PROPERTY FOLDER "dependencies")
     list(APPEND ATen_THIRD_PARTY_INCLUDE ${CMAKE_BINARY_DIR}/include)
     link_directories(${CMAKE_BINARY_DIR}/sleef/lib)
@@ -1012,7 +1018,8 @@ endforeach()
 install(FILES ${ops_h} ${ops_generated_headers}
   DESTINATION ${AT_INSTALL_INCLUDE_DIR}/ATen/ops)
 install(FILES ${CMAKE_BINARY_DIR}/aten/src/ATen/Declarations.yaml
-  DESTINATION ${AT_INSTALL_SHARE_DIR}/ATen)
+  DESTINATION ${AT_INSTALL_SHARE_DIR}/ATen
+  COMPONENT torch)
 
 if(ATEN_NO_TEST)
   message("disable test because ATEN_NO_TEST is set")

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1199,7 +1199,7 @@ if(USE_XPU)
   list(APPEND ${Caffe2_XPU_INCLUDE} ${TORCH_XPU_OPS_DIR}/src/ATen/)
   set(TORCH_XPU_OPS_PYTORCH_DEPS ATEN_CPU_FILES_GEN_TARGET)
 
-  add_subdirectory(${TORCH_ROOT}/third_party/torch-xpu-ops
+  pytorch_add_thirdparty_subdirectory(${TORCH_ROOT}/third_party/torch-xpu-ops
       ${CMAKE_BINARY_DIR}/caffe2/aten_xpu)
   if(NOT TARGET torch_xpu_ops)
     message(WARNING "Failed to include ATen XPU implementation target")
@@ -1217,6 +1217,15 @@ if(USE_XPU)
         DESTINATION ${TORCH_INSTALL_INCLUDE_DIR}/ATen/
         FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
 
+    # torch-xpu-ops' own install rules were suppressed by the wrap above,
+    # so re-stage the shared libraries that libtorch_xpu.so loads at runtime.
+    foreach(_xpu_ops_target IN ITEMS torch-xpu-ops-sycltla-mha_fwd torch-xpu-ops-sycltla-mha_bwd)
+      if(TARGET ${_xpu_ops_target})
+        install(TARGETS ${_xpu_ops_target}
+            DESTINATION "${TORCH_INSTALL_LIB_DIR}"
+            COMPONENT libtorch)
+      endif()
+    endforeach()
   endif()
 endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -437,9 +437,16 @@ if(INTERN_BUILD_MOBILE OR NOT DISABLE_NNPACK_AND_FAMILY)
       set(PTHREADPOOL_BUILD_BENCHMARKS OFF CACHE BOOL "")
       set(PTHREADPOOL_LIBRARY_TYPE "static" CACHE STRING "")
       set(PTHREADPOOL_ALLOW_DEPRECATED_API ON CACHE BOOL "")
-      add_subdirectory(
+      pytorch_add_thirdparty_subdirectory(
         "${PTHREADPOOL_SOURCE_DIR}"
         "${CONFU_DEPENDENCIES_BINARY_DIR}/pthreadpool")
+      # pthreadpool's add_subdirectory transitively pulls in FXdiv, FP16,
+      # and psimd. Re-stage the public headers from each since the
+      # subprojects' own install rules were suppressed.
+      pytorch_install_thirdparty_headers("${PTHREADPOOL_SOURCE_DIR}/include")
+      pytorch_install_thirdparty_headers("${PROJECT_SOURCE_DIR}/third_party/FXdiv/include")
+      pytorch_install_thirdparty_headers("${PROJECT_SOURCE_DIR}/third_party/FP16/include")
+      pytorch_install_thirdparty_headers("${PROJECT_SOURCE_DIR}/third_party/psimd/include")
       set_property(TARGET pthreadpool PROPERTY POSITION_INDEPENDENT_CODE ON)
     endif()
 
@@ -478,9 +485,17 @@ if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(s390x|ppc64le)$")
         set(CPUINFO_RUNTIME_TYPE "shared" CACHE STRING "")
       endif()
     endif()
-    add_subdirectory(
+    pytorch_add_thirdparty_subdirectory(
       "${CPUINFO_SOURCE_DIR}"
       "${CONFU_DEPENDENCIES_BINARY_DIR}/cpuinfo")
+    # cpuinfo.h and clog.h are part of the libtorch public include surface;
+    # re-stage them since the subproject's own install rules were suppressed.
+    install(FILES "${CPUINFO_SOURCE_DIR}/include/cpuinfo.h"
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+      COMPONENT libtorch)
+    install(FILES "${CPUINFO_SOURCE_DIR}/deps/clog/include/clog.h"
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+      COMPONENT libtorch)
     # We build static version of cpuinfo but link
     # them into a shared library for Caffe2, so they need PIC.
     set_property(TARGET cpuinfo PROPERTY POSITION_INDEPENDENT_CODE ON)
@@ -586,9 +601,13 @@ if(USE_XNNPACK AND NOT USE_SYSTEM_XNNPACK)
       set(XNNPACK_BUILD_WITH_LIBM OFF CACHE BOOL "")
     endif()
 
-    add_subdirectory(
+    pytorch_add_thirdparty_subdirectory(
       "${XNNPACK_SOURCE_DIR}"
       "${CONFU_DEPENDENCIES_BINARY_DIR}/XNNPACK")
+    # xnnpack.h (and experiments-config.h next to it) are part of the
+    # libtorch public include surface; re-stage them since the subproject's
+    # own install rules were suppressed.
+    pytorch_install_thirdparty_headers("${XNNPACK_INCLUDE_DIR}")
 
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "14")
       foreach(xnn_tgt IN ITEMS XNNPACK microkernels-prod microkernels-all)
@@ -667,7 +686,7 @@ if(BUILD_TEST OR BUILD_MOBILE_BENCHMARK OR BUILD_MOBILE_TEST)
   set(INSTALL_GTEST OFF CACHE BOOL "Install gtest." FORCE)
   set(BUILD_GMOCK ON CACHE BOOL "Build gmock." FORCE)
 
-  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/googletest)
+  pytorch_add_thirdparty_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/googletest)
   include_directories(BEFORE SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../third_party/googletest/googletest/include)
   include_directories(BEFORE SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../third_party/googletest/googlemock/include)
 
@@ -676,7 +695,7 @@ if(BUILD_TEST OR BUILD_MOBILE_BENCHMARK OR BUILD_MOBILE_TEST)
   # We will not need to install benchmark since we link it statically.
   set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "Disable benchmark install to avoid overwriting vendor install.")
   if(NOT USE_SYSTEM_BENCHMARK)
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/benchmark)
+    pytorch_add_thirdparty_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/benchmark)
   else()
     add_library(benchmark SHARED IMPORTED)
     find_library(BENCHMARK_LIBRARY benchmark)
@@ -701,7 +720,9 @@ if(USE_FBGEMM)
     set(FBGEMM_BUILD_TESTS OFF CACHE BOOL "")
     set(FBGEMM_BUILD_BENCHMARKS OFF CACHE BOOL "")
     set(FBGEMM_LIBRARY_TYPE "static" CACHE STRING "")
-    add_subdirectory("${FBGEMM_SOURCE_DIR}")
+    pytorch_add_thirdparty_subdirectory("${FBGEMM_SOURCE_DIR}")
+    # fbgemm public headers live under include/fbgemm/; mirror legacy install.
+    pytorch_install_thirdparty_headers("${FBGEMM_SOURCE_DIR}/include")
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       target_compile_options_if_supported(asmjit -Wno-extra-semi)
@@ -771,15 +792,18 @@ if(NOT TARGET fp16 AND NOT USE_SYSTEM_FP16)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
     message(WARNING "FP16 is only cmake-2.8 compatible")
     set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
-    add_subdirectory(
+    pytorch_add_thirdparty_subdirectory(
       "${FP16_SOURCE_DIR}"
       "${CONFU_DEPENDENCIES_BINARY_DIR}/FP16")
     unset(CMAKE_POLICY_VERSION_MINIMUM)
   else()
-    add_subdirectory(
+    pytorch_add_thirdparty_subdirectory(
       "${FP16_SOURCE_DIR}"
       "${CONFU_DEPENDENCIES_BINARY_DIR}/FP16")
   endif()
+  # FP16 headers (fp16.h + fp16/ subdir) are part of the libtorch public
+  # include surface.
+  pytorch_install_thirdparty_headers("${FP16_SOURCE_DIR}/include")
 elseif(NOT TARGET fp16 AND USE_SYSTEM_FP16)
   add_library(fp16 STATIC "/usr/include/fp16.h")
   set_target_properties(fp16 PROPERTIES LINKER_LANGUAGE C)
@@ -1186,7 +1210,12 @@ if(USE_DISTRIBUTED AND USE_TENSORPIPE)
 
     # Tensorpipe uses cuda_add_library
     torch_update_find_cuda_flags()
-    add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/tensorpipe)
+    pytorch_add_thirdparty_subdirectory(${PROJECT_SOURCE_DIR}/third_party/tensorpipe)
+    # tensorpipe public headers live under tensorpipe/ at the repo root.
+    install(DIRECTORY "${PROJECT_SOURCE_DIR}/third_party/tensorpipe/tensorpipe/"
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tensorpipe"
+      COMPONENT libtorch
+      FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
     # Suppress warning to unblock libnop compilation by clang-17
     # See https://github.com/pytorch/pytorch/issues/151316
     target_compile_options_if_supported(tensorpipe -Wno-missing-template-arg-list-after-template-kw)
@@ -1247,7 +1276,7 @@ if(USE_GLOO)
       set(USE_RCCL_SAVED ${USE_RCCL})
       set(USE_NCCL OFF)
       set(USE_RCCL OFF)
-      add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/gloo)
+      pytorch_add_thirdparty_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/gloo)
       set(USE_NCCL ${USE_NCCL_SAVED})
       set(USE_RCCL ${USE_RCCL_SAVED})
 
@@ -1344,7 +1373,7 @@ if(CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO AND NOT INTERN_DISABLE_ONNX)
   add_definitions(-DONNXIFI_ENABLE_EXT=1)
   set(Python3_EXECUTABLE "${Python_EXECUTABLE}")
   if(NOT USE_SYSTEM_ONNX)
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/onnx EXCLUDE_FROM_ALL)
+    pytorch_add_thirdparty_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/onnx EXCLUDE_FROM_ALL)
   endif()
 
   add_definitions(-DONNX_NAMESPACE=${ONNX_NAMESPACE})
@@ -1531,7 +1560,7 @@ if(NOT INTERN_BUILD_MOBILE)
     set(AT_KLEIDIAI_ENABLED 1)
     set(KLEIDIAI_BUILD_TESTS OFF) # Disable building KLEIDIAI tests
     set(KLEIDIAI_SRC "${PROJECT_SOURCE_DIR}/third_party/kleidiai")
-    add_subdirectory(${KLEIDIAI_SRC})
+    pytorch_add_thirdparty_subdirectory(${KLEIDIAI_SRC})
     list(APPEND Caffe2_DEPENDENCY_LIBS kleidiai)
     # Recover build options.
     set(BUILD_SHARED_LIBS ${TEMP_BUILD_SHARED_LIBS} CACHE BOOL "Build shared libs" FORCE)
@@ -1591,7 +1620,10 @@ endif()
 set(FMT_INSTALL ON)
 set(TEMP_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libs" FORCE)
-add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/fmt)
+pytorch_add_thirdparty_subdirectory(${PROJECT_SOURCE_DIR}/third_party/fmt)
+# fmt public headers (<fmt/format.h>, etc.) are part of the libtorch public
+# include surface; re-stage them since fmt's own install rules are suppressed.
+pytorch_install_thirdparty_headers("${PROJECT_SOURCE_DIR}/third_party/fmt/include")
 
 # Disable compiler feature checks for `fmt`.
 #
@@ -1661,7 +1693,10 @@ if(USE_KINETO)
   endif()
 
   if(NOT TARGET kineto)
-    add_subdirectory("${KINETO_SOURCE_DIR}")
+    pytorch_add_thirdparty_subdirectory("${KINETO_SOURCE_DIR}")
+    # kineto's public headers ship under torch/include/kineto/.
+    pytorch_install_thirdparty_headers("${KINETO_SOURCE_DIR}/include"
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kineto")
     set_property(TARGET kineto PROPERTY POSITION_INDEPENDENT_CODE ON)
   endif()
   list(APPEND Caffe2_DEPENDENCY_LIBS kineto)

--- a/cmake/External/nnpack.cmake
+++ b/cmake/External/nnpack.cmake
@@ -66,9 +66,12 @@ if(ANDROID OR IOS OR ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAM
       message(WARNING "Ancient nnpack forces CMake compatibility")
       set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
     endif()
-    add_subdirectory(
+    pytorch_add_thirdparty_subdirectory(
       "${NNPACK_SOURCE_DIR}"
       "${CONFU_DEPENDENCIES_BINARY_DIR}/NNPACK")
+    # nnpack.h is part of the libtorch public include surface; re-stage it
+    # since NNPACK's own install rules were suppressed.
+    pytorch_install_thirdparty_headers("${NNPACK_SOURCE_DIR}/include")
     if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
       unset(CMAKE_POLICY_VERSION_MINIMUM)
     endif()

--- a/cmake/FileMirroring.cmake
+++ b/cmake/FileMirroring.cmake
@@ -21,14 +21,17 @@ install(FILES
   "${PROJECT_SOURCE_DIR}/aten/src/ATen/native/native_functions.yaml"
   "${PROJECT_SOURCE_DIR}/aten/src/ATen/native/tags.yaml"
   DESTINATION "${SKBUILD_PLATLIB_DIR}/torchgen/packaged/ATen/native"
+  COMPONENT torch
 )
 install(DIRECTORY
   "${PROJECT_SOURCE_DIR}/aten/src/ATen/templates/"
   DESTINATION "${SKBUILD_PLATLIB_DIR}/torchgen/packaged/ATen/templates"
+  COMPONENT torch
 )
 install(DIRECTORY
   "${PROJECT_SOURCE_DIR}/tools/autograd/"
   DESTINATION "${SKBUILD_PLATLIB_DIR}/torchgen/packaged/autograd"
+  COMPONENT torch
   PATTERN "BUILD.bazel" EXCLUDE
   PATTERN "*.bzl" EXCLUDE
 )
@@ -42,6 +45,7 @@ if(EXISTS "${_cutedsl_src}")
   set(_cutedsl_dest "${SKBUILD_PLATLIB_DIR}/torch/_inductor/kernel/vendored_templates/cutedsl/kernels")
   install(FILES "${_cutedsl_src}"
     DESTINATION "${_cutedsl_dest}"
+    COMPONENT torch
     RENAME "cutedsl_grouped_gemm.py"
   )
   # Only create __init__.py for cutedsl/kernels/ (the new directory).
@@ -50,6 +54,7 @@ if(EXISTS "${_cutedsl_src}")
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_empty_init.py" "")
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/_empty_init.py"
     DESTINATION "${_cutedsl_dest}"
+    COMPONENT torch
     RENAME "__init__.py"
   )
 elseif(USE_CUDA)
@@ -65,6 +70,7 @@ endif()
 install(FILES
   "${PROJECT_SOURCE_DIR}/torch/_utils_internal.py"
   DESTINATION "${SKBUILD_PLATLIB_DIR}/tools/shared"
+  COMPONENT torch
 )
 install(FILES
   "${PROJECT_SOURCE_DIR}/third_party/valgrind-headers/callgrind.h"

--- a/cmake/InstallComponents.cmake
+++ b/cmake/InstallComponents.cmake
@@ -1,0 +1,67 @@
+# Install components used to control which install() rules end up in the
+# wheel. scikit-build-core packages only the components listed in
+# pyproject.toml's `install.components` setting, so rules tagged with an
+# unlisted component are silently skipped during wheel build while still
+# being available for non-wheel `cmake --install --component <name>` flows.
+#
+# Components:
+#   libtorch     Default. Shared libraries, headers, runtime data, and
+#                anything else that would belong in the libtorch C++
+#                distribution.
+#   torch        Python frontend: libtorch_python, the _C extension shim,
+#                generated .py files, type stubs, yaml/jinja templates
+#                consumed by torch's Python side, and similar artifacts.
+#   dev          CMake config files consumed by downstream
+#                find_package(Torch) / find_package(Caffe2) users
+#                (Caffe2Config, public/*.cmake, Modules_CUDA_fix, ...).
+#   third_party  Sentinel for vendored subprojects added via
+#                pytorch_add_thirdparty_subdirectory(). Not included in
+#                the wheel, so subproject install() rules (e.g. libfbgemm.a,
+#                lib64/cmake/foo-config.cmake) become no-ops at install time.
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "libtorch")
+
+# Wrap add_subdirectory() for vendored third-party projects so that any
+# install() rules registered by the subdirectory go to the "third_party"
+# component instead of the default. Build behavior is unchanged: targets
+# are still configured and built; only the install rules are reassigned.
+#
+# Defined as a macro (not a function) so that variables and policies set
+# by the third-party CMakeLists propagate to the caller as they would for
+# a bare add_subdirectory().
+macro(pytorch_add_thirdparty_subdirectory)
+  set(_pytorch_saved_default_component "${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}")
+  set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "third_party")
+  add_subdirectory(${ARGV})
+  set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "${_pytorch_saved_default_component}")
+  unset(_pytorch_saved_default_component)
+endmacro()
+
+# Re-stage public headers from a vendored subproject (whose own install()
+# rules were suppressed via pytorch_add_thirdparty_subdirectory) into the
+# torch/include/ portion of the wheel. Picks up header files only --
+# leaving build artifacts (.a, .so, .cmake configs) out of the wheel.
+#
+# Usage:
+#   pytorch_install_thirdparty_headers(<src_include_dir>
+#       [DESTINATION <subdir-of-torch/include>]
+#       [PATTERNS pattern1 pattern2 ...])
+#
+# DESTINATION defaults to "${CMAKE_INSTALL_INCLUDEDIR}" (= torch/include).
+# PATTERNS defaults to common C/C++ header globs.
+function(pytorch_install_thirdparty_headers SRC_DIR)
+  cmake_parse_arguments(_arg "" "DESTINATION" "PATTERNS" ${ARGN})
+  if(NOT _arg_DESTINATION)
+    set(_arg_DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+  endif()
+  if(NOT _arg_PATTERNS)
+    set(_arg_PATTERNS "*.h" "*.hpp" "*.cuh" "*.inc")
+  endif()
+  set(_files_matching FILES_MATCHING)
+  foreach(_p IN LISTS _arg_PATTERNS)
+    list(APPEND _files_matching PATTERN "${_p}")
+  endforeach()
+  install(DIRECTORY "${SRC_DIR}/"
+    DESTINATION "${_arg_DESTINATION}"
+    COMPONENT libtorch
+    ${_files_matching})
+endfunction()

--- a/cmake/Modules/FindITT.cmake
+++ b/cmake/Modules/FindITT.cmake
@@ -14,7 +14,11 @@ IF (NOT ITT_FOUND)
   SET(ITT_ROOT "${PROJECT_SOURCE_DIR}/third_party/ittapi")
   FIND_PATH(ITT_INCLUDE_DIR ittnotify.h PATHS ${ITT_ROOT} PATH_SUFFIXES include)
   IF (ITT_INCLUDE_DIR)
-    ADD_SUBDIRECTORY(${ITT_ROOT})
+    pytorch_add_thirdparty_subdirectory(${ITT_ROOT})
+    # ittapi public headers (ittnotify.h, jitprofiling.h, etc.) ship in
+    # nightly under torch/include/. Re-stage them since ittapi's own
+    # install rules were suppressed.
+    pytorch_install_thirdparty_headers("${ITT_ROOT}/include")
     SET(ITT_LIBRARIES ittnotify)
     SET(ITT_FOUND ON)
   ENDIF (ITT_INCLUDE_DIR)

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -175,7 +175,11 @@ IF(NOT MKLDNN_FOUND)
     ENDIF()
   ENDIF()
 
-  ADD_SUBDIRECTORY(${MKLDNN_ROOT})
+  pytorch_add_thirdparty_subdirectory(${MKLDNN_ROOT})
+  # dnnl public headers (dnnl.h, dnnl_*.hpp, oneapi/dnnl/...) ship in
+  # nightly under torch/include/. Re-stage them since dnnl's own install
+  # rules were suppressed.
+  pytorch_install_thirdparty_headers("${MKLDNN_ROOT}/include")
 
   IF(NOT TARGET dnnl)
     MESSAGE("Failed to include MKL-DNN target")

--- a/cmake/PackageData.cmake
+++ b/cmake/PackageData.cmake
@@ -19,6 +19,7 @@ endif()
 # Type stubs
 install(DIRECTORY "${TORCH_SRC_DIR}/"
   DESTINATION "."
+  COMPONENT torch
   FILES_MATCHING
   PATTERN "*.pyi"
   PATTERN "py.typed"
@@ -40,10 +41,12 @@ install(FILES
   "${TORCH_SRC_DIR}/utils/model_dump/skeleton.html"
   "${TORCH_SRC_DIR}/utils/model_dump/code.js"
   DESTINATION "utils/model_dump"
+  COMPONENT torch
   OPTIONAL
 )
 install(DIRECTORY "${TORCH_SRC_DIR}/utils/model_dump/"
   DESTINATION "utils/model_dump"
+  COMPONENT torch
   FILES_MATCHING PATTERN "*.mjs"
 )
 
@@ -60,16 +63,19 @@ install(DIRECTORY "${TORCH_SRC_DIR}/_inductor/codegen/"
 )
 install(DIRECTORY "${TORCH_SRC_DIR}/_inductor/kernel/flex/templates/"
   DESTINATION "_inductor/kernel/flex/templates"
+  COMPONENT torch
   FILES_MATCHING PATTERN "*.jinja"
 )
 install(DIRECTORY "${TORCH_SRC_DIR}/_inductor/kernel/templates/"
   DESTINATION "_inductor/kernel/templates"
+  COMPONENT torch
   FILES_MATCHING PATTERN "*.jinja"
 )
 
 # Export serde data
 install(DIRECTORY "${TORCH_SRC_DIR}/_export/serde/"
   DESTINATION "_export/serde"
+  COMPONENT torch
   FILES_MATCHING
   PATTERN "*.yaml"
   PATTERN "*.thrift"
@@ -85,10 +91,12 @@ install(FILES "${TORCH_SRC_DIR}/csrc/inductor/aoti_runtime/model.h"
 # package scanning; install explicitly so it ends up in the wheel).
 install(FILES "${TORCH_SRC_DIR}/testing/_internal/generated/annotated_fn_args.py"
   DESTINATION "testing/_internal/generated"
+  COMPONENT torch
 )
 
 # Dynamo data
 install(FILES "${TORCH_SRC_DIR}/_dynamo/graph_break_registry.json"
   DESTINATION "_dynamo"
+  COMPONENT torch
   OPTIONAL
 )

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -36,11 +36,17 @@ macro(custom_protobuf_find)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
     message(WARNING "Ancient protobuf forces CMake compatibility")
     set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/protobuf/cmake)
+    pytorch_add_thirdparty_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/protobuf/cmake)
     unset(CMAKE_POLICY_VERSION_MINIMUM)
   else()
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/protobuf/cmake)
+    pytorch_add_thirdparty_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/protobuf/cmake)
   endif()
+  # Re-stage protobuf's public headers (google/protobuf/*) since its own
+  # install rules were suppressed.
+  install(DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../third_party/protobuf/src/google"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    COMPONENT libtorch
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.inc")
 
   set(CMAKE_POSITION_INDEPENDENT_CODE ${__caffe2_CMAKE_POSITION_INDEPENDENT_CODE})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,12 @@ provider-path = "tools/metadata"
 # scikit-build-core auto-strips binaries in Release builds. PyTorch needs to
 # keep symbols (e.g. for torch.utils.cpp_extension, ABI checks in CI).
 strip = false
+# Restrict the wheel to install() rules tagged with these components. Rules
+# in third-party subprojects (wrapped via pytorch_add_thirdparty_subdirectory
+# in cmake/InstallComponents.cmake) default to "third_party" and are skipped,
+# keeping vendored static archives and their cmake configs out of the wheel.
+# See cmake/InstallComponents.cmake for the full list of components.
+components = ["libtorch", "torch", "dev"]
 
 [tool.scikit-build.wheel]
 # CMake install destinations (lib/, include/, share/cmake/) are relative to

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -473,7 +473,7 @@ if(NOT TORCH_PYTHON_LINK_FLAGS STREQUAL "")
     set_target_properties(torch_python PROPERTIES LINK_FLAGS "${TORCH_PYTHON_LINK_FLAGS}")
 endif()
 
-install(TARGETS torch_python DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+install(TARGETS torch_python DESTINATION "${TORCH_INSTALL_LIB_DIR}" COMPONENT torch)
 
 # Build the torch._C Python extension module from the thin stub that
 # forwards to torch_python.  This was historically built by setuptools;
@@ -501,6 +501,7 @@ if(BUILD_PYTHON AND NOT BUILD_LIBTORCH_WHL)
     RUNTIME DESTINATION "."
     LIBRARY DESTINATION "."
     ARCHIVE DESTINATION "lib"
+    COMPONENT torch
   )
 endif()
 
@@ -531,7 +532,7 @@ add_custom_target(
 add_dependencies(torch_python gen_torch_version)
 # version.py is gitignored (generated), so scikit-build-core won't include it
 # via Python package collection. Install it explicitly via cmake instead.
-install(FILES "${TORCH_SRC_DIR}/version.py" DESTINATION ".")
+install(FILES "${TORCH_SRC_DIR}/version.py" DESTINATION "." COMPONENT torch)
 
 # Skip building this library under MacOS, since it is currently failing to build on Mac
 # Github issue #61930


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #184873
* #180250
* #180249
* #180248
* #180247
* #180243

Move all install() rules onto named components so scikit-build-core
can restrict the wheel to the subset that actually belongs there.
The default component is "libtorch" (shared libraries, headers,
runtime data); explicit "torch" tags cover Python-side artifacts
(libtorch_python, the _C extension, version.py, type stubs, yaml /
jinja templates, torchgen packaged inputs, etc.); the existing "dev"
tag for find_package(Torch) configs is kept; and a new "third_party"
sentinel absorbs install rules from vendored subprojects so they
become no-ops at install time.

cmake/InstallComponents.cmake defines two helpers used at every
vendored subproject site:

  pytorch_add_thirdparty_subdirectory()    wraps add_subdirectory()
      and temporarily overrides CMAKE_INSTALL_DEFAULT_COMPONENT_NAME
      to "third_party" so the subproject's untagged install() rules
      land in the suppressed component.

  pytorch_install_thirdparty_headers()     mirrors the subset of a
      subproject's public headers that the wheel actually needs
      (since we just suppressed the upstream install()), tagged with
      "libtorch". This keeps libfbgemm.a, libkineto.a, libcpuinfo.a,
      libtorch_xpu_ops.a, and the corresponding lib64/cmake/* configs
      out of the wheel while preserving the include surface that
      torch's public headers and downstream cpp_extension consumers
      depend on.

Each add_subdirectory(third_party/...) site is rewritten to use the
wrap macro and, where the subproject contributes public headers, an
immediately-following pytorch_install_thirdparty_headers() (or, for
sleef's generated sleef.h and torch-xpu-ops' sycltla .so libraries,
an explicit install() rule). pyproject.toml selects the wheel
contents via install.components = ["libtorch", "torch", "dev"].

Co-Generated with [Claude Code](https://claude.com/claude-code)

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal