### PR TITLE
Fix Crash on exit with invalid device pointer in CudaIPCSentData destructor

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -97,6 +97,13 @@ def send_and_delete_tensors(queue, event, device, dtype, count, size=5):
     event.wait()
 
 
+def limbo_cleanup_worker(q, e):
+    t = torch.zeros(5, 5, device="cuda")
+    q.put(t)
+    e.wait()
+    del t
+
+
 def send_tensor_with_untyped_storage(queue, event):
     tensors = torch.ones(2, device="cuda").chunk(2, dim=0)
     specs = []
@@ -534,6 +541,21 @@ class TestMultiprocessing(TestCase):
         del t
         e.set()
         p.join(1)
+
+    @unittest.skipIf(not TEST_CUDA_IPC, "CUDA IPC not available")
+    def test_cuda_ipc_limbo_cleanup_at_exit(self):
+        ctx = mp.get_context("spawn")
+        q = ctx.Queue()
+        e = ctx.Event()
+
+        p = ctx.Process(target=limbo_cleanup_worker, args=(q, e))
+        p.start()
+
+        t_received = q.get()
+        e.set()
+        p.join(5)
+        self.assertEqual(p.exitcode, 0)
+        del t_received
 
     @unittest.skipIf(not TEST_CUDA_IPC, "CUDA IPC not available")
     def test_cuda_ipc_deadlock(self):

--- a/torch/csrc/CudaIPCTypes.cpp
+++ b/torch/csrc/CudaIPCTypes.cpp
@@ -41,12 +41,12 @@ struct CudaIPCGlobalEntities {
   CudaIPCGlobalEntities& operator=(const CudaIPCGlobalEntities&) = delete;
   CudaIPCGlobalEntities& operator=(CudaIPCGlobalEntities&&) = delete;
   ~CudaIPCGlobalEntities() {
+    alive = false;
     CudaIPCSentDataLimbo_.collect();
     safe_clean_current_file();
     if (next_available_ref_counters_file_) {
       warnProducerTerminatedBeforeSharedTensorsReleased();
     }
-    alive = false;
   }
   void safe_clean_current_file() {
     std::lock_guard<std::mutex> lock(ref_counters_mutex_);
@@ -194,6 +194,9 @@ CudaIPCSentData::CudaIPCSentData(
 }
 
 CudaIPCSentData::~CudaIPCSentData() {
+  if (!CudaIPCGlobalEntities::alive) {
+    original_ptr_.release_context();
+  }
   ReturnRefCounter(handle_, offset_);
 #if !defined(USE_ROCM)
   try {


### PR DESCRIPTION
The crash occurred during program exit (`__run_exit_handlers`). The destructor of the global singleton `CudaIPCGlobalEntities` was calling `collect()` on `CudaIPCSentDataLimbo`, which in turn destroyed instances of `CudaIPCSentData`. Inside `~CudaIPCSentData()`, the destructor of `original_ptr_` (an `at::DataPtr`) was implicitly invoked, attempting to free the device memory using the `CUDACachingAllocator`. However, at this late stage of program termination, the CUDA context or the allocator's internal state had already been destroyed, leading to the "invalid device pointer" error.

```
test/test_multiprocessing.py::TestMultiprocessing::test_integer_parameter_serialization_cuda
PASSED [100%]

======================= 1 passed, 41 deselected in 4.44s =======================
Unhandled exception:
    @     0x55b8c52dc366  std::__terminate()
    @     0x55b8c52dc2f8  std::terminate()
    @     0x55b89876447f  torch::CudaIPCSentData::~CudaIPCSentData()
    @     0x55b898763fb1  torch::(anonymous namespace)::CudaIPCGlobalEntities::~CudaIPCGlobalEntities()
    @     0x7f8a4ddb65cd  __run_exit_handlers
    @     0x7f8a4ddb671a  exit
    @     0x55b8c51f4aec  Py_Exit
    @     0x55b8c51fdb36  _PyErr_PrintEx
    @     0x55b8c4a591ed  devtools::python_launcher::Launcher_Main()
    @     0x7f8a4dd9ef12  __libc_start_main
    @     0x55b8979d502a  _start
libc++abi: terminating due to uncaught exception of type c10::Error: invalid device pointer: 0x7f8a19a00000
Exception raised from free at third_party/py/torch/c10/cuda/CUDACachingAllocator.cpp:4658 (most recent call first):
```

This change prevents the deallocation from occurring if we are already in the middle of global destruction.



