### PR TITLE
Fix non-strict export state aliases

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -17435,6 +17435,70 @@ def forward(self, x):
                 # Verify no tensor constants in graph signature
                 self.assertEqual(len(ep.graph_signature.lifted_tensor_constants), 0)
 
+    def test_export_parameter_alias_in_container(self):
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.p1 = torch.nn.Parameter(torch.ones(2, 2))
+                self._flat_weights = [self.p1]
+
+            def forward(self, x):
+                return x + self._flat_weights[0]
+
+        m = Module()
+        sample_inputs = (torch.ones(2, 2),)
+
+        ep = torch.export.export(m, sample_inputs, strict=False)
+
+        self.assertEqual(len(ep.graph_signature.lifted_tensor_constants), 0)
+        param_inputs = ep.graph_signature.inputs_to_parameters
+        self.assertEqual(list(param_inputs.values()), ["p1"])
+        param_input_name = next(
+            name for name, target in param_inputs.items() if target == "p1"
+        )
+
+        add_nodes = [
+            node
+            for node in ep.graph.nodes
+            if node.op == "call_function" and node.target == torch.ops.aten.add.Tensor
+        ]
+        self.assertEqual(len(add_nodes), 1)
+        self.assertEqual(add_nodes[0].args[1].name, param_input_name)
+        self.assertEqual(ep.module()(*sample_inputs), m(*sample_inputs))
+        self.assertIs(m._flat_weights[0], m.p1)
+
+    def test_export_buffer_alias_in_container(self):
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("b1", torch.ones(2, 2))
+                self.buffers_list = [self.b1]
+
+            def forward(self, x):
+                return x + self.buffers_list[0]
+
+        m = Module()
+        sample_inputs = (torch.ones(2, 2),)
+
+        ep = torch.export.export(m, sample_inputs, strict=False)
+
+        self.assertEqual(len(ep.graph_signature.lifted_tensor_constants), 0)
+        buffer_inputs = ep.graph_signature.inputs_to_buffers
+        self.assertEqual(list(buffer_inputs.values()), ["b1"])
+        buffer_input_name = next(
+            name for name, target in buffer_inputs.items() if target == "b1"
+        )
+
+        add_nodes = [
+            node
+            for node in ep.graph.nodes
+            if node.op == "call_function" and node.target == torch.ops.aten.add.Tensor
+        ]
+        self.assertEqual(len(add_nodes), 1)
+        self.assertEqual(add_nodes[0].args[1].name, buffer_input_name)
+        self.assertEqual(ep.module()(*sample_inputs), m(*sample_inputs))
+        self.assertIs(m.buffers_list[0], m.b1)
+
     @contextmanager
     def distributed_env(self, world_size):
         try:

--- a/torch/_export/passes/lift_constants_pass.py
+++ b/torch/_export/passes/lift_constants_pass.py
@@ -181,6 +181,7 @@ def lift_constants_pass(
     gm: torch.fx.GraphModule,
     graph_signature: ExportGraphSignature,
     constant_attrs: ConstantAttrMap,
+    param_buffer_attrs: ConstantAttrMap | None = None,
 ) -> dict[str, _ConstantAttributeType]:
     """
     Takes a graph module, graph signature, and modifies them inplace to lift any
@@ -195,6 +196,10 @@ def lift_constants_pass(
             fully-qualified path in `gm`. This is used to maintain consistent
             location of constants between the original module and the exported
             version.
+        param_buffer_attrs (ConstantAttr): A mapping from a parameter/buffer value to
+            its fully-qualified path in the original module. This is used to
+            recognize stale aliases to registered state and reuse the existing
+            parameter/buffer input instead of lifting another constant.
 
     Returns:
         A dictionary of fqn => constant value.
@@ -221,12 +226,27 @@ def lift_constants_pass(
         raise AssertionError(
             f"input nodes count {len(input_nodes)} != input specs count {len(input_specs)}"
         )
+    state_input_placeholders: dict[str, torch.fx.Node] = {}
+    found_first_user_input = False
     for i, (node, input_spec) in enumerate(zip(input_nodes, input_specs)):
         used_target_names.add(input_spec.target)
-        if input_spec.kind == InputKind.USER_INPUT:
+        if input_spec.kind in (InputKind.PARAMETER, InputKind.BUFFER):
+            if input_spec.target is not None:
+                state_input_placeholders[input_spec.target] = node
+        if input_spec.kind == InputKind.USER_INPUT and not found_first_user_input:
             first_user_input = node
             first_user_input_loc = i
-            break
+            found_first_user_input = True
+
+    def _get_state_input_placeholder(
+        constant_val: torch.Tensor,
+    ) -> torch.fx.Node | None:
+        if param_buffer_attrs is None or constant_val not in param_buffer_attrs:
+            return None
+        for fqn in param_buffer_attrs[constant_val]:
+            if fqn in state_input_placeholders:
+                return state_input_placeholders[fqn]
+        return None
 
     lifted_objs = ConstantAttrMap()
     renamed_targets = {}
@@ -285,6 +305,14 @@ def lift_constants_pass(
                         constant_fqn = get_constant_fqn(node, constant_name)
                     num_custom_obj += 1
             elif isinstance(constant_val, torch.Tensor):
+                if (
+                    state_input_node := _get_state_input_placeholder(constant_val)
+                ) is not None:
+                    node.replace_all_uses_with(state_input_node)
+                    gm.graph.erase_node(node)
+                    renamed_targets[node.name] = state_input_node.name
+                    continue
+
                 # Remove the parameterness of constant_val
                 if isinstance(constant_val, torch.nn.Parameter):
                     log.debug(
@@ -443,7 +471,15 @@ def _materialize_and_lift_constants(
     gm: torch.fx.GraphModule,
     export_graph_signature: ExportGraphSignature,
     constant_attrs: ConstantAttrMap,
+    param_buffer_attrs: ConstantAttrMap | None = None,
 ) -> dict[str, _ConstantAttributeType]:
     constants = rewrite_script_object_meta(gm)
-    constants.update(lift_constants_pass(gm, export_graph_signature, constant_attrs))
+    constants.update(
+        lift_constants_pass(
+            gm,
+            export_graph_signature,
+            constant_attrs,
+            param_buffer_attrs=param_buffer_attrs,
+        )
+    )
     return constants

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -548,6 +548,15 @@ def _remap_constants(
                 constants[target] = constant
 
 
+def _gather_param_buffer_attrs(m: torch.nn.Module) -> ConstantAttrMap:
+    params_buffers = ConstantAttrMap()
+    for name, param in m.named_parameters(remove_duplicate=False):
+        params_buffers.add(param, name)
+    for name, buffer in m.named_buffers(remove_duplicate=False):
+        params_buffers.add(buffer, name)
+    return params_buffers
+
+
 def _replace_unbacked_bindings(gm: torch.fx.GraphModule) -> None:
     """
     When we run an interpreter-based pass over a GraphModule, execution of data-dependent operators
