### PR TITLE
Fix invalid Dynamo setattr exception timing

### DIFF
--- a/test/dynamo/test_exceptions.py
+++ b/test/dynamo/test_exceptions.py
@@ -1127,6 +1127,52 @@ class ExceptionTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(fn(torch.zeros(1)), 1)
 
+    @parametrize("use_builtin", [False, True])
+    def test_invalid_weakref_setattr_in_try_except(self, use_builtin):
+        class Custom:
+            pass
+
+        attr_name = "__weakref__"
+
+        def fn(x, obj):
+            try:
+                if use_builtin:
+                    setattr(obj, attr_name, None)
+                else:
+                    obj.__weakref__ = None
+            except AttributeError:
+                return x + 1
+            return x + 2
+
+        x = torch.ones(3)
+        ref = fn(x, Custom())
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        res = opt_fn(x, Custom())
+        self.assertEqual(ref, res)
+
+    @parametrize("use_builtin", [False, True])
+    def test_invalid_dunder_dict_setattr_in_try_except(self, use_builtin):
+        class Custom:
+            pass
+
+        attr_name = "__dict__"
+
+        def fn(x, obj):
+            try:
+                if use_builtin:
+                    setattr(obj, attr_name, [])
+                else:
+                    obj.__dict__ = []
+            except TypeError:
+                return x + 1
+            return x + 2
+
+        x = torch.ones(3)
+        ref = fn(x, Custom())
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        res = opt_fn(x, Custom())
+        self.assertEqual(ref, res)
+
     def test_exception_traceback_access(self):
         # Test that __traceback__ is accessible after raising/catching an exception
         def fn(x):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -166,6 +166,19 @@ def is_standard_delattr(val: object) -> bool:
     return val in (object.__delattr__, BaseException.__delattr__)
 
 
+_PY_TPFLAGS_HEAPTYPE = 1 << 9
+
+
+def _is_opaque_heap_type_getset_descriptor(descriptor: object) -> bool:
+    owner = getattr(descriptor, "__objclass__", None)
+    return (
+        isinstance(descriptor, types.GetSetDescriptorType)
+        and getattr(descriptor, "__name__", None) != "__dict__"
+        and isinstance(owner, type)
+        and bool(getattr(owner, "__flags__", 0) & _PY_TPFLAGS_HEAPTYPE)
+    )
+
+
 def is_forbidden_context_manager(ctx: object) -> bool:
     f_ctxs: list[Any] = []
 
@@ -2611,7 +2624,48 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
             if isinstance(descriptor, types.GetSetDescriptorType):
                 if name_str == "__dict__":
+                    if not isinstance(value, variables.DeletedVariable):
+                        try:
+                            is_dict = pydict_check(value)
+                        except NotImplementedError:
+                            unimplemented(
+                                gb_type="C-level descriptor setattr on user-defined object",
+                                context=f"object={self}, name={name_str}, descriptor={descriptor}",
+                                explanation=(
+                                    "Dynamo does not yet model this C-level descriptor setter "
+                                    "for user-defined objects."
+                                ),
+                                hints=[*graph_break_hints.SUPPORTABLE],
+                            )
+                        if not is_dict:
+                            raise_observed_exception(
+                                TypeError,
+                                tx,
+                                args=[
+                                    "__dict__ must be set to a dictionary, "
+                                    f"not a '{value.python_type_name()}'"
+                                ],
+                            )
                     self.dict_vt = None
+                elif name_str == "__weakref__":
+                    raise_observed_exception(
+                        AttributeError,
+                        tx,
+                        args=[
+                            f"attribute '__weakref__' of "
+                            f"'{type(self.value).__name__}' objects is not writable"
+                        ],
+                    )
+                elif _is_opaque_heap_type_getset_descriptor(descriptor):
+                    unimplemented(
+                        gb_type="C-level descriptor setattr on user-defined object",
+                        context=f"object={self}, name={name_str}, descriptor={descriptor}",
+                        explanation=(
+                            "Dynamo does not yet model this C-level descriptor setter "
+                            "for user-defined objects."
+                        ),
+                        hints=[*graph_break_hints.SUPPORTABLE],
+                    )
                 # C get/set descriptors are applied by STORE_ATTR itself, so
                 # replay must stay descriptor-aware rather than using the
                 # descriptor-bypassing instance-dict or slot paths.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185079

Dynamo records user object attribute mutations as side effects and replays them
later when reconstructing the frame. That is safe for ordinary instance dict and
slot writes, but it changes eager semantics for opaque C getset descriptors: a
write such as `obj.__weakref__ = None` raises immediately in eager mode and can
be caught by the surrounding `try/except`, while Dynamo previously replayed the
write after the compiled graph and raised outside that handler.

Validate the known heap getset descriptor cases before recording them. Keep
`__dict__` replayable after checking that the assigned value is a dict, surface
`__weakref__` as an observed `AttributeError`, and graph break for other opaque
heap getset setters whose behavior Dynamo does not model. This keeps the
existing Python property and slot descriptor paths intact. This follows the root
cause identified in the abandoned drafts for this issue while preserving the
current descriptor-aware replay infrastructure.

Fixes #165385
Generated by my agent

Test Plan:
- python -m pytest -q test/dynamo/test_exceptions.py -k 'invalid_weakref_setattr_in_try_except or invalid_dunder_dict_setattr_in_try_except or frozen_dataclass_setattr_raises'
- python -m pytest -q test/dynamo/test_user_defined_object.py -k 'slots_with_property_setter or readonly_property_assignment_raises or property_deleter or property_without_deleter_raises or slot_and_dict_mutation_same_object or dunder_dict_assignment_updates_attribute_lookup or custom_descriptor_shadows_base_slot or slots_special_weakref or slots_special_inherit_dict_weakref'
- python -m pytest -q test/dynamo/test_exceptions.py
- python -m pytest -q test/dynamo/test_user_defined_object.py
- python -m pytest -q test/dynamo/test_misc.py -k 'set_descriptor or dict_with_descriptor or dict_descriptor_interaction or property_setter or property_setter_in_init or user_defined_data_descriptor or setattr_mutation or object_setattr or nesteduserfunction_setattr'
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos