### PR TITLE
Drop redundant tuple/list/int wrappers around tensor shape and numel

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -3388,12 +3388,10 @@ from torch.utils._mode_utils import no_dispatch
 
 # replace symbols in size and strides with their hints without guarding.
 def _remove_symbols_without_guarding(x: torch.Tensor, fallback: int) -> torch.Tensor:
-    shape = list(x.shape)
-
     def realize_symbol(d: torch.SymInt | int) -> int:
         return optimization_hint(d, fallback=fallback)
 
-    shape = [realize_symbol(s) for s in shape]
+    shape = [realize_symbol(s) for s in x.shape]
     stride = [realize_symbol(s) for s in x.stride()]
     return x.new_empty_strided(shape, stride=stride)
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4673,7 +4673,7 @@ def meta_repeat(self, repeats):
     # number of target dimensions is larger than the
     # number of source dimensions.
     num_new_dimensions = len(repeats) - self.dim()
-    padded_size = (1,) * num_new_dimensions + tuple(self.shape)
+    padded_size = (1,) * num_new_dimensions + self.shape
     target_size = [padded_size[i] * repeats[i] for i in range(len(repeats))]
     return self.new_empty(target_size)
 
@@ -6359,7 +6359,7 @@ def alloc_with_matching_layout(
     query: Tensor,
     res_shape: tuple[int, ...],
 ):
-    if tuple(query.shape) == res_shape:
+    if query.shape == res_shape:
         res = torch.empty_like(query)
     else:
         dim_order = sorted(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6359,7 +6359,7 @@ def alloc_with_matching_layout(
     query: Tensor,
     res_shape: tuple[int, ...],
 ):
-    if tuple(query.shape) == res_shape:
+    if query.shape == res_shape:
         res = torch.empty_like(query)
     else:
         dim_order = sorted(

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -250,7 +250,7 @@ def TensorMeta(
             raise AssertionError(
                 f"tensorlike must be torch.Tensor, got {type(tensorlike)}"
             )  # mypy
-        inferred_shape = tuple(tensorlike.shape)
+        inferred_shape = tensorlike.shape
         inferred_strides = tuple(tensorlike.stride())
         inferred_dtype = tensorlike.dtype
         inferred_device = tensorlike.device

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -250,8 +250,8 @@ def TensorMeta(
             raise AssertionError(
                 f"tensorlike must be torch.Tensor, got {type(tensorlike)}"
             )  # mypy
-        inferred_shape = tuple(tensorlike.shape)
-        inferred_strides = tuple(tensorlike.stride())
+        inferred_shape = tensorlike.shape
+        inferred_strides = tensorlike.stride()
         inferred_dtype = tensorlike.dtype
         inferred_device = tensorlike.device
     else:

--- a/torch/backends/_nnapi/serializer.py
+++ b/torch/backends/_nnapi/serializer.py
@@ -422,7 +422,7 @@ class _NnapiSerializer:
                 f"Can't handle input with dtype '{tensor.dtype}'"
             )
         return Operand(
-            shape=tuple(tensor.shape),
+            shape=tensor.shape,
             # pyrefly: ignore [bad-argument-type]
             op_type=op_type,
             dim_order=dim_order,

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -215,7 +215,7 @@ def all_gather_single(
         # If not, it will use torch.cat which needs the data anyway, so
         # wait early to avoid AsyncCollectiveTensor dispatch overhead.
         if isinstance(res, AsyncCollectiveTensor):
-            shape = list(res.shape)
+            shape = res.shape
             numel_between = math.prod(shape[1:gather_dim]) if gather_dim > 1 else 1
             can_use_view = shape[0] == group_size and numel_between == 1
             if not can_use_view:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -7467,7 +7467,7 @@ def _prepare_shrink_target_group(
     target_pg = group if group is not None else _get_default_group()
 
     # Cache frequently accessed properties to avoid repeated calls
-    group_size = int(target_pg.size())
+    group_size = target_pg.size()
     group_info: _ShrinkGroupInfo = {
         "process_group": target_pg,
         "is_default_group": (target_pg == _get_default_group()),

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -7479,7 +7479,7 @@ def _prepare_shrink_target_group(
     target_pg = group if group is not None else _get_default_group()
 
     # Cache frequently accessed properties to avoid repeated calls
-    group_size = int(target_pg.size())
+    group_size = target_pg.size()
     group_info: _ShrinkGroupInfo = {
         "process_group": target_pg,
         "is_default_group": (target_pg == _get_default_group()),

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -264,7 +264,7 @@ def common_reduction_strategy(
         is_reduction_linear = reduction_linear
         if reduction_op == "avg":
             output_spec = op_spec.output_spec
-            local_shape = list(output_spec.tensor_meta.shape)  # type:ignore[union-attr]
+            local_shape = output_spec.tensor_meta.shape  # type:ignore[union-attr]
             for dim in reduce_dims:
                 if not is_tensor_evenly_shardable_on_dim(local_shape, output_spec, dim):
                     is_reduction_linear = False

--- a/torch/distributed/tensor/_ops/strategy_validation.py
+++ b/torch/distributed/tensor/_ops/strategy_validation.py
@@ -1671,7 +1671,7 @@ def _validate_aten_op_for_sample(
 
     input_shapes = tuple(t.shape for _, t in tensors)
     gt_list = ground_truth if isinstance(ground_truth, list) else [ground_truth]
-    output_shapes = tuple(tuple(gt.shape) for gt in gt_list)
+    output_shapes = tuple(gt.shape for gt in gt_list)
     n_outputs = len(gt_list)
     first_gt = gt_list[0]
 

--- a/torch/fx/experimental/_dynamism.py
+++ b/torch/fx/experimental/_dynamism.py
@@ -80,7 +80,7 @@ def track_dynamism_across_examples(
             if not isinstance(value, (int, float, torch.Tensor)):
                 continue
             if isinstance(value, torch.Tensor):
-                shape: tuple[int | float, ...] = tuple(value.shape)
+                shape: tuple[int | float, ...] = value.shape
                 is_tensor = True
             else:
                 shape = (value,)

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -1803,8 +1803,7 @@ class ConstraintGenerator:
 
             if isinstance(t, torch.Tensor):
                 if len(t.shape) > 0:
-                    res = list(t.shape)
-                    attr_type = TensorType(res)
+                    attr_type = TensorType(t.shape)
                     output, counter = gen_tvar(counter)
                     self.symbol_dict[n] = output
                     return [BinConstraintT(output, attr_type, op_eq)], counter

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -168,7 +168,7 @@ class Embedding(Module):
             )
             self.reset_parameters()
         else:
-            if list(_weight.shape) != [num_embeddings, embedding_dim]:
+            if _weight.shape != (num_embeddings, embedding_dim):
                 raise AssertionError(
                     "Shape of weight does not match num_embeddings and embedding_dim"
                 )
@@ -404,7 +404,7 @@ class EmbeddingBag(Module):
             )
             self.reset_parameters()
         else:
-            if list(_weight.shape) != [num_embeddings, embedding_dim]:
+            if _weight.shape != (num_embeddings, embedding_dim):
                 raise AssertionError(
                     "Shape of weight does not match num_embeddings and embedding_dim"
                 )

--- a/torch/utils/_content_store.py
+++ b/torch/utils/_content_store.py
@@ -173,7 +173,7 @@ class ContentStoreWriter:
             t.dtype,
             h,
             t.storage_offset(),
-            tuple(t.shape),
+            t.shape,
             t.stride(),
             torch._utils.get_tensor_metadata(t),
         )

--- a/torch/utils/benchmark/examples/compare.py
+++ b/torch/utils/benchmark/examples/compare.py
@@ -27,7 +27,7 @@ class FauxTorch:
     def extra_overhead(self, result):
         # time.sleep has a ~65 us overhead, so only fake a
         # per-element overhead if numel is large enough.
-        numel = int(result.numel())
+        numel = result.numel()
         if numel > 5000:
             time.sleep(numel * self._extra_ns_per_element * 1e-9)
         return result

--- a/torch/utils/benchmark/utils/fuzzer.py
+++ b/torch/utils/benchmark/utils/fuzzer.py
@@ -299,7 +299,7 @@ class FuzzedTensor:
         tensor = raw_tensor[tuple(slices)]
 
         properties = {
-            "numel": int(tensor.numel()),
+            "numel": tensor.numel(),
             "order": order,
             "steps": steps,
             "is_contiguous": tensor.is_contiguous(),

--- a/torch/utils/benchmark/utils/sparse_fuzzer.py
+++ b/torch/utils/benchmark/utils/sparse_fuzzer.py
@@ -109,7 +109,7 @@ class FuzzedSparseTensor(FuzzedTensor):
         is_hybrid = len(size[sparse_dim:]) > 0
 
         properties = {
-            "numel": int(tensor.numel()),
+            "numel": tensor.numel(),
             "shape": tensor.size(),
             "is_coalesced": tensor.is_coalesced(),
             "density": density,


### PR DESCRIPTION
Drop redundant `tuple(t.shape)` / `list(t.shape)` wrappers and `int(t.numel())` casts across `torch/`, on paths where the value is a concrete tensor:
  - `torch.Size` is already an immutable tuple subclass that compares equal to plain tuples and is SymInt-aware. Wrapping it in `tuple()` / `list()` discards that machinery.
  - `.numel()` returns `int` on a concrete tensor, so the cast does nothing there.

Two spots that are not plain wrapper removals:
  - `torch/distributed/distributed_c10d.py` drops `int(target_pg.size())`. That is a `ProcessGroup`, not a tensor — it returns a plain `int`, so the cast is merely redundant.
  - `torch/nn/modules/sparse.py` now compares `_weight.shape != (num_embeddings, embedding_dim)` against a tuple instead of a list. `torch.Size` compares equal to a tuple, so this is equivalent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98
