### PR TITLE
nn: add missing memory_format overload to Module.to()

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, overload, TypeVar, Union
 from typing_extensions import Self
 
 import torch
-from torch import device, dtype, Tensor
+from torch import device, dtype, memory_format, Tensor
 from torch._prims_common import DeviceLikeType
 from torch.nn.parameter import Buffer, Parameter
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
@@ -1250,6 +1250,9 @@ class Module:
 
     @overload
     def to(self, tensor: Tensor, non_blocking: bool = ...) -> Self: ...
+
+    @overload
+    def to(self, memory_format: memory_format) -> Self: ...
 
     def to(self, *args, **kwargs):
         r"""Move and/or cast the parameters and buffers.

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, overload, TypeVar, Union
 from typing_extensions import Self
 
 import torch
-from torch import device, dtype, Tensor
+from torch import device, dtype, memory_format, Tensor
 from torch._prims_common import DeviceLikeType
 from torch.nn.parameter import Buffer, Parameter
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
@@ -1252,6 +1252,9 @@ class Module:
 
     @overload
     def to(self, tensor: Tensor, non_blocking: bool = ...) -> Self: ...
+
+    @overload
+    def to(self, memory_format: memory_format) -> Self: ...
 
     def to(self, *args, **kwargs):
         r"""Move and/or cast the parameters and buffers.


### PR DESCRIPTION
## Summary

`Module.to(memory_format=torch.channels_last)` is documented and works at runtime, but there was no matching `@overload` for type checkers. This causes `no-matching-overload` errors in tools like `ty` (Astral).

Add the missing overload and import `memory_format` from `torch`.

Fixes #184642.