### PR TITLE
Avoid guard overhead for size scalar tensor item

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9824,6 +9824,36 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         # Previously would crash with guard on data dependent error
         fn(a, x)
 
+    @torch._dynamo.config.patch(capture_scalar_outputs=False)
+    def test_symint_tensor_item_does_not_graph_break(self):
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        def fn(x):
+            n = x.shape[0]
+            if n == torch.tensor(n).item():
+                return x + 1
+            return x - 1
+
+        opt_fn = torch.compile(fn, backend=cnts, dynamic=True)
+
+        for n in (3, 4, 5):
+            x = torch.ones(n)
+            self.assertEqual(opt_fn(x), x + 1)
+
+        self.assertEqual(cnts.frame_count, 1)
+
+    @torch._dynamo.config.patch(capture_scalar_outputs=False)
+    def test_python_int_tensor_item_still_graph_breaks(self):
+        counters.clear()
+
+        def fn(x, y):
+            return y + torch.tensor(x).item()
+
+        opt_fn = torch.compile(fn, backend="eager", dynamic=True)
+        y = torch.ones(3)
+        self.assertEqual(opt_fn(3, y), y + 3)
+        self.assertEqual(sum(counters["graph_break"].values()), 1)
+
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_symint_fold_nontrivial_product_modulo(self):
         @torch.compile(fullgraph=True, backend="eager")

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -6,11 +6,13 @@ import unittest
 import torch
 import torch._dynamo.testing
 import torch.utils._pytree as pytree
+from torch._dynamo.exc import UserError
 from torch._higher_order_ops.associative_scan import associative_scan
 from torch._higher_order_ops.map import _fake_map
 from torch._higher_order_ops.scan import _fake_scan, scan
 from torch._inductor.custom_graph_pass import CustomGraphPass
 from torch._inductor.test_case import TestCase
+from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_utils import (
     decorateIf,
     instantiate_parametrized_tests,
@@ -2378,6 +2380,41 @@ class MapTests(TestCase):
             dynamic=dynamic,
             autograd=autograd,
         )
+
+
+class SymIntItemTests(TestCase):
+    @unittest.skipIf(not HAS_CPU, "requires CPU")
+    def test_shape_symint_tensor_item_codegen(self):
+        def fn(x):
+            n = x.shape[0]
+            if n == torch.tensor(n).item():
+                return x + 1
+            return x - 1
+
+        x = torch.ones(3)
+        compiled_fn = torch.compile(fn, dynamic=True)
+
+        actual, source_codes = run_and_get_code(compiled_fn, x)
+        self.assertEqual(actual, fn(x))
+        self.assertEqual(compiled_fn(torch.ones(4)), fn(torch.ones(4)))
+
+        code = "\n".join(source_codes)
+        self.assertNotIn("scalar_tensor", code)
+        self.assertNotIn("_local_scalar_dense", code)
+        self.assertNotIn(".item(", code)
+        self.assertNotIn("torch._refs.tensor", code)
+        self.assertNotRegex(code, r"(?:s\d+|arg\d+_\d+)\s*==\s*(?:s\d+|arg\d+_\d+)")
+
+    @unittest.skipIf(not HAS_CPU, "requires CPU")
+    def test_shape_symint_tensor_item_expression_not_folded(self):
+        def fn(x):
+            n = x.shape[0] + 2**63
+            if n == torch.tensor(n).item():
+                return x + 1
+            return x - 1
+
+        with self.assertRaisesRegex(UserError, "Could not guard on data-dependent"):
+            torch.compile(fn, dynamic=True, fullgraph=True)(torch.ones(3))
 
 
 instantiate_parametrized_tests(CondTests)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1498,7 +1498,28 @@ class TensorVariable(VariableTracker):
         tx: "InstructionTranslator",
         *args: VariableTracker,
         **kwargs: VariableTracker,
-    ) -> None:
+    ) -> VariableTracker | None:
+        example_value = self.proxy.node.meta.get("example_value")
+        # Keep input tensor .item() data-dependent by default, but let
+        # graph-created scalar tensors recover the symbolic scalar they
+        # were constructed from.
+        if (
+            self.source is None
+            and not args
+            and not kwargs
+            and getattr(example_value, "item_memo", None) is not None
+        ):
+            from .builder import wrap_fx_proxy
+
+            return wrap_fx_proxy(
+                tx,
+                tx.output.create_proxy(
+                    "call_method",
+                    "item",
+                    *proxy_args_kwargs([self], {}),
+                ),
+            )
+
         # We enable capture_scalar_outputs when full_graph=True by default.
         if not tx.one_graph and not config.capture_scalar_outputs:
             self._warn_capture_scalar_outputs()

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -160,6 +160,44 @@ def _is_tensor_constructor(func: OpOverload) -> bool:
     )
 
 
+def _is_size_derived_sym(scalar: object) -> bool:
+    if not isinstance(scalar, (torch.SymBool, torch.SymFloat, torch.SymInt)):
+        return False
+
+    # Fake tensor is used below Dynamo, so keep Dynamo source imports lazy.
+    from torch._dynamo.source import TensorProperty, TensorPropertySource
+    from torch.fx.experimental.symbolic_shapes import free_symbols
+
+    shape_env = scalar.node.shape_env
+    if shape_env is None:
+        return False
+
+    symbols = free_symbols(scalar)
+    expr = scalar.node.expr
+    # Only bare size symbols are guaranteed to have already satisfied tensor
+    # constructor value checks. Expressions like s0 + 2**63 can overflow int64.
+    return (
+        len(symbols) == 1
+        and expr in symbols
+        and all(
+            any(
+                isinstance(source, TensorPropertySource)
+                and source.prop is TensorProperty.SIZE
+                for source in shape_env.var_to_sources.get(symbol, ())
+            )
+            for symbol in symbols
+        )
+    )
+
+
+def _scalar_tensor_item_preserves_value(scalar: object, dtype: torch.dtype) -> bool:
+    return (
+        (isinstance(scalar, torch.SymBool) and dtype == torch.bool)
+        or (isinstance(scalar, torch.SymInt) and dtype == torch.int64)
+        or (isinstance(scalar, torch.SymFloat) and dtype == torch.float64)
+    )
+
+
 def register_op_impl(
     run_impl_check: Callable[[OpOverload], bool]
     | OpOverload
@@ -236,7 +274,14 @@ def constructors(
     # to fail? hmmm)
     with in_kernel_invocation_manager(fake_mode):
         r = func(*args, **new_kwargs)
-    return FakeTensor(fake_mode, r, out_device)
+    out = FakeTensor(fake_mode, r, out_device)
+    if func is aten.scalar_tensor.default:
+        scalar = new_kwargs["s"]
+        if _scalar_tensor_item_preserves_value(
+            scalar, r.dtype
+        ) and _is_size_derived_sym(scalar):
+            out.item_memo = scalar
+    return out
 
 
 @register_op_impl(aten.is_pinned.default)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185031

Dynamo used to lose the identity between a size-derived SymInt and the
scalar tensor built from it. In a pattern like `n == torch.tensor(n).item()`,
`Tensor.item()` graph-broke with capture_scalar_outputs disabled and the
resumed frame compared two stack locals, producing an unnecessary equality
guard.

The fix records `item_memo` for fake `aten.scalar_tensor` results when the
input is a bare size-derived symbolic scalar and the scalar tensor dtype makes
`.item()` a value-preserving round trip. `TensorVariable.method_item` can then
recover that memo for sourceless graph-created scalar tensors without changing
source-backed input tensor `.item()` behavior. Broader memoization for arbitrary
symbolic expressions was avoided because expressions can still need constructor
checks such as int64 overflow handling.

Fixes #167736
Generated by my agent

Test Plan:
- python test/dynamo/test_misc.py MiscTests.test_symint_tensor_item_does_not_graph_break
- python test/dynamo/test_misc.py MiscTests.test_python_int_tensor_item_still_graph_breaks
- python test/inductor/test_control_flow.py SymIntItemTests.test_shape_symint_tensor_item_codegen
- python test/inductor/test_control_flow.py SymIntItemTests.test_shape_symint_tensor_item_expression_not_folded
- TORCH_LOGS="guards,recompiles,dynamic" python repro script for torch.tensor(n).item() dynamic-size branch
- lintrunner -a torch/_subclasses/fake_impls.py torch/_dynamo/variables/tensor.py test/dynamo/test_misc.py test/inductor/test_control_flow.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @mlazos