### PR TITLE
Fix export CIA decomps with backend kernels

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -55,6 +55,7 @@ from torch.export._trace import (
     _export_to_torch_ir,
     DEFAULT_EXPORT_DYNAMO_CONFIG,
 )
+from torch.export.exported_program import _split_decomp_table_to_cia_and_python_decomp
 from torch.export.graph_signature import (
     ExportGraphSignature,
     InputKind,
@@ -4614,6 +4615,94 @@ def forward(self, p_linear_weight, p_linear_bias, x):
     getitem_2 = split_with_sizes[2];  split_with_sizes = None
     return (getitem, getitem_1, getitem_2)""",
         )
+
+    def test_run_decompositions_decomposes_cia_op_with_backend_kernel(self):
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            lib.define("foo_with_backend(Tensor x) -> Tensor")
+            lib.impl("foo_with_backend", lambda x: x.sin(), "CompositeImplicitAutograd")
+            lib.impl("foo_with_backend", lambda x: x.cos(), "CPU")
+
+            op = torch.ops.mylib.foo_with_backend.default
+
+            class Foo(torch.nn.Module):
+                def forward(self, x):
+                    return op(x)
+
+            ep = export(Foo(), (torch.randn(2, 3),))
+            ep = ep.run_decompositions({op: lambda x: x + 1})
+
+            self.assertExpectedInline(
+                str(ep.graph_module.code).strip(),
+                """\
+def forward(self, x):
+    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    return (add,)""",
+            )
+
+    def test_run_decompositions_keeps_cia_decomp_with_non_dense_backend_kernel(self):
+        op = torch.ops.aten.linear.default
+        self.assertFalse(
+            torch._C._dispatch_has_kernel_for_dispatch_key(
+                op.name(), torch._C.DispatchKey.CPU
+            )
+        )
+        self.assertTrue(
+            torch._C._dispatch_has_kernel_for_dispatch_key(
+                op.name(), torch._C.DispatchKey.NestedTensorCPU
+            )
+        )
+
+        cia_decomp_table, python_decomp_table = (
+            _split_decomp_table_to_cia_and_python_decomp(
+                {op: lambda x, weight, bias: x}
+            )
+        )
+
+        self.assertIn(op, cia_decomp_table)
+        self.assertIn(op, python_decomp_table)
+
+    def test_run_decompositions_keeps_cia_decomp_with_python_backend_kernel(self):
+        op = torch.ops.aten.broadcast_tensors.default
+        runtime_backend_keys = torch._C._dispatch_keyset_full_after(
+            torch._C.DispatchKey.BackendSelect
+        ).remove(torch._C.DispatchKey.PythonDispatcher)
+
+        self.assertFalse(
+            torch._C._dispatch_has_kernel_for_any_dispatch_key(
+                op.name(), runtime_backend_keys
+            )
+        )
+        self.assertTrue(op.has_kernel_for_any_dispatch_key(runtime_backend_keys))
+
+        cia_decomp_table, python_decomp_table = (
+            _split_decomp_table_to_cia_and_python_decomp({op: lambda tensors: tensors})
+        )
+
+        self.assertIn(op, cia_decomp_table)
+        self.assertIn(op, python_decomp_table)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
+    def test_run_decompositions_decomposes_cia_op_with_cuda_kernel(self):
+        class Foo(torch.nn.Module):
+            def forward(self, a, b, c):
+                output, _ = torch.ops.aten._fused_rms_norm.default(a, b, c, 1e-5)
+                return torch.sinh(output)
+
+        def count_fused_rms_norm(ep):
+            return sum(
+                node.target == torch.ops.aten._fused_rms_norm.default
+                for node in ep.graph.nodes
+            )
+
+        normalized_shape = (3, 3, 3)
+        input_tensor = torch.randn(3, 3, 3, device="cuda", requires_grad=True)
+        weight_tensor = torch.randn(3, 3, 3, device="cuda", requires_grad=True)
+
+        ep = export(Foo(), (input_tensor, normalized_shape, weight_tensor))
+        self.assertEqual(count_fused_rms_norm(ep), 1)
+
+        ep = ep.run_decompositions(get_decompositions({torch.ops.aten._fused_rms_norm}))
+        self.assertEqual(count_fused_rms_norm(ep), 0)
 
     def test_export_cond_preserve_torch_fn_for_subgraphs(self):
         class MySubModule(torch.nn.Module):

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -188,6 +188,15 @@ _BACKEND_KEYS_TO_OVERRIDE = [
 ]
 
 
+_RUNTIME_BACKEND_KEYS = torch._C._dispatch_keyset_full_after(
+    torch._C.DispatchKey.BackendSelect
+).remove(torch._C.DispatchKey.PythonDispatcher)
+
+
+def _has_backend_kernel(op_overload: torch._ops.OperatorBase) -> bool:
+    return op_overload.has_kernel_for_any_dispatch_key(_RUNTIME_BACKEND_KEYS)
+
+
 @contextmanager
 def _override_composite_implicit_decomp(cia_ops_to_callable):
     # This function overrides CompositeImplicitAutograd decomp for
@@ -293,13 +302,16 @@ def _split_decomp_table_to_cia_and_python_decomp(
         #        decomp_table = {aten.linear: some_op}
         # For (1), we want to remove all the CIA ops that weren't handled by user as
         # it suggests they are safe to decompose, so we should remove from preservable_list.
-        # for (2), we just plumb the custom decomp to AOTDIspatcher.
-        # In both cases, we want to remove this CIA op from the decomp_table as it is special
-        # handled.
+        # for (2), we just plumb the custom decomp to AOTDispatcher.
+        # In both cases, we handle this CIA op specially for AOTDispatcher.
+        # Ops with backend kernels must also remain in the regular decomp table
+        # because proxy tracing preserves those kernels instead of redispatching
+        # through CompositeImplicitAutograd.
         if op in all_preservable_cia_ops:
             cia_ops_to_callable[op] = decomp_table[op]
             all_preservable_cia_ops.remove(op)
-            del decomp_table[op]
+            if not _has_backend_kernel(op):
+                del decomp_table[op]
         # If it is a custom op, we want to still preserve or do whatever
         # with it if it is a functional CIA. The reason we don't remove
         # from CIA list is because we don't query custom ops.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184967

ExportedProgram.run_decompositions splits CompositeImplicitAutograd (CIA) decompositions into a CIA override table and a regular ProxyTensor decomposition table. For CIA ops with runtime backend kernels, ProxyTensor preserves the backend kernel for eager fidelity instead of redispatching through CompositeImplicitAutograd. That meant a user-requested decomposition for aten._fused_rms_norm was removed from the regular table and never applied on CUDA, where the op has a native backend kernel.

Keep explicitly requested CIA decompositions in the regular decomposition table whenever the op has a runtime backend kernel, while still threading them through the CIA override table for the existing AOTDispatcher path. The backend-kernel check uses the OpOverload dispatch query over the runtime backend keyset below BackendSelect, so C++ kernels, non-dense backends such as NestedTensor, and Python py_impl backend registrations are all handled. CIA ops without runtime backend kernels keep the old behavior and are removed from the regular table.

I considered keeping every CIA decomposition in the regular table unconditionally, but that would broaden decomposition behavior for CIA ops that only redispatch through CompositeImplicitAutograd. Restricting this to ops with runtime backend kernels targets the bypass that caused the bug.

Fixes #171897
Generated by my agent

Test Plan:
- python test/export/test_export.py -k run_decompositions_decomposes_cia_op_with
- python test/export/test_export.py -k run_decompositions_keeps_cia_decomp_with_non_dense_backend_kernel
- python test/export/test_export.py -k run_decompositions_keeps_cia_decomp_with_python_backend_kernel
- python test/export/test_export.py -k export_preserve_linear
- python test/export/test_export.py -k export_decomp_torture_case_1
- Inline issue repro: CPU 1 -> 0 and CUDA 1 -> 0 for aten._fused_rms_norm count after run_decompositions
- lintrunner -a
- git diff --cached --check