### PR TITLE
Fix ONNX type promotion overload selection

### DIFF
--- a/test/onnx/test_fx_type_promotion.py
+++ b/test/onnx/test_fx_type_promotion.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: onnx"]
 
+import torch
 from torch.onnx._internal.fx.passes import type_promotion
 from torch.testing._internal import common_utils
 
@@ -23,6 +24,37 @@ class TestGeneratedTypePromotionRuleSet(common_utils.TestCase):
 
     def test_initialize_type_promotion_table_succeeds(self):
         type_promotion.TypePromotionTable()
+
+
+class TestFindCompatibleOpOverload(common_utils.TestCase):
+    def test_selects_schema_compatible_overload(self):
+        condition = torch.tensor([True, False])
+        args = (condition, torch.tensor(0.0), -1000.0)
+
+        overload = type_promotion.find_compatible_op_overload(
+            torch.ops.aten.where, args, {}
+        )
+
+        self.assertEqual(overload, torch.ops.aten.where.ScalarOther)
+
+
+class TestTypePromotionONNXExport(common_utils.TestCase):
+    def test_where_with_bool_tensor_and_mixed_scalars_exports(self):
+        class WhereModel(torch.nn.Module):
+            def forward(self, condition):
+                return torch.where(condition, 0, -1000.0)
+
+        model = WhereModel().eval()
+        condition = torch.randn(1, 1, 4, 4) > 0
+
+        onnx_program = torch.onnx.export(
+            model,
+            (condition,),
+            dynamo=True,
+            verbose=False,
+        )
+
+        self.assertIsNotNone(onnx_program)
 
 
 if __name__ == "__main__":

--- a/torch/onnx/_internal/fx/passes/type_promotion.py
+++ b/torch/onnx/_internal/fx/passes/type_promotion.py
@@ -22,7 +22,7 @@ from torch._refs import linalg as _linalg_refs, nn as _nn_refs, special as _spec
 from torch._refs.nn import functional as _functional_refs
 from torch.fx.experimental import proxy_tensor
 from torch.onnx._internal.fx import _pass, type_utils as fx_type_utils
-from torch.utils import _python_dispatch, _pytree
+from torch.utils import _pytree
 
 
 if TYPE_CHECKING:
@@ -1260,23 +1260,6 @@ def get_type_promotion_rule(
     return rule
 
 
-class _OpTraceDispatchMode(_python_dispatch.TorchDispatchMode):
-    """Trace ops that were dispatched.
-
-    Utilize the dispatch mechanism in [`__torch_dispatch__`](https://dev-discuss.pytorch.org/t/what-and-why-is-torch-dispatch/557)
-    to trace op overloads that were dispatched to. This is used to find the compatible
-    op overload for a given op overload packet for different set of args and kwargs.
-    """
-
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self.traced_ops = []
-
-    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
-        self.traced_ops.append(func)
-        return func(*args, **kwargs)
-
-
 def find_compatible_op_overload(
     op: torch._ops.OpOverloadPacket, args: tuple, kwargs: dict
 ) -> torch._ops.OpOverload:
@@ -1311,22 +1294,27 @@ def find_compatible_op_overload(
         >>> find_compatible_op_overload(packet, args, {})._overloadname
         'Tensor_Tensor'
     """
-    # Utilize the dispatch mechanism to find the compatible op overload.
-    op_trace_dispatch_mode = _OpTraceDispatchMode()
-    with op_trace_dispatch_mode:
-        op(*args, **kwargs)
-    if len(op_trace_dispatch_mode.traced_ops) < 1:
-        raise AssertionError("Expected at least 1 traced op, got 0")
+    exceptions = {}
+    for overload_name in op.overloads():
+        op_overload = getattr(op, overload_name)
+        if not isinstance(op_overload, torch._ops.OpOverload):
+            raise AssertionError(f"Expected OpOverload, got {type(op_overload)}")
+        try:
+            torch._C._check_schema_allow_fake_script_object(
+                op_overload._schema, *args, **kwargs
+            )
+        except RuntimeError as e:
+            exceptions[overload_name] = e
+        else:
+            return op_overload
 
-    new_op_overload = op_trace_dispatch_mode.traced_ops[0]
-    if not isinstance(new_op_overload, torch._ops.OpOverload):
-        raise AssertionError(f"Expected OpOverload, got {type(new_op_overload)}")
-    if new_op_overload.overloadpacket != op:
-        raise AssertionError(
-            f"Expected same OpOverload packet, got {new_op_overload.overloadpacket} != {op}"
-        )
-
-    return new_op_overload
+    error_messages = "\n".join(
+        f"Overload name {name}:\n{exception}" for name, exception in exceptions.items()
+    )
+    raise RuntimeError(
+        f"Cannot find a compatible OpOverload for {op} with the provided "
+        f"arguments. Tried overloads:\n{error_messages}"
+    )
 
 
 class _TypePromotionInterpreter(torch.fx.Interpreter):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185005

The ONNX type-promotion pass previously found compatible overloads by executing an OpOverloadPacket under TorchDispatchMode and using the first dispatched op. That couples schema resolution to runtime implementation details. For aten.where with mixed tensor/scalar arguments, packet execution can dispatch intermediate ops or the tensor implementation overload before the scalar where overload, causing the pass to rewrite the FX node to an incompatible target and fail during decomposition.

Resolve compatible overloads by checking each candidate overload schema against the post-promotion args and kwargs with torch._C._check_schema_allow_fake_script_object. This keeps selection inside the original overload packet and avoids dispatch side effects. I used schema validation instead of filtering traced dispatch output because it directly answers which overload accepts the FX arguments while preserving FakeScriptObject support.

Fixes #169002

Generated by my agent

Test Plan:
- python test/onnx/test_fx_type_promotion.py
- inline ONNX export repro with opset_version=17 and torch.where(condition, 0, -1000.0)
- lintrunner -a