### PR TITLE
[Test] Make test/dynamo/test_callback.py device agnostic

### DIFF
--- a/test/dynamo/test_callback.py
+++ b/test/dynamo/test_callback.py
@@ -1,12 +1,14 @@
 # Owner(s): ["module: dynamo"]
 
+import unittest
 from unittest.mock import Mock
 
 import torch
 from torch._dynamo.callback import callback_handler, CallbackArgs, CallbackTrigger
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._guards import CompileId
-from torch.testing._internal.triton_utils import HAS_CUDA_AND_TRITON, requires_gpu
+from torch.testing._internal.inductor_utils import HAS_GPU
+from torch.testing._internal.triton_utils import HAS_CUDA_AND_TRITON
 
 
 device_type = (
@@ -61,7 +63,7 @@ class CallbackTests(TestCase):
             callback_handler._CompilationCallbackHandler__pending_callbacks_counter, 0
         )
 
-    @requires_gpu
+    @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
     @torch._inductor.config.patch(force_disable_caches=True)
     def test_triggers(self) -> None:
         torch._dynamo.reset()


### PR DESCRIPTION
Replace @requires_gpu decorator with @unittest.skipIf(not HAS_GPU) to properly check for both GPU and Triton availability, following the same pattern as test_modes.py.

Changes
  - Import HAS_GPU from inductor_utils instead of requires_gpu from triton_utils
  - Replace @requires_gpu with @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
  - Keeps HAS_CUDA_AND_TRITON for CUDA-specific cudagraph recording check


Test Plan:
-   TEST_CONFIG=cpu python test/dynamo/test_callback.py CallbackTests -v
-   TEST_CONFIG=cuda python test/dynamo/test_callback.py CallbackTests -v
All tests pass.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98