### PR TITLE
Fix regional Inductor input-derived SymInt expressions

### DIFF
--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -7,6 +7,7 @@ import warnings
 from typing import Any, TYPE_CHECKING
 
 import torch
+import torch._inductor.config as inductor_config
 import torch._inductor.test_case
 import torch.fx.traceback as fx_traceback
 import torch.utils.checkpoint
@@ -582,6 +583,130 @@ class RegionalInductorTests(torch._inductor.test_case.TestCase):
 
         fn(x).sum().backward()
         self.assertEqual(x.grad, x * 3)
+
+    def test_regional_inductor_unbacked_expr(self):
+        class Model(torch.nn.Module):
+            def forward(self, c):
+                d = torch.concat([c, c], dim=0)
+                with fx_traceback.annotate({"compile_with_inductor": "my_region"}):
+                    d = d + 1
+                return d
+
+        model = Model()
+        c = torch.randn((64, 32))
+        torch._dynamo.decorators.mark_unbacked(c, 0)
+
+        res = torch.compile(
+            model,
+            backend=aot_eager_regional_inductor(serialize=False),
+            fullgraph=True,
+        )(c)
+        self.assertEqual(res, model(c))
+
+    def test_regional_inductor_unbacked_multi_symbol_expr(self):
+        def fn(a, b):
+            d = torch.concat([a, b], dim=0)
+            with fx_traceback.annotate({"compile_with_inductor": "my_region"}):
+                d = d + 1
+            return d
+
+        a = torch.randn((64, 32))
+        b = torch.randn((48, 32))
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.decorators.mark_unbacked(b, 0)
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(serialize=False),
+            fullgraph=True,
+        )
+        self.assertEqual(opt_fn(a, b), fn(a, b))
+
+    def test_regional_inductor_unbacked_multi_symbol_expr_affine(self):
+        def fn(a, b):
+            d = torch.concat([a, b], dim=0)
+            with fx_traceback.annotate({"compile_with_inductor": "my_region"}):
+                d = torch.nn.functional.pad(d, (0, 0, 0, 1))
+                d = d + 1
+            return d
+
+        a = torch.randn((64, 32))
+        b = torch.randn((48, 32))
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.decorators.mark_unbacked(b, 0)
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(serialize=False),
+            fullgraph=True,
+        )
+        self.assertEqual(opt_fn(a, b), fn(a, b))
+
+    def test_regional_inductor_unbacked_rounded_multi_symbol_expr(self):
+        def fn(a, b):
+            d = torch.concat([a, b], dim=0)
+            dim0 = d.shape[0]
+            rounded_dim0 = 8 * ((dim0 + 7) // 8)
+            d = torch.nn.functional.pad(d, (0, 0, 0, rounded_dim0 - dim0))
+            with fx_traceback.annotate({"compile_with_inductor": "my_region"}):
+                d = d + 1
+            return d
+
+        a = torch.randn((63, 32))
+        b = torch.randn((46, 32))
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.decorators.mark_unbacked(b, 0)
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(serialize=False),
+            fullgraph=True,
+        )
+        self.assertEqual(opt_fn(a, b), fn(a, b))
+
+    def _check_regional_inductor_unbacked_dynamic_padding_inside_region(self):
+        def fn(a, b):
+            d = torch.concat([a, b], dim=0)
+            with fx_traceback.annotate({"compile_with_inductor": "my_region"}):
+                dim0 = d.shape[0]
+                d = torch.nn.functional.pad(d, (0, 0, 2 * dim0, 0))
+                d = d + 1
+            return d
+
+        a = torch.randn((5, 3))
+        b = torch.randn((7, 3))
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.decorators.mark_unbacked(b, 0)
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(serialize=False),
+            fullgraph=True,
+        )
+        self.assertEqual(opt_fn(a, b), fn(a, b))
+
+    def test_regional_inductor_unbacked_dynamic_padding_inside_region(self):
+        self._check_regional_inductor_unbacked_dynamic_padding_inside_region()
+
+    def test_regional_inductor_unbacked_multi_symbol_expr_cpp_wrapper(self):
+        def fn(a, b):
+            d = torch.concat([a, b], dim=0)
+            with fx_traceback.annotate({"compile_with_inductor": "my_region"}):
+                d = d + 1
+            return d
+
+        a = torch.randn((64, 32))
+        b = torch.randn((48, 32))
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.decorators.mark_unbacked(b, 0)
+
+        with inductor_config.patch(cpp_wrapper=True):
+            opt_fn = torch.compile(
+                fn,
+                backend=aot_eager_regional_inductor(serialize=False),
+                fullgraph=True,
+            )
+            self.assertEqual(opt_fn(a, b), fn(a, b))
 
 
 @skipIfTorchDynamo("Not a suitable dynamo wrapped test")

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
 from torch.utils._sympy.functions import (
+    CleanDiv,
     FloorDiv,
     Identity,
     Mod,
@@ -799,6 +800,51 @@ class TestPrecomputedSizeHinting(InductorTestCase):
         # optimization_hint should resolve ps0 -> s0*5 -> 50, then add 3 -> 53
         hint = sizevars.optimization_hint(expr)
         self.assertEqual(hint, 53)
+
+    def test_substitute_precomputed_size_scaled_expression(self):
+        sizevars = SizeVarAllocator()
+        u0, u1 = sympy.symbols("u0 u1", integer=True)
+
+        ps0 = sizevars.lookup_precomputed_size(u0 + u1)
+        self.assertEqual(sizevars.substitute_precomputed_sizes(u0 + u1 + 1), ps0 + 1)
+        self.assertEqual(
+            sizevars.substitute_precomputed_sizes(32 * u0 + 32 * u1), 32 * ps0
+        )
+        self.assertEqual(
+            sizevars.substitute_precomputed_sizes(u0 + 2 * u1), u0 + 2 * u1
+        )
+
+        rounded = 8 * FloorDiv(u0 + u1 + 39, 8)
+        ps1 = sizevars.lookup_precomputed_size(rounded)
+        self.assertEqual(sizevars.substitute_precomputed_sizes(32 * rounded), 32 * ps1)
+        self.assertEqual(
+            sizevars.substitute_precomputed_sizes(4 * FloorDiv(u0 + u1 + 39, 8)),
+            CleanDiv(ps1, 2),
+        )
+        self.assertEqual(
+            sizevars.substitute_precomputed_sizes(
+                u0 + u1 + 4 * FloorDiv(u0 + u1 + 39, 8)
+            ),
+            ps0 + CleanDiv(ps1, 2),
+        )
+        self.assertEqual(
+            sizevars.substitute_precomputed_sizes(rounded, skip={ps1}),
+            8 * FloorDiv(ps0 + 39, 8),
+        )
+
+        sizevars = SizeVarAllocator()
+        ps_double = sizevars.lookup_precomputed_size(2 * u0 + 2 * u1)
+        ps_sum = sizevars.lookup_precomputed_size(u0 + u1)
+        self.assertEqual(
+            sizevars.substitute_precomputed_sizes(u0 + u1, allowed=[ps_sum]), ps_sum
+        )
+        self.assertEqual(
+            sizevars.substitute_precomputed_sizes(u0 + u1, allowed=[ps_double]),
+            CleanDiv(ps_double, 2),
+        )
+        self.assertEqual(
+            sizevars.substitute_precomputed_sizes(u0 + u1, allowed=[]), u0 + u1
+        )
 
 
 class TestHintDisproves(InductorTestCase):

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -2431,6 +2431,7 @@ class Kernel(CodeGen, Generic[CSEVariableType]):
         if isinstance(index, (list, tuple)):
             return [self.rename_indexing(x) for x in index]
         index = V.graph.sizevars.simplify(index)
+        index = V.graph.sizevars.substitute_precomputed_sizes(index)
         sorted_symbols = sorted(index.free_symbols, key=lambda s: s.name)
         replacements = {
             x: self.args.size(x)

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -579,6 +579,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         value: ir.TensorBox,
         bound_vars: OrderedSet[sympy.Symbol],
     ):
+        """Bind input-derived shape symbols from runtime tensor metadata."""
         code = self.prefix
 
         @functools.cache
@@ -590,6 +591,20 @@ class CppWrapperCpu(PythonWrapperCodegen):
         def strideof(name):
             self.codegen_input_stride_var_decl(code, name)
             return f"{name}_stride"
+
+        def bind_precomputed_size(
+            expr: sympy.Expr,
+            base_name: str,
+            name_fn: Callable[[str], str],
+            dim: int,
+        ):
+            sym = self._lookup_input_precomputed_size(expr)
+            if sym is None or sym in bound_vars:
+                return
+            base_name = name_fn(base_name)
+            code.writeline(f"int64_t {sym} = {base_name}[{dim}];")
+            bound_vars.add(sym)
+            self.computed_sizes.add(sym)
 
         def codegen_symbol(
             sym_or_exp: sympy.Symbol | sympy.Expr,
@@ -603,6 +618,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 code.writeline(f"int64_t {sym_or_exp} = {name_fn(base_name)}[{dim}];")
                 bound_vars.add(sym_or_exp)
             elif isinstance(sym_or_exp, sympy.Expr):
+                bind_precomputed_size(sym_or_exp, base_name, name_fn, dim)
                 undefined_symbols = [
                     sym for sym in sym_or_exp.free_symbols if sym not in bound_vars
                 ]
@@ -1925,6 +1941,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
     def codegen_cpp_sizevar(self, x: sympy.Expr, *, simplify: bool = True) -> str:
         maybe_simplified_x = V.graph.sizevars.simplify(x) if simplify else x
+        maybe_simplified_x = V.graph.sizevars.substitute_precomputed_sizes(
+            maybe_simplified_x, allowed=self.input_precomputed_sizes
+        )
         # In AOT mode, emit runtime checks for potential division/modulo by zero
         # to prevent SIGFPE crashes when symbolic tensor shapes can be 0
         if V.graph.aot_mode:
@@ -1953,10 +1972,16 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
     def ensure_size_computed(self, sym: sympy.Symbol):
         if isinstance(sym, sympy.Symbol) and symbol_is_type(sym, SymT.PRECOMPUTED_SIZE):
+            if sym in self.input_precomputed_sizes:
+                self.computed_sizes.add(sym)
+                return
             if sym in self.computed_sizes:
                 return
             self.computed_sizes.add(sym)
             expr = V.graph.sizevars.inv_precomputed_replacements[sym]
+            expr = V.graph.sizevars.substitute_precomputed_sizes(
+                expr, allowed=self.input_precomputed_sizes, skip=OrderedSet([sym])
+            )
             self.writeline(f"int64_t {sym} = {cexpr(expr)};")
 
     def _generate_symbolic_call_arg_helper(
@@ -1971,9 +1996,15 @@ class CppWrapperCpu(PythonWrapperCodegen):
             # its own {} scope block, so we must redeclare the variable each
             # time since prior declarations are no longer visible.
             self.kernel_numel_expr.add((arg.inner, graph))
-            self.writeline(f"int64_t {arg.inner} = {cexpr(arg.inner_expr)};")
+            expr = V.graph.sizevars.substitute_precomputed_sizes(
+                arg.inner_expr, allowed=self.input_precomputed_sizes
+            )
+            self.writeline(f"int64_t {arg.inner} = {cexpr(expr)};")
         else:
-            self.writeline(f"{arg.inner} = {cexpr(arg.inner_expr)};")
+            expr = V.graph.sizevars.substitute_precomputed_sizes(
+                arg.inner_expr, allowed=self.input_precomputed_sizes
+            )
+            self.writeline(f"{arg.inner} = {cexpr(expr)};")
 
     def _codegen_dynamic_scalar(self, node):
         (data,) = (t.codegen_reference() for t in node.inputs)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -40,6 +40,7 @@ from torch.fx.experimental.symbolic_shapes import (
 from torch.fx.node import _get_qualified_name
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.utils._ordered_set import OrderedSet
+from torch.utils._sympy.functions import CleanDiv
 from torch.utils._sympy.singleton_int import SingletonInt
 from torch.utils._sympy.symbol import symbol_is_type, SymT
 
@@ -1286,6 +1287,7 @@ class PythonWrapperCodegen(CodeGen):
             OrderedSet()
         )  # str of sympy.Symbol
         self.computed_sizes: OrderedSet[sympy.Symbol] = OrderedSet()
+        self.input_precomputed_sizes: OrderedSet[sympy.Symbol] = OrderedSet()
         self.launcher_fn_name = None
         # This function can be overridden to change the launcher name
         self.set_launcher_fn_name()
@@ -1296,6 +1298,8 @@ class PythonWrapperCodegen(CodeGen):
         # caching during lowering of nested subgraphs
         self.codegened_graph_stack = []
         self.computed_sizes_stack = []
+
+        self.register_input_precomputed_sizes()
 
         self.write_header()
 
@@ -2286,12 +2290,34 @@ class PythonWrapperCodegen(CodeGen):
                 self.estimate_peak = EfficientPeakEstimate()
             self.memory_plan_reuse()
 
+    def _lookup_input_precomputed_size(self, expr: Expr | int) -> sympy.Symbol | None:
+        if (
+            not isinstance(expr, Expr)
+            or isinstance(expr, sympy.Symbol)
+            or not expr.free_symbols
+        ):
+            return None
+
+        sym = V.graph.sizevars.lookup_precomputed_size(expr)
+        if isinstance(sym, sympy.Symbol) and symbol_is_type(sym, SymT.PRECOMPUTED_SIZE):
+            self.input_precomputed_sizes.add(sym)
+            return sym
+        return None
+
+    def register_input_precomputed_sizes(self):
+        for value in self.get_graph_inputs().values():
+            if not isinstance(value, ir.TensorBox):
+                continue
+            for expr in chain.from_iterable([value.get_size(), value.get_stride()]):
+                self._lookup_input_precomputed_size(expr)
+
     def codegen_input_symbol_assignment(
         self,
         name: str,
         value: ir.TensorBox,
         bound_vars: OrderedSet[sympy.Symbol],
     ):
+        """Bind input-derived shape symbols from runtime tensor metadata."""
         code = self.prefix
 
         @functools.cache
@@ -2304,6 +2330,63 @@ class PythonWrapperCodegen(CodeGen):
             code.writeline(f"{name}_stride = {name}.stride()")
             return f"{name}_stride"
 
+        @functools.cache
+        def dimof(base_name, dim):
+            dim_symbol = sympy.Symbol(f"{base_name}_{dim}", integer=True)
+            code.writeline(f"{dim_symbol} = {base_name}[{dim}]")
+            return dim_symbol
+
+        def clean_solution(expr):
+            numerator, denominator = sympy.fraction(expr)
+            if denominator != 1:
+                return CleanDiv(numerator, denominator)
+            return expr
+
+        def bind_precomputed_size(
+            expr: Expr,
+            base_name: str,
+            name_fn: Callable[[str], str],
+            dim: int,
+        ):
+            sym = self._lookup_input_precomputed_size(expr)
+            if sym is None or sym in bound_vars:
+                return
+            base_name = name_fn(base_name)
+            code.writeline(f"{sym} = {base_name}[{dim}]")
+            bound_vars.add(sym)
+            self.computed_sizes.add(sym)
+
+        def codegen_symbol(
+            sym_or_exp: sympy.Symbol | sympy.Expr,
+            base_name: str,
+            name_fn: Callable[[str], str],
+            dim: int,
+        ):
+            if isinstance(sym_or_exp, sympy.Symbol):
+                if sym_or_exp in bound_vars:
+                    return
+                code.writeline(f"{sym_or_exp} = {name_fn(base_name)}[{dim}]")
+                bound_vars.add(sym_or_exp)
+            elif isinstance(sym_or_exp, sympy.Expr):
+                bind_precomputed_size(sym_or_exp, base_name, name_fn, dim)
+                undefined_symbols = [
+                    sym for sym in sym_or_exp.free_symbols if sym not in bound_vars
+                ]
+                if len(undefined_symbols) != 1:
+                    return
+
+                from torch.utils._sympy.solve import try_solve
+
+                free_symbol = undefined_symbols.pop()
+                base_name = name_fn(base_name)
+                size_symbol = dimof(base_name, dim)
+                solution = try_solve(sympy.Eq(sym_or_exp, size_symbol), free_symbol)
+                if solution is not None:
+                    code.writeline(
+                        f"{free_symbol} = {pexpr(clean_solution(solution[1]))}"
+                    )
+                    bound_vars.add(free_symbol)
+
         if isinstance(value, sympy.Expr):
             if not isinstance(value, sympy.Symbol) or value in bound_vars:
                 return
@@ -2311,13 +2394,9 @@ class PythonWrapperCodegen(CodeGen):
             bound_vars.add(value)
         elif isinstance(value, ir.TensorBox):
             for dim, size in enumerate(value.get_size()):
-                if isinstance(size, sympy.Symbol) and size not in bound_vars:
-                    code.writeline(f"{size} = {sizeof(name)}[{dim}]")
-                    bound_vars.add(size)
+                codegen_symbol(size, name, sizeof, dim)
             for dim, stride in enumerate(value.get_stride()):
-                if isinstance(stride, sympy.Symbol) and stride not in bound_vars:
-                    code.writeline(f"{stride} = {strideof(name)}[{dim}]")
-                    bound_vars.add(stride)
+                codegen_symbol(stride, name, strideof, dim)
         elif isinstance(
             value, (ir.TorchBindObject, ir.GeneratorState, ir.OpaqueObjectState)
         ):
@@ -2350,6 +2429,9 @@ class PythonWrapperCodegen(CodeGen):
             bound_vars: OrderedSet[sympy.Symbol],
         ):
             for expr in chain.from_iterable([value.get_size(), value.get_stride()]):
+                expr = V.graph.sizevars.substitute_precomputed_sizes(
+                    expr, allowed=bound_vars
+                )
                 if not isinstance(expr, Expr) or isinstance(expr, sympy.Symbol):
                     continue
 
@@ -2371,10 +2453,16 @@ class PythonWrapperCodegen(CodeGen):
 
     def ensure_size_computed(self, sym: sympy.Symbol):
         if isinstance(sym, sympy.Symbol) and symbol_is_type(sym, SymT.PRECOMPUTED_SIZE):
+            if sym in self.input_precomputed_sizes:
+                self.computed_sizes.add(sym)
+                return
             if sym in self.computed_sizes:
                 return
             self.computed_sizes.add(sym)
             expr = V.graph.sizevars.inv_precomputed_replacements[sym]
+            expr = V.graph.sizevars.substitute_precomputed_sizes(
+                expr, allowed=self.input_precomputed_sizes, skip=OrderedSet([sym])
+            )
             arg = SymbolicCallArg(sym, expr)
             self.writeline(SymbolicCallArgLine(self, arg, V.graph))
 
@@ -2385,6 +2473,10 @@ class PythonWrapperCodegen(CodeGen):
         raise RuntimeError("codegen_cpp_sizevar is only implemented for cpp_wrapper!")
 
     def codegen_python_sizevar(self, x: Expr, *, simplify: bool = True) -> str:
+        x = V.graph.sizevars.simplify(x) if simplify else x
+        x = V.graph.sizevars.substitute_precomputed_sizes(
+            x, allowed=self.input_precomputed_sizes
+        )
         return pexpr(x, simplify=simplify)
 
     def codegen_sizevar(self, x: Expr) -> str:
@@ -3131,7 +3223,10 @@ class PythonWrapperCodegen(CodeGen):
     def _generate_symbolic_call_arg_helper(
         self, arg: SymbolicCallArg, graph: GraphLowering
     ) -> None:
-        self.writeline(f"{arg.inner} = {pexpr(arg.inner_expr)}")
+        expr = V.graph.sizevars.substitute_precomputed_sizes(
+            arg.inner_expr, allowed=self.input_precomputed_sizes
+        )
+        self.writeline(f"{arg.inner} = {pexpr(expr)}")
 
     def generate_workspace_allocation(self, ws: WorkspaceArg):
         name = ws.get_name()

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -23,7 +23,7 @@ from torch.fx.experimental.symbolic_shapes import (
     SymNode,
 )
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._sympy.functions import FloorDiv, Mod, ModularIndexing
+from torch.utils._sympy.functions import CleanDiv, FloorDiv, Mod, ModularIndexing
 from torch.utils._sympy.numbers import int_oo
 from torch.utils._sympy.symbol import symbol_is_type, SymT
 from torch.utils._sympy.value_ranges import IntInfinity, ValueRanges
@@ -976,6 +976,148 @@ class SizeVarAllocator:
         if any(symbol_is_type(s, SymT.PRECOMPUTED_SIZE) for s in expr.free_symbols):  # type: ignore[attr-defined]
             return sympy_subs(expr, self.inv_precomputed_replacements)  # type: ignore[arg-type]
         return expr
+
+    @staticmethod
+    def _scale_precomputed_size(sym: sympy.Symbol, scale: Expr) -> Expr:
+        scale = sympy.simplify(scale)
+        if scale == 0:
+            return sympy.S.Zero
+        if scale == 1:
+            return sym
+        if scale == -1:
+            return -sym
+        if isinstance(scale, sympy.Rational):
+            numerator = scale.p * sym
+            denominator = scale.q
+            if denominator == 1:
+                return numerator
+            return CleanDiv(numerator, denominator)
+        return scale * sym
+
+    def _try_substitute_scaled_precomputed_size(
+        self, expr: Expr, source: Expr, sym: sympy.Symbol
+    ) -> Expr | None:
+        if source == 0:
+            return None
+
+        scale = sympy.cancel(expr / source)
+        source_symbols = source.free_symbols
+        if isinstance(scale, Expr) and scale.free_symbols.isdisjoint(source_symbols):
+            return self._scale_precomputed_size(sym, scale)
+        return None
+
+    def _try_substitute_affine_precomputed_size(
+        self, expr: Expr, source: Expr, sym: sympy.Symbol
+    ) -> Expr | None:
+        source_symbols = tuple(sorted(source.free_symbols, key=lambda s: s.name))
+        if not source_symbols:
+            return None
+
+        try:
+            source_expanded = sympy.expand(source)
+            expr_expanded = sympy.expand(expr)
+            source_poly = sympy.Poly(source_expanded, *source_symbols)
+        except sympy.PolynomialError:
+            return None
+
+        if source_poly.total_degree() != 1:
+            return None
+
+        source_symbol_set = OrderedSet(source_symbols)
+        scale = None
+        for source_symbol in source_symbols:
+            source_coeff = source_expanded.coeff(source_symbol)
+            if source_coeff == 0:
+                continue
+            expr_coeff = expr_expanded.coeff(source_symbol)
+            candidate = sympy.cancel(expr_coeff / source_coeff)
+            if not isinstance(candidate, Expr) or not candidate.free_symbols.isdisjoint(
+                source_symbol_set
+            ):
+                return None
+            if scale is None:
+                scale = candidate
+            elif sympy.simplify(scale - candidate) != 0:
+                return None
+
+        if scale is None:
+            return None
+
+        remainder = sympy.simplify(expr - scale * source)
+        if not remainder.free_symbols.isdisjoint(source_symbol_set):
+            return None
+        return self._scale_precomputed_size(sym, scale) + remainder
+
+    def _substitute_precomputed_size(
+        self, expr: Expr | int, source: Expr, sym: sympy.Symbol
+    ) -> Expr | int:
+        if not isinstance(expr, Expr):
+            return expr
+        if expr == source:
+            return sym
+
+        result = sympy_subs(expr, {source: sym})
+        if not isinstance(result, Expr) or result != expr:
+            return result
+
+        result = self._try_substitute_scaled_precomputed_size(expr, source, sym)
+        if result is not None:
+            return result
+
+        result = self._try_substitute_affine_precomputed_size(expr, source, sym)
+        if result is not None:
+            return result
+
+        if expr.args:
+            args = tuple(
+                self._substitute_precomputed_size(arg, source, sym)
+                if isinstance(arg, Expr)
+                else arg
+                for arg in expr.args
+            )
+            if args != expr.args:
+                return expr.func(*args)
+
+        return expr
+
+    def substitute_precomputed_sizes(
+        self,
+        expr: Expr | int,
+        *,
+        allowed: Iterable[sympy.Symbol] | None = None,
+        skip: Iterable[sympy.Symbol] | None = None,
+    ) -> Expr | int:
+        """Replace known precomputed-size expressions with their runtime symbols."""
+        if not isinstance(expr, Expr):
+            return expr
+
+        allowed_set = OrderedSet(allowed) if allowed is not None else None
+        skipped = OrderedSet(skip or ())
+        replacements = [
+            (source, sym)
+            for source, sym in self.precomputed_replacements.items()
+            if sym not in skipped and (allowed_set is None or sym in allowed_set)
+        ]
+        if not replacements:
+            return expr
+
+        replacements.sort(
+            key=lambda item: (
+                len(item[0].free_symbols),
+                sympy.count_ops(item[0]),
+                str(item[0]),
+            ),
+            reverse=True,
+        )
+
+        result = expr
+        for _ in range(len(replacements)):
+            previous = result
+            for source, sym in replacements:
+                result = self._substitute_precomputed_size(result, source, sym)
+            if result == previous:
+                break
+        return result
 
     def replace_backed_symbols_with_hints(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185058

Regional Inductor can hand the wrapper a tensor input whose size or stride is a composite unbacked SymInt expression, such as 2*u0, u0 + u1, or a rounded padded expression. The wrapper previously only bound bare input symbols from tensor metadata, so later verification and kernel argument generation could reference unbound base symbols that were not recoverable from the regional subgraph inputs.

Bind composite input-derived dimensions through PRECOMPUTED_SIZE symbols sourced from runtime tensor size/stride metadata, and substitute those symbols through wrapper size rendering, symbolic call arguments, and kernel indexing. Keep the single-symbol solve path for recoverable expressions, using integer CleanDiv when solving introduces division. To avoid introducing a precomputed symbol before a runtime value is available, the substitution helper now supports an allowed set so wrapper verification and generic size rendering only use input-derived or already-bound symbols, while kernel argument collection can still introduce computed precomputed sizes.

This keeps the fix in the wrapper/sizevar machinery where the missing binding originates instead of special-casing regional Inductor tests or particular expression shapes.

Fixes #167012
Generated by my agent

Test Plan:
- PYTHONPATH=. PYTORCH_PRINT_REPRO_ON_FAILURE=0 python - <<'PY' ... original CPU regional unbacked concat repro ... PY
- PYTHONPATH=. PYTORCH_PRINT_REPRO_ON_FAILURE=0 python - <<'PY' ... dynamic-padding-inside-region blocker repro ... PY
- PYTHONPATH=. PYTORCH_PRINT_REPRO_ON_FAILURE=0 python test/dynamo/test_regional_inductor.py RegionalInductorTests.test_regional_inductor_unbacked_expr RegionalInductorTests.test_regional_inductor_unbacked_multi_symbol_expr RegionalInductorTests.test_regional_inductor_unbacked_multi_symbol_expr_affine RegionalInductorTests.test_regional_inductor_unbacked_rounded_multi_symbol_expr RegionalInductorTests.test_regional_inductor_unbacked_dynamic_padding_inside_region RegionalInductorTests.test_regional_inductor_unbacked_multi_symbol_expr_cpp_wrapper
- PYTHONPATH=. PYTORCH_PRINT_REPRO_ON_FAILURE=0 python test/inductor/test_indexing.py TestPrecomputedSizeHinting
- PYTHONPATH=. PYTORCH_PRINT_REPRO_ON_FAILURE=0 python test/dynamo/test_regional_inductor.py RegionalInductorInvokeSubgraphTests.test_unbacked_expr_input_serialize_False RegionalInductorTests.test_simple_serialize_False
- PYTHONPATH=. PYTORCH_PRINT_REPRO_ON_FAILURE=0 python - <<'PY' ... CUDA original issue repro ... PY
- PYTHONPATH=. PYTORCH_PRINT_REPRO_ON_FAILURE=0 python - <<'PY' ... CUDA rounded multi-symbol repro ... PY
- python -m py_compile torch/_inductor/sizevars.py torch/_inductor/codegen/wrapper.py torch/_inductor/codegen/cpp_wrapper_cpu.py torch/_inductor/codegen/common.py
- git diff --check
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98