### PR TITLE
[inductor] Score broadcast reuse for expensive pointwise tiling

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1442,7 +1442,7 @@ class CommonTemplate:
             )
 
         device = torch.device(self.device)
-        n, c, h, w = 4, 32, 8, 8
+        n, c, h, w = 8, 32, 8, 8
         image_args = [
             torch.randn((n, c, h, w), device=device, dtype=torch.float32)
             for _ in range(3)
@@ -1464,10 +1464,12 @@ class CommonTemplate:
                 "triton.max_tiles": 2,
                 "triton.prefer_nd_tiling": False,
             },
+            rtol=1e-4,
+            atol=1e-4,
         )
 
         self._assert_pointwise_ndims(triton_code, 2)
-        self.assertIn("ynumel = 128", triton_code)
+        self.assertIn("ynumel = 256", triton_code)
         self.assertIn("xnumel = 64", triton_code)
 
     @requires_gpu()
@@ -1508,6 +1510,8 @@ class CommonTemplate:
                 "triton.max_tiles": 2,
                 "triton.prefer_nd_tiling": False,
             },
+            rtol=1e-4,
+            atol=1e-4,
         )
 
         self._assert_pointwise_ndims(triton_code, 1)
@@ -1521,7 +1525,7 @@ class CommonTemplate:
         n, c, h, w = 4, 32, 8, 8
         result, (triton_code,) = self._run_and_compare(
             foo,
-            torch.randn((n, c, h, w), device=device, dtype=torch.float32),
+            torch.rand((n, c, h, w), device=device, dtype=torch.float32) + 0.1,
             torch.randn((c,), device=device, dtype=torch.float32),
             torch.randn((c,), device=device, dtype=torch.float32),
             expected_num_triton_kernels=1,
@@ -1530,6 +1534,8 @@ class CommonTemplate:
                 "triton.max_tiles": 2,
                 "triton.prefer_nd_tiling": False,
             },
+            rtol=1e-4,
+            atol=1e-4,
         )
 
         self._assert_pointwise_ndims(triton_code, 1)
@@ -1562,6 +1568,105 @@ class CommonTemplate:
                 "triton.max_tiles": 2,
                 "triton.prefer_nd_tiling": False,
             },
+            rtol=1e-4,
+            atol=1e-4,
+        )
+
+        self._assert_pointwise_ndims(triton_code, 1)
+
+    @requires_gpu()
+    def test_expensive_broadcast_reuse_tiling_rejects_intermediate_cat(self):
+        def foo(
+            x0,
+            x1,
+            x2,
+            mean0,
+            var0,
+            weight0,
+            bias0,
+            mean1,
+            var1,
+            weight1,
+            bias1,
+        ):
+            def bn_affine(x, mean, var, weight, bias):
+                scale = torch.reciprocal(torch.sqrt(var + 1e-5))
+                return (x - mean[:, None, None]) * scale[:, None, None] * weight[
+                    :, None, None
+                ] + bias[:, None, None]
+
+            cat = torch.cat((x0, bn_affine(x1, mean0, var0, weight0, bias0)), dim=1)
+            return cat + bn_affine(x2, mean1, var1, weight1, bias1)
+
+        device = torch.device(self.device)
+        n, c, h, w = 8, 16, 8, 8
+        result, (triton_code,) = self._run_and_compare(
+            foo,
+            torch.randn((n, c, h, w), device=device, dtype=torch.float32),
+            torch.randn((n, c, h, w), device=device, dtype=torch.float32),
+            torch.randn((n, 2 * c, h, w), device=device, dtype=torch.float32),
+            torch.randn((c,), device=device, dtype=torch.float32),
+            torch.rand((c,), device=device, dtype=torch.float32) + 0.1,
+            torch.randn((c,), device=device, dtype=torch.float32),
+            torch.randn((c,), device=device, dtype=torch.float32),
+            torch.randn((2 * c,), device=device, dtype=torch.float32),
+            torch.rand((2 * c,), device=device, dtype=torch.float32) + 0.1,
+            torch.randn((2 * c,), device=device, dtype=torch.float32),
+            torch.randn((2 * c,), device=device, dtype=torch.float32),
+            expected_num_triton_kernels=1,
+            config_patches={
+                "force_pointwise_cat": True,
+                "triton.coalesce_tiling_analysis": True,
+                "triton.max_tiles": 2,
+                "triton.prefer_nd_tiling": False,
+            },
+            rtol=1e-4,
+            atol=1e-4,
+        )
+
+        self.assertIn("tl.where", triton_code)
+        self._assert_pointwise_ndims(triton_code, 1)
+
+    @requires_gpu()
+    def test_expensive_broadcast_reuse_tiling_rejects_small_fp16_work(self):
+        def foo(x0, x1, mean0, var0, weight0, bias0, mean1, var1, weight1, bias1):
+            def bn_affine(x, mean, var, weight, bias):
+                scale = torch.reciprocal(torch.sqrt(var.float() + 1e-5))
+                result = (x.float() - mean.float()[:, None, None]) * scale[
+                    :, None, None
+                ] * weight[:, None, None] + bias[:, None, None]
+                return result.to(torch.float16)
+
+            return torch.relu(
+                bn_affine(x0, mean0, var0, weight0, bias0)
+                + bn_affine(x1, mean1, var1, weight1, bias1)
+            )
+
+        device = torch.device(self.device)
+        n, c, h, w = 32, 2048, 7, 7
+        image_args = [
+            torch.randn((n, c, h, w), device=device, dtype=torch.float16)
+            for _ in range(2)
+        ]
+        channel_args = [
+            torch.randn((c,), device=device, dtype=torch.float16),
+            torch.rand((c,), device=device, dtype=torch.float16) + 0.1,
+            torch.randn((c,), device=device, dtype=torch.float16),
+            torch.randn((c,), device=device, dtype=torch.float16),
+        ]
+        result, (triton_code,) = self._run_and_compare(
+            foo,
+            *image_args,
+            *channel_args,
+            *channel_args,
+            expected_num_triton_kernels=1,
+            config_patches={
+                "triton.coalesce_tiling_analysis": True,
+                "triton.max_tiles": 2,
+                "triton.prefer_nd_tiling": False,
+            },
+            rtol=1e-2,
+            atol=1e-2,
         )
 
         self._assert_pointwise_ndims(triton_code, 1)

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1426,6 +1426,92 @@ class CommonTemplate:
         # Singleton splits should be discarded.
         self._assert_pointwise_ndims(triton_code, 2)
 
