### PR TITLE
[inductor] Improve overlap collective prefetch priority

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -1227,6 +1227,81 @@ class TestCrossPGOverlap(InductorTestCase):
             f"Off-path reduce_scatters drifted to end: rs={rs_starts}, mm={mm_positions}, names={node_names}",
         )
 
+    @torch._inductor.config.patch(
+        {"test_configs.assume_bucketing_reduces_latency": False}
+    )
+    def test_prefetch_prioritizes_larger_hidden_time(self):
+        """
+        When multiple future collectives have the same semantic priority, choose
+        the one that can consume more of the current overlap window first.
+        """
+        group_name = self.pg1_name
+
+        def func(a, b, c):
+            group_size = 1
+            mm = torch.mm(a, a)
+
+            ag_small = torch.ops._c10d_functional.all_gather_into_tensor(
+                b, group_size, group_name
+            )
+            ag_large = torch.ops._c10d_functional.all_gather_into_tensor(
+                c, group_size, group_name
+            )
+
+            wait_small = torch.ops._c10d_functional.wait_tensor(ag_small)
+            wait_large = torch.ops._c10d_functional.wait_tensor(ag_large)
+            return mm.sum() + wait_small.sum() + wait_large.sum()
+
+        with FakeTensorMode():
+            a = torch.ones(4, 4, device=self.device)
+            b = torch.ones(4, 4, device=self.device)
+            c = torch.ones(4, 4, device=self.device)
+            traced = make_fx(func)(a, b, c)
+
+        ag_small, ag_large = traced.graph.find_nodes(
+            op="call_function",
+            target=torch.ops._c10d_functional.all_gather_into_tensor.default,
+        )
+        (mm,) = traced.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.mm.default
+        )
+
+        def custom_runtime(node: fx.Node, override_size: int | None) -> float | None:
+            if node is ag_small:
+                return 1.0
+            if node is ag_large:
+                return 8.0
+            if node.target == torch.ops.aten.mm.default:
+                return 8.0
+            return 0.0
+
+        from torch._inductor.fx_passes.overlap_scheduling import OverlapScheduler
+
+        scheduler = OverlapScheduler(
+            traced,
+            # Each all_gather has a 128B footprint in this graph.  Limit in-flight
+            # collectives to one so picking the larger hidden-time candidate
+            # reduces total exposed time, rather than only changing order.
+            max_in_flight_gb=0.0000002,
+            max_compute_pre_fetch=200,
+            collective_bucketing=False,
+            insert_overlap_deps=False,
+            compute_overlap_multipler=1.0,
+            max_coll_distance=200,
+            custom_runtime_estimation=custom_runtime,
+            collective_estimator="analytical",
+        )
+        scheduler.run()
+
+        self.assertIn(mm, scheduler.collective_info[ag_large].hiding_nodes)
+        self.assertNotIn(mm, scheduler.collective_info[ag_small].hiding_nodes)
+        self.assertEqual(scheduler.collective_info[ag_large].exposed_time_ms, 0.0)
+        self.assertEqual(scheduler.collective_info[ag_small].exposed_time_ms, 1.0)
+        self.assertEqual(
+            sum(info.exposed_time_ms for info in scheduler.collective_info.values()),
+            1.0,
+        )
+
 
 @requires_accelerator_dist_backend(["nccl", "xccl"])
 @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -1336,7 +1336,8 @@ class OverlapScheduler:
                 key = get_full_bucket_key(coll, self.bucket_mode)
                 bucket_groups[key].append(coll)
 
-            # Sort bucket groups by minimum domination index, larger groups first as tiebreaker
+            # Sort bucket groups by the best candidate priority in each group,
+            # with larger groups first as tiebreaker.
             sorted_bucket_keys = sorted(
                 bucket_groups.keys(),
                 key=lambda k: (

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -1276,14 +1276,18 @@ class OverlapScheduler:
         ):
             return
 
-        # Compile candidates - limit by distance to bound compile time
+        # Compile candidates - limit by number of plausible candidates to bound
+        # compile time.  Do not stop after seeing max_node_distance raw entries:
+        # early entries may be filtered by PG/prefetch distance, while later
+        # entries can still use the current overlap window.
         candidates = []
-        for i, collective in enumerate(self.unscheduled_collectives):
-            if i > self.max_node_distance:
-                break
-
+        for collective in self.unscheduled_collectives:
             pg_name = get_group_name(collective)
             if pg_name == exclude_pg:
+                continue
+
+            pg_available_time = remaining_time_per_pg.get(pg_name, 0.0)
+            if pg_available_time <= 0:
                 continue
 
             if (
@@ -1295,6 +1299,8 @@ class OverlapScheduler:
                 continue
 
             candidates.append(collective)
+            if len(candidates) >= self.max_node_distance:
+                break
 
         def get_priority(n: fx.Node) -> int:
             dominates_next_compute = (
@@ -1309,13 +1315,18 @@ class OverlapScheduler:
             else:
                 return 3  # Off-path, doesn't block reduce_scatter
 
-        candidates.sort(
-            key=lambda n: (
+        def overlap_priority(n: fx.Node) -> object:
+            return (
                 get_priority(n),
                 self.compute_index_domination[n],
+                -min(
+                    remaining_time_per_pg.get(get_group_name(n), 0.0),
+                    self.collective_info[n].exposed_time_ms,
+                ),
                 self.node_idx[n],
-            ),
-        )
+            )
+
+        candidates.sort(key=overlap_priority)
 
         if self.prioritize_bucketing_during_scheduling:
             # group candidates by bucket key first so same-bucket
@@ -1329,7 +1340,7 @@ class OverlapScheduler:
             sorted_bucket_keys = sorted(
                 bucket_groups.keys(),
                 key=lambda k: (
-                    min(self.compute_index_domination[c] for c in bucket_groups[k]),
+                    min(overlap_priority(c) for c in bucket_groups[k]),
                     -len(bucket_groups[k]),
                 ),
             )
@@ -1338,9 +1349,7 @@ class OverlapScheduler:
             candidates = []
             for b_key in sorted_bucket_keys:
                 group = bucket_groups[b_key]
-                group.sort(
-                    key=lambda n: (self.compute_index_domination[n], self.node_idx[n])
-                )
+                group.sort(key=overlap_priority)
                 candidates.extend(group)
 
         for collective in candidates:

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -1315,7 +1315,7 @@ class OverlapScheduler:
             else:
                 return 3  # Off-path, doesn't block reduce_scatter
 
-        def overlap_priority(n: fx.Node) -> object:
+        def overlap_priority(n: fx.Node) -> tuple[int, int, float, int]:
             return (
                 get_priority(n),
                 self.compute_index_domination[n],


### PR DESCRIPTION
## Summary

Improve overlap scheduling for compute/collective reordering by prioritizing collective prefetch candidates that can consume more of the currently available overlap window.

This changes `_schedule_collectives_for_overlap` to:

- skip candidates whose PG has no remaining overlap window
- count `max_coll_distance` over plausible candidates instead of raw unscheduled collective entries
- prefer candidates with larger `min(available_compute_window, collective_exposed_time)`
- preserve the same overlap priority when `prioritize_bucketing_during_scheduling` groups candidates by bucket key

## Motivation

The previous scheduler primarily ordered candidates by semantic priority, compute domination, and original graph order. When multiple collectives had the same semantic priority, this could spend a limited compute overlap window on a small/short collective while leaving a longer collective exposed.

This is suboptimal under memory or in-flight limits. If only one collective can be prefetched before a compute node, the scheduler should prefer the collective that can hide more latency under that compute window, not simply the earlier one in graph order.

There was also a subtle interaction with bucket grouping: even after adding a better candidate priority, `prioritize_bucketing_during_scheduling=True` could regroup and sort candidates by domination/original order, effectively discarding the overlap-window priority in the default path.

## Example / Experimental Observation

The added unit test constructs this case:

- one `mm` provides an 8ms compute overlap window
- `ag_small` has estimated collective time 1ms
- `ag_large` has estimated collective time 8ms
- in-flight memory is limited so only one 128B all_gather can be prefetched
- bucket latency reduction is disabled to isolate scheduling behavior

Old behavior:

| Candidate chosen for overlap | Remaining exposed time |
|---|---|
| `ag_small` is hidden by `mm` | `ag_large` remains exposed, total exposed time = 8ms |

New behavior:

| Candidate chosen for overlap | Remaining exposed time |
|---|---|
| `ag_large` is hidden by `mm` | only `ag_small` remains exposed, total exposed time = 1ms |

This demonstrates that the new priority reduces exposed communication time in a constrained prefetch window.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos