### PR TITLE
Avoid contiguity guards on maybe-singleton symbolic dims

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -364,6 +364,27 @@ class TestDynamismExpression(TestCase):
             dynamic_shapes=dynamic_shapes,
         )
 
+    def test_export_dynamic_dim_slice_with_step(self):
+        class SliceStep(torch.nn.Module):
+            def forward(self, input1):
+                return input1[::9, :]
+
+        model = SliceStep()
+        inp = (torch.randn(41, 6),)
+        ep = export(
+            model,
+            inp,
+            dynamic_shapes={"input1": {0: Dim("t1", min=1, max=1000)}},
+        )
+
+        for length in (1, 9, 10, 41):
+            test_inp = torch.randn(length, 6)
+            expected = model(test_inp)
+            actual = ep.module()(test_inp)
+            self.assertEqual(actual, expected)
+            self.assertEqual(actual.stride(), expected.stride())
+            self.assertEqual(actual.is_contiguous(), expected.is_contiguous())
+
     def test_no_grad_param_inplace(self):
         class Foo(torch.nn.Module):
             def __init__(self):

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1017,6 +1017,18 @@ def forward(self, x_1):
             )
         )
 
+    def test_contiguous_metadata_does_not_guard_on_symbolic_singleton_dim(self):
+        shape_env = ShapeEnv()
+        s0 = create_symint(shape_env, 41, duck=False)
+        a = torch.empty_strided(((s0 + 8) // 9, 6), (54, 1), device="meta")
+
+        self.assertFalse(
+            torch._prims_common.is_contiguous_for_memory_format_or_false(
+                a, memory_format=torch.contiguous_format
+            )
+        )
+        self.assertEqual(len(shape_env.guards), 0)
+
     def test_sympy_optimized_add_binary_search(self):
         import sympy
 

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -263,15 +263,15 @@ def check_contiguous_sizes_strides(sizes, strides, false_if_dde=False):
     """
 
     from torch.fx.experimental.symbolic_shapes import (
-        guard_or_false,
         guard_or_true,
         is_nested_int,
+        statically_known_true,
     )
 
     def eval_eager(x):
         return bool(x)
 
-    maybe_guard_or_false = guard_or_false if false_if_dde else eval_eager
+    maybe_length_one = statically_known_true if false_if_dde else eval_eager
     maybe_guard_or_true = guard_or_true if false_if_dde else eval_eager
 
     expected_stride = 1
@@ -280,7 +280,7 @@ def check_contiguous_sizes_strides(sizes, strides, false_if_dde=False):
     # pyrefly: ignore [bad-assignment]
     for x, y in reversed(tuple(zip(sizes, strides))):
         # Skips checking strides when a dimension has length 1.
-        if maybe_guard_or_false(x == 1):
+        if maybe_length_one(x == 1):
             continue
 
         if maybe_guard_or_true(y != expected_stride) and maybe_guard_or_true(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185084

`check_contiguous_sizes_strides(..., false_if_dde=True)` is used by metadata and fake-tensor paths that should return a conservative boolean instead of specializing input shapes. Its singleton-dimension skip used `guard_or_false(x == 1)`, which recorded a guard when the example output dimension was not 1.

For a dynamic slice like `input[::9, :]`, the output size is `(t + 8) // 9`. The metadata contiguity query therefore emitted `((t + 8) // 9) != 1`, excluding valid input sizes 1 through 9 and causing named `Dim("t", min=1, max=1000)` export to fail. `Dim.DYNAMIC` appeared to work only because it tolerates the extra inferred guard.

Use `statically_known_true` for the singleton skip on the `false_if_dde` path. This preserves eager boolean behavior for normal contiguity checks while keeping `or_false` metadata queries conservative when singleton-ness is symbolic.

Fixes #165032
Generated by my agent

Test Plan:
- python test/test_dynamic_shapes.py TestPySymInt.test_contiguous_metadata_does_not_guard_on_symbolic_singleton_dim
- python test/export/test_export.py TestDynamismExpression.test_export_dynamic_dim_slice_with_step
- python test/export/test_export_strict.py StrictExportTestDynamismExpression.test_export_dynamic_dim_slice_with_step_strict
- lintrunner -a
- git diff --check