### PR TITLE
[Inductor] Fix CuTeDSL grouped GEMM fake tensor descriptors

### DIFF
--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -45,6 +45,7 @@ from torch._inductor.codecache import (
 from torch._inductor.compile_worker.subproc_pool import (
     AnyPool,
     SubprocException,
+    SubprocKind,
     SubprocPool,
 )
 from torch._inductor.compile_worker.tracked_process_pool import (
@@ -281,7 +282,7 @@ class AsyncCompile:
 
     @staticmethod
     @functools.lru_cache(1)
-    def process_pool() -> AnyPool:
+    def process_pool(kind: SubprocKind = SubprocKind.FORK) -> AnyPool:
         assert get_compile_threads() > 1
         AsyncCompile._ready_future = None
         log.info(
@@ -294,7 +295,9 @@ class AsyncCompile:
         if config.worker_start_method == "subprocess":
             # Wrapper around ProcessPoolExecutor forks in a new process we control
             pool = SubprocPool(
-                get_compile_threads(), quiesce=config.quiesce_async_compile_pool
+                get_compile_threads(),
+                kind=kind,
+                quiesce=config.quiesce_async_compile_pool,
             )
         else:
             if config.worker_start_method == "spawn":
@@ -634,7 +637,7 @@ class AsyncCompile:
             env_vars = ["TORCHINDUCTOR_CACHE_DIR", "TORCHINDUCTOR_CUTLASS_DIR"]
             extra_env = {v: os.environ[v] for v in env_vars if v in os.environ}
 
-            subprocess_task = self.process_pool().submit(
+            subprocess_task = self.process_pool(SubprocKind.SPAWN).submit(
                 _worker_compile_pycodecache_kernel,
                 kernel_name,
                 source_code,

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -132,7 +132,7 @@ class SubprocPool:
         self,
         nprocs: int,
         pickler: SubprocPickler | None = None,
-        kind: SubprocKind = SubprocKind.FORK,
+        kind: SubprocKind = SubprocKind.SPAWN,
         quiesce: bool = False,
     ) -> None:
         entry = os.path.join(os.path.dirname(__file__), "__main__.py")

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -132,7 +132,7 @@ class SubprocPool:
         self,
         nprocs: int,
         pickler: SubprocPickler | None = None,
-        kind: SubprocKind = SubprocKind.SPAWN,
+        kind: SubprocKind = SubprocKind.FORK,
         quiesce: bool = False,
     ) -> None:
         entry = os.path.join(os.path.dirname(__file__), "__main__.py")

--- a/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
+++ b/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
@@ -54,13 +54,30 @@ _TORCH_TO_CUTLASS_DTYPE = {
     torch.int64: cutlass.Int64,
 }
 
-def _to_fake_cute_tensor(shape, dtype, assumed_align=16):
+def _to_fake_cute_tensor(shape, dtype, assumed_align=16, static_dims=()):
     ndim = len(shape)
-    dyn_shape = tuple(cute.sym_int64() for _ in range(ndim))
+    dyn_shape = tuple(
+        int(s) if i in static_dims else cute.sym_int64() for i, s in enumerate(shape)
+    )
     stride_order = tuple(range(ndim - 1, -1, -1))
     return cute.runtime.make_fake_compact_tensor(
         _TORCH_TO_CUTLASS_DTYPE[dtype], dyn_shape,
         stride_order=stride_order, assumed_align=assumed_align,
+    )
+
+
+def _to_fake_cute_tensor_like(t, assumed_align=16):
+    # Preserve static singleton modes so the artificial grouped GEMM L mode
+    # is not selected as the matrix leading dimension.
+    fake_shape = tuple(1 if int(s) == 1 else cute.sym_int64() for s in t.shape)
+    fake_stride = tuple(
+        int(s) if int(s) in (0, 1) else cute.sym_int64() for s in t.stride()
+    )
+    return cute.runtime.make_fake_tensor(
+        _TORCH_TO_CUTLASS_DTYPE[t.dtype],
+        fake_shape,
+        fake_stride,
+        assumed_align=assumed_align,
     )
 
 
@@ -243,8 +260,12 @@ def launch_build_group_ptrs_from_bases(
             stride_C_m_elems=sC_m,
             stride_C_n_elems=sC_n,
             out_ptrs=_to_fake_cute_tensor(ptrs_t.shape, ptrs_t.dtype),
-            out_problem=_to_fake_cute_tensor(probs_t.shape, probs_t.dtype, assumed_align=4),
-            out_strides_abc=_to_fake_cute_tensor(strides_t.shape, strides_t.dtype, assumed_align=4),
+            out_problem=_to_fake_cute_tensor(
+                probs_t.shape, probs_t.dtype, assumed_align=4, static_dims=(1,)
+            ),
+            out_strides_abc=_to_fake_cute_tensor(
+                strides_t.shape, strides_t.dtype, assumed_align=4, static_dims=(1, 2)
+            ),
             stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
             options="--enable-tvm-ffi",
         )
@@ -314,12 +335,16 @@ def launch_build_group_ptrs_from_bases(
         c_unsq = {{get_output()}}.unsqueeze(-1)
         gemm_executor = cute.compile(
             grouped_gemm,
-            _to_fake_cute_tensor(a_unsq.shape, a_unsq.dtype),
-            _to_fake_cute_tensor(b_unsq.shape, b_unsq.dtype),
-            _to_fake_cute_tensor(c_unsq.shape, c_unsq.dtype),
+            _to_fake_cute_tensor_like(a_unsq),
+            _to_fake_cute_tensor_like(b_unsq),
+            _to_fake_cute_tensor_like(c_unsq),
             G,
-            _to_fake_cute_tensor(probs_t.shape, probs_t.dtype, assumed_align=4),
-            _to_fake_cute_tensor(strides_t.shape, strides_t.dtype, assumed_align=4),
+            _to_fake_cute_tensor(
+                probs_t.shape, probs_t.dtype, assumed_align=4, static_dims=(1,)
+            ),
+            _to_fake_cute_tensor(
+                strides_t.shape, strides_t.dtype, assumed_align=4, static_dims=(1, 2)
+            ),
             _to_fake_cute_tensor(ptrs_t.shape, ptrs_t.dtype),
             total_num_clusters,
             _to_fake_cute_tensor(tensormap_workspace_t.shape, tensormap_workspace_t.dtype),


### PR DESCRIPTION
All tests in `test/inductor/test_cutedsl_grouped_mm.py` are failing with two errors: 
```
  File "/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py", line 513, in _lazy_init
    raise RuntimeError(
RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method
```
and
```
  File "/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/utils/layout.py", line 65, in from_tensor
    raise ValueError(f"Invalid leading dimension: {tensor.leading_dim}")
ValueError: Invalid leading dimension: 2
```
This PR addresses both failures. First one, by using `SubprocKind.SPAWN` instead `SubprocKind.FORK` in the compiler. The second by making a proper fake tensor descriptors.

This latter change adds:
- `_to_fake_cute_tensor_like()` for initial matrix operands, preserving singleton dimensions and stride-0/stride-1 layout.
- `static_dims` support in `_to_fake_cute_tensor()`, so fixed metadata dimensions remain static while the group dimension stays dynamic.

Co-authored with Codex.

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo