### PR TITLE
[inductor] Avoid pointwise cat for complex output branches

### DIFF
--- a/test/inductor/test_pad_as_cat.py
+++ b/test/inductor/test_pad_as_cat.py
@@ -75,6 +75,79 @@ class TestCatMultiConsumer(TestCase):
             f"Expected {expected_bytes} bytes, got {metrics.num_bytes_accessed}.",
         )
 
+    @torch._inductor.config.patch(fx_graph_cache=False)
+    @requires_gpu()
+    def test_complex_output_cat_uses_concat_kernel(self):
+        """Do not inline mutually exclusive complex cat branches."""
+
+        def branch(x, mean, var, weight, bias):
+            mean = mean[None, :, None, None]
+            var = var[None, :, None, None]
+            weight = weight[None, :, None, None]
+            bias = bias[None, :, None, None]
+            return (x - mean) * torch.rsqrt(var + 1e-5) * weight + bias
+
+        def fn(x0, x1, x2, x3, mean, var, weight, bias):
+            return torch.cat(
+                [
+                    branch(x0, mean, var, weight, bias),
+                    branch(x1, mean, var, weight, bias),
+                    branch(x2, mean, var, weight, bias),
+                    branch(x3, mean, var, weight, bias),
+                ],
+                dim=1,
+            )
+
+        inputs = [
+            torch.randn(2, 4, 4, 4, device=GPU_TYPE),
+            torch.randn(2, 4, 4, 4, device=GPU_TYPE),
+            torch.randn(2, 4, 4, 4, device=GPU_TYPE),
+            torch.randn(2, 4, 4, 4, device=GPU_TYPE),
+            torch.randn(4, device=GPU_TYPE),
+            torch.randn(4, device=GPU_TYPE).abs(),
+            torch.randn(4, device=GPU_TYPE),
+            torch.randn(4, device=GPU_TYPE),
+        ]
+        result, (code,) = run_and_get_code(torch.compile(fn), *inputs)
+        self.assertEqual(result, fn(*inputs))
+        self.assertNotIn("tl.where", code)
+
+    @torch._inductor.config.patch(fx_graph_cache=False)
+    @requires_gpu()
+    def test_complex_cat_with_pointwise_consumer_still_fuses(self):
+        """Keep pointwise_cat when downstream pointwise fusion can use it."""
+
+        def branch(x, mean, var, weight, bias):
+            mean = mean[None, :, None, None]
+            var = var[None, :, None, None]
+            weight = weight[None, :, None, None]
+            bias = bias[None, :, None, None]
+            return (x - mean) * torch.rsqrt(var + 1e-5) * weight + bias
+
+        def fn(x0, x1, mean, var, weight, bias):
+            cat = torch.cat(
+                [
+                    branch(x0, mean, var, weight, bias),
+                    branch(x1, mean, var, weight, bias),
+                ],
+                dim=1,
+            )
+            return cat + 1
+
+        inputs = [
+            torch.randn(2, 4, 4, 4, device=GPU_TYPE),
+            torch.randn(2, 4, 4, 4, device=GPU_TYPE),
+            torch.randn(4, device=GPU_TYPE),
+            torch.randn(4, device=GPU_TYPE).abs(),
+            torch.randn(4, device=GPU_TYPE),
+            torch.randn(4, device=GPU_TYPE),
+        ]
+        compiled = torch.compile(fn)
+        metrics.reset()
+        result = compiled(*inputs)
+        self.assertEqual(result, fn(*inputs))
+        self.assertEqual(metrics.generated_kernel_count, 1)
+
 
 class TestPadAsCat(TestCase):
     @requires_gpu()

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2178,18 +2178,32 @@ def cat(inputs, dim=0):
     def additional_pointwise_ops(op: torch._ops.OpOverload):
         return op in (aten.cat.default, aten.constant_pad_nd.default)
 
-    if len(inputs) <= config.max_complex_pointwise_cat_inputs or (
-        (len(inputs) <= config.max_pointwise_cat_inputs)
-        and all(op_count(t) <= MAX_SIMPLE_OP_COUNT for t in inputs)
+    input_op_counts = [op_count(t) for t in inputs]
+    all_inputs_simple = all(count <= MAX_SIMPLE_OP_COUNT for count in input_op_counts)
+
+    if len(inputs) <= config.max_pointwise_cat_inputs and (
+        len(inputs) <= config.max_complex_pointwise_cat_inputs or all_inputs_simple
     ):
         pointwise_uses = all(
+            is_pointwise_use(use, additional_pointwise_ops)
+            for use in V.current_node.users
+        )
+        has_pointwise_use = any(
             is_pointwise_use(use, additional_pointwise_ops)
             for use in V.current_node.users
         )
         # fuse in case we will be used in a pointwise node, and there are any inputs we
         # we can prevent materialization of.
         fuse_pointwise_use = (
-            any(should_lower_cat_input(inp) for inp in inputs) and pointwise_uses
+            any(should_lower_cat_input(inp) for inp in inputs)
+            and pointwise_uses
+            and (
+                all_inputs_simple
+                or (
+                    has_pointwise_use
+                    and len(inputs) <= config.max_complex_pointwise_cat_inputs
+                )
+            )
         )
 
         # horizontal fuse in case all inputs will require a copy kernel anyway.
@@ -2233,7 +2247,9 @@ def cat(inputs, dim=0):
         has_multi_consumers = any_input_has_multi_consumers()
 
         horizontal_fuse_cat = (
-            all(should_lower_cat_input(inp) for inp in inputs) and not fusable_reduction
+            all_inputs_simple
+            and all(should_lower_cat_input(inp) for inp in inputs)
+            and not fusable_reduction
         )
 
         if not has_multi_consumers and (fuse_pointwise_use or horizontal_fuse_cat):


### PR DESCRIPTION
Stack from better-benchmark issue 27.

This changes cat lowering so complex final-output cats use ConcatKernel instead of pointwise_cat, while keeping pointwise_cat for downstream pointwise consumers. The motivating case is branchy BN-style cats where pointwise_cat evaluates mutually exclusive branch bodies under masks.

Validation:
- python3 -m py_compile torch/_inductor/lowering.py test/inductor/test_pad_as_cat.py
- git diff --check
- python3 test/inductor/test_pad_as_cat.py TestCatMultiConsumer.test_complex_output_cat_uses_concat_kernel TestCatMultiConsumer.test_complex_cat_with_pointwise_consumer_still_fuses

Local better-benchmark B200 results:
- pointwise_6d842b54b40d: 245.8 us baseline -> 67.7 us patched
- pointwise_8be04df3df80: 73.9 us baseline -> 46.5 us patched
- pointwise_b0c74cbb35c4: remains one kernel, 20.7 us patched

Submitted by my agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo