### PR TITLE
[Bugfix] fix `torch.library._register_fake` crashes when any unrelated `LazyLoader` module in `sys.modules` fails to import

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -5359,6 +5359,49 @@ except RuntimeError as e:
         # lib1 = torch.library.Library(...) is on line 2 of the script.
         self.assertIn("<string>:2", result.stdout)
 
+    def test_register_fake_with_broken_lazy_loader_in_sys_modules(self):
+        # Regression test for register_fake crashing when an unrelated
+        # LazyLoader module in sys.modules raises on attribute access.
+        # Previously _register_fake reached inspect.findsource and
+        # inspect.getmodule, both of which iterate sys.modules and access
+        # __file__ on every entry; a LazyLoader whose underlying import is
+        # missing turns that into an ImportError that propagates out.
+        # Run in a subprocess so the broken module never enters this
+        # process's sys.modules.
+        script = """\
+import sys
+import types
+
+class BrokenLazyLoader(types.ModuleType):
+    def __getattr__(self, name):
+        raise ImportError(
+            f"simulated lazy import failure for {self.__name__} (asked for {name})"
+        )
+
+sys.modules["_broken_lazy_loader_for_test"] = BrokenLazyLoader(
+    "_broken_lazy_loader_for_test"
+)
+
+import torch
+
+lib = torch.library.Library("_test_lazy_loader_ns", "FRAGMENT")
+lib.define("foo(Tensor x) -> Tensor")
+
+@torch.library.register_fake("_test_lazy_loader_ns::foo", lib=lib)
+def _foo_fake(x):
+    return torch.empty_like(x)
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
 
 class MiniOpTestOther(CustomOpTestCaseBase):
     test_ns = "mini_op_test"

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -42,8 +42,8 @@ def get_source(stacklevel: int) -> str:
     Use stacklevel=2 to get the caller's caller's source
     etc.
     """
-    frame = inspect.getframeinfo(sys._getframe(stacklevel))
-    source = f"{frame.filename}:{frame.lineno}"
+    frame = sys._getframe(stacklevel)
+    source = f"{frame.f_code.co_filename}:{frame.f_lineno}"
     return source
 
 

--- a/torch/library.py
+++ b/torch/library.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 import contextlib
 import functools
-import inspect
 import re
 import sys
 import weakref
@@ -330,10 +329,7 @@ class Library:
 
         source = torch._library.utils.get_source(_stacklevel + 1)
         frame = sys._getframe(_stacklevel)
-        caller_module = inspect.getmodule(frame)
-        # Can be none if you call register_fake from somewhere there isn't a module
-        # (e.g. __main__)
-        caller_module_name = None if caller_module is None else caller_module.__name__
+        caller_module_name = frame.f_globals.get("__name__")
 
         # TODO(rzou): We're gonna need to stage this change with torchvision,
         # since torchvision is github first.


### PR DESCRIPTION
fix https://github.com/pytorch/pytorch/issues/185046


## Root cause of https://github.com/pytorch/pytorch/issues/185046

`torch/_library/utils.py`:

```python
def get_source(stacklevel: int) -> str:
    frame = inspect.getframeinfo(sys._getframe(stacklevel))
    source = f"{frame.filename}:{frame.lineno}"
    return source
```

Only `frame.filename` and `frame.lineno` are used. But `inspect.getframeinfo` does much more than needed: it calls `findsource → getmodule`, which on a cache miss walks `sys.modules` and calls `hasattr(m, "__file__")` on every module. That `hasattr` has a side effect on `LazyLoader`-backed modules: it runs the module body. This is documented CPython behavior of `importlib.util.LazyLoader` — it is the whole point of the class — so any caller of `inspect.getmodule` is exposed.

`get_source` only needs `frame.f_code.co_filename` and `frame.f_lineno` from the raw frame; it never needs the source listing or module object.

## Proposed fix

Avoid `inspect.getframeinfo` entirely. Read the two fields directly from the frame.

```python
def get_source(stacklevel: int) -> str:
    frame = sys._getframe(stacklevel)
    source = f"{frame.f_code.co_filename}:{frame.f_lineno}"
    return source
```

This produces the exact same diagnostic string, is strictly faster (no source reading, no `sys.modules` walk), and removes the LazyLoader hazard from this code path.
