### PR TITLE
[inductor] Pair maxpool value and offset lowering

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5122,6 +5122,54 @@ class CommonTemplate:
         with config.patch({"triton.use_block_ptr": use_block_ptr}):
             self.common(fn, (torch.randn(1, 3, *[10] * dim),))
 
+    def test_low_memory_max_pool_offsets_ties_padding_ceil(self):
+        prims = torch.ops.prims
+
+        def fn(x):
+            return prims._low_memory_max_pool_with_offsets(
+                x,
+                [3, 3],
+                [2, 2],
+                [1, 1],
+                [1, 1],
+                True,
+            )
+
+        x = torch.ones(1, 1, 3, 3, device=self.device)
+        self.common(fn, (x,))
+
+        actual_vals, actual_offsets = torch.compile(fn)(x)
+        expected_vals, expected_offsets = fn(x)
+        self.assertEqual(actual_vals, expected_vals)
+        self.assertEqual(actual_offsets, expected_offsets)
+        self.assertEqual(
+            actual_offsets.cpu(),
+            torch.tensor([[[[4, 3], [1, 0]]]], dtype=torch.int8),
+        )
+
+    def test_low_memory_max_pool_offsets_nan(self):
+        prims = torch.ops.prims
+
+        def fn(x):
+            return prims._low_memory_max_pool_with_offsets(
+                x,
+                [2, 2],
+                [1, 1],
+                [0, 0],
+                [1, 1],
+                False,
+            )
+
+        x = torch.tensor(
+            [[[[1.0, float("nan")], [0.0, 2.0]]]],
+            device=self.device,
+        )
+        actual_vals, actual_offsets = torch.compile(fn)(x)
+        expected_vals, expected_offsets = fn(x)
+        self.assertEqual(torch.isnan(actual_vals), torch.isnan(expected_vals))
+        self.assertEqual(actual_offsets, expected_offsets)
+        self.assertEqual(actual_offsets.item(), 1)
+
     @xfail_if_mps  # aten::full with zero-sized dim triggers AcceleratorError on MPS
     def test_max_unpool_empty_output(self):
         class Unpool1d(nn.Module):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5339,6 +5339,18 @@ def _max_pool_with_offsets(
         ]
         return x_loader([*prefix, *ih])
 
+    # Keep the pooled value and window offset in one argmax-style state for
+    # small unrolled windows, so fused code can avoid a separate max chain.
+    paired = _small_unrolled_max_pool_with_offsets(
+        x,
+        dtype,
+        fn_inner,
+        new_size,
+        kernel_size,
+    )
+    if paired is not None:
+        return paired
+
     result = Reduction.create(
         reduction_type="max",
         input_node=x,
@@ -5366,6 +5378,61 @@ def _max_pool_with_offsets(
         # Only realize if reduction isn't unrolled
         offsets.realize()
 
+    return result, offsets
+
+
+def _small_unrolled_max_pool_with_offsets(
+    x,
+    dtype,
+    inner_fn,
+    ranges,
+    reduction_ranges,
+):
+    reduction_numel = V.graph.sizevars.simplify(sympy_product(reduction_ranges))
+    if (
+        not isinstance(reduction_numel, sympy.Integer)
+        or reduction_numel <= 0
+        or int(reduction_numel) >= config.unroll_reductions_threshold
+    ):
+        return None
+
+    reduction_ranges = V.graph.sizevars.guard_int_seq(reduction_ranges)
+    reduction_indices = tuple(
+        tuple(sympy.expand(i) for i in rindex)
+        for rindex in itertools.product(*[range(x) for x in reduction_ranges])
+    )
+    strides = [1] * len(reduction_ranges)
+    for i in range(len(reduction_ranges) - 2, -1, -1):
+        strides[i] = strides[i + 1] * reduction_ranges[i + 1]
+    combine_fn = ir.get_reduction_combine_fn("argmax", dtype)
+
+    def flatten_index(rindex):
+        return sum(i * stride for i, stride in zip(rindex, strides))
+
+    def unrolled(index):
+        first, *rest = reduction_indices
+        best_value = inner_fn(index, first)
+        best_offset = ops.index_expr(flatten_index(first), torch.int64)
+        for rindex in rest:
+            value = inner_fn(index, rindex)
+            offset = ops.index_expr(flatten_index(rindex), torch.int64)
+            best_value, best_offset = combine_fn(
+                (best_value, best_offset), (value, offset)
+            )
+        return best_value, best_offset
+
+    result = Pointwise.create(
+        device=x.get_device(),
+        dtype=dtype,
+        inner_fn=lambda index: unrolled(index)[0],
+        ranges=ranges,
+    )
+    offsets = Pointwise.create(
+        device=x.get_device(),
+        dtype=torch.int64,
+        inner_fn=lambda index: unrolled(index)[1],
+        ranges=ranges,
+    )
     return result, offsets
 
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5411,8 +5411,8 @@ def _small_unrolled_max_pool_with_offsets(
         greater = ops.gt(a_value, b_value)
         equal = ops.eq(a_value, b_value)
         if is_float_dtype(dtype):
-            a_isnan = ops.ne(a_value, a_value)
-            b_isnan = ops.ne(b_value, b_value)
+            a_isnan = ops.isnan(a_value)
+            b_isnan = ops.isnan(b_value)
             b_is_not_nan = ops.logical_not(b_isnan)
             greater = ops.logical_or(
                 ops.logical_and(a_isnan, b_is_not_nan),

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5416,8 +5416,9 @@ def _small_unrolled_max_pool_with_offsets(
         for rindex in rest:
             value = inner_fn(index, rindex)
             offset = ops.index_expr(flatten_index(rindex), torch.int64)
-            best_value, best_offset = combine_fn(
-                (best_value, best_offset), (value, offset)
+            best_value, best_offset = cast(
+                tuple[Any, Any],
+                combine_fn((best_value, best_offset), (value, offset)),
             )
         return best_value, best_offset
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5404,7 +5404,28 @@ def _small_unrolled_max_pool_with_offsets(
     strides = [1] * len(reduction_ranges)
     for i in range(len(reduction_ranges) - 2, -1, -1):
         strides[i] = strides[i + 1] * reduction_ranges[i + 1]
-    combine_fn = ir.get_reduction_combine_fn("argmax", dtype)
+
+    def combine_fn(a: tuple[Any, Any], b: tuple[Any, Any]):
+        a_value, a_offset = a
+        b_value, b_offset = b
+        greater = ops.gt(a_value, b_value)
+        equal = ops.eq(a_value, b_value)
+        if is_float_dtype(dtype):
+            a_isnan = ops.ne(a_value, a_value)
+            b_isnan = ops.ne(b_value, b_value)
+            b_is_not_nan = ops.logical_not(b_isnan)
+            greater = ops.logical_or(
+                ops.logical_and(a_isnan, b_is_not_nan),
+                ops.logical_and(greater, b_is_not_nan),
+            )
+            equal = ops.logical_or(equal, ops.logical_and(a_isnan, b_isnan))
+        mask = ops.logical_or(
+            greater, ops.logical_and(equal, ops.lt(a_offset, b_offset))
+        )
+        return (
+            ops.where(mask, a_value, b_value),
+            ops.where(mask, a_offset, b_offset),
+        )
 
     def flatten_index(rindex):
         return sum(i * stride for i, stride in zip(rindex, strides))


### PR DESCRIPTION
Summary:
- Add a small-window maxpool-with-offsets lowering path that carries pooled value and offset as one paired comparator state instead of lowering them as separate value/argmax work.
- Keep the path conservative: static kernel/window, supported padding/ceil cases, and fallback to the existing lowering otherwise.
- Add targeted Inductor tests for offsets, ties, padding/ceil, and NaN-sensitive behavior.

Validation:
- git diff --check HEAD^..HEAD
- python -m py_compile torch/_inductor/lowering.py test/inductor/test_torchinductor.py
- focused low-memory maxpool-with-offsets tests: 4 passed locally
- generated code inspection for the two better-benchmark maxpool repros: one fused pointwise Triton kernel, 9 loads, 2 stores, no reduction kernel
- B200 canonical repro harness under GPU lock: pointwise_485ad74a8b0e 1 kernel, 644.5 us; pointwise_e33f44c6dd73 1 kernel, 217.4 us

Context:
- This targets the better-benchmark issue27 maxpool-with-offsets cases where the value and offset are computed from the same small window but the generic lowering pays extra comparator/tie-break instruction work. Prior NCU comparison on pointwise_485ad74a8b0e showed executed instructions dropping from ~545M to ~386M with DRAM roughly unchanged when using the paired comparator direction.

Submitted by my agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo