### PR TITLE
fix sdpa incorrect early return on 0 head dim qk w/ valid v

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -728,17 +728,22 @@ Tensor scaled_dot_product_attention(
     bool enable_gqa) {
   using sdp::SDPBackend;
   validate_sdpa_input(query_, key, value, attn_mask_, dropout_p, is_causal, scale);
-  // NB: This op is CompositeImplicitAutograd — autograd traces through the
-  // implementation rather than using an explicit backward formula. We must
-  // return early here because the scale computation (1/sqrt(head_dim)) is
-  // undefined when head_dim is 0, and backends don't uniformly handle
-  // zero-element tensors. We use the sum()*0 trick (same pattern as
-  // _batch_norm_impl_index in Normalization.cpp) to make the output depend
-  // on all inputs so that backward() produces correctly-shaped zero
-  // gradients instead of None.
-  if (TORCH_GUARD_OR_FALSE(query_.sym_numel().sym_eq(0)) ||
-      TORCH_GUARD_OR_FALSE(key.sym_numel().sym_eq(0)) ||
-      TORCH_GUARD_OR_FALSE(value.sym_numel().sym_eq(0))) {
+  // NB: This op is CompositeImplicitAutograd -- autograd traces through the
+  // implementation rather than using an explicit backward formula.
+  // Return early when the output is truly empty or softmax is undefined.
+  // We guard on value.numel()==0 (covers B, H, L_k, or head_dim_v being 0)
+  // and on L_q==0 (the one output dimension not present in value).
+  // When only head_dim_qk is 0, the result is well-defined (uniform attention)
+  // and falls through to the math backend.
+  // We use the sum()*0 trick (same pattern as _batch_norm_impl_index in
+  // Normalization.cpp) to make the output depend on all inputs so that
+  // backward() produces correctly-shaped zero gradients instead of None.
+  // For nested tensors, dim -2 is irregular so sym_size(-2) is unavailable.
+  // Fall back to checking query numel for nested tensors.
+  if (TORCH_GUARD_OR_FALSE(value.sym_numel().sym_eq(0)) ||
+      (query_.is_nested()
+          ? TORCH_GUARD_OR_FALSE(query_.sym_numel().sym_eq(0))
+          : TORCH_GUARD_OR_FALSE(query_.sym_size(-2).sym_eq(0)))) {
     auto output_shape = query_.sym_sizes().vec();
     output_shape[output_shape.size() - 1] = value.sym_size(-1);
     auto out = at::zeros_symint(output_shape, query_.options());

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2212,25 +2212,64 @@ class TestSDPA(NNTestCase):
         y = torch.nn.functional.scaled_dot_product_attention(x, x, x)
         self.assertFalse(y.isnan().any().item())
 
-    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-    def test_sdpa_zero_sized_tensors(self, device, dtype):
-        zero_size_configs = [
-            (0, 4, 10, 64),
-            (2, 4, 0, 64),
-            (2, 4, 10, 0),
-            (0, 0, 0, 0),
-        ]
-        for b, h, s, d in zero_size_configs:
-            q = torch.zeros(b, h, s, d, dtype=dtype, device=device, requires_grad=True)
-            k = torch.zeros(b, h, s, d, dtype=dtype, device=device, requires_grad=True)
-            v = torch.zeros(b, h, s, 32, dtype=dtype, device=device, requires_grad=True)
-            out = torch.nn.functional.scaled_dot_product_attention(q, k, v)
-            self.assertEqual(out.shape, (b, h, s, 32))
-            self.assertEqual(out, torch.zeros(b, h, s, 32, dtype=dtype, device=device))
-            out.sum().backward()
-            self.assertEqual(q.grad.shape, q.shape)
-            self.assertEqual(k.grad.shape, k.shape)
-            self.assertEqual(v.grad.shape, v.shape)
+    @parametrize(
+        "q_shape,k_shape,v_shape",
+        [
+            # B=0: no batches, output is empty
+            ((0, 4, 10, 64), (0, 4, 10, 64), (0, 4, 10, 32)),
+            # H=0: no heads, output is empty
+            ((2, 0, 10, 64), (2, 0, 10, 64), (2, 0, 10, 32)),
+            # L_q=0: no query positions, output is empty
+            ((2, 4, 0, 64), (2, 4, 10, 64), (2, 4, 10, 32)),
+            # L_k=0: softmax over empty set, undefined
+            ((2, 4, 10, 64), (2, 4, 0, 64), (2, 4, 0, 32)),
+            # head_dim_v=0: output last dim is 0
+            ((2, 4, 10, 64), (2, 4, 10, 64), (2, 4, 10, 0)),
+            # all zero
+            ((0, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)),
+        ],
+    )
+    def test_sdpa_zero_output(self, device, q_shape, k_shape, v_shape):
+        q = torch.randn(*q_shape, device=device, requires_grad=True)
+        k = torch.randn(*k_shape, device=device, requires_grad=True)
+        v = torch.randn(*v_shape, device=device, requires_grad=True)
+        out = F.scaled_dot_product_attention(q, k, v)
+        expected_shape = list(q_shape)
+        expected_shape[-1] = v_shape[-1]
+        self.assertEqual(out.shape, tuple(expected_shape))
+        self.assertEqual(out, torch.zeros(expected_shape, device=device))
+        out.sum().backward()
+        self.assertEqual(q.grad.shape, q.shape)
+        self.assertEqual(k.grad.shape, k.shape)
+        self.assertEqual(v.grad.shape, v.shape)
+
+    @parametrize("value_dim", [1, 8])
+    @parametrize("scale", [None, 1.0])
+    def test_sdpa_zero_qk_head_dim_matches_eager_attention(self, device, value_dim, scale):
+        torch.manual_seed(0)
+        query = torch.empty((1, 16, 16, 0), device=device, requires_grad=True)
+        key = torch.empty((1, 16, 16, 0), device=device, requires_grad=True)
+        value = torch.randn((1, 16, 16, value_dim), device=device, requires_grad=True)
+        grad_output = torch.randn((1, 16, 16, value_dim), device=device)
+
+        actual = F.scaled_dot_product_attention(query, key, value, dropout_p=0.0, scale=scale)
+        actual.backward(grad_output)
+        actual_query_grad = query.grad.detach().clone()
+        actual_key_grad = key.grad.detach().clone()
+        actual_value_grad = value.grad.detach().clone()
+
+        query_ref = query.detach().clone().requires_grad_()
+        key_ref = key.detach().clone().requires_grad_()
+        value_ref = value.detach().clone().requires_grad_()
+        scores = torch.matmul(query_ref, key_ref.transpose(-2, -1))
+        probs = torch.softmax(scores, dim=-1, dtype=torch.float32).to(query_ref.dtype)
+        expected = torch.matmul(probs, value_ref)
+        expected.backward(grad_output)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual_query_grad, query_ref.grad)
+        self.assertEqual(actual_key_grad, key_ref.grad)
+        self.assertEqual(actual_value_grad, value_ref.grad)
 
     def test_sdpa_output_shape_uses_value_head_dim(self, device):
         # Regression test for https://github.com/pytorch/pytorch/issues/176767


### PR DESCRIPTION
fixes #184330

today in attention.cpp, we have this check in `scaled_dot_product_attention`: 
https://github.com/pytorch/pytorch/blob/93c10b22b50317447f2ba046680a57c4c8681d4a/aten/src/ATen/native/transformers/attention.cpp#L739-L746

which guards against empty outputs by checking if any of q/k/v has numel()==0. however, this is too strict since even if head dim of q/k = 0 but v still has valid elements, then attention output is still defined (should just be the mean of all values). 

the guard should actually just check if any of v's dims are 0 (which checks for empty batch, head dims, 0 kv seqlen, and 0 v headdim) and if q seqlen = 0. 

note that in the head_dim=0 case, you will end up using math backend since flash/cudnn doesnt support this