### PR TITLE
Include CPU thread count in FX graph cache key

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -463,6 +463,30 @@ class TestFxGraphCache(TestCase):
         torch._dynamo.reset()
         clear_caches()
 
+    @config.patch({"fx_graph_cache": True, "fx_graph_remote_cache": False})
+    @config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False})
+    def test_cpu_thread_count_change_misses_fx_graph_cache(self):
+        def fn(x, y):
+            return (x + y).relu()
+
+        x = torch.randn(1 << 12)
+        y = torch.randn(1 << 12)
+        compiled_fn = torch.compile(fn, backend="inductor")
+        orig_num_threads = torch.get_num_threads()
+
+        try:
+            torch.set_num_threads(1)
+            self.assertEqual(fn(x, y), compiled_fn(x, y))
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+            torch.set_num_threads(2)
+            self.assertEqual(fn(x, y), compiled_fn(x, y))
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+        finally:
+            torch.set_num_threads(orig_num_threads)
+
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
@@ -2825,6 +2849,79 @@ class TestCustomPartitionerFn(CustomPartitionerFn):
 
 
 class TestFxGraphCacheHashing(TestCase):
+    def _fx_graph_cache_key(self, gm, example_inputs):
+        details = FxGraphHashDetails(gm, example_inputs, cast(Any, {}), [])
+        return FxGraphCachePickler(gm).get_key(details)
+
+    def _no_input_factory_graph(self, device=None):
+        graph = torch.fx.Graph()
+        kwargs: dict[str, Any] = {"dtype": torch.float32}
+        if device is not None:
+            kwargs["device"] = torch.device(device)
+        result = graph.call_function(torch.empty, ((4,),), kwargs)
+        graph.output(result)
+        return torch.fx.GraphModule({}, graph)
+
+    def test_cpu_thread_count_affects_cache_key(self):
+        def fn(x):
+            return x + 1
+
+        gm = torch.fx.symbolic_trace(fn)
+        x = torch.ones(4)
+        orig_num_threads = torch.get_num_threads()
+
+        try:
+            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
+                torch.set_num_threads(1)
+                key_1 = self._fx_graph_cache_key(gm, [x])
+                torch.set_num_threads(2)
+                key_2 = self._fx_graph_cache_key(gm, [x])
+                self.assertNotEqual(key_1, key_2)
+
+            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": True}):
+                torch.set_num_threads(1)
+                key_1 = self._fx_graph_cache_key(gm, [x])
+                torch.set_num_threads(2)
+                key_2 = self._fx_graph_cache_key(gm, [x])
+                self.assertEqual(key_1, key_2)
+
+            with config.patch({"cpp.threads": 4, "cpp.dynamic_threads": False}):
+                torch.set_num_threads(1)
+                key_1 = self._fx_graph_cache_key(gm, [x])
+                torch.set_num_threads(2)
+                key_2 = self._fx_graph_cache_key(gm, [x])
+                self.assertEqual(key_1, key_2)
+        finally:
+            torch.set_num_threads(orig_num_threads)
+
+    def test_cpu_thread_count_affects_cache_key_for_no_input_cpu_factory(self):
+        gm = self._no_input_factory_graph()
+        orig_num_threads = torch.get_num_threads()
+
+        try:
+            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
+                torch.set_num_threads(1)
+                key_1 = self._fx_graph_cache_key(gm, [])
+                torch.set_num_threads(2)
+                key_2 = self._fx_graph_cache_key(gm, [])
+                self.assertNotEqual(key_1, key_2)
+        finally:
+            torch.set_num_threads(orig_num_threads)
+
+    def test_cpu_thread_count_ignored_for_explicit_non_cpu_factory(self):
+        gm = self._no_input_factory_graph(device="cuda")
+        orig_num_threads = torch.get_num_threads()
+
+        try:
+            with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
+                torch.set_num_threads(1)
+                key_1 = self._fx_graph_cache_key(gm, [])
+                torch.set_num_threads(2)
+                key_2 = self._fx_graph_cache_key(gm, [])
+                self.assertEqual(key_1, key_2)
+        finally:
+            torch.set_num_threads(orig_num_threads)
+
     @unittest.skipIf(not torch.backends.mkldnn.is_available(), "requires MKLDNN")
     def test_cacheability_validator_checks_mkldnn_constant(self):
         graph = torch.fx.Graph()

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -102,6 +102,7 @@ from torch._inductor.utils import (
     determine_aoti_mmap_flags,
     is_linux,
     is_windows,
+    parallel_num_threads,
     XPU_KERNEL_FORMAT,
 )
 from torch._library.fake_class_registry import FakeScriptObject
@@ -126,6 +127,7 @@ from torch.fx.experimental.symbolic_shapes import (
     has_guarding_hint,
     ShapeEnv,
 )
+from torch.utils._device import _device_constructors
 from torch.utils._ordered_set import OrderedSet
 
 from .cache_key import (
@@ -201,6 +203,35 @@ autotuning_log = torch._logging.getArtifactLogger(__name__, "autotuning")
 log = logging.getLogger(__name__)
 
 AOTAUTOGRAD_CACHE_PREFIX = "a"
+
+
+def _device_constructor_sort_key(target: Any) -> str:
+    return ".".join(
+        x
+        for x in (
+            getattr(target, "__module__", None),
+            getattr(target, "__qualname__", None),
+            getattr(target, "__name__", None),
+            repr(target),
+        )
+        if x
+    )
+
+
+@lru_cache(None)
+def _default_device_constructor_targets() -> tuple[Any, ...]:
+    return tuple(sorted(_device_constructors(), key=_device_constructor_sort_key))
+
+
+@lru_cache(None)
+def _default_device_constructor_overload_packets() -> tuple[Any, ...]:
+    packets: list[Any] = []
+    for target in _default_device_constructor_targets():
+        if (name := getattr(target, "__name__", None)) is None:
+            continue
+        if (packet := getattr(torch.ops.aten, name, None)) is not None:
+            packets.append(packet)
+    return tuple(packets)
 
 
 def get_cpp_wrapper_cubin_path_name() -> str:
@@ -1191,10 +1222,136 @@ class FxGraphHashDetails:
     # don't affect compiled output (like compile_region_name which is
     # just a debug label).
     EXCLUDED_KWARGS = ["graph_id", "compile_region_name"]
+    TENSOR_METADATA_KEYS = ("val", "example_value")
+    LIKE_FACTORY_TARGETS = (
+        torch.empty_like,
+        torch.full_like,
+        torch.ones_like,
+        torch.rand_like,
+        torch.randint_like,
+        torch.randn_like,
+        torch.zeros_like,
+    )
+    LIKE_FACTORY_PACKETS = (
+        torch.ops.aten.empty_like,
+        torch.ops.aten.full_like,
+        torch.ops.aten.ones_like,
+        torch.ops.aten.rand_like,
+        torch.ops.aten.randint_like,
+        torch.ops.aten.randn_like,
+        torch.ops.aten.zeros_like,
+    )
+
+    @classmethod
+    def _contains_tensor(cls, value: Any) -> bool:
+        if isinstance(value, torch.Tensor):
+            return True
+        if isinstance(value, (list, tuple, AbstractSet)):
+            return any(cls._contains_tensor(x) for x in value)
+        if isinstance(value, dict):
+            return any(
+                cls._contains_tensor(x)
+                for x in itertools.chain(value.keys(), value.values())
+            )
+        return False
+
+    @classmethod
+    def _contains_cpu_tensor(cls, value: Any) -> bool:
+        if isinstance(value, torch.Tensor):
+            return value.device.type == "cpu"
+        if isinstance(value, (list, tuple, AbstractSet)):
+            return any(cls._contains_cpu_tensor(x) for x in value)
+        if isinstance(value, dict):
+            return any(
+                cls._contains_cpu_tensor(x)
+                for x in itertools.chain(value.keys(), value.values())
+            )
+        return False
+
+    @staticmethod
+    def _device_type(value: Any) -> str | None:
+        if isinstance(value, torch.device):
+            return value.type
+        if isinstance(value, str):
+            try:
+                return torch.device(value).type
+            except RuntimeError:
+                return None
+        return None
+
+    @classmethod
+    def _is_factory_target(
+        cls, target: Any, targets: tuple[Any, ...], packets: tuple[Any, ...]
+    ) -> bool:
+        if target in targets or target in packets:
+            return True
+        overload_packet = getattr(target, "overloadpacket", None)
+        return overload_packet in packets
+
+    @classmethod
+    def _tensor_metadata(cls, node: torch.fx.Node) -> tuple[Any, ...]:
+        return tuple(
+            node.meta[key] for key in cls.TENSOR_METADATA_KEYS if key in node.meta
+        )
+
+    @classmethod
+    def _factory_device_type(cls, node: torch.fx.Node) -> str | None:
+        if node.op != "call_function":
+            return None
+
+        is_default_device_factory = cls._is_factory_target(
+            node.target,
+            _default_device_constructor_targets(),
+            _default_device_constructor_overload_packets(),
+        )
+        is_like_factory = cls._is_factory_target(
+            node.target,
+            cls.LIKE_FACTORY_TARGETS,
+            cls.LIKE_FACTORY_PACKETS,
+        )
+        if not (is_default_device_factory or is_like_factory):
+            return None
+
+        device_type = cls._device_type(node.kwargs.get("device"))
+        if device_type is not None:
+            return device_type
+
+        schema = getattr(node.target, "_schema", None)
+        if schema is not None:
+            for arg, value in zip(schema.arguments, node.args):
+                if arg.name == "device":
+                    device_type = cls._device_type(value)
+                    if device_type is not None:
+                        return device_type
+
+        if is_like_factory:
+            return None
+        return torch.device(torch.get_default_device()).type
+
+    @classmethod
+    def _may_generate_cpu_cpp_code(
+        cls, gm: torch.fx.GraphModule | None, example_inputs: Sequence[InputType]
+    ) -> bool:
+        if cls._contains_cpu_tensor(example_inputs):
+            return True
+        if gm is None:
+            return False
+        for module in gm.modules():
+            if not isinstance(module, torch.fx.GraphModule):
+                continue
+            for node in module.graph.nodes:
+                tensor_metadata = cls._tensor_metadata(node)
+                if cls._contains_cpu_tensor(tensor_metadata):
+                    return True
+                if not cls._contains_tensor(tensor_metadata) and (
+                    cls._factory_device_type(node) == "cpu"
+                ):
+                    return True
+        return False
 
     def __init__(
         self,
-        gm: torch.fx.GraphModule,
+        gm: torch.fx.GraphModule | None,
         example_inputs: Sequence[InputType],
         fx_kwargs: _CompileFxKwargs,
         inputs_to_check: Sequence[int],
@@ -1294,6 +1451,17 @@ class FxGraphHashDetails:
             torch.is_deterministic_algorithms_warn_only_enabled(),
             torch.utils.deterministic.fill_uninitialized_memory,  # type: ignore[attr-defined]
         )
+
+        # CPU C++ kernels specialize on torch.get_num_threads() when cpp.threads
+        # is automatic and dynamic threading is disabled. Include that resolved
+        # value so FX graph cache entries compiled under one thread count are not
+        # reused under another.
+        if (
+            config.cpp.threads < 1
+            and not config.cpp.dynamic_threads
+            and self._may_generate_cpu_cpp_code(gm, example_inputs)
+        ):
+            self.cpp_runtime_thread_count = parallel_num_threads()
 
         # Provenance tracking level affects whether provenance data is stored
         # in the CompiledFxGraph, so it must be part of the cache key.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185049

CPU Inductor C++ codegen can specialize generated OpenMP pragmas on the
resolved runtime thread count when cpp.threads is automatic and dynamic
threading is disabled. Dynamo already guards on torch.set_num_threads()
and recompiles when the value changes, but the Inductor FX graph cache key
did not include that resolved thread count. A second Dynamo compile could
therefore load an FX graph cache entry generated under a stale
`num_threads(N)` value.

Fix this by adding `parallel_num_threads()` to `FxGraphHashDetails` only
when thread-count specialization is active and the graph may generate CPU
C++ code. The CPU check covers CPU tensor inputs, CPU tensor metadata, and
factory graphs that allocate on the default CPU device, while leaving keys
stable for dynamic-thread mode, explicit cpp.threads, and non-CPU factory
graphs.

This preserves the existing dynamic-thread behavior from the related
hardcoded OpenMP thread-count fix while making the cache key match the
compiled CPU code specialization.

Fixes #167463
Generated by my agent

Test Plan:
- python test/inductor/test_codecache.py -k cpu_thread_count
- python test/inductor/test_codecache.py TestFxGraphCacheHashing -q
- lintrunner -a
- python test/inductor/test_cpu_repro.py -k test_parallel_num_threads (blocked by local torchvision import mismatch: RuntimeError: operator torchvision::nms does not exist)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos