### PR TITLE
[size-hint] Cache _sub_unbacked_exprs (#184915)

### DIFF
--- a/torch/fx/experimental/_size_hinting.py
+++ b/torch/fx/experimental/_size_hinting.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from functools import lru_cache
 from typing import Any, TYPE_CHECKING
 
 import sympy
@@ -290,9 +291,11 @@ def _get_unbacked_replacements(shape_env: ShapeEnv) -> dict[sympy.Expr, sympy.Ex
     return shape_env._unbacked_replacements
 
 
+@lru_cache(maxsize=1024)
 def _sub_unbacked_exprs(shape_env: ShapeEnv, expr: sympy.Expr) -> sympy.Expr:
     """Substitute unbacked expressions with canonical equivalents.
-    Used by optimization_hint to maximize consistency when hinting unbacked symbols."""
+    Used by optimization_hint to maximize consistency when hinting unbacked symbols.
+    """
     replacements = _get_unbacked_replacements(shape_env)
 
     # consider making this threshold configurable


### PR DESCRIPTION
Summary:

## Problem

A lot of time spent in `_sub_unbacked_exprs` is due to `sympy.subs` which is slow because it evaluates one replacement at a time. https://github.com/sympy/sympy/issues/22240

This slowness will compound if Inductor calls size-hint a lot (e.g. triton template generation)

| Function | cumtime | % | calls |
|----------|---------|---|-------|
| `_sub_unbacked_exprs` | 45.8s | 84% | 201 |
| `expr.subs(replacements)` (in _sub_unbacked loop) | 39.8s | 73% | 606 |
| `basic.is_same` (sympy internal comparison) | 24.5s | 45% | 957K |
| `_get_unbacked_replacements` (union-find rebuild) | 5.7s | 10.5% | 201 |
| `_build_canonical_expr_mapping` (union_expr loop) | 4.0s | 7.3% | 201 |

## Solution
Adding back `lru_cache` but setting `maxsize=1024` to cache up to 1024 unbacked exprs.

Reviewed By: ChrisZheng1985

Differential Revision: D106109920


