### PR TITLE
[AOTI][5/N] Read Level 0 schema in save_gpu_kernel for AOTI (#184918)

### DIFF
--- a/test/inductor/test_triton_launcher_integration.py
+++ b/test/inductor/test_triton_launcher_integration.py
@@ -1,0 +1,263 @@
+# Owner(s): ["module: inductor"]
+"""Tests for save_gpu_kernel() Level 0 schema integration (diff 3/N).
+
+Validates that save_gpu_kernel reads metadata from launch_metadata_schema
+when available, falling back to hasattr probing for older Triton versions.
+
+Run:
+  buck2 test @fbcode//mode/opt --modifier ovr_config//triton:beta \
+    fbcode//caffe2/test/inductor:test_triton_launcher_integration
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from torch.testing._internal.common_utils import TestCase
+
+
+def _make_mock_launcher(
+    metadata_name="test_kernel_0d1d2d",
+    num_warps=4,
+    shared=0,
+    launch_metadata_schema=None,
+):
+    """Create a mock launcher with bin (CompiledKernel)."""
+    launcher = MagicMock()
+    launcher.config = MagicMock()
+    launcher.def_args = ["X", "Y", "N"]
+    launcher.call_args = ["X", "Y", "N"]
+    launcher.global_scratch = None
+    launcher.profile_scratch = None
+
+    bin_mock = MagicMock()
+    bin_mock.metadata.name = metadata_name
+    bin_mock.metadata.num_warps = num_warps
+    bin_mock.metadata.shared = shared
+    bin_mock.num_warps = num_warps
+    bin_mock.shared = shared
+    bin_mock.launch_metadata_schema = launch_metadata_schema
+    bin_mock.asm = {"cubin": b"\x00", "ptx": "mock_ptx"}
+    launcher.bin = bin_mock
+
+    return launcher
+
+
+def _make_mock_autotuner(kernel_name="test_kernel"):
+    """Create a mock CachingAutotuner (self) for save_gpu_kernel."""
+    autotuner = MagicMock()
+    autotuner.inductor_meta = {"kernel_name": kernel_name}
+    autotuner.triton_meta = {"signature": {0: "*fp32"}}
+    autotuner.device_props = MagicMock()
+    autotuner.device_props.type = "cuda"
+    return autotuner
+
+
+class SaveGpuKernelSchemaTest(TestCase):
+    """Unit tests for save_gpu_kernel() reading from Level 0 schema."""
+
+    def _call_save_gpu_kernel(self, launcher, kernel_name="test_kernel"):
+        """Call save_gpu_kernel with mocks and return the params passed to cache."""
+        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+        autotuner = _make_mock_autotuner(kernel_name)
+        with (
+            patch(
+                "torch._inductor.codecache.CudaKernelParamCache.set"
+            ) as mock_cache_set,
+            patch(
+                "torch._inductor.runtime.triton_heuristics.config_to_dict",
+                return_value={"BLOCK_SIZE": 1024},
+            ),
+        ):
+            CachingAutotuner.save_gpu_kernel(autotuner, stream=0, launcher=launcher)
+            mock_cache_set.assert_called_once()
+            _key, params, _binary, _bin_type, _asm, _asm_type = (
+                mock_cache_set.call_args[0]
+            )
+        return params
+
+    def test_schema_path_reads_entry_name(self):
+        """When schema exists, mangled_name should come from schema['entry_name']."""
+        schema = {
+            "abi_version": 1,
+            "entry_name": "schema_kernel_name",
+            "num_warps": 8,
+            "shared_mem": 4096,
+        }
+        launcher = _make_mock_launcher(
+            metadata_name="metadata_kernel_name",
+            launch_metadata_schema=schema,
+        )
+        params = self._call_save_gpu_kernel(launcher)
+        self.assertEqual(params["mangled_name"], "schema_kernel_name")
+
+    def test_schema_path_reads_num_warps(self):
+        """When schema exists, num_warps should come from schema."""
+        schema = {
+            "abi_version": 1,
+            "entry_name": "test_kernel",
+            "num_warps": 16,
+            "shared_mem": 8192,
+        }
+        launcher = _make_mock_launcher(
+            num_warps=4,
+            launch_metadata_schema=schema,
+        )
+        params = self._call_save_gpu_kernel(launcher)
+        self.assertEqual(params["num_warps"], 16)
+
+    def test_schema_path_reads_shared_mem(self):
+        """When schema exists, shared_mem should come from schema."""
+        schema = {
+            "abi_version": 1,
+            "entry_name": "test_kernel",
+            "num_warps": 4,
+            "shared_mem": 49152,
+        }
+        launcher = _make_mock_launcher(
+            shared=0,
+            launch_metadata_schema=schema,
+        )
+        params = self._call_save_gpu_kernel(launcher)
+        self.assertEqual(params["shared_mem"], 49152)
+
+    def test_fallback_when_no_schema(self):
+        """Without schema, should use hasattr probing (metadata.name, etc.)."""
+        launcher = _make_mock_launcher(
+            metadata_name="fallback_name",
+            num_warps=4,
+            shared=1024,
+            launch_metadata_schema=None,
+        )
+        params = self._call_save_gpu_kernel(launcher)
+        self.assertEqual(params["mangled_name"], "fallback_name")
+        self.assertEqual(params["num_warps"], 4)
+        self.assertEqual(params["shared_mem"], 1024)
+
+
+# =========================================================================
+# E2E tests: AOTI pipeline → save_gpu_kernel schema integration
+# Requires GPU + torch + inductor. Run via buck2 on H100.
+# =========================================================================
+
+_HAS_GPU = False
+try:
+    import torch
+
+    _HAS_GPU = hasattr(torch, "cuda") and torch.cuda.is_available()
+except (ImportError, AttributeError):
+    pass
+
+
+@unittest.skipUnless(_HAS_GPU, "requires CUDA GPU")
+class SaveGpuKernelAOTIE2ETest(TestCase):
+    """E2E tests for 3/N: verify AOTI pipeline uses save_gpu_kernel schema path."""
+
+    def setUp(self):
+        super().setUp()
+        # Fix a known module-loading-order issue (see D74745573):
+        # torch.utils.cpp_extension.CUDA_HOME is evaluated at import time.
+        # In CI's RE sandbox, CUDA_HOME env var isn't set yet at that point,
+        # so the module-level variable caches None. We fix both the env var
+        # AND the already-cached module variable.
+        # NOTE: triton.fb is fbcode-only; OSS CI sets CUDA_HOME via env.
+        import os
+
+        if "CUDA_HOME" not in os.environ and "CUDA_PATH" not in os.environ:
+            try:
+                from triton.fb.build import build_paths
+
+                os.environ["CUDA_HOME"] = build_paths.sdk_home
+            except ImportError:
+                pass
+
+        import torch.utils.cpp_extension
+
+        if torch.utils.cpp_extension.CUDA_HOME is None:
+            torch.utils.cpp_extension.CUDA_HOME = os.environ.get("CUDA_HOME")
+
+    def test_aoti_pipeline_correctness(self):
+        """Full AOTI pipeline (export → compile → load → run) should produce correct results."""
+        import torch._dynamo
+        import torch._inductor
+        import torch.export
+
+        torch._dynamo.reset()
+
+        class AddModel(torch.nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+        model = AddModel().to("cuda")
+        x = torch.randn(1024, device="cuda")
+        y = torch.randn(1024, device="cuda")
+        expected = model(x, y)
+
+        ep = torch.export.export(model, (x, y))
+        pkg_path = torch._inductor.aoti_compile_and_package(ep)
+        loaded = torch._inductor.aoti_load_package(pkg_path)
+        result = loaded(x, y)
+        torch.testing.assert_close(result, expected)
+
+    def test_aoti_schema_populated(self):
+        """AOTI compilation should call save_gpu_kernel with a populated schema."""
+        import torch._dynamo
+        import torch._inductor
+        import torch._inductor.runtime.triton_heuristics as th
+        import torch.export
+
+        torch._dynamo.reset()
+
+        original_save = th.CachingAutotuner.save_gpu_kernel
+        schema_info = {"called": False, "schema_used": False, "schema_keys": None}
+
+        def patched_save_gpu_kernel(self, stream, launcher):
+            schema = getattr(launcher.bin, "launch_metadata_schema", None)
+            schema_info["called"] = True
+            if schema is not None:
+                schema_info["schema_used"] = True
+                schema_info["schema_keys"] = list(schema.keys())
+            return original_save(self, stream, launcher)
+
+        th.CachingAutotuner.save_gpu_kernel = patched_save_gpu_kernel
+        try:
+
+            class MulAddModel(torch.nn.Module):
+                def forward(self, x, y, z):
+                    return x * y + z
+
+            model = MulAddModel().to("cuda")
+            x = torch.randn(512, device="cuda")
+            y = torch.randn(512, device="cuda")
+            z = torch.randn(512, device="cuda")
+            expected = model(x, y, z)
+
+            ep = torch.export.export(model, (x, y, z))
+            pkg_path = torch._inductor.aoti_compile_and_package(ep)
+            loaded = torch._inductor.aoti_load_package(pkg_path)
+            result = loaded(x, y, z)
+
+            torch.testing.assert_close(result, expected)
+
+            self.assertTrue(
+                schema_info["called"],
+                "save_gpu_kernel was never called during AOTI compilation",
+            )
+            # launch_metadata_schema is only available on Triton beta (fbcode
+            # uses ovr_config//triton:beta via BUCK modifiers).  OSS CI may run
+            # with a Triton version that doesn't expose the schema yet, so we
+            # conditionally validate the schema contents here.  The Level 0
+            # schema reading logic is fully covered by SaveGpuKernelSchemaTest
+            # unit tests above (with mocks).
+            if schema_info["schema_used"]:
+                self.assertIn("entry_name", schema_info["schema_keys"])
+                self.assertIn("num_warps", schema_info["schema_keys"])
+                self.assertIn("shared_mem", schema_info["schema_keys"])
+        finally:
+            th.CachingAutotuner.save_gpu_kernel = original_save
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1413,6 +1413,15 @@ use_fast_triton_launcher: bool = (
     os.environ.get("TORCHINDUCTOR_USE_FAST_TRITON_LAUNCHER", "1") == "1"
 )
 
+# Use the Level 0 launch_metadata_schema from CompiledKernel.bin
+# (versioned, stable contract) instead of hasattr probing of
+# CompiledKernel internals in save_gpu_kernel().
+# When True (default), prefers schema["entry_name"]/["num_warps"]/["shared_mem"].
+# When False, forces the legacy hasattr fallback path.
+use_launch_metadata_schema: bool = (
+    os.environ.get("TORCHINDUCTOR_USE_LAUNCH_METADATA_SCHEMA", "1") == "1"
+)
+
 # gemm autotuning global cache dir
 global_cache_dir: str | None
 if is_fbcode():

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1665,34 +1665,60 @@ class CachingAutotuner(KernelInterface):
         return launcher
 
     def save_gpu_kernel(self, stream, launcher):
+        """Save compiled GPU kernel metadata to the CudaKernelParamCache."""
         key = self.inductor_meta.get("kernel_name", None)  # unique kernel name
         assert key is not None, "kernel_name can not be None"
-        params = {
-            "mangled_name": (
-                launcher.bin.metadata.name
-                if hasattr(launcher.bin.metadata, "name")
-                else launcher.bin.metadata["name"]
-            ),
-            "num_warps": (
-                launcher.bin.num_warps
-                if hasattr(launcher.bin, "num_warps")
-                else launcher.bin.metadata.num_warps
-            ),
-            "shared_mem": (
-                launcher.bin.shared
-                if hasattr(launcher.bin, "shared")
-                else launcher.bin.metadata.shared
-            ),
-            "stream": stream,
-            # User defined triton kernels will have arbitrary kwarg names
-            "config": config_to_dict(launcher.config),
-            "inductor_meta": self.inductor_meta,
-            "triton_meta": self.triton_meta,
-            "def_args": launcher.def_args,
-            "call_args": launcher.call_args,
-            "global_scratch": launcher.global_scratch,
-            "profile_scratch": launcher.profile_scratch,
-        }
+
+        from torch._inductor import config as inductor_config
+
+        # Prefer Level 0 launch metadata schema (versioned, stable contract)
+        # over hasattr probing of CompiledKernel internals.
+        # TODO: When the AOTI C++ launch path gains cuLaunchKernelEx support for
+        # CTA clusters, add num_ctas/cluster_dims here from the schema.
+        # Currently num_ctas is already captured via config_to_dict(launcher.config)
+        # for scratch space scaling, but is not used in the actual kernel launch.
+        schema = getattr(launcher.bin, "launch_metadata_schema", None)
+        if schema is not None and inductor_config.use_launch_metadata_schema:
+            params = {
+                "mangled_name": schema["entry_name"],
+                "num_warps": schema["num_warps"],
+                "shared_mem": schema["shared_mem"],
+                "stream": stream,
+                "config": config_to_dict(launcher.config),
+                "inductor_meta": self.inductor_meta,
+                "triton_meta": self.triton_meta,
+                "def_args": launcher.def_args,
+                "call_args": launcher.call_args,
+                "global_scratch": launcher.global_scratch,
+                "profile_scratch": launcher.profile_scratch,
+            }
+        else:
+            # Fallback: hasattr probing for older Triton versions
+            params = {
+                "mangled_name": (
+                    launcher.bin.metadata.name
+                    if hasattr(launcher.bin.metadata, "name")
+                    else launcher.bin.metadata["name"]
+                ),
+                "num_warps": (
+                    launcher.bin.num_warps
+                    if hasattr(launcher.bin, "num_warps")
+                    else launcher.bin.metadata.num_warps
+                ),
+                "shared_mem": (
+                    launcher.bin.shared
+                    if hasattr(launcher.bin, "shared")
+                    else launcher.bin.metadata.shared
+                ),
+                "stream": stream,
+                "config": config_to_dict(launcher.config),
+                "inductor_meta": self.inductor_meta,
+                "triton_meta": self.triton_meta,
+                "def_args": launcher.def_args,
+                "call_args": launcher.call_args,
+                "global_scratch": launcher.global_scratch,
+                "profile_scratch": launcher.profile_scratch,
+            }
 
         from torch._inductor import config
         from torch._inductor.codecache import CudaKernelParamCache


### PR DESCRIPTION
Summary:

Modify save_gpu_kernel() to prefer the Level 0 launch_metadata_schema
dict (versioned, stable contract from 1/N) when available on
CompiledKernel.bin, falling back to hasattr probing of CompiledKernel
internals for older Triton versions.

Schema path reads: schema["entry_name"], schema["num_warps"],
schema["shared_mem"] — matching the abi_version=1 contract.

Also adds use_launch_metadata_schema config flag
(TORCHINDUCTOR_USE_LAUNCH_METADATA_SCHEMA env var, default True)
to control the new vs legacy metadata loading path.

Test Plan:
```
buck2 test fbcode//mode/opt --modifier ovr_config//triton:beta \
  fbcode//caffe2/test/inductor:test_triton_launcher_integration
```
Pass 6, Fail 0:
- SaveGpuKernelSchemaTest (4 unit tests, no GPU):
  - test_schema_path_reads_entry_name
  - test_schema_path_reads_num_warps
  - test_schema_path_reads_shared_mem
  - test_fallback_when_no_schema
- SaveGpuKernelAOTIE2ETest (2 E2E tests, H100):
  - test_aoti_pipeline_correctness: full AOTI export → compile → load → run
  - test_aoti_schema_populated: monkey-patch verifies launch_metadata_schema
    is populated and has expected keys (entry_name, num_warps, shared_mem)

Reviewed By: htyu

Differential Revision: D105888729




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo