### PR TITLE
[inductor] Canonicalize duplicate mean and var reductions

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6548,6 +6548,29 @@ class CommonTemplate:
 
         self.common(fn, (torch.rand([1, 17, 2048]),))
 
+    def test_mean_var_canonicalized_to_var_mean(self):
+        from torch._inductor.fx_passes.post_grad import (
+            canonicalize_mean_var_to_var_mean,
+        )
+
+        def fn(x):
+            mean = aten.mean.dim(x, [-1], True)
+            var = aten.var.correction(x, [-1], correction=1, keepdim=True)
+            return x - mean, var
+
+        x = torch.randn([2, 4, 16])
+        gm = make_fx(fn)(x)
+        canonicalize_mean_var_to_var_mean(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        targets = [node.target for node in gm.graph.nodes if node.op == "call_function"]
+        self.assertIn(aten.var_mean.correction, targets)
+        self.assertNotIn(aten.mean.dim, targets)
+        self.assertNotIn(aten.var.correction, targets)
+        self.assertEqual(targets.count(operator.getitem), 2)
+        torch.testing.assert_close(gm(x), fn(x))
+
     def test_var_correction(self):
         def fn(x):
             dim = -1

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -141,6 +141,102 @@ def _chain_random_ops_for_ordering(graph: torch.fx.Graph) -> None:
     preserve_node_ordering(graph, additional_deps_map)
 
 
+def _get_arg_value_or_default(
+    node: torch.fx.Node, arg_number: int, kwarg_name: str, default: Any
+) -> Any:
+    if len(node.args) > arg_number:
+        return node.args[arg_number]
+    return node.kwargs.get(kwarg_name, default)
+
+
+def _is_mean_dim_node(node: torch.fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target == aten.mean.dim
+        and _get_arg_value_or_default(node, 3, "dtype", None) is None
+    )
+
+
+def _is_var_correction_node(node: torch.fx.Node) -> bool:
+    return node.op == "call_function" and node.target == aten.var.correction
+
+
+def _normalize_reduction_dim_arg(dim: Any) -> Any:
+    if isinstance(dim, (list, tuple)):
+        return tuple(dim)
+    return dim
+
+
+def _same_mean_var_reduction(mean_node: torch.fx.Node, var_node: torch.fx.Node) -> bool:
+    return (
+        mean_node.args[0] is var_node.args[0]
+        and _normalize_reduction_dim_arg(get_arg_value(mean_node, 1, "dim"))
+        == _normalize_reduction_dim_arg(get_arg_value(var_node, 1, "dim"))
+        and _get_arg_value_or_default(mean_node, 2, "keepdim", False)
+        == _get_arg_value_or_default(var_node, 3, "keepdim", False)
+    )
+
+
+def canonicalize_mean_var_to_var_mean(graph: torch.fx.Graph) -> None:
+    """
+    Replace same-input mean/var reduction pairs with var_mean so the first sum is shared.
+    """
+    mean_nodes = [node for node in graph.nodes if _is_mean_dim_node(node)]
+    if not mean_nodes:
+        return
+
+    node_positions = {node: pos for pos, node in enumerate(graph.nodes)}
+    remaining_mean_nodes = OrderedSet(mean_nodes)
+
+    for var_node in list(graph.nodes):
+        if not _is_var_correction_node(var_node):
+            continue
+
+        mean_node = next(
+            (
+                node
+                for node in remaining_mean_nodes
+                if _same_mean_var_reduction(node, var_node)
+            ),
+            None,
+        )
+        if mean_node is None:
+            continue
+
+        dim = get_arg_value(var_node, 1, "dim")
+        correction = _get_arg_value_or_default(var_node, 2, "correction", None)
+        keepdim = _get_arg_value_or_default(var_node, 3, "keepdim", False)
+        first_node = (
+            mean_node
+            if node_positions[mean_node] < node_positions[var_node]
+            else var_node
+        )
+
+        with graph.inserting_before(first_node):
+            var_mean_node = graph.call_function(
+                aten.var_mean.correction,
+                args=(var_node.args[0], dim),
+                kwargs={"correction": correction, "keepdim": keepdim},
+            )
+            var_getitem = graph.call_function(operator.getitem, args=(var_mean_node, 0))
+            mean_getitem = graph.call_function(
+                operator.getitem, args=(var_mean_node, 1)
+            )
+
+        var_mean_node.meta.update(var_node.meta)
+        if "val" in var_node.meta and "val" in mean_node.meta:
+            var_mean_node.meta["val"] = (var_node.meta["val"], mean_node.meta["val"])
+        var_getitem.meta.update(var_node.meta)
+        mean_getitem.meta.update(mean_node.meta)
+
+        var_node.replace_all_uses_with(var_getitem)
+        mean_node.replace_all_uses_with(mean_getitem)
+        graph.erase_node(var_node)
+        graph.erase_node(mean_node)
+        remaining_mean_nodes.remove(mean_node)
+        counters["inductor"]["mean_var_to_var_mean"] += 1
+
+
 def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
     """
     Passes that run on after grad.  This is called once on the forwards
@@ -205,6 +301,9 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         GraphTransformObserver(gm, "remove_assert_ops").apply_graph_pass(
             remove_assert_ops
         )
+        GraphTransformObserver(
+            gm, "canonicalize_mean_var_to_var_mean"
+        ).apply_graph_pass(canonicalize_mean_var_to_var_mean)
         for i, patterns in enumerate(pass_patterns):
             GraphTransformObserver(gm, f"pass_pattern_{i}").apply_graph_pass(
                 patterns.apply


### PR DESCRIPTION
Summary:
- Canonicalize exact same-input `aten.mean.dim` + `aten.var.correction` pairs to `aten.var_mean.correction` in post-grad FX.
- Reuse the shared first reduction for LayerNorm-style graphs that currently emit duplicate mean and variance reductions.
- Add a focused FX pass test for the rewrite.

Related better-benchmark issue: https://github.com/eellison/better-benchmark/issues/48

Test Plan:
- `python -m py_compile torch/_inductor/fx_passes/post_grad.py test/inductor/test_torchinductor.py`
- Deterministic CUDA compile smoke for mean+var+LN epilogue: rewrite counter `mean_var_to_var_mean=1`, generated 1 kernel, max abs error `2.86102294921875e-06`

submitted by my agent


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
