### PR TITLE
Fix INTERNAL ASSERT on list subclass with raising __len__

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10778,6 +10778,24 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
             self.assertRaises((ValueError, RuntimeError), lambda: torch.set_num_threads(invalid_val))
             self.assertRaises((ValueError, RuntimeError), lambda: torch.set_num_interop_threads(invalid_val))
 
+    def test_intlist_arg_with_misbehaving_list_subclass(self) -> None:
+        # Regression test for https://github.com/pytorch/pytorch/issues/184877:
+        # an INTERNAL ASSERT fired when the arg parser tried to format a type
+        # error for a list subclass whose __len__/__iter__ raised.
+        class Foo(list):
+            def __iter__(self):
+                raise RuntimeError("should not be called")
+
+            def __len__(self):
+                raise RuntimeError("should not be called")
+
+        x = Foo()
+        x.append("a")
+        with self.assertRaisesRegex(
+            TypeError, r"found element of type str at pos 0"
+        ):
+            torch.randn(x)
+
     def _get_tensor_prop(self, t):
         preserved = (
             id(t),

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1039,7 +1039,7 @@ static bool is_int_or_symint(PyObject* obj) {
 static bool is_int_or_symint_list(
     PyObject* obj,
     int broadcast_size,
-    int64_t* failed_idx = nullptr,
+    py::object* failed_item = nullptr,
     std::vector<PyObject*>* overloaded_args = nullptr) {
   const bool is_tuple = PyTuple_Check(obj);
   if (is_tuple || PyList_Check(obj)) {
@@ -1074,8 +1074,8 @@ static bool is_int_or_symint_list(
         bool r =
             (jit::tracer::isTracing() && THPVariable_Check(item_ptr) &&
              THPVariable_Unpack(item_ptr).sizes().empty());
-        if (!r && failed_idx != nullptr) {
-          *failed_idx = 0;
+        if (!r && failed_item != nullptr) {
+          *failed_item = py::reinterpret_borrow<py::object>(item_ptr);
         }
         if (!r && !has_torch_func) {
           return false;
@@ -1096,8 +1096,8 @@ auto FunctionParameter::check(
     PyObject* obj,
     std::vector<PyObject*>& overloaded_args,
     int argnum,
-    int64_t* failed_idx) -> bool {
-  if (_check(obj, overloaded_args, argnum, failed_idx)) {
+    py::object* failed_item) -> bool {
+  if (_check(obj, overloaded_args, argnum, failed_item)) {
     return true;
   }
   // NB: This will not detect torch function inside elements of a list.  So
@@ -1117,7 +1117,7 @@ auto FunctionParameter::_check(
     PyObject* obj,
     std::vector<PyObject*>& overloaded_args,
     int argnum,
-    int64_t* failed_idx) -> bool {
+    py::object* failed_item) -> bool {
   switch (type_) {
     case ParameterType::TENSOR: {
       if (is_tensor_and_append_overloaded(obj, &overloaded_args)) {
@@ -1219,7 +1219,7 @@ auto FunctionParameter::_check(
     // Allow SymInt where int is expected; we'll guard in this case
     case ParameterType::INT_LIST:
     case ParameterType::SYM_INT_LIST:
-      return is_int_or_symint_list(obj, size, failed_idx, &overloaded_args);
+      return is_int_or_symint_list(obj, size, failed_item, &overloaded_args);
     case ParameterType::DISPATCH_KEY_SET:
       return py::isinstance<c10::DispatchKeySet>(py::handle(obj));
     default:
@@ -1693,9 +1693,8 @@ bool FunctionSignature::parse(
   if (max_pos_args == 1 &&
       (params[0].type_ == ParameterType::INT_LIST ||
        params[0].type_ == ParameterType::SYM_INT_LIST)) {
-    int64_t failed_idx = -1;
     allow_varargs_intlist = is_int_or_symint_list(
-        args, params[0].size, &failed_idx, &overloaded_args);
+        args, params[0].size, /*failed_item=*/nullptr, &overloaded_args);
   }
 
   if (static_cast<size_t>(nargs) > max_pos_args && !allow_varargs_intlist) {
@@ -1735,7 +1734,7 @@ bool FunctionSignature::parse(
       is_kwd = true;
     }
 
-    int64_t failed_idx = -1;
+    py::object failed_item;
     bool varargs_eligible = allow_varargs_intlist && arg_pos == 0 && !is_kwd;
     if ((!obj && param.optional) || (Py_IsNone(obj) && param.allow_none)) {
       dst[i++] = nullptr;
@@ -1745,7 +1744,7 @@ bool FunctionSignature::parse(
         missing_args(*this, i);
       }
       return false;
-    } else if (param.check(obj, overloaded_args, i, &failed_idx)) {
+    } else if (param.check(obj, overloaded_args, i, &failed_item)) {
       dst[i++] = obj;
       // XXX: the Variable check is necessary because sizes become tensors when
       // tracer is enabled. This behavior easily leads to ambiguities, and we
@@ -1753,7 +1752,7 @@ bool FunctionSignature::parse(
     } else if (
         varargs_eligible &&
         (is_int_or_symint_list(
-            args, param.size, &failed_idx, &overloaded_args))) {
+            args, param.size, &failed_item, &overloaded_args))) {
       // take all positional arguments as this parameter
       // e.g. permute(1, 2, 3) -> permute((1, 2, 3))
       dst[i++] = args;
@@ -1771,36 +1770,30 @@ bool FunctionSignature::parse(
                 param.type_name(),
                 Py_TYPE(obj)->tp_name));
       } else {
-        // foo(): argument 'other' (position 2) must be str, not int
-        if (failed_idx != -1) {
-          if (!(PyTuple_Check(obj) || PyList_Check(obj))) {
-            TORCH_INTERNAL_ASSERT(varargs_eligible);
-            obj = args;
-          }
-          TORCH_INTERNAL_ASSERT(failed_idx < PySequence_Size(obj));
+        // foo(): argument 'other' (position 2) must be ...
+        // is_int_or_symint_list only type-checks index 0, so "at pos 0" is
+        // accurate whenever failed_item is set.
+        if (failed_item) {
           TORCH_CHECK_TYPE(
               false,
               fmt::format(
-                  "{}(): argument '{}' (position {}) must be {}, but found element of type {} at pos {}",
+                  "{}(): argument '{}' (position {}) must be {}, but found element of type {} at pos 0",
                   name,
                   param.name,
                   arg_pos + 1,
                   param.type_name(),
-                  Py_TYPE(py::reinterpret_steal<py::object>(
-                              PySequence_GetItem(obj, failed_idx))
-                              .ptr())
-                      ->tp_name,
-                  failed_idx));
+                  Py_TYPE(failed_item.ptr())->tp_name));
+        } else {
+          TORCH_CHECK_TYPE(
+              false,
+              fmt::format(
+                  "{}(): argument '{}' (position {}) must be {}, not {}",
+                  name,
+                  param.name,
+                  arg_pos + 1,
+                  param.type_name(),
+                  Py_TYPE(obj)->tp_name));
         }
-        TORCH_CHECK_TYPE(
-            false,
-            fmt::format(
-                "{}(): argument '{}' (position {}) must be {}, not {}",
-                name,
-                param.name,
-                arg_pos + 1,
-                param.type_name(),
-                Py_TYPE(obj)->tp_name));
       }
     } else {
       return false;

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -144,13 +144,13 @@ struct FunctionParameter {
       PyObject* obj,
       std::vector<PyObject*>& overloaded_args,
       int argnum,
-      int64_t* failed_idx = nullptr);
+      py::object* failed_item = nullptr);
 
   bool _check(
       PyObject* obj,
       std::vector<PyObject*>& overloaded_args,
       int argnum,
-      int64_t* failed_idx = nullptr);
+      py::object* failed_item = nullptr);
 
   void set_default_str(const std::string& str);
   TORCH_PYTHON_API std::string type_name() const;


### PR DESCRIPTION
Fixes #184877. `is_int_or_symint_list` returns the failing element directly so the error site no longer revisits the sequence via `PySequence_*`, which dispatched through user-overridden `__len__` and crashed.