### PR TITLE
Enable symm ops (async TP) for XPU

### DIFF
--- a/torch/_inductor/fx_passes/micro_pipeline_tp.py
+++ b/torch/_inductor/fx_passes/micro_pipeline_tp.py
@@ -629,9 +629,12 @@ def fuse_all_gather_matmul(all_gather: _AllGatherMatch) -> None:
             A_shard, [B_0, B_1, B_2, ...], gather_dim, group_name,
         )
     """
-    if (
-        not torch.distributed.is_available()
-        or not torch.distributed.is_nccl_available()
+    if not (
+        torch.distributed.is_available()
+        and (
+            torch.distributed.is_nccl_available()
+            or torch.distributed.is_xccl_available()
+        )
     ):
         return
 
@@ -875,9 +878,12 @@ def fuse_matmul_reduce_scatter(reduce_scatter: _ReduceScatterMatch) -> None:
 
     Returns boolean indicating if fusion was successful or not.
     """
-    if (
-        not torch.distributed.is_available()
-        or not torch.distributed.is_nccl_available()
+    if not (
+        torch.distributed.is_available()
+        and (
+            torch.distributed.is_nccl_available()
+            or torch.distributed.is_xccl_available()
+        )
     ):
         return
 

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -112,7 +112,7 @@ def get_symm_mem_workspace(
     tensor = _group_name_to_workspace_tensor.get(group_name)
     size = tensor.numel() * tensor.element_size() if tensor is not None else 0
     if tensor is None or size < min_size:
-        if torch.cuda.is_current_stream_capturing():
+        if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
             curr_size = 0 if tensor is None else tensor.numel() * tensor.element_size()
             raise RuntimeError(
                 f"get_symm_mem_workspace(): the requested size ({min_size} bytes) "
@@ -127,19 +127,19 @@ def get_symm_mem_workspace(
             (max(size, min_size),),
             [1],
             torch.uint8,
-            torch.device(f"cuda:{torch.cuda.current_device()}"),
+            torch.device(torch.accelerator.current_device_index()),
             group_name,
         )
         _group_name_to_workspace_tensor[group_name] = tensor
     return _SymmetricMemory.rendezvous(tensor)
 
 
-_backend_streams: dict[int, torch.cuda.Stream] = {}
+_backend_streams: dict[int, torch.Stream] = {}
 
 
-def _get_backend_stream(priority: int = 0) -> torch.cuda.Stream:
+def _get_backend_stream(priority: int = 0) -> torch.Stream:
     if priority not in _backend_streams:
-        _backend_streams[priority] = torch.cuda.Stream(priority=priority)
+        _backend_streams[priority] = torch.Stream(priority=priority)
     return _backend_streams[priority]
 
 
@@ -176,7 +176,7 @@ def _pipelined_multi_all_gather_and_consume(
 
     symm_mem.barrier(channel=0)
     backend_stream = _get_backend_stream()
-    backend_stream.wait_stream(torch.cuda.current_stream())
+    backend_stream.wait_stream(torch.accelerator.current_stream())
 
     for x, y in zip(shard, ag_out):
         if not x.is_contiguous():
@@ -261,7 +261,7 @@ def _pipelined_multi_all_gather_and_consume(
     # and "b" with the first shard_consumer for now.
     copy_shard(dst=local_p2p_bufs, src=shard)
     symm_mem.barrier(channel=1)
-    backend_stream.wait_stream(torch.cuda.current_stream())
+    backend_stream.wait_stream(torch.accelerator.current_stream())
 
     # At this point, all ranks have copied their local shard to
     # their local p2p buffer. Each rank can now copy and consume
@@ -270,7 +270,7 @@ def _pipelined_multi_all_gather_and_consume(
 
     for step in range(1, group_size):
         if step % 2 == 0:
-            stream = torch.cuda.current_stream()
+            stream = torch.accelerator.current_stream()
         else:
             stream = backend_stream
         remote_rank = (step + rank) % group_size
@@ -283,13 +283,13 @@ def _pipelined_multi_all_gather_and_consume(
         # Copy from input to the all-gather output. Opportunistically overlap
         # it with the last shard_consumer.
         if group_size % 2 == 0:
-            stream = torch.cuda.current_stream()
+            stream = torch.accelerator.current_stream()
         else:
             stream = backend_stream
         with stream:
             copy_shard(dst=shards[rank], src=shard)
 
-    torch.cuda.current_stream().wait_stream(backend_stream)
+    torch.accelerator.current_stream().wait_stream(backend_stream)
     symm_mem.barrier(channel=0)
 
 
@@ -348,7 +348,7 @@ def _pipelined_produce_and_all2all(
 
     symm_mem.barrier(channel=0)
     backend_stream = _get_backend_stream()
-    backend_stream.wait_stream(torch.cuda.current_stream())
+    backend_stream.wait_stream(torch.accelerator.current_stream())
 
     def get_p2p_buf(rank: int, idx: int) -> torch.Tensor:
         if idx not in (0, 1):
@@ -367,7 +367,7 @@ def _pipelined_produce_and_all2all(
     for step in range(1, group_size):
         remote_rank = (rank - step) % group_size
         if step % 2 == 0:
-            stream = torch.cuda.current_stream()
+            stream = torch.accelerator.current_stream()
             p2p_buf = local_p2p_buf_1
             remote_p2p_buf = get_p2p_buf(remote_rank, 1)
         else:
@@ -423,7 +423,7 @@ def _pipelined_produce_and_all2all(
             # the correct order, there's very little room for the scheduling
             # order of subsequent kernels to be inconsistent across ranks.
             if step == 2:
-                torch.cuda._sleep(100)
+                torch.accelerator._sleep(100)
             chunk_producer((rank + step) % group_size, p2p_buf)
             symm_mem.barrier(channel=step % 2)
             out_chunks[remote_rank].copy_(remote_p2p_buf)
@@ -433,10 +433,10 @@ def _pipelined_produce_and_all2all(
 
     # If the sleep wasn't issued in the above loop, do it now.
     if group_size == 2:
-        torch.cuda._sleep(100)
+        torch.accelerator._sleep(100)
 
     chunk_producer(rank, out_chunks[rank])
-    torch.cuda.current_stream().wait_stream(backend_stream)
+    torch.accelerator.current_stream().wait_stream(backend_stream)
     symm_mem.barrier(channel=0)
 
 
@@ -488,6 +488,7 @@ network interfaces.
 
 
 @torch.library.impl(lib, "get_remote_tensors", "CUDA")
+@torch.library.impl(lib, "get_remote_tensors", "XPU")
 def _get_remote_tensors_default(
     local: torch.Tensor, group_name: c10d.GroupName
 ) -> tuple[torch.Tensor, ...]:
@@ -699,7 +700,7 @@ def _pipelined_all_gather_and_consume_last_dim(
 
     symm_mem.barrier(channel=0)
     backend_stream = _get_backend_stream()
-    backend_stream.wait_stream(torch.cuda.current_stream())
+    backend_stream.wait_stream(torch.accelerator.current_stream())
 
     def copy_shard(dst: torch.Tensor, src: torch.Tensor) -> None:
         dst.copy_(src)
@@ -718,7 +719,7 @@ def _pipelined_all_gather_and_consume_last_dim(
 
     copy_shard(dst=local_p2p_buf, src=shard)
     symm_mem.barrier(channel=1)
-    backend_stream.wait_stream(torch.cuda.current_stream())
+    backend_stream.wait_stream(torch.accelerator.current_stream())
 
     # At this point, all ranks have copied their local shard to
     # their local p2p buffer. Each rank can now copy and consume
@@ -727,7 +728,7 @@ def _pipelined_all_gather_and_consume_last_dim(
 
     for step in range(1, group_size):
         if step % 2 == 0:
-            stream = torch.cuda.current_stream()
+            stream = torch.accelerator.current_stream()
         else:
             stream = backend_stream
         remote_rank = (step + rank) % group_size
@@ -740,13 +741,13 @@ def _pipelined_all_gather_and_consume_last_dim(
         # Copy from input to the all-gather output. Opportunistically overlap
         # it with the last shard_consumer.
         if group_size % 2 == 0:
-            stream = torch.cuda.current_stream()
+            stream = torch.accelerator.current_stream()
         else:
             stream = backend_stream
         with stream:
             copy_shard(dst=shards[rank], src=shard)
 
-    torch.cuda.current_stream().wait_stream(backend_stream)
+    torch.accelerator.current_stream().wait_stream(backend_stream)
     symm_mem.barrier(channel=0)
 
 
@@ -787,7 +788,7 @@ def _fused_all_gather_matmul_last_gather_dim_impl(
     ]
 
     first = True
-    events = [torch.cuda.Event() for _ in outputs]
+    events = [torch.Event() for _ in outputs]
 
     def default_consumer(shard: torch.Tensor, rank: int) -> None:
         nonlocal first
@@ -850,6 +851,7 @@ def _fused_all_gather_matmul_fallback(
 
 
 @torch.library.impl(lib, "fused_all_gather_matmul", "CUDA")
+@torch.library.impl(lib, "fused_all_gather_matmul", "XPU")
 def _fused_all_gather_matmul(
     A_shard: torch.Tensor,
     Bs: list[torch.Tensor],
@@ -912,6 +914,7 @@ def _should_use_fused_all_gather_matmul_native(
 
     return (
         "TORCH_SYMM_MEM_ENABLE_NATIVE_ASYNC_TP" in os.environ
+        and torch.cuda.is_available()
         and A_shard.is_contiguous()
         and gather_dim == 0
         # _async_input_mm requires local_M to be divisible by world_size.
@@ -1095,6 +1098,7 @@ def _fused_all_gather_scaled_matmul_fallback(
 
 
 @torch.library.impl(lib, "fused_all_gather_scaled_matmul", "CUDA")
+@torch.library.impl(lib, "fused_all_gather_scaled_matmul", "XPU")
 def _fused_all_gather_scaled_matmul(
     A_shard: torch.Tensor,
     Bs: list[torch.Tensor],
@@ -1203,6 +1207,7 @@ def restride_A_shard_for_fused_all_gather_matmul(
 
 
 @torch.library.impl(lib, "fused_matmul_reduce_scatter", "CUDA")
+@torch.library.impl(lib, "fused_matmul_reduce_scatter", "XPU")
 def _fused_matmul_reduce_scatter(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -1337,6 +1342,7 @@ def _fused_matmul_reduce_scatter_impl(
 
 
 @torch.library.impl(lib, "fused_scaled_matmul_reduce_scatter", "CUDA")
+@torch.library.impl(lib, "fused_scaled_matmul_reduce_scatter", "XPU")
 def _fused_scaled_matmul_reduce_scatter(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -1635,7 +1641,7 @@ def _maybe_convert_scalar_types_to_dtypes(
 class Work(_Work):
     def __init__(self) -> None:
         super().__init__()
-        self.event = torch.cuda.Event()
+        self.event = torch.Event()
         self.event.record()
 
     def wait(self, timeout: timedelta = timedelta(seconds=0)) -> bool:
@@ -1713,7 +1719,7 @@ def _low_contention_all_gather(
     output = tensor.new_empty(tensor.shape[0] * world_size, *tensor.shape[1:])
     chunks = output.chunk(world_size)
 
-    _get_backend_stream().wait_stream(torch.cuda.current_stream())
+    _get_backend_stream().wait_stream(torch.accelerator.current_stream())
     with _get_backend_stream():
         if not input_is_symm_mem:
             local_buf = symm_mem.get_buffer(rank, tensor.shape, tensor.dtype)
@@ -1752,7 +1758,7 @@ def _low_contention_reduce_scatter_with_symm_mem_input(
     a2a_res = torch.empty_like(tensor)
     chunks = a2a_res.chunk(world_size)
 
-    _get_backend_stream().wait_stream(torch.cuda.current_stream())
+    _get_backend_stream().wait_stream(torch.accelerator.current_stream())
     with _get_backend_stream():
         # pull + offline reduction
         symm_mem.barrier()
@@ -1790,7 +1796,7 @@ def _low_contention_reduce_scatter_with_workspace(
         raise AssertionError
     chunks = tensor.chunk(world_size)
 
-    _get_backend_stream().wait_stream(torch.cuda.current_stream())
+    _get_backend_stream().wait_stream(torch.accelerator.current_stream())
     with _get_backend_stream():
         # push + offline reduction
         workspace.barrier()

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -112,7 +112,10 @@ def get_symm_mem_workspace(
     tensor = _group_name_to_workspace_tensor.get(group_name)
     size = tensor.numel() * tensor.element_size() if tensor is not None else 0
     if tensor is None or size < min_size:
-        if torch.accelerator.is_available() and torch.accelerator.current_stream().is_capturing():
+        if (
+            torch.accelerator.is_available()
+            and torch.accelerator.current_stream().is_capturing()
+        ):
             curr_size = 0 if tensor is None else tensor.numel() * tensor.element_size()
             raise RuntimeError(
                 f"get_symm_mem_workspace(): the requested size ({min_size} bytes) "

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -112,7 +112,7 @@ def get_symm_mem_workspace(
     tensor = _group_name_to_workspace_tensor.get(group_name)
     size = tensor.numel() * tensor.element_size() if tensor is not None else 0
     if tensor is None or size < min_size:
-        if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+        if torch.accelerator.is_available() and torch.accelerator.current_stream().is_capturing():
             curr_size = 0 if tensor is None else tensor.numel() * tensor.element_size()
             raise RuntimeError(
                 f"get_symm_mem_workspace(): the requested size ({min_size} bytes) "
@@ -422,8 +422,8 @@ def _pipelined_produce_and_all2all(
             # scheduled first. Once the first chunk_producer is scheduled in
             # the correct order, there's very little room for the scheduling
             # order of subsequent kernels to be inconsistent across ranks.
-            if step == 2:
-                torch.accelerator._sleep(100)
+            if step == 2 and torch.cuda.is_available():
+                torch.cuda._sleep(100)
             chunk_producer((rank + step) % group_size, p2p_buf)
             symm_mem.barrier(channel=step % 2)
             out_chunks[remote_rank].copy_(remote_p2p_buf)
@@ -432,8 +432,8 @@ def _pipelined_produce_and_all2all(
             symm_mem.barrier(channel=step % 2)
 
     # If the sleep wasn't issued in the above loop, do it now.
-    if group_size == 2:
-        torch.accelerator._sleep(100)
+    if group_size == 2 and torch.cuda.is_available():
+        torch.cuda._sleep(100)
 
     chunk_producer(rank, out_chunks[rank])
     torch.accelerator.current_stream().wait_stream(backend_stream)
@@ -915,6 +915,7 @@ def _should_use_fused_all_gather_matmul_native(
     return (
         "TORCH_SYMM_MEM_ENABLE_NATIVE_ASYNC_TP" in os.environ
         and torch.cuda.is_available()
+        and A_shard.device.type == "cuda"
         and A_shard.is_contiguous()
         and gather_dim == 0
         # _async_input_mm requires local_M to be divisible by world_size.


### PR DESCRIPTION
### Summary

We are working on add XPU symmetric backend and also want to enable symm ops (async TP) for XPU.

### Motivation

We are working on add XPU symmetric backend and also want to enable symm ops (async TP) for XPU.  With those symm ops, communication and computation could be overlapped to reduce communication overhead on Intel client GPUs.

### Changes

- Backend enabling in https://github.com/intel/torch-xpu-ops/pull/2041
- Python ops enabling in this PR

### Test Plan

Ops test is verified via https://github.com/intel/torch-xpu-ops/pull/3747

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo