### PR TITLE
Run full GC in Dynamo post-compile cleanup

### DIFF
--- a/test/dynamo/test_convert_frame_gc.py
+++ b/test/dynamo/test_convert_frame_gc.py
@@ -1,0 +1,33 @@
+# Owner(s): ["module: dynamo"]
+
+import unittest.mock
+
+import torch
+import torch._dynamo.config
+import torch._dynamo.test_case
+
+
+class ConvertFrameGCTests(torch._dynamo.test_case.TestCase):
+    def tearDown(self):
+        torch._dynamo.reset()
+        super().tearDown()
+
+    @torch._dynamo.config.patch(run_gc_after_compile=True)
+    def test_run_gc_after_compile_uses_full_gc(self):
+        def fn(x):
+            return x + 1
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+
+        with unittest.mock.patch("torch._dynamo.convert_frame.gc.collect") as collect:
+            opt_fn(torch.ones(2))
+
+        collect.assert_called()
+        self.assertIn(unittest.mock.call(), collect.mock_calls)
+        self.assertNotIn(unittest.mock.call(1), collect.mock_calls)
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -2167,8 +2167,8 @@ def _compile(
 
             if torch._dynamo.config.run_gc_after_compile:
                 with dynamo_timed("gc", dynamo_compile_column_us="gc_time_us"):
-                    log.info("run_gc_after_compile: running gc")
-                    gc.collect(1)
+                    log.info("run_gc_after_compile: running full gc")
+                    gc.collect()
 
             output = None
             if tracer_output:


### PR DESCRIPTION
Summary:
PT2 warmup-disabled OmniFM training can retain several GiB of first-step compile-time CUDA allocations. Prior memory snapshots showed the retained tensors are collectable Python cyclic garbage: full gc.collect() releases them, while the existing Dynamo gc.collect(1) cleanup does not.

The leak happens on the path where explicit APF PT2 warmup does not run. When trainer.pt2_warmup_settings stays enabled, APF's Pt2WarmupController runs perform_garbage_collection(), which is a full gc.collect(), after warmup batch 1 and again during warmup cleanup, followed by torch.cuda.empty_cache(). That path already has aggressive full-GC cleanup around the compile warmup.

However, APF can mutate trainer.pt2_warmup_settings.enable to false at runtime. In particular, Scribe datasets disable explicit PT2 warmup via _update_pt2_warmup_config(), even if the static config has pt2_warmup_settings.enable=true. When explicit PT2 warmup is disabled, the first PT2 compile moves onto the normal training path. That path only gets Dynamo's torch._dynamo.config.run_gc_after_compile cleanup, which currently calls gc.collect(1). Generation-1 collection is not enough for the observed retained cyclic garbage, so the first-step compile allocations can survive and appear as a memory leak.

This changes the existing Dynamo post-compile cleanup in convert_frame from gc.collect(1) to full gc.collect(), preserving the existing run_gc_after_compile gate and gc_time_us telemetry. This makes the warmup-disabled/runtime-disabled path get the same class of full Python GC that the explicit APF PT2 warmup path already performs.

Added a focused Dynamo unittest that verifies run_gc_after_compile invokes full gc.collect() and not gc.collect(1).

Test Plan:
baseline masat job: aps-shrunk-training-online-zqi
online training job when pt2_warmup_settings is mutated to false by APF at runtime, 
memory leaked (e.g., triton_merge_sorted_seq_impl) into iterations

test mast job: aps-shrunk-online-64gpu-bs896-no-ne
after adding the same full garbage collection in this diff:
~7.3 GB memory leak is freed

Differential Revision: D105349756




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98