### PR TITLE
Use Python gcda discovery for code coverage

### DIFF
--- a/tools/code_coverage/package/oss/utils.py
+++ b/tools/code_coverage/package/oss/utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
 from ..util.setting import CompilerType, TestType, TOOLS_FOLDER
 from ..util.utils import print_error, remove_file

--- a/tools/code_coverage/package/oss/utils.py
+++ b/tools/code_coverage/package/oss/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import subprocess
 
 from ..util.setting import CompilerType, TestType, TOOLS_FOLDER
@@ -78,14 +79,10 @@ def clean_up_gcda() -> None:
 
 
 def get_gcda_files() -> list[str]:
-    folder_has_gcda = os.path.join(get_pytorch_folder(), "build")
-    if os.path.isdir(folder_has_gcda):
-        # TODO use glob
-        # output = glob.glob(f"{folder_has_gcda}/**/*.gcda")
-        output = subprocess.check_output(["find", folder_has_gcda, "-iname", "*.gcda"])
-        return output.decode("utf-8").split("\n")
-    else:
+    build_dir = Path(get_pytorch_folder()) / "build"
+    if not build_dir.is_dir():
         return []
+    return sorted(str(path) for path in build_dir.rglob("*.gcda") if path.is_file())
 
 
 def run_oss_python_test(binary_file: str) -> None:

--- a/tools/test/test_code_coverage.py
+++ b/tools/test/test_code_coverage.py
@@ -1,0 +1,46 @@
+import importlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+def import_oss_utils():
+    os.environ.setdefault("HOME", str(Path.home()))
+    return importlib.import_module("tools.code_coverage.package.oss.utils")
+
+
+class TestCodeCoverageUtils(unittest.TestCase):
+    def test_get_gcda_files_recursively_discovers_and_sorts_files(self) -> None:
+        oss_utils = import_oss_utils()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            build_dir = Path(tmpdir) / "build"
+            nested_dir = build_dir / "aten" / "nested"
+            nested_dir.mkdir(parents=True)
+
+            top_level = build_dir / "top.gcda"
+            deep_file = nested_dir / "deep.gcda"
+            top_level.touch()
+            deep_file.touch()
+            (build_dir / "ignore.txt").touch()
+
+            with mock.patch.object(
+                oss_utils, "get_pytorch_folder", return_value=tmpdir
+            ):
+                self.assertEqual(
+                    oss_utils.get_gcda_files(),
+                    sorted([str(top_level), str(deep_file)]),
+                )
+
+    def test_get_gcda_files_returns_empty_when_build_folder_missing(self) -> None:
+        oss_utils = import_oss_utils()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.object(
+                oss_utils, "get_pytorch_folder", return_value=tmpdir
+            ):
+                self.assertEqual(oss_utils.get_gcda_files(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Replace shell-based `.gcda` discovery in the OSS code coverage tool with pure Python path traversal.

## What changed

- switch `get_gcda_files()` to use `Path.rglob("*.gcda")`
- return a sorted list of files for deterministic behavior
- avoid returning empty entries from newline splitting
- add focused unit tests for recursive discovery and missing `build/` handling

## Why

The previous implementation depended on the external `find` command and split its output by newline, which could leave an empty path in the result. That empty entry could later be passed to `gcov`, and the shell dependency also made the implementation less portable.

## Testing

- `python -m unittest tools.test.test_code_coverage -v`