### PR TITLE
Run cpp/test_jit and cpp/test_lazy sequentially in test_libtorch_jit

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1487,12 +1487,15 @@ test_libtorch_jit() {
   python cpp/jit/tests_setup.py setup
   popd
 
-  # Run jit and lazy tensor cpp tests together to finish them faster
+  # Run jit and lazy tensor cpp tests one at a time; running them concurrently
+  # has been observed to hang pytest-xdist worker teardown on some runners.
   if [[ "$BUILD_ENVIRONMENT" == *cuda* && "$TEST_CONFIG" != *nogpu* ]]; then
-    LTC_TS_CUDA=1 python test/run_test.py --cpp --verbose -i cpp/test_jit cpp/test_lazy
+    LTC_TS_CUDA=1 python test/run_test.py --cpp --verbose -i cpp/test_jit
+    LTC_TS_CUDA=1 python test/run_test.py --cpp --verbose -i cpp/test_lazy
   else
     # CUDA tests have already been skipped when CUDA is not available
-    python test/run_test.py --cpp --verbose -i cpp/test_jit cpp/test_lazy -k "not CUDA"
+    python test/run_test.py --cpp --verbose -i cpp/test_jit -k "not CUDA"
+    python test/run_test.py --cpp --verbose -i cpp/test_lazy -k "not CUDA"
   fi
 
   # Cleaning up test artifacts in the test folder


### PR DESCRIPTION
Running both binaries in a single `run_test.py` call puts them in the parallel-test `multiprocessing.Pool` simultaneously, which has been observed to hang pytest-xdist worker teardown on some runners. See https://github.com/pytorch/pytorch/actions/runs/26416445385/job/77763032718 for an example.

Splitting the invocation keeps each binary's pytest-xdist `-n NUM_PROCS` parallelism but removes the cross-binary concurrency.