### PR TITLE
[activation_checkpointing] Add per-node memory_budget API and cache key support

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -2585,6 +2585,46 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)
     @functorch_config.patch({"enable_autograd_cache": True})
+    def test_memory_budget_metadata_causes_cache_miss(self):
+        """Changing per-node memory_budget via MemoryBudgetMode invalidates cache."""
+        from torch._functorch._activation_checkpointing.memory_budget import (
+            MemoryBudgetMode,
+        )
+
+        class Model(torch.nn.Module):
+            def __init__(self, budget):
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10)
+                self.budget = budget
+
+            def forward(self, x):
+                with MemoryBudgetMode(self.budget):
+                    return self.linear(x).relu()
+
+        with fresh_cache():
+            model1 = Model(budget=0.3)
+            compiled_fn1 = torch.compile(model1, backend="inductor")
+            x1 = torch.randn(10, 10, requires_grad=True)
+            result1 = compiled_fn1(x1)
+            result1.sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            self._clear_dynamo_and_codecache()
+
+            model2 = Model(budget=0.8)
+            compiled_fn2 = torch.compile(model2, backend="inductor")
+            x2 = torch.randn(10, 10, requires_grad=True)
+            result2 = compiled_fn2(x2)
+            result2.sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
     @functorch_config.patch({"activation_memory_budget": 0.5})
     def test_custom_estimator_bypasses_cache(self):
         """Test that cache is bypassed when custom estimator lacks proper uuid."""

--- a/test/functorch/test_memory_budget.py
+++ b/test/functorch/test_memory_budget.py
@@ -1,0 +1,145 @@
+# Owner(s): ["module: functorch"]
+import unittest
+
+import torch
+import torch.fx.traceback as fx_traceback
+from torch._functorch._activation_checkpointing.memory_budget import (
+    MemoryBudgetMode,
+    set_memory_budget,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestSetMemoryBudget(TestCase):
+    def setUp(self):
+        fx_traceback.current_meta.pop("memory_budget", None)
+
+    def tearDown(self):
+        fx_traceback.current_meta.pop("memory_budget", None)
+
+    def test_sets_budget_in_current_meta(self):
+        set_memory_budget(0.5)
+        self.assertEqual(fx_traceback.current_meta["memory_budget"], 0.5)
+
+    def test_overwrites_previous_budget(self):
+        set_memory_budget(0.3)
+        set_memory_budget(0.8)
+        self.assertEqual(fx_traceback.current_meta["memory_budget"], 0.8)
+
+    def test_accepts_int_budget(self):
+        set_memory_budget(0)
+        self.assertEqual(fx_traceback.current_meta["memory_budget"], 0.0)
+        set_memory_budget(1)
+        self.assertEqual(fx_traceback.current_meta["memory_budget"], 1.0)
+
+    def test_rejects_invalid_type(self):
+        with self.assertRaises(TypeError):
+            set_memory_budget("0.5")
+
+    def test_rejects_out_of_range(self):
+        with self.assertRaises(ValueError):
+            set_memory_budget(-0.1)
+        with self.assertRaises(ValueError):
+            set_memory_budget(1.1)
+
+    def test_boundary_values(self):
+        set_memory_budget(0.0)
+        self.assertEqual(fx_traceback.current_meta["memory_budget"], 0.0)
+        set_memory_budget(1.0)
+        self.assertEqual(fx_traceback.current_meta["memory_budget"], 1.0)
+
+
+class TestMemoryBudgetMode(TestCase):
+    def setUp(self):
+        fx_traceback.current_meta.pop("memory_budget", None)
+
+    def tearDown(self):
+        fx_traceback.current_meta.pop("memory_budget", None)
+
+    def test_sets_budget_on_enter(self):
+        with MemoryBudgetMode(0.3):
+            self.assertEqual(fx_traceback.current_meta["memory_budget"], 0.3)
+
+    def test_clears_budget_on_exit(self):
+        with MemoryBudgetMode(0.3):
+            pass
+        self.assertNotIn("memory_budget", fx_traceback.current_meta)
+
+    def test_restores_previous_budget(self):
+        set_memory_budget(0.5)
+        with MemoryBudgetMode(0.3):
+            self.assertEqual(fx_traceback.current_meta["memory_budget"], 0.3)
+        self.assertEqual(fx_traceback.current_meta["memory_budget"], 0.5)
+
+    def test_nested_modes(self):
+        with MemoryBudgetMode(0.5):
+            self.assertEqual(fx_traceback.current_meta["memory_budget"], 0.5)
+            with MemoryBudgetMode(0.2):
+                self.assertEqual(fx_traceback.current_meta["memory_budget"], 0.2)
+            self.assertEqual(fx_traceback.current_meta["memory_budget"], 0.5)
+        self.assertNotIn("memory_budget", fx_traceback.current_meta)
+
+    def test_rejects_invalid_budget(self):
+        with self.assertRaises(TypeError):
+            MemoryBudgetMode("0.5")
+        with self.assertRaises(ValueError):
+            MemoryBudgetMode(-0.1)
+        with self.assertRaises(ValueError):
+            MemoryBudgetMode(1.1)
+
+    def test_repr(self):
+        mode = MemoryBudgetMode(0.3)
+        self.assertEqual(repr(mode), "MemoryBudgetMode(budget=0.3)")
+
+    def test_restores_on_exception(self):
+        set_memory_budget(0.5)
+        with self.assertRaises(RuntimeError):
+            with MemoryBudgetMode(0.3):
+                raise RuntimeError("test")
+        self.assertEqual(fx_traceback.current_meta["memory_budget"], 0.5)
+
+
+class TestMemoryBudgetCopyMetaFields(TestCase):
+    def test_memory_budget_in_copy_meta_fields(self):
+        import torch.fx.proxy as fx_proxy
+
+        self.assertIn("memory_budget", fx_proxy._COPY_META_FIELDS)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+class TestMemoryBudgetCompile(TestCase):
+    def test_memory_budget_propagates_to_nodes(self):
+        """Verify memory_budget metadata appears on FX graph nodes after compile."""
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                set_memory_budget(0.3)
+                x = x.sin()
+                set_memory_budget(0.8)
+                x = x.cos()
+                return x
+
+        graphs = []
+
+        def capture_backend(gm, example_inputs):
+            graphs.append(gm)
+            return gm
+
+        model = Model()
+        compiled = torch.compile(model, backend=capture_backend)
+        compiled(torch.randn(4, device="cuda"))
+
+        self.assertEqual(len(graphs), 1)
+        gm = graphs[0]
+        budgets = {
+            node.name: node.meta.get("memory_budget")
+            for node in gm.graph.nodes
+            if node.meta.get("memory_budget") is not None
+        }
+        self.assertTrue(len(budgets) > 0)
+        self.assertTrue(any(v == 0.3 for v in budgets.values()))
+        self.assertTrue(any(v == 0.8 for v in budgets.values()))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -3039,6 +3039,17 @@ class OutputGraph(OutputGraphCommon):
     ) -> CompiledFn:
         if self.compiler_fn is None:
             raise AssertionError("compiler_fn must not be None")
+
+        # Convert set_memory_budget / MemoryBudgetMode marker calls into
+        # node.meta["memory_budget"] annotations and strip the markers before
+        # any backend sees the graph. See
+        # torch/_functorch/_activation_checkpointing/memory_budget.py.
+        from torch._functorch._activation_checkpointing.memory_budget import (
+            propagate_memory_budgets_from_markers,
+        )
+
+        propagate_memory_budgets_from_markers(gm)
+
         tot = 0
         placeholders = []
         for node in gm.graph.nodes:

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3488,6 +3488,7 @@ MOD_INLINELIST = [
     "torch._dynamo.polyfills",
     "torch._dynamo.test_case",
     "torch._export.non_strict_utils",
+    "torch._functorch._activation_checkpointing.memory_budget",
     "torch._functorch._aot_autograd.subclass_parametrization",
     "torch._functorch.autograd_function",
     "torch._functorch.eager_transforms",

--- a/torch/_functorch/_activation_checkpointing/memory_budget.py
+++ b/torch/_functorch/_activation_checkpointing/memory_budget.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing_extensions import Self
+
+import torch
+import torch.fx.traceback as fx_traceback
+
+
+__all__ = [
+    "MemoryBudgetMode",
+    "set_memory_budget",
+    "propagate_memory_budgets_from_markers",
+]
+
+
+def _validate_budget(budget: float) -> float:
+    if not isinstance(budget, (int, float)):
+        raise TypeError(f"budget must be a float, got {type(budget)}")
+    if not (0.0 <= budget <= 1.0):
+        raise ValueError(f"budget must be between 0 and 1, got {budget}")
+    return float(budget)
+
+
+def set_memory_budget(budget: float) -> None:
+    """
+    Set the memory budget for activation checkpointing on subsequent FX nodes.
+
+    The memory budget controls the trade-off between memory usage and
+    recomputation during the backward pass:
+    - budget=0.0: Aggressive recomputation, minimal memory (save almost nothing)
+    - budget=1.0: No recomputation, maximum memory (save everything)
+
+    Args:
+        budget: Float between 0 and 1 controlling memory/recompute trade-off.
+    """
+    budget = _validate_budget(budget)
+    fx_traceback.current_meta["memory_budget"] = budget
+
+
+# allow_in_graph makes Dynamo emit set_memory_budget itself as an opaque
+# call_function node rather than tracing into its body. Without this, the
+# fx_traceback.current_meta dict mutation above would force a graph break,
+# and the marker would never reach the FX graph. The body still runs in
+# eager mode (e.g. plain Python or torch.fx.symbolic_trace), so the dict
+# update preserves preserve_node_meta()-based propagation for non-Dynamo
+# tracers. Under torch.compile, propagate_memory_budgets_from_markers
+# converts each marker node into node.meta["memory_budget"] on the
+# subsequent op nodes and erases the markers from the graph.
+torch._dynamo.allow_in_graph(set_memory_budget)
+
+
+class MemoryBudgetMode:
+    """
+    Context manager that sets memory_budget metadata on FX nodes during
+    PT2 compilation for activation checkpointing control.
+
+    The memory budget controls the trade-off between memory usage and
+    recomputation during the backward pass:
+    - budget=0.0: Aggressive recomputation, minimal memory
+    - budget=1.0: No recomputation, maximum memory
+
+    Example::
+
+        with MemoryBudgetMode(0.3):
+            x = self.encoder(x)   # nodes get budget=0.3
+        with MemoryBudgetMode(0.8):
+            x = self.head(x)      # nodes get budget=0.8
+
+    Limitation: under torch.compile, nested MemoryBudgetMode does not restore
+    the outer budget on exit -- the inner budget persists for ops emitted after
+    the inner ``__exit__`` until the next ``set_memory_budget`` /
+    ``MemoryBudgetMode``. Eager mode is unaffected.
+    """
+
+    def __init__(self, budget: float) -> None:
+        self.budget = _validate_budget(budget)
+        self._prev_budget: float | None = None
+
+    def __enter__(self) -> Self:
+        # Under torch.compile, fx_traceback.current_meta dict ops would force
+        # a Dynamo graph break (module-level mutable dict), so skip them and
+        # rely on the set_memory_budget marker + post-pass for propagation.
+        # In eager mode (including plain Python and fx.symbolic_trace), keep
+        # the dict-based behavior so preserve_node_meta()-based tracers still
+        # see the budget and so __exit__ can restore the previous value.
+        if not torch.compiler.is_compiling():
+            self._prev_budget = fx_traceback.current_meta.get("memory_budget", None)
+        set_memory_budget(self.budget)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore[no-untyped-def]
+        if torch.compiler.is_compiling():
+            return
+        if self._prev_budget is not None:
+            fx_traceback.current_meta["memory_budget"] = self._prev_budget
+        else:
+            fx_traceback.current_meta.pop("memory_budget", None)
+
+    def __repr__(self) -> str:
+        return f"MemoryBudgetMode(budget={self.budget})"
+
+
+def propagate_memory_budgets_from_markers(gm: torch.fx.GraphModule) -> bool:
+    """
+    Convert ``set_memory_budget`` marker nodes into ``node.meta["memory_budget"]``
+    annotations on the subsequent op nodes and remove the markers from the graph.
+
+    Returns True if any marker was found (and the graph was mutated), False
+    otherwise. Safe to call on graphs that contain no markers (no-op then).
+    """
+    current_budget: float | None = None
+    any_marker = False
+    nodes_to_erase: list[torch.fx.Node] = []
+    for node in gm.graph.nodes:
+        if node.op == "call_function" and node.target is set_memory_budget:
+            any_marker = True
+            if node.args:
+                arg0 = node.args[0]
+                if isinstance(arg0, (int, float)):
+                    current_budget = float(arg0)
+            nodes_to_erase.append(node)
+            continue
+        if node.op in ("placeholder", "output", "get_attr"):
+            continue
+        if current_budget is not None:
+            node.meta["memory_budget"] = current_budget
+    if not any_marker:
+        return False
+    for node in nodes_to_erase:
+        gm.graph.erase_node(node)
+    gm.graph.lint()
+    gm.recompile()
+    return True

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -510,6 +510,16 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
         )
         self.sac_context_fn_hashes = _collect_context_fn_hashes(gm)
 
+        # node.meta is stripped by GraphModule.__reduce__, so memory_budget
+        # values set via set_memory_budget()/MemoryBudgetMode would be invisible
+        # to the cache key. Extract them explicitly so that changing per-node
+        # budgets correctly invalidates the cache.
+        self.memory_budget_per_node: list[tuple[int, float]] = []
+        for i, node in enumerate(gm.graph.nodes):
+            budget = node.meta.get("memory_budget", None)
+            if isinstance(budget, (int, float)):
+                self.memory_budget_per_node.append((i, float(budget)))
+
         # Note: We use the live config module, not self.autograd_config (the
         # saved config), because activation_memory_budget_runtime_estimator and
         # activation_memory_budget_solver are excluded from save_config (in

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1160,6 +1160,24 @@ def aot_module_simplified(
     :func:`aot_module_simplified` removes these overheads.
     """
 
+    # Convert set_memory_budget / MemoryBudgetMode marker calls into
+    # node.meta["memory_budget"] annotations and strip the markers before
+    # cache-key computation and joint-graph retrace. See
+    # torch/_functorch/_activation_checkpointing/memory_budget.py for details.
+    _mb_gm: torch.fx.GraphModule | None = None
+    if isinstance(mod, torch.fx.GraphModule):
+        _mb_gm = mod
+    elif isinstance(mod, torch._dynamo.utils.GmWrapper) and isinstance(
+        mod.gm, torch.fx.GraphModule
+    ):
+        _mb_gm = mod.gm
+    if _mb_gm is not None:
+        from torch._functorch._activation_checkpointing.memory_budget import (
+            propagate_memory_budgets_from_markers,
+        )
+
+        propagate_memory_budgets_from_markers(_mb_gm)
+
     pre_grad_pass_timing: Literal["early", "late"] = resolve_pre_grad_pass_timing()
 
     if (

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -166,6 +166,7 @@ _COPY_META_FIELDS = [
     "_numeric_debug_handle",  # TODO deprecated
     "custom",
     "partitioner_tag",
+    "memory_budget",
 ]
 
 


### PR DESCRIPTION
Summary:
Adds `set_memory_budget()` and `MemoryBudgetMode` for setting per-node `memory_budget` metadata during torch.compile tracing. The partitioner reads this to override `config.activation_memory_budget` per-region, enabling fine-grained control over the recomputation vs memory trade-off at model definition time.

`set_memory_budget(budget)` directly sets `fx_traceback.current_meta["memory_budget"]` so all subsequently traced FX nodes inherit the value. `MemoryBudgetMode(budget)` is a context manager wrapper that sets the budget on enter and restores the previous value on exit.

The implementation uses the standard FX metadata propagation mechanism: `"memory_budget"` is added to `_COPY_META_FIELDS` in `proxy.py`, so the metadata is automatically copied from `current_meta` to new nodes during tracing.

Additionally, `AOTAutogradCacheDetails` now extracts per-node `memory_budget` values into a `memory_budget_per_node` field that becomes part of the cache key. Without this, `GraphModule.__reduce__()` strips `node.meta` during pickling, making budget values invisible to the cache and causing stale cache hits when budgets change.

== v1 -> v2 changes ==

v1 relied solely on `fx_traceback.current_meta["memory_budget"]` being copied to FX nodes via `_COPY_META_FIELDS`. Under `torch.compile`, that path silently dropped the budget: writing to `fx_traceback.current_meta` from inside `set_memory_budget` is a module-level mutable dict mutation, so Dynamo graph-broke at the call site and the marker never reached the FX graph. As a result `test_memory_budget_propagates_to_nodes` and `test_memory_budget_metadata_causes_cache_miss` both saw empty `memory_budget` metadata and the cache test got two cache hits instead of two misses.

v2 keeps the v1 eager-mode behavior intact and adds a marker-op + post-pass for the Dynamo path:

- `set_memory_budget` is decorated with `torch._dynamo.allow_in_graph` so Dynamo emits it as an opaque `call_function` node instead of tracing into its body. The body still runs in eager / `fx.symbolic_trace`, preserving the v1 `_COPY_META_FIELDS` propagation for non-Dynamo tracers.
- `propagate_memory_budgets_from_markers(gm)` walks the captured graph, copies each marker's budget onto subsequent op nodes' `node.meta["memory_budget"]`, and erases the marker nodes. It is invoked from two boundaries: `OutputGraph._call_user_compiler` (so every backend, including custom `capture_backend`s, sees clean per-node metadata) and `aot_module_simplified` (defense-in-depth for direct AOTAutograd entry, with `GmWrapper` unwrapping for the cudagraph wrapper path).
- `MemoryBudgetMode.__enter__/__exit__` gate the `fx_traceback.current_meta` dict ops behind `torch.compiler.is_compiling()` so the context manager doesn't graph-break under `torch.compile` while keeping the prev-budget save/restore behavior for eager users.
- `torch._functorch._activation_checkpointing.memory_budget` is added to `MOD_INLINELIST` in `trace_rules.py`. Without this, `torch/_functorch/` falls under `MOD_SKIPLIST` and Dynamo refuses to inline `MemoryBudgetMode.__init__`/`__enter__`/`__exit__`, graph-breaking at every `with MemoryBudgetMode(...)` regardless of the body.

Local CPU repros (`agent_space/test_mb_cpu_repro.py` for direct calls and `agent_space/test_cache_repro.py` for the `MemoryBudgetMode`-wrapped `nn.Linear` shape used by the cache test) now show `0.3` vs `0.8` budgets landing on the correct nodes and producing distinct `AOTAutogradCacheDetails.memory_budget_per_node` keys.

Test Plan:
```
buck test fbcode//caffe2/test/functorch:test_memory_budget
buck test fbcode//caffe2/test/dynamo:test_aot_autograd_cache -- test_memory_budget_metadata_causes_cache_miss
```

Differential Revision: D101822724


