### PR TITLE
[inductor] Fix CPU tiling crash with relational expressions in index

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -57,6 +57,21 @@ class TestIndexingSimplification(InductorTestCase):
             ModularIndexing(i, 1, 10),
         )
 
+    def test_simplify_index_in_vec_range_with_relational(self):
+        """Regression test for https://github.com/pytorch/pytorch/issues/181115
+
+        sympy.simplify crashes with 'StrictLessThan has no attribute diff'
+        when index expressions contain relational sub-expressions. This happens
+        with dynamic=True + torch.func.grad producing Piecewise/Min/Max terms.
+        """
+        i = sympy.Symbol("i", integer=True, nonnegative=True)
+        s0 = sympy.Symbol("s0", positive=True, integer=True)
+        index = sympy.Piecewise((i, i < s0), (s0 - 1, True))
+        result = simplify_index_in_vec_range(index, i, 16)
+        self.assertIsNotNone(result)
+        result2 = stride_at_vec_range(index, i, 16)
+        self.assertIsNotNone(result2)
+
     def test_analyze_lane_contiguity(self):
         sizevars = SizeVarAllocator()
         i = sympy.Symbol("i", integer=True, nonnegative=True)

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -186,7 +186,8 @@ def simplify_index_in_vec_range(index: sympy.Expr, var: sympy.Expr, vec_length: 
     if index.has(ModularIndexing):
         index = index.replace(ModularIndexing(var, div, mod), visit_modular_indexing)
 
-    index = sympy.simplify(index)
+    if not index.has(sympy.Rel):
+        index = sympy.simplify(index)
     if index != original_index:
         return simplify_index_in_vec_range(index, var, vec_length)
 


### PR DESCRIPTION
Summary:
## Context

`torch.compile(dynamic=True)` with `torch.func.grad` crashes in TorchInductor's CPU
codegen during vectorization tiling selection. The crash occurs in
`simplify_index_in_vec_range` when calling `sympy.simplify(index)` on an index expression
that contains relational sub-expressions (e.g., `StrictLessThan` from `Piecewise` terms).
`sympy.simplify` internally attempts to differentiate the expression via `.diff()`, which
relational objects don't support.

Fixes https://github.com/pytorch/pytorch/issues/181115

## This diff

Skips `sympy.simplify()` when the index expression contains relational sub-expressions
(`sympy.Rel` — the base class for `StrictLessThan`, `LessThan`, `Eq`, etc.). The
simplification is purely an optimization for reducing `FloorDiv`/`ModularIndexing` terms
and is safe to skip when relationals are present, since those expressions won't benefit
from the algebraic simplification anyway.

Test Plan:
```
buck2 run fbcode//mode/dev-nosan fbcode//caffe2/test/inductor:indexing \
  -- -r 'test_simplify_index_in_vec_range'
```
Both existing and new tests pass:
- `test_simplify_index_in_vec_range` — ok (no regression)
- `test_simplify_index_in_vec_range_with_relational` — ok (was crashing before fix)

Authored with Claude Code.

Differential Revision: D106223155




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo