### PR TITLE
Handle unbatched input for non-zeros padding modes in Conv1d/2d/3d

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9191,6 +9191,28 @@ class TestNNDeviceType(NNTestCase):
             torch._C._nn.thnn_conv2d(torch.rand([1, 1, 1, 1]), kernel_size=[1, 1], padding=[], stride=[1, 1],
                                      weight=torch.rand([1, 1]))
 
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float)
+    def test_conv_non_zeros_padding_unbatched(self, device, dtype):
+        for padding_mode in ("reflect", "replicate", "circular"):
+            conv1d = nn.Conv1d(3, 4, 3, padding=1, padding_mode=padding_mode).to(device, dtype)
+            x1d = torch.randn(3, 8, device=device, dtype=dtype)
+            batched_1d = conv1d(x1d.unsqueeze(0)).squeeze(0)
+            unbatched_1d = conv1d(x1d)
+            self.assertEqual(batched_1d, unbatched_1d)
+
+            conv2d = nn.Conv2d(3, 4, 3, padding=1, padding_mode=padding_mode).to(device, dtype)
+            x2d = torch.randn(3, 8, 8, device=device, dtype=dtype)
+            batched_2d = conv2d(x2d.unsqueeze(0)).squeeze(0)
+            unbatched_2d = conv2d(x2d)
+            self.assertEqual(batched_2d, unbatched_2d)
+
+            conv3d = nn.Conv3d(3, 4, 3, padding=1, padding_mode=padding_mode).to(device, dtype)
+            x3d = torch.randn(3, 8, 8, 8, device=device, dtype=dtype)
+            batched_3d = conv3d(x3d.unsqueeze(0)).squeeze(0)
+            unbatched_3d = conv3d(x3d)
+            self.assertEqual(batched_3d, unbatched_3d)
+
     @onlyCPU
     @dtypes(torch.float)
     def test_slow_conv3d_empty_stride(self, device, dtype):

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -365,7 +365,10 @@ class Conv1d(_ConvNd):
 
     def _conv_forward(self, input: Tensor, weight: Tensor, bias: Tensor | None):
         if self.padding_mode != "zeros":
-            return F.conv1d(
+            unbatched = input.dim() == 2
+            if unbatched:
+                input = input.unsqueeze(0)
+            out = F.conv1d(
                 F.pad(
                     input, self._reversed_padding_repeated_twice, mode=self.padding_mode
                 ),
@@ -376,6 +379,9 @@ class Conv1d(_ConvNd):
                 self.dilation,
                 self.groups,
             )
+            if unbatched:
+                out = out.squeeze(0)
+            return out
 
         return F.conv1d(
             input, weight, bias, self.stride, self.padding, self.dilation, self.groups
@@ -545,7 +551,10 @@ class Conv2d(_ConvNd):
 
     def _conv_forward(self, input: Tensor, weight: Tensor, bias: Tensor | None):
         if self.padding_mode != "zeros":
-            return F.conv2d(
+            unbatched = input.dim() == 3
+            if unbatched:
+                input = input.unsqueeze(0)
+            out = F.conv2d(
                 F.pad(
                     input, self._reversed_padding_repeated_twice, mode=self.padding_mode
                 ),
@@ -556,6 +565,9 @@ class Conv2d(_ConvNd):
                 self.dilation,
                 self.groups,
             )
+            if unbatched:
+                out = out.squeeze(0)
+            return out
 
         return F.conv2d(
             input, weight, bias, self.stride, self.padding, self.dilation, self.groups
@@ -715,7 +727,10 @@ class Conv3d(_ConvNd):
 
     def _conv_forward(self, input: Tensor, weight: Tensor, bias: Tensor | None):
         if self.padding_mode != "zeros":
-            return F.conv3d(
+            unbatched = input.dim() == 4
+            if unbatched:
+                input = input.unsqueeze(0)
+            out = F.conv3d(
                 F.pad(
                     input, self._reversed_padding_repeated_twice, mode=self.padding_mode
                 ),
@@ -726,6 +741,9 @@ class Conv3d(_ConvNd):
                 self.dilation,
                 self.groups,
             )
+            if unbatched:
+                out = out.squeeze(0)
+            return out
 
         return F.conv3d(
             input, weight, bias, self.stride, self.padding, self.dilation, self.groups


### PR DESCRIPTION
Fixes #104860

When `padding_mode` is not `"zeros"`, `Conv1d`, `Conv2d`, and `Conv3d` call `F.pad` on the input before performing the convolution. However, `F.pad` (particularly with `circular` mode) requires a batch dimension. This means unbatched inputs (e.g. a 3D tensor for `Conv2d`) fail with a cryptic error, even though the same input works fine with `padding_mode="zeros"`:

```python
conv = nn.Conv2d(256, 256, 3, padding=1, padding_mode="circular")
x = torch.randn(256, 32, 32)  # unbatched (C, H, W)
conv(x)  # RuntimeError
```

**Fix:** In `_conv_forward` for all three Conv classes, detect unbatched input, `unsqueeze(0)` to add a temporary batch dimension before `F.pad` + convolution, then `squeeze(0)` the result. This matches how `F.conv{1,2,3}d` already handles unbatched input internally when `padding_mode="zeros"`.

**Changes:**
- `torch/nn/modules/conv.py`: Add unsqueeze/squeeze in `_conv_forward` for `Conv1d`, `Conv2d`, `Conv3d`
- `test/test_nn.py`: Add `test_conv_non_zeros_padding_unbatched` verifying all three conv classes with all three non-zeros padding modes produce identical results for batched vs unbatched input

cc @albanD @jbschlosser @mikaylagawarecki