### PR TITLE
[Profiler] Guard traceActivities() behind USE_KINETO

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -1361,6 +1361,7 @@ void ProfilerResult::save(const std::string& path) {
   trace_->save(path);
 }
 
+#ifdef USE_KINETO
 const std::vector<const libkineto::ITraceActivity*>* ProfilerResult::
     traceActivities() {
   if (trace_) {
@@ -1368,6 +1369,7 @@ const std::vector<const libkineto::ITraceActivity*>* ProfilerResult::
   }
   return nullptr;
 }
+#endif
 
 } // namespace autograd::profiler
 

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -125,7 +125,9 @@ struct TORCH_API ProfilerResult {
   }
 
   void save(const std::string& path);
+#ifdef USE_KINETO
   const std::vector<const libkineto::ITraceActivity*>* traceActivities();
+#endif
 
  private:
   uint64_t trace_start_ns_ = 0;


### PR DESCRIPTION
Summary:
The parent diff (D106002228) added `ProfilerResult::traceActivities()` which calls `trace_->get()->activities()`, but the declaration and definition were not wrapped in `#ifdef USE_KINETO`. On the no-`USE_KINETO` ovrsource path, `interface_trace_t` resolves to `DummyTraceBuffer` (an empty struct with no `activities()` method), and `libkineto::ITraceActivity` does not exist at all, causing build failures on all ARVR ovrsource consumers (clang19 Linux and MSVC Windows).

The pybind binding in `init.cpp` was already correctly guarded; the implementation in `profiler_kineto.cpp` and the declaration in `profiler_kineto.h` were missed. This wraps both in `#ifdef USE_KINETO` / `#endif` to match.

Authored by Claude.

Test Plan:
The fix restores the build for ovrsource targets that were broken by D106002228. Repro command from CI:
```
buck build --flagfile fbsource//arvr/mode/fb-linux-nh/opt-stripped fbsource//arvr/projects/nimble/prod/tools/HandReplay:HandReplay
```

Differential Revision: D106109028


