### PR TITLE
[autograd] Validate forward-mode jacobian/hessian require vectorize=T…

### DIFF
--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -765,6 +765,24 @@ class TestAutogradFunctional(TestCase):
             autogradF.jacobian(foo, inp, strict=True, vectorize=True)
 
     @base_and_logging_tensor
+    def test_jacobian_err_check_forward_mode_requires_vectorize(self, ctors):
+        # See https://github.com/pytorch/pytorch/issues/184842 -
+        # strategy='forward-mode' with vectorize=False must be rejected at
+        # argument-validation time with a ValueError, not at execution time
+        # with a NotImplementedError raised from deep inside _jacfwd.
+        def foo(x):
+            return x.exp()
+
+        inp = ctors.rand(4)
+        with self.assertRaisesRegex(
+            ValueError, r'strategy="forward-mode"` requires `vectorize=True`'
+        ):
+            autogradF.jacobian(foo, inp, strategy="forward-mode", vectorize=False)
+
+        # The combination that *is* supported keeps working.
+        autogradF.jacobian(foo, inp, strategy="forward-mode", vectorize=True)
+
+    @base_and_logging_tensor
     def test_jacobian_no_grad(self, ctors):
         def exp_reducer(x):
             return x.exp().sum(dim=1)
@@ -1123,6 +1141,26 @@ class TestAutogradFunctional(TestCase):
         inp = ctors.rand(4)
         with self.assertRaisesRegex(RuntimeError, "not supported together"):
             autogradF.hessian(foo, inp, strict=True, vectorize=True)
+
+    @base_and_logging_tensor
+    def test_hessian_err_check_forward_mode_requires_vectorize(self, ctors):
+        # See https://github.com/pytorch/pytorch/issues/184842 - same as
+        # the jacobian case, but for outer_jacobian_strategy on hessian.
+        def foo(x):
+            return (x**3).sum()
+
+        inp = ctors.rand(4)
+        with self.assertRaisesRegex(
+            ValueError,
+            r'outer_jacobian_strategy="forward-mode"` requires `vectorize=True`',
+        ):
+            autogradF.hessian(
+                foo, inp, outer_jacobian_strategy="forward-mode", vectorize=False
+            )
+
+        autogradF.hessian(
+            foo, inp, outer_jacobian_strategy="forward-mode", vectorize=True
+        )
 
     @base_and_logging_tensor
     def test_hessian_no_grad(self, ctors):

--- a/torch/autograd/functional.py
+++ b/torch/autograd/functional.py
@@ -684,6 +684,12 @@ def jacobian(
             'Otherwise, prefer to use "reverse-mode".'
         )
     if strategy == "forward-mode":
+        if not vectorize:
+            raise ValueError(
+                'torch.autograd.functional.jacobian: `strategy="forward-mode"` '
+                "requires `vectorize=True`. Please either set `vectorize=True` "
+                'or use `strategy="reverse-mode"`.'
+            )
         if create_graph:
             raise NotImplementedError(
                 "torch.autograd.functional.jacobian: `create_graph=True` "
@@ -953,6 +959,13 @@ def hessian(
     ):
         raise AssertionError(
             'Expected strategy to be either "forward-mode" or "reverse-mode".'
+        )
+    if outer_jacobian_strategy == "forward-mode" and not vectorize:
+        raise ValueError(
+            "torch.autograd.functional.hessian: "
+            '`outer_jacobian_strategy="forward-mode"` requires `vectorize=True`. '
+            "Please either set `vectorize=True` or use "
+            '`outer_jacobian_strategy="reverse-mode"`.'
         )
 
     def ensure_single_output_function(*inp):


### PR DESCRIPTION
Fixes #184842

`torch.autograd.functional.jacobian(strategy="forward-mode", vectorize=False)`
is an unsupported combination, but the API used to accept it at call time
and then raise `NotImplementedError` from deep inside `_jacfwd`'s fallback
branch. The same shape failure applied to
`torch.autograd.functional.hessian(outer_jacobian_strategy="forward-mode", vectorize=False)`.
The constraint itself is real (`"forward-mode"` requires `vectorize=True`),
so the right place to surface it is at argument validation. So, the call now
fails at the API boundary with a `ValueError` that names the offending
argument, instead of in the middle of execution with an error that points
at internals.

I considered putting only one check in `jacobian()` and letting `hessian()`
inherit it via its internal `jacobian` call, but the resulting error
message would mention `strategy=` instead of `outer_jacobian_strategy=`,
which is confusing for `hessian` users. Two narrowly-scoped checks keep
the messages aligned with each function's public API. The pre-existing
`NotImplementedError` in `_jacfwd` is left in place as a defense-in-depth
fallback for callers that reach the private helper directly.

## Changes

### `torch/autograd/functional.py`
- `jacobian`: early `ValueError` when `strategy == "forward-mode"` and
  `not vectorize`, placed right after the existing strategy whitelist
  check so it matches the surrounding validation style.
- `hessian`: early `ValueError` when
  `outer_jacobian_strategy == "forward-mode"` and `not vectorize`.

### `test/autograd/test_functional.py`
- `test_jacobian_err_check_forward_mode_requires_vectorize`: covers the
  rejected combination and the supported `vectorize=True` path.
- `test_hessian_err_check_forward_mode_requires_vectorize`: same for
  `outer_jacobian_strategy`.

## Tested all my changes with:

`python -m pytest test/autograd/test_functional.py`. 

All tests passed.

cc @ezyang @albanD @gqchen @nikitaved @soulitzer @Varal7 @bobrenjc93 @malfet