### PR TITLE
[inductor] Diagonal-symmetric mm TritonTemplate for Gram matrices

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1320,6 +1320,20 @@ class aten_distributed_optimizations:
     allow_comms_decompositions: bool = False
 
 
+class math_kernel_optimizations:
+    """Optimized kernels for ops with known mathematical properties.
+
+    When the FX graph carries meta["math"] annotations (e.g., {"symmetric": True}),
+    inductor can select specialized kernels that exploit these properties.
+    Each flag controls a specific optimization independently.
+    """
+
+    # Diagonal-symmetric Triton mm for mm nodes whose output is known symmetric.
+    # Computes only upper triangle and mirrors to lower, ~1.5x speedup.
+    # Requires meta["math"]["symmetric"] = True on the mm node.
+    diag_symm_mm: bool = False
+
+
 def parallel_compile_enabled_internally() -> bool:
     """
     TODO: Remove when parallel compiled is fully enabled internally. For rollout, use a

--- a/torch/_inductor/fx_passes/decomp_comms.py
+++ b/torch/_inductor/fx_passes/decomp_comms.py
@@ -423,15 +423,13 @@ def decomp_gram_matrix_all_gather(gm: fx.GraphModule) -> fx.GraphModule:
     transformed = 0
 
     # 1. Find Gram mms and trace each to its all_gather source.
-    # Tag ALL Gram mms with math properties (symmetric, PSD) regardless of
-    # whether they're decomposable -- downstream kernels use these annotations.
+    # Tag Gram mms as symmetric for downstream kernel selection.
     ag_to_grams: dict[fx.Node, list[fx.Node]] = defaultdict(list)
     ag_infos: dict[fx.Node, AllGatherInfo] = {}
 
     for gram_mm in find_gram_mms(graph):
         math_props = gram_mm.meta.get("math", {})
         math_props["symmetric"] = True
-        math_props["positive_semidefinite"] = True
         gram_mm.meta["math"] = math_props
 
         info = find_all_gather_ancestor(gram_source(gram_mm))
@@ -565,7 +563,7 @@ def decomp_gram_matrix_all_gather(gm: fx.GraphModule) -> fx.GraphModule:
                 chain.add(n)
             n = n.next
 
-        # Insert all_reduce(sum) after each Gram mm.
+        # Insert all_reduce(sum) after each Gram mm
         for mm_node in gram_mms:
             with graph.inserting_before(mm_node.next):
                 ar = graph.call_function(

--- a/torch/_inductor/fx_passes/decomp_comms.py
+++ b/torch/_inductor/fx_passes/decomp_comms.py
@@ -422,11 +422,18 @@ def decomp_gram_matrix_all_gather(gm: fx.GraphModule) -> fx.GraphModule:
     graph = gm.graph
     transformed = 0
 
-    # 1. Find Gram mms and trace each to its all_gather source
+    # 1. Find Gram mms and trace each to its all_gather source.
+    # Tag ALL Gram mms with math properties (symmetric, PSD) regardless of
+    # whether they're decomposable -- downstream kernels use these annotations.
     ag_to_grams: dict[fx.Node, list[fx.Node]] = defaultdict(list)
     ag_infos: dict[fx.Node, AllGatherInfo] = {}
 
     for gram_mm in find_gram_mms(graph):
+        math_props = gram_mm.meta.get("math", {})
+        math_props["symmetric"] = True
+        math_props["positive_semidefinite"] = True
+        gram_mm.meta["math"] = math_props
+
         info = find_all_gather_ancestor(gram_source(gram_mm))
         if info is None:
             continue
@@ -558,7 +565,7 @@ def decomp_gram_matrix_all_gather(gm: fx.GraphModule) -> fx.GraphModule:
                 chain.add(n)
             n = n.next
 
-        # Insert all_reduce(sum) after each Gram mm
+        # Insert all_reduce(sum) after each Gram mm.
         for mm_node in gram_mms:
             with graph.inserting_before(mm_node.next):
                 ar = graph.call_function(

--- a/torch/_inductor/kernel/diag_symm_mm.py
+++ b/torch/_inductor/kernel/diag_symm_mm.py
@@ -1,0 +1,87 @@
+"""
+Diagonal-symmetric matrix multiplication TritonTemplate.
+
+When an mm node has meta["math"]["symmetric"] = True, the output C = A @ B.T
+is known symmetric. This template computes only upper-triangle tiles and
+mirrors to lower, achieving ~1.5x speedup over full mm for large matrices.
+
+Integrates into inductor's autotuning as a choice in tuned_mm alongside
+cuBLAS and standard Triton mm.
+
+Gated by config.math_kernel_optimizations.diag_symm_mm.
+"""
+
+import logging
+
+import torch
+from torch._inductor.kernel.mm_common import mm_grid
+from torch._inductor.select_algorithm import TritonTemplate
+
+
+log = logging.getLogger(__name__)
+aten = torch.ops.aten
+
+
+diag_symm_mm_template = TritonTemplate(
+    name="diag_symm_mm",
+    grid=mm_grid,
+    source=r"""
+{{def_kernel("A", "B")}}
+    M = {{size("A", 0)}}
+    K = {{size("A", 1)}}
+
+    if M * K == 0:
+        return
+
+    stride_am = {{stride("A", 0)}}
+    stride_ak = {{stride("A", 1)}}
+    stride_bm = {{stride("B", 0)}}
+    stride_bk = {{stride("B", 1)}}
+
+    pid = tl.program_id(0)
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(M, BLOCK_N)
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = tl.minimum(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // group_size
+
+    m_idx = pid_m * BLOCK_M
+    n_idx = pid_n * BLOCK_N
+
+    if m_idx + BLOCK_M <= n_idx:
+        return
+
+    offs_m = m_idx + tl.arange(0, BLOCK_M)
+    offs_n = n_idx + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    a_ptrs = A + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = B + offs_n[:, None] * stride_bm + offs_k[None, :] * stride_bk
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+
+    for k_start in range(0, K, BLOCK_K):
+        k_remaining = K - k_start
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        acc = tl.dot(a, tl.trans(b), acc, allow_tf32=ALLOW_TF32)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+
+    idx_m = offs_m[:, None]
+    idx_n = offs_n[None, :]
+    mask = (idx_m < M) & (idx_n < M)
+
+    {{store_output(("idx_m", "idx_n"), "acc", "mask", val_shape=("BLOCK_M", "BLOCK_N"))}}
+
+    # Mirror to lower triangle: load back post-epilogue value, then transpose.
+    # Output is contiguous with stride (M, 1), guaranteed by mm_args FixedLayout.
+    c_ptrs = {{output}} + idx_m * M + idx_n
+    fused = tl.load(c_ptrs, mask=mask)
+    c_ptrs_t = {{output}} + offs_n[:, None] * M + offs_m[None, :]
+    c_mask_t = (offs_n[:, None] < M) & (offs_m[None, :] < M)
+    tl.store(c_ptrs_t, tl.trans(fused), mask=c_mask_t)
+""",
+)

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -440,6 +440,24 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
 
         templates_to_use.append(mm_contiguous_subgraph_template)
 
+    if (
+        out_dtype is None
+        and is_nonzero
+        and static_shape
+        and m == n
+        and inductor_config.math_kernel_optimizations.diag_symm_mm
+        and is_triton(layout.device)
+    ):
+        node = V.graph.current_node
+        if node is not None and node.meta.get("math", {}).get(
+            "symmetric", False
+        ):
+            from torch._inductor.kernel.diag_symm_mm import (
+                diag_symm_mm_template,
+            )
+
+            templates_to_use.append(diag_symm_mm_template)
+
     choices.extend(
         V.choices.get_template_configs(
             kernel_inputs,

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -449,12 +449,8 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
         and is_triton(layout.device)
     ):
         node = V.graph.current_node
-        if node is not None and node.meta.get("math", {}).get(
-            "symmetric", False
-        ):
-            from torch._inductor.kernel.diag_symm_mm import (
-                diag_symm_mm_template,
-            )
+        if node is not None and node.meta.get("math", {}).get("symmetric", False):
+            from torch._inductor.kernel.diag_symm_mm import diag_symm_mm_template
 
             templates_to_use.append(diag_symm_mm_template)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #184886
* #184370

Tag Gram mm nodes in decomp_comms with math properties
(meta["math"]["symmetric"] = True) and add a TritonTemplate that exploits
the symmetry: compute only upper-triangle tiles, mirror to lower.

The template takes two inputs A, B (C = A @ B.T) and integrates into
tuned_mm as an autotuning choice alongside cuBLAS and standard Triton mm.
Activated when config.math_kernel_optimizations.diag_symm_mm = True and
the mm node carries the symmetric annotation.

  **H100 microbenchmarks** (bf16, CUDA event timing, 50 warmup + 200 iters, median):

  Square shapes (K == M, Gram: `C = A @ A.T`):

  | M×K | cuBLAS (μs) | diag_symm (μs) | Speedup |
  |-----|-------------|-----------------|---------|
  | 128×128 | 18.7 | 26.4 | 0.71x |
  | 256×256 | 18.8 | 26.2 | 0.72x |
  | 512×512 | 19.5 | 26.5 | 0.73x |
  | 1024×1024 | 19.6 | 28.5 | 0.69x |
  | 2048×2048 | 37.2 | 47.6 | 0.78x |
  | 4096×4096 | 230.8 | 183.5 | **1.26x** |
  | 8192×8192 | 2717.3 | 1858.9 | **1.46x** |

  Rectangular shapes (Muon-like, output always M×M):

  | M×K | cuBLAS (μs) | diag_symm (μs) | Speedup |
  |-----|-------------|-----------------|---------|
  | 4096×8192 | 425.4 | 352.4 | **1.21x** |
  | 4096×16384 | 2054.8 | 1648.2 | **1.25x** |
  | 8192×4096 | 978.2 | 671.4 | **1.46x** |
  | 8192×16384 | 10756.3 | 6482.7 | **1.66x** |

  For M ≤ 2048, Triton kernel launch overhead (~13μs) dominates — cuBLAS wins.
  Autotuning handles backend selection; the template is only competitive at M ≥ 4096.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo