### PR TITLE
Fix AOT synthetic-base out view returns

### DIFF
--- a/test/inductor/test_auto_functionalize.py
+++ b/test/inductor/test_auto_functionalize.py
@@ -506,6 +506,62 @@ def forward(self, arg0_1: "f32[3][1]cpu", arg1_1: "f32[3][1]cpu", arg2_1: "f32[3
                 self.assertEqual(aot_eager_ret, eager_ret)
                 self.assertEqual(inductor_ret, eager_ret)
 
+    def test_out_return_preserves_view_after_graph_break(self):
+        sz = 9
+
+        def f(data, other1, other2):
+            inp = data[:sz]
+            output = data[:sz]
+            torch._dynamo.graph_break()
+            expected = torch.empty_like(output)
+            torch.addcmul(
+                inp,
+                other1.view(inp.shape),
+                other2.view(inp.shape),
+                out=expected,
+            )
+            result = torch.addcmul(
+                inp,
+                other1.view(inp.shape),
+                other2.view(inp.shape),
+                out=output,
+            )
+            return output, result, expected
+
+        data = torch.randn(2 * sz, dtype=torch.float64)
+        other1 = torch.randn(sz, dtype=torch.float64)
+        other2 = torch.randn(sz, dtype=torch.float64)
+
+        output, result, expected = torch.compile(f, backend="aot_eager")(
+            data, other1, other2
+        )
+
+        self.assertEqual(output.shape, (sz,))
+        self.assertEqual(result.shape, (sz,))
+        self.assertEqual(expected.shape, (sz,))
+        self.assertEqual(result.data_ptr(), output.data_ptr())
+        self.assertEqual(output, expected)
+        self.assertEqual(result, expected)
+
+        def same_metadata_view(data, other):
+            inp = data.view(data.shape)
+            output = data.view(data.shape)
+            torch._dynamo.graph_break()
+            expected = torch.empty_like(output)
+            torch.add(inp, other, out=expected)
+            result = torch.add(inp, other, out=output)
+            return data, output, result, expected
+
+        base, output, result, expected = torch.compile(
+            same_metadata_view, backend="aot_eager"
+        )(torch.randn(sz), torch.randn(sz))
+
+        self.assertIs(output._base, base)
+        self.assertIs(result._base, base)
+        self.assertEqual(result.data_ptr(), output.data_ptr())
+        self.assertEqual(output, expected)
+        self.assertEqual(result, expected)
+
     @torch._inductor.config.patch(enable_auto_functionalized_v2=True)
     def test_auto_functionalize_with_returns_v2(self):
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:

--- a/torch/_functorch/_aot_autograd/input_output_analysis.py
+++ b/torch/_functorch/_aot_autograd/input_output_analysis.py
@@ -24,6 +24,7 @@ from torch.fx.experimental.symbolic_shapes import is_concrete_int
 
 from .collect_metadata_analysis import coerce_tangent_and_suggest_memory_format
 from .descriptors import AOTInput, InputMutationAOTOutput, TangentAOTInput
+from .functional_utils import has_same_metadata
 from .schemas import (
     AOTConfig,
     BackwardSignature,
@@ -231,19 +232,36 @@ def create_synthetic_base_metadata(
     ]
     existing_output_infos = []
     for o in m.output_info:
+        synthetic_base_info_for_output = (
+            None if o.base_idx is None else synthetic_base_info[o.base_idx]
+        )
         new_base_idx = (
             None
             if o.base_idx is None
             else (
-                synthetic_base_info[o.base_idx]
-                if isinstance(synthetic_base_info[o.base_idx], int)
-                else synthetic_base_info[o.base_idx][0]  # type: ignore[index]
+                synthetic_base_info_for_output
+                if isinstance(synthetic_base_info_for_output, int)
+                else synthetic_base_info_for_output[0]  # type: ignore[index]
             )
         )
-        # If base_idx is changed for OutputType.is_input, we need to update the output type to reflect the change
+        is_input_replaced_by_synthetic_base_view = (
+            o.base_idx is not None
+            and new_base_idx is not None
+            and isinstance(synthetic_base_info_for_output, tuple)
+            and (
+                outer_args[o.base_idx]._base is not None
+                or not has_same_metadata(
+                    outer_args[o.base_idx], inner_args[new_base_idx]
+                )
+            )
+        )
+        # If OutputType.is_input is remapped to another base, including a
+        # synthetic base replacing the original input view, the output must be
+        # regenerated as an alias of that base.
         new_output_type = (
             OutputType.alias_of_input
-            if o.output_type == OutputType.is_input and o.base_idx != new_base_idx
+            if o.output_type == OutputType.is_input
+            and (o.base_idx != new_base_idx or is_input_replaced_by_synthetic_base_view)
             else o.output_type
         )
         existing_output_infos.append(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185029

AOTAutograd rewrites aliased inputs with mutation into a synthetic-base calling convention. During that remapping, outputs classified as OutputType.is_input were only converted to alias_of_input when the numeric base index changed.

That missed cases where an original input view was replaced by a synthetic base at the same numeric position. The runtime epilogue then treated the user output as the base input itself, so an out= operation returning a view could return the full base tensor instead of replaying the out view.

Update synthetic-base metadata remapping so is_input outputs become alias_of_input when the original input has been replaced by a different synthetic-base view, either because the index changed, the original input is an autograd view, or its metadata differs from the synthetic base. This keeps the runtime on the alias replay path for out= view returns. I fixed this in the AOT metadata layer rather than changing auto-functionalize out= returns because the incorrect behavior comes from losing the original view relationship during synthetic-base remapping.

Fixes #167764
Generated by my agent

Test Plan:
- python test/inductor/test_auto_functionalize.py -k test_out_return_preserves_view_after_graph_break -q
- python test/inductor/test_auto_functionalize.py -k test_cumulative_out_preserves_out_dtype_under_compile -q
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo