### PR TITLE
[FSDP][AC] Bypass SAC tracking for all-gather internals

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_autograd.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_autograd.py
@@ -9,7 +9,12 @@ from typing import Any
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, OffloadPolicy
+from torch.distributed.fsdp import (
+    CPUOffloadPolicy,
+    fully_shard,
+    MixedPrecisionPolicy,
+    OffloadPolicy,
+)
 from torch.nn.parallel.scatter_gather import _is_namedtuple
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
@@ -24,6 +29,12 @@ from torch.testing._internal.common_utils import run_tests, TEST_HPU
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
+)
+from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils.checkpoint import (
+    checkpoint,
+    CheckpointPolicy,
+    create_selective_checkpoint_contexts,
 )
 
 
@@ -42,6 +53,58 @@ class TestFullyShardAutograd(FSDPTest):
         for param in module.parameters():
             if param.grad is not None:
                 param.grad.div_(group.size())
+
+    @skip_if_lt_x_gpu(2)
+    def test_all_gather_internals_bypass_sac_not_torch_dispatch_modes(self):
+        fsdp_internal_ops = (
+            torch.ops.aten.split_with_sizes.default,
+            torch.ops.aten._foreach_copy_.default,
+        )
+        observed_ops: collections.Counter[Any] = collections.Counter()
+        policy_ops: collections.Counter[Any] = collections.Counter()
+
+        class CountAllGatherInternalsMode(TorchDispatchMode):
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                if func in fsdp_internal_ops:
+                    observed_ops[func] += 1
+                kwargs = {} if kwargs is None else kwargs
+                return func(*args, **kwargs)
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            policy_ops[op] += 1
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        torch.manual_seed(42)
+        model = nn.Sequential(
+            nn.Linear(8, 16, bias=False, device=device_type),
+            nn.ReLU(),
+            nn.Linear(16, 8, bias=False, device=device_type),
+        )
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+        )
+        fully_shard(model[0], mp_policy=mp_policy)
+        fully_shard(model, mp_policy=mp_policy)
+        inp = torch.randn(
+            (2, 8), device=device_type, dtype=torch.bfloat16, requires_grad=True
+        )
+        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+
+        with CountAllGatherInternalsMode():
+            out = checkpoint(
+                model,
+                inp,
+                use_reentrant=False,
+                context_fn=context_fn,
+                early_stop=False,
+            )
+            out.sum().backward()
+
+        self.assertIsNotNone(inp.grad)
+        self.assertGreater(sum(observed_ops[op] for op in fsdp_internal_ops), 0)
+        for op in fsdp_internal_ops:
+            self.assertEqual(policy_ops[op], 0)
 
     @skip_if_lt_x_gpu(2)
     def test_unused_forward_output(self):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16207,6 +16207,99 @@ class TestSelectiveActivationCheckpoint(TestCase):
         out = checkpoint(fn, x_wrapper, use_reentrant=False, context_fn=context_fn)
         out.sum().backward()
 
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_profiler_record_function_ignored(self):
+        call_count = [0]
+        policy_calls = []
+        profiler_ops = {
+            torch.ops.profiler._record_function_enter.default,
+            torch.ops.profiler._record_function_enter_new.default,
+            torch.ops.profiler._record_function_exit._RecordFunction,
+            torch.ops.profiler._record_function_exit.default,
+        }
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            policy_calls.append(op)
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def fn(x):
+            call_count[0] += 1
+            with torch.profiler.record_function("shared"):
+                y = x.sin()
+            if call_count[0] > 1:
+                with torch.profiler.record_function("recompute_only"):
+                    pass
+            return y.cos()
+
+        x = torch.randn(3, requires_grad=True)
+        x_ref = x.detach().clone().requires_grad_()
+        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+        out = checkpoint(
+            fn, x, use_reentrant=False, context_fn=context_fn, early_stop=False
+        )
+        out.sum().backward()
+
+        ref = x_ref.sin().cos()
+        ref.sum().backward()
+        self.assertEqual(x.grad, x_ref.grad)
+        self.assertTrue(profiler_ops.isdisjoint(policy_calls))
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_sac_bypass_context_skips_storage_and_counters(self):
+        from torch.utils.checkpoint import (
+            _bypass_sac_dispatch_modes,
+            _CachedTorchDispatchMode,
+            _CachingTorchDispatchMode,
+        )
+
+        policy_calls = []
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            policy_calls.append(op)
+            return CheckpointPolicy.MUST_SAVE
+
+        x = torch.randn(3)
+        storage = defaultdict(dict)
+        with _CachingTorchDispatchMode(policy_fn, storage) as caching_mode:
+            with _bypass_sac_dispatch_modes():
+                bypassed_out = x.sin()
+            saved_out = x.sin()
+
+        self.assertEqual(policy_calls, [torch.ops.aten.sin.default])
+        self.assertEqual(caching_mode.func_counter[torch.ops.aten.sin.default], 1)
+        self.assertIn(0, storage[torch.ops.aten.sin.default])
+
+        cached_mode = _CachedTorchDispatchMode(None, storage, False)
+        with cached_mode:
+            with _bypass_sac_dispatch_modes():
+                cached_bypassed_out = x.sin()
+            replayed_out = x.sin()
+
+        self.assertEqual(cached_bypassed_out, bypassed_out)
+        self.assertEqual(replayed_out, saved_out)
+        self.assertEqual(cached_mode.func_counter[torch.ops.aten.sin.default], 1)
+
+        nested_policy_calls = []
+
+        def nested_policy_fn(ctx, op, *args, **kwargs):
+            nested_policy_calls.append(op)
+            return CheckpointPolicy.MUST_SAVE
+
+        nested_storage = defaultdict(dict)
+        with _CachingTorchDispatchMode(nested_policy_fn, nested_storage) as nested_mode:
+            with _bypass_sac_dispatch_modes():
+                with _bypass_sac_dispatch_modes():
+                    x.cos()
+                x.cos()
+            x.cos()
+
+        self.assertEqual(nested_policy_calls, [torch.ops.aten.cos.default])
+        self.assertEqual(nested_mode.func_counter[torch.ops.aten.cos.default], 1)
+
+        with _CachedTorchDispatchMode(None, {}, False):
+            with self.assertRaisesRegex(RuntimeError, "not found in storage"):
+                x.sin()
+
     def test_bad_inputs(self):
         bad_op_list1 = [2]
 

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -16,6 +16,7 @@ from torch.distributed.fsdp._common_utils import (
     replace_grad_tensors,
 )
 from torch.profiler import record_function
