### PR TITLE
[Inductor] Emit real-extent block_ptr loads for split reductions via a split grid dim (#184946)

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -106,6 +106,31 @@ def xfail_if_tensor_descriptor(fn):
     return fn
 
 
+# (name, op, atol) for the reductions exercised by the grid-split tests. Kept in
+# one table so the parametrisations below name ops instead of repeating lambdas.
+_GRID_SPLIT_REDUCTIONS = (
+    ("sum", torch.Tensor.sum, 1e-2),
+    ("amax", torch.Tensor.amax, 0),
+    ("amin", torch.Tensor.amin, 0),
+    ("prod", torch.Tensor.prod, 1e-2),
+    ("mean", torch.Tensor.mean, 1e-3),
+)
+
+
+def _reduce(t: torch.Tensor, op: Callable[..., Any], dim: Any) -> torch.Tensor:
+    """Reduce over ``dim``, or over the whole tensor when ``dim`` is None."""
+    return op(t) if dim is None else op(t, dim)
+
+
+def _reduction_subtests(*names: str) -> list[Any]:
+    """``(op, atol)`` subtests for the named reductions, or all of them if unnamed."""
+    return [
+        subtest((op, atol), name=name)
+        for name, op, atol in _GRID_SPLIT_REDUCTIONS
+        if not names or name in names
+    ]
+
+
 class BlockDescriptorTestBase(InductorTestCase):
     block_descriptor_constructor_str = "tl.make_block_ptr"
 
@@ -139,6 +164,22 @@ class BlockDescriptorTestBase(InductorTestCase):
 
     def _get_lines_containing_substr(self, code: str, substr: str) -> str:
         return "\n".join(line for line in code.split("\n") if substr in line)
+
+    def _assert_grid_split_reduction(self, code):
+        # rsplit_start is unique to the grid-dim-split path. No-op on the
+        # tensor-descriptor backends, which fall back off TMA for the partial store.
+        if self.block_descriptor_constructor_str == "tl.make_block_ptr":
+            joined = "\n".join(code)
+            self.assertIn("rsplit_start", joined)
+            self.assertIn("boundary_check", joined)
+
+    def _skip_if_host_side_tma(self):
+        # Pre-existing, unrelated: make_tensordesc_arg arity mismatch in
+        # static_triton_launcher fails all host-TMA descriptor kernels.
+        if config.triton.enable_host_side_tma:
+            raise unittest.SkipTest(
+                "host-side TMA static-launcher arg mismatch (pre-existing, unrelated)"
+            )
 
     def _run_and_compare(
         self: InductorTestCase,
@@ -1596,6 +1637,229 @@ class CommonTemplate:
                 self.assertTrue("boundary_check=[0, 1, 2]" in code)
                 # Loading b
                 self.assertTrue("boundary_check=[0, 1]" in code)
+
+    # Each split partition is its own grid program reducing a slice of the true
+    # reduction axis, so stage-1 loads stay real-extent block_ptrs.
+    #
+    # Ranks 1-4 with the reduced dim at every position. Extents are prime, so the
+    # split factor cannot divide them and every case exercises the boundary-checked
+    # tail; 2d_pow2 is the control where the split does divide evenly. A scalar
+    # output has no block_ptr store, hence 3 descriptors instead of 4.
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+        }
+    )
+    @parametrize("reduction_fn,atol", _reduction_subtests())
+    @parametrize(
+        "shape,dim,expected_num_block_pointers",
+        [
+            subtest(((100003,), 0, 3), name="1d"),
+            subtest(((8, 100003), 1, 4), name="2d_inner"),
+            subtest(((100003, 8), 0, 4), name="2d_outer"),
+            subtest(((8, 131072), 1, 4), name="2d_pow2"),
+            subtest(((4, 8, 20011), 2, 4), name="3d_inner"),
+            subtest(((4, 20011, 8), 1, 4), name="3d_middle"),
+            subtest(((20011, 4, 8), 0, 4), name="3d_outer"),
+            subtest(((2, 4, 8, 20011), 3, 4), name="4d_inner"),
+            subtest(((2, 4, 20011, 8), 2, 4), name="4d_middle2"),
+            subtest(((2, 20011, 4, 8), 1, 4), name="4d_middle1"),
+            subtest(((20011, 2, 4, 8), 0, 4), name="4d_outer"),
+        ],
+    )
+    def test_grid_split_reduction_block_ptr(
+        self, reduction_fn, atol, shape, dim, expected_num_block_pointers
+    ):
+        self._skip_if_host_side_tma()
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: _reduce(t, reduction_fn, dim),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=expected_num_block_pointers,
+            atol=atol,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "shape,dim",
+        [
+            subtest(((100003, 4, 8), 0), name="3d_outer"),
+            subtest(((4, 100003, 8), 1), name="3d_middle"),
+            subtest(((2, 100003, 4, 8), 1), name="4d_middle"),
+            subtest(((2, 4, 100003, 8), 2), name="4d_middle2"),
+        ],
+    )
+    def test_grid_split_reduction_large_extent_int32(self, shape, dim):
+        self._skip_if_host_side_tma()
+        # The split inflates the stage-1 iteration numel past int32 even though the
+        # data fits, and an int64 fallback would disable the block_ptr gate.
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=4,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+        if self.block_descriptor_constructor_str == "tl.make_block_ptr":
+            input_block_ptrs = self._get_lines_containing_substr(
+                "\n".join(code), "tl.make_block_ptr(in_ptr0"
+            )
+            self.assertIn(str(shape[dim]), input_block_ptrs)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn,make_input,atol,rtol",
+        [
+            subtest(
+                (torch.Tensor.amax, lambda s, d: -torch.rand(*s, device=d) - 1.0, 0, 0),
+                name="amax_all_negative",
+            ),
+            subtest(
+                (torch.Tensor.amin, lambda s, d: torch.rand(*s, device=d) + 1.0, 0, 0),
+                name="amin_all_positive",
+            ),
+            subtest(
+                (
+                    torch.Tensor.prod,
+                    lambda s, d: torch.rand(*s, device=d) * 2e-3 + 0.999,
+                    0,
+                    1e-3,
+                ),
+                name="prod_near_one",
+            ),
+        ],
+    )
+    def test_grid_split_reduction_zero_padding_does_not_leak(
+        self, reduction_fn, make_input, atol, rtol
+    ):
+        self._skip_if_host_side_tma()
+        # block_ptr can only pad with zero, which is not the identity for these ops.
+        # The inputs are chosen so a leaked padding lane changes the answer: 0 beats
+        # every element of an all-negative amax, loses to an all-positive amin, and
+        # zeroes a product of near-1 values. Correctness here comes from the
+        # accumulator mask, not from the padding value.
+        x = make_input((8, 100003), self.device)
+        _, code = self._run_and_compare(
+            lambda t: _reduce(t, reduction_fn, 1),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=4,
+            atol=atol,
+            rtol=rtol,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "dtype,atol,rtol",
+        [
+            subtest((torch.float32, 1e-2, 1e-2), name="fp32"),
+            subtest((torch.bfloat16, 1.0, 1e-1), name="bf16"),
+            subtest((torch.float16, 0.5, 1e-1), name="fp16"),
+        ],
+    )
+    def test_grid_split_reduction_dtypes(self, dtype, atol, rtol):
+        self._skip_if_host_side_tma()
+        x = torch.randn(8, 100003, device=self.device, dtype=dtype)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=4,
+            atol=atol,
+            rtol=rtol,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn",
+        [
+            # cast bool->int so _run_and_compare's allclose works on the output
+            subtest(lambda t: t.all(dim=1).to(torch.int32), name="all"),
+            subtest(lambda t: t.any(dim=1).to(torch.int32), name="any"),
+        ],
+    )
+    def test_grid_split_reduction_bool(self, reduction_fn):
+        self._skip_if_host_side_tma()
+        x = torch.rand(8, 100003, device=self.device) > 0.5
+        _, code = self._run_and_compare(
+            reduction_fn, x, expected_num_triton_kernels=2, expected_num_block_pointers=4
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": True,
+        }
+    )
+    def test_grid_split_reduction_int(self):
+        self._skip_if_host_side_tma()
+        x = torch.randint(-100, 100, (8, 100003), device=self.device, dtype=torch.int32)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=4,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_red_split_dim_as_grid_dim": False,
+        }
+    )
+    def test_grid_split_reduction_disabled_by_default(self):
+        self._skip_if_host_side_tma()
+        # With the flag off, split reductions use the classic reshape path and must
+        # NOT emit the grid-split markers -- confirms the feature is fully gated.
+        x = torch.randn(8, 100003, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=3,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self.assertNotIn("rsplit_start", "\n".join(code))
 
 
 @unittest.skipIf(not HAS_GPU, "requires triton GPU backend")

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -140,6 +140,27 @@ class BlockDescriptorTestBase(InductorTestCase):
     def _get_lines_containing_substr(self, code: str, substr: str) -> str:
         return "\n".join(line for line in code.split("\n") if substr in line)
 
+    def _assert_grid_split_reduction(self, code):
+        # rsplit_start only appears on the grid-dim-split path, so its presence
+        # proves the split was lowered as a grid dim (not the classic reshape);
+        # boundary_check confirms the real-extent block_ptr. Guarded to the
+        # make_block_ptr backend (no-op on the tensor-descriptor backends, which
+        # fall back off TMA for the single-element partial store).
+        if self.block_descriptor_constructor_str == "tl.make_block_ptr":
+            joined = "\n".join(code)
+            self.assertIn("rsplit_start", joined)
+            self.assertIn("boundary_check", joined)
+
+    def _skip_if_host_side_tma(self):
+        # Host-side TMA is broken by a pre-existing Triton static-launcher arg-count
+        # mismatch (runtime/static_triton_launcher.py: make_tensordesc_arg is called
+        # with 3 args but the installed Triton backend takes 2), which fails ALL
+        # host-TMA descriptor kernels regardless of split reductions.
+        if config.triton.enable_host_side_tma:
+            raise unittest.SkipTest(
+                "host-side TMA static-launcher arg mismatch (pre-existing, unrelated)"
+            )
+
     def _run_and_compare(
         self: InductorTestCase,
         func: Callable[..., Any],
@@ -147,7 +168,7 @@ class BlockDescriptorTestBase(InductorTestCase):
         compile_kwargs: dict | None = None,
         expected_num_block_pointers: int | None = None,
         expected_num_programs: int = 1,
-        expected_num_triton_kernels: int = 1,
+        expected_num_triton_kernels: int | None = 1,
         config_patches: dict | None = None,
         rtol: float | None = None,
         atol: float | None = None,
@@ -1596,6 +1617,212 @@ class CommonTemplate:
                 self.assertTrue("boundary_check=[0, 1, 2]" in code)
                 # Loading b
                 self.assertTrue("boundary_check=[0, 1]" in code)
+
+    # -------- force_split_reduction_as_grid_dim (split lowered as a grid dim) -------
+    # This path lowers a split reduction so each split partition is a grid program
+    # (program_id(0)) reducing its slice [rsplit_start, rsplit_end) of the TRUE
+    # reduction axis into buf0[..., partition]; stage-2 combines over the split
+    # axis. Every stage-1 load stays a real-extent, boundary-checked block_ptr
+    # (no [split, block_size] over-covering staircase / OOB read).
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn,atol",
+        [
+            subtest((lambda t, d: t.sum(d) if d is not None else t.sum(), 1e-2), name="sum"),
+            subtest((lambda t, d: t.amax(d) if d is not None else t.amax(), 0), name="amax"),
+            subtest((lambda t, d: t.amin(d) if d is not None else t.amin(), 0), name="amin"),
+            subtest((lambda t, d: t.prod(d) if d is not None else t.prod(), 1e-2), name="prod"),
+            subtest((lambda t, d: t.mean(d) if d is not None else t.mean(), 1e-3), name="mean"),
+        ],
+    )
+    @parametrize(
+        "shape,dim",
+        [
+            subtest(((100003,), None), name="1d_full"),
+            subtest(((1, 100003), None), name="2d_full"),
+            subtest(((8, 100003), 1), name="2d_inner"),
+            subtest(((100003, 8), 0), name="2d_outer"),
+            subtest(((4, 8, 20000), 2), name="3d_inner"),
+            subtest(((4, 20000, 8), 1), name="3d_middle"),
+            subtest(((20000, 4, 8), 0), name="3d_outer"),
+        ],
+    )
+    def test_grid_split_reduction_block_ptr(self, reduction_fn, atol, shape, dim):
+        self._skip_if_host_side_tma()
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: reduction_fn(t, dim),
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn,atol",
+        [
+            subtest((lambda t, d: t.sum(d), 1e-2), name="sum"),
+            subtest((lambda t, d: t.amax(d), 0), name="amax"),
+            subtest((lambda t, d: t.amin(d), 0), name="amin"),
+        ],
+    )
+    @parametrize(
+        "shape,dim",
+        [
+            subtest(((8, 16, 4000), (1, 2)), name="3d_inner2"),
+            subtest(((4, 8, 6000), (0, 1, 2)), name="3d_full"),
+            subtest(((4, 50000, 8), (0, 1)), name="3d_outer2"),
+            subtest(((2, 4, 8, 3000), (1, 2, 3)), name="4d"),
+        ],
+    )
+    def test_grid_split_reduction_multi_axis(self, reduction_fn, atol, shape, dim):
+        self._skip_if_host_side_tma()
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: reduction_fn(t, dim),
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn,atol",
+        [
+            subtest((lambda t, d: t.sum(d) if d is not None else t.sum(), 1e-2), name="sum"),
+            subtest((lambda t, d: t.prod(d) if d is not None else t.prod(), 1e-2), name="prod"),
+        ],
+    )
+    @parametrize(
+        "shape,dim",
+        [
+            subtest(((99991,), None), name="1d_prime"),
+            subtest(((3, 99991), 1), name="2d_inner_prime"),
+            subtest(((99991, 3), 0), name="2d_outer_prime"),
+        ],
+    )
+    def test_grid_split_reduction_non_divisible(self, reduction_fn, atol, shape, dim):
+        self._skip_if_host_side_tma()
+        # Prime reduction lengths: the partition chunk does not divide the axis, so
+        # the last partition's boundary-checked tail is exercised.
+        x = torch.randn(*shape, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: reduction_fn(t, dim),
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=1e-2,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "dtype,atol,rtol",
+        [
+            subtest((torch.float32, 1e-2, 1e-2), name="fp32"),
+            subtest((torch.bfloat16, 1.0, 1e-1), name="bf16"),
+            subtest((torch.float16, 0.5, 1e-1), name="fp16"),
+        ],
+    )
+    def test_grid_split_reduction_dtypes(self, dtype, atol, rtol):
+        self._skip_if_host_side_tma()
+        x = torch.randn(8, 100003, device=self.device, dtype=dtype)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=None,
+            atol=atol,
+            rtol=rtol,
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    @parametrize(
+        "reduction_fn",
+        [
+            # cast bool->int so _run_and_compare's allclose works on the output
+            subtest(lambda t: t.all(dim=1).to(torch.int32), name="all"),
+            subtest(lambda t: t.any(dim=1).to(torch.int32), name="any"),
+        ],
+    )
+    def test_grid_split_reduction_bool(self, reduction_fn):
+        self._skip_if_host_side_tma()
+        x = torch.rand(8, 100003, device=self.device) > 0.5
+        _, code = self._run_and_compare(
+            reduction_fn, x, expected_num_triton_kernels=None
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": True,
+        }
+    )
+    def test_grid_split_reduction_int(self):
+        self._skip_if_host_side_tma()
+        x = torch.randint(-100, 100, (8, 100003), device=self.device, dtype=torch.int32)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1), x, expected_num_triton_kernels=None
+        )
+        self._assert_grid_split_reduction(code)
+
+    @config.patch(
+        {
+            "triton.cooperative_reductions": False,
+            "split_reductions": True,
+            "force_split_reduction_as_grid_dim": False,
+        }
+    )
+    def test_grid_split_reduction_disabled_by_default(self):
+        self._skip_if_host_side_tma()
+        # With the flag off, split reductions use the classic reshape path and must
+        # NOT emit the grid-split markers -- confirms the feature is fully gated.
+        x = torch.randn(8, 100003, device=self.device)
+        _, code = self._run_and_compare(
+            lambda t: t.sum(dim=1),
+            x,
+            expected_num_triton_kernels=None,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        self.assertNotIn("rsplit_start", "\n".join(code))
 
 
 @unittest.skipIf(not HAS_GPU, "requires triton GPU backend")

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -35,7 +35,7 @@ from .virtualized import V
 
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Sequence
     from functools import partial
 
     from triton import Config as TritonConfig

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -534,6 +534,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         override_cooperative_reduction: bool | None = None,
         tiling_scores: dict[str, sympy.Expr] | None = None,
         mix_order_reduction: bool = False,
+        split_as_grid_reduction: bool = False,
     ) -> None:
         if pid_cache is None:
             pid_cache = {}
@@ -562,6 +563,18 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
             else self.should_use_persistent_reduction()
         )
         self.mix_order_reduction: bool = mix_order_reduction
+        # Split lowered as an extra grid dim; the count is read from the x numel.
+        self.split_as_grid_reduction: bool = split_as_grid_reduction
+        if self.split_as_grid_reduction and self.cooperative_reduction:
+            # Both partition the reduction with their own rsplit_* bounds off
+            # program_id(0); the second definition would silently shadow the first.
+            raise AssertionError(
+                "split_as_grid_reduction and cooperative_reduction are mutually exclusive"
+            )
+        if self.split_as_grid_reduction and self.persistent_reduction:
+            # Only the looped path emits the per-partition bounds; a persistent
+            # kernel would drop them and reduce the full axis in every program.
+            self.persistent_reduction = False
         self.no_x_dim = self.want_no_x_dim()
         self.code_hash: str | None = None
         # Info to enable multiple store_output calls for epilogue subtiling
@@ -4807,6 +4820,20 @@ class SIMDScheduling(BaseScheduling):
                     range_r = node_ranges[1]  # (K)
                     tiling = cls.create_tiling(range_y_x, range_r)
                     return _TilingSelection(tiling, None, None)
+
+        # Split on x, kept rows on y. Flattening rows*split into one x would force
+        # `xindex // split`, a non-affine index the block_ptr matcher rejects.
+        for node in EnableReduction.filter(node_schedule):
+            if isinstance(node.node, ir.ComputedBuffer):
+                split = node.node._grid_split_factor
+                if not split:
+                    continue
+                if V.graph.sizevars.statically_known_equals(numel, split):
+                    tiling = cls.create_tiling([split], [reduction_numel])
+                else:
+                    rows = numel // split
+                    tiling = cls.create_tiling([rows, split], [reduction_numel])
+                return _TilingSelection(tiling, None, None)
 
         # # TODO: enable by default
         if (

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -534,6 +534,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         override_cooperative_reduction: bool | None = None,
         tiling_scores: dict[str, sympy.Expr] | None = None,
         mix_order_reduction: bool = False,
+        split_as_grid_reduction: bool = False,
     ) -> None:
         if pid_cache is None:
             pid_cache = {}
@@ -562,6 +563,15 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
             else self.should_use_persistent_reduction()
         )
         self.mix_order_reduction: bool = mix_order_reduction
+        # True when the split is lowered as an extra grid dim (see
+        # Reduction.create_multilayer_split_as_grid); the split count is read from
+        # the x numel in codegen. Sits with the other reduction-mode flags above.
+        self.split_as_grid_reduction: bool = split_as_grid_reduction
+        if self.split_as_grid_reduction and self.persistent_reduction:
+            # The per-partition [rsplit_start, rsplit_end) bounds are only emitted on
+            # the looped path, so force looped (a persistent kernel drops them and
+            # each program would reduce the full axis).
+            self.persistent_reduction = False
         self.no_x_dim = self.want_no_x_dim()
         self.code_hash: str | None = None
         # Info to enable multiple store_output calls for epilogue subtiling
@@ -4807,6 +4817,20 @@ class SIMDScheduling(BaseScheduling):
                     range_r = node_ranges[1]  # (K)
                     tiling = cls.create_tiling(range_y_x, range_r)
                     return _TilingSelection(tiling, None, None)
+
+        # Split-as-grid-dim reduction: put the split on x (its own grid dim) and any
+        # kept rows on y (affine), rather than flattening rows*split into one x (which
+        # would force `xindex // split`, a non-affine index off the block_ptr path).
+        # For a full/1-D reduction (numel == split) the split is the only pointwise dim.
+        for node in EnableReduction.filter(node_schedule):
+            if isinstance(node.node, ir.ComputedBuffer):
+                split = getattr(node.node, "_grid_split_factor", 0)
+                if not split:
+                    continue
+                if V.graph.sizevars.statically_known_equals(numel, split):
+                    return cls.create_tiling([split], [reduction_numel]), None
+                rows = numel // split
+                return cls.create_tiling([rows, split], [reduction_numel]), None
 
         # # TODO: enable by default
         if (

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -296,6 +296,18 @@ class SIMDKernelFeatures:
             reduction_hint_val = ReductionHint.DEFAULT
         return reduction_hint_val
 
+    def get_grid_split(self) -> int:
+        """
+        If this kernel's stage-1 reduction was tagged for split-as-grid-dim
+        lowering, return the split factor; otherwise 0. The tag is set on the
+        realized stage-1 buffer by ``Reduction.create_multilayer_split_as_grid``.
+        """
+        for n in self.reduction_nodes():
+            factor = getattr(n.node, "_grid_split_factor", 0)
+            if factor:
+                return factor
+        return 0
+
     @cache_on_self
     def buffer_read_counts(self) -> dict[str, int]:
         """Counts how many times each buffer is read within the kernel"""

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -212,6 +212,13 @@ class SIMDKernelFeatures:
         # conservative here.
         total_numel = self.numel * self.reduction_numel
 
+        # The split is a pointwise dim while the reduction axis keeps its true
+        # extent, so total_numel counts each element `split` times. Divide it out;
+        # storage_size() and any_index_expr_overflows_int32() still bound the rest.
+        grid_split = self.get_grid_split()
+        if grid_split:
+            total_numel = FloorDiv(total_numel, grid_split)
+
         from .simd import SIMDScheduling
 
         if SIMDScheduling.can_use_32bit_indexing(total_numel, buffers):
@@ -322,6 +329,13 @@ class SIMDKernelFeatures:
         else:
             reduction_hint_val = ReductionHint.DEFAULT
         return reduction_hint_val
+
+    def get_grid_split(self) -> int:
+        """The grid split factor, or 0 if this kernel is not split as a grid dim."""
+        for n in self.reduction_nodes():
+            if isinstance(n.node, ir.ComputedBuffer) and n.node._grid_split_factor:
+                return n.node._grid_split_factor
+        return 0
 
     @cache_on_self
     def buffer_read_counts(self) -> dict[str, int]:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -568,8 +568,13 @@ class BlockDescriptorOptions:
         return sympy_subs(expr, {roffset: replacement})
 
     def remove_roffsets(self, expr: sympy.Expr) -> sympy.Expr:
+        # Split-as-grid-dim: start the looped block_ptr at this program's partition
+        # offset (rsplit_start) instead of 0; other kernels zero the roffset.
+        replacement: sympy.Expr = sympy.Integer(0)
+        if getattr(V.kernel, "split_as_grid_reduction", 0):
+            replacement = sympy.Symbol("rsplit_start", integer=True, nonnegative=True)
         for symt in TritonSymbols.reduction_types:
-            expr = self.replace_offset(expr, sympy.Integer(0), symt)
+            expr = self.replace_offset(expr, replacement, symt)
         return expr
 
     def compute_boundary_check(
@@ -805,8 +810,13 @@ class BlockPtrOptions(BlockDescriptorOptions):
         return sympy_subs(expr, {roffset: replacement})
 
     def remove_roffsets(self, expr: sympy.Expr) -> sympy.Expr:
+        # Split-as-grid-dim: start the looped block_ptr at this program's partition
+        # offset (rsplit_start) instead of 0; other kernels zero the roffset.
+        replacement: sympy.Expr = sympy.Integer(0)
+        if getattr(V.kernel, "split_as_grid_reduction", 0):
+            replacement = sympy.Symbol("rsplit_start", integer=True, nonnegative=True)
         for symt in TritonSymbols.reduction_types:
-            expr = self.replace_offset(expr, sympy.Integer(0), symt)
+            expr = self.replace_offset(expr, replacement, symt)
         return expr
 
     def format(self, name: str, roffset=True) -> str:
@@ -2955,13 +2965,13 @@ class TMACompatibilityChecker:
             )
             return False
 
-        # `no_x_dim` => XBLOCK=1, and for reductions this means only one element
-        # is to be stored . However the TMA API requires that
-        # the store will be 16 byte aligned, which is not attainable with a single
-        # element
-        if self.for_store and self.kernel.no_x_dim:
+        # no_x_dim / split_as_grid_reduction => XBLOCK==1, so a reduction store is a
+        # single element and can't meet TMA's 16-byte alignment; fall back off TMA.
+        if self.for_store and (
+            self.kernel.no_x_dim or self.kernel.split_as_grid_reduction
+        ):
             log.debug(
-                "%s stores with `no_x_dim` cannot load 16 bytes.",
+                "%s single-element stores cannot load 16 bytes.",
                 self.failed_debug_prefix,
             )
             return False
@@ -3327,6 +3337,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if self.cooperative_reduction:
             self.init_cooperative_reduction()
 
+        if self.split_as_grid_reduction:
+            self.init_split_as_grid_reduction()
+
         self.codegen_range_tree()
 
         if self.cooperative_reduction:
@@ -3673,6 +3686,37 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.body.writeline(
                 "rsplit_end = tl.where(rsplit_end < rnumel, rsplit_end, rnumel)"
             )
+
+    def init_split_as_grid_reduction(self):
+        """Emit per-partition reduction bounds for a split-as-grid-dim reduction.
+
+        The split is the x grid dim (one program per partition via program_id(0),
+        XBLOCK == 1); each program reduces [rsplit_start, rsplit_end) of the true
+        axis into buf0[..., program_id(0)] and stage-2 combines over the split axis.
+        rsplit_chunk is a multiple of RBLOCK so partitions never overlap.
+        """
+        if not self.split_as_grid_reduction:
+            raise AssertionError("expected split_as_grid_reduction")
+        # The split count is the x dim extent (see get_tiling_and_scores).
+        split = self.numels["x"]
+        # The flat [rsplit_start, rsplit_end) bounds assume a single reduction dim;
+        # more would silently misapply them, so fail loudly.
+        reduction_trees = [t for t in self.range_trees if t.is_reduction]
+        if len(reduction_trees) != 1:
+            raise AssertionError(
+                "split_as_grid_reduction requires exactly one reduction dimension, "
+                f"got {len(reduction_trees)}"
+            )
+        self.body.splice(
+            f"""\
+            rsplit_id = tl.program_id(0)
+            num_rblocks = (rnumel + RBLOCK - 1) // RBLOCK
+            rsplit_chunk = (num_rblocks + {split} - 1) // {split} * RBLOCK
+            rsplit_start = rsplit_chunk * rsplit_id
+            rsplit_end = rsplit_chunk * (rsplit_id + 1)
+            rsplit_end = tl.where(rsplit_end < rnumel, rsplit_end, rnumel)
+            """,
+        )
 
     def init_cooperative_reduction_mask(self):
         rsplit_arange = "tl.arange(0, RSPLIT_NEXT_POWER_OF_2)"
@@ -6085,6 +6129,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self._handle_pdl_before_access(self.post_loop_store, var)
 
         if isinstance(indexing, (BlockPtrOptions, TensorDescriptorOptions)):
+            if isinstance(indexing, TensorDescriptorOptions):
+                # store_reduction emits the descriptor store inline (not through
+                # codegen_block_ptr), so record that a device-side TMA was emitted.
+                # Otherwise the tma_min_block_sizes strip in codegen_kernel drops the
+                # innermost-block >=16-byte floor for this store, the autotuner keeps
+                # XBLOCK==1, and the descriptor fails to compile ("at least 16 bytes
+                # in the last dimension").
+                self._emitted_device_tma = True
             self.post_loop_store.writeline(
                 DeferredLine(
                     name,
@@ -6572,10 +6624,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             for level, tree in enumerate(loop_trees):
                 with self.body.indent(offset=level):
                     prefix = tree.prefix
-                    loop_start = "rsplit_start" if self.cooperative_reduction else "0"
-                    loop_end = (
-                        "rsplit_end" if self.cooperative_reduction else f"{prefix}numel"
+                    partitioned = (
+                        self.cooperative_reduction or self.split_as_grid_reduction
                     )
+                    loop_start = "rsplit_start" if partitioned else "0"
+                    loop_end = "rsplit_end" if partitioned else f"{prefix}numel"
                     # Conditionalize pipelining on HIP for Triton due to
                     # reports of numerical inaccuracies on older Triton
                     if torch.version.hip and get_triton_version() > (3, 2):
@@ -6951,6 +7004,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         }
         if self.mix_order_reduction:
             out["RSPLIT_SIZE"] = self.rsplit_size
+        if self.split_as_grid_reduction:
+            # Clamp the x (split) grid axis to XBLOCK == 1 so each program owns one
+            # partition; R0_BLOCK is still autotuned.
+            out["split_as_grid_reduction"] = True
         if config.deterministic or config.test_configs.force_filter_reduction_configs:
             out["has_loadstore_with_contiguous_rdim"] = (
                 self.has_load_with_contiguous_rdim
@@ -8250,6 +8307,9 @@ class TritonScheduling(SIMDScheduling):
             kernel_kwargs["override_cooperative_reduction"] = False
 
         kernel_type.apply_feature_required_overrides(kernel_features, kernel_kwargs)
+
+        if kernel_features.get_grid_split():
+            kernel_kwargs["split_as_grid_reduction"] = True
 
         kernel_kwargs = V.choices.triton_kernel_kwargs(
             kernel_type, kernel_features, kernel_args, kernel_kwargs

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -572,8 +572,13 @@ class BlockDescriptorOptions:
         return sympy_subs(expr, {roffset: replacement})
 
     def remove_roffsets(self, expr: sympy.Expr) -> sympy.Expr:
+        # Split-as-grid-dim: start the looped block_ptr at this program's partition
+        # offset (rsplit_start) instead of 0; other kernels zero the roffset.
+        replacement: sympy.Expr = sympy.Integer(0)
+        if getattr(V.kernel, "split_as_grid_reduction", 0):
+            replacement = sympy.Symbol("rsplit_start", integer=True, nonnegative=True)
         for symt in TritonSymbols.reduction_types:
-            expr = self.replace_offset(expr, sympy.Integer(0), symt)
+            expr = self.replace_offset(expr, replacement, symt)
         return expr
 
     def compute_boundary_check(
@@ -809,8 +814,13 @@ class BlockPtrOptions(BlockDescriptorOptions):
         return sympy_subs(expr, {roffset: replacement})
 
     def remove_roffsets(self, expr: sympy.Expr) -> sympy.Expr:
+        # Split-as-grid-dim: start the looped block_ptr at this program's partition
+        # offset (rsplit_start) instead of 0; other kernels zero the roffset.
+        replacement: sympy.Expr = sympy.Integer(0)
+        if getattr(V.kernel, "split_as_grid_reduction", 0):
+            replacement = sympy.Symbol("rsplit_start", integer=True, nonnegative=True)
         for symt in TritonSymbols.reduction_types:
-            expr = self.replace_offset(expr, sympy.Integer(0), symt)
+            expr = self.replace_offset(expr, replacement, symt)
         return expr
 
     def format(self, name: str, roffset=True) -> str:
@@ -2955,11 +2965,11 @@ class TMACompatibilityChecker:
             )
             return False
 
-        # Strict multirow reductions are forced persistent and can settle on
-        # XBLOCK=1 after the initial TMA probe. Their output store must therefore
-        # use the scalar fallback rather than a 16-byte tensor descriptor.
+        # These all settle on XBLOCK=1, so the store cannot reach TMA's 16-byte
+        # minimum and must fall back off the tensor descriptor.
         if self.for_store and (
-            self.kernel.no_x_dim or self.kernel.features.has_strict_multirow_reduction()
+            self.kernel.no_x_dim or self.kernel.split_as_grid_reduction
+            or self.kernel.features.has_strict_multirow_reduction()
         ):
             log.debug(
                 "%s stores with XBLOCK=1 cannot transfer 16 bytes.",
@@ -3338,6 +3348,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if self.cooperative_reduction:
             self.init_cooperative_reduction()
 
+        if self.split_as_grid_reduction:
+            self.init_split_as_grid_reduction()
+
         self.codegen_range_tree()
 
         if self.cooperative_reduction:
@@ -3694,6 +3707,37 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.body.writeline(
                 "rsplit_end = tl.where(rsplit_end < rnumel, rsplit_end, rnumel)"
             )
+
+    def init_split_as_grid_reduction(self):
+        """Emit per-partition reduction bounds for a split-as-grid-dim reduction.
+
+        The split is the x grid dim (one program per partition via program_id(0),
+        XBLOCK == 1); each program reduces [rsplit_start, rsplit_end) of the true
+        axis into buf0[..., program_id(0)] and stage-2 combines over the split axis.
+        rsplit_chunk is a multiple of RBLOCK so partitions never overlap.
+        """
+        if not self.split_as_grid_reduction:
+            raise AssertionError("expected split_as_grid_reduction")
+        # The split count is the x dim extent (see get_tiling_and_scores).
+        split = self.numels["x"]
+        # The flat [rsplit_start, rsplit_end) bounds assume a single reduction dim;
+        # more would silently misapply them, so fail loudly.
+        reduction_trees = [t for t in self.range_trees if t.is_reduction]
+        if len(reduction_trees) != 1:
+            raise AssertionError(
+                "split_as_grid_reduction requires exactly one reduction dimension, "
+                f"got {len(reduction_trees)}"
+            )
+        self.body.splice(
+            f"""\
+            rsplit_id = tl.program_id(0)
+            num_rblocks = (rnumel + RBLOCK - 1) // RBLOCK
+            rsplit_chunk = (num_rblocks + {split} - 1) // {split} * RBLOCK
+            rsplit_start = rsplit_chunk * rsplit_id
+            rsplit_end = rsplit_chunk * (rsplit_id + 1)
+            rsplit_end = tl.where(rsplit_end < rnumel, rsplit_end, rnumel)
+            """,
+        )
 
     def init_cooperative_reduction_mask(self):
         rsplit_arange = "tl.arange(0, RSPLIT_NEXT_POWER_OF_2)"
@@ -6166,6 +6210,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self._handle_pdl_before_access(self.post_loop_store, var)
 
         if isinstance(indexing, (BlockPtrOptions, TensorDescriptorOptions)):
+            if isinstance(indexing, TensorDescriptorOptions):
+                # store_reduction bypasses codegen_block_ptr, so without this
+                # codegen_kernel strips the >=16-byte floor and the store won't compile.
+                self._emitted_device_tma = True
             self.post_loop_store.writeline(
                 DeferredLine(
                     name,
@@ -6656,10 +6704,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             for level, tree in enumerate(loop_trees):
                 with self.body.indent(offset=level):
                     prefix = tree.prefix
-                    loop_start = "rsplit_start" if self.cooperative_reduction else "0"
-                    loop_end = (
-                        "rsplit_end" if self.cooperative_reduction else f"{prefix}numel"
+                    partitioned = (
+                        self.cooperative_reduction or self.split_as_grid_reduction
                     )
+                    loop_start = "rsplit_start" if partitioned else "0"
+                    loop_end = "rsplit_end" if partitioned else f"{prefix}numel"
                     # Conditionalize pipelining on HIP for Triton due to
                     # reports of numerical inaccuracies on older Triton
                     if torch.version.hip and get_triton_version() > (3, 2):
@@ -7039,6 +7088,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         }
         if self.mix_order_reduction:
             out["RSPLIT_SIZE"] = self.rsplit_size
+        if self.split_as_grid_reduction:
+            # Clamp the x (split) grid axis to XBLOCK == 1 so each program owns one
+            # partition; R0_BLOCK is still autotuned.
+            out["split_as_grid_reduction"] = True
         if config.deterministic or config.test_configs.force_filter_reduction_configs:
             out["has_loadstore_with_contiguous_rdim"] = (
                 self.has_load_with_contiguous_rdim
@@ -8388,6 +8441,9 @@ class TritonScheduling(SIMDScheduling):
             kernel_kwargs["override_cooperative_reduction"] = False
 
         kernel_type.apply_feature_required_overrides(kernel_features, kernel_kwargs)
+
+        if kernel_features.get_grid_split():
+            kernel_kwargs["split_as_grid_reduction"] = True
 
         kernel_kwargs = V.choices.triton_kernel_kwargs(
             kernel_type, kernel_features, kernel_args, kernel_kwargs

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1052,6 +1052,12 @@ conv_1x1_as_mm = False
 # enabling both of these will implicitly disable split_reductions
 split_reductions = os.getenv("TORCHINDUCTOR_SPLIT_REDUCTIONS", "1") == "1"
 
+# Lower a split reduction as an extra grid dim rather than reshaping the reduction
+# axis, so stage-1 loads stay block_ptr-eligible. Requires split_reductions.
+force_red_split_dim_as_grid_dim = (
+    os.getenv("TORCHINDUCTOR_FORCE_RED_SPLIT_DIM_AS_GRID_DIM", "0") == "1"
+)
+
 # A deterministic mode that skips any on device benchmarking in Inductor
 # if we know they affect numerics.  WARNING: Expect perf hit in this mode.
 deterministic = os.getenv("TORCHINDUCTOR_DETERMINISTIC") == "1"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1052,6 +1052,16 @@ conv_1x1_as_mm = False
 # enabling both of these will implicitly disable split_reductions
 split_reductions = os.getenv("TORCHINDUCTOR_SPLIT_REDUCTIONS", "1") == "1"
 
+# Lower a split reduction as an extra grid dimension instead of reshaping the
+# reduction axis into a synthetic [split, block_size] tile.  Reserving a grid dim
+# for the split lets stage-1 keep the reduction axis at its true extent, so its
+# loads stay real-extent, boundary-checked block_ptr tiles (no over-covering
+# staircase / out-of-bounds read) on block_ptr backends.  Experimental; only
+# affects codegen when split_reductions is also enabled.
+force_split_reduction_as_grid_dim = (
+    os.getenv("TORCHINDUCTOR_FORCE_SPLIT_REDUCTION_AS_GRID_DIM", "0") == "1"
+)
+
 # A deterministic mode that skips any on device benchmarking in Inductor
 # if we know they affect numerics.  WARNING: Expect perf hit in this mode.
 deterministic = os.getenv("TORCHINDUCTOR_DETERMINISTIC") == "1"

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2212,6 +2212,20 @@ class Reduction(Loops):
         # TODO(jansel): realize the reduction so we can do dynamic indexing
         reduction_numel = sympy_product(reduction_ranges)
         block_size = FloorDiv(reduction_numel + (split - 1), split)
+
+        if config.force_split_reduction_as_grid_dim and is_triton(device):
+            return cls.create_multilayer_split_as_grid(
+                device,
+                dst_dtype,
+                src_dtype,
+                inner_fn,
+                ranges,
+                reduction_ranges,
+                reduction_type,
+                split,
+                reduction_hint,
+            )
+
         default = cls.default_value(reduction_type, dst_dtype)
         wrapper_fn = cls._multilayer_wrap_loader(
             inner_fn,
@@ -2235,6 +2249,86 @@ class Reduction(Loops):
             reduction_type,
             split,
             reduction_hint,
+        )
+
+    @classmethod
+    def create_multilayer_split_as_grid(
+        cls,
+        device: torch.device,
+        dst_dtype: torch.dtype,
+        src_dtype: torch.dtype,
+        inner_fn: Callable[..., Any],
+        ranges: Sequence[_IntLike],
+        reduction_ranges: Sequence[_IntLike],
+        reduction_type: ReductionType,
+        split: _IntLike,
+        reduction_hint: ReductionHint,
+    ) -> TensorBox:
+        """
+        Split a reduction using an extra grid dimension for the split factor.
+
+        Unlike ``create_multilayer``, stage-1 keeps the reduction axis at its true
+        extent (no ``[split, block_size]`` reshape) and drops the split index from
+        the load, so each stage-1 load stays a real-extent, boundary-checked
+        block_ptr. Each split partition ``p`` reduces one contiguous chunk of the
+        reduction axis (bounded in codegen via ``rsplit_start``/``rsplit_end``,
+        keyed on the split grid dim) and stores its partial to ``buf0[..., p]``;
+        stage-2 combines over the appended split axis.
+        """
+        intermediate_dtype = (
+            dst_dtype
+            if dst_dtype not in (torch.float16, torch.bfloat16)
+            else torch.float
+        )
+
+        def wrapper_fn(
+            index: Sequence[Symbol], reduction_index: Sequence[Symbol]
+        ) -> OpsValue:
+            # Drop the trailing split index from the load; the split partition is
+            # applied by the per-program reduction loop bounds in codegen.
+            *new_index, _split_block = index
+            return inner_fn(new_index, reduction_index)
+
+        intermediate = TensorBox.create(
+            Reduction(
+                device=device,
+                dtype=intermediate_dtype,
+                inner_fn=wrapper_fn,
+                ranges=[*ranges, split],
+                reduction_ranges=[*reduction_ranges],
+                reduction_type=reduction_type,
+                src_dtype=src_dtype,
+                reduction_hint=reduction_hint,
+            )
+        )
+        intermediate.realize()
+        # Tag the realized stage-1 buffer so its kernel lowers the split axis as a
+        # grid dim; the tag is what bounds each partition's loop to its own slice.
+        stage1_buf = V.graph.name_to_buffer.get(intermediate.get_name())
+        if not isinstance(stage1_buf, ComputedBuffer):
+            raise AssertionError(
+                "split-as-grid stage-1 must realize to a ComputedBuffer, got "
+                f"{type(stage1_buf).__name__}"
+            )
+        stage1_buf._grid_split_factor = split
+        intermediate_loader = intermediate.make_loader()
+
+        def intermediate_fn(
+            index: Sequence[_IntLike], reduction_index: Sequence[_IntLike]
+        ) -> OpsValue:
+            return intermediate_loader([*index, *reduction_index])
+
+        return TensorBox.create(
+            Reduction(
+                device=device,
+                dtype=dst_dtype,
+                inner_fn=intermediate_fn,
+                ranges=ranges,
+                reduction_ranges=[split],
+                reduction_type=reduction_type,
+                src_dtype=src_dtype,
+                reduction_hint=reduction_hint,
+            )
         )
 
     @classmethod
@@ -5442,6 +5536,9 @@ class ComputedBuffer(OperationBuffer):
     _original_inner_fn: Callable[..., Any] | None = None
     _original_ranges: Sequence[_IntLike] | None = None
     _original_reduction_ranges: Sequence[_IntLike] | None = None
+    # split factor when the split is lowered as a grid dim (0 = not split-as-grid);
+    # see Reduction.create_multilayer_split_as_grid, read by get_grid_split.
+    _grid_split_factor: int = 0
 
     @contextlib.contextmanager
     def with_original_inner_fn(self) -> Iterator[None]:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2311,6 +2311,25 @@ class Reduction(Loops):
         # TODO(jansel): realize the reduction so we can do dynamic indexing
         reduction_numel = sympy_product(reduction_ranges)
         block_size = FloorDiv(reduction_numel + (split - 1), split)
+
+        # strict_reduction needs the classic lowering's fixed summation order.
+        if (
+            config.force_red_split_dim_as_grid_dim
+            and is_triton(device)
+            and not strict_reduction
+        ):
+            return cls.create_multilayer_split_as_grid(
+                device,
+                dst_dtype,
+                src_dtype,
+                inner_fn,
+                ranges,
+                reduction_ranges,
+                reduction_type,
+                split,
+                reduction_hint,
+            )
+
         default = cls.default_value(reduction_type, dst_dtype)
         wrapper_fn = cls._multilayer_wrap_loader(
             inner_fn,
@@ -2335,6 +2354,89 @@ class Reduction(Loops):
             split,
             reduction_hint,
             strict_reduction,
+        )
+
+    @classmethod
+    def create_multilayer_split_as_grid(
+        cls,
+        device: torch.device,
+        dst_dtype: torch.dtype,
+        src_dtype: torch.dtype,
+        inner_fn: Callable[..., Any],
+        ranges: Sequence[_IntLike],
+        reduction_ranges: Sequence[_IntLike],
+        reduction_type: ReductionType,
+        split: _IntLike,
+        reduction_hint: ReductionHint,
+    ) -> TensorBox:
+        """
+        Split a reduction using an extra grid dimension for the split factor.
+
+        Unlike ``create_multilayer``, stage-1 keeps the reduction axis at its true
+        extent (no ``[split, block_size]`` reshape) and drops the split index from
+        the load, so each stage-1 load stays a real-extent, boundary-checked
+        block_ptr. Each split partition ``p`` reduces one contiguous chunk of the
+        reduction axis (bounded in codegen via ``rsplit_start``/``rsplit_end``,
+        keyed on the split grid dim) and stores its partial to ``buf0[..., p]``;
+        stage-2 combines over the appended split axis.
+        """
+        intermediate_dtype = (
+            dst_dtype
+            if dst_dtype not in (torch.float16, torch.bfloat16)
+            else torch.float
+        )
+
+        def wrapper_fn(
+            index: Sequence[Symbol], reduction_index: Sequence[Symbol]
+        ) -> OpsValue:
+            # Drop the trailing split index from the load; the split partition is
+            # applied by the per-program reduction loop bounds in codegen.
+            *new_index, _split_block = index
+            return inner_fn(new_index, reduction_index)
+
+        intermediate = TensorBox.create(
+            Reduction(
+                device=device,
+                dtype=intermediate_dtype,
+                inner_fn=wrapper_fn,
+                ranges=[*ranges, split],
+                reduction_ranges=[*reduction_ranges],
+                reduction_type=reduction_type,
+                src_dtype=src_dtype,
+                reduction_hint=reduction_hint,
+            )
+        )
+        intermediate.realize()
+        # Tag the realized stage-1 buffer so its kernel lowers the split axis as a
+        # grid dim; the tag is what bounds each partition's loop to its own slice.
+        stage1_buf = V.graph.name_to_buffer.get(intermediate.get_name())
+        if not isinstance(stage1_buf, ComputedBuffer):
+            raise AssertionError(
+                "split-as-grid stage-1 must realize to a ComputedBuffer, got "
+                f"{type(stage1_buf).__name__}"
+            )
+        stage1_buf._grid_split_factor = split
+        intermediate_loader = intermediate.make_loader()
+
+        def intermediate_fn(
+            index: Sequence[_IntLike], reduction_index: Sequence[_IntLike]
+        ) -> OpsValue:
+            return intermediate_loader([*index, *reduction_index])
+
+        numel_hint = V.graph.sizevars.optimization_hint(sympy_product(ranges))
+        return TensorBox.create(
+            Reduction(
+                device=device,
+                dtype=dst_dtype,
+                inner_fn=intermediate_fn,
+                ranges=ranges,
+                reduction_ranges=[split],
+                reduction_type=reduction_type,
+                src_dtype=src_dtype,
+                reduction_hint=cls._multilayer_second_step_hint(
+                    split, numel_hint, reduction_hint
+                ),
+            )
         )
 
     @classmethod
@@ -5542,6 +5644,9 @@ class ComputedBuffer(OperationBuffer):
     _original_inner_fn: Callable[..., Any] | None = None
     _original_ranges: Sequence[_IntLike] | None = None
     _original_reduction_ranges: Sequence[_IntLike] | None = None
+    # split factor when the split is lowered as a grid dim (0 = not split-as-grid);
+    # see Reduction.create_multilayer_split_as_grid, read by get_grid_split.
+    _grid_split_factor: int = 0
 
     @contextlib.contextmanager
     def with_original_inner_fn(self) -> Iterator[None]:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4701,7 +4701,8 @@ def reduction(
     """args to @triton.heuristics()"""
     inductor_meta = {} if inductor_meta is None else inductor_meta
     inductor_meta["reduction_hint"] = reduction_hint
-    if inductor_meta.get("no_x_dim"):
+    if inductor_meta.get("no_x_dim") or inductor_meta.get("split_as_grid_reduction"):
+        # Pin the split (x) grid axis to XBLOCK == 1: one partition per program.
         size_hints["x"] = 1
 
     if triton_meta is None:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4658,7 +4658,8 @@ def reduction(
     """args to @triton.heuristics()"""
     inductor_meta = {} if inductor_meta is None else inductor_meta
     inductor_meta["reduction_hint"] = reduction_hint
-    if inductor_meta.get("no_x_dim"):
+    if inductor_meta.get("no_x_dim") or inductor_meta.get("split_as_grid_reduction"):
+        # Pin the split (x) grid axis to XBLOCK == 1: one partition per program.
         size_hints["x"] = 1
 
     if triton_meta is None:


### PR DESCRIPTION
Summary:

## Motivation

The standard programming model for reduction codegen parallelises the output elements (`xnumel`) across the device. This is effective when `xnumel` is large, but it parallelises poorly when `xnumel` is small. Every 1-D reduction hits this case, since it reduces to a single output element, and so do 2-D and higher reductions with a small kept extent, such as `(1, 1000)` or `(10, 1000)` reduced over `dim=1`. These shapes are common enough that their codegen is worth improving.

Inductor already has a code path for the small-`xnumel` case: split reductions. This diff addresses the principal shortcoming of that path on block-pointer backends, namely that it does not emit block pointers. Block-pointer support for reductions was extended substantially by Blaine Burton Rister; the split-reduction path was one of the remaining cases that still fell back to unstructured pointer loads. The scope here is split reductions over a **single reduction dimension**.

## Why split reductions lose block pointers

Consider `sum` over an input of shape `[1, 100003]` with `dim=1`. The classic lowering decomposes the reduction into two stages by reshaping the reduction axis, here with a split factor of 13:

```
[1, 100003]  --reshape-->  [13, 7693]
[13, 7693]   --stage 1 (dim=1)-->  [13, 1]
[13, 1]      --stage 2 (dim=0)-->  [1, 1]
```

The split factor does not generally divide the reduction extent evenly, so the reshaped buffer has a tail: `13 * 7693 = 100009` elements against the 100003 that actually exist. That tail must be masked to avoid out-of-bounds reads, and it cannot be expressed as a rectangular region of the `[13, 7693]` view — the final row is partially valid. This is the root cause of the missing block pointers: the mask is applied to the value rather than expressible as a block-pointer boundary, which forces unstructured pointer arithmetic.

Constraining the split factor to always divide `rnumel` would avoid the tail, but that is not possible in general — here `rnumel` is prime — and it is undesirable regardless, because the split factor should be chosen for occupancy and remain independent of the input shape, particularly under dynamic shapes.

## Approach

The reshape is not introduced in the first place. The split factor instead becomes an additional spatial block, and therefore an additional `program_id`. The reduction axis retains its true extent of 100003, and each program is assigned a slice of it by adjusting the offset of the block pointer. Every load is consequently rectangular, and only the final partition's overshoot needs masking, which the block pointer's own `boundary_check` expresses directly.

## Implementation

`Reduction.create_multilayer` dispatches to `create_multilayer_split_as_grid` when the flag is enabled on a Triton device. Stage 1 becomes `Reduction(ranges=[*ranges, split], reduction_ranges=[*reduction_ranges])`: the split is appended as a trailing output range while the reduction axis is left intact, and the loader drops the trailing split index because the per-partition slice is applied during codegen. The realised stage-1 buffer is tagged with `_grid_split_factor`, a declared field on `ComputedBuffer`. Stage 2 is an ordinary `Reduction(ranges=ranges, reduction_ranges=[split])` over the appended axis.

In codegen, the partition occupies its own grid program via `program_id(0)` with `XBLOCK == 1` (pinned by the `size_hints` clamp), and each program reduces `[rsplit_start, rsplit_end)` of the true axis into `buf0[..., partition]`. Kept rows remain affine on `y`. `rsplit_chunk` is a multiple of `RBLOCK`, so partitions never overlap and no per-tile out-of-bounds region exists; the only masked lanes are the overshoot past the true extent on the final partition.

Note that `padding_option` on a block pointer can only be zero, which is not the identity for `amax`, `amin` or `prod`. The zero padding therefore provides memory safety only; numerical correctness for those operators continues to come from the accumulator mask, which discards padded lanes before they reach the accumulator.

Index dtype: because the split is a pointwise dim while the reduction axis keeps its
true extent, `numel * reduction_numel` counts every element `split` times. Left alone
that inflated figure pushes `select_index_dtype` to int64 on large-extent shapes, and
the int64 path disables the block-pointer gate entirely (the triton#2821 workaround
requires int32), so the load would fall back to exactly the unstructured form this
change exists to remove. `select_index_dtype` therefore divides the split factor back
out. The per-buffer `storage_size()` check and `any_index_expr_overflows_int32()` still
run afterwards, so the real data extent and the individual index expressions remain
bounded independently.

Tensor descriptors: the size-1 stage-1 store cannot meet TMA's 16-byte minimum, so it declines TMA and falls back to a block pointer. A companion change preserves the `tma_min_block_sizes` floor for genuine device-TMA reduction stores.

Gated by `config.force_red_split_dim_as_grid_dim` (environment variable `TORCHINDUCTOR_FORCE_RED_SPLIT_DIM_AS_GRID_DIM`), default off. With the flag off, split reductions are byte-identical to upstream.

## Before and after

`torch.sum(x, dim=1)` with `x` of shape `[1, 100003]`, under `use_block_ptr=True`, `prefer_nd_tiling=True`, `tile_reductions=True`, `split_reductions=True`.

Before (`force_red_split_dim_as_grid_dim=False`) — the reduction axis is reshaped to `[13, 7693]`, the split index enters the address expression, the tail is guarded by an explicit value comparison, and the load is unstructured:

```python
def triton_red_fused_sum_0(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK, R0_BLOCK):
    xnumel = 13            # the split factor, as a pointwise dim
    r0_numel = 7693        # reshaped block_size, not the true extent
    ...
    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
        r0_1 = r0_offset + r0_base
        tmp0 = (r0_1 + 7693*x0).to(tl.int32)
        tmp1 = tl.full([1, 1], 100003, tl.int32)
        tmp2 = tmp0 < tmp1                                     # tail guard on the value
        tmp3 = tl.load(in_ptr0 + (r0_1 + 7693*x0),             # unstructured load
                       r0_mask & tmp2 & xmask, other=0.0)
        _tmp5 = tl.where(r0_mask & xmask, _tmp5 + tmp3, _tmp5)
```

After (`force_red_split_dim_as_grid_dim=True`) — the axis keeps its true extent, the partition is a grid program expressed through the block-pointer offset, and the tail is handled by `boundary_check` together with the `rsplit_end` clamp:

```python
def triton_red_fused_sum_0(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK, R0_BLOCK):
    xnumel = 13
    r0_numel = 100003      # true extent preserved
    rsplit_id    = tl.program_id(0)
    num_rblocks  = (rnumel + RBLOCK - 1) // RBLOCK
    rsplit_chunk = (num_rblocks + 13 - 1) // 13 * RBLOCK       # multiple of RBLOCK
    rsplit_start = rsplit_chunk * rsplit_id
    rsplit_end   = rsplit_chunk * (rsplit_id + 1)
    rsplit_end   = tl.where(rsplit_end < rnumel, rsplit_end, rnumel)

    block_ptr0 = tl.make_block_ptr(in_ptr0, shape=[100003], strides=[1],
                                   block_shape=[R0_BLOCK], order=[0],
                                   offsets=[rsplit_start])     # partition via the offset
    for r0_offset in tl.range(rsplit_start, rsplit_end, R0_BLOCK):
        tmp0 = tl.load(block_ptr0, boundary_check=[0], padding_option='zero')
        _tmp2 = tl.where(r0_mask & xmask, _tmp2 + tmp0, _tmp2)
        block_ptr0 = tl.advance(block_ptr0, [R0_BLOCK])
```

Both produce results matching eager.

## Files (mirrored in fbcode and xplat)

- `config.py`: the `force_red_split_dim_as_grid_dim` flag.
- `ir.py`: the `create_multilayer` gate, `create_multilayer_split_as_grid`, and the `_grid_split_factor` field on `ComputedBuffer`.
- `simd_kernel_features.py`: `get_grid_split`, which reads the tag, and the index-dtype
  correction described above.
- `simd.py`: tiling selection places the split on `x` and kept rows on `y`, with the `numel == split` case tiling as `[split]`; kernel plumbing and the persistent-to-looped guard.
- `triton.py`: `init_split_as_grid_reduction`, `remove_roffsets` (which bakes `rsplit_start` into the offset), loop-bound selection, TMA handling, and kernel construction.
- `runtime/triton_heuristics.py`: the `size_hints["x"] = 1` clamp.
- `test/inductor/test_torchinductor_strided_blocks.py`: `test_grid_split_reduction*` coverage.

This change was developed with the assistance of an AI coding agent.

Test Plan:
A100 (`devvm53434`), block-pointer backend.

## Targeted

```
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/inductor:torchinductor_strided_blocks -- --regex "grid_split"
```
Pass 70, Fail 0.

## Full file

```
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/inductor:torchinductor_strided_blocks
```
Pass 170, Fail 1. The single failure is `test_broadcast_with_singleton_dims_cuda`, which is pre-existing: it fails identically with this diff's source changes reverted (expects 4 block pointers, gets 3) and is unrelated to split reductions. Skips are the host-side-TMA and Triton-CPU variants, which require `cc >= 9.0`.

## Coverage

`test_grid_split_reduction_block_ptr` is a systematic matrix over ranks 1 through 4 with the reduced dimension at every position, run against `sum`, `amax`, `amin`, `prod` and `mean` (55 cases):

| case | shape | dim |
|---|---|---|
| 1d | `(100003,)` | 0 |
| 2d_inner / 2d_outer | `(8, 100003)` / `(100003, 8)` | 1 / 0 |
| 2d_pow2 | `(8, 131072)` | 1 |
| 3d_inner / 3d_middle / 3d_outer | `(4, 8, 20011)` / `(4, 20011, 8)` / `(20011, 4, 8)` | 2 / 1 / 0 |
| 4d_inner / 4d_middle2 / 4d_middle1 / 4d_outer | `(2, 4, 8, 20011)` / `(2, 4, 20011, 8)` / `(2, 20011, 4, 8)` / `(20011, 2, 4, 8)` | 3 / 2 / 1 / 0 |

100003 and 20011 are prime, so the split factor cannot divide the reduction extent and every case exercises the boundary-checked tail; `2d_pow2` is the control in which the split does divide evenly. Each case asserts the number of block pointers and the number of Triton kernels, checks that the grid-split markers are present, and compares numerics against eager. A scalar output has no block-pointer store, hence 3 descriptors rather than 4.

Additional tests:

- `test_grid_split_reduction_zero_padding_does_not_leak`: a block pointer can only pad with zero, which is not the identity for `amax`, `amin` or `prod`. Inputs are chosen so that a leaked padding lane would change the result — `amax` over an all-negative tensor and `amin` over an all-positive tensor, both compared at `atol=0, rtol=0`, and `prod` over values near 1, which a leaked zero would collapse.
- `test_grid_split_reduction_dtypes`: fp32, bf16, fp16.
- `test_grid_split_reduction_bool` and `test_grid_split_reduction_int`: `all`/`any` on bool, `sum` on int32.
- `test_grid_split_reduction_large_extent_int32`: ranks 3 and 4 with a 100003 extent, where
  the split-inflated iteration numel exceeds int32 while the data does not. Asserts the stage-1
  load is still a block pointer carrying the true reduction length, which fails if the index
  dtype is not corrected.
- `test_grid_split_reduction_disabled_by_default`: with the flag off, no grid-split markers are emitted and numerics match eager, confirming the default path is unchanged from upstream.

`expected_num_triton_kernels` no longer accepts `None`, so no test in this file can silently skip the kernel-count assertion.

`arc lint` clean. The fbcode and xplat mirrors are byte-identical.

Differential Revision: D105903967


