### PR TITLE
[Inductor] Fix CPU bool argmin/argmax incorrect indices

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12471,10 +12471,10 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         t1[:, 100] = float("nan")
         self.common(fn, (t1,))
 
-    @requires_cuda
     def test_max_min_bool(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/174069
-        # max/min on boolean tensors returned incorrect indices in Triton
+        # and https://github.com/pytorch/pytorch/issues/184893.
+        # max/min on boolean tensors returned incorrect indices in Triton and CPU C++ codegen.
         def fn(x):
             return (
                 x.max(0),
@@ -12483,17 +12483,26 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 x.min(1),
             )
 
-        # Unrolled reduction
-        t1 = torch.randint(2, size=(6, 6), dtype=torch.bool)
-        self.common(fn, (t1,))
+        shapes = (
+            # Unrolled reduction
+            (6, 6),
+            # Persistent reduction
+            (32, 32),
+            # Non-persistent reduction
+            (1028, 1028),
+        )
+        if self.device == "cpu":
+            shapes = (
+                # Minimal CPU repro shapes for issue 184893
+                (2, 32),
+                (7, 32),
+                (32, 32),
+            )
 
-        # Persistent reduction
-        t1 = torch.randint(2, size=(32, 32), dtype=torch.bool)
-        self.common(fn, (t1,))
-
-        # Non-persistent reduction
-        t1 = torch.randint(2, size=(1028, 1028), dtype=torch.bool)
-        self.common(fn, (t1,))
+        for seed, shape in enumerate(shapes, start=2):
+            torch.manual_seed(seed)
+            t1 = torch.randint(2, size=shape, dtype=torch.bool)
+            self.common(fn, (t1,))
 
     def test_conv_backward(self):
         def fn(rank4_inps, rank3_inps, rank5_inps):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12497,6 +12497,14 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 (2, 32),
                 (7, 32),
                 (32, 32),
+                # Tail shapes exercise bool min/max value reductions together
+                # with arg reductions. This catches CPU C++ vector tail codegen
+                # that is only valid for arg reductions but accidentally affects
+                # bool value reductions.
+                (9, 33),
+                (17, 19),
+                (7, 31),
+                (2, 127),
             )
 
         for seed, shape in enumerate(shapes, start=2):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -63,8 +63,6 @@ test_failures = {
     # PDL tests are CUDA SM90+ only, skip on CPU
     "test_pdl_mutation_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     "test_pdl_template_and_delay_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
-    # Bool argmax/argmin fix is Triton-only (see #174069), skip on CPU
-    "test_max_min_bool_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     # With tensorify enabled, SymInt div no longer graph-breaks; the full
     # model compiles but Inductor hangs on the complex dynamic-shape graph.
     "test_AllenaiLongformerBase_repro_dynamic_shapes": TestFailure(

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -161,6 +161,10 @@ VECTORIZABLE_DTYPES: list[torch.dtype] = [
 ]
 
 
+def _arg_reduction_value_dtype(dtype: torch.dtype) -> torch.dtype:
+    return torch.uint8 if dtype == torch.bool else dtype
+
+
 def reduction_init(reduction_type, dtype):
     if dtype in DTYPE_LOWP_FP:
         # Since load promotes all half-precision inputs to float, the initial
@@ -171,17 +175,20 @@ def reduction_init(reduction_type, dtype):
     if reduction_type == "prod":
         return 1
     if reduction_type in ("max", "argmax", "min", "argmin"):
-        cdtype = DTYPE_TO_CPP[dtype]
-        if dtype == torch.bool and reduction_type in ("argmin", "argmax"):
-            cdtype = DTYPE_TO_CPP[torch.float]
+        compute_dtype = (
+            _arg_reduction_value_dtype(dtype)
+            if reduction_type in ("argmin", "argmax")
+            else dtype
+        )
+        cdtype = DTYPE_TO_CPP[compute_dtype]
         min_var = (
             f"-std::numeric_limits<{cdtype}>::infinity()"
-            if is_float_dtype(dtype)
+            if is_float_dtype(compute_dtype)
             else f"std::numeric_limits<{cdtype}>::min()"
         )
         max_var = (
             f"std::numeric_limits<{cdtype}>::infinity()"
-            if is_float_dtype(dtype)
+            if is_float_dtype(compute_dtype)
             else f"std::numeric_limits<{cdtype}>::max()"
         )
         init_var = min_var if reduction_type in ("max", "argmax") else max_var
@@ -201,7 +208,7 @@ def reduction_acc_type(reduction_type, dtype):
         return f"Welford<{scalar_type}>"
     if reduction_type in ("argmin", "argmax"):
         if dtype == torch.bool:
-            scalar_type = DTYPE_TO_CPP[torch.float]
+            scalar_type = DTYPE_TO_CPP[_arg_reduction_value_dtype(dtype)]
         return f"IndexValue<{scalar_type}>"
     return scalar_type
 
@@ -246,11 +253,12 @@ def reduction_combine(
             and next_value.dtype == torch.bool
             and not next_value.is_vec
         ):
+            compute_type = DTYPE_TO_CPP[_arg_reduction_value_dtype(next_value.dtype)]
             if index is not None:
-                return f"{reduction_type}_combine({var}, static_cast<float>({next_value}), {index})"
+                return f"{reduction_type}_combine({var}, static_cast<{compute_type}>({next_value}), {index})"
             else:
                 return (
-                    f"{reduction_type}_combine({var}, static_cast<float>({next_value}))"
+                    f"{reduction_type}_combine({var}, static_cast<{compute_type}>({next_value}))"
                 )
         if index is not None:
             return f"{reduction_type}_combine({var}, {next_value}, {index})"
@@ -2736,6 +2744,7 @@ class CppVecKernel(CppKernel):
         tiling_factor,
         tiling_idx,
         tail_size=None,
+        use_bool_arg_reduction_loads=False,
     ):
         super().__init__(args, num_threads)
         self.vec_isa = cpu_vec_isa.pick_vec_isa()
@@ -2745,6 +2754,7 @@ class CppVecKernel(CppKernel):
         self.tiling_idx = tiling_idx
         self.tail_size = tail_size
         self.num_elems = tail_size if tail_size else tiling_factor
+        self.use_bool_arg_reduction_loads = use_bool_arg_reduction_loads
 
     def _try_get_const_stride(self, index: sympy.Expr, itervar: sympy.Symbol):
         if self.index_indirect_depends_on(index, itervar):
@@ -2818,7 +2828,14 @@ class CppVecKernel(CppKernel):
         loadbuf = f"{var} + {cexpr_index(index)}" if index != 0 else var
         if dtype == torch.bool:
             # TODO: should we consider load mask here?
-            line = f"{self._get_mask_type()}::from({loadbuf}, {cexpr_index(self.num_elems)})"
+            if self.use_bool_arg_reduction_loads:
+                line = (
+                    f"{self._get_vec_type(torch.uint8)}::loadu("
+                    f"reinterpret_cast<const uint8_t*>({loadbuf}), "
+                    f"{cexpr_index(self.num_elems)})"
+                )
+            else:
+                line = f"{self._get_mask_type()}::from({loadbuf}, {cexpr_index(self.num_elems)})"
         else:
             line = (
                 f"{load_mask_str}.template loadu<{cpp_type},{num_vectors}>({loadbuf})"
@@ -2982,7 +2999,12 @@ class CppVecKernel(CppKernel):
         elif stride == 1:
             # load contiguously
             line = self._get_vec_load_line(var, index, dtype, self._load_mask)  # type: ignore[arg-type]
-            csevar = self.cse.generate(self.loads, line, dtype=dtype)  # type: ignore[assignment]
+            csevar_dtype = (
+                torch.uint8
+                if dtype == torch.bool and self.use_bool_arg_reduction_loads
+                else dtype
+            )
+            csevar = self.cse.generate(self.loads, line, dtype=csevar_dtype)  # type: ignore[assignment]
         else:
             csevar = self._load_or_store_non_contiguous(var, index, dtype)  # type: ignore[assignment]
         assert isinstance(csevar, CppCSEVariable)
@@ -3090,8 +3112,10 @@ class CppVecKernel(CppKernel):
         Returns:
             The result of the reduction operation
         """
-        # Note: For argmax and argmin on bool type, we always convert bool to float.
-        # Fix issue: https://github.com/pytorch/pytorch/issues/143568
+        # For bool argmax/argmin, keep CPU C++ values byte-sized rather than
+        # widening the whole reduction at lowering time.
+        # Fix issues: https://github.com/pytorch/pytorch/issues/143568 and
+        # https://github.com/pytorch/pytorch/issues/184893
         assert reduction_type in VECTORIZABLE_RTYPES
         argmax_or_argmin = reduction_type in ("argmax", "argmin")
         logical_index = None
@@ -3409,20 +3433,23 @@ class CppVecKernel(CppKernel):
             return f"Welford<{vec_type}>()"
 
         if reduction_type in ("argmin", "argmax"):
-            # For bool argmin/argmax, we use float for computations
-            compute_dtype = torch.float if dtype == torch.bool else scalar_type
+            compute_dtype = (
+                _arg_reduction_value_dtype(dtype)
+                if dtype == torch.bool
+                else scalar_type
+            )
             cdtype = DTYPE_TO_CPP[compute_dtype]
             acc_type = self.reduction_acc_type_vec(reduction_type, dtype)
             if reduction_type == "argmin":
                 val = (
                     f"std::numeric_limits<{cdtype}>::infinity()"
-                    if is_float_dtype(dtype) or dtype == torch.bool
+                    if is_float_dtype(compute_dtype)
                     else f"std::numeric_limits<{cdtype}>::max()"
                 )
             else:
                 val = (
                     f"-std::numeric_limits<{cdtype}>::infinity()"
-                    if is_float_dtype(dtype) or dtype == torch.bool
+                    if is_float_dtype(compute_dtype)
                     else f"std::numeric_limits<{cdtype}>::min()"
                 )
             return f"{acc_type}({val})"
@@ -3445,10 +3472,9 @@ class CppVecKernel(CppKernel):
         if reduction_type in ("argmin", "argmax"):
             n_idx = self._get_num_vectors(torch.int64)
             if dtype == torch.bool:
-                # For bool argmin/argmax, we use float for computations
-                # so n_src must be computed from float, not bool
-                n_src = self._get_num_vectors(torch.float)
-                return f"IndexValueVec<{DTYPE_TO_CPP[torch.float]}, {n_src}, {n_idx}>"
+                compute_dtype = _arg_reduction_value_dtype(dtype)
+                n_src = self._get_num_vectors(compute_dtype)
+                return f"IndexValueVec<{DTYPE_TO_CPP[compute_dtype]}, {n_src}, {n_idx}>"
             n_src = self._get_num_vectors(scalar_type)
             return f"IndexValueVec<{DTYPE_TO_CPP[scalar_type]}, {n_src}, {n_idx}>"
         if dtype == torch.bool:
@@ -3535,12 +3561,17 @@ class CppVecKernel(CppKernel):
             cdtype = DTYPE_TO_CPP[src_dtype]
             compute_dtype = src_dtype
             if src_dtype == torch.bool:
-                # For bool argmin/argmax, we use float for computations
-                cdtype = DTYPE_TO_CPP[torch.float]
-                compute_dtype = torch.float
-                # Convert bool VecMask to float vector for argmax_combine_vec
-                if isinstance(next_value, CppCSEVariable) and next_value.is_vec:
-                    (next_value,) = unify_mask_base_type(self.compute, (next_value,))
+                compute_dtype = _arg_reduction_value_dtype(src_dtype)
+                cdtype = DTYPE_TO_CPP[compute_dtype]
+                # Convert bool VecMask to byte vector for argmax_combine_vec.
+                if (
+                    isinstance(next_value, CppCSEVariable)
+                    and next_value.is_vec
+                    and next_value.dtype == torch.bool
+                ):
+                    (next_value,) = unify_mask_base_type(
+                        self.compute, (next_value,), compute_dtype
+                    )
             n_src = self._get_num_vectors(compute_dtype)
             n_idx = self._get_num_vectors(torch.int64)
             t_extra = ""
@@ -3685,6 +3716,7 @@ class CppTile2DKernel(CppVecKernel):
         tiling_indices,
         inner_tail_size=None,
         outer_tail_size=None,
+        use_bool_arg_reduction_loads=False,
     ):
         super().__init__(
             args,
@@ -3692,6 +3724,7 @@ class CppTile2DKernel(CppVecKernel):
             tiling_factor,
             tiling_indices[1],
             inner_tail_size,
+            use_bool_arg_reduction_loads,
         )
         self.tiling_indices = tiling_indices
         self.inner_tail_size = inner_tail_size
@@ -3934,6 +3967,39 @@ class KernelOpStats:
     mask_op_count: int = 0
 
 
+def _uses_bool_arg_reduction_tiling(fn_list) -> bool:
+    if not fn_list or not all(
+        isinstance(fn, functools.partial) and fn.args for fn in fn_list
+    ):
+        return False
+
+    scheduler_nodes = [fn.args[0] for fn in fn_list]
+    return all(
+        node.is_reduction()
+        and getattr(node.node.data, "src_dtype", None) == torch.bool
+        and getattr(node.node.data, "reduction_type", None) in ("argmin", "argmax")
+        for node in scheduler_nodes
+    )
+
+
+def _pick_tiling_dtype(
+    all_dtypes: OrderedSet[torch.dtype],
+    fn_list,
+) -> torch.dtype:
+    if all_dtypes and all(dtype in (torch.bool, torch.int64) for dtype in all_dtypes):
+        if _uses_bool_arg_reduction_tiling(fn_list):
+            return torch.uint8
+
+    return torch.float
+
+
+def _tiling_factor_for_dtype(dtype: torch.dtype) -> int:
+    vec_isa = cpu_vec_isa.pick_vec_isa()
+    if dtype == torch.uint8:
+        return vec_isa.bit_width() // 8
+    return vec_isa.nelements(dtype=dtype)
+
+
 class TilingSelect:
     """
     Implement the heuristic to select the tiling factors and tiling indices.
@@ -3951,7 +4017,7 @@ class TilingSelect:
         assert all_dtypes
         if any(dtype not in VECTORIZABLE_DTYPES for dtype in all_dtypes):
             return [], [], KernelOpStats()
-        dtype = torch.float
+        dtype = _pick_tiling_dtype(all_dtypes, fn_list)
         _lowp_fp_dtype = get_loop_body_lowp_fp(loop_bodies[0])[0]
         if _lowp_fp_dtype and all(
             (get_loop_body_lowp_fp(loop_body)[0] == _lowp_fp_dtype)
@@ -3959,7 +4025,7 @@ class TilingSelect:
         ):
             dtype = _lowp_fp_dtype
 
-        tiling_factor = cpu_vec_isa.pick_vec_isa().nelements(dtype=dtype)
+        tiling_factor = _tiling_factor_for_dtype(dtype)
         tiling_indices = self._select_tiling_indices(
             fn_list, var_sizes_list, tiling_factor
         )
@@ -4525,6 +4591,7 @@ class CppKernelProxy(CppKernel):
         # should not do this again to avoid context conflict. By now, we only control the
         # config.inplace_buffers. In the future, we could maintain more contexts.
         with torch._inductor.config.patch(inplace_buffers=False):
+            use_bool_arg_reduction_loads = _uses_bool_arg_reduction_tiling(fn_list)
             tiling_select = TilingSelect()
             tiling_factors, tiling_indices, tiling_stats = tiling_select.select_tiling(
                 fn_list, var_sizes_list
@@ -4575,7 +4642,11 @@ class CppKernelProxy(CppKernel):
                 metrics.generated_cpp_vec_kernel_count += 1
                 loop = self.loop_nest.tile(tiling_indices[0], factor=tiling_factors[0])
                 vec_kernel = codegen_kernel(
-                    self.vec_kernel_cls, tiling_factors[0], tiling_indices[0]
+                    self.vec_kernel_cls,
+                    tiling_factors[0],
+                    tiling_indices[0],
+                    None,
+                    use_bool_arg_reduction_loads,
                 )
                 tail_size = loop.size - loop.tiled_size
                 vec_kernel.active_ranges = {loop.var: (0, loop.tiled_size)}
@@ -4587,6 +4658,7 @@ class CppKernelProxy(CppKernel):
                         tiling_factors[0],
                         tiling_indices[0],
                         tail_size,
+                        use_bool_arg_reduction_loads,
                     )
                 else:
                     tail_kernel = scalar_kernel
@@ -4622,6 +4694,9 @@ class CppKernelProxy(CppKernel):
                     self.tile2d_kernel_cls,
                     tiling_factors[0],
                     tiling_indices,
+                    None,
+                    None,
+                    use_bool_arg_reduction_loads,
                 )
                 tile2d_kernel.active_ranges = {
                     outer_loop.var: outer_ranges["main"],
@@ -4648,6 +4723,7 @@ class CppKernelProxy(CppKernel):
                             tiling_indices,
                             _inner_tail_size,
                             _outer_tail_size,
+                            use_bool_arg_reduction_loads,
                         )
                         kernel.active_ranges = {
                             outer_loop.var: outer_ranges[outer_r],
@@ -4656,7 +4732,11 @@ class CppKernelProxy(CppKernel):
                         tail_kernel.append(kernel)
                 else:
                     vec_kernel = codegen_kernel(
-                        self.vec_kernel_cls, tiling_factors[0], tiling_indices[0]
+                        self.vec_kernel_cls,
+                        tiling_factors[0],
+                        tiling_indices[0],
+                        None,
+                        use_bool_arg_reduction_loads,
                     )
                     vec_kernel.active_ranges = {
                         outer_loop.var: outer_ranges["main"],

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -257,9 +257,7 @@ def reduction_combine(
             if index is not None:
                 return f"{reduction_type}_combine({var}, static_cast<{compute_type}>({next_value}), {index})"
             else:
-                return (
-                    f"{reduction_type}_combine({var}, static_cast<{compute_type}>({next_value}))"
-                )
+                return f"{reduction_type}_combine({var}, static_cast<{compute_type}>({next_value}))"
         if index is not None:
             return f"{reduction_type}_combine({var}, {next_value}, {index})"
         else:
@@ -2800,6 +2798,15 @@ class CppVecKernel(CppKernel):
         num_vectors = self._get_num_vectors(dtype)
         return f"{mask}.template cast<{DTYPE_TO_CPP[dtype]},{num_vectors}>()"
 
+    def _arg_reduction_compute_dtype(self, dtype: torch.dtype) -> torch.dtype:
+        if dtype != torch.bool:
+            return DTYPE_TO_COMPUTATION_DTYPE[dtype]
+        return (
+            _arg_reduction_value_dtype(dtype)
+            if self.use_bool_arg_reduction_loads
+            else torch.float
+        )
+
     def _get_vec_load_line(
         self,
         var: str,
@@ -3140,7 +3147,12 @@ class CppVecKernel(CppKernel):
 
         vec_ns = "at::vec"
         vec = f"{vec_ns}::Vectorized<{DTYPE_TO_CPP[dtype]}>"
-        acc_type = reduction_acc_type(reduction_type, init_dtype)
+        acc_dtype = (
+            self._arg_reduction_compute_dtype(init_dtype)
+            if argmax_or_argmin
+            else init_dtype
+        )
+        acc_type = reduction_acc_type(reduction_type, acc_dtype)
         acc_type_vec = self.reduction_acc_type_vec(reduction_type, init_dtype)
 
         acc = self.reduction_cse.generate(
@@ -3154,7 +3166,7 @@ class CppVecKernel(CppKernel):
         self.is_reduction = True
         self.reduction_prefix_generators.append(
             self._gen_reduction_prefix(
-                acc, acc_type, reduction_type, init_dtype, reduction_init
+                acc, acc_type, reduction_type, acc_dtype, reduction_init
             )
         )
         self.reduction_prefix_generators.append(
@@ -3277,7 +3289,7 @@ class CppVecKernel(CppKernel):
             acc,
             acc_type,
             reduction_type,
-            init_dtype,
+            acc_dtype,
             reduction_combine_fn=reduction_combine,
             reduction_init_fn=reduction_init,
         )
@@ -3433,11 +3445,7 @@ class CppVecKernel(CppKernel):
             return f"Welford<{vec_type}>()"
 
         if reduction_type in ("argmin", "argmax"):
-            compute_dtype = (
-                _arg_reduction_value_dtype(dtype)
-                if dtype == torch.bool
-                else scalar_type
-            )
+            compute_dtype = self._arg_reduction_compute_dtype(dtype)
             cdtype = DTYPE_TO_CPP[compute_dtype]
             acc_type = self.reduction_acc_type_vec(reduction_type, dtype)
             if reduction_type == "argmin":
@@ -3472,7 +3480,7 @@ class CppVecKernel(CppKernel):
         if reduction_type in ("argmin", "argmax"):
             n_idx = self._get_num_vectors(torch.int64)
             if dtype == torch.bool:
-                compute_dtype = _arg_reduction_value_dtype(dtype)
+                compute_dtype = self._arg_reduction_compute_dtype(dtype)
                 n_src = self._get_num_vectors(compute_dtype)
                 return f"IndexValueVec<{DTYPE_TO_CPP[compute_dtype]}, {n_src}, {n_idx}>"
             n_src = self._get_num_vectors(scalar_type)
@@ -3561,9 +3569,9 @@ class CppVecKernel(CppKernel):
             cdtype = DTYPE_TO_CPP[src_dtype]
             compute_dtype = src_dtype
             if src_dtype == torch.bool:
-                compute_dtype = _arg_reduction_value_dtype(src_dtype)
+                compute_dtype = self._arg_reduction_compute_dtype(src_dtype)
                 cdtype = DTYPE_TO_CPP[compute_dtype]
-                # Convert bool VecMask to byte vector for argmax_combine_vec.
+                # Convert bool VecMask to the arg-reduction value vector type.
                 if (
                     isinstance(next_value, CppCSEVariable)
                     and next_value.is_vec

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6949,12 +6949,17 @@ def make_reduction(
 ) -> Callable[..., TensorBox]:
     def inner(x, axis=None, keepdims=False, *, dtype=None) -> TensorBox:
         # For argmax/argmin on boolean tensors, cast to int32 first to ensure
-        # correct comparison in Triton. See https://github.com/pytorch/pytorch/issues/174069
-        # Only apply on Triton backend; MPS handles bool comparisons natively.
+        # correct comparison in Triton and CPU C++ vectorized reductions.
+        # See https://github.com/pytorch/pytorch/issues/174069 and
+        # https://github.com/pytorch/pytorch/issues/184893.
+        # Do not apply this generically; MPS handles bool comparisons natively.
         if (
             reduction_type in ("argmax", "argmin")
             and x.get_dtype() == torch.bool
-            and is_triton(x)
+            and (
+                is_triton(x)
+                or (ir.get_device_type(x) == "cpu" and config.cpu_backend == "cpp")
+            )
         ):
             x = to_dtype(x, torch.int32)
         kwargs = _make_reduction_inner(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6949,17 +6949,15 @@ def make_reduction(
 ) -> Callable[..., TensorBox]:
     def inner(x, axis=None, keepdims=False, *, dtype=None) -> TensorBox:
         # For argmax/argmin on boolean tensors, cast to int32 first to ensure
-        # correct comparison in Triton and CPU C++ vectorized reductions.
+        # correct comparison in Triton. CPU C++ handles bool arg reductions in
+        # codegen so it can keep byte-sized values instead of widening at lowering.
         # See https://github.com/pytorch/pytorch/issues/174069 and
         # https://github.com/pytorch/pytorch/issues/184893.
         # Do not apply this generically; MPS handles bool comparisons natively.
         if (
             reduction_type in ("argmax", "argmin")
             and x.get_dtype() == torch.bool
-            and (
-                is_triton(x)
-                or (ir.get_device_type(x) == "cpu" and config.cpu_backend == "cpp")
-            )
+            and is_triton(x)
         ):
             x = to_dtype(x, torch.int32)
         kwargs = _make_reduction_inner(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7630,9 +7630,16 @@ def reduce_max(x, dim=None, keepdim=False):
                 reduce_argmax_value(x, axis=dim, keepdims=keepdim),
                 reduce_argmax(x, axis=dim, keepdims=keepdim),
             )
+        arg_x = x
+        if (
+            x.get_dtype() == torch.bool
+            and ir.get_device_type(x) == "cpu"
+            and config.cpu_backend == "cpp"
+        ):
+            arg_x = to_dtype(x, torch.int32)
         return (
             reduce_amax(x, axis=dim, keepdims=keepdim),
-            reduce_argmax(x, axis=dim, keepdims=keepdim),
+            reduce_argmax(arg_x, axis=dim, keepdims=keepdim),
         )
 
     return reduce_amax(x, axis=None, keepdims=keepdim)
@@ -7648,9 +7655,16 @@ def reduce_min(x, dim=None, keepdim=False):
                 reduce_argmin_value(x, axis=dim, keepdims=keepdim),
                 reduce_argmin(x, axis=dim, keepdims=keepdim),
             )
+        arg_x = x
+        if (
+            x.get_dtype() == torch.bool
+            and ir.get_device_type(x) == "cpu"
+            and config.cpu_backend == "cpp"
+        ):
+            arg_x = to_dtype(x, torch.int32)
         return (
             reduce_amin(x, axis=dim, keepdims=keepdim),
-            reduce_argmin(x, axis=dim, keepdims=keepdim),
+            reduce_argmin(arg_x, axis=dim, keepdims=keepdim),
         )
 
     return reduce_amin(x, axis=None, keepdims=keepdim)


### PR DESCRIPTION
Fixes #184893

Summary:

When using `torch.compile` with the Inductor backend on CPU, `max(dim)[1]`
(argmax) and `min(dim)[1]` (argmin) could return incorrect indices for
boolean tensors.

Root cause:

CPU C++ codegen represents vectorized boolean values as `VecMask<float, N>`.
In that representation, true lanes are all-bits-set mask payloads rather than
numeric `1` values. For bool argmin/argmax reductions, this can send the
comparison through the floating arg-reduction path, where true lanes can be
treated like NaN-ish float mask values instead of ordinary boolean values.

Patch:

This extends the bool argmin/argmax fix from #174076 to CPU C++ codegen,
so boolean arg reductions compare `int32` values internally (`False -> 0`,
`True -> 1`) before selecting indices. Public result dtypes are unchanged.

Tests:

The existing `test_max_min_bool` test now runs on CPU as well as CUDA, using
deterministic CPU repro shapes for #184893. The stale CPU dynamic-shapes skip
for `test_max_min_bool_dynamic_shapes` is also removed.

Test plan:

- `python test/inductor/test_torchinductor.py CpuTests.test_max_min_bool_cpu -v`
- `python test/inductor/test_torchinductor_dynamic_shapes.py DynamicShapesCpuTests.test_max_min_bool_dynamic_shapes_cpu -v`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos