### PR TITLE
[inductor] Use persistent path for small fused online softmax

### DIFF
--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -28,6 +28,52 @@ def _prepare_softmax(x, dim):
     return xmax, xsum
 
 
+def _gptneo_like_masked_softmax(attn_mask, bmm, cumsum):
+    bsz = 32
+    nhead = 16
+    seq = 128
+    neg_inf = torch.full((), -3.4028234663852886e38, device=bmm.device)
+    logits = bmm.view(bsz, nhead, seq, seq)
+    logits = torch.where(attn_mask[:, :, :seq, :seq], logits, neg_inf)
+
+    i = torch.arange(seq, device=bmm.device)
+    q = i.view(1, 1, seq, 1)
+    k = i.view(1, 1, 1, seq)
+    causal = k <= q
+
+    batch = torch.arange(bsz, device=bmm.device).view(bsz, 1, 1, 1)
+    same_segment = cumsum[batch, q] == cumsum[batch, k]
+    mask = causal & same_segment
+    bias = torch.where(mask.expand(bsz, -1, seq, seq), 0.0, neg_inf)
+    return torch.softmax(logits + bias, dim=-1).view(bsz * nhead, seq, seq)
+
+
+def _swin_like_relative_bias_softmax(bmm, relative_position_index, bias_table):
+    batch = 4
+    nhead = 2
+    seq = 49
+    logits = bmm.view(batch, nhead, seq, seq)
+    bias = bias_table[relative_position_index.view(-1)]
+    bias = bias.view(seq, seq, nhead).permute(2, 0, 1).contiguous()
+    return torch.softmax(logits + bias.unsqueeze(0), dim=-1).view(
+        batch * nhead, seq, seq
+    )
+
+
+def _all_masked_guard_softmax(bmm):
+    batch = 4
+    nhead = 2
+    seq = 128
+    neg_inf = torch.full((), -3.4028234663852886e38, device=bmm.device)
+    logits = bmm.view(batch, nhead, seq, seq)
+    mask = torch.tril(torch.ones(seq, seq, device=bmm.device, dtype=torch.bool))
+    logits = logits + torch.where(mask.view(1, 1, seq, seq), 0.0, neg_inf)
+    has_unmasked = (logits != neg_inf).any(dim=-1, keepdim=True)
+    return torch.where(has_unmasked, torch.softmax(logits, dim=-1), 0.0).view(
+        batch * nhead, seq, seq
+    )
+
+
 class TestOnlineSoftmax(TestCase):
     def do_test_acc_and_perf(self, op):
         if DO_PERF_TEST:
@@ -104,6 +150,43 @@ class TestOnlineSoftmax(TestCase):
         """
         wrapper_code = self.get_softmax_wrapper(1024)
         self.assertEqual(wrapper_code.count("for r0_offset in"), 0)
+
+    def test_codegen_gptneo_masked_softmax_r128_persistent_reduction(self):
+        torch.manual_seed(0)
+        attn_mask = torch.ones(1, 1, 2048, 2048, device=GPU_TYPE, dtype=torch.bool)
+        bmm = torch.randn(32 * 16, 128, 128, device=GPU_TYPE)
+        cumsum = torch.randint(0, 32, (32, 128), device=GPU_TYPE)
+
+        ref = _gptneo_like_masked_softmax(attn_mask, bmm, cumsum)
+        act, (code,) = run_and_get_code(
+            torch.compile(_gptneo_like_masked_softmax), attn_mask, bmm, cumsum
+        )
+
+        torch.testing.assert_close(act, ref)
+        self.assertIn("triton_heuristics.persistent_reduction", code)
+        self.assertEqual(code.count("for r0_offset in"), 0)
+
+    def test_codegen_softmax_persistent_reduction_neutral_guards(self):
+        torch.manual_seed(0)
+
+        swin_bmm = torch.randn(4 * 2, 49, 49, device=GPU_TYPE)
+        relative_position_index = torch.randint(0, 169, (49, 49), device=GPU_TYPE)
+        bias_table = torch.randn(169, 2, device=GPU_TYPE)
+        _, (swin_code,) = run_and_get_code(
+            torch.compile(_swin_like_relative_bias_softmax),
+            swin_bmm,
+            relative_position_index,
+            bias_table,
+        )
+        self.assertIn("triton_heuristics.persistent_reduction", swin_code)
+        self.assertEqual(swin_code.count("for r0_offset in"), 0)
+
+        all_masked_bmm = torch.randn(4 * 2, 128, 128, device=GPU_TYPE)
+        _, (all_masked_code,) = run_and_get_code(
+            torch.compile(_all_masked_guard_softmax), all_masked_bmm
+        )
+        self.assertIn("triton_heuristics.persistent_reduction", all_masked_code)
+        self.assertEqual(all_masked_code.count("for r0_offset in"), 0)
 
     @inductor_config.patch("triton.persistent_reductions", False)
     def test_sdpa(self):

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -417,11 +417,23 @@ class InductorChoices:
         """
         if not config.triton.persistent_reductions:
             return False
+        reduction_hint = features.get_reduction_hint()
         threshold = {
             ReductionHint.INNER: 1024,
-        }.get(features.get_reduction_hint(), 64)
+        }.get(reduction_hint, 64)
 
-        if features.get_reduction_hint() not in (
+        if (
+            reduction_hint == ReductionHint.DEFAULT
+            and not cooperative_reduction
+            and features.has_only_reduction_type("online_softmax_reduce")
+        ):
+            # Some fused softmax rows are logically inner reductions, but are
+            # demoted to DEFAULT by the fused pointwise/multiple-output shape.
+            # For moderate static rows, the persistent path avoids replaying
+            # the mask/bias/logit body in a second pass.
+            threshold = 128
+
+        if reduction_hint not in (
             ReductionHint.INNER,
             ReductionHint.OUTER_TINY,
         ):

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -102,6 +102,12 @@ class SIMDKernelFeatures:
     def reduction_nodes(self) -> list[SchedulerNode]:
         return [n for n in self.scheduler_nodes() if n.is_reduction()]
 
+    def has_only_reduction_type(self, reduction_type: str) -> bool:
+        reductions = self.reduction_nodes()
+        return bool(reductions) and all(
+            node.node.get_reduction_type() == reduction_type for node in reductions
+        )
+
     @cache_on_self
     def buf_accesses(self) -> dict[str, list[Dep]]:
         """only needed for config.benchmark_kernel"""

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -14,6 +14,7 @@ import torch
 from ...utils._ordered_set import OrderedSet
 from ...utils._sympy.functions import FloorDiv, ModularIndexing
 from ...utils._sympy.symbol import make_symbol, SymT
+from .. import ir
 from ..dependencies import Dep, extract_loop_body_with_args, MemoryDep
 from ..runtime.hints import ReductionHint
 from ..scheduler import SchedulerNode
@@ -104,9 +105,15 @@ class SIMDKernelFeatures:
 
     def has_only_reduction_type(self, reduction_type: str) -> bool:
         reductions = self.reduction_nodes()
-        return bool(reductions) and all(
-            node.node.get_reduction_type() == reduction_type for node in reductions
-        )
+        if not reductions:
+            return False
+        for node in reductions:
+            assert isinstance(node.node, (ir.ComputedBuffer, ir.TemplateBuffer)), (
+                f"{type(node.node)=}"
+            )
+            if node.node.get_reduction_type() != reduction_type:
+                return False
+        return True
 
     @cache_on_self
     def buf_accesses(self) -> dict[str, list[Dep]]:


### PR DESCRIPTION
Submitted by my agent.

## Summary

Use the persistent reduction path for small fused `online_softmax_reduce` kernels that are marked `ReductionHint.DEFAULT` but contain only online-softmax reductions.

Some fused masked softmax rows are logically inner reductions, but the fused pointwise/multiple-output shape demotes the reduction hint to DEFAULT. For moderate static rows, the non-persistent path replays the mask/bias/logit body in a second pass. This patch allows the persistent path for pure `online_softmax_reduce` DEFAULT kernels at `R <= 128`, while leaving cooperative reductions excluded.

Better-benchmark issue: eellison/better-benchmark#46.

## Evidence

B200 benchmark results, same harness:

- `amax_sum_11133e3f9217`: `28.640 us -> 22.464 us`, `1.275x`; generated `triton_red -> triton_per`, load sites `7 -> 4`
- `amax_sum_4b162354068b`: `26.400 us -> 20.288 us`, `1.301x`; load sites `6 -> 3`
- `amax_sum_f5fb3a355fc1`: `25.600 us -> 20.288 us`, `1.262x`; load sites `8 -> 4`

Neutral rows stayed persistent:

- `amax_sum_17ab35828f89`: `67.360 us -> 67.392 us`
- `any_amax_sum_2da4fabb8348`: `19.456 us -> 19.328 us`
- `amax_sum_0ee54b388f56`: `11.968 us -> 12.064 us`

## Validation

- `git diff --check`
- `python -m py_compile torch/_inductor/choices.py torch/_inductor/codegen/simd_kernel_features.py test/inductor/test_online_softmax.py`
- New focused tests: 2 passed
- Existing online-softmax codegen guard tests: 2 passed


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo