### PR TITLE
Fix ExportedProgram pickle after graph_module edits

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -2146,6 +2146,45 @@ class TestSaveLoad(TestCase):
 
         self.assertTrue(torch.allclose(ep.module()(*inp), loaded_ep.module()(*inp)))
 
+    def test_torch_save_exported_program_with_call_module(self):
+        class Module(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        inp = (torch.randn(3, 2),)
+        ep = export(Module(), inp, dynamic_shapes={"x": {0: Dim("batch")}})
+
+        add_node = next(node for node in ep.graph.nodes if node.op == "call_function")
+        scale_after_add = torch.nn.Linear(2, 2, bias=False)
+        with torch.no_grad():
+            scale_after_add.weight.copy_(2 * torch.eye(2))
+        ep.graph_module.add_submodule("scale_after_add", scale_after_add)
+        with ep.graph.inserting_after(add_node):
+            scale_node = ep.graph.call_module("scale_after_add")
+            add_node.replace_all_uses_with(scale_node)
+            scale_node.args = (add_node,)
+        ep.graph_module.recompile()
+        add_node.meta["unpickleable_debug_metadata"] = lambda value: value
+
+        runtime_inp = (torch.randn(5, 2),)
+        expected = ep.module()(*runtime_inp)
+
+        buffer = io.BytesIO()
+        torch.save(ep, buffer)
+        serialized = buffer.getvalue()
+        buffer.seek(0)
+        # weights_only=False because this test intentionally verifies the
+        # ExportedProgram pickle path, not the safe weights-only loader.
+        loaded_ep = torch.load(buffer, weights_only=False)
+        loaded_ep_meta = torch.load(
+            io.BytesIO(serialized), weights_only=False, map_location="meta"
+        )
+
+        self.assertEqual(loaded_ep.module()(*runtime_inp), expected)
+        self.assertEqual(
+            loaded_ep_meta.graph_module.scale_after_add.weight.device.type, "meta"
+        )
+
     def test_deserialize_torch_artifact_dict(self):
         data = {"key": torch.tensor([1, 2, 3])}
         buf = io.BytesIO()

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -91,6 +91,23 @@ __all__ = [
 ]
 
 
+_SERIALIZED_GRAPH_MODULE_NODE_META_KEY = "_serialized_graph_module_node_meta"
+_SERIALIZED_GRAPH_MODULE_NODE_META_KEYS = frozenset(
+    {
+        "nn_module_stack",
+        "stack_trace",
+        "tensor_meta",
+        "torch_fn",
+        "unbacked_bindings",
+        "val",
+    }
+)
+
+
+def _exported_program_node_metadata_key_filter(key: str) -> bool:
+    return key in _SERIALIZED_GRAPH_MODULE_NODE_META_KEYS
+
+
 PassType = Callable[[torch.fx.GraphModule], PassResult | None]
 
 
@@ -1139,6 +1156,81 @@ class ExportedProgram:
         self.validate()
 
         self._guards_code = _convert_guards_to_code(self._graph_module)
+
+    def __copy__(self):
+        ep = self.__class__.__new__(self.__class__)
+        ep.__dict__.update(self.__dict__)
+        return ep
+
+    def __deepcopy__(self, memo):
+        ep = self.__class__.__new__(self.__class__)
+        memo[id(self)] = ep
+        ep.__dict__.update(copy.deepcopy(self.__dict__, memo))
+        return ep
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+
+        # GraphModule's default pickle path reconstructs the graph from Python
+        # source. Strip the export-only tracer, which cannot be reconstructed
+        # without scope_root, and separately preserve node metadata that
+        # ExportedProgram.module() needs.
+        from torch.fx._graph_pickler import GraphPickler, Options
+
+        state[_SERIALIZED_GRAPH_MODULE_NODE_META_KEY] = GraphPickler.dumps(
+            [
+                {
+                    key: value
+                    for key, value in node.meta.items()
+                    if _exported_program_node_metadata_key_filter(key)
+                }
+                for node in self.graph.nodes
+            ],
+            Options(
+                ops_filter=None,
+                node_metadata_key_filter=_exported_program_node_metadata_key_filter,
+            ),
+        )
+        # Shallow-clone the GraphModule so parameters and buffers stay visible
+        # to the outer torch.save storage handling and map_location.
+        graph_module_cls = self.graph_module.__class__
+        graph_module = graph_module_cls.__new__(graph_module_cls)
+        graph_module.__dict__ = self.graph_module.__dict__.copy()
+        graph_module.graph = copy.deepcopy(self.graph)
+        graph_module._tracer_cls = None
+        graph_module.graph._tracer_cls = None
+        state["_graph_module"] = graph_module
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        serialized_node_meta = state.pop(_SERIALIZED_GRAPH_MODULE_NODE_META_KEY, None)
+        if serialized_node_meta is None:
+            self.__dict__.update(state)
+            return
+
+        from torch.fx._graph_pickler import GraphPickler
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        node_meta = GraphPickler.loads(
+            serialized_node_meta,
+            FakeTensorMode(shape_env=ShapeEnv()),
+        )
+        if not isinstance(node_meta, list):
+            raise TypeError(
+                f"Expected list of node metadata, got {type(node_meta).__name__}"
+            )
+        self.__dict__.update(state)
+        nodes = list(self.graph.nodes)
+        if len(nodes) != len(node_meta):
+            raise RuntimeError(
+                f"Expected {len(nodes)} metadata entries, got {len(node_meta)}"
+            )
+        for node, meta in zip(nodes, node_meta):
+            if not isinstance(meta, dict):
+                raise TypeError(
+                    f"Expected node metadata dict, got {type(meta).__name__}"
+                )
+            node.meta = meta
 
     @property
     @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185170

Modified ExportedPrograms can contain call_module nodes when users edit the underlying FX graph. The schematized torch.export.save path still rejects that graph form by design, but the Python torch.save path should be able to round-trip the object when weights_only=False is explicitly requested.

The load failure came from FX GraphModule pickling. GraphModule pickles by dropping the in-memory graph and retracing generated Python source on load, using the stored graph tracer class. ExportedProgram graphs created by export can record _ModuleStackTracer as that tracer, but _ModuleStackTracer requires a scope_root constructor argument and cannot be rebuilt by GraphModule's no-arg retracing path. Simply clearing the tracer is not enough for ExportedProgram because the retraced graph also loses node metadata such as meta["val"], which ExportedProgram.module() needs.

Fix this by giving ExportedProgram an explicit pickle state. The GraphModule stays on the normal torch.save path so parameters, buffers, and map_location handling continue to work. For the pickled copy only, clone the GraphModule container, deep-copy its graph, and clear the non-reconstructable tracer from that copied graph. Preserve the export metadata needed after GraphModule retracing in an allowlisted sidecar serialized through FX GraphPickler. Optional user/pass metadata is intentionally not included, so unpickleable debug metadata does not regress torch.save behavior.

This avoids serializing the entire GraphModule as an opaque nested byte blob, which would hide its tensor storages from the outer torch.save machinery.

Fixes #161671
Generated by my agent

Test Plan:
- python test/export/test_serialize.py TestSaveLoad.test_torch_save_exported_program_with_call_module
- python test/export/test_serialize.py TestSaveLoad
- lintrunner -a torch/export/exported_program.py test/export/test_serialize.py && git diff --check