### PR TITLE
Fix prim view functionalization in export decompositions

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7326,6 +7326,61 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         after = list(ep.state_dict.keys())
         self.assertEqual(before, after)
 
+    def test_run_decompositions_prims_views(self):
+        class BroadcastInDim(torch.nn.Module):
+            def forward(self, x):
+                x = x.clone()
+                return torch.ops.prims.broadcast_in_dim(
+                    x, (2, 3, 4, 5), (0, 1, 2)
+                ).clone()
+
+        class Squeeze(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.prims.squeeze(x, (1,)).clone()
+
+        class Transpose(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.prims.transpose(x, (1, 0)).clone()
+
+        class ViewOf(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.prims.view_of(x).clone()
+
+        class SplitDim(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.prims.split_dim(x, 1, 3).clone()
+
+        class AsStrided(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.prims.as_strided(x, (2, 2), (3, 1), 0).clone()
+
+        test_cases = [
+            (BroadcastInDim(), torch.randn(2, 3, 4)),
+            (Squeeze(), torch.randn(2, 1, 3)),
+            (Transpose(), torch.randn(2, 3)),
+            (ViewOf(), torch.randn(2, 3)),
+            (SplitDim(), torch.randn(2, 6)),
+            (AsStrided(), torch.randn(3, 3)),
+        ]
+
+        prim_view_ops = {
+            torch.ops.prims.broadcast_in_dim.default,
+            torch.ops.prims.squeeze.default,
+            torch.ops.prims.transpose.default,
+            torch.ops.prims.view_of.default,
+            torch.ops.prims.split_dim.default,
+            torch.ops.prims.as_strided.default,
+        }
+
+        for mod, x in test_cases:
+            ep = export(mod, (x,)).run_decompositions()
+
+            self.assertEqual(ep.module()(x), mod(x))
+            targets = {
+                node.target for node in ep.graph.nodes if node.op == "call_function"
+            }
+            self.assertTrue(targets.isdisjoint(prim_view_ops))
+
     def test_export_func_with_keyword_only_args(self):
         class Module(torch.nn.Module):
             def forward(self, arg1, arg2, *args, kw1, kw2):

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -352,6 +352,97 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
         meta_clone = prims._clone_meta(tensor, memory_format=torch.preserve_format)
         self.assertEqual(tensor.contiguous().stride(), meta_clone.stride())
 
+    def test_broadcast_in_dim_functionalize_validates_args(self):
+        def fn(x):
+            return prims.broadcast_in_dim(x, (2,), (-1,))
+
+        x = torch.randn(2)
+        msg = "broadcast_dimensions must be strictly ascending"
+        with self.assertRaisesRegex(AssertionError, msg):
+            fn(x)
+        with self.assertRaisesRegex(AssertionError, msg):
+            torch.func.functionalize(fn)(x)
+
+    def test_as_strided_functionalize_validates_args(self):
+        def fn(x):
+            return prims.as_strided(x, (2, 2), (1,), 0)
+
+        x = torch.randn(3, 3)
+        msg = r"len\(size\)=2 != len\(stride\)=1"
+        with self.assertRaisesRegex(AssertionError, msg):
+            fn(x)
+        with self.assertRaisesRegex(AssertionError, msg):
+            torch.func.functionalize(fn)(x)
+
+    def test_view_prims_functionalize(self):
+        test_cases = [
+            (
+                lambda x: prims.broadcast_in_dim(x, (2, 3, 4, 5), (0, 1, 2)),
+                torch.randn(2, 3, 4),
+            ),
+            (lambda x: prims.squeeze(x, (1,)), torch.randn(2, 1, 3)),
+            (lambda x: prims.transpose(x, (1, 0)), torch.randn(2, 3)),
+            (lambda x: prims.view_of(x), torch.randn(2, 3)),
+            (lambda x: prims.split_dim(x, 1, 3), torch.randn(2, 6)),
+            (lambda x: prims.as_strided(x, (2, 2), (3, 1), 0), torch.randn(3, 3)),
+        ]
+
+        for fn, x in test_cases:
+            self.assertEqual(torch.func.functionalize(fn)(x), fn(x))
+
+    def test_view_prims_functionalize_backward_not_supported(self):
+        test_cases = [
+            (
+                lambda x: prims.broadcast_in_dim(x, (2, 3, 4, 5), (0, 1, 2)),
+                torch.randn(2, 3, 4),
+            ),
+            (lambda x: prims.squeeze(x, (1,)), torch.randn(2, 1, 3)),
+            (lambda x: prims.transpose(x, (1, 0)), torch.randn(2, 3)),
+            (lambda x: prims.view_of(x), torch.randn(2, 3)),
+            (lambda x: prims.split_dim(x, 1, 3), torch.randn(2, 6)),
+            (lambda x: prims.as_strided(x, (2, 2), (3, 1), 0), torch.randn(3, 3)),
+        ]
+
+        for fn, x in test_cases:
+            expected = fn(x)
+            x = x.detach().clone().requires_grad_()
+            y = fn(x)
+            self.assertTrue(y.requires_grad)
+            self.assertEqual(y.detach(), expected)
+            with self.assertRaisesRegex(RuntimeError, "backwards not supported on prim"):
+                y.sum().backward()
+
+            x = x.detach().clone().requires_grad_()
+            y = torch.func.functionalize(fn)(x)
+            self.assertTrue(y.requires_grad)
+            self.assertEqual(y.detach(), expected)
+            with self.assertRaisesRegex(RuntimeError, "backwards not supported on prim"):
+                y.sum().backward()
+
+    def test_view_prims_functionalize_user_hook_before_backward_error(self):
+        def fn(x):
+            return prims.view_of(x)
+
+        x = torch.randn(2, 3, requires_grad=True)
+        y = torch.func.functionalize(fn)(x)
+        seen = []
+        y.register_hook(lambda grad: seen.append("user") or grad)
+
+        with self.assertRaisesRegex(RuntimeError, "backwards not supported on prim"):
+            y.sum().backward()
+        self.assertEqual(seen, ["user"])
+
+    def test_view_prims_functionalize_closed_over_tensor_backward_not_supported(self):
+        x = torch.randn(2, 3, requires_grad=True)
+
+        def fn():
+            return prims.view_of(x)
+
+        y = torch.func.functionalize(fn)()
+        self.assertTrue(y.requires_grad)
+        with self.assertRaisesRegex(RuntimeError, "backwards not supported on prim"):
+            y.sum().backward()
+
     def test_check_deprecation_warning(self):
         with self.assertWarnsRegex(FutureWarning, 'will be removed in the future'):
             torch._prims_common.check(True, lambda: 'message')

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -38,6 +38,7 @@ prim = torch.library.Library("prims", "DEF")
 prim_impl = torch.library.Library("prims", "IMPL", "CompositeExplicitAutograd")
 prim_backend_select_impl = torch.library.Library("prims", "IMPL", "BackendSelect")
 prim_autograd_impl = torch.library.Library("prims", "IMPL", "Autograd")
+prim_functionalize_impl = torch.library.Library("prims", "IMPL", "Functionalize")
 prim_meta_impl = torch.library.Library("prims", "IMPL", "Meta")
 
 # Experimental module containing prototype "primitive" operations.
@@ -307,6 +308,33 @@ def _make_prim(
     def _autograd_impl(*args, **kwargs):
         return backwards_not_supported(_prim)(*args, **kwargs)
 
+    def _functionalize_impl(*args, **kwargs):
+        flat_args, _ = tree_flatten((args, kwargs))
+
+        def _hook_tensor(arg):
+            if not isinstance(arg, torch.Tensor):
+                return None
+            if torch._is_functional_tensor(arg):
+                return torch._from_functional_tensor(arg)
+            return arg
+
+        def _requires_grad(arg):
+            t = _hook_tensor(arg)
+            return t is not None and t.requires_grad
+
+        out = _prim_impl(*args, **kwargs)
+        if torch.is_grad_enabled() and any(_requires_grad(a) for a in flat_args):
+            flat_out, _ = tree_flatten(out)
+
+            def _raise_backward_not_supported(grad_input, grad_output):
+                raise RuntimeError("backwards not supported on prim")
+
+            for t in flat_out:
+                inner = _hook_tensor(t)
+                if inner is not None and inner.grad_fn is not None:
+                    inner.grad_fn.register_hook(_raise_backward_not_supported)
+        return out
+
     def _backend_select_impl(*args, **kwargs):
         if kwargs.get("device") and kwargs["device"].type == "meta":
             return meta(*args, **kwargs)
@@ -343,6 +371,9 @@ def _make_prim(
         if return_type == RETURN_TYPE.VIEW or register_conj_neg_fallthrough:
             prim_def._lib.impl(name, torch.library.fallthrough_kernel, "Conjugate")
             prim_def._lib.impl(name, torch.library.fallthrough_kernel, "Negative")
+
+    if return_type == RETURN_TYPE.VIEW:
+        prim_functionalize_impl.impl(name, _functionalize_impl)
 
     _prim_packet = getattr(torch._ops.ops.prims, name)
     _prim = _prim_packet.default
@@ -1267,7 +1298,7 @@ _as_strided_doc = """
 """
 
 as_strided = _make_prim(
-    schema="as_strided(Tensor(a!) a, SymInt[] size, SymInt[] stride, SymInt storage_offset) -> Tensor(a!)",
+    schema="as_strided(Tensor(a) a, SymInt[] size, SymInt[] stride, SymInt storage_offset) -> Tensor(a)",
     meta=_as_strided_meta,
     impl_aten=_as_strided_aten,
     return_type=RETURN_TYPE.VIEW,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185130

ExportedProgram.run_decompositions retraces exported graphs under functionalization before prim view operators are lowered. Prim view ops such as prims.broadcast_in_dim have aliasing schemas, so functionalization rejected them as custom non-ATen operators with alias-annotated outputs.

Register a Functionalize implementation for prim view ops in _make_prim so they lower through each prim's existing implementation. This preserves the prim meta validation before using the ATen view implementation, instead of registering a raw ATen lowering that accepts invalid prim inputs.

While making this generic, prims.as_strided also needed its alias schema corrected from Tensor(a!) -> Tensor(a!) to Tensor(a) -> Tensor(a). as_strided is a non-mutating view, matching aten.as_strided, and the mutable schema confused functionalization alias correction.

Prims intentionally do not support backward. The Functionalize path preserves that contract for grad-enabled view outputs by attaching the same backward error to the underlying grad_fn. I considered wrapping the Functionalize lowering in a custom autograd.Function, but functorch functionalization does not support that custom_function_call path, so a grad_fn hook is the narrower option that works with torch.func.functionalize while preserving user tensor hook ordering.

Fixes #162734
Generated by my agent

Test Plan:
- python inline issue reproducer with torch.export.export(...).run_decompositions()
- python inline invalid broadcast_in_dim functionalization probe
- python inline prims.as_strided schema/functionality/autograd probe
- python inline closed-over requires-grad view_of functionalization probe
- python test/export/test_export.py -k test_run_decompositions_prims_views
- python test/export/test_export_training_ir_to_run_decomp.py -k test_run_decompositions_prims_views
- python test/test_prims.py TestPrimsBasic.test_as_strided_functionalize_validates_args TestPrimsBasic.test_broadcast_in_dim_functionalize_validates_args TestPrimsBasic.test_view_prims_functionalize TestPrimsBasic.test_view_prims_functionalize_backward_not_supported TestPrimsBasic.test_view_prims_functionalize_user_hook_before_backward_error TestPrimsBasic.test_view_prims_functionalize_closed_over_tensor_backward_not_supported
- python test/test_prims.py -k functionalize
- python test/test_prims.py -k test_broadcast_in_dim
- lintrunner -a