### PR TITLE
Add input validation to prevent division-by-zero in LR schedulers

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -550,6 +550,22 @@ class TestLRScheduler(TestCase):
         closed_form_scheduler = ConstantLR(self.opt, factor=1.0 / 3, total_iters=4)
         self._test_against_closed_form(scheduler, closed_form_scheduler, 20)
 
+    def test_constantlr_factor_zero_raises(self):
+        with self.assertRaises(ValueError):
+            ConstantLR(self.opt, factor=0.0, total_iters=5)
+
+    def test_step_lr_step_size_zero_raises(self):
+        with self.assertRaises(ValueError):
+            StepLR(self.opt, step_size=0)
+
+    def test_polynomial_lr_total_iters_zero_raises(self):
+        with self.assertRaises(ValueError):
+            PolynomialLR(self.opt, total_iters=0)
+
+    def test_cosine_annealing_lr_t_max_zero_raises(self):
+        with self.assertRaises(ValueError):
+            CosineAnnealingLR(self.opt, T_max=0)
+
     def test_closed_form_multi_step_lr(self):
         scheduler = MultiStepLR(self.opt, gamma=0.1, milestones=[2, 5, 9])
         closed_form_scheduler = MultiStepLR(self.opt, gamma=0.1, milestones=[2, 5, 9])

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -625,6 +625,10 @@ class StepLR(LRScheduler):
         gamma: float = 0.1,
         last_epoch: int = -1,
     ) -> None:
+        if step_size <= 0:
+            raise ValueError(
+                f"Expected positive step_size, but got step_size={step_size}"
+            )
         self.step_size = step_size
         self.gamma = gamma
         super().__init__(optimizer, last_epoch)
@@ -810,9 +814,9 @@ class ConstantLR(LRScheduler):
         total_iters: int = 5,
         last_epoch: int = -1,
     ) -> None:
-        if factor > 1.0 or factor < 0:
+        if factor > 1.0 or factor <= 0:
             raise ValueError(
-                "Constant multiplicative factor expected to be between 0 and 1."
+                "Constant multiplicative factor expected to be strictly between 0 and 1."
             )
 
         self.factor = factor
@@ -1267,6 +1271,10 @@ class PolynomialLR(LRScheduler):
         power: float = 1.0,
         last_epoch: int = -1,
     ) -> None:
+        if total_iters <= 0:
+            raise ValueError(
+                f"Expected positive total_iters, but got total_iters={total_iters}"
+            )
         self.total_iters = total_iters
         self.power = power
         super().__init__(optimizer, last_epoch)
@@ -1391,6 +1399,10 @@ class CosineAnnealingLR(LRScheduler):
         eta_min: float = 0.0,
         last_epoch: int = -1,
     ) -> None:
+        if T_max <= 0:
+            raise ValueError(
+                f"Expected positive T_max, but got T_max={T_max}"
+            )
         self.T_max = T_max
         self.eta_min = eta_min
         super().__init__(optimizer, last_epoch)


### PR DESCRIPTION
## Summary

Fixes #185006

- **ConstantLR**: `factor=0` is silently accepted but causes `ZeroDivisionError` in `get_lr()` after `total_iters` steps (computes `1.0 / self.factor`). Changed validation from `factor < 0` to `factor <= 0`, consistent with `LinearLR`'s existing `start_factor <= 0` check.
- **StepLR**: `step_size=0` causes `ZeroDivisionError` via modulo in `get_lr()`. Added `step_size > 0` validation.
- **PolynomialLR**: `total_iters=0` causes `ZeroDivisionError` in `get_lr()`. Added `total_iters > 0` validation.
- **CosineAnnealingLR**: `T_max=0` causes `ZeroDivisionError` in `get_lr()`. Added `T_max > 0` validation.

All four now raise `ValueError` at construction time with a clear message.

## Test plan

Added four tests verifying that zero values raise `ValueError`:

```bash
python -m pytest test/optim/test_lrscheduler.py -k "test_constantlr_factor_zero_raises or test_step_lr_step_size_zero_raises or test_polynomial_lr_total_iters_zero_raises or test_cosine_annealing_lr_t_max_zero_raises" -v
```

cc @pytorch/optim