### PR TITLE
[Test][distributed] Refactor some distributed test helpers to be device-agnostic

### DIFF
--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -58,7 +58,7 @@ class ReplicateTest(MultiProcContinuousTest):
     def _init_pg(cls, rank, world_size, rdvz_file):
         if torch.accelerator.is_available():
             if torch.accelerator.device_count() < world_size:
-                sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
+                sys.exit(TEST_SKIPS[f"multi-device-{world_size}"].exit_code)
             torch.accelerator.set_device_index(rank)
         super()._init_pg(rank, world_size, rdvz_file)
 

--- a/test/distributed/test_c10d_logger.py
+++ b/test/distributed/test_c10d_logger.py
@@ -41,7 +41,7 @@ def with_comms(func=None):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         if torch.get_device_module(device_type).device_count() < self.world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
+            sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)
         self.create_pg(device_type)
         func(self)
         self.destroy_comms()

--- a/test/distributed/test_c10d_object_collectives.py
+++ b/test/distributed/test_c10d_object_collectives.py
@@ -45,7 +45,7 @@ def with_comms(func=None):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         if device_type != "cpu" and device_count < self.world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
+            sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)
 
         self.pg = self.create_pg(device=device_type)
         try:

--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -528,7 +528,7 @@ elif TEST_XPU:
 def exit_if_lt_x_accelerators(x):
     if torch.accelerator.is_available():
         if torch.accelerator.device_count() < x:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{x}"].exit_code)
+            sys.exit(TEST_SKIPS[f"multi-device-{x}"].exit_code)
 
 
 def with_comms(func=None):
@@ -540,7 +540,7 @@ def with_comms(func=None):
         if (
             BACKEND == dist.Backend.NCCL or BACKEND == dist.Backend.XCCL
         ) and torch.accelerator.device_count() < self.world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
+            sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)
 
         kwargs["device"] = DEVICE
         self.pg = self.create_pg(device=DEVICE)

--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -41,7 +41,7 @@ def with_comms(func=None):
             torch.cuda.is_available()
             and torch.accelerator.device_count() < self.world_size
         ):
-            sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
+            sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)
 
         self.pg = self.create_pg(device=DEVICE)
         self.device = DEVICE

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -165,14 +165,14 @@ TEST_SKIPS = {
     "small_worldsize": TestSkip(73, "Skipped due to small world size."),
     "odd_worldsize": TestSkip(87, "Skipped due to odd world size."),
     "no_cuda": TestSkip(74, "CUDA is not available."),
-    "multi-gpu-1": TestSkip(75, "Need at least 1 CUDA device"),
-    "multi-gpu-2": TestSkip(77, "Need at least 2 CUDA devices"),
-    "multi-gpu-3": TestSkip(80, "Need at least 3 CUDA devices"),
-    "multi-gpu-4": TestSkip(81, "Need at least 4 CUDA devices"),
-    "multi-gpu-5": TestSkip(82, "Need at least 5 CUDA devices"),
-    "multi-gpu-6": TestSkip(83, "Need at least 6 CUDA devices"),
-    "multi-gpu-7": TestSkip(84, "Need at least 7 CUDA devices"),
-    "multi-gpu-8": TestSkip(85, "Need at least 8 CUDA devices"),
+    "multi-device-1": TestSkip(75, "Need at least 1 accelerator device"),
+    "multi-device-2": TestSkip(77, "Need at least 2 accelerator devices"),
+    "multi-device-3": TestSkip(80, "Need at least 3 accelerator devices"),
+    "multi-device-4": TestSkip(81, "Need at least 4 accelerator devices"),
+    "multi-device-5": TestSkip(82, "Need at least 5 accelerator devices"),
+    "multi-device-6": TestSkip(83, "Need at least 6 accelerator devices"),
+    "multi-device-7": TestSkip(84, "Need at least 7 accelerator devices"),
+    "multi-device-8": TestSkip(85, "Need at least 8 accelerator devices"),
     "nccl": TestSkip(76, "c10d not compiled with NCCL support"),
     "skipIfRocm": TestSkip(78, "Test skipped for ROCm"),
     "no_peer_access": TestSkip(79, "Test skipped because no GPU peer access"),
@@ -211,20 +211,16 @@ def requires_ddp_rank(device):
 
 
 def skip_if_no_gpu(func):
-    """Skips if the world size exceeds the number of GPUs, ensuring that if the
-    test is run, each rank has its own GPU via ``torch.cuda.device(rank)``."""
+    """Skips if the world size exceeds the number of devices, ensuring that if the
+    test is run, each rank has its own device via``torch.accelerator.set_device_index(rank)``."""
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if not (TEST_CUDA or TEST_HPU or TEST_XPU):
-            sys.exit(TEST_SKIPS["no_cuda"].exit_code)
+        if not torch.accelerator.is_available():
+            sys.exit(TEST_SKIPS["no_accelerator"].exit_code)
         world_size = int(os.environ["WORLD_SIZE"])
-        if TEST_CUDA and torch.cuda.device_count() < world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
-        if TEST_HPU and torch.hpu.device_count() < world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
-        if TEST_XPU and torch.xpu.device_count() < world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
+        if torch.accelerator.device_count() < world_size:
+            sys.exit(TEST_SKIPS[f"multi-device-{world_size}"].exit_code)
 
         return func(*args, **kwargs)
 
@@ -264,7 +260,7 @@ def require_n_gpus_for_nccl_backend(n, backend):
         @wraps(func)
         def wrapper(*args, **kwargs):
             if backend == "nccl" and torch.cuda.device_count() < n:
-                sys.exit(TEST_SKIPS[f"multi-gpu-{n}"].exit_code)
+                sys.exit(TEST_SKIPS[f"multi-device-{n}"].exit_code)
             else:
                 return func(*args, **kwargs)
 
@@ -290,13 +286,7 @@ def import_transformers_or_skip():
 
 
 def at_least_x_gpu(x):
-    if TEST_CUDA and torch.cuda.device_count() >= x:
-        return True
-    if TEST_HPU and torch.hpu.device_count() >= x:
-        return True
-    if TEST_XPU and torch.xpu.device_count() >= x:
-        return True
-    return False
+    return torch.accelerator.is_available() and torch.accelerator.device_count() >= x
 
 
 def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:
@@ -318,15 +308,14 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if torch.cuda.is_available() and torch.cuda.device_count() >= x:
+            if (
+                torch.accelerator.is_available()
+                and torch.accelerator.device_count() >= x
+            ):
                 return func(*args, **kwargs)
-            if TEST_HPU and torch.hpu.device_count() >= x:
+            if allow_cpu and not torch.accelerator.is_available():
                 return func(*args, **kwargs)
-            if TEST_XPU and torch.xpu.device_count() >= x:
-                return func(*args, **kwargs)
-            if allow_cpu and not (torch.cuda.is_available() or TEST_HPU or TEST_XPU):
-                return func(*args, **kwargs)
-            test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
+            test_skip = TEST_SKIPS[f"multi-device-{x}"]
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 
@@ -385,7 +374,7 @@ def nccl_skip_if_lt_x_gpu(backend, x):
                 return func(*args, **kwargs)
             if torch.cuda.is_available() and torch.cuda.device_count() >= x:
                 return func(*args, **kwargs)
-            test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
+            test_skip = TEST_SKIPS[f"multi-device-{x}"]
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 
@@ -807,11 +796,7 @@ def init_multigpu_helper(world_size: int, backend: str):
     On a single node, all visible GPUs are evenly
     divided to subsets, each process only uses a subset.
     """
-    nGPUs = torch.cuda.device_count()
-    if TEST_HPU:
-        nGPUs = torch.hpu.device_count()
-    if TEST_XPU:
-        nGPUs = torch.xpu.device_count()
+    nGPUs = torch.accelerator.device_count()
     visible_devices = range(nGPUs)
 
     # If rank is less than or equal to number of available GPU's

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -165,14 +165,14 @@ TEST_SKIPS = {
     "small_worldsize": TestSkip(73, "Skipped due to small world size."),
     "odd_worldsize": TestSkip(87, "Skipped due to odd world size."),
     "no_cuda": TestSkip(74, "CUDA is not available."),
-    "multi-gpu-1": TestSkip(75, "Need at least 1 CUDA device"),
-    "multi-gpu-2": TestSkip(77, "Need at least 2 CUDA devices"),
-    "multi-gpu-3": TestSkip(80, "Need at least 3 CUDA devices"),
-    "multi-gpu-4": TestSkip(81, "Need at least 4 CUDA devices"),
-    "multi-gpu-5": TestSkip(82, "Need at least 5 CUDA devices"),
-    "multi-gpu-6": TestSkip(83, "Need at least 6 CUDA devices"),
-    "multi-gpu-7": TestSkip(84, "Need at least 7 CUDA devices"),
-    "multi-gpu-8": TestSkip(85, "Need at least 8 CUDA devices"),
+    "multi-device-1": TestSkip(75, "Need at least 1 accelerator device"),
+    "multi-device-2": TestSkip(77, "Need at least 2 accelerator devices"),
+    "multi-device-3": TestSkip(80, "Need at least 3 accelerator devices"),
+    "multi-device-4": TestSkip(81, "Need at least 4 accelerator devices"),
+    "multi-device-5": TestSkip(82, "Need at least 5 accelerator devices"),
+    "multi-device-6": TestSkip(83, "Need at least 6 accelerator devices"),
+    "multi-device-7": TestSkip(84, "Need at least 7 accelerator devices"),
+    "multi-device-8": TestSkip(85, "Need at least 8 accelerator devices"),
     "nccl": TestSkip(76, "c10d not compiled with NCCL support"),
     "skipIfRocm": TestSkip(78, "Test skipped for ROCm"),
     "no_peer_access": TestSkip(79, "Test skipped because no GPU peer access"),
@@ -211,20 +211,16 @@ def requires_ddp_rank(device):
 
 
 def skip_if_no_gpu(func):
-    """Skips if the world size exceeds the number of GPUs, ensuring that if the
-    test is run, each rank has its own GPU via ``torch.cuda.device(rank)``."""
+    """Skips if the world size exceeds the number of devices, ensuring that if the
+    test is run, each rank has its own device via``torch.accelerator.set_device_index(rank)``."""
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if not (TEST_CUDA or TEST_HPU or TEST_XPU):
-            sys.exit(TEST_SKIPS["no_cuda"].exit_code)
+        if not torch.accelerator.is_available():
+            sys.exit(TEST_SKIPS["no_accelerator"].exit_code)
         world_size = int(os.environ["WORLD_SIZE"])
-        if TEST_CUDA and torch.cuda.device_count() < world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
-        if TEST_HPU and torch.hpu.device_count() < world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
-        if TEST_XPU and torch.xpu.device_count() < world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
+        if torch.accelerator.device_count() < world_size:
+            sys.exit(TEST_SKIPS[f"multi-device-{world_size}"].exit_code)
 
         return func(*args, **kwargs)
 
@@ -264,7 +260,7 @@ def require_n_gpus_for_nccl_backend(n, backend):
         @wraps(func)
         def wrapper(*args, **kwargs):
             if backend == "nccl" and torch.cuda.device_count() < n:
-                sys.exit(TEST_SKIPS[f"multi-gpu-{n}"].exit_code)
+                sys.exit(TEST_SKIPS[f"multi-device-{n}"].exit_code)
             else:
                 return func(*args, **kwargs)
 
@@ -290,13 +286,7 @@ def import_transformers_or_skip():
 
 
 def at_least_x_gpu(x):
-    if TEST_CUDA and torch.cuda.device_count() >= x:
-        return True
-    if TEST_HPU and torch.hpu.device_count() >= x:
-        return True
-    if TEST_XPU and torch.xpu.device_count() >= x:
-        return True
-    return False
+    return torch.accelerator.is_available() and torch.accelerator.device_count() >= x
 
 
 def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:
@@ -318,15 +308,14 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if torch.cuda.is_available() and torch.cuda.device_count() >= x:
+            if (
+                torch.accelerator.is_available()
+                and torch.accelerator.device_count() >= x
+            ):
                 return func(*args, **kwargs)
-            if TEST_HPU and torch.hpu.device_count() >= x:
+            if allow_cpu and not torch.accelerator.is_available():
                 return func(*args, **kwargs)
-            if TEST_XPU and torch.xpu.device_count() >= x:
-                return func(*args, **kwargs)
-            if allow_cpu and not (torch.cuda.is_available() or TEST_HPU or TEST_XPU):
-                return func(*args, **kwargs)
-            test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
+            test_skip = TEST_SKIPS[f"multi-device-{x}"]
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 
@@ -385,7 +374,7 @@ def nccl_skip_if_lt_x_gpu(backend, x):
                 return func(*args, **kwargs)
             if torch.cuda.is_available() and torch.cuda.device_count() >= x:
                 return func(*args, **kwargs)
-            test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
+            test_skip = TEST_SKIPS[f"multi-device-{x}"]
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 
@@ -790,11 +779,7 @@ def init_multigpu_helper(world_size: int, backend: str):
     On a single node, all visible GPUs are evenly
     divided to subsets, each process only uses a subset.
     """
-    nGPUs = torch.cuda.device_count()
-    if TEST_HPU:
-        nGPUs = torch.hpu.device_count()
-    if TEST_XPU:
-        nGPUs = torch.xpu.device_count()
+    nGPUs = torch.accelerator.device_count()
     visible_devices = range(nGPUs)
 
     # If rank is less than or equal to number of available GPU's

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -1217,7 +1217,7 @@ class FSDPTestMixin:
 
         print(f"dist init r={self.rank}, world={self.world_size}")
         if DEVICE_TYPE != "cpu" and torch.accelerator.device_count() < self.world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
+            sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)
 
         # Specify gloo backend to make 'init_process_group()' succeed,
         # Actual tests will be skipped if there are not enough GPUs.
@@ -1560,7 +1560,7 @@ class FSDPTest(FSDPTestMixin, MultiProcessTestCase):
 
         print(f"dist init r={self.rank}, world={self.world_size}")
         if torch.accelerator.device_count() < self.world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
+            sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)
 
         # Specify gloo backend to make 'init_process_group()' succeed,
         # Actual tests will be skipped if there are not enough GPUs.
@@ -1632,7 +1632,7 @@ class FSDPTestContinuous(FSDPTestMixin, MultiProcContinuousTest):
         os.environ["TORCH_NCCL_DESYNC_DEBUG"] = "0"
 
         if torch.accelerator.device_count() < world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
+            sys.exit(TEST_SKIPS[f"multi-device-{world_size}"].exit_code)
 
         device_id = rank % DEVICE_COUNT
         if TEST_CUDA or TEST_XPU:

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -102,7 +102,7 @@ def with_comms(func=None, init_rpc=True, backend="nccl"):
                 or backend != dist.get_default_backend_for_device(acc)
                 or torch.accelerator.device_count() < self.world_size
             ):
-                sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
+                sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)
         self.init_comms(init_rpc=init_rpc, backend=backend)
         func(self, *args, **kwargs)
         self.destroy_comms(destroy_rpc=init_rpc)

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -707,7 +707,7 @@ class DTensorContinuousTestBase(DTensorTestMixin, MultiProcContinuousTest):
         # we skip the test.
         if torch.accelerator.is_available():
             if world_size > torch.accelerator.device_count():
-                sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
+                sys.exit(TEST_SKIPS[f"multi-device-{world_size}"].exit_code)
             else:
                 torch.accelerator.set_device_index(rank)
 
@@ -802,7 +802,7 @@ class DTensorTestBase(DTensorTestMixin, MultiProcessTestCase):
             gpu_backend in backend for gpu_backend in ACCELERATOR_DIST_BACKENDS
         )
         if requires_gpu and torch.accelerator.device_count() < self.world_size:
-            sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
+            sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)
 
         curr_backend = dist.get_default_backend_for_device(self.device_type)
 

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -608,7 +608,7 @@ class TestDistBackend(MultiProcessTestCase):
         if torch.cuda.is_available() and torch.cuda.device_count() < int(
             self.world_size
         ):
-            sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
+            sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)
         try:
             pg_timeout_seconds = CUSTOM_PG_TIMEOUT.get(test_name, default_pg_timeout)
             timeout = timedelta(seconds=pg_timeout_seconds)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -604,7 +604,7 @@ class TestDistBackend(MultiProcessTestCase):
         if torch.cuda.is_available() and torch.cuda.device_count() < int(
             self.world_size
         ):
-            sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
+            sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)
         try:
             pg_timeout_seconds = CUSTOM_PG_TIMEOUT.get(test_name, default_pg_timeout)
             timeout = timedelta(seconds=pg_timeout_seconds)


### PR DESCRIPTION
Use `torch.accelerator` instead of device specific APIs in some helpers

- `skip_if_no_gpu`
- `at_least_x_gpu`
- `skip_if_lt_x_gpu`
- `init_multigpu_helper`