### PR TITLE
[inductor] Add FP64-heavy pointwise autotune candidate

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -134,12 +134,8 @@ class TestTritonHeuristics(TestCase):
                 for cfg in configs
             )
 
-        self.assertTrue(
-            has_fp64_heavy_candidate(get_configs({"in_ptr0": "*fp64"}, 16))
-        )
-        self.assertFalse(
-            has_fp64_heavy_candidate(get_configs({"in_ptr0": "*fp32"}, 0))
-        )
+        self.assertTrue(has_fp64_heavy_candidate(get_configs({"in_ptr0": "*fp64"}, 16)))
+        self.assertFalse(has_fp64_heavy_candidate(get_configs({"in_ptr0": "*fp32"}, 0)))
         self.assertFalse(
             has_fp64_heavy_candidate(get_configs({"in_ptr0": "*fp64"}, 15))
         )

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -58,6 +58,7 @@ from torch._inductor.runtime.triton_heuristics import (
     CachingAutotunerPlugin,
     DEFER,
     make_matmul_triton_config,
+    pointwise,
     template,
     triton_config,
 )
@@ -102,6 +103,46 @@ class TestTritonHeuristics(TestCase):
             if key not in cfg.kwargs:
                 continue
             self.assertTrue(cfg.kwargs[key] <= TRITON_MAX_BLOCK[label])
+
+    def test_fp64_heavy_pointwise_config_guard(self):
+        device = DeviceProperties(
+            type="cuda",
+            index=0,
+            multi_processor_count=1,
+            cc=90,
+            major=9,
+            max_threads_per_block=1024,
+            warp_size=32,
+        )
+
+        def get_configs(signature, num_fp64_compute_ops):
+            return pointwise(
+                {"x": 2**20},
+                triton_meta={"signature": signature, "device": device},
+                inductor_meta={
+                    "autotune_pointwise": True,
+                    "num_fp64_compute_ops": num_fp64_compute_ops,
+                },
+                return_configs=True,
+            )
+
+        def has_fp64_heavy_candidate(configs):
+            return any(
+                cfg.kwargs == {"XBLOCK": 256}
+                and cfg.num_warps == 8
+                and cfg.num_stages == 1
+                for cfg in configs
+            )
+
+        self.assertTrue(
+            has_fp64_heavy_candidate(get_configs({"in_ptr0": "*fp64"}, 16))
+        )
+        self.assertFalse(
+            has_fp64_heavy_candidate(get_configs({"in_ptr0": "*fp32"}, 0))
+        )
+        self.assertFalse(
+            has_fp64_heavy_candidate(get_configs({"in_ptr0": "*fp64"}, 15))
+        )
 
     def test_native_matmul_config_block_numel_limit(self):
         device = DeviceProperties(

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -2031,6 +2031,7 @@ class CSE(Generic[CSEVariableType, AugmentedKeyT]):
         dtype: torch.dtype | None = None,
         shape: BlockShapeType = None,
     ) -> CSEVariableType:
+        """Return a cached CSE variable for expr, emitting an assignment when needed."""
         if isinstance(expr, OpsValue):
             expr = expr.value
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -2078,6 +2078,12 @@ class CSE(Generic[CSEVariableType, AugmentedKeyT]):
                     else:
                         line = f"{expr}{self.suffix}"
                     buffer.writeline(line)
+                    if (
+                        assignment
+                        and dtype is torch.float64
+                        and buffer is V.kernel.compute
+                    ):
+                        V.kernel.num_fp64_compute_ops += 1
 
                     # cpp backend cannot determine is_vec at this point
                     if (
@@ -2157,6 +2163,7 @@ class Kernel(CodeGen, Generic[CSEVariableType]):
         self.num_load = 0
         self.num_store = 0
         self.num_reduction = 0
+        self.num_fp64_compute_ops = 0
 
         self.cse: CSE[CSEVariableType, Any] = CSE(self.newvar_prefix, self.suffix)
         self.must_keep_buffers: OrderedSet[str] = OrderedSet()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5990,6 +5990,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             # Triton will not accept an OrderedSet for autotune_hints
             "autotune_hints": set(self.autotune_hints),  # noqa: set_linter
         }
+        if self.num_fp64_compute_ops:
+            out["num_fp64_compute_ops"] = self.num_fp64_compute_ops
         if self.mix_order_reduction:
             out["RSPLIT_SIZE"] = self.rsplit_size
         if config.deterministic or config.test_configs.force_filter_reduction_configs:
@@ -6235,6 +6237,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.codegen_prologue(self.body)
         self.codegen_body()
         self._filter_pdl(self.body)
+        if self.num_fp64_compute_ops:
+            inductor_meta["num_fp64_compute_ops"] = self.num_fp64_compute_ops
 
         # Compute configs after codegen_body() so we know if the kernel
         # uses atomic ops. On HIP, buffer ops don't support atomics, so

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3242,6 +3242,38 @@ def triton_config(
     return config
 
 
+_FP64_HEAVY_POINTWISE_OP_THRESHOLD = 16
+
+
+def _is_cuda_device(triton_meta: dict[str, Any]) -> bool:
+    device = triton_meta.get("device")
+    return getattr(device, "type", None) == "cuda" and torch.version.hip is None
+
+
+def _should_add_fp64_heavy_pointwise_config(
+    size_hints: dict[str, int],
+    triton_meta: dict[str, Any],
+    inductor_meta: dict[str, Any],
+) -> bool:
+    return (
+        len(size_hints) == 1
+        and size_hints["x"] > 256
+        and _is_cuda_device(triton_meta)
+        and inductor_meta.get("num_fp64_compute_ops", 0)
+        >= _FP64_HEAVY_POINTWISE_OP_THRESHOLD
+    )
+
+
+def _append_unique_config(configs: list[Config], new_config: Config) -> None:
+    if not any(
+        cfg.kwargs == new_config.kwargs
+        and cfg.num_warps == new_config.num_warps
+        and cfg.num_stages == new_config.num_stages
+        for cfg in configs
+    ):
+        configs.append(new_config)
+
+
 def _get_nd_reduction_numels(r: int, size_hints: dict[str, int]) -> dict[str, int]:
     """
     Converts a linear reduction numel to ND, in row major order.
@@ -3772,6 +3804,15 @@ def pointwise(
                     [  # intel-xpu-backend-for-triton #5133
                         triton_config_with_settings(size_hints, 32),
                     ]
+                )
+            if _should_add_fp64_heavy_pointwise_config(
+                size_hints, triton_meta, inductor_meta
+            ):
+                _append_unique_config(
+                    configs,
+                    triton_config_with_settings(
+                        size_hints, 256, num_warps=8, num_stages=1
+                    ),
                 )
     if len(size_hints) == 2:
         # Only avoiding tuning on TileHint.SQUARE if not on ROCm builds


### PR DESCRIPTION
Summary:
- Count FP64 compute-heavy CSE assignments in Triton pointwise codegen metadata.
- Add a guarded CUDA 1D pointwise autotune candidate `XBLOCK=256,num_warps=8,num_stages=1` only when the generated kernel has enough FP64 compute work.
- Add guard tests so FP32 and low-op FP64 pointwise kernels do not get the candidate.

Context:
- better-benchmark issue 27 root cause: high-op FP64 pointwise kernels are register-pressure/occupancy limited, not memory-traffic limited.
- Main repro: `pointwise_a2382a85ee99`, a 372-op FP64 pointwise expression with sqrt/log/div-heavy body.

Evidence:
- Prior NCU deep dive on `pointwise_a2382a85ee99`: default `512x8` had about 172 regs/thread and low active-warps occupancy; `256x8` reduced to about 104 regs/thread and raised active warps.
- Validation branch benchmark under GPU lock for `pointwise_a2382a85ee99`: 1 generated kernel, compiled default 71.9 us, coord-desc 71.8 us, memcopy SOL 13.9 us. This matches the intended 256x8 path and is substantially better than the earlier 512x8 baseline.

Validation:
- `git diff --check origin/main...HEAD`
- `python -m py_compile torch/_inductor/codegen/common.py torch/_inductor/codegen/triton.py torch/_inductor/runtime/triton_heuristics.py test/inductor/test_triton_heuristics.py`
- Focused GPU test via lock: `TestTritonHeuristics.test_fp64_heavy_pointwise_config_guard` passed
- Local torch import/build validated in `/data/users/eellison/pytorch_issue27_fp64_validate` with CUDA available

Risk:
- This is intentionally an autotune candidate, not a default replacement. The guard requires CUDA 1D pointwise plus FP64-heavy static op signal; low-op FP64 and FP32 cases are excluded.

Submitted by my agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo