### PR TITLE
[Test]Refactor test_custom_ops.py to be device agnostic

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -62,7 +62,6 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
     TEST_WITH_TORCHDYNAMO,
-    TEST_XPU,
     TestCase,
 )
 from torch.testing._internal.custom_op_db import numpy_nonzero

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -58,6 +58,7 @@ from torch.testing._internal.common_utils import (
     subtest,
     TemporaryFileName,
     TEST_ACCELERATOR,
+    TEST_MPS,
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
     TEST_WITH_TORCHDYNAMO,
@@ -1682,6 +1683,7 @@ class TestCustomOp(CustomOpTestCaseBase):
             op(x)
 
     @skipIfXpu(msg="Deprecated torch.custom_ops API")
+    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
     @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_separate(self):
         @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
@@ -1707,14 +1709,19 @@ class TestCustomOp(CustomOpTestCaseBase):
         self.assertEqual(result, foo_cuda(x_cuda))
 
     @skipIfXpu(msg="Deprecated torch.custom_ops API")
+    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
     @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_multiple(self):
         @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
         def foo(x: torch.Tensor) -> torch.Tensor:
             raise NotImplementedError
 
-        @custom_ops.impl(f"{TestCustomOp.test_ns}::foo")
+        @custom_ops.impl(f"{TestCustomOp.test_ns}::foo", device_types="cpu")
         def foo_impl(x):
+            return x.cos()
+
+        @custom_ops.impl(f"{TestCustomOp.test_ns}::foo", device_types=device_type)
+        def foo_impl_device(x):
             return x.cos()
 
         op = self.get_op(f"{self.test_ns}::foo")
@@ -1724,7 +1731,7 @@ class TestCustomOp(CustomOpTestCaseBase):
 
         x_cuda = x.to(device_type)
         result = op(x_cuda)
-        self.assertEqual(result, foo_impl(x_cuda))
+        self.assertEqual(result, foo_impl_device(x_cuda))
 
     def test_impl_abstract_overload(self):
         lib = self.lib()
@@ -2310,6 +2317,7 @@ Dynamic shape operator
         self._test_impl_device("foo3", ["cpu", "cuda"], "cpu")
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
     @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_device_cuda(self):
         self._test_impl_device("foo4", "default", device_type)
@@ -4646,6 +4654,7 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(y, x.cos())
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
     @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_split_device(self):
         cpu_call_count = 0
@@ -4682,6 +4691,7 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(cuda_call_count, 1)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
     @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_multi_types(self):
         @torch.library.custom_op(

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -40,7 +40,6 @@ from torch._utils_internal import get_file_path_2  # @manual
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing._internal import custom_op_db
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     OpDTypes,
@@ -1683,7 +1682,7 @@ class TestCustomOp(CustomOpTestCaseBase):
             op(x)
 
     @skipIfXpu(msg="Deprecated torch.custom_ops API")
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "requires CUDA or XPU")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_separate(self):
         @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
         def foo(x: torch.Tensor) -> torch.Tensor:
@@ -1708,7 +1707,7 @@ class TestCustomOp(CustomOpTestCaseBase):
         self.assertEqual(result, foo_cuda(x_cuda))
 
     @skipIfXpu(msg="Deprecated torch.custom_ops API")
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "requires CUDA or XPU")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_multiple(self):
         @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
         def foo(x: torch.Tensor) -> torch.Tensor:
@@ -2311,7 +2310,7 @@ Dynamic shape operator
         self._test_impl_device("foo3", ["cpu", "cuda"], "cpu")
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "requires cuda or xpu")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_device_cuda(self):
         self._test_impl_device("foo4", "default", device_type)
         self._test_impl_device("foo5", [device_type], device_type)
@@ -4647,7 +4646,7 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(y, x.cos())
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_split_device(self):
         cpu_call_count = 0
         cuda_call_count = 0
@@ -4662,7 +4661,7 @@ Please use `add.register_fake` to add an fake impl.""",
             out_np = np.sin(x_np)
             return torch.from_numpy(out_np)
 
-        @f.register_kernel("cuda")
+        @f.register_kernel(device_type)
         def _(x: Tensor) -> Tensor:
             nonlocal cuda_call_count
             cuda_call_count += 1
@@ -4676,17 +4675,17 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(cpu_call_count, 1)
         self.assertEqual(cuda_call_count, 0)
 
-        x = x.cuda()
+        x = x.to(device_type)
         y = f(x)
         self.assertEqual(y, x.sin())
         self.assertEqual(cpu_call_count, 1)
         self.assertEqual(cuda_call_count, 1)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_multi_types(self):
         @torch.library.custom_op(
-            "_torch_testing::f", mutates_args=(), device_types=("cpu", "cuda")
+            "_torch_testing::f", mutates_args=(), device_types=("cpu", device_type)
         )
         def f(x: Tensor) -> Tensor:
             x_np = x.cpu().numpy()
@@ -4696,7 +4695,7 @@ Please use `add.register_fake` to add an fake impl.""",
         x = torch.randn(3)
         y = f(x)
         self.assertEqual(y, x.sin())
-        x = x.cuda()
+        x = x.to(device_type)
         y = f(x)
         self.assertEqual(y, x.sin())
 

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -60,6 +60,7 @@ from torch.testing._internal.common_utils import (
     subtest,
     TemporaryFileName,
     TEST_ACCELERATOR,
+    TEST_MPS,
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
     TEST_WITH_TORCHDYNAMO,
@@ -2046,6 +2047,7 @@ TORCH_LIBRARY(_test_pyobject_dispatch_cpp_fallback_torch_function, m) {
             op(x)
 
     @skipIfXpu(msg="Deprecated torch.custom_ops API")
+    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
     @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_separate(self):
         @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
@@ -2071,14 +2073,19 @@ TORCH_LIBRARY(_test_pyobject_dispatch_cpp_fallback_torch_function, m) {
         self.assertEqual(result, foo_cuda(x_cuda))
 
     @skipIfXpu(msg="Deprecated torch.custom_ops API")
+    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
     @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_multiple(self):
         @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
         def foo(x: torch.Tensor) -> torch.Tensor:
             raise NotImplementedError
 
-        @custom_ops.impl(f"{TestCustomOp.test_ns}::foo")
+        @custom_ops.impl(f"{TestCustomOp.test_ns}::foo", device_types="cpu")
         def foo_impl(x):
+            return x.cos()
+
+        @custom_ops.impl(f"{TestCustomOp.test_ns}::foo", device_types=device_type)
+        def foo_impl_device(x):
             return x.cos()
 
         op = self.get_op(f"{self.test_ns}::foo")
@@ -2088,7 +2095,7 @@ TORCH_LIBRARY(_test_pyobject_dispatch_cpp_fallback_torch_function, m) {
 
         x_cuda = x.to(device_type)
         result = op(x_cuda)
-        self.assertEqual(result, foo_impl(x_cuda))
+        self.assertEqual(result, foo_impl_device(x_cuda))
 
     def test_impl_abstract_overload(self):
         lib = self.lib()
@@ -2674,6 +2681,7 @@ Dynamic shape operator
         self._test_impl_device("foo3", ["cpu", "cuda"], "cpu")
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
     @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_device_cuda(self):
         self._test_impl_device("foo4", "default", device_type)
@@ -5360,6 +5368,7 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(y, x.cos())
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
     @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_split_device(self):
         cpu_call_count = 0
@@ -5396,6 +5405,7 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(cuda_call_count, 1)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
     @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_multi_types(self):
         @torch.library.custom_op(

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -40,13 +40,18 @@ from torch._utils_internal import get_file_path_2  # @manual
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing._internal import custom_op_db
+from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
+    onlyAccelerator,
     OpDTypes,
     ops,
     PYTORCH_CUDA_MEMCHECK,
+    skipMPS,
+    skipXPUIf,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_LINUX,
     IS_MACOS,
@@ -56,11 +61,9 @@ from torch.testing._internal.common_utils import (
     scoped_load_inline,
     skipIfCrossRef,
     skipIfTorchDynamo,
-    skipIfXpu,
     subtest,
     TemporaryFileName,
     TEST_ACCELERATOR,
-    TEST_MPS,
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
     TEST_WITH_TORCHDYNAMO,
@@ -170,6 +173,21 @@ class CustomOpTestCaseBase(TestCase):
 
     def get_op(self, qualname):
         return torch._custom_op.impl.get_op(qualname)
+
+    def _test_impl_device(self, name, types, device):
+        lib = self.lib()
+        torch.library.define(f"{self.test_ns}::{name}", "(Tensor x) -> Tensor", lib=lib)
+
+        @torch.library.impl(f"{self.test_ns}::{name}", types)
+        def f(x):
+            x_np = x.cpu().numpy()
+            y = torch.from_numpy(np.sin(x_np))
+            return y.to(device=x.device)
+
+        x = torch.randn(3, device=device)
+        y = getattr(self.ns(), name)(x)
+        if not torch.allclose(y, x.sin()):
+            raise AssertionError("expected y to equal x.sin()")
 
 
 @requires_compile
@@ -669,6 +687,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
 
 
 class TestCustomOp(CustomOpTestCaseBase):
+    hw_classification = HardwareClassification.GENERIC
     test_ns = "_test_custom_op"
 
     @skipIfTorchDynamo("PyObject dispatch test is eager-only")
@@ -2045,57 +2064,6 @@ TORCH_LIBRARY(_test_pyobject_dispatch_cpp_fallback_torch_function, m) {
         with self.assertRaisesRegex(RuntimeError, "is not a Tensor"):
             op(x)
 
-    @skipIfXpu(msg="Deprecated torch.custom_ops API")
-    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
-    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
-    def test_impl_separate(self):
-        @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
-        def foo(x: torch.Tensor) -> torch.Tensor:
-            raise NotImplementedError
-
-        @custom_ops.impl(f"{TestCustomOp.test_ns}::foo", device_types="cpu")
-        def foo_cpu(x):
-            return x.sin()
-
-        @custom_ops.impl(f"{TestCustomOp.test_ns}::foo", device_types=device_type)
-        def foo_cuda(x):
-            return x.cos()
-
-        x = torch.randn(3)
-        op = self.get_op(f"{self.test_ns}::foo")
-        result = op(x)
-        self.assertEqual(result, foo_cpu(x))
-
-        x_cuda = x.to(device_type)
-        op = self.get_op(f"{self.test_ns}::foo")
-        result = op(x_cuda)
-        self.assertEqual(result, foo_cuda(x_cuda))
-
-    @skipIfXpu(msg="Deprecated torch.custom_ops API")
-    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
-    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
-    def test_impl_multiple(self):
-        @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
-        def foo(x: torch.Tensor) -> torch.Tensor:
-            raise NotImplementedError
-
-        @custom_ops.impl(f"{TestCustomOp.test_ns}::foo", device_types="cpu")
-        def foo_impl(x):
-            return x.cos()
-
-        @custom_ops.impl(f"{TestCustomOp.test_ns}::foo", device_types=device_type)
-        def foo_impl_device(x):
-            return x.cos()
-
-        op = self.get_op(f"{self.test_ns}::foo")
-        x = torch.randn(3)
-        result = op(x)
-        self.assertEqual(result, foo_impl(x))
-
-        x_cuda = x.to(device_type)
-        result = op(x_cuda)
-        self.assertEqual(result, foo_impl_device(x_cuda))
-
     def test_impl_abstract_overload(self):
         lib = self.lib()
         lib.define("sin.blah(Tensor x) -> Tensor")
@@ -2658,34 +2626,11 @@ Dynamic shape operator
         )
         self.assertTrue(ns.bar.overload._defined_in_python)
 
-    def _test_impl_device(self, name, types, device):
-        lib = self.lib()
-        torch.library.define(f"{self.test_ns}::{name}", "(Tensor x) -> Tensor", lib=lib)
-
-        @torch.library.impl(f"{self.test_ns}::{name}", types)
-        def f(x):
-            x_np = x.cpu().numpy()
-            y = torch.from_numpy(np.sin(x_np))
-            return y.to(device=x.device)
-
-        x = torch.randn(3, device=device)
-        y = getattr(self.ns(), name)(x)
-        if not torch.allclose(y, x.sin()):
-            raise AssertionError("expected y to equal x.sin()")
-
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_impl_device_cpu(self):
         self._test_impl_device("foo1", "default", "cpu")
         self._test_impl_device("foo2", ["cpu"], "cpu")
         self._test_impl_device("foo3", ["cpu", "cuda"], "cpu")
-
-    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
-    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
-    def test_impl_device_cuda(self):
-        self._test_impl_device("foo4", "default", device_type)
-        self._test_impl_device("foo5", [device_type], device_type)
-        self._test_impl_device("foo6", ["cpu", device_type], device_type)
 
     def test_impl_device_function(self):
         lib = self.lib()
@@ -2935,6 +2880,74 @@ TORCH_LIBRARY(test_autograd_function_backed_op, m) {
         self.assertEqual(received, [torch.contiguous_format, torch.channels_last])
 
 
+class TestCustomOpDevice(CustomOpTestCaseBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @skipXPUIf(True, "Deprecated torch.custom_ops API")
+    @skipMPS
+    @onlyAccelerator
+    def test_impl_separate(self, device):
+        device_type = torch.device(device).type
+
+        @custom_ops.custom_op(f"{self.test_ns}::foo")
+        def foo(x: torch.Tensor) -> torch.Tensor:
+            raise NotImplementedError
+
+        @custom_ops.impl(f"{self.test_ns}::foo", device_types="cpu")
+        def foo_cpu(x):
+            return x.sin()
+
+        @custom_ops.impl(f"{self.test_ns}::foo", device_types=device_type)
+        def foo_cuda(x):
+            return x.cos()
+
+        x = torch.randn(3)
+        op = self.get_op(f"{self.test_ns}::foo")
+        result = op(x)
+        self.assertEqual(result, foo_cpu(x))
+
+        x_acc = x.to(device)
+        op = self.get_op(f"{self.test_ns}::foo")
+        result = op(x_acc)
+        self.assertEqual(result, foo_cuda(x_acc))
+
+    @skipXPUIf(True, "Deprecated torch.custom_ops API")
+    @skipMPS
+    @onlyAccelerator
+    def test_impl_multiple(self, device):
+        device_type = torch.device(device).type
+
+        @custom_ops.custom_op(f"{self.test_ns}::foo")
+        def foo(x: torch.Tensor) -> torch.Tensor:
+            raise NotImplementedError
+
+        @custom_ops.impl(f"{self.test_ns}::foo", device_types="cpu")
+        def foo_impl(x):
+            return x.cos()
+
+        @custom_ops.impl(f"{self.test_ns}::foo", device_types=device_type)
+        def foo_impl_device(x):
+            return x.cos()
+
+        op = self.get_op(f"{self.test_ns}::foo")
+        x = torch.randn(3)
+        result = op(x)
+        self.assertEqual(result, foo_impl(x))
+
+        x_acc = x.to(device)
+        result = op(x_acc)
+        self.assertEqual(result, foo_impl_device(x_acc))
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    @skipMPS
+    @onlyAccelerator
+    def test_impl_device_accelerator(self, device):
+        device_type = torch.device(device).type
+        self._test_impl_device("foo4", "default", device)
+        self._test_impl_device("foo5", [device_type], device)
+        self._test_impl_device("foo6", ["cpu", device_type], device)
+
+
 def op_with_incorrect_schema(testcase, name):
     lib = testcase.lib()
     lib.define(f"{name}(Tensor x) -> Tensor")
@@ -3049,6 +3062,8 @@ class MiniOpTest(CustomOpTestCaseBase):
 
 
 class TestCustomOpAPI(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize(
         "tags, opname",
         [
@@ -5367,62 +5382,6 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(y, x.cos())
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
-    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
-    def test_split_device(self):
-        cpu_call_count = 0
-        cuda_call_count = 0
-
-        @torch.library.custom_op(
-            "_torch_testing::f", mutates_args=(), device_types="cpu"
-        )
-        def f(x: Tensor) -> Tensor:
-            nonlocal cpu_call_count
-            cpu_call_count += 1
-            x_np = x.numpy()
-            out_np = np.sin(x_np)
-            return torch.from_numpy(out_np)
-
-        @f.register_kernel(device_type)
-        def _(x: Tensor) -> Tensor:
-            nonlocal cuda_call_count
-            cuda_call_count += 1
-            x_np = x.cpu().numpy()
-            out_np = np.sin(x_np)
-            return torch.from_numpy(out_np).to(x.device)
-
-        x = torch.randn(3)
-        y = f(x)
-        self.assertEqual(y, x.sin())
-        self.assertEqual(cpu_call_count, 1)
-        self.assertEqual(cuda_call_count, 0)
-
-        x = x.to(device_type)
-        y = f(x)
-        self.assertEqual(y, x.sin())
-        self.assertEqual(cpu_call_count, 1)
-        self.assertEqual(cuda_call_count, 1)
-
-    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(TEST_MPS, "doesn't work with MPS")
-    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
-    def test_multi_types(self):
-        @torch.library.custom_op(
-            "_torch_testing::f", mutates_args=(), device_types=("cpu", device_type)
-        )
-        def f(x: Tensor) -> Tensor:
-            x_np = x.cpu().numpy()
-            out_np = np.sin(x_np)
-            return torch.from_numpy(out_np).to(x.device)
-
-        x = torch.randn(3)
-        y = f(x)
-        self.assertEqual(y, x.sin())
-        x = x.to(device_type)
-        y = f(x)
-        self.assertEqual(y, x.sin())
-
-    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_overloading(self):
         called_f = 0
         called_f1 = 0
@@ -6107,6 +6066,69 @@ Please use `add.register_fake` to add an fake impl.""",
                 torch.library.get_kernel("test_invalid_kernel::cpu_only_op", "CUDA")
 
 
+class TestCustomOpAPIDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    @skipMPS
+    @onlyAccelerator
+    def test_split_device(self, device):
+        device_type = torch.device(device).type
+        cpu_call_count = 0
+        cuda_call_count = 0
+
+        @torch.library.custom_op(
+            "_torch_testing::f", mutates_args=(), device_types="cpu"
+        )
+        def f(x: Tensor) -> Tensor:
+            nonlocal cpu_call_count
+            cpu_call_count += 1
+            x_np = x.numpy()
+            out_np = np.sin(x_np)
+            return torch.from_numpy(out_np)
+
+        @f.register_kernel(device_type)
+        def _(x: Tensor) -> Tensor:
+            nonlocal cuda_call_count
+            cuda_call_count += 1
+            x_np = x.cpu().numpy()
+            out_np = np.sin(x_np)
+            return torch.from_numpy(out_np).to(x.device)
+
+        x = torch.randn(3)
+        y = f(x)
+        self.assertEqual(y, x.sin())
+        self.assertEqual(cpu_call_count, 1)
+        self.assertEqual(cuda_call_count, 0)
+
+        x = x.to(device)
+        y = f(x)
+        self.assertEqual(y, x.sin())
+        self.assertEqual(cpu_call_count, 1)
+        self.assertEqual(cuda_call_count, 1)
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    @skipMPS
+    @onlyAccelerator
+    def test_multi_types(self, device):
+        device_type = torch.device(device).type
+
+        @torch.library.custom_op(
+            "_torch_testing::f", mutates_args=(), device_types=("cpu", device_type)
+        )
+        def f(x: Tensor) -> Tensor:
+            x_np = x.cpu().numpy()
+            out_np = np.sin(x_np)
+            return torch.from_numpy(out_np).to(x.device)
+
+        x = torch.randn(3)
+        y = f(x)
+        self.assertEqual(y, x.sin())
+        x = x.to(device)
+        y = f(x)
+        self.assertEqual(y, x.sin())
+
+
 class TestLibrarySourceLocation(TestCase):
     def test_library_source_location(self):
         # Library.__init__ uses sys._getframe(1) to capture the caller's
@@ -6731,6 +6753,12 @@ class TestOpProfiles(TestCase):
 only_for = ("cpu", "cuda", "xpu")
 instantiate_device_type_tests(
     TestCustomOpTesting, globals(), only_for=only_for, allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestCustomOpDevice, globals(), allow_xpu=True, allow_mps=True
+)
+instantiate_device_type_tests(
+    TestCustomOpAPIDevice, globals(), allow_xpu=True, allow_mps=True
 )
 instantiate_parametrized_tests(TestCustomOp)
 instantiate_parametrized_tests(TestCustomOpAPI)

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -40,7 +40,6 @@ from torch._utils_internal import get_file_path_2  # @manual
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing._internal import custom_op_db
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     OpDTypes,
@@ -2047,7 +2046,7 @@ TORCH_LIBRARY(_test_pyobject_dispatch_cpp_fallback_torch_function, m) {
             op(x)
 
     @skipIfXpu(msg="Deprecated torch.custom_ops API")
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "requires CUDA or XPU")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_separate(self):
         @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
         def foo(x: torch.Tensor) -> torch.Tensor:
@@ -2072,7 +2071,7 @@ TORCH_LIBRARY(_test_pyobject_dispatch_cpp_fallback_torch_function, m) {
         self.assertEqual(result, foo_cuda(x_cuda))
 
     @skipIfXpu(msg="Deprecated torch.custom_ops API")
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "requires CUDA or XPU")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_multiple(self):
         @custom_ops.custom_op(f"{TestCustomOp.test_ns}::foo")
         def foo(x: torch.Tensor) -> torch.Tensor:
@@ -2675,7 +2674,7 @@ Dynamic shape operator
         self._test_impl_device("foo3", ["cpu", "cuda"], "cpu")
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "requires cuda or xpu")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_impl_device_cuda(self):
         self._test_impl_device("foo4", "default", device_type)
         self._test_impl_device("foo5", [device_type], device_type)
@@ -5361,7 +5360,7 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(y, x.cos())
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_split_device(self):
         cpu_call_count = 0
         cuda_call_count = 0
@@ -5376,7 +5375,7 @@ Please use `add.register_fake` to add an fake impl.""",
             out_np = np.sin(x_np)
             return torch.from_numpy(out_np)
 
-        @f.register_kernel("cuda")
+        @f.register_kernel(device_type)
         def _(x: Tensor) -> Tensor:
             nonlocal cuda_call_count
             cuda_call_count += 1
@@ -5390,17 +5389,17 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(cpu_call_count, 1)
         self.assertEqual(cuda_call_count, 0)
 
-        x = x.cuda()
+        x = x.to(device_type)
         y = f(x)
         self.assertEqual(y, x.sin())
         self.assertEqual(cpu_call_count, 1)
         self.assertEqual(cuda_call_count, 1)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_multi_types(self):
         @torch.library.custom_op(
-            "_torch_testing::f", mutates_args=(), device_types=("cpu", "cuda")
+            "_torch_testing::f", mutates_args=(), device_types=("cpu", device_type)
         )
         def f(x: Tensor) -> Tensor:
             x_np = x.cpu().numpy()
@@ -5410,7 +5409,7 @@ Please use `add.register_fake` to add an fake impl.""",
         x = torch.randn(3)
         y = f(x)
         self.assertEqual(y, x.sin())
-        x = x.cuda()
+        x = x.to(device_type)
         y = f(x)
         self.assertEqual(y, x.sin())
 

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -64,7 +64,6 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
     TEST_WITH_TORCHDYNAMO,
-    TEST_XPU,
     TestCase,
 )
 from torch.testing._internal.custom_op_db import numpy_nonzero


### PR DESCRIPTION
Make 5 tests in TestCustomOp and TestCustomOpAPI classes device-agnostic by replacing hardcoded CUDA specific code with accelerator generic patterns, and add hw_classification.

  Changes:
  - Extract the 5 tests into new TestCustomOpDevice / TestCustomOpAPIDevice classes,
    parameterized via instantiate_device_type_tests (test methods take a `device` param)
  - Replace @unittest.skipIf(not TEST_CUDA/TEST_XPU) with @onlyAccelerator/@skipMPS/@skipXPUIf
  - Replace .cuda() with .to(device)
  - Replace hardcoded "cuda" with the device parameter
  - Strip the device index (e.g. "cuda:0" -> "cuda") before passing it to custom-op
    registration calls (custom_ops.impl, register_kernel), which require a bare device type
  - Add hw_classification = HardwareClassification.ACCELERATOR to the new classes, and
    HardwareClassification.GENERIC to TestCustomOp and TestCustomOpAPI
  - Remove TEST_XPU and skipIfXpu imports (no longer needed); restore the TEST_CUDA import
    (still needed by unrelated tests elsewhere in the file)

  Tests modified:
  - TestCustomOp.test_impl_separate -> TestCustomOpDevice.test_impl_separate
  - TestCustomOp.test_impl_multiple -> TestCustomOpDevice.test_impl_multiple
  - TestCustomOp.test_impl_device_cuda -> TestCustomOpDevice.test_impl_device_accelerator
  - TestCustomOpAPI.test_split_device -> TestCustomOpAPIDevice.test_split_device
  - TestCustomOpAPI.test_multi_types -> TestCustomOpAPIDevice.test_multi_types

  These tests now run on any accelerator (CUDA, ROCm, XPU) via instantiate_device_type_tests,
  not just CUDA/XPU through manual gating.

Test plan:
python test/test_custom_ops.py TestCustomOpDeviceCUDA.test_impl_separate_cuda TestCustomOpDeviceCUDA.test_impl_multiple_cuda TestCustomOpDeviceCUDA.test_impl_device_accelerator_cuda TestCustomOpAPIDeviceCUDA.test_split_device_cuda TestCustomOpAPIDeviceCUDA.test_multi_types_cuda -v

test_impl_separate_cuda (__main__.TestCustomOpDeviceCUDA.test_impl_separate_cuda) ... ok
test_impl_multiple_cuda (__main__.TestCustomOpDeviceCUDA.test_impl_multiple_cuda) ... ok
test_impl_device_accelerator_cuda (__main__.TestCustomOpDeviceCUDA.test_impl_device_accelerator_cuda) ... ok
test_split_device_cuda (__main__.TestCustomOpAPIDeviceCUDA.test_split_device_cuda) ... ok
test_multi_types_cuda (__main__.TestCustomOpAPIDeviceCUDA.test_multi_types_cuda) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.641s

OK

python test/test_custom_ops.py TestCustomOpDeviceCPU TestCustomOpAPIDeviceCPU -v

Ran 5 tests in 0.579s

OK (skipped=5)

Co-authored-by: @Sanskaaar1  <[sanspras@redhat.com](mailto:sanspras@redhat.com)>

CC: @fffrog @albanD @jbschlosser 