### PR TITLE
Simplify ordered symbolic Min/Max terms

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7058,6 +7058,24 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
                 strict=False,
             ).graph
 
+    def test_sym_min_positive_affine_guard_nonstrict(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                s = x.shape[1]
+                torch._check(torch.sym_min(64 * s, 512 * s) == 64 * s)
+                return x + 1
+
+        seq_len = torch.export.Dim("seq_len", min=1, max=128)
+
+        ep = export(
+            M(),
+            (torch.randn(1, 12),),
+            dynamic_shapes=({1: seq_len},),
+            strict=False,
+        )
+        x = torch.randn(1, 16)
+        self.assertTrue(torch.allclose(ep.module()(x), x + 1))
+
     def test_math_pow(self):
         class M(torch.nn.Module):
             def forward(self, x, y):

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -23,6 +23,8 @@ from torch.testing._internal.common_utils import (
 from torch.utils._sympy.functions import (
     FloorDiv,
     Identity,
+    Max,
+    Min,
     OpaqueUnaryFn_cos,
     BitwiseFn_bitwise_and,
     simple_floordiv_gcd,
@@ -948,6 +950,14 @@ class TestSympySolve(TestCase):
 
 
 class TestSympyFunctions(TestCase):
+    def test_min_max_simplify_ordered_positive_terms(self):
+        s = sympy.Symbol("s", positive=True, integer=True)
+
+        self.assertEqual(Min(64 * s, 512 * s), 64 * s)
+        self.assertEqual(Max(64 * s, 512 * s), 512 * s)
+        self.assertEqual(Min(64 * s + 64, 512 * s + 512), 64 * s + 64)
+        self.assertEqual(Max(64 * s + 64, 512 * s + 512), 512 * s + 512)
+
     def test_pickle(self):
         x = OpaqueUnaryFn_cos(sympy.Symbol("a"))
         r = pickle.loads(pickle.dumps(x))

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -923,8 +923,9 @@ class MinMaxBase(Expr, LatticeOp):  # type: ignore[misc]
         replaces that member; if this is never true, then the value is simply
         appended to the localzeros.
 
-        Unlike the sympy implementation, we only look for zero and one, we don't
-        do generic is connected test pairwise which is slow
+        Unlike the sympy implementation, we mostly look for zero and one.  For
+        two symbolic arguments, we also use a small dominance check when the
+        difference is simple enough to avoid the slow generic pairwise search.
         """
 
         # First, collapse all numeric arguments
@@ -944,10 +945,21 @@ class MinMaxBase(Expr, LatticeOp):  # type: ignore[misc]
             else:
                 other_values.add(arg)
 
-        # Special cases when there is only one symbolic value
         if num_value is None:
+            if len(other_values) == 2:
+                a, b = other_values
+                diff = a - b
+                if not _is_wide_add(diff):
+                    try:
+                        if diff.is_nonnegative:
+                            return {a} if cls is Max else {b}
+                        if diff.is_nonpositive:
+                            return {b} if cls is Max else {a}
+                    except (TypeError, ValueError):
+                        pass
             return other_values
 
+        # Special cases when there is only one symbolic value
         if len(other_values) == 0:
             return {num_value}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185076

Export can generate symbolic guards such as min(64*s, 512*s) == 64*s after tracing view-related shape logic. The dynamic dimension is positive, but our custom SymPy Min/Max implementation skipped the simple two-term dominance case, leaving the Min expression unsimplified and causing a false constraint violation during non-strict export.

This change adds a narrow dominance check for two symbolic Min/Max arguments when their difference is simple enough to query cheaply. That fixes the root cause in symbolic simplification instead of special-casing export or decomposition, while preserving the existing avoidance of expensive generic pairwise Min/Max reasoning.

Fixes #165480

Generated by my agent

Test Plan:
- Minimized export repro from state/165480/notes now prints REPRO_FIXED
- python test/test_sympy_utils.py -k test_min_max_simplify_ordered_positive_terms
- python test/export/test_export.py -k test_sym_min_positive_affine_guard_nonstrict
- python test/test_sympy_utils.py
- python test/export/test_export.py -k test_export_max_nonstrict
- python test/test_dynamic_shapes.py -k test_sym_max_multi_max_simplify
- lintrunner -a

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01