### PR TITLE
docs: correct torch.addcdiv prose to match implementation order

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -460,8 +460,8 @@ add_docstr(
     r"""
 addcdiv(input, tensor1, tensor2, *, value=1, out=None) -> Tensor
 
-Performs the element-wise division of :attr:`tensor1` by :attr:`tensor2`,
-multiplies the result by the scalar :attr:`value` and adds it to :attr:`input`.
+Multiplies :attr:`tensor1` by the scalar :attr:`value`, divides the result by
+:attr:`tensor2`, and adds it to :attr:`input`.
 
 .. warning::
     Integer division with addcdiv is no longer supported, and in a future


### PR DESCRIPTION
Fixes #170869.

The first sentence of the torch.addcdiv docstring describes the operation as dividing tensor1 by tensor2 first and then multiplying the quotient by value, which suggests the evaluation order (tensor1 / tensor2) * value. The CPU and CUDA pointwise kernels in aten/src/ATen/native/cpu/PointwiseOpsKernel.cpp and aten/src/ATen/native/cuda/PointwiseOpsKernel.cu actually evaluate value * tensor1 / tensor2 left to right, so the scalar multiplication is applied before the division. The mismatch is visible to users when value * tensor1 or tensor1 / tensor2 overflows or underflows in finite-precision floating point, which is exactly the scenario in the linked feedback issue.

This patch reorders the prose to "multiplies tensor1 by the scalar value, divides the result by tensor2, and adds it to input" so the description lines up with what the kernel does. The math block (input_i + value * (tensor1_i / tensor2_i)) is mathematically equivalent and stays unchanged, as does the rest of the docstring (warning block, args, example).

This is the same wording previously approved by @jbschlosser in #171408, which was closed for stale/CLA reasons rather than on technical grounds.