### PR TITLE
[Test]Make test_python_dispatch.py device-generic

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -2833,7 +2833,10 @@ class TestWrapperSubclassAliasing(TestCase):
         self._test_wrapper_subclass_aliasing(op, args, kwargs)
 
     def test_wrapper_subclass_aliasing_conv2d(self, device):
-        args = (torch.randn(4, 4, 4, 4), torch.randn(4, 4, 4, 4))
+        args = (
+            torch.randn(4, 4, 4, 4, device=device),
+            torch.randn(4, 4, 4, 4, device=device),
+        )
         kwargs = {}
         # conv2d has a default arg 'int[2] strides=0',
         # which torchscript expands into 'int[2] strides=[0, 0]'
@@ -2846,12 +2849,12 @@ class TestWrapperSubclassAliasing(TestCase):
 
     def test_wrapper_subclass_aliasing_out_op(self, device):
         # Make sure that _return_and_correct_aliasing can handle kwargs w mutable tensors
-        args = (torch.ones(4), torch.ones(4))
-        kwargs = {"out": torch.empty(4)}
+        args = (torch.ones(4, device=device), torch.ones(4, device=device))
+        kwargs = {"out": torch.empty(4, device=device)}
         self._test_wrapper_subclass_aliasing(torch.ops.aten.add.out, args, kwargs)
 
     def test_wrapper_subclass_aliasing_fft_fft2(self, device):
-        args = (torch.randn(4, 4),)
+        args = (torch.randn(4, 4, device=device),)
         kwargs = {}
         # fft_fft2 has a default arg 'int[1] dim=[-2,-1]',
         # Make sure that _return_and_correct_aliasing can handle this case


### PR DESCRIPTION
Make 3 tests in TestWrapperSubclassAliasing properly use the device parameter from instantiate_device_type_tests, enabling them to run on all accelerators (CPU, CUDA, XPU, MPS).

  Modified tests:
  - test_wrapper_subclass_aliasing_conv2d
  - test_wrapper_subclass_aliasing_out_op
  - test_wrapper_subclass_aliasing_fft_fft2

Test plan:
TEST_CONFIG=cuda python test/test_python_dispatch.py TestWrapperSubclassAliasingCUDA -v
TEST_CONFIG=cpu python test/test_python_dispatch.py TestWrapperSubclassAliasingCPU -v

All 20 tests pass on both CPU and CUDA.

CC: @fffrog @albanD @jbschlosser 
