### PR TITLE
[inductor] Tune small multi-output mix-order reductions

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -58,6 +58,7 @@ from torch._inductor.runtime.triton_heuristics import (
     CachingAutotunerPlugin,
     DEFER,
     make_matmul_triton_config,
+    persistent_reduction,
     template,
     triton_config,
 )
@@ -205,6 +206,32 @@ class TestTritonHeuristics(TestCase):
         cfg = autotuner.configs[0]
         self.assertEqual(cfg.kwargs["XBLOCK"], 128)
         self.assertEqual(cfg.kwargs["R0_BLOCK"], 512)
+
+    def test_mix_order_small_multi_output_rsplit_config(self):
+        cfg = persistent_reduction(
+            size_hints={"x": 32768, "r0_": 512},
+            triton_meta={},
+            inductor_meta={"RSPLIT_SIZE": 32, "num_reduction": 2},
+            return_configs=True,
+        )[0]
+        self.assertEqual(cfg.kwargs["RSPLIT_SIZE"], 32)
+        self.assertEqual(cfg.kwargs["XBLOCK"], 2)
+        self.assertEqual(cfg.kwargs["NUM_STAGES"], 1)
+        self.assertEqual(cfg.num_warps, 1)
+
+        # Do not apply the special postprocess to nearby r0=128 cases. Those
+        # were neutral/noisy in the benchmark sweep and should keep the generic
+        # mix-order config shape.
+        cfg = persistent_reduction(
+            size_hints={"x": 524288, "r0_": 128},
+            triton_meta={},
+            inductor_meta={"RSPLIT_SIZE": 128, "num_reduction": 2},
+            return_configs=True,
+        )[0]
+        self.assertEqual(cfg.kwargs["RSPLIT_SIZE"], 128)
+        self.assertEqual(cfg.kwargs["XBLOCK"], 4)
+        self.assertEqual(cfg.kwargs["NUM_STAGES"], 3)
+        self.assertEqual(cfg.num_warps, 4)
 
     def _test_artificial_zgrid(self):
         def forward(primals_1, primals_2, primals_5):

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2339,7 +2339,16 @@ class SIMDScheduling(BaseScheduling):
             # heuristics based on number of SMs
             device_prop = DeviceProperties.create(node1.get_device())
             num_sm = device_prop.multi_processor_count
-            estimated_num_splits = num_sm * 8
+            rnumel_hint = V.graph.sizevars.optimization_hint(rnumel)
+            num_node2_reductions = sum(
+                1 for subnode in node2.get_nodes() if subnode.is_reduction()
+            )
+            # Small multi-output mix-order reductions do better with fewer,
+            # larger split chunks to reduce workspace traffic.
+            split_multiplier = (
+                4 if rnumel_hint == 512 and num_node2_reductions > 1 else 8
+            )
+            estimated_num_splits = num_sm * split_multiplier
 
             # split_size is decided based on hint.
             # optimization_hint is fine here: the result is clamped to [16, 128],

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4656,6 +4656,15 @@ def persistent_reduction(
         new_configs = []
         rsplit_size = inductor_meta.get("RSPLIT_SIZE")
         rnumel_hint = size_hints["r0_"]
+        # Keep this special case narrow: it targets small multi-output
+        # mix-order kernels where RSPLIT_SIZE=32 was validated against nearby
+        # RSPLIT_SIZE=128 cases that should keep the generic postprocess.
+        small_multi_output_mix_order = (
+            rnumel_hint == 512
+            and rsplit_size == 32
+            and inductor_meta.get("num_reduction", 0) > 1
+            and not max_autotune_enabled
+        )
         min_x_block = 1
         if rnumel_hint <= 512:
             min_x_block = 4
@@ -4670,7 +4679,11 @@ def persistent_reduction(
             required_x_block = max(
                 required_x_block, tma_min_block_sizes.get("XBLOCK", 1)
             )
-        x_block = min(max(rsplit_size // 32, min_x_block, required_x_block), 16)
+        if small_multi_output_mix_order:
+            x_block = max(2, required_x_block)
+        else:
+            x_block = max(rsplit_size // 32, min_x_block, required_x_block)
+        x_block = min(x_block, 16)
         for c in configs:
             c.kwargs["RSPLIT_SIZE"] = rsplit_size
             # small XBLOCK to use less registers/smem
@@ -4681,15 +4694,20 @@ def persistent_reduction(
             # With large rnumel, we have higher chance of out-of-shared memory
             # To avoid adding too much autotuning overhead, we just constrain NUM_STAGES
             # if rnumel is large
-            if inductor_meta.get("mix_order_reduction_allow_multi_stages", True):
+            if small_multi_output_mix_order:
+                MAX_NUM_STAGES = 1
+            elif inductor_meta.get("mix_order_reduction_allow_multi_stages", True):
                 MAX_NUM_STAGES = 2 if rnumel_hint > 8192 else 3
             else:
                 MAX_NUM_STAGES = 1
             c.kwargs["NUM_STAGES"] = min(max(num_iters // 4, 1), MAX_NUM_STAGES)
 
             if rnumel_hint <= 1024:
-                c.num_warps //= 2
-                c.num_warps = max(c.num_warps, 1)
+                if small_multi_output_mix_order:
+                    c.num_warps = 1
+                else:
+                    c.num_warps //= 2
+                    c.num_warps = max(c.num_warps, 1)
                 new_configs.append(c)
 
                 if max_autotune_enabled:


### PR DESCRIPTION
Summary:
- tune small multi-output mix-order reductions by using fewer split chunks for the validated rnumel=512 case
- postprocess the resulting RSPLIT_SIZE=32 config to use smaller XBLOCK, one stage, and one warp
- add a heuristic unit test covering the target case and a nearby rnumel=128 case that should keep generic behavior

Benchmark evidence on B200, better-benchmark issue 27 repros:
- sum_sum_sum_e06c904e550e: 194.5 us -> 67.4 us, RSPLIT_SIZE 16 -> 32
- sum_sum_sum_e2d4961f3571: 92.1 us -> 87.7 us, RSPLIT_SIZE 16 -> 32
- sum_sum_sum_dc96c4651516: 852.0 us -> 803.7 us, RSPLIT_SIZE unchanged at 128
- sum_sum_sum_e7a56f82f536: 283.6 us -> 282.6 us, RSPLIT_SIZE unchanged at 128
- sum_sum_c50720f2fd4d: 139.4 us -> 138.0 us, non-mix-order contrast unchanged

Validation:
- python3 -m py_compile torch/_inductor/codegen/simd.py torch/_inductor/heuristics/triton_codegen/reduction.py test/inductor/test_triton_heuristics.py
- python3 test/inductor/test_triton_heuristics.py -k test_mix_order_small_multi_output_rsplit_config
- git diff --check

Submitted by my agent.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo