### PR TITLE
[inductor] Prototype channel-resident reduction suffix

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -183,6 +183,60 @@ class KernelTests(torch._inductor.test_case.TestCase):
         self.assertIsNone(_re.search(r"\b__dunder_add_kernel_0\b", code))
         self.assertIsNotNone(_re.search(r"\b_dunder_add_kernel_0\b", code))
 
+    @requires_cuda_and_triton
+    @inductor_config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.channel_resident_reduction_suffix": True,
+            "triton.multi_kernel": False,
+            "triton.use_block_ptr": False,
+        }
+    )
+    def test_channel_resident_reduction_suffix_store_elision(self):
+        n, c, h, w = 64, 32, 7, 7
+
+        def f(mask2d, mm, x, mean, invstd, gamma, beta):
+            scale = mask2d.to(torch.float32) * 1.25
+            expanded = (mm * scale).view(n, c, 1, 1).expand(n, c, h, w)
+            div = expanded / (h * w)
+            norm = (x - mean) * invstd
+            relu6_in = norm * gamma[None, :, None, None]
+            relu6_in = relu6_in + beta[None, :, None, None]
+            full = torch.where(
+                (relu6_in <= 0.0) | (relu6_in >= 6.0),
+                torch.full((), 0.0, device=x.device),
+                div,
+            )
+            centered = x - mean
+            sum0 = full.sum(dim=(0, 2, 3))
+            sum1 = (full * centered).sum(dim=(0, 2, 3))
+            invstd_1d = invstd.squeeze()
+            scale0 = (sum0 * (1.0 / (n * h * w)))[None, :, None, None]
+            scale1 = (sum1 * (1.0 / (n * h * w)) * invstd_1d.square())[
+                None, :, None, None
+            ]
+            out_scale = (invstd_1d * gamma)[None, :, None, None]
+            out = (full - centered * scale1 - scale0) * out_scale
+            return out, sum1 * invstd_1d
+
+        args = (
+            torch.randint(0, 2, (n, c), device=GPU_TYPE, dtype=torch.bool),
+            torch.randn(n, c, device=GPU_TYPE),
+            torch.randn(n, c, h, w, device=GPU_TYPE),
+            torch.randn(1, c, 1, 1, device=GPU_TYPE),
+            torch.randn(1, c, 1, 1, device=GPU_TYPE),
+            torch.randn(c, device=GPU_TYPE),
+            torch.randn(c, device=GPU_TYPE),
+        )
+        expected = f(*args)
+        actual, (code,) = run_and_get_code(torch.compile(f, fullgraph=True), *args)
+
+        self.assertEqual(actual, expected, atol=1e-4, rtol=1e-4)
+        self.assertIn("'channel_resident_reduction_suffix': True", code)
+        self.assertEqual(code.count("tl.load(in_out_ptr"), 0)
+        self.assertEqual(code.count("tl.store(in_out_ptr"), 1)
+        self.assertEqual(code.count("tl.store("), 2)
+
     @requires_gpu
     def test_triton_kernel_ill_formed(self):
         if inductor_config.cpp_wrapper:

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -2870,10 +2870,17 @@ class CSEProxy(DefaultHandler):
     def store(
         self, name: str, index: sympy.Expr, value: CSEVariable, mode: StoreMode = None
     ) -> None:
-        self.kernel.store_buffer_names.add(name)
         # Update store cache when mode is None or "tma"
         if mode != "atomic_add":
             self._update_store_cache(name, value)
+        should_elide_channel_resident_store = getattr(
+            self.kernel, "should_elide_channel_resident_reduction_store", None
+        )
+        if should_elide_channel_resident_store is not None and (
+            should_elide_channel_resident_store(name, value, mode=mode)
+        ):
+            return
+        self.kernel.store_buffer_names.add(name)
         if name not in V.graph.removed_buffers:
             self.kernel.store(name, index, value, mode=mode)
             self.kernel.num_store += 1

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3255,7 +3255,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if len(self.features.reduction_nodes()) < 2:
             return False
         node_schedule = self.features.node_schedule
-        if DisableReduction not in node_schedule or EnableReduction not in node_schedule:
+        if (
+            DisableReduction not in node_schedule
+            or EnableReduction not in node_schedule
+        ):
             return False
         # Reusing loop-local full tiles is only correct when every R loop is
         # forced to a single iteration. Reuse the existing persistent-RBLOCK
@@ -3272,12 +3275,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.min_rblock = max(self.min_rblock or 1, persistent_rblock)
         return True
 
-    def _has_channel_resident_reduction_tile_shape(
-        self, value: CSEVariable
-    ) -> bool:
+    def _has_channel_resident_reduction_tile_shape(self, value: CSEVariable) -> bool:
         if value.shape is None:
             return False
-        value_dims = {str(dim) for dim in value.shape}
+        value_dims = OrderedSet([str(dim) for dim in value.shape])
         reduction_blocks = [
             tree.block_size_str() for tree in self.range_trees if tree.is_reduction
         ]
@@ -3297,11 +3298,13 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             return False
         if not output.users:
             return False
-        scheduled_names = {
-            node.get_name()
-            for node in self.features.scheduler_nodes()
-            if isinstance(node, SchedulerNode)
-        }
+        scheduled_names = OrderedSet(
+            [
+                node.get_name()
+                for node in self.features.scheduler_nodes()
+                if isinstance(node, SchedulerNode)
+            ]
+        )
         for user in output.users:
             if isinstance(user.node, OutputNode):
                 return False

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -63,6 +63,7 @@ from ..scheduler import (
     BaseSchedulerNode,
     FusedExternTritonKernelSchedulerNode,
     FusedSchedulerNode,
+    OutputNode,
     Scheduler,
     SchedulerNode,
 )
@@ -116,6 +117,7 @@ from .simd import (
     SIMDKernel,
     SIMDScheduling,
 )
