### PR TITLE
Clean up unused variables, redundant casts and namespaces in CUDA kernels

### DIFF
--- a/aten/src/ATen/cuda/detail/BLASConstants.cu
+++ b/aten/src/ATen/cuda/detail/BLASConstants.cu
@@ -2,9 +2,7 @@
 #include <ATen/Tensor.h>
 #include <ATen/cuda/Exceptions.h>
 
-namespace at {
-namespace cuda {
-namespace detail {
+namespace at::cuda::detail {
 
 __device__ __constant__ float cublas_one_device;
 __device__ __constant__ float cublas_zero_device;
@@ -44,6 +42,4 @@ float *get_user_alpha_ptr() {
   return alpha_ptr;
 }
 
-} // namespace detail
-} // namespace cuda
-} // namespace at
+} // namespace at::cuda::detail

--- a/aten/src/ATen/cuda/detail/BLASConstants.cu
+++ b/aten/src/ATen/cuda/detail/BLASConstants.cu
@@ -11,7 +11,7 @@ __device__ __constant__ float cublas_zero_device;
 
 float *get_cublas_device_one() {
   static float *ptr = nullptr;
-  static auto init_flag = [&]() {
+  [[maybe_unused]] static auto init_flag = [&]() {
     const float one = 1.f;
     AT_CUDA_CHECK(cudaMemcpyToSymbol(cublas_one_device, &one, sizeof(float)));
     AT_CUDA_CHECK(cudaGetSymbolAddress(reinterpret_cast<void**>(&ptr), cublas_one_device));
@@ -23,7 +23,7 @@ float *get_cublas_device_one() {
 
 float *get_cublas_device_zero() {
   static float *ptr = nullptr;
-  static auto init_flag = [&]() {
+  [[maybe_unused]] static auto init_flag = [&]() {
     const float zero = 0.f;
     AT_CUDA_CHECK(cudaMemcpyToSymbol(cublas_zero_device, &zero, sizeof(float)));
     AT_CUDA_CHECK(cudaGetSymbolAddress(reinterpret_cast<void**>(&ptr), cublas_zero_device));

--- a/aten/src/ATen/cuda/detail/IndexUtils.cu
+++ b/aten/src/ATen/cuda/detail/IndexUtils.cu
@@ -1,9 +1,7 @@
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <vector>
 
-namespace at {
-namespace cuda {
-namespace detail {
+namespace at::cuda::detail {
 
 struct SizeAndStride {
   int64_t size;
@@ -70,6 +68,4 @@ bool maybeOverlappingIndices(const TensorBase& t) {
   return false;
 }
 
-} // detail
-} // cuda
-} // at
+} // namespace at::cuda::detail

--- a/aten/src/ATen/native/cuda/AmpKernels.cu
+++ b/aten/src/ATen/native/cuda/AmpKernels.cu
@@ -89,7 +89,7 @@ void _amp_foreach_non_finite_check_and_unscale_cuda_(TensorList scaled_grads,
                                                      Tensor& found_inf,
                                                      const Tensor& inv_scale)
 {
-  if (scaled_grads.size() == 0) {
+  if (scaled_grads.empty()) {
     return;
   }
 

--- a/aten/src/ATen/native/cuda/ConvolutionMM2d.cu
+++ b/aten/src/ATen/native/cuda/ConvolutionMM2d.cu
@@ -99,7 +99,7 @@ void slow_conv2d_shape_check(
                   " but got ", gO_sizes[dimf]);
     } else if (bias.defined()) {
       const auto b_sizes = bias.sizes();
-      int64_t nOutputPlane = b_sizes.size() == 0 ? 1 : b_sizes[0];
+      int64_t nOutputPlane = b_sizes.empty() ? 1 : b_sizes[0];
       TORCH_CHECK(gO_sizes[dimf] == nOutputPlane,
                   "Expected grad_output dim ", dimf, " to have size ",
                   nOutputPlane, " but got ", gO_sizes[dimf]);

--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -670,11 +670,6 @@ const Tensor& gradInput) {
   const int64_t inputHeight = input.size(-2);
   const int64_t inputWidth = input.size(-1);
 
-  const int64_t in_stride_n = input.ndimension() == 4 ? input.stride(-4) : 0;
-  const int64_t in_stride_c = input.stride(-3);
-  const int64_t in_stride_h = input.stride(-2);
-  const int64_t in_stride_w = input.stride(-1);
-
   const Tensor gradOutput = gradOutput_.contiguous(memory_format);
 
   const int64_t outputHeight = gradOutput.size(-2);

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -45,9 +45,9 @@ __global__ static void max_pool3d_with_indices_single_out_frame(
   int offsetZ,
   bool channels_last)
 {
-  int oColumn = blockIdx.x * blockDim.x + threadIdx.x;
-  int oRow = blockIdx.y * blockDim.y + threadIdx.y;
-  int oFrame = 0;
+  int64_t oColumn = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t oRow = blockIdx.y * blockDim.y + threadIdx.y;
+  int64_t oFrame = 0;
   // used only for channels-first indexing
   int64_t slice = 0;
   // used only for channels-last indexing
@@ -193,10 +193,10 @@ __global__ static void max_pool3d_with_indices_backward_single_out_frame(
   int offsetZ,
   bool channels_last)
 {
-  int oColumn = blockIdx.x * blockDim.x + threadIdx.x;
-  int oRow = blockIdx.y * blockDim.y + threadIdx.y;
+  int64_t oColumn = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t oRow = blockIdx.y * blockDim.y + threadIdx.y;
 
-  int oFrame = 0;
+  int64_t oFrame = 0;
   // used only for channels-first indexing
   int64_t slice = 0;
   // used only for channels-last indexing

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -86,7 +86,7 @@ __global__ static void max_pool3d_with_indices_single_out_frame(
     int64_t maxIndex = tStart * iheight * iwidth + hStart * iwidth + wStart;
 
     if (!channels_last) {
-        inputData += (int64_t) slice * itime * iheight * iwidth;
+        inputData += slice * itime * iheight * iwidth;
     } else {
         inputData += ((int64_t) batch * itime * iheight * iwidth * features) + channel;
     }
@@ -119,7 +119,7 @@ __global__ static void max_pool3d_with_indices_single_out_frame(
 
     int64_t out_index;
     if (!channels_last) {
-      out_index = (int64_t) slice*otime*oheight*owidth + oFrame*oheight*owidth + oRow*owidth + oColumn;
+      out_index = slice*otime*oheight*owidth + oFrame*oheight*owidth + oRow*owidth + oColumn;
     } else {
       out_index = ((int64_t) batch*otime*oheight*owidth + oFrame*oheight*owidth + oRow*owidth + oColumn)*features + channel;
     }
@@ -218,14 +218,14 @@ __global__ static void max_pool3d_with_indices_backward_single_out_frame(
   {
     int64_t out_index;
     if (!channels_last) {
-      out_index = (int64_t) slice*otime*oheight*owidth + oFrame*oheight*owidth + oRow*owidth + oColumn;
+      out_index = slice*otime*oheight*owidth + oFrame*oheight*owidth + oRow*owidth + oColumn;
     } else {
       out_index = ((int64_t) batch*otime*oheight*owidth + oFrame*oheight*owidth + oRow*owidth + oColumn)*features + channel;
     }
     int64_t maxIndex = indicesData[out_index];
     if (maxIndex != -1) {
       if (!channels_last) {
-        gpuAtomicAddNoReturn(&gradInputData[(int64_t) slice * itime  * iheight * iwidth + maxIndex],
+        gpuAtomicAddNoReturn(&gradInputData[slice * itime  * iheight * iwidth + maxIndex],
           gradOutputData[out_index]);
       } else {
         gpuAtomicAddNoReturn(&gradInputData[((int64_t) batch * itime * iheight * iwidth + maxIndex) * features + channel],
@@ -304,7 +304,7 @@ void max_pool3d_with_indices_out_cuda_template(
   const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
   const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
 
-  TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 3,
+  TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 3,
     "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
   const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
   const int dH = stride.empty() ? kH :
@@ -434,7 +434,7 @@ void max_pool3d_with_indices_backward_out_cuda_template(
   const int kH = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[1], "int");
   const int kW = kernel_size.size() == 1 ? kT : c10::checked_convert<int>(kernel_size[2], "int");
 
-  TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 3,
+  TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 3,
     "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
   const int dT = stride.empty() ? kT : c10::checked_convert<int>(stride[0], "int");
   const int dH = stride.empty() ? kH :

--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -58,7 +58,7 @@ fused_dropout_kernel_vec(at::cuda::detail::TensorInfo<const scalar_t, IndexType>
 
   // Helps align the total number of times curand_uniform4 is called by each thread for the same totalElements
   // in the vec=2 and vec=4 cases.
-  bool gridxvec_loop_state = 0;
+  bool gridxvec_loop_state = false;
   accscalar_t scale = 1.0 / p;
 
   constexpr int RAND_SIZE = (VEC + 4 - 1) / 4;

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -324,8 +324,6 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
   if (scale_grad_by_freq) {
     count = at::empty_like(indices, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
     AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "embedding_dense_backward_cuda", [&] () {
-      cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-
       // Compute an increasing sequence per unique item in sortedIndices:
       // sorted: 2 5 5 5 7 7 8 9 9
       //  count: 1 1 2 3 1 2 1 1 2

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -212,8 +212,6 @@ Tensor embedding_bag_backward_cuda_sum_avg(
   if (scale_grad_by_freq) {
     count = at::empty_like(indices, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
     AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "embedding_bag_backward_cuda_sum_avg", [&] () {
-      cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-
       // Compute an increasing sequence per unique item in sortedIndices:
       // sorted: 2 5 5 5 7 7 8 9 9
       //  count: 1 1 2 3 1 2 1 1 2

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -232,7 +232,7 @@ std::vector<Tensor> foreach_tensor_max_cuda(TensorList tensors) {
   int i = 0;
   for (const auto& t : tensors) {
     if (t.numel() != 0) {
-      result.emplace_back(vec_res[i]);
+      result.emplace_back(std::move(vec_res[i]));
       i++;
     } else {
       result.emplace_back(at::native::empty_cuda(
@@ -588,7 +588,7 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
   int i = 0;
   for (const auto& t : tensors) {
     if (t.numel() != 0) {
-      result.emplace_back(vec_res[i]);
+      result.emplace_back(std::move(vec_res[i]));
       i++;
     } else {
       result.emplace_back(at::zeros({}, res_option));

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -167,7 +167,7 @@ std::vector<Tensor> foreach_tensor_max_cuda(TensorList tensors) {
 
   std::vector<at::Tensor> vec_res;
   vec_res.reserve(ntensors);
-  for (const auto i : c10::irange(ntensors)) {
+  for ([[maybe_unused]] const auto i : c10::irange(ntensors)) {
     vec_res.push_back(at::native::empty_cuda(
         {},
         optTypeMetaToScalarType(options.dtype_opt()),
@@ -467,7 +467,7 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
   std::vector<at::Tensor> vec_res;
   vec_res.reserve(ntensors);
   const auto res_option = options.dtype(output_dtype);
-  for (const auto i : c10::irange(ntensors)) {
+  for ([[maybe_unused]] const auto i : c10::irange(ntensors)) {
     vec_res.push_back(at::native::empty_cuda(
         {},
         optTypeMetaToScalarType(res_option.dtype_opt()),

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -639,7 +639,7 @@ makeLinearIndex(Tensor self, IOptTensorListRef orig, bool check_range) {
   }
   auto [linearIndex, nElemBefore, strideBefore, nElemAfter, dims_before, dims_indexed] =
     computeLinearIndex(self, indices, check_range);
-  return std::make_tuple(linearIndex, self, nElemBefore, strideBefore, nElemAfter, std::move(inversePerm),
+  return std::make_tuple(std::move(linearIndex), std::move(self), nElemBefore, strideBefore, nElemAfter, std::move(inversePerm),
                          dims_before, dims_indexed);
 }
 namespace {

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -639,7 +639,7 @@ makeLinearIndex(Tensor self, IOptTensorListRef orig, bool check_range) {
   }
   auto [linearIndex, nElemBefore, strideBefore, nElemAfter, dims_before, dims_indexed] =
     computeLinearIndex(self, indices, check_range);
-  return std::make_tuple(linearIndex, self, nElemBefore, strideBefore, nElemAfter, inversePerm,
+  return std::make_tuple(linearIndex, self, nElemBefore, strideBefore, nElemAfter, std::move(inversePerm),
                          dims_before, dims_indexed);
 }
 namespace {
@@ -1151,7 +1151,7 @@ void index_add_cuda_impl(const Tensor& self, int64_t dim, const Tensor& index, c
   if (globalContext().deterministicAlgorithms()){
     torch::List<std::optional<Tensor>> indices;
     indices.reserve(dim + 1);
-    for (const auto i: c10::irange(dim)) {
+    for ([[maybe_unused]] const auto i : c10::irange(dim)) {
       indices.emplace_back();
     }
     indices.emplace_back(index.to(at::kLong));

--- a/aten/src/ATen/native/cuda/Nonzero.cu
+++ b/aten/src/ATen/native/cuda/Nonzero.cu
@@ -122,7 +122,7 @@ __global__ void flag_kernel(const T* d_in, int64_t * d_out, const int64_t * agg,
     if (remaining >= BLOCK_THREADS * ITEMS_PER_THREAD) {
       BlockLoadT(temp_storage.load).Load(t_input_itr, data);
     } else {
-      BlockLoadT(temp_storage.load).Load(t_input_itr, data, remaining, int(0));
+      BlockLoadT(temp_storage.load).Load(t_input_itr, data, remaining, 0);
     }
 
     // Barrier for smem reuse

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -124,7 +124,7 @@ Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps,
     // skip
   } else if (steps == 1) {
     r.fill_(start);
-  } else if (isIntegralType(r.scalar_type(), 0)) {
+  } else if (isIntegralType(r.scalar_type(), /*includeBool=*/false)) {
     AT_DISPATCH_INTEGRAL_TYPES(r.scalar_type(), "linspace_cuda", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
@@ -179,7 +179,7 @@ Tensor& logspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps,
     } else {
       r.fill_(std::pow(base, start.to<double>()));
     }
-  } else if (isIntegralType(r.scalar_type(), 0)) {
+  } else if (isIntegralType(r.scalar_type(), /*includeBool=*/false)) {
     AT_DISPATCH_INTEGRAL_TYPES(r.scalar_type(), "logspace_cuda", [&]() {
       float scalar_base = static_cast<float>(base); // Use float to avoid promotion to double
       scalar_t scalar_start = start.to<scalar_t>();

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -423,15 +423,8 @@ TORCH_IMPL_FUNC(replication_pad1d_out_cuda) (
       "replication_pad1d only supports input tensors with less than 2^63 - 1 elements");
 
   int64_t padL = paddingSize[0];
-  int64_t padR = paddingSize[1];
-  constexpr int64_t planeDim = -2;
-  constexpr int64_t dimw = -1;
 
   int numInputDims = input.ndimension();
-
-  int64_t numPlanes = input.size(planeDim);
-  int64_t inputW = input.size(dimw);
-  int64_t outputW  = output.size(dimw);
 
   if (input.numel() == 0) {
     return;
@@ -492,7 +485,6 @@ TORCH_IMPL_FUNC(replication_pad1d_backward_out_cuda) (
   if (numInputDims == 3) {
     dimw++;
   }
-  int64_t iwidth = input.size(dimw);
 
   if (gradInput.numel() == 0) {
     return;
@@ -609,27 +601,7 @@ TORCH_IMPL_FUNC(replication_pad3d_out_cuda) (
   const auto pfront = paddingSize[4];
   // const auto pback = paddingSize[5]; // Ignored here
 
-  int planeDim = 0;
-  int dimd = 1;
-  int dimh = 2;
-  int dimw = 3;
-
   int numInputDims = input.dim();
-
-  if (numInputDims == 5) {
-    planeDim++;
-    dimd++;
-    dimh++;
-    dimw++;
-  }
-
-  const auto numPlanes = input.size(planeDim);
-  const auto inputD = input.size(dimd);
-  const auto inputH = input.size(dimh);
-  const auto inputW = input.size(dimw);
-  const auto outputD = output.size(dimd);
-  const auto outputH = output.size(dimh);
-  const auto outputW = output.size(dimw);
 
   if (input.numel() == 0) {
     return;

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -479,12 +479,8 @@ TORCH_IMPL_FUNC(replication_pad1d_backward_out_cuda) (
       "replication_pad1d only supports output tensors with less than 2^63 - 1 elements");
 
   const int64_t padL = paddingSize[0];
-  int64_t dimw = 1;
 
   int64_t numInputDims = input.ndimension();
-  if (numInputDims == 3) {
-    dimw++;
-  }
 
   if (gradInput.numel() == 0) {
     return;

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -299,7 +299,7 @@ __global__ void CatArrayBatchedCopy_alignedK_contig(
       }
 
       using LT = at::native::memory::aligned_vector<T, kILP>;
-      ((LT*)reg_data)[0] = const_cast<LT*>((LT*)(data + inputOffset))[0];
+      ((LT*)reg_data)[0] = ((LT*)(data + inputOffset))[0];
 
       #pragma unroll
       for (int i = 0; i < kILP; ++i) {

--- a/aten/src/ATen/native/cuda/SortStable.cu
+++ b/aten/src/ATen/native/cuda/SortStable.cu
@@ -124,7 +124,7 @@ inline void segmented_sort_large_segments(
       indices.get(), nsort, nsort_divider);
   const int64_t* initial_indices = indices.get();
 
-  for (auto i : c10::irange(nsegments)) {
+  for ([[maybe_unused]] auto i : c10::irange(nsegments)) {
     at::cuda::cub::radix_sort_pairs<scalar_t, int64_t>(
         self_ptr, values_ptr, initial_indices, indices_ptr, nsort, descending);
     indices_ptr += nsort;

--- a/aten/src/ATen/native/cuda/TensorShape.cu
+++ b/aten/src/ATen/native/cuda/TensorShape.cu
@@ -515,7 +515,7 @@ get_chunk_cat_metadata(
   // Inline computing `chunk_size` to avoid redundant computation
   int64_t chunk_size = 0;
   for (const auto i : c10::irange(num_tensors)) {
-    at::Tensor tensor = tensors[i];
+    const at::Tensor& tensor = tensors[i];
     srcs.push_back(reinterpret_cast<int64_t>(tensor.data_ptr()));
     auto sizes = tensor.sizes();
     auto [pad_size_along_dim, trailing_numel] =
@@ -543,13 +543,13 @@ get_chunk_cat_metadata(
       leading_dim,
       num_blocks_per_chunk,
       slice_size,
-      srcs,
-      block_idx_to_tensor_idx,
-      tensor_idx_to_start_tensor_bytes,
-      start_block_idx_per_tensor_chunk,
-      actual_tensor_sizes,
-      pad_tensor_chunk_sizes,
-      num_blocks_per_tensor_chunk);
+      std::move(srcs),
+      std::move(block_idx_to_tensor_idx),
+      std::move(tensor_idx_to_start_tensor_bytes),
+      std::move(start_block_idx_per_tensor_chunk),
+      std::move(actual_tensor_sizes),
+      std::move(pad_tensor_chunk_sizes),
+      std::move(num_blocks_per_tensor_chunk));
 }
 
 // See [CUDA kernel for chunk_cat_cuda]

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -149,8 +149,6 @@ struct UniqueCub {
       const bool consecutive,
       const bool return_inverse,
       const bool return_counts) {
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-
     int64_t num_inp = self.numel();
     Tensor sorted;
     if (consecutive) {

--- a/aten/src/ATen/native/cuda/int4mm.cu
+++ b/aten/src/ATen/native/cuda/int4mm.cu
@@ -1159,7 +1159,6 @@ at::Tensor _weight_int4pack_mm_cuda(
       qGroupSize == 256);
 
   TORCH_CHECK(qScaleAndZeros.dim() == 3);
-  auto numQGroups = qScaleAndZeros.size(0);
   TORCH_CHECK(
       kTiles * kKTileSize >= qGroupSize &&
       isEvenDivisor(kTiles * kKTileSize, qGroupSize));

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1614,12 +1614,12 @@ void LayerNormBackwardKernelImplInternal(
   }
 
   if (dgamma->defined() || dbeta->defined()) {
-    T* dgamma_data =
-        dgamma->defined() ? dgamma->template data_ptr<T>() : nullptr;
-    T* dbeta_data = dbeta->defined() ? dbeta->template data_ptr<T>() : nullptr;
-
 #if defined(USE_ROCM)
     if (M < 128) {
+      T* dgamma_data =
+          dgamma->defined() ? dgamma->template data_ptr<T>() : nullptr;
+      T* dbeta_data =
+          dbeta->defined() ? dbeta->template data_ptr<T>() : nullptr;
       // For small batch size, do colwise reduce directly.
       const int64_t B = (N + kCUDANumThreads - 1) / kCUDANumThreads;
       GammaBetaBackwardSimpleCUDAKernel<T, T_ACC, rms_norm>

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -1289,7 +1289,7 @@ void cuComputePartGradGammaBeta(
     const int i2_off = blockIdx.x * blockDim.x + thr_load_col_off;
     alignas(sizeof(double)) extern __shared__ char shared[];
     T_ACC * buf = reinterpret_cast<T_ACC*>(&shared); // buf has at least blockDim.x * blockDim.y * blockDim.y + (blockDim.y - 1)*(blockDim.x/blockDim.y) elements
-    T_ACC* warp_buf1 = (T_ACC*)buf;
+    T_ACC* warp_buf1 = buf;
     T_ACC* warp_buf2 = warp_buf1 + blockDim.y * blockDim.y * row_stride;
     // compute partial sums from strided inputs
     // do this to increase number of loads in flight

--- a/c10/cuda/test/impl/CUDAAssertionsTest_catches_stream.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_catches_stream.cu
@@ -27,7 +27,7 @@ __global__ void cuda_multiple_vars_always_fail_assertion_kernel(
   if (i != 0) {
     CUDA_KERNEL_ASSERT2(i == -i);
   } else {
-    CUDA_KERNEL_ASSERT2(i == i + 1);
+    CUDA_KERNEL_ASSERT2(false);
   }
 }
 

--- a/torch/csrc/distributed/c10d/quantization/quantization_gpu.cu
+++ b/torch/csrc/distributed/c10d/quantization/quantization_gpu.cu
@@ -42,9 +42,7 @@ __global__ void _bfloat16_to_float_cuda_kernel(
          col += col_incre) {
       const uint16_t* input_row = input + row * ncols;
       float* output_row = output + row * ncols;
-      uint32_t val_fp32 = static_cast<uint32_t>(
-                              reinterpret_cast<const uint16_t*>(input_row)[col])
-          << 16;
+      uint32_t val_fp32 = static_cast<uint32_t>(input_row[col]) << 16;
       reinterpret_cast<uint32_t*>(output_row)[col] = val_fp32;
     }
   }

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -589,7 +589,7 @@ static bool check_group_multicast_support(
   } else {
     // We don't expect this to happen. But we want to let the user to know if
     // this happens.
-    if (ranks_with_multicast_support.size() != 0) {
+    if (!ranks_with_multicast_support.empty()) {
       LOG(WARNING)
           << "Only a subset of ranks in the group has multicast support: "
           << ranks_with_multicast_support << " (world_size=" << reqs.size()

--- a/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cu
@@ -2,8 +2,7 @@
 
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh>
 
-namespace c10d {
-namespace intra_node_comm {
+namespace c10d::intra_node_comm {
 
 static constexpr size_t kOneShotThreshBytes = 256 * 1024;
 static constexpr size_t kTwoShotThreshBytes = 10 * 1024 * 1024;
@@ -120,5 +119,4 @@ int64_t getIntraNodeCommUsageCounter() {
   return usageCounter;
 }
 
-} // namespace intra_node_comm
-} // namespace c10d
+} // namespace c10d::intra_node_comm


### PR DESCRIPTION
  Mechanical clang-tidy cleanups across CUDA kernels. No behavior changes.

  - Remove unused variables
  - Drop redundant casts; convert `.size() == 0` to `.empty()`
  - Replace per-iteration `Tensor` copy with `const Tensor&`; rewrite intentional always-false assert
  - Concatenate nested namespaces; use bool literals