### PR TITLE
Add FlightRecorderEntry dataclass

### DIFF
--- a/test/distributed/flight_recorder/test_fr_analysis.py
+++ b/test/distributed/flight_recorder/test_fr_analysis.py
@@ -2,6 +2,7 @@
 
 import copy
 import math
+from dataclasses import asdict
 from typing import Any
 
 from torch.distributed.flight_recorder.components.builder import build_db
@@ -30,8 +31,8 @@ def create_one_event(
     return FlightRecorderEntry(
         process_group=pg_info,
         profiling_name=f"nccl:{collective_name}",
-        collective_seq_id=str(collective_seq_id),
-        p2p_seq_id=str(p2p_seq_id),
+        collective_seq_id=collective_seq_id,
+        p2p_seq_id=p2p_seq_id,
         record_id=-1,
         input_sizes=input_sizes,
         output_sizes=output_sizes,
@@ -189,8 +190,8 @@ class FlightRecorderOpBackendTest(TestCase):
         return FlightRecorderEntry(
             process_group=("0", "default"),
             profiling_name=f"{backend}:{collective}",
-            collective_seq_id="1",
-            p2p_seq_id="0",
+            collective_seq_id=1,
+            p2p_seq_id=0,
             record_id=-1,
             input_sizes=[[4, 4]],
             output_sizes=[[4, 4]],
@@ -275,8 +276,7 @@ def create_one_entry(
         output_dtypes,
     )
     event.record_id = record_id
-    event.is_p2p = False
-    return event
+    return asdict(event)
 
 
 class FlightRecorderE2ETest(TestCase):

--- a/test/distributed/flight_recorder/test_fr_analysis.py
+++ b/test/distributed/flight_recorder/test_fr_analysis.py
@@ -8,6 +8,7 @@ from torch.distributed.flight_recorder.components.builder import build_db
 from torch.distributed.flight_recorder.components.config_manager import JobConfig
 from torch.distributed.flight_recorder.components.types import (
     COLLECTIVES,
+    FlightRecorderEntry,
     MatchInfo,
     MatchState,
     Op,
@@ -26,19 +27,21 @@ def create_one_event(
     p2p_seq_id=0,
     output_dtypes="float32",
 ):
-    return {
-        "profiling_name": f"nccl:{collective_name}",
-        "state": state,
-        "process_group": pg_info,
-        "input_sizes": input_sizes,
-        "output_sizes": output_sizes,
-        "input_dtypes": "float32",
-        "output_dtypes": output_dtypes,
-        "collective_seq_id": str(collective_seq_id),
-        "p2p_seq_id": str(p2p_seq_id),
-        "time_created_ns": 0,
-        "frames": [],
-    }
+    return FlightRecorderEntry(
+        process_group=pg_info,
+        profiling_name=f"nccl:{collective_name}",
+        collective_seq_id=str(collective_seq_id),
+        p2p_seq_id=str(p2p_seq_id),
+        record_id=-1,
+        input_sizes=input_sizes,
+        output_sizes=output_sizes,
+        state=state,
+        is_p2p=False,
+        input_dtypes="float32",
+        output_dtypes=output_dtypes,
+        time_created_ns=0,
+        frames=[],
+    )
 
 
 class FlightRecorderEventTest(TestCase):
@@ -183,19 +186,21 @@ class FlightRecorderOpBackendTest(TestCase):
     """Tests that the Op class accepts all supported backend prefixes."""
 
     def _make_event(self, backend: str, collective: str = "all_reduce"):
-        return {
-            "profiling_name": f"{backend}:{collective}",
-            "state": "completed",
-            "process_group": ("0", "default"),
-            "input_sizes": [[4, 4]],
-            "output_sizes": [[4, 4]],
-            "input_dtypes": "float32",
-            "output_dtypes": "float32",
-            "collective_seq_id": "1",
-            "p2p_seq_id": "0",
-            "time_created_ns": 0,
-            "frames": [],
-        }
+        return FlightRecorderEntry(
+            process_group=("0", "default"),
+            profiling_name=f"{backend}:{collective}",
+            collective_seq_id="1",
+            p2p_seq_id="0",
+            record_id=-1,
+            input_sizes=[[4, 4]],
+            output_sizes=[[4, 4]],
+            state="completed",
+            is_p2p=False,
+            input_dtypes="float32",
+            output_dtypes="float32",
+            time_created_ns=0,
+            frames=[],
+        )
 
     def test_nccl_backend(self):
         op = Op(self._make_event("nccl"), {"0": {0, 1}}, "0")
@@ -269,8 +274,8 @@ def create_one_entry(
         p2p_seq_id,
         output_dtypes,
     )
-    event.update({"record_id": record_id})
-    event.update({"is_p2p": False})
+    event.record_id = record_id
+    event.is_p2p = False
     return event
 
 

--- a/torch/distributed/flight_recorder/components/builder.py
+++ b/torch/distributed/flight_recorder/components/builder.py
@@ -9,7 +9,7 @@ import ast
 import copy
 import os
 import sys
-from typing import Any, cast  # type: ignore[attr-defined]
+from typing import Any
 
 from torch.distributed.flight_recorder.components.fr_logger import FlightRecorderLogger
 from torch.distributed.flight_recorder.components.types import (
@@ -140,7 +140,7 @@ def build_groups_memberships(
 
 
 def build_collectives(
-    all_entries: dict[int, list[dict[str, Any]]],
+    all_entries: dict[int, list[FlightRecorderEntry]],
     _groups: dict[str, Group],
     _memberships: dict[str, set[Any]],
     _pg_guids: dict[tuple[str, int], str],
@@ -176,7 +176,6 @@ def build_collectives(
     }
     """
     tracebacks: list[Traceback] = []
-    typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
 
     collectives: list[Collective] = []
     nccl_calls: list[NCCLCall] = []
@@ -186,27 +185,27 @@ def build_collectives(
     mismatch = {_groups[g].id: 0 for g in _groups}
 
     # For best effort partial analysis.
-    dumps_ranks = {int(key) for key in typed_entries}
+    dumps_ranks = {int(key) for key in all_entries}
     """
     - it doesn't matter what order I put collectives/ncclops into their table. we can later on re-sort it by start time
     - there could be multiple options for the "first" collective to pair up (rank 0,1 might do a bcast while rank 2,3 do a bcast)
     - within a group, the first collective must be the same on all ranks in the group, then it can be marked as a
     collective and removed
     """
-    while typed_entries:
+    while all_entries:
         # we greedily match collectives, starting arbitrarily with the trace from the first rank
         # later, if we exhaust the first rank, we continue with the next 'first rank'
-        rank_iter = iter(typed_entries)
+        rank_iter = iter(all_entries)
         first_rank = next(rank_iter)
         other_ranks = list(rank_iter)
 
-        if len(typed_entries[first_rank]) == 0:
-            typed_entries.pop(first_rank)
+        if len(all_entries[first_rank]) == 0:
+            all_entries.pop(first_rank)
             continue
 
         # lets match the first collective! we need to know which ranks are involved, and ensure that this same
         # collective is also the first one on those ranks within that group
-        entries = typed_entries[first_rank]
+        entries = all_entries[first_rank]
         current_entry = entries[0]
         desc = current_entry.process_group[1]
         # For db build and logs printing, we want to use the original pg_name, not the hash one.
@@ -232,20 +231,20 @@ def build_collectives(
             else find_coalesced_group_with_non_p2p
         )
         maybe_coalesced_group = find_coalesced_group(
-            pg_name, cast(list[dict[str, Any]], entries), _pg_guids, first_rank
+            pg_name, entries, _pg_guids, first_rank
         )
         if len(maybe_coalesced_group) > 1:
             num_coalesced_entries = len(maybe_coalesced_group)
             # We need a copy of the original expected ranks to avoid modifying it.
             candidate_ranks = copy.deepcopy(expected_ranks)
             done_ranks = set()
-            all_coalesced_entries = {}
+            all_coalesced_entries: dict[int, list[tuple[int, FlightRecorderEntry]]] = {}
             while candidate_ranks:
                 curr = candidate_ranks.pop()
                 done_ranks.add(curr)
                 grp = (
-                    find_coalesced_group(pg_name, typed_entries[curr], _pg_guids, curr)  # type: ignore[arg-type]
-                    if curr in typed_entries
+                    find_coalesced_group(pg_name, all_entries[curr], _pg_guids, curr)
+                    if curr in all_entries
                     else []
                 )
                 all_coalesced_entries[curr] = grp
@@ -314,7 +313,7 @@ def build_collectives(
                 for i, k in idx_map.items():
                     for _ in range(1, num_coalesced_entries):
                         try:
-                            typed_entries[i].pop(k)
+                            all_entries[i].pop(k)
                         except IndexError:
                             # In the case of a missing rank symptom that a rank didn't schedule the coalesced collective,
                             # we should not fail the analysis script here.
@@ -325,7 +324,7 @@ def build_collectives(
                 all_entries,
                 _pg_guids,
                 (pg_name, desc),
-                cast(dict[str, Any], current_entry),
+                current_entry,
                 _memberships,
                 mismatch,
                 match_record,
@@ -337,7 +336,7 @@ def build_collectives(
                 match_record,
                 dumps_ranks,
                 first_rank,
-                cast(dict[str, Any], current_entry),
+                current_entry,
                 mismatch,
                 get_version_detail(version),
                 pg_name,
@@ -415,7 +414,7 @@ def build_db(
     if args.verbose:
         os.environ["FR_TRACE_VERBOSE_OUTPUT"] = "1"
     # temporary state used for building database
-    entries = {}
+    entries: dict[int, list[FlightRecorderEntry]] = {}
     pg_config = {}
     version_by_ranks = {}
     for dump in details.values():
@@ -428,7 +427,7 @@ def build_db(
 
     # Ensure version is consistent across all ranks.
     check_version(version_by_ranks, version)
-    entries = align_trace_from_beginning(cast(dict[int, list[dict[str, Any]]], entries))
+    entries = align_trace_from_beginning(entries)
     stack_id_trace_map: dict[str, int] = {}
     if args.just_print_entries:
         entries, stack_id_trace_map = add_stack_id_in_entries(entries)

--- a/torch/distributed/flight_recorder/components/builder.py
+++ b/torch/distributed/flight_recorder/components/builder.py
@@ -16,6 +16,7 @@ from torch.distributed.flight_recorder.components.types import (
     Collective,
     Database,
     EntryState,
+    FlightRecorderEntry,
     Group,
     MatchStateRecord,
     Membership,
@@ -139,7 +140,7 @@ def build_groups_memberships(
 
 
 def build_collectives(
-    all_entries: dict[int, list[dict[str, Any]]],
+    all_entries: dict[int, list[FlightRecorderEntry]],
     _groups: dict[str, Group],
     _memberships: dict[str, set[Any]],
     _pg_guids: dict[tuple[str, int], str],
@@ -206,9 +207,9 @@ def build_collectives(
         # collective is also the first one on those ranks within that group
         entries = all_entries[first_rank]
         current_entry = entries[0]
-        desc = current_entry["process_group"][1]
+        desc = current_entry.process_group[1]
         # For db build and logs printing, we want to use the original pg_name, not the hash one.
-        original_pg_name = current_entry["process_group"][0]
+        original_pg_name = current_entry.process_group[0]
         pg_name = _pg_guids[(original_pg_name, first_rank)]
         expected_ranks = set(_memberships[pg_name])
         entry_state = EntryState(current_entry, expected_ranks)
@@ -418,7 +419,12 @@ def build_db(
     version_by_ranks = {}
     for dump in details.values():
         rank = dump["rank"]
-        entries[rank] = dump["entries"]
+        entries[rank] = [
+            entry
+            if isinstance(entry, FlightRecorderEntry)
+            else FlightRecorderEntry.from_dict(entry)
+            for entry in dump["entries"]
+        ]
         version_by_ranks[rank] = dump["version"]
         pg_config[rank] = dump["pg_config"]
 

--- a/torch/distributed/flight_recorder/components/builder.py
+++ b/torch/distributed/flight_recorder/components/builder.py
@@ -9,7 +9,7 @@ import ast
 import copy
 import os
 import sys
-from typing import Any  # type: ignore[attr-defined]
+from typing import Any, cast  # type: ignore[attr-defined]
 
 from torch.distributed.flight_recorder.components.fr_logger import FlightRecorderLogger
 from torch.distributed.flight_recorder.components.types import (
@@ -140,7 +140,7 @@ def build_groups_memberships(
 
 
 def build_collectives(
-    all_entries: dict[int, list[FlightRecorderEntry]],
+    all_entries: dict[int, list[dict[str, Any]]],
     _groups: dict[str, Group],
     _memberships: dict[str, set[Any]],
     _pg_guids: dict[tuple[str, int], str],
@@ -176,6 +176,7 @@ def build_collectives(
     }
     """
     tracebacks: list[Traceback] = []
+    typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
 
     collectives: list[Collective] = []
     nccl_calls: list[NCCLCall] = []
@@ -185,27 +186,27 @@ def build_collectives(
     mismatch = {_groups[g].id: 0 for g in _groups}
 
     # For best effort partial analysis.
-    dumps_ranks = {int(key) for key in all_entries}
+    dumps_ranks = {int(key) for key in typed_entries}
     """
     - it doesn't matter what order I put collectives/ncclops into their table. we can later on re-sort it by start time
     - there could be multiple options for the "first" collective to pair up (rank 0,1 might do a bcast while rank 2,3 do a bcast)
     - within a group, the first collective must be the same on all ranks in the group, then it can be marked as a
     collective and removed
     """
-    while all_entries:
+    while typed_entries:
         # we greedily match collectives, starting arbitrarily with the trace from the first rank
         # later, if we exhaust the first rank, we continue with the next 'first rank'
-        rank_iter = iter(all_entries)
+        rank_iter = iter(typed_entries)
         first_rank = next(rank_iter)
         other_ranks = list(rank_iter)
 
-        if len(all_entries[first_rank]) == 0:
-            all_entries.pop(first_rank)
+        if len(typed_entries[first_rank]) == 0:
+            typed_entries.pop(first_rank)
             continue
 
         # lets match the first collective! we need to know which ranks are involved, and ensure that this same
         # collective is also the first one on those ranks within that group
-        entries = all_entries[first_rank]
+        entries = typed_entries[first_rank]
         current_entry = entries[0]
         desc = current_entry.process_group[1]
         # For db build and logs printing, we want to use the original pg_name, not the hash one.
@@ -231,7 +232,7 @@ def build_collectives(
             else find_coalesced_group_with_non_p2p
         )
         maybe_coalesced_group = find_coalesced_group(
-            pg_name, entries, _pg_guids, first_rank
+            pg_name, cast(list[dict[str, Any]], entries), _pg_guids, first_rank
         )
         if len(maybe_coalesced_group) > 1:
             num_coalesced_entries = len(maybe_coalesced_group)
@@ -243,8 +244,8 @@ def build_collectives(
                 curr = candidate_ranks.pop()
                 done_ranks.add(curr)
                 grp = (
-                    find_coalesced_group(pg_name, all_entries[curr], _pg_guids, curr)  # type: ignore[index]
-                    if curr in all_entries  # type: ignore[comparison-overlap]
+                    find_coalesced_group(pg_name, typed_entries[curr], _pg_guids, curr)  # type: ignore[arg-type]
+                    if curr in typed_entries
                     else []
                 )
                 all_coalesced_entries[curr] = grp
@@ -313,7 +314,7 @@ def build_collectives(
                 for i, k in idx_map.items():
                     for _ in range(1, num_coalesced_entries):
                         try:
-                            all_entries[i].pop(k)
+                            typed_entries[i].pop(k)
                         except IndexError:
                             # In the case of a missing rank symptom that a rank didn't schedule the coalesced collective,
                             # we should not fail the analysis script here.
@@ -324,7 +325,7 @@ def build_collectives(
                 all_entries,
                 _pg_guids,
                 (pg_name, desc),
-                current_entry,
+                cast(dict[str, Any], current_entry),
                 _memberships,
                 mismatch,
                 match_record,
@@ -336,7 +337,7 @@ def build_collectives(
                 match_record,
                 dumps_ranks,
                 first_rank,
-                current_entry,
+                cast(dict[str, Any], current_entry),
                 mismatch,
                 get_version_detail(version),
                 pg_name,
@@ -420,17 +421,14 @@ def build_db(
     for dump in details.values():
         rank = dump["rank"]
         entries[rank] = [
-            entry
-            if isinstance(entry, FlightRecorderEntry)
-            else FlightRecorderEntry.from_dict(entry)
-            for entry in dump["entries"]
+            FlightRecorderEntry.from_dict(entry) for entry in dump["entries"]
         ]
         version_by_ranks[rank] = dump["version"]
         pg_config[rank] = dump["pg_config"]
 
     # Ensure version is consistent across all ranks.
     check_version(version_by_ranks, version)
-    entries = align_trace_from_beginning(entries)
+    entries = align_trace_from_beginning(cast(dict[int, list[dict[str, Any]]], entries))
     stack_id_trace_map: dict[str, int] = {}
     if args.just_print_entries:
         entries, stack_id_trace_map = add_stack_id_in_entries(entries)

--- a/torch/distributed/flight_recorder/components/types.py
+++ b/torch/distributed/flight_recorder/components/types.py
@@ -6,6 +6,7 @@
 
 import math
 import os
+from dataclasses import dataclass, field
 from enum import auto, Enum
 from typing import (
     _eval_type,  # pyrefly: ignore [missing-module-attribute]
@@ -29,6 +30,7 @@ __all__ = [
     "Collective",
     "NCCLCall",
     "Database",
+    "FlightRecorderEntry",
     "EntryState",
     "Op",
     "MatchStateRecord",
@@ -179,6 +181,44 @@ class Database(NamedTuple):
     ncclcalls: list[NCCLCall]
 
 
+@dataclass
+class FlightRecorderEntry:
+    process_group: tuple[str, str]
+    profiling_name: str
+    collective_seq_id: int | str
+    p2p_seq_id: int | str
+    record_id: int
+    input_sizes: list[list[int]]
+    output_sizes: list[list[int]]
+    state: str
+    is_p2p: bool
+    input_dtypes: Any = None
+    output_dtypes: Any = None
+    time_created_ns: int = 0
+    frames: list[dict[str, str]] = field(default_factory=list)
+    stack_id: int = -1
+
+    @classmethod
+    def from_dict(cls, entry: dict[str, Any]) -> "FlightRecorderEntry":
+        process_group = entry["process_group"]
+        return cls(
+            process_group=(process_group[0], process_group[1]),
+            profiling_name=entry["profiling_name"],
+            collective_seq_id=entry["collective_seq_id"],
+            p2p_seq_id=entry["p2p_seq_id"],
+            record_id=entry["record_id"],
+            input_sizes=entry["input_sizes"],
+            output_sizes=entry["output_sizes"],
+            state=entry["state"],
+            is_p2p=entry["is_p2p"],
+            input_dtypes=entry.get("input_dtypes"),
+            output_dtypes=entry.get("output_dtypes"),
+            time_created_ns=entry.get("time_created_ns", 0),
+            frames=entry.get("frames", []),
+            stack_id=entry.get("stack_id", -1),
+        )
+
+
 # TODO: We need to add a schema for the following
 types = [
     TypeInfo.from_type(t)  # type: ignore[type-var]
@@ -245,20 +285,20 @@ class EntryState:
     log the error info during analysis.
     """
 
-    def __init__(self, entry: dict[str, Any], expected_ranks: set[int]) -> None:
-        self.pg_name = entry["process_group"][0]
-        self.desc = entry["process_group"][1]
+    def __init__(self, entry: FlightRecorderEntry, expected_ranks: set[int]) -> None:
+        self.pg_name = entry.process_group[0]
+        self.desc = entry.process_group[1]
         self.pg_desc = (
             f"{self.pg_name}:{self.desc}" if self.desc != "undefined" else self.pg_name
         )
-        self.profiling_name = entry["profiling_name"]
-        self.collective_seq_id = entry["collective_seq_id"]
-        self.p2p_seq_id = entry["p2p_seq_id"]
-        self.record_id = entry["record_id"]
-        self.input_sizes = entry["input_sizes"]
-        self.output_sizes = entry["output_sizes"]
-        self.collective_state = entry["state"]
-        self.collective_frames = entry.get("frames", [])
+        self.profiling_name = entry.profiling_name
+        self.collective_seq_id = entry.collective_seq_id
+        self.p2p_seq_id = entry.p2p_seq_id
+        self.record_id = entry.record_id
+        self.input_sizes = entry.input_sizes
+        self.output_sizes = entry.output_sizes
+        self.collective_state = entry.state
+        self.collective_frames = entry.frames
         self.expected_ranks = expected_ranks
         self.missing_ranks: set[int]
         self.input_numel: int
@@ -309,7 +349,7 @@ class EntryState:
         id: int,
         errors: set[tuple[int, MatchInfo]] | None = None,
         idx_map: dict[int, int] | None = None,
-        all_entries: dict[int, list[dict[str, Any]]] | None = None,
+        all_entries: dict[int, list[FlightRecorderEntry]] | None = None,
     ) -> Collective:
         if not errors:
             return Collective(
@@ -337,22 +377,22 @@ class EntryState:
             for rank, error in errors:
                 idx = idx_map[rank]
                 entry = all_entries[rank][idx]
-                desc = entry["process_group"][1]
-                pg_name = entry["process_group"][0]
+                desc = entry.process_group[1]
+                pg_name = entry.process_group[0]
                 mismatch_collectives[rank] = Collective(
                     id=id,
-                    group_id=entry["process_group"][0],
-                    record_id=entry["record_id"],
+                    group_id=entry.process_group[0],
+                    record_id=entry.record_id,
                     pg_desc=f"{pg_name}:{desc}" if desc != "undefined" else pg_name,
                     pass_check=False,
-                    collective_seq_id=entry["collective_seq_id"],
-                    p2p_seq_id=entry["p2p_seq_id"],
-                    collective_name=entry["profiling_name"],
-                    input_sizes=entry["input_sizes"],
-                    output_sizes=entry["output_sizes"],
+                    collective_seq_id=entry.collective_seq_id,
+                    p2p_seq_id=entry.p2p_seq_id,
+                    collective_name=entry.profiling_name,
+                    input_sizes=entry.input_sizes,
+                    output_sizes=entry.output_sizes,
                     expected_ranks=self.expected_ranks,
-                    collective_state=entry["state"],
-                    collective_frames=entry.get("frames", []),
+                    collective_state=entry.state,
+                    collective_frames=entry.frames,
                     type_of_mismatch=error,
                 )
             return Collective(
@@ -381,7 +421,7 @@ class EntryState:
 
     def to_nccl_call(
         self,
-        all_entries: dict[int, list[dict[str, Any]]],
+        all_entries: dict[int, list[FlightRecorderEntry]],
         idx_map: dict[int, int],
         nccl_call_id: int,
         collective_id: Any,
@@ -414,9 +454,9 @@ class Op:
     """
 
     def __init__(
-        self, event: dict[Any, Any], memberships: dict[str, set[Any]], pg_name: str
+        self, event: FlightRecorderEntry, memberships: dict[str, set[Any]], pg_name: str
     ):
-        self.profiling_name = event["profiling_name"]
+        self.profiling_name = event.profiling_name
         comm_lib_backend, name = self.profiling_name.split(":")
         if comm_lib_backend not in ["nccl", "ncclx", "gloo", "xccl"]:
             raise AssertionError(
@@ -425,10 +465,10 @@ class Op:
         parts = name.split(" ")
         type = parts[0]
         meta = parts[1] if len(parts) == 2 else None
-        self.state = event["state"]
+        self.state = event.state
         # Store the hashed pg_name for accessing memberships, and original pg info for display
         self.pg_name = pg_name  # This is the hashed version used for memberships lookup
-        self.original_pg_name, self.pg_desc = event["process_group"]
+        self.original_pg_name, self.pg_desc = event.process_group
         if type not in COLLECTIVES | P2P | {"coalesced"}:
             raise AssertionError(f"{type} is not a supported operation")
         self.type = type
@@ -447,17 +487,17 @@ class Op:
         self._init_global_src_dst(memberships[pg_name])
         self.pg_size = len(memberships[pg_name])
         if type in P2P | COLLECTIVES:
-            self.input_sizes = event["input_sizes"]
-            self.output_sizes = event["output_sizes"]
+            self.input_sizes = event.input_sizes
+            self.output_sizes = event.output_sizes
         else:
             self.input_sizes, self.output_sizes = None, None
-        self.collective_seq_id = event["collective_seq_id"]
-        self.stack_id = event.get("stack_id", -1)
-        self.p2p_seq_id = event["p2p_seq_id"]
-        self.input_dtypes = event["input_dtypes"]
-        self.output_dtypes = event["output_dtypes"]
-        self.time_created_ns = event["time_created_ns"]
-        self.collective_frames = event.get("frames", [])
+        self.collective_seq_id = event.collective_seq_id
+        self.stack_id = event.stack_id
+        self.p2p_seq_id = event.p2p_seq_id
+        self.input_dtypes = event.input_dtypes
+        self.output_dtypes = event.output_dtypes
+        self.time_created_ns = event.time_created_ns
+        self.collective_frames = event.frames
         self.is_verbose = os.getenv("FR_TRACE_VERBOSE_OUTPUT", "0") == "1"
 
     def _init_global_src_dst(self, pg_ranks: set[Any]) -> None:

--- a/torch/distributed/flight_recorder/components/types.py
+++ b/torch/distributed/flight_recorder/components/types.py
@@ -11,6 +11,7 @@ from enum import auto, Enum
 from typing import (
     _eval_type,  # pyrefly: ignore [missing-module-attribute]
     Any,
+    cast,
     Generic,
     NamedTuple,
     TypeVar,
@@ -185,8 +186,8 @@ class Database(NamedTuple):
 class FlightRecorderEntry:
     process_group: tuple[str, str]
     profiling_name: str
-    collective_seq_id: int | str
-    p2p_seq_id: int | str
+    collective_seq_id: int
+    p2p_seq_id: int
     record_id: int
     input_sizes: list[list[int]]
     output_sizes: list[list[int]]
@@ -200,22 +201,22 @@ class FlightRecorderEntry:
 
     @classmethod
     def from_dict(cls, entry: dict[str, Any]) -> "FlightRecorderEntry":
-        process_group = entry["process_group"]
+        process_group = cast(tuple[str, str], entry["process_group"])
         return cls(
             process_group=(process_group[0], process_group[1]),
-            profiling_name=entry["profiling_name"],
-            collective_seq_id=entry["collective_seq_id"],
-            p2p_seq_id=entry["p2p_seq_id"],
-            record_id=entry["record_id"],
-            input_sizes=entry["input_sizes"],
-            output_sizes=entry["output_sizes"],
-            state=entry["state"],
-            is_p2p=entry["is_p2p"],
+            profiling_name=cast(str, entry["profiling_name"]),
+            collective_seq_id=int(entry["collective_seq_id"]),
+            p2p_seq_id=int(entry["p2p_seq_id"]),
+            record_id=cast(int, entry["record_id"]),
+            input_sizes=cast(list[list[int]], entry["input_sizes"]),
+            output_sizes=cast(list[list[int]], entry["output_sizes"]),
+            state=cast(str, entry["state"]),
+            is_p2p=cast(bool, entry["is_p2p"]),
             input_dtypes=entry.get("input_dtypes"),
             output_dtypes=entry.get("output_dtypes"),
-            time_created_ns=entry.get("time_created_ns", 0),
-            frames=entry.get("frames", []),
-            stack_id=entry.get("stack_id", -1),
+            time_created_ns=cast(int, entry.get("time_created_ns", 0)),
+            frames=cast(list[dict[str, str]], entry.get("frames", [])),
+            stack_id=cast(int, entry.get("stack_id", -1)),
         )
 
 
@@ -349,7 +350,7 @@ class EntryState:
         id: int,
         errors: set[tuple[int, MatchInfo]] | None = None,
         idx_map: dict[int, int] | None = None,
-        all_entries: dict[int, list[FlightRecorderEntry]] | None = None,
+        all_entries: dict[int, list[dict[str, Any]]] | None = None,
     ) -> Collective:
         if not errors:
             return Collective(
@@ -374,9 +375,10 @@ class EntryState:
             if all_entries is None:
                 raise AssertionError("all_entries is None")
             mismatch_collectives = {}
+            typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
             for rank, error in errors:
                 idx = idx_map[rank]
-                entry = all_entries[rank][idx]
+                entry = typed_entries[rank][idx]
                 desc = entry.process_group[1]
                 pg_name = entry.process_group[0]
                 mismatch_collectives[rank] = Collective(
@@ -421,14 +423,15 @@ class EntryState:
 
     def to_nccl_call(
         self,
-        all_entries: dict[int, list[FlightRecorderEntry]],
+        all_entries: dict[int, list[dict[str, Any]]],
         idx_map: dict[int, int],
         nccl_call_id: int,
         collective_id: Any,
     ) -> list[NCCLCall]:
         result = []
+        typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
         for i, k in idx_map.items():
-            all_entries[i].pop(k)
+            typed_entries[i].pop(k)
             result.append(
                 NCCLCall(
                     id=nccl_call_id,
@@ -486,6 +489,8 @@ class Op:
             self._src, self._dst = -1, -1
         self._init_global_src_dst(memberships[pg_name])
         self.pg_size = len(memberships[pg_name])
+        self.input_sizes: list[list[int]] | None
+        self.output_sizes: list[list[int]] | None
         if type in P2P | COLLECTIVES:
             self.input_sizes = event.input_sizes
             self.output_sizes = event.output_sizes
@@ -544,6 +549,13 @@ class Op:
 
     def dtype_mismatch(self, other: "Op") -> bool:
         if (
+            self.input_sizes is None
+            or self.output_sizes is None
+            or other.input_sizes is None
+            or other.output_sizes is None
+        ):
+            return False
+        if (
             (
                 self.type not in ["scatter", "gather", "broadcast"]
                 and set(self.input_dtypes) != set(self.output_dtypes)
@@ -601,6 +613,13 @@ class Op:
                     MatchState.COLLECTIVE_TYPE_MISMATCH,
                     f"Expected collective type: '{self.type}' does not match found collective type: '{other.type}'",
                 )
+            if (
+                self.input_sizes is None
+                or self.output_sizes is None
+                or other.input_sizes is None
+                or other.output_sizes is None
+            ):
+                return MatchInfo(MatchState.SIZE_OR_SYNTAX_MISMATCH)
             if (
                 self.type not in ["all_to_all", "scatter"]
                 and self.input_sizes != other.input_sizes

--- a/torch/distributed/flight_recorder/components/types.py
+++ b/torch/distributed/flight_recorder/components/types.py
@@ -350,7 +350,7 @@ class EntryState:
         id: int,
         errors: set[tuple[int, MatchInfo]] | None = None,
         idx_map: dict[int, int] | None = None,
-        all_entries: dict[int, list[dict[str, Any]]] | None = None,
+        all_entries: dict[int, list[FlightRecorderEntry]] | None = None,
     ) -> Collective:
         if not errors:
             return Collective(
@@ -375,10 +375,9 @@ class EntryState:
             if all_entries is None:
                 raise AssertionError("all_entries is None")
             mismatch_collectives = {}
-            typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
             for rank, error in errors:
                 idx = idx_map[rank]
-                entry = typed_entries[rank][idx]
+                entry = all_entries[rank][idx]
                 desc = entry.process_group[1]
                 pg_name = entry.process_group[0]
                 mismatch_collectives[rank] = Collective(
@@ -423,15 +422,14 @@ class EntryState:
 
     def to_nccl_call(
         self,
-        all_entries: dict[int, list[dict[str, Any]]],
+        all_entries: dict[int, list[FlightRecorderEntry]],
         idx_map: dict[int, int],
         nccl_call_id: int,
         collective_id: Any,
     ) -> list[NCCLCall]:
         result = []
-        typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
         for i, k in idx_map.items():
-            typed_entries[i].pop(k)
+            all_entries[i].pop(k)
             result.append(
                 NCCLCall(
                     id=nccl_call_id,

--- a/torch/distributed/flight_recorder/components/utils.py
+++ b/torch/distributed/flight_recorder/components/utils.py
@@ -6,7 +6,7 @@
 
 import argparse
 import math
-from typing import Any, cast
+from typing import Any
 
 from torch.distributed.flight_recorder.components.fr_logger import FlightRecorderLogger
 from torch.distributed.flight_recorder.components.types import (
@@ -66,18 +66,18 @@ def format_frames(frames: list[dict[str, str]]) -> str:
 
 
 def match_one_event(
-    event_a: dict[Any, Any],
-    event_b: dict[Any, Any],
+    event_a: FlightRecorderEntry,
+    event_b: FlightRecorderEntry,
     memberships: dict[str, set[Any]],
     pg_name: str,
 ) -> MatchInfo:
-    op_a = Op(cast(FlightRecorderEntry, event_a), memberships, pg_name)
-    op_b = Op(cast(FlightRecorderEntry, event_b), memberships, pg_name)
+    op_a = Op(event_a, memberships, pg_name)
+    op_b = Op(event_b, memberships, pg_name)
     return op_a.match(op_b)
 
 
 def match_coalesced_groups(
-    all_rank_events: dict[Any, Any],
+    all_rank_events: dict[int, list[tuple[int, FlightRecorderEntry]]],
     group_size: int,
     groups: dict[str, Group],
     memberships: dict[str, set[Any]],
@@ -106,15 +106,12 @@ def match_coalesced_groups(
         rank0 [send:1 (100B), send:1 (1000B)]
         rank1 [recv:0 (1000B), recv:0 (100B)]   —> not okay
     """
-    typed_events = cast(
-        dict[int, list[tuple[int, FlightRecorderEntry]]], all_rank_events
-    )
     all_ops = {
         rank: [
             Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
-            for i, e in typed_events[rank]
+            for i, e in all_rank_events[rank]
         ]
-        for rank in typed_events
+        for rank in all_rank_events
     }
 
     def visualize_ops(
@@ -124,9 +121,9 @@ def match_coalesced_groups(
         all_ops = {
             rank: [
                 Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
-                for i, e in typed_events[rank]
+                for i, e in all_rank_events[rank]
             ]
-            for rank in typed_events
+            for rank in all_rank_events
         }
 
         i = 0
@@ -137,7 +134,7 @@ def match_coalesced_groups(
             progress = False
             for r in all_ops:
                 if len(all_ops[r]) > i:
-                    rank, event = typed_events[r][i]
+                    rank, event = all_rank_events[r][i]
                     # Check if the pg_guid exists for this rank and process group
                     pg_key = (event.process_group[0], rank)
                     if pg_key in _pg_guids:
@@ -210,7 +207,7 @@ def match_coalesced_groups(
 
 # We enabled the creating FR entry for non-P2P slow path collective ops in v2.7.
 def match_coalesced_groups_with_non_p2p(
-    all_rank_events: dict[Any, Any],
+    all_rank_events: dict[int, list[tuple[int, FlightRecorderEntry]]],
     pg_info: tuple[str, str],
     memberships: dict[str, set[Any]],
     _pg_guids: dict[tuple[str, int], str],
@@ -243,15 +240,12 @@ def match_coalesced_groups_with_non_p2p(
         rank0 [send:1 (100B), send:1 (1000B)]
         rank1 [recv:0 (1000B), recv:0 (100B)]   —> not okay
     """
-    typed_events = cast(
-        dict[int, list[tuple[int, FlightRecorderEntry]]], all_rank_events
-    )
     all_ops = {
         rank: [
             Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
-            for _, e in typed_events[rank]
+            for _, e in all_rank_events[rank]
         ]
-        for rank in typed_events
+        for rank in all_rank_events
     }
     is_p2p = any(op.type in P2P for ops in all_ops.values() for op in ops)
     pg_name = pg_info[0]
@@ -263,9 +257,9 @@ def match_coalesced_groups_with_non_p2p(
         all_ops = {
             rank: [
                 Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
-                for _, e in typed_events[rank]
+                for _, e in all_rank_events[rank]
             ]
-            for rank in typed_events
+            for rank in all_rank_events
         }
 
         i = 0
@@ -276,7 +270,7 @@ def match_coalesced_groups_with_non_p2p(
             progress = False
             for r in all_ops:
                 if len(all_ops[r]) > i:
-                    rank, event = typed_events[r][i]
+                    rank, event = all_rank_events[r][i]
                     # Check if the pg_guid exists for this rank and process group
                     pg_key = (event.process_group[0], rank)
                     if pg_key in _pg_guids:
@@ -341,7 +335,8 @@ def match_coalesced_groups_with_non_p2p(
                 return False
         else:
             all_coalesced_entries = {
-                rank: [e for _, e in typed_events[rank]] for rank in typed_events
+                rank: [e for _, e in all_rank_events[rank]]
+                for rank in all_rank_events
             }
             current_entry = all_coalesced_entries[first_rank][0]
             my_ops.pop(0)
@@ -353,10 +348,10 @@ def match_coalesced_groups_with_non_p2p(
 
             # Iterate through all the ranks and check if there is a mismatch for the current entry.
             check_current_entry_match(
-                cast(dict[int, list[dict[str, Any]]], all_coalesced_entries),
+                all_coalesced_entries,
                 _pg_guids,
                 pg_info,
-                cast(dict[str, Any], current_entry),
+                current_entry,
                 memberships,
                 mismatch,
                 match_record,
@@ -364,11 +359,11 @@ def match_coalesced_groups_with_non_p2p(
 
             # Use heuristics to decide what type of errors and error messages we should print.
             error_analysis(
-                cast(dict[int, list[dict[str, Any]]], all_coalesced_entries),
+                all_coalesced_entries,
                 match_record,
                 dumps_ranks,
                 first_rank,
-                cast(dict[str, Any], current_entry),
+                current_entry,
                 mismatch,
                 get_version_detail(version),
                 pg_info[0],
@@ -391,7 +386,7 @@ def match_coalesced_groups_with_non_p2p(
                     for r in match_record.found_ranks
                 }
                 for i, k in idx_map.items():
-                    typed_events[i].pop(k)
+                    all_rank_events[i].pop(k)
                 for r in match_record.found_ranks:
                     if r != first_rank:
                         all_ops[r].pop(0)
@@ -410,9 +405,7 @@ def match_coalesced_groups_with_non_p2p(
                         len(collectives),
                         errors=match_record.errors,
                         idx_map=idx_map,
-                        all_entries=cast(
-                            dict[int, list[dict[str, Any]]], all_coalesced_entries
-                        ),
+                        all_entries=all_coalesced_entries,
                     )
                 )
                 return False
@@ -423,30 +416,28 @@ def match_coalesced_groups_with_non_p2p(
 
 
 def check_size_alltoall(
-    alltoall_cases: list[dict[str, Any]],
+    alltoall_cases: list[FlightRecorderEntry],
 ) -> tuple[bool, int, int]:
     input_numel = 0
     output_numel = 0
-    for e in cast(list[FlightRecorderEntry], alltoall_cases):
+    for e in alltoall_cases:
         input_numel += math.prod(e.input_sizes[0])
         output_numel += math.prod(e.output_sizes[0])
     return input_numel != output_numel, input_numel, output_numel
 
 
 def check_current_entry_match(
-    all_entries: dict[int, list[dict[str, Any]]],
+    all_entries: dict[int, list[FlightRecorderEntry]],
     _pg_guids: dict[tuple[str, int], str],
     pg_info: tuple[str, str],
-    current_entry: dict[str, Any],
+    current_entry: FlightRecorderEntry,
     _memberships: dict[str, set[Any]],
     mismatch: dict[str, int],
     match_record: MatchStateRecord,
 ) -> None:
-    typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
-    typed_current_entry = cast(FlightRecorderEntry, current_entry)
     pg_name, desc = pg_info[0], pg_info[1]
     for o in match_record.expected_ranks.intersection(set(match_record.other_ranks)):
-        for i, e in enumerate(typed_entries[o]):
+        for i, e in enumerate(all_entries[o]):
             # step over ops from other PGs
             # only check match state when seq_id matches
             if (
@@ -455,8 +446,8 @@ def check_current_entry_match(
                 and e.collective_seq_id == match_record.entry_state.collective_seq_id
             ):
                 match_info = match_one_event(
-                    cast(dict[Any, Any], typed_current_entry),
-                    cast(dict[Any, Any], e),
+                    current_entry,
+                    e,
                     _memberships,
                     pg_name,
                 )
@@ -485,17 +476,15 @@ def check_current_entry_match(
 
 
 def error_analysis(
-    all_entries: dict[int, list[dict[str, Any]]],
+    all_entries: dict[int, list[FlightRecorderEntry]],
     match_record: MatchStateRecord,
     dumps_ranks: set[int],
     first_rank: int,
-    current_entry: dict[str, Any],
+    current_entry: FlightRecorderEntry,
     mismatch: dict[str, int],
     version: tuple[int, int],
     pg_name: str,
 ) -> None:
-    typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
-    typed_current_entry = cast(FlightRecorderEntry, current_entry)
     major_v, minor_v = version[0], version[1]
     # case one: not every rank join the collective or in the flight recorder.
     if (
@@ -521,12 +510,12 @@ def error_analysis(
     ) == 1 and match_record.expected_ranks.issubset(dumps_ranks):
         # case two: alltoall or alltoall_base case.
         if match_record.has_undecided_case:
-            alltoall_cases = [typed_current_entry] + [
-                typed_entries[o][match_record.found_idx[o]]
+            alltoall_cases = [current_entry] + [
+                all_entries[o][match_record.found_idx[o]]
                 for o in match_record.found_ranks
             ]
             fail_check, total_input_numel, total_output_numel = check_size_alltoall(
-                cast(list[dict[str, Any]], alltoall_cases)
+                alltoall_cases
             )
             if major_v <= 2 and minor_v <= 3:
                 # We don't log the input/output sizes for alltoall before v2.4,
@@ -597,7 +586,7 @@ def error_analysis(
 
 def find_coalesced_group(
     pg_name: str,
-    entries: list[dict[str, Any]],
+    entries: list[FlightRecorderEntry],
     _pg_guids: dict[tuple[str, int], str],
     rank: int,
 ) -> list[tuple[int, FlightRecorderEntry]]:
@@ -606,7 +595,7 @@ def find_coalesced_group(
     """
     found = []
     collective_seq_id = None
-    for i, e in enumerate(cast(list[FlightRecorderEntry], entries)):
+    for i, e in enumerate(entries):
         if _pg_guids[(e.process_group[0], rank)] != pg_name:
             continue
         elif collective_seq_id is None:
@@ -629,7 +618,7 @@ def find_coalesced_group(
 # We enabled the creating FR entry for non-P2P slow path collective ops in v2.7.
 def find_coalesced_group_with_non_p2p(
     pg_name: str,
-    entries: list[dict[str, Any]],
+    entries: list[FlightRecorderEntry],
     _pg_guids: dict[tuple[str, int], str],
     rank: int,
 ) -> list[tuple[int, FlightRecorderEntry]]:
@@ -638,7 +627,7 @@ def find_coalesced_group_with_non_p2p(
     """
     found = []
     collective_seq_id = None
-    for i, e in enumerate(cast(list[FlightRecorderEntry], entries)):
+    for i, e in enumerate(entries):
         if _pg_guids[(e.process_group[0], rank)] != pg_name:
             continue
         elif collective_seq_id is None:
@@ -660,16 +649,15 @@ def find_coalesced_group_with_non_p2p(
 
 
 def just_print_entries(
-    all_entries: dict[int, list[dict[str, Any]]],
+    all_entries: dict[int, list[FlightRecorderEntry]],
     _groups: dict[str, Group],
     _memberships: dict[str, set[Any]],
     _pg_guids: dict[tuple[str, int], str],
     args: argparse.Namespace,
     stack_id_trace_map: dict[str, int],
 ) -> None:
-    typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
     rows = []
-    ranks = sorted(typed_entries.keys())
+    ranks = sorted(all_entries.keys())
     headers = [
         f"Rank {rank}"
         for rank in ranks
@@ -682,10 +670,10 @@ def just_print_entries(
         for rank in ranks:
             if args.selected_ranks is not None and rank not in args.selected_ranks:
                 continue
-            if len(typed_entries[rank]) == 0:
+            if len(all_entries[rank]) == 0:
                 row.append("")
             else:
-                entry = typed_entries[rank].pop(0)
+                entry = all_entries[rank].pop(0)
                 pg_name = _pg_guids[(entry.process_group[0], rank)]
                 if (
                     args.pg_filters is None
@@ -741,13 +729,12 @@ def get_version_detail(version: str) -> tuple[int, int]:
 
 
 def add_stack_id_in_entries(
-    entries: dict[int, list[dict[str, Any]]],
-) -> tuple[dict[int, list[dict[str, Any]]], dict[str, int]]:
-    typed_entries = cast(dict[int, list[FlightRecorderEntry]], entries)
+    entries: dict[int, list[FlightRecorderEntry]],
+) -> tuple[dict[int, list[FlightRecorderEntry]], dict[str, int]]:
     stack_id = 0
     stack_id_trace_map = {}
-    for rank in typed_entries:
-        for dump in typed_entries[rank]:
+    for rank in entries:
+        for dump in entries[rank]:
             if dump.frames:
                 frames = str(dump.frames)
                 if frames not in stack_id_trace_map:
@@ -763,8 +750,8 @@ def add_stack_id_in_entries(
 
 
 def align_trace_from_beginning(
-    entries: dict[int, list[dict[str, Any]]],
-) -> dict[int, list[dict[str, Any]]]:
+    entries: dict[int, list[FlightRecorderEntry]],
+) -> dict[int, list[FlightRecorderEntry]]:
     """
     Align the trace entries by record ID for entries.
     This function takes a dictionary of rank names to lists of trace entries as input.
@@ -783,8 +770,7 @@ def align_trace_from_beginning(
     """
 
     maximum_starting_record_id = 0
-    typed_entries = cast(dict[int, list[FlightRecorderEntry]], entries)
-    for rank in typed_entries:
+    for rank in entries:
         # Although this is a ring buffer, we already sort the entries by `record_id` when dumping, we just
         # need to find the largest starting point. For example, if the buffer has the following entries:
         # Rank 0: [0, 1, 2, 3, 4, 5, 6]
@@ -795,15 +781,15 @@ def align_trace_from_beginning(
         # we don't have complete records from all ranks so we need to ignore them.
         # If we don't have any trace from some ranks, ignore them
         # as well.
-        if len(typed_entries[rank]) == 0:
+        if len(entries[rank]) == 0:
             continue
-        first_record_id = typed_entries[rank][0].record_id
+        first_record_id = entries[rank][0].record_id
         maximum_starting_record_id = max(maximum_starting_record_id, first_record_id)
 
-    for rank in typed_entries:
-        typed_entries[rank] = [
+    for rank in entries:
+        entries[rank] = [
             entry
-            for entry in typed_entries[rank]
+            for entry in entries[rank]
             if entry.record_id >= maximum_starting_record_id
         ]
 

--- a/torch/distributed/flight_recorder/components/utils.py
+++ b/torch/distributed/flight_recorder/components/utils.py
@@ -12,6 +12,7 @@ from torch.distributed.flight_recorder.components.fr_logger import FlightRecorde
 from torch.distributed.flight_recorder.components.types import (
     Collective,
     EntryState,
+    FlightRecorderEntry,
     Group,
     MatchInfo,
     MatchState,
@@ -65,8 +66,8 @@ def format_frames(frames: list[dict[str, str]]) -> str:
 
 
 def match_one_event(
-    event_a: dict[Any, Any],
-    event_b: dict[Any, Any],
+    event_a: FlightRecorderEntry,
+    event_b: FlightRecorderEntry,
     memberships: dict[str, set[Any]],
     pg_name: str,
 ) -> MatchInfo:
@@ -76,7 +77,7 @@ def match_one_event(
 
 
 def match_coalesced_groups(
-    all_rank_events: dict[Any, Any],
+    all_rank_events: dict[int, list[tuple[int, FlightRecorderEntry]]],
     group_size: int,
     groups: dict[str, Group],
     memberships: dict[str, set[Any]],
@@ -107,7 +108,7 @@ def match_coalesced_groups(
     """
     all_ops = {
         rank: [
-            Op(e, memberships, _pg_guids[(e["process_group"][0], rank)])
+            Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
             for i, e in all_rank_events[rank]
         ]
         for rank in all_rank_events
@@ -119,7 +120,7 @@ def match_coalesced_groups(
     ) -> None:
         all_ops = {
             rank: [
-                Op(e, memberships, _pg_guids[(e["process_group"][0], rank)])
+                Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
                 for i, e in all_rank_events[rank]
             ]
             for rank in all_rank_events
@@ -135,7 +136,7 @@ def match_coalesced_groups(
                 if len(all_ops[r]) > i:
                     rank, event = all_rank_events[r][i]
                     # Check if the pg_guid exists for this rank and process group
-                    pg_key = (event["process_group"][0], rank)
+                    pg_key = (event.process_group[0], rank)
                     if pg_key in _pg_guids:
                         row.append(
                             Op(
@@ -206,7 +207,7 @@ def match_coalesced_groups(
 
 # We enabled the creating FR entry for non-P2P slow path collective ops in v2.7.
 def match_coalesced_groups_with_non_p2p(
-    all_rank_events: dict[Any, Any],
+    all_rank_events: dict[int, list[tuple[int, FlightRecorderEntry]]],
     pg_info: tuple[str, str],
     memberships: dict[str, set[Any]],
     _pg_guids: dict[tuple[str, int], str],
@@ -241,7 +242,7 @@ def match_coalesced_groups_with_non_p2p(
     """
     all_ops = {
         rank: [
-            Op(e, memberships, _pg_guids[(e["process_group"][0], rank)])
+            Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
             for _, e in all_rank_events[rank]
         ]
         for rank in all_rank_events
@@ -255,7 +256,7 @@ def match_coalesced_groups_with_non_p2p(
     ) -> None:
         all_ops = {
             rank: [
-                Op(e, memberships, _pg_guids[(e["process_group"][0], rank)])
+                Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
                 for _, e in all_rank_events[rank]
             ]
             for rank in all_rank_events
@@ -271,7 +272,7 @@ def match_coalesced_groups_with_non_p2p(
                 if len(all_ops[r]) > i:
                     rank, event = all_rank_events[r][i]
                     # Check if the pg_guid exists for this rank and process group
-                    pg_key = (event["process_group"][0], rank)
+                    pg_key = (event.process_group[0], rank)
                     if pg_key in _pg_guids:
                         row.append(
                             Op(
@@ -413,20 +414,22 @@ def match_coalesced_groups_with_non_p2p(
     return True
 
 
-def check_size_alltoall(alltoall_cases: list[dict[str, Any]]) -> tuple[bool, int, int]:
+def check_size_alltoall(
+    alltoall_cases: list[FlightRecorderEntry],
+) -> tuple[bool, int, int]:
     input_numel = 0
     output_numel = 0
     for e in alltoall_cases:
-        input_numel += math.prod(e["input_sizes"][0])
-        output_numel += math.prod(e["output_sizes"][0])
+        input_numel += math.prod(e.input_sizes[0])
+        output_numel += math.prod(e.output_sizes[0])
     return input_numel != output_numel, input_numel, output_numel
 
 
 def check_current_entry_match(
-    all_entries: dict[int, list[dict[str, Any]]],
+    all_entries: dict[int, list[FlightRecorderEntry]],
     _pg_guids: dict[tuple[str, int], str],
     pg_info: tuple[str, str],
-    current_entry: dict[str, Any],
+    current_entry: FlightRecorderEntry,
     _memberships: dict[str, set[Any]],
     mismatch: dict[str, int],
     match_record: MatchStateRecord,
@@ -437,9 +440,9 @@ def check_current_entry_match(
             # step over ops from other PGs
             # only check match state when seq_id matches
             if (
-                _pg_guids[(e["process_group"][0], o)] == pg_name
-                and e["process_group"][1] == desc
-                and e["collective_seq_id"] == match_record.entry_state.collective_seq_id
+                _pg_guids[(e.process_group[0], o)] == pg_name
+                and e.process_group[1] == desc
+                and e.collective_seq_id == match_record.entry_state.collective_seq_id
             ):
                 match_info = match_one_event(current_entry, e, _memberships, pg_name)
                 if (
@@ -467,11 +470,11 @@ def check_current_entry_match(
 
 
 def error_analysis(
-    all_entries: dict[int, list[dict[str, Any]]],
+    all_entries: dict[int, list[FlightRecorderEntry]],
     match_record: MatchStateRecord,
     dumps_ranks: set[int],
     first_rank: int,
-    current_entry: dict[str, Any],
+    current_entry: FlightRecorderEntry,
     mismatch: dict[str, int],
     version: tuple[int, int],
     pg_name: str,
@@ -577,32 +580,32 @@ def error_analysis(
 
 def find_coalesced_group(
     pg_name: str,
-    entries: list[dict[str, Any]],
+    entries: list[FlightRecorderEntry],
     _pg_guids: dict[tuple[str, int], str],
     rank: int,
-) -> list[tuple[int, dict[str, Any]]]:
+) -> list[tuple[int, FlightRecorderEntry]]:
     """Given a list of entries, if the collective_seq_id of the first entry matches that of subsequent ones,
     build an return a list of entries terminating in a 'coalesced' op entry all sharing a collective_seq_id
     """
     found = []
     collective_seq_id = None
     for i, e in enumerate(entries):
-        if _pg_guids[(e["process_group"][0], rank)] != pg_name:
+        if _pg_guids[(e.process_group[0], rank)] != pg_name:
             continue
         elif collective_seq_id is None:
             collective_seq_id = (
-                e["p2p_seq_id"] if e["is_p2p"] else e["collective_seq_id"]
+                e.p2p_seq_id if e.is_p2p else e.collective_seq_id
             )
             found.append((i, e))
-        elif not e["is_p2p"] and e["collective_seq_id"] == collective_seq_id:
+        elif not e.is_p2p and e.collective_seq_id == collective_seq_id:
             found.append((i, e))
-        elif e["is_p2p"] and e["p2p_seq_id"] == collective_seq_id:
+        elif e.is_p2p and e.p2p_seq_id == collective_seq_id:
             found.append((i, e))
         else:
             break
 
     if len(found) > 1:
-        if found[-1][1]["profiling_name"] != "nccl:coalesced":
+        if found[-1][1].profiling_name != "nccl:coalesced":
             raise AssertionError
         return found
     return []
@@ -611,32 +614,32 @@ def find_coalesced_group(
 # We enabled the creating FR entry for non-P2P slow path collective ops in v2.7.
 def find_coalesced_group_with_non_p2p(
     pg_name: str,
-    entries: list[dict[str, Any]],
+    entries: list[FlightRecorderEntry],
     _pg_guids: dict[tuple[str, int], str],
     rank: int,
-) -> list[tuple[int, dict[str, Any]]]:
+) -> list[tuple[int, FlightRecorderEntry]]:
     """Given a list of entries, if the collective_seq_id of the first entry matches that of subsequent ones,
     build an return a list of entries terminating in a 'coalesced' op entry all sharing a collective_seq_id
     """
     found = []
     collective_seq_id = None
     for i, e in enumerate(entries):
-        if _pg_guids[(e["process_group"][0], rank)] != pg_name:
+        if _pg_guids[(e.process_group[0], rank)] != pg_name:
             continue
         elif collective_seq_id is None:
             collective_seq_id = (
-                e["p2p_seq_id"] if e["is_p2p"] else e["collective_seq_id"]
+                e.p2p_seq_id if e.is_p2p else e.collective_seq_id
             )
             found.append((i, e))
-        elif not e["is_p2p"] and e["collective_seq_id"] == collective_seq_id:
+        elif not e.is_p2p and e.collective_seq_id == collective_seq_id:
             found.append((i, e))
-        elif e["is_p2p"] and e["p2p_seq_id"] == collective_seq_id:
+        elif e.is_p2p and e.p2p_seq_id == collective_seq_id:
             found.append((i, e))
         else:
             break
 
     if len(found) > 1:
-        name = found[-1][1]["profiling_name"]
+        name = found[-1][1].profiling_name
         if name.startswith("nccl:") and not name.endswith("_coalesced"):
             logger.error("Rank %s does not have a coalesced end.", rank)
         return found
@@ -644,7 +647,7 @@ def find_coalesced_group_with_non_p2p(
 
 
 def just_print_entries(
-    all_entries: dict[int, list[dict[str, Any]]],
+    all_entries: dict[int, list[FlightRecorderEntry]],
     _groups: dict[str, Group],
     _memberships: dict[str, set[Any]],
     _pg_guids: dict[tuple[str, int], str],
@@ -669,11 +672,11 @@ def just_print_entries(
                 row.append("")
             else:
                 entry = all_entries[rank].pop(0)
-                pg_name = _pg_guids[(entry["process_group"][0], rank)]
+                pg_name = _pg_guids[(entry.process_group[0], rank)]
                 if (
                     args.pg_filters is None
-                    or entry["process_group"][1] in args.pg_filters
-                    or entry["process_group"][0] in args.pg_filters
+                    or entry.process_group[1] in args.pg_filters
+                    or entry.process_group[0] in args.pg_filters
                 ):
                     row.append(str(Op(entry, _memberships, pg_name)))
                 else:
@@ -724,29 +727,29 @@ def get_version_detail(version: str) -> tuple[int, int]:
 
 
 def add_stack_id_in_entries(
-    entries: dict[int, list[dict[str, Any]]],
-) -> tuple[dict[int, list[dict[str, Any]]], dict[str, int]]:
+    entries: dict[int, list[FlightRecorderEntry]],
+) -> tuple[dict[int, list[FlightRecorderEntry]], dict[str, int]]:
     stack_id = 0
     stack_id_trace_map = {}
     for rank in entries:
         for dump in entries[rank]:
-            if dump.get("frames", []):
-                frames = str(dump["frames"])
+            if dump.frames:
+                frames = str(dump.frames)
                 if frames not in stack_id_trace_map:
                     stack_id_trace_map[frames] = stack_id
-                    dump["stack_id"] = stack_id
+                    dump.stack_id = stack_id
                     stack_id += 1
                 else:
-                    dump["stack_id"] = stack_id_trace_map[frames]
+                    dump.stack_id = stack_id_trace_map[frames]
             else:
-                dump["stack_id"] = -1
+                dump.stack_id = -1
 
     return entries, stack_id_trace_map
 
 
 def align_trace_from_beginning(
-    entries: dict[int, list[dict[str, Any]]],
-) -> dict[int, list[dict[str, Any]]]:
+    entries: dict[int, list[FlightRecorderEntry]],
+) -> dict[int, list[FlightRecorderEntry]]:
     """
     Align the trace entries by record ID for entries.
     This function takes a dictionary of rank names to lists of trace entries as input.
@@ -778,14 +781,14 @@ def align_trace_from_beginning(
         # as well.
         if len(entries[rank]) == 0:
             continue
-        first_record_id = entries[rank][0]["record_id"]
+        first_record_id = entries[rank][0].record_id
         maximum_starting_record_id = max(maximum_starting_record_id, first_record_id)
 
     for rank in entries:
         entries[rank] = [
             entry
             for entry in entries[rank]
-            if entry["record_id"] >= maximum_starting_record_id
+            if entry.record_id >= maximum_starting_record_id
         ]
 
     return entries

--- a/torch/distributed/flight_recorder/components/utils.py
+++ b/torch/distributed/flight_recorder/components/utils.py
@@ -6,7 +6,7 @@
 
 import argparse
 import math
-from typing import Any
+from typing import Any, cast
 
 from torch.distributed.flight_recorder.components.fr_logger import FlightRecorderLogger
 from torch.distributed.flight_recorder.components.types import (
@@ -66,18 +66,18 @@ def format_frames(frames: list[dict[str, str]]) -> str:
 
 
 def match_one_event(
-    event_a: FlightRecorderEntry,
-    event_b: FlightRecorderEntry,
+    event_a: dict[Any, Any],
+    event_b: dict[Any, Any],
     memberships: dict[str, set[Any]],
     pg_name: str,
 ) -> MatchInfo:
-    op_a = Op(event_a, memberships, pg_name)
-    op_b = Op(event_b, memberships, pg_name)
+    op_a = Op(cast(FlightRecorderEntry, event_a), memberships, pg_name)
+    op_b = Op(cast(FlightRecorderEntry, event_b), memberships, pg_name)
     return op_a.match(op_b)
 
 
 def match_coalesced_groups(
-    all_rank_events: dict[int, list[tuple[int, FlightRecorderEntry]]],
+    all_rank_events: dict[Any, Any],
     group_size: int,
     groups: dict[str, Group],
     memberships: dict[str, set[Any]],
@@ -106,12 +106,15 @@ def match_coalesced_groups(
         rank0 [send:1 (100B), send:1 (1000B)]
         rank1 [recv:0 (1000B), recv:0 (100B)]   —> not okay
     """
+    typed_events = cast(
+        dict[int, list[tuple[int, FlightRecorderEntry]]], all_rank_events
+    )
     all_ops = {
         rank: [
             Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
-            for i, e in all_rank_events[rank]
+            for i, e in typed_events[rank]
         ]
-        for rank in all_rank_events
+        for rank in typed_events
     }
 
     def visualize_ops(
@@ -121,9 +124,9 @@ def match_coalesced_groups(
         all_ops = {
             rank: [
                 Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
-                for i, e in all_rank_events[rank]
+                for i, e in typed_events[rank]
             ]
-            for rank in all_rank_events
+            for rank in typed_events
         }
 
         i = 0
@@ -134,7 +137,7 @@ def match_coalesced_groups(
             progress = False
             for r in all_ops:
                 if len(all_ops[r]) > i:
-                    rank, event = all_rank_events[r][i]
+                    rank, event = typed_events[r][i]
                     # Check if the pg_guid exists for this rank and process group
                     pg_key = (event.process_group[0], rank)
                     if pg_key in _pg_guids:
@@ -207,7 +210,7 @@ def match_coalesced_groups(
 
 # We enabled the creating FR entry for non-P2P slow path collective ops in v2.7.
 def match_coalesced_groups_with_non_p2p(
-    all_rank_events: dict[int, list[tuple[int, FlightRecorderEntry]]],
+    all_rank_events: dict[Any, Any],
     pg_info: tuple[str, str],
     memberships: dict[str, set[Any]],
     _pg_guids: dict[tuple[str, int], str],
@@ -240,12 +243,15 @@ def match_coalesced_groups_with_non_p2p(
         rank0 [send:1 (100B), send:1 (1000B)]
         rank1 [recv:0 (1000B), recv:0 (100B)]   —> not okay
     """
+    typed_events = cast(
+        dict[int, list[tuple[int, FlightRecorderEntry]]], all_rank_events
+    )
     all_ops = {
         rank: [
             Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
-            for _, e in all_rank_events[rank]
+            for _, e in typed_events[rank]
         ]
-        for rank in all_rank_events
+        for rank in typed_events
     }
     is_p2p = any(op.type in P2P for ops in all_ops.values() for op in ops)
     pg_name = pg_info[0]
@@ -257,9 +263,9 @@ def match_coalesced_groups_with_non_p2p(
         all_ops = {
             rank: [
                 Op(e, memberships, _pg_guids[(e.process_group[0], rank)])
-                for _, e in all_rank_events[rank]
+                for _, e in typed_events[rank]
             ]
-            for rank in all_rank_events
+            for rank in typed_events
         }
 
         i = 0
@@ -270,7 +276,7 @@ def match_coalesced_groups_with_non_p2p(
             progress = False
             for r in all_ops:
                 if len(all_ops[r]) > i:
-                    rank, event = all_rank_events[r][i]
+                    rank, event = typed_events[r][i]
                     # Check if the pg_guid exists for this rank and process group
                     pg_key = (event.process_group[0], rank)
                     if pg_key in _pg_guids:
@@ -335,7 +341,7 @@ def match_coalesced_groups_with_non_p2p(
                 return False
         else:
             all_coalesced_entries = {
-                rank: [e for _, e in all_rank_events[rank]] for rank in all_rank_events
+                rank: [e for _, e in typed_events[rank]] for rank in typed_events
             }
             current_entry = all_coalesced_entries[first_rank][0]
             my_ops.pop(0)
@@ -347,10 +353,10 @@ def match_coalesced_groups_with_non_p2p(
 
             # Iterate through all the ranks and check if there is a mismatch for the current entry.
             check_current_entry_match(
-                all_coalesced_entries,
+                cast(dict[int, list[dict[str, Any]]], all_coalesced_entries),
                 _pg_guids,
                 pg_info,
-                current_entry,
+                cast(dict[str, Any], current_entry),
                 memberships,
                 mismatch,
                 match_record,
@@ -358,11 +364,11 @@ def match_coalesced_groups_with_non_p2p(
 
             # Use heuristics to decide what type of errors and error messages we should print.
             error_analysis(
-                all_coalesced_entries,
+                cast(dict[int, list[dict[str, Any]]], all_coalesced_entries),
                 match_record,
                 dumps_ranks,
                 first_rank,
-                current_entry,
+                cast(dict[str, Any], current_entry),
                 mismatch,
                 get_version_detail(version),
                 pg_info[0],
@@ -385,7 +391,7 @@ def match_coalesced_groups_with_non_p2p(
                     for r in match_record.found_ranks
                 }
                 for i, k in idx_map.items():
-                    all_rank_events[i].pop(k)
+                    typed_events[i].pop(k)
                 for r in match_record.found_ranks:
                     if r != first_rank:
                         all_ops[r].pop(0)
@@ -404,7 +410,9 @@ def match_coalesced_groups_with_non_p2p(
                         len(collectives),
                         errors=match_record.errors,
                         idx_map=idx_map,
-                        all_entries=all_coalesced_entries,
+                        all_entries=cast(
+                            dict[int, list[dict[str, Any]]], all_coalesced_entries
+                        ),
                     )
                 )
                 return False
@@ -415,28 +423,30 @@ def match_coalesced_groups_with_non_p2p(
 
 
 def check_size_alltoall(
-    alltoall_cases: list[FlightRecorderEntry],
+    alltoall_cases: list[dict[str, Any]],
 ) -> tuple[bool, int, int]:
     input_numel = 0
     output_numel = 0
-    for e in alltoall_cases:
+    for e in cast(list[FlightRecorderEntry], alltoall_cases):
         input_numel += math.prod(e.input_sizes[0])
         output_numel += math.prod(e.output_sizes[0])
     return input_numel != output_numel, input_numel, output_numel
 
 
 def check_current_entry_match(
-    all_entries: dict[int, list[FlightRecorderEntry]],
+    all_entries: dict[int, list[dict[str, Any]]],
     _pg_guids: dict[tuple[str, int], str],
     pg_info: tuple[str, str],
-    current_entry: FlightRecorderEntry,
+    current_entry: dict[str, Any],
     _memberships: dict[str, set[Any]],
     mismatch: dict[str, int],
     match_record: MatchStateRecord,
 ) -> None:
+    typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
+    typed_current_entry = cast(FlightRecorderEntry, current_entry)
     pg_name, desc = pg_info[0], pg_info[1]
     for o in match_record.expected_ranks.intersection(set(match_record.other_ranks)):
-        for i, e in enumerate(all_entries[o]):  # type: ignore[index]
+        for i, e in enumerate(typed_entries[o]):
             # step over ops from other PGs
             # only check match state when seq_id matches
             if (
@@ -444,7 +454,12 @@ def check_current_entry_match(
                 and e.process_group[1] == desc
                 and e.collective_seq_id == match_record.entry_state.collective_seq_id
             ):
-                match_info = match_one_event(current_entry, e, _memberships, pg_name)
+                match_info = match_one_event(
+                    cast(dict[Any, Any], typed_current_entry),
+                    cast(dict[Any, Any], e),
+                    _memberships,
+                    pg_name,
+                )
                 if (
                     match_info.state in [MatchState.FULLY_MATCHED, MatchState.UNDECIDED]
                     and mismatch[pg_name] == 0
@@ -470,15 +485,17 @@ def check_current_entry_match(
 
 
 def error_analysis(
-    all_entries: dict[int, list[FlightRecorderEntry]],
+    all_entries: dict[int, list[dict[str, Any]]],
     match_record: MatchStateRecord,
     dumps_ranks: set[int],
     first_rank: int,
-    current_entry: FlightRecorderEntry,
+    current_entry: dict[str, Any],
     mismatch: dict[str, int],
     version: tuple[int, int],
     pg_name: str,
 ) -> None:
+    typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
+    typed_current_entry = cast(FlightRecorderEntry, current_entry)
     major_v, minor_v = version[0], version[1]
     # case one: not every rank join the collective or in the flight recorder.
     if (
@@ -504,12 +521,12 @@ def error_analysis(
     ) == 1 and match_record.expected_ranks.issubset(dumps_ranks):
         # case two: alltoall or alltoall_base case.
         if match_record.has_undecided_case:
-            alltoall_cases = [current_entry] + [
-                all_entries[o][match_record.found_idx[o]]
+            alltoall_cases = [typed_current_entry] + [
+                typed_entries[o][match_record.found_idx[o]]
                 for o in match_record.found_ranks
             ]
             fail_check, total_input_numel, total_output_numel = check_size_alltoall(
-                alltoall_cases
+                cast(list[dict[str, Any]], alltoall_cases)
             )
             if major_v <= 2 and minor_v <= 3:
                 # We don't log the input/output sizes for alltoall before v2.4,
@@ -580,7 +597,7 @@ def error_analysis(
 
 def find_coalesced_group(
     pg_name: str,
-    entries: list[FlightRecorderEntry],
+    entries: list[dict[str, Any]],
     _pg_guids: dict[tuple[str, int], str],
     rank: int,
 ) -> list[tuple[int, FlightRecorderEntry]]:
@@ -589,13 +606,11 @@ def find_coalesced_group(
     """
     found = []
     collective_seq_id = None
-    for i, e in enumerate(entries):
+    for i, e in enumerate(cast(list[FlightRecorderEntry], entries)):
         if _pg_guids[(e.process_group[0], rank)] != pg_name:
             continue
         elif collective_seq_id is None:
-            collective_seq_id = (
-                e.p2p_seq_id if e.is_p2p else e.collective_seq_id
-            )
+            collective_seq_id = e.p2p_seq_id if e.is_p2p else e.collective_seq_id
             found.append((i, e))
         elif not e.is_p2p and e.collective_seq_id == collective_seq_id:
             found.append((i, e))
@@ -614,7 +629,7 @@ def find_coalesced_group(
 # We enabled the creating FR entry for non-P2P slow path collective ops in v2.7.
 def find_coalesced_group_with_non_p2p(
     pg_name: str,
-    entries: list[FlightRecorderEntry],
+    entries: list[dict[str, Any]],
     _pg_guids: dict[tuple[str, int], str],
     rank: int,
 ) -> list[tuple[int, FlightRecorderEntry]]:
@@ -623,13 +638,11 @@ def find_coalesced_group_with_non_p2p(
     """
     found = []
     collective_seq_id = None
-    for i, e in enumerate(entries):
+    for i, e in enumerate(cast(list[FlightRecorderEntry], entries)):
         if _pg_guids[(e.process_group[0], rank)] != pg_name:
             continue
         elif collective_seq_id is None:
-            collective_seq_id = (
-                e.p2p_seq_id if e.is_p2p else e.collective_seq_id
-            )
+            collective_seq_id = e.p2p_seq_id if e.is_p2p else e.collective_seq_id
             found.append((i, e))
         elif not e.is_p2p and e.collective_seq_id == collective_seq_id:
             found.append((i, e))
@@ -647,15 +660,16 @@ def find_coalesced_group_with_non_p2p(
 
 
 def just_print_entries(
-    all_entries: dict[int, list[FlightRecorderEntry]],
+    all_entries: dict[int, list[dict[str, Any]]],
     _groups: dict[str, Group],
     _memberships: dict[str, set[Any]],
     _pg_guids: dict[tuple[str, int], str],
     args: argparse.Namespace,
     stack_id_trace_map: dict[str, int],
 ) -> None:
+    typed_entries = cast(dict[int, list[FlightRecorderEntry]], all_entries)
     rows = []
-    ranks = sorted(all_entries.keys())
+    ranks = sorted(typed_entries.keys())
     headers = [
         f"Rank {rank}"
         for rank in ranks
@@ -668,10 +682,10 @@ def just_print_entries(
         for rank in ranks:
             if args.selected_ranks is not None and rank not in args.selected_ranks:
                 continue
-            if len(all_entries[rank]) == 0:
+            if len(typed_entries[rank]) == 0:
                 row.append("")
             else:
-                entry = all_entries[rank].pop(0)
+                entry = typed_entries[rank].pop(0)
                 pg_name = _pg_guids[(entry.process_group[0], rank)]
                 if (
                     args.pg_filters is None
@@ -727,12 +741,13 @@ def get_version_detail(version: str) -> tuple[int, int]:
 
 
 def add_stack_id_in_entries(
-    entries: dict[int, list[FlightRecorderEntry]],
-) -> tuple[dict[int, list[FlightRecorderEntry]], dict[str, int]]:
+    entries: dict[int, list[dict[str, Any]]],
+) -> tuple[dict[int, list[dict[str, Any]]], dict[str, int]]:
+    typed_entries = cast(dict[int, list[FlightRecorderEntry]], entries)
     stack_id = 0
     stack_id_trace_map = {}
-    for rank in entries:
-        for dump in entries[rank]:
+    for rank in typed_entries:
+        for dump in typed_entries[rank]:
             if dump.frames:
                 frames = str(dump.frames)
                 if frames not in stack_id_trace_map:
@@ -748,8 +763,8 @@ def add_stack_id_in_entries(
 
 
 def align_trace_from_beginning(
-    entries: dict[int, list[FlightRecorderEntry]],
-) -> dict[int, list[FlightRecorderEntry]]:
+    entries: dict[int, list[dict[str, Any]]],
+) -> dict[int, list[dict[str, Any]]]:
     """
     Align the trace entries by record ID for entries.
     This function takes a dictionary of rank names to lists of trace entries as input.
@@ -768,7 +783,8 @@ def align_trace_from_beginning(
     """
 
     maximum_starting_record_id = 0
-    for rank in entries:
+    typed_entries = cast(dict[int, list[FlightRecorderEntry]], entries)
+    for rank in typed_entries:
         # Although this is a ring buffer, we already sort the entries by `record_id` when dumping, we just
         # need to find the largest starting point. For example, if the buffer has the following entries:
         # Rank 0: [0, 1, 2, 3, 4, 5, 6]
@@ -779,15 +795,15 @@ def align_trace_from_beginning(
         # we don't have complete records from all ranks so we need to ignore them.
         # If we don't have any trace from some ranks, ignore them
         # as well.
-        if len(entries[rank]) == 0:
+        if len(typed_entries[rank]) == 0:
             continue
-        first_record_id = entries[rank][0].record_id
+        first_record_id = typed_entries[rank][0].record_id
         maximum_starting_record_id = max(maximum_starting_record_id, first_record_id)
 
-    for rank in entries:
-        entries[rank] = [
+    for rank in typed_entries:
+        typed_entries[rank] = [
             entry
-            for entry in entries[rank]
+            for entry in typed_entries[rank]
             if entry.record_id >= maximum_starting_record_id
         ]
 


### PR DESCRIPTION
Summary
- Add a typed FlightRecorderEntry dataclass for flight recorder trace entries.
- Convert raw dump entry dicts once at the build_db boundary, then use attribute access through builder/types/utils.
- Update flight recorder analysis test helpers to construct FlightRecorderEntry instances directly.

Root cause problem
The flight recorder analyzer passed entries as dict[str, Any] through the matching and DB-building code even though every entry has a stable schema. This made call sites rely on repeated string-key access and obscured the required fields.

Proposed fix
Define FlightRecorderEntry in components/types.py, adapt raw dump dictionaries with FlightRecorderEntry.from_dict in build_db, and type the downstream analyzer helpers around FlightRecorderEntry.

Why this is the right long term fix
Keeping the raw-dump conversion at the boundary gives the analyzer a typed internal representation without changing the dump format. New consumers can use explicit fields, and future schema changes only need to update the dataclass adapter rather than many string-key call sites.

Testing
- python3 -m py_compile torch/distributed/flight_recorder/components/types.py torch/distributed/flight_recorder/components/utils.py torch/distributed/flight_recorder/components/builder.py test/distributed/flight_recorder/test_fr_analysis.py
- git diff --check
- Custom smoke test loading flight recorder modules directly and building a matched all-reduce DB from raw dict dumps

Note: Running python3 test/distributed/flight_recorder/test_fr_analysis.py is blocked in this image because top-level torch import requires typing_extensions, and apt is currently locked by unattended-upgrade.

Drafted via Codex, published after manual review by @bobrenjc93