### PR TITLE
add a deprecation warning for quantized tensor creation

### DIFF
--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -108,6 +108,12 @@ inline Tensor new_qtensor(
     IntArrayRef sizes,
     const TensorOptions& options,
     QuantizerPtr quantizer) {
+  TORCH_WARN_ONCE(
+      "torch.quantize_per_tensor, torch.quantize_per_channel and other quantized "
+      "tensor creation functions that produce tensors with dtype torch.quint8, "
+      "torch.qint8, and torch.qint32 are deprecated and will be removed in a "
+      "future PyTorch release. Please see "
+      "https://github.com/pytorch/pytorch/issues/184982 for more information.");
   auto memory_format = options.memory_format_opt().value_or(MemoryFormat::Contiguous);
   auto device = options.device();
   at::Allocator* allocator = nullptr;

--- a/test/quantization/core/test_quantized_tensor.py
+++ b/test/quantization/core/test_quantized_tensor.py
@@ -140,6 +140,10 @@ def _compress_uniform_simplified(X, bit_rate, xmin, xmax, fp16_scale_bias=True):
     return Xq, loss
 
 class TestQuantizedTensor(TestCase):
+    def test_quantized_tensor_creation_deprecation_warning(self):
+        with self.assertWarnsOnceRegex(UserWarning, ".*deprecated and will be removed"):
+            torch.quantize_per_tensor(torch.randn(4), 0.1, 10, torch.quint8)
+
     def test_qtensor_equal(self):
         x = torch.rand(5)
         x_q = torch.quantize_per_tensor(x, 0.1, 10, torch.quint4x2)


### PR DESCRIPTION
Summary:

Adds a deprecation warning for creation of tensors with dtype `quint8`, `qint8`, `qint32`. Since this is in c++, this covers both Python and c++ callsites.

The warning links to https://github.com/pytorch/pytorch/issues/184982, so we can update the messaging without pushing code.

Test Plan:

```bash
(pt) dev@gpu-dev-ec86df55:~/pytorch (main)$ python
Python 3.13.13 | packaged by Anaconda, Inc. | (main, Apr 14 2026, 06:19:41) [GCC 14.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> x = torch.quantize_per_tensor(torch.randn(4), 0.1, 10, torch.quint8)
<python-input-1>:1: UserWarning: torch.quantize_per_tensor, torch.quantize_per_channel and other quantized tensor creation functions that produce tensors with dtype torch.quint8, torch.qint8, and torch.qint32 are deprecated and will be removed in a future PyTorch release. Please see https://github.com/pytorch/pytorch/issues/184982 for more information. (Triggered internally at /home/dev/pytorch/aten/src/ATen/quantized/Quantizer.cpp:111.)
>>> x
tensor([ 0.6000,  0.5000, -1.0000, -0.7000], size=(4,), dtype=torch.quint8,
       quantization_scheme=torch.per_tensor_affine, scale=0.1, zero_point=10)
```