### PR TITLE
[inductor] Use non-online softmax for huge inner reductions

### DIFF
--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -86,10 +86,50 @@ class TestOnlineSoftmax(TestCase):
 
     @parametrize("V", [2048, 50304])
     @parametrize("use_log_softmax", [False, True])
+    @inductor_config.patch(large_non_online_softmax=True)
     def test_codegen_online_softmax(self, use_log_softmax, V):
         wrapper_code = self.get_softmax_wrapper(use_log_softmax=use_log_softmax, V=V)
 
-        self.assertEqual(wrapper_code.count("for r0_offset in"), 2)
+        if V >= inductor_config.large_non_online_softmax_min_rnumel:
+            self.assertNotIn("online_softmax_reduce", wrapper_code)
+            self.assertEqual(wrapper_code.count("for r0_offset in"), 3)
+        else:
+            self.assertEqual(wrapper_code.count("for r0_offset in"), 2)
+
+    @parametrize("fn", [torch.softmax, torch.log_softmax])
+    @inductor_config.patch(large_non_online_softmax=True)
+    def test_codegen_huge_softmax_uses_non_online(self, fn):
+        @torch.compile
+        def f(x):
+            return fn(x, dim=-1)
+
+        x = torch.randn(1024, 8192, dtype=torch.bfloat16, device=GPU_TYPE)
+        _out, (code,) = run_and_get_code(f, x)
+        self.assertNotIn("online_softmax_reduce", code)
+        self.assertEqual(code.count("for r0_offset in"), 3)
+
+    @inductor_config.patch(large_non_online_softmax=False)
+    def test_codegen_huge_softmax_can_force_online(self):
+        @torch.compile
+        def f(x):
+            return torch.softmax(x, dim=-1)
+
+        x = torch.randn(1024, 8192, dtype=torch.bfloat16, device=GPU_TYPE)
+        _out, (code,) = run_and_get_code(f, x)
+        self.assertIn("online_softmax_reduce", code)
+        self.assertEqual(code.count("for r0_offset in"), 2)
+
+    @inductor_config.patch(large_non_online_softmax=True)
+    def test_codegen_huge_softmax_with_final_sum_uses_non_online(self):
+        @torch.compile
+        def f(x):
+            return torch.softmax(x, dim=-1).sum()
+
+        x = torch.randn(1024, 8192, dtype=torch.bfloat16, device=GPU_TYPE)
+        _out, codes = run_and_get_code(f, x)
+        code = "\n".join(codes)
+        self.assertNotIn("online_softmax_reduce", code)
+        self.assertIn("triton_helpers.max2", code)
 
     def test_no_online_softmax_for_cpu(self):
         code = self.get_softmax_wrapper(V=2048, device="cpu")

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -218,6 +218,21 @@ cpp_cache_precompile_headers: bool = (
 
 online_softmax = os.environ.get("TORCHINDUCTOR_ONLINE_SOFTMAX", "1") == "1"
 
+large_non_online_softmax = (
+    os.environ.get("TORCHINDUCTOR_LARGE_NON_ONLINE_SOFTMAX", "1") == "1"
+)
+large_non_online_softmax_min_xnumel = int(
+    os.environ.get("TORCHINDUCTOR_LARGE_NON_ONLINE_SOFTMAX_MIN_XNUMEL", "1024")
+)
+large_non_online_softmax_min_rnumel = int(
+    os.environ.get("TORCHINDUCTOR_LARGE_NON_ONLINE_SOFTMAX_MIN_RNUMEL", "8192")
+)
+large_non_online_softmax_max_input_numel = int(
+    os.environ.get(
+        "TORCHINDUCTOR_LARGE_NON_ONLINE_SOFTMAX_MAX_INPUT_NUMEL", str(1 << 31)
+    )
+)
+
 apply_gumbel_max_trick = (
     os.environ.get("TORCHINDUCTOR_APPLY_GUMBEL_MAX_TRICK", "1") == "1"
 )

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8682,8 +8682,13 @@ def prepare_softmax_online(x, dim):
 
     rnumel = V.graph.sizevars.simplify(sympy_product(kwargs["reduction_ranges"]))
 
-    if V.graph.sizevars.statically_known_geq(
-        rnumel, config.unroll_reductions_threshold
+    use_non_online_large_inner = _should_use_large_non_online_softmax(x, dim, kwargs)
+
+    if (
+        V.graph.sizevars.statically_known_geq(
+            rnumel, config.unroll_reductions_threshold
+        )
+        and not use_non_online_large_inner
     ):
         max_tensor, sum_tensor = OnlineSoftmaxReduction.create(
             input_node=x, num_output=2, **kwargs
@@ -8694,6 +8699,49 @@ def prepare_softmax_online(x, dim):
         exp = lowerings[aten.exp](sub(x, amax))
         xsum = sum_(exp, dim, keepdims=True)
         return amax, xsum
+
+
+def _should_use_large_non_online_softmax(x, dim, kwargs):
+    """
+    Use the regular max/sum lowering for large non-persistent inner softmax
+    prepares.  The online combine saves one full input pass, but on huge rows it
+    can become instruction-bound; this keeps the first automatic guard narrow.
+    """
+    if not config.large_non_online_softmax:
+        return False
+
+    device = x.get_device()
+    if device is None or device.type != "cuda":
+        return False
+
+    size = x.get_size()
+    if canonicalize_dim(len(size), dim) != len(size) - 1:
+        return False
+
+    if len(kwargs["reduction_ranges"]) != 1:
+        return False
+
+    xnumel = V.graph.sizevars.simplify(sympy_product(kwargs["ranges"]))
+    rnumel = V.graph.sizevars.simplify(sympy_product(kwargs["reduction_ranges"]))
+    persistent_threshold = 1024 * (16 if config.triton.multi_kernel else 1)
+    min_rnumel = max(
+        config.large_non_online_softmax_min_rnumel,
+        persistent_threshold + 1,
+    )
+    if not V.graph.sizevars.statically_known_geq(
+        xnumel, config.large_non_online_softmax_min_xnumel
+    ):
+        return False
+    if not V.graph.sizevars.statically_known_geq(rnumel, min_rnumel):
+        return False
+
+    max_input_numel = config.large_non_online_softmax_max_input_numel
+    if max_input_numel > 0 and not V.graph.sizevars.statically_known_leq(
+        xnumel * rnumel, max_input_numel
+    ):
+        return False
+
+    return True
 
 
 def _is_sm100_or_later():


### PR DESCRIPTION
Summary:
- Use regular max/sum softmax lowering for huge CUDA inner softmax rows where online softmax is instruction-bound.
- Keep the guard narrow: CUDA, innermost single reduction dim, xnumel >= 1024, rnumel >= max(8192, persistent threshold + 1), and bounded total input numel.
- Add focused codegen tests for huge softmax/log_softmax and a config escape hatch.

Context:
- better-benchmark issue: https://github.com/eellison/better-benchmark/issues/43
- replaces the earlier block-pair online-softmax draft direction on this PR.
- primary repros: amax_sum_3ed297ef02cd, amax_sum_f0661488d68c, amax_sum_sum_1bad0f362efd, amax_sum_sum_dc96a87ba8db.

Local validation:
- git diff --check
- python -m py_compile torch/_inductor/config.py torch/_inductor/lowering.py test/inductor/test_online_softmax.py
- pytest -q test/inductor/test_online_softmax.py -k "test_codegen_online_softmax or huge_softmax"  # 8 passed

B200 benchmark evidence from the local prototype:
- amax_sum_f0661488d68c: 2184.0 us -> 1546.2 us
- amax_sum_sum_dc96a87ba8db: 3537.1 us -> 2798.6 us

Submitted by my agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo