### PR TITLE
Use .reshape() instead of .contiguous().view() in stride-agnostic paths

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6841,9 +6841,7 @@ def multi_head_attention_forward(
         if not torch.jit.is_scripting():
             del v
 
-        attn_output = (
-            attn_output.transpose(0, 1).contiguous().view(tgt_len * bsz, embed_dim)
-        )
+        attn_output = attn_output.transpose(0, 1).reshape(tgt_len * bsz, embed_dim)
         attn_output = linear(attn_output, out_proj_weight, out_proj_bias)
         attn_output = attn_output.view(tgt_len, bsz, attn_output.size(1))
 
@@ -6878,14 +6876,12 @@ def multi_head_attention_forward(
             q, k, v, attn_mask, dropout_p, is_causal
         )
         # Free q, k, v and their backing projection storage before the
-        # .contiguous() call below allocates.  In self-attention the three
-        # tensors are views of a single packed projection, so releasing all
-        # references here lets the allocator reclaim that memory immediately.
+        # reshape() below allocates.  In self-attention the three tensors are
+        # views of a single packed projection, so releasing all references
+        # here lets the allocator reclaim that memory immediately.
         if not torch.jit.is_scripting():
             del q, k, v
-        attn_output = (
-            attn_output.permute(2, 0, 1, 3).contiguous().view(bsz * tgt_len, embed_dim)
-        )
+        attn_output = attn_output.permute(2, 0, 1, 3).reshape(bsz * tgt_len, embed_dim)
 
         attn_output = linear(attn_output, out_proj_weight, out_proj_bias)
         attn_output = attn_output.view(tgt_len, bsz, attn_output.size(1))

--- a/torch/nn/utils/_expanded_weights/instance_norm_expanded_weights.py
+++ b/torch/nn/utils/_expanded_weights/instance_norm_expanded_weights.py
@@ -54,8 +54,8 @@ class InstanceNormPerSampleGrad(torch.autograd.Function):
             )
             running_mean_ = running_mean.repeat(b) if running_mean is not None else None
             running_var_ = running_var.repeat(b) if running_var is not None else None
-            input_reshaped = input.contiguous().view(new_shape)
-            grad_output_reshaped = grad_output.contiguous().view(new_shape)
+            input_reshaped = input.reshape(new_shape)
+            grad_output_reshaped = grad_output.reshape(new_shape)
             mean = torch.mean(
                 input_reshaped, (0,) + tuple(range(2, input.dim())), False
             )

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -549,8 +549,6 @@ def attention_23(
     # Reshape output back to 3D if input was 3D
     if input_shape_len == 3:
         # output: (batch_size, q_num_heads, q_sequence_length, v_head_size) -> (batch_size, q_sequence_length, hidden_size)
-        output = (
-            output.transpose(1, 2).contiguous().view(batch_size, q_sequence_length, -1)
-        )
+        output = output.transpose(1, 2).reshape(batch_size, q_sequence_length, -1)
 
     return output, present_key, present_value, qk_output


### PR DESCRIPTION
`.reshape` only copies when needed; `.contiguous().view` always copies. Applied where the downstream op (`linear`/`bmm`, `var_mean`, `native_batch_norm_backward`) is stride-agnostic. SDPA, autograd `View`, and quantized MHA left alone.