### PR TITLE
[inductor] Fold sparse one-hot sum reductions

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -193,6 +193,20 @@ class CudaReproTests(TestCase):
                 mask, value, torch.tensor(0.0, device=target.device)
             ).sum(dim=[1], keepdim=True)
 
+        def target_depends_on_vocab_dim(target, value):
+            iota = torch.arange(value.shape[1], device=target.device)
+            mask = target == iota
+            return torch.where(
+                mask, value, torch.tensor(0.0, device=target.device)
+            ).sum(dim=[1], keepdim=True)
+
+        def explicit_sum_dtype(target, value):
+            iota = torch.arange(value.shape[1], device=target.device)
+            mask = target == iota
+            return torch.where(
+                mask, value, torch.tensor(0.0, device=target.device)
+            ).sum(dim=[1], keepdim=True, dtype=torch.float32)
+
         target = torch.tensor(
             [[0], [3], [-100], [-1], [vocab], [5]],
             device=device_type,
@@ -200,6 +214,10 @@ class CudaReproTests(TestCase):
         )
         scale = torch.randn(target.shape, device=device_type)
         value = torch.randn(target.shape[0], vocab, device=device_type)
+        large_target = torch.randint(
+            0, vocab, (9000, 1), device=device_type, dtype=torch.int64
+        )
+        large_value = torch.randn(large_target.shape[0], vocab, device=device_type)
 
         counters.clear()
         actual, (code,) = run_and_get_code(
@@ -216,6 +234,37 @@ class CudaReproTests(TestCase):
         self.assertEqual(actual, vocab_dependent_value(target, value))
         self.assertEqual(counters["inductor"]["sparse_one_hot_sum"], 1)
         FileCheck().check_not("rnumel").run(code)
+
+        target_2d = torch.randint(
+            0, vocab, value.shape, device=device_type, dtype=torch.int64
+        )
+        counters.clear()
+        actual, (code,) = run_and_get_code(
+            torch.compile(target_depends_on_vocab_dim, fullgraph=True),
+            target_2d,
+            value,
+        )
+        self.assertEqual(actual, target_depends_on_vocab_dim(target_2d, value))
+        self.assertEqual(counters["inductor"]["sparse_one_hot_sum"], 0)
+        FileCheck().check("rnumel").run(code)
+
+        counters.clear()
+        actual, (code,) = run_and_get_code(
+            torch.compile(explicit_sum_dtype, fullgraph=True), target, value
+        )
+        self.assertEqual(actual, explicit_sum_dtype(target, value))
+        self.assertEqual(counters["inductor"]["sparse_one_hot_sum"], 0)
+        FileCheck().check("rnumel").run(code)
+
+        counters.clear()
+        actual, (code,) = run_and_get_code(
+            torch.compile(vocab_dependent_value, fullgraph=True),
+            large_target,
+            large_value,
+        )
+        self.assertEqual(actual, vocab_dependent_value(large_target, large_value))
+        self.assertEqual(counters["inductor"]["sparse_one_hot_sum"], 0)
+        FileCheck().check("rnumel").run(code)
 
     def test_view_replay_padding_issue_163328(self):
         class ReproModule(nn.Module):

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -170,6 +170,53 @@ class CudaReproTests(TestCase):
         compiled = compile_fx_inner(mod, inps)
         compiled(inps)
 
+    def test_sparse_one_hot_sum_fold(self):
+        vocab = 8
+
+        def invariant_value(target, scale):
+            safe_target = torch.where(target != -100, target, 0)
+            iota = torch.arange(vocab, device=target.device).view(1, vocab)
+            one_hot = torch.where(
+                safe_target.expand(target.shape[0], vocab) == iota,
+                torch.tensor(-1.0, device=target.device),
+                torch.tensor(0.0, device=target.device),
+            )
+            valid_scale = torch.where(
+                target != -100, scale, torch.tensor(0.0, device=target.device)
+            )
+            return (one_hot * valid_scale).sum(dim=[1], keepdim=True)
+
+        def vocab_dependent_value(target, value):
+            iota = torch.arange(value.shape[1], device=target.device)
+            mask = target == iota
+            return torch.where(
+                mask, value, torch.tensor(0.0, device=target.device)
+            ).sum(dim=[1], keepdim=True)
+
+        target = torch.tensor(
+            [[0], [3], [-100], [-1], [vocab], [5]],
+            device=device_type,
+            dtype=torch.int64,
+        )
+        scale = torch.randn(target.shape, device=device_type)
+        value = torch.randn(target.shape[0], vocab, device=device_type)
+
+        counters.clear()
+        actual, (code,) = run_and_get_code(
+            torch.compile(invariant_value, fullgraph=True), target, scale
+        )
+        self.assertEqual(actual, invariant_value(target, scale))
+        self.assertEqual(counters["inductor"]["sparse_one_hot_sum"], 1)
+        FileCheck().check_not("rnumel").run(code)
+
+        counters.clear()
+        actual, (code,) = run_and_get_code(
+            torch.compile(vocab_dependent_value, fullgraph=True), target, value
+        )
+        self.assertEqual(actual, vocab_dependent_value(target, value))
+        self.assertEqual(counters["inductor"]["sparse_one_hot_sum"], 1)
+        FileCheck().check_not("rnumel").run(code)
+
     def test_view_replay_padding_issue_163328(self):
         class ReproModule(nn.Module):
             def __init__(self):

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -80,6 +80,7 @@ PatternMatcherPass = functools.partial(
 log = logging.getLogger(__name__)
 aten = torch.ops.aten
 prims = torch.ops.prims
+_SPARSE_ONE_HOT_MAX_OUTER_NUMEL = 8192
 
 # First pass_patterns[0] are applied, then [1], then [2]
 pass_patterns = [
@@ -1035,6 +1036,31 @@ def _match_iota_eq(
     return None
 
 
+def _broadcasts_over_reduction_dim(
+    node: torch.fx.Node, input_ndim: int, reduce_dim: int
+) -> bool:
+    shape = _node_tensor_shape(node)
+    if shape is None:
+        return False
+
+    dim = len(shape) - input_ndim + reduce_dim
+    if dim < 0:
+        return True
+    if dim >= len(shape):
+        return False
+    return statically_known_true(sym_eq(shape[dim], 1))
+
+
+def _has_profitable_sparse_one_hot_outer_numel(
+    input_shape: torch.Size, reduce_dim: int
+) -> bool:
+    outer_numel: Any = 1
+    for dim, size in enumerate(input_shape):
+        if dim != reduce_dim:
+            outer_numel *= size
+    return statically_known_true(outer_numel <= _SPARSE_ONE_HOT_MAX_OUTER_NUMEL)
+
+
 def _match_sparse_one_hot_value(
     node: torch.fx.Node,
 ) -> tuple[torch.fx.Node, torch.fx.Node, torch.fx.Node | None, Any] | None:
@@ -1113,6 +1139,8 @@ def fold_sparse_one_hot_sum(graph: torch.fx.Graph) -> None:
         input_shape = _node_tensor_shape(sum_input)
         if input_shape is None:
             continue
+        if not _has_profitable_sparse_one_hot_outer_numel(input_shape, reduce_dim):
+            continue
 
         match = _match_sparse_one_hot_value(sum_input)
         if match is None:
@@ -1128,6 +1156,8 @@ def fold_sparse_one_hot_sum(graph: torch.fx.Graph) -> None:
         if not isinstance(target_val, torch.Tensor) or not is_integer_dtype(
             target_val.dtype
         ):
+            continue
+        if not _broadcasts_over_reduction_dim(target, len(input_shape), reduce_dim):
             continue
 
         depends_on_reduction_dim = _value_depends_on_reduction_dim(

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -209,6 +209,10 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
             GraphTransformObserver(gm, f"pass_pattern_{i}").apply_graph_pass(
                 patterns.apply
             )
+        if is_inference:
+            GraphTransformObserver(gm, "fold_sparse_one_hot_sum").apply_graph_pass(
+                fold_sparse_one_hot_sum
+            )
         if config.partitioned_scatter_enabled:
             GraphTransformObserver(
                 gm, "partitioned_scatter_optimization"
@@ -886,6 +890,294 @@ def register_lowering_pattern(
         # pyrefly: ignore [bad-argument-type]
         pass_dict=pass_patterns[pass_number],
     )
+
+
+def _node_tensor_shape(node: torch.fx.Node) -> torch.Size | None:
+    val = node.meta.get("val")
+    if isinstance(val, torch.Tensor):
+        return val.shape
+    return None
+
+
+def _is_zero_arg(arg: Any) -> bool:
+    if isinstance(arg, (int, float)) and arg == 0:
+        return True
+    if not isinstance(arg, torch.fx.Node) or arg.op != "call_function":
+        return False
+
+    if arg.target is aten.scalar_tensor.default:
+        return (
+            len(arg.args) >= 1
+            and isinstance(arg.args[0], (int, float))
+            and arg.args[0] == 0
+        )
+
+    if arg.target is aten.full.default:
+        shape = get_arg_value(arg, 0, "size")
+        if shape != [] and shape != ():
+            return False
+        fill_value = get_arg_value(arg, 1, "fill_value")
+        return fill_value == 0
+
+    return False
+
+
+def _is_scalar_constant_node(node: Any) -> bool:
+    if not isinstance(node, torch.fx.Node) or node.op != "call_function":
+        return False
+
+    if node.target is aten.scalar_tensor.default:
+        return True
+
+    if node.target is aten.full.default:
+        shape = get_arg_value(node, 0, "size")
+        return shape == [] or shape == ()
+
+    return False
+
+
+def _get_single_reduction_dim(node: torch.fx.Node) -> int | None:
+    if node.op != "call_function" or node.target is not aten.sum.dim_IntList:
+        return None
+    if get_arg_value(node, 3, "dtype") is not None:
+        return None
+
+    dims = get_arg_value(node, 1, "dim")
+    if not isinstance(dims, (list, tuple)) or len(dims) != 1:
+        return None
+
+    input_node = node.args[0]
+    if not isinstance(input_node, torch.fx.Node):
+        return None
+    input_shape = _node_tensor_shape(input_node)
+    if input_shape is None:
+        return None
+
+    dim = dims[0]
+    if dim < 0:
+        dim += len(input_shape)
+    if dim < 0 or dim >= len(input_shape):
+        return None
+    return dim
+
+
+def _get_keepdim(node: torch.fx.Node) -> bool:
+    keepdim = get_arg_value(node, 2, "keepdim")
+    return bool(keepdim) if keepdim is not None else False
+
+
+def _find_iota_length(node: torch.fx.Node, reduce_dim: int) -> Any | None:
+    cur = node
+    while cur.op == "call_function" and cur.target in (
+        aten.expand.default,
+        aten.view.default,
+        aten.reshape.default,
+        aten.unsqueeze.default,
+    ):
+        if cur.target is aten.unsqueeze.default:
+            dim = get_arg_value(cur, 1, "dim")
+            shape = _node_tensor_shape(cur)
+            if shape is None:
+                return None
+            if dim < 0:
+                dim += len(shape)
+            if dim != reduce_dim:
+                return None
+        if not isinstance(cur.args[0], torch.fx.Node):
+            return None
+        cur = cur.args[0]
+
+    if cur.op != "call_function" or cur.target is not prims.iota.default:
+        return None
+
+    start = cur.kwargs.get("start", 0)
+    step = cur.kwargs.get("step", 1)
+    if start != 0 or step != 1:
+        return None
+
+    length = cur.args[0]
+    if isinstance(length, torch.fx.Node):
+        return None
+    shape = _node_tensor_shape(node)
+    if shape is not None:
+        dim = 0 if len(shape) == 1 else reduce_dim
+        if dim >= len(shape) or not statically_known_true(sym_eq(shape[dim], length)):
+            return None
+    return length
+
+
+def _strip_target_broadcast(node: torch.fx.Node) -> torch.fx.Node:
+    cur = node
+    while (
+        cur.op == "call_function"
+        and cur.target in (aten.expand.default, aten.expand_as.default)
+        and isinstance(cur.args[0], torch.fx.Node)
+    ):
+        cur = cur.args[0]
+    return cur
+
+
+def _match_iota_eq(
+    cond: torch.fx.Node, reduce_dim: int
+) -> tuple[torch.fx.Node, Any] | None:
+    if cond.op != "call_function" or cond.target is not aten.eq.Tensor:
+        return None
+    lhs, rhs = cond.args
+    if not isinstance(lhs, torch.fx.Node) or not isinstance(rhs, torch.fx.Node):
+        return None
+
+    lhs_iota_len = _find_iota_length(lhs, reduce_dim)
+    rhs_iota_len = _find_iota_length(rhs, reduce_dim)
+    if lhs_iota_len is not None and rhs_iota_len is None:
+        return _strip_target_broadcast(rhs), lhs_iota_len
+    if rhs_iota_len is not None and lhs_iota_len is None:
+        return _strip_target_broadcast(lhs), rhs_iota_len
+    return None
+
+
+def _match_sparse_one_hot_value(
+    node: torch.fx.Node,
+) -> tuple[torch.fx.Node, torch.fx.Node, torch.fx.Node | None, Any] | None:
+    if node.op == "call_function" and node.target is aten.where.self:
+        cond, value, zero = node.args
+        if (
+            isinstance(cond, torch.fx.Node)
+            and isinstance(value, torch.fx.Node)
+            and _is_zero_arg(zero)
+        ):
+            return cond, value, None, zero
+        return None
+
+    if node.op != "call_function" or node.target is not aten.mul.Tensor:
+        return None
+
+    for one_hot_index, value_index in ((0, 1), (1, 0)):
+        one_hot = node.args[one_hot_index]
+        value = node.args[value_index]
+        if (
+            not isinstance(one_hot, torch.fx.Node)
+            or not isinstance(value, torch.fx.Node)
+            or one_hot.op != "call_function"
+            or one_hot.target is not aten.where.self
+        ):
+            continue
+
+        cond, coeff, zero = one_hot.args
+        if (
+            isinstance(cond, torch.fx.Node)
+            and isinstance(coeff, torch.fx.Node)
+            and _is_scalar_constant_node(coeff)
+            and _is_zero_arg(zero)
+        ):
+            return cond, value, coeff, zero
+
+    return None
+
+
+def _value_depends_on_reduction_dim(
+    value: torch.fx.Node, input_ndim: int, reduce_dim: int
+) -> bool | None:
+    shape = _node_tensor_shape(value)
+    if shape is None:
+        return None
+
+    value_dim = len(shape) - input_ndim + reduce_dim
+    if value_dim < 0:
+        return False
+    if statically_known_true(sym_eq(shape[value_dim], 1)):
+        return False
+    if len(shape) != input_ndim:
+        return None
+    return True
+
+
+def fold_sparse_one_hot_sum(graph: torch.fx.Graph) -> None:
+    """
+    Fold reductions of sparse one-hot selects:
+
+        sum(where(iota(vocab) == target, value, 0), vocab_dim)
+
+    into a guarded value or gather.  Invalid targets must stay zero, and the
+    gather path substitutes index 0 before indexing so out-of-range targets do
+    not fault.
+    """
+    changed = False
+
+    for node in list(graph.nodes):
+        reduce_dim = _get_single_reduction_dim(node)
+        if reduce_dim is None:
+            continue
+
+        sum_input = node.args[0]
+        assert isinstance(sum_input, torch.fx.Node)
+        input_shape = _node_tensor_shape(sum_input)
+        if input_shape is None:
+            continue
+
+        match = _match_sparse_one_hot_value(sum_input)
+        if match is None:
+            continue
+
+        cond, value, coeff, zero = match
+        iota_match = _match_iota_eq(cond, reduce_dim)
+        if iota_match is None:
+            continue
+
+        target, vocab_size = iota_match
+        target_val = target.meta.get("val")
+        if not isinstance(target_val, torch.Tensor) or not is_integer_dtype(
+            target_val.dtype
+        ):
+            continue
+
+        depends_on_reduction_dim = _value_depends_on_reduction_dim(
+            value, len(input_shape), reduce_dim
+        )
+        if depends_on_reduction_dim is None:
+            continue
+
+        if depends_on_reduction_dim:
+            value_shape = _node_tensor_shape(value)
+            target_shape = _node_tensor_shape(target)
+            if (
+                value_shape is None
+                or target_shape is None
+                or len(value_shape) != len(target_shape)
+            ):
+                continue
+
+        keepdim = _get_keepdim(node)
+        with graph.inserting_before(node):
+            ge_zero = graph.call_function(aten.ge.Scalar, (target, 0))
+            lt_vocab = graph.call_function(aten.lt.Scalar, (target, vocab_size))
+            valid = graph.call_function(aten.logical_and.default, (ge_zero, lt_vocab))
+
+            selected = value
+            if depends_on_reduction_dim:
+                zero_index = graph.call_function(aten.mul.Scalar, (target, 0))
+                safe_target = graph.call_function(
+                    aten.where.self, (valid, target, zero_index)
+                )
+                selected = graph.call_function(
+                    aten.gather.default, (value, reduce_dim, safe_target)
+                )
+
+            if coeff is not None:
+                selected = graph.call_function(aten.mul.Tensor, (selected, coeff))
+
+            replacement = graph.call_function(aten.where.self, (valid, selected, zero))
+            if not keepdim:
+                replacement = graph.call_function(
+                    aten.squeeze.dim, (replacement, reduce_dim)
+                )
+
+        replacement.meta.update(node.meta)
+        node.replace_all_uses_with(replacement)
+        counters["inductor"]["sparse_one_hot_sum"] += 1
+        changed = True
+
+    if changed:
+        graph.eliminate_dead_code()
 
 
 ################################################################################


### PR DESCRIPTION
Summary:
- folds sparse CE-style one-hot reductions in Inductor post-grad FX
- handles vocab-invariant values as guarded scalar values
- handles vocab-dependent values as guarded gathers with safe indexing for invalid targets
- now gates the rewrite to cases that broadcast the target over the reduced vocab dim and have static outer numel `<= 8192`

Context:
- better-benchmark issue: https://github.com/eellison/better-benchmark/issues/44
- relevant repros: `sum_a8c7f14e9218`, `sum_cfe874779dd6`, `sum_403da67893be`, `sum_046be72c7ad9`, `sum_6eb0b2e3c35e`

Validation:
- `python -m py_compile torch/_inductor/fx_passes/post_grad.py test/inductor/test_cuda_repro.py`
- `python -m ruff check torch/_inductor/fx_passes/post_grad.py test/inductor/test_cuda_repro.py`
- `git diff --check`
- Targeted CUDA test on built checkout with this patch: `CudaReproTests.test_sparse_one_hot_sum_fold`
- Direct PR-head source-only test command is blocked locally by missing `torch/lib/libtorch_global_deps.so` in that worktree.

Benchmark data, B200 GPU 5, no CD, no shared cache, `n_warmup=5`, `n_rep=20`:
- `sum_a8c7f14e9218`: 70.464 us -> 63.232 us, 1.11x, gap 1.110 -> 0.997, kernels 1 -> 1
- `sum_cfe874779dd6`: 988.800 us -> 873.920 us, 1.13x, gap 2.068 -> 1.832, kernels 3 -> 2
- `sum_403da67893be`: 401.024 us -> 400.000 us, neutral, kernels 1 -> 1
- `sum_046be72c7ad9`: 1753.088 us -> 1700.544 us, 1.03x, kernels 3 -> 2
- `sum_6eb0b2e3c35e`: 1570.848 us -> 1568.800 us, neutral, kernels 1 -> 1

Risk:
- matcher is intentionally narrow: single-dim sum, no explicit sum dtype, scalar zero branch, iota equality, integer target, target broadcasts over the reduction dim, and static outer numel capped at 8192.
- invalid targets such as `-100`, `-1`, and `vocab` preserve zero-output semantics without unsafe gather indexing.

submitted by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
