### PR TITLE
Clarify torch.compiler.reset cache behavior

### DIFF
--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -59,9 +59,11 @@ def compile(*args, **kwargs):
 
 def reset() -> None:
     """
-    This function clears all compilation caches and restores the system to its initial state.
-    It is recommended to call this function, especially after using operations like `torch.compile(...)`
-    to ensure a clean state before another unrelated compilation
+    Reset the in-process compiler state.
+
+    This function clears Dynamo's in-memory compilation caches and related
+    process-local state used by :func:`torch.compile`. It does not delete
+    filesystem caches, such as Inductor's disk cache.
     """
     import torch._dynamo
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184959

The public torch.compiler.reset docstring claimed that it cleared all compilation caches and restored compiler state completely. The implementation delegates to torch._dynamo.reset(), whose intended contract is narrower: it resets Dynamo's in-memory and process-local compiler state and explicitly does not affect filesystem caches. Existing Inductor cache tests rely on the disk cache surviving a reset, so deleting the Inductor cache from this API would be a behavior change rather than the root fix.

Update the torch.compiler.reset docstring to describe the actual contract and call out that filesystem caches, including Inductor's disk cache, are not deleted. This keeps reset behavior unchanged while correcting the public API documentation generated from the docstring.

Test Plan:
- python - <<'PY'
  import inspect
  import torch.compiler

  doc = inspect.getdoc(torch.compiler.reset)
  print(doc)
  assert "all compilation caches" not in doc
  assert "filesystem caches" in doc
  assert "Inductor's disk cache" in doc
  PY
- python -m compileall -q torch/compiler/__init__.py
- lintrunner -a
- git diff --check

Fixes #172024
Generated by my agent