### PR TITLE
[MPS] embedding backward to metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Embedding.h
+++ b/aten/src/ATen/native/mps/kernels/Embedding.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <c10/metal/common.h>
+
+template <typename idx_type_t = uint32_t>
+struct EmbeddingDenseBackwardParams {
+  ::c10::metal::array<idx_type_t, ::c10::metal::max_ndim> outer_sizes;
+  ::c10::metal::array<idx_type_t, ::c10::metal::max_ndim> grad_outer_strides;
+  ::c10::metal::array<idx_type_t, ::c10::metal::max_ndim> indices_strides;
+  idx_type_t grad_feature_stride;
+  idx_type_t outer_ndim;
+  idx_type_t feature_size;
+  int64_t padding_idx;
+  bool scale_grad_by_freq;
+};

--- a/aten/src/ATen/native/mps/kernels/Embedding.metal
+++ b/aten/src/ATen/native/mps/kernels/Embedding.metal
@@ -1,0 +1,120 @@
+#include <ATen/native/mps/kernels/Embedding.h>
+#include <c10/metal/atomic.h>
+#include <c10/metal/utils.h>
+#include <metal_stdlib>
+
+using namespace metal;
+using namespace c10::metal;
+
+template <typename O>
+static inline void resolve_outer_offsets(
+    uint tid,
+    constant EmbeddingDenseBackwardParams<uint32_t>& params,
+    thread O& grad_offset,
+    thread O& indices_offset) {
+  grad_offset = 0;
+  indices_offset = 0;
+  uint remaining = tid;
+  uint nd = params.outer_ndim;
+  for (uint d = 0; d < nd; ++d) {
+    uint dim_idx = nd - 1 - d;
+    uint dim_size = params.outer_sizes[dim_idx];
+    uint coord = remaining % dim_size;
+    remaining /= dim_size;
+    grad_offset += static_cast<O>(coord) *
+        static_cast<O>(params.grad_outer_strides[dim_idx]);
+    indices_offset +=
+        static_cast<O>(coord) * static_cast<O>(params.indices_strides[dim_idx]);
+  }
+}
+
+template <typename I, typename O>
+kernel void embedding_dense_backward_count(
+    constant I* indices [[buffer(0)]],
+    device atomic_uint* counts [[buffer(1)]],
+    constant EmbeddingDenseBackwardParams<uint32_t>& params [[buffer(2)]],
+    uint tid [[thread_position_in_grid]]) {
+  O grad_offset_unused = 0;
+  O indices_offset = 0;
+  resolve_outer_offsets<O>(tid, params, grad_offset_unused, indices_offset);
+  long weight_idx = static_cast<long>(indices[indices_offset]);
+  if (weight_idx == params.padding_idx) {
+    return;
+  }
+  atomic_fetch_add_explicit(counts + weight_idx, 1u, memory_order_relaxed);
+}
+
+template <typename T, typename I, typename O>
+kernel void embedding_dense_backward(
+    constant T* grad [[buffer(0)]],
+    constant I* indices [[buffer(1)]],
+    constant uint* counts [[buffer(2)]],
+    device AtomicType_t<T>* grad_weight [[buffer(3)]],
+    constant EmbeddingDenseBackwardParams<uint32_t>& params [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  uint feature_size = params.feature_size;
+  uint index_pos = tid / feature_size;
+  uint feature_idx = tid % feature_size;
+
+  O grad_outer_offset = 0;
+  O indices_offset = 0;
+  resolve_outer_offsets<O>(
+      index_pos, params, grad_outer_offset, indices_offset);
+
+  long weight_idx = static_cast<long>(indices[indices_offset]);
+  if (weight_idx == params.padding_idx) {
+    return;
+  }
+
+  O grad_offset = grad_outer_offset +
+      static_cast<O>(feature_idx) * static_cast<O>(params.grad_feature_stride);
+  auto grad_val = static_cast<opmath_t<T>>(grad[grad_offset]);
+  if (params.scale_grad_by_freq) {
+    uint c = counts[weight_idx];
+    if (c == 0) {
+      return;
+    }
+    grad_val /= static_cast<opmath_t<T>>(c);
+  }
+
+  AtomicType<T>::atomic_add(
+      grad_weight,
+      static_cast<long>(weight_idx) * feature_size + feature_idx,
+      static_cast<T>(grad_val));
+}
+
+#define REGISTER_EMBEDDING_DENSE_BACKWARD_COUNT(I, O, OSUFFIX)                \
+  template [[host_name("embedding_dense_backward_count_" #I "_" #OSUFFIX)]]   \
+  kernel void embedding_dense_backward_count<I, O>(                           \
+      constant I * indices [[buffer(0)]],                                     \
+      device atomic_uint * counts [[buffer(1)]],                              \
+      constant EmbeddingDenseBackwardParams<uint32_t> & params [[buffer(2)]], \
+      uint tid [[thread_position_in_grid]])
+
+#define REGISTER_EMBEDDING_DENSE_BACKWARD(T, I, O, OSUFFIX)                   \
+  template [[host_name("embedding_dense_backward_" #T "_" #I "_" #OSUFFIX)]]  \
+  kernel void embedding_dense_backward<T, I, O>(                              \
+      constant T * grad [[buffer(0)]],                                        \
+      constant I * indices [[buffer(1)]],                                     \
+      constant uint * counts [[buffer(2)]],                                   \
+      device AtomicType_t<T> * grad_weight [[buffer(3)]],                     \
+      constant EmbeddingDenseBackwardParams<uint32_t> & params [[buffer(4)]], \
+      uint tid [[thread_position_in_grid]])
+
+REGISTER_EMBEDDING_DENSE_BACKWARD_COUNT(int, uint, 32);
+REGISTER_EMBEDDING_DENSE_BACKWARD_COUNT(int, ulong, 64);
+REGISTER_EMBEDDING_DENSE_BACKWARD_COUNT(long, uint, 32);
+REGISTER_EMBEDDING_DENSE_BACKWARD_COUNT(long, ulong, 64);
+
+REGISTER_EMBEDDING_DENSE_BACKWARD(float, int, uint, 32);
+REGISTER_EMBEDDING_DENSE_BACKWARD(float, int, ulong, 64);
+REGISTER_EMBEDDING_DENSE_BACKWARD(float, long, uint, 32);
+REGISTER_EMBEDDING_DENSE_BACKWARD(float, long, ulong, 64);
+REGISTER_EMBEDDING_DENSE_BACKWARD(half, int, uint, 32);
+REGISTER_EMBEDDING_DENSE_BACKWARD(half, int, ulong, 64);
+REGISTER_EMBEDDING_DENSE_BACKWARD(half, long, uint, 32);
+REGISTER_EMBEDDING_DENSE_BACKWARD(half, long, ulong, 64);
+REGISTER_EMBEDDING_DENSE_BACKWARD(bfloat, int, uint, 32);
+REGISTER_EMBEDDING_DENSE_BACKWARD(bfloat, int, ulong, 64);
+REGISTER_EMBEDDING_DENSE_BACKWARD(bfloat, long, uint, 32);
+REGISTER_EMBEDDING_DENSE_BACKWARD(bfloat, long, ulong, 64);

--- a/aten/src/ATen/native/mps/kernels/Embedding.metal
+++ b/aten/src/ATen/native/mps/kernels/Embedding.metal
@@ -49,7 +49,7 @@ kernel void embedding_dense_backward(
     constant T* grad [[buffer(0)]],
     constant I* indices [[buffer(1)]],
     constant uint* counts [[buffer(2)]],
-    device AtomicType_t<T>* grad_weight [[buffer(3)]],
+    device AtomicType_t<float>* grad_weight [[buffer(3)]],
     constant EmbeddingDenseBackwardParams<uint32_t>& params [[buffer(4)]],
     uint tid [[thread_position_in_grid]]) {
   uint feature_size = params.feature_size;
@@ -68,19 +68,19 @@ kernel void embedding_dense_backward(
 
   O grad_offset = grad_outer_offset +
       static_cast<O>(feature_idx) * static_cast<O>(params.grad_feature_stride);
-  auto grad_val = static_cast<opmath_t<T>>(grad[grad_offset]);
+  float grad_val = static_cast<float>(grad[grad_offset]);
   if (params.scale_grad_by_freq) {
     uint c = counts[weight_idx];
     if (c == 0) {
       return;
     }
-    grad_val /= static_cast<opmath_t<T>>(c);
+    grad_val /= static_cast<float>(c);
   }
 
-  AtomicType<T>::atomic_add(
+  AtomicType<float>::atomic_add(
       grad_weight,
       static_cast<long>(weight_idx) * feature_size + feature_idx,
-      static_cast<T>(grad_val));
+      grad_val);
 }
 
 #define REGISTER_EMBEDDING_DENSE_BACKWARD_COUNT(I, O, OSUFFIX)                \
@@ -97,7 +97,7 @@ kernel void embedding_dense_backward(
       constant T * grad [[buffer(0)]],                                        \
       constant I * indices [[buffer(1)]],                                     \
       constant uint * counts [[buffer(2)]],                                   \
-      device AtomicType_t<T> * grad_weight [[buffer(3)]],                     \
+      device AtomicType_t<float> * grad_weight [[buffer(3)]],                 \
       constant EmbeddingDenseBackwardParams<uint32_t> & params [[buffer(4)]], \
       uint tid [[thread_position_in_grid]])
 

--- a/aten/src/ATen/native/mps/operations/Embedding.mm
+++ b/aten/src/ATen/native/mps/operations/Embedding.mm
@@ -1,0 +1,114 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/core/Tensor.h>
+#include <ATen/native/CanUse32BitIndexMath.h>
+#include <ATen/native/Pool.h>
+#include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/Embedding.h>
+
+#include <fmt/format.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/embedding_dense_backward_native.h>
+#include <ATen/ops/zeros.h>
+#endif
+
+namespace at::native {
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Embedding_metallib.h>
+#endif
+
+Tensor embedding_dense_backward_mps(const Tensor& grad_,
+                                    const Tensor& indices,
+                                    int64_t num_weights,
+                                    int64_t padding_idx,
+                                    bool scale_grad_by_freq) {
+  using namespace at::native::mps;
+
+  auto indices_arg = TensorArg(indices, "indices", 2);
+  checkScalarTypes("embedding_backward", indices_arg, {kLong, kInt});
+  auto grad_arg = TensorArg(grad_, "grad", 1);
+  checkScalarTypes("embedding_backward", grad_arg, {kFloat, kHalf, kBFloat16});
+
+  auto D = grad_.size(-1);
+  const bool low_prec = grad_.scalar_type() == kHalf || grad_.scalar_type() == kBFloat16;
+
+  auto num_indices = indices.numel();
+  if (num_indices == 0 || D == 0 || num_weights == 0) {
+    return at::zeros({num_weights, D}, grad_.options());
+  }
+
+  // Accumulate into float for stable precision
+  auto grad_weight_acc = at::zeros({num_weights, D}, grad_.options().dtype(low_prec ? kFloat : grad_.scalar_type()));
+
+  auto outer_ndim = indices.dim();
+  TORCH_CHECK(grad_.dim() == outer_ndim + 1,
+              "embedding_dense_backward_mps: grad dim (",
+              grad_.dim(),
+              ") must equal indices dim + 1 (",
+              outer_ndim + 1,
+              ")");
+  TORCH_CHECK(outer_ndim < static_cast<int64_t>(c10::metal::max_ndim),
+              "embedding_dense_backward_mps: indices ndim ",
+              outer_ndim,
+              " exceeds metal max_ndim ",
+              c10::metal::max_ndim);
+  TORCH_CHECK(num_indices <= std::numeric_limits<int32_t>::max() &&
+                  num_indices * D <= std::numeric_limits<int32_t>::max() &&
+                  num_weights * D <= std::numeric_limits<int32_t>::max(),
+              "embedding_dense_backward_mps: tensor is larger than INT32_MAX");
+
+  EmbeddingDenseBackwardParams<uint32_t> params{};
+  params.outer_ndim = static_cast<uint32_t>(outer_ndim);
+  for (auto d = 0; d < outer_ndim; ++d) {
+    params.outer_sizes[d] = safe_downcast<uint32_t, int64_t>(indices.size(d));
+    params.indices_strides[d] = safe_downcast<uint32_t, int64_t>(indices.stride(d));
+    params.grad_outer_strides[d] = safe_downcast<uint32_t, int64_t>(grad_.stride(d));
+  }
+  params.grad_feature_stride = safe_downcast<uint32_t, int64_t>(grad_.stride(-1));
+  params.feature_size = static_cast<uint32_t>(D);
+  params.padding_idx = padding_idx;
+  params.scale_grad_by_freq = scale_grad_by_freq;
+
+  const auto use_32bit_offsets = at::native::canUse32BitIndexMath(grad_) && at::native::canUse32BitIndexMath(indices);
+  const auto offset_suffix = use_32bit_offsets ? "32" : "64";
+
+  Tensor counts;
+  if (scale_grad_by_freq) {
+    counts = at::zeros({num_weights}, indices.options().dtype(kUInt32));
+  }
+
+  auto stream = at::mps::getCurrentMPSStream();
+  const auto idx_type_str = scalarToMetalTypeString(indices);
+  const auto grad_type_str = scalarToMetalTypeString(grad_);
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
+
+      if (scale_grad_by_freq) {
+        auto count_pso = lib.getPipelineStateForFunc(
+            fmt::format("embedding_dense_backward_count_{}_{}", idx_type_str, offset_suffix));
+        [computeEncoder setComputePipelineState:count_pso];
+        mtl_setArgs(computeEncoder, indices, counts, params);
+        mtl_dispatch1DJob(computeEncoder, count_pso, num_indices);
+      }
+
+      auto bwd_pso = lib.getPipelineStateForFunc(
+          fmt::format("embedding_dense_backward_{}_{}_{}", grad_type_str, idx_type_str, offset_suffix));
+      [computeEncoder setComputePipelineState:bwd_pso];
+      const auto counts_buf = scale_grad_by_freq ? counts : grad_weight_acc;
+      mtl_setArgs(computeEncoder, grad_, indices, counts_buf, grad_weight_acc, params);
+      mtl_dispatch1DJob(computeEncoder, bwd_pso, num_indices * D);
+    }
+  });
+
+  return low_prec ? grad_weight_acc.to(grad_.scalar_type()) : grad_weight_acc;
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -3,6 +3,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch_v2.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/Embedding.h>
 #include <ATen/native/mps/kernels/Indexing.h>
 
 #include <ATen/AccumulateType.h>
@@ -13,9 +14,11 @@
 #include <ATen/core/TensorBody.h>
 #include <ATen/mps/MPSAllocatorInterface.h>
 #include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/IndexKernel.h>
 #include <ATen/native/IndexingUtils.h>
 #include <ATen/native/LinearAlgebraUtils.h>
+#include <ATen/native/Pool.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorAdvancedIndexing.h>
 #include <c10/util/SmallVector.h>
@@ -873,74 +876,86 @@ Tensor embedding_dense_backward_mps(const Tensor& grad_,
                                     int64_t num_weights,
                                     int64_t padding_idx,
                                     bool scale_grad_by_freq) {
-  // TODO: implement padding_idx & scale_grad_by_freq.
   using namespace at::native::mps;
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* incomingGradTensor_ = nil;
-    MPSGraphTensor* indicesTensor_ = nil;
-    MPSGraphTensor* outgoingGradTensor_ = nil;
-  };
 
-  IntArrayRef incoming_gradient_shape = grad_.sizes();
-  int64_t num_incoming_gradient_dims = incoming_gradient_shape.size();
+  auto indices_arg = TensorArg(indices, "indices", 2);
+  checkScalarTypes("embedding_backward", indices_arg, {kLong, kInt});
+  auto grad_arg = TensorArg(grad_, "grad", 1);
+  checkScalarTypes("embedding_backward", grad_arg, {kFloat, kHalf, kBFloat16});
 
-  IntArrayRef indices_shape = indices.sizes();
-  int64_t num_indices_dims = indices_shape.size();
+  auto D = grad_.size(-1);
+  auto grad_weight = at::zeros({num_weights, D}, grad_.options());
 
-  int64_t D = incoming_gradient_shape[num_incoming_gradient_dims - 1];
-  c10::SmallVector<int64_t, 2> outgoing_gradient_shape{num_weights, D};
-  Tensor outgoing_gradient = at::empty(
-      IntArrayRef(outgoing_gradient_shape), grad_.scalar_type(), std::nullopt, kMPS, std::nullopt, std::nullopt);
+  auto num_indices = indices.numel();
+  if (num_indices == 0 || D == 0 || num_weights == 0) {
+    return grad_weight;
+  }
 
-  if (outgoing_gradient.numel() == 0) {
-    return outgoing_gradient;
+  auto outer_ndim = indices.dim();
+  TORCH_CHECK(grad_.dim() == outer_ndim + 1,
+              "embedding_dense_backward_mps: grad dim (",
+              grad_.dim(),
+              ") must equal indices dim + 1 (",
+              outer_ndim + 1,
+              ")");
+  TORCH_CHECK(outer_ndim < static_cast<int64_t>(c10::metal::max_ndim),
+              "embedding_dense_backward_mps: indices ndim ",
+              outer_ndim,
+              " exceeds metal max_ndim ",
+              c10::metal::max_ndim);
+  TORCH_CHECK(num_indices <= std::numeric_limits<int32_t>::max() &&
+                  num_indices * D <= std::numeric_limits<int32_t>::max() &&
+                  num_weights * D <= std::numeric_limits<int32_t>::max(),
+              "embedding_dense_backward_mps: tensor is larger than INT32_MAX");
+
+  EmbeddingDenseBackwardParams<uint32_t> params{};
+  params.outer_ndim = static_cast<uint32_t>(outer_ndim);
+  for (auto d = 0; d < outer_ndim; ++d) {
+    params.outer_sizes[d] = safe_downcast<uint32_t, int64_t>(indices.size(d));
+    params.indices_strides[d] = safe_downcast<uint32_t, int64_t>(indices.stride(d));
+    params.grad_outer_strides[d] = safe_downcast<uint32_t, int64_t>(grad_.stride(d));
+  }
+  params.grad_feature_stride = safe_downcast<uint32_t, int64_t>(grad_.stride(-1));
+  params.feature_size = static_cast<uint32_t>(D);
+  params.padding_idx = padding_idx;
+  params.scale_grad_by_freq = scale_grad_by_freq;
+
+  const auto use_32bit_offsets = at::native::canUse32BitIndexMath(grad_) && at::native::canUse32BitIndexMath(indices);
+  const auto offset_suffix = use_32bit_offsets ? "32" : "64";
+
+  Tensor counts;
+  if (scale_grad_by_freq) {
+    counts = at::zeros({num_weights}, indices.options().dtype(kUInt32));
   }
 
   auto stream = at::mps::getCurrentMPSStream();
+  const auto idx_type_str = scalarToMetalTypeString(indices);
+  const auto grad_type_str = scalarToMetalTypeString(grad_);
 
-  @autoreleasepool {
-    std::string key = "edb_mps:" + getTensorsStringKey({grad_, indices}) + ":num_weights" +
-        std::to_string(num_weights) + ":padding_idx" + std::to_string(padding_idx) + ":scaled" +
-        std::to_string(scale_grad_by_freq);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* incomingGradTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_));
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
 
-      MPSGraphTensor* indicesTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(indices));
-
-      MPSGraphTensor* reshapedIndicesTensor = indicesTensor;
-
-      MPSGraphTensor* castGradTensor = incomingGradTensor;
-      MPSDataType dataType = mps::getMPSDataType(grad_);
-      // issue 105486100, scatterNDWithUpdatesTensor produces wrong result for float16
-      if (dataType == MPSDataTypeFloat16) {
-        castGradTensor = [mpsGraph castTensor:incomingGradTensor toType:MPSDataTypeFloat32 name:@"castGradTensor"];
-      }
-      if (num_indices_dims != 0) {
-        reshapedIndicesTensor = [mpsGraph expandDimsOfTensor:indicesTensor axes:@[ @-1 ] name:nil];
+      if (scale_grad_by_freq) {
+        auto count_pso = lib.getPipelineStateForFunc(
+            fmt::format("embedding_dense_backward_count_{}_{}", idx_type_str, offset_suffix));
+        [computeEncoder setComputePipelineState:count_pso];
+        mtl_setArgs(computeEncoder, indices, counts, params);
+        mtl_dispatch1DJob(computeEncoder, count_pso, num_indices);
       }
 
-      auto outgoingGradTensor = [mpsGraph scatterNDWithUpdatesTensor:castGradTensor
-                                                       indicesTensor:reshapedIndicesTensor
-                                                               shape:getMPSShape(IntArrayRef(outgoing_gradient_shape))
-                                                     batchDimensions:0
-                                                                mode:MPSGraphScatterModeAdd
-                                                                name:@"edb"];
-      if (dataType == MPSDataTypeFloat16) {
-        outgoingGradTensor = [mpsGraph castTensor:outgoingGradTensor toType:MPSDataTypeFloat16 name:@"castGradTensor"];
-      }
-      newCachedGraph->incomingGradTensor_ = incomingGradTensor;
-      newCachedGraph->indicesTensor_ = indicesTensor;
-      newCachedGraph->outgoingGradTensor_ = outgoingGradTensor;
-    });
-    auto incomingGradPlaceholder = Placeholder(cachedGraph->incomingGradTensor_, grad_);
-    auto indicesPlaceholder = Placeholder(cachedGraph->indicesTensor_, indices);
-    auto outgoingGradPlaceholder = Placeholder(cachedGraph->outgoingGradTensor_, outgoing_gradient);
+      auto bwd_pso = lib.getPipelineStateForFunc(
+          fmt::format("embedding_dense_backward_{}_{}_{}", grad_type_str, idx_type_str, offset_suffix));
+      [computeEncoder setComputePipelineState:bwd_pso];
+      // When scale_grad_by_freq is false, counts is undefined, so bind grad_weight
+      // as a harmless placeholder buffer so the kernel signature is satisfied
+      const auto counts_buf = scale_grad_by_freq ? counts : grad_weight;
+      mtl_setArgs(computeEncoder, grad_, indices, counts_buf, grad_weight, params);
+      mtl_dispatch1DJob(computeEncoder, bwd_pso, num_indices * D);
+    }
+  });
 
-    auto feeds = dictionaryFromPlaceholders(incomingGradPlaceholder, indicesPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outgoingGradPlaceholder);
-  }
-  return outgoing_gradient;
+  return grad_weight;
 }
 
 Tensor& masked_fill__mps(Tensor& self, const Tensor& mask, const Tensor& value) {

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -3,7 +3,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch_v2.h>
 #include <ATen/native/mps/OperationUtils.h>
-#include <ATen/native/mps/kernels/Embedding.h>
 #include <ATen/native/mps/kernels/Indexing.h>
 
 #include <ATen/AccumulateType.h>
@@ -30,7 +29,6 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/native/IndexKernel.h>
-#include <ATen/ops/embedding_dense_backward_native.h>
 #include <ATen/ops/flip_native.h>
 #include <ATen/ops/index.h>
 #include <ATen/ops/index_add_native.h>
@@ -869,93 +867,6 @@ Tensor& masked_fill__mps(Tensor& self, const Tensor& mask, const Scalar& value) 
 
   namedinference::propagate_names_if_nonempty(self, maybe_outnames);
   return self;
-}
-
-Tensor embedding_dense_backward_mps(const Tensor& grad_,
-                                    const Tensor& indices,
-                                    int64_t num_weights,
-                                    int64_t padding_idx,
-                                    bool scale_grad_by_freq) {
-  using namespace at::native::mps;
-
-  auto indices_arg = TensorArg(indices, "indices", 2);
-  checkScalarTypes("embedding_backward", indices_arg, {kLong, kInt});
-  auto grad_arg = TensorArg(grad_, "grad", 1);
-  checkScalarTypes("embedding_backward", grad_arg, {kFloat, kHalf, kBFloat16});
-
-  auto D = grad_.size(-1);
-  auto grad_weight = at::zeros({num_weights, D}, grad_.options());
-
-  auto num_indices = indices.numel();
-  if (num_indices == 0 || D == 0 || num_weights == 0) {
-    return grad_weight;
-  }
-
-  auto outer_ndim = indices.dim();
-  TORCH_CHECK(grad_.dim() == outer_ndim + 1,
-              "embedding_dense_backward_mps: grad dim (",
-              grad_.dim(),
-              ") must equal indices dim + 1 (",
-              outer_ndim + 1,
-              ")");
-  TORCH_CHECK(outer_ndim < static_cast<int64_t>(c10::metal::max_ndim),
-              "embedding_dense_backward_mps: indices ndim ",
-              outer_ndim,
-              " exceeds metal max_ndim ",
-              c10::metal::max_ndim);
-  TORCH_CHECK(num_indices <= std::numeric_limits<int32_t>::max() &&
-                  num_indices * D <= std::numeric_limits<int32_t>::max() &&
-                  num_weights * D <= std::numeric_limits<int32_t>::max(),
-              "embedding_dense_backward_mps: tensor is larger than INT32_MAX");
-
-  EmbeddingDenseBackwardParams<uint32_t> params{};
-  params.outer_ndim = static_cast<uint32_t>(outer_ndim);
-  for (auto d = 0; d < outer_ndim; ++d) {
-    params.outer_sizes[d] = safe_downcast<uint32_t, int64_t>(indices.size(d));
-    params.indices_strides[d] = safe_downcast<uint32_t, int64_t>(indices.stride(d));
-    params.grad_outer_strides[d] = safe_downcast<uint32_t, int64_t>(grad_.stride(d));
-  }
-  params.grad_feature_stride = safe_downcast<uint32_t, int64_t>(grad_.stride(-1));
-  params.feature_size = static_cast<uint32_t>(D);
-  params.padding_idx = padding_idx;
-  params.scale_grad_by_freq = scale_grad_by_freq;
-
-  const auto use_32bit_offsets = at::native::canUse32BitIndexMath(grad_) && at::native::canUse32BitIndexMath(indices);
-  const auto offset_suffix = use_32bit_offsets ? "32" : "64";
-
-  Tensor counts;
-  if (scale_grad_by_freq) {
-    counts = at::zeros({num_weights}, indices.options().dtype(kUInt32));
-  }
-
-  auto stream = at::mps::getCurrentMPSStream();
-  const auto idx_type_str = scalarToMetalTypeString(indices);
-  const auto grad_type_str = scalarToMetalTypeString(grad_);
-
-  dispatch_sync_with_rethrow(stream->queue(), ^() {
-    @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
-
-      if (scale_grad_by_freq) {
-        auto count_pso = lib.getPipelineStateForFunc(
-            fmt::format("embedding_dense_backward_count_{}_{}", idx_type_str, offset_suffix));
-        [computeEncoder setComputePipelineState:count_pso];
-        mtl_setArgs(computeEncoder, indices, counts, params);
-        mtl_dispatch1DJob(computeEncoder, count_pso, num_indices);
-      }
-
-      auto bwd_pso = lib.getPipelineStateForFunc(
-          fmt::format("embedding_dense_backward_{}_{}_{}", grad_type_str, idx_type_str, offset_suffix));
-      [computeEncoder setComputePipelineState:bwd_pso];
-      // When scale_grad_by_freq is false, counts is undefined, so bind grad_weight
-      // as a harmless placeholder buffer so the kernel signature is satisfied
-      const auto counts_buf = scale_grad_by_freq ? counts : grad_weight;
-      mtl_setArgs(computeEncoder, grad_, indices, counts_buf, grad_weight, params);
-      mtl_dispatch1DJob(computeEncoder, bwd_pso, num_indices * D);
-    }
-  });
-
-  return grad_weight;
 }
 
 Tensor& masked_fill__mps(Tensor& self, const Tensor& mask, const Tensor& value) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7673,37 +7673,61 @@ class TestMPS(TestCaseMPS):
         with self.assertRaisesRegex(RuntimeError, "Index to scalar can have only 1 value"):
             helper(22, 0, [])
 
