### PR TITLE
nn: raise ValueError for unsupported (ndim, pad_size) in non-constant F.pad

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9595,6 +9595,21 @@ class TestNNDeviceType(NNTestCase):
     @onlyNativeDeviceTypes
     @dtypes(torch.float64, torch.complex128)
     def test_pad(self, device, dtype):
+        # Unsupported (ndim, pad_size) combinations for non-constant modes raise ValueError
+        for mode in ('reflect', 'replicate', 'circular'):
+            # pad_size=2 requires 2D or 3D input
+            self.assertRaisesRegex(
+                ValueError,
+                "does not support 4D input with padding size 2",
+                lambda: F.pad(torch.randn(1, 1, 4, 4, device=device, dtype=dtype), (1, 1), mode=mode),
+            )
+            # pad_size=4 requires 3D or 4D input
+            self.assertRaisesRegex(
+                ValueError,
+                "does not support 5D input with padding size 4",
+                lambda: F.pad(torch.randn(1, 1, 4, 4, 4, device=device, dtype=dtype), (1, 1, 1, 1), mode=mode),
+            )
+
         # Assert assertion errors are raised for invalid circular padding values
         inputs = torch.randn(1, 1, 4, device=device, dtype=dtype, requires_grad=True)
         # Should raise error when trying to wrap around more than once

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5562,9 +5562,11 @@ def pad(
         :class:`torch.nn.ReflectionPad2d`, and :class:`torch.nn.ReplicationPad2d`
         for concrete examples on how each of the padding modes works. Constant
         padding is implemented for arbitrary dimensions. Circular, replicate and
-        reflection padding are implemented for padding the last 3 dimensions of a
-        4D or 5D input tensor, the last 2 dimensions of a 3D or 4D input tensor,
-        or the last dimension of a 2D or 3D input tensor.
+        reflection padding support only specific ``(ndim, pad_size)`` combinations:
+
+        - ``pad`` size 2 (pads last dim): ``input`` must be 2D or 3D
+        - ``pad`` size 4 (pads last 2 dims): ``input`` must be 3D or 4D
+        - ``pad`` size 6 (pads last 3 dims): ``input`` must be 4D or 5D
 
     Note:
         When using the CUDA backend, this operation may induce nondeterministic
@@ -5600,6 +5602,25 @@ def pad(
         return handle_torch_function(
             torch.nn.functional.pad, (input,), input, pad, mode=mode, value=value
         )
+    if mode != "constant":
+        ndim = input.dim()
+        pad_len = len(pad)
+        # Non-constant modes only implement 1D/2D/3D spatial padding:
+        #   pad_len=2 (last dim)  -> requires 2D or 3D input
+        #   pad_len=4 (last 2 dims) -> requires 3D or 4D input
+        #   pad_len=6 (last 3 dims) -> requires 4D or 5D input
+        _valid: dict[int, set[int]] = {2: {2}, 3: {2, 4}, 4: {4, 6}, 5: {6}}
+        allowed = _valid.get(ndim)
+        if allowed is None or pad_len not in allowed:
+            valid_desc = (
+                "2D or 3D input with pad size 2, "
+                "3D or 4D input with pad size 4, "
+                "or 4D or 5D input with pad size 6"
+            )
+            raise ValueError(
+                f"Padding mode '{mode}' does not support {ndim}D input with "
+                f"padding size {pad_len}. Supported: {valid_desc}."
+            )
     if not torch.jit.is_scripting():
         if torch.are_deterministic_algorithms_enabled() and (
             input.is_cuda or input.is_xpu


### PR DESCRIPTION
## Summary

`torch.nn.functional.pad` with non-constant modes (`reflect`, `replicate`, `circular`) hits `NotImplementedError` deep inside C++ dispatch for unsupported `(ndim, pad_size)` combinations. The error message is informative but the wrong exception type is raised — and only after crossing the Python/C++ boundary.

This PR adds Python-level argument validation that raises `ValueError` up front, before C++ dispatch, with a clear message.

### Valid combinations (non-constant modes)

| input ndim | valid pad sizes |
|---|---|
| 2D | 2 |
| 3D | 2, 4 |
| 4D | 4, 6 |
| 5D | 6 |

### Before
```python
F.pad(torch.randn(1,1,4,4), (1,1), mode='circular')
# NotImplementedError: Padding size 2 is not supported for 4D input tensor.
```

### After
```python
F.pad(torch.randn(1,1,4,4), (1,1), mode='circular')
# ValueError: Padding mode 'circular' does not support 4D input with padding size 2. ...
```

## Changes
- `torch/nn/functional.py`: early validation + docstring update
- `test/test_nn.py`: two new parametrized error-path tests

Fixes #184845.