### PR TITLE
[docs] Document exception tracing behavior in torch/_dynamo/exc.py

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -20,6 +20,32 @@ Observed Exceptions:
     - Special handling for StopIteration, LookupError, etc.
     - Exception state management during compilation
 
+    When an exception is raised inside a ``torch.compile`` region,
+    TorchDynamo does **not** immediately propagate it to the caller.
+    Instead, Dynamo symbolically traces the exception so that
+    ``try``/``except`` blocks inside the compiled function can be
+    captured in the FX graph and reasoned about statically.
+
+    Common Python exception types are wrapped in ``ObservedException``
+    subclasses (e.g. ``StopIteration`` → ``ObservedUserStopIteration``,
+    ``KeyError`` → ``ObservedKeyError``).  The full mapping is defined in
+    ``observed_exception_map``.  For exception types not present in that
+    map, :func:`get_dynamo_observed_exception` creates a new
+    ``ObservedException`` subclass dynamically at tracing time.
+
+    If an observed exception is **not caught** inside the compiled region
+    it propagates out and is re-raised as the original exception type in
+    eager mode, preserving the original traceback for the user.
+
+    .. note::
+        This behaviour means that exception-based control flow (e.g.
+        ``StopIteration`` from a custom iterator, ``KeyError`` from a
+        dict access) is generally supported inside ``torch.compile``
+        regions.  However, raising or catching exceptions that depend on
+        *data-dependent* conditions may still cause a graph break because
+        Dynamo cannot statically determine which branch will be taken at
+        compile time.
+
 Error Formatting:
     - Stack trace filtering and formatting
     - Error message augmentation


### PR DESCRIPTION
## Summary

Expands the module-level docstring of `torch/_dynamo/exc.py` to explicitly document how exceptions are handled when raised inside a `torch.compile` region.

This is purely a documentation improvement — no functional changes.

## Motivation

The `ObservedException` hierarchy and `observed_exception_map` are central to how TorchDynamo handles exceptions during tracing, but this behaviour was not documented at the module level. Users and contributors reading this file had no high-level explanation of *why* these classes exist or how they relate to the user-visible `torch.compile` behaviour.

This PR adds a clear narrative to the `Observed Exceptions` section of the module docstring covering:

- Why Dynamo wraps exceptions in `ObservedException` subclasses during tracing
- How `try`/`except` control flow inside compiled functions is captured
- What happens when an observed exception propagates out of the compiled region (re-raised in eager mode)
- The role of `observed_exception_map` and `get_dynamo_observed_exception`
- A `.. note::` callout about data-dependent conditions causing graph breaks

## Related

Related to #184340 (exception handling improvements in symbolic tracing).

## Testing

Documentation-only change. No new tests required.

## CC

@albanD @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98