-    def test_embedding_dense_backward(self):
+    @parametrize("dtype", [torch.float32, torch.bfloat16])
+    @parametrize("idx_dtype", [torch.int32, torch.int64])
+    @parametrize("padding_idx", [None, 0, 2])
+    @parametrize("scale_grad_by_freq", [False, True])
+    def test_embedding_dense_backward(self, dtype, idx_dtype, padding_idx, scale_grad_by_freq):
         def helper(n, d, m, idx):
-            embeddingMPS = nn.Embedding(n, d, max_norm=True, device='mps')
+            kw = dict(max_norm=True, padding_idx=padding_idx, scale_grad_by_freq=scale_grad_by_freq)
+            embeddingMPS = nn.Embedding(n, d, device='mps', dtype=dtype, **kw)
             embedding_weight = embeddingMPS.weight.detach().cpu()
-            W_MPS = torch.randn((m, d), requires_grad=True, device='mps')
-            idx_MPS = torch.tensor(idx, device='mps')
+            W_MPS = torch.randn((m, d), requires_grad=True, device='mps', dtype=dtype)
+            idx_MPS = torch.tensor(idx, device='mps', dtype=idx_dtype)
             a_MPS = embeddingMPS.weight.clone() @ W_MPS.t()  # weight must be cloned for this to be differentiable
             a_MPS.retain_grad()
             b_MPS = embeddingMPS(idx_MPS) @ W_MPS.t()  # modifies weight in-place
             b_MPS.retain_grad()
-            out_MPS = (a_MPS.unsqueeze(0) + b_MPS)
-            loss_MPS = out_MPS.sigmoid().prod()
+            loss_MPS = (a_MPS.unsqueeze(0) + b_MPS).sigmoid().prod()
             loss_MPS.backward()
 
-            embeddingCPU = nn.Embedding(n, d, max_norm=True, _weight=embedding_weight)
+            embeddingCPU = nn.Embedding(n, d, _weight=embedding_weight, **kw)
             W_CPU = W_MPS.to('cpu')
-            idx_CPU = torch.tensor(idx)
-            a_CPU = embeddingCPU.weight.clone() @ W_CPU.t()  # weight must be cloned for this to be differentiable
+            idx_CPU = idx_MPS.cpu()
+            a_CPU = embeddingCPU.weight.clone() @ W_CPU.t()
             a_CPU.retain_grad()
-            b_CPU = embeddingCPU(idx_CPU) @ W_CPU.t()  # modifies weight in-place
+            b_CPU = embeddingCPU(idx_CPU) @ W_CPU.t()
             b_CPU.retain_grad()
-            out_CPU = (a_CPU.unsqueeze(0) + b_CPU)
-            loss_CPU = out_CPU.sigmoid().prod()
+            loss_CPU = (a_CPU.unsqueeze(0) + b_CPU).sigmoid().prod()
             loss_CPU.backward()
 
-            self.assertEqual(b_CPU.grad, b_MPS.grad)
-            self.assertEqual(a_CPU.grad, a_MPS.grad)
+            atol = {torch.float32: 1e-5, torch.bfloat16: 5e-3}[dtype]
+            self.assertEqual(b_CPU.grad, b_MPS.grad, atol=atol, rtol=atol)
+            self.assertEqual(a_CPU.grad, a_MPS.grad, atol=atol, rtol=atol)
+            self.assertEqual(embeddingCPU.weight.grad, embeddingMPS.weight.grad, atol=atol, rtol=atol)
 
         helper(3, 5, 7, [0, 1, 2])
         helper(3, 6, 7, [0, 1, 2])  # verify if changes in shape would cause cached graph lookup problems
         helper(3, 5, 7, 2)  # test scalar index
+
+    def test_embedding_dense_backward_strided(self):
+        torch.manual_seed(0)
+        weight = torch.randn(8, 5)
+        ids0 = torch.randint(0, 8, (3, 4))
+        grad0 = torch.randn(3, 4, 5)
+        layouts = {
+            "grad permuted": lambda i, g: (i, g.permute(1, 0, 2).contiguous().permute(1, 0, 2)),
+            "grad sliced": lambda i, g: (i, torch.cat([g, g], dim=1)[:, ::2, :]),
+            "ids permuted": lambda i, g: (i.t().contiguous().t(), g),
+            "ids sliced": lambda i, g: (torch.cat([i, i], dim=1)[:, ::2], g),
+        }
+        for name, layout in layouts.items():
+            def run(device):
+                w = weight.to(device).detach().clone().requires_grad_()
+                ids, g = layout(ids0.to(device), grad0.to(device))
+                nn.functional.embedding(ids, w, padding_idx=0, scale_grad_by_freq=True).backward(g)
+                return w.grad.cpu()
+            self.assertEqual(run("mps"), run("cpu"), msg=name)
 
     # Test pytorch gather
     def test_gather(self):


### PR DESCRIPTION
Move embedding backward to metal. This PR does 2 things:
1. Migrates the embedding backward to metal
2. And fixes the TODO for the op `// TODO: implement padding_idx & scale_grad_by_freq.`, which would fail silently before if provided

Perf:
| Shape | Indices | Weight | Contiguous | Strided |
|---|---|---|---:|---:|
| small fp32 | 512 | 5000x128 | 1.08x | 1.57x |
| small fp32 scale | 512 | 5000x128 | 1.34x | 1.40x |
| small bf16 | 512 | 5000x128 | 1.98x | 2.06x |
| small bf16 scale | 512 | 5000x128 | 1.67x | 1.68x |
| medium fp32 | 32x128 | 20000x512 | 1.90x | 1.90x |
| medium fp32 scale | 32x128 | 20000x512 | 1.74x | 1.74x |
| medium bf16 | 32x128 | 20000x512 | 1.20x | 1.21x |
| medium bf16 scale | 32x128 | 20000x512 | 1.17x | 1.16x |
| large fp32 | 64x256 | 50000x1024 | 1.67x | 1.68x |
| large fp32 scale | 64x256 | 50000x1024 | 1.52x | 1.51x |
| large bf16 | 64x256 | 50000x1024 | 1.17x | 1.18x |
| large bf16 scale | 64x256 | 50000x1024 | 1.11x | 1.11x |