### PR TITLE
Fix nested int guards for in-graph jagged tensors

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -4068,8 +4068,6 @@ class GraphModule(torch.nn.Module):
         values = torch.randn(10, 5).requires_grad_(True)
         self._validate_compile(fn, arg_fn=lambda: (values,))
 
-    # AssertionError: s2 (could be from ['<ephemeral: intermediate_offsets_or_lengths>',
-    @unittest.expectedFailure
     def test_in_graph_construction_from_intermediate_5(self):
         # non-shared intermediate
         def fn(values):
@@ -4084,6 +4082,20 @@ class GraphModule(torch.nn.Module):
 
         values = torch.randn(10, 5).requires_grad_(True)
         self._validate_compile(fn, arg_fn=lambda: (values,))
+
+    def test_as_nested_tensor_from_intermediate_layer_norm(self):
+        def fn(nt, i):
+            expanded_i = i.expand(nt.shape[0], -1, -1)
+            nested_i = torch.nested.as_nested_tensor(expanded_i, layout=torch.jagged)
+            return torch.nn.functional.layer_norm(nested_i, (4,))
+
+        nt = torch.nested.nested_tensor(
+            [torch.randn(2, 4), torch.randn(3, 4)], layout=torch.jagged
+        )
+        i = torch.randn(1, 5, 4)
+        opt_fn = torch.compile(fn, fullgraph=True, backend="eager")
+
+        self.assertEqualIgnoringNestedInts(fn(nt, i), opt_fn(nt, i))
 
     #
     # Case 3: in-graph construction where offsets are both direct graph inputs

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1087,6 +1087,22 @@ def forward(self, x_1):
         self.assertTrue(shape_env.evaluate_expr(test1))
         self.assertTrue(shape_env.evaluate_expr(test2))
 
+    def test_singleton_int_coeff_in_static_eval_cache(self):
+        from torch._dynamo.source import EphemeralSource
+
+        def check(coeff):
+            shape_env = ShapeEnv(duck_shape=False)
+            s0 = shape_env.create_symbol(
+                torch._C._get_nested_int(7, 1), source=EphemeralSource("lhs")
+            )
+            s1 = shape_env.create_symbol(
+                torch._C._get_nested_int(7, coeff), source=EphemeralSource("rhs")
+            )
+            return shape_env._maybe_evaluate_static(sympy.Eq(s0, s1))
+
+        self.assertEqual(check(1), sympy.true)
+        self.assertEqual(check(2), sympy.false)
+
     def test_sympy_optimized_add(self):
         shape_env = ShapeEnv()
         s0 = create_symint(shape_env, 2)

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -976,6 +976,12 @@ class TestSingletonInt(TestCase):
         test_eq(j1, j1x2, False)
         test_eq(j1, sympy.Integer(1), False)
         test_eq(j1, sympy.Integer(3), False)
+        self.assertEqual(j1, j1_copy)
+        self.assertNotEqual(j1, j2)
+        self.assertNotEqual(j1, j1x2)
+        self.assertEqual(hash(j1), hash(j1_copy))
+        self.assertNotEqual(hash(j1), hash(j1x2))
+        self.assertEqual(pickle.loads(pickle.dumps(j1x2)), j1x2)
 
         def test_ineq(a, b, expected, *, strict=True):
             greater = (sympy.Gt, is_gt) if strict else (sympy.Ge, is_ge)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2509,7 +2509,7 @@ def safe_expand(r: _SympyT) -> _SympyT:
 class _SymbolInfo(NamedTuple):
     k: sympy.Symbol
     vr: ValueRanges[sympy.Expr] | None
-    val: sympy.Integer | None
+    val: sympy.Basic | None
     is_size_like: bool
 
 
@@ -2531,11 +2531,16 @@ def _maybe_evaluate_static_worker(
     # Simplify making use of value range lower bound
     new_shape_env = {}
     new_range_env = {}
+    has_singleton_int = False
     for idx, sinfo in enumerate(symbol_info):
         k, vr, val, is_size_like = sinfo
         if isinstance(val, SingletonInt):
-            # Skip var_ranges logic for SingletonInt which is only used
-            # for jagged layout NestedTensors today
+            # SingletonInt represents nested-int identity, not a runtime size.
+            # Fold identity comparisons here; tensor aliasing guards track when
+            # input nested-int identities can change.
+            has_singleton_int = True
+            if not unbacked_only:
+                new_shape_env[k] = val
             continue
         if vr is None:
             raise AssertionError(f"vr must not be None for symbol {k}")
@@ -2595,16 +2600,28 @@ def _maybe_evaluate_static_worker(
     try:
         # pyrefly: ignore [missing-attribute]
         new_expr = expr.xreplace(new_shape_env)
-    except RecursionError:
-        log.warning("RecursionError in sympy.xreplace(%s, %s)", expr, new_shape_env)
+    except (RecursionError, ValueError, NotImplementedError) as e:
+        if isinstance(e, RecursionError):
+            log.warning("RecursionError in sympy.xreplace(%s, %s)", expr, new_shape_env)
+        elif has_singleton_int:
+            return None
+        else:
+            raise
         return None
 
     # We need to canonicalize, as after expand we may have something like `a + b = a` and
     # sympy will not simplify the a. The two appearances of the a will then make value ranges
     # analysis give lose bounds
-    new_expr = canonicalize_bool_expr(safe_expand(new_expr))
+    try:
+        new_expr = canonicalize_bool_expr(safe_expand(new_expr))
+    except (ValueError, NotImplementedError):
+        if has_singleton_int:
+            return None
+        raise
     if new_expr.is_number:
         return new_expr
+    if has_singleton_int and new_expr.has(SingletonInt):
+        return None
 
     # Check if the range can solve it statically
     out = bound_sympy(new_expr, new_range_env)

--- a/torch/utils/_sympy/singleton_int.py
+++ b/torch/utils/_sympy/singleton_int.py
@@ -11,13 +11,13 @@ class SingletonInt(sympy.AtomicExpr):
     # situations with other more exotic Expr types.
     _op_priority = 99999
 
-    def __new__(cls, *args, coeff=None, **kwargs):
-        instance = super().__new__(cls, *args, **kwargs)
+    def __new__(cls, val, coeff=1):
+        instance = super().__new__(cls, sympy.sympify(val), sympy.sympify(coeff))
         return instance
 
     # The semantics of this class should match that of NestedIntSymNodeImpl in
     # c10/core/NestedIntSymNodeImpl.h
-    def __init__(self, val, *, coeff=1) -> None:
+    def __init__(self, val, coeff=1) -> None:
         self._val = val
         self._coeff = coeff
         super().__init__()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185016

torch.compile could crash when a jagged NestedTensor was created inside the compiled region and a later operation compared its ragged dimension, as in layer_norm on torch.nested.as_nested_tensor(..., layout=torch.jagged). The ragged dimension is represented by a SingletonInt-backed symbolic value with only an EphemeralSource for in-graph intermediates. Static guard evaluation skipped SingletonInt values, so identity comparisons such as nested_dim != 4 were emitted as Python guards. Guard codegen then tried to render the ephemeral-only source and failed with an internal IndexError.

Fix this by allowing best-effort static evaluation to substitute SingletonInt values and fold nested-int identity comparisons. This keeps unsupported SingletonInt arithmetic conservative by returning None when substitution or simplification cannot handle it, and it does not drop guards. Input nested-int identity changes remain covered by Dynamo tensor aliasing guards. SingletonInt now includes the coefficient in its SymPy structural identity so cached static-eval results distinguish j from 2*j.

I considered the prior PR's approach of skipping ephemeral-only guards, but that can silently weaken guards when the comparison is semantically meaningful. Folding only the nested-int identity comparisons preserves the existing guard model while avoiding the crash.

Fixes #168307

Generated by my agent

Test Plan:

python test/test_sympy_utils.py TestSingletonInt

python test/test_dynamic_shapes.py TestPySymInt.test_singleton_int_coeff_in_static_eval_cache

python test/dynamo/test_subclasses.py TestNestedTensor.test_as_nested_tensor_from_intermediate_layer_norm TestNestedTensor.test_in_graph_construction_from_intermediate_5

python test/dynamo/test_subclasses.py TestNestedTensor

lintrunner -a

git diff --check

git diff --cached --check

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98