### PR TITLE
Fix custom op autograd defaults with tensorlist outputs

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4567,6 +4567,43 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertTrue(called_impl)
         self.assertTrue(called_abstract)
 
+    @skipIfTorchDynamo("recursive dynamo")
+    @unittest.skipIf(IS_WINDOWS, "torch.compile doesn't work on windows")
+    def test_compile_autograd_list_output_default_args(self):
+        @torch.library.custom_op(
+            "_torch_testing::list_output_default_args",
+            mutates_args=(),
+        )
+        def f(
+            x: Tensor,
+            a: Optional[float] = None,
+            b: bool = False,
+            c: bool = True,
+        ) -> list[Tensor]:
+            return [x.clone()]
+
+        @f.register_fake
+        def _(x, a=None, b=False, c=True):
+            return [torch.empty_like(x)]
+
+        def backward(ctx, grads):
+            return (grads[0], None, None, None)
+
+        def setup_context(ctx, inputs, output):
+            self.assertEqual(len(inputs), 4)
+            self.assertEqual(inputs[1:], (None, False, True))
+
+        f.register_autograd(backward, setup_context=setup_context)
+
+        @torch.compile(backend="aot_eager", fullgraph=True)
+        def compiled(x):
+            return f(x, None, False, True)
+
+        x = torch.randn(2, 3, requires_grad=True)
+        (out,) = compiled(x)
+        (grad,) = torch.autograd.grad(out.sum(), x)
+        self.assertEqual(grad, torch.ones_like(x))
+
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_register_autograd_error_cases(self):
         @torch.library.custom_op("_torch_testing::g", mutates_args=())

--- a/torch/_library/autograd.py
+++ b/torch/_library/autograd.py
@@ -205,11 +205,24 @@ def supports_tensorlist(cls: Any) -> Any:
             grad_inputs, not_list_of_optional_tensor
         )
         if grad_inputs_spec != metadata.input_spec:
-            raise RuntimeError(
-                f"Expected the return from backward to be of the same structure "
-                f"as the inputs. Got: {grad_inputs_spec} (return from backward), "
-                f"{metadata.input_spec} (inputs)"
-            )
+            # The dispatcher may omit trailing arguments that are equal to their
+            # defaults. setup_context still sees the default-filled schema
+            # inputs, so custom-op backward formulas may return trailing None
+            # gradients for those omitted non-Tensor defaults. They are not
+            # Autograd Function inputs, so drop them before returning to
+            # autograd.
+            metadata_leaf_idx = metadata.input_spec.num_leaves - 1
+            if is_same_structure_with_trailing_none_leaves(
+                grad_inputs_spec,
+                metadata.input_spec,
+            ) and all(grad is None for grad in flat_grad_inputs[metadata_leaf_idx:]):
+                flat_grad_inputs = flat_grad_inputs[:metadata_leaf_idx] + [None]
+            else:
+                raise RuntimeError(
+                    f"Expected the return from backward to be of the same structure "
+                    f"as the inputs. Got: {grad_inputs_spec} (return from backward), "
+                    f"{metadata.input_spec} (inputs)"
+                )
         return tuple(flat_grad_inputs + [None])
 
     def new_apply(*args):
@@ -249,3 +262,21 @@ def not_list_of_optional_tensor(tree):
     if isinstance(tree, list):
         return any(l is not None and not isinstance(l, Tensor) for l in tree)
     return True
+
+
+def is_same_structure_with_trailing_none_leaves(
+    grad_inputs_spec: Any,
+    input_spec: Any,
+) -> bool:
+    if grad_inputs_spec.type is not tuple or input_spec.type is not tuple:
+        return False
+    if grad_inputs_spec.context != input_spec.context:
+        return False
+
+    grad_input_children = grad_inputs_spec.children()
+    input_children = input_spec.children()
+    if len(grad_input_children) <= len(input_children):
+        return False
+    if grad_input_children[: len(input_children)] != input_children:
+        return False
+    return all(child.is_leaf() for child in grad_input_children[len(input_children) :])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185132

Custom op autograd wraps generated autograd.Functions with supports_tensorlist when an operator has TensorList-like inputs or outputs. That wrapper records the pytree input spec from the arguments that the dispatcher actually passed to autograd. The dispatcher may elide trailing arguments whose values equal their schema defaults, while setup_context still receives the default-filled schema inputs. A backward formula can therefore correctly return one slot per schema input, but supports_tensorlist compared that return structure against the shorter dispatcher input structure and raised during compiled backward.

Handle this at the tensorlist autograd boundary by accepting only the narrow mismatch produced by elided trailing defaults: the backward return must have the same top-level prefix structure as the recorded inputs, and every extra trailing gradient slot must be None. Those slots are not autograd.Function inputs, so they are trimmed before returning to autograd; non-None extras and other structure mismatches still raise the existing error. This keeps the fix scoped to omitted non-Tensor default gradients instead of changing the arguments stored in the autograd graph.

I considered default-filling before calling Generated.apply, but that would force omitted default constants into the autograd.Function inputs. Trimming the redundant None gradients preserves the dispatcher elision behavior and matches the existing acceptance of trailing None gradients for non-tensor inputs.

Fixes #162687
Generated by my agent

Test Plan:
- python - <<'PY' ... PY  # issue-style torch.compile(fullgraph=True) repro with default-valued custom-op args
- python test/test_custom_ops.py -k test_compile_autograd_list_output_default_args
- python test/test_custom_ops.py -k test_supports_tensorlist
- python test/test_custom_ops.py -k test_register_autograd_defaults
- python -m py_compile torch/_library/autograd.py && git diff --check
- lintrunner -a