### PR TITLE
[MPS] Validate probabilities in bernoulli

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Distributions.metal
+++ b/aten/src/ATen/native/mps/kernels/Distributions.metal
@@ -1,3 +1,5 @@
+#include <c10/metal/atomic.h>
+#include <c10/metal/error.h>
 #include <c10/metal/random.h>
 #include <c10/metal/special_math.h>
 #include <c10/metal/utils.h>
@@ -280,6 +282,7 @@ kernel void bernoulli_tensor(
     device const float* probs [[buffer(1)]],
     constant long2& seed_base_offset [[buffer(2)]],
     constant uint& numel [[buffer(3)]],
+    device c10::metal::ErrorMessages* error_buf [[buffer(4)]],
     uint tid [[thread_position_in_grid]]) {
   uint base = tid * 4;
   uint4 raw =
@@ -288,6 +291,10 @@ kernel void bernoulli_tensor(
   for (uint i = 0; i < count; ++i) {
     float u = c10::metal::detail::uint32_to_uniform_float(raw[i]);
     float p = probs[base + i];
+    if (!(p >= 0.0f && p <= 1.0f)) {
+      TORCH_REPORT_ERROR(error_buf, "bernoulli_mps_ expects p to be in [0, 1]");
+      return;
+    }
     output[base + i] = c10::metal::cast_to<T>(u < p ? 1u : 0u);
   }
 }
@@ -302,6 +309,7 @@ kernel void bernoulli_tensor(
       device const float*,                                                     \
       constant long2&,                                                         \
       constant uint&,                                                          \
+      device c10::metal::ErrorMessages*,                                       \
       uint)
 
 REGISTER_BERNOULLI(float);

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -328,7 +328,8 @@ static Tensor& bernoulli_tensor_mps_impl(Tensor& self, const Tensor& p_, std::op
         auto computeEncoder = stream->commandEncoder();
         [computeEncoder setComputePipelineState:pso];
         const auto numel = c10::checked_convert<uint32_t>(output.numel(), "uint32_t");
-        mtl_setArgs(computeEncoder, output, p_float, std::array<long, 2>{seed, base_offset}, numel);
+        mtl_setArgs(
+            computeEncoder, output, p_float, std::array<long, 2>{seed, base_offset}, numel, stream->getErrorBuffer());
         mtl_dispatch1DJob(computeEncoder, pso, at::ceil_div(numel, 4u));
       }
     });

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8259,6 +8259,19 @@ class TestMPS(TestCaseMPS):
             uniq = mps_out.unique()
             self.assertEqual(uniq, torch.arange(2, device='mps', dtype=dtype))
 
+    def test_bernoulli_invalid_probabilities(self):
+        for bad_p in (-0.1, 1.1, float("nan"), float("inf"), float("-inf")):
+            with self.assertRaisesRegex(RuntimeError, r"expects p to be in \[0, 1\]"):
+                torch.empty(4, device="mps").bernoulli_(bad_p)
+        # Tensor-p path: error is async; force a sync to surface it.
+        mixed = torch.tensor([0.5, 1.5, -0.3, float("nan"), float("inf")], device="mps")
+        with self.assertRaisesRegex(RuntimeError, r"expects p to be in \[0, 1\]"):
+            torch.bernoulli(mixed)
+            torch.mps.synchronize()
+        with self.assertRaisesRegex(RuntimeError, r"expects p to be in \[0, 1\]"):
+            torch.empty_like(mixed).bernoulli_(mixed)
+            torch.mps.synchronize()
+
     @parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
     def test_dropout(self, dtype):
         shapes = [

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8259,19 +8259,6 @@ class TestMPS(TestCaseMPS):
             uniq = mps_out.unique()
             self.assertEqual(uniq, torch.arange(2, device='mps', dtype=dtype))
 
-    def test_bernoulli_invalid_probabilities(self):
-        for bad_p in (-0.1, 1.1, float("nan"), float("inf"), float("-inf")):
-            with self.assertRaisesRegex(RuntimeError, r"expects p to be in \[0, 1\]"):
-                torch.empty(4, device="mps").bernoulli_(bad_p)
-        # Tensor-p path: error is async; force a sync to surface it.
-        mixed = torch.tensor([0.5, 1.5, -0.3, float("nan"), float("inf")], device="mps")
-        with self.assertRaisesRegex(RuntimeError, r"expects p to be in \[0, 1\]"):
-            torch.bernoulli(mixed)
-            torch.mps.synchronize()
-        with self.assertRaisesRegex(RuntimeError, r"expects p to be in \[0, 1\]"):
-            torch.empty_like(mixed).bernoulli_(mixed)
-            torch.mps.synchronize()
-
     @parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
     def test_dropout(self, dtype):
         shapes = [
@@ -14792,6 +14779,20 @@ class TestErrorInputs(TestCase):
             torch.mps.synchronize()
         with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
             torch.nn.functional.one_hot(torch.tensor([-1], device=device), num_classes=8)
+            torch.mps.synchronize()
+
+    def test_bernoulli_invalid_probabilities(self, device):
+        # Scalar-p path: host-side TORCH_CHECK
+        for bad_p in (-0.1, 1.1, float("nan"), float("inf"), float("-inf")):
+            with self.assertRaisesRegex(RuntimeError, r"expects p to be in \[0, 1\]"):
+                torch.empty(4, device=device).bernoulli_(bad_p)
+        # Tensor-p path: device-side assert
+        mixed = torch.tensor([0.5, 1.5, -0.3, float("nan"), float("inf")], device=device)
+        with self.assertRaisesRegex(torch.AcceleratorError, r"expects p to be in \[0, 1\]"):
+            torch.bernoulli(mixed)
+            torch.mps.synchronize()
+        with self.assertRaisesRegex(torch.AcceleratorError, r"expects p to be in \[0, 1\]"):
+            torch.empty_like(mixed).bernoulli_(mixed)
             torch.mps.synchronize()
 
 


### PR DESCRIPTION
If you do this on the current main:
```python
import torch

p = torch.tensor([0.5, 1.5, -0.3, float("nan"), float("inf")], device="mps")
torch.bernoulli(p)
```
It silently computes the output, while CPU raises the error:
```
RuntimeError: Expected p_in >= 0 && p_in <= 1 to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
```