### PR TITLE
Add SAC-driven fully overlapped activation CPU offload (primarily aimed at GH200/GB200/GB300 superchips) 

### DIFF
--- a/test/dynamo/test_activation_offloading.py
+++ b/test/dynamo/test_activation_offloading.py
@@ -19,6 +19,11 @@ from torch._inductor.utils import run_fw_bw_and_get_code
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import serialTest
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.utils.checkpoint import (
+    checkpoint,
+    CheckpointPolicy,
+    create_selective_checkpoint_contexts,
+)
 
 
 networkx = pytest.importorskip("networkx")
@@ -43,6 +48,14 @@ def get_fw_bw_graph(
         dynamic=dynamic,
     )(*inps).sum().backward()
     return (fw_graph_cell[0], bw_graph_cell[0])
+
+
+def count_graphmodule_code(gm, text):
+    return sum(
+        module.code.count(text)
+        for module in gm.modules()
+        if isinstance(module, torch.fx.GraphModule)
+    )
 
 
 @unittest.skipIf(not HAS_GPU, "requires GPU")
@@ -161,8 +174,8 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
         self.assertNotIn("streams.join", fw_code)
         self.assertNotIn("streams.record_stream", fw_code)
 
-        # Verify keepalive: ao.wait_tensor for offload should reference the GPU tensor
-        # (cos_1) as its 2nd arg to extend its lifetime
+        # Verify last_use_of_storage: ao.wait_tensor for offload should reference
+        # the GPU tensor as its storage-lifetime arg.
         for node in fw_graph.graph.nodes:
             if (
                 node.op == "call_function"
@@ -170,11 +183,11 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
                 and isinstance(node.args[0], torch.fx.Node)
                 and node.args[0].target == torch.ops.ao.offload.default
             ):
-                self.assertEqual(len(node.args), 2)
+                self.assertEqual(len(node.args), 3)
                 offload_node = node.args[0]
-                keepalive_node = node.args[1]
-                # keepalive should be the same GPU tensor that was offloaded
-                self.assertIs(keepalive_node, offload_node.args[0])
+                self.assertIsNone(node.args[1])
+                last_use_node = node.args[2]
+                self.assertIs(last_use_node, offload_node.args[0])
 
         bw_code = bw_graph.code
         # Backward: ao.reload produces async GPU tensor, ao.wait_tensor synchronizes
@@ -233,7 +246,7 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
             )
 
     def test_partitioner_offload_ao_ops_sink_wait(self):
-        """Test that sink_wait moves ao.wait_tensor for offload to end of forward graph."""
+        """Test that sink_wait pipelines ao.wait_tensor for offload."""
         reset_user_object_tracking()
         torch._dynamo.reset()
         with torch._functorch.config.patch(
@@ -244,7 +257,6 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
         ):
             fw_graph, _ = get_fw_bw_graph(self.fn, [self.x])
 
-        # The ao.wait_tensor for offload should be sunk to just before the output node
         nodes = list(fw_graph.graph.nodes)
         output_node = next(n for n in nodes if n.op == "output")
         output_idx = nodes.index(output_node)
@@ -257,17 +269,17 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
                 and node.args[0].target == torch.ops.ao.offload.default
             ):
                 wait_idx = nodes.index(node)
-                # ao.wait_tensor should be immediately before output
-                self.assertEqual(wait_idx, output_idx - 1)
+                offload_idx = nodes.index(node.args[0])
+                self.assertGreater(wait_idx, offload_idx)
+                self.assertLess(wait_idx, output_idx)
 
     def test_partitioner_offload_ao_ops_prefetch(self):
-        """Test that prefetch moves ao.reload earlier in backward graph."""
+        """Test that prefetch keeps reloads structurally one wait ahead."""
         reset_user_object_tracking()
         torch._dynamo.reset()
         with torch._functorch.config.patch(
             enable_activation_offloading=True,
             activation_offload_separate_stream=True,
-            activation_reload_prefetch=True,
             joint_custom_pass=self.joint_custom_pass,
         ):
             _, bw_graph = get_fw_bw_graph(self.fn, [self.x])
@@ -312,7 +324,6 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
             enable_activation_offloading=True,
             activation_offload_separate_stream=True,
             activation_offload_sink_wait=True,
-            activation_reload_prefetch=True,
             joint_custom_pass=self.joint_custom_pass,
         ):
             x_compile = [x.detach().clone().requires_grad_(True) for x in x_larger]
@@ -341,6 +352,20 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
         x = torch.randn(4, device=GPU_TYPE)
         with self.assertRaisesRegex(RuntimeError, "no pending transfer"):
             _pop_wait(x)
+
+    def test_wait_tensor_error_duplicate_transfer(self):
+        """Test _register_wait raises RuntimeError on duplicate registration."""
+        from torch._functorch._activation_offloading.offload_ops import (
+            _clear_wait_registry,
+            _register_wait,
+        )
+
+        _clear_wait_registry()
+        x = torch.empty(4, device="cpu", pin_memory=True)
+        _register_wait(x, torch.device(GPU_TYPE))
+        with self.assertRaisesRegex(RuntimeError, "already registered"):
+            _register_wait(x, torch.device(GPU_TYPE))
+        _clear_wait_registry()
 
     def test_offload_reload_fake_tensor(self):
         """Test fake tensor implementations for offload, reload, and wait_tensor."""
@@ -392,7 +417,7 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
 
         bw_code = bw_graph.code
         self.assertEqual(bw_code.count("ao.reload.default"), 3)
-        self.assertEqual(bw_code.count("ao.wait_tensor.default"), 3)
+        self.assertEqual(count_graphmodule_code(bw_graph, "ao.wait_tensor.default"), 3)
 
     def test_multiple_tensors_offload_ao_ops_accuracy(self):
         """Test accuracy when offloading all saved tensors with ao ops."""
@@ -455,19 +480,183 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
         (FileCheck().check("ao.offload").check("ao.wait_tensor").run(fw_code))
         (FileCheck().check("ao.reload").check("ao.wait_tensor").run(bw_code))
 
-    def test_estimate_transfer_time_config(self):
-        """Test bandwidth config controls transfer time estimation."""
-        from torch._functorch._activation_offloading.activation_offloading import (
-            _estimate_transfer_time_in_ms,
-        )
+    def test_cpu_offload_policy_auto_enables_async(self):
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op == torch.ops.aten.cos.default:
+                return CheckpointPolicy.MUST_CPU_OFFLOAD
+            return CheckpointPolicy.PREFER_RECOMPUTE
 
-        size_bytes = 1024**3  # 1 GB
-        # 1 GB at 50 GB/s = 20 ms
-        with torch._functorch.config.patch(activation_offload_cpu_gpu_bw=50.0):
-            self.assertAlmostEqual(_estimate_transfer_time_in_ms(size_bytes), 20.0)
-        # 1 GB at 25 GB/s = 40 ms
-        with torch._functorch.config.patch(activation_offload_cpu_gpu_bw=25.0):
-            self.assertAlmostEqual(_estimate_transfer_time_in_ms(size_bytes), 40.0)
+        context_fn = partial(create_selective_checkpoint_contexts, policy_fn)
+
+        def region(x):
+            return torch.cos(x) * torch.sin(x)
+
+        def fn(x):
+            return checkpoint(
+                region,
+                x,
+                use_reentrant=False,
+                context_fn=context_fn,
+            )
+
+        x = torch.randn(8, 8, requires_grad=True, device=GPU_TYPE)
+        reset_user_object_tracking()
+        torch._dynamo.reset()
+        with torch._functorch.config.patch(
+            enable_activation_offloading=False,
+            activation_offload_separate_stream=False,
+            activation_offload_sink_wait=False,
+        ):
+            fw_graph, bw_graph = get_fw_bw_graph(fn, [x])
+
+        self.assertIn("ao.offload.default", fw_graph.code)
+        self.assertIn("control_deps", fw_graph.code)
+        self.assertTrue(
+            any(
+                "ao.wait_tensor.default" in module.code
+                for module in fw_graph.modules()
+                if isinstance(module, torch.fx.GraphModule)
+            )
+        )
+        self.assertIn("ao.reload.default", bw_graph.code)
+        self.assertIn("ao.wait_tensor.default", bw_graph.code)
+
+    def test_must_cpu_offload_unsupported_errors(self):
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op == torch.ops.aten.transpose.int:
+                return CheckpointPolicy.MUST_CPU_OFFLOAD
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        context_fn = partial(create_selective_checkpoint_contexts, policy_fn)
+
+        def region(x):
+            y = x.transpose(0, 1)
+            return y.sin()
+
+        def fn(x):
+            return checkpoint(
+                region,
+                x,
+                use_reentrant=False,
+                context_fn=context_fn,
+            )
+
+        x = torch.randn(8, 8, requires_grad=True, device=GPU_TYPE)
+        reset_user_object_tracking()
+        torch._dynamo.reset()
+        with (
+            torch._functorch.config.patch(enable_activation_offloading=False),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "MUST_CPU_OFFLOAD cannot be honored",
+            ),
+        ):
+            get_fw_bw_graph(fn, [x])
+
+    def test_prefer_cpu_offload_unsupported_falls_back(self):
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op == torch.ops.aten.transpose.int:
+                return CheckpointPolicy.PREFER_CPU_OFFLOAD
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        context_fn = partial(create_selective_checkpoint_contexts, policy_fn)
+
+        def region(x):
+            y = x.transpose(0, 1)
+            return y.sin()
+
+        def fn(x):
+            return checkpoint(
+                region,
+                x,
+                use_reentrant=False,
+                context_fn=context_fn,
+            )
+
+        x = torch.randn(8, 8, requires_grad=True, device=GPU_TYPE)
+        reset_user_object_tracking()
+        torch._dynamo.reset()
+        with torch._functorch.config.patch(enable_activation_offloading=False):
+            fw_graph, bw_graph = get_fw_bw_graph(fn, [x])
+
+        self.assertNotIn("ao.offload.default", fw_graph.code)
+        self.assertNotIn("ao.reload.default", bw_graph.code)
+
+    def test_eager_cpu_offload_policy_correctness(self):
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op == torch.ops.aten.cos.default:
+                return CheckpointPolicy.MUST_CPU_OFFLOAD
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        context_fn = partial(create_selective_checkpoint_contexts, policy_fn)
+
+        def region(x):
+            return (torch.cos(x) * torch.sin(x)).sum()
+
+        x_ref = torch.randn(8, 8, requires_grad=True, device=GPU_TYPE)
+        x = x_ref.detach().clone().requires_grad_(True)
+
+        region(x_ref).backward()
+        checkpoint(
+            region,
+            x,
+            use_reentrant=False,
+            context_fn=context_fn,
+        ).backward()
+
+        self.assertEqual(x.grad, x_ref.grad)
+
+    def test_cpu_offload_policy_three_step_training_correctness(self):
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op == torch.ops.aten.relu.default:
+                return CheckpointPolicy.MUST_CPU_OFFLOAD
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        context_fn = partial(create_selective_checkpoint_contexts, policy_fn)
+
+        def offloaded_model(x, w1, w2):
+            def region(a, b):
+                return torch.relu(a @ b)
+
+            hidden = checkpoint(
+                region,
+                x,
+                w1,
+                use_reentrant=False,
+                context_fn=context_fn,
+            )
+            return hidden @ w2
+
+        def baseline_model(x, w1, w2):
+            return torch.relu(x @ w1) @ w2
+
+        torch.manual_seed(0)
+        x = torch.randn(8, 8, device=GPU_TYPE)
+        target = torch.randn(8, 8, device=GPU_TYPE)
+        params_ref = [
+            torch.randn(8, 8, device=GPU_TYPE, requires_grad=True),
+            torch.randn(8, 8, device=GPU_TYPE, requires_grad=True),
+        ]
+        params_compiled = [p.detach().clone().requires_grad_(True) for p in params_ref]
+        compiled_model = torch.compile(offloaded_model, backend="aot_eager")
+
+        for _ in range(3):
+            for param in params_ref + params_compiled:
+                param.grad = None
+
+            loss_ref = (baseline_model(x, *params_ref) - target).pow(2).mean()
+            loss_compiled = (compiled_model(x, *params_compiled) - target).pow(2).mean()
+            loss_ref.backward()
+            loss_compiled.backward()
+
+            self.assertEqual(loss_compiled, loss_ref)
+            for compiled_param, ref_param in zip(params_compiled, params_ref):
+                self.assertEqual(compiled_param.grad, ref_param.grad)
+
+            with torch.no_grad():
+                for compiled_param, ref_param in zip(params_compiled, params_ref):
+                    ref_param -= 0.01 * ref_param.grad
+                    compiled_param -= 0.01 * compiled_param.grad
 
 
 @unittest.skipIf(not HAS_GPU, "requires GPU")

--- a/torch/_functorch/_activation_offloading/activation_offloading.py
+++ b/torch/_functorch/_activation_offloading/activation_offloading.py
@@ -577,15 +577,17 @@ def activation_offload_sink_wait_async(fwd_module: fx.GraphModule) -> None:
 
 def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
     """
-    Prefetch backward reload operations by moving ao.reload nodes earlier
-    in the graph to overlap data transfer with computation, while keeping
-    ao.wait_tensor at its original position.
+    Prefetch backward reload operations structurally using a prefetch window.
+    Places each reload node W steps ahead of its corresponding wait_tensor node,
+    and enforces staggering in Inductor's scheduler by making the reload node
+    depend on a backward compute node of the prior layer.
     """
     graph: fx.Graph = bwd_module.graph
     nodes_list: list[fx.Node] = list(graph.nodes)
+    node_to_idx = {node: idx for idx, node in enumerate(nodes_list)}
 
     # Identify reload + wait pairs
-    reload_patterns: dict[fx.Node, ReloadNodeInfo] = {}
+    pairs: list[tuple[fx.Node, fx.Node]] = []
     for node in graph.nodes:
         if not (
             node.op == "call_function" and node.target == torch.ops.ao.reload.default
@@ -597,16 +599,71 @@ def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
         )
         if wait_node is None:
             continue
-        transfer_size_bytes: int = _calculate_transfer_size(node)
-        transfer_time_ms: float = _estimate_transfer_time_in_ms(transfer_size_bytes)
-        reload_patterns[node] = ReloadNodeInfo(
-            reload_group_nodes=[node],
-            wait_event_node=wait_node,
-            transfer_size_bytes=transfer_size_bytes,
-            transfer_time_ms=transfer_time_ms,
-        )
+        pairs.append((node, wait_node))
 
-    reorder_for_prefetch(nodes_list, reload_patterns)
+    if not pairs:
+        return
+
+    # Sort pairs chronologically based on their wait_node's index in the graph
+    pairs.sort(key=lambda p: node_to_idx[p[1]])
+
+    # Get prefetch window
+    W = config.activation_reload_prefetch_window
+    if W <= 0:
+        W = 1
+
+    # Place the reload nodes
+    placeholders = [n for n in graph.nodes if n.op == "placeholder"]
+    if not placeholders:
+        return
+    start_node = placeholders[-1]
+
+    def find_first_compute_user(wait_node: fx.Node) -> fx.Node:
+        queue = [wait_node]
+        visited = set()
+        while queue:
+            curr = queue.pop(0)
+            if curr in visited:
+                continue
+            visited.add(curr)
+
+            if curr != wait_node:
+                is_view = (
+                    curr.op == "call_function"
+                    and (
+                        curr.target in _LIFETIME_TRANSPARENT_TARGETS
+                        or "view" in str(curr.target)
+                        or "reshape" in str(curr.target)
+                        or "permute" in str(curr.target)
+                        or "transpose" in str(curr.target)
+                        or curr.target == operator.getitem
+                    )
+                )
+                if curr.op == "call_function" and not is_view:
+                    return curr
+
+            for user in curr.users:
+                queue.append(user)
+
+        return wait_node
+
+    for i, (reload_node, wait_node) in enumerate(pairs):
+        if i < W:
+            # Place reload node right after the last placeholder (start of backward)
+            start_node.append(reload_node)
+            start_node = reload_node
+        else:
+            # Place reload node immediately after a compute user of the pair W steps ahead
+            _, target_wait_node = pairs[i - W]
+            target_compute_node = find_first_compute_user(target_wait_node)
+            target_compute_node.append(reload_node)
+
+            # Enforce staggering in Inductor's scheduler by making this reload depend on target_compute_node
+            args = list(reload_node.args)
+            while len(args) < 3:
+                args.append(None)
+            args[2] = target_compute_node
+            reload_node.args = tuple(args)
 
 
 def _calculate_transfer_size(device_put_node: fx.Node) -> int:

--- a/torch/_functorch/_activation_offloading/activation_offloading.py
+++ b/torch/_functorch/_activation_offloading/activation_offloading.py
@@ -13,7 +13,10 @@ import torch
 import torch.fx as fx
 from torch._functorch._activation_offloading.offload_ops import (  # noqa: F401 -- registers ao::offload, ao::reload, ao::wait_tensor ops
     offload,
+    record_stream_event,
     reload,
+    reload_after,
+    reload_inplace,
     wait_tensor,
 )
 from torch._inductor.fx_passes.overlap_scheduling import benchmark_node, is_compute_node
@@ -42,7 +45,7 @@ def _find_all_effective_users(node: fx.Node, op_types: OpTypes) -> OrderedSet[fx
         if user.op == "output":
             continue
         effective_users.add(user)
-        if op_types.is_view(user):
+        if op_types.is_view(user) or user.target == torch.ops.aten._unsafe_view.default:
             effective_users.update(_find_all_effective_users(user, op_types))
     return effective_users
 
@@ -232,7 +235,7 @@ def offload_activation_fw_async(graph: fx.Graph) -> None:
         with graph.inserting_after(offload_node):
             wait_node: fx.Node = graph.call_function(
                 torch.ops.ao.wait_tensor.default,
-                args=(offload_node, node),
+                args=(offload_node, node, last_user),
                 name=CPU_OFFLOAD_PREFIX + str(node.name),
             )
             wait_node.meta["val"] = offload_node.meta["val"]
@@ -517,10 +520,9 @@ def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
     ao.wait_tensor at its original position.
     """
     graph: fx.Graph = bwd_module.graph
-    nodes_list: list[fx.Node] = list(graph.nodes)
 
-    # Identify reload + wait pairs
-    reload_patterns: dict[fx.Node, ReloadNodeInfo] = {}
+    reload_nodes: list[fx.Node] = []
+    wait_nodes: list[fx.Node] = []
     for node in graph.nodes:
         if not (
             node.op == "call_function" and node.target == torch.ops.ao.reload.default
@@ -530,18 +532,95 @@ def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
             (u for u in node.users if u.target == torch.ops.ao.wait_tensor.default),
             None,
         )
-        if wait_node is None:
-            continue
-        transfer_size_bytes: int = _calculate_transfer_size(node)
-        transfer_time_ms: float = _estimate_transfer_time_in_ms(transfer_size_bytes)
-        reload_patterns[node] = ReloadNodeInfo(
-            reload_group_nodes=[node],
-            wait_event_node=wait_node,
-            transfer_size_bytes=transfer_size_bytes,
-            transfer_time_ms=transfer_time_ms,
-        )
+        if wait_node is not None:
+            reload_nodes.append(node)
+            wait_nodes.append(wait_node)
 
-    reorder_for_prefetch(nodes_list, reload_patterns)
+    if not reload_nodes:
+        return
+
+    placeholders = graph.find_nodes(op="placeholder")
+    if not placeholders:
+        return
+    last_placeholder = placeholders[-1]
+
+    window = config.activation_reload_prefetch_window
+    if window < 0:
+        raise ValueError(
+            f"activation_reload_prefetch_window must be >= 0, got {window}"
+        )
+    if window == 0:
+        window = len(reload_nodes)
+
+    # The reload inputs are saved CPU activation placeholders, so a small initial
+    # window can be issued as soon as backward starts. Later reloads are inserted
+    # after compute-stream release events from earlier reloaded activations. This
+    # keeps the host from allocating every reload destination at backward entry.
+    for reload_node in reversed(reload_nodes[:window]):
+        last_placeholder.append(reload_node)
+
+    op_types: OpTypes = get_default_op_list()
+    for idx, reload_node in enumerate(reload_nodes[window:]):
+        release_wait_node = wait_nodes[idx]
+        target_wait_node = wait_nodes[idx + window]
+        nodes_list = list(graph.nodes)
+        node_to_index = {node: node_idx for node_idx, node in enumerate(nodes_list)}
+        release_users = _find_all_effective_users(release_wait_node, op_types)
+        release_point = (
+            max(release_users, key=lambda n: node_to_index[n])
+            if release_users
+            else release_wait_node
+        )
+        with graph.inserting_after(release_point):
+            release_token = graph.call_function(
+                torch.ops.ao.record_stream_event.default,
+                args=(release_wait_node,),
+                name=f"release_{release_wait_node.name}",
+            )
+            release_token.meta["val"] = torch.empty((), device="cpu")
+            release_token.meta["tensor_meta"] = extract_tensor_metadata(
+                release_token.meta["val"]
+            )
+
+        reload_val = reload_node.meta["val"]
+        reuse_val = release_wait_node.meta["val"]
+        if (
+            reload_val.shape == reuse_val.shape
+            and reload_val.stride() == reuse_val.stride()
+            and reload_val.dtype == reuse_val.dtype
+        ):
+            reload_node.target = torch.ops.ao.reload_inplace.default
+            reload_node.args = (
+                reload_node.args[0],
+                release_wait_node,
+                release_token,
+            )
+            reload_node.meta["val"] = torch.empty((), device="cpu")
+            reload_node.meta["tensor_meta"] = extract_tensor_metadata(
+                reload_node.meta["val"]
+            )
+            target_wait_node.args = (
+                release_wait_node,
+                target_wait_node.args[1],
+                reload_node,
+            )
+        else:
+            reload_node.target = torch.ops.ao.reload_after.default
+            reload_node.args = (
+                reload_node.args[0],
+                reload_node.args[1],
+                release_token,
+            )
+        release_token.append(reload_node)
+
+    # Make the one-activation lookahead explicit in dataflow so later compiler
+    # scheduling cannot sink a reload back to its own wait.
+    for idx, wait_node in enumerate(wait_nodes[:-1]):
+        wait_args = list(wait_node.args)
+        while len(wait_args) < 4:
+            wait_args.append(None)
+        wait_args[3] = reload_nodes[idx + 1]
+        wait_node.args = tuple(wait_args)
 
 
 def _calculate_transfer_size(device_put_node: fx.Node) -> int:

--- a/torch/_functorch/_activation_offloading/activation_offloading.py
+++ b/torch/_functorch/_activation_offloading/activation_offloading.py
@@ -16,6 +16,10 @@ from torch._functorch._activation_offloading.offload_ops import (  # noqa: F401 
     reload,
     wait_tensor,
 )
+from torch._inductor.fx_passes.control_dependencies import (
+    add_order_only_dependency,
+    apply_order_only_dependencies,
+)
 from torch._inductor.fx_passes.overlap_scheduling import benchmark_node, is_compute_node
 from torch._subclasses.fake_tensor import extract_tensor_metadata
 from torch.utils._ordered_set import OrderedSet
@@ -383,7 +387,9 @@ def can_offload(
     if node in static_lifetime_input_nodes:
         log.debug("\tSkipped! Cannot offload static input nodes.")
         return False
-    if op_types.is_view(node):
+    if op_types.is_view(node) and not node.meta.get(
+        "allow_activation_offload_view", False
+    ):
         log.debug("\tSkipped! Cannot offload views.")
         return False
     if node.target == operator.getitem:
@@ -565,14 +571,14 @@ def activation_offload_sink_wait_async(fwd_module: fx.GraphModule) -> None:
     # prepend moves the node from its current position (no manual removal needed)
     for wait_node in wait_nodes_to_sink:
         if prefetch_dep is not None:
-            # We must use prefetch_dependency to force the Inductor scheduler
-            # to schedule this wait_tensor node at the end of the graph.
-            args = list(wait_node.args)
-            while len(args) < 4:
-                args.append(None)
-            args[3] = prefetch_dep
-            wait_node.args = tuple(args)
+            # Order-only edge: force the Inductor scheduler to place wait_tensor
+            # after the last compute node, without adding a real tensor argument
+            # that would otherwise keep the dep alive across the wait.
+            add_order_only_dependency(wait_node, prefetch_dep)
         output_node.prepend(wait_node)
+
+    if prefetch_dep is not None:
+        apply_order_only_dependencies(graph)
 
 
 def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
@@ -607,10 +613,9 @@ def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
     # Sort pairs chronologically based on their wait_node's index in the graph
     pairs.sort(key=lambda p: node_to_idx[p[1]])
 
-    # Get prefetch window
-    W = config.activation_reload_prefetch_window
-    if W <= 0:
-        W = 1
+    # Always prefetch one layer ahead. Larger windows submit H2Ds too early and
+    # do not match the intended staggered reload pipeline.
+    W = 1
 
     # Place the reload nodes
     placeholders = [n for n in graph.nodes if n.op == "placeholder"]
@@ -647,23 +652,62 @@ def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
 
         return wait_node
 
+    def is_real_compute_node(node: fx.Node) -> bool:
+        if node.op != "call_function":
+            return False
+        if node.target in (
+            torch.ops.ao.offload.default,
+            torch.ops.ao.reload.default,
+            torch.ops.ao.wait_tensor.default,
+        ):
+            return False
+        is_view = (
+            node.target in _LIFETIME_TRANSPARENT_TARGETS
+            or "view" in str(node.target)
+            or "reshape" in str(node.target)
+            or "permute" in str(node.target)
+            or "transpose" in str(node.target)
+            or node.target == operator.getitem
+        )
+        return not is_view
+
+    def find_compute_before(node: fx.Node) -> fx.Node | None:
+        node_idx = node_to_idx.get(node)
+        if node_idx is None:
+            return None
+        for prev in reversed(nodes_list[:node_idx]):
+            if is_real_compute_node(prev):
+                return prev
+        return None
+
     for i, (reload_node, wait_node) in enumerate(pairs):
         if i < W:
             # Place reload node right after the last placeholder (start of backward)
             start_node.append(reload_node)
             start_node = reload_node
         else:
-            # Place reload node immediately after a compute user of the pair W steps ahead
+            # Submit each reload right after the previous reload is consumed.
+            # ao.reload then waits for the compute stream up to this point only,
+            # so the H2D copy can overlap the next layer's backward compute.
             _, target_wait_node = pairs[i - W]
             target_compute_node = find_first_compute_user(target_wait_node)
-            target_compute_node.append(reload_node)
+            consumer_compute_node = find_first_compute_user(wait_node)
+            pre_consumer_compute_node = find_compute_before(consumer_compute_node)
+            target_wait_node.append(reload_node)
+            add_order_only_dependency(wait_node, target_compute_node)
+            if pre_consumer_compute_node is not None:
+                add_order_only_dependency(wait_node, pre_consumer_compute_node)
 
-            # Enforce staggering in Inductor's scheduler by making this reload depend on target_compute_node
+            # Stagger transfer-stream submissions: ao.reload reads
+            # prefetch_dependency only to wait for the current stream at this
+            # graph point. Must be a single Tensor.
             args = list(reload_node.args)
             while len(args) < 3:
                 args.append(None)
-            args[2] = target_compute_node
+            args[2] = target_wait_node
             reload_node.args = tuple(args)
+
+    apply_order_only_dependencies(graph)
 
 
 def _calculate_transfer_size(device_put_node: fx.Node) -> int:
@@ -915,8 +959,11 @@ def enable_activation_offloading(
         offload_chosen_sets_async(fwd_module, bwd_module)
         if config.activation_offload_sink_wait:
             activation_offload_sink_wait_async(fwd_module)
-        if config.activation_reload_prefetch:
-            activation_reload_prefetch_async(bwd_module)
+        # Bwd reload prefetch is mandatory under separate-stream offload.
+        # Without it, the natural reload placement under sink_wait produces
+        # wrong gradients (the reload-result lifetimes are too short, and
+        # the wait registry can't sequence the H2D pile correctly).
+        activation_reload_prefetch_async(bwd_module)
     else:
         # Use synchronous device_put (1 node each)
         offload_chosen_sets(fwd_module, bwd_module)

--- a/torch/_functorch/_activation_offloading/activation_offloading.py
+++ b/torch/_functorch/_activation_offloading/activation_offloading.py
@@ -7,7 +7,6 @@ applied to graphs produced by both AOT Autograd partitioners and make_fx-based t
 
 import logging
 import operator
-from dataclasses import dataclass
 
 import torch
 import torch.fx as fx
@@ -20,12 +19,12 @@ from torch._inductor.fx_passes.control_dependencies import (
     add_order_only_dependency,
     apply_order_only_dependencies,
 )
-from torch._inductor.fx_passes.overlap_scheduling import benchmark_node, is_compute_node
 from torch._subclasses.fake_tensor import extract_tensor_metadata
 from torch.utils._ordered_set import OrderedSet
+from torch.utils.checkpoint import CheckpointPolicy
 
 from .. import config
-from ..partitioners import _size_of, get_default_op_list, OpTypes
+from ..partitioners import get_default_op_list, OpTypes
 
 
 log: logging.Logger = logging.getLogger(__name__)
@@ -35,6 +34,7 @@ log: logging.Logger = logging.getLogger(__name__)
 # NOTE: right now we are using these prefixes as identifiers for offload/reload
 CPU_OFFLOAD_PREFIX = "cpu_offload_"
 GPU_RELOAD_PREFIX = "gpu_reload_"
+FORWARD_OFFLOAD_WAIT_DISTANCE = 4
 
 
 _LIFETIME_TRANSPARENT_TARGETS = (
@@ -63,39 +63,6 @@ def _find_all_effective_users(node: fx.Node, op_types: OpTypes) -> OrderedSet[fx
         else:
             effective_users.update(_find_all_effective_users(user, op_types))
     return effective_users
-
-
-@dataclass
-class ReloadNodeInfo:
-    """
-    Information about backward reload related nodes for each reload operation.
-
-    Pattern: ao.reload → ao.wait_tensor
-
-    - Reload group (ao.reload): Performs the actual asynchronous data transfer.
-      Can be moved earlier in the graph to overlap with computation.
-    - Wait node (ao.wait_tensor): Synchronization point that blocks until the data
-      transfer completes. Must remain at the point where the data is first needed.
-    """
-
-    reload_group_nodes: list[fx.Node]
-    wait_event_node: fx.Node
-    transfer_size_bytes: int
-    transfer_time_ms: float
-
-
-@dataclass
-class ReloadQueueEntry:
-    """
-    Entry in the reload queue for prefetch scheduling.
-
-    Attributes:
-        pattern: The reload pattern information
-        remaining_time_ms: Remaining overlap time needed in milliseconds
-    """
-
-    pattern: ReloadNodeInfo
-    remaining_time_ms: float
 
 
 def offload_activation_fw(graph: fx.Graph) -> None:
@@ -239,13 +206,10 @@ def offload_activation_fw_async(graph: fx.Graph) -> None:
             last_user: fx.Node = node
 
         # Push the offload one hop further: past the downstream ops of the
-        # last consumer. Without keepalive, the GPU buffer is freed right after
-        # offload and enters the allocator's record_stream pending queue. If
-        # the very next op (e.g., down-proj mm) allocates a large output, the
-        # allocator may grab the pending block and insert cudaStreamWaitEvent,
-        # stalling compute. Pushing past that op lets the D2H overlap with
-        # later compute (attention, next layer) where no conflicting allocation
-        # occurs.
+        # last consumer. If the very next op (e.g., down-proj mm) allocates a
+        # large output, the allocator may otherwise need to wait on the D2H
+        # stream before reusing memory. Pushing past that op lets the D2H
+        # overlap with later compute (attention, next layer).
         if downstream := _find_all_effective_users(last_user, op_types):
             insert_after = max(downstream, key=lambda n: node_to_index[n])
         else:
@@ -261,15 +225,14 @@ def offload_activation_fw_async(graph: fx.Graph) -> None:
             offload_node.meta["tensor_meta"] = extract_tensor_metadata(
                 offload_node.meta["val"]
             )
-        # No keepalive: the GPU tensor is freed right after offload, exactly as
-        # activation checkpointing would free it after the last forward consumer.
-        # The offload op's set_stream + copy_ triggers record_stream on the GPU
-        # tensor, which guards the D2H window — the allocator won't reuse the
-        # block until the transfer stream finishes reading it.
+        # Keep the source storage live until the sunk wait runs. record_stream
+        # protects allocator reuse, but Inductor can also reuse planned buffers
+        # within the compiled graph; this edge prevents an async D2H from
+        # reading a buffer after later forward compute has overwritten it.
         with graph.inserting_after(offload_node):
             wait_node: fx.Node = graph.call_function(
                 torch.ops.ao.wait_tensor.default,
-                args=(offload_node,),
+                args=(offload_node, None, node),
                 name=CPU_OFFLOAD_PREFIX + str(node.name),
             )
             wait_node.meta["val"] = offload_node.meta["val"]
@@ -337,7 +300,7 @@ def can_offload(
     fwd_outputs: OrderedSet[fx.Node],
     model_outputs: OrderedSet[fx.Node],
     static_lifetime_input_nodes: OrderedSet[fx.Node],
-) -> bool:
+) -> tuple[bool, str | None]:
     """
     Determine if a node can be offloaded to CPU.
 
@@ -379,32 +342,38 @@ def can_offload(
     op_types: OpTypes = get_default_op_list()
 
     if node not in fwd_outputs:
-        log.debug("\tSkipped! Can only offload nodes in fwd_module_outputs.")
-        return False
+        reason = "can only offload nodes in forward module outputs"
+        log.debug("\tSkipped! %s", reason)
+        return False, reason
     if node in model_outputs:
-        log.debug("\tSkipped! Cannot offload model outputs.")
-        return False
+        reason = "cannot offload model outputs"
+        log.debug("\tSkipped! %s", reason)
+        return False, reason
     if node in static_lifetime_input_nodes:
-        log.debug("\tSkipped! Cannot offload static input nodes.")
-        return False
+        reason = "cannot offload static input nodes"
+        log.debug("\tSkipped! %s", reason)
+        return False, reason
     if op_types.is_view(node) and not node.meta.get(
         "allow_activation_offload_view", False
     ):
-        log.debug("\tSkipped! Cannot offload views.")
-        return False
+        reason = "cannot offload views"
+        log.debug("\tSkipped! %s", reason)
+        return False, reason
     if node.target == operator.getitem:
-        log.debug("\tSkipped! Cannot offload getitems.")
-        return False
+        reason = "cannot offload getitems"
+        log.debug("\tSkipped! %s", reason)
+        return False, reason
     if hasattr(node, "meta") and "val" in node.meta:
         if (
             isinstance(val := node.meta["val"], torch.Tensor)
             and not val.is_contiguous()
         ):
-            log.debug("\tSkipped! Cannot offload non-contiguous tensors.")
-            return False
+            reason = "cannot offload non-contiguous tensors"
+            log.debug("\tSkipped! %s", reason)
+            return False, reason
 
     log.debug("\tGood!")
-    return True
+    return True, None
 
 
 def choose_offload_sets(
@@ -434,12 +403,20 @@ def choose_offload_sets(
 
     should_perform_offloading = False
     for node in fwd_module.graph.nodes:
-        if node.meta.get("should_offload", False) and can_offload(
+        if not node.meta.get("should_offload", False):
+            continue
+        offloadable, reason = can_offload(
             node, fwd_outputs, model_outputs, static_lifetime_input_nodes
-        ):
+        )
+        if offloadable:
             node.meta["saved_for_offloading"] = True
             node.meta["original_device"] = node.meta["val"].device
             should_perform_offloading = True
+        elif node.meta.get("recompute") == CheckpointPolicy.MUST_CPU_OFFLOAD:
+            raise RuntimeError(
+                f"CheckpointPolicy.MUST_CPU_OFFLOAD cannot be honored for "
+                f"{node.name}: {reason}."
+            )
 
     return should_perform_offloading
 
@@ -543,15 +520,12 @@ def find_last_compute_node(graph: fx.Graph) -> fx.Node | None:
 
 
 def activation_offload_sink_wait_async(fwd_module: fx.GraphModule) -> None:
-    """Sink ao.wait_tensor operations for offload completion to the end of the graph.
+    """Pipeline ao.wait_tensor operations for offload completion.
 
-    This allows computation to overlap with offload operations.
-
-    NOTE: Sinking waits to the end delays GPU memory release of the source
-    tensor (kept alive via the wait's keepalive arg) until the end of the
-    compiled graph. For per-layer compile this is fine (one layer's worth of
-    memory), but for full-model compile this means offloaded GPU tensors are
-    not freed until the entire forward pass completes.
+    Each wait is moved after a few later offloads have been submitted, giving
+    the D2H copy overlap while keeping the source storage live only until its
+    transfer completion is observed. The final waits fall back to the last
+    forward compute node.
     """
     graph: fx.Graph = fwd_module.graph
     output_node: fx.Node = graph.find_nodes(op="output")[0]
@@ -566,27 +540,43 @@ def activation_offload_sink_wait_async(fwd_module: fx.GraphModule) -> None:
         and node.args[0].target == torch.ops.ao.offload.default
     ]
 
-    prefetch_dep = find_last_compute_node(graph)
+    last_compute = find_last_compute_node(graph)
+    node_to_idx = {node: idx for idx, node in enumerate(graph.nodes)}
 
-    # prepend moves the node from its current position (no manual removal needed)
-    for wait_node in wait_nodes_to_sink:
-        if prefetch_dep is not None:
-            # Order-only edge: force the Inductor scheduler to place wait_tensor
-            # after the last compute node, without adding a real tensor argument
-            # that would otherwise keep the dep alive across the wait.
-            add_order_only_dependency(wait_node, prefetch_dep)
-        output_node.prepend(wait_node)
+    for i, wait_node in enumerate(wait_nodes_to_sink):
+        offload_node = wait_node.args[0]
+        if not isinstance(offload_node, fx.Node):
+            raise RuntimeError(
+                f"Expected ao.wait_tensor input to be an FX node, got {offload_node!r}"
+            )
+        target_idx = i + FORWARD_OFFLOAD_WAIT_DISTANCE
+        if target_idx < len(wait_nodes_to_sink):
+            anchor_offload_node = wait_nodes_to_sink[target_idx].args[0]
+            if not isinstance(anchor_offload_node, fx.Node):
+                raise RuntimeError(
+                    "Expected pipelined ao.wait_tensor input to be an FX node, "
+                    f"got {anchor_offload_node!r}"
+                )
+            wait_anchor = anchor_offload_node
+        else:
+            wait_anchor = last_compute
+        if wait_anchor is None or node_to_idx[wait_anchor] < node_to_idx[offload_node]:
+            wait_anchor = offload_node
 
-    if prefetch_dep is not None:
-        apply_order_only_dependencies(graph)
+        if wait_anchor is not None:
+            add_order_only_dependency(wait_node, wait_anchor)
+            wait_anchor.append(wait_node)
+        else:
+            output_node.prepend(wait_node)
+
+    apply_order_only_dependencies(graph)
 
 
 def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
     """
-    Prefetch backward reload operations structurally using a prefetch window.
-    Places each reload node W steps ahead of its corresponding wait_tensor node,
-    and enforces staggering in Inductor's scheduler by making the reload node
-    depend on a backward compute node of the prior layer.
+    Prefetch backward reload operations using a fixed one-step pipeline.
+    Each reload is submitted after the previous offloaded activation reaches
+    its wait point, which staggers H2D copies through backward compute.
     """
     graph: fx.Graph = bwd_module.graph
     nodes_list: list[fx.Node] = list(graph.nodes)
@@ -633,22 +623,18 @@ def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
             visited.add(curr)
 
             if curr != wait_node:
-                is_view = (
-                    curr.op == "call_function"
-                    and (
-                        curr.target in _LIFETIME_TRANSPARENT_TARGETS
-                        or "view" in str(curr.target)
-                        or "reshape" in str(curr.target)
-                        or "permute" in str(curr.target)
-                        or "transpose" in str(curr.target)
-                        or curr.target == operator.getitem
-                    )
+                is_view = curr.op == "call_function" and (
+                    curr.target in _LIFETIME_TRANSPARENT_TARGETS
+                    or "view" in str(curr.target)
+                    or "reshape" in str(curr.target)
+                    or "permute" in str(curr.target)
+                    or "transpose" in str(curr.target)
+                    or curr.target == operator.getitem
                 )
                 if curr.op == "call_function" and not is_view:
                     return curr
 
-            for user in curr.users:
-                queue.append(user)
+            queue.extend(curr.users)
 
         return wait_node
 
@@ -675,7 +661,8 @@ def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
         node_idx = node_to_idx.get(node)
         if node_idx is None:
             return None
-        for prev in reversed(nodes_list[:node_idx]):
+        for idx in range(node_idx - 1, -1, -1):
+            prev = nodes_list[idx]
             if is_real_compute_node(prev):
                 return prev
         return None
@@ -710,223 +697,47 @@ def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
     apply_order_only_dependencies(graph)
 
 
-def _calculate_transfer_size(device_put_node: fx.Node) -> int:
-    """Calculate the size in bytes of data being transferred."""
-
-    # ao.offload(tensor) -> tensor at args[0]
-    # ao.reload(tensor, device) -> tensor at args[0]
-    if device_put_node.target in (
-        torch.ops.ao.offload.default,
-        torch.ops.ao.reload.default,
-    ):
-        return _size_of(device_put_node.args[0])  # pyrefly: ignore [bad-argument-type]
-    raise ValueError(f"Unexpected transfer op: {device_put_node.target}")
-
-
-def _estimate_transfer_time_in_ms(transfer_size_bytes: int) -> float:
-    """Estimate transfer time in milliseconds based on size and bandwidth.
-
-    Uses config.activation_offload_cpu_gpu_bw (GB/s) which should be set by
-    the user to match their hardware.
-    """
-    return (
-        transfer_size_bytes / (1024**3) * 1_000 / config.activation_offload_cpu_gpu_bw
-    )
+def _validate_topological_order(graph: fx.Graph) -> None:
+    seen: set[fx.Node] = set()
+    for node in graph.nodes:
+        missing = [dep.name for dep in node.all_input_nodes if dep not in seen]
+        if missing:
+            raise RuntimeError(
+                f"Activation offload rewrite produced non-topological node "
+                f"{node.name}; missing dependencies: {missing}"
+            )
+        seen.add(node)
 
 
-def identify_reload_patterns(
-    graph: fx.Graph, nodes_list: list[fx.Node], node_to_idx: dict[fx.Node, int]
-) -> dict[fx.Node, ReloadNodeInfo]:
-    """
-    Identify backward reload patterns in the graph.
-
-    Pattern: fork → wait_stream → device_put → record_event → join → wait_event
-
-    This uses position-based matching since these nodes are inserted together in
-    add_backward_reload_stream_ops() in a specific order. Since stream operations
-    do not have data dependencies between them, they are unsuitable for subgroup
-    pattern matching type of checks.
-
-    Returns a dict mapping device_put node to ReloadNodeInfo containing:
-    - reload_group_nodes: fork → wait_stream → device_put → record_event → join
-    - wait_event_node: the wait_event node
-    - transfer_size_bytes: size of data being transferred
-    - transfer_time_ms: estimated transfer time in milliseconds
-    """
-    patterns: dict[fx.Node, ReloadNodeInfo] = {}
-
-    # Find all GPU reload device_put nodes whose inputs are placeholder nodes
-    reload_nodes: list[fx.Node] = [
-        node
-        for node in graph.find_nodes(
-            op="call_function", target=torch.ops.prims.device_put.default
-        )
-        if GPU_RELOAD_PREFIX in node.name
-        and (
-            node.args
-            and isinstance(node.args[0], fx.Node)
-            and node.args[0].op == "placeholder"
-        )
-    ]
-
-    # Extract patterns for each reload device_put node
-    for reload_node in reload_nodes:
-        reload_node_idx: int = node_to_idx[reload_node]
-
-        fork_node: fx.Node = nodes_list[reload_node_idx - 2]
-        wait_stream_node: fx.Node = nodes_list[reload_node_idx - 1]
-        record_event_node: fx.Node = nodes_list[reload_node_idx + 1]
-        join_node: fx.Node = nodes_list[reload_node_idx + 2]
-        wait_event_node: fx.Node = nodes_list[reload_node_idx + 3]
-
-        # Calculate transfer size and time
-        transfer_size_bytes: int = _calculate_transfer_size(reload_node)
-        transfer_time_ms: float = _estimate_transfer_time_in_ms(transfer_size_bytes)
-
-        patterns[reload_node] = ReloadNodeInfo(
-            reload_group_nodes=[
-                fork_node,
-                wait_stream_node,
-                reload_node,
-                record_event_node,
-                join_node,
-            ],
-            wait_event_node=wait_event_node,
-            transfer_size_bytes=transfer_size_bytes,
-            transfer_time_ms=transfer_time_ms,
-        )
-
-    return patterns
-
-
-def reorder_for_prefetch(
-    nodes_list: list[fx.Node],
-    reload_patterns: dict[fx.Node, ReloadNodeInfo],
+def _validate_transfer_wait_pairs(
+    graph: fx.Graph,
+    transfer_op,
+    label: str,
 ) -> None:
-    """
-    Reorder nodes to prefetch reload operations by directly manipulating the graph.
-
-    This follows the algorithm as follows:
-    - Go through nodes in reverse order
-    - When encountering a reload pattern, add it to a queue with its transfer time
-    - When encountering a compute node, use its runtime to satisfy overlap requirements
-    - Place reload patterns when their overlap requirement is satisfied
-    - When encountering placeholder nodes, flush queue as reloads cannot move before inputs
-    """
-
-    # Build a set of all nodes in reload groups for quick lookup
-    reload_group_nodes_set: set[fx.Node] = set()
-    for pattern in reload_patterns.values():
-        reload_group_nodes_set.update(pattern.reload_group_nodes)
-
-    # Queue to hold reload group nodes waiting to be placed (FIFO)
-    reload_queue: list[ReloadQueueEntry] = []
-
-    # Loop through nodes in reverse
-    for node in reversed(nodes_list):
-        if node.op == "output":
+    for node in graph.nodes:
+        if node.op != "call_function" or node.target != transfer_op:
             continue
-        elif node.op == "placeholder":
-            # Flush queue - place all remaining reloads after the last placeholder
-            while reload_queue:
-                entry: ReloadQueueEntry = reload_queue.pop(0)
-                for reload_group_node in reversed(entry.pattern.reload_group_nodes):
-                    node.append(reload_group_node)
-            break
-        elif node in reload_patterns:
-            pattern: ReloadNodeInfo = reload_patterns[node]
-            reload_queue.append(
-                ReloadQueueEntry(
-                    pattern=pattern, remaining_time_ms=pattern.transfer_time_ms
-                )
-            )
-        elif node in reload_group_nodes_set:
-            continue
-        else:
-            if not reload_queue:
-                continue
-            compute_runtime_ms: float = (
-                benchmark_node(node) if is_compute_node(node) else 0
-            )
-            reload_queue[0].remaining_time_ms -= compute_runtime_ms
-
-            # Pop and place reload if its remaining time is satisfied (<= 0)
-            if reload_queue[0].remaining_time_ms <= 0:
-                entry: ReloadQueueEntry = reload_queue.pop(0)
-                for reload_group_node in entry.pattern.reload_group_nodes:
-                    node.prepend(reload_group_node)
-
-
-def activation_offload_sink_wait(fwd_module: fx.GraphModule) -> None:
-    """
-    Sink wait_event operations for offload completion to the end of the graph.
-
-    This function identifies wait_event nodes for offload completion and moves them
-    to the end of the graph, allowing computation to overlap with offload operations.
-
-    Args:
-        fwd_module: Forward module graph
-    """
-    graph: fx.Graph = fwd_module.graph
-    nodes_list: list[fx.Node] = list(graph.nodes)
-    node_to_idx: dict[fx.Node, int] = {node: idx for idx, node in enumerate(nodes_list)}
-
-    # Find all CPU offload device_put nodes
-    offload_nodes: list[fx.Node] = [
-        node
-        for node in graph.find_nodes(
-            op="call_function", target=torch.ops.prims.device_put.default
-        )
-        if CPU_OFFLOAD_PREFIX in node.name
-    ]
-
-    # Collect all wait_event nodes that need to be moved
-    wait_nodes_to_sink: list[fx.Node] = []
-    for offload_node in offload_nodes:
-        offload_idx: int = node_to_idx[offload_node]
-        wait_event_node: fx.Node = nodes_list[offload_idx + 3]
-
-        # Validate it's actually a wait_event node
-        if not (
-            wait_event_node.op == "call_function"
-            and wait_event_node.target == torch.ops.streams.wait_event.default
-        ):
-            raise ValueError(
-                f"Expected wait_event node three positions after {offload_node.name}"
+        waits = [
+            user
+            for user in node.users
+            if user.op == "call_function"
+            and user.target == torch.ops.ao.wait_tensor.default
+            and user.args
+            and user.args[0] is node
+        ]
+        if len(waits) != 1:
+            raise RuntimeError(
+                f"Expected exactly one ao.wait_tensor for ao.{label} "
+                f"{node.name}, found {len(waits)}"
             )
 
-        wait_nodes_to_sink.append(wait_event_node)
 
-    # Find the output node, and move all wait_event nodes to just before the output node
-    output_node: fx.Node = graph.find_nodes(op="output")[0]
-    for wait_node in wait_nodes_to_sink:
-        output_node.prepend(wait_node)
-
-
-def activation_reload_prefetch(bwd_module: fx.GraphModule) -> None:
-    """
-    Prefetch backward reload operations by moving them earlier in the graph
-    to overlap communication with computation.
-
-    This function identifies backward reload patterns (fork → wait_stream → device_put →
-    record_event → join) and moves them earlier in the execution order to overlap
-    the data transfer with computation, while keeping the wait_event at its original
-    position.
-
-    Args:
-        bwd_module: Backward module graph
-    """
-    graph: fx.Graph = bwd_module.graph
-    nodes_list: list[fx.Node] = list(graph.nodes)
-    node_to_idx: dict[fx.Node, int] = {node: idx for idx, node in enumerate(nodes_list)}
-
-    # Step 1: Identify reload patterns
-    reload_patterns: dict[fx.Node, ReloadNodeInfo] = identify_reload_patterns(
-        graph, nodes_list, node_to_idx
-    )
-
-    # Step 2: Reorder nodes by directly manipulating the graph
-    reorder_for_prefetch(nodes_list, reload_patterns)
+def _validate_async_ao_graph(
+    fwd_module: fx.GraphModule,
+    bwd_module: fx.GraphModule,
+) -> None:
+    _validate_topological_order(fwd_module.graph)
+    _validate_topological_order(bwd_module.graph)
 
 
 def enable_activation_offloading(
@@ -934,6 +745,8 @@ def enable_activation_offloading(
     bwd_module: fx.GraphModule,
     num_fwd_outputs: int,
     static_lifetime_input_nodes: OrderedSet[fx.Node],
+    *,
+    force_async: bool = False,
 ) -> None:
     """
     Main entry point for activation offloading.
@@ -954,16 +767,30 @@ def enable_activation_offloading(
         return
 
     # Step 2: Add offload and reload nodes to the graphs
-    if config.activation_offload_separate_stream:
+    use_async = force_async or config.activation_offload_separate_stream
+    sink_forward_waits = force_async or config.activation_offload_sink_wait
+
+    if use_async:
         # Use async ao ops (2 nodes each: offload/reload + wait_tensor)
         offload_chosen_sets_async(fwd_module, bwd_module)
-        if config.activation_offload_sink_wait:
+        _validate_transfer_wait_pairs(
+            fwd_module.graph,
+            torch.ops.ao.offload.default,
+            "offload",
+        )
+        _validate_transfer_wait_pairs(
+            bwd_module.graph,
+            torch.ops.ao.reload.default,
+            "reload",
+        )
+        if sink_forward_waits:
             activation_offload_sink_wait_async(fwd_module)
         # Bwd reload prefetch is mandatory under separate-stream offload.
         # Without it, the natural reload placement under sink_wait produces
         # wrong gradients (the reload-result lifetimes are too short, and
         # the wait registry can't sequence the H2D pile correctly).
         activation_reload_prefetch_async(bwd_module)
+        _validate_async_ao_graph(fwd_module, bwd_module)
     else:
         # Use synchronous device_put (1 node each)
         offload_chosen_sets(fwd_module, bwd_module)

--- a/torch/_functorch/_activation_offloading/activation_offloading.py
+++ b/torch/_functorch/_activation_offloading/activation_offloading.py
@@ -13,10 +13,7 @@ import torch
 import torch.fx as fx
 from torch._functorch._activation_offloading.offload_ops import (  # noqa: F401 -- registers ao::offload, ao::reload, ao::wait_tensor ops
     offload,
-    record_stream_event,
     reload,
-    reload_after,
-    reload_inplace,
     wait_tensor,
 )
 from torch._inductor.fx_passes.overlap_scheduling import benchmark_node, is_compute_node
@@ -36,16 +33,30 @@ CPU_OFFLOAD_PREFIX = "cpu_offload_"
 GPU_RELOAD_PREFIX = "gpu_reload_"
 
 
+_LIFETIME_TRANSPARENT_TARGETS = (
+    torch.ops.aten._unsafe_view.default,
+    torch.ops.aten.unbind.int,
+    torch.ops.aten.split.Tensor,
+    torch.ops.aten.split_with_sizes.default,
+    operator.getitem,
+)
+
+
 def _find_all_effective_users(node: fx.Node, op_types: OpTypes) -> OrderedSet[fx.Node]:
-    """Find all effective users of a node, where view ops extend the lifetime
-    of the original node. If a user is a view op, recursively find users of
-    the view."""
+    """Find all effective users of a node, where view-like ops extend the lifetime
+    of the original node. Views and multi-output split-like ops (unbind/split) are
+    transparent: we recurse through them so the "last user" we pick is always a
+    real consumer that produces a single Tensor, never a list-producing node."""
     effective_users: OrderedSet[fx.Node] = OrderedSet()
     for user in node.users:
         if user.op == "output":
             continue
-        effective_users.add(user)
-        if op_types.is_view(user) or user.target == torch.ops.aten._unsafe_view.default:
+        is_transparent = (
+            op_types.is_view(user) or user.target in _LIFETIME_TRANSPARENT_TARGETS
+        )
+        if not is_transparent:
+            effective_users.add(user)
+        else:
             effective_users.update(_find_all_effective_users(user, op_types))
     return effective_users
 
@@ -191,6 +202,10 @@ def reload_activation_bw(graph: fx.Graph) -> None:
 def offload_activation_fw_async(graph: fx.Graph) -> None:
     """Insert async CPU offload operations in the forward pass graph.
 
+    Places the offload (D2H copy) after the last effective consumer of the
+    activation so the transfer overlaps with subsequent compute. The wait_tensor
+    is later sunk to the end of the graph by activation_offload_sink_wait_async.
+
     Uses ao.offload + ao.wait_tensor ops which encapsulate stream management
     internally, producing a clean 2-node IR per offloaded tensor.
     """
@@ -219,7 +234,20 @@ def offload_activation_fw_async(graph: fx.Graph) -> None:
         else:
             last_user: fx.Node = node
 
-        with graph.inserting_after(last_user):
+        # Push the offload one hop further: past the downstream ops of the
+        # last consumer. Without keepalive, the GPU buffer is freed right after
+        # offload and enters the allocator's record_stream pending queue. If
+        # the very next op (e.g., down-proj mm) allocates a large output, the
+        # allocator may grab the pending block and insert cudaStreamWaitEvent,
+        # stalling compute. Pushing past that op lets the D2H overlap with
+        # later compute (attention, next layer) where no conflicting allocation
+        # occurs.
+        if downstream := _find_all_effective_users(last_user, op_types):
+            insert_after = max(downstream, key=lambda n: node_to_index[n])
+        else:
+            insert_after = last_user
+
+        with graph.inserting_after(insert_after):
             offload_node: fx.Node = graph.call_function(
                 torch.ops.ao.offload.default,
                 args=(node,),
@@ -229,13 +257,15 @@ def offload_activation_fw_async(graph: fx.Graph) -> None:
             offload_node.meta["tensor_meta"] = extract_tensor_metadata(
                 offload_node.meta["val"]
             )
-        # The keepalive=node arg extends the GPU tensor's lifetime in the
-        # graph so the allocator doesn't reclaim it before the async D2H
-        # copy completes.
+        # No keepalive: the GPU tensor is freed right after offload, exactly as
+        # activation checkpointing would free it after the last forward consumer.
+        # The offload op's set_stream + copy_ triggers record_stream on the GPU
+        # tensor, which guards the D2H window — the allocator won't reuse the
+        # block until the transfer stream finishes reading it.
         with graph.inserting_after(offload_node):
             wait_node: fx.Node = graph.call_function(
                 torch.ops.ao.wait_tensor.default,
-                args=(offload_node, node, last_user),
+                args=(offload_node,),
                 name=CPU_OFFLOAD_PREFIX + str(node.name),
             )
             wait_node.meta["val"] = offload_node.meta["val"]
@@ -484,6 +514,28 @@ def offload_chosen_sets_async(
     reload_activation_bw_async(bwd_module.graph)
 
 
+def find_last_compute_node(graph: fx.Graph) -> fx.Node | None:
+    """Walk backward through graph nodes to find the last compute node producing a Tensor."""
+    for node in reversed(graph.nodes):
+        if node.op in ("placeholder", "output"):
+            continue
+        if node.op == "call_function" and node.target in (
+            torch.ops.ao.offload.default,
+            torch.ops.ao.reload.default,
+            torch.ops.ao.wait_tensor.default,
+        ):
+            continue
+        val = node.meta.get("val")
+        if val is not None:
+            if isinstance(val, torch.Tensor):
+                return node
+            if isinstance(val, (list, tuple)) and any(
+                isinstance(x, torch.Tensor) for x in val
+            ):
+                return node
+    return None
+
+
 def activation_offload_sink_wait_async(fwd_module: fx.GraphModule) -> None:
     """Sink ao.wait_tensor operations for offload completion to the end of the graph.
 
@@ -508,8 +560,18 @@ def activation_offload_sink_wait_async(fwd_module: fx.GraphModule) -> None:
         and node.args[0].target == torch.ops.ao.offload.default
     ]
 
+    prefetch_dep = find_last_compute_node(graph)
+
     # prepend moves the node from its current position (no manual removal needed)
     for wait_node in wait_nodes_to_sink:
+        if prefetch_dep is not None:
+            # We must use prefetch_dependency to force the Inductor scheduler
+            # to schedule this wait_tensor node at the end of the graph.
+            args = list(wait_node.args)
+            while len(args) < 4:
+                args.append(None)
+            args[3] = prefetch_dep
+            wait_node.args = tuple(args)
         output_node.prepend(wait_node)
 
 
@@ -520,9 +582,10 @@ def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
     ao.wait_tensor at its original position.
     """
     graph: fx.Graph = bwd_module.graph
+    nodes_list: list[fx.Node] = list(graph.nodes)
 
-    reload_nodes: list[fx.Node] = []
-    wait_nodes: list[fx.Node] = []
+    # Identify reload + wait pairs
+    reload_patterns: dict[fx.Node, ReloadNodeInfo] = {}
     for node in graph.nodes:
         if not (
             node.op == "call_function" and node.target == torch.ops.ao.reload.default
@@ -532,95 +595,18 @@ def activation_reload_prefetch_async(bwd_module: fx.GraphModule) -> None:
             (u for u in node.users if u.target == torch.ops.ao.wait_tensor.default),
             None,
         )
-        if wait_node is not None:
-            reload_nodes.append(node)
-            wait_nodes.append(wait_node)
-
-    if not reload_nodes:
-        return
-
-    placeholders = graph.find_nodes(op="placeholder")
-    if not placeholders:
-        return
-    last_placeholder = placeholders[-1]
-
-    window = config.activation_reload_prefetch_window
-    if window < 0:
-        raise ValueError(
-            f"activation_reload_prefetch_window must be >= 0, got {window}"
+        if wait_node is None:
+            continue
+        transfer_size_bytes: int = _calculate_transfer_size(node)
+        transfer_time_ms: float = _estimate_transfer_time_in_ms(transfer_size_bytes)
+        reload_patterns[node] = ReloadNodeInfo(
+            reload_group_nodes=[node],
+            wait_event_node=wait_node,
+            transfer_size_bytes=transfer_size_bytes,
+            transfer_time_ms=transfer_time_ms,
         )
-    if window == 0:
-        window = len(reload_nodes)
 
-    # The reload inputs are saved CPU activation placeholders, so a small initial
-    # window can be issued as soon as backward starts. Later reloads are inserted
-    # after compute-stream release events from earlier reloaded activations. This
-    # keeps the host from allocating every reload destination at backward entry.
-    for reload_node in reversed(reload_nodes[:window]):
-        last_placeholder.append(reload_node)
-
-    op_types: OpTypes = get_default_op_list()
-    for idx, reload_node in enumerate(reload_nodes[window:]):
-        release_wait_node = wait_nodes[idx]
-        target_wait_node = wait_nodes[idx + window]
-        nodes_list = list(graph.nodes)
-        node_to_index = {node: node_idx for node_idx, node in enumerate(nodes_list)}
-        release_users = _find_all_effective_users(release_wait_node, op_types)
-        release_point = (
-            max(release_users, key=lambda n: node_to_index[n])
-            if release_users
-            else release_wait_node
-        )
-        with graph.inserting_after(release_point):
-            release_token = graph.call_function(
-                torch.ops.ao.record_stream_event.default,
-                args=(release_wait_node,),
-                name=f"release_{release_wait_node.name}",
-            )
-            release_token.meta["val"] = torch.empty((), device="cpu")
-            release_token.meta["tensor_meta"] = extract_tensor_metadata(
-                release_token.meta["val"]
-            )
-
-        reload_val = reload_node.meta["val"]
-        reuse_val = release_wait_node.meta["val"]
-        if (
-            reload_val.shape == reuse_val.shape
-            and reload_val.stride() == reuse_val.stride()
-            and reload_val.dtype == reuse_val.dtype
-        ):
-            reload_node.target = torch.ops.ao.reload_inplace.default
-            reload_node.args = (
-                reload_node.args[0],
-                release_wait_node,
-                release_token,
-            )
-            reload_node.meta["val"] = torch.empty((), device="cpu")
-            reload_node.meta["tensor_meta"] = extract_tensor_metadata(
-                reload_node.meta["val"]
-            )
-            target_wait_node.args = (
-                release_wait_node,
-                target_wait_node.args[1],
-                reload_node,
-            )
-        else:
-            reload_node.target = torch.ops.ao.reload_after.default
-            reload_node.args = (
-                reload_node.args[0],
-                reload_node.args[1],
-                release_token,
-            )
-        release_token.append(reload_node)
-
-    # Make the one-activation lookahead explicit in dataflow so later compiler
-    # scheduling cannot sink a reload back to its own wait.
-    for idx, wait_node in enumerate(wait_nodes[:-1]):
-        wait_args = list(wait_node.args)
-        while len(wait_args) < 4:
-            wait_args.append(None)
-        wait_args[3] = reload_nodes[idx + 1]
-        wait_node.args = tuple(wait_args)
+    reorder_for_prefetch(nodes_list, reload_patterns)
 
 
 def _calculate_transfer_size(device_put_node: fx.Node) -> int:
@@ -691,16 +677,6 @@ def identify_reload_patterns(
         record_event_node: fx.Node = nodes_list[reload_node_idx + 1]
         join_node: fx.Node = nodes_list[reload_node_idx + 2]
         wait_event_node: fx.Node = nodes_list[reload_node_idx + 3]
-
-        # Validate the nodes are what we expect
-        # Removed in follow-up commit
-        _validate_pattern_nodes(  # noqa: F821  # pyrefly: ignore [unknown-name]
-            fork_node,
-            wait_stream_node,
-            record_event_node,
-            join_node,
-            wait_event_node,
-        )
 
         # Calculate transfer size and time
         transfer_size_bytes: int = _calculate_transfer_size(reload_node)

--- a/torch/_functorch/_activation_offloading/offload_ops.py
+++ b/torch/_functorch/_activation_offloading/offload_ops.py
@@ -13,8 +13,8 @@ Offload pattern (AC-inspired -- no keepalive):
     cpu_tensor = ao.wait_tensor(cpu_tensor)
         The GPU buffer is freed by the compiler right after offload, exactly as
         activation checkpointing would free it after the last forward consumer.
-        The caching allocator's record_stream guards the D2H window, preventing
-        reuse of the GPU block until the transfer stream finishes reading it.
+        An explicit record_stream guards the D2H window, preventing reuse of the
+        GPU block until the transfer stream finishes reading it.
 
 Reload pattern:
     gpu_tensor = ao.reload(cpu_tensor, device)
@@ -69,21 +69,25 @@ def _clear_wait_registry() -> None:
     _wait_registry.clear()
 
 
-@custom_op("ao::offload", mutates_args=())
+# Treat the source as logically mutated: the async D2H copy is an outstanding
+# read of its storage, so later compiler-generated in-place writes must not
+# reuse that storage until the copy is sequenced.
+@custom_op("ao::offload", mutates_args={"tensor"})
 def offload(tensor: torch.Tensor) -> torch.Tensor:
     """Async offload a GPU tensor to CPU on the dedicated transfer stream.
 
-    Uses set_stream + copy_ so that the caching allocator calls record_stream
-    on the source GPU tensor. This is intentional: without keepalive, the
-    compiler frees the GPU buffer right after this op (the AC free point).
-    record_stream prevents the allocator from reusing the block while the D2H
-    is still reading it on the transfer stream, without stalling compute.
+    Explicitly records the source GPU tensor on the transfer stream. This is
+    intentional: without keepalive, the compiler frees the GPU buffer right
+    after this op (the AC free point). record_stream prevents the allocator from
+    reusing the block while the D2H is still reading it on the transfer stream,
+    without stalling compute.
     """
     device = tensor.device
     transfer_stream = _get_or_create_transfer_stream(device)
     current_stream = torch.accelerator.current_stream(device)
 
     transfer_stream.wait_stream(current_stream)
+    tensor.record_stream(transfer_stream)
 
     torch.accelerator.set_stream(transfer_stream)
     result = torch.empty_like(tensor, device="cpu", pin_memory=True)
@@ -163,7 +167,7 @@ def _(
 # before the transfer finishes.
 _lib = torch.library.Library("ao", "DEF")
 _lib.define(
-    "wait_tensor(Tensor(a) tensor, Tensor? keepalive=None, Tensor? last_use_of_storage=None, Tensor? prefetch_dependency=None) -> Tensor(a)"
+    "wait_tensor(Tensor(a) tensor, Tensor? keepalive=None, Tensor? last_use_of_storage=None) -> Tensor(a)"
 )
 
 
@@ -172,7 +176,6 @@ def _ao_wait_tensor(
     tensor: torch.Tensor,
     keepalive: torch.Tensor | None = None,
     last_use_of_storage: torch.Tensor | None = None,
-    prefetch_dependency: torch.Tensor | None = None,
 ) -> torch.Tensor:
     completion_event, device = _pop_wait(tensor)
     current_stream = torch.accelerator.current_stream(device)
@@ -188,7 +191,6 @@ def _ao_wait_tensor_fake(
     tensor: torch.Tensor,
     keepalive: torch.Tensor | None = None,
     last_use_of_storage: torch.Tensor | None = None,
-    prefetch_dependency: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return tensor
 
@@ -202,9 +204,8 @@ def wait_tensor(
     tensor: torch.Tensor,
     keepalive: torch.Tensor | None = None,
     last_use_of_storage: torch.Tensor | None = None,
-    prefetch_dependency: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Callable wrapper so ``wait_tensor`` can be imported by name for op registration."""
     return torch.ops.ao.wait_tensor.default(
-        tensor, keepalive, last_use_of_storage, prefetch_dependency
+        tensor, keepalive, last_use_of_storage
     )

--- a/torch/_functorch/_activation_offloading/offload_ops.py
+++ b/torch/_functorch/_activation_offloading/offload_ops.py
@@ -4,17 +4,16 @@ These ops encapsulate stream management internally, producing a clean 2-node
 IR pattern (offload/reload + wait_tensor) similar to c10d functional collectives.
 
 A single dedicated transfer stream handles all D2H/H2D copies.
-Completion events are keyed by output tensor data_ptr() and stored in a
-module-level registry, so ``ao.wait_tensor`` takes only the tensor itself
+Completion events are keyed by output tensor device and data_ptr(), then stored
+in a module-level registry, so ``ao.wait_tensor`` takes only the tensor itself
 (plus optional ``keepalive`` and ``last_use_of_storage`` args).
 
-Offload pattern (AC-inspired -- no keepalive):
+Offload pattern:
     cpu_tensor = ao.offload(gpu_tensor)
-    cpu_tensor = ao.wait_tensor(cpu_tensor)
-        The GPU buffer is freed by the compiler right after offload, exactly as
-        activation checkpointing would free it after the last forward consumer.
-        An explicit record_stream guards the D2H window, preventing reuse of the
-        GPU block until the transfer stream finishes reading it.
+    cpu_tensor = ao.wait_tensor(cpu_tensor, last_use_of_storage=gpu_tensor)
+        The explicit last_use_of_storage edge keeps the GPU storage live until
+        the sunk wait completes. This prevents compiler-planned buffer reuse
+        from overwriting storage still being read by the async D2H copy.
 
 Reload pattern:
     gpu_tensor = ao.reload(cpu_tensor, device)
@@ -41,26 +40,39 @@ def _get_or_create_transfer_stream(device: torch.device) -> torch.cuda.Stream:
     return _transfer_streams[device]
 
 
-# --- Wait registry: maps data_ptr() -> (completion_event, device) ---
+# --- Wait registry: maps (device, data_ptr()) -> (completion_event, device) ---
 # Created by ao.offload / ao.reload, consumed (popped) by ao.wait_tensor.
-# Not thread-safe — graph execution is single-threaded Python.
-_wait_registry: dict[int, tuple[torch.Event, torch.device]] = {}
+# Not thread-safe: graph execution is single-threaded Python.
+_WaitKey = tuple[str, int, int]
+_wait_registry: dict[_WaitKey, tuple[torch.Event, torch.device]] = {}
+
+
+def _wait_key(tensor: torch.Tensor) -> _WaitKey:
+    device_index = -1 if tensor.device.index is None else tensor.device.index
+    return (tensor.device.type, device_index, tensor.data_ptr())
 
 
 def _register_wait(tensor: torch.Tensor, device: torch.device) -> torch.Event:
     """Create an event for an async transfer and register it for wait_tensor."""
+    key = _wait_key(tensor)
+    if key in _wait_registry:
+        raise RuntimeError(
+            f"ao.wait_tensor: pending transfer already registered for "
+            f"tensor key={key}. Every ao.offload/ao.reload result must be "
+            "waited exactly once before its storage is reused."
+        )
     event = torch.Event()
-    _wait_registry[tensor.data_ptr()] = (event, device)
+    _wait_registry[key] = (event, device)
     return event
 
 
 def _pop_wait(tensor: torch.Tensor) -> tuple[torch.Event, torch.device]:
-    key = tensor.data_ptr()
+    key = _wait_key(tensor)
     try:
         return _wait_registry.pop(key)
     except KeyError:
         raise RuntimeError(
-            f"ao.wait_tensor: no pending transfer for tensor with data_ptr={key}. "
+            f"ao.wait_tensor: no pending transfer for tensor key={key}. "
             "Every ao.wait_tensor must be paired with a preceding ao.offload or ao.reload."
         ) from None
 
@@ -112,17 +124,19 @@ def reload(
 ) -> torch.Tensor:
     """Async reload a CPU tensor to GPU on the dedicated transfer stream.
 
-    The GPU tensor is allocated and populated on the transfer stream. The
-    compute stream waits on the recorded event before first use.
+    The GPU tensor is allocated on the compute stream, then populated on the
+    transfer stream. The compute stream waits on the recorded event before first
+    use.
     """
     transfer_stream = _get_or_create_transfer_stream(device)
     current_stream = torch.accelerator.current_stream(device)
 
-    if prefetch_dependency is not None:
-        transfer_stream.wait_stream(current_stream)
-
-    torch.accelerator.set_stream(transfer_stream)
     result = torch.empty_like(tensor, device=device)
+    result.record_stream(transfer_stream)
+    # The destination allocation is owned by the current stream. Make the copy
+    # stream wait for that stream before writing into the destination storage.
+    transfer_stream.wait_stream(current_stream)
+    torch.accelerator.set_stream(transfer_stream)
     completion_event = _register_wait(result, device)
     result.copy_(tensor, non_blocking=True)
     transfer_stream.record_event(completion_event)
@@ -206,6 +220,4 @@ def wait_tensor(
     last_use_of_storage: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Callable wrapper so ``wait_tensor`` can be imported by name for op registration."""
-    return torch.ops.ao.wait_tensor.default(
-        tensor, keepalive, last_use_of_storage
-    )
+    return torch.ops.ao.wait_tensor.default(tensor, keepalive, last_use_of_storage)

--- a/torch/_functorch/_activation_offloading/offload_ops.py
+++ b/torch/_functorch/_activation_offloading/offload_ops.py
@@ -104,6 +104,7 @@ def _(tensor: torch.Tensor) -> torch.Tensor:
 def reload(
     tensor: torch.Tensor,
     device: torch.device,
+    prefetch_dependency: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Async reload a CPU tensor to GPU on the dedicated transfer stream.
 
@@ -112,6 +113,9 @@ def reload(
     """
     transfer_stream = _get_or_create_transfer_stream(device)
     current_stream = torch.accelerator.current_stream(device)
+
+    if prefetch_dependency is not None:
+        transfer_stream.wait_stream(current_stream)
 
     torch.accelerator.set_stream(transfer_stream)
     result = torch.empty_like(tensor, device=device)
@@ -127,6 +131,7 @@ def reload(
 def _(
     tensor: torch.Tensor,
     device: torch.device,
+    prefetch_dependency: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return torch.empty_like(tensor, device=device)
 

--- a/torch/_functorch/_activation_offloading/offload_ops.py
+++ b/torch/_functorch/_activation_offloading/offload_ops.py
@@ -11,12 +11,12 @@ module-level registry, so ``ao.wait_tensor`` takes only the tensor itself
 Offload pattern:
     cpu_tensor = ao.offload(gpu_tensor)
     cpu_tensor = ao.wait_tensor(cpu_tensor, keepalive=gpu_tensor)
-        keepalive frees the GPU tensor's storage after the D2H copy completes.
+        keepalive keeps the GPU tensor live until the D2H copy completes.
 
 Reload pattern:
     gpu_tensor = ao.reload(cpu_tensor, device)
     gpu_tensor = ao.wait_tensor(gpu_tensor, keepalive=cpu_tensor)
-        keepalive frees the CPU tensor's storage after the H2D copy completes.
+        keepalive keeps the CPU tensor live until the H2D copy completes.
 
 The optional ``last_use_of_storage`` arg creates a dependency on a tensor whose
 storage must outlive the async transfer but is not otherwise connected by a
@@ -42,6 +42,7 @@ def _get_or_create_transfer_stream(device: torch.device) -> torch.Stream:
 # Created by ao.offload / ao.reload, consumed (popped) by ao.wait_tensor.
 # Not thread-safe — graph execution is single-threaded Python.
 _wait_registry: dict[int, tuple[torch.Event, torch.device]] = {}
+_stream_event_registry: dict[int, tuple[torch.Event, torch.device]] = {}
 
 
 def _register_wait(tensor: torch.Tensor, device: torch.device) -> torch.Event:
@@ -64,6 +65,23 @@ def _pop_wait(tensor: torch.Tensor) -> tuple[torch.Event, torch.device]:
 
 def _clear_wait_registry() -> None:
     _wait_registry.clear()
+    _stream_event_registry.clear()
+
+
+def _register_stream_event(token: torch.Tensor, device: torch.device) -> torch.Event:
+    event = torch.Event()
+    _stream_event_registry[token.data_ptr()] = (event, device)
+    return event
+
+
+def _pop_stream_event(token: torch.Tensor) -> tuple[torch.Event, torch.device]:
+    key = token.data_ptr()
+    try:
+        return _stream_event_registry.pop(key)
+    except KeyError:
+        raise RuntimeError(
+            f"ao.reload_after: no pending stream event for token with data_ptr={key}."
+        ) from None
 
 
 @custom_op("ao::offload", mutates_args=())
@@ -106,20 +124,15 @@ def reload(
 ) -> torch.Tensor:
     """Async reload a CPU tensor to GPU on the dedicated transfer stream.
 
-    The GPU tensor is allocated on the compute stream to avoid cross-stream
-    allocator ownership issues. The H2D copy runs on the transfer stream.
-    The completion event is keyed by the output tensor's data_ptr.
+    The GPU tensor is allocated and populated on the transfer stream. The
+    compute stream waits on the recorded event before first use.
     """
     transfer_stream = _get_or_create_transfer_stream(device)
     current_stream = torch.accelerator.current_stream(device)
 
-    # Allocate on compute stream so the allocator tracks ownership correctly
+    torch.accelerator.set_stream(transfer_stream)
     result = torch.empty_like(tensor, device=device)
     completion_event = _register_wait(result, device)
-
-    transfer_stream.wait_stream(current_stream)
-
-    torch.accelerator.set_stream(transfer_stream)
     result.copy_(tensor, non_blocking=True)
     transfer_stream.record_event(completion_event)
     torch.accelerator.set_stream(current_stream)
@@ -135,6 +148,80 @@ def _(
     return torch.empty_like(tensor, device=device)
 
 
+@custom_op("ao::record_stream_event", mutates_args=())
+def record_stream_event(tensor: torch.Tensor) -> torch.Tensor:
+    """Record a compute-stream event and return a CPU token for a later reload."""
+    device = tensor.device
+    current_stream = torch.accelerator.current_stream(device)
+    token = torch.empty((), device="cpu")
+    event = _register_stream_event(token, device)
+    current_stream.record_event(event)
+    return token
+
+
+@record_stream_event.register_fake
+def _(tensor: torch.Tensor) -> torch.Tensor:
+    return torch.empty((), device="cpu")
+
+
+@custom_op("ao::reload_after", mutates_args=())
+def reload_after(
+    tensor: torch.Tensor,
+    device: torch.device,
+    wait_token: torch.Tensor,
+) -> torch.Tensor:
+    """Reload CPU tensor after the compute-stream event represented by wait_token."""
+    event, event_device = _pop_stream_event(wait_token)
+    if event_device != device:
+        raise RuntimeError(
+            f"ao.reload_after: token device {event_device} does not match reload device {device}"
+        )
+    event.synchronize()
+    return reload(tensor, device)
+
+
+@reload_after.register_fake
+def _(
+    tensor: torch.Tensor,
+    device: torch.device,
+    wait_token: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(tensor, device=device)
+
+
+@custom_op("ao::reload_inplace", mutates_args={"dst"})
+def reload_inplace(
+    tensor: torch.Tensor,
+    dst: torch.Tensor,
+    wait_token: torch.Tensor,
+) -> torch.Tensor:
+    """Reload CPU tensor into an existing GPU buffer after wait_token."""
+    event, device = _pop_stream_event(wait_token)
+    if dst.device != device:
+        raise RuntimeError(
+            f"ao.reload_inplace: token device {device} does not match dst device {dst.device}"
+        )
+    transfer_stream = _get_or_create_transfer_stream(device)
+    current_stream = torch.accelerator.current_stream(device)
+
+    torch.accelerator.set_stream(transfer_stream)
+    transfer_stream.wait_event(event)
+    completion_event = _register_wait(dst, device)
+    dst.copy_(tensor, non_blocking=True)
+    transfer_stream.record_event(completion_event)
+    torch.accelerator.set_stream(current_stream)
+    return torch.empty((), device="cpu")
+
+
+@reload_inplace.register_fake
+def _(
+    tensor: torch.Tensor,
+    dst: torch.Tensor,
+    wait_token: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty((), device="cpu")
+
+
 # ao::wait_tensor is defined via torch.library with an aliasing schema so the
 # output can alias the input (custom_op forbids this).
 #
@@ -148,11 +235,9 @@ def _(
 #
 # ``keepalive`` is the source tensor of the async transfer. It creates a
 # graph dependency that extends the source tensor's lifetime until the
-# compute stream has waited on the transfer completion event. After the
-# wait, the op frees the source tensor's storage via ``resize_(0)`` since
-# it is no longer needed:
-#   - Offload (D2H): keepalive is the GPU tensor; freed after the D2H copy.
-#   - Reload (H2D): keepalive is the CPU tensor; freed after the H2D copy.
+# compute stream has waited on the transfer completion event:
+#   - Offload (D2H): keepalive is the GPU tensor.
+#   - Reload (H2D): keepalive is the CPU tensor.
 #
 # ``last_use_of_storage`` is an optional tensor whose storage is shared with
 # other live tensors (views/aliases). Passing it here tells the scheduler
@@ -164,7 +249,7 @@ def _(
 # before the transfer finishes.
 _lib = torch.library.Library("ao", "DEF")
 _lib.define(
-    "wait_tensor(Tensor(a) tensor, Tensor? keepalive=None, Tensor? last_use_of_storage=None) -> Tensor(a)"
+    "wait_tensor(Tensor(a) tensor, Tensor? keepalive=None, Tensor? last_use_of_storage=None, Tensor? prefetch_dependency=None) -> Tensor(a)"
 )
 
 
@@ -173,15 +258,14 @@ def _ao_wait_tensor(
     tensor: torch.Tensor,
     keepalive: torch.Tensor | None = None,
     last_use_of_storage: torch.Tensor | None = None,
+    prefetch_dependency: torch.Tensor | None = None,
 ) -> torch.Tensor:
     completion_event, device = _pop_wait(tensor)
     current_stream = torch.accelerator.current_stream(device)
 
     current_stream.wait_event(completion_event)
-    if keepalive is not None:
-        storage = keepalive.untyped_storage()
-        if storage.size() > 0:
-            storage.resize_(0)
+    if tensor.device == device:
+        tensor.record_stream(current_stream)
     return tensor
 
 
@@ -190,10 +274,16 @@ def _ao_wait_tensor_fake(
     tensor: torch.Tensor,
     keepalive: torch.Tensor | None = None,
     last_use_of_storage: torch.Tensor | None = None,
+    prefetch_dependency: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return tensor
 
 
+has_side_effect(torch.ops.ao.offload.default)
+has_side_effect(torch.ops.ao.reload.default)
+has_side_effect(torch.ops.ao.record_stream_event.default)
+has_side_effect(torch.ops.ao.reload_after.default)
+has_side_effect(torch.ops.ao.reload_inplace.default)
 has_side_effect(torch.ops.ao.wait_tensor.default)
 
 
@@ -201,6 +291,9 @@ def wait_tensor(
     tensor: torch.Tensor,
     keepalive: torch.Tensor | None = None,
     last_use_of_storage: torch.Tensor | None = None,
+    prefetch_dependency: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Callable wrapper so ``wait_tensor`` can be imported by name for op registration."""
-    return torch.ops.ao.wait_tensor.default(tensor, keepalive, last_use_of_storage)
+    return torch.ops.ao.wait_tensor.default(
+        tensor, keepalive, last_use_of_storage, prefetch_dependency
+    )

--- a/torch/_functorch/_activation_offloading/offload_ops.py
+++ b/torch/_functorch/_activation_offloading/offload_ops.py
@@ -8,10 +8,13 @@ Completion events are keyed by output tensor data_ptr() and stored in a
 module-level registry, so ``ao.wait_tensor`` takes only the tensor itself
 (plus optional ``keepalive`` and ``last_use_of_storage`` args).
 
-Offload pattern:
+Offload pattern (AC-inspired -- no keepalive):
     cpu_tensor = ao.offload(gpu_tensor)
-    cpu_tensor = ao.wait_tensor(cpu_tensor, keepalive=gpu_tensor)
-        keepalive keeps the GPU tensor live until the D2H copy completes.
+    cpu_tensor = ao.wait_tensor(cpu_tensor)
+        The GPU buffer is freed by the compiler right after offload, exactly as
+        activation checkpointing would free it after the last forward consumer.
+        The caching allocator's record_stream guards the D2H window, preventing
+        reuse of the GPU block until the transfer stream finishes reading it.
 
 Reload pattern:
     gpu_tensor = ao.reload(cpu_tensor, device)
@@ -29,12 +32,12 @@ from torch.fx import has_side_effect
 
 
 # --- Global transfer stream (one per device, lazily created) ---
-_transfer_streams: dict[torch.device, torch.Stream] = {}
+_transfer_streams: dict[torch.device, torch.cuda.Stream] = {}
 
 
-def _get_or_create_transfer_stream(device: torch.device) -> torch.Stream:
+def _get_or_create_transfer_stream(device: torch.device) -> torch.cuda.Stream:
     if device not in _transfer_streams:
-        _transfer_streams[device] = torch.Stream(device=device)
+        _transfer_streams[device] = torch.cuda.Stream(device=device)
     return _transfer_streams[device]
 
 
@@ -42,7 +45,6 @@ def _get_or_create_transfer_stream(device: torch.device) -> torch.Stream:
 # Created by ao.offload / ao.reload, consumed (popped) by ao.wait_tensor.
 # Not thread-safe — graph execution is single-threaded Python.
 _wait_registry: dict[int, tuple[torch.Event, torch.device]] = {}
-_stream_event_registry: dict[int, tuple[torch.Event, torch.device]] = {}
 
 
 def _register_wait(tensor: torch.Tensor, device: torch.device) -> torch.Event:
@@ -65,36 +67,17 @@ def _pop_wait(tensor: torch.Tensor) -> tuple[torch.Event, torch.device]:
 
 def _clear_wait_registry() -> None:
     _wait_registry.clear()
-    _stream_event_registry.clear()
-
-
-def _register_stream_event(token: torch.Tensor, device: torch.device) -> torch.Event:
-    event = torch.Event()
-    _stream_event_registry[token.data_ptr()] = (event, device)
-    return event
-
-
-def _pop_stream_event(token: torch.Tensor) -> tuple[torch.Event, torch.device]:
-    key = token.data_ptr()
-    try:
-        return _stream_event_registry.pop(key)
-    except KeyError:
-        raise RuntimeError(
-            f"ao.reload_after: no pending stream event for token with data_ptr={key}."
-        ) from None
 
 
 @custom_op("ao::offload", mutates_args=())
 def offload(tensor: torch.Tensor) -> torch.Tensor:
     """Async offload a GPU tensor to CPU on the dedicated transfer stream.
 
-    Callers MUST pair this with an ``ao.wait_tensor`` that passes the source GPU
-    tensor as ``keepalive`` to extend its lifetime past the async D2H copy.
-    Do NOT use ``record_stream`` — it causes memory fragmentation and
-    unbounded memory growth.
-
-    Uses pinned-memory allocation + copy_ so the transfer is compatible
-    with CUDA graph capture.
+    Uses set_stream + copy_ so that the caching allocator calls record_stream
+    on the source GPU tensor. This is intentional: without keepalive, the
+    compiler frees the GPU buffer right after this op (the AC free point).
+    record_stream prevents the allocator from reusing the block while the D2H
+    is still reading it on the transfer stream, without stalling compute.
     """
     device = tensor.device
     transfer_stream = _get_or_create_transfer_stream(device)
@@ -146,80 +129,6 @@ def _(
     device: torch.device,
 ) -> torch.Tensor:
     return torch.empty_like(tensor, device=device)
-
-
-@custom_op("ao::record_stream_event", mutates_args=())
-def record_stream_event(tensor: torch.Tensor) -> torch.Tensor:
-    """Record a compute-stream event and return a CPU token for a later reload."""
-    device = tensor.device
-    current_stream = torch.accelerator.current_stream(device)
-    token = torch.empty((), device="cpu")
-    event = _register_stream_event(token, device)
-    current_stream.record_event(event)
-    return token
-
-
-@record_stream_event.register_fake
-def _(tensor: torch.Tensor) -> torch.Tensor:
-    return torch.empty((), device="cpu")
-
-
-@custom_op("ao::reload_after", mutates_args=())
-def reload_after(
-    tensor: torch.Tensor,
-    device: torch.device,
-    wait_token: torch.Tensor,
-) -> torch.Tensor:
-    """Reload CPU tensor after the compute-stream event represented by wait_token."""
-    event, event_device = _pop_stream_event(wait_token)
-    if event_device != device:
-        raise RuntimeError(
-            f"ao.reload_after: token device {event_device} does not match reload device {device}"
-        )
-    event.synchronize()
-    return reload(tensor, device)
-
-
-@reload_after.register_fake
-def _(
-    tensor: torch.Tensor,
-    device: torch.device,
-    wait_token: torch.Tensor,
-) -> torch.Tensor:
-    return torch.empty_like(tensor, device=device)
-
-
-@custom_op("ao::reload_inplace", mutates_args={"dst"})
-def reload_inplace(
-    tensor: torch.Tensor,
-    dst: torch.Tensor,
-    wait_token: torch.Tensor,
-) -> torch.Tensor:
-    """Reload CPU tensor into an existing GPU buffer after wait_token."""
-    event, device = _pop_stream_event(wait_token)
-    if dst.device != device:
-        raise RuntimeError(
-            f"ao.reload_inplace: token device {device} does not match dst device {dst.device}"
-        )
-    transfer_stream = _get_or_create_transfer_stream(device)
-    current_stream = torch.accelerator.current_stream(device)
-
-    torch.accelerator.set_stream(transfer_stream)
-    transfer_stream.wait_event(event)
-    completion_event = _register_wait(dst, device)
-    dst.copy_(tensor, non_blocking=True)
-    transfer_stream.record_event(completion_event)
-    torch.accelerator.set_stream(current_stream)
-    return torch.empty((), device="cpu")
-
-
-@reload_inplace.register_fake
-def _(
-    tensor: torch.Tensor,
-    dst: torch.Tensor,
-    wait_token: torch.Tensor,
-) -> torch.Tensor:
-    return torch.empty((), device="cpu")
 
 
 # ao::wait_tensor is defined via torch.library with an aliasing schema so the
@@ -281,9 +190,6 @@ def _ao_wait_tensor_fake(
 
 has_side_effect(torch.ops.ao.offload.default)
 has_side_effect(torch.ops.ao.reload.default)
-has_side_effect(torch.ops.ao.record_stream_event.default)
-has_side_effect(torch.ops.ao.reload_after.default)
-has_side_effect(torch.ops.ao.reload_inplace.default)
 has_side_effect(torch.ops.ao.wait_tensor.default)
 
 

--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -362,6 +362,47 @@ def populate_fw_metadata_with_stream_indices(
     fw_metadata.mutated_inp_stream_indices = stream_indices
 
 
+def _expand_dict_returning_deps(
+    deps: list[Node],
+    visited: set[Node],
+    graph: torch.fx.Graph,
+    sync_node: Node,
+) -> list[Node]:
+    expanded: list[Node] = []
+    for dep in deps:
+        if not (
+            dep.op == "call_function"
+            and dep.target is torch.ops.higher_order.triton_kernel_wrapper_functional
+        ):
+            expanded.append(dep)
+            continue
+
+        after_sync_getitems = [
+            user
+            for user in dep.users
+            if user not in visited
+            and user.op == "call_function"
+            and user.target is operator.getitem
+        ]
+        if not after_sync_getitems:
+            expanded.append(dep)
+            continue
+
+        with graph.inserting_before(sync_node):
+            for old_getitem in after_sync_getitems:
+                new_getitem = graph.call_function(
+                    operator.getitem,
+                    args=(dep, old_getitem.args[1]),
+                )
+                new_getitem.meta.update(old_getitem.meta)
+                visited.add(new_getitem)
+                expanded.append(new_getitem)
+                old_getitem.replace_all_uses_with(new_getitem)
+                graph.erase_node(old_getitem)
+
+    return expanded
+
+
 def _wrap_sync_node(
     gm: torch.fx.GraphModule,
     sync_node: Node,
@@ -390,6 +431,12 @@ def _wrap_sync_node(
         for dep in deps_before_sync
         if any(user not in visited for user in dep.users)
     ]
+    deps_with_uses_after_sync = _expand_dict_returning_deps(
+        deps_with_uses_after_sync,
+        visited,
+        graph,
+        sync_node,
+    )
 
     # Create subgraph that executes sync and passes through only used dependencies
     subgraph_module = _create_subgraph_for_node(
@@ -448,6 +495,7 @@ def _wrap_sync_node(
 
             user.args = map_arg(user.args, _replace)
             user.kwargs = map_arg(user.kwargs, _replace)
+            user.meta.pop("eager_input_vals", None)
 
     # Remove original sync node
     sync_node.replace_all_uses_with(control_deps_node)

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -227,10 +227,6 @@ activation_offload_separate_stream = False
 # activation offloading wait sinking when using separate stream (fwd graph)
 activation_offload_sink_wait = False
 
-# CPU ↔ GPU bandwidth in GB/s, used to estimate transfer times for prefetch
-# scheduling. This is hardware-specific and should be set by the user.
-activation_offload_cpu_gpu_bw: float = 50.0
-
 # If FakeTensor.data_ptr() should error.
 # This option is independent of AOTAutograd and torch.compile, but our policy
 # is to turn it off during torch.compile.

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -230,9 +230,9 @@ activation_offload_sink_wait = False
 # activation reloading with prefetching when using separate streams (bwd graph)
 activation_reload_prefetch = False
 
-# Maximum number of activation reloads to prefetch ahead in the backward graph.
-# 0 means unbounded prefetch.
+# Deprecated/unused. Kept for backward compatibility with user scripts.
 activation_reload_prefetch_window: int = 0
+
 
 # CPU ↔ GPU bandwidth in GB/s, used to estimate transfer times for prefetch
 # scheduling. This is hardware-specific and should be set by the user.

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -227,13 +227,6 @@ activation_offload_separate_stream = False
 # activation offloading wait sinking when using separate stream (fwd graph)
 activation_offload_sink_wait = False
 
-# activation reloading with prefetching when using separate streams (bwd graph)
-activation_reload_prefetch = False
-
-# Deprecated/unused. Kept for backward compatibility with user scripts.
-activation_reload_prefetch_window: int = 0
-
-
 # CPU ↔ GPU bandwidth in GB/s, used to estimate transfer times for prefetch
 # scheduling. This is hardware-specific and should be set by the user.
 activation_offload_cpu_gpu_bw: float = 50.0

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -230,6 +230,10 @@ activation_offload_sink_wait = False
 # activation reloading with prefetching when using separate streams (bwd graph)
 activation_reload_prefetch = False
 
+# Maximum number of activation reloads to prefetch ahead in the backward graph.
+# 0 means unbounded prefetch.
+activation_reload_prefetch_window: int = 0
+
 # CPU ↔ GPU bandwidth in GB/s, used to estimate transfer times for prefetch
 # scheduling. This is hardware-specific and should be set by the user.
 activation_offload_cpu_gpu_bw: float = 50.0

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -163,9 +163,30 @@ class MinCutOptions:
 
 
 def must_recompute(node: fx.Node) -> bool:
+    if node.meta.get("recompute", None) not in [
+        CheckpointPolicy.MUST_RECOMPUTE,
+        CheckpointPolicy.PREFER_RECOMPUTE,
+    ]:
+        return False
+    # Recomputing from a value that was explicitly moved to CPU would require
+    # making the offloaded GPU activation available again before the recompute.
+    for inp in node.all_input_nodes:
+        if must_offload(inp):
+            return False
+    return True
+
+
+def has_recompute_policy(node: fx.Node) -> bool:
     return node.meta.get("recompute", None) in [
         CheckpointPolicy.MUST_RECOMPUTE,
         CheckpointPolicy.PREFER_RECOMPUTE,
+    ]
+
+
+def must_offload(node: fx.Node) -> bool:
+    return node.meta.get("recompute", None) in [
+        CheckpointPolicy.MUST_CPU_OFFLOAD,
+        CheckpointPolicy.PREFER_CPU_OFFLOAD,
     ]
 
 
@@ -181,7 +202,7 @@ def _is_assert_only_symbool(node: fx.Node) -> bool:
 
 def has_recomputable_ops(fx_g: fx.GraphModule) -> bool:
     for node in fx_g.graph.nodes:
-        if must_recompute(node):
+        if has_recompute_policy(node) or must_offload(node):
             return True
     return False
 
@@ -1244,6 +1265,41 @@ def _extract_fwd_bwd_modules(
     return fwd_module, bwd_module
 
 
+def _propagate_save_for_offloaded_deps(
+    joint_module: fx.GraphModule,
+    forward_node_names: OrderedSet[str],
+) -> None:
+    """Save forward descendants whose recompute chain depends on CPU offload."""
+    offloaded_nodes = [
+        node
+        for node in joint_module.graph.nodes
+        if must_offload(node) and node.name in forward_node_names
+    ]
+    if not offloaded_nodes:
+        return
+
+    queue: deque[fx.Node] = deque(offloaded_nodes)
+    visited: OrderedSet[fx.Node] = OrderedSet(offloaded_nodes)
+    flipped = 0
+
+    while queue:
+        node = queue.popleft()
+        for user in node.users:
+            if user in visited or user.name not in forward_node_names:
+                continue
+            visited.add(user)
+            if has_recompute_policy(user):
+                user.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+                flipped += 1
+            queue.append(user)
+
+    if flipped:
+        log.info(
+            "Activation CPU offload forced %d recompute-tagged descendants to save",
+            flipped,
+        )
+
+
 def default_partition(
     joint_module: fx.GraphModule,
     _joint_inputs: Any,
@@ -1309,6 +1365,13 @@ def default_partition(
             )
 
         joint_module = cleanup_recompute_tags(joint_module, is_default_partition=True)
+
+    has_cpu_offload_policy = False
+    for node in joint_module.graph.nodes:
+        if must_offload(node):
+            node.meta["should_offload"] = True
+            has_cpu_offload_policy = True
+    _propagate_save_for_offloaded_deps(joint_module, forward_node_names)
 
     if not config.unsafe_allow_optimization_of_collectives:
         force_save_collectives(joint_module)
@@ -1461,7 +1524,7 @@ def default_partition(
         bw_module = reordering_to_mimic_autograd_engine(bw_module)
 
     # pyrefly: ignore [unbound-name]
-    if config.enable_activation_offloading:
+    if config.enable_activation_offloading or has_cpu_offload_policy:
         from ._activation_offloading.activation_offloading import (
             enable_activation_offloading,
         )
@@ -1471,6 +1534,7 @@ def default_partition(
             bw_module,
             num_fwd_outputs,
             static_lifetime_input_nodes,
+            force_async=has_cpu_offload_policy,
         )
 
     # raise all getitem ops to as early as possible
@@ -2052,8 +2116,8 @@ def cleanup_recompute_tags(
             for user in node.users:
                 if (
                     must_recompute(user)
-                    and "ac_graph_id" in user.meta
-                    and "ac_graph_id" in node.meta
+                    and user.meta.get("ac_graph_id") is not None
+                    and node.meta.get("ac_graph_id") is not None
                     and user.meta["ac_graph_id"] > node.meta["ac_graph_id"]
                 ):
                     node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
@@ -2309,8 +2373,9 @@ def solve_min_cut(
             if config.unsafe_allow_optimization_of_collectives or not is_collective:
                 return False
         # This bans recomputation of the node unless we've been forced not to by
-        # user annotation
-        if must_recompute(node):
+        # user annotation or the node is explicitly being saved through CPU
+        # offload.
+        if must_recompute(node) or must_offload(node):
             return False
 
         if "val" in node.meta and isinstance(node.meta["val"], torch.SymFloat):
@@ -2349,6 +2414,15 @@ def solve_min_cut(
                     reason="must be computed in backward: required for gradient",
                 )
                 continue
+
+        if must_offload(node):
+            nx_graph.add_edge(
+                node.name + "_in",
+                node.name + "_out",
+                capacity=0,
+                reason="must save through CPU offload: marked by checkpoint policy",
+            )
+            continue
 
         if must_recompute(node):
             # If user explicitly says they want to recompute a node, we honor it
@@ -3777,11 +3851,7 @@ def min_cut_rematerialization_partition(
     # picks it up downstream.
     has_cpu_offload_policy = False
     for node in joint_graph.nodes:
-        policy = node.meta.get("recompute")
-        if policy in (
-            CheckpointPolicy.MUST_CPU_OFFLOAD,
-            CheckpointPolicy.PREFER_CPU_OFFLOAD,
-        ):
+        if must_offload(node):
             node.meta["should_offload"] = True
             has_cpu_offload_policy = True
 
@@ -3789,6 +3859,10 @@ def min_cut_rematerialization_partition(
         static_lifetime_input_indices = []
     node_info = classify_nodes(
         joint_module, static_lifetime_input_indices, num_fwd_outputs
+    )
+    _propagate_save_for_offloaded_deps(
+        joint_module,
+        OrderedSet(node.name for node in node_info.required_fw_nodes),
     )
 
     # networkx blows up on graphs with no required backward nodes
@@ -3906,6 +3980,7 @@ def min_cut_rematerialization_partition(
             bw_module,
             num_fwd_outputs,
             node_info.static_lifetime_input_nodes,
+            force_async=has_cpu_offload_policy,
         )
 
     # raise all getitem ops to as early as possible

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1385,7 +1385,11 @@ def default_partition(
         if is_multi_output(node):
             # Must be ordered before MUST_SAVE tags to avoid saving tuples marked MUST_SAVE.
             continue
-        if node.meta.get("recompute") == CheckpointPolicy.MUST_SAVE:
+        if node.meta.get("recompute") in (
+            CheckpointPolicy.MUST_SAVE,
+            CheckpointPolicy.MUST_CPU_OFFLOAD,
+            CheckpointPolicy.PREFER_CPU_OFFLOAD,
+        ):
             if is_opaque_node(node):
                 saved_opaque_nodes.append(node)
             else:
@@ -3198,7 +3202,12 @@ def choose_saved_values_set(
     must_save_nodes = [
         i
         for i in recomputable_banned_nodes
-        if i.meta.get("recompute", False) == CheckpointPolicy.MUST_SAVE
+        if i.meta.get("recompute", False)
+        in (
+            CheckpointPolicy.MUST_SAVE,
+            CheckpointPolicy.MUST_CPU_OFFLOAD,
+            CheckpointPolicy.PREFER_CPU_OFFLOAD,
+        )
     ]
     recomputable_banned_nodes = [
         i for i in recomputable_banned_nodes if i not in must_save_nodes
@@ -3763,6 +3772,19 @@ def min_cut_rematerialization_partition(
     force_save_effectful_ops(joint_module)
     force_save_bw_mutation_src(joint_module)
 
+    # Bridge selective-activation-checkpoint's CPU_OFFLOAD policies into the
+    # activation-offloading pipeline: tag the node so `enable_activation_offloading`
+    # picks it up downstream.
+    has_cpu_offload_policy = False
+    for node in joint_graph.nodes:
+        policy = node.meta.get("recompute")
+        if policy in (
+            CheckpointPolicy.MUST_CPU_OFFLOAD,
+            CheckpointPolicy.PREFER_CPU_OFFLOAD,
+        ):
+            node.meta["should_offload"] = True
+            has_cpu_offload_policy = True
+
     if static_lifetime_input_indices is None:
         static_lifetime_input_indices = []
     node_info = classify_nodes(
@@ -3805,6 +3827,47 @@ def min_cut_rematerialization_partition(
     if config._sync_decision_cross_ranks:
         saved_values = _sync_decision_cross_ranks(joint_graph, saved_values)
 
+    # Honor `should_offload` from custom joint passes. The activation offloading pass
+    # can only act on tensors that cross the autograd boundary as saved values, but the
+    # min-cut partitioner may pick to recompute the marked node instead. We force-add
+    # it here, and drop any of its transparent (view/permute/getitem) descendants that
+    # were saved, since those can be re-derived from the now-saved upstream tensor for
+    # free in backward.
+    transparent_targets = OrderedSet(
+        [
+            torch.ops.aten.view.default,
+            torch.ops.aten._unsafe_view.default,
+            torch.ops.aten.reshape.default,
+            torch.ops.aten.permute.default,
+            torch.ops.aten.transpose.int,
+            torch.ops.aten.expand.default,
+            torch.ops.aten.unbind.int,
+            operator.getitem,
+        ]
+    )
+    forced_saves = [n for n in joint_graph.nodes if n.meta.get("should_offload", False)]
+    if forced_saves:
+        saved_set = OrderedSet(saved_values)
+        for forced in forced_saves:
+            if forced not in saved_set:
+                saved_values.append(forced)
+                saved_set.add(forced)
+            # BFS forward through transparent ops and remove any descendant that's
+            # currently saved (it can be re-derived from `forced` at zero cost).
+            stack = [forced]
+            visited: OrderedSet[fx.Node] = OrderedSet()
+            while stack:
+                cur = stack.pop()
+                for user in cur.users:
+                    if user in visited:
+                        continue
+                    visited.add(user)
+                    if user.target in transparent_targets:
+                        if user in saved_set:
+                            saved_set.remove(user)
+                            saved_values = [v for v in saved_values if v is not user]
+                        stack.append(user)
+
     saved_sym_nodes = list(
         filter(
             lambda n: is_sym_node(n) and not _is_assert_only_symbool(n), saved_values
@@ -3833,7 +3896,7 @@ def min_cut_rematerialization_partition(
     bw_module = reordering_to_mimic_autograd_engine(bw_module)
 
     # pyrefly: ignore [unbound-name]
-    if config.enable_activation_offloading:
+    if config.enable_activation_offloading or has_cpu_offload_policy:
         from ._activation_offloading.activation_offloading import (
             enable_activation_offloading,
         )

--- a/torch/_inductor/fx_passes/control_dependencies.py
+++ b/torch/_inductor/fx_passes/control_dependencies.py
@@ -69,6 +69,7 @@ ORDER_ONLY_DEPENDENCIES_META_KEY = "inductor_order_only_dependencies"
 def add_order_only_dependency(node: fx.Node, dep: fx.Node) -> None:
     node.meta.setdefault(ORDER_ONLY_DEPENDENCIES_META_KEY, []).append(dep)
 
+
 # control_deps wraps side-effecting ops (e.g. record_event, wait_event)
 # and must not be eliminated by DCE even when its outputs are unused.
 from torch.fx.node import has_side_effect

--- a/torch/_inductor/fx_passes/control_dependencies.py
+++ b/torch/_inductor/fx_passes/control_dependencies.py
@@ -58,6 +58,17 @@ class ControlDeps(HigherOrderOperator):
 
 control_deps = ControlDeps()
 
+# Meta key for declaring order-only (happens-before) dependencies on an fx.Node.
+# Callers stamp the consumer node with `add_order_only_dependency(consumer, dep)`;
+# `apply_order_only_dependencies` later materializes the edges by wrapping the
+# consumer in `control_deps`. This is the lightweight alternative to threading a
+# fake tensor argument through the consumer op just to force scheduling order.
+ORDER_ONLY_DEPENDENCIES_META_KEY = "inductor_order_only_dependencies"
+
+
+def add_order_only_dependency(node: fx.Node, dep: fx.Node) -> None:
+    node.meta.setdefault(ORDER_ONLY_DEPENDENCIES_META_KEY, []).append(dep)
+
 # control_deps wraps side-effecting ops (e.g. record_event, wait_event)
 # and must not be eliminated by DCE even when its outputs are unused.
 from torch.fx.node import has_side_effect
@@ -281,3 +292,28 @@ def _create_subgraph_for_node(
             out.meta["val"] = result.meta["val"]
 
     return _LazyGraphModule(owning_module, subgraph)
+
+
+def apply_order_only_dependencies(graph: fx.Graph, verbose: bool = False) -> None:
+    """Materialize meta-declared order-only edges into control_deps wrappers.
+
+    Scans every node for ORDER_ONLY_DEPENDENCIES_META_KEY entries and routes
+    them through `preserve_node_ordering`. After this call the meta key is
+    cleared from each processed node so the pass is idempotent.
+    """
+    additional_deps_map: dict[fx.Node, OrderedSet[fx.Node]] = {}
+    for node in graph.nodes:
+        deps = node.meta.pop(ORDER_ONLY_DEPENDENCIES_META_KEY, None)
+        if not deps:
+            continue
+        # Filter out self-deps and non-Node entries defensively.
+        filtered: OrderedSet[fx.Node] = OrderedSet(
+            d for d in deps if isinstance(d, fx.Node) and d is not node
+        )
+        if filtered:
+            additional_deps_map[node] = filtered
+
+    if not additional_deps_map:
+        return
+
+    preserve_node_ordering(graph, additional_deps_map, verbose=verbose)

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -413,6 +413,21 @@ META_ONLY_OPS = OrderedSet(
 )
 
 
+def _is_control_deps_ordering_only_use(
+    user: torch.fx.Node,
+    view: torch.fx.Node,
+) -> bool:
+    if not (
+        user.op == "call_function"
+        and isinstance(user.target, torch._ops.HigherOrderOperator)
+        and user.target._name == "control_deps"
+    ):
+        return False
+    additional_deps = pytree.tree_leaves(user.args[0])
+    pass_through = pytree.tree_leaves(user.args[2:])
+    return view in additional_deps and view not in pass_through
+
+
 def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
     """
     Reinplaces in-placeable operations.
@@ -495,6 +510,8 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                     user.target is torch.ops.aten.copy_.default
                     and mutated_arg is user.args[0]
                 ):
+                    continue
+                if _is_control_deps_ordering_only_use(user, view):
                     continue
                 return True
         return False

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8387,6 +8387,13 @@ def process_subgraph_nodes(graph_module: torch.fx.GraphModule, args: list[Any]):
 from torch._inductor.fx_passes.control_dependencies import control_deps
 
 
+def _flatten_control_deps(deps, dep_names: list[str]) -> None:
+    for dep in pytree.tree_leaves(deps):
+        if isinstance(dep, IRNode):
+            dep.realize()
+            dep_names.append(dep.get_name())
+
+
 @register_lowering(control_deps, type_promotion_kind=None)
 def control_deps_op_lowering(additional_deps, subgraph_fn, *args):
     """
@@ -8397,25 +8404,11 @@ def control_deps_op_lowering(additional_deps, subgraph_fn, *args):
     2. Execute the target operation normally
     3. Track the dependencies for the scheduler
     """
-    # Pair lowered deps with their original FX nodes so we can handle void ops
-    # (e.g. record_event) that lower to None but still create operations that
-    # subsequent control_deps nodes (e.g. wait_event) must be ordered after.
-    original_dep_nodes = V.graph.current_node.args[0]
-    assert isinstance(original_dep_nodes, tuple)
-
-    dep_names = []
-    for dep, orig_node in zip(additional_deps, original_dep_nodes, strict=True):
-        dep_ir_nodes = [
-            dep_leaf
-            for dep_leaf in pytree.tree_leaves(dep)
-            if isinstance(dep_leaf, IRNode)
-        ]
-        for dep_ir_node in dep_ir_nodes:
-            dep_ir_node.realize()
-            dep_names.append(dep_ir_node.get_name())
+    dep_names: list[str] = []
+    _flatten_control_deps(additional_deps, dep_names)
+    for orig_node in pytree.tree_leaves(V.graph.current_node.args[0]):
         if isinstance(orig_node, torch.fx.Node):
-            found = V.graph._void_ctrl_dep_op_names.get(orig_node, [])
-            dep_names.extend(found)
+            dep_names.extend(V.graph._void_ctrl_dep_op_names.get(orig_node, []))
 
     original_args = V.graph.current_node.args
     arg_offset = 2  # first two args (additional_deps, subgraph)
@@ -8466,6 +8459,23 @@ def control_deps_op_lowering(additional_deps, subgraph_fn, *args):
             op_name = op.operation_name
             assert op_name is not None
             V.graph.additional_buffer_deps[op_name].add(dep_name)
+
+    input_ids = tuple(id(a) for a in args)
+    output_leaves = pytree.tree_leaves(output)
+    for op in new_ops:
+        if not isinstance(op, ir.OperationBuffer):
+            continue
+        for val in output_leaves:
+            if id(val) not in input_ids or not isinstance(val, IRNode):
+                continue
+            val.realize()
+            cast(Any, op).mutation_outputs.append(
+                ir.MutationOutput(
+                    ir.NoneLayout(device=val.get_device()),
+                    val,
+                    op,
+                )
+            )
 
     return output
 
@@ -8614,7 +8624,9 @@ def with_effects(token, op, *args, **kwargs):
             # Patch has_side_effects to return True
             new_op.has_side_effects = lambda: True  # pyrefly: ignore[missing-attribute]
             if prev_effect_buffer:
-                op_name = new_op.get_name()  # pyrefly: ignore[missing-attribute]
+                op_name = (
+                    new_op.get_operation_name()
+                )  # pyrefly: ignore[missing-attribute]
                 V.graph.additional_star_deps[op_name].add(prev_effect_buffer.get_name())
         # Update the effectful ops chain to point to the latest operation
         V.graph.effectful_ops[effect_type] = (

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1241,6 +1241,52 @@ class _VersionWrapper:
         return self.val
 
 
+class _OffloadWrapper:
+    # Correctness-first eager fallback for CPU_OFFLOAD SAC policies.
+    def __init__(self, val) -> None:
+        self.val: torch.Tensor | Any = val
+        self.device: torch.device | None = None
+        self.version: int | None = None
+        self.ref: ReferenceType[torch.Tensor] | None = None
+        if not isinstance(val, torch.Tensor) or val.device.type == "cpu":
+            return
+
+        self.device = val.device
+        self.version = val._version
+        self.ref = weakref.ref(val)
+        if val.layout == torch.strided:
+            self.val = torch.empty_strided(
+                tuple(val.size()),
+                tuple(val.stride()),
+                dtype=val.dtype,
+                device="cpu",
+                pin_memory=val.device.type == "cuda",
+            )
+            self.val.copy_(val, non_blocking=val.device.type == "cuda")
+        else:
+            self.val = val.to("cpu")
+
+    def get_val(self, allow_cache_entry_mutation):
+        if (
+            self.version is not None
+            and not allow_cache_entry_mutation
+            and self.ref is not None
+        ):
+            original = self.ref()
+            if original is not None and original._version != self.version:
+                raise RuntimeError(
+                    "Tensor cached during selective activation checkpoint has been mutated"
+                )
+        if self.device is None:
+            return self.val
+        non_blocking = (
+            isinstance(self.val, torch.Tensor)
+            and self.val.device.type == "cpu"
+            and self.val.is_pinned()
+        )
+        return self.val.to(self.device, non_blocking=non_blocking)
+
+
 def _detach_helper(x):
     # We detach for two separate reasons:
     # - For view ops, we need to ensure that when the tensor is returned from
@@ -1404,14 +1450,20 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
         if policy in (
             CheckpointPolicy.MUST_SAVE,
             CheckpointPolicy.PREFER_SAVE,
-            # CPU_OFFLOAD policies require the value to be saved across the autograd
-            # boundary so the compile-time offload pipeline can lift it to CPU. Under
-            # compile, the actual D2H/H2D is inserted by the activation offloading
-            # pass; under eager we behave like MUST_SAVE (no transfer) for now.
             CheckpointPolicy.MUST_CPU_OFFLOAD,
             CheckpointPolicy.PREFER_CPU_OFFLOAD,
         ) or is_compiling:
-            self.storage[key][idx] = tree_map(lambda x: _VersionWrapper(_detach_helper(x)), out)
+            wrapper = (
+                _VersionWrapper
+                if is_compiling
+                or policy
+                not in (
+                    CheckpointPolicy.MUST_CPU_OFFLOAD,
+                    CheckpointPolicy.PREFER_CPU_OFFLOAD,
+                )
+                else _OffloadWrapper
+            )
+            self.storage[key][idx] = tree_map(lambda x: wrapper(_detach_helper(x)), out)
         else:
             self.storage[key][idx] = _RECOMPUTE
         return out

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1401,7 +1401,16 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
                 for node in itertools.islice(reversed(graph.nodes), num_new):
                     node.meta["recompute"] = policy
 
-        if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
+        if policy in (
+            CheckpointPolicy.MUST_SAVE,
+            CheckpointPolicy.PREFER_SAVE,
+            # CPU_OFFLOAD policies require the value to be saved across the autograd
+            # boundary so the compile-time offload pipeline can lift it to CPU. Under
+            # compile, the actual D2H/H2D is inserted by the activation offloading
+            # pass; under eager we behave like MUST_SAVE (no transfer) for now.
+            CheckpointPolicy.MUST_CPU_OFFLOAD,
+            CheckpointPolicy.PREFER_CPU_OFFLOAD,
+        ) or is_compiling:
             self.storage[key][idx] = tree_map(lambda x: _VersionWrapper(_detach_helper(x)), out)
         else:
             self.storage[key][idx] = _RECOMPUTE


### PR DESCRIPTION
# SAC-Driven Activation CPU Offload

## Summary

This PR adds a `torch.compile` path for activation CPU offload driven by
Selective Activation Checkpointing policies:

```python
CheckpointPolicy.MUST_CPU_OFFLOAD
CheckpointPolicy.PREFER_CPU_OFFLOAD
```

The intent is that users describe what should be offloaded through SAC policy,
and the compiler handles the rest. They should not need to call AO ops directly,
install a custom AOTAutograd pass, pick a prefetch window, or tune CPU/GPU
bandwidth constants.

Under compile, supported CPU-offload policies lower to async D2H/H2D copies with
explicit `ao.offload`, `ao.reload`, and `ao.wait_tensor` nodes. Eager mode gets a
correctness-first fallback that saves selected tensors on CPU and reloads them
when needed, but eager is not trying to provide async overlap.

Unsupported `MUST_CPU_OFFLOAD` cases fail clearly. Unsupported
`PREFER_CPU_OFFLOAD` cases fall back safely.

## User API

The public API is SAC policy:

```python
from functools import partial

import torch
from torch.utils.checkpoint import (
    CheckpointPolicy,
    checkpoint,
    create_selective_checkpoint_contexts,
)


def policy_fn(ctx, op, *args, **kwargs):
    if op == torch.ops.aten.mm.default:
        return CheckpointPolicy.MUST_CPU_OFFLOAD
    return CheckpointPolicy.PREFER_RECOMPUTE


context_fn = partial(create_selective_checkpoint_contexts, policy_fn)


def model(x, w):
    return checkpoint(
        lambda x, w: x @ w,
        x,
        w,
        use_reentrant=False,
        context_fn=context_fn,
    )


compiled_model = torch.compile(model)
```

## What Changed

### Checkpointing and partitioning

`torch.utils.checkpoint` now treats `MUST_CPU_OFFLOAD` and
`PREFER_CPU_OFFLOAD` as save policies.

For compiled graphs, AOTAutograd sees those policies and automatically invokes
activation offload. The partitioner marks offloaded values as saved across the
forward/backward boundary through their CPU copy, rather than also saving the
original GPU tensor or trying to recompute it.

The partitioner also walks forward descendants of offloaded values. If a
recompute-tagged node would need an activation that has been moved to CPU, that
node is forced to save instead. This avoids producing graphs that look valid on
paper but require a no-longer-resident GPU tensor in backward.

### AO runtime

The runtime keeps the explicit AO IR, but tightens the stream and lifetime model:

- D2H offload runs on a transfer stream after waiting for compute.
- The source GPU tensor records the transfer stream so the caching allocator
  cannot reuse storage while the copy is reading it.
- H2D reload allocates the destination on the compute stream, records it on the
  transfer stream, and waits before writing into it.
- `ao.wait_tensor` makes compute wait at the first real use.
- waits are keyed by device and data pointer, with loud errors for missing or
  duplicate waits.
- forward waits carry `last_use_of_storage` so Inductor's planned buffer reuse
  cannot overwrite storage still being read by async D2H.

This moves away from relying on `resize_(0)` as the lifetime mechanism.

### Scheduling

The old bandwidth-estimated reload prefetch path is removed. There is no
user-facing prefetch window and no `activation_offload_cpu_gpu_bw` tuning knob.

The new schedule is structural:

- forward waits are pipelined with a small bounded distance instead of all being
  sunk to graph output.
- backward reloads use a fixed one-step pipeline: reload the next activation
  after the current offloaded activation reaches its wait/first-use point.
- rewritten graphs are validated for topological order and one wait per
  transfer.

This came from trace debugging: loose placement can accidentally cluster all
H2Ds together, which destroys the intended overlap.

### Compiler ordering

The PR also includes the Inductor ordering fixes needed for the AO schedule to
survive lowering and scheduling:

- flatten nested `control_deps` dependency containers.
- treat `control_deps` dependencies as ordering-only in reinplace.
- expand dict-returning Triton wrapper deps when needed.
- model pass-through `control_deps` outputs with `MutationOutput` instead of
  fake identity kernels.
- use operation names for effectful dependency tracking where buffer names do
  not exist.

These are in the same problem area as #183803 and #183804.

## Tests

The updated tests cover:

- SAC CPU-offload policies automatically enabling compile-time activation
  offload.
- clear `MUST_CPU_OFFLOAD` errors for unsupported cases.
- safe `PREFER_CPU_OFFLOAD` fallback.
- eager fallback correctness.
- multi-step loss and elementwise per-parameter gradient checks.
- fake tensor behavior for AO ops.
- missing-wait and double-wait registry errors.
- multiple offloaded tensors.
- bounded forward wait placement.
- structural one-step backward reload placement.

Local lint passed:

```text
lintrunner -a
```

## Local Validation

Large nanoGPT-like runs were used for profiling and correctness on 120GB GH200:

```text
nlayer=12, dmodel=1536, nhead=12, seqlen=1024, batch=64, bf16
```

Twenty-step correctness checks passed for qkv, up_proj, and full-block targets
against baseline, including loss equality and elementwise per-parameter gradient
comparison.

Profiling summary:

```text
target      mode            steady_ms  peak_alloc  kernels  H2D overlap  D2H overlap
qkv         baseline            283.3      63.39G      589        -            -
qkv         selective_ac         298.3      56.64G      613        -            -
qkv         offload             285.6      56.64G      589      99.7%        99.6%

```

The cleanest comparison is qkv: offload gets the same allocated-memory saving as
selective AC, keeps the baseline main-compute kernel count, and is much closer
to baseline step time. The remaining gap is copy pressure rather than extra
compute kernels.

## Related Work

This PR connects several existing activation-offload threads:

- #177621 added the AO ops used here.
- #177627 makes the partitioner aware of offloaded tensors.
- #177628 removes the old stream-op path.
- #180874 adds eager SAC CPU-offload support.
- #183802 moves stream handling toward metadata plus allocator-safe stream
  recording.
- #183803 and #183804 address ordering issues needed by AO scheduling.
- #170284 tracks SAC compatibility with async activation offload.
- #158657 asks for checkpoint-level CPU/NVMe offload.
- #174960 discusses async activation offload and prefetch in FSDP.

This PR focuses on the compiled SAC-driven CPU activation offload path. It does
not add FSDP policy integration, NVMe offload, or a pinned-memory pool.

## Suggested Review Order

1. `torch/utils/checkpoint.py` and `torch/_functorch/partitioners.py` for policy
   flow and save/recompute/offload semantics.
2. `torch/_functorch/_activation_offloading/offload_ops.py` for runtime stream
   and lifetime correctness.
3. `torch/_functorch/_activation_offloading/activation_offloading.py` for wait
   sinking, reload scheduling, and graph validation.
4. Inductor ordering changes in `control_dependencies.py`, `reinplace.py`,
   `lowering.py`, and `_aot_autograd/streams.py`.
5. `test/dynamo/test_activation_offloading.py` for expected behavior and
   regression coverage.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98