### PR TITLE
autograd: raise ValueError for forward-mode without vectorize in jacobian/hessian

### DIFF
--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -765,6 +765,18 @@ class TestAutogradFunctional(TestCase):
             autogradF.jacobian(foo, inp, strict=True, vectorize=True)
 
     @base_and_logging_tensor
+    def test_jacobian_forward_mode_requires_vectorize(self, ctors):
+        def foo(x):
+            return x.exp()
+
+        inp = ctors.rand(4)
+        with self.assertRaisesRegex(
+            ValueError,
+            'strategy="forward-mode" requires vectorize=True',
+        ):
+            autogradF.jacobian(foo, inp, strategy="forward-mode", vectorize=False)
+
+    @base_and_logging_tensor
     def test_jacobian_no_grad(self, ctors):
         def exp_reducer(x):
             return x.exp().sum(dim=1)
@@ -1027,6 +1039,20 @@ class TestAutogradFunctional(TestCase):
         x = ctors.randn(2)
         y = ctors.randn(3)
         self._check_hessian_vectorize_correctness(f, (x, y))
+
+    @base_and_logging_tensor
+    def test_hessian_forward_mode_requires_vectorize(self, ctors):
+        def foo(x):
+            return x.exp().sum()
+
+        inp = ctors.rand(4)
+        with self.assertRaisesRegex(
+            ValueError,
+            'outer_jacobian_strategy="forward-mode" requires vectorize=True',
+        ):
+            autogradF.hessian(
+                foo, inp, outer_jacobian_strategy="forward-mode", vectorize=False
+            )
 
     @parametrize("vectorize", [True, False])
     @base_and_logging_tensor

--- a/torch/autograd/functional.py
+++ b/torch/autograd/functional.py
@@ -685,8 +685,8 @@ def jacobian(
         )
     if strategy == "forward-mode" and not vectorize:
         raise ValueError(
-            'torch.autograd.functional.jacobian: strategy="forward-mode" requires vectorize=True. '
-            "Please set vectorize=True or use strategy=\"reverse-mode\"."
+            'strategy="forward-mode" requires vectorize=True. '
+            'Please set vectorize=True or use strategy="reverse-mode".'
         )
     if strategy == "forward-mode":
         if create_graph:

--- a/torch/autograd/functional.py
+++ b/torch/autograd/functional.py
@@ -683,6 +683,11 @@ def jacobian(
             'function has more outputs than inputs, "forward-mode" tends to be more performant. '
             'Otherwise, prefer to use "reverse-mode".'
         )
+    if strategy == "forward-mode" and not vectorize:
+        raise ValueError(
+            'torch.autograd.functional.jacobian: strategy="forward-mode" requires vectorize=True. '
+            "Please set vectorize=True or use strategy=\"reverse-mode\"."
+        )
     if strategy == "forward-mode":
         if create_graph:
             raise NotImplementedError(
@@ -953,6 +958,12 @@ def hessian(
     ):
         raise AssertionError(
             'Expected strategy to be either "forward-mode" or "reverse-mode".'
+        )
+    if outer_jacobian_strategy == "forward-mode" and not vectorize:
+        raise ValueError(
+            'torch.autograd.functional.hessian: outer_jacobian_strategy="forward-mode" '
+            "requires vectorize=True. Please set vectorize=True or use "
+            'outer_jacobian_strategy="reverse-mode".'
         )
 
     def ensure_single_output_function(*inp):


### PR DESCRIPTION
## Summary

`torch.autograd.functional.jacobian` with `strategy='forward-mode'` and `vectorize=False` (the default) silently accepts the call then crashes with `NotImplementedError` deep inside `_jacfwd`. The same issue affects `hessian` with `outer_jacobian_strategy='forward-mode'`.

This PR adds an early `ValueError` at argument-validation time for both functions so users get a clear, actionable message instead of an obscure runtime crash.

### Before
```
NotImplementedError: Computing Jacobian using forward-AD or forward-over-reverse
Hessian is only implemented for `vectorize=True`.
```
(raised inside `_jacfwd`, after the call was already accepted)

### After
```
ValueError: torch.autograd.functional.jacobian: strategy="forward-mode" requires vectorize=True.
Please set vectorize=True or use strategy="reverse-mode".
```
(raised immediately at argument validation)

## Changes
- `torch/autograd/functional.py`: guard in `jacobian` and `hessian` before reaching `_jacfwd`
- `test/autograd/test_functional.py`: two new tests

Fixes #184842.