+    @requires_gpu()
+    def test_expensive_broadcast_reuse_tiling(self):
+        def foo(x0, x1, x2, mean0, var0, weight0, bias0, mean1, var1, weight1, bias1):
+            def bn_affine(x, mean, var, weight, bias):
+                scale = torch.reciprocal(torch.sqrt(var + 1e-5))
+                return (x - mean[:, None, None]) * scale[:, None, None] * weight[
+                    :, None, None
+                ] + bias[:, None, None]
+
+            return torch.relu(
+                bn_affine(x0, mean0, var0, weight0, bias0)
+                + bn_affine(x1, mean1, var1, weight1, bias1)
+                + bn_affine(x2, mean0, var0, weight0, bias0)
+            )
+
+        device = torch.device(self.device)
+        n, c, h, w = 4, 32, 8, 8
+        image_args = [
+            torch.randn((n, c, h, w), device=device, dtype=torch.float32)
+            for _ in range(3)
+        ]
+        channel_args = [
+            torch.randn((c,), device=device, dtype=torch.float32),
+            torch.rand((c,), device=device, dtype=torch.float32) + 0.1,
+            torch.randn((c,), device=device, dtype=torch.float32),
+            torch.randn((c,), device=device, dtype=torch.float32),
+        ]
+        result, (triton_code,) = self._run_and_compare(
+            foo,
+            *image_args,
+            *channel_args,
+            *channel_args,
+            expected_num_triton_kernels=1,
+            config_patches={
+                "triton.coalesce_tiling_analysis": True,
+                "triton.max_tiles": 2,
+                "triton.prefer_nd_tiling": False,
+            },
+        )
+
+        self._assert_pointwise_ndims(triton_code, 2)
+        self.assertIn("ynumel = 128", triton_code)
+        self.assertIn("xnumel = 64", triton_code)
+
+    @requires_gpu()
+    def test_expensive_broadcast_reuse_tiling_rejects_small_suffix(self):
+        def foo(x0, x1, x2, mean0, var0, weight0, bias0, mean1, var1, weight1, bias1):
+            def bn_affine(x, mean, var, weight, bias):
+                scale = torch.reciprocal(torch.sqrt(var + 1e-5))
+                return (x - mean[:, None, None]) * scale[:, None, None] * weight[
+                    :, None, None
+                ] + bias[:, None, None]
+
+            return torch.relu(
+                bn_affine(x0, mean0, var0, weight0, bias0)
+                + bn_affine(x1, mean1, var1, weight1, bias1)
+                + bn_affine(x2, mean0, var0, weight0, bias0)
+            )
+
+        device = torch.device(self.device)
+        n, c, h, w = 4, 32, 7, 7
+        image_args = [
+            torch.randn((n, c, h, w), device=device, dtype=torch.float32)
+            for _ in range(3)
+        ]
+        channel_args = [
+            torch.randn((c,), device=device, dtype=torch.float32),
+            torch.rand((c,), device=device, dtype=torch.float32) + 0.1,
+            torch.randn((c,), device=device, dtype=torch.float32),
+            torch.randn((c,), device=device, dtype=torch.float32),
+        ]
+        result, (triton_code,) = self._run_and_compare(
+            foo,
+            *image_args,
+            *channel_args,
+            *channel_args,
+            expected_num_triton_kernels=1,
+            config_patches={
+                "triton.coalesce_tiling_analysis": True,
+                "triton.max_tiles": 2,
+                "triton.prefer_nd_tiling": False,
+            },
+        )
+
+        self._assert_pointwise_ndims(triton_code, 1)
+
     # Integration test to ensure that matched dims & strides from match_mod_div_expr
     # are unsigned and signed integers respectively. This test case has the following
     # index:=(ModularIndexing(xindex, 4, 4)) + 4*(ModularIndexing(xindex, 32, 2))

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1486,7 +1486,7 @@ class CommonTemplate:
             )
 
         device = torch.device(self.device)
-        n, c, h, w = 4, 32, 7, 7
+        n, c, h, w = 4, 32, 2, 3
         image_args = [
             torch.randn((n, c, h, w), device=device, dtype=torch.float32)
             for _ in range(3)
@@ -1504,6 +1504,60 @@ class CommonTemplate:
             *channel_args,
             expected_num_triton_kernels=1,
             config_patches={
+                "triton.coalesce_tiling_analysis": True,
+                "triton.max_tiles": 2,
+                "triton.prefer_nd_tiling": False,
+            },
+        )
+
+        self._assert_pointwise_ndims(triton_code, 1)
+
+    @requires_gpu()
+    def test_expensive_broadcast_reuse_tiling_rejects_full_shape_expensive(self):
+        def foo(x, bias0, bias1):
+            return torch.sqrt(x + 1e-5) + bias0[:, None, None] + bias1[:, None, None]
+
+        device = torch.device(self.device)
+        n, c, h, w = 4, 32, 8, 8
+        result, (triton_code,) = self._run_and_compare(
+            foo,
+            torch.randn((n, c, h, w), device=device, dtype=torch.float32),
+            torch.randn((c,), device=device, dtype=torch.float32),
+            torch.randn((c,), device=device, dtype=torch.float32),
+            expected_num_triton_kernels=1,
+            config_patches={
+                "triton.coalesce_tiling_analysis": True,
+                "triton.max_tiles": 2,
+                "triton.prefer_nd_tiling": False,
+            },
+        )
+
+        self._assert_pointwise_ndims(triton_code, 1)
+
+    @requires_gpu()
+    def test_expensive_broadcast_reuse_tiling_rejects_predicated_cat(self):
+        def foo(x0, x1, var0, var1):
+            scale0 = torch.reciprocal(torch.sqrt(var0 + 1e-5))
+            scale1 = torch.reciprocal(torch.sqrt(var1 + 1e-5))
+            return torch.cat(
+                (
+                    x0 * scale0[:, None, None],
+                    x1 * scale1[:, None, None],
+                ),
+                dim=1,
+            )
+
+        device = torch.device(self.device)
+        n, c, h, w = 4, 16, 8, 8
+        result, (triton_code,) = self._run_and_compare(
+            foo,
+            torch.randn((n, c, h, w), device=device, dtype=torch.float32),
+            torch.randn((n, c, h, w), device=device, dtype=torch.float32),
+            torch.rand((c,), device=device, dtype=torch.float32) + 0.1,
+            torch.rand((c,), device=device, dtype=torch.float32) + 0.1,
+            expected_num_triton_kernels=1,
+            config_patches={
+                "force_pointwise_cat": True,
                 "triton.coalesce_tiling_analysis": True,
                 "triton.max_tiles": 2,
                 "triton.prefer_nd_tiling": False,

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -4118,7 +4118,7 @@ class SIMDScheduling(BaseScheduling):
 
         sizevars = V.graph.sizevars
         pointwise_hint = sizevars.optimization_hint(pointwise_numel, fallback=0)
-        if pointwise_hint <= 0:
+        if pointwise_hint < 16384:
             return {}
 
         broadcast_reads_by_key: dict[tuple[str, sympy.Expr], sympy.Expr] = {}

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -3888,6 +3888,146 @@ class SIMDScheduling(BaseScheduling):
         return ranked_tilings
 
     @classmethod
+    def _expensive_pointwise_origin_score(
+        cls,
+        node_schedule: list[NodeScheduleEntry],
+    ) -> int:
+        expensive_ops = {
+            "acos": 32,
+            "asin": 32,
+            "atan": 32,
+            "cos": 32,
+            "cosh": 32,
+            "div": 8,
+            "erf": 32,
+            "erfc": 32,
+            "exp": 32,
+            "expm1": 32,
+            "lgamma": 32,
+            "log": 32,
+            "log10": 32,
+            "log1p": 32,
+            "log2": 32,
+            "pow": 16,
+            "reciprocal": 8,
+            "rsqrt": 16,
+            "sin": 32,
+            "sinh": 32,
+            "sqrt": 16,
+            "tan": 32,
+            "tanh": 32,
+            "truediv": 8,
+        }
+
+        score = 0
+        seen_origin_ids: OrderedSet[int] = OrderedSet()
+        for schedule_entry in NodeScheduleMarker.only_nodes(node_schedule):
+            for node in schedule_entry.get_nodes():
+                if not isinstance(node, scheduler.SchedulerNode) or node.node is None:
+                    continue
+                for origin in node.node.get_origins():
+                    origin_id = id(origin)
+                    if origin_id in seen_origin_ids:
+                        continue
+                    seen_origin_ids.add(origin_id)
+                    score += expensive_ops.get(cls._origin_target_name(origin), 0)
+
+        return score
+
+    @staticmethod
+    def _origin_target_name(origin: Any) -> str:
+        target = getattr(origin, "target", None)
+        if target is None:
+            return ""
+        overloadpacket = getattr(target, "overloadpacket", None)
+        if overloadpacket is not None:
+            return str(overloadpacket).rsplit(".", 1)[-1]
+        name = getattr(target, "__name__", None)
+        if name is not None:
+            return name
+        return str(target).rsplit(".", 1)[-1]
+
+    @classmethod
+    def compute_broadcast_reuse_scores(
+        cls,
+        node_schedule: list[NodeScheduleEntry],
+        pointwise_numel: sympy.Expr,
+        coalesce_analysis: CoalesceVarAnalysis,
+    ) -> dict[sympy.Expr, int]:
+        """
+        Score pointwise splits that expose reuse of expensive broadcast work.
+
+        For a flattened NCHW pointwise kernel, a channel-only expression has an
+        index like `c` and is invariant over the trailing H*W suffix. Splitting
+        after `c` lets Triton evaluate expensive scalar chains as [YBLOCK, 1]
+        and broadcast them across [YBLOCK, XBLOCK].
+        """
+        expensive_op_score = cls._expensive_pointwise_origin_score(node_schedule)
+        if expensive_op_score == 0:
+            return {}
+
+        norm_read_writes = coalesce_analysis.norm_read_writes
+        iter_vars = list(norm_read_writes.index_vars)
+        if len(iter_vars) <= 1:
+            return {}
+
+        sizevars = V.graph.sizevars
+        pointwise_hint = sizevars.optimization_hint(pointwise_numel, fallback=0)
+        if pointwise_hint <= 0:
+            return {}
+
+        scores: Counter[sympy.Expr] = Counter()
+        num_broadcast_reads: Counter[sympy.Expr] = Counter()
+        ranges = norm_read_writes.var_ranges
+        min_suffix_coalesced_score = pointwise_hint * 16
+
+        for read_expr, buf_names in norm_read_writes.reads.items():
+            read_vars = read_expr.free_symbols
+            if any(var in read_vars for var in norm_read_writes.reduce_vars):
+                continue
+
+            read_iter_var_indices = [
+                idx for idx, var in enumerate(iter_vars) if var in read_vars
+            ]
+            if not read_iter_var_indices:
+                continue
+
+            split_idx = max(read_iter_var_indices)
+            if split_idx == len(iter_vars) - 1:
+                continue
+
+            trailing_numel = sympy_product(
+                ranges[var] for var in iter_vars[split_idx + 1 :]
+            )
+            if V.graph.sizevars.statically_known_lt(trailing_numel, 64):
+                continue
+
+            reuse_factor = sizevars.optimization_hint(trailing_numel, fallback=1)
+            if reuse_factor < 64:
+                continue
+
+            suffix_coalesced_score = sum(
+                coalesce_analysis.coalesced_by_var.get(var, 0)
+                for var in iter_vars[split_idx + 1 :]
+            )
+            if suffix_coalesced_score < min_suffix_coalesced_score:
+                continue
+
+            # Treat the saved scalar work as an equivalent score in the same
+            # rough units as memory coalescing. Require multiple broadcast reads
+            # and coalesced suffix traffic so unrelated expensive pointwise ops
+            # do not trigger on a lone broadcast bias.
+            split_var = iter_vars[split_idx]
+            num_reads = len(buf_names)
+            saved_elems = pointwise_hint * (reuse_factor - 1) // reuse_factor
+            scores[split_var] += expensive_op_score * num_reads * saved_elems
+            num_broadcast_reads[split_var] += num_reads
+
+        return {
+            var: score for var, score in scores.items() if num_broadcast_reads[var] >= 2
+        }
+
+    @classmethod
     def compute_tiling_strategy(
         cls,
         node_schedule: list[NodeScheduleEntry],
@@ -3910,6 +4050,13 @@ class SIMDScheduling(BaseScheduling):
 
         pw_ranges = [ranges[v] for v in all_iter_vars]
         red_ranges = [ranges[v] for v in all_red_vars]
+        broadcast_reuse_scores = (
+            cls.compute_broadcast_reuse_scores(
+                node_schedule, pointwise_numel, coalesce_analysis
+            )
+            if reduction_numel == 1
+            else {}
+        )
 
         # Sometimes dynamic shapes is unable to prove equality without hint
         get_hint = V.graph.sizevars.optimization_hint
@@ -3988,7 +4135,10 @@ class SIMDScheduling(BaseScheduling):
 
                 prod *= v_range
                 splits.append(prod)
-                split_scores.append(coalesce_analysis.coalesced_by_var.get(v, 0))
+                split_scores.append(
+                    coalesce_analysis.coalesced_by_var.get(v, 0)
+                    + (broadcast_reuse_scores.get(v, 0) if is_pointwise else 0)
+                )
                 prod = 1
 
             if prod != 1 or (is_pointwise and len(splits) == 0):
@@ -4027,9 +4177,9 @@ class SIMDScheduling(BaseScheduling):
 
         # TODO, add tests, reduction splits if config.triton.tile_reductions
         # TODO: we should ignore tiny increases in score for extra splits
-        overlapping_iter_vars = (
-            all_iter_vars & coalesce_analysis.coalesced_by_var.keys()
-        )
+        scored_iter_vars = OrderedSet(coalesce_analysis.coalesced_by_var.keys())
+        scored_iter_vars.update(broadcast_reuse_scores.keys())
+        overlapping_iter_vars = all_iter_vars & scored_iter_vars
         for v in overlapping_iter_vars:
             score_split.append(
                 (

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -3918,6 +3918,26 @@ class SIMDScheduling(BaseScheduling):
         }
 
     @staticmethod
+    def _has_cat_origin(node_schedule: list[NodeScheduleEntry]) -> bool:
+        for schedule_entry in NodeScheduleMarker.only_nodes(node_schedule):
+            for node in schedule_entry.get_nodes():
+                if not isinstance(node, scheduler.SchedulerNode):
+                    continue
+
+                for origin in node.node.get_origins():
+                    if getattr(origin, "op", None) != "call_function":
+                        continue
+
+                    if getattr(origin, "target", None) == torch.ops.aten.cat.default:
+                        return True
+
+                    original_aten = getattr(origin, "meta", {}).get("original_aten")
+                    if original_aten == torch.ops.aten.cat.default:
+                        return True
+
+        return False
+
+    @staticmethod
     def _read_score(
         read_expr: sympy.Expr,
         var_ranges: dict[sympy.Symbol, sympy.Expr],
@@ -4112,18 +4132,29 @@ class SIMDScheduling(BaseScheduling):
         if norm_read_writes.reduce_vars:
             return {}
 
+        # Pointwise cat lowers to predicated, mutually exclusive regions. The
+        # dataflow score below does not model branch exclusivity, so cat-origin
+        # regions must not introduce a broadcast-only tiling score.
+        if cls._has_cat_origin(node_schedule):
+            return {}
+
         iter_vars = list(norm_read_writes.index_vars)
         if len(iter_vars) <= 1:
             return {}
 
         sizevars = V.graph.sizevars
+        min_pointwise_hint = 16384
         pointwise_hint = sizevars.optimization_hint(pointwise_numel, fallback=0)
-        if pointwise_hint < 16384:
+        if pointwise_hint < min_pointwise_hint:
             return {}
 
+        # Low-precision broadcast sources need more total work before the
+        # special-function savings reliably amortize the extra 2D tiling shape.
+        min_low_precision_pointwise_hint = 4_000_000
         broadcast_reads_by_key: dict[tuple[str, sympy.Expr], sympy.Expr] = {}
         trailing_vars_by_split: dict[sympy.Expr, OrderedSet[sympy.Symbol]] = {}
         reuse_factor_by_split: dict[sympy.Expr, int] = {}
+        max_read_itemsize_by_split: dict[sympy.Expr, int] = {}
         ranges = norm_read_writes.var_ranges
 
         for read_expr, buf_names in norm_read_writes.reads.items():
@@ -4159,6 +4190,16 @@ class SIMDScheduling(BaseScheduling):
             split_var = iter_vars[split_idx]
             trailing_vars_by_split[split_var] = OrderedSet(iter_vars[split_idx + 1 :])
             reuse_factor_by_split[split_var] = reuse_factor
+            read_itemsizes = [
+                buf.dtype.itemsize
+                for buf_name in buf_names
+                if (buf := V.graph.try_get_buffer(buf_name)) is not None
+            ]
+            if read_itemsizes:
+                max_read_itemsize_by_split[split_var] = max(
+                    max_read_itemsize_by_split.get(split_var, 0),
+                    *read_itemsizes,
+                )
             for buf_name in buf_names:
                 broadcast_reads_by_key[(buf_name, read_expr)] = split_var
 
@@ -4180,6 +4221,11 @@ class SIMDScheduling(BaseScheduling):
                 continue
             reuse_factor = reuse_factor_by_split[var]
             saved_elems = pointwise_hint * (reuse_factor - 1) // reuse_factor
+            if (
+                max_read_itemsize_by_split.get(var, 0) <= 2
+                and pointwise_hint < min_low_precision_pointwise_hint
+            ):
+                continue
             scores[var] = op_score * saved_elems
 
         return scores

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -18,6 +18,7 @@ import sympy
 
 import torch
 import torch._logging
+import torch.fx
 from torch._inductor import metrics
 from torch._inductor.ir import MultiTemplateBuffer
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
@@ -3887,12 +3888,9 @@ class SIMDScheduling(BaseScheduling):
 
         return ranked_tilings
 
-    @classmethod
-    def _expensive_pointwise_origin_score(
-        cls,
-        node_schedule: list[NodeScheduleEntry],
-    ) -> int:
-        expensive_ops = {
+    @staticmethod
+    def _expensive_pointwise_ops() -> dict[str, int]:
+        return {
             "acos": 32,
             "asin": 32,
             "atan": 32,
@@ -3919,33 +3917,181 @@ class SIMDScheduling(BaseScheduling):
             "truediv": 8,
         }
 
-        score = 0
-        seen_origin_ids: OrderedSet[int] = OrderedSet()
-        for schedule_entry in NodeScheduleMarker.only_nodes(node_schedule):
-            for node in schedule_entry.get_nodes():
-                if not isinstance(node, scheduler.SchedulerNode) or node.node is None:
-                    continue
-                for origin in node.node.get_origins():
-                    origin_id = id(origin)
-                    if origin_id in seen_origin_ids:
-                        continue
-                    seen_origin_ids.add(origin_id)
-                    score += expensive_ops.get(cls._origin_target_name(origin), 0)
+    @staticmethod
+    def _read_score(
+        read_expr: sympy.Expr,
+        var_ranges: dict[sympy.Symbol, sympy.Expr],
+        buf_names: OrderedSet[str],
+    ) -> int:
+        indexed_ranges = [
+            var_ranges[var]
+            for var in read_expr.free_symbols
+            if var in var_ranges and not symbol_is_type(var, SymT.INDIRECT)
+        ]
+        numel_hint = V.graph.sizevars.optimization_hint(
+            sympy_product(indexed_ranges), fallback=0
+        )
+        if numel_hint <= 0:
+            return 0
 
-        return score
+        total_score = 0
+        for buf_name in buf_names:
+            buf = V.graph.try_get_buffer(buf_name)
+            if buf is None:
+                continue
+            buf_numel = V.graph.sizevars.optimization_hint(
+                sympy_product(buf.get_size()), fallback=0
+            )
+            if buf_numel <= 0:
+                continue
+            total_score += min(buf_numel, numel_hint) * buf.dtype.itemsize
+
+        return total_score
+
+    @classmethod
+    def _normalized_index_exprs_for_node(
+        cls,
+        node: scheduler.SchedulerNode,
+        pointwise_numel: sympy.Expr,
+        reduction_numel: sympy.Expr,
+        coalesce_analysis: CoalesceVarAnalysis,
+    ) -> dict[str, sympy.Expr] | None:
+        from torch._inductor.tiling_utils import apply_var_mapping, get_pw_red_splits
+
+        norm_read_writes = coalesce_analysis.norm_read_writes
+        norm_pw_vars = list(norm_read_writes.index_vars)
+        norm_red_vars = list(norm_read_writes.reduce_vars)
+        pw_splits = [norm_read_writes.var_ranges[var] for var in norm_pw_vars]
+        red_splits = [norm_read_writes.var_ranges[var] for var in norm_red_vars]
+        (iter_vars, n_pw_splits), (red_vars, n_red_splits) = get_pw_red_splits(
+            node, pointwise_numel, reduction_numel
+        )
+
+        groups = pw_splits + red_splits
+        lengths = SIMDKernel.prepare_split_iteration_lengths(
+            groups, (n_pw_splits, n_red_splits), reduction_numel
+        )
+        try:
+            new_ranges, return_getters_groups = SIMDKernel._split_iteration_ranges(
+                groups, lengths
+            )
+        except CantSplit:
+            return None
+
+        var_map = apply_var_mapping(
+            iter_vars,
+            red_vars,
+            norm_pw_vars,
+            norm_red_vars,
+            new_ranges,
+            return_getters_groups,
+        )
+
+        def remove_identity(expr: sympy.Expr) -> sympy.Expr:
+            return expr.replace(Identity, lambda x: x)
+
+        return {
+            name: V.graph.sizevars.simplify_with_ranges(
+                sympy_subs(remove_identity(expr), var_map),
+                norm_read_writes.var_ranges,
+            )
+            for name, expr in node._body.indexing_exprs.items()
+        }
 
     @staticmethod
-    def _origin_target_name(origin: Any) -> str:
-        target = getattr(origin, "target", None)
-        if target is None:
-            return ""
-        overloadpacket = getattr(target, "overloadpacket", None)
-        if overloadpacket is not None:
-            return str(overloadpacket).rsplit(".", 1)[-1]
-        name = getattr(target, "__name__", None)
-        if name is not None:
-            return name
-        return str(target).rsplit(".", 1)[-1]
+    def _fx_arg_nodes(arg: Any) -> Iterator[torch.fx.Node]:
+        if isinstance(arg, torch.fx.Node):
+            yield arg
+        elif isinstance(arg, (list, tuple)):
+            for item in arg:
+                yield from SIMDScheduling._fx_arg_nodes(item)
+        elif isinstance(arg, dict):
+            for item in arg.values():
+                yield from SIMDScheduling._fx_arg_nodes(item)
+
+    @classmethod
+    def _score_expensive_broadcast_dependents(
+        cls,
+        node_schedule: list[NodeScheduleEntry],
+        pointwise_numel: sympy.Expr,
+        reduction_numel: sympy.Expr,
+        coalesce_analysis: CoalesceVarAnalysis,
+        broadcast_reads_by_key: dict[tuple[str, sympy.Expr], sympy.Expr],
+        trailing_vars_by_split: dict[sympy.Expr, OrderedSet[sympy.Symbol]],
+    ) -> Counter[sympy.Expr]:
+        expensive_ops = cls._expensive_pointwise_ops()
+        scores: Counter[sympy.Expr] = Counter()
+
+        for schedule_entry in NodeScheduleMarker.only_nodes(node_schedule):
+            for node in schedule_entry.get_nodes():
+                if not isinstance(node, scheduler.SchedulerNode):
+                    continue
+
+                normalized_index_exprs = cls._normalized_index_exprs_for_node(
+                    node, pointwise_numel, reduction_numel, coalesce_analysis
+                )
+                if normalized_index_exprs is None:
+                    continue
+
+                node_vars: dict[torch.fx.Node, OrderedSet[sympy.Symbol]] = {}
+                node_splits: dict[torch.fx.Node, OrderedSet[sympy.Expr]] = {}
+
+                for fx_node in node._body.root_block.graph.nodes:
+                    vars_used: OrderedSet[sympy.Symbol] = OrderedSet()
+                    source_splits: OrderedSet[sympy.Expr] = OrderedSet()
+
+                    if (
+                        fx_node.op == "call_module"
+                        and fx_node.target == "get_index"
+                        and fx_node.args
+                    ):
+                        index_name = fx_node.args[0]
+                        if isinstance(index_name, str):
+                            index_expr = normalized_index_exprs.get(index_name)
+                            if index_expr is not None:
+                                vars_used.update(index_expr.free_symbols)
+                    elif fx_node.op == "call_method" and fx_node.target == "load":
+                        buffer_name = fx_node.args[1] if len(fx_node.args) > 1 else None
+                        index_node = fx_node.args[2] if len(fx_node.args) > 2 else None
+                        index_expr = None
+                        if isinstance(index_node, torch.fx.Node):
+                            vars_used.update(node_vars.get(index_node, OrderedSet()))
+                            if (
+                                index_node.op == "call_module"
+                                and index_node.target == "get_index"
+                                and index_node.args
+                            ):
+                                index_name = index_node.args[0]
+                                if isinstance(index_name, str):
+                                    index_expr = normalized_index_exprs.get(index_name)
+
+                        if isinstance(buffer_name, str) and index_expr is not None:
+                            split_var = broadcast_reads_by_key.get(
+                                (buffer_name, index_expr)
+                            )
+                            if split_var is not None:
+                                source_splits.add(split_var)
+                    else:
+                        for arg_node in cls._fx_arg_nodes(
+                            (fx_node.args, fx_node.kwargs)
+                        ):
+                            vars_used.update(node_vars.get(arg_node, OrderedSet()))
+                            source_splits.update(
+                                node_splits.get(arg_node, OrderedSet())
+                            )
+
+                    if fx_node.op == "call_method":
+                        op_score = expensive_ops.get(str(fx_node.target), 0)
+                        if op_score:
+                            for split_var in source_splits:
+                                trailing_vars = trailing_vars_by_split[split_var]
+                                if not vars_used & trailing_vars:
+                                    scores[split_var] += op_score
+
+                    node_vars[fx_node] = vars_used
+                    node_splits[fx_node] = source_splits
+
+        return scores
 
     @classmethod
     def compute_broadcast_reuse_scores(
@@ -3962,11 +4108,10 @@ class SIMDScheduling(BaseScheduling):
         after `c` lets Triton evaluate expensive scalar chains as [YBLOCK, 1]
         and broadcast them across [YBLOCK, XBLOCK].
         """
-        expensive_op_score = cls._expensive_pointwise_origin_score(node_schedule)
-        if expensive_op_score == 0:
+        norm_read_writes = coalesce_analysis.norm_read_writes
+        if norm_read_writes.reduce_vars:
             return {}
 
-        norm_read_writes = coalesce_analysis.norm_read_writes
         iter_vars = list(norm_read_writes.index_vars)
         if len(iter_vars) <= 1:
             return {}
@@ -3976,16 +4121,17 @@ class SIMDScheduling(BaseScheduling):
         if pointwise_hint <= 0:
             return {}
 
-        scores: Counter[sympy.Expr] = Counter()
-        num_broadcast_reads: Counter[sympy.Expr] = Counter()
+        broadcast_reads_by_key: dict[tuple[str, sympy.Expr], sympy.Expr] = {}
+        trailing_vars_by_split: dict[sympy.Expr, OrderedSet[sympy.Symbol]] = {}
+        reuse_factor_by_split: dict[sympy.Expr, int] = {}
         ranges = norm_read_writes.var_ranges
-        min_suffix_coalesced_score = pointwise_hint * 16
 
         for read_expr, buf_names in norm_read_writes.reads.items():
-            read_vars = read_expr.free_symbols
-            if any(var in read_vars for var in norm_read_writes.reduce_vars):
+            read_score = cls._read_score(read_expr, ranges, buf_names)
+            if read_score == 0:
                 continue
 
+            read_vars = read_expr.free_symbols
             read_iter_var_indices = [
                 idx for idx, var in enumerate(iter_vars) if var in read_vars
             ]
@@ -3999,33 +4145,44 @@ class SIMDScheduling(BaseScheduling):
             trailing_numel = sympy_product(
                 ranges[var] for var in iter_vars[split_idx + 1 :]
             )
-            if V.graph.sizevars.statically_known_lt(trailing_numel, 64):
-                continue
-
             reuse_factor = sizevars.optimization_hint(trailing_numel, fallback=1)
-            if reuse_factor < 64:
+            if reuse_factor < 8:
                 continue
 
             suffix_coalesced_score = sum(
                 coalesce_analysis.coalesced_by_var.get(var, 0)
                 for var in iter_vars[split_idx + 1 :]
             )
-            if suffix_coalesced_score < min_suffix_coalesced_score:
+            if suffix_coalesced_score == 0:
                 continue
 
-            # Treat the saved scalar work as an equivalent score in the same
-            # rough units as memory coalescing. Require multiple broadcast reads
-            # and coalesced suffix traffic so unrelated expensive pointwise ops
-            # do not trigger on a lone broadcast bias.
             split_var = iter_vars[split_idx]
-            num_reads = len(buf_names)
-            saved_elems = pointwise_hint * (reuse_factor - 1) // reuse_factor
-            scores[split_var] += expensive_op_score * num_reads * saved_elems
-            num_broadcast_reads[split_var] += num_reads
+            trailing_vars_by_split[split_var] = OrderedSet(iter_vars[split_idx + 1 :])
+            reuse_factor_by_split[split_var] = reuse_factor
+            for buf_name in buf_names:
+                broadcast_reads_by_key[(buf_name, read_expr)] = split_var
 
-        return {
-            var: score for var, score in scores.items() if num_broadcast_reads[var] >= 2
-        }
+        if not broadcast_reads_by_key:
+            return {}
+
+        expensive_scores = cls._score_expensive_broadcast_dependents(
+            node_schedule,
+            pointwise_numel,
+            sympy.S.One,
+            coalesce_analysis,
+            broadcast_reads_by_key,
+            trailing_vars_by_split,
+        )
+
+        scores: dict[sympy.Expr, int] = {}
+        for var, op_score in expensive_scores.items():
+            if op_score == 0:
+                continue
+            reuse_factor = reuse_factor_by_split[var]
+            saved_elems = pointwise_hint * (reuse_factor - 1) // reuse_factor
+            scores[var] = op_score * saved_elems
+
+        return scores
 
     @classmethod
     def compute_tiling_strategy(

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -3924,7 +3924,11 @@ class SIMDScheduling(BaseScheduling):
                 if not isinstance(node, scheduler.SchedulerNode):
                     continue
 
-                for origin in node.node.get_origins():
+                ir_node = node.node
+                if ir_node is None:
+                    continue
+
+                for origin in ir_node.get_origins():
                     if getattr(origin, "op", None) != "call_function":
                         continue
 


### PR DESCRIPTION
Summary:
- Score pointwise tiling splits when a split exposes reuse of expensive broadcast expressions.
- Require actual expensive work depending on broadcast-indexed reads, nontrivial reuse, coalesced suffix traffic, and enough total work.
- Harden against predicated cat-origin schedules and low-precision small-work regressions.

Context:
- better-benchmark issue: https://github.com/eellison/better-benchmark/issues/41
- representative wins: pointwise_42ab411e21f6, pointwise_42d933d52272, pointwise_226a109e3e14, pointwise_f564ff7f54c2, pointwise_3bd84c5c45de, pointwise_bc30b7a4c3fd, pointwise_ece0de807834.
- regression guards: pointwise_57287c224f10 and pointwise_b0c74cbb35c4 now stay 1D.

Local validation:
- git diff --check
- python -m py_compile torch/_inductor/codegen/simd.py test/inductor/test_torchinductor_strided_blocks.py
- lintrunner --take RUFF,PYFMT,FLAKE8 on touched files
- focused GPU strided-block tests: Ran 18 tests in 16.084s, OK (skipped=6)

B200 spot checks after hardening:
- pointwise_42ab411e21f6: 44.800 us baseline -> 34.592 us hardened
- pointwise_f564ff7f54c2: 33.600 us baseline -> 26.464 us hardened
- pointwise_57287c224f10: 18.208 us baseline -> 18.208 us hardened
- pointwise_b0c74cbb35c4: 24.288 us baseline -> 24.256 us hardened

Submitted by my agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo