### PR TITLE
[fx][_library] Honor wrapped op's schema.is_mutable in is_impure's auto_functionalized HOP branch (#185137)

### DIFF
--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -673,9 +673,24 @@ def is_impure(
             torch.ops.higher_order.auto_functionalized_v2,
         ):
             # Check if the auto-functionalized operator (the first argument) is
-            # side-effectful
+            # side-effectful. First the hardcoded allowlist (for ops that are
+            # side-effectful for reasons unrelated to schema-declared mutation),
+            # then fall through to the same schema.is_mutable check the
+            # OpOverload branch above uses -- without this fallback, an op
+            # registered via torch.library.custom_op(..., mutates_args=[...])
+            # is correctly flagged as impure when seen as a raw OpOverload but
+            # incorrectly flagged as pure when wrapped here in an
+            # auto_functionalized HOP (the typical post-functionalization
+            # form).
             if args and len(args) > 0:
-                return args[0] in _side_effectful_functions
+                wrapped = args[0]
+                if wrapped in _side_effectful_functions:
+                    return True
+                if isinstance(wrapped, torch._ops.OpOverload):
+                    wrapped_schema = getattr(wrapped, "_schema", None)
+                    if wrapped_schema is not None and wrapped_schema.is_mutable:
+                        return True
+                return False
 
         if _get_effect(op) is not None:
             return True


### PR DESCRIPTION
Summary:

`torch._library.utils.is_impure` (consumed by `torch.fx.Node.is_impure` and by every FX pass that asks "can I optimize across this node?") has two parallel branches that should answer the same question for the same underlying op:

**OpOverload branch** (lines 653-656): correctly consults `schema.is_mutable`, which catches any op whose schema has `Tensor(aN!)`-style alias annotations -- including registrations via `torch.library.custom_op(..., mutates_args=[...])`, since `infer_schema` emits exactly those annotations for each mutated arg.

**HigherOrderOperator branch** (lines 671-672): only consults the hardcoded `_side_effectful_functions` allowlist, never falls through to the wrapped op's `schema.is_mutable`.

The asymmetry means: a custom op registered with `mutates_args=[...]` is correctly flagged as impure when seen as a raw `OpOverload`, but incorrectly flagged as pure when wrapped in `auto_functionalized(custom_op, ...)` (the typical form after FX functionalization, which is what most downstream passes see).

Empirically (from a small probe importing a custom_op with declared `mutates_args`):

```
>>> from torch._library.utils import is_impure
>>> hop = torch.ops.higher_order.auto_functionalized
>>> is_impure(my_mutating_custom_op.default)          # OpOverload branch
True
>>> is_impure(hop, args=(my_mutating_custom_op.default,))  # HOP branch
False  # <- bug
```

Any FX pass that uses `is_impure()` to decide what's safe to optimize across gets the wrong answer for HOP-wrapped mutating custom ops. This affects CSE, DCE, reordering, and anything else that gates on `is_impure()` for post-functionalized graphs — e.g., CSE can merge two reads of the same tensor across an intervening `auto_functionalized(my_mutating_op)` call because the HOP incorrectly looks pure, silently reusing a stale value.

Fix is 5 lines in the HOP branch: after the existing `_side_effectful_functions` check, fall through to `schema.is_mutable` on the wrapped `OpOverload` -- the same check the OpOverload branch already does. Brings parity between the two branches without changing behavior for ops outside this corner case.

Likely historical reason for the gap: `is_impure` predates the `torch.library.custom_op(mutates_args=...)` API. The HOP branch was originally written when `_side_effectful_functions` was the only impurity signal worth checking for an auto_functionalized wrapped op. Schema-level alias annotations only became reachable for user-registered ops after `infer_schema` started emitting them, and the HOP branch never picked up the parallel check.

Test Plan:
Verified with the probe below: post-fix, `is_impure(hop, args=(op,))` returns `True` for a `custom_op(mutates_args=...)`-registered op.

```python
import torch
from torch._library.utils import is_impure

torch.library.custom_op("test::mutating_op", mutates_args=["x"])
def mutating_op(x: torch.Tensor) -> None:
    x.add_(1)

hop = torch.ops.higher_order.auto_functionalized
op = torch.ops.test.mutating_op.default

assert is_impure(op) is True           # OpOverload branch — already correct
assert is_impure(hop, args=(op,)) is True  # HOP branch — was False before fix
```

Differential Revision: D106300052


