### PR TITLE
[Test]Refactor test/dynamo/test_compiler_bisector.py to be device generic

### DIFF
--- a/test/dynamo/test_compiler_bisector.py
+++ b/test/dynamo/test_compiler_bisector.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import unittest
 from contextlib import contextmanager
 from importlib import import_module
 
@@ -11,7 +12,7 @@ from torch._inductor.compiler_bisector import CompilerBisector
 from torch._inductor.custom_graph_pass import CustomGraphPass
 from torch._inductor.test_case import TestCase
 from torch.library import _scoped_library, Library
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.inductor_utils import HAS_GPU
 
 
 aten = torch.ops.aten
@@ -22,7 +23,7 @@ i64 = torch.int64
 i32 = torch.int32
 
 
-@requires_cuda_and_triton
+@unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
 class TestCompilerBisector(TestCase):
     test_ns = "_test_bisector"
 


### PR DESCRIPTION
  Replace CUDA-specific decorator with device-agnostic check:
  - Import: requires_cuda_and_triton → HAS_GPU
  - Decorator: @requires_cuda_and_triton → @unittest.skipIf(not HAS_GPU)

  This enables all tests to run on any GPU with Triton (CUDA, XPU, etc.) instead of being CUDA-only.

  Test Plan:

-   TEST_CONFIG=cuda python test/dynamo/test_compiler_bisector.py -v
-   TEST_CONFIG=cpu python test/dynamo/test_compiler_bisector.py -v

  Both pass 10/11 tests (1 pre-existing subprocess error unrelated to changes)"


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @fffrog @albanD @jbschlosser 