### PR TITLE
Migrate deprecated torch.norm calls to torch.linalg.*

### DIFF
--- a/torch/_lobpcg.py
+++ b/torch/_lobpcg.py
@@ -756,10 +756,14 @@ class LOBPCG:
     def update(self):
         """Set and update iteration variables."""
         if self.ivars["istep"] == 0:
-            X_norm = float(torch.norm(self.X))
+            X_norm = float(torch.linalg.vector_norm(self.X))
             iX_norm = X_norm**-1
-            A_norm = float(torch.norm(_utils.matmul(self.A, self.X))) * iX_norm
-            B_norm = float(torch.norm(_utils.matmul(self.B, self.X))) * iX_norm
+            A_norm = (
+                float(torch.linalg.vector_norm(_utils.matmul(self.A, self.X))) * iX_norm
+            )
+            B_norm = (
+                float(torch.linalg.vector_norm(_utils.matmul(self.B, self.X))) * iX_norm
+            )
             self.fvars["X_norm"] = X_norm
             self.fvars["A_norm"] = A_norm
             self.fvars["B_norm"] = B_norm
@@ -792,8 +796,9 @@ class LOBPCG:
         A_norm = self.fvars["A_norm"]
         B_norm = self.fvars["B_norm"]
         E, X, R = self.E, self.X, self.R
-        rerr = torch.norm(R, 2, (0,)) / (
-            torch.norm(X, 2, (0,)) * (A_norm + torch.abs(E[: X.shape[-1]]) * B_norm)
+        rerr = torch.linalg.vector_norm(R, ord=2, dim=(0,)) / (
+            torch.linalg.vector_norm(X, ord=2, dim=(0,))
+            * (A_norm + torch.abs(E[: X.shape[-1]]) * B_norm)
         )
         converged = rerr < tol
         count = 0
@@ -1109,7 +1114,7 @@ class LOBPCG:
         self.ivars.pop("ortho_i", 0)
         self.ivars.pop("ortho_j", 0)
 
-        BV_norm = torch.norm(mm_B(self.B, V))
+        BV_norm = torch.linalg.vector_norm(mm_B(self.B, V))
         BU = mm_B(self.B, U)
         VBU = mm(V.mT, BU)
         i = j = 0
@@ -1131,10 +1136,10 @@ class LOBPCG:
                     return U
                 BU = mm_B(self.B, U)
                 UBU = mm(U.mT, BU)
-                U_norm = torch.norm(U)
-                BU_norm = torch.norm(BU)
+                U_norm = torch.linalg.vector_norm(U)
+                BU_norm = torch.linalg.vector_norm(BU)
                 R = UBU - torch.eye(UBU.shape[-1], device=UBU.device, dtype=UBU.dtype)
-                R_norm = torch.norm(R)
+                R_norm = torch.linalg.vector_norm(R)
                 # https://github.com/pytorch/pytorch/issues/33810 workaround:
                 rerr = float(R_norm) * float(BU_norm * U_norm) ** -1
                 vkey = f"ortho_UBUmI_rerr[{i}, {j}]"
@@ -1142,8 +1147,8 @@ class LOBPCG:
                 if rerr < tau_ortho:
                     break
             VBU = mm(V.mT, BU)
-            VBU_norm = torch.norm(VBU)
-            U_norm = torch.norm(U)
+            VBU_norm = torch.linalg.vector_norm(VBU)
+            U_norm = torch.linalg.vector_norm(U)
             rerr = float(VBU_norm) * float(BV_norm * U_norm) ** -1
             vkey = f"ortho_VBU_rerr[{i}]"
             self.fvars[vkey] = rerr

--- a/torch/ao/ns/fx/utils.py
+++ b/torch/ao/ns/fx/utils.py
@@ -478,8 +478,8 @@ def compute_sqnr(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     Return:
         float or tuple of floats
     """
-    Ps = torch.norm(x)
-    Pn = torch.norm(x - y)
+    Ps = torch.linalg.vector_norm(x)
+    Pn = torch.linalg.vector_norm(x - y)
     return 20 * torch.log10(Ps / Pn)
 
 

--- a/torch/ao/quantization/_equalize.py
+++ b/torch/ao/quantization/_equalize.py
@@ -275,5 +275,5 @@ def converged(curr_modules, prev_modules, threshold=1e-4):
         prev_weight = get_module_weight(prev_modules[name])
 
         difference = curr_weight.sub(prev_weight)
-        summed_norms += torch.norm(difference)
+        summed_norms += torch.linalg.vector_norm(difference)
     return bool(summed_norms < threshold)

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -59,7 +59,7 @@ def _orthogonalize_gram_schmidt(matrices, epsilon=0):
             # Note that col ** 2 can underflow/overflow if we use FP16.
             # May need to consider multiplying a scaling factor and dividing it later, or using bfloat16 instead.
             try:
-                col /= torch.norm(col, dim=1, keepdim=True)
+                col /= torch.linalg.vector_norm(col, dim=1, keepdim=True)
             except ZeroDivisionError:
                 logger.error(
                     "The matrices to be orthogonalized has at least a column of all 0s. Please set a small value such as 1e-8 "
@@ -68,7 +68,7 @@ def _orthogonalize_gram_schmidt(matrices, epsilon=0):
                 # Recover the values from NaNs to 0s.
                 col.fill_(0.0)
         else:
-            col /= torch.norm(col, dim=1, keepdim=True) + epsilon
+            col /= torch.linalg.vector_norm(col, dim=1, keepdim=True) + epsilon
         # Project it on the rest and remove it.
         if i + 1 < num_cols:
             rest = matrices[:, :, i + 1 :]

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -1391,5 +1391,11 @@ def _compute_norm(t, n, dim):
         dim = dims[dim]
     dims.remove(dim)
 
-    norm = torch.norm(t, p=n, dim=dims)
-    return norm
+    # torch.norm: 'nuc' and 'fro' over a matrix dim are matrix norms;
+    # everything else (numeric n, 'fro' elsewhere) is the flat p-norm.
+    is_matrix_dim = len(dims) == 2
+    if n == "nuc" or (n == "fro" and is_matrix_dim):
+        return torch.linalg.matrix_norm(
+            t, ord=n, dim=dims if is_matrix_dim else (-2, -1)
+        )
+    return torch.linalg.vector_norm(t, ord=2 if n == "fro" else n, dim=dims)

--- a/torch/optim/_adafactor.py
+++ b/torch/optim/_adafactor.py
@@ -391,12 +391,16 @@ def _single_tensor_adafactor(
                 )
             # same as (g * g).mean(dim=-1) w/o materializing an intermediate size g
             row_mean = (
-                torch.norm(grad, dim=-1, keepdim=True).square_().div_(grad.size(-1))
+                torch.linalg.vector_norm(grad, dim=-1, keepdim=True)
+                .square_()
+                .div_(grad.size(-1))
             )
             row_var.lerp_(row_mean, one_minus_beta2_t)
             # same as (g * g).mean(dim=-2) w/o materializing an intermediate size g
             col_mean = (
-                torch.norm(grad, dim=-2, keepdim=True).square_().div_(grad.size(-2))
+                torch.linalg.vector_norm(grad, dim=-2, keepdim=True)
+                .square_()
+                .div_(grad.size(-2))
             )
             col_var.lerp_(col_mean, one_minus_beta2_t)
             var_estimate = row_var @ col_var
@@ -542,7 +546,8 @@ def _multi_tensor_adafactor(
                 )
             # same as (g * g).mean(dim=-1) w/o materializing an intermediate size g
             row_means = [
-                torch.norm(grad, dim=-1, keepdim=True) for grad in device_grads
+                torch.linalg.vector_norm(grad, dim=-1, keepdim=True)
+                for grad in device_grads
             ]
             torch._foreach_mul_(row_means, row_means)
             torch._foreach_div_(row_means, [grad.size(-1) for grad in device_grads])
@@ -551,7 +556,8 @@ def _multi_tensor_adafactor(
 
             # same as (g * g).mean(dim=-2) w/o materializing an intermediate size g
             col_means = [
-                torch.norm(grad, dim=-2, keepdim=True) for grad in device_grads
+                torch.linalg.vector_norm(grad, dim=-2, keepdim=True)
+                for grad in device_grads
             ]
             torch._foreach_mul_(col_means, col_means)
             torch._foreach_div_(col_means, [grad.size(-2) for grad in device_grads])


### PR DESCRIPTION
torch.norm is deprecated. Replace 22 call sites with the new torch.linalg.vector_norm API.


Authored by Claude.