### PR TITLE
[Inductor][TP] Fuse slice-cat TP collective patterns

### DIFF
--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -15,7 +15,9 @@ from torch._inductor.fx_passes.post_grad import remove_noop_ops, view_to_reshape
 from torch._inductor.utils import fresh_cache, run_and_get_triton_code
 from torch.distributed._functional_collectives import (
     all_gather_single,
+    all_gather_tensor,
     reduce_scatter_single,
+    reduce_scatter_tensor,
 )
 from torch.distributed._symmetric_memory import _test_mode
 from torch.distributed.distributed_c10d import _get_group_size_by_name
@@ -89,18 +91,36 @@ class MicroPipelineTPTest(TestCase):
 
         def func(
             inp: torch.Tensor,
-        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        ) -> tuple[
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+        ]:
             a = all_gather_single(inp, gather_dim=0, group=group.group_name)
             b = all_gather_single(inp, gather_dim=1, group=group.group_name)
             c = _fp8_all_gather(inp, gather_dim=0, group_name=group.group_name)
             d = _fp8_all_gather(inp, gather_dim=1, group_name=group.group_name)
-            return a, b, c, d
+            e_full = all_gather_tensor(inp, gather_dim=0, group=group.group_name)
+            e = torch.cat(
+                [e_full.narrow(0, 0, 64), e_full.narrow(0, 64, 64)],
+                dim=1,
+            )
+            f_full = all_gather_tensor(inp, gather_dim=0, group=group.group_name)
+            f_cat = torch.cat(
+                [f_full.narrow(0, 0, 64), f_full.narrow(0, 64, 64)],
+                dim=1,
+            )
+            f = f_cat.narrow(1, 0, 32)
+            return a, b, c, d, e, f
 
         inp = torch.rand(64, 32, device="cuda")
 
         gm = _make_post_grad_fx(func, inp)
         all_gathers = find_all_gather_patterns(gm.graph)
-        self.assertEqual(len(all_gathers), 4)
+        self.assertEqual(len(all_gathers), 6)
 
         # If this test fails, please update find_all_gather_patterns instead of
         # modifying the following assertions.
@@ -135,21 +155,42 @@ class MicroPipelineTPTest(TestCase):
             torch.ops.aten.view.dtype,
         )
 
+        self.assertEqual(all_gathers[4].gather_dim, 1)
+        self.assertEqual(
+            all_gathers[4].res_node.target,
+            torch.ops.aten.cat.default,
+        )
+
+        self.assertEqual(all_gathers[5].gather_dim, 1)
+        self.assertEqual(
+            all_gathers[5].res_node.target,
+            torch.ops.aten.slice.Tensor,
+        )
+
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
     def test_find_reduce_scatter_patterns(self):
         group = dist.group.WORLD
 
-        def func(inp: torch.Tensor) -> torch.Tensor:
+        def func(
+            inp: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
             a = reduce_scatter_single(inp, "sum", scatter_dim=0, group=group.group_name)
             b = reduce_scatter_single(inp, "avg", scatter_dim=1, group=group.group_name)
-            return a, b
+            c_inp = torch.cat(
+                [inp.narrow(1, 0, 16), inp.narrow(1, 16, 16)],
+                dim=0,
+            )
+            c = reduce_scatter_tensor(
+                c_inp, "avg", scatter_dim=0, group=group.group_name
+            )
+            return a, b, c
 
         inp = torch.rand(64, 32, device="cuda")
 
         gm = make_fx(func)(inp)
         reduce_scatters = find_reduce_scatter_patterns(gm.graph)
-        self.assertEqual(len(reduce_scatters), 2)
+        self.assertEqual(len(reduce_scatters), 3)
 
         # If this test fails, please update find_reduce_scatter_patterns
         # instead of modifying the following assertions.
@@ -170,6 +211,8 @@ class MicroPipelineTPTest(TestCase):
 
         self.assertEqual(reduce_scatters[0].reduce_op, "sum")
         self.assertEqual(reduce_scatters[0].scatter_dim, 0)
+        self.assertEqual(reduce_scatters[2].reduce_op, "avg")
+        self.assertEqual(reduce_scatters[2].scatter_dim, 1)
 
         self.assertEqual(reduce_scatters[1].reduce_op, "avg")
         self.assertEqual(reduce_scatters[1].scatter_dim, 1)
@@ -267,6 +310,66 @@ class MicroPipelineTPTest(TestCase):
             code = run_and_get_triton_code(compiled, A_shard, B)
 
         self.assertNotIn("fused_all_gather_matmul", code)
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @fresh_cache()
+    def test_fuse_all_gather_matmul_slice_cat(self):
+        group = dist.group.WORLD
+
+        def func(A_shard: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+            A_full = all_gather_tensor(A_shard, gather_dim=0, group=group)
+            chunk = A_shard.shape[0]
+            A = torch.cat(
+                [
+                    A_full.narrow(0, 0, chunk),
+                    A_full.narrow(0, chunk, chunk),
+                ],
+                dim=1,
+            )
+            return A @ B
+
+        A_shard = torch.rand(64, 2048, device="cuda")
+        torch._dynamo.decorators.mark_unbacked(
+            A_shard, 0, hint_override=A_shard.shape[0]
+        )
+        B = torch.rand(4096, 16, device="cuda")
+
+        gm = _make_post_grad_fx(func, A_shard, B)
+        with _test_mode():
+            micro_pipeline_tp_pass(gm.graph)
+
+        self.assertIn("fused_all_gather_matmul", str(gm.graph))
+        self.assertNotIn("all_gather_into_tensor", str(gm.graph))
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @fresh_cache()
+    def test_fuse_all_gather_matmul_slice_cat_trim(self):
+        group = dist.group.WORLD
+
+        def func(A_shard: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+            A_full = all_gather_tensor(A_shard, gather_dim=0, group=group)
+            chunk = A_shard.shape[0]
+            A = torch.cat(
+                [
+                    A_full.narrow(0, 0, chunk),
+                    A_full.narrow(0, chunk, chunk),
+                ],
+                dim=1,
+            )
+            return A.narrow(1, 0, 4096) @ B
+
+        A_shard = torch.rand(64, 2048, device="cuda")
+        torch._dynamo.decorators.mark_unbacked(
+            A_shard, 0, hint_override=A_shard.shape[0]
+        )
+        B = torch.rand(4096, 16, device="cuda")
+
+        gm = _make_post_grad_fx(func, A_shard, B)
+        with _test_mode():
+            micro_pipeline_tp_pass(gm.graph)
+
+        self.assertIn("fused_all_gather_matmul", str(gm.graph))
+        self.assertNotIn("all_gather_into_tensor", str(gm.graph))
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "Test requires FP8 support")
@@ -367,6 +470,34 @@ class MicroPipelineTPTest(TestCase):
 
         self.assertIn("fused_matmul_reduce_scatter", code)
         self.assertNotIn("reduce_scatter_tensor", code)
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @fresh_cache()
+    def test_fuse_matmul_reduce_scatter_slice_cat(self):
+        group = dist.group.WORLD
+
+        def func(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+            C = A @ B
+            half_out = B.shape[1] // 2
+            C = torch.cat(
+                [
+                    C.narrow(1, 0, half_out),
+                    C.narrow(1, half_out, half_out),
+                ],
+                dim=0,
+            )
+            return reduce_scatter_tensor(C, "avg", 0, group)
+
+        A = torch.rand(64, 32, device="cuda")
+        B = torch.rand(32, 16, device="cuda")
+        torch._dynamo.decorators.mark_unbacked(B, 1, hint_override=B.shape[1])
+
+        gm = _make_post_grad_fx(func, A, B)
+        with _test_mode():
+            micro_pipeline_tp_pass(gm.graph)
+
+        self.assertIn("fused_matmul_reduce_scatter", str(gm.graph))
+        self.assertNotIn("reduce_scatter_tensor", str(gm.graph))
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "Test requires FP8 support")

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -25,6 +25,7 @@ from torch._inductor.comms import (
 )
 from torch._inductor.compile_fx import compile_fx as inductor_compile_fx
 from torch._inductor.fx_passes.bucketing import (
+    _insert_fn_trace_before_node,
     _trace as bucketing_trace,
     all_gather_merge_fn_to_trace_custom_ops,
     is_all_gather_into_tensor,
@@ -157,6 +158,43 @@ class TestBucketingTrace(torch._dynamo.test_case.TestCase):
         ]
         self.assertTrue(any("u0" in shape for shape in symbolic_shapes))
         self.assertTrue(any("(u0//4)" in shape for shape in symbolic_shapes))
+
+    def test_replacement_updates_layout_dependent_user_metadata(self):
+        graph = torch.fx.Graph()
+        base = graph.placeholder("base")
+        original = graph.call_function(
+            torch.ops.aten.as_strided.default,
+            args=(base, [2, 4], [4, 1], 0),
+        )
+        transposed = graph.call_function(
+            torch.ops.aten.transpose.int,
+            args=(original, 0, 1),
+        )
+        graph.output(transposed)
+
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
+        with fake_mode:
+            base_val = torch.empty(32)
+            original_val = torch.as_strided(base_val, (2, 4), (4, 1), 0)
+            transposed_val = original_val.transpose(0, 1)
+        base.meta["val"] = base_val
+        original.meta["val"] = original_val
+        transposed.meta["val"] = transposed_val
+
+        def replacement_fn(x):
+            return [torch.as_strided(x, (2, 4), (8, 1), 0)]
+
+        _insert_fn_trace_before_node(
+            gm.graph,
+            replacement_fn,
+            (base_val,),
+            original,
+            [base],
+            [original],
+        )
+
+        self.assertEqual(transposed.meta["val"].stride(), (1, 8))
 
 
 @requires_accelerator_dist_backend(["nccl", "xccl"])

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 import logging
 import operator
 from collections import defaultdict
@@ -257,6 +258,98 @@ def _populate_node_meta(
                 )
                 for original_node in bucket_nodes
             ]
+
+
+def _meta_arg(arg: object) -> object:
+    if isinstance(arg, torch.fx.Node):
+        return arg.meta.get("val", arg)
+    return arg
+
+
+def _same_tensor_metadata(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+    def same_dim(lhs_dim: object, rhs_dim: object) -> bool:
+        from torch.fx.experimental.symbolic_shapes import statically_known_true
+
+        try:
+            return statically_known_true(lhs_dim == rhs_dim)
+        except Exception:
+            return lhs_dim == rhs_dim
+
+    def same_dims(lhs_dims: tuple[object, ...], rhs_dims: tuple[object, ...]) -> bool:
+        return len(lhs_dims) == len(rhs_dims) and all(
+            same_dim(lhs_dim, rhs_dim) for lhs_dim, rhs_dim in zip(lhs_dims, rhs_dims)
+        )
+
+    return (
+        lhs.dtype == rhs.dtype
+        and lhs.device == rhs.device
+        and lhs.layout == rhs.layout
+        and same_dims(tuple(lhs.shape), tuple(rhs.shape))
+        and same_dims(tuple(lhs.stride()), tuple(rhs.stride()))
+        and same_dim(lhs.storage_offset(), rhs.storage_offset())
+    )
+
+
+def _same_metadata(lhs: object, rhs: object) -> bool:
+    lhs_leaves, lhs_spec = pytree.tree_flatten(lhs)
+    rhs_leaves, rhs_spec = pytree.tree_flatten(rhs)
+    if lhs_spec != rhs_spec or len(lhs_leaves) != len(rhs_leaves):
+        return False
+    for lhs_leaf, rhs_leaf in zip(lhs_leaves, rhs_leaves):
+        if isinstance(lhs_leaf, torch.Tensor) or isinstance(rhs_leaf, torch.Tensor):
+            if not isinstance(lhs_leaf, torch.Tensor) or not isinstance(
+                rhs_leaf, torch.Tensor
+            ):
+                return False
+            if not _same_tensor_metadata(lhs_leaf, rhs_leaf):
+                return False
+    return True
+
+
+def _recompute_changed_user_metadata(start_users: list[torch.fx.Node]) -> None:
+    """
+    Repair fake metadata after bucketing replaces a value with a layout-different
+    equivalent. The replacement is semantically valid, but downstream stride
+    metadata is no longer valid until consumers are re-run from metadata.
+    """
+    worklist = collections.deque(start_users)
+    queued: OrderedSet[torch.fx.Node] = OrderedSet(start_users)
+    while worklist:
+        node = worklist.popleft()
+        queued.discard(node)
+        if node.op != "call_function" or not callable(node.target):
+            continue
+        if "val" not in node.meta:
+            continue
+
+        args = pytree.tree_map(_meta_arg, node.args)
+        kwargs = pytree.tree_map(_meta_arg, node.kwargs)
+        if any(
+            isinstance(leaf, torch.fx.Node)
+            for leaf in pytree.tree_leaves((args, kwargs))
+        ):
+            continue
+
+        fake_mode = detect_fake_mode((node.meta.get("val"), args, kwargs))
+        try:
+            with fake_mode if fake_mode is not None else contextlib.nullcontext():
+                new_val = node.target(*args, **kwargs)
+        except Exception:
+            logger.debug(
+                "Skipping metadata repair for bucketing user %s",
+                node.name,
+                exc_info=True,
+            )
+            continue
+
+        if _same_metadata(node.meta["val"], new_val):
+            continue
+
+        node.meta["val"] = new_val
+        for user in node.users:
+            if user not in queued:
+                queued.add(user)
+                worklist.append(user)
 
 
 def bucket_key(node: torch.fx.Node, mode: BucketMode | None = None) -> object | None:
@@ -1104,8 +1197,11 @@ def _insert_fn_trace_before_node(  # type: ignore[no-untyped-def]
         replacements = {  # noqa: C416
             orig_out: new_out for orig_out, new_out in zip(g_fn_outs, g_fn_new_outs)
         }
+        replaced_users = []
         for orig_out, new_out in zip(g_fn_outs, g_fn_new_outs):
+            replaced_users.extend(orig_out.users)
             orig_out.replace_all_uses_with(new_out)
+        _recompute_changed_user_metadata(replaced_users)
 
         return replacements, new_nodes
 

--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -71,7 +71,7 @@ def _get_tensor(node: torch.fx.Node) -> torch.Tensor:
 
 @dataclass
 class _AllGatherMatch:
-    match: Match
+    match: Match | list[torch.fx.Node]
     shard_node: torch.fx.Node
     ag_node: torch.fx.Node
     res_node: torch.fx.Node
@@ -82,12 +82,18 @@ class _AllGatherMatch:
         self.res_node.replace_all_uses_with(new_node)
 
     def erase(self) -> None:
-        for node in reversed(self.match.nodes):
+        nodes = self.match.nodes if isinstance(self.match, Match) else self.match
+        for node in reversed(nodes):
             if len(node.users) == 0:
                 node.graph.erase_node(node)
 
 
 def find_all_gather_patterns(graph: torch.fx.Graph):
+    """Find all-gather outputs that can fuse with downstream matmul users.
+
+    This recognizes both the direct all-gather form and slice/cat reassembly
+    forms that preserve the same tensor-parallel communication contract.
+    """
     c10d = torch.ops._c10d_functional
     split_targets = [aten.split.Tensor, aten.split.sizes, aten.split_with_sizes.default]
 
@@ -175,7 +181,90 @@ def find_all_gather_patterns(graph: torch.fx.Graph):
     # Match in reverse to ensure longer patterns is prioritized
     all_gathers = []
     visited_ag_nodes = OrderedSet[torch.fx.Node]()
+
+    def _match_slice_cat_all_gather(
+        node: torch.fx.Node,
+    ) -> _AllGatherMatch | None:
+        res_node = node
+        trim_node = None
+        if node.target is aten.slice.Tensor:
+            if len(node.args) < 4 or not isinstance(node.args[0], torch.fx.Node):
+                return None
+            trim_node = node
+            node = node.args[0]
+
+        if node.target is not aten.cat.default:
+            return None
+        cat_inputs = node.args[0]
+        if not isinstance(cat_inputs, (list, tuple)) or len(cat_inputs) == 0:
+            return None
+        gather_dim = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim", 0)
+        if not isinstance(gather_dim, int):
+            return None
+        if trim_node is not None and (
+            len(trim_node.args) < 4
+            or trim_node.args[1] != gather_dim
+            or trim_node.args[2] != 0
+        ):
+            return None
+
+        slice_nodes: list[torch.fx.Node] = []
+        wait_node = None
+        for inp in cat_inputs:
+            if not (
+                isinstance(inp, torch.fx.Node)
+                and inp.target is aten.slice.Tensor
+                and len(inp.args) >= 2
+                and inp.args[1] == 0
+            ):
+                return None
+            cur_wait = inp.args[0]
+            if not (
+                isinstance(cur_wait, torch.fx.Node)
+                and cur_wait.target is c10d.wait_tensor.default
+            ):
+                return None
+            if wait_node is None:
+                wait_node = cur_wait
+            elif wait_node is not cur_wait:
+                return None
+            slice_nodes.append(inp)
+
+        if wait_node is None:
+            return None
+        ag_node = wait_node.args[0]
+        if not (
+            isinstance(ag_node, torch.fx.Node)
+            and ag_node.target is c10d.all_gather_into_tensor.default
+        ):
+            return None
+        group_name = ag_node.kwargs.get("group_name")
+        if group_name is None and len(ag_node.args) >= 3:
+            group_name = ag_node.args[2]
+        if group_name is None:
+            return None
+
+        return _AllGatherMatch(
+            match=[
+                ag_node,
+                wait_node,
+                *slice_nodes,
+                node,
+                *((trim_node,) if trim_node is not None else ()),
+            ],
+            shard_node=cast("torch.fx.Node", ag_node.args[0]),
+            ag_node=ag_node,
+            res_node=res_node,
+            gather_dim=gather_dim,
+            group_name=cast("torch.distributed.distributed_c10d.GroupName", group_name),
+        )
+
     for node in reversed(graph.nodes):
+        if ag_match := _match_slice_cat_all_gather(node):
+            if ag_match.ag_node not in visited_ag_nodes:
+                visited_ag_nodes.add(ag_match.ag_node)
+                all_gathers.append(ag_match)
+            continue
         for target, patterns in res_node_target_to_patterns.items():
             if node.target != target:
                 continue
@@ -207,7 +296,7 @@ def find_all_gather_patterns(graph: torch.fx.Graph):
 
 @dataclass
 class _ReduceScatterMatch:
-    match: Match
+    match: Match | list[torch.fx.Node]
     input_node: torch.fx.Node
     reduce_scatter_node: torch.fx.Node
     wait_tensor_node: torch.fx.Node
@@ -242,12 +331,18 @@ class _ReduceScatterMatch:
             )
 
     def erase(self) -> None:
-        for node in reversed(self.match.nodes):
+        nodes = self.match.nodes if isinstance(self.match, Match) else self.match
+        for node in reversed(nodes):
             if len(node.users) == 0:
                 node.graph.erase_node(node)
 
 
 def find_reduce_scatter_patterns(graph: torch.fx.Graph):
+    """Find matmul outputs that can fuse with downstream reduce-scatter users.
+
+    This recognizes both the direct reduce-scatter form and slice/cat forms
+    that reassemble the same tensor-parallel communication payload.
+    """
     c10d = torch.ops._c10d_functional
     split_targets = [aten.split.Tensor, aten.split.sizes, aten.split_with_sizes.default]
 
@@ -317,9 +412,81 @@ def find_reduce_scatter_patterns(graph: torch.fx.Graph):
     )
 
     reduce_scatters = []
+
+    def _match_slice_cat_reduce_scatter(
+        wait_node: torch.fx.Node,
+    ) -> _ReduceScatterMatch | None:
+        if wait_node.target is not c10d.wait_tensor.default:
+            return None
+        reduce_scatter_node = wait_node.args[0]
+        if not (
+            isinstance(reduce_scatter_node, torch.fx.Node)
+            and reduce_scatter_node.target is c10d.reduce_scatter_tensor.default
+        ):
+            return None
+        cat_node = reduce_scatter_node.args[0]
+        if not (
+            isinstance(cat_node, torch.fx.Node) and cat_node.target is aten.cat.default
+        ):
+            return None
+        cat_dim = (
+            cat_node.args[1]
+            if len(cat_node.args) > 1
+            else cat_node.kwargs.get("dim", 0)
+        )
+        if cat_dim != 0:
+            return None
+        cat_inputs = cat_node.args[0]
+        if not isinstance(cat_inputs, (list, tuple)) or len(cat_inputs) == 0:
+            return None
+
+        slice_nodes: list[torch.fx.Node] = []
+        input_node = None
+        scatter_dim = None
+        for inp in cat_inputs:
+            if not (
+                isinstance(inp, torch.fx.Node)
+                and inp.target is aten.slice.Tensor
+                and len(inp.args) >= 2
+            ):
+                return None
+            cur_input = inp.args[0]
+            cur_dim = inp.args[1]
+            if not isinstance(cur_input, torch.fx.Node) or not isinstance(cur_dim, int):
+                return None
+            if input_node is None:
+                input_node = cur_input
+                scatter_dim = cur_dim
+            elif input_node is not cur_input or scatter_dim != cur_dim:
+                return None
+            slice_nodes.append(inp)
+
+        if input_node is None or scatter_dim is None:
+            return None
+        group_name = reduce_scatter_node.kwargs.get("group_name")
+        if group_name is None and len(reduce_scatter_node.args) >= 4:
+            group_name = reduce_scatter_node.args[3]
+        reduce_op = reduce_scatter_node.kwargs.get("reduce_op")
+        if reduce_op is None and len(reduce_scatter_node.args) >= 2:
+            reduce_op = reduce_scatter_node.args[1]
+        if group_name is None or reduce_op is None:
+            return None
+
+        return _ReduceScatterMatch(
+            match=[*slice_nodes, cat_node, reduce_scatter_node, wait_node],
+            input_node=input_node,
+            reduce_scatter_node=reduce_scatter_node,
+            wait_tensor_node=wait_node,
+            reduce_op=cast(str, reduce_op),
+            scatter_dim=scatter_dim,
+            group_name=cast("torch.distributed.distributed_c10d.GroupName", group_name),
+        )
+
     for node in reversed(graph.nodes):
         if node.target == c10d.wait_tensor.default:
-            if match := non_zero_dim_reduce_scatter_pattern_single_user.match(node):
+            if rs_match := _match_slice_cat_reduce_scatter(node):
+                reduce_scatters.append(rs_match)
+            elif match := non_zero_dim_reduce_scatter_pattern_single_user.match(node):
                 assert isinstance(match, Match)
                 reduce_scatters.append(
                     _ReduceScatterMatch(
@@ -404,7 +571,6 @@ class _Matmul:
             mm_node = self.nodes[0]
             assert mm_node.target in (aten.mm.default, aten._scaled_mm.default)
             mm_node.replace_all_uses_with(new_node)
-            graph.erase_node(mm_node)
             return
 
         # An ND-matmul is reshape -> mm -> reshape sequence. We first replace
@@ -913,21 +1079,27 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> None:
 
         filter_matmul = _filter_out_scaled_matmul
 
+    matmul = _find_producer_matmul(input_node)
+    if matmul is None:
+        log.debug(
+            "no producer matmul found for reduce scatter, skipping fuse_matmul_reduce_scatter fusion"
+        )
+        return
+
     # Currently fused_matmul_reduce_scatter doesn't return the matmul result,
     # so we can't apply the fusion if the matmul result is used by multiple
     # users. This is not a fundamental limitation of the fused op and can be
     # addressed if needed.
-    if len(input_node.users) != 1:
+    match_nodes = (
+        reduce_scatter.match.nodes
+        if isinstance(reduce_scatter.match, Match)
+        else reduce_scatter.match
+    )
+    if len(input_node.users) != 1 and not all(
+        user in match_nodes for user in input_node.users
+    ):
         log.warning(
             "matmul result has more than one user, skipping fused_matmul_reduce_scatter fusion."
-        )
-        return
-
-    matmul = _find_producer_matmul(input_node)
-
-    if matmul is None:
-        log.warning(
-            "no producer matmul found for reduce scatter, skipping fuse_matmul_reduce_scatter fusion"
         )
         return
 


### PR DESCRIPTION
Stacked PRs:
 * #183838
 * #186255
 * #183839
 * #183840
 * #183837
 * __->__#184911


--- --- ---

### [Inductor][TP] Fuse slice-cat TP collective patterns


Graph-level chunking can expose tensor-parallel collective values through simple slice/cat reassembly before a matmul, or can feed reduce-scatter from an equivalent slice/cat form after a matmul. The existing micro-pipeline TP matcher only recognized the direct all-gather/matmul and matmul/reduce-scatter patterns, so these semantically equivalent graphs missed fusion.

Teach the all-gather and reduce-scatter matchers to recognize slice/cat forms that reassemble a single collective value without changing the TP communication contract. The replacement and erase logic remains scoped to the matched nodes, and the matmul multi-user guard still rejects users outside the matched reassembly.

Fixes #184833

Test Plan:

python test/distributed/tensor/parallel/test_micro_pipeline_tp.py MicroPipelineTPTest.test_find_all_gather_patterns MicroPipelineTPTest.test_find_reduce_scatter_patterns MicroPipelineTPTest.test_fuse_all_gather_matmul_slice_cat MicroPipelineTPTest.test_fuse_all_gather_matmul_slice_cat_trim MicroPipelineTPTest.test_fuse_matmul_reduce_scatter_slice_cat -v

lintrunner --config=.lintrunner.toml torch/_inductor/fx_passes/micro_pipeline_tp.py test/distributed/tensor/parallel/test_micro_pipeline_tp.py


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo