### PR TITLE
Raise error when class attributes shadow registered parameters or modules

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -733,6 +733,31 @@ class TestNN(NNTestCase):
         m.register_parameter('param_name', param3)
         self.assertEqual(m.param_name, param3)
 
+    def test_class_attr_shadows_registered_module(self):
+        class BadModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.relu = nn.ReLU()
+
+            def relu(self):
+                return "method"
+
+        with self.assertRaisesRegex(AttributeError, "class attribute would shadow"):
+            BadModule()
+
+    def test_class_attr_shadows_registered_parameter(self):
+        class BadModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(3))
+
+            @property
+            def weight(self):
+                return None
+
+        with self.assertRaisesRegex(AttributeError, "class attribute would shadow"):
+            BadModule()
+
     def test_add_module_raises_error_if_attr_exists(self):
         methods_to_test = ['add_module', 'register_module']
         for fn in methods_to_test:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1968,6 +1968,21 @@ class Module:
             f"'{type(self).__name__}' object has no attribute '{name}'"
         )
 
+    def _check_attr_shadowing(self, name: str, category: str) -> None:
+        for cls in type(self).__mro__:
+            if cls is Module:
+                break
+            if name in cls.__dict__:
+                attr = cls.__dict__[name]
+                if callable(attr) or isinstance(attr, property):
+                    kind = "property" if isinstance(attr, property) else type(attr).__name__
+                    raise AttributeError(
+                        f"cannot register {category} '{name}': a {kind} with the same "
+                        f"name is already defined as a class attribute in "
+                        f"{cls.__qualname__}. The class attribute would shadow the "
+                        f"registered {category}, making it inaccessible."
+                    )
+
     def __setattr__(self, name: str, value: Union[Tensor, "Module"]) -> None:
         def remove_from(*dicts_or_sets) -> None:
             for d in dicts_or_sets:
@@ -1983,6 +1998,7 @@ class Module:
                 raise AttributeError(
                     "cannot assign parameters before Module.__init__() call"
                 )
+            self._check_attr_shadowing(name, "parameter")
             remove_from(
                 self.__dict__,
                 self._buffers,
@@ -2004,6 +2020,7 @@ class Module:
                     raise AttributeError(
                         "cannot assign module before Module.__init__() call"
                     )
+                self._check_attr_shadowing(name, "module")
                 remove_from(
                     self.__dict__,
                     self._parameters,


### PR DESCRIPTION
Fixes #78618

When a class defines a method or property with the same name as a parameter or submodule assigned in `__init__`, the registration silently succeeds but the attribute becomes inaccessible:

```python
class BadModule(nn.Module):
    def __init__(self):
        super().__init__()
        self.attr1 = nn.ReLU()  # stored in _modules

    def attr1(self):            # class method shadows it
        return "on the class"

b = BadModule()
b.attr1()  # returns "on the class", not the ReLU module
```

This happens because `__setattr__` stores modules/parameters in `_modules`/`_parameters` (not `self.__dict__`), so Python's normal lookup finds the class-level method/property first, and `__getattr__` is never called.

**Fix:** Add `_check_attr_shadowing` in `__setattr__` that scans the MRO (up to but excluding `nn.Module`) for callable or property class attributes that would shadow the registration. Raises `AttributeError` with a clear message at registration time.

**Changes:**
- `torch/nn/modules/module.py`: Add `_check_attr_shadowing` method, called from both the Parameter and Module branches of `__setattr__`
- `test/test_nn.py`: Add `test_class_attr_shadows_registered_module` and `test_class_attr_shadows_registered_parameter`

cc @albanD @jbschlosser