### PR TITLE
Fix FX GraphModule serialization of string annotations

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1801,6 +1801,42 @@ class TestFX(JitTestCase):
         offsets = torch.LongTensor([0, 4])
         self.assertEqual(loaded(input, offsets), traced(input, offsets))
 
+    def test_save_string_type_annotation(self):
+        def f(x: "torch.Tensor") -> "torch.Tensor":
+            return x
+
+        traced = symbolic_trace(f)
+        _, (body, import_block) = traced.__reduce__()
+        self.assertExpectedInline(
+            import_block + body["_code"].rstrip(),
+            """\
+NoneType = type(None)
+_torch_Tensor_ = 'torch.Tensor'
+from math import inf
+from math import nan
+from torch import device
+import torch
+import torch.fx._pytree as fx_pytree
+import torch.utils._pytree as pytree
+
+
+def forward(self, x : _torch_Tensor_) -> _torch_Tensor_:
+    return x""",
+        )
+
+        bio = io.BytesIO()
+        torch.save(traced, bio)
+        bio.seek(0)
+        loaded = torch.load(bio, weights_only=False)
+        loaded.graph.lint()
+
+        x = torch.randn(2, 3)
+        self.assertEqual(loaded(x), traced(x))
+        self.assertEqual(
+            loaded.forward.__annotations__,
+            {"x": "torch.Tensor", "return": "torch.Tensor"},
+        )
+
     def test_return_tuple(self):
         class M(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -175,9 +175,13 @@ def _format_import_statement(name: str, obj: object, importer: Importer) -> str:
 
 
 def _format_import_block(globals: dict[str, Any], importer: Importer) -> str:
-    import_strs: set[str] = {
-        _format_import_statement(name, obj, importer) for name, obj in globals.items()
-    }
+    import_strs: set[str] = set()
+    for name, obj in globals.items():
+        if isinstance(obj, str):
+            # Forward-reference string annotations are globals in generated code.
+            import_strs.add(f"{name} = {obj!r}")
+        else:
+            import_strs.add(_format_import_statement(name, obj, importer))
     # Sort the imports so we have a stable import block that allows us to
     # hash the graph module and get a consistent key for use in a cache.
     return "\n".join(sorted(import_strs))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185051

FX codegen represents forward-reference annotations as generated globals whose values are the original strings. GraphModule serialization formatted every generated global as an importable Python object, so a string annotation reached Importer.get_name and crashed because str has no __name__.

Handle string globals in the serialized import block by emitting literal bindings instead of import statements. This preserves the generated code contract and keeps string annotations available when the serialized forward source is executed. I kept the fix local to import-block formatting rather than changing type_repr so normal FX codegen behavior and existing annotation rendering remain unchanged.

Fixes #167117

Generated by my agent

Test Plan:

- Reproduced the original torch.save failure with a symbolic_trace function annotated as "torch.Tensor".

- python test/test_fx.py TestFX.test_save_string_type_annotation (blocked locally by installed torchvision RuntimeError: operator torchvision::nms does not exist).

- python runpy harness blocking torchvision for TestFX.test_save_string_type_annotation (passed).

- python runpy harness blocking torchvision for TestFX.test_save_string_type_annotation and TestFX.test_pickle_nonetype_annotation (passed).

- Direct post-fix torch.save/torch.load reproducer preserving annotations (passed).

- lintrunner -a (passed).