### PR TITLE
Remove stale "loop is faster than ={0}" workaround in vec

### DIFF
--- a/aten/src/ATen/cpu/vec/sve/vec_qint.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_qint.h
@@ -178,14 +178,8 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
   }
 
   static Vectorized<c10::qint32> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -341,14 +335,8 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
   }
 
   static Vectorized<c10::qint8> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -484,14 +472,8 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
   }
 
   static Vectorized<c10::quint8> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -187,10 +187,8 @@ class Vectorized<float> {
     if (count == size()) {
       return vld1q_f32(reinterpret_cast<const float*>(ptr));
     } else {
-      __at_align__ float tmp_values[size()];
-      for (const auto i : c10::irange(size())) {
-        tmp_values[i] = 0.0;
-      }
+      // Zero tail past `count`.
+      __at_align__ float tmp_values[size()] = {};
       std::memcpy(
           tmp_values,
           reinterpret_cast<const float*>(ptr),

--- a/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
@@ -199,10 +199,8 @@ class Vectorized<c10::Half> : public Vectorized16<
     if (count == size()) {
       return vld1q_f16(reinterpret_cast<const float16_t*>(ptr));
     }
-    __at_align__ float16_t tmp_values[size()];
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ float16_t tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const float16_t*>(ptr),

--- a/aten/src/ATen/cpu/vec/vec128/vec128_int_aarch64.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_int_aarch64.h
@@ -379,10 +379,7 @@ Vectorized<int8_t> Vectorized<int8_t>::blend(
     if (count == size()) {                                                    \
       return vld1q_s##bit(reinterpret_cast<const int##bit##_t*>(ptr));        \
     } else {                                                                  \
-      __at_align__ int##bit##_t tmp_values[size()];                           \
-      for (const auto i : c10::irange(size())) {                              \
-        tmp_values[i] = 0;                                                    \
-      }                                                                       \
+      __at_align__ int##bit##_t tmp_values[size()] = {};                      \
       std::memcpy(                                                            \
           tmp_values,                                                         \
           reinterpret_cast<const int##bit##_t*>(ptr),                         \

--- a/aten/src/ATen/cpu/vec/vec128/vec128_uint_aarch64.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_uint_aarch64.h
@@ -255,10 +255,7 @@ Vectorized<uint8_t> Vectorized<uint8_t>::blend(
     if (count == size()) {                                                     \
       return vld1q_u##bit(reinterpret_cast<const uint##bit##_t*>(ptr));        \
     } else {                                                                   \
-      __at_align__ uint##bit##_t tmp_values[size()];                           \
-      for (const auto i : c10::irange(size())) {                               \
-        tmp_values[i] = 0;                                                     \
-      }                                                                        \
+      __at_align__ uint##bit##_t tmp_values[size()] = {};                      \
       std::memcpy(                                                             \
           tmp_values,                                                          \
           reinterpret_cast<const uint##bit##_t*>(ptr),                         \

--- a/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
@@ -256,13 +256,8 @@ class Vectorized16 {
     // explicitly so the memcpy bound is provable to gcc-14 (#159962) and
     // out-of-contract callers stay safe.
     const int n = std::clamp(static_cast<int>(count), 0, size());
-    __at_align__ int16_t tmp_values[size()];
-#ifndef __msvc_cl__
-#pragma unroll
-#endif
-    for (const auto i : c10::irange(n, size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `n`.
+    __at_align__ int16_t tmp_values[size()] = {};
     std::memcpy(tmp_values, ptr, n * sizeof(int16_t));
     return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(tmp_values));
   }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -99,14 +99,8 @@ class Vectorized<c10::complex<double>> {
     if (count == size())
       return _mm256_loadu_pd(reinterpret_cast<const double*>(ptr));
 
-    __at_align__ double tmp_values[2 * size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(2 * size())) {
-      tmp_values[i] = 0.0;
-    }
+    // Zero tail past `count`.
+    __at_align__ double tmp_values[2 * size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const double*>(ptr),

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -164,14 +164,8 @@ class Vectorized<c10::complex<float>> {
     if (count == size())
       return _mm256_loadu_ps(reinterpret_cast<const float*>(ptr));
 
-    __at_align__ float tmp_values[2 * size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(2 * size())) {
-      tmp_values[i] = 0.0;
-    }
+    // Zero tail past `count`.
+    __at_align__ float tmp_values[2 * size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const float*>(ptr),

--- a/aten/src/ATen/cpu/vec/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_double.h
@@ -83,14 +83,8 @@ class Vectorized<double> {
     if (count == size())
       return _mm256_loadu_pd(reinterpret_cast<const double*>(ptr));
 
-    __at_align__ double tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0.0;
-    }
+    // Zero tail past `count`.
+    __at_align__ double tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const double*>(ptr),

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -114,14 +114,8 @@ class Vectorized<float> {
   static Vectorized<float> loadu(const void* ptr, int64_t count = size()) {
     if (count == size())
       return _mm256_loadu_ps(reinterpret_cast<const float*>(ptr));
-    __at_align__ float tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0.0;
-    }
+    // Zero tail past `count`.
+    __at_align__ float tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const float*>(ptr),

--- a/aten/src/ATen/cpu/vec/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_int.h
@@ -114,10 +114,7 @@ class Vectorized<int64_t> : public Vectorizedi {
   }
   static Vectorized<int64_t> loadu(const void* ptr, int64_t count) {
     __at_align__ int64_t tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to one using "={1}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
+    // Fill tail with 1; loop for GCC 11 auto-vec.
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
@@ -266,10 +263,7 @@ class Vectorized<int32_t> : public Vectorizedi {
   }
   static Vectorized<int32_t> loadu(const void* ptr, int32_t count) {
     __at_align__ int32_t tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to one using "={1}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
+    // Fill tail with 1; loop for GCC 11 auto-vec.
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
@@ -568,10 +562,7 @@ class Vectorized<int16_t> : public Vectorizedi {
   }
   static Vectorized<int16_t> loadu(const void* ptr, int16_t count) {
     __at_align__ int16_t tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to one using "={1}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
+    // Fill tail with 1; loop for GCC 11 auto-vec.
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
@@ -918,10 +909,7 @@ class Vectorized8 : public Vectorizedi {
   }
   static Vectorized<T> loadu(const void* ptr, T count) {
     __at_align__ T tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to one using "={1}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
+    // Fill tail with 1; loop for GCC 11 auto-vec.
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -384,14 +384,8 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
   }
 
   static Vectorized<c10::qint32> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -600,14 +594,8 @@ struct Vectorized<c10::qint8> : public Vectorizedqi {
   }
 
   static Vectorized<c10::qint8> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -811,14 +799,8 @@ struct Vectorized<c10::quint8> : public Vectorizedqi {
   }
 
   static Vectorized<c10::quint8> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -1055,14 +1037,8 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
   }
 
   static Vectorized<c10::qint32> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -1190,14 +1166,8 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
   }
 
   static Vectorized<c10::qint8> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -1314,14 +1284,8 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
   }
 
   static Vectorized<c10::quint8> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
@@ -169,14 +169,8 @@ class Vectorized<c10::complex<double>> {
     if (count == size())
       return _mm512_loadu_pd(reinterpret_cast<const double*>(ptr));
 
-    __at_align__ double tmp_values[2 * size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(2 * size())) {
-      tmp_values[i] = 0.0;
-    }
+    // Zero tail past `count`.
+    __at_align__ double tmp_values[2 * size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const double*>(ptr),

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
@@ -668,14 +668,8 @@ class Vectorized<c10::complex<float>> {
     if (count == size())
       return _mm512_loadu_ps(reinterpret_cast<const float*>(ptr));
 
-    __at_align__ float tmp_values[2 * size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(2 * size())) {
-      tmp_values[i] = 0.0;
-    }
+    // Zero tail past `count`.
+    __at_align__ float tmp_values[2 * size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const float*>(ptr),

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -411,14 +411,8 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
   }
 
   static Vectorized<c10::qint32> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -635,14 +629,8 @@ struct Vectorized<c10::qint8> : public Vectorizedqi {
   }
 
   static Vectorized<c10::qint8> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -870,14 +858,8 @@ struct Vectorized<c10::quint8> : public Vectorizedqi {
   }
 
   static Vectorized<c10::quint8> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -1172,14 +1154,8 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
   }
 
   static Vectorized<c10::qint32> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -1324,14 +1300,8 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
   }
 
   static Vectorized<c10::qint8> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
@@ -1465,14 +1435,8 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
   }
 
   static Vectorized<c10::quint8> loadu(const void* ptr, int64_t count) {
-    __at_align__ value_type tmp_values[size()];
-    // Ensure uninitialized memory does not change the output value See
-    // https://github.com/pytorch/pytorch/issues/32502 for more details. We do
-    // not initialize arrays to zero using "={0}" because gcc would compile it
-    // to two instructions while a loop would be compiled to one instruction.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 0;
-    }
+    // Zero tail past `count`.
+    __at_align__ value_type tmp_values[size()] = {};
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),


### PR DESCRIPTION
The 2020-era GCC quirk (#32502) the loops worked around no longer applies. On PyTorch's minimum compilers (GCC 11.3, Clang 16, MSVC VS 16.10), the loop and `= {}` brace-init emit identical assembly (verified via godbolt).

Zero-init sites use `= {}`.

Test Plan: existing CI; no runtime behavior change.

Authored by Claude.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01