@@ -598,6 +607,7 @@ def _produce_aten_artifact(
     fake_args,
     fake_kwargs,
     fake_params_buffers,
+    param_buffer_attrs: ConstantAttrMap | None = None,
     _prettify_placeholder_names=True,
 ) -> ATenExportArtifact:
     """
@@ -638,7 +648,10 @@ def _produce_aten_artifact(
     # script objects are always stored in constants no matter whether they're initial inputs or
     # they're lifted in aot" before rewrite_script_object_meta
     constants = _materialize_and_lift_constants(
-        gm, export_graph_signature, constant_attrs
+        gm,
+        export_graph_signature,
+        constant_attrs,
+        param_buffer_attrs=param_buffer_attrs,
     )
 
     if pre_dispatch:
@@ -1021,6 +1034,7 @@ def _export_to_aten_ir(
         if decompose_custom_triton_ops
         else _disable_custom_triton_op_functional_decomposition
     )
+    param_buffer_attrs = _gather_param_buffer_attrs(mod)
     # This _reparameterize_module makes sure inputs and module.params/buffers have the same fake_mode,
     # otherwise aot_export_module will error out because it sees a mix of fake_modes.
     # And we want aot_export_module to use the fake_tensor mode in dynamo to keep the pipeline easy to reason about.
@@ -1090,6 +1104,7 @@ def _export_to_aten_ir(
         fake_args=fake_args,
         fake_kwargs=fake_kwargs,
         fake_params_buffers=fake_params_buffers,
+        param_buffer_attrs=param_buffer_attrs,
         _prettify_placeholder_names=_prettify_placeholder_names,
     )
 
@@ -1988,6 +2003,7 @@ def _export_to_aten_ir_make_fx(
         )
         return gm, sig
 
+    param_buffer_attrs = _gather_param_buffer_attrs(mod)
     # This _reparameterize_module makes sure inputs and module.params/buffers have the same fake_mode,
     # otherwise aot_export_module will error out because it sees a mix of fake_modes.
     # And we want aot_export_module to use the fake_tensor mode in dynamo to keep the pipeline easy to reason about.
@@ -2045,6 +2061,7 @@ def _export_to_aten_ir_make_fx(
         fake_args=fake_args,
         fake_kwargs=fake_kwargs,
         fake_params_buffers=fake_params_buffers,
+        param_buffer_attrs=param_buffer_attrs,
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185106

Non-strict export reparametrizes registered parameters and buffers before tracing, but plain Python containers can still hold aliases to the original registered tensors. When forward reads such an alias, make_fx emits a get_attr tensor constant and lift_constants_pass used to lift it as a separate CONSTANT_TENSOR input even though the graph already has the corresponding PARAMETER or BUFFER input.

Fix this at constant lifting time by carrying original parameter/buffer identities into lift_constants_pass and rewriting stale state aliases to the existing state placeholder instead of creating a duplicate constant. This avoids mutating user containers before tracing, so existing RNN _flat_weights assignment warning behavior remains intact.

The alternative considered was recursively replacing aliases in module containers before tracing, but that can make the assignment detector snapshot fake aliases and can leak fake tensors back into user-visible containers. Matching registered state during constant lifting keeps the fix localized to export graph construction.

Fixes #163303

Generated by my agent

Test Plan:

python test/export/test_lift_unlift.py

python test/export/test_export.py TestExport.test_export_parameter_alias_in_container TestExport.test_export_buffer_alias_in_container TestExport.test_export_rnn_variants_with_warning

git diff --check && lintrunner -a