### PR TITLE
Validate forward-mode autograd.functional vectorize usage

### DIFF
--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -765,6 +765,15 @@ class TestAutogradFunctional(TestCase):
             autogradF.jacobian(foo, inp, strict=True, vectorize=True)
 
     @base_and_logging_tensor
+    def test_jacobian_err_check_forward_mode_requires_vectorize(self, ctors):
+        def foo(x):
+            raise AssertionError("foo should not be called")
+
+        inp = ctors.rand(4)
+        with self.assertRaisesRegex(ValueError, "requires `vectorize=True`"):
+            autogradF.jacobian(foo, inp, strategy="forward-mode")
+
+    @base_and_logging_tensor
     def test_jacobian_no_grad(self, ctors):
         def exp_reducer(x):
             return x.exp().sum(dim=1)
@@ -1123,6 +1132,17 @@ class TestAutogradFunctional(TestCase):
         inp = ctors.rand(4)
         with self.assertRaisesRegex(RuntimeError, "not supported together"):
             autogradF.hessian(foo, inp, strict=True, vectorize=True)
+
+    @base_and_logging_tensor
+    def test_hessian_err_check_forward_mode_requires_vectorize(self, ctors):
+        def foo(x):
+            raise AssertionError("foo should not be called")
+
+        inp = ctors.rand(4)
+        with self.assertRaisesRegex(
+            ValueError, '`outer_jacobian_strategy="forward-mode"`'
+        ):
+            autogradF.hessian(foo, inp, outer_jacobian_strategy="forward-mode")
 
     @base_and_logging_tensor
     def test_hessian_no_grad(self, ctors):

--- a/torch/autograd/functional.py
+++ b/torch/autograd/functional.py
@@ -578,9 +578,11 @@ def _jacfwd(func, inputs, strict=False, vectorize=False):
             jacobian_input_output, (is_outputs_tuple, is_inputs_tuple)
         )
     else:
-        raise NotImplementedError(
-            "Computing Jacobian using forward-AD or forward-over-reverse Hessian is"
-            "only implemented for `vectorize=True`."
+        raise ValueError(
+            "torch.autograd.functional.jacobian: "
+            '`strategy="forward-mode"` requires `vectorize=True`. '
+            "Please either set `vectorize=True` or "
+            '`strategy="reverse-mode"`.'
         )
 
 
@@ -621,7 +623,7 @@ def jacobian(
             more information.
         strategy (str, optional): Set to ``"forward-mode"`` or ``"reverse-mode"`` to
             determine whether the Jacobian will be computed with forward or reverse
-            mode AD. Currently, ``"forward-mode"`` requires ``vectorized=True``.
+            mode AD. Currently, ``"forward-mode"`` requires ``vectorize=True``.
             Defaults to ``"reverse-mode"``. If ``func`` has more outputs than
             inputs, ``"forward-mode"`` tends to be more performant. Otherwise,
             prefer to use ``"reverse-mode"``.
@@ -707,7 +709,7 @@ def jacobian(
             if strict:
                 raise RuntimeError(
                     "torch.autograd.functional.jacobian: `strict=True` "
-                    "and `vectorized=True` are not supported together. "
+                    "and `vectorize=True` are not supported together. "
                     "Please either set `strict=False` or "
                     "`vectorize=False`."
                 )
@@ -893,7 +895,7 @@ def hessian(
             computed in reverse-mode AD. Setting strategy to ``"forward-mode"``
             or ``"reverse-mode"`` determines whether the outer Jacobian will be
             computed with forward or reverse mode AD. Currently, computing the outer
-            Jacobian in ``"forward-mode"`` requires ``vectorized=True``. Defaults
+            Jacobian in ``"forward-mode"`` requires ``vectorize=True``. Defaults
             to ``"reverse-mode"``.
 
     Returns:
@@ -953,6 +955,13 @@ def hessian(
     ):
         raise AssertionError(
             'Expected strategy to be either "forward-mode" or "reverse-mode".'
+        )
+    if outer_jacobian_strategy == "forward-mode" and not vectorize:
+        raise ValueError(
+            "torch.autograd.functional.hessian: "
+            '`outer_jacobian_strategy="forward-mode"` requires `vectorize=True`. '
+            "Please either set `vectorize=True` or "
+            '`outer_jacobian_strategy="reverse-mode"`.'
         )
 
     def ensure_single_output_function(*inp):


### PR DESCRIPTION
## Issue

Fixes #184842

## Summary

Reject `torch.autograd.functional.jacobian(..., strategy="forward-mode", vectorize=False)` with a `ValueError` before evaluating the user function.

This also adds the same public validation for `torch.autograd.functional.hessian(..., outer_jacobian_strategy="forward-mode", vectorize=False)` and updates nearby docs/error text to use the public `vectorize=True` argument name.

## Test plan

- `python test/autograd/test_functional.py` in a nightly wheel-backed local environment
- `lintrunner -a --take RUFF torch/autograd/functional.py test/autograd/test_functional.py`
- `ruff check torch/autograd/functional.py test/autograd/test_functional.py`
- `ruff format --check torch/autograd/functional.py test/autograd/test_functional.py`
- `python3.12 -m py_compile torch/autograd/functional.py test/autograd/test_functional.py`

## Checklist

- [x] Passes lint (`lintrunner -a --take RUFF` on changed files)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)
- [ ] Included benchmark results (not applicable; no performance impact)

## BC-breaking?

No. This changes the error type for an unsupported argument combination from `NotImplementedError` to `ValueError`.