### PR TITLE
Support decreasing derived export dims

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -55,6 +55,7 @@ from torch.export._trace import (
     _export_to_torch_ir,
     DEFAULT_EXPORT_DYNAMO_CONFIG,
 )
+from torch.export.dynamic_shapes import refine_dynamic_shapes_from_suggested_fixes
 from torch.export.graph_signature import (
     ExportGraphSignature,
     InputKind,
@@ -4827,6 +4828,88 @@ def forward(self, p_linear_weight, p_linear_bias, x):
             ep.module()(torch.randn(4), torch.randn(6))
 
         self.assertEqual(ep.module()(torch.randn(4), torch.randn(5)).size()[0], 4)
+
+    def test_derived_dim_decreasing(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(32, 16)
+
+            def forward(self, x, y):
+                return self.linear(torch.cat([x, y], dim=1))
+
+        foo = Foo()
+        x, y = torch.randn(1, 10), torch.randn(1, 22)
+        x_dim = torch.export.Dim("x_dim", min=2, max=30)
+        y_dim = 32 - x_dim
+
+        self.assertEqual(y_dim.min, 2)
+        self.assertEqual(y_dim.max, 30)
+
+        ep = export(
+            foo,
+            (x, y),
+            dynamic_shapes={"x": {1: x_dim}, "y": {1: y_dim}},
+        )
+        self.assertEqual(
+            ep.module()(torch.randn(1, 12), torch.randn(1, 20)).shape,
+            torch.Size([1, 16]),
+        )
+
+    def test_decreasing_derived_dim_suggested_fixes(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(32, 16)
+
+            def forward(self, x, y):
+                return self.linear(torch.cat([x, y], dim=1))
+
+        foo = Foo()
+        x, y = torch.randn(1, 10), torch.randn(1, 22)
+        x_dim = torch.export.Dim("x_dim", min=1, max=31)
+        y_dim = torch.export.Dim("y_dim", min=1, max=31)
+        dynamic_shapes = {"x": {1: x_dim}, "y": {1: y_dim}}
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.UserError,
+            "y_dim = 32 - x_dim",
+        ) as cm:
+            export(foo, (x, y), dynamic_shapes=dynamic_shapes)
+
+        new_shapes = refine_dynamic_shapes_from_suggested_fixes(
+            cm.exception.msg, dynamic_shapes
+        )
+        self.assertEqual(new_shapes["x"][1].max, 30)
+        self.assertEqual(new_shapes["y"][1].root, new_shapes["x"][1])
+        self.assertEqual(new_shapes["y"][1].fn(10), 22)
+        export(foo, (x, y), dynamic_shapes=new_shapes)
+
+    def test_decreasing_derived_dim_suggested_root_range(self):
+        class Foo(torch.nn.Module):
+            def forward(self, x, y):
+                if x.shape[0] <= 16:
+                    return x.sum() + y.sum()
+                return x.sum() - y.sum()
+
+        foo = Foo()
+        x, y = torch.randn(10), torch.randn(22)
+        y_dim = torch.export.Dim("y_dim", min=2, max=30)
+        dynamic_shapes = {"x": (32 - y_dim,), "y": (y_dim,)}
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.UserError,
+            "y_dim = Dim\\('y_dim', min=16, max=30\\)",
+        ) as cm:
+            export(foo, (x, y), dynamic_shapes=dynamic_shapes)
+
+        new_shapes = refine_dynamic_shapes_from_suggested_fixes(
+            cm.exception.msg, dynamic_shapes
+        )
+        self.assertEqual(new_shapes["y"][0].min, 16)
+        self.assertEqual(new_shapes["y"][0].max, 30)
+        self.assertEqual(new_shapes["x"][0].fn(22), 10)
+        export(foo, (x, y), dynamic_shapes=new_shapes)
 
     def test_derived_dim_nested(self):
         class Foo(torch.nn.Module):
@@ -16675,6 +16758,22 @@ def forward(self, x):
         )
         self.assertEqual(dx.root, dz)
         self.assertEqual(dy.root, dz)
+
+        dm = Dim("dm", min=2, max=30)
+        dn = 32 - dm
+        decreasing_inputs = (torch.randn(10), torch.randn(22))
+        decreasing_dynamic_shapes = {"x": (dm,), "y": (dn,)}
+        self.assertExpectedInline(
+            _dump_dynamic_shapes(decreasing_dynamic_shapes, decreasing_inputs),
+            """DynamicShapesSpec(dynamic_shapes=(['dm'], ['32 - dm']), dims={'dm': RootDim(min=2, max=30, derived=['32 - dm'])})""",
+        )
+        (loaded_dm,), (loaded_dn,) = _load_dynamic_shapes(
+            _dump_dynamic_shapes(decreasing_dynamic_shapes, decreasing_inputs)
+        )
+        self.assertEqual(loaded_dn.root, loaded_dm)
+        self.assertEqual(loaded_dn.fn(10), 22)
+        self.assertEqual(loaded_dn.min, 2)
+        self.assertEqual(loaded_dn.max, 30)
 
     def test_dynamic_shapes_serdes_various(self):
         # serialization for dataclass inputs, Dim.AUTO/STATIC, and kwargs

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -162,7 +162,7 @@ class Dim:
         ep = torch.export(Foo(), (x, y), dynamic_shapes=dynamic_shapes)
 
     Named Dims also allow specification of relationships between dimensions, up
-    to univariate linear relations.  For example, the following indicates one
+    to univariate linear relations. For example, the following indicates one
     dimension is a multiple of another plus 4::
 
         s0 = Dim("s0")
@@ -194,7 +194,7 @@ class Dim:
         if type(other) is not int:
             raise NotImplementedError(
                 f"Attempted to add {other} to {self.__name__}, where an integer was expected. "
-                "(Only increasing linear operations with integer coefficients are supported.)"
+                "(Only linear operations with integer coefficients are supported.)"
             )
         return self._derive(lambda x: x + other)
 
@@ -206,27 +206,33 @@ class Dim:
         if type(other) is not int:
             raise NotImplementedError(
                 f"Attempted to subtract {other} from {self.__name__}, where an integer was expected. "
-                "(Only increasing linear operations with integer coefficients are supported.)"
+                "(Only linear operations with integer coefficients are supported.)"
             )
         return self._derive(lambda x: x - other)
 
     def __rsub__(self, other) -> "Dim":
-        raise NotImplementedError(
-            f"Attempted to negate {self.__name__}. "
-            "(Only increasing linear operations with integer coefficients are supported.)"
-        )
+        # e.g., 32 - dim
+        if type(other) is not int:
+            raise NotImplementedError(
+                f"Attempted to subtract {self.__name__} from {other}, where an integer was expected. "
+                "(Only linear operations with integer coefficients are supported.)"
+            )
+        return self._derive(lambda x: other - x)
 
     def __mul__(self, other) -> "Dim":
         # e.g., dim * 2
-        if type(other) is not int or other <= 0:
+        if type(other) is not int or other == 0:
             raise NotImplementedError(
-                f"Attempted to multiply {other} with {self.__name__}, where a positive integer was expected. "
-                "(Only increasing linear operations with integer coefficients are supported.)"
+                f"Attempted to multiply {other} with {self.__name__}, where a nonzero integer was expected. "
+                "(Only linear operations with integer coefficients are supported.)"
             )
         return self._derive(lambda x: x * other)
 
     def __rmul__(self, other) -> "Dim":
         return self * other
+
+    def __neg__(self) -> "Dim":
+        return self * -1
 
     def _derived_name(self, fn) -> str:
         from sympy import sympify
@@ -284,10 +290,9 @@ class _DerivedDim(Dim):
     """
     Class for derived :func:`Dim` types.
 
-    Currently we only support increasing linear expressions with integer coefficients.
+    Currently we only support linear expressions with integer coefficients.
     In other words, a derived Dim can always be written in the form Ax + B, where
-    x is a regular Dim (i.e., non-derived Dim), A and B are integers, and A is positive.
-    (In particular, the latter ensures that x < y => Ax + B < Ay + B.)
+    x is a regular Dim (i.e., non-derived Dim), A and B are integers, and A is nonzero.
     These restrictions on the form of derived Dims makes the metatheory simpler: e.g.,
     it simplifies computing ranges for derived Dims, solving for underlying regular Dims,
     deciding equalities between derived Dims, and so on.
@@ -301,45 +306,47 @@ class _DerivedDim(Dim):
         self.root = root
         self.fn = fn
 
-    @property
-    def min(self):  # type: ignore[override]
-        # assume that self.fn is an increasing function
-        # TODO(avik): use sympy value range analysis instead?
+    def _derived_range(self):
         from sympy import Integer
 
         from torch.utils._sympy.numbers import int_oo
 
-        if self.root.min is -int_oo:  # type: ignore[attr-defined]
-            return -int_oo  # fn not needed cuz increasing
+        def eval_endpoint(value):
+            if value is int_oo or value is -int_oo:
+                return self.fn(value)
+            return self.fn(Integer(value))
 
-        _min_symint = self.fn(Integer(self.root.min))  # type: ignore[attr-defined]
+        endpoints = (
+            eval_endpoint(self.root.min),  # type: ignore[attr-defined]
+            eval_endpoint(self.root.max),  # type: ignore[attr-defined]
+        )
+        return min(endpoints), max(endpoints)
+
+    @property
+    def min(self):  # type: ignore[override]
+        _min_symint, _ = self._derived_range()
         root = self.root  # type: ignore[attr-defined]
         if _min_symint < 0:
             raise AssertionError(
                 f"Expected derived min value of {self.__name__} to be >= 0. "
-                f"Please specify an appropriate min value for {root.__name__} "
-                f"(currently {root.min})."
+                f"Please specify appropriate min/max values for {root.__name__} "
+                f"(currently min={root.min}, max={root.max})."
             )
         return int(_min_symint)
 
     @property
     def max(self):  # type: ignore[override]
-        # assume that self.fn is an increasing function
-        # TODO(avik): use sympy value range analysis instead?
-        from sympy import Integer
-
         from torch.utils._sympy.numbers import int_oo
 
-        if self.root.max is int_oo:  # type: ignore[attr-defined]
-            return int_oo  # fn not needed cuz increasing
-
-        _max_symint = self.fn(Integer(self.root.max))  # type: ignore[attr-defined]
+        _, _max_symint = self._derived_range()
         root = self.root  # type: ignore[attr-defined]
+        if _max_symint is int_oo:
+            return int_oo
         if _max_symint > sys.maxsize - 1:
             raise AssertionError(
                 f"Expected derived max value of {self.__name__} to be <= {sys.maxsize - 1}. "
-                f"Please specify an appropriate max value for {root.__name__} "
-                f"(currently {root.max})."
+                f"Please specify appropriate min/max values for {root.__name__} "
+                f"(currently min={root.min}, max={root.max})."
             )
         return int(_max_symint)
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3495,6 +3495,26 @@ class DimConstraints:
                 and dim.max == c.get("max", int_oo)  # type: ignore[attr-defined]
             )
 
+        def _root_range_for_derived_expr(
+            expr: sympy.Expr,
+            root: sympy.Symbol,
+            c: Mapping[str, Any],
+        ) -> dict[str, Any]:
+            modulus, remainder = sympy.polys.polytools.div(expr, root)
+            if not isinstance(modulus, sympy.Integer) or modulus == 0:
+                raise AssertionError(
+                    f"Expected {expr} to have a nonzero integer coefficient for {root}"
+                )
+            c_min = c.get("min", 2)
+            c_max = c.get("max", int_oo)
+            if modulus > 0:
+                min_ = math.ceil((c_min - remainder) / modulus)
+                max_ = math.floor((c_max - remainder) / modulus)
+            else:
+                min_ = math.ceil((c_max - remainder) / modulus)
+                max_ = math.floor((c_min - remainder) / modulus)
+            return {"min": min_, "max": max_}
+
         # 1) newly introduced roots
         # this part we handle adding newly introduced roots
         # these arise from guards like "x.shape[0] % 3 == 0"
@@ -3511,15 +3531,13 @@ class DimConstraints:
                 root = next(iter(c["eq"].free_symbols))
                 if str(root) not in name_to_dim:
                     introduced_roots[str(root)] = k
-                    # calculate necessary min & max
-                    modulus, remainder = sympy.polys.polytools.div(c["eq"], root)
-                    c_min = c.get("min", 2)
-                    min_ = math.ceil((c_min - remainder) / modulus)
-                    c_max = c.get("max", int_oo)
-                    max_ = math.floor((c_max - remainder) / modulus)
+                    # calculate necessary min & max for the new root
+                    root_range = _root_range_for_derived_expr(c["eq"], root, c)
                     # create result & dim
-                    results[str(root)] = {"min": min_, "max": max_}
-                    name_to_dim[str(root)] = Dim(str(root), min=min_, max=max_)
+                    results[str(root)] = root_range
+                    name_to_dim[str(root)] = Dim(
+                        str(root), min=root_range["min"], max=root_range["max"]
+                    )
                     # remove old root min/max bounds
                     c.pop("min", None)
                     c.pop("max", None)
@@ -3593,10 +3611,7 @@ class DimConstraints:
                         if "min" in c or "max" in c:
                             expr = sympy.sympify(k)
                             s = next(iter(expr.free_symbols))
-                            result = {
-                                "min": try_solve(sympy.Eq(expr, c["min"]), s)[1],  # type: ignore[arg-type, index]
-                                "max": try_solve(sympy.Eq(expr, c["max"]), s)[1],  # type: ignore[arg-type, index]
-                            }
+                            result = _root_range_for_derived_expr(expr, s, c)
                             if not _check_same_range(
                                 result,
                                 name_to_dim[mroot],  # type: ignore[index, arg-type]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184952

torch.export can suggest constraints such as y_dim = 32 - x_dim when it discovers a sum-to-constant relation between input dimensions. The constraint solver and suggestion printer already represent that as a valid linear relation, but public Dim arithmetic still rejected int - Dim and _DerivedDim range computation assumed positive coefficients. That made the generated suggested fix fail before it could be passed back to export.

This change generalizes derived Dim arithmetic to nonzero integer coefficients, computes derived ranges from both endpoints so decreasing affine expressions get correct min/max bounds, and fixes suggested-root range inversion for negative coefficients. I chose this over suppressing the suggestion because the solver already relies on these decreasing affine relations and the suggested expression is a useful supported shape contract once Dim can represent it.

Tests cover direct 32 - Dim export, refine_dynamic_shapes_from_suggested_fixes on the reported error, decreasing-root suggested ranges, and dynamic shape serde round trips for decreasing derived dims.

Fixes #172561

Generated by my agent

Test Plan:
- python test/export/test_export.py TestExport.test_derived_dim_decreasing TestExport.test_decreasing_derived_dim_suggested_fixes TestExport.test_decreasing_derived_dim_suggested_root_range
- python test/export/test_export.py TestExport.test_derived_dim_basic TestExport.test_derived_dim_nested TestExport.test_derived_dim_integer TestExport.test_derived_dim_repeat_derived TestExport.test_derived_dim_out_of_order TestExport.test_derived_dim_out_of_order_repeat_derived TestExport.test_specialize_derived_dim_roots TestExport.test_derived_dim_out_of_order_simplified TestExport.test_derived_dim_out_of_order_simplified_repeat_non_derived TestExport.test_derived_dim_1_2 TestExport.test_dim_1_2 TestExport.test_suggested_fixes_new_roots TestExport.test_refine_dynamic_shapes_from_suggested_fixes TestExport.test_dynamic_shapes_serdes_generic TestExport.test_dynamic_shapes_serdes_user_errors
- python test/export/test_export.py TestExport.test_dynamic_shapes_serdes_generic TestExport.test_derived_dim_decreasing TestExport.test_decreasing_derived_dim_suggested_fixes TestExport.test_decreasing_derived_dim_suggested_root_range
- lintrunner -a torch/export/dynamic_shapes.py torch/fx/experimental/symbolic_shapes.py test/export/test_export.py
- lintrunner -a