+from torch.utils.checkpoint import _bypass_sac_dispatch_modes
 from torch.utils.hooks import RemovableHandle
 
 from ._fsdp_api import CPUOffloadPolicy, MixedPrecisionPolicy, OffloadPolicy
@@ -392,14 +393,15 @@ class FSDPParamGroup:
             return
 
         with record_function(self._with_fqn("FSDP::all_gather")):
-            self._all_gather_result = foreach_all_gather(
-                self.fsdp_params,
-                self._all_gather_process_group,
-                async_op,
-                *self.comm_ctx.get_all_gather_streams(async_op, self._training_state),
-                self.device,
-                self._all_gather_comm,
-            )
+            with _bypass_sac_dispatch_modes():
+                self._all_gather_result = foreach_all_gather(
+                    self.fsdp_params,
+                    self._all_gather_process_group,
+                    async_op,
+                    *self.comm_ctx.get_all_gather_streams(async_op, self._training_state),
+                    self.device,
+                    self._all_gather_comm,
+                )
 
     @_disable_functorch_if_active
     def wait_for_unshard(self):
@@ -448,11 +450,12 @@ class FSDPParamGroup:
 
         else:
             with record_function(self._with_fqn("FSDP::all_gather_copy_out")):
-                foreach_all_gather_copy_out(
-                    self._all_gather_result,
-                    self.fsdp_params,
-                    self._all_gather_process_group,
-                )
+                with _bypass_sac_dispatch_modes():
+                    foreach_all_gather_copy_out(
+                        self._all_gather_result,
+                        self.fsdp_params,
+                        self._all_gather_process_group,
+                    )
 
         for fsdp_param in self.fsdp_params:
             fsdp_param.init_unsharded_param()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -398,7 +398,9 @@ class FSDPParamGroup:
                     self.fsdp_params,
                     self._all_gather_process_group,
                     async_op,
-                    *self.comm_ctx.get_all_gather_streams(async_op, self._training_state),
+                    *self.comm_ctx.get_all_gather_streams(
+                        async_op, self._training_state
+                    ),
                     self.device,
                     self._all_gather_comm,
                 )

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -8,6 +8,7 @@ import uuid
 import warnings
 import weakref
 from collections import defaultdict
+from contextvars import ContextVar
 from typing import *  # noqa: F403
 from typing_extensions import Self
 import enum
@@ -1333,6 +1334,29 @@ SAC_IGNORED_OPS = {
     # can result in incorrectness if these ops are selected cached.
     torch.ops.prim.device.default,
 } | set(torch._subclasses.functional_tensor.FunctionalTensor.metadata_fns)  # type: ignore[has-type]
+SAC_IGNORED_OPS.update({
+    # Profiler annotations may legitimately differ between forward and recompute
+    # since they can depend on global runtime state such as FSDP hook ordering.
+    torch.ops.profiler._record_function_enter.default,
+    torch.ops.profiler._record_function_enter_new.default,
+    torch.ops.profiler._record_function_exit._RecordFunction,
+    torch.ops.profiler._record_function_exit.default,
+})
+
+
+_sac_dispatch_mode_bypass: ContextVar[bool] = ContextVar(
+    "_sac_dispatch_mode_bypass", default=False
+)
+
+
+@contextlib.contextmanager
+def _bypass_sac_dispatch_modes():
+    """Bypass SAC bookkeeping without disabling unrelated TorchDispatchModes."""
+    token = _sac_dispatch_mode_bypass.set(True)
+    try:
+        yield
+    finally:
+        _sac_dispatch_mode_bypass.reset(token)
 
 
 def _sac_storage_key(func, args):
@@ -1366,6 +1390,9 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         kwargs = {} if kwargs is None else kwargs
+        if _sac_dispatch_mode_bypass.get():
+            return func(*args, **kwargs)
+
         is_compiling = _is_compiling(func, args, kwargs)
 
         if is_compiling:
@@ -1435,6 +1462,10 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
         return super().__enter__()
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        kwargs = {} if kwargs is None else kwargs
+        if _sac_dispatch_mode_bypass.get():
+            return func(*args, **kwargs)
+
         if func in SAC_IGNORED_OPS:
             return func(*args, **kwargs)
 
@@ -1460,7 +1491,6 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
                 "on any region computed under selective activation checkpoint."
             )
         elif entry is _RECOMPUTE:
-            kwargs = {} if kwargs is None else kwargs
             return func(*args, **kwargs)
         else:
             func_storage[idx] = _CONSUMED


### PR DESCRIPTION
Fixes a selective activation checkpointing replay mismatch seen in TorchTitan DeepSeek V3 with FSDP+EP.

TorchTitan tracking issue: https://github.com/pytorch/torchtitan/issues/3427

During non-reentrant checkpoint recompute, SAC installs a `TorchDispatchMode` to track ops for replay. FSDP pre-forward hooks may run during that recompute and unshard parameters via all-gather. The all-gather implementation performs communication/materialization internals such as `aten.split_with_sizes.default` and `aten._foreach_copy_.default`; those are not user/model-region ops and may differ between the original forward and recompute.

This introduces an internal SAC bypass context for runtime plumbing regions. SAC caching/replay modes execute ops directly under that bypass without policy calls, storage updates/lookups, or counter increments. FSDP wraps all-gather and copy-out internals in that bypass while preserving the outer FSDP profiler ranges. This keeps unrelated ambient `TorchDispatchMode`s able to observe FSDP internals, unlike a blanket `no_dispatch()` guard.

Profiler `record_function` enter/exit ops are also ignored by SAC because annotations may legitimately differ between forward and recompute and do not produce model values.

The updated regression coverage checks that ambient dispatch modes can still see FSDP all-gather internals, while SAC does not replay-index them. Targeted SAC/FSDP tests and the original TorchTitan repro passed in the H100 validation container.

Authored with codex gpt-5.5 xhigh