### PR TITLE
Fix non-strict export tensor subclass attr tracing

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -3890,6 +3890,52 @@ graph():
         ep = export(m, (ref_x,))
         self.assertTrue(torch.allclose(ep.module()(ref_x), ref_out))
 
+    @testing.expectedFailureSerDerNonStrict  # local subclass can't be pickled
+    @testing.expectedFailureSerDer  # local subclass can't be pickled
+    def test_nonstrict_subclass_attr_access_in_torch_function(self):
+        class DummyTensor(torch.Tensor):
+            @staticmethod
+            def __new__(cls, inner: torch.Tensor):
+                return torch.Tensor._make_wrapper_subclass(cls, inner.shape)
+
+            def __init__(self, inner: torch.Tensor):
+                self.inner = inner
+
+            def __tensor_flatten__(self):
+                return ["inner"], None
+
+            @classmethod
+            def __tensor_unflatten__(
+                cls,
+                tensor_data_dict,
+                extra_metadata,
+                outer_size=None,
+                outer_stride=None,
+            ):
+                return DummyTensor(tensor_data_dict["inner"])
+
+            @classmethod
+            def __torch_function__(cls, func, types, args=(), kwargs=None):
+                kwargs = kwargs or {}
+                if func == torch.nn.functional.linear:
+                    return func(args[0], args[1].inner, **kwargs)
+                with torch._C.DisableTorchFunctionSubclass():
+                    return func(*args, **kwargs)
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                kwargs = kwargs or {}
+                if func == torch.ops.aten.detach.default:
+                    return DummyTensor(func(args[0].inner, **kwargs))
+                raise ValueError(f"unsupported op {func}")
+
+        m = torch.nn.Linear(32, 16, bias=False)
+        m.weight = torch.nn.Parameter(DummyTensor(m.weight))
+        inp = (torch.randn(32),)
+
+        ep = export(m, inp, strict=False)
+        self.assertEqual(ep.module()(*inp), m(*inp))
+
     def test_subclass_nested_attr_access_submodule(self):
         class Bar(torch.nn.Module):
             def __init__(self):

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -88,6 +88,7 @@ from torch.export.dynamic_shapes import (
 from torch.export.exported_program import OutputKind
 from torch.fx._symbolic_trace import _ConstantAttributeType
 from torch.fx.experimental.proxy_tensor import (
+    get_proxy_mode,
     get_proxy_slot,
     make_fx,
     PreDispatchTorchFunctionMode,
@@ -1810,6 +1811,17 @@ def _export_to_aten_ir_make_fx(
                     non_strict_root, assigned_buffers
                 )
 
+            def _find_tracer():
+                if torch._C._is_torch_function_mode_enabled():
+                    for mode in torch.overrides._get_current_function_mode_stack():
+                        if isinstance(mode, PreDispatchTorchFunctionMode):
+                            return mode.tracer
+
+                # __torch_function__ temporarily removes torch function modes while
+                # it runs, but the proxy dispatch mode still carries the same tracer.
+                proxy_mode = get_proxy_mode()
+                return proxy_mode.tracer if proxy_mode is not None else None
+
             def custom_getattribute(self, attr, *, original_getattr, attrs_to_proxy):
                 """
                 The idea here is that we override subclass getattr methods to proxy
@@ -1818,32 +1830,19 @@ def _export_to_aten_ir_make_fx(
                 system.
                 """
                 out = original_getattr(self, attr)
-                if attr in attrs_to_proxy:
-                    if torch._C._is_torch_function_mode_enabled():
-                        if isinstance(out, torch.Tensor):
-                            # When we get here there is no guarantee that we will hit the
-                            # PreDispatchTorchFunctionMode, so we manually peak into the torch
-                            # function mode list and tweak the PreDispatchTorchFunctionMode.
-                            # This has side effect of proxying stuff like
-                            # proxy.node.meta["val"] = extract_val(val) because at that time, torch function
-                            # mode is still active. It seems bad to turn it off inside proxy_tensor.py, so
-                            # I guess we will just rely on DCE for now to remove extra stuff like detach
-                            torch_function_mode_stack = (
-                                torch.overrides._get_current_function_mode_stack()
-                            )
-                            for mode in torch_function_mode_stack:
-                                if isinstance(mode, PreDispatchTorchFunctionMode):
-                                    tracer = mode.tracer
-                                    proxy = get_proxy_slot(self, tracer).proxy
-                                    inner_proxy = tracer.create_proxy(
-                                        "call_function",
-                                        torch.ops.export.access_subclass_inner_tensor.default,
-                                        (proxy, attr),
-                                        {},
-                                    )
-                                    track_tensor_tree(
-                                        out, inner_proxy, constant=None, tracer=tracer
-                                    )
+                if attr in attrs_to_proxy and isinstance(out, torch.Tensor):
+                    tracer = _find_tracer()
+                    if tracer is not None:
+                        proxy = get_proxy_slot(self, tracer).proxy
+                        inner_proxy = tracer.create_proxy(
+                            "call_function",
+                            torch.ops.export.access_subclass_inner_tensor.default,
+                            (proxy, attr),
+                            {},
+                        )
+                        track_tensor_tree(
+                            out, inner_proxy, constant=None, tracer=tracer
+                        )
                 return out
 
             @contextmanager
@@ -1872,6 +1871,9 @@ def _export_to_aten_ir_make_fx(
                             instance = subclass_types_to_instances[subclass_type][0]
                             # Query subclass specific attrs
                             attrs_to_proxy = set(dir(instance)) - set(dir(torch.Tensor))
+                            if hasattr(instance, "__tensor_flatten__"):
+                                inner_keys, _ = instance.__tensor_flatten__()
+                                attrs_to_proxy.update(inner_keys)
                             tensor_type_to_old_getattribute[subclass_type] = (
                                 subclass_type.__getattribute__,  # type: ignore[attr-defined]
                                 attrs_to_proxy,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185059

Non-strict export proxies tensor subclass attribute reads by temporarily
installing a custom __getattribute__ on wrapper subclasses. The attribute
set only used set(dir(instance)) - set(dir(torch.Tensor)), so wrapper
inner tensors whose names overlap Tensor attributes, such as "inner", were
not proxied. When a subclass __torch_function__ then accessed that inner
tensor, the tracing TorchFunctionMode had also been temporarily popped by
__torch_function__ dispatch, so the access was missed and the fake inner
tensor was later lifted as an invalid constant.

Fix this by including the tensor names returned from __tensor_flatten__ in
the proxied attribute set, and by falling back to the active proxy dispatch
mode to recover the same tracer when the PreDispatchTorchFunctionMode is
not on the torch function mode stack. This keeps the existing non-strict
subclass attribute proxying path instead of special-casing linear or the
specific DummyTensor repro.

The other option would be to only use __tensor_flatten__ names for subclass
attrs, but existing non-strict export also proxies subclass-defined attrs
from dir(instance), so this patch preserves that behavior and extends it
with the canonical inner tensor names.

Fixes #167007
Generated by my agent

Test Plan:
- python test/export/test_export.py TestExport.test_nonstrict_subclass_attr_access_in_torch_function -v
- python test/export/test_export.py TestExport.test_subclass_nested_attr_access -v
- python test/export/test_export.py TestExport.test_nonstrict_subclass_attr_access_in_torch_function TestExport.test_subclass_nested_attr_access -v
- lintrunner -a
- git diff --cached --check