### PR TITLE
Raise TypeError for invalid torch.export.load inputs

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -2191,6 +2191,23 @@ class TestSaveLoad(TestCase):
 
         self.assertTrue(torch.allclose(ep.module()(*inp), loaded_ep.module()(*inp)))
 
+    def test_load_rejects_exported_program_input(self):
+        ep = export(torch.nn.ReLU(), (torch.randn(2, 3),), strict=True)
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "`f` must be a path-like object or a readable and seekable "
+            "file-like object.*ExportedProgram",
+        ):
+            load(ep)  # type: ignore[arg-type]
+
+    def test_load_closed_file_like_propagates_io_error(self):
+        buffer = io.BytesIO()
+        buffer.close()
+
+        with self.assertRaisesRegex(ValueError, "I/O operation on closed file"):
+            load(buffer)
+
     def test_save_extra(self):
         inp = (torch.tensor([0.1, 0.1]),)
 

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -71,6 +71,31 @@ AOTI_FILES: TypeAlias = list[str | Weights] | dict[str, list[str | Weights]]
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+def _invalid_load_input_type_error(f: Any) -> TypeError:
+    return TypeError(
+        "Unable to load package. `f` must be a path-like object or a "
+        "readable and seekable file-like object. "
+        f"Instead got {type(f).__name__}."
+    )
+
+
+def _is_readable_seekable_file_like(f: Any) -> bool:
+    required_methods = ("read", "seek", "tell")
+    if not all(callable(getattr(f, method, None)) for method in required_methods):
+        return False
+
+    readable = getattr(f, "readable", None)
+    seekable = getattr(f, "seekable", None)
+    if callable(readable) and callable(seekable):
+        return bool(readable() and seekable())
+
+    try:
+        f.seek(f.tell())
+        return True
+    except (AttributeError, io.UnsupportedOperation):
+        return False
+
+
 def is_pt2_package(serialized_model: bytes | str) -> bool:
     """
     Check if the serialized model is a PT2 Archive package.
@@ -1112,19 +1137,12 @@ def load_pt2(
 
     from torch._inductor.cpp_builder import normalize_path_separator
 
-    if not (
-        (isinstance(f, (io.IOBase, IO)) and f.readable() and f.seekable())
-        or (isinstance(f, (str, os.PathLike)) and os.fspath(f).endswith(".pt2"))
-    ):
-        # TODO: turn this into an error in 2.9
-        logger.warning(
-            "Unable to load package. f must be a buffer or a file ending in "
-            ".pt2. Instead got {%s}",
-            f,
-        )
-
     if isinstance(f, (str, os.PathLike)):
+        if not os.fspath(f).endswith(".pt2"):
+            logger.warning("Path does not end with .pt2; proceeding anyway: {%s}", f)
         f = os.fspath(f)
+    elif not _is_readable_seekable_file_like(f):
+        raise _invalid_load_input_type_error(f)
 
     weights = {}
     weight_maps = {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185121

`torch.export.load` delegates to `load_pt2`, which only warned when `f`
was neither a `.pt2` path nor a readable, seekable buffer. It still passed the
invalid object to `PT2ArchiveReader`, so calling `torch.export.load(ep)` with an
`ExportedProgram` crashed later with `AttributeError: 'ExportedProgram' object
has no attribute 'tell'`.

Validate `load_pt2` inputs before constructing the archive reader. Path-like
objects are normalized as before, non-`.pt2` paths keep the existing warning, and
file-like objects must expose readable/seekable behavior. Invalid objects now
raise a clear `TypeError` that names the accepted input shapes. Closed file
objects still surface their underlying I/O error instead of being converted to a
wrong-type error.

This revives the direction from abandoned PR #163285 while preserving structural
file-like support and closed-file error behavior.

Fixes #163040
Generated by my agent

Test Plan:
- python - <<'PY'
  import runpy
  import sys
  import types

  sys.modules["torch._native"] = types.ModuleType("torch._native")
  sys.argv = [
      "test/export/test_serialize.py",
      "TestSaveLoad.test_save_file",
      "TestSaveLoad.test_save_path",
      "TestSaveLoad.test_load_rejects_exported_program_input",
      "TestSaveLoad.test_load_closed_file_like_propagates_io_error",
      "TestSaveLoad.test_save_extra",
  ]
  runpy.run_path("test/export/test_serialize.py", run_name="__main__")
  PY
- git diff --cached --check
- lintrunner -a (blocked by unrelated local Pyrefly errors in torch/_tensor_iterator.py for missing torch._C._TensorIterator and torch._C._TensorIteratorSpec)