### PR TITLE
[inductor] Reassociate cat under surviving reductions

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -567,6 +567,44 @@ class TestPatternMatcher(TestCase):
         self.assertEqual(compiled_fn(x), test_fn(x))
         self.assertEqual(counters["inductor"]["partial_reduction_reuse"], 1)
 
+    @inductor_config.patch(fx_graph_remote_cache=False)
+    def test_cat_under_sum_reassociation(self):
+        def rewritten(a, b):
+            s = torch.sigmoid(a[:, 2:, :])
+            return torch.cat([s * b, (1.0 - s) * s * a[:, :2, :] * b], dim=1).sum(
+                dim=(0, 2)
+            )
+
+        def rewritten_keepdim_dtype(a, b, c):
+            s = torch.sigmoid(a[:, 2:, :])
+            return torch.cat([s * b, c, (1.0 - s) * s * a[:, :2, :] * b], dim=-2).sum(
+                dim=(-3, -1), keepdim=True, dtype=torch.float64
+            )
+
+        def guarded(a, b):
+            return torch.cat([a, b], dim=1).sum(dim=(1, 2))
+
+        a = torch.randn(3, 4, 5, device=GPU_TYPE)
+        b = torch.randn(3, 2, 5, device=GPU_TYPE)
+        c = torch.randn(3, 1, 5, device=GPU_TYPE)
+
+        counters.clear()
+        actual, _ = run_and_get_code(torch.compile(rewritten), a, b)
+        torch.testing.assert_close(actual, rewritten(a, b))
+        self.assertEqual(counters["inductor"]["cat_under_sum_reassociation"], 1)
+
+        counters.clear()
+        actual, _ = run_and_get_code(torch.compile(rewritten_keepdim_dtype), a, b, c)
+        torch.testing.assert_close(
+            actual, rewritten_keepdim_dtype(a, b, c), rtol=1e-6, atol=1e-6
+        )
+        self.assertEqual(counters["inductor"]["cat_under_sum_reassociation"], 1)
+
+        counters.clear()
+        actual, _ = run_and_get_code(torch.compile(guarded), a, b)
+        torch.testing.assert_close(actual, guarded(a, b))
+        self.assertEqual(counters["inductor"]["cat_under_sum_reassociation"], 0)
+
     def test_addmm(self):
         def fn(a, b, c):
             return torch.add(a, torch.mm(b, c)), torch.mm(b, c) + a

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -605,6 +605,59 @@ class TestPatternMatcher(TestCase):
         torch.testing.assert_close(actual, guarded(a, b))
         self.assertEqual(counters["inductor"]["cat_under_sum_reassociation"], 0)
 
+    @inductor_config.patch(fx_graph_remote_cache=False)
+    def test_cat_under_mean_reassociation(self):
+        def rewritten(a, b):
+            s = torch.sigmoid(a[:, 2:, :])
+            return torch.cat([s * b, (1.0 - s) * s * a[:, :2, :] * b], dim=1).mean(
+                dim=(0, 2)
+            )
+
+        def rewritten_keepdim_dtype(a, b, c):
+            s = torch.sigmoid(a[:, 2:, :])
+            return torch.cat(
+                [s * b, c, (1.0 - s) * s * a[:, :2, :] * b], dim=-2
+            ).mean(dim=(-3, -1), keepdim=True, dtype=torch.float64)
+
+        def guarded(a, b):
+            return torch.cat([a, b], dim=1).mean(dim=(1, 2))
+
+        a = torch.randn(3, 4, 5, device=GPU_TYPE)
+        b = torch.randn(3, 2, 5, device=GPU_TYPE)
+        c = torch.randn(3, 1, 5, device=GPU_TYPE)
+
+        counters.clear()
+        actual, _ = run_and_get_code(torch.compile(rewritten), a, b)
+        torch.testing.assert_close(actual, rewritten(a, b))
+        self.assertEqual(counters["inductor"]["cat_under_mean_reassociation"], 1)
+
+        counters.clear()
+        actual, _ = run_and_get_code(torch.compile(rewritten_keepdim_dtype), a, b, c)
+        torch.testing.assert_close(
+            actual, rewritten_keepdim_dtype(a, b, c), rtol=1e-6, atol=1e-6
+        )
+        self.assertEqual(counters["inductor"]["cat_under_mean_reassociation"], 1)
+
+        counters.clear()
+        actual, _ = run_and_get_code(torch.compile(guarded), a, b)
+        torch.testing.assert_close(actual, guarded(a, b))
+        self.assertEqual(counters["inductor"]["cat_under_mean_reassociation"], 0)
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        y = graph.placeholder("y")
+        cat = graph.call_function(aten.cat.default, args=([x, y],), kwargs={"dim": 1})
+        mean = graph.call_function(aten.mean.dim, args=(cat, [0, -3], False))
+        graph.output(mean)
+        x.meta["val"] = a
+        y.meta["val"] = b
+        cat.meta["val"] = torch.cat([a, b], dim=1)
+        mean.meta["val"] = torch.empty(4, device=GPU_TYPE)
+
+        counters.clear()
+        torch._inductor.fx_passes.post_grad._reassociate_cat_under_mean(graph)
+        self.assertEqual(counters["inductor"]["cat_under_mean_reassociation"], 0)
+
     def test_addmm(self):
         def fn(a, b, c):
             return torch.add(a, torch.mm(b, c)), torch.mm(b, c) + a

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -615,9 +615,9 @@ class TestPatternMatcher(TestCase):
 
         def rewritten_keepdim_dtype(a, b, c):
             s = torch.sigmoid(a[:, 2:, :])
