### PR TITLE
Fix data races on static bool config flags

### DIFF
--- a/aten/src/ATen/functorch/BatchedFallback.cpp
+++ b/aten/src/ATen/functorch/BatchedFallback.cpp
@@ -16,26 +16,28 @@
 #include <c10/util/llvmMathExtras.h>
 #include <c10/util/irange.h>
 
+#include <atomic>
+
 namespace at::functorch {
 
-static bool kVmapFallbackWarningEnabled = true;
+static constinit std::atomic<bool> kVmapFallbackWarningEnabled{true};
 
 bool isVmapFallbackWarningEnabled() {
-  return kVmapFallbackWarningEnabled;
+  return kVmapFallbackWarningEnabled.load(std::memory_order_relaxed);
 }
 
 void setVmapFallbackWarningEnabled(bool enabled) {
-  kVmapFallbackWarningEnabled = enabled;
+  kVmapFallbackWarningEnabled.store(enabled, std::memory_order_relaxed);
 }
 
-static bool kVmapFallbackEnabled = true;
+static constinit std::atomic<bool> kVmapFallbackEnabled{true};
 
 bool isVmapFallbackEnabled() {
-  return kVmapFallbackEnabled;
+  return kVmapFallbackEnabled.load(std::memory_order_relaxed);
 }
 
 void setVmapFallbackEnabled(bool enabled) {
-  kVmapFallbackEnabled = enabled;
+  kVmapFallbackEnabled.store(enabled, std::memory_order_relaxed);
 }
 
 // Given a linear index, return the actual index.

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -16,6 +16,7 @@
 #include <c10/util/irange.h>
 #include <c10/macros/Macros.h>
 #include <algorithm>
+#include <atomic>
 #include <limits>
 #include <utility>
 
@@ -92,7 +93,7 @@ constexpr int MIOPEN_DIM_MAX = 5;
 namespace at::native {
 
 
-static bool conv_benchmark_empty_cache = true;
+static constinit std::atomic<bool> conv_benchmark_empty_cache{true};
 
 // Check workload to activate fast depthwise FP16 cudnn conv kernels
 template <typename T>
@@ -2337,11 +2338,11 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward(
 }
 
 void _cudnn_set_conv_benchmark_empty_cache(bool enable) {
-  conv_benchmark_empty_cache = enable;
+  conv_benchmark_empty_cache.store(enable, std::memory_order_relaxed);
 }
 
 bool _cudnn_get_conv_benchmark_empty_cache() {
-  return conv_benchmark_empty_cache;
+  return conv_benchmark_empty_cache.load(std::memory_order_relaxed);
 }
 
 

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -3,6 +3,7 @@
 #include <c10/util/Logging.h>
 #include <c10/util/Type.h>
 
+#include <atomic>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -189,14 +190,14 @@ WarningHandler* get_warning_handler() noexcept(true) {
   return ThreadWarningHandler::get_handler();
 }
 
-static bool warn_always = false;
+static constinit std::atomic<bool> warn_always{false};
 
 void set_warnAlways(bool setting) noexcept(true) {
-  warn_always = setting;
+  warn_always.store(setting, std::memory_order_relaxed);
 }
 
 bool get_warnAlways() noexcept(true) {
-  return warn_always;
+  return warn_always.load(std::memory_order_relaxed);
 }
 
 WarnAlways::WarnAlways(bool setting /*=true*/)

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -118,6 +118,7 @@ void torchCheckFail(
     const char* file,
     uint32_t line,
     const std::string& msg) {
+  // NOLINTNEXTLINE(modernize-use-designated-initializers)
   throw ::c10::Error({func, file, line}, msg);
 }
 
@@ -126,6 +127,7 @@ void torchCheckFail(
     const char* file,
     uint32_t line,
     const char* msg) {
+  // NOLINTNEXTLINE(modernize-use-designated-initializers)
   throw ::c10::Error({func, file, line}, msg);
 }
 

--- a/test/test_tsan.py
+++ b/test/test_tsan.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: multithreading"]
 
 import weakref
+from functools import partial
 
 import torch
 from torch.testing._internal.common_utils import run_concurrently, run_tests, TestCase
@@ -55,6 +56,53 @@ class TestTSan(TestCase):
             grad_fns = run_concurrently(access_grad_fn, args=(y,), num_threads=4)
             for gf in grad_fns:
                 self.assertIs(gf, y.grad_fn)
+
+    def test_concurrent_config_flag_toggles(self):
+        """Concurrently set/read process-global bool config flags.
+
+        warn_always, the vmap fallback enable/warning flags, and (on CUDA
+        builds) the cudnn conv benchmark empty-cache flag are process-global
+        toggles accessed through dedicated setters/getters. They used to be
+        plain ``static bool``, so concurrent access from multiple threads was a
+        data race -- undefined behavior under the C++ memory model and reported
+        by TSan even though no real platform tears a bool load. They are now
+        ``static constinit std::atomic<bool>`` with relaxed ordering; this
+        hammers each accessor from several threads to guard against regressing.
+        """
+        functorch = torch._C._functorch
+
+        # (setter, getter): getter is None when no read accessor is exposed to
+        # Python, in which case the writer-vs-writer race still exercises it.
+        flags = [
+            (torch._C._set_warnAlways, torch._C._get_warnAlways),
+            (
+                functorch._set_vmap_fallback_enabled,
+                functorch._is_vmap_fallback_enabled,
+            ),
+            (functorch._set_vmap_fallback_warning_enabled, None),
+        ]
+        # CUDA-only binding; absent on the CPU-only TSan build.
+        if hasattr(torch._C, "_cudnn_set_conv_benchmark_empty_cache"):
+            flags.append(
+                (
+                    torch._C._cudnn_set_conv_benchmark_empty_cache,
+                    torch._C._cuda_get_conv_benchmark_empty_cache,
+                )
+            )
+
+        def toggle(setter, getter, idx):
+            for i in range(200):
+                setter(bool((idx + i) & 1))
+                if getter is not None:
+                    getter()
+
+        for setter, getter in flags:
+            original = getter() if getter is not None else None
+            try:
+                run_concurrently([partial(toggle, setter, getter, t) for t in range(4)])
+            finally:
+                if original is not None:
+                    setter(original)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Convert `warn_always`, `kVmapFallback{,Warning}Enabled`, and `conv_benchmark_empty_cache` to `static constinit std::atomic<bool>` with `memory_order_relaxed`. Matches the pattern from #181620. Relaxed ordering is sufficient: these are pure toggles that don't gate publication of any other non-atomic data.

Test Plan: existing CI; no runtime behavior change.

Authored by Claude.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01