### PR TITLE
Prefer .view() and drop redundant .contiguous() in tensor-creator chains

### DIFF
--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1489,7 +1489,7 @@ def concat_linear_woq_int4(gm: torch.fx.GraphModule):
         repack_w = torch.ops.aten._convert_weight_to_int4pack_for_cpu(
             concat_unpacked_wgt, 1
         )
-        concat_scale_zp = torch.cat(scale_zps, dim=1).contiguous()
+        concat_scale_zp = torch.cat(scale_zps, dim=1)
         return repack_w, concat_scale_zp
 
     graph = gm.graph

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -226,7 +226,7 @@ def _convert_to_0d_constant(
     const_value = get_constant_value(data)
     if const_value is not None:
         return V.graph.add_tensor_constant(
-            torch.tensor(const_value.value, dtype=dtype).reshape([])
+            torch.tensor(const_value.value, dtype=dtype).view([])
         )
 
     tensor_box.realize()

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -758,9 +758,7 @@ def indices(dimensions, dtype: DTypeLike | None = int, sparse=False):
     else:
         res = torch.empty((N,) + dimensions, dtype=dtype)
     for i, dim in enumerate(dimensions):
-        idx = torch.arange(dim, dtype=dtype).reshape(
-            shape[:i] + (dim,) + shape[i + 1 :]
-        )
+        idx = torch.arange(dim, dtype=dtype).view(shape[:i] + (dim,) + shape[i + 1 :])
         if sparse:
             res = res + (idx,)
         else:
@@ -1995,7 +1993,7 @@ def histogramdd(
     if weights is not None:
         # range=... is required : interleave min and max values per dimension
         mm = sample.aminmax(dim=0)
-        range = torch.cat(mm).reshape(2, -1).T.flatten()
+        range = torch.cat(mm).view(2, -1).T.flatten()
         range = tuple(range.tolist())
         weights = _util.cast_if_needed(weights, sample.dtype)
         w_kwd = {"weight": weights}

--- a/torch/_numpy/random.py
+++ b/torch/_numpy/random.py
@@ -184,7 +184,7 @@ def choice(a: ArrayLike, size=None, replace=True, p: ArrayLike | None = None):
     indices = torch.multinomial(p, num_el, replacement=replace)
 
     if _util.is_sequence(size):
-        indices = indices.reshape(size)
+        indices = indices.view(size)
 
     samples = a[indices]
 

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -206,7 +206,7 @@ def _iter_tensor(x_tensor):
                     x_tensor.crow_indices(), x_tensor.col_indices()
                 )
                 .repeat_interleave(x_blocksize[0] * x_blocksize[1], 1)
-                .mul_(torch.tensor(x_blocksize, device=x_tensor.device).reshape(2, 1))
+                .mul_(torch.tensor(x_blocksize, device=x_tensor.device).view(2, 1))
                 .add_(
                     torch.stack(
                         torch.where(torch.ones(x_blocksize, device=x_tensor.device))
@@ -224,7 +224,7 @@ def _iter_tensor(x_tensor):
                     x_tensor.ccol_indices(), x_tensor.row_indices(), transpose=True
                 )
                 .repeat_interleave(x_blocksize[0] * x_blocksize[1], 1)
-                .mul_(torch.tensor(x_blocksize, device=x_tensor.device).reshape(2, 1))
+                .mul_(torch.tensor(x_blocksize, device=x_tensor.device).view(2, 1))
                 .add_(
                     torch.stack(
                         torch.where(torch.ones(x_blocksize, device=x_tensor.device))

--- a/torch/quantization/_quantized_conversions.py
+++ b/torch/quantization/_quantized_conversions.py
@@ -69,7 +69,7 @@ def quantized_weight_reorder_for_mixed_dtypes_linear_cutlass(
                 [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15],
                 device=device,
             )
-            + (torch.arange(0, nrows // 16, device=device).reshape(-1, 1) * 16).expand(
+            + (torch.arange(0, nrows // 16, device=device).view(-1, 1) * 16).expand(
                 nrows // 16, 16
             )
         ).view(-1)
@@ -79,7 +79,7 @@ def quantized_weight_reorder_for_mixed_dtypes_linear_cutlass(
                 [0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15],
                 device=device,
             )
-            + (torch.arange(0, nrows // 16, device=device).reshape(-1, 1) * 16).expand(
+            + (torch.arange(0, nrows // 16, device=device).view(-1, 1) * 16).expand(
                 nrows // 16, 16
             )
         ).view(-1)

--- a/torch/quasirandom.py
+++ b/torch/quasirandom.py
@@ -71,7 +71,7 @@ class SobolEngine:
             self._scramble()
 
         self.quasi = self.shift.clone(memory_format=torch.contiguous_format)
-        self._first_point = (self.quasi / 2**self.MAXBIT).reshape(1, -1)
+        self._first_point = (self.quasi / 2**self.MAXBIT).view(1, -1)
         self.num_generated = 0
 
     def draw(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2874,7 +2874,7 @@ def error_inputs_embedding(op_info, device, **kwargs):
     indices = torch.rand(2, 2, device=device).long()
     weights = [
         torch.tensor(1.0, device=device),
-        torch.tensor(1.0, device=device).reshape(1, 1, 1),
+        torch.tensor(1.0, device=device).view(1, 1, 1),
     ]
 
     for weight in weights:

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3802,7 +3802,7 @@ def module_error_inputs_torch_nn_NLLLoss(module_info, device, dtype, requires_gr
     Error inputs for NLLLoss that test weight dtype must match input dtype.
     Regression test for device parity between CPU and CUDA with empty tensors.
     """
-    input_t = torch.tensor([], device=device, dtype=dtype).reshape((0, 0))
+    input_t = torch.tensor([], device=device, dtype=dtype).view((0, 0))
     weight_dtype = torch.float32 if dtype == torch.float16 else torch.float16
     weight_t = torch.tensor([], device=device, dtype=weight_dtype)
     target_t = torch.tensor([], device=device, dtype=torch.long)


### PR DESCRIPTION
  Replace .reshape() with .view() on 11 expression chains where the receiver is contiguous by construction, and drop one redundant .contiguous() on a torch.cat(...) result.

  The receivers in each case are produced by ops that always return contiguous tensors:
  - torch.tensor(...) / torch.arange(...) / torch.cat(...) / torch.multinomial(...)
  - .clone(memory_format=torch.contiguous_format) followed by a pointwise op

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo