### PR TITLE
Fix SIGSEGV from functorch key contamination via Tensor.set_data

### DIFF
--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -662,9 +662,12 @@ void TensorImpl::copy_tensor_metadata_except_version_counter(
   // Copying tensor metadata doesn't change the PyObject (maybe
   // it should), which means that we have to preserve whatever the
   // original Python keyset was (as it's associated with the PyObject
-  // being a tensor subclass or not)
-  dest_impl->key_set_ = (src_impl->key_set_ - c10::python_ks) |
-      (dest_impl->key_set_ & c10::python_ks);
+  // being a tensor subclass or not). Functorch transform keys are
+  // preserved for the same reason: they encode the TensorImpl
+  // subclass (TensorWrapper, BatchedTensorImpl), not tensor data.
+  constexpr auto preserve_ks = c10::python_ks | c10::functorch_transforms_ks;
+  dest_impl->key_set_ =
+      (src_impl->key_set_ - preserve_ks) | (dest_impl->key_set_ & preserve_ks);
   dest_impl->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
   dest_impl->storage_access_should_throw_ =
       src_impl->storage_access_should_throw_;

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -1491,6 +1491,22 @@ class TestAutogradFunction(TestCase):
         grad(f)(x)
         self.assertEqual(names, ["FooBarGeneratedBackward"])
 
+    def test_set_data_does_not_propagate_functorch_keys(self, device):
+        # Regression: Tensor.set_data used to copy FuncTorchGradWrapper onto a
+        # plain destination, triggering an unchecked cast in maybeGetTensorWrapper.
+        weight = nn.Parameter(torch.randn(8, 8, device=device))
+
+        def f(x):
+            weight.data = x.new_zeros(8, 8) + weight.detach()
+            return (x * weight).sum()
+
+        x = torch.randn(8, 8, device=device)
+        g = grad(f)(x)
+        self.assertEqual(g.shape, x.shape)
+        self.assertFalse(
+            torch._C._dispatch_keys(weight).has(DispatchKey.FuncTorchGradWrapper)
+        )
+
 
 @markDynamoStrictTest
 class TestAutogradFunctionVmapAPI(TestCase):

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -58,8 +58,6 @@ from torch.testing._internal.common_cuda import (
 )
 from torch.testing._internal.common_device_type import (
     dtypes,
-    expectedFailureCPU,
-    expectedFailureCUDA,
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
@@ -1508,20 +1506,6 @@ class TestAutogradFunction(TestCase):
         self.assertFalse(
             torch._C._dispatch_keys(weight).has(DispatchKey.FuncTorchGradWrapper)
         )
-
-    @expectedFailureCPU
-    @expectedFailureCUDA
-    def test_set_data_under_grad_raises(self, device):
-        # Used to SIGSEGV before the c10 fix. Now raises a Python error
-        # because the wrapper has no direct storage to copy from.
-        weight = nn.Parameter(torch.randn(8, 8, device=device))
-
-        def f(x):
-            weight.data = x.new_zeros(8, 8) + weight.detach()
-            return (x * weight).sum()
-
-        x = torch.randn(8, 8, device=device)
-        grad(f)(x)
 
 
 @markDynamoStrictTest

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -1501,8 +1501,11 @@ class TestAutogradFunction(TestCase):
             return (x * weight).sum()
 
         x = torch.randn(8, 8, device=device)
-        g = grad(f)(x)
-        self.assertEqual(g.shape, x.shape)
+        # may raise on backends where the wrapper has no storage
+        try:
+            grad(f)(x)
+        except RuntimeError:
+            pass
         self.assertFalse(
             torch._C._dispatch_keys(weight).has(DispatchKey.FuncTorchGradWrapper)
         )

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -58,6 +58,8 @@ from torch.testing._internal.common_cuda import (
 )
 from torch.testing._internal.common_device_type import (
     dtypes,
+    expectedFailureCPU,
+    expectedFailureCUDA,
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
@@ -1492,8 +1494,26 @@ class TestAutogradFunction(TestCase):
         self.assertEqual(names, ["FooBarGeneratedBackward"])
 
     def test_set_data_does_not_propagate_functorch_keys(self, device):
-        # Regression: Tensor.set_data used to copy FuncTorchGradWrapper onto a
-        # plain destination, triggering an unchecked cast in maybeGetTensorWrapper.
+        # set_data used to copy FuncTorchGradWrapper onto a plain destination,
+        # which then triggered an unchecked TensorWrapper cast. The return is
+        # x*x so functorch does not try to unwrap weight on output.
+        weight = nn.Parameter(torch.randn(8, 8, device=device))
+
+        def f(x):
+            weight.data = x.new_zeros(8, 8) + weight.detach()
+            return (x * x).sum()
+
+        x = torch.randn(8, 8, device=device)
+        grad(f)(x)
+        self.assertFalse(
+            torch._C._dispatch_keys(weight).has(DispatchKey.FuncTorchGradWrapper)
+        )
+
+    @expectedFailureCPU
+    @expectedFailureCUDA
+    def test_set_data_under_grad_raises(self, device):
+        # Used to SIGSEGV before the c10 fix. Now raises a Python error
+        # because the wrapper has no direct storage to copy from.
         weight = nn.Parameter(torch.randn(8, 8, device=device))
 
         def f(x):
@@ -1501,14 +1521,7 @@ class TestAutogradFunction(TestCase):
             return (x * weight).sum()
 
         x = torch.randn(8, 8, device=device)
-        # may raise on backends where the wrapper has no storage
-        try:
-            grad(f)(x)
-        except RuntimeError:
-            pass
-        self.assertFalse(
-            torch._C._dispatch_keys(weight).has(DispatchKey.FuncTorchGradWrapper)
-        )
+        grad(f)(x)
 
 
 @markDynamoStrictTest

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -1491,7 +1491,9 @@ class TestAutogradFunction(TestCase):
         grad(f)(x)
         self.assertEqual(names, ["FooBarGeneratedBackward"])
 
-    @skipIfTorchDynamo("set_data inside grad(f) is not traceable; the dispatch-key invariant only matters in eager")
+    @skipIfTorchDynamo(
+        "set_data inside grad(f) is not traceable; the dispatch-key invariant only matters in eager"
+    )
     def test_set_data_does_not_propagate_functorch_keys(self, device):
         # set_data used to copy FuncTorchGradWrapper onto a plain destination,
         # which then triggered an unchecked TensorWrapper cast. The return is

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -1491,6 +1491,7 @@ class TestAutogradFunction(TestCase):
         grad(f)(x)
         self.assertEqual(names, ["FooBarGeneratedBackward"])
 
+    @skipIfTorchDynamo("set_data inside grad(f) is not traceable; the dispatch-key invariant only matters in eager")
     def test_set_data_does_not_propagate_functorch_keys(self, device):
         # set_data used to copy FuncTorchGradWrapper onto a plain destination,
         # which then triggered an unchecked TensorWrapper cast. The return is

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -76,6 +76,7 @@ from torch.testing._internal.common_utils import (
     TEST_CUDA_MEM_LEAK_CHECK,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
+    xfailIfTorchDynamo,
 )
 from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten
 
@@ -1491,9 +1492,10 @@ class TestAutogradFunction(TestCase):
         grad(f)(x)
         self.assertEqual(names, ["FooBarGeneratedBackward"])
 
-    @skipIfTorchDynamo(
-        "set_data inside grad(f) is not traceable; the dispatch-key invariant only matters in eager"
-    )
+    # set_data inside grad(f) is not traceable; the dispatch-key invariant only
+    # matters in eager. xfail (not skip) so this flips to a failure and tells us
+    # to remove the marker if dynamo ever starts tracing the write.
+    @xfailIfTorchDynamo
     def test_set_data_does_not_propagate_functorch_keys(self, device):
         # set_data used to copy FuncTorchGradWrapper onto a plain destination,
         # which then triggered an unchecked TensorWrapper cast. The return is


### PR DESCRIPTION
Fixes #184876.

`copy_tensor_metadata_except_version_counter` already strips `python_ks` to
avoid poisoning a plain destination. Do the same for `functorch_transforms_ks`,
which encodes a `TensorWrapper`/`BatchedTensorImpl` subclass and triggers
an unchecked cast in `maybeGetTensorWrapper`.

Test Plan:
`python test/functorch/test_eager_transforms.py TestAutogradFunctionCPU.test_set_data_does_not_propagate_functorch_keys_cpu`
