### PR TITLE
fix buck build fbsource//xplat/caffe2/android:test_host (#185160)

### DIFF
--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -229,7 +229,7 @@ struct UnwindCache {
     Unwinder unwinder = Unwinder::unknown();
     try {
       unwinder = libraryFor(addr).unwinderFor(addr);
-    } catch (unwind::UnwindError& err) {
+    } catch ([[maybe_unused]] unwind::UnwindError& err) {
       // because unwinders are cached this will only print
       // once per frame that cannot be unwound.
       TORCH_WARN("Unsupported unwinding pattern: ", err.what());


### PR DESCRIPTION
Summary:

We want to default to opt for the dependencies that go through a excution transiton, however that breaks `buck build fbsource//xplat/caffe2/android:test_host` because TORCH_WARN gets compiled out, but [[maybe_unused]] allows TORCH_WARN to be missing

Test Plan: buck build fbsource//xplat/caffe2/android:test_host

Reviewed By: mzlee

Differential Revision: D106309775


