### PR TITLE
[inductor] Sink single-use dropout randoms into fused epilogues

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1339,6 +1339,85 @@ class CudaReproTests(TestCase):
         buf2 = torch.zeros((2, 512, 768), device=device_type)
         forward(buf0, buf1, buf2)
 
+    def _count_inductor_random_calls(self, code):
+        kernel_code = "\n".join(code)
+        return sum(
+            kernel_code.count(token)
+            for token in (
+                "tl.rand(",
+                "triton_helpers.rand4x(",
+                "triton_helpers.rand_eager_kernel(",
+            )
+        )
+
+    def _run_dropout_random_codegen(self, *, return_random=False, use_where=False):
+        batch, heads, rows, cols = 3, 8, 512, 512
+
+        @torch.compile(fullgraph=True)
+        def forward(bmm, full_mask, fill_value, inductor_seeds):
+            view = torch.ops.aten.view.default(bmm, [batch, heads, rows, cols])
+            masked = torch.ops.aten.where.self(full_mask, fill_value, view)
+            amax = torch.ops.aten.amax.default(masked, [-1], True)
+            sub = torch.ops.aten.sub.Tensor(masked, amax)
+            exp = torch.ops.aten.exp.default(sub)
+            denom = torch.ops.aten.sum.dim_IntList(exp, [-1], True)
+            softmax = torch.ops.aten.div.Tensor(exp, denom)
+            seed = torch.ops.prims.inductor_lookup_seed.default(inductor_seeds, 2)
+            rand = torch.ops.prims.inductor_random.default(
+                [batch, heads, rows, cols], seed, "rand"
+            )
+            mask = torch.ops.aten.gt.Scalar(rand, 0.1)
+            if use_where:
+                zero = torch.ops.aten.full.default(
+                    [batch, heads, rows, cols],
+                    0,
+                    dtype=torch.float32,
+                    layout=torch.strided,
+                    device=torch.device(device_type),
+                    pin_memory=False,
+                )
+                dropout = torch.ops.aten.where.self(mask, softmax, zero)
+            else:
+                dropout = torch.ops.aten.mul.Tensor(mask, softmax)
+            scaled = torch.ops.aten.mul.Tensor(dropout, 1.1111111111111112)
+            viewed = torch.ops.aten.view.default(scaled, [batch * heads, rows, cols])
+            output = torch.ops.aten.permute.default(viewed, [0, 2, 1])
+            if return_random:
+                return output, rand
+            return output
+
+        bmm = torch.randn((batch * heads, rows, cols), device=device_type)
+        full_mask = torch.zeros(
+            (batch, 1, rows, cols), dtype=torch.bool, device=device_type
+        )
+        fill_value = torch.tensor(float("-inf"), device=device_type)
+        seeds = torch.zeros((73,), dtype=torch.int64, device=device_type)
+        return run_and_get_code(forward, bmm, full_mask, fill_value, seeds)[1]
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    def test_single_use_random_sinks_into_dropout_epilogue(self):
+        code = self._run_dropout_random_codegen()
+        kernel_code = "\n".join(code)
+
+        self.assertEqual(self._count_inductor_random_calls(code), 1)
+        self.assertEqual(kernel_code.count("tl.store("), 1)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    def test_multi_use_random_does_not_sink_into_dropout_epilogue(self):
+        code = self._run_dropout_random_codegen(return_random=True)
+        kernel_code = "\n".join(code)
+
+        self.assertEqual(self._count_inductor_random_calls(code), 1)
+        self.assertEqual(kernel_code.count("tl.store("), 2)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    def test_non_dropout_threshold_random_does_not_sink_into_epilogue(self):
+        code = self._run_dropout_random_codegen(use_where=True)
+        kernel_code = "\n".join(code)
+
+        self.assertEqual(self._count_inductor_random_calls(code), 1)
+        self.assertEqual(kernel_code.count("tl.store("), 2)
+
     def test_issue100806(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2842,6 +2842,38 @@ def get_threads_per_round(device: torch.device):
     return threads_per_round
 
 
+def _can_defer_single_use_dropout_random(mode: str, device: torch.device) -> bool:
+    if mode != "rand" or device.type != "cuda" or config.align_random_eager:
+        return False
+
+    current_node = V.graph.current_node
+    if current_node is None or len(current_node.users) != 1:
+        return False
+
+    threshold = next(iter(current_node.users))
+    if (
+        threshold.op != "call_function"
+        or threshold.target
+        not in {
+            aten.gt.Scalar,
+            aten.ge.Scalar,
+            aten.lt.Scalar,
+            aten.le.Scalar,
+        }
+        or len(threshold.args) < 1
+        or threshold.args[0] is not current_node
+        or len(threshold.users) != 1
+    ):
+        return False
+
+    mask_user = next(iter(threshold.users))
+    return (
+        mask_user.op == "call_function"
+        and mask_user.target == aten.mul.Tensor
+        and any(arg is threshold for arg in mask_user.args)
+    )
+
+
 @register_lowering(inductor_prims.random, type_promotion_kind=None)
 def inductor_random(
     size: list[int],
@@ -2895,7 +2927,10 @@ def inductor_random(
         inner_fn=inner_fn,
         ranges=[*size],
     )
-    result.realize()
+    # Single-use dropout masks can inline RNG into a fused epilogue and avoid
+    # materializing random values to global memory.
+    if not _can_defer_single_use_dropout_random(mode, device):
+        result.realize()
     return result
 
 


### PR DESCRIPTION
Summary:
- Avoid materializing CUDA uniform random tensors when they are only used by a scalar threshold comparison feeding a fused dropout-style epilogue.
- Keep sinking disabled under `align_random_eager`, and keep multi-use and non-dropout threshold patterns materialized so RNG is not duplicated or semantically changed.
- Update/add CUDA codegen regressions for single-use dropout sinking, multi-use guard, and non-dropout threshold guard.

Context:
- better-benchmark issue: https://github.com/eellison/better-benchmark/issues/42
- primary validated repros: `amax_sum_0f87f6568d0f`, `amax_sum_f5253e4f250e`, `amax_sum_557afc9e24ea`
- pytorch/pytorch 184377 does not obsolete this: after recent random changes, the reduction/dropout repros still benefit when the single-use random temp store/reload is removed.

Validation:
- `git diff --check HEAD~1..HEAD`
- `python -m py_compile torch/_inductor/lowering.py test/inductor/test_cuda_repro.py`
- Focused CUDA codegen tests on a known-good built checkout:
  - single-use dropout mask sinks RNG into epilogue
  - multi-use random stays materialized
  - non-dropout threshold consumer via `where` stays materialized

Generated-code evidence:
- Canonical repros change from random temp store + final store to final store only:
  - `amax_sum_0f87f6568d0f`: `tl.store` 2 -> 1, `tl.load` 8 -> 7
  - `amax_sum_f5253e4f250e`: `tl.store` 2 -> 1, `tl.load` 6 -> 5
  - `amax_sum_557afc9e24ea`: `tl.store` 2 -> 1, `tl.load` 6 -> 5
- Guard tests show multi-use and non-dropout threshold cases still emit two stores.

B200 timings under GPU lock:
- `amax_sum_0f87f6568d0f`: 273.408 us -> 244.672 us, 11.74% faster
- `amax_sum_f5253e4f250e`: 500.704 us -> 495.520 us, 1.05% faster
- `amax_sum_557afc9e24ea`: 335.840 us -> 333.696 us, 0.64% faster

Risk:
- Guard is intentionally syntactic: CUDA uniform `rand`, one FX user, scalar threshold compare feeding the dropout multiply pattern. Multi-use randoms, `randn`, eager-aligned RNG, and non-dropout threshold users still realize as before.

Submitted by my agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo