### PR TITLE
[AutoGenEager] Promote scalar literals to tensors for AOTI eager compilation (#185174)

### DIFF
--- a/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
@@ -14,17 +14,59 @@
 #include <torch/csrc/inductor/aoti_runner/model_container_runner_xpu.h>
 #endif
 
+#include <ATen/Functions.h>
 #include <ATen/core/jit_type.h>
 
 namespace torch::inductor {
 
 namespace {
 
+// Find the first non-wrapped-number tensor on the IValue stack. Used as the
+// reference operand for at::result_type when aligning wrapped-number tensor
+// dtypes (see unpack_tensor_ivalue).
+// When a scalar tensor is wrapped number, dtype promotion gives it lower
+// priority than real tensors. See the comments here:
+// https://github.com/pytorch/pytorch/blob/v2.10.0/c10/core/TensorImpl.h#L1340-L1372
+inline std::optional<at::Tensor> find_reference_tensor(
+    const torch::jit::Stack& stack) {
+  for (const auto& ivalue : stack) {
+    if (ivalue.isTensor()) {
+      auto tensor = ivalue.toTensor();
+      // A reference tensor/dtype is only needed when an input tensor is a
+      // wrapped number that is originally a Python literal. This is a stubborn
+      // tech debt. Thus, here we simply pick the first input tensor `self` as
+      // the reference. Full list of relevant OpOverloads:
+      // https://fburl.com/code/3r94r47i
+      if (!tensor.unsafeGetTensorImpl()->is_wrapped_number()) {
+        return tensor;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
 inline void unpack_tensor_ivalue(
     const c10::IValue& ivalue,
     const c10::Device& device,
-    std::vector<at::Tensor>& inputs) {
-  inputs.push_back(ivalue.toTensor());
+    std::vector<at::Tensor>& inputs,
+    const std::optional<at::Tensor>& ref_tensor = std::nullopt) {
+  auto tensor = ivalue.toTensor();
+  // A wrapped-number tensor originates from a Python scalar (e.g. the 1.7 in
+  // ``torch.add(x, 1.7)``) that the arg parser promoted to a 0-dim tensor
+  // (see PythonArgs::tensor_slow in python_arg_parser.cpp).  The C++ arg
+  // parser always creates these with the scalar's native dtype (float64 for
+  // Python float, int64 for Python int), but the Python-side compiler uses
+  // torch.result_type to align the dtype with the first tensor operand.
+  // We call the same at::result_type here so runtime inputs match the
+  // compiled kernel's expectations.
+  if (ref_tensor.has_value() &&
+      tensor.unsafeGetTensorImpl()->is_wrapped_number()) {
+    auto ref_dtype = at::result_type(ref_tensor.value(), tensor);
+    if (tensor.scalar_type() != ref_dtype) {
+      tensor = tensor.to(ref_dtype);
+    }
+  }
+  inputs.push_back(std::move(tensor));
 }
 
 inline void unpack_optional_tensor_ivalue(
@@ -59,12 +101,13 @@ std::vector<at::Tensor> unpack_tensors(
     const std::vector<c10::Argument>& arguments,
     const torch::jit::Stack& stack,
     const c10::Device& device) {
+  auto ref_tensor = find_reference_tensor(stack);
   std::vector<at::Tensor> inputs;
   for (size_t idx = 0; idx < stack.size(); idx++) {
     const auto& ivalue = stack[idx];
     const auto& ivalue_arg = arguments[idx];
     if (ivalue.isTensor()) {
-      unpack_tensor_ivalue(ivalue, device, inputs);
+      unpack_tensor_ivalue(ivalue, device, inputs, ref_tensor);
     } else if (ivalue.isTensorList()) {
       unpack_tensor_list_ivalue(ivalue, device, inputs);
     } else if (ivalue.isOptionalTensorList()) {
@@ -89,6 +132,7 @@ bool is_default_value(
 std::vector<ParameterMetadata> unpack_input_parameters(
     const std::vector<c10::Argument>& arguments,
     const torch::jit::Stack& stack) {
+  auto ref_tensor = find_reference_tensor(stack);
   std::vector<ParameterMetadata> inputs_metadata;
   // Represent the order of argument and skip default parameter
   int64_t arg_order = 0;
@@ -129,7 +173,18 @@ std::vector<ParameterMetadata> unpack_input_parameters(
         inputs_metadata.emplace_back(std::move(t.value()), arg_order);
       }
     } else if (stack[idx].isTensor()) {
-      inputs_metadata.emplace_back(stack[idx].toTensor(), arg_order);
+      auto tensor = stack[idx].toTensor();
+      // Align wrapped-number tensor dtype via at::result_type, mirroring the
+      // Python-side torch.result_type call in _promote_scalar_args_to_tensors.
+      // This ensures cache metadata matches the compiled kernel's expectations.
+      if (ref_tensor.has_value() &&
+          tensor.unsafeGetTensorImpl()->is_wrapped_number()) {
+        auto ref_dtype = at::result_type(ref_tensor.value(), tensor);
+        if (tensor.scalar_type() != ref_dtype) {
+          tensor = tensor.to(ref_dtype);
+        }
+      }
+      inputs_metadata.emplace_back(std::move(tensor), arg_order);
     } else if (stack[idx].isString()) {
       inputs_metadata.emplace_back(stack[idx].toStringRef(), arg_order);
     } else if (stack[idx].isBool()) {


### PR DESCRIPTION
Summary:

Top remaining GLOBE × autogen_eager bucket post-D104909890: **AFG runtime input-count mismatch — 63 fails on `globe_job_id=18` (17% of remaining)**, dominated by int64 division ops (`aten.divide_.Tensor` 40, `aten.div_.Tensor` 12, `aten.div.Tensor` fp32 9, `aten.mul.Tensor` int64 2).

Root cause: when a Python scalar literal (e.g. `1.7` in `torch.add(x, 1.7)`) is passed to an op whose schema expects a Tensor, the C++ arg parser (`PythonArgs::tensor_slow`) promotes it to a 0-dim *wrapped-number* tensor and dispatches to the `.Tensor` overload. However, during AOTI eager compilation, `toPyObject` converts it back to a plain Python scalar. Dynamo then bakes it as a graph constant, causing a mismatch: the compiled kernel expects fewer tensor inputs than the C++ dispatcher supplies at runtime, throwing `Mismatched numbers of input tensors. Expected ... (2 vs. 1)` at `afg_bindings.cpp:2206`.

This diff fixes the divergence with three coordinated changes:

**Python (`aoti_eager_mtia.py`)**: Adds `_promote_scalar_args_to_tensors()` which inspects the op schema and converts bare Python scalars back to 0-dim tensors before tracing. The promoted tensor's dtype is aligned with the first tensor operand via `torch.result_type` (e.g. `float16` for `add(float16_tensor, 1.7)`), matching PyTorch's wrapped-number type promotion semantics where the scalar adopts the tensor's dtype. When no tensor operand is available, conservative defaults (float32/int32) are used. This also prevents specialisation on every distinct literal value when dynamic shapes are enabled.

**C++ runner (`aoti_model_runner_mtia.cpp`)**: Switched from `afg_->runFunction()` to `afg_->wrapperHook()` so that inputs that originated on CPU (the promoted scalar tensors) are automatically transferred to the MTIA device via `prepareAndTransferInputs()`. Preserves the contiguity check from D104909890.

**C++ dispatch (`kernel_holder.cpp`, fbcode + xplat)**: Adds dtype alignment for wrapped-number tensors in `unpack_tensors()` and `unpack_input_parameters()` to mirror the Python-side promotion. At runtime, the C++ arg parser creates wrapped-number tensors with the scalar's native dtype (float64 for Python float, int64 for Python int), but the compiled kernel expects the aligned dtype. Both functions now cast wrapped-number tensors to the first non-wrapped tensor's dtype via `at::result_type`. New helper `find_reference_tensor()` walks the IValue stack for the first non-wrapped tensor.

Stacked on D104909890 (in-place dispatch wrapper). Together they address bucket 1 (in-place + silent-wrong-`.out`, 397 fails) plus bucket 4 (input-count mismatch, ~52 of 63 fails — the int64 div ones). Remaining buckets 2 (`.out` compile crashes, 184) and 3 (schema holes, 106) need separate upstream cooperation.

Authored with Claude.

Test Plan:
Full unit-test suite — both platforms:

| Target | Result | TestX |
|---|---|---|
| `test_aoti_eager_dispatch-*******` | 51 / 51 pass | https://www.internalfb.com/intern/testinfra/testrun/30962247445908096 |
| `test_aoti_eager_dispatch-*******` | 51 / 51 pass | https://www.internalfb.com/intern/testinfra/testrun/4503599993061446 |

```
buck2 test //mtia/host_runtime/aoti_eager:test_aoti_eager_dispatch-*******
buck2 test //mtia/host_runtime/aoti_eager:test_aoti_eager_dispatch-*******
```

(51 = previous 50 + new `test_add_literal` covering the scalar-promotion path: `torch.add(fp16_tensor, 1.7)`.)

GLOBE bucket-4 elimination — same `buck2 run` template, on ******* RE, categorising the residual failures by `error_msg`:

```
buck2 run fbcode//mode/dev fbcode//mtia/coverage/scripts:run_op_tests \
    -- --op <OP> --mode inductor_autogen_eager --limit 30
```

| op | --limit | Bucket-4 baseline (job 18) | Bucket-4 post-fix | Net | Remaining failure mode |
|---|---|---:|---:|---|---|
| `aten.div_` | 30 | 12 (input-count mismatch on int64) | **0** | -12 ✅ | 12 surfaced as bucket 3 (`NotImplementedError: return type: int`) — separate upstream schema hole |
| `aten.div` | 30 | 9 (input-count mismatch) | **0** | -9 ✅ | 9 surfaced as bucket 3 (same) |
| `aten.mul` | 30 | 2 (input-count mismatch on int64) | **0** | -2 ✅ | 26 are bucket 2 `.out` INTERNAL ASSERT — separate compile-crash bug |
| `aten.divide_` | 30 | 40 (input-count mismatch on int64) | (RE workloadd flake) | (pending) | retry when ******* RE stabilises |

Confirmed via `grep -c` per-error-pattern on each log: every `Mismatched numbers of input tensors` count is **0** post-fix; the 12 (div_), 9 (div), and 2 (mul) cases that previously failed with input-count mismatch now PASS or surface a downstream issue. So the bucket-4 fix lands the ~23 of 63 fails I could validate on these three ops; the remaining 40 (divide_) are expected to behave the same once RE recovers.

Single-test sanity checks (*******, on a healthy RE machine):

| test | Result | TestX |
|---|---|---|
| `test_add` regex (9 tests, includes `test_add_literal` for scalar promotion + `test_inplace_add_mutates_self` + `test_out_variant_add_writes_to_out`) | 9 / 9 pass | https://www.internalfb.com/intern/testinfra/testrun/30962247445849056 |
| `test_mul` regex (7 tests) | 7 / 7 pass | https://www.internalfb.com/intern/testinfra/testrun/8162774675578225 |

Differential Revision: D96875611


