### PR TITLE
Use torch.sigmoid() in silu_backward decomposition

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -298,7 +298,7 @@ def silu(self: Tensor) -> Tensor:
 @out_wrapper("grad_input")
 @pw_cast_for_opmath
 def silu_backward(grad_output: Tensor, self: Tensor) -> Tensor:
-    sigmoid = 1 / (1 + torch.exp(-self))
+    sigmoid = torch.sigmoid(self)
     return grad_output * sigmoid * (1 + self * (1 - sigmoid))
 
 


### PR DESCRIPTION
Use `torch.sigmoid(self)` in the `silu_backward` decomposition instead of  `1 / (1 + torch.exp(-self))`.
It has the following pros:
  - Matches the `silu` forward decomposition, which already uses
    `torch.sigmoid`.
  - Lowers to a single `aten.sigmoid` node in the traced graph, so Inductor can match the dedicated sigmoid fusion path.
  - Numerically equivalent on IEEE floats.