### PR TITLE
[AI SLOP] Support SymInt list custom op returns

### DIFF
--- a/test/custom_operator/test_infer_schema_annotation.py
+++ b/test/custom_operator/test_infer_schema_annotation.py
@@ -118,6 +118,31 @@ class TestInferSchemaWithAnnotation(TestCase):
         result = torch.library.infer_schema(foo_op_7, mutates_args=mutates_args)
         self.assertEqual(result, "(Scalar x) -> Scalar")
 
+    def test_return_list_int(self):
+        def foo_op(x: torch.Tensor) -> list[int]:
+            return [x.shape[0]]
+
+        result = torch.library.infer_schema(foo_op, mutates_args=mutates_args)
+        self.assertEqual(result, "(Tensor x) -> SymInt[]")
+
+        def foo_op_2(x: torch.Tensor) -> typing.List[int]:  # noqa: UP006
+            return [x.shape[0]]
+
+        result = torch.library.infer_schema(foo_op_2, mutates_args=mutates_args)
+        self.assertEqual(result, "(Tensor x) -> SymInt[]")
+
+        def foo_op_3(x: torch.Tensor) -> tuple[list[int], int]:
+            return [x.shape[0]], x.shape[1]
+
+        result = torch.library.infer_schema(foo_op_3, mutates_args=mutates_args)
+        self.assertEqual(result, "(Tensor x) -> (SymInt[], SymInt)")
+
+        def foo_op_4(x: torch.Tensor) -> tuple[torch.Tensor, list[int]]:
+            return x, [x.shape[0]]
+
+        result = torch.library.infer_schema(foo_op_4, mutates_args=mutates_args)
+        self.assertEqual(result, "(Tensor x) -> (Tensor, SymInt[])")
+
     @unittest.expectedFailure
     def test_no_library_prefix(self):
         def foo_op(x: Tensor) -> Tensor:

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6544,6 +6544,68 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
                 int(str(symbol)[len(prefix_str[SymT.UNBACKED_INT]) :]) < next_index
             )
 
+    def test_unbacked_bindings_for_int_list_return_custom_op(self):
+        class M(torch.nn.Module):
+            def forward(self, a, b):
+                sizes = torch.ops.mylib.foo_int_list_unbacked(a, b)
+                return torch.empty(sizes[0], sizes[1], dtype=a.dtype, device=a.device)
+
+        @torch.library.custom_op("mylib::foo_int_list_unbacked", mutates_args={})
+        def foo_int_list_unbacked(a: torch.Tensor, b: torch.Tensor) -> list[int]:
+            return [int(b.item()), a.shape[1]]
+
+        @foo_int_list_unbacked.register_fake
+        def foo_int_list_unbacked_fake_impl(a, b):
+            u = torch.library.get_ctx().new_dynamic_size(min=0, max=a.shape[0])
+            return [u, a.shape[1]]
+
+        ep = export(
+            M(),
+            (torch.randn(10, 4), torch.tensor(3)),
+        )
+        foo = [
+            node
+            for node in ep.graph.nodes
+            if node.target is torch.ops.mylib.foo_int_list_unbacked.default
+        ][0]
+        unbacked_bindings = foo.meta["unbacked_bindings"]
+        self.assertEqual(len(unbacked_bindings), 1)
+        path = next(iter(unbacked_bindings.values()))
+        self.assertEqual(path, (pytree.SequenceKey(0),))
+
+    def test_unbacked_bindings_for_mixed_tensor_int_list_return_custom_op(self):
+        class M(torch.nn.Module):
+            def forward(self, a, b):
+                out, sizes = torch.ops.mylib.foo_mixed_int_list_unbacked(a, b)
+                return out, torch.empty(
+                    sizes[0], sizes[1], dtype=a.dtype, device=a.device
+                )
+
+        @torch.library.custom_op("mylib::foo_mixed_int_list_unbacked", mutates_args={})
+        def foo_mixed_int_list_unbacked(
+            a: torch.Tensor, b: torch.Tensor
+        ) -> tuple[torch.Tensor, list[int]]:
+            return a + 1, [int(b.item()), a.shape[1]]
+
+        @foo_mixed_int_list_unbacked.register_fake
+        def foo_mixed_int_list_unbacked_fake_impl(a, b):
+            u = torch.library.get_ctx().new_dynamic_size(min=0, max=a.shape[0])
+            return torch.empty_like(a), [u, a.shape[1]]
+
+        ep = export(
+            M(),
+            (torch.randn(10, 4), torch.tensor(3)),
+        )
+        foo = [
+            node
+            for node in ep.graph.nodes
+            if node.target is torch.ops.mylib.foo_mixed_int_list_unbacked.default
+        ][0]
+        unbacked_bindings = foo.meta["unbacked_bindings"]
+        self.assertEqual(len(unbacked_bindings), 1)
+        path = next(iter(unbacked_bindings.values()))
+        self.assertEqual(path, (pytree.SequenceKey(1), pytree.SequenceKey(0)))
+
     def test_torch_check_eq_commutativity(self):
         class M1(torch.nn.Module):
             def forward(self, x1, x2, x3, y):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -14660,6 +14660,118 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         # No error
         f(x)
 
+    @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
+    @torch._inductor.config.patch(implicit_fallbacks=True)
+    def test_custom_op_unbacked_symint_list_return(self):
+        @torch.library.custom_op("test_unbacked_symints::foo_list", mutates_args={})
+        def foo_list(x: torch.Tensor, y: torch.Tensor) -> list[int]:
+            return [int(y.item()), x.shape[1]]
+
+        @foo_list.register_fake
+        def _(x, y):
+            u0 = torch.library.get_ctx().new_dynamic_size(min=0, max=x.shape[0])
+            return [u0, x.shape[1]]
+
+        def f(x, y):
+            m, n = torch.ops.test_unbacked_symints.foo_list(x, y)
+            return torch.ones(m, n, dtype=x.dtype, device=x.device)
+
+        x = torch.randn(5, 4, device=self.device)
+        y = torch.tensor(3, device=self.device)
+
+        actual = torch.compile(f, fullgraph=True)(x, y)
+        expected = f(x, y)
+        self.assertEqual(actual, expected)
+
+    @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
+    @torch._inductor.config.patch({"implicit_fallbacks": True, "cpp_wrapper": True})
+    def test_custom_op_unbacked_symint_list_return_cpp_wrapper(self):
+        if self.device != "cpu":
+            self.skipTest("cpp_wrapper regression is CPU-specific")
+
+        @torch.library.custom_op(
+            "test_unbacked_symints::foo_list_cpp_wrapper", mutates_args={}
+        )
+        def foo_list_cpp_wrapper(x: torch.Tensor, y: torch.Tensor) -> list[int]:
+            return [int(y.item()), x.shape[1]]
+
+        @foo_list_cpp_wrapper.register_fake
+        def _(x, y):
+            u0 = torch.library.get_ctx().new_dynamic_size(min=0, max=x.shape[0])
+            return [u0, x.shape[1]]
+
+        def f(x, y):
+            m, n = torch.ops.test_unbacked_symints.foo_list_cpp_wrapper(x, y)
+            return torch.ones(m, n, dtype=x.dtype, device=x.device)
+
+        x = torch.randn(5, 4, device=self.device)
+        y = torch.tensor(3, device=self.device)
+
+        actual = torch.compile(f, fullgraph=True)(x, y)
+        expected = f(x, y)
+        self.assertEqual(actual, expected)
+
+    @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
+    @torch._inductor.config.patch(implicit_fallbacks=True)
+    def test_custom_op_unbacked_symint_list_mixed_return(self):
+        @torch.library.custom_op(
+            "test_unbacked_symints::foo_mixed_list", mutates_args={}
+        )
+        def foo_mixed_list(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> tuple[torch.Tensor, list[int]]:
+            return x + 1, [int(y.item()), x.shape[1]]
+
+        @foo_mixed_list.register_fake
+        def _(x, y):
+            u0 = torch.library.get_ctx().new_dynamic_size(min=0, max=x.shape[0])
+            return torch.empty_like(x), [u0, x.shape[1]]
+
+        def f(x, y):
+            out, sizes = torch.ops.test_unbacked_symints.foo_mixed_list(x, y)
+            m, n = sizes
+            return out + torch.ones(m, n, dtype=x.dtype, device=x.device)
+
+        x = torch.randn(5, 4, device=self.device)
+        y = torch.tensor(5, device=self.device)
+
+        actual = torch.compile(f, fullgraph=True)(x, y)
+        expected = f(x, y)
+        self.assertEqual(actual, expected)
+
+    @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
+    @torch._inductor.config.patch({"implicit_fallbacks": True, "cpp_wrapper": True})
+    def test_custom_op_unbacked_symint_list_mixed_return_cpp_wrapper(self):
+        if self.device != "cpu":
+            self.skipTest("cpp_wrapper regression is CPU-specific")
+
+        @torch.library.custom_op(
+            "test_unbacked_symints::foo_mixed_list_cpp_wrapper", mutates_args={}
+        )
+        def foo_mixed_list_cpp_wrapper(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> tuple[torch.Tensor, list[int]]:
+            return x + 1, [int(y.item()), x.shape[1]]
+
+        @foo_mixed_list_cpp_wrapper.register_fake
+        def _(x, y):
+            u0 = torch.library.get_ctx().new_dynamic_size(min=0, max=x.shape[0])
+            return torch.empty_like(x), [u0, x.shape[1]]
+
+        def f(x, y):
+            out, sizes = torch.ops.test_unbacked_symints.foo_mixed_list_cpp_wrapper(
+                x, y
+            )
+            m, n = sizes
+            return out + torch.ones(m, n, dtype=x.dtype, device=x.device)
+
+        x = torch.randn(5, 4, device=self.device)
+        y = torch.tensor(5, device=self.device)
+
+        actual = torch.compile(f, fullgraph=True)(x, y)
+        expected = f(x, y)
+        self.assertEqual(actual, expected)
+
     @requires_gpu()
     @torch._inductor.config.patch("layout_optimization", True)
     @torch._inductor.config.patch("keep_output_stride", False)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -3298,7 +3298,7 @@ end
 _libgomp: CDLL | None = None
 
 
-def custom_op_wrapper(op: str, *args: Any) -> list[c_void_p] | c_void_p | None:
+def custom_op_wrapper(op: str, *args: Any) -> list[Any] | c_void_p | int | None:
     # This function will be called from generated cpp wrapper code in the JIT mode.
     # Because tensors will be passed in as AtenTensorHandle, we need to explicitly convert them.
     def convert_arg(arg: Any) -> Any:
@@ -3336,15 +3336,18 @@ def custom_op_wrapper(op: str, *args: Any) -> list[c_void_p] | c_void_p | None:
     if result is None:
         return None
 
-    if isinstance(result, (list, tuple)):
-        # unsafe_alloc_void_ptrs_from_tensors expects result contains tensor only
-        result = [torch.tensor([]) if r is None else r for r in result]
-        for r in result:
-            assert isinstance(r, torch.Tensor), op + " returns a list of non-tensors"
-        return torch._C._aoti.unsafe_alloc_void_ptrs_from_tensors(result)  # type: ignore[arg-type]
+    def convert_result(r: Any) -> Any:
+        if r is None:
+            r = torch.tensor([])
+        if isinstance(r, torch.Tensor):
+            return torch._C._aoti.unsafe_alloc_void_ptr_from_tensor(r)
+        if isinstance(r, (list, tuple)):
+            return [convert_result(elem) for elem in r]
+        if isinstance(r, int):
+            return r
+        raise AssertionError(f"{op} returns an unsupported value: {type(r)}")
 
-    assert isinstance(result, torch.Tensor), op + " returns a non-tensor"
-    return torch._C._aoti.unsafe_alloc_void_ptr_from_tensor(result)
+    return convert_result(result)
 
 
 # Precompiled headers are persistent past program runtime, but associated with one

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2775,6 +2775,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
         these types are not guaranteed to be supported long-term.  When generating code
         for cpp_wrapper mode, we don't have to be forward-compatible, so changing this
         function's implementation in future is fine."""
+        if len(op._schema.returns) > 1 and any(
+            CppWrapperCpu._is_symint_list_type(r.type) for r in op._schema.returns
+        ):
+            return False
+
         supported_types = (
             torch.BoolType,
             torch.DeviceObjType,
@@ -2782,17 +2787,43 @@ class CppWrapperCpu(PythonWrapperCodegen):
             # ScalarTypeType, LayoutType, and MemoryFormatType are seen as IntType
             # when queried via torch.JitType.type.
             torch.IntType,
+            torch.SymIntType,
             torch.TensorType,
         )
 
-        def type_supported(t: torch.JitType) -> bool:
+        def type_supported(t: torch.JitType, *, is_return: bool) -> bool:
             if isinstance(t, torch.OptionalType):
-                return type_supported(t.getElementType())
+                return type_supported(t.getElementType(), is_return=is_return)
+            if isinstance(t, torch.ListType):
+                if is_return:
+                    return CppWrapperCpu._is_symint_list_type(t)
+                return isinstance(t.getElementType(), (torch.IntType, torch.SymIntType))
             return isinstance(t, supported_types)
 
         return all(
-            type_supported(a.type)
-            for a in chain(op._schema.arguments, op._schema.returns)
+            type_supported(a.type, is_return=False) for a in op._schema.arguments
+        ) and all(type_supported(r.type, is_return=True) for r in op._schema.returns)
+
+    @staticmethod
+    def _is_symint_list_type(t: torch.JitType) -> bool:
+        return isinstance(t, torch.ListType) and isinstance(
+            t.getElementType(), (torch.IntType, torch.SymIntType)
+        )
+
+    @classmethod
+    def _is_single_symint_list_return(cls, return_schema: Sequence[Any]) -> bool:
+        return len(return_schema) == 1 and cls._is_symint_list_type(
+            return_schema[0].real_type
+        )
+
+    @classmethod
+    def _symint_list_output_name(
+        cls, buf_name: str, idx: int, return_schema: Sequence[Any]
+    ) -> str:
+        return (
+            buf_name
+            if cls._is_single_symint_list_return(return_schema)
+            else f"{buf_name}_symint_list_{idx}"
         )
 
     def generate_fallback_kernel_with_runtime_lookup(
@@ -2837,10 +2868,33 @@ class CppWrapperCpu(PythonWrapperCodegen):
         else:
             return_schema = op_overload._schema.returns
 
-        # output_args has the same pytree structure as outputs
+        # output_args has the same pytree structure as outputs, except scalar list
+        # returns are materialized as C++ vectors named after the fallback node.
         if not return_schema:
             # kernel does not return a value
             output_args: _OUTPUT_ARGS_TYPE = []
+        elif self._is_single_symint_list_return(return_schema):
+            assert isinstance(outputs, (list, tuple))
+            assert all(isinstance(o, (int, sympy.Expr)) for o in outputs), outputs
+            output_args = [buf_name]
+        elif len(return_schema) > 1:
+            assert isinstance(outputs, (list, tuple))
+            assert len(outputs) == len(return_schema), (outputs, return_schema)
+            output_args = []
+            for idx, (output, ret) in enumerate(zip(outputs, return_schema)):
+                if self._is_symint_list_type(ret.real_type):
+                    assert isinstance(output, (list, tuple)), output
+                    assert all(isinstance(o, (int, sympy.Expr)) for o in output), output
+                    output_args.append(
+                        self._symint_list_output_name(buf_name, idx, return_schema)
+                    )
+                else:
+                    output_arg = extract_output_name(output)
+                    assert output_arg is None or isinstance(output_arg, str), (
+                        output,
+                        output_arg,
+                    )
+                    output_args.append(output_arg)
         elif isinstance(output_name := extract_output_name(outputs), str):
             output_args = [output_name]
         else:
@@ -2892,6 +2946,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         # overhead of calling back into Python, and covers most remaining fallback ops.
         if self._compatible_with_stableivalue(op_overload):
             self.generate_fallback_kernel_with_runtime_lookup_nopython(
+                buf_name,
                 get_args,
                 op_overload,
                 output_args,  # type: ignore[arg-type]
@@ -3075,6 +3130,7 @@ if (!custom_op_wrapper) {
 
     def generate_fallback_kernel_with_runtime_lookup_nopython(
         self,
+        buf_name: str,
         get_args: Callable[[], Sequence[str]],
         op_overload: torch._ops.OpOverload,
         output_args: Sequence[str | None],
@@ -3086,13 +3142,26 @@ if (!custom_op_wrapper) {
 
         In the future, we may switch over to directly calling c10::Dispatcher if we need
         to support more datatypes."""
+        return_types = [r.real_type for r in op_overload._schema.returns]
+        has_symint_list_return = any(self._is_symint_list_type(t) for t in return_types)
+
         if raw_outputs:
-            declarations_before_scope = [
-                f"RAIIAtenTensorHandle {output_arg};"
-                for output_arg, raw_output_arg in zip(output_args, raw_outputs)  # type: ignore[arg-type]
-                if output_arg is not None
-                and not isinstance(raw_output_arg, ir.MutationOutput)
-            ]
+            if has_symint_list_return:
+                self.include_extra_header("vector")
+            declarations_before_scope = []
+            for idx, (output_arg, raw_output_arg) in enumerate(
+                zip(output_args, raw_outputs)  # type: ignore[arg-type]
+            ):
+                if output_arg is None:
+                    continue
+                if self._is_symint_list_type(return_types[idx]):
+                    declarations_before_scope.append(
+                        f"std::vector<int64_t> {output_arg};"
+                    )
+                elif not isinstance(raw_output_arg, ir.MutationOutput):
+                    declarations_before_scope.append(
+                        f"RAIIAtenTensorHandle {output_arg};"
+                    )
         else:
             declarations_before_scope = [
                 f"RAIIAtenTensorHandle {output_arg};"
@@ -3161,7 +3230,7 @@ if (!custom_op_wrapper) {
                 parse_arg(a.type, c)
                 for a, c in zip(op_overload._schema.arguments, codegen_args)
             )
-            array_len = max(len(codegen_args), len(output_args))
+            array_len = max(len(codegen_args), len(output_args), len(return_types))
             dispatch_lines.writeline(
                 f"std::array<StableIValue, {array_len}> dispatch_vars{{{', '.join(ivalue_args)}}};"
             )
@@ -3176,9 +3245,17 @@ if (!custom_op_wrapper) {
             for idx, output_arg in enumerate(output_args):
                 if output_arg is None:
                     continue
-                dispatch_lines.writeline(
-                    f"{output_arg} = torch::stable::detail::to<AtenTensorHandle>(dispatch_vars[{idx}]);"
-                )
+                assert idx < len(return_types)
+                if self._is_symint_list_type(return_types[idx]):
+                    dispatch_lines.writeline(
+                        f"{output_arg} = torch::stable::detail::to<"
+                        f"std::vector<int64_t>>(dispatch_vars[{idx}]);"
+                    )
+                else:
+                    dispatch_lines.writeline(
+                        f"{output_arg} = torch::stable::detail::to<"
+                        f"AtenTensorHandle>(dispatch_vars[{idx}]);"
+                    )
 
         dispatch_lines.writeline("}")
         self.writelines(dispatch_lines.getvalue().splitlines())
@@ -3199,6 +3276,7 @@ if (!custom_op_wrapper) {
         This function calls into Python to dispatch, which allows it to handle datatypes
         that cannot be contained in StableIValue, at the cost of some performance."""
         self.load_custom_op_wrapper()
+        return_types = [r.real_type for r in op_overload._schema.returns]
 
         num_args = len(raw_args)
         py_args_var = f"py_args_{next(self.arg_var_id)}"
@@ -3233,23 +3311,52 @@ if (!custom_op_wrapper) {
             """
         )
 
-        if len(output_args) == 1 and (output := output_args[0]) is not None:
-            # result is a single tensor
-            lines += f"{output} = reinterpret_cast<AtenTensorHandle>(PyCapsule_GetPointer(py_{buf_name}.get(), NULL));\n"
-        else:
-            # result is a tuple of tensors
-            for idx, output_arg in enumerate(output_args):
-                if output_arg is None:
-                    continue
-                lines += f"{output_arg} = reinterpret_cast<AtenTensorHandle>(PyCapsule_GetPointer(PyList_GET_ITEM(py_{buf_name}.get(), {idx}), NULL));\n"
+        def py_result_at(idx: int) -> str:
+            if len(output_args) == 1:
+                return f"py_{buf_name}.get()"
+            return f"PyList_GET_ITEM(py_{buf_name}.get(), {idx})"
+
+        for idx, output_arg in enumerate(output_args):
+            if output_arg is None:
+                continue
+            if self._is_symint_list_type(return_types[idx]):
+                py_output_arg = f"py_{output_arg}"
+                lines += textwrap.dedent(
+                    f"""
+                    PyObject* {py_output_arg} = {py_result_at(idx)};
+                    {output_arg}.reserve(PyList_GET_SIZE({py_output_arg}));
+                    for (Py_ssize_t i = 0; i < PyList_GET_SIZE({py_output_arg}); ++i) {{
+                        PyObject* item = PyList_GET_ITEM({py_output_arg}, i);
+                        {output_arg}.push_back(PyLong_AsLongLong(item));
+                    }}
+                    if (PyErr_Occurred()) {{
+                        return;
+                    }}
+                    """
+                )
+            else:
+                lines += (
+                    f"{output_arg} = reinterpret_cast<AtenTensorHandle>("
+                    f"PyCapsule_GetPointer({py_result_at(idx)}, NULL));\n"
+                )
 
         if raw_outputs:
-            declarations_before_scope = [
-                f"RAIIAtenTensorHandle {output_arg};"
-                for output_arg, raw_output_arg in zip(output_args, raw_outputs)  # type: ignore[arg-type]
-                if output_arg is not None
-                and not isinstance(raw_output_arg, ir.MutationOutput)
-            ]
+            if any(self._is_symint_list_type(t) for t in return_types):
+                self.include_extra_header("vector")
+            declarations_before_scope = []
+            for idx, (output_arg, raw_output_arg) in enumerate(
+                zip(output_args, raw_outputs)  # type: ignore[arg-type]
+            ):
+                if output_arg is None:
+                    continue
+                if self._is_symint_list_type(return_types[idx]):
+                    declarations_before_scope.append(
+                        f"std::vector<int64_t> {output_arg};"
+                    )
+                elif not isinstance(raw_output_arg, ir.MutationOutput):
+                    declarations_before_scope.append(
+                        f"RAIIAtenTensorHandle {output_arg};"
+                    )
         else:
             declarations_before_scope = [
                 f"RAIIAtenTensorHandle {output_arg};"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -3899,12 +3899,18 @@ class PythonWrapperCodegen(CodeGen):
         # to access the unbacked symbol in a structured way.
         # For example, we might want to generate "u0 = outs[0].stride(1)"", where s = u0, and the keypath
         # describes the structure of "outs[0].stride(1)", like [SequenceKey(0), CallMethodKey("stride"), SequenceKey[1]].
+        def is_scalar_sequence_output(output: Any) -> bool:
+            return isinstance(output, (list, tuple)) and all(
+                isinstance(o, (int, sympy.Expr)) for o in output
+            )
+
+        scalar_sequence_output = is_scalar_sequence_output(outputs)
         for s, keypath in unbacked_bindings.items():
             # `go` recursively constructs a code expression by processing each element of
             # the keypath and construct the expression incrementally.
             # For example, given output name outs and keypath [SequenceKey(0), CallMethodKey("stride", 1)],
             # it generates "outs[0]" based on SequenceKey(0), then recursively go("outs[0]", [CallMethodKey("stride"), ...])
-            def go(expr: str, keypath: pytree.KeyPath):
+            def go(expr: str, keypath: pytree.KeyPath, *, tuple_index_sequences: bool):
                 if keypath == ():
                     return expr
 
@@ -3914,20 +3920,38 @@ class PythonWrapperCodegen(CodeGen):
                     and isinstance(keypath[1], pytree.SequenceKey)
                 ):
                     return go(
-                        f"{expr}.{keypath[0].name}({keypath[1].idx})", keypath[2:]
+                        f"{expr}.{keypath[0].name}({keypath[1].idx})",
+                        keypath[2:],
+                        tuple_index_sequences=tuple_index_sequences,
                     )
                 elif isinstance(keypath[0], CallMethodKey):
-                    return go(f"{expr}.{keypath[0].name}()", keypath[1:])
+                    return go(
+                        f"{expr}.{keypath[0].name}()",
+                        keypath[1:],
+                        tuple_index_sequences=tuple_index_sequences,
+                    )
                 elif isinstance(keypath[0], pytree.SequenceKey):
                     return (
-                        go(f"std::get<{keypath[0].idx}>({expr})", keypath[1:])
-                        if V.graph.cpp_wrapper
-                        else go(f"{expr}[{keypath[0].idx}]", keypath[1:])
+                        go(
+                            f"std::get<{keypath[0].idx}>({expr})",
+                            keypath[1:],
+                            tuple_index_sequences=tuple_index_sequences,
+                        )
+                        if V.graph.cpp_wrapper and tuple_index_sequences
+                        else go(
+                            f"{expr}[{keypath[0].idx}]",
+                            keypath[1:],
+                            tuple_index_sequences=tuple_index_sequences,
+                        )
                     )
                 elif isinstance(keypath[0], DivideByKey):
                     # TODO: need to assert divisibility
                     # TODO: this is invalid C++ codegen
-                    return go(f"{expr}.__floordiv__({keypath[0].divisor})", keypath[1:])
+                    return go(
+                        f"{expr}.__floordiv__({keypath[0].divisor})",
+                        keypath[1:],
+                        tuple_index_sequences=tuple_index_sequences,
+                    )
                 else:
                     raise AssertionError(f"unrecognized keypath {keypath}")
 
@@ -3936,6 +3960,12 @@ class PythonWrapperCodegen(CodeGen):
             # the keypath based on the context (e.g., single vs. multiple outputs).
             def go_outer():  # type: ignore[no-untyped-def]
                 if V.graph.cpp_wrapper:
+                    if scalar_sequence_output:
+                        return go(
+                            output_name,
+                            keypath,
+                            tuple_index_sequences=False,
+                        )
                     # Special handling for the top level buffer access,
                     # because self.get_name() is actually never bound; the
                     # individual output arguments are bound by
@@ -3950,12 +3980,24 @@ class PythonWrapperCodegen(CodeGen):
                             keypath[1:]
                             if isinstance(out, ir.MultiOutput) and len(out.indices) != 0
                             else keypath,
+                            tuple_index_sequences=True,
                         )
                     else:
                         assert isinstance(keypath[0], pytree.SequenceKey)
-                        return go(outputs[keypath[0].idx].get_name(), keypath[1:])
+                        output_idx = keypath[0].idx
+                        if is_scalar_sequence_output(outputs[output_idx]):
+                            return go(
+                                f"{output_name}_symint_list_{output_idx}",
+                                keypath[1:],
+                                tuple_index_sequences=False,
+                            )
+                        return go(
+                            outputs[output_idx].get_name(),
+                            keypath[1:],
+                            tuple_index_sequences=True,
+                        )
                 else:
-                    return go(output_name, keypath)
+                    return go(output_name, keypath, tuple_index_sequences=False)
 
             self.writeline(
                 f"{self.codegen_unbacked_symbol_decl(s)} = {go_outer()}{self.ending}"

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -125,8 +125,8 @@ def custom_op(
 
     The following types are supported for the return value:
 
-        ``torch.Tensor``, ``list[torch.Tensor]``, ``int``, ``float``,
-        ``bool``, ``torch.types.Number``.
+        ``torch.Tensor``, ``list[torch.Tensor]``, ``int``, ``list[int]``,
+        ``float``, ``bool``, ``torch.types.Number``.
 
     .. note::
         We recommend not passing in a ``schema`` arg and instead letting us infer

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -356,6 +356,8 @@ SUPPORTED_RETURN_TYPES = {
     Tensor: "Tensor",
     typing.List[Tensor]: "Tensor[]",  # noqa: UP006
     list[Tensor]: "Tensor[]",
+    typing.List[int]: "SymInt[]",  # noqa: UP006
+    list[int]: "SymInt[]",
     int: "SymInt",
     float: "float",
     bool: "bool",

--- a/torch/csrc/shim_common.cpp
+++ b/torch/csrc/shim_common.cpp
@@ -401,7 +401,7 @@ AOTITorchError aoti_torch_call_dispatcher(
     // we will convert to StableIValue and repopulate user input stack
     for (const auto idx : c10::irange(num_returns)) {
       const auto stack_idx = num_returns - idx - 1;
-      const c10::TypePtr& ret_type = schema.returns()[idx].real_type();
+      const c10::TypePtr& ret_type = schema.returns()[stack_idx].real_type();
       stack[stack_idx] = from_ivalue(
           ret_type, torch::jit::pop(ivalue_stack), TORCH_ABI_VERSION);
     }
@@ -556,7 +556,7 @@ AOTI_TORCH_EXPORT AOTITorchError torch_call_dispatcher(
     // we will convert to StableIValue and repopulate user input stack
     for (const auto idx : c10::irange(num_returns)) {
       const auto stack_idx = num_returns - idx - 1;
-      const c10::TypePtr& ret_type = schema.returns()[idx].real_type();
+      const c10::TypePtr& ret_type = schema.returns()[stack_idx].real_type();
       stack[stack_idx] = from_ivalue(
           ret_type, torch::jit::pop(ivalue_stack), extension_build_version);
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185044

Allow custom operators annotated as list[int] to infer SymInt[] returns and carry unbacked SymInt bindings through export and Inductor. The missing pieces were schema inference for list[int], cpp-wrapper naming/materialization for scalar-list return slots, and mixed tensor/SymInt[] handling when assigning unbacked symbols in generated wrapper code.

For mixed returns, cpp-wrapper Python fallback now converts nested tensor/int results into the form generated C++ expects. The StableIValue dispatcher shim also indexes return schema entries using the reversed boxed-stack slot, so heterogeneous multi-return conversion uses the matching return type.

Authored by Codex.

Test Plan:

```bash
lintrunner -a
python test/custom_operator/test_infer_schema_annotation.py -k test_return_list_int
python test/export/test_export.py TestExport.test_unbacked_bindings_for_int_list_return_custom_op TestExport.test_unbacked_bindings_for_mixed_tensor_int_list_return_custom_op
python test/inductor/test_torchinductor.py -k test_custom_op_unbacked_symint_list_return
python test/inductor/test_torchinductor.py -k test_custom_op_unbacked_symint_list_mixed_return
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo