### PR TITLE
Fix mkldnn transposed conv pointwise shape inference

### DIFF
--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -680,6 +680,20 @@ std::vector<int64_t> _original_deconv_weight_size(
   return weight_IOHW_sizes;
 }
 
+bool _is_fake_deconv_weight_prepacked(
+    const Tensor& input_t,
+    const Tensor& weight_t,
+    int64_t groups) {
+  if (!weight_t.is_meta() || weight_t.dim() <= 2 || input_t.dim() <= 1) {
+    return false;
+  }
+
+  const auto input_channels = input_t.sizes()[1];
+  const auto regular_input_channels = weight_t.sizes()[0];
+  const auto packed_input_channels = weight_t.sizes()[1] * groups;
+  return input_channels != regular_input_channels &&
+      input_channels == packed_input_channels;
+}
 
 Tensor _mkldnn_convolution_transpose(
     const Tensor& input_t,
@@ -797,7 +811,12 @@ Tensor mkldnn_convolution_transpose_pointwise_meta(
     torch::List<std::optional<at::Scalar>> scalars,
     std::optional<std::string_view> algorithm) {
 
-  std::vector<int64_t> weight_IOHW_sizes = _original_deconv_weight_size(weight_t, groups);
+  const bool is_prepacked_weight =
+      weight_t.is_mkldnn() ||
+      _is_fake_deconv_weight_prepacked(input_t, weight_t, groups);
+  std::vector<int64_t> weight_IOHW_sizes =
+      is_prepacked_weight ? _original_deconv_weight_size(weight_t, groups)
+                          : weight_t.sizes().vec();
   int64_t dim = input_t.ndimension() - 2;
   const auto padding_expanded = expand_param_if_needed(padding, "padding", dim);
   const auto stride_expanded = expand_param_if_needed(stride, "stride", dim);

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -14,6 +14,7 @@ from torch._inductor.utils import (
     is_mkldnn_fp16_supported,
     run_and_get_code,
 )
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.nn import functional as F
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_mkldnn import reduced_f32_on_and_off
@@ -428,6 +429,99 @@ class TestPatternMatcherGeneric(TestPatternMatcherBase):
     def test_conv_transpose3d_unary(self, device):
         self.device = device
         self._test_conv_transpose_unary_base(dim=5)
+
+    @skipIfNoDynamoSupport
+    @skipIfNoONEDNN
+    @skipIfXpu(
+        msg="The operator 'mkldnn::_convolution_transpose_pointwise' is not currently implemented for the XPU device."
+    )
+    def test_conv_transpose_pointwise_regular_weight_shape(self, device):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(3, 8, 3, 3))
+                self.bias = torch.nn.Parameter(torch.randn(8))
+
+            def forward(self, x):
+                y = torch.ops.mkldnn._convolution_transpose_pointwise.default(
+                    x,
+                    self.weight,
+                    self.bias,
+                    [1, 1],
+                    [1, 1],
+                    [2, 2],
+                    [1, 1],
+                    1,
+                    "none",
+                    [],
+                    "",
+                )
+                return torch.div(torch.clamp_max(torch.clamp_min(y + 3, 0), 6), 6)
+
+        torch.manual_seed(9150)
+        model = M().eval().to(device=device)
+        x = torch.randn(4, 3, 16, 16, device=device)
+
+        with torch.no_grad():
+            eager_out = model(x)
+            compiled_out = torch.compile(model, fullgraph=True)(x)
+
+        self.assertEqual(eager_out.shape, torch.Size([4, 8, 32, 32]))
+        self.assertEqual(compiled_out.shape, eager_out.shape)
+        torch.testing.assert_close(compiled_out, eager_out)
+
+    @skipIfNoONEDNN
+    @skipIfXpu(
+        msg="The operator 'mkldnn::_convolution_transpose_pointwise' is not currently implemented for the XPU device."
+    )
+    def test_conv_transpose_pointwise_fake_meta_shapes(self, device):
+        def check_case(groups, x_shape, weight_shape):
+            padding = [1, 1]
+            output_padding = [1, 1]
+            stride = [2, 2]
+            dilation = [1, 1]
+            x = torch.randn(*x_shape)
+            weight = torch.randn(*weight_shape)
+            bias = torch.randn(weight_shape[1] * groups)
+            expected_shape = torch.Size([x_shape[0], weight_shape[1] * groups, 32, 32])
+            expected_stride = (
+                expected_shape[1] * expected_shape[2] * expected_shape[3],
+                expected_shape[2] * expected_shape[3],
+                expected_shape[3],
+                1,
+            )
+            packed_weight = (
+                torch.ops.mkldnn._reorder_convolution_transpose_weight.default(
+                    weight,
+                    padding,
+                    output_padding,
+                    stride,
+                    dilation,
+                    groups,
+                    list(x_shape),
+                )
+            )
+
+            for weight_arg in (weight, packed_weight):
+                with FakeTensorMode(allow_non_fake_inputs=True) as mode:
+                    out = torch.ops.mkldnn._convolution_transpose_pointwise.default(
+                        mode.from_tensor(x),
+                        mode.from_tensor(weight_arg),
+                        mode.from_tensor(bias),
+                        padding,
+                        output_padding,
+                        stride,
+                        dilation,
+                        groups,
+                        "none",
+                        [],
+                        "",
+                    )
+                self.assertEqual(out.shape, expected_shape)
+                self.assertEqual(out.stride(), expected_stride)
+
+        check_case(groups=1, x_shape=(4, 3, 16, 16), weight_shape=(3, 8, 3, 3))
+        check_case(groups=2, x_shape=(4, 4, 16, 16), weight_shape=(4, 3, 3, 3))
 
     def _test_conv_binary_base(self, dim=4):
         if dim != 4 and dim != 5:

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -111,6 +111,22 @@ def _prepare_convolution_fusion_create(
             weight_size = prepacked_weight.transpose(0, 1).size()
         return weight_size
 
+    def _is_reordered_deconv_weight(weight):
+        current_node = V.graph.current_node
+        if current_node is not None and len(current_node.args) > 1:
+            weight_node = current_node.args[1]
+            if isinstance(weight_node, torch.fx.Node) and weight_node.target in (
+                torch.ops.mkldnn._reorder_convolution_transpose_weight,
+                torch.ops.mkldnn._reorder_convolution_transpose_weight.default,
+            ):
+                return True
+
+        try:
+            constant = V.graph.constants.get(weight.get_name())
+        except (AttributeError, KeyError, NotImplementedError):
+            constant = None
+        return isinstance(constant, torch.Tensor) and constant.is_mkldnn
+
     x.realize()
     weight.realize()
     if bias is not None:
@@ -133,10 +149,12 @@ def _prepare_convolution_fusion_create(
             output_padding = pad_listlike(output_padding, dims)
         assert isinstance(groups, (int, sympy.core.numbers.Integer))
         if transposed:
-            # When transposed, the size of the prepacked oneDNN weight is different
-            # from the PyTorch weight. We're not able to run aten conv with such
-            # size. We infer the output size from the input params here:
-            weight_size = _original_deconv_weight_size(weight_fake, groups)
+            if weight_fake.is_mkldnn or _is_reordered_deconv_weight(weight):
+                # Prepacked oneDNN deconv weights use [O, I, ...] storage, while
+                # PyTorch deconv weights use [I, O, ...].
+                weight_size = _original_deconv_weight_size(weight_fake, groups)
+            else:
+                weight_size = weight_fake.size()
             input_size = x_fake.size()
             output_size = _conv_input_size(
                 input_size,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184950

The mkldnn transposed convolution pointwise meta and Inductor lowering paths treated every transposed-convolution weight as if it were a reordered oneDNN weight. That is only valid for prepacked MKLDNN weights. Regular PyTorch transposed-convolution weights are laid out as [input_channels, output_channels / groups, ...], so applying the prepacked interpretation swapped the first two dimensions and made torch.compile infer the wrong output channel count.

Use the prepacked deconvolution weight-size conversion only when the weight is actually MKLDNN/reordered. For regular strided weights, preserve the tensor's existing IOHW/IODHW shape. The C++ meta path also handles fake tensors for reordered weights by recognizing the prepacked shape relative to the input channels, while Inductor detects reordered-weight FX nodes and MKLDNN constants.

I considered only changing the C++ meta kernel, but Inductor also computes a layout from fake tensors before calling the generated extern kernel. Updating both paths keeps the fake layout and runtime/meta behavior consistent.

Fixes #172711
Generated by my agent

Test Plan:
- ninja -C build lib/libtorch_cpu.so
- TORCHINDUCTOR_FX_GRAPH_CACHE=0 python standalone issue repro, eager/compiled both (4, 8, 32, 32) and allclose=True
- FakeTensorMode smoke check for regular and reordered mkldnn weights
- TORCHINDUCTOR_FX_GRAPH_CACHE=0 python test/inductor/test_mkldnn_pattern_matcher.py -k conv_transpose_pointwise_regular_weight_shape via local torchvision stub workaround
- TORCHINDUCTOR_FX_GRAPH_CACHE=0 python test/inductor/test_mkldnn_pattern_matcher.py -k conv_transpose_pointwise_fake_meta_shapes via local torchvision stub workaround
- TORCHINDUCTOR_FX_GRAPH_CACHE=0 python test/inductor/test_mkldnn_pattern_matcher.py -k conv_transpose2d_unary_cpu via local torchvision stub workaround
- python -m py_compile torch/_inductor/mkldnn_ir.py test/inductor/test_mkldnn_pattern_matcher.py
- git diff --check
- lintrunner -a

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos