### PR TITLE
Add lane analysis helpers for CuteDSL vector loads

### DIFF
--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -34,6 +34,7 @@ from torch._inductor.virtualized import V
 
 from ...utils import sympy_index_symbol
 from .cutedsl_op_overrides import CuteDSLCSEVariable, CuteDSLOpOverrides
+from .lane_analysis import classify_lane_expr
 
 
 # TODO setting the 'main' kernel w/ this suffix. We have 3 should probably just auto generate this
@@ -101,7 +102,8 @@ class CuteDSLIndexFragment:
         code: Python source expression for the index or index fragment.
         is_static_int: True when code is an inline integer index, not a fragment.
         is_lane_uniform: True when every vector lane has the same index.
-        is_contiguous: True when code is lane-contiguous in the vectorized index.
+        is_contiguous: True when code is aligned and contiguous for the full
+            requested vector width.
     """
 
     code: str
@@ -241,6 +243,7 @@ class CuteDSLTemplateKernel(Kernel):
             "gen_defines": lambda: self.gen_defines(**kwargs),
             "get_output": self.get_output,
             "get_tensor_buffers": self.get_tensor_buffers,
+            "add_tensor_inputs": self.add_tensor_inputs,
             "unpack_buffers": self.unpack_buffers,
             "modification": self.modification,
             "set_cute_hash": self.set_cute_hash,
@@ -406,6 +409,19 @@ class CuteDSLTemplateKernel(Kernel):
     def get_tensor_buffers(self):
         """Get list of tensor buffer names that were collected during modifications."""
         return self.collected_tensor_buffers
+
+    def add_tensor_inputs(self, buffers):
+        """Register extra tensor buffers and return their rendered input names."""
+        buffer_names = []
+        for buffer in buffers:
+            if isinstance(buffer, sympy.Expr):
+                # Symbolic size/index expressions are not kernel tensor inputs yet.
+                continue
+            remapped_name = self.args.input(buffer.get_name())
+            if remapped_name not in self.collected_tensor_buffers:
+                self.collected_tensor_buffers.append(remapped_name)
+            buffer_names.append(remapped_name)
+        return buffer_names
 
     def unpack_buffers(self, buffer_list_name: str, *, indent_width: int = 4):
         """Generate buffer unpacking code via render hook."""
@@ -886,20 +902,16 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         if self.vector_load_config.vec_size <= 1:
             return True, False, None
 
-        lane_contiguity = V.graph.sizevars.analyze_lane_contiguity(
+        lane_info = classify_lane_expr(
             semantic_expr,
             self.vector_load_config.index,
-        )
-        contiguous_width = self._aligned_contiguous_width(
-            semantic_expr,
-            self.vector_load_config.index,
-            lane_contiguity,
-            self.vector_load_config.vec_size,
+            max_width=self.vector_load_config.vec_size,
+            uniform_symbols=self._lane_uniform_symbols(),
         )
         return (
-            self._is_lane_uniform_expr(semantic_expr, self.vector_load_config.index),
-            lane_contiguity.stride == 1 and contiguous_width is not None,
-            contiguous_width,
+            lane_info.is_uniform,
+            lane_info.is_contiguous,
+            lane_info.contiguous_width,
         )
 
     @staticmethod
@@ -932,37 +944,20 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
                 replacements[sympy_index_symbol(var.name)] = var.index_expr
         return V.graph.sizevars.simplify(expr.xreplace(replacements))
 
-    def _is_lane_uniform_expr(
-        self, expr: sympy.Expr, vector_index: sympy.Symbol
-    ) -> bool:
-        """Return true when expr depends only on non-vectorized indices."""
-        allowed_symbols = OrderedSet(
-            sympy_index_symbol(source_expr)
-            for source_expr in self.kernel.cse._cache
-            if isinstance(source_expr, str) and source_expr != vector_index.name
+    def _lane_uniform_symbols(self) -> OrderedSet[sympy.Symbol]:
+        """Return generated CSE source symbols that are uniform across lanes."""
+        vector_index_name = (
+            None
+            if self.vector_load_config is None
+            else self.vector_load_config.index.name
         )
-        return bool(expr.free_symbols and expr.free_symbols <= allowed_symbols)
-
-    @staticmethod
-    def _aligned_contiguous_width(
-        expr: sympy.Expr,
-        vector_index: sympy.Symbol,
-        lane_contiguity,
-        max_width: int,
-    ) -> int | None:
-        """Narrow contiguous width until the first lane is statically aligned."""
-        start_expr = V.graph.sizevars.simplify(
-            expr.xreplace({vector_index: sympy.Integer(0)})
+        return OrderedSet(
+            [
+                sympy_index_symbol(source_expr)
+                for source_expr in self.kernel.cse._cache
+                if isinstance(source_expr, str) and source_expr != vector_index_name
+            ]
         )
-        for width in (max_width, 4, 2):
-            if (
-                width <= max_width
-                and lane_contiguity.is_contiguous_for(width)
-                and V.graph.sizevars.statically_known_multiple_of(start_expr, width)
-                and V.graph.sizevars.statically_known_geq(start_expr, 0)
-            ):
-                return width
-        return None
 
     def indirect_indexing(self, index_var: str, size, check, wrap_neg=True):
         """Convert index variable to symbolic form."""

--- a/torch/_inductor/codegen/cutedsl/lane_analysis.py
+++ b/torch/_inductor/codegen/cutedsl/lane_analysis.py
@@ -1,0 +1,95 @@
+# mypy: allow-untyped-defs
+
+import dataclasses
+
+import sympy
+
+from torch.utils._ordered_set import OrderedSet
+
+from ...virtualized import V
+
+
+@dataclasses.dataclass(frozen=True)
+class LaneExprInfo:
+    """Lane-wise uniformity and contiguity classification for an expression.
+
+    ``is_contiguous`` means the expression is aligned and contiguous for the
+    full ``max_width`` requested by ``classify_lane_expr``.
+    """
+
+    is_uniform: bool
+    is_contiguous: bool
+    contiguous_width: int | None
+
+
+def classify_lane_expr(
+    expr: sympy.Expr,
+    lane_var: sympy.Symbol,
+    *,
+    max_width: int,
+    uniform_symbols: OrderedSet[sympy.Symbol] | None = None,
+) -> LaneExprInfo:
+    """Classify whether an expression is uniform or full-width contiguous."""
+    if max_width <= 1:
+        return LaneExprInfo(True, False, None)
+
+    semantic_expr = V.graph.sizevars.simplify(expr)
+    if uniform_symbols is not None and semantic_expr.free_symbols <= uniform_symbols:
+        return LaneExprInfo(True, False, None)
+
+    lane_contiguity = V.graph.sizevars.analyze_lane_contiguity(semantic_expr, lane_var)
+    contiguous_width = aligned_contiguous_width(
+        semantic_expr,
+        lane_var,
+        max_width=max_width,
+        lane_contiguity=lane_contiguity,
+    )
+    return LaneExprInfo(
+        is_uniform=lane_contiguity.is_uniform_for(max_width),
+        is_contiguous=lane_contiguity.stride == 1 and contiguous_width == max_width,
+        contiguous_width=contiguous_width,
+    )
+
+
+def aligned_contiguous_width(
+    expr: sympy.Expr,
+    lane_var: sympy.Symbol,
+    *,
+    max_width: int,
+    lane_contiguity=None,
+) -> int | None:
+    """Return the largest aligned power-of-two contiguous lane width."""
+    assert max_width >= 2 and max_width.bit_count() == 1
+    if lane_contiguity is None:
+        lane_contiguity = V.graph.sizevars.analyze_lane_contiguity(expr, lane_var)
+    start_expr = lane_group_start(expr, lane_var)
+    width = max_width
+    while width >= 2:
+        if (
+            lane_contiguity.is_contiguous_for(width)
+            and V.graph.sizevars.statically_known_multiple_of(start_expr, width)
+            and V.graph.sizevars.statically_known_geq(start_expr, 0)
+        ):
+            return width
+        width //= 2
+    return None
+
+
+def lane_group_start(expr: sympy.Expr, lane_var: sympy.Symbol) -> sympy.Expr:
+    """Return the expression value at the first lane in the lane group."""
+    return V.graph.sizevars.simplify(expr.xreplace({lane_var: sympy.Integer(0)}))
+
+
+def decompose_affine_lane_expr(
+    expr: sympy.Expr, lane_var: sympy.Symbol
+) -> tuple[sympy.Expr, sympy.Expr] | None:
+    """Decompose an affine lane expression into ``(lane_coeff, rest)``."""
+    expr = V.graph.sizevars.simplify(expr)
+    lane_coeff = expr.coeff(lane_var)
+    rest = lane_group_start(expr, lane_var)
+    if lane_var in lane_coeff.free_symbols or lane_var in rest.free_symbols:
+        return None
+    residual = V.graph.sizevars.simplify(expr - (lane_coeff * lane_var + rest))
+    if residual != 0:
+        return None
+    return lane_coeff, rest

--- a/torch/_inductor/codegen/cutedsl/lane_analysis.py
+++ b/torch/_inductor/codegen/cutedsl/lane_analysis.py
@@ -11,10 +11,17 @@ from ...virtualized import V
 
 @dataclasses.dataclass(frozen=True)
 class LaneExprInfo:
-    """Lane-wise uniformity and contiguity classification for an expression.
+    """How an index expression changes across vectorized lanes.
 
-    ``is_contiguous`` means the expression is aligned and contiguous for the
-    full ``max_width`` requested by ``classify_lane_expr``.
+    A lane is one element of =a vectorized CuteDSL computation. For a 32-lane
+    mask/load, lane 0 is the first element in the group and lane 31 is the last.
+
+    Attributes:
+        is_uniform: All lanes evaluate to the same value, e.g. for flex-flash``b_idx``.
+        is_contiguous: Lanes evaluate to consecutive aligned values for the
+            requested width, e.g. ``kv_idx + lane`` when lane 0 is aligned.
+        contiguous_width: Largest aligned contiguous power-of-two width proven,
+            or None if no vector-width contiguity is proven.
     """
 
     is_uniform: bool
@@ -29,7 +36,24 @@ def classify_lane_expr(
     max_width: int,
     uniform_symbols: OrderedSet[sympy.Symbol] | None = None,
 ) -> LaneExprInfo:
-    """Classify whether an expression is uniform or full-width contiguous."""
+    """Classify how ``expr`` varies across ``lane_var`` vector lanes.
+
+    ``max_width`` is the requested vector width. We start with this as the
+    maximum width to check and then decrease in powers of two trying to find a width
+    that satisfies contiguity across lanes. We cap since we are trying to get vectorized loads
+    which are at 128 and 256(B200) bits so no need to check higher.
+
+    For example a ``lane_var = kv_idx`` and ``max_width = 8``:
+
+    - No dependency on lane var: ``q_idx`` returns
+      ``LaneExprInfo(is_uniform=True, is_contiguous=False, contiguous_width=None)``.
+    - ``kv_idx`` at an 8-aligned group start returns
+      ``LaneExprInfo(is_uniform=False, is_contiguous=True, contiguous_width=8)``.
+    - ``kv_idx + 4`` at a 4-aligned but not 8-aligned group start returns
+      ``LaneExprInfo(is_uniform=False, is_contiguous=False, contiguous_width=4)``.
+    - ``kv_idx * 2`` returns
+      ``LaneExprInfo(is_uniform=False, is_contiguous=False, contiguous_width=None)``.
+    """
     if max_width <= 1:
         return LaneExprInfo(True, False, None)
 
@@ -76,14 +100,34 @@ def aligned_contiguous_width(
 
 
 def lane_group_start(expr: sympy.Expr, lane_var: sympy.Symbol) -> sympy.Expr:
-    """Return the expression value at the first lane in the lane group."""
+    """Return the lane-group base value by evaluating ``expr`` at lane 0.
+
+    For example, if ``expr = base + lane_var``, this returns ``base``. This is
+    useful when checking vector-load alignment: a contiguous lane expression is only
+    safe to vectorize when the first lane's address is sufficiently aligned.
+    """
     return V.graph.sizevars.simplify(expr.xreplace({lane_var: sympy.Integer(0)}))
 
 
 def decompose_affine_lane_expr(
     expr: sympy.Expr, lane_var: sympy.Symbol
 ) -> tuple[sympy.Expr, sympy.Expr] | None:
-    """Decompose an affine lane expression into ``(lane_coeff, rest)``."""
+    """Return ``(stride, base)`` when ``expr`` is affine in ``lane_var``.
+
+    The result satisfies ``expr == stride * lane_var + base``, where neither
+    ``stride`` nor ``base`` depends on ``lane_var``.
+    For example: ``stride == 0`` means lane-uniform, ``stride == 1`` means
+    consecutive lanes access consecutive indices, and other strides are
+    non-contiguous gathers.
+
+    Examples with ``lane_var = i``:
+        ``b + i`` -> ``(1, b)``
+        ``b + 2 * i`` -> ``(2, b)``
+        ``b`` -> ``(0, b)``
+
+    Returns ``None`` for non-affine expressions or when the extracted stride or
+    base still depends on ``lane_var``.
+    """
     expr = V.graph.sizevars.simplify(expr)
     lane_coeff = expr.coeff(lane_var)
     rest = lane_group_start(expr, lane_var)

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -391,6 +391,12 @@ class MockGraphHandler:
         self.constants = {}
         self.scheduler = None
 
+    def try_get_buffer(self, buffer_name: str):
+        return self.name_to_buffer.get(buffer_name)
+
+    def get_buffer(self, buffer_name: str):
+        return self.name_to_buffer[buffer_name]
+
     def get_dtype(self, buffer_name: str) -> torch.dtype:
         """Return default dtype for any buffer (for testing)."""
         return torch.float32


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184438
* #185020
* __->__ #185019

# Summary

This is a prep commit, basically turns our old adhock sizevar vec/lane math into a more strongly typed variant and put it closer to cutedsl. It has 1 prep entry which is add_tensor_inputs. This basically mirrors what we have in mdofication wrapper but since for the packed lane shfit path we dont go through the graph replay im putting it here.

This is baiscally a noop PR and all prep. I read it all :)

### Note for the reviewer
I dont think this needs much review its mostly code motion / adding longer doc blocks and adding types



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo