### PR TITLE
Avoid graphsafe RNG inputs in descriptor compile

### DIFF
--- a/test/functorch/test_aot_joint_with_descriptors.py
+++ b/test/functorch/test_aot_joint_with_descriptors.py
@@ -12,6 +12,7 @@ import torch
 import torch.fx.traceback as fx_traceback
 import torch.nn as nn
 import torch.utils._pytree as pytree
+import torch.utils.checkpoint
 from torch._decomp import decomposition_table
 from torch._dynamo.functional_export import dynamo_graph_capture_for_export
 from torch._dynamo.testing import normalize_gm
@@ -35,6 +36,7 @@ from torch._functorch._aot_autograd.fx_utils import (
 from torch._functorch.aot_autograd import (
     aot_compile_joint_with_descriptors,
     aot_export_joint_with_descriptors,
+    boxed_nop_preserve_node_meta,
 )
 from torch._guards import tracing, TracingContext
 from torch.nn.attention.flex_attention import create_block_mask, flex_attention
@@ -795,6 +797,71 @@ class inner_f(torch.nn.Module):
         compiled_fn = torch.compile(fullgraph=True)(model_fn)
         compiled_fn(*dict(model.named_parameters()).values(), inputs).sum().backward()
         self.assertIsNotNone(model.linear.weight.grad)
+
+    @requires_cuda
+    @torch._dynamo.config.patch(inline_single_use_invoke_subgraph=False)
+    def test_export_compile_rng_hop_has_no_graphsafe_rng_inputs(self):
+        def inner(x):
+            return torch.nn.functional.dropout(torch.sin(x), p=0.5)
+
+        @torch.compiler.nested_compile_region
+        def region(x):
+            return torch.utils.checkpoint.checkpoint(inner, x, use_reentrant=False)
+
+        class CheckpointedDropout(nn.Module):
+            def forward(self, x):
+                return region(x)
+
+        model = CheckpointedDropout().cuda()
+        inputs = (torch.randn(8, device="cuda", requires_grad=True),)
+        fw_graphs = []
+        bw_graphs = []
+
+        def fw_compiler(gm, example_inputs):
+            fw_graphs.append(gm)
+            return boxed_nop_preserve_node_meta(gm, example_inputs)
+
+        def bw_compiler(gm, example_inputs):
+            bw_graphs.append(gm)
+            return boxed_nop_preserve_node_meta(gm, example_inputs)
+
+        gm = dynamo_graph_capture_for_export(model)(*inputs)
+        with tracing(gm.meta.get("tracing_context", None)):
+            with ExitStack() as stack:
+                joint_with_descriptors = aot_export_joint_with_descriptors(
+                    stack, gm, inputs
+                )
+                compiled_fn = aot_compile_joint_with_descriptors(
+                    joint_with_descriptors,
+                    fw_compiler=fw_compiler,
+                    bw_compiler=bw_compiler,
+                )
+
+        compiled_fn(*inputs).sum().backward()
+        self.assertEqual(len(fw_graphs), 1)
+        self.assertEqual(len(bw_graphs), 1)
+
+        fw_placeholder_names = [
+            node.name
+            for module in fw_graphs[0].modules()
+            if isinstance(module, torch.fx.GraphModule)
+            for node in module.graph.find_nodes(op="placeholder")
+        ]
+        self.assertFalse(
+            any("fwd_rng_state" in name for name in fw_placeholder_names),
+            fw_placeholder_names,
+        )
+
+        bw_placeholder_names = [
+            node.name
+            for module in bw_graphs[0].modules()
+            if isinstance(module, torch.fx.GraphModule)
+            for node in module.graph.find_nodes(op="placeholder")
+        ]
+        self.assertFalse(
+            any("bwd_rng_state" in name for name in bw_placeholder_names),
+            bw_placeholder_names,
+        )
 
     def test_preserve_annotate_simple(self):
         """Test basic linear module with aot_export_joint_with_descriptors"""

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1509,7 +1509,9 @@ def aot_compile_joint_with_descriptors(
     else:
         tracing_ctx = nullcontext()
 
-    with cache_ctx, tracing_ctx:
+    # The descriptor export path exposes partitioned graphs to user compilers,
+    # but graphsafe RNG adds internal Generator inputs without descriptors.
+    with cache_ctx, tracing_ctx, config.patch(graphsafe_rng_functionalization=False):
         compiled_fn, _ = aot_stage2_compile(
             jd._aot_state,
             jd._aot_graph_capture,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185088

`aot_compile_joint_with_descriptors` lets callers inspect and transform the
partitioned forward and backward graphs after `aot_export_joint_with_descriptors`.
The descriptor export has a public calling convention for params, buffers, user
inputs, tangents, tokens, and functionalized Philox RNG offsets, but it has no
descriptor for the graphsafe RNG Generator inputs that the partitioner appends
for recomputable CUDA RNG ops.

As a result, checkpointed CUDA RNG regions, including RNG inside invoke_subgraph
HOPs, could expose internal `fwd_rng_state_*` and `bwd_rng_state_*` placeholders
to user compilers in this API. Those placeholders are runtime plumbing for CUDA
graph-safe RNG, not user-visible inputs, and descriptor-based compilers cannot
map them back to the exported joint graph inputs.

Fix this by disabling graphsafe RNG functionalization while compiling a
`JointWithDescriptors`. This keeps descriptor compile on the existing
save/restore RNG-state functionalization path, which represents RNG state as
forward outputs and backward inputs rather than extra forward graph Generator
inputs. A broader alternative would be to add descriptors and a public calling
convention for graphsafe RNG states, but that would expose AOTDispatcher runtime
implementation details through an export-oriented API. For now, avoiding those
internal inputs at this API boundary is the smaller and clearer contract.

Add a CUDA regression test using Dynamo export, a nested compile region, and
non-reentrant activation checkpointing over dropout. The test verifies that both
the forward and backward compiler graphs no longer contain graphsafe RNG state
placeholders.

Fixes #164559
Generated by my agent

Test Plan:
- python test/functorch/test_aot_joint_with_descriptors.py -k test_export_compile_rng_hop_has_no_graphsafe_rng_inputs
- python test/functorch/test_aot_joint_with_descriptors.py
- lintrunner -a

cc @mlazos