+from .simd_kernel_features import DisableReduction, EnableReduction
 from .triton_utils import (
     config_of,
     equal_1_arg_indices,
@@ -3043,6 +3045,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self._load_counts: collections.Counter[str] = collections.Counter()
         self._pdl_load_index = 0
         self._pdl_has_wait = False
+        self._elided_channel_resident_store = False
+        self._channel_resident_store_vars: OrderedSet[CSEVariable] = OrderedSet()
+        self._initialized_channel_resident_vars: OrderedSet[CSEVariable] = OrderedSet()
+        self._emitted_channel_resident_reduction_loop = False
 
         # A set of autotuning hints to pass as part of triton_meta
         self.autotune_hints = OrderedSet[AutotuneHint]()
@@ -3233,6 +3239,141 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     def should_use_persistent_reduction(self) -> bool:
         return self.inside_reduction and V.choices.should_use_persistent_reduction(
             self.features, self.cooperative_reduction
+        )
+
+    @functools.cached_property
+    def channel_resident_reduction_suffix(self) -> bool:
+        if (
+            not config.triton.channel_resident_reduction_suffix
+            or not self.features.is_reduction()
+            or self.persistent_reduction
+            or self.cooperative_reduction
+            or self.mix_order_reduction
+            or self.num_reduction_dims != 1
+        ):
+            return False
+        if len(self.features.reduction_nodes()) < 2:
+            return False
+        node_schedule = self.features.node_schedule
+        if DisableReduction not in node_schedule or EnableReduction not in node_schedule:
+            return False
+        # Reusing loop-local full tiles is only correct when every R loop is
+        # forced to a single iteration. Reuse the existing persistent-RBLOCK
+        # profitability signal, then pin autotuning/dynamic scaling to that floor.
+        if not self.add_persistent_rblock:
+            return False
+        persistent_rblock = self._get_persistent_RBLOCK(self.features.reduction_numel)
+        if persistent_rblock > self.max_block("r0_"):
+            return False
+        if not V.graph.sizevars.statically_known_leq(
+            self.features.reduction_numel, 8192
+        ):
+            return False
+        self.min_rblock = max(self.min_rblock or 1, persistent_rblock)
+        return True
+
+    def _has_channel_resident_reduction_tile_shape(
+        self, value: CSEVariable
+    ) -> bool:
+        if value.shape is None:
+            return False
+        value_dims = {str(dim) for dim in value.shape}
+        reduction_blocks = [
+            tree.block_size_str() for tree in self.range_trees if tree.is_reduction
+        ]
+        non_reduction_blocks = [
+            tree.block_size_str() for tree in self.range_trees if not tree.is_reduction
+        ]
+        return all(block in value_dims for block in reduction_blocks) and any(
+            block in value_dims for block in non_reduction_blocks
+        )
+
+    def _all_users_are_in_this_kernel(self, name: str) -> bool:
+        if self.current_node is None:
+            return False
+        try:
+            output = self.current_node.get_output(name)
+        except KeyError:
+            return False
+        if not output.users:
+            return False
+        scheduled_names = {
+            node.get_name()
+            for node in self.features.scheduler_nodes()
+            if isinstance(node, SchedulerNode)
+        }
+        for user in output.users:
+            if isinstance(user.node, OutputNode):
+                return False
+            get_name = getattr(user.node, "get_name", None)
+            if get_name is None or get_name() not in scheduled_names:
+                return False
+        return True
+
+    def should_elide_channel_resident_reduction_store(
+        self, name: str, value: CSEVariable, mode: StoreMode = None
+    ) -> bool:
+        if (
+            mode is not None
+            or not self.inside_reduction
+            or not self.channel_resident_reduction_suffix
+            or not self._has_channel_resident_reduction_tile_shape(value)
+            or not self._all_users_are_in_this_kernel(name)
+        ):
+            return False
+        self._elided_channel_resident_store = True
+        self._channel_resident_store_vars.add(value)
+        return True
+
+    def codegen_channel_resident_initializers(self) -> None:
+        resident_vars = OrderedSet(self._channel_resident_store_vars)
+        resident_vars.update(
+            value
+            for value in self.cse._cache.values()
+            if self._has_channel_resident_reduction_tile_shape(value)
+        )
+        pending = resident_vars - self._initialized_channel_resident_vars
+        for value in pending:
+            assert value.shape is not None
+            dtype = value.dtype or torch.float32
+            zero = (
+                "0.0"
+                if dtype.is_floating_point
+                else "False"
+                if dtype is torch.bool
+                else "0"
+            )
+            shape = f"[{', '.join(map(str, value.shape))}]"
+            self.body.writeline(
+                f"{value} = tl.full({shape}, {zero}, {triton_type(dtype)})"
+            )
+        self._initialized_channel_resident_vars |= pending
+
+    def codegen_channel_resident_suffix_indices(
+        self, loop_trees: list[IterationRangesRoot]
+    ) -> None:
+        for tree in loop_trees:
+            self.body.writeline(f"{tree.prefix}offset = 0")
+            self.iteration_ranges_codegen_header(tree, self.body)
+        self.codegen_reduction_indices(self.body)
+
+    def _channel_resident_keep_vars(self) -> OrderedSet[CSEVariable]:
+        keep_vars: OrderedSet[CSEVariable] = OrderedSet(self.outside_loop_vars)
+        # R0_BLOCK is pinned to cover the full reduction domain for this
+        # prototype, so values materialized inside the loop remain valid after
+        # the single loop iteration and may feed the following full-output
+        # suffix.
+        keep_vars.update(self.cse._cache.values())
+        keep_vars.update(self.cse.store_cache.values())
+        return keep_vars
+
+    def _can_emit_channel_resident_suffix_without_loop(self) -> bool:
+        return (
+            self.channel_resident_reduction_suffix
+            and self._elided_channel_resident_store
+            and self._emitted_channel_resident_reduction_loop
+            and not self.post_loop_combine
+            and not self.post_loop_store
         )
 
     def want_no_x_dim(self):
@@ -5621,68 +5762,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 )
 
         elif self.inside_reduction and len(loop_trees) > 0:
-            # Write the loop headers.
-            for level, tree in enumerate(loop_trees):
-                with self.body.indent(offset=level):
-                    prefix = tree.prefix
-                    loop_start = "rsplit_start" if self.cooperative_reduction else "0"
-                    loop_end = (
-                        "rsplit_end" if self.cooperative_reduction else f"{prefix}numel"
-                    )
-                    # Conditionalize pipelining on HIP for Triton due to
-                    # reports of numerical inaccuracies on older Triton
-                    if torch.version.hip and get_triton_version() > (3, 2):
-                        num_stages = ", num_stages = 2"
-                    else:
-                        num_stages = ""
-                    self.body.writeline(
-                        f"for {prefix}offset in tl.range({loop_start}, {loop_end}, {prefix.upper()}BLOCK{num_stages}):"
-                    )
-                with self.body.indent(offset=level + 1):
-                    self.iteration_ranges_codegen_header(tree, self.body)
-
-            # The innermost loop performs the reduction.
-            with self.body.indent(offset=len(loop_trees)):
-                self.codegen_reduction_indices(self.body)
+            if self._can_emit_channel_resident_suffix_without_loop():
+                self.codegen_channel_resident_suffix_indices(loop_trees)
                 self.body.splice(self.indexing_code)
                 self.body.splice(self.loads)
                 self.body.splice(self.compute)
                 self.body.splice(self.stores)
-
-            # Write loop suffixes.
-            for level, tree in reversed([*enumerate(loop_trees)]):
-                with self.body.indent(offset=level + 1):
-                    # Advance pointers at the end of each loop.
-                    for block_ptr, advancement in self.pointer_advancements[
-                        tree.symt
-                    ].items():
-                        # Subtract any advancements made in the previous loop level.
-                        if level < len(loop_trees) - 1:
-                            prev_tree = loop_trees[level + 1]
-                            prev_advancements = self.pointer_advancements[
-                                prev_tree.symt
-                            ]
-                            # block_ptr may not exist in the inner loop's advancements
-                            # if its advancement was identity (zero) and was skipped
-                            if block_ptr in prev_advancements:
-                                prev_advancement = prev_advancements[block_ptr]
-                                prev_block = TritonSymbols.get_block_size(prev_tree)
-                                prev_num_iter = CeilDiv(prev_tree.numel, prev_block)
-                                advancement = [
-                                    cur - prev * prev_num_iter
-                                    for cur, prev in zip(advancement, prev_advancement)
-                                ]
-
-                        self.body.writeline(
-                            DeferredLine(
-                                self.block_ptr_to_buffer[block_ptr],
-                                f"{block_ptr} = tl.advance({block_ptr}, {V.kernel.index_to_str(advancement)})",
-                            )
-                        )
-
-                # Invalidate any cache entries that came from inside the loop.
-                self.cse.invalidate(self.outside_loop_vars)
-                tree.cache_clear()
+            else:
+                self._codegen_reduction_loop_body(loop_trees)
         else:
             self.body.splice(self.indexing_code)
             self.body.splice(self.loads)
@@ -5709,6 +5796,88 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.stores.clear()
         self.post_loop_combine.clear()
         self.post_loop_store.clear()
+
+    def _codegen_reduction_loop_body(self, loop_trees: list[IterationRangesRoot]):
+        if (
+            self.channel_resident_reduction_suffix
+            and self._elided_channel_resident_store
+        ):
+            self.codegen_channel_resident_initializers()
+
+        # Write the loop headers.
+        for level, tree in enumerate(loop_trees):
+            with self.body.indent(offset=level):
+                prefix = tree.prefix
+                loop_start = "rsplit_start" if self.cooperative_reduction else "0"
+                loop_end = (
+                    "rsplit_end" if self.cooperative_reduction else f"{prefix}numel"
+                )
+                # Conditionalize pipelining on HIP for Triton due to
+                # reports of numerical inaccuracies on older Triton
+                if torch.version.hip and get_triton_version() > (3, 2):
+                    num_stages = ", num_stages = 2"
+                else:
+                    num_stages = ""
+                self.body.writeline(
+                    f"for {prefix}offset in tl.range({loop_start}, {loop_end}, {prefix.upper()}BLOCK{num_stages}):"
+                )
+            with self.body.indent(offset=level + 1):
+                self.iteration_ranges_codegen_header(tree, self.body)
+
+        # The innermost loop performs the reduction.
+        with self.body.indent(offset=len(loop_trees)):
+            self.codegen_reduction_indices(self.body)
+            self.body.splice(self.indexing_code)
+            self.body.splice(self.loads)
+            self.body.splice(self.compute)
+            self.body.splice(self.stores)
+
+        # Write loop suffixes.
+        for level, tree in reversed([*enumerate(loop_trees)]):
+            with self.body.indent(offset=level + 1):
+                # Advance pointers at the end of each loop.
+                for block_ptr, advancement in self.pointer_advancements[
+                    tree.symt
+                ].items():
+                    # Subtract any advancements made in the previous loop level.
+                    if level < len(loop_trees) - 1:
+                        prev_tree = loop_trees[level + 1]
+                        prev_advancements = self.pointer_advancements[prev_tree.symt]
+                        # block_ptr may not exist in the inner loop's advancements
+                        # if its advancement was identity (zero) and was skipped
+                        if block_ptr in prev_advancements:
+                            prev_advancement = prev_advancements[block_ptr]
+                            prev_block = TritonSymbols.get_block_size(prev_tree)
+                            prev_num_iter = CeilDiv(prev_tree.numel, prev_block)
+                            advancement = [
+                                cur - prev * prev_num_iter
+                                for cur, prev in zip(advancement, prev_advancement)
+                            ]
+
+                    self.body.writeline(
+                        DeferredLine(
+                            self.block_ptr_to_buffer[block_ptr],
+                            f"{block_ptr} = tl.advance({block_ptr}, {V.kernel.index_to_str(advancement)})",
+                        )
+                    )
+
+            # Invalidate any cache entries that came from inside the loop.
+            # The channel-resident suffix path keeps loop-local values resident
+            # only when the full reduction domain fits in one tile.
+            keep_vars = self.outside_loop_vars
+            if (
+                self.channel_resident_reduction_suffix
+                and self._elided_channel_resident_store
+            ):
+                keep_vars = self._channel_resident_keep_vars()
+            self.cse.invalidate(keep_vars)
+            tree.cache_clear()
+
+        if (
+            self.channel_resident_reduction_suffix
+            and self._elided_channel_resident_store
+        ):
+            self._emitted_channel_resident_reduction_loop = True
 
     def kernel_benchmark_extra_args(self) -> list[str]:
         args = []
@@ -6011,6 +6180,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             out["native_matmul_persistent_rblock"] = rblock
         if self.add_persistent_rblock:
             out["add_persistent_rblock"] = True
+        if self.channel_resident_reduction_suffix:
+            out["channel_resident_reduction_suffix"] = True
         if (
             config.benchmark_kernel
             or config.profile_bandwidth

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2114,6 +2114,14 @@ class triton:
     # into a single kernel with two sequential reduction passes.
     nested_reduction = os.environ.get("TORCHINDUCTOR_NESTED_REDUCTION", "0") == "1"
 
+    # Prototype: keep full reduction tiles resident across a following mixed
+    # reduction suffix when a full RBLOCK is already profitable. This avoids
+    # storing and reloading full-size scratch values for BN-backward-shaped
+    # same-channel reductions. Disabled by default pending broader validation.
+    channel_resident_reduction_suffix = (
+        os.environ.get("TORCHINDUCTOR_CHANNEL_RESIDENT_REDUCTION_SUFFIX", "0") == "1"
+    )
+
     # Map for storing the amount of kernel runs with dumped input tensors
     # Based on hash of Triton source code to avoid bloating the folder
     debug_dump_kernel_inputs: dict[str, int] = {}


### PR DESCRIPTION
Submitted by my agent.

## Summary

This is a draft prototype for better-benchmark issue #45. It adds a default-off channel-resident reduction suffix path for a narrow Triton reduction shape where the generated kernel stores a full suffix value to the output buffer, reloads it later in the same kernel, and then overwrites it with the final output.

The implementation is intentionally guarded behind `TORCHINDUCTOR_CHANNEL_RESIDENT_REDUCTION_SUFFIX=1` while the codegen shape and profitability model are reviewed.

## Evidence

Target repro: `sum_sum_6e3dcc264797` from eellison/better-benchmark#45.

Fresh B200 locked benchmark, `--n-warmup 25 --n-rep 100 --no-cd`:

- Baseline: `49.312 us`, SOL `15.264 us`, gap `3.23x`
- Channel-resident enabled: `27.584 us`, SOL `15.168 us`, gap `1.82x`
- Speedup: about `1.79x`

Earlier NCU on the same target showed kernel duration `98.464 us -> 47.872 us`, LTS bytes `300.6 MB -> 146.3 MB`, global load instructions `1.807M -> 0.804M`, and global store instructions `0.503M -> 0.252M`.

## Validation

- `git diff --check`
- `python -m py_compile torch/_inductor/codegen/common.py torch/_inductor/codegen/triton.py torch/_inductor/config.py test/inductor/test_triton_kernels.py`
- `python test/inductor/test_triton_kernels.py -k test_channel_resident_reduction_suffix_store_elision`
- Negative sweep: only the positive target elided; disabled target, single reduction, small reduction numel, and graph-output-user cases did not match the elided shape.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo