### PR TITLE
Preserve requires_grad for custom op fake lowering

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2997,6 +2997,77 @@ def forward(self, add, tangents_1):
             torch.autograd.grad(loss, inp_x, create_graph=True)
         # Not checking equality of ref and x as Exception is expected
 
+    def test_custom_op_backward_compiler_preserves_requires_grad(self):
+        op_namespace = f"_test_163716_{type(self).__name__}"
+
+        @torch.library.custom_op(f"{op_namespace}::mm_fwd", mutates_args=())
+        def mm_fwd(input: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+            return input @ weight
+
+        @mm_fwd.register_fake
+        def mm_fwd_fake(input, weight):
+            return input @ weight
+
+        @torch.library.custom_op(
+            f"{op_namespace}::mm_bwd",
+            mutates_args=(),
+            schema="(Tensor grad_output, Tensor input, Tensor weight) -> (Tensor, Tensor?)",
+        )
+        def mm_bwd(
+            grad_output: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor | None]:
+            grad_input = grad_output @ weight.mT
+            grad_weight = input.mT @ grad_output if weight.requires_grad else None
+            return grad_input, grad_weight
+
+        @mm_bwd.register_fake
+        def mm_bwd_fake(grad_output, input, weight):
+            grad_input = grad_output @ weight.mT
+            grad_weight = input.mT @ grad_output if weight.requires_grad else None
+            return grad_input, grad_weight
+
+        def backward(ctx, grad_output):
+            input, weight = ctx.saved_tensors
+            return mm_bwd(grad_output, input, weight)
+
+        def setup_context(ctx, inputs, output):
+            ctx.save_for_backward(*inputs)
+
+        mm_fwd.register_autograd(backward, setup_context=setup_context)
+
+        seen_bw_requires_grad = None
+        saw_none_grad_weight = None
+
+        def bw_compiler(gm, example_inputs):
+            nonlocal seen_bw_requires_grad, saw_none_grad_weight
+            (saved_weight,) = [
+                example_input
+                for example_input in example_inputs
+                if isinstance(example_input, torch.Tensor)
+                and tuple(example_input.shape) == (3, 5)
+            ]
+            seen_bw_requires_grad = saved_weight.requires_grad
+            saw_none_grad_weight = gm(*example_inputs)[1] is None
+            return make_boxed_func(gm.forward)
+
+        def fn(input, weight):
+            return mm_fwd(input, weight)
+
+        compiled_fn = aot_function(fn, nop, bw_compiler=bw_compiler)
+
+        input = torch.randn(2, 3)
+        weight = torch.randn(3, 5, requires_grad=True)
+        ref_weight = weight.detach().clone().requires_grad_(True)
+
+        compiled_fn(input, weight).sum().backward()
+        fn(input, ref_weight).sum().backward()
+
+        self.assertIs(seen_bw_requires_grad, True)
+        self.assertIs(saw_none_grad_weight, False)
+        self.assertEqual(weight.grad, ref_weight.grad)
+
     # Partially addresses https://github.com/pytorch/pytorch/issues/106457
     def test_input_mutation_false_aliasing(self):
         def f(a, b):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -14337,6 +14337,69 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             check_lowp=False,
         )
 
+    @config.patch(implicit_fallbacks=True)
+    def test_custom_op_backward_fake_preserves_requires_grad(self):
+        op_namespace = f"_test_163716_inductor_{type(self).__name__}"
+        seen_fake_requires_grad = []
+
+        @torch.library.custom_op(f"{op_namespace}::mm_fwd", mutates_args=())
+        def mm_fwd(input: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+            return input @ weight
+
+        @mm_fwd.register_fake
+        def mm_fwd_fake(input, weight):
+            return input @ weight
+
+        @torch.library.custom_op(
+            f"{op_namespace}::mm_bwd",
+            mutates_args=(),
+            schema="(Tensor grad_output, Tensor input, Tensor weight) -> (Tensor, Tensor?)",
+        )
+        def mm_bwd(
+            grad_output: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor | None]:
+            grad_input = grad_output @ weight.mT
+            grad_weight = input.mT @ grad_output if weight.requires_grad else None
+            return grad_input, grad_weight
+
+        @mm_bwd.register_fake
+        def mm_bwd_fake(grad_output, input, weight):
+            seen_fake_requires_grad.append(weight.requires_grad)
+            grad_input = grad_output @ weight.mT
+            grad_weight = input.mT @ grad_output if weight.requires_grad else None
+            return grad_input, grad_weight
+
+        def backward(ctx, grad_output):
+            input, weight = ctx.saved_tensors
+            return mm_bwd(grad_output, input, weight)
+
+        def setup_context(ctx, inputs, output):
+            ctx.save_for_backward(*inputs)
+
+        mm_fwd.register_autograd(backward, setup_context=setup_context)
+
+        device = self.device
+
+        class MLP(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(4, 3, device=device))
+
+            def forward(self, input):
+                return mm_fwd(input, self.weight)
+
+        torch._dynamo.reset()
+        input = torch.randn(5, 4, device=device)
+        mlp = MLP()
+        out = torch.compile(mlp, backend="inductor")(input)
+        out.backward(torch.ones_like(out))
+
+        self.assertTrue(seen_fake_requires_grad)
+        self.assertTrue(all(seen_fake_requires_grad))
+        self.assertEqual(mlp.weight.grad, input.mT @ torch.ones_like(out))
+
     @requires_gpu()
     @skip_if_not_triton
     @config.patch(implicit_fallbacks=True)

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -136,6 +136,7 @@ def _create_graph(
         )(*args)
 
         if args_descs is not None:
+            flat_args, _ = pytree.tree_flatten(args)
             flat_args_descs, _ = pytree.tree_flatten(args_descs)
             flat_out_descs, _ = pytree.tree_flatten(out_descs)
 
@@ -175,6 +176,7 @@ def _create_graph(
                                 f"placeholders={[n for n in fx_g.graph.nodes if n.op == 'placeholder']}"
                             )
                         n.meta["desc"] = flat_args_descs[i]
+                        _copy_requires_grad_to_placeholder_meta(n, flat_args[i])
                         i += 1
                 elif n.op == "output":
                     n.meta["desc"] = flat_out_descs
@@ -208,6 +210,14 @@ def _detach_traced_inputs(flat_args: Any) -> Any:
             return t.detach()
 
     return pytree.tree_map_only(torch.Tensor, detach_tensor, flat_args)
+
+
+def _copy_requires_grad_to_placeholder_meta(node: torch.fx.Node, arg: Any) -> None:
+    if not isinstance(arg, torch.Tensor):
+        return
+    val = node.meta.get("val")
+    if isinstance(val, torch.Tensor):
+        val.requires_grad_(arg.requires_grad)
 
 
 def _prepare_graph_capture_tracing(

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -420,6 +420,7 @@ class GraphLowering(torch.fx.Interpreter):
 
         self.sizevars = SizeVarAllocator(shape_env)
         self.graph_input_names: list[str] = []
+        self.graph_input_requires_grad: dict[str, bool] = {}
         self.graph_inputs: dict[str, TensorBox | TorchBindObject | sympy.Expr] = {}
         self.graph_inputs_original: dict[str, InputBuffer] = {}
         self.partition_maps: list[GraphPartitionMap] | None = None
@@ -1290,6 +1291,7 @@ class GraphLowering(torch.fx.Interpreter):
             return opaque_obj
 
         assert isinstance(example, torch.Tensor), example
+        self.graph_input_requires_grad[target] = example.requires_grad
         # todo(chilli): We can remove the last check once we turn buffers into
         # static shape tensors. That's a hack to workaround Inductor believing
         # the buffer should be static but us passing in a fake tensor with

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -391,6 +391,9 @@ def ir_node_to_tensor(
         t = torch.empty_strided(
             size=size, stride=stride, dtype=dtype, device=device
         ).zero_()
+    name = x.maybe_get_name()
+    if name is not None and V.graph.graph_input_requires_grad.get(name, False):
+        t.requires_grad_(True)
     return t
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185096

AOTAutograd traces the joint/backward graph with fake tensor placeholder
metadata. The placeholder meta lost the original input requires_grad bit, so
lazy backward compilation later built example inputs where a saved parameter
looked like requires_grad=False. Inductor then reconstructed fake tensors from
its graph-input IR without carrying requires_grad either. Custom op backward
fake implementations that branch on weight.requires_grad could therefore take
the wrong branch and return None for the weight gradient, which crashed Inductor
lowering.

Fix this at both metadata handoffs. During AOTAutograd graph capture, copy the
requires_grad bit from the traced placeholder argument into the placeholder
meta tensor. During Inductor lowering, record requires_grad for graph inputs
and reapply it when ir_node_to_tensor rebuilds fake tensors from input IR
nodes. This keeps the fake/meta execution view consistent with the original
example inputs instead of special-casing custom ops or the failing None output.

An alternative was to patch only custom-op lowering or tolerate None inside
Inductor, but that would work around the symptom after metadata had already
been corrupted. Preserving the metadata at the handoffs keeps downstream
compiler behavior consistent for all fake/meta users that inspect
requires_grad.

Fixes #163716
Generated by my agent

Test Plan:
- Reproduced the original custom-op torch.compile repro before the fix; it failed with `AttributeError: 'NoneType' object has no attribute 'get_size'`.
- Ran the same repro after the fix; it passed and printed `OK True`.
- `python test/functorch/test_aotdispatch.py -k test_custom_op_backward_compiler_preserves_requires_grad` fails locally before running tests because the installed torchvision is incompatible with this checkout (`operator torchvision::nms does not exist`).
- `python - <<'PY' ... block torchvision import and run test/functorch/test_aotdispatch.py -k test_custom_op_backward_compiler_preserves_requires_grad ... PY` passed, 3 tests.
- `python test/inductor/test_torchinductor.py -k test_custom_op_backward_fake_preserves_requires_grad` fails locally before running tests because the installed torchvision is incompatible with this checkout (`operator torchvision::nms does not exist`).
- `python - <<'PY' ... block torchvision import and run test/inductor/test_torchinductor.py -k test_custom_op_backward_fake_preserves_requires_grad ... PY` passed, 2 tests.
- `lintrunner -a` passed.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo