### PR TITLE
[inductor] Use persistent reduction for R=2048 online softmax

### DIFF
--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -89,7 +89,8 @@ class TestOnlineSoftmax(TestCase):
     def test_codegen_online_softmax(self, use_log_softmax, V):
         wrapper_code = self.get_softmax_wrapper(use_log_softmax=use_log_softmax, V=V)
 
-        self.assertEqual(wrapper_code.count("for r0_offset in"), 2)
+        expected_num_loops = 0 if V == 2048 else 2
+        self.assertEqual(wrapper_code.count("for r0_offset in"), expected_num_loops)
 
     def test_no_online_softmax_for_cpu(self):
         code = self.get_softmax_wrapper(V=2048, device="cpu")
@@ -102,8 +103,16 @@ class TestOnlineSoftmax(TestCase):
         """
         Persistent reduction has no for loops.
         """
-        wrapper_code = self.get_softmax_wrapper(1024)
+        wrapper_code = self.get_softmax_wrapper(2048)
         self.assertEqual(wrapper_code.count("for r0_offset in"), 0)
+
+    def test_codegen_softmax_persistent_reduction_not_generic_inner_reduction(self):
+        def f(x):
+            return x.sum(dim=-1, keepdim=True)
+
+        x = torch.randn(1024, 2048, dtype=torch.bfloat16, device=GPU_TYPE)
+        _, (code,) = run_and_get_code(torch.compile(f), x)
+        self.assertNotIn("triton_heuristics.persistent_reduction", code)
 
     @inductor_config.patch("triton.persistent_reductions", False)
     def test_sdpa(self):

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -417,11 +417,19 @@ class InductorChoices:
         """
         if not config.triton.persistent_reductions:
             return False
+        reduction_hint = features.get_reduction_hint()
         threshold = {
             ReductionHint.INNER: 1024,
-        }.get(features.get_reduction_hint(), 64)
+        }.get(reduction_hint, 64)
 
-        if features.get_reduction_hint() not in (
+        if (
+            reduction_hint == ReductionHint.INNER
+            and not cooperative_reduction
+            and features.has_only_reduction_type("online_softmax_reduce")
+        ):
+            threshold = 2048
+
+        if reduction_hint not in (
             ReductionHint.INNER,
             ReductionHint.OUTER_TINY,
         ):

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -14,6 +14,7 @@ import torch
 from ...utils._ordered_set import OrderedSet
 from ...utils._sympy.functions import FloorDiv, ModularIndexing
 from ...utils._sympy.symbol import make_symbol, SymT
+from .. import ir
 from ..dependencies import Dep, extract_loop_body_with_args, MemoryDep
 from ..runtime.hints import ReductionHint
 from ..scheduler import SchedulerNode
@@ -101,6 +102,20 @@ class SIMDKernelFeatures:
 
     def reduction_nodes(self) -> list[SchedulerNode]:
         return [n for n in self.scheduler_nodes() if n.is_reduction()]
+
+    @staticmethod
+    def scheduler_node_reduction_type(node: SchedulerNode) -> str | None:
+        assert isinstance(node.node, (ir.ComputedBuffer, ir.TemplateBuffer)), (
+            f"{type(node.node)=}"
+        )
+        return node.node.get_reduction_type()
+
+    def has_only_reduction_type(self, reduction_type: str) -> bool:
+        reductions = self.reduction_nodes()
+        return bool(reductions) and all(
+            self.scheduler_node_reduction_type(node) == reduction_type
+            for node in reductions
+        )
 
     @cache_on_self
     def buf_accesses(self) -> dict[str, list[Dep]]:


### PR DESCRIPTION
Summary:
- raises the persistent-reduction threshold to 2048 only for non-cooperative inner `online_softmax_reduce` kernels
- keeps generic inner reductions unchanged
- adds tests for R=2048 online softmax and for generic R=2048 sum staying non-persistent

Context:
- better-benchmark issue: https://github.com/eellison/better-benchmark/issues/46
- clean validation repro: `amax_sum_a7ede60031ef`
- transfer repros: `amax_sum_5f0c26b7e967`, `amax_sum_4bd27b112605`

Validation:
- `python -m py_compile torch/_inductor/choices.py torch/_inductor/codegen/simd_kernel_features.py test/inductor/test_online_softmax.py`
- `git diff --check`
- Targeted tests:
  - `TestOnlineSoftmax.test_codegen_softmax_persistent_reduction`
  - `TestOnlineSoftmax.test_codegen_softmax_persistent_reduction_not_generic_inner_reduction`
- GPU codegen validation:
  - `softmax_R2048`: persistent `True`, no `for r0_offset`, `R0_BLOCK=2048`
  - `sum_R2048`: persistent `False`
  - `softmax_R4096`: persistent `False`, combine path still used

B200 GPU 2 timing, compilation/autotune outside lock and `do_bench` inside `/tmp/compile_utils_gpu_locks/gpu2.lock`:
- `8192 x 2048`: base/default 0.076231 ms, issue46 persistent 0.046172 ms, forced non-persistent 0.076266 ms
- `32768 x 2048`: base/default 0.267322 ms, issue46 persistent 0.153421 ms, forced non-persistent 0.267230 ms

This validates the intended rule: when R=2048 online softmax can stay persistent, choosing online/non-persistent is substantially worse.

Risk:
- scoped specifically to non-cooperative inner online softmax reductions; generic inner reductions remain on the previous threshold.
- validation used an existing built checkout while overriding this worktree's Inductor sources; full CI should run the direct test suite.

submitted by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
