### PR TITLE
Make constant SymInts hashable

### DIFF
--- a/test/distributed/_composable/test_replicate_with_compiler.py
+++ b/test/distributed/_composable/test_replicate_with_compiler.py
@@ -405,10 +405,8 @@ class DDP_TP_Test(InductorTestCase):
     def tearDown(self):
         dist.destroy_process_group()
 
-    @unittest.skip(
-        "Temporarily disabled due to SymInt error: `unhashable type: non-nested SymInt`"
-    )
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @torch._dynamo.config.patch(optimize_ddp="python_reducer")
     def test_ddp_tp(self):
         ref_model = Net()
         compiled_replicate_model = deepcopy(ref_model)
@@ -432,23 +430,17 @@ class DDP_TP_Test(InductorTestCase):
             compiled_replicate_model, device_mesh=dp_mesh
         )
         compiled_replicate_model = torch.compile(compiled_replicate_model)
-        data = torch.randn([1, DIM])
+        data = torch.randn([1, DIM], device=device_type)
         with compiled_autograd._enable(compiler_fn()):
             loss = compiled_replicate_model(data).sum()
-            # TODO: We need "pre-dispatch tracing of backward graph" to make this work:
-            # https://github.com/pytorch/pytorch/issues/127797#issuecomment-2291695474
-            with self.assertRaisesRegex(
-                AssertionError,
-                "Expected ProxyTensor, got <class 'torch.distributed.tensor.DTensor'>",
-            ):
-                loss.backward()
+            loss.backward()
 
-        # ref_loss = ref_model(data).sum()
-        # ref_loss.backward()
-        # for p1, p2 in zip(
-        #     ref_model.parameters(), compiled_replicate_model.parameters()
-        # ):
-        #     self.assertEqual(p1.grad, p2.grad)
+        ref_loss = ref_model(data).sum()
+        ref_loss.backward()
+        for p1, p2 in zip(
+            ref_model.parameters(), compiled_replicate_model.parameters()
+        ):
+            self.assertEqual(p1.grad, p2.grad)
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -785,6 +785,55 @@ class DTensorTest(DTensorTestBase):
         self.assertNotEqual(hash(sharded_tensor._spec), hash(replica_tensor._spec))
 
     @with_comms
+    def test_dtensor_spec_hash_dynamic_shapes(self):
+        # A symbolic shape must not make DTensorSpec unhashable.
+        from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        mesh = self.build_device_mesh()
+        s0 = ShapeEnv().create_unbacked_symint()
+
+        def spec():
+            meta = TensorMeta(torch.Size([s0, 4]), (4, 1), torch.float32)
+            return DTensorSpec(mesh, (Shard(0),), tensor_meta=meta)
+
+        self.assertEqual(hash(spec()), hash(spec()))
+
+    @with_comms
+    def test_dtensor_spec_dynamic_shapes_eq_hash_consistency(self):
+        # __eq__ and __hash__ must agree under dynamic shapes, and comparing
+        # specs must not specialize a symbolic dim by installing a ShapeEnv
+        # guard. Comparing a symbolic dim against another symbol or a constant
+        # used to evaluate `SymInt == ...` (raising on unbacked symints and
+        # guarding on backed ones); now it compares hashable surrogates.
+        from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        mesh = self.build_device_mesh()
+        shape_env = ShapeEnv()
+        s0 = shape_env.create_unbacked_symint()
+        s1 = shape_env.create_unbacked_symint()
+
+        def spec(dim):
+            meta = TensorMeta(torch.Size([dim, 4]), (4, 1), torch.float32)
+            return DTensorSpec(mesh, (Shard(0),), tensor_meta=meta)
+
+        # Same symbol: equal and same hash.
+        self.assertEqual(spec(s0), spec(s0))
+        self.assertEqual(hash(spec(s0)), hash(spec(s0)))
+
+        # Distinct symbols and symbol-vs-constant are distinct keys; comparing
+        # them must not raise or guard on the symbolic dim.
+        self.assertNotEqual(spec(s0), spec(s1))
+        self.assertNotEqual(spec(s0), spec(4))
+        self.assertEqual(len(shape_env.guards), 0)
+
+        # eq/hash contract: equal specs must hash equal.
+        for a, b in [(spec(s0), spec(s0)), (spec(4), spec(4))]:
+            if a == b:
+                self.assertEqual(hash(a), hash(b))
+
+    @with_comms
     def test_dtensor_properties(self):
         device_mesh = self.build_device_mesh()
         placements = [Shard(0)]

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -796,6 +796,18 @@ def forward(self, x_1):
         self.assertTrue(expect_true(i0 == 10 - i1))
         self.assertExpectedInline(str(i0), """u0""")
 
+    def test_constant_symint_is_hashable(self):
+        # Constants hash by value; symbolic stays unhashable so einops's
+        # TypeError-based cache-bypass keeps working.
+        shape_env = ShapeEnv()
+        const = shape_env.create_symintnode(sympy.Integer(42), hint=42)
+        self.assertEqual(hash(const), hash(42))
+        self.assertEqual({const: "ok"}[42], "ok")
+
+        symbolic = shape_env.create_unbacked_symint()
+        with self.assertRaises(TypeError):
+            hash(symbolic)
+
     def test_expect_true_double_digits(self):
         shape_env = ShapeEnv()
         ia = [shape_env.create_unbacked_symint() for _ in range(11)]  # allocate 10

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -618,14 +618,13 @@ class SymInt:
     def __hash__(self) -> builtins.int:
         if self.node.is_nested_int():
             return hash(self.node.nested_int())
-        else:
-            # We could support constant SymInts as well, but not doing it for now
-            raise TypeError("unhashable type: non-nested SymInt")
-            # TODO: Force specialization
-            # This can't be done because the TypeError here is load bearing
-            # for einops
-            # https://github.com/arogozhnikov/einops/blob/6181e1e95dc58c00a3143c1726da1c6ee0463164/einops/einops.py#L237
-            # return hash(builtins.int(self))
+        if self.node.expr.is_number:
+            # Constant SymInt: hash by value; nothing to specialize.
+            return hash(builtins.int(self.node.int_()))
+        # einops relies on this TypeError to bypass its lru_cache on
+        # dynamic shapes.
+        # See https://github.com/arogozhnikov/einops/blob/6181e1e95dc58c00a3143c1726da1c6ee0463164/einops/einops.py#L237
+        raise TypeError("unhashable type: non-nested SymInt")
 
     def as_integer_ratio(self) -> tuple["SymInt", builtins.int]:
         """Represent this int as an exact integer ratio"""

--- a/torch/distributed/tensor/_dtensor_spec.py
+++ b/torch/distributed/tensor/_dtensor_spec.py
@@ -73,6 +73,15 @@ class TensorMeta(NamedTuple):
     dtype: torch.dtype
 
 
+def _hashable_dim(d: Any) -> Any:
+    # Symbolic SymInts are unhashable by design; map dims to a hashable surrogate
+    # so DTensorSpec stays hashable under dynamic shapes (constants keep int value).
+    if isinstance(d, torch.SymInt):
+        i = d.node.maybe_as_int()
+        return i if i is not None else str(d)
+    return d
+
+
 # used internally to propagate the placements
 @dataclass
 class DTensorSpec:
@@ -422,15 +431,27 @@ class DTensorSpec:
             if not isinstance(value, TensorMeta | TensorMetadata):
                 raise AssertionError(repr(value))
 
+    def _hashable_shape_stride(self) -> tuple[tuple[Any, ...], tuple[Any, ...]]:
+        # Single source of truth for the shape/stride portion of both __hash__
+        # and __eq__, so the eq/hash contract holds under dynamic shapes.
+        # Comparing SymInts directly with `==` would additionally install a
+        # ShapeEnv guard, so eq compares these surrogates instead. Only called
+        # when tensor_meta is not None.
+        return (
+            tuple(_hashable_dim(d) for d in self.tensor_meta.shape),  # type: ignore[union-attr]
+            tuple(_hashable_dim(d) for d in self.tensor_meta.stride),  # type: ignore[union-attr]
+        )
+
     def _hash_key(self) -> tuple[Any, ...]:
         """Return the tuple used for hashing. Used by both __hash__ and _stable_hash."""
         if self.tensor_meta is not None:
+            shape, stride = self._hashable_shape_stride()
             return (
                 self.mesh,
                 self.placements,
                 self.shard_order,
-                self.tensor_meta.shape,
-                self.tensor_meta.stride,
+                shape,
+                stride,
                 self.tensor_meta.dtype,
             )
         return (self.mesh, self.placements, self.shard_order)
@@ -480,9 +501,8 @@ class DTensorSpec:
         if skip_shapes:
             return self.tensor_meta.dtype == other.tensor_meta.dtype
         return (
-            self.tensor_meta.shape == other.tensor_meta.shape  # type: ignore[union-attr]
-            and self.tensor_meta.stride == other.tensor_meta.stride  # type: ignore[union-attr]
-            and self.tensor_meta.dtype == other.tensor_meta.dtype  # type: ignore[union-attr]
+            self._hashable_shape_stride() == other._hashable_shape_stride()
+            and self.tensor_meta.dtype == other.tensor_meta.dtype
         )
 
     def __eq__(self, other: object, /) -> bool:

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -2084,31 +2084,55 @@ def _sym_register(
         set_proxy_slot(out, tracer, p_out_thunk)
 
 
+def _sym_op_arg_node(tracer: _ProxyTracer, a: object) -> object:
+    # Prefer the proxy node; fold to a literal only when the sym value has no
+    # proxy slot, so a tracked symbol with a constant replacement keeps its node
+    # while an untracked constant doesn't hit "is not tracked with proxy".
+    if not isinstance(a, py_sym_types):
+        return a
+
+    import sympy
+
+    def _as_literal(expr: sympy.Basic | int) -> object:
+        if isinstance(a, SymBool):
+            return bool(expr)
+        if isinstance(a, SymInt):
+            return int(expr)
+        return float(expr)
+
+    def _is_constant(expr: sympy.Basic | int) -> bool:
+        # int covers Python bool; BooleanAtom covers sympy.true/false, whose
+        # is_number is False. A non-constant SymBool (e.g. a relational like
+        # Eq(s0, 4)) is neither, so it is not folded and keeps its proxy/guard.
+        return (
+            isinstance(expr, (int, sympy.logic.boolalg.BooleanAtom))
+            or expr.is_number
+        )
+
+    unreplaced = a.node._expr
+    if _is_constant(unreplaced):
+        return _as_literal(unreplaced)
+
+    slot = get_proxy_slot(a, tracer, default=None)
+    if slot is not None:
+        return slot.force().node
+
+    replaced = a.node.expr
+    if _is_constant(replaced):
+        return _as_literal(replaced)
+
+    return get_proxy_slot(a, tracer).force().node
+
+
 def _compute_proxy(
     tracer: _ProxyTracer, func: OpOverload, args: tuple[object, ...], out: PySymType
 ) -> Proxy:
     # Handle torch.sym_sum
     n_args: tuple[object, ...]
     if len(args) == 1 and isinstance(args[0], (list, tuple)):
-        n_args = (
-            tuple(
-                (
-                    get_proxy_slot(a, tracer).force().node
-                    if isinstance(a, py_sym_types)
-                    else a
-                )
-                for a in args[0]
-            ),
-        )
+        n_args = (tuple(_sym_op_arg_node(tracer, a) for a in args[0]),)
     else:
-        n_args = tuple(
-            (
-                get_proxy_slot(a, tracer).force().node
-                if isinstance(a, py_sym_types)
-                else a
-            )
-            for a in args
-        )
+        n_args = tuple(_sym_op_arg_node(tracer, a) for a in args)
 
     # func doesn't have a __torch_function__ that Proxy can interpose, so
     # we gotta do it manually


### PR DESCRIPTION
Makes constant `SymInt`s hashable and fixes `DTensorSpec` hashing under dynamic
shapes, re-enabling `test_ddp_tp`.

Fixes #139111
Closes #157417

`SymInt.__hash__` hashes by value when `expr.is_number`; symbolic SymInts keep
raising `TypeError` (einops relies on it to bypass its `lru_cache`).
`DTensorSpec._hash_key` recursed into symbolic shape/stride SymInts and raised
`unhashable type: non-nested SymInt` (the actual `test_ddp_tp` failure); each
dim now maps to a hashable surrogate (`int` for constants, `str` for symbolic).
The spec hash only buckets the sharding cache, with `__eq__` authoritative.
 
