### PR TITLE
[inductor] Reuse expensive broadcast factors in pointwise tiling

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1426,6 +1426,75 @@ class CommonTemplate:
         # Singleton splits should be discarded.
         self._assert_pointwise_ndims(triton_code, 2)
 
+    @requires_gpu()
+    def test_pointwise_interior_broadcast_reuse_tiling(self):
+        def foo(x, table):
+            factor = torch.sin(table) + torch.cos(table)
+            return x * factor[:, None, :]
+
+        x = torch.randn((4, 8, 64), device=self.device, dtype=torch.float32)
+        table = torch.randn((4, 64), device=self.device, dtype=torch.float32)
+        result, (triton_code,) = self._run_and_compare(
+            foo,
+            x,
+            table,
+            expected_num_triton_kernels=1,
+            config_patches={
+                "triton.coalesce_tiling_analysis": True,
+                "triton.max_tiles": 3,
+                "triton.prefer_nd_tiling": False,
+            },
+        )
+
+        self._assert_pointwise_ndims(triton_code, 3)
+        self.assertIn("znumel = 4", triton_code)
+        self.assertIn("ynumel = 8", triton_code)
+        self.assertIn("xnumel = 64", triton_code)
+
+    @requires_gpu()
+    def test_pointwise_interior_broadcast_reuse_small_inner_guard(self):
+        def foo(x, table):
+            factor = torch.sin(table) + torch.cos(table)
+            return x * factor[:, None, :]
+
+        x = torch.randn((4, 8, 32), device=self.device, dtype=torch.float32)
+        table = torch.randn((4, 32), device=self.device, dtype=torch.float32)
+        result, (triton_code,) = self._run_and_compare(
+            foo,
+            x,
+            table,
+            expected_num_triton_kernels=1,
+            config_patches={
+                "triton.coalesce_tiling_analysis": True,
+                "triton.max_tiles": 3,
+                "triton.prefer_nd_tiling": False,
+            },
+        )
+
+        self._assert_pointwise_ndims(triton_code, 1)
+
+    @requires_gpu()
+    def test_pointwise_interior_broadcast_reuse_requires_expensive_op(self):
+        def foo(x, table):
+            factor = table + 1.0
+            return x * factor[:, None, :]
+
+        x = torch.randn((4, 8, 64), device=self.device, dtype=torch.float32)
+        table = torch.randn((4, 64), device=self.device, dtype=torch.float32)
+        result, (triton_code,) = self._run_and_compare(
+            foo,
+            x,
+            table,
+            expected_num_triton_kernels=1,
+            config_patches={
+                "triton.coalesce_tiling_analysis": True,
+                "triton.max_tiles": 3,
+                "triton.prefer_nd_tiling": False,
+            },
+        )
+
+        self._assert_pointwise_ndims(triton_code, 1)
+
     # Integration test to ensure that matched dims & strides from match_mod_div_expr
     # are unsigned and signed integers respectively. This test case has the following
     # index:=(ModularIndexing(xindex, 4, 4)) + 4*(ModularIndexing(xindex, 32, 2))

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -58,6 +58,7 @@ from torch._inductor.runtime.triton_heuristics import (
     CachingAutotunerPlugin,
     DEFER,
     make_matmul_triton_config,
+    pointwise,
     template,
     triton_config,
 )
@@ -102,6 +103,21 @@ class TestTritonHeuristics(TestCase):
             if key not in cfg.kwargs:
                 continue
             self.assertTrue(cfg.kwargs[key] <= TRITON_MAX_BLOCK[label])
+
+    def test_pointwise_tiling_scores_keep_inner_dim_coalesced(self):
+        cfgs = pointwise(
+            {"z": 128, "y": 16, "x": 256},
+            triton_meta={"device": object()},
+            inductor_meta={
+                "tiling_scores": {"z": 0, "y": 128, "x": 1024},
+                "autotune_pointwise": True,
+            },
+            return_configs=True,
+        )
+
+        kwargs = [cfg.kwargs for cfg in cfgs]
+        self.assertIn({"XBLOCK": 256, "YBLOCK": 4, "ZBLOCK": 1}, kwargs)
+        self.assertIn({"XBLOCK": 256, "YBLOCK": 8, "ZBLOCK": 1}, kwargs)
 
     def test_native_matmul_config_block_numel_limit(self):
         device = DeviceProperties(

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -3882,6 +3882,136 @@ class SIMDScheduling(BaseScheduling):
 
         return ranked_tilings
 
+    @staticmethod
+    def _expensive_pointwise_origin_score(
+        node_schedule: list[NodeScheduleEntry],
+    ) -> int:
+        expensive_ops = {
+            "acos": 32,
+            "asin": 32,
+            "atan": 32,
+            "cos": 32,
+            "cosh": 32,
+            "div": 8,
+            "erf": 32,
+            "erfc": 32,
+            "exp": 32,
+            "expm1": 32,
+            "lgamma": 32,
+            "log": 32,
+            "log10": 32,
+            "log1p": 32,
+            "log2": 32,
+            "pow": 16,
+            "reciprocal": 8,
+            "rsqrt": 16,
+            "sin": 32,
+            "sinh": 32,
+            "sqrt": 16,
+            "tan": 32,
+            "tanh": 32,
+            "truediv": 8,
+        }
+
+        def get_target_name(origin: Any) -> str:
+            target = getattr(origin, "target", None)
+            if target is None:
+                return ""
+            overloadpacket = getattr(target, "overloadpacket", None)
+            if overloadpacket is not None:
+                return str(overloadpacket).rsplit(".", 1)[-1]
+            name = getattr(target, "__name__", None)
+            if name is not None:
+                return name
+            return str(target).rsplit(".", 1)[-1]
+
+        score = 0
+        seen_origin_ids: OrderedSet[int] = OrderedSet()
+        for schedule_entry in NodeScheduleMarker.only_nodes(node_schedule):
+            for node in schedule_entry.get_nodes():
+                if not isinstance(node, scheduler.SchedulerNode) or node.node is None:
+                    continue
+                for origin in node.node.get_origins():
+                    origin_id = id(origin)
+                    if origin_id in seen_origin_ids:
+                        continue
+                    seen_origin_ids.add(origin_id)
+                    score += expensive_ops.get(get_target_name(origin), 0)
+
+        return score
+
+    @classmethod
+    def maybe_interior_reuse_pointwise_tiling(
+        cls,
+        node_schedule: list[NodeScheduleEntry],
+        pointwise_numel: sympy.Expr,
+        reduction_numel: sympy.Expr,
+        coalesce_analysis: CoalesceVarAnalysis,
+    ) -> tuple[dict[str, sympy.Expr], dict[str, sympy.Expr]] | None:
+        """
+        Select 3D pointwise tiling for RoPE-like broadcast factor reuse.
+
+        This targets expressions shaped like [outer, reuse, inner] where
+        table/trig-factor loads depend on the inner dimension, but not on the
+        middle reuse dimension. A 1D tile recomputes those factors for every
+        head. A [Z, Y, X] tile lets Triton build [Z, 1, X] values and broadcast
+        them across Y.
+        """
+        if reduction_numel != 1 or get_max_tiles(default=3) < 3:
+            return None
+
+        norm_read_writes = coalesce_analysis.norm_read_writes
+        iter_vars = list(norm_read_writes.index_vars)
+        if len(iter_vars) != 3:
+            return None
+
+        ranges = norm_read_writes.var_ranges
+        pointwise_ranges = [ranges[v] for v in iter_vars]
+        if free_unbacked_symbols(pointwise_ranges):
+            return None
+
+        sizevars = V.graph.sizevars
+        outer_var, reuse_var, inner_var = iter_vars
+        outer_numel, reuse_numel, inner_numel = pointwise_ranges
+        if (
+            sizevars.optimization_hint(inner_numel, fallback=0) < 64
+            or sizevars.optimization_hint(reuse_numel, fallback=0) < 2
+            or sizevars.optimization_hint(outer_numel, fallback=0) < 2
+        ):
+            return None
+
+        inner_score = coalesce_analysis.coalesced_by_var.get(inner_var, 0)
+        if inner_score <= 0:
+            return None
+
+        expensive_score = cls._expensive_pointwise_origin_score(node_schedule)
+        repeated_read_score = 0
+        repeated_read_count = 0
+        for read_expr, buf_names in norm_read_writes.reads.items():
+            read_iter_vars = read_expr.free_symbols & OrderedSet(iter_vars)
+            if reuse_var in read_iter_vars or inner_var not in read_iter_vars:
+                continue
+            repeated_read_count += len(buf_names)
+            repeated_read_score += len(buf_names) * sizevars.optimization_hint(
+                inner_numel, fallback=1
+            )
+
+        if repeated_read_count == 0:
+            return None
+        # Pure load reuse was not enough to pay for the 3D tiling overhead in
+        # issue-27 RoPE variants; require expensive broadcast work.
+        if expensive_score == 0:
+            return None
+
+        tiling = cls.create_tiling(pointwise_ranges, [reduction_numel])
+        reuse_score = max(
+            repeated_read_score * expensive_score,
+            inner_score // 8,
+            1,
+        )
+        tiling_score = cls.create_tiling([0, reuse_score, inner_score], [0])
+        return tiling, tiling_score
+
     @classmethod
     def compute_tiling_strategy(
         cls,
@@ -3905,6 +4035,11 @@ class SIMDScheduling(BaseScheduling):
 
         pw_ranges = [ranges[v] for v in all_iter_vars]
         red_ranges = [ranges[v] for v in all_red_vars]
+
+        if interior_reuse_tiling := cls.maybe_interior_reuse_pointwise_tiling(
+            node_schedule, pointwise_numel, reduction_numel, coalesce_analysis
+        ):
+            return interior_reuse_tiling
 
         # Sometimes dynamic shapes is unable to prove equality without hint
         get_hint = V.graph.sizevars.optimization_hint

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -3722,7 +3722,21 @@ def pointwise(
     )
 
     configs = None
-    if len(size_hints) == 1:
+    tiling_score_configs = pointwise_configs_from_tiling_scores(
+        size_hints,
+        inductor_meta.get("tiling_scores") or {},
+        triton_config_with_settings,
+    )
+    if tiling_score_configs:
+        if not inductor_meta.get("autotune_pointwise", True) and not (
+            inductor_meta.get("max_autotune")
+            or inductor_meta.get("max_autotune_pointwise")
+        ):
+            configs = tiling_score_configs[:1]
+        else:
+            configs = tiling_score_configs
+
+    if configs is None and len(size_hints) == 1:
         if not inductor_meta.get("autotune_pointwise", True) and not (
             inductor_meta.get("max_autotune")
             or inductor_meta.get("max_autotune_pointwise")
@@ -3773,7 +3787,7 @@ def pointwise(
                         triton_config_with_settings(size_hints, 32),
                     ]
                 )
-    if len(size_hints) == 2:
+    if configs is None and len(size_hints) == 2:
         # Only avoiding tuning on TileHint.SQUARE if not on ROCm builds
         # ROCm has observed improvement by diverging here
         if (
@@ -3825,7 +3839,7 @@ def pointwise(
                         triton_config_with_settings(size_hints, 4, 256),
                     ]
                 )
-    if len(size_hints) == 3:
+    if configs is None and len(size_hints) == 3:
         if not (
             inductor_meta.get("max_autotune")
             or inductor_meta.get("max_autotune_pointwise")
@@ -4235,6 +4249,56 @@ def adapt_config_for_tiling(
         register_intensive=register_intensive,
         waves_per_eu=waves_per_eu,
     )
+
+
+def pointwise_configs_from_tiling_scores(
+    size_hints,
+    tiling_scores,
+    make_config,
+) -> list[Config]:
+    if len(size_hints) != 3 or not all(dim in tiling_scores for dim in ("x", "y", "z")):
+        return []
+
+    # This path is for [outer, reuse, inner] pointwise tiling. Keep the
+    # coalesced inner dimension whole, then autotune a small reuse-dim tile.
+    if tiling_scores["x"] <= 0 or tiling_scores["y"] <= 0 or tiling_scores["z"] != 0:
+        return []
+
+    inner_block = min(size_hints["x"], TRITON_MAX_BLOCK["X"])
+    if inner_block < 64:
+        return []
+
+    total_numel = conditional_product(*size_hints.values())
+    target_products = [
+        max(1024, inner_block),
+        max(2048, inner_block),
+        max(512, inner_block),
+    ]
+
+    configs: list[Config] = []
+    seen: OrderedSet[tuple[tuple[tuple[str, int], ...], int, int]] = OrderedSet()
+    for target_product in target_products:
+        target_product = min(target_product, total_numel)
+        y_block = max(
+            1,
+            min(
+                size_hints["y"],
+                TRITON_MAX_BLOCK["Y"],
+                max(1, target_product // inner_block),
+            ),
+        )
+        cfg = make_config(
+            size_hints,
+            inner_block,
+            y_block,
+            1,
+        )
+        key = (tuple(sorted(cfg.kwargs.items())), cfg.num_warps, cfg.num_stages)
+        if key not in seen:
+            seen.add(key)
+            configs.append(cfg)
+
+    return configs
 
 
 def filter_reduction_configs_for_determinism(


### PR DESCRIPTION
Submitted by my agent.

Draft for better-benchmark issue 51.

This adds a narrow pointwise tiling path for RoPE-like `[outer, reuse, inner]` shapes where expensive broadcast expressions depend on the coalesced inner dimension but not the interior reuse/head dimension. The scheduler selects 3D tiling so the expensive factor is computed as `[Z, 1, X]` and broadcast over `Y`, and the runtime pointwise config path keeps the inner dimension whole with a modest reuse-dim tile.

The guard intentionally requires expensive origin ops. A pure load-reuse variant regressed `pointwise_fe3b8dac57c4`, so this draft does not try to optimize non-expensive table loads yet.

B200 evidence, same local machine/build:

- `pointwise_c04d168ffc54`: baseline 10.752 us -> patch 8.064 us, one kernel, gap about 1.33x -> 0.99x.
- `pointwise_fe3b8dac57c4`: baseline 7.552 us -> patch 7.744 us in the final guarded run, within noise-ish but no longer the earlier broad-heuristic regression; this path is mostly guarded out.

Standalone Triton ceiling for #51 was 8.26 us on c04d and 6.85 us on fe3b; this PR is targeting the expensive-trig c04d piece first.

Validation:

- `git diff --check`
- `python -m py_compile torch/_inductor/codegen/simd.py torch/_inductor/runtime/triton_heuristics.py test/inductor/test_triton_heuristics.py test/inductor/test_torchinductor_strided_blocks.py`
- `lintrunner --skip PYREFLY torch/_inductor/codegen/simd.py torch/_inductor/runtime/triton_heuristics.py test/inductor/test_triton_heuristics.py test/inductor/test_torchinductor_strided_blocks.py`
- `test/inductor/test_triton_heuristics.py -k test_pointwise_tiling_scores_keep_inner_dim_coalesced`
- `test/inductor/test_torchinductor_strided_blocks.py -k pointwise_interior_broadcast_reuse` on B200 (9 tests, 3 skipped)
- better-benchmark locked B200 run for `pointwise_c04d168ffc54` and `pointwise_fe3b8dac57c4`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo