### PR TITLE
Use AVX2 masked load/store for vec256 partial loadu/store

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -96,27 +96,22 @@ class Vectorized<c10::complex<double>> {
   static Vectorized<c10::complex<double>> loadu(
       const void* ptr,
       int64_t count = size()) {
-    if (count == size())
+    if (count >= size())
       return _mm256_loadu_pd(reinterpret_cast<const double*>(ptr));
-
-    // Zero tail past `count`.
-    __at_align__ double tmp_values[2 * size()] = {};
-    std::memcpy(
-        tmp_values,
-        reinterpret_cast<const double*>(ptr),
-        std::min<int64_t>(count, size()) * sizeof(c10::complex<double>));
-    return _mm256_load_pd(tmp_values);
+    // Masked load: each complex element occupies two double lanes; mask the
+    // first 2*count double lanes in, zero the rest.
+    const __m256i mask = _mm256_cmpgt_epi64(
+        _mm256_set1_epi64x(2 * count), _mm256_setr_epi64x(0, 1, 2, 3));
+    return _mm256_maskload_pd(reinterpret_cast<const double*>(ptr), mask);
   }
   void store(void* ptr, int count = size()) const {
-    if (count == size()) {
+    if (count >= size()) {
       _mm256_storeu_pd(reinterpret_cast<double*>(ptr), values);
     } else if (count > 0) {
-      double tmp_values[2 * size()];
-      _mm256_storeu_pd(reinterpret_cast<double*>(tmp_values), values);
-      std::memcpy(
-          ptr,
-          tmp_values,
-          std::min<int64_t>(count, size()) * sizeof(c10::complex<double>));
+      // Masked store: each complex element occupies two double lanes.
+      const __m256i mask = _mm256_cmpgt_epi64(
+          _mm256_set1_epi64x(2 * count), _mm256_setr_epi64x(0, 1, 2, 3));
+      _mm256_maskstore_pd(reinterpret_cast<double*>(ptr), mask, values);
     }
   }
   const c10::complex<double>& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -161,27 +161,24 @@ class Vectorized<c10::complex<float>> {
   static Vectorized<c10::complex<float>> loadu(
       const void* ptr,
       int64_t count = size()) {
-    if (count == size())
+    if (count >= size())
       return _mm256_loadu_ps(reinterpret_cast<const float*>(ptr));
-
-    // Zero tail past `count`.
-    __at_align__ float tmp_values[2 * size()] = {};
-    std::memcpy(
-        tmp_values,
-        reinterpret_cast<const float*>(ptr),
-        std::min<int64_t>(count, size()) * sizeof(c10::complex<float>));
-    return _mm256_load_ps(tmp_values);
+    // Masked load: each complex element occupies two float lanes; mask the
+    // first 2*count float lanes in, zero the rest.
+    const __m256i mask = _mm256_cmpgt_epi32(
+        _mm256_set1_epi32(static_cast<int32_t>(2 * count)),
+        _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7));
+    return _mm256_maskload_ps(reinterpret_cast<const float*>(ptr), mask);
   }
   void store(void* ptr, int count = size()) const {
-    if (count == size()) {
+    if (count >= size()) {
       _mm256_storeu_ps(reinterpret_cast<float*>(ptr), values);
     } else if (count > 0) {
-      float tmp_values[2 * size()];
-      _mm256_storeu_ps(reinterpret_cast<float*>(tmp_values), values);
-      std::memcpy(
-          ptr,
-          tmp_values,
-          std::min<int64_t>(count, size()) * sizeof(c10::complex<float>));
+      // Masked store: each complex element occupies two float lanes.
+      const __m256i mask = _mm256_cmpgt_epi32(
+          _mm256_set1_epi32(static_cast<int32_t>(2 * count)),
+          _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7));
+      _mm256_maskstore_ps(reinterpret_cast<float*>(ptr), mask, values);
     }
   }
   const c10::complex<float>& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_double.h
@@ -80,25 +80,21 @@ class Vectorized<double> {
     return b;
   }
   static Vectorized<double> loadu(const void* ptr, int64_t count = size()) {
-    if (count == size())
+    if (count >= size())
       return _mm256_loadu_pd(reinterpret_cast<const double*>(ptr));
-
-    // Zero tail past `count`.
-    __at_align__ double tmp_values[size()] = {};
-    std::memcpy(
-        tmp_values,
-        reinterpret_cast<const double*>(ptr),
-        std::min<int64_t>(count, size()) * sizeof(double));
-    return _mm256_load_pd(tmp_values);
+    // Masked load: lanes [0, count) are read, the rest are zero.
+    const __m256i mask = _mm256_cmpgt_epi64(
+        _mm256_set1_epi64x(count), _mm256_setr_epi64x(0, 1, 2, 3));
+    return _mm256_maskload_pd(reinterpret_cast<const double*>(ptr), mask);
   }
   void store(void* ptr, int count = size()) const {
-    if (count == size()) {
+    if (count >= size()) {
       _mm256_storeu_pd(reinterpret_cast<double*>(ptr), values);
     } else if (count > 0) {
-      double tmp_values[size()];
-      _mm256_storeu_pd(reinterpret_cast<double*>(tmp_values), values);
-      std::memcpy(
-          ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(double));
+      // Masked store: only lanes [0, count) are written.
+      const __m256i mask = _mm256_cmpgt_epi64(
+          _mm256_set1_epi64x(count), _mm256_setr_epi64x(0, 1, 2, 3));
+      _mm256_maskstore_pd(reinterpret_cast<double*>(ptr), mask, values);
     }
   }
   const double& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -112,24 +112,23 @@ class Vectorized<float> {
     return b;
   }
   static Vectorized<float> loadu(const void* ptr, int64_t count = size()) {
-    if (count == size())
+    if (count >= size())
       return _mm256_loadu_ps(reinterpret_cast<const float*>(ptr));
-    // Zero tail past `count`.
-    __at_align__ float tmp_values[size()] = {};
-    std::memcpy(
-        tmp_values,
-        reinterpret_cast<const float*>(ptr),
-        std::min<int64_t>(count, size()) * sizeof(float));
-    return _mm256_loadu_ps(tmp_values);
+    // Masked load: lanes [0, count) are read, the rest are zero.
+    const __m256i mask = _mm256_cmpgt_epi32(
+        _mm256_set1_epi32(static_cast<int32_t>(count)),
+        _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7));
+    return _mm256_maskload_ps(reinterpret_cast<const float*>(ptr), mask);
   }
   void store(void* ptr, int64_t count = size()) const {
-    if (count == size()) {
+    if (count >= size()) {
       _mm256_storeu_ps(reinterpret_cast<float*>(ptr), values);
     } else if (count > 0) {
-      float tmp_values[size()];
-      _mm256_storeu_ps(reinterpret_cast<float*>(tmp_values), values);
-      std::memcpy(
-          ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(float));
+      // Masked store: only lanes [0, count) are written.
+      const __m256i mask = _mm256_cmpgt_epi32(
+          _mm256_set1_epi32(static_cast<int32_t>(count)),
+          _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7));
+      _mm256_maskstore_ps(reinterpret_cast<float*>(ptr), mask, values);
     }
   }
   const float& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -372,10 +372,14 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
   }
 
   void store(void* ptr, int count = size()) const {
-    if (count != size()) {
-      memcpy(ptr, &vals, std::min<int64_t>(count, size()) * sizeof(value_type));
-    } else {
-      _mm256_storeu_si256((__m256i*)ptr, vals);
+    if (count >= size()) {
+      _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), vals);
+    } else if (count > 0) {
+      // Masked store: only lanes [0, count) are written.
+      const __m256i mask = _mm256_cmpgt_epi32(
+          _mm256_set1_epi32(static_cast<int32_t>(count)),
+          _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7));
+      _mm256_maskstore_epi32(reinterpret_cast<int*>(ptr), mask, vals);
     }
   }
 
@@ -384,13 +388,13 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
   }
 
   static Vectorized<c10::qint32> loadu(const void* ptr, int64_t count) {
-    // Zero tail past `count`.
-    __at_align__ value_type tmp_values[size()] = {};
-    std::memcpy(
-        tmp_values,
-        reinterpret_cast<const value_type*>(ptr),
-        std::min<int64_t>(count, size()) * sizeof(value_type));
-    return _mm256_loadu_si256((const __m256i*)tmp_values);
+    if (count >= size())
+      return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
+    // Masked load: lanes [0, count) are read, the rest are zero.
+    const __m256i mask = _mm256_cmpgt_epi32(
+        _mm256_set1_epi32(static_cast<int32_t>(count)),
+        _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7));
+    return _mm256_maskload_epi32(reinterpret_cast<const int*>(ptr), mask);
   }
 
   float_vec_return_type dequantize(


### PR DESCRIPTION
Replace the stack-buffer + memcpy pattern with a single masked load (`_mm256_maskload_*`) or store (`_mm256_maskstore_*`) where AVX2 supports it: float, double, complex<float>, complex<double>, and qint32. Same result, fewer instructions, page-fault-safe on masked-out lanes.

Skipped: int8/16/32/64 (loadu fills tail with 1, not 0); 8/16-bit qint and BFloat16/Half (no AVX2 mask op at that width); vec128/, vec512/, sve/ (out of scope).

Also fixes a latent UB on negative `count` (old code passed a huge size_t to memcpy); new path is a no-op for loadu (returns zeros) and store (writes nothing).


Authored by Claude.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01