### PR TITLE
Preserve unflattened module forward signatures

### DIFF
--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: export"]
 # flake8: noqa
 import copy
+import inspect
 import unittest
 from re import escape
 from typing import Any, List, Optional
@@ -379,6 +380,48 @@ class TestUnflatten(TestCase):
         ep.graph.eliminate_dead_code()
         unflattened = unflatten(ep)
         self.compare_outputs(ep.module(), unflattened, (torch.randn(2), torch.randn(5)))
+
+    def test_unflatten_reexport_dynamic_shapes(self):
+        class AdapterBase(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.adapter = torch.nn.Linear(2, 2)
+                self.act = torch.nn.ReLU()
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.act(self.adapter(x))
+
+        class Main(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.base = AdapterBase()
+
+            def forward(self, x: torch.Tensor):
+                return self.base(x)
+
+        model = Main().eval()
+        x = torch.rand(2, 2)
+        ep = export(
+            model,
+            (x,),
+            dynamic_shapes=({0: torch.export.Dim("batch", min=1, max=1024)},),
+        )
+        unflattened = unflatten(ep)
+
+        self.assertEqual(str(inspect.signature(unflattened.forward)), "(x)")
+        static_reexport = export(unflattened, (x,))
+        torch.testing.assert_close(static_reexport.module()(x), model(x))
+
+        for dynamic_shapes in (
+            ({0: torch.export.Dim("batch_tuple", min=1, max=1024)},),
+            {"x": {0: torch.export.Dim("batch_dict", min=1, max=1024)}},
+        ):
+            reexported = export(
+                unflattened,
+                (x,),
+                dynamic_shapes=dynamic_shapes,
+            )
+            torch.testing.assert_close(reexported.module()(x), model(x))
 
     def test_unflatten_wrong_input(self):
         class Mod(torch.nn.Module):

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -1,9 +1,11 @@
 # mypy: allow-untyped-defs
 import abc
 import copy
+import inspect
 import logging
 import operator
 import re
+import types
 from collections import defaultdict
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -592,6 +594,7 @@ class UnflattenedModule(_SubmoduleBase, torch.nn.Module):
         _reorder_submodules(self, fqn_order)
         self.graph.lint()
         self.finalize()
+        self._configure_forward_signature()
 
     def _print_graph(self):
         for fqn, mod in self.named_modules():
@@ -690,7 +693,40 @@ class UnflattenedModule(_SubmoduleBase, torch.nn.Module):
 
         return flat_args
 
-    def forward(self, *args, **kwargs):
+    def _configure_forward_signature(self):
+        signature = self.module_call_graph[0].signature
+        if signature is None or signature.forward_arg_names is None:
+            return
+
+        self_arg_name = "__unflattened_self"
+        while self_arg_name in signature.forward_arg_names:
+            self_arg_name += "_"
+
+        try:
+            parameters = [
+                inspect.Parameter(
+                    self_arg_name, inspect.Parameter.POSITIONAL_OR_KEYWORD
+                ),
+                *[
+                    inspect.Parameter(name, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+                    for name in signature.forward_arg_names
+                ],
+            ]
+            forward_signature = inspect.Signature(parameters)
+        except ValueError:
+            log.debug(
+                "Unable to install an introspection signature for UnflattenedModule.forward",
+                exc_info=True,
+            )
+            return
+
+        def forward(self, *args, **kwargs):
+            return self._forward_impl(*args, **kwargs)
+
+        forward.__signature__ = forward_signature  # type: ignore[attr-defined]
+        self.forward = types.MethodType(forward, self)
+
+    def _forward_impl(self, *args, **kwargs):
         flat_args = self.process_forward_inputs(*args, **kwargs)
         signature = self.module_call_graph[0].signature
 
@@ -710,6 +746,9 @@ class UnflattenedModule(_SubmoduleBase, torch.nn.Module):
                 *flat_args, enable_io_processing=False
             )
         return pytree.tree_unflatten(tree_out, signature.out_spec)
+
+    def forward(self, *args, **kwargs):
+        return self._forward_impl(*args, **kwargs)
 
     def finalize(self):
         self.__dict__["graph_module"] = torch.fx.GraphModule(self, self.graph)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184966

`torch.export.unflatten` produces an `UnflattenedModule` whose runtime
`forward` implementation accepts `*args, **kwargs`.  Re-exporting that module
with dynamic shapes asks export to bind example inputs through
`inspect.signature(module.forward)`, so a call like `module(x)` was rebound as
`args=(x,)`.  Dynamic shape validation then compared the user's
`({0: Dim(...)},)` spec against a nested input tree shaped like `((x,),)`,
which produced the reported tuple-vs-dict mismatch.

Install a per-instance introspection signature on unflattened modules using the
top-level `ModuleCallSignature.forward_arg_names` captured during the original
export.  The runtime implementation stays variadic, so existing adaptation and
constraint checking behavior is preserved, but signature binding used by export
sees the same top-level inputs as the original module.  This avoids generating a
new `forward` body with `exec`; only the inspectable signature needs to change.

Fixes #171964
Generated by my agent

Test Plan:
- python test/export/test_unflatten.py -k test_unflatten_reexport_dynamic_shapes
- python test/export/test_unflatten.py -k test_unflatten_preserve_signature
- python test/export/test_unflatten.py -k test_unflatten_eager
- python test/export/test_unflatten.py -k test_unflatten_wrong_input
- python test/export/test_unflatten.py TestUnflatten.test_unflatten_reexport_dynamic_shapes TestUnflatten.test_unflatten_preserve_signature TestUnflatten.test_unflatten_eager TestUnflatten.test_unflatten_wrong_input
- lintrunner -a