### PR TITLE
Fix linalg_pinv tensor tolerance broadcasting

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -507,6 +507,16 @@ std::tuple<Tensor, Tensor> get_atol_rtol(
   return std::make_tuple(std::move(atol_tensor), std::move(rtol_tensor));
 }
 
+Tensor expand_pinv_tolerance(
+    const Tensor& tolerance,
+    SymIntArrayRef batch_shape,
+    SymIntArrayRef singular_value_shape) {
+  if (at::is_expandable_to(tolerance.sym_sizes(), batch_shape)) {
+    return tolerance.expand_symint(batch_shape).unsqueeze(-1);
+  }
+  return tolerance.expand_symint(singular_value_shape);
+}
+
 } // anonymous namespace
 
 Tensor linalg_pinv(
@@ -540,7 +550,11 @@ Tensor linalg_pinv(
     // using linalg_svd breaks pytorch/xla, see https://github.com/pytorch/xla/issues/2755
     auto [U, S, V] = input.svd();
     Tensor max_val = at::narrow(S, /*dim=*/-1, /*start=*/0, /*length=*/1);  // singular values are sorted in descending order
-    Tensor tol = at::max(atol.unsqueeze(-1), rtol.unsqueeze(-1) * max_val);
+    const auto S_shape = c10::SymDimVector(S.sym_sizes().begin(), S.sym_sizes().end());
+    const auto batch_shape = c10::SymDimVector(S_shape.begin(), S_shape.end() - 1);
+    Tensor atol_expanded = expand_pinv_tolerance(atol, batch_shape, S_shape);
+    Tensor rtol_expanded = expand_pinv_tolerance(rtol, batch_shape, S_shape);
+    Tensor tol = at::max(atol_expanded, rtol_expanded * max_val);
     Tensor S_pseudoinv = at::where(S > tol, S.reciprocal(), at::zeros({}, S.options())).to(input.dtype());
     // computes V @ diag(S_pseudoinv) @ U.conj().T
     return at::matmul(V * S_pseudoinv.unsqueeze(-2), U.mH());
@@ -550,7 +564,11 @@ Tensor linalg_pinv(
     Tensor S_abs = S.abs();
     // eigenvalues are sorted in ascending order starting with negative values, we need a maximum value of abs(eigenvalues)
     Tensor max_val = S_abs.amax(/*dim=*/-1, /*keepdim=*/true);
-    Tensor tol = at::max(atol.unsqueeze(-1), rtol.unsqueeze(-1) * max_val);
+    const auto S_shape = c10::SymDimVector(S_abs.sym_sizes().begin(), S_abs.sym_sizes().end());
+    const auto batch_shape = c10::SymDimVector(S_shape.begin(), S_shape.end() - 1);
+    Tensor atol_expanded = expand_pinv_tolerance(atol, batch_shape, S_shape);
+    Tensor rtol_expanded = expand_pinv_tolerance(rtol, batch_shape, S_shape);
+    Tensor tol = at::max(atol_expanded, rtol_expanded * max_val);
     Tensor S_pseudoinv = at::where(S_abs > tol, S.reciprocal(), at::zeros({}, S.options())).to(input.dtype());
     // computes U @ diag(S_pseudoinv) @ U.conj().T
     return at::matmul(U * S_pseudoinv.unsqueeze(-2), U.mH());

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1497,6 +1497,69 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         ):
             opt_fn(torch.tensor([1]), torch.tensor([0]))
 
+    @parametrize("backend", ["aot_eager", "inductor"])
+    @unittest.skipUnless(torch._C.has_lapack, "LAPACK not available")
+    def test_linalg_pinv_tensor_tolerances_compile(self, backend):
+        def check(fn, args, expected_shape):
+            expected = fn(*args)
+            actual = torch.compile(fn, backend=backend, fullgraph=True)(*args)
+            self.assertEqual(expected.shape, expected_shape)
+            self.assertEqual(actual.shape, expected_shape)
+            self.assertEqual(actual, expected)
+
+        def pinv_rcond(x, rcond):
+            return torch.ops.aten.linalg_pinv(x, rcond=rcond, hermitian=False)
+
+        check(
+            pinv_rcond,
+            (
+                torch.randn(8, 3, dtype=torch.float64),
+                torch.tensor([0.1], dtype=torch.float64),
+            ),
+            torch.Size([3, 8]),
+        )
+
+        def pinv_rtol(x, rtol):
+            return torch.linalg.pinv(x, rtol=rtol, hermitian=False)
+
+        check(
+            pinv_rtol,
+            (
+                torch.randn(8, 3, dtype=torch.float64),
+                torch.tensor([0.1], dtype=torch.float64),
+            ),
+            torch.Size([3, 8]),
+        )
+
+        check(
+            pinv_rtol,
+            (
+                torch.randn(8, 3, dtype=torch.float64),
+                torch.full((1,), 0.1, dtype=torch.float64),
+            ),
+            torch.Size([3, 8]),
+        )
+        check(
+            pinv_rtol,
+            (
+                torch.randn(5, 8, 3, dtype=torch.float64),
+                torch.full((1, 1), 0.1, dtype=torch.float64),
+            ),
+            torch.Size([5, 3, 8]),
+        )
+
+        def pinv_hermitian(x, rtol):
+            return torch.linalg.pinv(x, rtol=rtol, hermitian=True)
+
+        check(
+            pinv_hermitian,
+            (
+                torch.randn(4, 4, dtype=torch.float64),
+                torch.tensor([0.1], dtype=torch.float64),
+            ),
+            torch.Size([4, 4]),
+        )
+
     @torch._dynamo.config.patch(error_on_recompile=True)
     @torch.fx.experimental._config.patch(use_duck_shape=False)
     def test_dynamic_shape_disable_duck_size(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184928

aten.linalg_pinv.atol_rtol_tensor used to unsqueeze tensor tolerances before broadcasting them with the singular values. For a 2D input, singular values have shape [k], so a tensor rcond/rtol with shape [1] became [1, 1], broadcasted the singular values to [1, k], and preserved that fake leading batch dimension in compiled output.

Fix this by expanding each tolerance either to the input batch shape followed by the singular-value dimension, or directly to the singular-value shape when it is not a batch tolerance. This keeps existing per-batch tolerance behavior while avoiding an extra batch dimension for singular-value-shaped tolerances. The same helper is used for the SVD and Hermitian paths.

The abandoned prior PR tried squeezing leading singleton dimensions after the fact. This patch instead fixes the broadcast shape before the comparison, which matches the documented tolerance semantics.

Fixes #173052

Generated by my agent

Test Plan:

python test/dynamo/test_repros.py --use-pytest -k linalg_pinv_tensor_tolerances_compile

lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98