### PR TITLE
Fix aot_eager_decomp_partition layer norm numerics

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -66,6 +66,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_FP8,
     SM70OrLater,
+    tf32_enabled,
 )
 from torch.testing._internal.common_device_type import (
     E4M3_MAX_POS,
@@ -9192,6 +9193,41 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
 
 
 class CUDAReproTests(torch._dynamo.test_case.TestCase):
+    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    def test_aot_eager_decomp_partition_layer_norm_sequence_reduction_conv_tf32(
+        self,
+    ):
+        if not torch.cuda.is_tf32_supported():
+            raise unittest.SkipTest("requires TF32")
+
+        height = 64
+        width = 64
+        channels = 16
+
+        class LayerNormSequenceReduction(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.norm = torch.nn.LayerNorm(channels)
+                self.sr = torch.nn.Conv2d(channels, channels, kernel_size=8, stride=8)
+
+            def forward(self, x):
+                x = self.norm(x)
+                batch, _, num_channels = x.shape
+                x = x.permute(0, 2, 1).reshape(batch, num_channels, height, width)
+                return self.sr(x)
+
+        torch.manual_seed(0)
+        model = LayerNormSequenceReduction().eval().cuda()
+        x = torch.randn(2, height * width, channels, device="cuda")
+
+        with torch.no_grad(), tf32_enabled():
+            eager = model(x)
+
+            compiled = torch.compile(
+                model, backend="aot_eager_decomp_partition", fullgraph=True
+            )(x)
+            torch.testing.assert_close(eager, compiled)
+
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     def test_cuda_sync(self):
         def fn(x):

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -49,6 +49,21 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def _inductor_decomp_table_without_native_layer_norm() -> dict[Any, Callable[..., Any]]:
+    decomp_table = import_module("torch._inductor.compile_fx").select_decomp_table()
+    decomp_table = dict(decomp_table)
+    # aot_eager_decomp_partition executes Inductor's decomp table eagerly. CUDA
+    # native_layer_norm and the generic decomposition are close but not
+    # bit-equivalent, and a following TF32 op can amplify that delta. Real
+    # Inductor can handle this as a codegen numerics/perf tradeoff; this eager
+    # debug backend keeps layer norm native to preserve eager numerics while
+    # isolating AOT/partitioning behavior.
+    native_layer_norm = torch.ops.aten.native_layer_norm
+    decomp_table.pop(native_layer_norm.default, None)
+    decomp_table.pop(native_layer_norm.out, None)
+    return decomp_table
+
+
 @register_backend
 def eager(
     gm: torch.fx.GraphModule, fake_tensor_inputs: list[torch.Tensor], **kwargs: Any
@@ -460,10 +475,8 @@ def aot_eager_decomp_partition(
             # these are taken from memory_efficient_fusion()
             fw_compiler=get_nop_func(),
             bw_compiler=get_nop_func(),
-            # NB: lambda here is to delay import of inductor
-            decompositions=lambda: import_module(
-                "torch._inductor.compile_fx"
-            ).select_decomp_table(),
+            # NB: the helper delays import of inductor
+            decompositions=_inductor_decomp_table_without_native_layer_norm,
             partition_fn=functools.partial(
                 min_cut_rematerialization_partition, compiler="inductor"
             ),
@@ -487,10 +500,8 @@ def aot_eager_decomp_partition_with_mode(
         # these are taken from memory_efficient_fusion()
         fw_compiler=functools.partial(boxed_nop_with_mode, mode=mode),
         bw_compiler=functools.partial(boxed_nop_with_mode, mode=mode),
-        # NB: lambda here is to delay import of inductor
-        decompositions=lambda: import_module(
-            "torch._inductor.compile_fx"
-        ).select_decomp_table(),
+        # NB: the helper delays import of inductor
+        decompositions=_inductor_decomp_table_without_native_layer_norm,
         partition_fn=functools.partial(
             min_cut_rematerialization_partition, compiler="inductor"
         ),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185072

aot_eager_decomp_partition executes Inductor's decomposition table with eager/nop compilers. For CUDA layer norm, the Inductor native_layer_norm decomposition is very close to the native CUDA kernel but not bit-equivalent. In the SegFormer sequence-reduction pattern, a following TF32 Conv2d can amplify that small difference enough for default assert_close to fail, even though the backend is meant to help isolate AOT and partitioning behavior against eager execution.

Keep aten.native_layer_norm native for the aot_eager_decomp_partition debug backends by copying Inductor's decomposition table and removing native_layer_norm.default/out from that copy. This preserves eager numerics for this debug backend without changing real Inductor's layer norm decomposition, fusion, or performance policy. I avoided a global Inductor fallback because that would regress existing generated/fused LayerNorm codegen, and avoided shape-specific fallback predicates because they encode the repro rather than a stable compiler invariant.

Fixes #165929

Generated by my agent

Test Plan:
- python test/dynamo/test_repros.py CUDAReproTests.test_aot_eager_decomp_partition_layer_norm_sequence_reduction_conv_tf32
- python test/dynamo/test_backends.py TestOptimizationsCPU.test_aot_eager_decomp_partition_cpu
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98