### PR TITLE
Skip XPU manywheel builds for Python 3.15

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -443,6 +443,14 @@ def generate_wheels_matrix(
             ):
                 continue
 
+            # TODO: Re-enable XPU for python 3.15 once the triton XPU 3.15
+            # wheel build is fixed (tracked in #184901). Triton XPU is
+            # currently skipped for 3.15/3.15t in build-triton-wheel.yml.
+            if arch_version in XPU_ARCHES and (
+                python_version == "3.15" or python_version == "3.15t"
+            ):
+                continue
+
             # cuda linux wheels require PYTORCH_EXTRA_INSTALL_REQUIREMENTS to install
 
             if (

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -562,24 +562,6 @@ jobs:
             build_name: "manywheel-py3_14t-xpu"
             timeout_minutes: 240
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0"
-          - desired_python: "3.15"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15-xpu"
-            timeout_minutes: 240
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0"
-          - desired_python: "3.15t"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15t-xpu"
-            timeout_minutes: 240
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1032,18 +1014,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu"
             build_name: "manywheel-py3_14t-xpu"
-          - desired_python: "3.15"
-            desired_cuda: "xpu"
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15-xpu"
-          - desired_python: "3.15t"
-            desired_cuda: "xpu"
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15t-xpu"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1388,13 +1358,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15-cuda13_2"
-          - desired_python: "3.15"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15-xpu"
           - desired_python: "3.15t"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -1423,13 +1386,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15t-cuda13_2"
-          - desired_python: "3.15t"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15t-xpu"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel


### PR DESCRIPTION
## Summary

Skip XPU manywheel builds for Python 3.15 / 3.15t in the same way #184600 skipped ROCm. Triton XPU 3.15 wheel builds are currently broken (see the exclusion in `.github/workflows/build-triton-wheel.yml`); without working triton-xpu, manywheel XPU 3.15 builds cannot link triton and fail.

## Change

`.github/scripts/generate_binary_build_matrix.py` — adds 8 lines mirroring the ROCm skip block:

```py
# TODO: Re-enable XPU for python 3.15 once the triton XPU 3.15
# wheel build is fixed (tracked in #184901). Triton XPU is
# currently skipped for 3.15/3.15t in build-triton-wheel.yml.
if arch_version in XPU_ARCHES and (
    python_version == "3.15" or python_version == "3.15t"
):
    continue
```

## Notes

The generated workflow YAML (`generated-linux-binary-manywheel-nightly.yml`) will need regenerating to drop the `manywheel-py3_15-xpu` / `manywheel-py3_15t-xpu` entries — that's 44 lines removed, fully derived from this script change via:

```bash
python .github/scripts/generate_ci_workflows.py
```

Will follow up with the regen commit, or happy for a maintainer to push it on this branch.

## References

- Umbrella: #184352 (Python 3.15 support for PyTorch)
- Tracking: #184901 (XPU triton 3.15 build failure)
- Related: #184829 (triton 3.15 wheel build that skipped XPU)
- Precedent: #184600 (ROCm 3.15 skip)
