### PR TITLE
Fix scoped Chromium event reset

### DIFF
--- a/test/dynamo/test_profiler.py
+++ b/test/dynamo/test_profiler.py
@@ -6,7 +6,7 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch._dynamo.utils
-from torch._dynamo.utils import ChromiumEventLogger, dynamo_timed
+from torch._dynamo.utils import chromium_event_timed, ChromiumEventLogger, dynamo_timed
 from torch.profiler import record_function
 from torch.testing._internal.common_utils import TemporaryFileName
 
@@ -90,6 +90,64 @@ class DynamoProfilerTests(torch._dynamo.test_case.TestCase):
             self.assertEqual(
                 length, 1, f"Thread {thread_id} saw {length} entries instead of 1"
             )
+
+    def test_chromium_event_timed_scoped_reset_preserves_outer_event(self):
+        logger = ChromiumEventLogger()
+
+        with patch.object(torch._dynamo.utils, "CHROMIUM_EVENT_LOG", logger):
+            logger.log_event_start(
+                "outer", 0, {"outer_metadata": True}, log_pt2_compile_event=True
+            )
+            with self.assertNoLogs("torch._dynamo.utils", level="WARNING"):
+                with chromium_event_timed("inner", reset_event_log_on_exit=True):
+                    self.assertEqual(logger.get_stack(), ["outer", "inner"])
+
+                self.assertEqual(logger.get_stack(), ["outer"])
+                self.assertEqual(logger.get_pt2_compile_substack(), ["outer"])
+                self.assertIn("outer", logger.get_event_data())
+
+                logger.log_event_end(
+                    "outer",
+                    1,
+                    {},
+                    0,
+                    log_pt2_compile_event=True,
+                )
+
+            self.assertEqual(logger.get_stack(), [])
+            self.assertEqual(logger.get_pt2_compile_substack(), [])
+            self.assertEqual(logger.get_event_data(), {})
+
+    def test_chromium_event_timed_scoped_reset_preserves_outer_record_function(self):
+        logger = ChromiumEventLogger()
+
+        with (
+            patch.object(torch._dynamo.utils, "CHROMIUM_EVENT_LOG", logger),
+            torch.profiler.profile(with_stack=False) as prof,
+        ):
+            logger.log_event_start("outer", 0, {})
+            self.assertIn("outer", logger.get_record_functions())
+
+            with chromium_event_timed("inner", reset_event_log_on_exit=True):
+                self.assertIn("outer", logger.get_record_functions())
+                self.assertIn("inner", logger.get_record_functions())
+
+            self.assertEqual(logger.get_stack(), ["outer"])
+            self.assertIn("outer", logger.get_record_functions())
+            self.assertNotIn("inner", logger.get_record_functions())
+
+            logger.log_event_end(
+                "outer",
+                1,
+                {},
+                0,
+                log_pt2_compile_event=False,
+            )
+            self.assertEqual(logger.get_record_functions(), {})
+
+        event_names = [event.name for event in prof.events()]
+        self.assertIn("outer", event_names)
+        self.assertIn("inner", event_names)
 
     def test_nested_compilation_events_in_profiler(self):
         """Verify nested compilation events (dynamo→inductor) show hierarchy"""

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2188,21 +2188,32 @@ class ChromiumEventLogger:
             if metadata:
                 CompileEventLogger.add_record_function_data(event_name, **metadata)
 
-    def reset(self) -> None:
-        # We this on every compile in case a compile crashes or restarts and we haven't
-        # cleared the stack.
+    def _reset_to_state(
+        self,
+        stack_depth: int,
+        pt2_compile_substack_depth: int,
+        event_data_keys: set[str],
+        record_function_keys: set[str],
+    ) -> None:
         stack = self.get_stack()
+        del stack[stack_depth:]
         substack = self.get_pt2_compile_substack()
-        stack.clear()
-        substack.clear()
+        del substack[pt2_compile_substack_depth:]
         event_data = self.get_event_data()
-        event_data.clear()
+        for event_name in list(event_data):
+            if event_name not in event_data_keys:
+                del event_data[event_name]
         # Clean up any lingering record functions (shouldn't happen in normal operation)
         record_functions = self.get_record_functions()
-        if record_functions:
-            for rf in record_functions.values():
+        for event_name, rf in list(record_functions.items()):
+            if event_name not in record_function_keys:
                 rf.__exit__(None, None, None)
-            record_functions.clear()
+                del record_functions[event_name]
+
+    def reset(self) -> None:
+        # We do this on every compile in case a compile crashes or restarts and
+        # we haven't cleared the stack.
+        self._reset_to_state(0, 0, set(), set())
 
     def log_event_end(
         self,
@@ -2383,6 +2394,14 @@ def chromium_event_timed(
     instead. Use this context manager only if you want to avoid dynamo_timed.
     """
     chromium_event_log = get_chromium_event_logger()
+    reset_state: tuple[int, int, set[str], set[str]] | None = None
+    if reset_event_log_on_exit:
+        reset_state = (
+            len(chromium_event_log.get_stack()),
+            len(chromium_event_log.get_pt2_compile_substack()),
+            set(chromium_event_log.get_event_data()),
+            set(chromium_event_log.get_record_functions()),
+        )
     chromium_start_time = time.time_ns()
     chromium_event_log.log_event_start(
         event_name,
@@ -2400,8 +2419,8 @@ def chromium_event_timed(
             chromium_start_time,
             log_pt2_compile_event,
         )
-        if reset_event_log_on_exit:
-            chromium_event_log.reset()
+        if reset_state is not None:
+            chromium_event_log._reset_to_state(*reset_state)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184973

`chromium_event_timed(..., reset_event_log_on_exit=True)` used the full
`ChromiumEventLogger.reset()` helper when the context exited. That cleared the
entire thread-local event stack, PT2 compile substack, event metadata, and
profiler record functions. If such a context ran inside an outer chromium event,
the outer start event was removed before the outer event ended, so the later end
path warned that the start event was not in the stack.

Record the logger state when entering a reset-on-exit context and restore only
to that saved state on exit. Plain `ChromiumEventLogger.reset()` still clears all
state for compile recovery, while scoped resets now clean up only events and
profiler ranges introduced by the scoped context.

The alternative was to downgrade or suppress the warning, but that would leave
the logger stack corrupted. Restoring to the entry state preserves the intended
outer event lifetime and removes only the inner scope's state.

Fixes #171148
Generated by my agent

Test Plan:
- python test/dynamo/test_profiler.py -k test_chromium_event_timed_scoped_reset_preserves_outer_event
- python test/dynamo/test_profiler.py -k test_chromium_event_timed_scoped_reset_preserves_outer_record_function
- python test/dynamo/test_profiler.py
- python test/profiler/test_record_function.py -k chromium
- python test/dynamo/test_structured_trace.py -k test_compiled_autograd_chromium
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos