### PR TITLE
Align parsePerProcessMemoryFraction's return type with other parsers

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -155,7 +155,7 @@ size_t CUDAAllocatorConfig::parseGraphCaptureRecordStreamReuse(
   return i;
 }
 
-double CUDAAllocatorConfig::parsePerProcessMemoryFraction(
+size_t CUDAAllocatorConfig::parsePerProcessMemoryFraction(
     const c10::CachingAllocator::ConfigTokenizer& tokenizer,
     size_t i) {
   tokenizer.checkToken(++i, ":");

--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -196,7 +196,7 @@ class C10_CUDA_API CUDAAllocatorConfig {
   size_t parseGraphCaptureRecordStreamReuse(
       const c10::CachingAllocator::ConfigTokenizer& tokenizer,
       size_t i);
-  double parsePerProcessMemoryFraction(
+  size_t parsePerProcessMemoryFraction(
       const c10::CachingAllocator::ConfigTokenizer& tokenizer,
       size_t i);
   size_t parsePinnedFreeCatchAll(


### PR DESCRIPTION
### Summary
CUDAAllocatorConfig::parsePerProcessMemoryFraction was declared to return double, but it actually returns the tokenizer index `i` (size_t), like the other parse* helpers. This change updates the declaration and definition in CUDAAllocatorConfig.h and CUDAAllocatorConfig.cpp so the return type is size_t.

### What changed
- c10/cuda/CUDAAllocatorConfig.h: parsePerProcessMemoryFraction return type double -> size_t
- c10/cuda/CUDAAllocatorConfig.cpp: matching definition change

Behavior is unchanged: the function still parses per_process_memory_fraction, validates it, stores it, and returns the updated tokenizer index.

### Root cause
Config parsers in this class follow one pattern: return the next tokenizer position after consuming a token. The parsed fraction is stored as a side effect; it is not the return value. The double return type was wrong on both declaration and definition and disagreed with the call site (i = parsePerProcessMemoryFraction(tokenizer, i)).

