### PR TITLE
Improve export error for untraceable lifted constants

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -410,6 +410,43 @@ graph():
 
         self.assertTrue(torch.allclose(res, res_export))
 
+    def test_no_grad_param_data_inplace_error(self):
+        class ClampedFeedForward(torch.nn.Module):
+            def __init__(self, input_size, hidden_size):
+                super().__init__()
+                self.fc1 = torch.nn.Linear(input_size, hidden_size)
+
+            def clamp_weights(self):
+                with torch.no_grad():
+                    for param in self.fc1.parameters():
+                        clamped_param = torch.clamp(param.data, -1, 1)
+                        param.copy_(clamped_param)
+
+            def forward(self, x):
+                x = self.fc1(x)
+                self.clamp_weights()
+                return x
+
+        class TestModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.ff = ClampedFeedForward(128, 64)
+
+            def forward(self, x):
+                return self.ff(x)
+
+        expected_msg = (
+            "torch.export found an untraceable tensor constant in the exported "
+            "program. Potential source model attribute: ff.lifted_tensor_0. "
+            "This can happen when forward reads or mutates module state through "
+            "`.data`, which bypasses export's parameter/buffer mutation "
+            "tracking. Use the parameter or buffer tensor directly for "
+            "supported no_grad mutations, or move the state update outside the "
+            "exported forward."
+        )
+        with self.assertRaisesRegex(RuntimeError, escape(expected_msg)):
+            export(TestModel(), (torch.randn(32, 128),), strict=False)
+
     def test_export_slice_unbacked_dim1(self):
         class MySlice(torch.nn.Module):
             def forward(self, x, seq_len):
@@ -1643,21 +1680,25 @@ graph():
                 out = self.fc2(out)
                 return out
 
+        expected_msg = escape(
+            "torch.export found an untraceable tensor constant in the exported "
+            "program. Potential source model attribute: "
+            "cache_layer.lifted_tensor_0. This can happen when forward reads "
+            "or mutates module state through `.data`, which bypasses export's "
+            "parameter/buffer mutation tracking. Use the parameter or buffer "
+            "tensor directly for supported no_grad mutations, or move the "
+            "state update outside the exported forward."
+        )
+
         with self.assertRaisesRegex(
             RuntimeError,
-            "We found a fake tensor in the exported program constant's list. "
-            "This typically means our tracing system encountered an op that we can't trace through. "
-            "For the potential source, you can refer to following model attribute: cache_layer.lifted_tensor_0. "
-            "Please file an issue on github.",
+            expected_msg,
         ):
             _ = export(MyModel(), (torch.randn(1, 3, 5),), strict=False)
 
         with self.assertWarnsRegex(
             UserWarning,
-            "We found a fake tensor in the exported program constant's list. "
-            "This typically means our tracing system encountered an op that we can't trace through. "
-            "For the potential source, you can refer to following model attribute: cache_layer.lifted_tensor_0. "
-            "Please file an issue on github.",
+            expected_msg,
         ):
             # can't trigger all variant of export because later on it will crash
             # and it is good because we warned :).

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -224,6 +224,17 @@ def _is_bogus_const_name(name: str):
     return splitted_names[-1].startswith("lifted_tensor")
 
 
+def _untraceable_lifted_tensor_constant_msg(const_name: str) -> str:
+    return (
+        f"torch.export found an untraceable tensor constant in the exported "
+        f"program. Potential source model attribute: {const_name}. This can "
+        f"happen when forward reads or mutates module state through `.data`, "
+        f"which bypasses export's parameter/buffer mutation tracking. Use the "
+        f"parameter or buffer tensor directly for supported no_grad mutations, "
+        f"or move the state update outside the exported forward."
+    )
+
+
 def _rewrite_tracepoint_node(gm: torch.fx.GraphModule):
     """
     In-place modify input graph module by replacing the export tracepoint with a new node
@@ -2315,13 +2326,7 @@ def _export_for_training(
             if isinstance(
                 val, torch._subclasses.fake_tensor.FakeTensor
             ) and _is_bogus_const_name(const):
-                error_msg = (
-                    f"We found a fake tensor in the exported program constant's list. "
-                    f"This typically means our tracing system encountered an op that "
-                    f"we can't trace through. For the potential source, you can refer to "
-                    f"following model attribute: {const}. "
-                    f"Please file an issue on github. "
-                )
+                error_msg = _untraceable_lifted_tensor_constant_msg(const)
                 if torch._export.config.error_on_lifted_constant_tensors:
                     raise RuntimeError(error_msg)
                 else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #184978

When non-strict export sees a bogus lifted fake tensor constant, it used to raise an internal diagnostic ending with "Please file an issue on github." Issue #170672 hits this path by reading parameters through .data before copying back into the parameter under no_grad. Direct no_grad parameter mutation is already supported, but .data bypasses export's parameter and buffer mutation tracking, leaving an untraceable fake tensor constant such as ff.lifted_tensor_0.

Update the diagnostic to describe the unsupported state-mutation pattern and suggest using the parameter or buffer tensor directly, or moving the update outside exported forward. This preserves the existing rejection semantics instead of trying to paper over .data mutation as supported. I considered making this a hard .data detector, but this guard is where the invalid exported program is reliably discovered, so the message is worded as a possible cause and still names the suspicious lifted attribute.

Fixes #170672

Generated by my agent

Test Plan:

python test/export/test_export.py -k 'test_no_grad_param' -k 'test_export_leak_compile'

lintrunner -a torch/export/_trace.py test/export/test_export.py