### PR TITLE
Fix DTensor nll_loss weighted mean bug (closes #185167)

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -341,6 +341,32 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertEqual(dist_y.to_local(), y)
 
     @with_comms
+    @skip_unless_torch_gpu
+    def test_nll_loss_weighted_mean_batch_sharded(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/185167
+        # F.nll_loss(weight=..., reduction='mean') returned wrong results when
+        # input was batch-sharded because per-rank denominator sum(w[t[n]])
+        # varies across ranks and cannot be averaged naively.
+        import torch.nn.functional as F
+
+        device_mesh = self.build_device_mesh()
+        torch.manual_seed(0)
+
+        log_probs = F.log_softmax(torch.randn(8, 4, device=self.device_type), dim=1)
+        target = torch.tensor([0, 3, 3, 3, 0, 1, 3, 2], device=self.device_type)
+        # Non-uniform weights so per-rank sum(weight[target]) differs across ranks
+        class_weight = torch.tensor([0.62, 2.0, 1.6, 1.39], device=self.device_type)
+
+        d_lp = distribute_tensor(log_probs, device_mesh, [Shard(0)])
+        d_tgt = distribute_tensor(target, device_mesh, [Replicate()])
+        d_w = distribute_tensor(class_weight, device_mesh, [Replicate()])
+
+        expected = F.nll_loss(log_probs, target, weight=class_weight, reduction="mean")
+        actual = F.nll_loss(d_lp, d_tgt, weight=d_w, reduction="mean")
+
+        self.assertEqual(actual.full_tensor(), expected, atol=1e-5, rtol=1e-5)
+
+    @with_comms
     def test_shard_math_ops(self):
         mesh_shape = (2, self.world_size // 2)
         mesh = DeviceMesh(


### PR DESCRIPTION
Fixes #185167

When input is batch-sharded (Shard(0)) and weight is non-None with
reduction='mean', the per-rank denominator sum(w[t[n]]) varies across
ranks. Averaging per-rank means does not recover the global weighted
mean (global_loss_sum / global_weight_sum).

Fix: add an `elif` branch in `nll_loss_forward_strategy` that detects
this case and forces full replication, so the op computes the correct
result directly on a single rank.

The xfail entries for `nn_functional_linear_cross_entropy` in
`dtensor_fails` / `dtensor_numeric_only_fails` (added in PR #184596)
can be removed once this lands.