### PR TITLE
scope __ubsan_ignore_undefined__ to the only UB path in TypeCast

### DIFF
--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -103,18 +103,16 @@ struct static_cast_with_inter_type<uint8_t, src_t> {
 
 template <>
 struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::BFloat16> {
-  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
-      c10::Half>
-  apply(c10::BFloat16 src) {
+  C10_HOST_DEVICE static inline c10::complex<c10::Half> apply(
+      c10::BFloat16 src) {
     return static_cast<c10::complex<c10::Half>>(c10::complex<float>{src});
   }
 };
 
 template <>
 struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Float8_e5m2> {
-  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
-      c10::Half>
-  apply(c10::Float8_e5m2 src) {
+  C10_HOST_DEVICE static inline c10::complex<c10::Half> apply(
+      c10::Float8_e5m2 src) {
     return static_cast<c10::complex<c10::Half>>(c10::complex<float>{src});
   }
 };
@@ -123,9 +121,8 @@ template <>
 struct static_cast_with_inter_type<
     c10::complex<c10::Half>,
     c10::Float8_e5m2fnuz> {
-  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
-      c10::Half>
-  apply(c10::Float8_e5m2fnuz src) {
+  C10_HOST_DEVICE static inline c10::complex<c10::Half> apply(
+      c10::Float8_e5m2fnuz src) {
     return static_cast<c10::complex<c10::Half>>(c10::complex<float>{src});
   }
 };
@@ -134,9 +131,8 @@ template <>
 struct static_cast_with_inter_type<
     c10::complex<c10::Half>,
     c10::Float8_e4m3fn> {
-  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
-      c10::Half>
-  apply(c10::Float8_e4m3fn src) {
+  C10_HOST_DEVICE static inline c10::complex<c10::Half> apply(
+      c10::Float8_e4m3fn src) {
     return static_cast<c10::complex<c10::Half>>(c10::complex<float>{src});
   }
 };
@@ -145,9 +141,8 @@ template <>
 struct static_cast_with_inter_type<
     c10::complex<c10::Half>,
     c10::Float8_e4m3fnuz> {
-  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
-      c10::Half>
-  apply(c10::Float8_e4m3fnuz src) {
+  C10_HOST_DEVICE static inline c10::complex<c10::Half> apply(
+      c10::Float8_e4m3fnuz src) {
     return static_cast<c10::complex<c10::Half>>(c10::complex<float>{src});
   }
 };
@@ -158,18 +153,15 @@ template <>
 struct static_cast_with_inter_type<
     c10::complex<c10::Half>,
     c10::Float8_e8m0fnu> {
-  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
-      c10::Half>
-  apply(c10::Float8_e8m0fnu src) {
+  C10_HOST_DEVICE static inline c10::complex<c10::Half> apply(
+      c10::Float8_e8m0fnu src) {
     return static_cast<c10::complex<c10::Half>>(c10::complex<float>{src});
   }
 };
 
 template <>
 struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::Half> {
-  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
-      c10::Half>
-  apply(c10::Half src) {
+  C10_HOST_DEVICE static inline c10::complex<c10::Half> apply(c10::Half src) {
     return static_cast<c10::complex<c10::Half>>(c10::complex<float>{src});
   }
 };
@@ -178,9 +170,8 @@ template <>
 struct static_cast_with_inter_type<
     c10::complex<c10::Half>,
     c10::complex<double>> {
-  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
-      c10::Half>
-  apply(c10::complex<double> src) {
+  C10_HOST_DEVICE static inline c10::complex<c10::Half> apply(
+      c10::complex<double> src) {
     return static_cast<c10::complex<c10::Half>>(
         static_cast<c10::complex<float>>(src));
   }

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -57,22 +57,15 @@ struct maybe_bool<true, src_t> {
   }
 };
 
-// Casts a non-integral (floating-point or fancy float like Half / BFloat16 /
-// Float8 / complex) value to an integer type. This is the only path through
-// static_cast_with_inter_type that can invoke undefined behavior at the C++
-// level (out-of-range or NaN float -> integer). PyTorch deliberately keeps the
-// platform-defined result for NumPy compatibility, so suppress UBSan only on
-// this narrow helper instead of the whole conversion template.
+// Float -> integer is UB on out-of-range/NaN values; we keep the
+// platform-defined result for NumPy compatibility and suppress UBSan only
+// here, so the dispatching template below stays UBSan-clean.
 template <typename dest_t, typename src_t>
 C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline dest_t
 unchecked_cast_to_int(src_t src) {
   return static_cast<dest_t>(src);
 }
 
-// Note: deliberately ignores undefined behavior, consistent with NumPy.
-// PyTorch's type conversions can cause a variety of undefined behavior,
-// including float to integral overflow and signed to unsigned integer overflow.
-// Some of this undefined behavior is addressed below.
 template <typename dest_t, typename src_t>
 struct static_cast_with_inter_type {
   C10_HOST_DEVICE static inline dest_t apply(src_t src) {
@@ -98,15 +91,8 @@ struct static_cast_with_inter_type<bool, src_t> {
   }
 };
 
-// Partial template instantiation for casting to uint8.
-// Note: Converting from negative float values to unsigned integer types is
-// undefined behavior in C++, and current CPU and GPU compilers exhibit
-// divergent behavior. Casting from negative float values to signed
-// integer types and then to unsigned integer types is not undefined,
-// however, so this cast improves the consistency of type conversions
-// to uint8 across compilers.
-// Further note: Type conversions across compilers still have other undefined
-// and divergent behavior.
+// Route float -> uint8 via int64 to get consistent results across CPU/GPU
+// compilers; float -> unsigned directly is UB and platform-divergent.
 template <typename src_t>
 struct static_cast_with_inter_type<uint8_t, src_t> {
   C10_HOST_DEVICE static inline uint8_t apply(src_t src) {

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -57,17 +57,33 @@ struct maybe_bool<true, src_t> {
   }
 };
 
+// Casts a non-integral (floating-point or fancy float like Half / BFloat16 /
+// Float8 / complex) value to an integer type. This is the only path through
+// static_cast_with_inter_type that can invoke undefined behavior at the C++
+// level (out-of-range or NaN float -> integer). PyTorch deliberately keeps the
+// platform-defined result for NumPy compatibility, so suppress UBSan only on
+// this narrow helper instead of the whole conversion template.
+template <typename dest_t, typename src_t>
+C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline dest_t
+unchecked_cast_to_int(src_t src) {
+  return static_cast<dest_t>(src);
+}
+
 // Note: deliberately ignores undefined behavior, consistent with NumPy.
 // PyTorch's type conversions can cause a variety of undefined behavior,
 // including float to integral overflow and signed to unsigned integer overflow.
 // Some of this undefined behavior is addressed below.
 template <typename dest_t, typename src_t>
 struct static_cast_with_inter_type {
-  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline dest_t apply(
-      src_t src) {
+  C10_HOST_DEVICE static inline dest_t apply(src_t src) {
     constexpr bool real = needs_real<dest_t, src_t>::value;
     auto r = maybe_real<real, src_t>::apply(src);
-    return static_cast<dest_t>(r);
+    if constexpr (
+        std::is_integral_v<dest_t> && !std::is_integral_v<decltype(r)>) {
+      return unchecked_cast_to_int<dest_t>(r);
+    } else {
+      return static_cast<dest_t>(r);
+    }
   }
 };
 
@@ -93,11 +109,14 @@ struct static_cast_with_inter_type<bool, src_t> {
 // and divergent behavior.
 template <typename src_t>
 struct static_cast_with_inter_type<uint8_t, src_t> {
-  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline uint8_t apply(
-      src_t src) {
+  C10_HOST_DEVICE static inline uint8_t apply(src_t src) {
     constexpr bool real = needs_real<uint8_t, src_t>::value;
-    return static_cast<uint8_t>(
-        static_cast<int64_t>(maybe_real<real, src_t>::apply(src)));
+    auto r = maybe_real<real, src_t>::apply(src);
+    if constexpr (std::is_integral_v<decltype(r)>) {
+      return static_cast<uint8_t>(static_cast<int64_t>(r));
+    } else {
+      return static_cast<uint8_t>(unchecked_cast_to_int<int64_t>(r));
+    }
   }
 };
 


### PR DESCRIPTION
Narrow `__ubsan_ignore_undefined__` in `c10/util/TypeCast.h` to where it's actually needed:
- Move the float -> integer cast into a small `unchecked_cast_to_int` helper.
- Drop the attribute from all `complex<c10::Half>` specializations, which are well-defined narrowing, not UB.
- Trim the surrounding comments to the essentials.