### PR TITLE
[inductor] Avoid masks for zero-stride cat source loads

### DIFF
--- a/test/inductor/test_pad_as_cat.py
+++ b/test/inductor/test_pad_as_cat.py
@@ -75,6 +75,26 @@ class TestCatMultiConsumer(TestCase):
             f"Expected {expected_bytes} bytes, got {metrics.num_bytes_accessed}.",
         )
 
+    @torch._inductor.config.patch(force_pointwise_cat=True)
+    @requires_gpu()
+    def test_zero_stride_cat_source_uses_scalar_reduction_load(self):
+        def fn(cls_token, patches, pos):
+            y = torch.cat([cls_token.expand(8, 2, 32), patches], dim=1) + pos
+            return torch.var_mean(y, dim=2, correction=0, keepdim=True)
+
+        args = (
+            torch.randn(1, 1, 32, device=GPU_TYPE),
+            torch.randn(8, 4, 32, device=GPU_TYPE),
+            torch.randn(1, 6, 32, device=GPU_TYPE),
+        )
+        expected = fn(*args)
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *args)
+
+        self.assertEqual(actual, expected)
+        self.assertRegex(code, r"tl\.load\(in_ptr0 \+ \(?r0_\d+\)?, r0_mask")
+        self.assertNotIn("tl.load(in_ptr0 + tl.broadcast_to", code)
+        self.assertNotIn("tl.load(in_ptr0 + (tl.broadcast_to", code)
+
 
 class TestPadAsCat(TestCase):
     @requires_gpu()

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1623,6 +1623,13 @@ def pointwise_cat(inputs, dim=0):
 
     inputs_loaders = [inp.make_loader() for inp in inputs]
 
+    def can_load_for_all_cat_regions(inp: TensorBox) -> bool:
+        strides = inp.maybe_get_stride()
+        # Out-of-region pointwise_cat indices only vary in the cat dimension.
+        return strides is not None and V.graph.sizevars.statically_known_equals(
+            strides[dim], 0
+        )
+
     def inner_fn(idx):
         idx_dim = ops.index_expr(idx[dim], torch.int64)
 
@@ -1654,13 +1661,16 @@ def pointwise_cat(inputs, dim=0):
             # in same int bitwidth as shape
             idx_load[dim] = Identity(idx_load[dim] - inputs_ranges[i][0])
 
-            masked_loads.append(
-                ops.masked(
-                    mask,
-                    lambda: inputs_loaders[i](idx_load),
-                    0.0,  # this value should be unused
-                ),
-            )
+            if can_load_for_all_cat_regions(inputs[i]):
+                masked_loads.append(inputs_loaders[i](idx_load))
+            else:
+                masked_loads.append(
+                    ops.masked(
+                        mask,
+                        lambda: inputs_loaders[i](idx_load),
+                        0.0,  # this value should be unused
+                    ),
+                )
 
         next_val = masked_loads[-1]
         for i in range((len(inputs)) - 2, -1, -1):


### PR DESCRIPTION
Summary:
- In `pointwise_cat`, load zero-stride cat sources directly instead of wrapping them in cat-region masks.
- Guard narrowly on `stride[cat_dim] == 0`, because out-of-region pointwise-cat indices only vary in the cat dimension.
- Add focused coverage for an expanded class-token cat feeding `var_mean`.

Context:
- better-benchmark issue: https://github.com/eellison/better-benchmark/issues/47
- issue 27 repros: var_mean_3c8a0f3690b9, var_mean_eebe86d9365d

Local validation:
- git diff --check
- python -m py_compile torch/_inductor/lowering.py test/inductor/test_pad_as_cat.py
- same-build overlay correctness on both target repros

B200 benchmark evidence:
- var_mean_3c8a0f3690b9: 121.760 us -> 103.200 us
- var_mean_eebe86d9365d: 121.728 us -> 102.400 us

Submitted by my agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo