### PR TITLE
Fix Inductor reuse for disjoint strided slices

### DIFF
--- a/test/inductor/test_quantization.py
+++ b/test/inductor/test_quantization.py
@@ -9,8 +9,11 @@ import torch._inductor
 import torch._inductor.fx_passes.group_batch_fusion
 from torch._dynamo.utils import counters
 from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.common_quantized import _bfloat16_to_float4_e2m1fn_x2
 from torch.testing._internal.common_utils import IS_LINUX
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_gpu
+from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
 
 log = logging.getLogger(__name__)
@@ -135,6 +138,28 @@ class TestQuantization(TestCase):
         self.assertTrue(
             self.compare_dict_tensors(ref_grad, res_grad, rtol=rtol, atol=atol)
         )
+
+    @requires_cuda_and_triton
+    def test_bfloat16_to_float4_pack_fuses(self):
+        def fn(x):
+            return _bfloat16_to_float4_e2m1fn_x2(x)
+
+        x = torch.randn((64, 64), device=GPU_TYPE, dtype=torch.bfloat16)
+        expected = fn(x)
+        actual, codes = run_and_get_code(torch.compile(fn, fullgraph=True), x)
+
+        self.assertEqual(actual.dtype, torch.float4_e2m1fn_x2)
+        self.assertEqual(actual.shape, (64, 32))
+        torch.testing.assert_close(
+            actual.view(torch.uint8),
+            expected.view(torch.uint8),
+            atol=0,
+            rtol=0,
+        )
+
+        code = "\n".join(codes)
+        self.assertEqual(code.count("@triton.jit"), 1)
+        self.assertEqual(code.count("tl.store"), 1)
 
     @requires_gpu()
     @torch._inductor.config.patch(

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -243,6 +243,49 @@ def extend_user_visible_output_strides(
     return result
 
 
+def _has_non_overlapping_strided_slice_users(n: Node) -> bool:
+    """Detect x[r::s] fanout where distinct residues do not reuse elements."""
+    users = list(n.users)
+    if len(users) <= 1:
+        return False
+
+    slice_dim: int | None = None
+    slice_step: int | None = None
+    residues: OrderedSet[int] = OrderedSet()
+    for user in users:
+        if user.target is not aten.slice.Tensor or len(user.args) < 5:
+            return False
+        if user.args[0] is not n:
+            return False
+
+        dim, start, _end, step = user.args[1:5]
+        if not (
+            isinstance(dim, int) and isinstance(start, int) and isinstance(step, int)
+        ):
+            return False
+        if start < 0 or step <= 1:
+            return False
+
+        if dim < 0:
+            val = n.meta.get("val")
+            if val is None:
+                return False
+            dim += val.dim()
+
+        if slice_dim is None:
+            slice_dim = dim
+            slice_step = step
+        elif dim != slice_dim or step != slice_step:
+            return False
+
+        residue = start % step
+        if residue in residues:
+            return False
+        residues.add(residue)
+
+    return True
+
+
 def mark_nodes_dislike_padding(
     g: Graph, user_visible_output_strides: dict[Node, tuple[int, ...]]
 ) -> None:
@@ -2023,6 +2066,9 @@ class GraphLowering(torch.fx.Interpreter):
             # already too many reads and rematerializing can be bad.
             num_users = len(OrderedSet(n.users))
             if num_users > 1 and isinstance(result, TensorBox):
+                reuse_users = (
+                    1 if _has_non_overlapping_strided_slice_users(n) else num_users
+                )
                 for user in n.users:
                     if user.target in needs_realized_inputs:
                         result.realize_hint()
@@ -2105,12 +2151,12 @@ class GraphLowering(torch.fx.Interpreter):
                     _data = _data.data
 
                 if isinstance(_data, StorageBox) and _data.should_realize_on_reuse(
-                    len(n.users)
+                    reuse_users
                 ):
                     result = maybe_apply_channels_last_stride_order(result, n)
 
                 # TODO(jansel): introduce a store vs inline choice
-                result.mark_reuse(len(n.users))
+                result.mark_reuse(reuse_users)
 
             # Realize if the IRNode already has accumulated lots of reads
             if isinstance(result, TensorBox) and result.has_exceeded_max_reads():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185052

Inductor decides whether to realize a pointwise producer based partly on how
many FX users consume it.  The bf16-to-float4 helper produces unpacked uint8
fp4 values and then packs them with two strided slices, uint8_data[1::2] and
uint8_data[::2].  Those two users look like reuse at the FX node level, but
they consume disjoint residue classes, so each produced element is still used
once.

Counting those disjoint slice users as duplicated reuse caused GraphLowering to
materialize the unpacked uint8 intermediate.  That split the conversion and pack
into two Triton kernels, which is the slow path reported for torch.compile NVFP4
casts.  Teach the reuse heuristic to recognize same-step, distinct-residue
slice fanout and use an effective reuse count of one for that case, preserving
fusion while leaving overlapping or dynamic slice patterns on the existing
conservative path.

A narrower alternative would have been a float4-specific pattern, but the bad
realization decision is not specific to float4; the fp4 pack is just the case
that exposed it.  A dedicated Blackwell fp4 conversion intrinsic could improve
this further, but it does not address the kernel split root cause fixed here.

Fixes #167098
Generated by my agent

Test Plan:
- python test/inductor/test_quantization.py TestQuantization.test_bfloat16_to_float4_pack_fuses
- python - <<'PY' ... run_and_get_code(torch.compile(fn, fullgraph=True), x) for x=(64,64) bf16 cuda ... PY
- python - <<'PY' ... benchmark _bfloat16_to_float4_e2m1fn_x2 compiled with CUDA events for M,K in {(4096,4096),(16384,16384)} ... PY
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos