### PR TITLE
Use torch.rsqrt() instead of 1 / torch.sqrt()

### DIFF
--- a/torch/nn/utils/_expanded_weights/instance_norm_expanded_weights.py
+++ b/torch/nn/utils/_expanded_weights/instance_norm_expanded_weights.py
@@ -62,7 +62,7 @@ class InstanceNormPerSampleGrad(torch.autograd.Function):
                 correction=0,
                 keepdim=False,
             )
-            rstd = 1 / torch.sqrt(var + eps)
+            rstd = torch.rsqrt(var + eps)
 
             # must use native batch norm since it supports all inputs. This may have used cuda or openmi during the forward but
             # it didn't save the metadata, so we don't know during the backward


### PR DESCRIPTION
Replace `1 / torch.sqrt(var + eps)` with `torch.rsqrt(var + eps)` at two `rstd` sites:

- `torch/_decomp/decompositions_for_jvp.py` — LayerNorm JVP decomposition
- `torch/nn/utils/_expanded_weights/instance_norm_expanded_weights.py` — per-sample-grad InstanceNorm backward

### Numerics

| Path | Before | After |
|---|---|---|
| fp64 | identical | identical (GPU `rsqrt` for double lowers to `1/sqrt`) |
| CPU | ~1 ULP | ~1 ULP (ATen CPU `rsqrt` is `1/sqrt`-based) |
| fp32 GPU eager | ~1 ULP | ~2 ULP (hardware `__frsqrt_rn`) |
| Inductor / Triton | already fused | unchanged |