### PR TITLE
Add Half and BFloat16 dispatch support for torch.trace on CPU

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1336,7 +1336,8 @@ Tensor trace_cpu(const Tensor& self) {
   // is set to true
   ScalarType dtype = get_dtype_from_self(self, std::nullopt, true);
   result = at::empty({}, self.options().dtype(dtype));
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX(self.scalar_type(), "trace", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+       at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "trace", [&] {
     using accscalar_t = at::acc_type<scalar_t, false>;
     accscalar_t sum = 0;
     const auto* t_data = self.const_data_ptr<scalar_t>();

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -22,7 +22,7 @@ from collections.abc import Sequence
 from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import (
     _dispatch_dtypes, floating_types, floating_types_and, complex_types, floating_and_complex_types,
-    floating_and_complex_types_and, all_types_and_complex_and, all_types_and, all_types_and_complex, integral_types_and,
+    floating_and_complex_types_and, all_types_and_complex_and, all_types_and, integral_types_and,
     empty_types, complex_types_and, integral_types, custom_types, all_types_complex_float8_and, float8_types,
     highest_precision_complex,
     highest_precision_float,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21408,7 +21408,7 @@ op_db: list[OpInfo] = [
            sample_inputs_func=sample_inputs_logsumexp,
            reference_inputs_func=reference_inputs_logsumexp),
     OpInfo('trace',
-           dtypes=all_types_and_complex(),
+           dtypes=all_types_and_complex_and(torch.half, torch.bfloat16),
            dtypesIfMPS=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
            dtypesIfCUDA=all_types_and_complex_and(torch.chalf, torch.bool, torch.half, torch.bfloat16),
            error_inputs_func=error_inputs_trace,


### PR DESCRIPTION
Fixes #184847

### Description
This PR registers both `at::ScalarType::Half` (`float16`) and `at::ScalarType::BFloat16` for the native `trace_cpu` operator kernel. 

Previously, calling `torch.trace()` on a `float16` CPU tensor raised a `NotImplementedError` because it hit an unregistered data type inside the underlying CPU dispatch macro, despite standard dtypes (and NumPy) handling it natively. 

**Technical Approach:**
* Upgraded the dispatch macro in `aten/src/ATen/native/ReduceOps.cpp` from `AT_DISPATCH_ALL_TYPES_AND_COMPLEX` to `AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2` to explicitly include `Half` and `BFloat16`.
* **Accumulator Safety Verified:** Checked that `at::acc_type<at::Half, false>` on the CPU backend properly resolves to a wider `float32` accumulator (`accscalar_t`). This ensures no precision truncation or early overflow occurs during the diagonal reduction loop before it narrows back down via `set_result`.

Thank you to the maintaining team for the review.