### PR TITLE
[torch] use sym_eq for unbacked-safe shape compare in is_same_shape (#184943)

### DIFF
--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
 
     import sympy
 
+    from torch.types import BoolLikeType
+
     class _WorksWithInt(typing.Protocol):
         def __add__(self, other: Any) -> typing.Self: ...
 
@@ -871,13 +873,18 @@ def is_valid_permutation(rank: int, perm: DimsSequenceType) -> bool:
     return isinstance(perm, Sequence) and sorted(perm) == list(range(rank))
 
 
-def is_same_shape(a: Sequence, b: Sequence) -> bool:
+def is_same_shape(a: Sequence, b: Sequence) -> BoolLikeType:
     """
     Compares two shapes a and b, returning True if they are the same
     (their ranks and corresponding lengths match) and False otherwise.
-    """
 
-    return tuple(a) == tuple(b)
+    Uses sym_eq for shape comparison so the result is safe to pass to
+    torch._check on tensors with unbacked SymInt dimensions; for backed
+    or concrete shapes the behaviour is unchanged.
+    """
+    from torch.fx.experimental.symbolic_shapes import sym_eq
+
+    return sym_eq(tuple(a), tuple(b))
 
 
 def is_cpu_scalar_tensor(a: object) -> TypeGuard[TensorLike]:

--- a/torch/testing/_internal/common_ops_unbacked.py
+++ b/torch/testing/_internal/common_ops_unbacked.py
@@ -18,7 +18,6 @@ ops_dde_xfail = {
     xfail("_upsample_bilinear2d_aa"),
     xfail("addmv"),
     xfail("allclose"),
-    xfail("as_strided_scatter"),
     xfail("baddbmm"),
     xfail("bernoulli"),
     xfail("cauchy"),


### PR DESCRIPTION
Summary:

`_prims_common.is_same_shape` was implemented as `tuple(a) == tuple(b)`. When the shapes contain unbacked `SymInts`, that comparison forces `__bool__` on a `SymBool`and raises `GuardOnDataDependentSymNode`, which is the failure mode observed in `TestUnbackedDTensorOpsCPU::test_unbacked_dtensor_op_db_as_strided_scatter_cpu_float32`:

failed while attempting to run meta for `aten.as_strided_scatter.default`
  File "torch/_prims/__init__.py", line 1803, in _as_strided_scatter_meta
    utils.is_same_shape(src.shape, size),
  File "torch/_prims_common/__init__.py", line 880, in is_same_shape
    return tuple(a) == tuple(b)
  File "torch/__init__.py", line 783, in __bool__
    return self.node.bool_()
  File "torch/fx/experimental/sym_node.py", line 576, in guard_bool
    r = self.evaluate()

Switch `is_same_shape` to dispatch to `torch.fx.experimental.symbolic_shapes.sym_eq`, which is purpose-built for this case ("like `==`, but when run on `list/tuple`, it will recursively test equality and use `sym_and` to join the results together, without guarding."). Return type widens from `bool` to `BoolLikeType`. `torch._check` accepts the resulting `SymBool` and the `_as_strided_scatter_meta` kernel becomes unbacked-friendly.

Audited the three other Python callers of `is_same_shape` (`_prims_common.check_same_shape`, `_prims_common.extract_shape`, `_refs.sum_to_size`); each wraps the result in not/if, so the bool(SymBool) was already happening at the caller and behavior on backed and unbacked shapes is unchanged for those sites.

Also drops the now-stale xfail(`as_strided_scatter`) from `ops_dde_xfail` so `TestUnbackedDTensorOpsCPU::test_unbacked_dtensor_op_db_as_strided_scatter_cpu_float32` and the corresponding `TestOpsUnbacked` test exercise the fix instead of being skipped.

Test Plan:
```
buck2 test fbcode//caffe2/test/distributed/tensor:test_dtensor_ops -- \
  -k test_unbacked_dtensor_op_db_as_strided_scatter_cpu_float32
buck2 test fbcode//caffe2/test:test_ops_unbacked -- -k as_strided_scatter
```

Reviewed By: aeolyus

Differential Revision: D106144152