-            return torch.cat(
-                [s * b, c, (1.0 - s) * s * a[:, :2, :] * b], dim=-2
-            ).mean(dim=(-3, -1), keepdim=True, dtype=torch.float64)
+            return torch.cat([s * b, c, (1.0 - s) * s * a[:, :2, :] * b], dim=-2).mean(
+                dim=(-3, -1), keepdim=True, dtype=torch.float64
+            )
 
         def guarded(a, b):
             return torch.cat([a, b], dim=1).mean(dim=(1, 2))

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -149,19 +149,24 @@ def _normalize_dim(dim: int, ndim: int) -> int | None:
     return dim
 
 
-def _sum_kwargs(dtype: Any | None) -> dict[str, Any]:
+def _dtype_kwargs(dtype: Any | None) -> dict[str, Any]:
     return {} if dtype is None else {"dtype": dtype}
 
 
-def _reassociate_cat_under_sum(graph: torch.fx.Graph) -> None:
+def _reassociate_cat_under_reduction(
+    graph: torch.fx.Graph,
+    reduction_op: torch._ops.OpOverload,
+    counter_name: str,
+) -> None:
     """
-    Rewrite sum(cat(xs, dim=C), dims) into cat(sum(x, dims), dim=C) when C is
-    not reduced.  This lets lowering avoid a masked reduction over cat arms.
+    Rewrite reduction(cat(xs, dim=C), dims) into
+    cat(reduction(x, dims), dim=C) when C is not reduced.  This lets lowering
+    avoid a masked reduction over cat arms.
     """
-    for sum_node in list(
-        graph.find_nodes(op="call_function", target=aten.sum.dim_IntList)
+    for reduction_node in list(
+        graph.find_nodes(op="call_function", target=reduction_op)
     ):
-        cat_node = get_arg_value(sum_node, 0, "input")
+        cat_node = get_arg_value(reduction_node, 0, "input")
         if not (
             isinstance(cat_node, torch.fx.Node)
             and cat_node.op == "call_function"
@@ -172,9 +177,9 @@ def _reassociate_cat_under_sum(graph: torch.fx.Graph) -> None:
 
         tensors = get_arg_value(cat_node, 0, "tensors")
         cat_dim = get_arg_value(cat_node, 1, "dim")
-        reduce_dims = get_arg_value(sum_node, 1, "dim")
-        keepdim = get_arg_value(sum_node, 2, "keepdim")
-        dtype = get_arg_value(sum_node, 3, "dtype")
+        reduce_dims = get_arg_value(reduction_node, 1, "dim")
+        keepdim = get_arg_value(reduction_node, 2, "keepdim")
+        dtype = get_arg_value(reduction_node, 3, "dtype")
 
         if cat_dim is None:
             cat_dim = 0
@@ -195,9 +200,9 @@ def _reassociate_cat_under_sum(graph: torch.fx.Graph) -> None:
             continue
 
         cat_val = cat_node.meta.get("val")
-        sum_val = sum_node.meta.get("val")
+        reduction_val = reduction_node.meta.get("val")
         if not isinstance(cat_val, torch.Tensor) or not isinstance(
-            sum_val, torch.Tensor
+            reduction_val, torch.Tensor
         ):
             continue
         if not is_gpu(cat_val.device.type):
@@ -235,32 +240,44 @@ def _reassociate_cat_under_sum(graph: torch.fx.Graph) -> None:
         if len(tensor_vals) != len(tensors):
             continue
 
-        new_sum_nodes = []
-        with graph.inserting_before(sum_node):
+        new_reduction_nodes = []
+        with graph.inserting_before(reduction_node):
             for tensor, tensor_val in zip(tensors, tensor_vals):
-                new_sum = graph.call_function(
-                    aten.sum.dim_IntList,
+                new_reduction = graph.call_function(
+                    reduction_op,
                     args=(tensor, normalized_reduce_dims, keepdim),
-                    kwargs=_sum_kwargs(dtype),
+                    kwargs=_dtype_kwargs(dtype),
                 )
-                new_sum.meta["val"] = aten.sum.dim_IntList(
+                new_reduction.meta["val"] = reduction_op(
                     tensor_val,
                     normalized_reduce_dims,
                     keepdim,
-                    **_sum_kwargs(dtype),
+                    **_dtype_kwargs(dtype),
                 )
-                new_sum_nodes.append(new_sum)
+                new_reduction_nodes.append(new_reduction)
             new_cat = graph.call_function(
                 aten.cat.default,
-                args=(new_sum_nodes,),
+                args=(new_reduction_nodes,),
                 kwargs={"dim": new_cat_dim},
             )
-            new_cat.meta.update(sum_node.meta)
-            sum_node.replace_all_uses_with(new_cat)
-            graph.erase_node(sum_node)
+            new_cat.meta.update(reduction_node.meta)
+            reduction_node.replace_all_uses_with(new_cat)
+            graph.erase_node(reduction_node)
             if len(cat_node.users) == 0:
                 graph.erase_node(cat_node)
-            counters["inductor"]["cat_under_sum_reassociation"] += 1
+            counters["inductor"][counter_name] += 1
+
+
+def _reassociate_cat_under_sum(graph: torch.fx.Graph) -> None:
+    _reassociate_cat_under_reduction(
+        graph, aten.sum.dim_IntList, "cat_under_sum_reassociation"
+    )
+
+
+def _reassociate_cat_under_mean(graph: torch.fx.Graph) -> None:
+    _reassociate_cat_under_reduction(
+        graph, aten.mean.dim, "cat_under_mean_reassociation"
+    )
 
 
 def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
@@ -329,6 +346,9 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         )
         GraphTransformObserver(gm, "reassociate_cat_under_sum").apply_graph_pass(
             _reassociate_cat_under_sum
+        )
+        GraphTransformObserver(gm, "reassociate_cat_under_mean").apply_graph_pass(
+            _reassociate_cat_under_mean
         )
         for i, patterns in enumerate(pass_patterns):
             GraphTransformObserver(gm, f"pass_pattern_{i}").apply_graph_pass(

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -209,7 +209,7 @@ def _reassociate_cat_under_sum(graph: torch.fx.Graph) -> None:
         if (
             normalized_cat_dim is None
             or any(dim is None for dim in normalized_reduce_dims)
-            or len(set(normalized_reduce_dims)) != len(normalized_reduce_dims)
+            or len(OrderedSet(normalized_reduce_dims)) != len(normalized_reduce_dims)
             or normalized_cat_dim in normalized_reduce_dims
         ):
             continue

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -141,6 +141,128 @@ def _chain_random_ops_for_ordering(graph: torch.fx.Graph) -> None:
     preserve_node_ordering(graph, additional_deps_map)
 
 
+def _normalize_dim(dim: int, ndim: int) -> int | None:
+    if dim < 0:
+        dim += ndim
+    if not 0 <= dim < ndim:
+        return None
+    return dim
+
+
+def _sum_kwargs(dtype: Any | None) -> dict[str, Any]:
+    return {} if dtype is None else {"dtype": dtype}
+
+
+def _reassociate_cat_under_sum(graph: torch.fx.Graph) -> None:
+    """
+    Rewrite sum(cat(xs, dim=C), dims) into cat(sum(x, dims), dim=C) when C is
+    not reduced.  This lets lowering avoid a masked reduction over cat arms.
+    """
+    for sum_node in list(
+        graph.find_nodes(op="call_function", target=aten.sum.dim_IntList)
+    ):
+        cat_node = get_arg_value(sum_node, 0, "input")
+        if not (
+            isinstance(cat_node, torch.fx.Node)
+            and cat_node.op == "call_function"
+            and cat_node.target is aten.cat.default
+            and len(cat_node.users) == 1
+        ):
+            continue
+
+        tensors = get_arg_value(cat_node, 0, "tensors")
+        cat_dim = get_arg_value(cat_node, 1, "dim")
+        reduce_dims = get_arg_value(sum_node, 1, "dim")
+        keepdim = get_arg_value(sum_node, 2, "keepdim")
+        dtype = get_arg_value(sum_node, 3, "dtype")
+
+        if cat_dim is None:
+            cat_dim = 0
+        if keepdim is None:
+            keepdim = False
+        if not (
+            isinstance(tensors, (list, tuple))
+            and len(tensors) > 1
+            and isinstance(cat_dim, int)
+            and isinstance(reduce_dims, (list, tuple))
+            and len(reduce_dims) > 0
+            and all(isinstance(dim, int) for dim in reduce_dims)
+            and isinstance(keepdim, bool)
+            and (dtype is None or isinstance(dtype, torch.dtype))
+        ):
+            continue
+        if not all(isinstance(tensor, torch.fx.Node) for tensor in tensors):
+            continue
+
+        cat_val = cat_node.meta.get("val")
+        sum_val = sum_node.meta.get("val")
+        if not isinstance(cat_val, torch.Tensor) or not isinstance(
+            sum_val, torch.Tensor
+        ):
+            continue
+        if not is_gpu(cat_val.device.type):
+            continue
+
+        ndim = cat_val.dim()
+        normalized_cat_dim = _normalize_dim(cat_dim, ndim)
+        normalized_reduce_dims = [_normalize_dim(dim, ndim) for dim in reduce_dims]
+        if (
+            normalized_cat_dim is None
+            or any(dim is None for dim in normalized_reduce_dims)
+            or len(set(normalized_reduce_dims)) != len(normalized_reduce_dims)
+            or normalized_cat_dim in normalized_reduce_dims
+        ):
+            continue
+        normalized_reduce_dims = [
+            dim for dim in normalized_reduce_dims if dim is not None
+        ]
+
+        if not keepdim:
+            new_cat_dim = normalized_cat_dim - sum(
+                dim < normalized_cat_dim for dim in normalized_reduce_dims
+            )
+        else:
+            new_cat_dim = normalized_cat_dim
+
+        tensor_vals = []
+        for tensor in tensors:
+            tensor_val = tensor.meta.get("val")
+            if not isinstance(tensor_val, torch.Tensor) or tensor_val.dim() != ndim:
+                break
+            if any(statically_known_true(size == 0) for size in tensor_val.shape):
+                break
+            tensor_vals.append(tensor_val)
+        if len(tensor_vals) != len(tensors):
+            continue
+
+        new_sum_nodes = []
+        with graph.inserting_before(sum_node):
+            for tensor, tensor_val in zip(tensors, tensor_vals):
+                new_sum = graph.call_function(
+                    aten.sum.dim_IntList,
+                    args=(tensor, normalized_reduce_dims, keepdim),
+                    kwargs=_sum_kwargs(dtype),
+                )
+                new_sum.meta["val"] = aten.sum.dim_IntList(
+                    tensor_val,
+                    normalized_reduce_dims,
+                    keepdim,
+                    **_sum_kwargs(dtype),
+                )
+                new_sum_nodes.append(new_sum)
+            new_cat = graph.call_function(
+                aten.cat.default,
+                args=(new_sum_nodes,),
+                kwargs={"dim": new_cat_dim},
+            )
+            new_cat.meta.update(sum_node.meta)
+            sum_node.replace_all_uses_with(new_cat)
+            graph.erase_node(sum_node)
+            if len(cat_node.users) == 0:
+                graph.erase_node(cat_node)
+            counters["inductor"]["cat_under_sum_reassociation"] += 1
+
+
 def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
     """
     Passes that run on after grad.  This is called once on the forwards
@@ -204,6 +326,9 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         GraphTransformObserver(gm, "remove_noop_ops").apply_graph_pass(remove_noop_ops)
         GraphTransformObserver(gm, "remove_assert_ops").apply_graph_pass(
             remove_assert_ops
+        )
+        GraphTransformObserver(gm, "reassociate_cat_under_sum").apply_graph_pass(
+            _reassociate_cat_under_sum
         )
         for i, patterns in enumerate(pass_patterns):
             GraphTransformObserver(gm, f"pass_pattern_{i}").apply_graph_pass(


### PR DESCRIPTION
Submitted by my agent.

## Summary

Reassociate channel cat under reductions when the cat dimension survives the reduction. This currently handles:

- `sum(cat(xs, dim=C), reduce_dims) -> cat(sum(x, adjusted_reduce_dims), dim=C)`
- `mean(cat(xs, dim=C), reduce_dims) -> cat(mean(x, adjusted_reduce_dims), dim=C)`

The rewrite avoids lowering as one masked reduction with all cat arms, duplicated branch work, and cat-region predicates.

## Evidence

Better-benchmark issue: eellison/better-benchmark#50.

- `sum_031c8d6c51f7`: `59.232 us -> 32.672 us`, about `1.81x`.
- `mean_f7170c220032`: local split no-cat mean prototype `70.40 us -> 63.36 us`; NCU on the current fused cat+mean kernel shows instruction/latency pressure rather than bandwidth: 491,520 CTAs, 115.4M executed instructions, 3.72% DRAM, and 0.66 eligible warps/scheduler.

## Validation

- `git diff --check`
- `python -m py_compile torch/_inductor/fx_passes/post_grad.py test/inductor/test_pattern_matcher.py`
- `PYTHONPATH=. python test/inductor/test_pattern_matcher.py -k test_cat_under_sum_reassociation`
- `PYTHONPATH=. python test/inductor/test_pattern_matcher.py -k test_cat_under_mean_reassociation`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo