### PR TITLE
Clarify undefined behavior for unsorted searchsorted inputs

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -14099,7 +14099,7 @@ the returned index satisfies the following rules:
 Args:
     sorted_sequence (Tensor): N-D or 1-D tensor, containing monotonically increasing sequence on the *innermost*
                               dimension unless :attr:`sorter` is provided, in which case the sequence does not
-                              need to be sorted. PyTorch does not validate this condition when :attr:`sorter` is 
+                              need to be sorted. PyTorch does not validate this condition when :attr:`sorter` is
                               not provided, and the behavior is undefined if the sequence is not sorted.
     values (Tensor or Scalar): N-D tensor or a Scalar containing the search value(s).
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -14099,7 +14099,8 @@ the returned index satisfies the following rules:
 Args:
     sorted_sequence (Tensor): N-D or 1-D tensor, containing monotonically increasing sequence on the *innermost*
                               dimension unless :attr:`sorter` is provided, in which case the sequence does not
-                              need to be sorted
+                              need to be sorted. PyTorch does not validate this condition when :attr:`sorter` is 
+                              not provided, and the behavior is undefined if the sequence is not sorted.
     values (Tensor or Scalar): N-D tensor or a Scalar containing the search value(s).
 
 Keyword args:


### PR DESCRIPTION
## Summary

Clarifies the `torch.searchsorted` documentation to explicitly state that PyTorch does not validate whether `sorted_sequence` is sorted when `sorter` is not provided, and that behavior is undefined otherwise.

This matches the existing behavior of the operator and aligns the documentation style with `torch.bucketize`, which already documents undefined behavior for unsorted boundaries.

## Motivation

Currently the docs state that `sorted_sequence` must be monotonically increasing, but do not explicitly mention that this precondition is not validated at runtime. Since the operator still returns indices for unsorted input, users may incorrectly assume the behavior is defined.

This PR is documentation-only and does not change runtime behavior.

fixes #184883