### PR TITLE
Validate packed RNN batch_sizes before fallback

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -140,6 +140,14 @@ struct PackedSequence {
   Tensor batch_sizes;
 };
 
+static void check_packed_sequence_batch_sizes(const Tensor& batch_sizes) {
+  TORCH_CHECK(batch_sizes.dim() == 1, "batch_sizes tensor should be 1D");
+  TORCH_CHECK(
+      batch_sizes.device().is_cpu(),
+      "batch_sizes tensor should be on CPU, but got ",
+      batch_sizes.device());
+}
+
 // Simple type for __getstate__/__setstate__ serialization
 //
 // Element 0 is a string key to say what kind of CellParam this is. It
@@ -1279,6 +1287,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
       double dropout_p,                                                     \
       bool train,                                                           \
       bool bidirectional) {                                                 \
+    check_packed_sequence_batch_sizes(batch_sizes);                         \
     if (use_cudnn(data)) {                                                  \
       Tensor output, hy;                                                    \
       NAME##_packed_cudnn_stub(                                             \
@@ -1369,6 +1378,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
       double dropout_p,                                                     \
       bool train,                                                           \
       bool bidirectional) {                                                 \
+    check_packed_sequence_batch_sizes(batch_sizes);                         \
     std::vector<QRNNCellParamsWrapper> params;                              \
     for (c10::intrusive_ptr<CellParamsBase> x : _params) {                  \
       params.emplace_back(std::move(x));                                    \
@@ -1508,6 +1518,7 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
       TensorList _params, bool has_biases,
       int64_t num_layers, double dropout_p, bool train, bool bidirectional) {
   TORCH_CHECK(hx.size() == 2, "lstm expects two hidden states");
+  check_packed_sequence_batch_sizes(batch_sizes);
   if (use_cudnn(data)) {
     Tensor output, hy, cy;
     lstm_packed_cudnn_stub(data.device().type(), output, hy, cy, data, batch_sizes, hx,
@@ -1776,6 +1787,7 @@ static std::tuple<Tensor, Tensor, Tensor> quantized_lstm_data(
     std::optional<ScalarType> dtype,
     bool use_dynamic) {
   auto hx = hx_.vec();
+  check_packed_sequence_batch_sizes(batch_sizes);
   std::vector<QRNNCellParamsWrapper> params;
   params.reserve(_params_.size());
   for (const auto& param : _params_) {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -9261,7 +9261,6 @@ class TestCudaAutocast(TestAutocast):
                 for grad, grad_control in zip(grads, grads_control):
                     self.assertEqual(grad.half(), grad_control)
 
-    @unittest.skipIf(not TEST_CUDNN, "CUDNN not available")
     def test_rnn_packed_sequence_batch_sizes_must_be_cpu(self):
         # Verify that passing batch_sizes on CUDA raises an error instead of segfaulting
         data = torch.randn([18, 16], dtype=torch.float32, device="cuda")
@@ -9286,6 +9285,25 @@ class TestCudaAutocast(TestAutocast):
                 train=False,
                 bidirectional=False,
             )
+
+        def rnn_tanh(data, batch_sizes, hx, params):
+            return torch.ops.aten.rnn_tanh(
+                data,
+                batch_sizes=batch_sizes,
+                hx=hx,
+                params=params,
+                has_biases=False,
+                num_layers=1,
+                dropout=0.5,
+                train=False,
+                bidirectional=False,
+            )
+
+        compiled_rnn_tanh = torch.compile(rnn_tanh, backend="eager")
+        with self.assertRaisesRegex(
+            RuntimeError, "batch_sizes tensor should be on CPU"
+        ):
+            compiled_rnn_tanh(data, batch_sizes, hx, params)
 
     @serialTest()
     def test_autocast_cache_leak(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184934

Packed RNN fallback code reads batch_sizes through const_data_ptr<int64_t>()
and indexes it on the host. If a CUDA batch_sizes tensor reaches this path,
for example through torch.compile(..., backend="eager") on aten.rnn_tanh, the
fallback can dereference device memory from CPU code and segfault before the
existing CUDNN/MIOpen packed-RNN checks run.

Add a shared packed-sequence batch_sizes validator in native RNN.cpp and call
it at the packed RNN entry points before vendor dispatch selection or fallback
PackedSequence construction. This keeps the existing valid CPU batch_sizes path
unchanged while turning invalid CUDA batch_sizes into the same RuntimeError used
by the vendor wrappers.

I considered limiting the check to rnn_tanh, but the same PackedLayer and
ReversedPackedLayer host reads are shared by packed rnn_relu, gru, lstm, and
quantized packed variants, so validating at the common packed entry points is
the narrower root-cause fix.

Fixes #173046
Generated by my agent

Test Plan:
- PYTHONPATH=/data/users/jansel/pytorch-issue-fixer/pytorch ninja -C build
- PYTHONPATH=/data/users/jansel/pytorch-issue-fixer/pytorch python setup.py develop
- Original torch.compile(..., backend="eager") aten.rnn_tanh CUDA batch_sizes repro now raises RuntimeError instead of segfaulting
- Targeted TestCudaAutocast.test_rnn_packed_sequence_batch_sizes_must_be_cpu run through a torchvision import stub passed
- Valid packed aten.rnn_tanh CUDA data with CPU batch_sizes smoke test passed in eager and compiled eager
- git diff --check
- lintrunner -a