### PR TITLE
[Inductor] Index expression codegen for user Triton kernel fusion

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -6401,6 +6401,93 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         self.assertEqual(out, fn(x))
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=2)
 
+    # -------------------------------------------------------------------------
+    # wrap_triton argument validation
+    # -------------------------------------------------------------------------
+
+    @requires_cuda_and_triton
+    def test_wrap_triton_output_tile_wrong_type(self):
+        @triton.jit
+        def k(out_ptr, BLOCK: tl.constexpr):
+            tl.store(
+                out_ptr + tl.arange(0, BLOCK), tl.zeros((BLOCK,), dtype=tl.float32)
+            )
+
+        with self.assertRaisesRegex(
+            TypeError, "output_tile must be a tuple of strings"
+        ):
+            wrap_triton(k, output_tile=["BLOCK"])
+        with self.assertRaisesRegex(
+            TypeError, "output_tile must be a tuple of strings"
+        ):
+            wrap_triton(k, output_tile=("BLOCK", 42))
+
+    @requires_cuda_and_triton
+    def test_wrap_triton_output_tile_empty(self):
+        @triton.jit
+        def k(out_ptr, BLOCK: tl.constexpr):
+            tl.store(
+                out_ptr + tl.arange(0, BLOCK), tl.zeros((BLOCK,), dtype=tl.float32)
+            )
+
+        with self.assertRaisesRegex(ValueError, "output_tile must be non-empty"):
+            wrap_triton(k, output_tile=())
+
+    @requires_cuda_and_triton
+    def test_wrap_triton_pid_remap_without_output_tile(self):
+        @triton.jit
+        def k(out_ptr, BLOCK: tl.constexpr):
+            tl.store(
+                out_ptr + tl.arange(0, BLOCK), tl.zeros((BLOCK,), dtype=tl.float32)
+            )
+
+        with self.assertRaisesRegex(ValueError, "pid_remap requires output_tile"):
+            wrap_triton(k, pid_remap=("pid",))
+
+    @requires_cuda_and_triton
+    def test_wrap_triton_pid_remap_wrong_type(self):
+        @triton.jit
+        def k(out_ptr, BLOCK: tl.constexpr):
+            tl.store(
+                out_ptr + tl.arange(0, BLOCK), tl.zeros((BLOCK,), dtype=tl.float32)
+            )
+
+        with self.assertRaisesRegex(TypeError, "pid_remap must be a tuple of strings"):
+            wrap_triton(k, output_tile=("BLOCK",), pid_remap=["pid"])
+
+    @requires_cuda_and_triton
+    def test_wrap_triton_pid_remap_length_mismatch(self):
+        @triton.jit
+        def k(out_ptr, BM: tl.constexpr, BN: tl.constexpr):
+            tl.store(out_ptr + tl.arange(0, BM), tl.zeros((BM,), dtype=tl.float32))
+
+        with self.assertRaisesRegex(
+            ValueError, "pid_remap length.*must match.*output_tile length"
+        ):
+            wrap_triton(k, output_tile=("BM", "BN"), pid_remap=("pid_m",))
+
+    @requires_cuda_and_triton
+    def test_wrap_triton_output_tile_not_in_kwargs(self):
+        @triton.jit
+        def copy_kernel(src_ptr, dst_ptr, n, BLOCK: tl.constexpr):
+            offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+            mask = offs < n
+            tl.store(dst_ptr + offs, tl.load(src_ptr + offs, mask=mask), mask=mask)
+
+        def fn(x):
+            out = torch.empty_like(x)
+            grid = (triton.cdiv(x.numel(), 16),)
+            wrap_triton(copy_kernel, output_tile=("WRONG",))[grid](
+                x, out, x.numel(), BLOCK=16
+            )
+            return out + 1
+
+        with self.assertRaisesRegex(
+            torch._inductor.exc.InductorError,
+            "output_tile name 'WRONG' is not a kernel argument",
+        ):
+            torch.compile(fn)(torch.randn(128, device="cuda"))
+
 
 if HAS_CUDA_AND_TRITON:
 

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -33,7 +33,7 @@ from torch._inductor.utils import (
     run_and_get_code,
     triton_version_uses_attrs_dict,
 )
-from torch._library import capture_triton
+from torch._library import capture_triton, wrap_triton
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import (
@@ -5972,6 +5972,32 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         out, code = run_and_get_code(torch.compile(fn), a, b, c)
         self.assertEqual(out, fn(a, b, c))
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=4)
+
+    @requires_cuda_and_triton
+    def test_wrap_fusion_ones_like(self):
+        @triton.jit
+        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offs < n_elements
+            x = tl.load(in_ptr0 + offs, mask=mask)
+            y = tl.load(in_ptr1 + offs, mask=mask)
+            tl.store(out_ptr + offs, x + y, mask=mask)
+
+        def fn(a, b):
+            out = torch.empty_like(a)
+            grid = (triton.cdiv(a.numel(), 1024),)
+            wrap_triton(add_kernel, output_tile={"x": "BLOCK_SIZE"})[grid](
+                a, b, out, a.numel(), BLOCK_SIZE=1024
+            )
+            return out + torch.cumsum(torch.ones_like(out), dim=0)
+
+        a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        b = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+
+        out, code = run_and_get_code(torch.compile(fn), a, b)
+        self.assertEqual(out, fn(a, b))
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
 
 if HAS_CUDA_AND_TRITON:

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -5974,92 +5974,81 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=4)
 
     @requires_cuda_and_triton
-    def test_wrap_fusion_ones_like(self):
+    def test_wrap_fusion_norm_quant(self):
         @triton.jit
-        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
-            pid = tl.program_id(0)
-            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-            mask = offs < n_elements
-            x = tl.load(in_ptr0 + offs, mask=mask)
-            y = tl.load(in_ptr1 + offs, mask=mask)
-            tl.store(out_ptr + offs, x + y, mask=mask)
+        def _normalization_fwd(
+            X,
+            X_row_stride: tl.constexpr,
+            Y,
+            Y_row_stride: tl.constexpr,
+            W,
+            n_cols_X: tl.constexpr,
+            eps: tl.constexpr,
+            BLOCK_SIZE: tl.constexpr,
+        ):
+            row_idx = tl.program_id(0)
+            col_offsets = tl.arange(0, BLOCK_SIZE)
+            mask = col_offsets < n_cols_X
 
-        def fn(a, b):
-            out = torch.empty_like(a)
-            grid = (triton.cdiv(a.numel(), 1024),)
-            wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
-                a, b, out, a.numel(), BLOCK_SIZE=1024
+            X += row_idx * X_row_stride
+            Y += row_idx * Y_row_stride
+
+            X_row = tl.load(X + col_offsets, mask=mask, other=0).to(tl.float32)
+            W_row = tl.load(W + col_offsets, mask=mask, other=0).to(tl.float32)
+
+            row_var = tl.sum(X_row * X_row, axis=0) / n_cols_X
+            inv_var = tl.math.rsqrt(row_var + eps)
+
+            normed = X_row * inv_var * W_row
+            tl.store(Y + col_offsets, normed.to(X_row.dtype), mask=mask)
+
+        def normalization(X: torch.Tensor, W: torch.Tensor, eps: float = 1e-6):
+            shape = X.shape
+            hidden_dim = shape[-1]
+            X = X.reshape(-1, hidden_dim)
+            num_rows, num_cols = X.shape
+
+            BLOCK_SIZE = triton.next_power_of_2(num_cols)
+            Y = torch.empty_like(X)
+
+            torch.library.wrap_triton(_normalization_fwd, output_tile=("BLOCK_SIZE",))[
+                (num_rows,)
+            ](
+                X,
+                X.stride(0),
+                Y,
+                Y.stride(0),
+                W,
+                num_cols,
+                eps,
+                BLOCK_SIZE=BLOCK_SIZE,
             )
-            return out + torch.cumsum(torch.ones_like(out), dim=0)
 
-        a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
-        b = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+            return Y.view(*shape)
 
-        out, code = run_and_get_code(torch.compile(fn), a, b)
-        self.assertEqual(out, fn(a, b))
+        FP8_DTYPE = torch.float8_e4m3fn
+        FP8_MAX = torch.finfo(FP8_DTYPE).max
+        FP8_MIN = -FP8_MAX
+
+        def fn(X, W):
+            X = normalization(X, W)
+            X_f32 = X.to(torch.float32)
+            abs_max = X_f32.abs().max(dim=-1, keepdim=True).values
+            S = abs_max / FP8_MAX
+            Y = (X_f32 / S).clamp(FP8_MIN, FP8_MAX).to(FP8_DTYPE)
+            return Y
+
+        X = torch.randn((4, 4096), device="cuda")
+        W = torch.randn((X.shape[-1]), device="cuda")
+
+        out, code = run_and_get_code(torch.compile(fn), X, W)
+        self.assertEqual(
+            out.view(torch.uint8).to(torch.int32),
+            fn(X, W).view(torch.uint8).to(torch.int32),
+            atol=1,
+            rtol=0,
+        )
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
-
-    @requires_cuda_and_triton
-    def test_wrap_fusion_non_unary_fusion_eq_shape(self):
-        @triton.jit
-        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
-            pid = tl.program_id(0)
-            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-            mask = offs < n_elements
-            x = tl.load(in_ptr0 + offs, mask=mask)
-            y = tl.load(in_ptr1 + offs, mask=mask)
-            tl.store(out_ptr + offs, x + y, mask=mask)
-
-        def fn(a, b, c):
-            out = torch.empty_like(a)
-            grid = (triton.cdiv(a.numel(), 1024),)
-            wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
-                a, b, out, a.numel(), BLOCK_SIZE=1024
-            )
-            out = out * c  # Non-unary epilogue
-
-            out2 = torch.empty_like(a)
-            add_kernel[grid](out, a, out2, a.numel(), BLOCK_SIZE=1024)
-            return out
-
-        a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
-        b = torch.randn(8, 16, dtype=torch.float32, device="cuda")
-        c = torch.randn(8, 16, dtype=torch.float32, device="cuda")
-
-        out, code = run_and_get_code(torch.compile(fn), a, b, c)
-        self.assertEqual(out, fn(a, b, c))
-        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
-
-    @requires_cuda_and_triton
-    def test_wrap_fusion_non_unary_fusion_broadcasted_shape(self):
-        @triton.jit
-        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
-            pid = tl.program_id(0)
-            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-            mask = offs < n_elements
-            x = tl.load(in_ptr0 + offs, mask=mask)
-            y = tl.load(in_ptr1 + offs, mask=mask)
-            tl.store(out_ptr + offs, x + y, mask=mask)
-
-        def fn(a, b, c):
-            out = torch.empty_like(a)
-            grid = (triton.cdiv(a.numel(), 1024),)
-            wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
-                a, b, out, a.numel(), BLOCK_SIZE=1024
-            )
-            out = out * c  # Non-unary epilogue
-
-            out2 = torch.empty_like(a)
-            add_kernel[grid](out, a, out2, a.numel(), BLOCK_SIZE=1024)
-            return out
-
-        a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
-        b = torch.randn(8, 16, dtype=torch.float32, device="cuda")
-        c = torch.randn(8, dtype=torch.float32, device="cuda").unsqueeze(1)
-
-        out, code = run_and_get_code(torch.compile(fn), a, b, c)
-        self.assertEqual(out, fn(a, b, c))
-        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
 
     @requires_cuda_and_triton
     def test_wrap_fusion_2d_matmul(self):
@@ -6166,6 +6155,94 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         out, code = run_and_get_code(torch.compile(fn), a, b)
         self.assertEqual(out, fn(a, b))
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
+
+    @requires_cuda_and_triton
+    def test_wrap_fusion_cumsum(self):
+        @triton.jit
+        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offs < n_elements
+            x = tl.load(in_ptr0 + offs, mask=mask)
+            y = tl.load(in_ptr1 + offs, mask=mask)
+            tl.store(out_ptr + offs, x + y, mask=mask)
+
+        def fn(a, b):
+            out = torch.empty_like(a)
+            grid = (triton.cdiv(a.numel(), 1024),)
+            wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
+                a, b, out, a.numel(), BLOCK_SIZE=1024
+            )
+            return out + torch.cumsum(torch.ones_like(out), dim=0)
+
+        a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        b = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+
+        out, code = run_and_get_code(torch.compile(fn), a, b)
+        self.assertEqual(out, fn(a, b))
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
+
+    @requires_cuda_and_triton
+    def test_wrap_fusion_non_unary_fusion_eq_shape(self):
+        @triton.jit
+        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offs < n_elements
+            x = tl.load(in_ptr0 + offs, mask=mask)
+            y = tl.load(in_ptr1 + offs, mask=mask)
+            tl.store(out_ptr + offs, x + y, mask=mask)
+
+        def fn(a, b, c):
+            out = torch.empty_like(a)
+            grid = (triton.cdiv(a.numel(), 1024),)
+            wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
+                a, b, out, a.numel(), BLOCK_SIZE=1024
+            )
+            out = out * c  # Non-unary epilogue
+
+            out2 = torch.empty_like(a)
+            add_kernel[grid](out, a, out2, a.numel(), BLOCK_SIZE=1024)
+            return out
+
+        a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        b = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        c = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+
+        out, code = run_and_get_code(torch.compile(fn), a, b, c)
+        self.assertEqual(out, fn(a, b, c))
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
+
+    @requires_cuda_and_triton
+    def test_wrap_fusion_non_unary_fusion_broadcasted_shape(self):
+        @triton.jit
+        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offs < n_elements
+            x = tl.load(in_ptr0 + offs, mask=mask)
+            y = tl.load(in_ptr1 + offs, mask=mask)
+            tl.store(out_ptr + offs, x + y, mask=mask)
+
+        def fn(a, b, c):
+            out = torch.empty_like(a)
+            grid = (triton.cdiv(a.numel(), 1024),)
+            wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
+                a, b, out, a.numel(), BLOCK_SIZE=1024
+            )
+            out = out * c  # Non-unary epilogue
+
+            out2 = torch.empty_like(a)
+            add_kernel[grid](out, a, out2, a.numel(), BLOCK_SIZE=1024)
+            return out
+
+        a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        b = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        c = torch.randn(8, dtype=torch.float32, device="cuda").unsqueeze(1)
+
+        out, code = run_and_get_code(torch.compile(fn), a, b, c)
+        self.assertEqual(out, fn(a, b, c))
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
 
 
 if HAS_CUDA_AND_TRITON:

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -6051,6 +6051,106 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
     @requires_cuda_and_triton
+    def test_wrap_fusion_grouped_matmul(self):
+        # https://triton-lang.org/main/getting-started/tutorials/03-matrix-multiplication.html
+        @triton.jit
+        def matmul_kernel(
+            a_ptr,
+            b_ptr,
+            c_ptr,
+            M,
+            N,
+            K,
+            stride_am,
+            stride_ak,
+            stride_bk,
+            stride_bn,
+            stride_cm,
+            stride_cn,
+            BLOCK_SIZE_M: tl.constexpr,
+            BLOCK_SIZE_N: tl.constexpr,
+            BLOCK_SIZE_K: tl.constexpr,  #
+            GROUP_SIZE_M: tl.constexpr,
+        ):
+            pid = tl.program_id(axis=0)
+            num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+            num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+            num_pid_in_group = GROUP_SIZE_M * num_pid_n
+            group_id = pid // num_pid_in_group
+            first_pid_m = group_id * GROUP_SIZE_M
+            group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+            pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+            pid_n = (pid % num_pid_in_group) // group_size_m
+
+            offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+            offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+            offs_k = tl.arange(0, BLOCK_SIZE_K)
+            a_ptrs = a_ptr + (
+                offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
+            )
+            b_ptrs = b_ptr + (
+                offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+            )
+
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            for k in range(tl.cdiv(K, BLOCK_SIZE_K)):
+                a = tl.load(
+                    a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0
+                )
+                b = tl.load(
+                    b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0
+                )
+                accumulator = tl.dot(a, b, accumulator)
+                a_ptrs += BLOCK_SIZE_K * stride_ak
+                b_ptrs += BLOCK_SIZE_K * stride_bk
+
+            c = accumulator.to(tl.float16)
+
+            offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+            offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+            c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+            tl.store(c_ptrs, c, mask=c_mask)
+
+        def fn(A, B, b):
+            M, K = A.shape
+            K, N = B.shape
+            C = torch.empty((M, N), device=A.device, dtype=torch.float16)
+            BLOCK_M, BLOCK_N, BLOCK_K = 64, 64, 32
+            GROUP_SIZE_M = 8
+            grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N),)
+            torch.library.wrap_triton(
+                matmul_kernel,
+                output_tile=("BLOCK_SIZE_M", "BLOCK_SIZE_N"),
+                pid_remap=("pid_m", "pid_n"),
+            )[grid](
+                A,
+                B,
+                C,
+                M,
+                N,
+                K,
+                A.stride(0),
+                A.stride(1),
+                B.stride(0),
+                B.stride(1),
+                C.stride(0),
+                C.stride(1),
+                BLOCK_SIZE_M=BLOCK_M,
+                BLOCK_SIZE_N=BLOCK_N,
+                BLOCK_SIZE_K=BLOCK_K,
+                GROUP_SIZE_M=GROUP_SIZE_M,
+            )
+            return (C + b).relu()
+
+        A = torch.randn(1024, 512, device="cuda")
+        B = torch.randn(512, 2048, device="cuda")
+        b = torch.randn(2048, device="cuda")
+        out, code = run_and_get_code(torch.compile(fn), A, B, b)
+        self.assertEqual(out, fn(A, B, b))
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
+
+    @requires_cuda_and_triton
     def test_wrap_fusion_2d_matmul(self):
         @triton.jit
         def naive_matmul_kernel(
@@ -6102,7 +6202,7 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
             grid = (triton.cdiv(N, BLOCK_N), triton.cdiv(M, BLOCK_M))
 
             torch.library.wrap_triton(
-                naive_matmul_kernel, output_tile=("BLOCK_N", "BLOCK_M")
+                naive_matmul_kernel, output_tile=("BLOCK_M", "BLOCK_N")
             )[grid](
                 A,
                 B,
@@ -6121,7 +6221,7 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
                 BLOCK_K=BLOCK_K,
             )
 
-            return C + b
+            return (C + b).relu()
 
         A = torch.randn(1024, 512, device="cuda")
         B = torch.randn(512, 2048, device="cuda")

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -6373,6 +6373,37 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
 
     @requires_cuda_and_triton
+    def test_wrap_fusion_nested_store_codegen_aliases_indentation(self):
+        # tl.store stored at different indentation level to kernel body.
+        @triton.jit
+        def add_kernel_nested(
+            in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr
+        ):
+            pid = tl.program_id(0)
+            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offs < n_elements
+            x = tl.load(in_ptr0 + offs, mask=mask)
+            y = tl.load(in_ptr1 + offs, mask=mask)
+            if BLOCK_SIZE > 0:
+                tl.store(out_ptr + offs, x + y, mask=mask)
+
+        def fn(a, b, c):
+            out = torch.empty_like(a)
+            grid = (triton.cdiv(a.numel(), 1024),)
+            wrap_triton(add_kernel_nested, output_tile=("BLOCK_SIZE",))[grid](
+                a, b, out, a.numel(), BLOCK_SIZE=1024
+            )
+            return out * c
+
+        a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        b = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        c = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+
+        out, code = run_and_get_code(torch.compile(fn), a, b, c)
+        self.assertEqual(out, fn(a, b, c))
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
+
+    @requires_cuda_and_triton
     def test_wrap_fusion_2d_tile_reduction_no_fuse(self):
         @triton.jit
         def tile2d_kernel(

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -6157,6 +6157,30 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
     @requires_cuda_and_triton
+    def test_wrap_fusion_reduction_epilogue(self):
+        @triton.jit
+        def row_scale_kernel(x_ptr, out_ptr, row_stride, BLOCK_SIZE: tl.constexpr):
+            row = tl.program_id(0)
+            cols = tl.arange(0, BLOCK_SIZE)
+            x = tl.load(x_ptr + row * row_stride + cols)
+            tl.store(out_ptr + row * row_stride + cols, x * 2.0)
+
+        def fn(x):
+            B, N = x.shape
+            out = torch.empty_like(x)
+            BLOCK_SIZE = N
+            wrap_triton(row_scale_kernel, output_tile=("BLOCK_SIZE",))[(B,)](
+                x, out, x.stride(0), BLOCK_SIZE=BLOCK_SIZE
+            )
+            row_max = out.abs().amax(dim=-1, keepdim=True)
+            return out / row_max
+
+        x = torch.randn(4, 128, device="cuda")
+        out, code = run_and_get_code(torch.compile(fn), x)
+        self.assertEqual(out, fn(x))
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=1)
+
+    @requires_cuda_and_triton
     def test_wrap_fusion_cumsum(self):
         @triton.jit
         def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
@@ -6243,6 +6267,39 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         out, code = run_and_get_code(torch.compile(fn), a, b, c)
         self.assertEqual(out, fn(a, b, c))
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
+
+    @requires_cuda_and_triton
+    def test_wrap_fusion_2d_tile_reduction_no_fuse(self):
+        @triton.jit
+        def tile2d_kernel(
+            x_ptr,
+            out_ptr,
+            stride_m,
+            BLOCK_M: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            pid_m = tl.program_id(1)
+            pid_n = tl.program_id(0)
+            rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+            rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+            x = tl.load(x_ptr + rm[:, None] * stride_m + rn[None, :])
+            tl.store(out_ptr + rm[:, None] * stride_m + rn[None, :], x * 2.0)
+
+        def fn(x):
+            M, N = x.shape
+            out = torch.empty_like(x)
+            BLOCK_M, BLOCK_N = 32, 32
+            grid = (triton.cdiv(N, BLOCK_N), triton.cdiv(M, BLOCK_M))
+            wrap_triton(tile2d_kernel, output_tile=("BLOCK_N", "BLOCK_M"))[grid](
+                x, out, x.stride(0), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N
+            )
+            row_max = out.abs().amax(dim=-1, keepdim=True)
+            return out / row_max
+
+        x = torch.randn(64, 64, device="cuda")
+        out, code = run_and_get_code(torch.compile(fn), x)
+        self.assertEqual(out, fn(x))
+        self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=2)
 
 
 if HAS_CUDA_AND_TRITON:

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -6016,7 +6016,7 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
             wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
                 a, b, out, a.numel(), BLOCK_SIZE=1024
             )
-            out = out * c # Non-unary epilogue
+            out = out * c  # Non-unary epilogue
 
             out2 = torch.empty_like(a)
             add_kernel[grid](out, a, out2, a.numel(), BLOCK_SIZE=1024)
@@ -6047,7 +6047,7 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
             wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
                 a, b, out, a.numel(), BLOCK_SIZE=1024
             )
-            out = out * c # Non-unary epilogue
+            out = out * c  # Non-unary epilogue
 
             out2 = torch.empty_like(a)
             add_kernel[grid](out, a, out2, a.numel(), BLOCK_SIZE=1024)
@@ -6061,6 +6061,85 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         self.assertEqual(out, fn(a, b, c))
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
 
+    @requires_cuda_and_triton
+    def test_wrap_fusion_2d_matmul(self):
+        @triton.jit
+        def naive_matmul_kernel(
+            A,
+            B,
+            C,
+            M,
+            N,
+            K,
+            stride_am,
+            stride_ak,
+            stride_bk,
+            stride_bn,
+            stride_cm,
+            stride_cn,
+            BLOCK_M: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+            BLOCK_K: tl.constexpr,
+        ):
+            pid_n = tl.program_id(0)
+            pid_m = tl.program_id(1)
+
+            rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+            rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+            rk = tl.arange(0, BLOCK_K)
+
+            A_ptr = A + (rm[:, None] * stride_am + rk[None, :] * stride_ak)
+            B_ptr = B + (rk[:, None] * stride_bk + rn[None, :] * stride_bn)
+
+            acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+            for _ in range(0, K, BLOCK_K):
+                a = tl.load(A_ptr)
+                b = tl.load(B_ptr)
+                acc += tl.dot(a, b)
+                A_ptr += BLOCK_K * stride_ak
+                B_ptr += BLOCK_K * stride_bk
+
+            C_ptr = C + (rm[:, None] * stride_cm + rn[None, :] * stride_cn)
+            mask = (rm[:, None] < M) & (rn[None, :] < N)
+            tl.store(C_ptr, acc, mask=mask)
+
+        def fn(A, B, b):
+            M, K = A.shape
+            K, N = B.shape
+
+            C = torch.empty((M, N), device=A.device, dtype=A.dtype)
+
+            BLOCK_M, BLOCK_N, BLOCK_K = 64, 64, 32
+            grid = (triton.cdiv(N, BLOCK_N), triton.cdiv(M, BLOCK_M))
+
+            torch.library.wrap_triton(
+                naive_matmul_kernel, output_tile=("BLOCK_N", "BLOCK_M")
+            )[grid](
+                A,
+                B,
+                C,
+                M,
+                N,
+                K,
+                A.stride(0),
+                A.stride(1),
+                B.stride(0),
+                B.stride(1),
+                C.stride(0),
+                C.stride(1),
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+                BLOCK_K=BLOCK_K,
+            )
+
+            return C + b
+
+        A = torch.randn(1024, 512, device="cuda")
+        B = torch.randn(512, 2048, device="cuda")
+        b = torch.randn(2048, device="cuda")
+        out, code = run_and_get_code(torch.compile(fn), A, B, b)
+        self.assertEqual(out, fn(A, B, b))
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
 
 
 if HAS_CUDA_AND_TRITON:

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -5987,7 +5987,7 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         def fn(a, b):
             out = torch.empty_like(a)
             grid = (triton.cdiv(a.numel(), 1024),)
-            wrap_triton(add_kernel, output_tile={"x": "BLOCK_SIZE"})[grid](
+            wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
                 a, b, out, a.numel(), BLOCK_SIZE=1024
             )
             return out + torch.cumsum(torch.ones_like(out), dim=0)
@@ -6013,7 +6013,7 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         def fn(a, b, c):
             out = torch.empty_like(a)
             grid = (triton.cdiv(a.numel(), 1024),)
-            wrap_triton(add_kernel, output_tile={"x": "BLOCK_SIZE"})[grid](
+            wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
                 a, b, out, a.numel(), BLOCK_SIZE=1024
             )
             out = out * c # Non-unary epilogue
@@ -6044,7 +6044,7 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         def fn(a, b, c):
             out = torch.empty_like(a)
             grid = (triton.cdiv(a.numel(), 1024),)
-            wrap_triton(add_kernel, output_tile={"x": "BLOCK_SIZE"})[grid](
+            wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
                 a, b, out, a.numel(), BLOCK_SIZE=1024
             )
             out = out * c # Non-unary epilogue

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -6000,7 +6000,7 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
     @requires_cuda_and_triton
-    def test_wrap_fusion_non_unary_fusion(self):
+    def test_wrap_fusion_non_unary_fusion_eq_shape(self):
         @triton.jit
         def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
             pid = tl.program_id(0)
@@ -6029,6 +6029,38 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         out, code = run_and_get_code(torch.compile(fn), a, b, c)
         self.assertEqual(out, fn(a, b, c))
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
+
+    @requires_cuda_and_triton
+    def test_wrap_fusion_non_unary_fusion_broadcasted_shape(self):
+        @triton.jit
+        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offs < n_elements
+            x = tl.load(in_ptr0 + offs, mask=mask)
+            y = tl.load(in_ptr1 + offs, mask=mask)
+            tl.store(out_ptr + offs, x + y, mask=mask)
+
+        def fn(a, b, c):
+            out = torch.empty_like(a)
+            grid = (triton.cdiv(a.numel(), 1024),)
+            wrap_triton(add_kernel, output_tile={"x": "BLOCK_SIZE"})[grid](
+                a, b, out, a.numel(), BLOCK_SIZE=1024
+            )
+            out = out * c # Non-unary epilogue
+
+            out2 = torch.empty_like(a)
+            add_kernel[grid](out, a, out2, a.numel(), BLOCK_SIZE=1024)
+            return out
+
+        a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        b = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        c = torch.randn(8, dtype=torch.float32, device="cuda").unsqueeze(1)
+
+        out, code = run_and_get_code(torch.compile(fn), a, b, c)
+        self.assertEqual(out, fn(a, b, c))
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
+
 
 
 if HAS_CUDA_AND_TRITON:

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -6016,7 +6016,11 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
             wrap_triton(add_kernel, output_tile={"x": "BLOCK_SIZE"})[grid](
                 a, b, out, a.numel(), BLOCK_SIZE=1024
             )
-            return out * c
+            out = out * c # Non-unary epilogue
+
+            out2 = torch.empty_like(a)
+            add_kernel[grid](out, a, out2, a.numel(), BLOCK_SIZE=1024)
+            return out
 
         a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
         b = torch.randn(8, 16, dtype=torch.float32, device="cuda")

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -5999,6 +5999,33 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         self.assertEqual(out, fn(a, b))
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
 
+    @requires_cuda_and_triton
+    def test_wrap_fusion_non_unary_fusion(self):
+        @triton.jit
+        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offs < n_elements
+            x = tl.load(in_ptr0 + offs, mask=mask)
+            y = tl.load(in_ptr1 + offs, mask=mask)
+            tl.store(out_ptr + offs, x + y, mask=mask)
+
+        def fn(a, b, c):
+            out = torch.empty_like(a)
+            grid = (triton.cdiv(a.numel(), 1024),)
+            wrap_triton(add_kernel, output_tile={"x": "BLOCK_SIZE"})[grid](
+                a, b, out, a.numel(), BLOCK_SIZE=1024
+            )
+            return out * c
+
+        a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        b = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        c = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+
+        out, code = run_and_get_code(torch.compile(fn), a, b, c)
+        self.assertEqual(out, fn(a, b, c))
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
+
 
 if HAS_CUDA_AND_TRITON:
 

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -6141,6 +6141,32 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         self.assertEqual(out, fn(A, B, b))
         self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=3)
 
+    @requires_cuda_and_triton
+    def test_wrap_fusion_cast(self):
+        @triton.jit
+        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offs < n_elements
+            x = tl.load(in_ptr0 + offs, mask=mask)
+            y = tl.load(in_ptr1 + offs, mask=mask)
+            tl.store(out_ptr + offs, x + y, mask=mask)
+
+        def fn(a, b):
+            out = torch.empty_like(a)
+            grid = (triton.cdiv(a.numel(), 1024),)
+            wrap_triton(add_kernel, output_tile=("BLOCK_SIZE",))[grid](
+                a, b, out, a.numel(), BLOCK_SIZE=1024
+            )
+            return out.to(torch.float16)
+
+        a = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+        b = torch.randn(8, 16, dtype=torch.float32, device="cuda")
+
+        out, code = run_and_get_code(torch.compile(fn), a, b)
+        self.assertEqual(out, fn(a, b))
+        self.check_code(code[0], num_kernels=1, num_allocs=1, num_deallocs=2)
+
 
 if HAS_CUDA_AND_TRITON:
 

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -36,6 +36,7 @@ from torch._inductor.utils import (
 from torch._library import capture_triton, wrap_triton
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
 from torch.testing._internal.common_utils import (
     parametrize,
     skipIfRocm,
@@ -5974,6 +5975,9 @@ class TestUserKernelEpilogueFusion(torch._inductor.test_case.TestCase):
         self.check_code(code[0], num_kernels=2, num_allocs=2, num_deallocs=4)
 
     @requires_cuda_and_triton
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FP8, "fp8e4nv (float8_e4m3fn) requires SM 8.9+"
+    )
     def test_wrap_fusion_norm_quant(self):
         @triton.jit
         def _normalization_fwd(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1200,11 +1200,17 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             output_tile_var = kwargs.get("output_tile")
             if output_tile_var is not None:
                 output_tile = output_tile_var.as_python_constant()
-                kernel_side_table.set_output_tile(kernel_var.kernel_idx, output_tile)
+                kernel_side_table.set_output_tile(
+                    kernel_var.kernel_idx,  # pyrefly: ignore[missing-attribute]
+                    output_tile,
+                )
             pid_remap_var = kwargs.get("pid_remap")
             if pid_remap_var is not None:
                 pid_remap = pid_remap_var.as_python_constant()
-                kernel_side_table.set_pid_remap(kernel_var.kernel_idx, pid_remap)
+                kernel_side_table.set_pid_remap(
+                    kernel_var.kernel_idx,  # pyrefly: ignore[missing-attribute]
+                    pid_remap,
+                )
             # wrap_triton / capture_triton is a no-op in dynamo
             return kernel_var
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1195,12 +1195,16 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                     ],
                 )
             kernel_var = args[0]
+            from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
+
             output_tile_var = kwargs.get("output_tile")
             if output_tile_var is not None:
-                from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
-
                 output_tile = output_tile_var.as_python_constant()
                 kernel_side_table.set_output_tile(kernel_var.kernel_idx, output_tile)
+            pid_remap_var = kwargs.get("pid_remap")
+            if pid_remap_var is not None:
+                pid_remap = pid_remap_var.as_python_constant()
+                kernel_side_table.set_pid_remap(kernel_var.kernel_idx, pid_remap)
             # wrap_triton / capture_triton is a no-op in dynamo
             return kernel_var
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1183,20 +1183,26 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             *args: VariableTracker,
             **kwargs: VariableTracker,
         ) -> VariableTracker:
-            if len(args) == 1:
-                # wrap_triton / capture_triton is a no-op in dynamo
-                return args[0]
+            if len(args) != 1:
+                unimplemented(
+                    gb_type="torch.library.wrap_triton call with > 1 args",
+                    context=f"args={args}, kwargs={kwargs}",
+                    explanation="Attempted to call `wrap_triton`/`capture_triton`"
+                    " with > 1 args. Dynamo does not support this.",
+                    hints=[
+                        "Remove the wrap_triton/capture_triton call or its additional args.",
+                        *graph_break_hints.SUPPORTABLE,
+                    ],
+                )
+            kernel_var = args[0]
+            output_tile_var = kwargs.get("output_tile")
+            if output_tile_var is not None:
+                from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 
-            unimplemented(
-                gb_type="torch.library.wrap_triton call with > 1 args",
-                context=f"args={args}, kwargs={kwargs}",
-                explanation="Attempted to call `wrap_triton`/`capture_triton`"
-                " with > 1 args. Dynamo does not support this.",
-                hints=[
-                    "Remove the wrap_triton/capture_triton call or its additional args.",
-                    *graph_break_hints.SUPPORTABLE,
-                ],
-            )
+                output_tile = output_tile_var.as_python_constant()
+                kernel_side_table.set_output_tile(kernel_var.kernel_idx, output_tile)
+            # wrap_triton / capture_triton is a no-op in dynamo
+            return kernel_var
 
         @register(*REWRITE_OPS_TO_TENSOR_SIZE_METHOD)
         def handle_tensor_size_rewrites(

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -151,7 +151,7 @@ class KernelSideTable:
     id_to_kernel: dict[int, "TritonKernelType"] = {}
     kernel_to_id: dict["TritonKernelType", int] = {}
     constant_args: dict[int, dict[str, Any]] = {}
-    output_tiles: dict[int, dict[str, str]] = {}
+    output_tiles: dict[int, tuple[str, ...]] = {}
     lock = threading.Lock()
 
     # Returns index on the table
@@ -189,11 +189,11 @@ class KernelSideTable:
             )
         return self.constant_args[idx]
 
-    def set_output_tile(self, kernel_idx: int, output_tile: dict[str, str]) -> None:
+    def set_output_tile(self, kernel_idx: int, output_tile: tuple[str, ...]) -> None:
         with self.lock:
             self.output_tiles[kernel_idx] = output_tile
 
-    def get_output_tile(self, kernel_idx: int) -> "dict[str, str] | None":
+    def get_output_tile(self, kernel_idx: int) -> "tuple[str, ...] | None":
         return self.output_tiles.get(kernel_idx)
 
     # Resets the table (only meant to be used in unit tests)
@@ -2348,7 +2348,7 @@ class TraceableTritonKernelWrapper:
     kernel_idx: int | None
     grid: Optional["TritonGridType"]
     kernel_source: "Source | None"
-    output_tile: dict[str, str] | None
+    output_tile: tuple[str, ...] | None
 
     def __init__(
         self,
@@ -2356,7 +2356,7 @@ class TraceableTritonKernelWrapper:
         kernel_idx: int | None,
         grid: Optional["TritonGridType"],
         kernel_source: "Source | None" = None,
-        output_tile: dict[str, str] | None = None,
+        output_tile: tuple[str, ...] | None = None,
     ) -> None:
         self.kernel = None
         self.grid = None

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -151,6 +151,7 @@ class KernelSideTable:
     id_to_kernel: dict[int, "TritonKernelType"] = {}
     kernel_to_id: dict["TritonKernelType", int] = {}
     constant_args: dict[int, dict[str, Any]] = {}
+    output_tiles: dict[int, dict[str, str]] = {}
     lock = threading.Lock()
 
     # Returns index on the table
@@ -188,12 +189,20 @@ class KernelSideTable:
             )
         return self.constant_args[idx]
 
+    def set_output_tile(self, kernel_idx: int, output_tile: dict[str, str]) -> None:
+        with self.lock:
+            self.output_tiles[kernel_idx] = output_tile
+
+    def get_output_tile(self, kernel_idx: int) -> "dict[str, str] | None":
+        return self.output_tiles.get(kernel_idx)
+
     # Resets the table (only meant to be used in unit tests)
     # This is only safe assuming single threaded execution
     def reset_table(self) -> None:
         self.id_to_kernel = {}
         self.kernel_to_id = {}
         self.constant_args = {}
+        self.output_tiles = {}
 
 
 kernel_side_table = KernelSideTable()
@@ -2339,6 +2348,7 @@ class TraceableTritonKernelWrapper:
     kernel_idx: int | None
     grid: Optional["TritonGridType"]
     kernel_source: "Source | None"
+    output_tile: dict[str, str] | None
 
     def __init__(
         self,
@@ -2346,13 +2356,17 @@ class TraceableTritonKernelWrapper:
         kernel_idx: int | None,
         grid: Optional["TritonGridType"],
         kernel_source: "Source | None" = None,
+        output_tile: dict[str, str] | None = None,
     ) -> None:
         self.kernel = None
         self.grid = None
         self.kernel_source = kernel_source
+        self.output_tile = output_tile
         tracing_triton_hopifier_singleton.init_variable(self, kernel, kernel_idx, grid)
         if self.kernel is None:
             raise AssertionError("kernel was not initialized properly")
+        if output_tile is not None:
+            kernel_side_table.set_output_tile(self.kernel_idx, output_tile)
 
     def __getitem__(self, *args: Sequence[Any]) -> "TraceableTritonKernelWrapper":
         return tracing_triton_hopifier_singleton.call_getitem(self, args)  # type: ignore[return-value]

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1180,7 +1180,7 @@ class TritonStores:
 @functools.cache
 def identify_triton_stores(source_code: str) -> TritonStores:
     """
-    Parse Python source code of triton kernel and find all tl.store calls.
+    Parse Python source code of the Triton kernel and find all tl.store calls.
     Returns a TritonStores object containing information about pointer, value, and mask.
 
     tl.store signature: store(pointer, value, mask=None, boundary_check=(), ...)

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1,4 +1,3 @@
-import ast
 import collections
 import copy
 import dataclasses
@@ -1163,69 +1162,6 @@ def identify_accessed_tensors(
             ),
             only_tt_stores=False,  # Conservative false
         )
-
-
-@dataclasses.dataclass
-class TritonStore:
-    store_node: ast.Call
-    store_pointer_node: ast.Expr
-    store_value_node: ast.Expr
-
-
-@dataclasses.dataclass
-class TritonStores:
-    stores: list[TritonStore]
-
-
-@functools.cache
-def identify_triton_stores(source_code: str) -> TritonStores:
-    """
-    Parse Python source code of the Triton kernel and find all tl.store calls.
-    Returns a TritonStores object containing information about pointer, value, and mask.
-
-    tl.store signature: store(pointer, value, mask=None, boundary_check=(), ...)
-    """
-    return identify_triton_stores_from_ast(ast.parse(source_code))
-
-
-def identify_triton_stores_from_ast(tree: ast.Module) -> TritonStores:
-    stores = []
-
-    def _extract_arg(node, arg_name, positional_index):
-        """
-        Extract an argument from a Call node, checking both positional and keyword args.
-        Returns the AST node for the argument, or None if not found.
-        """
-        # Check positional args first
-        if len(node.args) > positional_index:
-            return node.args[positional_index]
-
-        # Check keyword args
-        for keyword in node.keywords:
-            if keyword.arg == arg_name:
-                return keyword.value
-
-        return None
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call):
-            # Check if this is a tl.store call
-            if (
-                isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "tl"
-                and node.func.attr == "store"
-            ):
-                # Extract required arguments
-                pointer_node = _extract_arg(node, "pointer", 0)
-                value_node = _extract_arg(node, "value", 1)
-
-                if pointer_node is None or value_node is None:
-                    continue
-
-                stores.append(TritonStore(node, pointer_node, value_node))
-
-    return TritonStores(stores=stores)
 
 
 ###############################################################################

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -905,7 +905,7 @@ def get_tma_stores(
 @dataclasses.dataclass
 class TensorAccesses:
     read_writes: "ReadWrites"
-    can_fuse_epilogue: bool
+    only_tt_stores: bool
 
 
 @MemoizeWithCycleCheck
@@ -927,7 +927,7 @@ def analyze_kernel_access(
 
     Returns ReadWrites with StarDep objects for each accessed tensor.
     """
-    from torch._inductor.dependencies import Dep, ReadWrites, StarDep
+    from torch._inductor.dependencies import Dep, ReadWrites, UserTritonDep
 
     # Name of mutation op to mutated parameter indices
     # List from Triton Github include/triton/Dialect/Triton/IR/TritonOps.td
@@ -948,6 +948,7 @@ def analyze_kernel_access(
     }
     UNKNOWN_OPS = {"tt.elementwise_inline_asm"}
 
+    only_tt_stores = True
     write_stack: list[Param | Intermediate] = []
     read_stack: list[Param | Intermediate] = []
 
@@ -1008,9 +1009,12 @@ def analyze_kernel_access(
                         write_stack.append(arg)
                     if name in read_set:
                         read_stack.append(arg)
-            else:
-                write_stack.extend(op.args[idx] for idx in WRITE_OPS.get(op.name, []))
-                read_stack.extend(op.args[idx] for idx in READ_OPS.get(op.name, []))
+            elif op.name in WRITE_OPS:
+                if op.name != "tt.store":
+                    only_tt_stores = False
+                write_stack.extend(op.args[idx] for idx in WRITE_OPS[op.name])
+            elif op.name in READ_OPS:
+                read_stack.extend(op.args[idx] for idx in READ_OPS[op.name])
 
     # For these ops, only the first argument (base pointer) refers to actual
     # memory. The remaining arguments are shape/stride/offset metadata and
@@ -1056,10 +1060,12 @@ def analyze_kernel_access(
     read_count = _find_arg_access_count(read_stack, skip_loads=False)
 
     writes: OrderedSet[Dep] = OrderedSet(
-        StarDep(tensor_names[i]) for i in sorted(write_count.keys())
+        UserTritonDep(tensor_names[i], access_count=write_count[i])
+        for i in sorted(write_count.keys())
     )
     reads: OrderedSet[Dep] = OrderedSet(
-        StarDep(tensor_names[i]) for i in sorted(read_count.keys())
+        UserTritonDep(tensor_names[i], access_count=read_count[i])
+        for i in sorted(read_count.keys())
     )
 
     read_writes = ReadWrites(
@@ -1068,26 +1074,7 @@ def analyze_kernel_access(
         index_exprs=OrderedSet(),
     )
 
-    def _decide_can_fuse_epilogue():
-        # only do epilogue fusion if the kernel has a single output tensor
-        if len(write_count) != 1:
-            return False
-
-        written_arg_index = next(iter(write_count))
-        # only do epilogue fusion if the written tensor is written exactly once
-        if write_count[written_arg_index] != 1:
-            return False
-
-        written_arg_name = next(iter(writes)).name
-        #  cannot fuse if the kernel also reads from the output buffer
-        if any(read_dep.name == written_arg_name for read_dep in reads):
-            return False
-
-        return True
-
-    can_fuse_epilogue = _decide_can_fuse_epilogue()
-
-    return TensorAccesses(read_writes=read_writes, can_fuse_epilogue=can_fuse_epilogue)
+    return TensorAccesses(read_writes=read_writes, only_tt_stores=only_tt_stores)
 
 
 def identify_accessed_tensors(
@@ -1102,7 +1089,7 @@ def identify_accessed_tensors(
     3) Analyzes the graph to detect which input tensors are read and/or written
     """
 
-    from torch._inductor.dependencies import Dep, ReadWrites, StarDep
+    from torch._inductor.dependencies import Dep, ReadWrites, UserTritonDep
     from torch._inductor.ir import TensorBox
 
     ttir_module = None
@@ -1166,7 +1153,7 @@ def identify_accessed_tensors(
             for key, value in kwargs.items()
             if isinstance(value, (Tensor, TensorBox))
         ]
-        all_deps = OrderedSet(StarDep(name) for name in all_tensor_names)
+        all_deps = OrderedSet(UserTritonDep(name) for name in all_tensor_names)
         all_deps = typing.cast(OrderedSet[Dep], all_deps)
         return TensorAccesses(
             ReadWrites(
@@ -1174,7 +1161,7 @@ def identify_accessed_tensors(
                 writes=all_deps,
                 index_exprs=OrderedSet(),
             ),
-            can_fuse_epilogue=False,
+            only_tt_stores=False,  # Conservative false
         )
 
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -2375,8 +2375,9 @@ class TraceableTritonKernelWrapper:
         self.output_tile = output_tile
         self.pid_remap = pid_remap
         tracing_triton_hopifier_singleton.init_variable(self, kernel, kernel_idx, grid)
-        if self.kernel is None:
+        if self.kernel is None or self.kernel_idx is None:
             raise AssertionError("kernel was not initialized properly")
+
         if output_tile is not None:
             kernel_side_table.set_output_tile(self.kernel_idx, output_tile)
         if pid_remap is not None:

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -152,6 +152,7 @@ class KernelSideTable:
     kernel_to_id: dict["TritonKernelType", int] = {}
     constant_args: dict[int, dict[str, Any]] = {}
     output_tiles: dict[int, tuple[str, ...]] = {}
+    pid_remaps: dict[int, tuple[str, ...]] = {}
     lock = threading.Lock()
 
     # Returns index on the table
@@ -196,6 +197,13 @@ class KernelSideTable:
     def get_output_tile(self, kernel_idx: int) -> "tuple[str, ...] | None":
         return self.output_tiles.get(kernel_idx)
 
+    def set_pid_remap(self, kernel_idx: int, pid_remap: tuple[str, ...]) -> None:
+        with self.lock:
+            self.pid_remaps[kernel_idx] = pid_remap
+
+    def get_pid_remap(self, kernel_idx: int) -> "tuple[str, ...] | None":
+        return self.pid_remaps.get(kernel_idx)
+
     # Resets the table (only meant to be used in unit tests)
     # This is only safe assuming single threaded execution
     def reset_table(self) -> None:
@@ -203,6 +211,7 @@ class KernelSideTable:
         self.kernel_to_id = {}
         self.constant_args = {}
         self.output_tiles = {}
+        self.pid_remaps = {}
 
 
 kernel_side_table = KernelSideTable()
@@ -2349,6 +2358,7 @@ class TraceableTritonKernelWrapper:
     grid: Optional["TritonGridType"]
     kernel_source: "Source | None"
     output_tile: tuple[str, ...] | None
+    pid_remap: tuple[str, ...] | None
 
     def __init__(
         self,
@@ -2357,16 +2367,20 @@ class TraceableTritonKernelWrapper:
         grid: Optional["TritonGridType"],
         kernel_source: "Source | None" = None,
         output_tile: tuple[str, ...] | None = None,
+        pid_remap: tuple[str, ...] | None = None,
     ) -> None:
         self.kernel = None
         self.grid = None
         self.kernel_source = kernel_source
         self.output_tile = output_tile
+        self.pid_remap = pid_remap
         tracing_triton_hopifier_singleton.init_variable(self, kernel, kernel_idx, grid)
         if self.kernel is None:
             raise AssertionError("kernel was not initialized properly")
         if output_tile is not None:
             kernel_side_table.set_output_tile(self.kernel_idx, output_tile)
+        if pid_remap is not None:
+            kernel_side_table.set_pid_remap(self.kernel_idx, pid_remap)
 
     def __getitem__(self, *args: Sequence[Any]) -> "TraceableTritonKernelWrapper":
         return tracing_triton_hopifier_singleton.call_getitem(self, args)  # type: ignore[return-value]

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2006,12 +2006,6 @@ class SIMDScheduling(BaseScheduling):
         ):
             return scheduler.ForeachKernelSchedulerNode.can_fuse(node1, node2)
 
-        if isinstance(node1, scheduler.ExternKernelSchedulerNode) and isinstance(
-            node1.node, ir.UserDefinedTritonKernel
-        ):
-            # Fusion legality for UserDefinedTritonKernel is validated upstream.
-            return True
-
         _, (numel1, rnumel1) = node1.group
         _, (numel2, rnumel2) = node2.group
         why = WhyNoFuse(node1, node2)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2006,6 +2006,12 @@ class SIMDScheduling(BaseScheduling):
         ):
             return scheduler.ForeachKernelSchedulerNode.can_fuse(node1, node2)
 
+        if isinstance(node1, scheduler.ExternKernelSchedulerNode) and isinstance(
+            node1.node, ir.UserDefinedTritonKernel
+        ):
+            # Fusion legality for UserDefinedTritonKernel is validated upstream.
+            return True
+
         _, (numel1, rnumel1) = node1.group
         _, (numel2, rnumel2) = node2.group
         why = WhyNoFuse(node1, node2)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7148,6 +7148,12 @@ class FusedUserTritonKernel(TritonKernel):
             line = (
                 f"tl.load({param_name} + ({indexing.index_str}), {indexing.mask_str})"
             )
+            if (
+                dtype in (torch.float16, torch.bfloat16)
+                and config.triton.codegen_upcast_to_fp32
+            ):
+                line += ".to(tl.float32)"
+                dtype = torch.float32
             return self.cse.generate(self.loads, line, dtype=dtype, shape=shape)
         else:
             raise AssertionError(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7061,7 +7061,7 @@ class FusedUserTritonKernel(TritonKernel):
     """
 
     # TODO(jjvraw): indent buffer should respect the user's indent level.
-    # TODO(jjvraw): alias args for input pointers in case of in-place pointer arithmetic. 
+    # TODO(jjvraw): alias args for input pointers in case of in-place pointer arithmetic.
     #               e.g. out += BLOCK_SIZE.
     # TODO(jjvraw): handle reduction ops.
     def __init__(
@@ -7069,8 +7069,6 @@ class FusedUserTritonKernel(TritonKernel):
         tiling: dict[str, sympy.Expr],
         features: SIMDKernelFeatures,
         scheduler_node: FusedUserTritonSchedulerNode,
-        out_arg_name: str,
-        introduce_new_store: bool,
         additional_buf_args: list[tuple[str, str]],
         block_aliases: dict[str, str] | None = None,
         pid_cache: dict[str, str] | None = None,
@@ -7087,8 +7085,6 @@ class FusedUserTritonKernel(TritonKernel):
         )
         self.scheduler_node = scheduler_node
         self.ir_node: ir.UserDefinedTritonKernel = self.scheduler_node.kernel_node.node
-        self.out_arg_name = out_arg_name
-        self.introduce_new_store = introduce_new_store
         self.block_aliases = block_aliases
         self.additional_buf_args = {buf: param for param, buf in additional_buf_args}
 
@@ -7101,7 +7097,6 @@ class FusedUserTritonKernel(TritonKernel):
         self.func_def = self.kernel_stores.func_def
 
         self.new_store_cse_var: CSEVariable | None = None
-        self.new_store_buf = IndentedBuffer()
 
     def load(self, name: str, index: sympy.Expr) -> TritonCSEVariable:
         assert len(self.ir_node.mutable_args) == 1
@@ -7142,12 +7137,7 @@ class FusedUserTritonKernel(TritonKernel):
     ) -> None:
         assert isinstance(self.scheduler_node.epilogue.node, ir.ComputedBuffer)
         if name == self.scheduler_node.fused_epilogue.node.get_name():
-            if self.introduce_new_store:
-                indexing = self.indexing(index, dense_indexing=True, block_ptr=False)
-                line = f"tl.store({self.out_arg_name} + ({indexing.index_str}), {value}, {indexing.mask_str})"
-                self.new_store_buf.writeline(line)
-            else:
-                self.new_store_cse_var = value
+            self.new_store_cse_var = value
         else:
             super().store(name, index, value, mode)
 
@@ -7189,12 +7179,29 @@ class FusedUserTritonKernel(TritonKernel):
         load_lines = [indentations + l for l in self.loads.get_lines_ref()]
         compute_lines = [indentations + l for l in self.compute.get_lines_ref()]
 
-        # TODO(jjvraw): Should we gate on pid_remap as well?
-        if self.introduce_new_store:
+        if self.additional_buf_args:
             self.codegen_new_params()
-            src_lines = ast.unparse(self.kernel_ast).splitlines()
-            store_line_index = self.kernel_stores.stores[0].store_node.lineno - 1
-            store_lines = [indentations + l for l in self.new_store_buf.get_lines_ref()]
+
+        def _replace_arg(call_node, arg_name, positional_index, new_arg):
+            if len(call_node.args) > positional_index:
+                call_node.args[positional_index] = new_arg
+            for keyword in call_node.keywords:
+                if keyword.arg == arg_name:
+                    keyword.value = new_arg
+
+        _replace_arg(
+            self.kernel_stores.stores[0].store_node,
+            "value",
+            1,
+            ast.Name(self.new_store_cse_var.name),
+        )
+        src_with_store_replaced = ast.unparse(self.kernel_ast)
+        src_lines = src_with_store_replaced.splitlines()
+        # Re-parse to get correct line numbers after AST modification + unparse.
+        kernel_stores = identify_triton_stores(src_with_store_replaced)
+        store_line_index = kernel_stores.stores[0].store_node.lineno - 1
+
+        if self.block_aliases:
             numel_buf = IndentedBuffer()
             self.codegen_static_numels(numel_buf)
             numel_lines = [indentations + l for l in numel_buf.get_lines_ref()]
@@ -7202,7 +7209,7 @@ class FusedUserTritonKernel(TritonKernel):
             indexing_lines = [
                 indentations + l for l in self.indexing_code.get_lines_ref()
             ]
-            def_line_index = self.func_def.lineno - 1
+            def_line_index = kernel_stores.func_def.lineno - 1
             new_src_lines = (
                 src_lines[: def_line_index + 1]
                 + self.codegen_aliases()
@@ -7212,29 +7219,9 @@ class FusedUserTritonKernel(TritonKernel):
                 + indexing_lines
                 + load_lines
                 + compute_lines
-                + store_lines
-                + src_lines[store_line_index + 1 :]
+                + src_lines[store_line_index:]
             )
         else:
-
-            def _replace_arg(call_node, arg_name, positional_index, new_arg):
-                if len(call_node.args) > positional_index:
-                    call_node.args[positional_index] = new_arg
-                for keyword in call_node.keywords:
-                    if keyword.arg == arg_name:
-                        keyword.value = new_arg
-
-            _replace_arg(
-                self.kernel_stores.stores[0].store_node,
-                "value",
-                1,
-                ast.Name(self.new_store_cse_var.name),
-            )
-            src_with_store_replaced = ast.unparse(self.kernel_ast)
-            src_lines = src_with_store_replaced.splitlines()
-            kernel_stores = identify_triton_stores(src_with_store_replaced)
-            # identify the store again — parse-modify-unparse may shift its line
-            store_line_index = kernel_stores.stores[0].store_node.lineno - 1
             new_src_lines = (
                 src_lines[:store_line_index]
                 + load_lines

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7060,10 +7060,6 @@ class FusedUserTritonKernel(TritonKernel):
     in the scheduler.
     """
 
-    # TODO(jjvraw): indent buffer should respect the user's indent level.
-    # TODO(jjvraw): alias args for input pointers in case of in-place pointer arithmetic.
-    #               e.g. out += BLOCK_SIZE.
-    # TODO(jjvraw): handle reduction ops.
     def __init__(
         self,
         tiling: dict[str, sympy.Expr],
@@ -7073,6 +7069,9 @@ class FusedUserTritonKernel(TritonKernel):
         block_aliases: dict[str, str] | None = None,
         pid_cache: dict[str, str] | None = None,
     ) -> None:
+        self.ir_node: ir.UserDefinedTritonKernel = scheduler_node.kernel_node.node
+        override_persistent = True if features.is_reduction() else None
+
         super().__init__(
             tiling,
             features=features,
@@ -7082,9 +7081,9 @@ class FusedUserTritonKernel(TritonKernel):
             hint_override=None,
             is_combo_kernel=False,
             pid_cache=pid_cache,
+            override_persistent_reduction=override_persistent,
         )
         self.scheduler_node = scheduler_node
-        self.ir_node: ir.UserDefinedTritonKernel = self.scheduler_node.kernel_node.node
         self.block_aliases = block_aliases
         self.additional_buf_args = {buf: param for param, buf in additional_buf_args}
 
@@ -7097,12 +7096,31 @@ class FusedUserTritonKernel(TritonKernel):
         self.func_def = self.kernel_stores.func_def
 
         self.new_store_cse_var: CSEVariable | None = None
+        self.intermediate_cse_vars: dict[str, CSEVariable] = {}
+
+        writing_node = scheduler_node.writing_node
+        assert isinstance(writing_node.node, ir.ComputedBuffer)
+        self.epilogue_output_names: OrderedSet[str] = writing_node.get_buffer_names()
+        self.output_store_dtype: torch.dtype = writing_node.node.layout.dtype
+
+    def want_no_x_dim(self) -> bool:
+        # For now, we enforce 1d reductions. Thus, supress XBLOCK=1 for reductions.
+        return self.features.is_reduction()
+
+    def _get_persistent_RBLOCK(self, rnumel) -> int | str:
+        if self.ir_node.output_tile:
+            # For now, only allow 1d persistent reductions, hence len(grid) == 1.
+            assert len(self.ir_node.output_tile) == 1
+            return self.ir_node.output_tile[0]
+        raise AssertionError(
+            "Reduction epilogue fusion requires an annotated output_tile on the user kernel"
+        )
 
     def load(self, name: str, index: sympy.Expr) -> TritonCSEVariable:
         assert len(self.ir_node.mutable_args) == 1
         if name == self.ir_node.mutable_args[0].get_name():
-            # when the fused epilogue nodes tries to load the mutated buffer
-            # we replace the load with the expression stored by the user kernel
+            # Replace loads of the mutation buffer with the value the user
+            # kernel computed (the original tl.store expression).
             loaded_expr = self.original_stored_expr
             indexing = self.indexing(index)
             dtype = V.graph.get_dtype(name)
@@ -7114,7 +7132,12 @@ class FusedUserTritonKernel(TritonKernel):
                 self.loads, loaded_expr, dtype=dtype, shape=shape
             )
             return result_var
+        elif name in self.intermediate_cse_vars:
+            # An earlier epilogue snode stored to this buffer; return its
+            # captured CSE variable directly instead of emitting a tl.load.
+            return self.intermediate_cse_vars[name]
         elif name in self.additional_buf_args:
+            # This is a "new" buffer which isn't in the original user's context
             param_name = self.additional_buf_args[name]
             dtype = V.graph.get_dtype(name)
             indexing = self.indexing(index, block_ptr=False)
@@ -7135,18 +7158,21 @@ class FusedUserTritonKernel(TritonKernel):
     def store(
         self, name: str, index: sympy.Expr, value: CSEVariable, mode: StoreMode = None
     ) -> None:
-        assert isinstance(self.scheduler_node.epilogue.node, ir.ComputedBuffer)
-        if name == self.scheduler_node.fused_epilogue.node.get_name():
-            store_dtype = self.scheduler_node.fused_epilogue.node.layout.dtype
-            cast_var = self.cse.generate(
+        if name in self.epilogue_output_names:
+            self.new_store_cse_var = self.cse.generate(
                 self.compute,
-                f"{value}.to({triton_store_type(store_dtype)})",
-                dtype=store_dtype,
+                f"{value}.to({triton_store_type(self.output_store_dtype)})",
+                dtype=self.output_store_dtype,
                 shape=value.shape,
             )
-            self.new_store_cse_var = cast_var
         else:
-            super().store(name, index, value, mode)
+            self.intermediate_cse_vars[name] = value
+
+    def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
+        # Both pointwise and reduction outputs use the same capture path: the
+        # existing tl.store pointer/mask are valid (legality-checked), only the
+        # value operand is replaced via AST rewriting.
+        self.store(name, index, value)
 
     def codegen_new_params(self) -> None:
         new_args = [ast.arg(arg=p) for p in self.additional_buf_args.values()]
@@ -7154,7 +7180,8 @@ class FusedUserTritonKernel(TritonKernel):
         ast.fix_missing_locations(self.kernel_ast)
 
     def codegen_aliases(self) -> list[str]:
-        assert self.block_aliases
+        if not self.block_aliases:
+            return []
 
         aliases = []
         indentations = " " * self.kernel_stores.stores[0].store_node.col_offset
@@ -7168,19 +7195,22 @@ class FusedUserTritonKernel(TritonKernel):
         Returns a string which is the source code of a modified version of the user kernel that includes
         the epilogue.
 
-        Epilogue fusion is gated on pointwise operations. There are two paths:
+        There are two injection paths:
 
-            1. The epilogue requires additional index expressions.
-               The user must have annotated tile dimensions via torch.library.wrap_triton.
-               New index/load/compute/store lines are injected into the kernel body.
-            2. The epilogue is strictly unary. Only the stored value is replaced via AST rewriting,
-               preserving the original index expression.
+            1. block_aliases is not None
+               - Full body injection: range tree, static numels, indexing, loads, computes,
+                 and any BLOCK aliases are inserted after the function def line.
+            2. block_aliases is None (unary pointwise, no tile annotations):
+               - Only load/compute lines are inserted before the tl.store.
+
+        In both paths the tl.store value operand is replaced with the epilogue output variable.
+        For reductions the pointer and mask are preserved unchanged; legality ensures the
+        output buffer has the same shape/layout as the user kernel's mutable argument.
         """
         with self:
-            index_vars = self.split_and_set_ranges(
-                self.scheduler_node.epilogue.get_ranges()
-            )
-            self.scheduler_node.epilogue.codegen(index_vars)
+            for sn in self.scheduler_node.epilogue.get_nodes():
+                index_vars = self.split_and_set_ranges(sn.get_ranges())
+                sn.codegen(index_vars)
 
         indentations = " " * self.kernel_stores.stores[0].store_node.col_offset
         load_lines = [indentations + l for l in self.loads.get_lines_ref()]
@@ -7208,7 +7238,7 @@ class FusedUserTritonKernel(TritonKernel):
         kernel_stores = identify_triton_stores(src_with_store_replaced)
         store_line_index = kernel_stores.stores[0].store_node.lineno - 1
 
-        if self.block_aliases:
+        if self.block_aliases is not None:
             numel_buf = IndentedBuffer()
             self.codegen_static_numels(numel_buf)
             numel_lines = [indentations + l for l in numel_buf.get_lines_ref()]

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7108,11 +7108,11 @@ class FusedUserTritonKernel(TritonKernel):
         # For now, we enforce 1d reductions. Thus, suppress XBLOCK=1 for reductions.
         return self.features.is_reduction()
 
-    def _get_persistent_RBLOCK(self, rnumel) -> int | str:
+    def _get_persistent_RBLOCK(self, rnumel) -> int:
         if self.ir_node.output_tile:
             # For now, only allow 1d persistent reductions, hence len(grid) == 1.
             assert len(self.ir_node.output_tile) == 1
-            return self.ir_node.output_tile[0]
+            return int(self.ir_node.kwargs[self.ir_node.output_tile[0]])
         raise AssertionError(
             "Reduction epilogue fusion requires an annotated output_tile on the user kernel"
         )
@@ -7230,11 +7230,15 @@ class FusedUserTritonKernel(TritonKernel):
             self.codegen_new_params()
 
         def _replace_arg(call_node, arg_name, positional_index, new_arg):
+            replaced = False
             if len(call_node.args) > positional_index:
                 call_node.args[positional_index] = new_arg
+                replaced = True
             for keyword in call_node.keywords:
                 if keyword.arg == arg_name:
                     keyword.value = new_arg
+                    replaced = True
+            assert replaced, f"Failed to replace '{arg_name}' in tl.store call"
 
         assert self.new_store_cse_var is not None
         _replace_arg(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7029,7 +7029,8 @@ def identify_triton_stores_from_ast(tree: ast.Module) -> UserTritonMeta:
         return None
 
     for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef):
+        # Store kernel function definition
+        if isinstance(node, ast.FunctionDef) and not func_def:
             func_def = node
         if isinstance(node, ast.Call):
             # Check if this is a tl.store call

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7061,6 +7061,8 @@ class FusedUserDefinedTritonKernel(TritonKernel):
 
     # returns a str which is the src code of a modified version of the user kernel that includes the epilogues
     def codegen(self) -> str:
+        from torch._higher_order_ops.triton_kernel_wrap import identify_triton_stores
+
         with self:
             index_vars = self.split_and_set_ranges(
                 self.scheduler_node.fused_epilogue.get_ranges()
@@ -7092,10 +7094,11 @@ class FusedUserDefinedTritonKernel(TritonKernel):
         # then, we need to inject the additional `load` and `compute` lines generated when we `codegen` the epilogue nodes
 
         src_lines = src_with_store_replaced.splitlines()
+        kernel_stores = identify_triton_stores(src_with_store_replaced)
 
         # identify the store again, because the previous parse-modify-unparse could've change its location
         # python ast lineno is 1-indexed
-        store_line_index = self.kernel_stores.stores[0].store_node.lineno - 1
+        store_line_index = kernel_stores.stores[0].store_node.lineno - 1
 
         indentations = " " * self.kernel_stores.stores[0].store_node.col_offset
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6994,6 +6994,7 @@ class UserTritonStore:
 @dataclasses.dataclass
 class UserTritonStores:
     stores: list[UserTritonStore]
+    func_def: ast.FunctionDef | None = None
 
 
 @functools.cache
@@ -7009,6 +7010,7 @@ def identify_triton_stores(source_code: str) -> UserTritonStores:
 
 def identify_triton_stores_from_ast(tree: ast.Module) -> UserTritonStores:
     stores = []
+    func_def = None
 
     def _extract_arg(node, arg_name, positional_index):
         """
@@ -7027,6 +7029,8 @@ def identify_triton_stores_from_ast(tree: ast.Module) -> UserTritonStores:
         return None
 
     for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            func_def = node
         if isinstance(node, ast.Call):
             # Check if this is a tl.store call
             if (
@@ -7044,7 +7048,7 @@ def identify_triton_stores_from_ast(tree: ast.Module) -> UserTritonStores:
 
                 stores.append(UserTritonStore(node, pointer_node, value_node))
 
-    return UserTritonStores(stores=stores)
+    return UserTritonStores(stores=stores, func_def=func_def)
 
 
 class FusedUserTritonKernel(TritonKernel):
@@ -7056,6 +7060,9 @@ class FusedUserTritonKernel(TritonKernel):
     in the scheduler.
     """
 
+    # TODO(jjvraw): indent buffer should respect the user's indent level.
+    # TODO(jjvraw): handle non-unary epilogues.
+    # TODO(jjvraw): handle reduction ops.
     def __init__(
         self,
         tiling: dict[str, sympy.Expr],
@@ -7088,6 +7095,7 @@ class FusedUserTritonKernel(TritonKernel):
         self.original_stored_expr = ast.unparse(
             self.kernel_stores.stores[0].store_value_node
         ).replace("\n", "")
+        self.func_def = self.kernel_stores.func_def
 
         self.new_store_cse_var: CSEVariable | None = None
         self.new_store_buf = IndentedBuffer()
@@ -7150,7 +7158,7 @@ class FusedUserTritonKernel(TritonKernel):
                The user must have annotated tile dimensions via torch.library.wrap_triton.
                New index/load/compute/store lines are injected into the kernel body.
             2. The epilogue is strictly unary. Only the stored value is replaced via AST rewriting,
-               preserving the original index expression. 
+               preserving the original index expression.
         """
         with self:
             index_vars = self.split_and_set_ranges(
@@ -7162,7 +7170,7 @@ class FusedUserTritonKernel(TritonKernel):
         load_lines = [indentations + l for l in self.loads.get_lines_ref()]
         compute_lines = [indentations + l for l in self.compute.get_lines_ref()]
 
-        # TODO(JJVRAW): Should we gate on pid_remap as well?
+        # TODO(jjvraw): Should we gate on pid_remap as well?
         if self.introduce_new_store:
             src_lines = ast.unparse(self.kernel_ast).splitlines()
             store_line_index = self.kernel_stores.stores[0].store_node.lineno - 1
@@ -7174,10 +7182,7 @@ class FusedUserTritonKernel(TritonKernel):
             indexing_lines = [
                 indentations + l for l in self.indexing_code.get_lines_ref()
             ]
-            # TODO(JJVRAW) CLEAN THIS UP, again, we should use AST parsing for this.
-            def_line_index = next(
-                i for i, line in enumerate(src_lines) if line.strip().startswith("def ")
-            )
+            def_line_index = self.func_def.lineno - 1
             new_src_lines = (
                 src_lines[: def_line_index + 1]
                 + self.codegen_aliases()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6992,13 +6992,13 @@ class UserTritonStore:
 
 
 @dataclasses.dataclass
-class UserTritonStores:
-    stores: list[UserTritonStore]
+class UserTritonMeta:
+    stores: list[TritonStore]
     func_def: ast.FunctionDef | None = None
 
 
 @functools.cache
-def identify_triton_stores(source_code: str) -> UserTritonStores:
+def identify_triton_stores(source_code: str) -> UserTritonMeta:
     """
     Parse Python source code of the Triton kernel and find all tl.store calls.
     Returns a TritonStores object containing information about pointer, value, and mask.
@@ -7008,7 +7008,7 @@ def identify_triton_stores(source_code: str) -> UserTritonStores:
     return identify_triton_stores_from_ast(ast.parse(source_code))
 
 
-def identify_triton_stores_from_ast(tree: ast.Module) -> UserTritonStores:
+def identify_triton_stores_from_ast(tree: ast.Module) -> UserTritonMeta:
     stores = []
     func_def = None
 
@@ -7048,7 +7048,7 @@ def identify_triton_stores_from_ast(tree: ast.Module) -> UserTritonStores:
 
                 stores.append(UserTritonStore(node, pointer_node, value_node))
 
-    return UserTritonStores(stores=stores, func_def=func_def)
+    return UserTritonMeta(stores=stores, func_def=func_def)
 
 
 class FusedUserTritonKernel(TritonKernel):
@@ -7169,9 +7169,9 @@ class FusedUserTritonKernel(TritonKernel):
             self.intermediate_cse_vars[name] = value
 
     def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
-        # Both pointwise and reduction outputs use the same capture path: the
-        # existing tl.store pointer/mask are valid (legality-checked), only the
-        # value operand is replaced via AST rewriting.
+        # The user-original tl.store pointer/mask are valid (checked in scheduler), and
+        # only the value operand is replaced via AST rewriting. We may share the same
+        # path as `self.store` here.
         self.store(name, index, value)
 
     def codegen_new_params(self) -> None:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7061,6 +7061,9 @@ class FusedUserTritonKernel(TritonKernel):
         tiling: dict[str, sympy.Expr],
         features: SIMDKernelFeatures,
         scheduler_node: FusedUserTritonSchedulerNode,
+        out_arg_name: str,
+        block_aliases: dict[str, str] | None = None,
+        pid_cache: dict[str, str] | None = None,
     ) -> None:
         super().__init__(
             tiling,
@@ -7070,12 +7073,12 @@ class FusedUserTritonKernel(TritonKernel):
             fixed_config=None,
             hint_override=None,
             is_combo_kernel=False,
+            pid_cache=pid_cache,
         )
         self.scheduler_node = scheduler_node
-        assert isinstance(
-            self.scheduler_node.kernel_node.node, ir.UserDefinedTritonKernel
-        )
         self.ir_node: ir.UserDefinedTritonKernel = self.scheduler_node.kernel_node.node
+        self.out_arg_name = out_arg_name
+        self.block_aliases = block_aliases
 
         self.kernel_ast = ast.parse(self.ir_node.kernel_src)
         self.kernel_stores = identify_triton_stores_from_ast(self.kernel_ast)
@@ -7083,6 +7086,9 @@ class FusedUserTritonKernel(TritonKernel):
         self.original_stored_expr = ast.unparse(
             self.kernel_stores.stores[0].store_value_node
         ).replace("\n", "")
+
+        self.new_store_cse_var: CSEVariable | None = None
+        self.new_store_index: sympy.Expr | None = None
 
     def load(self, name: str, index: sympy.Expr) -> TritonCSEVariable:
         assert len(self.ir_node.mutable_args) == 1
@@ -7111,63 +7117,113 @@ class FusedUserTritonKernel(TritonKernel):
         self, name: str, index: sympy.Expr, value: CSEVariable, mode: StoreMode = None
     ) -> None:
         assert isinstance(self.scheduler_node.epilogue.node, ir.ComputedBuffer)
-        if name == self.scheduler_node.epilogue.node.get_name():
-            # when the fused epilogue nodes tries to store to its destination buffer
-            # we remember this expr and then later replace it into the `tl.store` call of the original kernel
+        if name == self.scheduler_node.fused_epilogue.node.get_name():
             self.new_store_cse_var = value
+            indexing = self.indexing(index, dense_indexing=True, block_ptr=False)
+            self.new_store_index_str = indexing.index_str
+            self.new_store_mask_str = indexing.mask_str
         else:
             super().store(name, index, value, mode)
 
-    # returns a str which is the src code of a modified version of the user kernel that includes the epilogues
+    def codegen_aliases(self) -> list[str]:
+        assert self.block_aliases
+
+        aliases = []
+        indentations = " " * self.kernel_stores.stores[0].store_node.col_offset
+        for varname, alias in self.block_aliases.items():
+            aliases.append(f"{indentations}{varname}: tl.constexpr = {alias}")
+
+        return aliases
+
     def codegen(self) -> str:
+        """
+        Returns a string which is the source code of a modified version of the user kernel that includes
+        the epilogue.
+
+        In general, epilogue fusion is gated on pointwise operations, there are then two paths depending on
+        whether the epilogue requires additional new index expressions:
+
+            1. The user has wrapped the kernel (using torch.library.wrap_triton), annotating the output
+               tile dimensions. This enables inductor to generate new index expressions which the epilogue
+               may require. It follows, appropriate constraints on epilogue fusion are loosened.
+            2. Without these annotations, epilogues are strictly unary pointwise operations with no additional
+               load expressions. In this path, the pointwise instructions are code-generated and, subsequently,
+               appropriately replacing the value operand of the user kernel's stroe while preserving the original
+               index expression.
+        """
         with self:
             index_vars = self.split_and_set_ranges(
                 self.scheduler_node.epilogue.get_ranges()
             )
             self.scheduler_node.epilogue.codegen(index_vars)
 
-        new_store_value_node = ast.Name(self.new_store_cse_var.name)
-
-        def _replace_arg(
-            call_node: ast.Call,
-            arg_name: str,
-            positional_index: int,
-            new_arg,
-        ):
-            if len(call_node.args) > positional_index:
-                call_node.args[positional_index] = new_arg
-
-            # Check keyword args
-            for keyword in call_node.keywords:
-                if keyword.arg == arg_name:
-                    keyword.value = new_arg
-
-        _replace_arg(
-            self.kernel_stores.stores[0].store_node, "value", 1, new_store_value_node
-        )
-
-        src_with_store_replaced = ast.unparse(self.kernel_ast)
-
-        # then, we need to inject the additional `load` and `compute` lines generated when we `codegen` the epilogue nodes
-
-        src_lines = src_with_store_replaced.splitlines()
-        kernel_stores = identify_triton_stores(src_with_store_replaced)
-
-        # identify the store again, because the previous parse-modify-unparse could've change its location
-        # python ast lineno is 1-indexed
-        store_line_index = kernel_stores.stores[0].store_node.lineno - 1
-
         indentations = " " * self.kernel_stores.stores[0].store_node.col_offset
-
         load_lines = [indentations + l for l in self.loads.get_lines_ref()]
         compute_lines = [indentations + l for l in self.compute.get_lines_ref()]
 
-        new_src_lines = (
-            src_lines[:store_line_index]
-            + load_lines
-            + compute_lines
-            + src_lines[store_line_index:]
-        )
+        # TODO(JJVRAW): Should we gate on pid_remap as well?
+        if self.block_aliases is not None:
+            src_lines = ast.unparse(self.kernel_ast).splitlines()
+            store_line_index = self.kernel_stores.stores[0].store_node.lineno - 1
+
+            # TODO(JJVRAW): User AST rewriting for this.
+            new_store = (
+                f"{indentations}tl.store("
+                f"{self.out_arg_name} + ({self.new_store_index_str}), "
+                f"{self.new_store_cse_var.name}, "
+                f"{self.new_store_mask_str})"
+            )
+            numel_buf = IndentedBuffer()
+            self.codegen_static_numels(numel_buf)
+            numel_lines = [indentations + l for l in numel_buf.get_lines_ref()]
+            body_lines = [indentations + l for l in self.body.get_lines_ref()]
+            indexing_lines = [
+                indentations + l for l in self.indexing_code.get_lines_ref()
+            ]
+            # TODO(JJVRAW) CLEAN THIS UP, again, we should use AST parsing for this.
+            def_line_index = next(
+                i for i, line in enumerate(src_lines) if line.strip().startswith("def ")
+            )
+
+            new_src_lines = (
+                src_lines[: def_line_index + 1]
+                + self.codegen_aliases()
+                + src_lines[def_line_index + 1 : store_line_index]
+                + numel_lines
+                + body_lines
+                + indexing_lines
+                + load_lines
+                + compute_lines
+                + [new_store]
+                + src_lines[store_line_index + 1 :]
+            )
+        else:
+
+            def _replace_arg(call_node, arg_name, positional_index, new_arg):
+                if len(call_node.args) > positional_index:
+                    call_node.args[positional_index] = new_arg
+                for keyword in call_node.keywords:
+                    if keyword.arg == arg_name:
+                        keyword.value = new_arg
+
+            _replace_arg(
+                self.kernel_stores.stores[0].store_node,
+                "value",
+                1,
+                ast.Name(self.new_store_cse_var.name),
+            )
+            src_with_store_replaced = ast.unparse(self.kernel_ast)
+            src_lines = src_with_store_replaced.splitlines()
+            kernel_stores = identify_triton_stores(src_with_store_replaced)
+            # identify the store again — parse-modify-unparse may shift its line
+            store_line_index = kernel_stores.stores[0].store_node.lineno - 1
+            new_src_lines = (
+                src_lines[:store_line_index]
+                + load_lines
+                + compute_lines
+                + src_lines[store_line_index:]
+            )
+
         return "\n".join(new_src_lines)
 
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6985,19 +6985,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
 
 @dataclasses.dataclass
-class TritonStore:
+class UserTritonStore:
     store_node: ast.Call
     store_pointer_node: ast.Expr
     store_value_node: ast.Expr
 
 
 @dataclasses.dataclass
-class TritonStores:
-    stores: list[TritonStore]
+class UserTritonStores:
+    stores: list[UserTritonStore]
 
 
 @functools.cache
-def identify_triton_stores(source_code: str) -> TritonStores:
+def identify_triton_stores(source_code: str) -> UserTritonStores:
     """
     Parse Python source code of the Triton kernel and find all tl.store calls.
     Returns a TritonStores object containing information about pointer, value, and mask.
@@ -7007,7 +7007,7 @@ def identify_triton_stores(source_code: str) -> TritonStores:
     return identify_triton_stores_from_ast(ast.parse(source_code))
 
 
-def identify_triton_stores_from_ast(tree: ast.Module) -> TritonStores:
+def identify_triton_stores_from_ast(tree: ast.Module) -> UserTritonStores:
     stores = []
 
     def _extract_arg(node, arg_name, positional_index):
@@ -7042,9 +7042,9 @@ def identify_triton_stores_from_ast(tree: ast.Module) -> TritonStores:
                 if pointer_node is None or value_node is None:
                     continue
 
-                stores.append(TritonStore(node, pointer_node, value_node))
+                stores.append(UserTritonStore(node, pointer_node, value_node))
 
-    return TritonStores(stores=stores)
+    return UserTritonStores(stores=stores)
 
 
 class FusedUserTritonKernel(TritonKernel):
@@ -7110,8 +7110,8 @@ class FusedUserTritonKernel(TritonKernel):
     def store(
         self, name: str, index: sympy.Expr, value: CSEVariable, mode: StoreMode = None
     ) -> None:
-        assert isinstance(self.scheduler_node.fused_epilogue.node, ir.ComputedBuffer)
-        if name == self.scheduler_node.fused_epilogue.node.get_name():
+        assert isinstance(self.scheduler_node.epilogue.node, ir.ComputedBuffer)
+        if name == self.scheduler_node.epilogue.node.get_name():
             # when the fused epilogue nodes tries to store to its destination buffer
             # we remember this expr and then later replace it into the `tl.store` call of the original kernel
             self.new_store_cse_var = value
@@ -7122,9 +7122,9 @@ class FusedUserTritonKernel(TritonKernel):
     def codegen(self) -> str:
         with self:
             index_vars = self.split_and_set_ranges(
-                self.scheduler_node.fused_epilogue.get_ranges()
+                self.scheduler_node.epilogue.get_ranges()
             )
-            self.scheduler_node.fused_epilogue.codegen(index_vars)
+            self.scheduler_node.epilogue.codegen(index_vars)
 
         new_store_value_node = ast.Name(self.new_store_cse_var.name)
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7061,7 +7061,6 @@ class FusedUserTritonKernel(TritonKernel):
     """
 
     # TODO(jjvraw): indent buffer should respect the user's indent level.
-    # TODO(jjvraw): handle non-unary epilogues.
     # TODO(jjvraw): handle reduction ops.
     def __init__(
         self,
@@ -7070,6 +7069,7 @@ class FusedUserTritonKernel(TritonKernel):
         scheduler_node: FusedUserTritonSchedulerNode,
         out_arg_name: str,
         introduce_new_store: bool,
+        additional_buf_args: list[tuple[str, str]],
         block_aliases: dict[str, str] | None = None,
         pid_cache: dict[str, str] | None = None,
     ) -> None:
@@ -7086,8 +7086,9 @@ class FusedUserTritonKernel(TritonKernel):
         self.scheduler_node = scheduler_node
         self.ir_node: ir.UserDefinedTritonKernel = self.scheduler_node.kernel_node.node
         self.out_arg_name = out_arg_name
-        self.block_aliases = block_aliases
         self.introduce_new_store = introduce_new_store
+        self.block_aliases = block_aliases
+        self.additional_buf_args = {buf: param for param, buf in additional_buf_args}
 
         self.kernel_ast = ast.parse(self.ir_node.kernel_src)
         self.kernel_stores = identify_triton_stores_from_ast(self.kernel_ast)
@@ -7116,8 +7117,19 @@ class FusedUserTritonKernel(TritonKernel):
                 self.loads, loaded_expr, dtype=dtype, shape=shape
             )
             return result_var
+        elif name in self.additional_buf_args:
+            param_name = self.additional_buf_args[name]
+            dtype = V.graph.get_dtype(name)
+            indexing = self.indexing(index, block_ptr=False)
+            if indexing.expand_shape:
+                shape = indexing.expand_shape
+            else:
+                shape = TritonSymbols.get_block_shape(indexing.index)
+            line = (
+                f"tl.load({param_name} + ({indexing.index_str}), {indexing.mask_str})"
+            )
+            return self.cse.generate(self.loads, line, dtype=dtype, shape=shape)
         else:
-            # The scheduler should prevent this.
             raise AssertionError(
                 f"Epilogue attempted to load from '{name}'. "
                 "Inductor indexing variables are not defined in user kernel scope. "
@@ -7136,6 +7148,11 @@ class FusedUserTritonKernel(TritonKernel):
                 self.new_store_cse_var = value
         else:
             super().store(name, index, value, mode)
+
+    def codegen_new_params(self) -> None:
+        new_args = [ast.arg(arg=p) for p in self.additional_buf_args.values()]
+        self.func_def.args.args[:0] = new_args
+        ast.fix_missing_locations(self.kernel_ast)
 
     def codegen_aliases(self) -> list[str]:
         assert self.block_aliases
@@ -7172,6 +7189,7 @@ class FusedUserTritonKernel(TritonKernel):
 
         # TODO(jjvraw): Should we gate on pid_remap as well?
         if self.introduce_new_store:
+            self.codegen_new_params()
             src_lines = ast.unparse(self.kernel_ast).splitlines()
             store_line_index = self.kernel_stores.stores[0].store_node.lineno - 1
             store_lines = [indentations + l for l in self.new_store_buf.get_lines_ref()]

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7062,6 +7062,7 @@ class FusedUserTritonKernel(TritonKernel):
         features: SIMDKernelFeatures,
         scheduler_node: FusedUserTritonSchedulerNode,
         out_arg_name: str,
+        introduce_new_store: bool,
         block_aliases: dict[str, str] | None = None,
         pid_cache: dict[str, str] | None = None,
     ) -> None:
@@ -7079,6 +7080,7 @@ class FusedUserTritonKernel(TritonKernel):
         self.ir_node: ir.UserDefinedTritonKernel = self.scheduler_node.kernel_node.node
         self.out_arg_name = out_arg_name
         self.block_aliases = block_aliases
+        self.introduce_new_store = introduce_new_store
 
         self.kernel_ast = ast.parse(self.ir_node.kernel_src)
         self.kernel_stores = identify_triton_stores_from_ast(self.kernel_ast)
@@ -7088,7 +7090,7 @@ class FusedUserTritonKernel(TritonKernel):
         ).replace("\n", "")
 
         self.new_store_cse_var: CSEVariable | None = None
-        self.new_store_index: sympy.Expr | None = None
+        self.new_store_buf = IndentedBuffer()
 
     def load(self, name: str, index: sympy.Expr) -> TritonCSEVariable:
         assert len(self.ir_node.mutable_args) == 1
@@ -7118,10 +7120,12 @@ class FusedUserTritonKernel(TritonKernel):
     ) -> None:
         assert isinstance(self.scheduler_node.epilogue.node, ir.ComputedBuffer)
         if name == self.scheduler_node.fused_epilogue.node.get_name():
-            self.new_store_cse_var = value
-            indexing = self.indexing(index, dense_indexing=True, block_ptr=False)
-            self.new_store_index_str = indexing.index_str
-            self.new_store_mask_str = indexing.mask_str
+            if self.introduce_new_store:
+                indexing = self.indexing(index, dense_indexing=True, block_ptr=False)
+                line = f"tl.store({self.out_arg_name} + ({indexing.index_str}), {value}, {indexing.mask_str})"
+                self.new_store_buf.writeline(line)
+            else:
+                self.new_store_cse_var = value
         else:
             super().store(name, index, value, mode)
 
@@ -7140,16 +7144,13 @@ class FusedUserTritonKernel(TritonKernel):
         Returns a string which is the source code of a modified version of the user kernel that includes
         the epilogue.
 
-        In general, epilogue fusion is gated on pointwise operations, there are then two paths depending on
-        whether the epilogue requires additional new index expressions:
+        Epilogue fusion is gated on pointwise operations. There are two paths:
 
-            1. The user has wrapped the kernel (using torch.library.wrap_triton), annotating the output
-               tile dimensions. This enables inductor to generate new index expressions which the epilogue
-               may require. It follows, appropriate constraints on epilogue fusion are loosened.
-            2. Without these annotations, epilogues are strictly unary pointwise operations with no additional
-               load expressions. In this path, the pointwise instructions are code-generated and, subsequently,
-               appropriately replacing the value operand of the user kernel's stroe while preserving the original
-               index expression.
+            1. The epilogue requires additional index expressions.
+               The user must have annotated tile dimensions via torch.library.wrap_triton.
+               New index/load/compute/store lines are injected into the kernel body.
+            2. The epilogue is strictly unary. Only the stored value is replaced via AST rewriting,
+               preserving the original index expression. 
         """
         with self:
             index_vars = self.split_and_set_ranges(
@@ -7162,17 +7163,10 @@ class FusedUserTritonKernel(TritonKernel):
         compute_lines = [indentations + l for l in self.compute.get_lines_ref()]
 
         # TODO(JJVRAW): Should we gate on pid_remap as well?
-        if self.block_aliases is not None:
+        if self.introduce_new_store:
             src_lines = ast.unparse(self.kernel_ast).splitlines()
             store_line_index = self.kernel_stores.stores[0].store_node.lineno - 1
-
-            # TODO(JJVRAW): User AST rewriting for this.
-            new_store = (
-                f"{indentations}tl.store("
-                f"{self.out_arg_name} + ({self.new_store_index_str}), "
-                f"{self.new_store_cse_var.name}, "
-                f"{self.new_store_mask_str})"
-            )
+            store_lines = [indentations + l for l in self.new_store_buf.get_lines_ref()]
             numel_buf = IndentedBuffer()
             self.codegen_static_numels(numel_buf)
             numel_lines = [indentations + l for l in numel_buf.get_lines_ref()]
@@ -7184,7 +7178,6 @@ class FusedUserTritonKernel(TritonKernel):
             def_line_index = next(
                 i for i, line in enumerate(src_lines) if line.strip().startswith("def ")
             )
-
             new_src_lines = (
                 src_lines[: def_line_index + 1]
                 + self.codegen_aliases()
@@ -7194,7 +7187,7 @@ class FusedUserTritonKernel(TritonKernel):
                 + indexing_lines
                 + load_lines
                 + compute_lines
-                + [new_store]
+                + store_lines
                 + src_lines[store_line_index + 1 :]
             )
         else:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7137,7 +7137,14 @@ class FusedUserTritonKernel(TritonKernel):
     ) -> None:
         assert isinstance(self.scheduler_node.epilogue.node, ir.ComputedBuffer)
         if name == self.scheduler_node.fused_epilogue.node.get_name():
-            self.new_store_cse_var = value
+            store_dtype = self.scheduler_node.fused_epilogue.node.layout.dtype
+            cast_var = self.cse.generate(
+                self.compute,
+                f"{value}.to({triton_store_type(store_dtype)})",
+                dtype=store_dtype,
+                shape=value.shape,
+            )
+            self.new_store_cse_var = cast_var
         else:
             super().store(name, index, value, mode)
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7061,6 +7061,8 @@ class FusedUserTritonKernel(TritonKernel):
     """
 
     # TODO(jjvraw): indent buffer should respect the user's indent level.
+    # TODO(jjvraw): alias args for input pointers in case of in-place pointer arithmetic. 
+    #               e.g. out += BLOCK_SIZE.
     # TODO(jjvraw): handle reduction ops.
     def __init__(
         self,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6984,7 +6984,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             code.writeline(f"{entry.mask_name()} = {entry.name} < {x}numel")
 
 
-class FusedUserDefinedTritonKernel(TritonKernel):
+class FusedUserTritonKernel(TritonKernel):
     """
     When fusing a user-defined triton kernel with epilogues, we use this class
     to generate the modified triton kernel source.

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6993,7 +6993,7 @@ class UserTritonStore:
 
 @dataclasses.dataclass
 class UserTritonMeta:
-    stores: list[TritonStore]
+    stores: list[UserTritonStore]
     func_def: ast.FunctionDef | None = None
 
 
@@ -7095,16 +7095,17 @@ class FusedUserTritonKernel(TritonKernel):
         ).replace("\n", "")
         self.func_def = self.kernel_stores.func_def
 
-        self.new_store_cse_var: CSEVariable | None = None
-        self.intermediate_cse_vars: dict[str, CSEVariable] = {}
+        self.new_store_cse_var: TritonCSEVariable | None = None
+        self.intermediate_cse_vars: dict[str, TritonCSEVariable] = {}
 
         writing_node = scheduler_node.writing_node
         assert isinstance(writing_node.node, ir.ComputedBuffer)
         self.epilogue_output_names: OrderedSet[str] = writing_node.get_buffer_names()
+        assert isinstance(writing_node.node.layout, ir.Layout)
         self.output_store_dtype: torch.dtype = writing_node.node.layout.dtype
 
     def want_no_x_dim(self) -> bool:
-        # For now, we enforce 1d reductions. Thus, supress XBLOCK=1 for reductions.
+        # For now, we enforce 1d reductions. Thus, suppress XBLOCK=1 for reductions.
         return self.features.is_reduction()
 
     def _get_persistent_RBLOCK(self, rnumel) -> int | str:
@@ -7172,6 +7173,7 @@ class FusedUserTritonKernel(TritonKernel):
                 shape=value.shape,
             )
         else:
+            assert isinstance(value, TritonCSEVariable)
             self.intermediate_cse_vars[name] = value
 
     def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
@@ -7181,6 +7183,7 @@ class FusedUserTritonKernel(TritonKernel):
         self.store(name, index, value)
 
     def codegen_new_params(self) -> None:
+        assert self.func_def is not None
         new_args = [ast.arg(arg=p) for p in self.additional_buf_args.values()]
         self.func_def.args.args[:0] = new_args
         ast.fix_missing_locations(self.kernel_ast)
@@ -7215,6 +7218,7 @@ class FusedUserTritonKernel(TritonKernel):
         """
         with self:
             for sn in self.scheduler_node.epilogue.get_nodes():
+                assert isinstance(sn, SchedulerNode)
                 index_vars = self.split_and_set_ranges(sn.get_ranges())
                 sn.codegen(index_vars)
 
@@ -7232,6 +7236,7 @@ class FusedUserTritonKernel(TritonKernel):
                 if keyword.arg == arg_name:
                     keyword.value = new_arg
 
+        assert self.new_store_cse_var is not None
         _replace_arg(
             self.kernel_stores.stores[0].store_node,
             "value",
@@ -7252,6 +7257,7 @@ class FusedUserTritonKernel(TritonKernel):
             indexing_lines = [
                 indentations + l for l in self.indexing_code.get_lines_ref()
             ]
+            assert kernel_stores.func_def is not None
             def_line_index = kernel_stores.func_def.lineno - 1
             new_src_lines = (
                 src_lines[: def_line_index + 1]
@@ -7445,6 +7451,7 @@ class TritonScheduling(SIMDScheduling):
     def benchmark_fused_nodes(self, nodes, n_spills_threshold=8) -> tuple[float, str]:
         """
         Benchmark fused list of nodes and return the execution time
+
         in milliseconds on randomly generated inputs.
         """
         src_code = self.generate_kernel_code_from_nodes(nodes, benchmark_kernel=True)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6984,6 +6984,69 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             code.writeline(f"{entry.mask_name()} = {entry.name} < {x}numel")
 
 
+@dataclasses.dataclass
+class TritonStore:
+    store_node: ast.Call
+    store_pointer_node: ast.Expr
+    store_value_node: ast.Expr
+
+
+@dataclasses.dataclass
+class TritonStores:
+    stores: list[TritonStore]
+
+
+@functools.cache
+def identify_triton_stores(source_code: str) -> TritonStores:
+    """
+    Parse Python source code of the Triton kernel and find all tl.store calls.
+    Returns a TritonStores object containing information about pointer, value, and mask.
+
+    tl.store signature: store(pointer, value, mask=None, boundary_check=(), ...)
+    """
+    return identify_triton_stores_from_ast(ast.parse(source_code))
+
+
+def identify_triton_stores_from_ast(tree: ast.Module) -> TritonStores:
+    stores = []
+
+    def _extract_arg(node, arg_name, positional_index):
+        """
+        Extract an argument from a Call node, checking both positional and keyword args.
+        Returns the AST node for the argument, or None if not found.
+        """
+        # Check positional args first
+        if len(node.args) > positional_index:
+            return node.args[positional_index]
+
+        # Check keyword args
+        for keyword in node.keywords:
+            if keyword.arg == arg_name:
+                return keyword.value
+
+        return None
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            # Check if this is a tl.store call
+            if (
+                isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "tl"
+                and node.func.attr == "store"
+            ):
+                # Extract required arguments
+                pointer_node = _extract_arg(node, "pointer", 0)
+                value_node = _extract_arg(node, "value", 1)
+
+                if pointer_node is None or value_node is None:
+                    continue
+
+                stores.append(TritonStore(node, pointer_node, value_node))
+
+    return TritonStores(stores=stores)
+
+
 class FusedUserTritonKernel(TritonKernel):
     """
     When fusing a user-defined triton kernel with epilogues, we use this class
@@ -6999,10 +7062,6 @@ class FusedUserTritonKernel(TritonKernel):
         features: SIMDKernelFeatures,
         scheduler_node: FusedUserTritonSchedulerNode,
     ) -> None:
-        from torch._higher_order_ops.triton_kernel_wrap import (
-            identify_triton_stores_from_ast,
-        )
-
         super().__init__(
             tiling,
             features=features,
@@ -7061,8 +7120,6 @@ class FusedUserTritonKernel(TritonKernel):
 
     # returns a str which is the src code of a modified version of the user kernel that includes the epilogues
     def codegen(self) -> str:
-        from torch._higher_order_ops.triton_kernel_wrap import identify_triton_stores
-
         with self:
             index_vars = self.split_and_set_ranges(
                 self.scheduler_node.fused_epilogue.get_ranges()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7105,7 +7105,8 @@ class FusedUserTritonKernel(TritonKernel):
         self.output_store_dtype: torch.dtype = writing_node.node.layout.dtype
 
     def want_no_x_dim(self) -> bool:
-        # For now, we enforce 1d reductions. Thus, suppress XBLOCK=1 for reductions.
+        # Legality enforces len(output_tile == 1) for reduction epilogues, so
+        # the non-reduction x-dimension always collapses to XBLOCK=1.
         return self.features.is_reduction()
 
     def _get_persistent_RBLOCK(self, rnumel) -> int:
@@ -7186,16 +7187,18 @@ class FusedUserTritonKernel(TritonKernel):
         assert self.func_def is not None
         new_args = [ast.arg(arg=p) for p in self.additional_buf_args.values()]
         self.func_def.args.args[:0] = new_args
-        ast.fix_missing_locations(self.kernel_ast)
 
     def codegen_aliases(self) -> list[str]:
         if not self.block_aliases:
             return []
 
+        # Aliases are injected at the top of the function body, so use the
+        # function body's indentation level, not the store's col_offset
+        assert self.func_def is not None and self.func_def.body
+        body_indent = " " * self.func_def.body[0].col_offset
         aliases = []
-        indentations = " " * self.kernel_stores.stores[0].store_node.col_offset
         for varname, alias in self.block_aliases.items():
-            aliases.append(f"{indentations}{varname}: tl.constexpr = {alias}")
+            aliases.append(f"{body_indent}{varname}: tl.constexpr = {alias}")
 
         return aliases
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import ast
 import collections
 import contextlib
-import copy
 import dataclasses
 import functools
 import itertools
@@ -6987,7 +6986,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
 class FusedUserDefinedTritonKernel(TritonKernel):
     """
-    When fusing a user-defined triton kernel with epilogues, we use this class to generate the modified triton kernel source
+    When fusing a user-defined triton kernel with epilogues, we use this class
+    to generate the modified triton kernel source.
+
+    For now, we assume a single mutated buffer, enforced by fusion legality checks
+    in the scheduler.
     """
 
     def __init__(
@@ -6996,6 +6999,10 @@ class FusedUserDefinedTritonKernel(TritonKernel):
         features: SIMDKernelFeatures,
         scheduler_node: FusedExternTritonKernelSchedulerNode,
     ) -> None:
+        from torch._higher_order_ops.triton_kernel_wrap import (
+            identify_triton_stores_from_ast,
+        )
+
         super().__init__(
             tiling,
             features=features,
@@ -7010,17 +7017,15 @@ class FusedUserDefinedTritonKernel(TritonKernel):
             self.scheduler_node.kernel_node.node, ir.UserDefinedTritonKernel
         )
         self.ir_node: ir.UserDefinedTritonKernel = self.scheduler_node.kernel_node.node
-        assert self.ir_node.can_fuse_epilogue()
 
-        # must be true because `self.ir_node.can_fuse_epilogue()`
-        assert len(self.ir_node.kernel_stores.stores) == 1
+        self.kernel_ast = ast.parse(self.ir_node.kernel_src)
+        self.kernel_stores = identify_triton_stores_from_ast(self.kernel_ast)
+        assert len(self.kernel_stores.stores) == 1
         self.original_stored_expr = ast.unparse(
-            self.ir_node.kernel_stores.stores[0].store_value_node
-        )
-        self.original_stored_expr = self.original_stored_expr.replace("\n", "")
+            self.kernel_stores.stores[0].store_value_node
+        ).replace("\n", "")
 
     def load(self, name: str, index: sympy.Expr) -> TritonCSEVariable:
-        # must be true because `self.ir_node.can_fuse_epilogue()`
         assert len(self.ir_node.mutable_args) == 1
         if name == self.ir_node.mutable_args[0].get_name():
             # when the fused epilogue nodes tries to load the mutated buffer
@@ -7062,17 +7067,6 @@ class FusedUserDefinedTritonKernel(TritonKernel):
             )
             self.scheduler_node.fused_epilogue.codegen(index_vars)
 
-        # Generate a new AST where the store value expr is replaced with the new value
-        new_ast = copy.deepcopy(self.ir_node.kernel_ast)
-        from torch._higher_order_ops.triton_kernel_wrap import (
-            identify_triton_stores,
-            identify_triton_stores_from_ast,
-        )
-
-        # avoid redundant cache entry of new_ast
-        kernel_stores = identify_triton_stores_from_ast(new_ast)
-        assert len(kernel_stores.stores) == 1
-
         new_store_value_node = ast.Name(self.new_store_cse_var.name)
 
         def _replace_arg(
@@ -7090,21 +7084,20 @@ class FusedUserDefinedTritonKernel(TritonKernel):
                     keyword.value = new_arg
 
         _replace_arg(
-            kernel_stores.stores[0].store_node, "value", 1, new_store_value_node
+            self.kernel_stores.stores[0].store_node, "value", 1, new_store_value_node
         )
 
-        src_with_store_replaced = ast.unparse(new_ast)
+        src_with_store_replaced = ast.unparse(self.kernel_ast)
 
         # then, we need to inject the additional `load` and `compute` lines generated when we `codegen` the epilogue nodes
 
         src_lines = src_with_store_replaced.splitlines()
 
         # identify the store again, because the previous parse-modify-unparse could've change its location
-        kernel_stores = identify_triton_stores(src_with_store_replaced)
         # python ast lineno is 1-indexed
-        store_line_index = kernel_stores.stores[0].store_node.lineno - 1
+        store_line_index = self.kernel_stores.stores[0].store_node.lineno - 1
 
-        indentations = " " * kernel_stores.stores[0].store_node.col_offset
+        indentations = " " * self.kernel_stores.stores[0].store_node.col_offset
 
         load_lines = [indentations + l for l in self.loads.get_lines_ref()]
         compute_lines = [indentations + l for l in self.compute.get_lines_ref()]

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -61,8 +61,8 @@ from ..runtime.hints import (
 from ..runtime.runtime_utils import get_max_y_grid, next_power_of_2
 from ..scheduler import (
     BaseSchedulerNode,
-    FusedExternTritonKernelSchedulerNode,
     FusedSchedulerNode,
+    FusedUserTritonSchedulerNode,
     Scheduler,
     SchedulerNode,
 )
@@ -6997,7 +6997,7 @@ class FusedUserDefinedTritonKernel(TritonKernel):
         self,
         tiling: dict[str, sympy.Expr],
         features: SIMDKernelFeatures,
-        scheduler_node: FusedExternTritonKernelSchedulerNode,
+        scheduler_node: FusedUserTritonSchedulerNode,
     ) -> None:
         from torch._higher_order_ops.triton_kernel_wrap import (
             identify_triton_stores_from_ast,

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -78,7 +78,12 @@ from .common import (
 )
 from .cpp_utils import cexpr
 from .custom_extern_kernel_codegen import CUSTOM_EXTERN_KERNEL_CODEGEN
-from .triton_utils import config_of, should_unwrap_unspec_arg, signature_to_meta
+from .triton_utils import (
+    config_of,
+    should_unwrap_unspec_arg,
+    signature_of,
+    signature_to_meta,
+)
 
 
 if TYPE_CHECKING:
@@ -325,13 +330,14 @@ def user_defined_kernel_grid_fn_code(
 
 
 def user_defined_triton_kernel_transitive_closure_source_code(
-    kernel, epilogue_fusion: tuple[ir.ComputedBuffer, str] | None = None
+    kernel,
+    epilogue_fusion: tuple[ir.ComputedBuffer, str, list[tuple[str, str]]] | None = None,
 ) -> str:
     """
     Given a triton kernel function pointer collect the transitive closure of
     its dependencies
 
-    epilogue_fusion: Optional[(fused epilogue node, modified kerel src code)]
+    epilogue_fusion: Optional[(fused epilogue node, modified kernel src code, additional buf args)]
     """
     compile_wrapper = IndentedBuffer()
     kernel_src = kernel.src
@@ -2897,7 +2903,7 @@ class PythonWrapperCodegen(CodeGen):
         restore_value_args,
         reset_to_zero_args,
         grids: list[list[int | sympy.Expr]],
-        epilogue_fusion: tuple[ir.ComputedBuffer, str] | None,
+        epilogue_fusion: tuple[ir.ComputedBuffer, str, list[tuple[str, str]]] | None,
     ):
         """Codegen a user-defined Triton kernel and return its cache entry.
 
@@ -3034,6 +3040,24 @@ class PythonWrapperCodegen(CodeGen):
             indices=arg_indices,
             argdefs=[ArgName(x) for x in kernel.arg_names],
         )
+        config_sig: list[KernelArgType] = signature
+        config_indices: list[int] = arg_indices
+        if epilogue_fusion is not None:
+            # New params are prepended in the modified kernel source, so prepend
+            # them in the signature dict too (order must match fn.arg_names for
+            # filtered_signature() in _interpret_args_grid).  Also shift the
+            # existing arg_indices so divisible_by_16 claims remain correct.
+            n_new = len(epilogue_fusion[2])
+            prepend: dict[str, str] = {}
+            new_sig_items: list[KernelArgType] = []
+            for param_name, buf_name in epilogue_fusion[2]:
+                buf = V.graph.get_buffer(buf_name)
+                arg = TensorArg(name=param_name, buffer=buf_name, dtype=buf.get_dtype())
+                new_sig_items.append(arg)
+                prepend[param_name] = signature_of(arg, size_dtype=None)
+            triton_signature = {**prepend, **triton_signature}
+            config_sig = new_sig_items + signature
+            config_indices = list(range(n_new)) + [i + n_new for i in arg_indices]
         triton_meta: dict[str, Any] = {
             "signature": triton_signature,
             "device": DeviceProperties.create(V.graph.get_current_device_or_throw()),
@@ -3050,8 +3074,8 @@ class PythonWrapperCodegen(CodeGen):
             },
             "configs": [
                 config_of(
-                    signature,
-                    indices=arg_indices,
+                    config_sig,
+                    indices=config_indices,
                     pointer_range_override=(),
                 )
             ],

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -368,6 +368,26 @@ class StarDep(Dep):
         return False
 
 
+@dataclasses.dataclass(frozen=True)
+class UserTritonDep(StarDep):
+    # pyrefly: ignore [bad-override]
+    access_count: int = 1
+
+    # depends on the entire buffer
+    @property
+    # pyrefly: ignore [bad-override]
+    def index(self) -> sympy.Expr:
+        raise NotImplementedError("UserTritonDep does not have an index")
+
+    def get_numel(self) -> sympy.Expr:
+        return V.graph.get_numel(self.name)  # type: ignore[return-value]
+
+    def rename(self, renames: dict[str, str]) -> "UserTritonDep":
+        if self.name in renames:
+            return UserTritonDep(renames[self.name], self.mode, self.access_count)
+        return self
+
+
 # Used for tracking mutation ordering
 # if A reads a buffer and B mutates it
 # B must be ordered after A

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -371,6 +371,10 @@ class StarDep(Dep):
 @dataclasses.dataclass(frozen=True)
 class UserTritonDep(StarDep):
     # pyrefly: ignore [bad-override]
+
+    # `access_count == 1` is enforced during fusion legality.
+    # Thus, conservatively default to 0 when unknown.
+    # Explicitly set during ttir parsing (analyze_kernel_access)
     access_count: int = 0
 
     # depends on the entire buffer

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -371,7 +371,7 @@ class StarDep(Dep):
 @dataclasses.dataclass(frozen=True)
 class UserTritonDep(StarDep):
     # pyrefly: ignore [bad-override]
-    access_count: int = 1
+    access_count: int = 0
 
     # depends on the entire buffer
     @property

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7961,17 +7961,19 @@ class UserDefinedTritonKernel(ExternKernel):
         return self._codegen(wrapper, epilogue_fusion=None)
 
     def codegen_with_epilogue_fusion(
-        self, wrapper: PythonWrapperCodegen, epilogue_fusion: tuple[ComputedBuffer, str]
+        self,
+        wrapper: PythonWrapperCodegen,
+        epilogue_fusion: tuple[ComputedBuffer, str, list[tuple[str, str]]],
     ) -> None:
         """
-        epilogue_fusion: (fused epilogue node, modified kerel src code)
+        epilogue_fusion: (fused epilogue node, modified kernel src code, additional buf args)
         """
         return self._codegen(wrapper, epilogue_fusion)
 
     def _codegen(
         self,
         wrapper: PythonWrapperCodegen,
-        epilogue_fusion: tuple[ComputedBuffer, str] | None,
+        epilogue_fusion: tuple[ComputedBuffer, str, list[tuple[str, str]]] | None,
     ) -> None:
         """Overrides the parent member.
         See https://github.com/pytorch/pytorch/issues/151692"""
@@ -8008,8 +8010,13 @@ class UserDefinedTritonKernel(ExternKernel):
             assert len(self.formal_accesses.read_writes.writes) == 1
             mutable_arg_name = next(iter(self.formal_accesses.read_writes.writes)).name
             assert mutable_arg_name in named_args
-            epilogue_computed_buffer, _ = epilogue_fusion
+            epilogue_computed_buffer, _, additional_args = epilogue_fusion
             named_args[mutable_arg_name] = epilogue_computed_buffer
+            prepended = {
+                param_name: V.graph.get_buffer(buf_name)
+                for param_name, buf_name in additional_args
+            }
+            named_args = {**prepended, **named_args}
 
         arg_names = [p.name for p in kernel.params]  # type: ignore[attr-defined]
         constexprs = [p.num for p in kernel.params if p.is_constexpr]  # type: ignore[attr-defined]

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8091,6 +8091,7 @@ class UserDefinedTritonKernel(ExternKernel):
         grid: Any,
         tma_descriptor_metadata: dict[str, Any],
         kernel_args: dict[str, Any],
+        output_tile: dict[str, str] | None = None,
     ) -> None:
         inputs: list[IRNode] = []
         kwargs: dict[str, IRNode] = {}
@@ -8120,6 +8121,7 @@ class UserDefinedTritonKernel(ExternKernel):
         )
         self.kernel_idx = kernel_idx
         self.grid = grid
+        self.output_tile = output_tile
 
         kernel, configs, _, _ = self.get_kernel_and_metadata()
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8182,9 +8182,9 @@ class UserDefinedTritonKernel(ExternKernel):
             )
         }
 
-        tracked = OrderedSet([
-            dep.name for dep in self.formal_accesses.read_writes.reads_and_writes()
-        ])
+        tracked = OrderedSet(
+            [dep.name for dep in self.formal_accesses.read_writes.reads_and_writes()]
+        )
         reads = OrderedSet(
             dep.rename(formal_to_inductor)
             for dep in self.formal_accesses.read_writes.reads_and_writes()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8106,6 +8106,7 @@ class UserDefinedTritonKernel(ExternKernel):
         tma_descriptor_metadata: dict[str, Any],
         kernel_args: dict[str, Any],
         output_tile: tuple[str, ...] | None = None,
+        pid_remap: tuple[str, ...] | None = None,
     ) -> None:
         inputs: list[IRNode] = []
         kwargs: dict[str, IRNode] = {}
@@ -8136,6 +8137,7 @@ class UserDefinedTritonKernel(ExternKernel):
         self.kernel_idx = kernel_idx
         self.grid = grid
         self.output_tile = output_tile
+        self.pid_remap = pid_remap
 
         kernel, configs, _, _ = self.get_kernel_and_metadata()
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8164,12 +8164,7 @@ class UserDefinedTritonKernel(ExternKernel):
         if not config.epilogue_fusion_user_defined_triton_kernel:
             return super().get_read_writes()
 
-        # Maps format kernel arg names to inductor buffer names.
-        formal_to_inductor = {
-            formal_arg_dep.name: self.kernel_args[formal_arg_dep.name].get_name()
-            for formal_arg_dep in self.formal_accesses.read_writes.reads_and_writes()
-        }
-
+        # Map formal kernel arg names to inductor buffer names.
         write_renames = {
             dep.name: mut_output.get_name()
             for dep, mut_output in zip(
@@ -8182,18 +8177,13 @@ class UserDefinedTritonKernel(ExternKernel):
             )
         }
 
-        tracked = OrderedSet(
-            [dep.name for dep in self.formal_accesses.read_writes.reads_and_writes()]
-        )
+        # All tensor args need to be included in reads, to avoid false dead-node-elimination
+        # see: https://github.com/pytorch/pytorch/issues/181864
         reads = OrderedSet(
-            dep.rename(formal_to_inductor)
-            for dep in self.formal_accesses.read_writes.reads_and_writes()
-            if dep.name in formal_to_inductor
+            dependencies.UserTritonDep(arg.get_name())
+            for arg in self.kernel_args.values()
+            if isinstance(arg, TensorBox)
         )
-        # Tensor args not accessed in the kernel body still need to be in reads.
-        for name, arg in self.kernel_args.items():
-            if name not in tracked and isinstance(arg, TensorBox):
-                reads.add(dependencies.UserTritonDep(arg.get_name()))
 
         return dependencies.ReadWrites(
             reads=reads,

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8005,8 +8005,8 @@ class UserDefinedTritonKernel(ExternKernel):
         }
 
         if epilogue_fusion:
-            assert len(self.arg_accesses.read_writes.writes) == 1
-            mutable_arg_name = next(iter(self.arg_accesses.read_writes.writes)).name
+            assert len(self.formal_accesses.read_writes.writes) == 1
+            mutable_arg_name = next(iter(self.formal_accesses.read_writes.writes)).name
             assert mutable_arg_name in named_args
             epilogue_computed_buffer, _ = epilogue_fusion
             named_args[mutable_arg_name] = epilogue_computed_buffer
@@ -8136,8 +8136,8 @@ class UserDefinedTritonKernel(ExternKernel):
         # pyrefly: ignore [missing-attribute]
         self.kernel_src = kernel.src
         self.kernel_args = kernel_args
-        # names in `arg_accesses.read_writes` are names of formal arguments in the kernel's prototype
-        self.arg_accesses = identify_accessed_tensors(
+        # names in `formal_accesses.read_writes` are names of formal arguments in the kernel's prototype
+        self.formal_accesses = identify_accessed_tensors(
             kernel,
             {**kernel_args, **autotuned_kwargs},
             tma_descriptor_metadata,
@@ -8147,7 +8147,7 @@ class UserDefinedTritonKernel(ExternKernel):
         # includes scalars, so writes may reference non-tensor args like SymInts.
         self.mutable_args = [
             kernel_args[key.name]
-            for key in self.arg_accesses.read_writes.writes
+            for key in self.formal_accesses.read_writes.writes
             if isinstance(kernel_args.get(key.name), TensorBox)
         ]
 
@@ -8159,43 +8159,51 @@ class UserDefinedTritonKernel(ExternKernel):
 
     @override
     def get_read_writes(self) -> dependencies.ReadWrites:
-        # Limit the new `get_read_writes` to `epilogue_fusion_user_defined_triton_kernel`
-        # to avoid potential regression to existing models.
+        # Limit override to `epilogue_fusion_user_defined_triton_kernel` to
+        # avoid potential regression to existing models.
         if not config.epilogue_fusion_user_defined_triton_kernel:
             return super().get_read_writes()
 
-        # Maps kernel arg names to inductor-generated arg names.
-        # We keep to scheduler formality and include writes as reads.
-        read_renames = {
+        # Maps format kernel arg names to inductor buffer names.
+        formal_to_inductor = {
             formal_arg_dep.name: self.kernel_args[formal_arg_dep.name].get_name()
-            for formal_arg_dep in self.arg_accesses.read_writes.reads
+            for formal_arg_dep in self.formal_accesses.read_writes.reads_and_writes()
         }
 
-        formal_arg_writes = list(self.arg_accesses.read_writes.writes)
         write_renames = {
-            formal_arg_dep.name: mut_output.get_name()
-            for formal_arg_dep, mut_output in zip(
-                formal_arg_writes, self.mutation_outputs
+            dep.name: mut_output.get_name()
+            for dep, mut_output in zip(
+                (
+                    d
+                    for d in self.formal_accesses.read_writes.writes
+                    if isinstance(self.kernel_args.get(d.name), TensorBox)
+                ),
+                self.mutation_outputs,
             )
         }
 
-        read_writes = dependencies.ReadWrites(
-            reads=OrderedSet(
-                [
-                    dep.rename(read_renames)
-                    for dep in self.arg_accesses.read_writes.reads
-                ]
-            ),
+        tracked = OrderedSet([
+            dep.name for dep in self.formal_accesses.read_writes.reads_and_writes()
+        ])
+        reads = OrderedSet(
+            dep.rename(formal_to_inductor)
+            for dep in self.formal_accesses.read_writes.reads_and_writes()
+            if dep.name in formal_to_inductor
+        )
+        # Tensor args not accessed in the kernel body still need to be in reads.
+        for name, arg in self.kernel_args.items():
+            if name not in tracked and isinstance(arg, TensorBox):
+                reads.add(dependencies.UserTritonDep(arg.get_name()))
+
+        return dependencies.ReadWrites(
+            reads=reads,
             writes=OrderedSet(
-                [
-                    dep.rename(write_renames)
-                    for dep in self.arg_accesses.read_writes.writes
-                ]
+                dep.rename(write_renames)
+                for dep in self.formal_accesses.read_writes.writes
+                if dep.name in write_renames
             ),
             index_exprs=OrderedSet(),
         )
-        return read_writes
-
 
     def get_outputs(self) -> list[Buffer]:
         return list(self.mutation_outputs)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6286,7 +6286,6 @@ def is_node_sequence(
 @ir_dataclass(frozen=False)
 class InputsKernel(OperationBuffer):
     inputs: Sequence[IRNode | Sequence[IRNode]]
-    _DepType = dependencies.StarDep
 
     def input_name(self, i: int) -> str:
         input = self.inputs[i]
@@ -6295,17 +6294,18 @@ class InputsKernel(OperationBuffer):
 
     def get_read_writes(self) -> dependencies.ReadWrites:
         reads = OrderedSet[dependencies.Dep]()
+        StarDep = dependencies.StarDep
         for input in self.inputs:
             if isinstance(input, Sequence):
-                reads.update(self._DepType(x.get_name()) for x in input)
+                reads.update(StarDep(x.get_name()) for x in input)
             elif isinstance(input, ShapeAsConstantBuffer):
                 # Skip creating dependency for symbolics as they're visible globally
                 continue
             else:
-                reads.add(self._DepType(input.get_name()))
+                reads.add(StarDep(input.get_name()))
 
         writes = OrderedSet[dependencies.Dep](
-            self._DepType(buf.get_name()) for buf in self.get_outputs()
+            StarDep(buf.get_name()) for buf in self.get_outputs()
         )
 
         return dependencies.ReadWrites(
@@ -7924,8 +7924,6 @@ class UserDefinedTritonKernel(ExternKernel):
     A user-defined triton kernel (e.g. via @triton.jit).
     """
 
-    _DepType = dependencies.UserTritonDep
-
     def get_kernel_and_metadata(self) -> tuple[Kernel, Any, list[str], list[str]]:
         from triton.runtime.autotuner import Autotuner
 
@@ -8158,6 +8156,46 @@ class UserDefinedTritonKernel(ExternKernel):
             for buf in self.mutable_args
         ]
         V.graph.register_operation(self)
+
+    @override
+    def get_read_writes(self) -> dependencies.ReadWrites:
+        # Limit the new `get_read_writes` to `epilogue_fusion_user_defined_triton_kernel`
+        # to avoid potential regression to existing models.
+        if not config.epilogue_fusion_user_defined_triton_kernel:
+            return super().get_read_writes()
+
+        # Maps kernel arg names to inductor-generated arg names.
+        # We keep to scheduler formality and include writes as reads.
+        read_renames = {
+            formal_arg_dep.name: self.kernel_args[formal_arg_dep.name].get_name()
+            for formal_arg_dep in self.arg_accesses.read_writes.reads
+        }
+
+        formal_arg_writes = list(self.arg_accesses.read_writes.writes)
+        write_renames = {
+            formal_arg_dep.name: mut_output.get_name()
+            for formal_arg_dep, mut_output in zip(
+                formal_arg_writes, self.mutation_outputs
+            )
+        }
+
+        read_writes = dependencies.ReadWrites(
+            reads=OrderedSet(
+                [
+                    dep.rename(read_renames)
+                    for dep in self.arg_accesses.read_writes.reads
+                ]
+            ),
+            writes=OrderedSet(
+                [
+                    dep.rename(write_renames)
+                    for dep in self.arg_accesses.read_writes.writes
+                ]
+            ),
+            index_exprs=OrderedSet(),
+        )
+        return read_writes
+
 
     def get_outputs(self) -> list[Buffer]:
         return list(self.mutation_outputs)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6286,6 +6286,7 @@ def is_node_sequence(
 @ir_dataclass(frozen=False)
 class InputsKernel(OperationBuffer):
     inputs: Sequence[IRNode | Sequence[IRNode]]
+    _DepType = dependencies.StarDep
 
     def input_name(self, i: int) -> str:
         input = self.inputs[i]
@@ -6294,18 +6295,17 @@ class InputsKernel(OperationBuffer):
 
     def get_read_writes(self) -> dependencies.ReadWrites:
         reads = OrderedSet[dependencies.Dep]()
-        StarDep = dependencies.StarDep
         for input in self.inputs:
             if isinstance(input, Sequence):
-                reads.update(StarDep(x.get_name()) for x in input)
+                reads.update(self._DepType(x.get_name()) for x in input)
             elif isinstance(input, ShapeAsConstantBuffer):
                 # Skip creating dependency for symbolics as they're visible globally
                 continue
             else:
-                reads.add(StarDep(input.get_name()))
+                reads.add(self._DepType(input.get_name()))
 
         writes = OrderedSet[dependencies.Dep](
-            StarDep(buf.get_name()) for buf in self.get_outputs()
+            self._DepType(buf.get_name()) for buf in self.get_outputs()
         )
 
         return dependencies.ReadWrites(
@@ -7923,6 +7923,8 @@ class UserDefinedTritonKernel(ExternKernel):
     """
     A user-defined triton kernel (e.g. via @triton.jit).
     """
+
+    _DepType = dependencies.UserTritonDep
 
     def get_kernel_and_metadata(self) -> tuple[Kernel, Any, list[str], list[str]]:
         from triton.runtime.autotuner import Autotuner

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8173,6 +8173,14 @@ class UserDefinedTritonKernel(ExternKernel):
             MutationOutput(NoneLayout(device=self.device), buf, self)
             for buf in self.mutable_args
         ]
+
+        if output_tile is not None:
+            for name in output_tile:
+                if name not in kernel_args:
+                    raise ValueError(
+                        f"output_tile name '{name}' is not a kernel argument. "
+                        f"Available arguments: {list(kernel_args.keys())}"
+                    )
         V.graph.register_operation(self)
 
     @override

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7956,62 +7956,6 @@ class UserDefinedTritonKernel(ExternKernel):
 
         return kernel, configs, restore_value_args, reset_to_zero_args
 
-    def can_fuse_epilogue(self) -> bool:
-        """
-        For kernels like
-
-        @triton.jit
-        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
-            pid = tl.program_id(0)
-            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-            mask = offs < n_elements
-            x = tl.load(in_ptr0 + offs, mask=mask)
-            y = tl.load(in_ptr1 + offs, mask=mask)
-            tl.store(out_ptr + offs, x + y, mask=mask)
-
-        @torch.compile
-        def fn(a, b):
-            out = torch.empty_like(a)
-            grid = (triton.cdiv(a.numel(), 1024),)
-            add_kernel[grid](a, b, out, a.numel(), BLOCK_SIZE=1024)
-            return out.relu()
-
-        We can potentially fuse the relu epilogue into the add_kernel.
-        We do this by pruning the `out` tensor allocation and directly writing the relu-output.
-        """
-
-        if not config.epilogue_fusion_user_defined_triton_kernel:
-            return False
-
-        if not self.arg_accesses.can_fuse_epilogue:
-            return False
-
-        # We achieve fusion by parsing the original src into a python AST,
-        # then identify the expr containing the original value written via tl.store().
-        # We generate an expr for the value after the epilogue and replace that into the tl.store.
-        # So far we only support the simple case where there is a single tl.store in the kernel.
-        if len(self.kernel_stores.stores) != 1:
-            return False
-
-        # Only fuse if the mutated arg is originally an "empty" tensor.
-        # This is because we don't know exactly which element of that tensor is being written to.
-        # If the kernel only writes to a subset of the tensor, then we only apply the epilogue to that subset.
-        # In these edge cases, our fusion is only correct if the original tensor is empty,
-        # where the semantics is that content values are UB, and we can rely on the fact that `epilogue(UB) == UB`.
-        assert len(self.mutable_args) == 1
-        if not isinstance(self.mutable_args[0], TensorBox):
-            return False
-        if not isinstance(self.mutable_args[0].data, StorageBox):
-            return False
-        if not isinstance(self.mutable_args[0].data.data, ComputedBuffer):
-            return False
-        if not isinstance(self.mutable_args[0].data.data.data, Pointwise):
-            return False
-        if not all(r == 0 for r in self.mutable_args[0].data.data.data.ranges):
-            return False
-
-        return True
-
     @override
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         return self._codegen(wrapper, epilogue_fusion=None)
@@ -8185,19 +8129,12 @@ class UserDefinedTritonKernel(ExternKernel):
             arg for arg in kernel.arg_names if arg in kernel_args
         ]
 
-        from torch._higher_order_ops.triton_kernel_wrap import (
-            identify_accessed_tensors,
-            identify_triton_stores,
-        )
+        from torch._higher_order_ops.triton_kernel_wrap import identify_accessed_tensors
 
         autotuned_kwargs = configs[0].kwargs if len(configs) > 0 else {}
 
-        import ast
-
         # pyrefly: ignore [missing-attribute]
         self.kernel_src = kernel.src
-        self.kernel_ast = ast.parse(self.kernel_src)
-        self.kernel_stores = identify_triton_stores(self.kernel_src)
         self.kernel_args = kernel_args
         # names in `arg_accesses.read_writes` are names of formal arguments in the kernel's prototype
         self.arg_accesses = identify_accessed_tensors(

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8098,7 +8098,7 @@ class UserDefinedTritonKernel(ExternKernel):
         grid: Any,
         tma_descriptor_metadata: dict[str, Any],
         kernel_args: dict[str, Any],
-        output_tile: dict[str, str] | None = None,
+        output_tile: tuple[str, ...] | None = None,
     ) -> None:
         inputs: list[IRNode] = []
         kwargs: dict[str, IRNode] = {}

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7987,7 +7987,24 @@ class UserDefinedTritonKernel(ExternKernel):
             reset_to_zero_args,
         ) = self.get_kernel_and_metadata()
 
-        # Definition of kernel
+        # When fusing an epilogue, the mutable arg is replaced by the epilogue's
+        # output buffer (which may have a different dtype). Compute all epilogue
+        # overrides upfront so both the kernel definition (signature) and the
+        # call site see the correct buffer.
+        kernel_kwargs = self.kwargs
+        epilogue_pre_args: dict[str, Any] = {}
+        epilogue_out_override: dict[str, Any] = {}
+        if epilogue_fusion:
+            assert len(self.formal_accesses.read_writes.writes) == 1
+            mutable_arg_name = next(iter(self.formal_accesses.read_writes.writes)).name
+            epilogue_computed_buffer, _, additional_args = epilogue_fusion
+            kernel_kwargs = {**self.kwargs, mutable_arg_name: epilogue_computed_buffer}
+            epilogue_pre_args = {
+                param_name: V.graph.get_buffer(buf_name)
+                for param_name, buf_name in additional_args
+            }
+            epilogue_out_override = {mutable_arg_name: epilogue_computed_buffer}
+
         (
             new_name,
             triton_meta,
@@ -7996,7 +8013,7 @@ class UserDefinedTritonKernel(ExternKernel):
         ) = wrapper.define_user_defined_triton_kernel(
             kernel,
             configs,
-            self.kwargs,
+            kernel_kwargs,
             restore_value_args,
             reset_to_zero_args,
             self.grid,
@@ -8005,18 +8022,8 @@ class UserDefinedTritonKernel(ExternKernel):
         named_args = {
             k: self.get_kwargs_value(k) for k in self.ordered_kwargs_for_cpp_kernel
         }
-
-        if epilogue_fusion:
-            assert len(self.formal_accesses.read_writes.writes) == 1
-            mutable_arg_name = next(iter(self.formal_accesses.read_writes.writes)).name
-            assert mutable_arg_name in named_args
-            epilogue_computed_buffer, _, additional_args = epilogue_fusion
-            named_args[mutable_arg_name] = epilogue_computed_buffer
-            prepended = {
-                param_name: V.graph.get_buffer(buf_name)
-                for param_name, buf_name in additional_args
-            }
-            named_args = {**prepended, **named_args}
+        named_args.update(epilogue_out_override)
+        named_args = {**epilogue_pre_args, **named_args}
 
         arg_names = [p.name for p in kernel.params]  # type: ignore[attr-defined]
         constexprs = [p.num for p in kernel.params if p.is_constexpr]  # type: ignore[attr-defined]

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8566,6 +8566,7 @@ def triton_kernel_wrap_(
         tma_descriptor_metadata=tma_descriptor_metadata,
         kernel_args={**kwargs, **constant_args},
         output_tile=kernel_side_table.get_output_tile(kernel_idx),
+        pid_remap=kernel_side_table.get_pid_remap(kernel_idx),
     )
     return {key: val for key, val in kwargs.items() if isinstance(val, TensorBox)}
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8565,6 +8565,7 @@ def triton_kernel_wrap_(
         grid=grid,
         tma_descriptor_metadata=tma_descriptor_metadata,
         kernel_args={**kwargs, **constant_args},
+        output_tile=kernel_side_table.get_output_tile(kernel_idx),
     )
     return {key: val for key, val in kwargs.items() if isinstance(val, TensorBox)}
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3188,7 +3188,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
                 )
                 return False
         else:
-            if self.epilogue_requires_new_store(writing_node):
+            if self.epilogue_requires_indexing(writing_node):
                 why(
                     "epilogue requires expressions not available in user's Triton kernel"
                 )
@@ -3237,7 +3237,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
 
         return self.scheduler.can_fuse_vertical(self, node2)
 
-    def epilogue_requires_new_store(self, node2: SchedulerNode) -> bool:
+    def epilogue_requires_indexing(self, node2: SchedulerNode) -> bool:
         # The epilogue can only read from the output buffer.
         # Any other tensor/s would require additional load expressions.
         written_buffer_name = self.node.mutation_outputs[0].name
@@ -3351,7 +3351,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         writing_node = self.writing_node
 
         epilogue_needs_indexing = any(
-            self.kernel_node.epilogue_requires_new_store(sn) for sn in epilogue_nodes
+            self.kernel_node.epilogue_requires_indexing(sn) for sn in epilogue_nodes
         )
         if is_reduction_ep:
             # Only 1D-grid reductions are supported: XBLOCK=1, no tile alias needed.

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -33,7 +33,7 @@ from typing_extensions import ParamSpec
 
 from torch.utils._ordered_set import OrderedSet
 
-from .ir import ComputedBuffer, Pointwise
+from .ir import ComputedBuffer
 
 
 if TYPE_CHECKING:
@@ -2158,13 +2158,6 @@ class ExternKernelSchedulerNode(BaseSchedulerNode):
         assert self.node is not None
         return hasattr(self.node, "has_side_effects") and self.node.has_side_effects()
 
-    def get_ranges(self) -> Sequence[Sequence[sympy.Expr]]:
-        if not isinstance(self.node, ir.UserDefinedTritonKernel):
-            return ([], [])
-        assert len(self.node.mutable_args) == 1
-        numel = math.prod(self.node.mutable_args[0].shape)
-        return ([numel], [])
-
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         assert isinstance(self.node, ir.ExternKernel)
         return self.node.codegen(wrapper)
@@ -3108,9 +3101,6 @@ class FusedExternTritonKernelSchedulerNode(FusedSchedulerNode):
 
     def is_extern(self) -> bool:
         return True
-
-    def get_ranges(self) -> Sequence[Sequence[sympy.Expr]]:
-        return self.kernel_node.get_ranges()
 
 
 class ForeachKernelSchedulerNode(FusedSchedulerNode):
@@ -7417,16 +7407,12 @@ class Scheduler:
                 why("node1 is extern but not a triton kernel")
                 return False
 
-            if not config.epilogue_fusion_user_defined_triton_kernel:
-                why("epilogue fusion for user defined triton kernel is disabled")
-                return False
-
             if not node1.node.arg_accesses.only_tt_stores:
                 why("node1's triton kernel has non-store writes")
                 return False
 
             write_deps = list(node1.node.arg_accesses.read_writes.writes)
-            if len(write_deps) != 1:
+            if len(write_deps) != 1 or len(node1.node.mutable_args) != 1:
                 why("node1's triton kernel has multiple outputs")
                 return False
 
@@ -7448,8 +7434,6 @@ class Scheduler:
                     return False
                 if not isinstance(arg.data.data, ir.ComputedBuffer):
                     return False
-                if not isinstance(arg.data.data.data, ir.Pointwise):
-                    return False
                 if not all(r == 0 for r in arg.data.data.data.ranges):
                     return False
                 return True
@@ -7469,10 +7453,10 @@ class Scheduler:
             if not isinstance(node2, SchedulerNode):
                 why("node1 is extern but node2 is not SchedulerNode")
                 return False
-            if not isinstance(node2.node, ComputedBuffer):
-                why("node1 is extern but node2.node is not SchedulerNode")
-                return False
-            if not isinstance(node2.node.data, Pointwise):
+
+            if not isinstance(node2.node, ComputedBuffer) or not isinstance(
+                node2.node.data, ir.Pointwise
+            ):
                 why("node1 is extern but node2.node.data is not Pointwise")
                 return False
 
@@ -7481,7 +7465,7 @@ class Scheduler:
             # The epilogue can only read from the output buffer.
             # Any other tensor/s would require additional load expressions.
             if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
-                why("epilogue reads from buffers other than the mutated output")
+                why("node2 reads from buffers other than the mutated output")
                 return False
 
             # the epilogue depends on expressions which may not available in the user triton kernel
@@ -7490,11 +7474,8 @@ class Scheduler:
             for symbol in node2_inner_fn_free_symbols:
                 usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
                 if any(usage != "load" for usage in usages):
+                    why("node2 requires expressions not available in node1")
                     return False
-
-            if node1.node.mutable_args[0].layout != node2.node.layout:
-                why("node1 and node2 uses different buf layouts")
-                return False
 
             def _is_other_node_that_references_mutation_buffer(
                 other_node: BaseSchedulerNode,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3238,18 +3238,9 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         block_aliases = None
         pid_cache = {}
         if ir_node.output_tile:
-
-            def _construct_block_aliases(mapping: dict[str, str]):
-                expected_keys = OrderedSet(["x", "y", "z"])
-                block_aliases = {}
-                for prefix, alias in mapping.items():
-                    if prefix not in expected_keys:
-                        raise
-                    block_aliases[f"{prefix.upper()}BLOCK"] = alias
-
-                return block_aliases
-
-            block_aliases = _construct_block_aliases(ir_node.output_tile)
+            # TODO(jjvraw): Assert against grid size.
+            _axes = ["XBLOCK", "YBLOCK", "ZBLOCK"]
+            block_aliases = {_axes[i]: name for i, name in enumerate(ir_node.output_tile)}
             pid_cache = {}
 
         fused_user_kernel = FusedUserTritonKernel(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3152,7 +3152,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
 
             node_schedule = node2.get_nodes()
             _, (numel_ep, rnumel_ep) = node2.group
-            # TODO(jjvraw): Do we need to be explicit here about reductions? Or is it implied via 
+            # TODO(jjvraw): Do we need to be explicit here about reductions? Or is it implied via
             # FusedSchedulerNode.
             if isinstance(node2, FusedSchedulerNode) and any(
                 isinstance(sn, SchedulerNode)
@@ -3182,7 +3182,9 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             if not SIMDScheduling.tiling_is_compatible(
                 node_schedule, numel_ep, rnumel_ep, tiling
             ):
-                why("epilogue iteration space is incompatible with output_tile dimensions")
+                why(
+                    "epilogue iteration space is incompatible with output_tile dimensions"
+                )
                 return False
         else:
             if self.epilogue_requires_new_store(writing_node):
@@ -3206,7 +3208,9 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         real_written_buffer_name = self.scheduler.mutation_real_name.get(
             written_buffer_name, written_buffer_name
         )
-        mutation_buffer_names = OrderedSet([written_buffer_name, real_written_buffer_name])
+        mutation_buffer_names = OrderedSet(
+            [written_buffer_name, real_written_buffer_name]
+        )
 
         # Exclude nodes that are part of this fusion attempt.
         # For a FusedSchedulerNode epilogue, also exclude its constituent snodes since
@@ -3329,9 +3333,10 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
             epilogue_nodes, numel_ep, reduction_numel=rnumel
         )
 
-        excluded_names = OrderedSet([
-            ir_node.mutation_outputs[0].name
-        ]) | self.epilogue.get_buffer_names()
+        excluded_names = (
+            OrderedSet([ir_node.mutation_outputs[0].name])
+            | self.epilogue.get_buffer_names()
+        )
         external_reads = OrderedSet(
             d.name
             for sn in epilogue_nodes

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3290,7 +3290,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         # pyrefly: ignore[bad-assignment]
         self.outputs = self.writing_node.get_outputs()
 
-    @property
+    @functools.cached_property
     def writing_node(self) -> SchedulerNode:
         ep_names = OrderedSet(sn.get_name() for sn in self.epilogue.get_nodes())
         writers = [

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3157,6 +3157,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             _is_other_node_that_references_mutation_buffer(node)
             for node in self.scheduler.nodes
         ):
+            why("epilogue has other references")
             return False
 
         return self.scheduler.can_fuse_vertical(self, node2)
@@ -3169,14 +3170,14 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         self,
         scheduler: Scheduler,
         kernel_node: UserTritonSchedulerNode,
-        fused_epilogue: SchedulerNode,
+        epilogue: SchedulerNode,
     ) -> None:
-        snodes = typing.cast(list[BaseSchedulerNode], [kernel_node, fused_epilogue])
+        snodes = typing.cast(list[BaseSchedulerNode], [kernel_node, epilogue])
         super().__init__(scheduler, snodes)
         self.kernel_node = kernel_node
-        self.fused_epilogue = fused_epilogue
+        self.epilogue = epilogue
         self.min_order = self.kernel_node.min_order
-        self.outputs = fused_epilogue.outputs
+        self.outputs = epilogue.outputs
 
     @classmethod
     def epilogue_fuse(
@@ -3197,7 +3198,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         return cls(scheduler, node1, node2)
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
-        assert isinstance(self.fused_epilogue.node, ir.ComputedBuffer)
+        assert isinstance(self.epilogue.node, ir.ComputedBuffer)
         from torch._inductor.codegen.simd import SIMDScheduling
         from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
         from torch._inductor.codegen.triton import FusedUserTritonKernel
@@ -3207,13 +3208,13 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
 
         # Epilogue fusion is gated on pointwise operations, thus 1D tiling, with no reduction.
         tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
-        kernel_features = SIMDKernelFeatures([self.fused_epilogue], numel)
+        kernel_features = SIMDKernelFeatures([self.epilogue], numel)
 
         fused_user_kernel = FusedUserTritonKernel(tiling, kernel_features, self)
         new_kernel_src = fused_user_kernel.codegen()
 
         return self.kernel_node.node.codegen_with_epilogue_fusion(
-            wrapper, (self.fused_epilogue.node, new_kernel_src)
+            wrapper, (self.epilogue.node, new_kernel_src)
         )
 
     def is_extern(self) -> bool:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3122,6 +3122,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
 
         written_buffer_name = self.node.mutation_outputs[0].name
 
+        # TODO(jjvraw): Gate this with whether we have block info & pid mapping.
         # The epilogue can only read from the output buffer.
         # Any other tensor/s would require additional load expressions.
         if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
@@ -3130,16 +3131,20 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             )
             return False
 
-        # the epilogue depends on expressions which may not available in the user's Triton kernel
+        # The epilogue may depend on expressions which may not available in the user triton kernel
         # (e.g. indexing exprs used not in a load)
-        node2_inner_fn_free_symbols = node2.node.data.inner_fn_free_symbols()
-        for symbol in node2_inner_fn_free_symbols:
-            usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
-            if any(usage != "load" for usage in usages):
-                why(
-                    "epilogue requires expressions not available in user's Triton kernel"
-                )
-                return False
+        # If the user has provided the dimensions of the output_tile, we may be able to attempt fusion.
+        if self.output_tile:
+            # TODO: is_compatible
+            pass
+        else:
+            node2_inner_fn_free_symbols = node2.node.data.inner_fn_free_symbols()
+            for symbol in node2_inner_fn_free_symbols:
+                usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
+                if any(usage != "load" for usage in usages):
+                    why("node2 requires expressions not available in node1")
+                    return False
+
 
         if self.node.mutable_args[0].layout != node2.node.layout:
             why("user's Triton kernel and epilogue have different buffer layouts")
@@ -7550,29 +7555,6 @@ class Scheduler:
 
         if isinstance(node1, UserTritonSchedulerNode):
             return node1.can_fuse_with(node2)
-
-            # # TODO(JJVRAW): Gate this with whether we have block info & pid mapping.
-            #
-            # # The epilogue can only read from the output buffer.
-            # # Any other tensor/s would require additional load expressions.
-            # if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
-            #     why("node2 reads from buffers other than the mutated output")
-            #     return False
-
-            # # The epilogue may depend on expressions which may not available in the user triton kernel
-            # # (e.g. indexing exprs used not in a load)
-            # # If the user has provided the dimensions of the output_tile, we may be able to attempt fusion.
-            # if node1.output_tile:
-            #     # TODO: is_compatible
-            #     pass
-            # else:
-            #     node2_inner_fn_free_symbols = node2.node.data.inner_fn_free_symbols()
-            #     for symbol in node2_inner_fn_free_symbols:
-            #         usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
-            #         if any(usage != "load" for usage in usages):
-            #             why("node2 requires expressions not available in node1")
-            #             return False
-
         if (
             isinstance(node2, (ExternKernelSchedulerNode, NopKernelSchedulerNode))
             and not node2.is_template()

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3140,6 +3140,10 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
                 )
                 return False
 
+        if self.node.mutable_args[0].layout != node2.node.layout:
+            why("user's Triton kernel and epilogue have different buffer layouts")
+            return False
+
         def _is_other_node_that_references_mutation_buffer(
             other_node: BaseSchedulerNode,
         ):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3053,6 +3053,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         self.formal_reads = self.node.formal_accesses.read_writes.reads
         self.formal_writes = self.node.formal_accesses.read_writes.writes
         self.output_tile = self.node.output_tile
+        self.pid_remap = self.node.pid_remap
 
         numel = math.prod(node.mutable_args[0].shape)
         rnumel = 1
@@ -3358,8 +3359,10 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
             tiling = SIMDScheduling.create_tiling([numel_ep], [rnumel])
         elif ir_node.output_tile:
             k = len(ir_node.output_tile)
+            # output_tile is specified in tensor dimension order (outermost first),
+            # but Inductor's x/y convention is innermost-first.
             block_aliases = dict(
-                zip(["XBLOCK", "YBLOCK", "ZBLOCK"][:k], ir_node.output_tile)
+                zip(["XBLOCK", "YBLOCK", "ZBLOCK"][:k], reversed(ir_node.output_tile))
             )
             if k == 1:
                 tiling = SIMDScheduling.create_tiling([numel_ep], [sympy.S.One])
@@ -3374,13 +3377,23 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         pass_aliases = (
             block_aliases if (epilogue_needs_indexing or is_reduction_ep) else None
         )
+        # pid_remap is also in tensor dimension order (outermost first), reverse
+        # to match Inductor's grid dim ordering (dim 0 = x = innermost).
+        pid_cache = (
+            {
+                f"tl.program_id({i})": name
+                for i, name in enumerate(reversed(ir_node.pid_remap))
+            }
+            if ir_node.pid_remap
+            else {}
+        )
         fused_user_kernel = FusedUserTritonKernel(
             tiling,
             kernel_features,
             self,
             additional_args,
             block_aliases=pass_aliases,
-            pid_cache={},
+            pid_cache=pid_cache,
         )
         new_kernel_src = fused_user_kernel.codegen()
         return self.kernel_node.node.codegen_with_epilogue_fusion(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3125,7 +3125,6 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
             return False
 
-
         # The epilogue require additional index expressions, if the user has provided the
         # dimensions of the "output tile", we may be able to attempt fusion.
         if self.output_tile:
@@ -3165,7 +3164,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         # Any other tensor/s would require additional load expressions.
         written_buffer_name = self.node.mutation_outputs[0].name
         if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
-            return True # TODO(jjvraw): This should be True when finished testing.
+            return True  # TODO(jjvraw): This should be True when finished testing.
 
         # The epilogue may depend on expressions which may not available in the user triton kernel
         # (e.g. indexing exprs used not in a load)
@@ -3173,9 +3172,9 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         for symbol in node2_inner_fn_free_symbols:
             usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
             if any(usage != "load" for usage in usages):
-                return True 
+                return True
 
-        return False 
+        return False
 
 
 class FusedUserTritonSchedulerNode(FusedSchedulerNode):
@@ -3193,7 +3192,9 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         self.epilogue = epilogue
         self.min_order = self.kernel_node.min_order
         self.outputs = epilogue.outputs
-        self.introduce_new_store = self.kernel_node.epilogue_requires_new_store(self.fused_epilogue)
+        self.introduce_new_store = self.kernel_node.epilogue_requires_new_store(
+            self.epilogue
+        )
 
     @classmethod
     def epilogue_fuse(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3040,6 +3040,12 @@ class FusedNestedReductions(FusedSchedulerNode):
 class UserTritonSchedulerNode(ExternKernelSchedulerNode):
     def __init__(self, scheduler: Scheduler, node: ir.UserDefinedTritonKernel) -> None:
         super().__init__(scheduler, node)
+        assert isinstance(self.node, ir.UserDefinedTritonKernel)
+
+        self.only_tt_stores = self.node.formal_accesses.only_tt_stores
+        self.formal_reads = self.node.formal_accesses.read_writes.reads
+        self.formal_writes = self.node.formal_accesses.read_writes.writes
+
         # TODO(JJVRAW)
         numel = math.prod(node.mutable_args[0].shape)
         rnumel = 1
@@ -7403,17 +7409,16 @@ class Scheduler:
             return False
 
         if isinstance(node1, UserTritonSchedulerNode):
-            if not node1.node.arg_accesses.only_tt_stores:
-                why("node1's triton kernel has non-store writes")
+            if not node1.only_tt_stores:
+                why("user Triton fusion only supports `tl.store`")
                 return False
 
-            write_deps = list(node1.node.arg_accesses.read_writes.writes)
-            if len(write_deps) != 1 or len(node1.node.mutable_args) != 1:
-                why("node1's triton kernel has multiple outputs")
+            if len(node1.node.mutable_args) != 1 or len(node1.formal_writes) != 1:
+                why("node1's triton kernel has multiple stores")
                 return False
 
-            assert isinstance(write_deps[0], UserTritonDep)
-            if write_deps[0].access_count != 1:
+            formal_writes = list(node1.formal_writes)
+            if formal_writes[0].access_count != 1:
                 why("node1's triton kernel writes to output more than once")
                 return False
 
@@ -7439,10 +7444,8 @@ class Scheduler:
                 why("node1's triton kernel output is not an empty tensor")
                 return False
 
-            if any(
-                dep.name == write_deps[0].name
-                for dep in node1.node.arg_accesses.read_writes.reads
-            ):
+            formal_arg_name = formal_writes[0].name
+            if any(dep.name == formal_arg_name for dep in node1.formal_reads):
                 why("node1's triton kernel reads from its output buffer")
                 return False
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3239,6 +3239,9 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
 
         block_aliases = None
         pid_cache = {}
+        epilogue_needs_indexing = self.kernel_node.epilogue_requires_new_store(
+            self.fused_epilogue
+        )
         if ir_node.output_tile:
             k = len(ir_node.output_tile)
             _all_axes = ["XBLOCK", "YBLOCK", "ZBLOCK"]
@@ -3259,7 +3262,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
             kernel_features,
             self,
             additional_args,
-            block_aliases=block_aliases,
+            block_aliases=block_aliases if epilogue_needs_indexing else None,
             pid_cache=pid_cache,
         )
         new_kernel_src = fused_user_kernel.codegen()

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3052,6 +3052,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         self.only_tt_stores = self.node.formal_accesses.only_tt_stores
         self.formal_reads = self.node.formal_accesses.read_writes.reads
         self.formal_writes = self.node.formal_accesses.read_writes.writes
+        self.output_tile = self.node.output_tile
 
         numel = math.prod(node.mutable_args[0].shape)
         rnumel = 1
@@ -3199,18 +3200,46 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         assert isinstance(self.epilogue.node, ir.ComputedBuffer)
+        assert isinstance(self.kernel_node.node, ir.UserDefinedTritonKernel)
         from torch._inductor.codegen.simd import SIMDScheduling
         from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
         from torch._inductor.codegen.triton import FusedUserTritonKernel
 
         ir_node = self.kernel_node.node
         numel = math.prod(ir_node.mutable_args[0].shape)
-
         # Epilogue fusion is gated on pointwise operations, thus 1D tiling, with no reduction.
         tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
+
+        # TODO: What do we actually need from features here?
         kernel_features = SIMDKernelFeatures([self.epilogue], numel)
 
-        fused_user_kernel = FusedUserTritonKernel(tiling, kernel_features, self)
+        formal_out_arg_name = next(iter(self.kernel_node.formal_writes)).name
+
+        block_aliases = None
+        pid_cache = {}
+        if ir_node.output_tile:
+
+            def _construct_block_aliases(mapping: dict[str, str]):
+                expected_keys = {"x", "y", "z"}
+                block_aliases = {}
+                for prefix, alias in mapping.items():
+                    if prefix not in expected_keys:
+                        raise
+                    block_aliases[f"{prefix.upper()}BLOCK"] = alias
+
+                return block_aliases
+
+            block_aliases = _construct_block_aliases(ir_node.output_tile)
+            pid_cache = {}
+
+        fused_user_kernel = FusedUserTritonKernel(
+            tiling,
+            kernel_features,
+            self,
+            formal_out_arg_name,
+            block_aliases=block_aliases,
+            pid_cache=pid_cache,
+        )
         new_kernel_src = fused_user_kernel.codegen()
 
         return self.kernel_node.node.codegen_with_epilogue_fusion(
@@ -7521,6 +7550,28 @@ class Scheduler:
 
         if isinstance(node1, UserTritonSchedulerNode):
             return node1.can_fuse_with(node2)
+
+            # # TODO(JJVRAW): Gate this with whether we have block info & pid mapping.
+            #
+            # # The epilogue can only read from the output buffer.
+            # # Any other tensor/s would require additional load expressions.
+            # if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
+            #     why("node2 reads from buffers other than the mutated output")
+            #     return False
+
+            # # The epilogue may depend on expressions which may not available in the user triton kernel
+            # # (e.g. indexing exprs used not in a load)
+            # # If the user has provided the dimensions of the output_tile, we may be able to attempt fusion.
+            # if node1.output_tile:
+            #     # TODO: is_compatible
+            #     pass
+            # else:
+            #     node2_inner_fn_free_symbols = node2.node.data.inner_fn_free_symbols()
+            #     for symbol in node2_inner_fn_free_symbols:
+            #         usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
+            #         if any(usage != "load" for usage in usages):
+            #             why("node2 requires expressions not available in node1")
+            #             return False
 
         if (
             isinstance(node2, (ExternKernelSchedulerNode, NopKernelSchedulerNode))

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3148,8 +3148,42 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         # The epilogue may require additional index expressions.
         # If the user has provided the dimensions of the "output tile", we may be able to fuse.
         if self.output_tile:
-            # TODO(jjvraw): is_compatible
-            pass
+            from .codegen.simd import SIMDScheduling
+
+            node_schedule = node2.get_nodes()
+            _, (numel_ep, rnumel_ep) = node2.group
+            # TODO(jjvraw): Do we need to be explicit here about reductions? Or is it implied via 
+            # FusedSchedulerNode.
+            if isinstance(node2, FusedSchedulerNode) and any(
+                isinstance(sn, SchedulerNode)
+                and isinstance(sn.node, ComputedBuffer)
+                and isinstance(sn.node.data, ir.Reduction)
+                for sn in node2.snodes
+            ):
+                # Reduction intermediates require a 1D tile large enough for a persistent
+                # reduction (single pass over the full reduction width).
+                if len(self.output_tile) != 1:
+                    why("reduction epilogue fusion only supports a 1D output_tile")
+                    return False
+                tile_val = self.node.kwargs.get(self.output_tile[0])
+                if tile_val is not None and not V.graph.sizevars.statically_known_geq(
+                    tile_val, rnumel_ep
+                ):
+                    why("user kernel does not support 1d persistent reduction")
+                    return False
+            k = len(self.output_tile)
+            tiling = (
+                SIMDScheduling.create_tiling([numel_ep], [rnumel_ep])
+                if k == 1
+                else SIMDScheduling.create_tiling(
+                    list(self.node.mutable_args[0].shape[-k:]), [rnumel_ep]
+                )
+            )
+            if not SIMDScheduling.tiling_is_compatible(
+                node_schedule, numel_ep, rnumel_ep, tiling
+            ):
+                why("epilogue iteration space is incompatible with output_tile dimensions")
+                return False
         else:
             if self.epilogue_requires_new_store(writing_node):
                 why(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3179,7 +3179,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         assert isinstance(self.fused_epilogue.node, ir.ComputedBuffer)
         from torch._inductor.codegen.simd import SIMDScheduling
         from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
-        from torch._inductor.codegen.triton import FusedUserDefinedTritonKernel
+        from torch._inductor.codegen.triton import FusedUserTritonKernel
 
         ir_node = self.kernel_node.node
         numel = math.prod(ir_node.mutable_args[0].shape)
@@ -3188,7 +3188,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
         kernel_features = SIMDKernelFeatures([self.fused_epilogue], numel)
 
-        fused_user_kernel = FusedUserDefinedTritonKernel(tiling, kernel_features, self)
+        fused_user_kernel = FusedUserTritonKernel(tiling, kernel_features, self)
         new_kernel_src = fused_user_kernel.codegen()
 
         return self.kernel_node.node.codegen_with_epilogue_fusion(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2141,13 +2141,6 @@ class ExternKernelSchedulerNode(BaseSchedulerNode):
         self._init_from_node(node)
         self.set_read_writes(node.get_read_writes())
 
-        if isinstance(node, ir.UserDefinedTritonKernel):
-            numel = math.prod(node.mutable_args[0].shape)
-            rnumel = 1
-            device = node.get_device_or_error()
-            # pyrefly: ignore [bad-assignment]
-            self.group = (device, (numel, rnumel))
-
     def debug_str_extra(self) -> str:
         return f"{self.get_name()}.node.kernel = {getattr(self.node, 'python_kernel_name', None)}"
 
@@ -3044,14 +3037,24 @@ class FusedNestedReductions(FusedSchedulerNode):
         return FusedNestedReductions(self.node1, new_node2)
 
 
-class FusedExternTritonKernelSchedulerNode(FusedSchedulerNode):
+class UserTritonSchedulerNode(ExternKernelSchedulerNode):
+    def __init__(self, scheduler: Scheduler, node: ir.UserDefinedTritonKernel) -> None:
+        super().__init__(scheduler, node)
+        # TODO(JJVRAW)
+        numel = math.prod(node.mutable_args[0].shape)
+        rnumel = 1
+        device = node.get_device_or_error()
+        # pyrefly: ignore [bad-assignment]
+        self.group = (device, (numel, rnumel))
+
+
+class FusedUserTritonSchedulerNode(FusedSchedulerNode):
     def __init__(
         self,
         scheduler: Scheduler,
-        kernel_node: ExternKernelSchedulerNode,
+        kernel_node: UserTritonSchedulerNode,
         fused_epilogue: SchedulerNode,
     ) -> None:
-        assert isinstance(kernel_node.node, ir.UserDefinedTritonKernel)
         snodes = typing.cast(list[BaseSchedulerNode], [kernel_node, fused_epilogue])
         super().__init__(scheduler, snodes)
         self.kernel_node = kernel_node
@@ -3062,10 +3065,9 @@ class FusedExternTritonKernelSchedulerNode(FusedSchedulerNode):
     @classmethod
     def epilogue_fuse(
         cls,
-        node1: ExternKernelSchedulerNode,
+        node1: UserTritonSchedulerNode,
         node2: SchedulerNode,
     ) -> FusedSchedulerNode:
-        assert isinstance(node1.node, ir.UserDefinedTritonKernel)
         scheduler = node1.scheduler
 
         assert len(node1.node.mutation_outputs) == 1
@@ -3080,7 +3082,6 @@ class FusedExternTritonKernelSchedulerNode(FusedSchedulerNode):
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         assert isinstance(self.fused_epilogue.node, ir.ComputedBuffer)
-        assert isinstance(self.kernel_node.node, ir.UserDefinedTritonKernel)
         numel = math.prod(self.kernel_node.node.mutable_args[0].shape)
         from torch._inductor.codegen.simd import SIMDScheduling
 
@@ -4127,10 +4128,7 @@ class Scheduler:
         if config._post_fusion_custom_pass is not None:
             self.nodes = config._post_fusion_custom_pass(self.nodes)
 
-        if any(
-            isinstance(node, FusedExternTritonKernelSchedulerNode)
-            for node in self.nodes
-        ):
+        if any(isinstance(node, FusedUserTritonSchedulerNode) for node in self.nodes):
             # if a user triton kernel has been epilogue-fused,
             # there is likely an opportunity to prune an NopKernel
             # (which is originally used to generate the buffer which the triton kernel writes to)
@@ -4371,6 +4369,8 @@ class Scheduler:
             return NopKernelSchedulerNode(self, node)
         elif isinstance(node, (ir.ComputedBuffer, ir.TemplateBuffer)):
             return SchedulerNode(self, node)
+        elif isinstance(node, ir.UserDefinedTritonKernel):
+            return UserTritonSchedulerNode(self, node)
         elif isinstance(node, ir.ExternKernel):
             return ExternKernelSchedulerNode(self, node)
         else:
@@ -7078,9 +7078,9 @@ class Scheduler:
             return not node.is_template() and not is_output_of_multi_outputs_template(
                 node.node
             )
+        if isinstance(node, UserTritonSchedulerNode):
+            return not config.epilogue_fusion_user_defined_triton_kernel
         if isinstance(node, ExternKernelSchedulerNode):
-            if isinstance(node.node, ir.UserDefinedTritonKernel):
-                return not config.epilogue_fusion_user_defined_triton_kernel
             return not node.is_template() and not is_output_of_multi_outputs_template(
                 node.node
             )
@@ -7402,11 +7402,7 @@ class Scheduler:
             why("node1 is nop")
             return False
 
-        if isinstance(node1, ExternKernelSchedulerNode):
-            if not isinstance(node1.node, ir.UserDefinedTritonKernel):
-                why("node1 is extern but not a triton kernel")
-                return False
-
+        if isinstance(node1, UserTritonSchedulerNode):
             if not node1.node.arg_accesses.only_tt_stores:
                 why("node1's triton kernel has non-store writes")
                 return False
@@ -8141,14 +8137,14 @@ class Scheduler:
             score = MixOrderReduction.get_fusion_score(node1, node2)
             return _construct_return_value(score, 0, True)
 
-        # For UserDefinedTritonKernel, the write deps are UserTritonDep that won't
+        # For UserTritonSchedulerNode, the write deps are UserTritonDep that won't
         # match the epilogue's MemoryDep via set intersection.  For templates,
         # view/reshape between the template output and epilogue can produce
         # different index expressions that don't match via set intersection.
         # Fall back to name-based matching so that the fusion score reflects
         # the actual shared buffers.
         if (
-            isinstance(node1.node, ir.UserDefinedTritonKernel)
+            isinstance(node1, UserTritonSchedulerNode)
             or node1.is_template()
             or node2.is_template()
         ):
@@ -8468,7 +8464,7 @@ class Scheduler:
     ) -> None:
         assert isinstance(
             scheduler_node,
-            (ExternKernelSchedulerNode, FusedExternTritonKernelSchedulerNode),
+            (ExternKernelSchedulerNode, FusedUserTritonSchedulerNode),
         )
         # 'decide_inplace_update' stores the inplace update decisions in
         # the current kernel from where 'allocate' retrieve those decisions.
@@ -9794,11 +9790,10 @@ class BaseScheduling:  # noqa: docstring_linter
             return node1.fuse_with(node2)
         elif isinstance(node1, FusedMixOrderReductions):
             return node1.fuse_with(node2)
-        elif isinstance(node1, ExternKernelSchedulerNode) and isinstance(
+        elif isinstance(node1, UserTritonSchedulerNode) and isinstance(
             node2, SchedulerNode
         ):
-            assert isinstance(node1.node, ir.UserDefinedTritonKernel)
-            return FusedExternTritonKernelSchedulerNode.epilogue_fuse(node1, node2)
+            return FusedUserTritonSchedulerNode.epilogue_fuse(node1, node2)
         else:
             return FusedSchedulerNode.fuse(node1, node2)
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3181,7 +3181,11 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
                 )
             )
             if not SIMDScheduling.tiling_is_compatible(
-                node_schedule, numel_ep, rnumel_ep, tiling
+                # pyrefly: ignore [bad-argument-type]
+                node_schedule,
+                numel_ep,
+                rnumel_ep,
+                tiling,
             ):
                 why(
                     "epilogue iteration space is incompatible with output_tile dimensions"
@@ -3196,6 +3200,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
 
         layout1 = self.node.mutable_args[0].layout
         layout2 = writing_node.node.layout
+        assert isinstance(layout1, ir.Layout) and isinstance(layout2, ir.Layout)
         if (
             layout1.size != layout2.size
             or layout1.stride != layout2.stride
@@ -3206,6 +3211,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
 
         written_buffer_name = self.node.mutation_outputs[0].name
         # Other nodes read the real (pre-mutation) buffer, not the mutation output.
+        assert written_buffer_name is not None
         real_written_buffer_name = self.scheduler.mutation_real_name.get(
             written_buffer_name, written_buffer_name
         )
@@ -3246,7 +3252,9 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
 
         # Reductions always require additional indexing (reduction dimension);
         # the symbol-usage check below is only valid for Pointwise nodes.
-        if not isinstance(node2.node.data, ir.Pointwise):
+        if not isinstance(node2.node, ComputedBuffer) or not isinstance(
+            node2.node.data, ir.Pointwise
+        ):
             return True
 
         # The epilogue depends on expressions not originally available in the user
@@ -3262,6 +3270,8 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
 
 
 class FusedUserTritonSchedulerNode(FusedSchedulerNode):
+    """A fused scheduler node combining a UserTritonSchedulerNode with an epilogue."""
+
     kernel_node: UserTritonSchedulerNode
 
     def __init__(
@@ -3277,6 +3287,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         self.kernel_node = kernel_node
         self.epilogue = epilogue
         self.min_order = self.kernel_node.min_order
+        # pyrefly: ignore[bad-assignment]
         self.outputs = self.writing_node.get_outputs()
 
     @property
@@ -3291,7 +3302,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
             )
         ]
         assert len(writers) == 1
-        return writers[0]
+        return typing.cast(SchedulerNode, writers[0])
 
     @classmethod
     def epilogue_fuse(
@@ -3318,7 +3329,12 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         return cls(scheduler, node1, node2)
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
+        """
+        Generate code for the fused user-defined Triton kernel.
+        """
+
         assert isinstance(self.kernel_node.node, ir.UserDefinedTritonKernel)
+        assert isinstance(self.writing_node.node, ir.ComputedBuffer)
         from torch._inductor.codegen.simd import SIMDScheduling
         from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
         from torch._inductor.codegen.triton import FusedUserTritonKernel
@@ -3331,7 +3347,10 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
             rnumel, sympy.S.One
         )
         kernel_features = SIMDKernelFeatures(
-            epilogue_nodes, numel_ep, reduction_numel=rnumel
+            # pyrefly: ignore [bad-argument-type]
+            epilogue_nodes,
+            numel_ep,
+            reduction_numel=rnumel,
         )
 
         excluded_names = (
@@ -3347,8 +3366,6 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         additional_args = [
             (f"_fused_in_ptr{i}", name) for i, name in enumerate(external_reads)
         ]
-
-        writing_node = self.writing_node
 
         epilogue_needs_indexing = any(
             self.kernel_node.epilogue_requires_indexing(sn) for sn in epilogue_nodes
@@ -3396,8 +3413,9 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
             pid_cache=pid_cache,
         )
         new_kernel_src = fused_user_kernel.codegen()
+
         return self.kernel_node.node.codegen_with_epilogue_fusion(
-            wrapper, (writing_node.node, new_kernel_src, additional_args)
+            wrapper, (self.writing_node.node, new_kernel_src, additional_args)
         )
 
     def is_extern(self) -> bool:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3120,13 +3120,15 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             why("epilogue of user's Triton kernel is not Pointwise")
             return False
 
-        # TODO(jjvraw): Remove this when we can handle, note this is testing in epilogue_requires_new_store
         written_buffer_name = self.node.mutation_outputs[0].name
-        if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
+        if self.epilogue_requires_new_store(node2) and not self.output_tile:
+            why(
+                "epilogue reads additional buffers but kernel has no output_tile annotation"
+            )
             return False
 
-        # The epilogue require additional index expressions, if the user has provided the
-        # dimensions of the "output tile", we may be able to attempt fusion.
+        # The epilogue may require additional index expressions.
+        # If the user has provided the dimensions of the "output tile", we may be able to fuse.
         if self.output_tile:
             # TODO(jjvraw): is_compatible
             pass
@@ -3164,7 +3166,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         # Any other tensor/s would require additional load expressions.
         written_buffer_name = self.node.mutation_outputs[0].name
         if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
-            return True  # TODO(jjvraw): This should be True when finished testing.
+            return True
 
         # The epilogue may depend on expressions which may not available in the user triton kernel
         # (e.g. indexing exprs used not in a load)
@@ -3226,10 +3228,18 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         # Epilogue fusion is gated on pointwise operations, thus 1D tiling, with no reduction.
         tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
 
-        # TODO: What do we actually need from features here?
+        # TODO(jjvraw): What do we actually need from features here?
         kernel_features = SIMDKernelFeatures([self.epilogue], numel)
 
         formal_out_arg_name = next(iter(self.kernel_node.formal_writes)).name
+
+        written_buffer_name = ir_node.mutation_outputs[0].name
+        extra_reads = [
+            d
+            for d in self.fused_epilogue.read_writes.reads
+            if d.name != written_buffer_name
+        ]
+        additional_args = [(f"_fused_in_ptr{i}", dep.name) for i, dep in enumerate(extra_reads)]
 
         block_aliases = None
         pid_cache = {}
@@ -3254,13 +3264,13 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
             self,
             formal_out_arg_name,
             self.introduce_new_store and ir_node.output_tile is not None,
+            additional_args,
             block_aliases=block_aliases,
             pid_cache=pid_cache,
         )
         new_kernel_src = fused_user_kernel.codegen()
-
         return self.kernel_node.node.codegen_with_epilogue_fusion(
-            wrapper, (self.epilogue.node, new_kernel_src)
+            wrapper, (self.epilogue.node, new_kernel_src, additional_args)
         )
 
     def is_extern(self) -> bool:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3120,31 +3120,23 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             why("epilogue of user's Triton kernel is not Pointwise")
             return False
 
+        # TODO(jjvraw): Remove this when we can handle, note this is testing in epilogue_requires_new_store
         written_buffer_name = self.node.mutation_outputs[0].name
-
-        # TODO(jjvraw): Gate this with whether we have block info & pid mapping.
-        # The epilogue can only read from the output buffer.
-        # Any other tensor/s would require additional load expressions.
         if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
-            why(
-                "epilogue of user's Triton kernel reads from buffers other than the mutated output"
-            )
             return False
 
-        # The epilogue may depend on expressions which may not available in the user triton kernel
-        # (e.g. indexing exprs used not in a load)
-        # If the user has provided the dimensions of the output_tile, we may be able to attempt fusion.
+
+        # The epilogue require additional index expressions, if the user has provided the
+        # dimensions of the "output tile", we may be able to attempt fusion.
         if self.output_tile:
-            # TODO: is_compatible
+            # TODO(jjvraw): is_compatible
             pass
         else:
-            node2_inner_fn_free_symbols = node2.node.data.inner_fn_free_symbols()
-            for symbol in node2_inner_fn_free_symbols:
-                usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
-                if any(usage != "load" for usage in usages):
-                    why("node2 requires expressions not available in node1")
-                    return False
-
+            if self.epilogue_requires_new_store(node2):
+                why(
+                    "epilogue requires expressions not available in user's Triton kernel"
+                )
+                return False
 
         if self.node.mutable_args[0].layout != node2.node.layout:
             why("user's Triton kernel and epilogue have different buffer layouts")
@@ -3168,6 +3160,23 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
 
         return self.scheduler.can_fuse_vertical(self, node2)
 
+    def epilogue_requires_new_store(self, node2: SchedulerNode) -> bool:
+        # The epilogue can only read from the output buffer.
+        # Any other tensor/s would require additional load expressions.
+        written_buffer_name = self.node.mutation_outputs[0].name
+        if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
+            return True # TODO(jjvraw): This should be True when finished testing.
+
+        # The epilogue may depend on expressions which may not available in the user triton kernel
+        # (e.g. indexing exprs used not in a load)
+        node2_inner_fn_free_symbols = node2.node.data.inner_fn_free_symbols()
+        for symbol in node2_inner_fn_free_symbols:
+            usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
+            if any(usage != "load" for usage in usages):
+                return True 
+
+        return False 
+
 
 class FusedUserTritonSchedulerNode(FusedSchedulerNode):
     kernel_node: UserTritonSchedulerNode
@@ -3184,6 +3193,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         self.epilogue = epilogue
         self.min_order = self.kernel_node.min_order
         self.outputs = epilogue.outputs
+        self.introduce_new_store = self.kernel_node.epilogue_requires_new_store(self.fused_epilogue)
 
     @classmethod
     def epilogue_fuse(
@@ -3225,7 +3235,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         if ir_node.output_tile:
 
             def _construct_block_aliases(mapping: dict[str, str]):
-                expected_keys = {"x", "y", "z"}
+                expected_keys = OrderedSet(["x", "y", "z"])
                 block_aliases = {}
                 for prefix, alias in mapping.items():
                     if prefix not in expected_keys:
@@ -3242,6 +3252,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
             kernel_features,
             self,
             formal_out_arg_name,
+            self.introduce_new_store and ir_node.output_tile is not None,
             block_aliases=block_aliases,
             pid_cache=pid_cache,
         )

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3120,13 +3120,6 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             why("epilogue of user's Triton kernel is not Pointwise")
             return False
 
-        written_buffer_name = self.node.mutation_outputs[0].name
-        if self.epilogue_requires_new_store(node2) and not self.output_tile:
-            why(
-                "epilogue reads additional buffers but kernel has no output_tile annotation"
-            )
-            return False
-
         # The epilogue may require additional index expressions.
         # If the user has provided the dimensions of the "output tile", we may be able to fuse.
         if self.output_tile:
@@ -3143,6 +3136,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             why("user's Triton kernel and epilogue have different buffer layouts")
             return False
 
+        written_buffer_name = self.node.mutation_outputs[0].name
         def _is_other_node_that_references_mutation_buffer(
             other_node: BaseSchedulerNode,
         ):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3038,6 +3038,13 @@ class FusedNestedReductions(FusedSchedulerNode):
 
 
 class UserTritonSchedulerNode(ExternKernelSchedulerNode):
+    """
+    A scheduler node for user-defined Triton kernels.
+    """
+
+    # pyrefly: ignore [bad-override]
+    node: ir.UserDefinedTritonKernel
+
     def __init__(self, scheduler: Scheduler, node: ir.UserDefinedTritonKernel) -> None:
         super().__init__(scheduler, node)
         assert isinstance(self.node, ir.UserDefinedTritonKernel)
@@ -3053,6 +3060,13 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         self.group = (device, (numel, rnumel))
 
     def can_fuse_with(self, node2: BaseSchedulerNode) -> bool:
+        """
+        Allow unary a unary pointwise epilogue pointwise to be fused into this kernel.
+
+        Fusion of user-defined kernels is initially gated on `config.epilogue_fusion_user_defined_triton_kernel`
+        (see `Scheduler.unfusable_nodes`).
+        """
+
         why = WhyNoFuse(self, node2)
         if not self.only_tt_stores:
             why("user Triton fusion only supports `tl.store`")
@@ -3062,8 +3076,9 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             why("user's Triton kernel has multiple stores")
             return False
 
-        formal_writes = list(self.formal_writes)
-        if formal_writes[0].access_count != 1:
+        formal_write = next(iter(self.formal_writes))
+        assert isinstance(formal_write, dependencies.UserTritonDep)
+        if formal_write.access_count != 1:
             why("user's Triton kernel writes to output more than once")
             return False
 
@@ -3089,7 +3104,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             why("user's Triton kernel output is not an empty tensor")
             return False
 
-        formal_arg_name = formal_writes[0].name
+        formal_arg_name = formal_write.name
         if any(dep.name == formal_arg_name for dep in self.formal_reads):
             why("user's Triton kernel reads from its output buffer")
             return False
@@ -3144,6 +3159,8 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
 
 
 class FusedUserTritonSchedulerNode(FusedSchedulerNode):
+    kernel_node: UserTritonSchedulerNode
+
     def __init__(
         self,
         scheduler: Scheduler,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3069,6 +3069,35 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         """
 
         why = WhyNoFuse(self, node2)
+
+        # We allow FusedSchedulerNode, only if the last constituent node will
+        # have a materialised store. The remaining conditions must then hold for
+        # said `writing_node`.
+        writing_node: BaseSchedulerNode
+        if isinstance(node2, FusedSchedulerNode):
+            fused_names = OrderedSet(sn.get_name() for sn in node2.snodes)
+            epilogue_snodes = [
+                sn
+                for sn in node2.snodes
+                if any(
+                    not self.scheduler.can_buffer_be_removed_through_fusion(
+                        w.name, fused_names
+                    )
+                    for w in sn.read_writes.writes
+                    if w.name in self.scheduler.name_to_buf
+                )
+            ]
+            if len(epilogue_snodes) != 1:
+                why("fused epilogue introduces more than one materialized store")
+                return False
+            writing_node = epilogue_snodes[0]
+        else:
+            writing_node = node2
+
+        if not isinstance(writing_node, SchedulerNode):
+            why("epilogue of user's Triton kernel is not a SchedulerNode")
+            return False
+
         if not self.only_tt_stores:
             why("user Triton fusion only supports `tl.store`")
             return False
@@ -3110,12 +3139,8 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             why("user's Triton kernel reads from its output buffer")
             return False
 
-        if not isinstance(node2, SchedulerNode):
-            why("epilogue of user's Triton kernel is not a SchedulerNode")
-            return False
-
-        if not isinstance(node2.node, ComputedBuffer) or not isinstance(
-            node2.node.data, ir.Pointwise
+        if not isinstance(writing_node.node, ComputedBuffer) or not isinstance(
+            writing_node.node.data, ir.Pointwise
         ):
             why("epilogue of user's Triton kernel is not Pointwise")
             return False
@@ -3126,14 +3151,14 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             # TODO(jjvraw): is_compatible
             pass
         else:
-            if self.epilogue_requires_new_store(node2):
+            if self.epilogue_requires_new_store(writing_node):
                 why(
                     "epilogue requires expressions not available in user's Triton kernel"
                 )
                 return False
 
         layout1 = self.node.mutable_args[0].layout
-        layout2 = node2.node.layout
+        layout2 = writing_node.node.layout
         if (
             layout1.size != layout2.size
             or layout1.stride != layout2.stride
@@ -3143,15 +3168,26 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             return False
 
         written_buffer_name = self.node.mutation_outputs[0].name
+        # Other nodes read the real (pre-mutation) buffer, not the mutation output.
+        real_written_buffer_name = self.scheduler.mutation_real_name.get(
+            written_buffer_name, written_buffer_name
+        )
+        mutation_buffer_names = {written_buffer_name, real_written_buffer_name}
+
+        # Exclude nodes that are part of this fusion attempt.
+        # For a FusedSchedulerNode epilogue, also exclude its constituent snodes since
+        # they appear individually in scheduler.nodes but will be consumed by the fusion.
+        fusion_node_set: set[BaseSchedulerNode] = {self, node2}
+        if isinstance(node2, FusedSchedulerNode):
+            fusion_node_set.update(node2.snodes)
 
         def _is_other_node_that_references_mutation_buffer(
             other_node: BaseSchedulerNode,
-        ):
-            return (
-                (other_node is not self)
-                and (other_node is not node2)
-                and written_buffer_name in other_node.used_buffer_names()
-            )
+        ) -> bool:
+            if other_node in fusion_node_set:
+                return False
+            reads = {d.name for d in other_node.read_writes.reads}
+            return bool(reads & mutation_buffer_names)
 
         if any(
             _is_other_node_that_references_mutation_buffer(node)
@@ -3169,8 +3205,14 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
             return True
 
-        # The epilogue may depend on expressions which may not available in the user triton kernel
-        # (e.g. indexing exprs used not in a load)
+        # Reductions always require additional indexing (reduction dimension);
+        # the symbol-usage check below is only valid for Pointwise nodes.
+        if not isinstance(node2.node.data, ir.Pointwise):
+            return True
+
+        # The epilogue depends on expressions not originally available in the user
+        # triton kernel.
+        # (e.g. indexing exprs used not in a load).
         node2_inner_fn_free_symbols = node2.node.data.inner_fn_free_symbols()
         for symbol in node2_inner_fn_free_symbols:
             usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
@@ -3187,20 +3229,36 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         self,
         scheduler: Scheduler,
         kernel_node: UserTritonSchedulerNode,
-        epilogue: SchedulerNode,
+        epilogue: SchedulerNode | FusedSchedulerNode,
     ) -> None:
-        snodes = typing.cast(list[BaseSchedulerNode], [kernel_node, epilogue])
+        snodes = typing.cast(
+            list[BaseSchedulerNode], [kernel_node, *epilogue.get_nodes()]
+        )
         super().__init__(scheduler, snodes)
         self.kernel_node = kernel_node
         self.epilogue = epilogue
         self.min_order = self.kernel_node.min_order
-        self.outputs = epilogue.outputs
+        self.outputs = self.writing_node.get_outputs()
+
+    @property
+    def writing_node(self) -> SchedulerNode:
+        ep_names = OrderedSet(sn.get_name() for sn in self.epilogue.get_nodes())
+        writers = [
+            sn
+            for sn in self.epilogue.get_nodes()
+            if any(
+                not self.scheduler.can_buffer_be_removed_through_fusion(n, ep_names)
+                for n in sn.get_buffer_names()
+            )
+        ]
+        assert len(writers) == 1
+        return writers[0]
 
     @classmethod
     def epilogue_fuse(
         cls,
         node1: UserTritonSchedulerNode,
-        node2: SchedulerNode,
+        node2: SchedulerNode | FusedSchedulerNode,
     ) -> FusedSchedulerNode:
         scheduler = node1.scheduler
 
@@ -3212,62 +3270,82 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         # for `Scheduler.dead_node_elimination` to remove.
         real_name = scheduler.mutation_real_name.get(mutated_name, mutated_name)
         scheduler.name_to_buf[real_name].users.remove(NodeUser(node1))
+
+        ep_names = OrderedSet(sn.get_name() for sn in node2.get_nodes())
+        for name in node2.get_buffer_names():
+            if scheduler.can_buffer_be_removed_through_fusion(name, ep_names):
+                V.graph.removed_buffers.add(name)
+
         return cls(scheduler, node1, node2)
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
-        assert isinstance(self.epilogue.node, ir.ComputedBuffer)
         assert isinstance(self.kernel_node.node, ir.UserDefinedTritonKernel)
         from torch._inductor.codegen.simd import SIMDScheduling
         from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
         from torch._inductor.codegen.triton import FusedUserTritonKernel
 
         ir_node = self.kernel_node.node
-        numel = math.prod(ir_node.mutable_args[0].shape)
+        epilogue_nodes = typing.cast(list[SchedulerNode], self.epilogue.get_nodes())
 
-        # TODO(jjvraw): What do we actually need from features here?
-        kernel_features = SIMDKernelFeatures([self.epilogue], numel)
-
-        written_buffer_name = ir_node.mutation_outputs[0].name
-        extra_reads = [
-            d
-            for d in self.fused_epilogue.read_writes.reads
-            if d.name != written_buffer_name
-        ]
-        additional_args = [
-            (f"_fused_in_ptr{i}", dep.name) for i, dep in enumerate(extra_reads)
-        ]
-
-        block_aliases = None
-        pid_cache = {}
-        epilogue_needs_indexing = self.kernel_node.epilogue_requires_new_store(
-            self.fused_epilogue
+        _, (numel_ep, rnumel) = self.epilogue.group
+        is_reduction_ep = not V.graph.sizevars.statically_known_equals(
+            rnumel, sympy.S.One
         )
-        if ir_node.output_tile:
-            k = len(ir_node.output_tile)
-            _all_axes = ["XBLOCK", "YBLOCK", "ZBLOCK"]
-            block_aliases = dict(zip(_all_axes[:k], ir_node.output_tile))
+        kernel_features = SIMDKernelFeatures(
+            epilogue_nodes, numel_ep, reduction_numel=rnumel
+        )
 
+        excluded_names = {
+            ir_node.mutation_outputs[0].name
+        } | self.epilogue.get_buffer_names()
+        external_reads = OrderedSet(
+            d.name
+            for sn in epilogue_nodes
+            for d in sn.read_writes.reads
+            if d.name not in excluded_names
+        )
+        additional_args = [
+            (f"_fused_in_ptr{i}", name) for i, name in enumerate(external_reads)
+        ]
+
+        writing_node = self.writing_node
+
+        epilogue_needs_indexing = any(
+            self.kernel_node.epilogue_requires_new_store(sn) for sn in epilogue_nodes
+        )
+        if is_reduction_ep:
+            # Only 1D-grid reductions are supported: XBLOCK=1, no tile alias needed.
+            block_aliases: dict[str, str] | None = {}
+            tiling = SIMDScheduling.create_tiling([numel_ep], [rnumel])
+        elif ir_node.output_tile:
+            k = len(ir_node.output_tile)
+            block_aliases = dict(
+                zip(["XBLOCK", "YBLOCK", "ZBLOCK"][:k], ir_node.output_tile)
+            )
             if k == 1:
-                tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
+                tiling = SIMDScheduling.create_tiling([numel_ep], [sympy.S.One])
             else:
-                output_shape = ir_node.mutable_args[0].shape
                 tiling = SIMDScheduling.create_tiling(
-                    list(output_shape[-k:]), [sympy.S.One]
+                    list(ir_node.mutable_args[0].shape[-k:]), [sympy.S.One]
                 )
         else:
-            tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
+            block_aliases = None
+            tiling = SIMDScheduling.create_tiling([numel_ep], [sympy.S.One])
 
+        pass_aliases = (
+            block_aliases if (epilogue_needs_indexing or is_reduction_ep) else None
+        )
         fused_user_kernel = FusedUserTritonKernel(
             tiling,
             kernel_features,
             self,
             additional_args,
-            block_aliases=block_aliases if epilogue_needs_indexing else None,
-            pid_cache=pid_cache,
+            block_aliases=pass_aliases,
+            pid_cache={},
         )
         new_kernel_src = fused_user_kernel.codegen()
         return self.kernel_node.node.codegen_with_epilogue_fusion(
-            wrapper, (self.epilogue.node, new_kernel_src, additional_args)
+            wrapper, (writing_node.node, new_kernel_src, additional_args)
         )
 
     def is_extern(self) -> bool:
@@ -9877,7 +9955,7 @@ class BaseScheduling:  # noqa: docstring_linter
         elif isinstance(node1, FusedMixOrderReductions):
             return node1.fuse_with(node2)
         elif isinstance(node1, UserTritonSchedulerNode) and isinstance(
-            node2, SchedulerNode
+            node2, (SchedulerNode, FusedSchedulerNode)
         ):
             return FusedUserTritonSchedulerNode.epilogue_fuse(node1, node2)
         else:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3137,6 +3137,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             return False
 
         written_buffer_name = self.node.mutation_outputs[0].name
+
         def _is_other_node_that_references_mutation_buffer(
             other_node: BaseSchedulerNode,
         ):
@@ -3188,9 +3189,6 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         self.epilogue = epilogue
         self.min_order = self.kernel_node.min_order
         self.outputs = epilogue.outputs
-        self.introduce_new_store = self.kernel_node.epilogue_requires_new_store(
-            self.epilogue
-        )
 
     @classmethod
     def epilogue_fuse(
@@ -3219,13 +3217,9 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
 
         ir_node = self.kernel_node.node
         numel = math.prod(ir_node.mutable_args[0].shape)
-        # Epilogue fusion is gated on pointwise operations, thus 1D tiling, with no reduction.
-        tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
 
         # TODO(jjvraw): What do we actually need from features here?
         kernel_features = SIMDKernelFeatures([self.epilogue], numel)
-
-        formal_out_arg_name = next(iter(self.kernel_node.formal_writes)).name
 
         written_buffer_name = ir_node.mutation_outputs[0].name
         extra_reads = [
@@ -3233,22 +3227,31 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
             for d in self.fused_epilogue.read_writes.reads
             if d.name != written_buffer_name
         ]
-        additional_args = [(f"_fused_in_ptr{i}", dep.name) for i, dep in enumerate(extra_reads)]
+        additional_args = [
+            (f"_fused_in_ptr{i}", dep.name) for i, dep in enumerate(extra_reads)
+        ]
 
         block_aliases = None
         pid_cache = {}
         if ir_node.output_tile:
-            # TODO(jjvraw): Assert against grid size.
-            _axes = ["XBLOCK", "YBLOCK", "ZBLOCK"]
-            block_aliases = {_axes[i]: name for i, name in enumerate(ir_node.output_tile)}
-            pid_cache = {}
+            k = len(ir_node.output_tile)
+            _all_axes = ["XBLOCK", "YBLOCK", "ZBLOCK"]
+            block_aliases = dict(zip(_all_axes[:k], ir_node.output_tile))
+
+            if k == 1:
+                tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
+            else:
+                output_shape = ir_node.mutable_args[0].shape
+                tiling = SIMDScheduling.create_tiling(
+                    list(output_shape[-k:]), [sympy.S.One]
+                )
+        else:
+            tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
 
         fused_user_kernel = FusedUserTritonKernel(
             tiling,
             kernel_features,
             self,
-            formal_out_arg_name,
-            self.introduce_new_store and ir_node.output_tile is not None,
             additional_args,
             block_aliases=block_aliases,
             pid_cache=pid_cache,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -68,7 +68,7 @@ from .comm_analysis import (
     estimate_nccl_collective_runtime,
     estimate_nccl_collective_runtime_nccl_estimator,
 )
-from .dependencies import Dep, MemoryDep, StarDep, WeakDep
+from .dependencies import Dep, MemoryDep, StarDep, UserTritonDep, WeakDep
 from .exc import GPUTooOldForTriton, TritonMissing
 from .fx_utils import count_flops_fx
 from .ir import (
@@ -2141,7 +2141,7 @@ class ExternKernelSchedulerNode(BaseSchedulerNode):
         self._init_from_node(node)
         self.set_read_writes(node.get_read_writes())
 
-        if isinstance(node, ir.UserDefinedTritonKernel) and node.can_fuse_epilogue():
+        if isinstance(node, ir.UserDefinedTritonKernel):
             numel = math.prod(node.mutable_args[0].shape)
             rnumel = 1
             device = node.get_device_or_error()
@@ -2159,13 +2159,11 @@ class ExternKernelSchedulerNode(BaseSchedulerNode):
         return hasattr(self.node, "has_side_effects") and self.node.has_side_effects()
 
     def get_ranges(self) -> Sequence[Sequence[sympy.Expr]]:
-        if (
-            isinstance(self.node, ir.UserDefinedTritonKernel)
-            and self.node.can_fuse_epilogue()
-        ):
-            numel = math.prod(self.node.mutable_args[0].shape)
-            return ([numel], [])
-        return ([], [])
+        if not isinstance(self.node, ir.UserDefinedTritonKernel):
+            return ([], [])
+        assert len(self.node.mutable_args) == 1
+        numel = math.prod(self.node.mutable_args[0].shape)
+        return ([numel], [])
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         assert isinstance(self.node, ir.ExternKernel)
@@ -3090,7 +3088,6 @@ class FusedExternTritonKernelSchedulerNode(FusedSchedulerNode):
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         assert isinstance(self.fused_epilogue.node, ir.ComputedBuffer)
         assert isinstance(self.kernel_node.node, ir.UserDefinedTritonKernel)
-        assert self.kernel_node.node.can_fuse_epilogue()
         numel = math.prod(self.kernel_node.node.mutable_args[0].shape)
         from torch._inductor.codegen.simd import SIMDScheduling
 
@@ -7093,7 +7090,7 @@ class Scheduler:
             )
         if isinstance(node, ExternKernelSchedulerNode):
             if isinstance(node.node, ir.UserDefinedTritonKernel):
-                return not node.node.can_fuse_epilogue()
+                return not config.epilogue_fusion_user_defined_triton_kernel
             return not node.is_template() and not is_output_of_multi_outputs_template(
                 node.node
             )
@@ -7420,8 +7417,53 @@ class Scheduler:
                 why("node1 is extern but not a triton kernel")
                 return False
 
-            if not node1.node.can_fuse_epilogue():
-                why("node1's triton kernel doesn't support epilogue fusion")
+            if not config.epilogue_fusion_user_defined_triton_kernel:
+                why("epilogue fusion for user defined triton kernel is disabled")
+                return False
+
+            if not node1.node.arg_accesses.only_tt_stores:
+                why("node1's triton kernel has non-store writes")
+                return False
+
+            write_deps = list(node1.node.arg_accesses.read_writes.writes)
+            if len(write_deps) != 1:
+                why("node1's triton kernel has multiple outputs")
+                return False
+
+            assert isinstance(write_deps[0], UserTritonDep)
+            if write_deps[0].access_count != 1:
+                why("node1's triton kernel writes to output more than once")
+                return False
+
+            # Only fuse if the mutated arg is originally an "empty" tensor.
+            # This is because we don't know exactly which element of that tensor is being written to.
+            # If the kernel only writes to a subset of the tensor, then we only apply the epilogue to
+            # that subset. In these edge cases, our fusion is only correct if the original tensor is empty,
+            # where the semantics is that content values are UB, and we can rely on the fact that
+            # `epilogue(UB) == UB`.
+            def _is_empty_tensor(arg) -> bool:
+                if not isinstance(arg, ir.TensorBox):
+                    return False
+                if not isinstance(arg.data, ir.StorageBox):
+                    return False
+                if not isinstance(arg.data.data, ir.ComputedBuffer):
+                    return False
+                if not isinstance(arg.data.data.data, ir.Pointwise):
+                    return False
+                if not all(r == 0 for r in arg.data.data.data.ranges):
+                    return False
+                return True
+
+            mutable_arg = node1.node.mutable_args[0]
+            if not _is_empty_tensor(mutable_arg):
+                why("node1's triton kernel output is not an empty tensor")
+                return False
+
+            if any(
+                dep.name == write_deps[0].name
+                for dep in node1.node.arg_accesses.read_writes.reads
+            ):
+                why("node1's triton kernel reads from its output buffer")
                 return False
 
             if not isinstance(node2, SchedulerNode):
@@ -7434,7 +7476,6 @@ class Scheduler:
                 why("node1 is extern but node2.node.data is not Pointwise")
                 return False
 
-            assert len(node1.node.mutation_outputs) == 1
             written_buffer_name = node1.node.mutation_outputs[0].name
 
             # The epilogue can only read from the output buffer.
@@ -7451,8 +7492,6 @@ class Scheduler:
                 if any(usage != "load" for usage in usages):
                     return False
 
-            # should be true now because we checked `can_fuse_epilogue`
-            assert len(node1.node.mutable_args) == 1
             if node1.node.mutable_args[0].layout != node2.node.layout:
                 why("node1 and node2 uses different buf layouts")
                 return False
@@ -7710,10 +7749,10 @@ class Scheduler:
                         ),
                     ):
                         remaining.remove(rd)  # noqa: B909
-                    elif isinstance(cd, StarDep) and (
-                        self.fusable_stardep_write_and_read_on_empty_tensor(
-                            rd, cd, node1.node
-                        )
+                    elif isinstance(
+                        cd, UserTritonDep
+                    ) and self.fusable_usertriton_write_and_read_on_empty_tensor(
+                        rd, cd
                     ):
                         remaining.remove(rd)  # noqa: B909
 
@@ -7967,21 +8006,15 @@ class Scheduler:
         write_index = sympy_subs(write.index, dict(zip(write.var_names, write_vars)))
         return sizevars.statically_known_equals(read_index, write_index)
 
-    # on tensors that are "empty" (i.e. with undefined values),
-    # we relax the conditions for fusion and additionally allow matching a writing StarDep with any read dep.
-    # This makes use of the fact that `f(UB) = UB`.
-    def fusable_stardep_write_and_read_on_empty_tensor(
-        self, read: Dep, write: StarDep, writing_node: ir.Operation | None
+    # On tensors that are "empty" (i.e. with undefined values),
+    # we relax the conditions for fusion and additionally allow matching a writing
+    # UserTritonDep with any read dep. This makes use of the fact that `f(UB) = UB`.
+    def fusable_usertriton_write_and_read_on_empty_tensor(
+        self, read: Dep, write: UserTritonDep
     ) -> bool:
-        if not isinstance(writing_node, ir.UserDefinedTritonKernel):
-            return False
-        if not writing_node.can_fuse_epilogue():
-            return False
         read_name = self.mutation_renames.get(read.name, read.name)
         write_name = self.mutation_renames.get(write.name, write.name)
-        if isinstance(write, StarDep) and read_name == write_name:
-            return True
-        return False
+        return read_name == write_name
 
     @staticmethod
     def deps_match_normalized(dep1: Dep, dep2: Dep) -> bool:
@@ -8127,17 +8160,14 @@ class Scheduler:
             score = MixOrderReduction.get_fusion_score(node1, node2)
             return _construct_return_value(score, 0, True)
 
-        # For UserDefinedTritonKernel, the write deps are StarDep that won't
+        # For UserDefinedTritonKernel, the write deps are UserTritonDep that won't
         # match the epilogue's MemoryDep via set intersection.  For templates,
         # view/reshape between the template output and epilogue can produce
         # different index expressions that don't match via set intersection.
         # Fall back to name-based matching so that the fusion score reflects
         # the actual shared buffers.
         if (
-            (
-                isinstance(node1.node, ir.UserDefinedTritonKernel)
-                and node1.node.can_fuse_epilogue()
-            )
+            isinstance(node1.node, ir.UserDefinedTritonKernel)
             or node1.is_template()
             or node2.is_template()
         ):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3088,16 +3088,14 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         assert isinstance(self.fused_epilogue.node, ir.ComputedBuffer)
-        numel = math.prod(self.kernel_node.node.mutable_args[0].shape)
         from torch._inductor.codegen.simd import SIMDScheduling
-
-        tiling, _ = SIMDScheduling.get_tiling_and_scores([self.fused_epilogue], numel)
-
         from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
-
-        kernel_features = SIMDKernelFeatures([self.fused_epilogue], numel)
-
         from torch._inductor.codegen.triton import FusedUserDefinedTritonKernel
+
+        ir_node = self.kernel_node.node
+        numel = math.prod(ir_node.mutable_args[0].shape)
+        tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
+        kernel_features = SIMDKernelFeatures([self.fused_epilogue], numel)
 
         fused_user_kernel = FusedUserDefinedTritonKernel(tiling, kernel_features, self)
         new_kernel_src = fused_user_kernel.codegen()

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3132,7 +3132,13 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
                 )
                 return False
 
-        if self.node.mutable_args[0].layout != node2.node.layout:
+        layout1 = self.node.mutable_args[0].layout
+        layout2 = node2.node.layout
+        if (
+            layout1.size != layout2.size
+            or layout1.stride != layout2.stride
+            or layout1.device != layout2.device
+        ):
             why("user's Triton kernel and epilogue have different buffer layouts")
             return False
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3063,7 +3063,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
 
     def can_fuse_with(self, node2: BaseSchedulerNode) -> bool:
         """
-        Allow unary a unary pointwise epilogue pointwise to be fused into this kernel.
+        Allow a unary pointwise epilogue pointwise to be fused into this kernel.
 
         Fusion of user-defined kernels is initially gated on `config.epilogue_fusion_user_defined_triton_kernel`
         (see `Scheduler.unfusable_nodes`).

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3046,12 +3046,101 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         self.formal_reads = self.node.formal_accesses.read_writes.reads
         self.formal_writes = self.node.formal_accesses.read_writes.writes
 
-        # TODO(JJVRAW)
         numel = math.prod(node.mutable_args[0].shape)
         rnumel = 1
         device = node.get_device_or_error()
         # pyrefly: ignore [bad-assignment]
         self.group = (device, (numel, rnumel))
+
+    def can_fuse_with(self, node2: BaseSchedulerNode) -> bool:
+        why = WhyNoFuse(self, node2)
+        if not self.only_tt_stores:
+            why("user Triton fusion only supports `tl.store`")
+            return False
+
+        if len(self.node.mutable_args) != 1 or len(self.formal_writes) != 1:
+            why("user's Triton kernel has multiple stores")
+            return False
+
+        formal_writes = list(self.formal_writes)
+        if formal_writes[0].access_count != 1:
+            why("user's Triton kernel writes to output more than once")
+            return False
+
+        # Only fuse if the mutated arg is originally an "empty" tensor.
+        # This is because we don't know exactly which element of that tensor is being written to.
+        # If the kernel only writes to a subset of the tensor, then we only apply the epilogue to
+        # that subset. In these edge cases, our fusion is only correct if the original tensor is empty,
+        # where the semantics is that content values are UB, and we can rely on the fact that
+        # `epilogue(UB) == UB`.
+        def _is_empty_tensor(arg) -> bool:
+            if not isinstance(arg, ir.TensorBox):
+                return False
+            if not isinstance(arg.data, ir.StorageBox):
+                return False
+            if not isinstance(arg.data.data, ir.ComputedBuffer):
+                return False
+            if not all(r == 0 for r in arg.data.data.data.ranges):
+                return False
+            return True
+
+        mutable_arg = self.node.mutable_args[0]
+        if not _is_empty_tensor(mutable_arg):
+            why("user's Triton kernel output is not an empty tensor")
+            return False
+
+        formal_arg_name = formal_writes[0].name
+        if any(dep.name == formal_arg_name for dep in self.formal_reads):
+            why("user's Triton kernel reads from its output buffer")
+            return False
+
+        if not isinstance(node2, SchedulerNode):
+            why("epilogue of user's Triton kernel is not a SchedulerNode")
+            return False
+
+        if not isinstance(node2.node, ComputedBuffer) or not isinstance(
+            node2.node.data, ir.Pointwise
+        ):
+            why("epilogue of user's Triton kernel is not Pointwise")
+            return False
+
+        written_buffer_name = self.node.mutation_outputs[0].name
+
+        # The epilogue can only read from the output buffer.
+        # Any other tensor/s would require additional load expressions.
+        if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
+            why(
+                "epilogue of user's Triton kernel reads from buffers other than the mutated output"
+            )
+            return False
+
+        # the epilogue depends on expressions which may not available in the user's Triton kernel
+        # (e.g. indexing exprs used not in a load)
+        node2_inner_fn_free_symbols = node2.node.data.inner_fn_free_symbols()
+        for symbol in node2_inner_fn_free_symbols:
+            usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
+            if any(usage != "load" for usage in usages):
+                why(
+                    "epilogue requires expressions not available in user's Triton kernel"
+                )
+                return False
+
+        def _is_other_node_that_references_mutation_buffer(
+            other_node: BaseSchedulerNode,
+        ):
+            return (
+                (other_node is not self)
+                and (other_node is not node2)
+                and written_buffer_name in other_node.used_buffer_names()
+            )
+
+        if any(
+            _is_other_node_that_references_mutation_buffer(node)
+            for node in self.scheduler.nodes
+        ):
+            return False
+
+        return self.scheduler.can_fuse_vertical(self, node2)
 
 
 class FusedUserTritonSchedulerNode(FusedSchedulerNode):
@@ -3094,6 +3183,8 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
 
         ir_node = self.kernel_node.node
         numel = math.prod(ir_node.mutable_args[0].shape)
+
+        # Epilogue fusion is gated on pointwise operations, thus 1D tiling, with no reduction.
         tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
         kernel_features = SIMDKernelFeatures([self.fused_epilogue], numel)
 
@@ -4133,7 +4224,7 @@ class Scheduler:
             self.nodes = config._post_fusion_custom_pass(self.nodes)
 
         if any(isinstance(node, FusedUserTritonSchedulerNode) for node in self.nodes):
-            # if a user triton kernel has been epilogue-fused,
+            # if a user's Triton kernel has been epilogue-fused,
             # there is likely an opportunity to prune an NopKernel
             # (which is originally used to generate the buffer which the triton kernel writes to)
             self.dead_node_elimination()
@@ -7407,87 +7498,7 @@ class Scheduler:
             return False
 
         if isinstance(node1, UserTritonSchedulerNode):
-            if not node1.only_tt_stores:
-                why("user Triton fusion only supports `tl.store`")
-                return False
-
-            if len(node1.node.mutable_args) != 1 or len(node1.formal_writes) != 1:
-                why("node1's triton kernel has multiple stores")
-                return False
-
-            formal_writes = list(node1.formal_writes)
-            if formal_writes[0].access_count != 1:
-                why("node1's triton kernel writes to output more than once")
-                return False
-
-            # Only fuse if the mutated arg is originally an "empty" tensor.
-            # This is because we don't know exactly which element of that tensor is being written to.
-            # If the kernel only writes to a subset of the tensor, then we only apply the epilogue to
-            # that subset. In these edge cases, our fusion is only correct if the original tensor is empty,
-            # where the semantics is that content values are UB, and we can rely on the fact that
-            # `epilogue(UB) == UB`.
-            def _is_empty_tensor(arg) -> bool:
-                if not isinstance(arg, ir.TensorBox):
-                    return False
-                if not isinstance(arg.data, ir.StorageBox):
-                    return False
-                if not isinstance(arg.data.data, ir.ComputedBuffer):
-                    return False
-                if not all(r == 0 for r in arg.data.data.data.ranges):
-                    return False
-                return True
-
-            mutable_arg = node1.node.mutable_args[0]
-            if not _is_empty_tensor(mutable_arg):
-                why("node1's triton kernel output is not an empty tensor")
-                return False
-
-            formal_arg_name = formal_writes[0].name
-            if any(dep.name == formal_arg_name for dep in node1.formal_reads):
-                why("node1's triton kernel reads from its output buffer")
-                return False
-
-            if not isinstance(node2, SchedulerNode):
-                why("node1 is extern but node2 is not SchedulerNode")
-                return False
-
-            if not isinstance(node2.node, ComputedBuffer) or not isinstance(
-                node2.node.data, ir.Pointwise
-            ):
-                why("node1 is extern but node2.node.data is not Pointwise")
-                return False
-
-            written_buffer_name = node1.node.mutation_outputs[0].name
-
-            # The epilogue can only read from the output buffer.
-            # Any other tensor/s would require additional load expressions.
-            if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
-                why("node2 reads from buffers other than the mutated output")
-                return False
-
-            # the epilogue depends on expressions which may not available in the user triton kernel
-            # (e.g. indexing exprs used not in a load)
-            node2_inner_fn_free_symbols = node2.node.data.inner_fn_free_symbols()
-            for symbol in node2_inner_fn_free_symbols:
-                usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
-                if any(usage != "load" for usage in usages):
-                    why("node2 requires expressions not available in node1")
-                    return False
-
-            def _is_other_node_that_references_mutation_buffer(
-                other_node: BaseSchedulerNode,
-            ):
-                return (
-                    (other_node is not node1)
-                    and (other_node is not node2)
-                    and written_buffer_name in other_node.used_buffer_names()
-                )
-
-            if any(
-                _is_other_node_that_references_mutation_buffer(node)
-                for node in self.nodes
-            ):
-                return False
+            return node1.can_fuse_with(node2)
 
         if (
             isinstance(node2, (ExternKernelSchedulerNode, NopKernelSchedulerNode))

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3126,6 +3126,8 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
                 return False
             if not isinstance(arg.data.data, ir.ComputedBuffer):
                 return False
+            if not isinstance(arg.data.data.data, ir.Pointwise):
+                return False
             if not all(r == 0 for r in arg.data.data.data.ranges):
                 return False
             return True
@@ -3166,10 +3168,8 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
                 if len(self.output_tile) != 1:
                     why("reduction epilogue fusion only supports a 1D output_tile")
                     return False
-                tile_val = self.node.kwargs.get(self.output_tile[0])
-                if tile_val is not None and not V.graph.sizevars.statically_known_geq(
-                    tile_val, rnumel_ep
-                ):
+                tile_val = self.node.kwargs[self.output_tile[0]]
+                if not V.graph.sizevars.statically_known_geq(tile_val, rnumel_ep):
                     why("user kernel does not support 1d persistent reduction")
                     return False
             k = len(self.output_tile)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3172,12 +3172,12 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         real_written_buffer_name = self.scheduler.mutation_real_name.get(
             written_buffer_name, written_buffer_name
         )
-        mutation_buffer_names = {written_buffer_name, real_written_buffer_name}
+        mutation_buffer_names = OrderedSet([written_buffer_name, real_written_buffer_name])
 
         # Exclude nodes that are part of this fusion attempt.
         # For a FusedSchedulerNode epilogue, also exclude its constituent snodes since
         # they appear individually in scheduler.nodes but will be consumed by the fusion.
-        fusion_node_set: set[BaseSchedulerNode] = {self, node2}
+        fusion_node_set: OrderedSet[BaseSchedulerNode] = OrderedSet([self, node2])
         if isinstance(node2, FusedSchedulerNode):
             fusion_node_set.update(node2.snodes)
 
@@ -3186,7 +3186,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         ) -> bool:
             if other_node in fusion_node_set:
                 return False
-            reads = {d.name for d in other_node.read_writes.reads}
+            reads = OrderedSet([d.name for d in other_node.read_writes.reads])
             return bool(reads & mutation_buffer_names)
 
         if any(
@@ -3295,9 +3295,9 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
             epilogue_nodes, numel_ep, reduction_numel=rnumel
         )
 
-        excluded_names = {
+        excluded_names = OrderedSet([
             ir_node.mutation_outputs[0].name
-        } | self.epilogue.get_buffer_names()
+        ]) | self.epilogue.get_buffer_names()
         external_reads = OrderedSet(
             d.name
             for sn in epilogue_nodes

--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -528,7 +528,9 @@ def capture_triton(triton_kernel: Callable, /) -> Any:
 
 
 @exposed_in("torch.library")
-def wrap_triton(triton_kernel: Callable, /) -> Any:
+def wrap_triton(
+    triton_kernel: Callable, /, output_tile: dict[str, str] | None = None
+) -> Any:
     """Allows capture of a triton kernel into a graph via make_fx or
     non-strict ``torch.export``.
 
@@ -598,7 +600,7 @@ def wrap_triton(triton_kernel: Callable, /) -> Any:
     if isinstance(triton_kernel, JITFunction):
         if not is_wrap_triton_enabled():
             return triton_kernel
-        return TraceableTritonKernelWrapper(triton_kernel, None, None)
+        return TraceableTritonKernelWrapper(triton_kernel, None, None, output_tile=output_tile)
 
     if isinstance(triton_kernel, Autotuner):
         # TRITON_INTERPRET=1 can make @triton.autotune wrap an

--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -603,7 +603,36 @@ def wrap_triton(
     if isinstance(triton_kernel, JITFunction):
         if not is_wrap_triton_enabled():
             return triton_kernel
-        return TraceableTritonKernelWrapper(triton_kernel, None, None, output_tile=output_tile, pid_remap=pid_remap)
+
+        if output_tile is not None:
+            if not isinstance(output_tile, tuple) or not all(
+                isinstance(s, str) for s in output_tile
+            ):
+                raise TypeError(
+                    f"output_tile must be a tuple of strings, got {output_tile!r}"
+                )
+            if len(output_tile) == 0:
+                raise ValueError("output_tile must be non-empty")
+
+        if pid_remap is not None:
+            if output_tile is None:
+                raise ValueError("pid_remap requires output_tile to also be specified")
+            if not isinstance(pid_remap, tuple) or not all(
+                isinstance(s, str) for s in pid_remap
+            ):
+                raise TypeError(
+                    f"pid_remap must be a tuple of strings, got {pid_remap!r}"
+                )
+
+            if len(pid_remap) != len(output_tile):
+                raise ValueError(
+                    f"pid_remap length ({len(pid_remap)}) must match "
+                    f"output_tile length ({len(output_tile)})"
+                )
+
+        return TraceableTritonKernelWrapper(
+            triton_kernel, None, None, output_tile=output_tile, pid_remap=pid_remap
+        )
 
     if isinstance(triton_kernel, Autotuner):
         # TRITON_INTERPRET=1 can make @triton.autotune wrap an

--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -529,7 +529,7 @@ def capture_triton(triton_kernel: Callable, /) -> Any:
 
 @exposed_in("torch.library")
 def wrap_triton(
-    triton_kernel: Callable, /, output_tile: dict[str, str] | None = None
+    triton_kernel: Callable, /, output_tile: tuple[str, ...] | None = None
 ) -> Any:
     """Allows capture of a triton kernel into a graph via make_fx or
     non-strict ``torch.export``.

--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -529,7 +529,10 @@ def capture_triton(triton_kernel: Callable, /) -> Any:
 
 @exposed_in("torch.library")
 def wrap_triton(
-    triton_kernel: Callable, /, output_tile: tuple[str, ...] | None = None
+    triton_kernel: Callable,
+    /,
+    output_tile: tuple[str, ...] | None = None,
+    pid_remap: tuple[str, ...] | None = None,
 ) -> Any:
     """Allows capture of a triton kernel into a graph via make_fx or
     non-strict ``torch.export``.
@@ -600,7 +603,7 @@ def wrap_triton(
     if isinstance(triton_kernel, JITFunction):
         if not is_wrap_triton_enabled():
             return triton_kernel
-        return TraceableTritonKernelWrapper(triton_kernel, None, None, output_tile=output_tile)
+        return TraceableTritonKernelWrapper(triton_kernel, None, None, output_tile=output_tile, pid_remap=pid_remap)
 
     if isinstance(triton_kernel, Autotuner):
         # TRITON_INTERPRET=1 can make @triton.autotune wrap an


### PR DESCRIPTION
Enables epilogue fusion for epilogues that require additional index expressions outside the user kernel's scope. This is done by parameterising `FusedUserTritonKernel` with the output tile/block dimension, which the user annotates using `wrap_triton`:

```python
wrap_triton(some_kernel, output_tile=("BLOCK_SIZE",))[GRID](...)
```
Examples:

**Non-unary pointwise**: the addition of `b` and `relu` activation is fused into the matmul kernel:
```python
wrap_triton(matmul_kernel, output_tile=("BLOCK_SIZE_M", "BLOCK_SIZE_N"))[GRID](
         A,  B, C,  BLOCK_SIZE_M, BLOCK_SIZE_N,  ...)
return (C + b).relu()
```
**Epilogue containing a reduction**: the (fp8 quant) abs-max reduction, scaling, clamp, and FP8 cast is fused into the normalisation kernel:
> Only support for 1d persistent reductions. Furthermore, we assert that reduction operations are strictly intermediate operations, i.e., their results are not stored. 

```python
wrap_triton(normalization_fwd, output_tile=("BLOCK_SIZE",))[(num_rows,)](
    X, Y, BLOCK_SIZE, ...
)
X_f32 = Y.view(*shape).to(torch.float32)
abs_max = X_f32.abs().max(dim=-1, keepdim=True).values
return (X_f32 / (abs_max / FP8_MAX)).clamp(FP8_MIN, FP8_MAX).to(FP8_DTYPE)
```
**Grouped PID**: for kernels that remap program IDs, supply pid_remap. The same fusion cases as above apply:
```python
wrap_triton(
    matmul_kernel,
    output_tile=("BLOCK_SIZE_M", "BLOCK_SIZE_N"),
    pid_remap=("pid_m", "pid_n"),
)[grid](...)
```

See `test_triton_kernels.py` for examples.

It seems there was prior discussion around introducing a new `tl.store` overload via `triton_helpers` to explicitly mark the output index expression. Under the constraint that fusion is only applied to kernels writing to "empty" tensors, all what code generation needs is the values of, or aliases to, `XBLOCK`,  `YBLOCK` etc., that respect the user kernel's configuration. `wrap_triton` provides this via `output_tile`, and handles `pid_remap` for grouped-PID kernels that require loading new parameters with arbitrary index expressions (`pid_remap` then populates `pid_cache` prior to codegen, same as Triton template codegen).

More broadly, I'd propose extending the usage of `wrap_triton` as the interface for opting into fusion. This keeps user kernel fusion opt-in, per-kernel rather than a global flag.

This PR maintains the invariant that epilogues must produce only one store, implying no layout transformations or reduced stores, while allowing reads from additional buffers to support epilogue computation. These restrictions can be loosened incrementally alongside scoring heuristics. The intention here is to validate whether this route is viable, while also laying the plumbing for future extensions.

I've left some review comments where context may be helpful. 

This PR is rebased on a refactor: 
- #181138


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @mlazos