### PR TITLE
[functorch] Enable output-strided tangent guessing by default

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -10335,6 +10335,30 @@ class TestAOTModuleSimplified(AOTTestCase):
     # But for models working in channels_last memory format this will add additional contiguous() calls.
     # The fix is predicting tangents memory format to be similar to outputs memory format.
     # And coerce runtime tangents to that traced memory format.
+    def test_output_strided_tangent_is_preserved_by_default(self):
+        self.assertTrue(torch._functorch.config.guess_tangent_strides_as_outputs)
+
+        with GradsNoForceContiguousContextManager() as ctx:
+
+            def fn(x):
+                r = (x + 1).transpose(0, 1)
+                return torch.ops._test_aotdispatch_lib.log_tangents_memory_format(r)
+
+            x = torch.randn(4, 8, requires_grad=True)
+            out = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+            self.assertEqual(out.stride(), (1, 8))
+
+            grad = torch.empty_strided(
+                out.shape,
+                out.stride(),
+                dtype=out.dtype,
+                device=out.device,
+            )
+            grad.normal_()
+            out.backward(grad)
+
+            self.assertEqual(ctx.tangent_strides, [out.stride()])
+
     def test_grads_no_force_contiguous_dense(self):
         with GradsNoForceContiguousContextManager() as ctx:
 

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -400,11 +400,10 @@ unsafe_allow_optimization_of_collectives = False
 disable_guess_zero_tangent_for_mutated_input_subclass = False
 
 # See Note [Tangents memory format]
-# By default tangents strideness is guessed to be contiguous,
-# At runtime non contiguous tangents will be coerced to be contiguous.
-# This config changes this guess for tangents strides to be the same as outputs.
+# Tangent strideness is guessed to match output strides.
+# At runtime tangents with different strides will be coerced to the output strides.
 # TODO(ivankobzarev): Remove this config once extra memory usage is investigated.
-guess_tangent_strides_as_outputs = not is_fbcode()
+guess_tangent_strides_as_outputs = True
 
 
 # This is a temporary config to ensure all ranks take the same decision in the partitioner


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184922

AOTAutograd records expected tangent layout through MemoryFormatMeta. When
`guess_tangent_strides_as_outputs` is disabled, non-channels-last transposed
outputs are represented only as `torch.contiguous_format`, so runtime tangents
are coerced to contiguous before the backward graph runs. For merge_attention
with transposed inputs this inserts large gradient copies and causes the
backward performance cliff reported in the issue.

The previous fix enabled output-stride guessing for OSS builds but kept fbcode
on the old default. Current source already contains the local_map fallback that
made exact output-stride metadata safe for local/global shape mismatches, so the
remaining root cause is the environment-specific default. Make the config true
unconditionally so static dense outputs use their actual output size and stride
as the expected tangent layout everywhere.

I considered adding a merge_attention-specific workaround or another fbcode-only
skip, but both would leave AOTAutograd's tangent layout model inconsistent. The
config default is the narrower root-cause fix now that known local_map coverage
is handled.

Fixes #173313
Generated by my agent

Test Plan:
- GUESS_TANGENT_MODE=default python <full merge_attention repro>: backward 2.58ms on NVIDIA B200
- GUESS_TANGENT_MODE=false python <full merge_attention repro>: backward 10.36ms on NVIDIA B200
- python test/functorch/test_aotdispatch.py -k test_output_strided_tangent_is_preserved_by_default, with local torchvision import blocked because installed torchvision is incompatible with this source build: PASS
- python test/functorch/test_aotdispatch.py -k test_noncontig_nonmemformat_tangents, with the same torchvision workaround: PASS
- python test/higher_order_ops/test_local_map.py -k test_local_map_with_local_shapes_hop_tracing: PASS
- python test/higher_order_ops/test_local_map.py -k test_fx_annotations: PASS
- git diff --check: PASS
- lintrunner -a: PASS