### PR TITLE
Cancel in-progress docker-builds on new commits to a ciflow PR

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -16,7 +16,7 @@ on:
     - cron: 1 3 * * 3
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' && github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -16,7 +16,7 @@ on:
     - cron: 1 3 * * 3
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' && github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' && github.run_id }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary

The `docker-builds` workflow is triggered on a PR by pushing a
`ciflow/docker/<PR_NUMBER>` tag. That push is a `push` event, not a
`pull_request` event, so `github.event.pull_request.number` is empty
and the concurrency group falls back to `github.sha`. Each new commit
on the PR re-points the ciflow tag to a different SHA, producing a
different concurrency group and leaving previous runs in flight
instead of cancelling them.

This PR switches the fallback to `github.ref_name`, which stays
constant (`refs/tags/ciflow/docker/<PR_NUMBER>` -> `ref_name =
ciflow/docker/<PR_NUMBER>`) across re-tagging for the same PR, so a
new push will cancel the previous run.

To preserve existing behavior on branch pushes (`main`, `release/*`)
and scheduled runs — where successive commits should *not* cancel
each other — the group also includes `github.sha` when
`github.ref_type == 'branch'`. For `workflow_dispatch`, `github.run_id`
is added so each manual dispatch gets its own group.

This matches the pattern already used by `.github/workflows/inductor.yml`.

## Behavior by trigger

| Trigger | Concurrency group | Cancels prior? |
|---|---|---|
| `ciflow/docker/<PR>` tag push | `docker-builds-ciflow/docker/<PR>--` | yes |
| Push to `main` | `docker-builds-main-<sha>-` | no |
| Push to `release/*` | `docker-builds-release/X-<sha>-` | no |
| `workflow_dispatch` | `docker-builds-<ref_name>--<run_id>` | no |
| `schedule` | `docker-builds-main-<sha>-` | no |

## Test plan

- [ ] Push two commits to a PR that triggers `ciflow/docker/<PR>`; confirm the second push cancels the first docker-builds run.
- [ ] Confirm pushes to `main` continue to run docker-builds without cancelling each other.

Authored by Claude.