### PR TITLE
[DTensor] Fix PendingUnbackedSymbolNotFound from _StridedShard offset .tolist() in sharding prop

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -392,6 +392,53 @@ def forward(self, arg0_1, arg1_1, arg2_1):
             compiled_out = compiled_fn(x)
             self.assertEqual(opt_fn, compiled_out)
 
+    def test_strided_shard_view_unbacked_local(self):
+        # Regression for torchtitan #3409: during compile-time sharding
+        # propagation for any _StridedShard view op,
+        # _StridedShard.local_shard_size_and_offset used to materialize
+        # offsets via .tolist() on a fake offsets tensor, allocating one
+        # unbacked SymInt per element. These symbols never reached the
+        # returned DTensor's tensor_meta, tripping the downstream
+        # PendingUnbackedSymbolNotFound check. The bug triggers for any
+        # _StridedShard view under compile regardless of whether the local
+        # tensor has backed or unbacked dims; torch.nonzero (producing an
+        # unbacked dim 0) is simply how torchtitan #3409 surfaced it.
+        #
+        # The bug lives in pure sharding-propagation arithmetic on rank 0
+        # alone (no collectives are issued during fake-tensor view tracing),
+        # so the FakeStore + world_size=2 setup used by this test class is
+        # equivalent to the multi-rank scenario for the no-offset path
+        # being exercised here.
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        global_bs = 16
+        slen = 4
+        dim = 4
+        split_factor = 8
+
+        def fn(sentinel):
+            nz = torch.nonzero(sentinel).flatten()
+            n_unbacked = nz.size(0)
+            torch._check(n_unbacked >= 1)
+            torch._check(n_unbacked <= global_bs)
+            local = torch.randn(n_unbacked, slen, dim)
+            dt = DTensor.from_local(
+                local,
+                mesh,
+                (_StridedShard(dim=0, split_factor=split_factor),),
+                shape=(global_bs, slen, dim),
+                stride=(slen * dim, dim, 1),
+                run_check=False,
+            )
+            return dt.view(-1, dim)
+
+        sentinel = torch.ones(global_bs, dtype=torch.int64)
+        out = torch.compile(fn, backend="aot_eager", fullgraph=True)(sentinel)
+        self.assertEqual(
+            out.placements,
+            (_StridedShard(dim=0, split_factor=split_factor),),
+        )
+        self.assertEqual(out.shape, (global_bs * slen, dim))
+
     def test_device_mesh_compile(self):
         def fn(x: DeviceMesh):
             # test size()

--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -238,11 +238,8 @@ dtensor_compiled_fails = {
     xfail("cartesian_prod"),
     xfail("flatten"),
     xfail("kron"),
-    xfail("linalg.tensorsolve"),
-    xfail("nn.functional.instance_norm"),
     xfail("ravel"),
     xfail("reshape_as"),
-    xfail("take_along_dim"),
     xfail("view_as"),
     # View-type ops that decompose into as_strided (at autograd level).
     # DTensor doesn't have a sharding strategy for as_strided.
@@ -292,7 +289,6 @@ dtensor_compiled_fails = {
     xfail("nn.functional.gaussian_nll_loss"),
     xfail("nn.functional.logsigmoid"),
     xfail("scatter"),
-    xfail("take_along_dim"),
     # False positives: these have no sharding strategy and their
     # eager DTensor failure is registered elsewhere.
     xfail("nn.functional.multilabel_soft_margin_loss"),

--- a/torch/distributed/tensor/_utils.py
+++ b/torch/distributed/tensor/_utils.py
@@ -17,6 +17,7 @@ from torch.distributed.tensor._op_schema import OpSchema
 from torch.distributed.tensor.placement_types import (
     _is_shard_like,
     _StridedShard,
+    _StridedShardOffsetMode,
     Partial,
     Placement,
     Replicate,
@@ -163,7 +164,13 @@ def _get_shard_size_and_offsets(
         "rank": rank,
     }
     if isinstance(placement, _StridedShard):
-        kwargs["return_first_offset"] = False
+        kwargs["offset_mode"] = (
+            _StridedShardOffsetMode.NONE if skip_offset else _StridedShardOffsetMode.ALL
+        )
+        # _StridedShard.local_shard_size_and_offset materializes the offsets list
+        # via .tolist() on a (potentially fake) index tensor; under FakeTensorMode
+        # that allocates one unbacked SymInt per element. Skip when the caller
+        # discards the offsets anyway.
     shard_size, shard_offsets = placement._local_shard_size_and_offset(**kwargs)
     if skip_offset:
         return shard_size, None

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -4,6 +4,7 @@
 import functools
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from enum import IntEnum
 from typing import cast, TypeGuard, TypeVar
 
 import torch
@@ -44,6 +45,12 @@ def _raise_error(method_name, _):
 Placement.__eq__ = functools.partial(_raise_error, method_name="__eq__")
 Placement.__hash__ = functools.partial(_raise_error, method_name="__hash__")
 Placement.__fx_repr__ = functools.partial(_raise_error, method_name="__fx_repr__")
+
+
+class _StridedShardOffsetMode(IntEnum):
+    FIRST = 0
+    ALL = 1
+    NONE = 2
 
 
 class Shard(torch._C._distributed.Shard):
@@ -1118,10 +1125,10 @@ class _StridedShard(torch._C._distributed.StridedShard):
         curr_local_size: int,
         num_chunks: int,
         rank: RankType,
-        return_first_offset: bool = True,
-    ) -> tuple[int, int | list[int]]:
+        offset_mode: _StridedShardOffsetMode = _StridedShardOffsetMode.FIRST,
+    ) -> tuple[int, int | list[int] | None]:
         return self.local_shard_size_and_offset(
-            curr_local_size, num_chunks, rank, return_first_offset
+            curr_local_size, num_chunks, rank, offset_mode
         )
 
     @maybe_run_for_local_tensor
@@ -1130,8 +1137,8 @@ class _StridedShard(torch._C._distributed.StridedShard):
         curr_local_size: IntLikeType,
         num_chunks: int,
         rank: RankType,
-        return_first_offset: bool = True,
-    ) -> tuple[int, list[int] | int]:
+        offset_mode: _StridedShardOffsetMode = _StridedShardOffsetMode.FIRST,
+    ) -> tuple[int, list[int] | int | None]:
         """
         Compute the local shard size and offset(s) for a _StridedShard placement.
 
@@ -1144,16 +1151,19 @@ class _StridedShard(torch._C._distributed.StridedShard):
             curr_local_size (int): The current size of the tensor dimension to be sharded.
             num_chunks (int): Number of chunks to split the dimension into (typically the mesh dimension size).
             rank (RankType): The rank index to compute the shard for.
-            return_first_offset (bool): If True, return only the first offset as an int. If False,
-                return all offsets as a list. Defaults to True.
+            offset_mode (_StridedShardOffsetMode): Controls offset materialization.
+                FIRST returns only the first offset as an int, ALL returns all offsets
+                as a list, and NONE skips offset materialization. Defaults to FIRST.
 
         Returns:
             tuple: A tuple containing:
-                - local_shard_size (int): The number of elements in the local shard for this rank.
-                - offset (int | list[int]): If return_first_offset is True, returns the first offset
-                  as an int. If False or if the shard size is 0, returns a list of all offsets
-                  (which may be empty for empty shards).
+                - local_shard_size (int): The number of elements in the local shard
+                  for this rank.
+                - offset (int | list[int] | None): Determined by offset_mode. FIRST
+                  returns the first offset as an int, ALL returns a list of all offsets,
+                  and NONE returns None.
         """
+        offset_mode = _StridedShardOffsetMode(offset_mode)
         # indices_tensor is 1D torch.arange(logical_dim_size) unsqueezed
         # so that we can reuse self._split_tensor which splits on self.dim
         shape = [1] * self.dim + [curr_local_size]
@@ -1172,12 +1182,15 @@ class _StridedShard(torch._C._distributed.StridedShard):
         sharded_indices = [shard.view(-1) for shard in sharded_indices]
 
         local_shard_size = _StridedShard._local_shard_size(sharded_indices, rank)
+        if offset_mode is _StridedShardOffsetMode.NONE:
+            # Avoid .tolist() which creates unbacked SymInts under FakeTensorMode.
+            return local_shard_size, None
         if local_shard_size > 0:
             offsets = sharded_indices[rank].tolist()
         else:
             offsets = []
 
-        if return_first_offset:
+        if offset_mode is _StridedShardOffsetMode.FIRST:
             # Always return an int for consistency across ranks.
             # For empty shards, return -1 as an invalid offset indicator.
             offsets = offsets[0] if len(offsets) > 0 else -1


### PR DESCRIPTION
Summary:
DTensor sharding propagation for view-like ops only needs the local output shape, but _StridedShard still materialized offsets with .tolist() before _utils discarded them. Under FakeTensorMode this created fresh unbacked SymInts that were not bound to the returned DTensor metadata and later tripped PendingUnbackedSymbolNotFound.
    
Forward the existing skip_offset request into _StridedShard and return None for offsets when callers only need the local shard size. Normal offset-producing callers keep the existing default behavior.
    
Authored with Codex.
    
Test Plan:
    python test/distributed/tensor/test_dtensor_compile.py TestDTensorCompile.test_strided_shard_view_unbacked_local -v
    
Fixes pytorch/torchtitan#3409