### PR TITLE
Preserve constants added during export decompositions

### DIFF
--- a/test/onnx/ops/test_ops.py
+++ b/test/onnx/ops/test_ops.py
@@ -10,6 +10,7 @@ import torch
 from torch.onnx._internal.exporter import _testing as onnx_testing
 from torch.onnx.ops import _impl, _symbolic_impl
 from torch.testing._internal import common_utils
+from torch.utils._python_dispatch import TorchDispatchMode
 
 
 class SchemaTest(common_utils.TestCase):
@@ -190,6 +191,81 @@ class SymbolicOpsTest(common_utils.TestCase):
         outputs = node.outputs
         self.assertEqual(list(outputs[0].shape), [1, 2, 3])
         self.assertEqual(outputs[0].dtype, ir.DataType.INT64)
+
+    def test_symbolic_export_with_dispatch_mode_lifted_constants(self):
+        def qdq(x, scale, zero_point):
+            q = torch.onnx.ops.symbolic(
+                "QuantizeLinear",
+                (x, scale, zero_point),
+                attrs={},
+                dtype=zero_point.dtype,
+                shape=x.shape,
+            )
+            return torch.onnx.ops.symbolic(
+                "DequantizeLinear",
+                (q, scale, zero_point),
+                attrs={},
+                dtype=scale.dtype,
+                shape=x.shape,
+            )
+
+        class Quantizer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("scale", torch.tensor(0.1, dtype=torch.float32))
+                self.register_buffer("zero_point", torch.tensor(128, dtype=torch.uint8))
+
+            def forward(self, x):
+                return qdq(x, self.scale, self.zero_point)
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.quantizer = Quantizer()
+
+            def forward(self, x):
+                return torch.relu(x + x)
+
+        class QuantMode(TorchDispatchMode):
+            def __init__(self, model):
+                super().__init__()
+                self.model = model
+
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                args = [
+                    self.model.quantizer(arg)
+                    if isinstance(arg, torch.Tensor) and arg.dtype == torch.float32
+                    else arg
+                    for arg in args
+                ]
+                kwargs = {
+                    key: self.model.quantizer(value)
+                    if isinstance(value, torch.Tensor) and value.dtype == torch.float32
+                    else value
+                    for key, value in (kwargs or {}).items()
+                }
+                return func(*args, **kwargs)
+
+        model = Model().eval()
+        with QuantMode(model), torch.no_grad():
+            onnx_program = torch.onnx.export(
+                model, (torch.randn(2, 3),), dynamo=True, verbose=False
+            )
+
+        if onnx_program is None:
+            raise AssertionError("onnx_program is None")
+        lifted_constants = set(
+            onnx_program.exported_program.graph_signature.lifted_tensor_constants
+        )
+        self.assertGreaterEqual(len(lifted_constants), 2)
+        self.assertLessEqual(
+            lifted_constants,
+            set(onnx_program.exported_program.constants),
+        )
+        self.assertLessEqual(
+            lifted_constants,
+            set(onnx_program.model.graph.initializers.keys()),
+        )
 
     def test_symbolic_preserves_dynamic_shapes(self):
         class Model(torch.nn.Module):

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -521,8 +521,14 @@ def _decompose_and_get_gm_with_new_signature_constants(
                     ep.graph_signature, new_graph_signature
                 )
 
-                constants = _materialize_and_lift_constants(
-                    gm, new_graph_signature, new_fake_constant_attrs
+                constants = {
+                    **ep.constants,
+                    **aten_export_artifact.constants,
+                }
+                constants.update(
+                    _materialize_and_lift_constants(
+                        gm, new_graph_signature, new_fake_constant_attrs
+                    )
                 )
 
                 placeholder_naming_pass(
@@ -571,7 +577,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
                 if name not in unwrapped_params_buffers:
                     new_state_dict.pop(name)
 
-        return gm, new_graph_signature, new_state_dict
+        return gm, new_graph_signature, new_state_dict, constants
 
     old_placeholders = [
         node for node in ep.graph_module.graph.nodes if node.op == "placeholder"
@@ -810,7 +816,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
         ):
             for k, v in old_node.meta.items():
                 new_node.meta[k] = v
-    return gm, new_graph_signature, ep.state_dict
+    return gm, new_graph_signature, ep.state_dict, ep.constants
 
 
 def _remove_unnecessary_copy_op_pass(
@@ -1012,6 +1018,7 @@ def _decompose_exported_program(
         gm,
         new_graph_signature,
         state_dict,
+        constants,
     ) = _decompose_and_get_gm_with_new_signature_constants(
         ep,
         cia_to_decomp=cia_to_decomp,
@@ -1050,7 +1057,7 @@ def _decompose_exported_program(
         range_constraints=new_range_constraints,
         module_call_graph=new_module_call_graph,
         example_inputs=ep.example_inputs,
-        constants=ep.constants,
+        constants=constants,
     )
     return exported_program
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185090

ExportedProgram.run_decompositions retraces the exported module to produce the decomposed graph. When a TorchDispatchMode is active during that retrace, it can insert ONNX symbolic ops that cause AOT export and the constant lifting pass to discover new lifted tensor constants. The new graph signature kept those CONSTANT_TENSOR inputs, but the rebuilt ExportedProgram reused only the original constants dict, so verifier rejected the program with "Constant tensor lifted_tensor_0 is not in the constants dictionary".

Preserve the constants produced by the retraced AOT artifact, merge them with the original ExportedProgram constants and any constants materialized by the later lifting pass, and pass the merged table into the decomposed ExportedProgram. This keeps the graph signature and constants dictionary in sync while preserving existing parameter and buffer handling.

I considered handling this in the ONNX exporter after decomposition, but the invariant belongs to ExportedProgram construction: every lifted constant target in the signature must be present in ExportedProgram.constants regardless of which downstream caller triggered run_decompositions.

Fixes #164461
Generated by my agent

Test Plan:
- python test/onnx/ops/test_ops.py -k test_symbolic_export_with_dispatch_mode_lifted_constants
- python test/export/test_export.py -k test_lifted_constants
- python test/export/test_export.py -k test_nested_module_with_constant_buffer
- lintrunner -a
- git diff --check --cached