### PR TITLE
Speed up sympy_subs on symbolic Min/Max

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -2,8 +2,10 @@
 
 import importlib.util
 import unittest
+from unittest.mock import patch
 
 from sympy import I, Max, Min, Symbol, sympify
+from sympy.functions.elementary.miscellaneous import MinMaxBase
 
 import torch
 from torch._inductor.fx_utils import count_flops_fx, countable_fx
@@ -91,6 +93,45 @@ class TestUtils(TestCase):
         expr = Min(2, Max(0, Identity(q0)))
         result = sympy_subs(expr, {q0: I})
         self.assertTrue(result.has(I))
+
+    def testSympySubsSympyMinMaxSkipsExpensiveSymbolicSimplification(self):
+        x = Symbol("x", integer=True, positive=True)
+        y = Symbol("y", integer=True, positive=True)
+        z = Symbol("z", integer=True, positive=True)
+        expr = Min(Max(x + y, y + z), x + z)
+
+        with (
+            patch.object(
+                MinMaxBase,
+                "_collapse_arguments",
+                side_effect=AssertionError("_collapse_arguments called"),
+            ),
+            patch.object(
+                MinMaxBase,
+                "_find_localzeros",
+                side_effect=AssertionError("_find_localzeros called"),
+            ),
+        ):
+            result = sympy_subs(expr, {x: x + 1})
+
+        self.assertIs(result.func, Min)
+        max_arg = next(arg for arg in result.args if arg.func is Max)
+        self.assertEqual(set(result.args), {x + z + 1, max_arg})
+        self.assertEqual(set(max_arg.args), {x + y + 1, y + z})
+
+    def testSympySubsSympyMinMaxEvaluatesConcreteSubstitution(self):
+        x = Symbol("x", integer=True)
+        y = Symbol("y", integer=True, positive=True)
+        r = Symbol("r", positive=True)
+
+        self.assertEqual(sympy_subs(Max(x, 0), {x: -1}), 0)
+        self.assertEqual(sympy_subs(Min(x, 0), {x: -1}), -1)
+        self.assertEqual(sympy_subs(Max(x, 0), {x: y}), y)
+        self.assertEqual(sympy_subs(Min(x, 0), {x: y}), 0)
+        self.assertEqual(sympy_subs(Max(x, 1), {x: y}), y)
+        self.assertEqual(sympy_subs(Min(x, 1), {x: y}), 1)
+        self.assertEqual(sympy_subs(Max(x, 1), {x: r}), Max(1, r))
+        self.assertEqual(sympy_subs(Min(x, 1), {x: r}), Min(1, r))
 
     def testIdentityComparisonNoRecursion(self):
         self.assertTrue(Identity(sympify("0")) >= 0)

--- a/torch/fx/experimental/_size_hinting.py
+++ b/torch/fx/experimental/_size_hinting.py
@@ -17,6 +17,7 @@ import sys
 from typing import Any, TYPE_CHECKING
 
 import sympy
+from sympy.core.operations import ShortCircuit
 
 from torch.utils._sympy.numbers import int_oo
 
@@ -30,6 +31,88 @@ SYMPY_FACTOR_MAX_FREE_SYMBOLS = 50
 
 if TYPE_CHECKING:
     from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+
+def _rebuild_sympy_min_max(cls: type[sympy.Expr], args: tuple[Any, ...]) -> sympy.Basic:
+    min_max_args = tuple(sympy.sympify(arg) for arg in args)
+    if not any(getattr(arg, "free_symbols", ()) for arg in min_max_args):
+        return cls(*min_max_args)
+
+    try:
+        # Keep SymPy's inexpensive validation, identity removal, and flattening,
+        # but skip _collapse_arguments and _find_localzeros.  Those two
+        # optimizations dominate sympy_subs on symbolic Min/Max expressions.
+        filtered_args = frozenset(
+            cls._new_args_filter(min_max_args)  # type: ignore[attr-defined]
+        )
+    except ShortCircuit:
+        return cls.zero  # type: ignore[attr-defined]
+
+    if not filtered_args:
+        return cls.identity  # type: ignore[attr-defined]
+    filtered_args = _collapse_sympy_min_max_numeric(cls, filtered_args)
+    if not filtered_args:
+        return cls.identity  # type: ignore[attr-defined]
+    if len(filtered_args) == 1:
+        return next(iter(filtered_args))
+    return cls(*filtered_args, evaluate=False)
+
+
+def _collapse_sympy_min_max_numeric(
+    cls: type[sympy.Expr], values: frozenset[sympy.Expr]
+) -> set[sympy.Expr]:
+    other_values: set[sympy.Expr] = set()
+    num_value: sympy.Expr | None = None
+    for arg in values:
+        if arg.is_Number:
+            if num_value is None:
+                num_value = arg
+            elif cls is sympy.Max:
+                num_value = max(num_value, arg)
+            elif cls is sympy.Min:
+                num_value = min(num_value, arg)
+            else:
+                raise AssertionError(f"impossible {cls}")
+        else:
+            other_values.add(arg)
+
+    if num_value is None:
+        return other_values
+    if len(other_values) == 0:
+        return {num_value}
+    if len(other_values) == 1:
+        other_value = next(iter(other_values))
+        if num_value in (0.0, 0) and other_value.is_nonnegative:
+            return other_values if cls is sympy.Max else {num_value}
+        if num_value == 1 and other_value.is_integer and other_value.is_positive:
+            return other_values if cls is sympy.Max else {num_value}
+
+    other_values.add(num_value)
+    return other_values
+
+
+def _xreplace_sympy_min_max(
+    expr: sympy.Basic, rule: dict[sympy.Expr, sympy.Expr]
+) -> tuple[sympy.Basic, bool]:
+    if expr in rule:
+        return rule[expr], True
+    if rule:
+        args: list[Any] = []
+        changed = False
+        for arg in expr.args:
+            _xreplace = getattr(arg, "_xreplace", None)
+            if _xreplace is not None:
+                new_arg, arg_changed = _xreplace_sympy_min_max(arg, rule)
+                args.append(new_arg)
+                changed |= arg_changed
+            else:
+                args.append(arg)
+        if changed:
+            new_args = tuple(args)
+            if expr.func in (sympy.Min, sympy.Max):
+                return _rebuild_sympy_min_max(expr.func, new_args), True
+            return expr.func(*new_args), True
+    return expr, False
 
 
 def _sympy_subs(expr: sympy.Basic, replacements: dict[sympy.Expr, Any]) -> sympy.Basic:
@@ -53,9 +136,9 @@ def _sympy_subs(expr: sympy.Basic, replacements: dict[sympy.Expr, Any]) -> sympy
             return replacement
 
     # xreplace is faster than subs, but is way more picky
-    return sympy.sympify(expr).xreplace(
-        {k: to_symbol(k, v) for k, v in replacements.items()}
-    )
+    expr = sympy.sympify(expr)
+    replacements = {k: to_symbol(k, v) for k, v in replacements.items()}
+    return _xreplace_sympy_min_max(expr, replacements)[0]
 
 
 def _maybe_realize_expr(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185133

sympy_subs uses SymPy xreplace for substitution. When a replacement changes an argument inside a plain sympy.Min or sympy.Max, xreplace rebuilds the node with the normal SymPy constructor. For symbolic arguments that constructor spends most of its time trying to prove argument ordering in _collapse_arguments and _find_localzeros, which makes common dynamic-shape expressions with Min/Max very expensive to substitute.

Add a scoped rebuild path for plain sympy.Min and sympy.Max during sympy_subs. The custom traversal mirrors SymPy Basic._xreplace, but when it reconstructs Min/Max with symbolic arguments it keeps cheap validation, identity removal, flattening, and simple numeric/sign simplifications while skipping the expensive ordering simplification. Direct replacement and concrete Min/Max evaluation still use the normal SymPy path. I kept this local to sympy_subs instead of monkey-patching SymPy globally or converting all users to torch.utils._sympy Min/Max, because the issue is specifically substitution-time reconstruction and the narrower change has a smaller compatibility surface.

Tests cover avoiding the expensive symbolic Min/Max simplification path, preserving concrete/sign-aware simplifications, and preserving positive-real behavior for Min/Max with 1 while still simplifying positive integer symbols.

Fixes #162671
Generated by my agent

Test Plan:
- python test/inductor/test_utils.py -k SympySubs
- python test/inductor/test_utils.py
- lintrunner -a
- git diff --check

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo