### PR TITLE
Support wrapper subclass storages in HOP alias checks

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -7115,6 +7115,35 @@ class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
         ):
             _assert_tensors_nonaliasing(a, a)
 
+    def test_hop_aliasing_checks_all_subclass_inner_tensors(self):
+        from torch._dynamo.output_graph import SubgraphTracer
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.testing._internal.two_tensor import TwoTensor
+
+        fake_mode = FakeTensorMode()
+        with fake_mode:
+            first_inner = torch.randn(2)
+            second_inner = torch.randn(2)
+            subclass_input = TwoTensor(first_inner, second_inner)
+            subclass_output = TwoTensor(first_inner.clone(), second_inner)
+
+        graph = torch.fx.Graph()
+        placeholder = graph.placeholder("x")
+        placeholder.meta["example_value"] = subclass_input
+        output_value = graph.call_function(torch.ops.aten.clone.default, (placeholder,))
+        output_value.meta["example_value"] = subclass_output
+        graph.output((output_value,))
+
+        class DummyTracer:
+            pass
+
+        tracer = DummyTracer()
+        tracer.graph = graph
+
+        aliasing_info = SubgraphTracer.has_aliasing(tracer)
+        self.assertTrue(aliasing_info.has_aliasing)
+        self.assertIn("Input-to-output aliasing", aliasing_info.msg)
+
     def test_flop_counter_for_cond(self):
         from torch.utils.flop_counter import FlopCounterMode
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -4620,14 +4620,14 @@ class SubgraphTracer(fx.Tracer):
 
         for node in self.graph.nodes:
             if node.op == "placeholder":
-                example_value = _collect_fake_inputs([node])[0]
-                if isinstance(example_value, torch.Tensor):
-                    for storage in get_tensor_storages(example_value):
-                        if storage in input_storages:
-                            # input-input aliasing
-                            msg = f"Input-to-input aliasing detected at nodes {input_storages[storage]} and {node}"
-                            return AliasingInfo(True, msg)
-                        input_storages[storage] = node
+                for example_value in _collect_fake_inputs([node]):
+                    if isinstance(example_value, torch.Tensor):
+                        for storage in get_tensor_storages(example_value):
+                            if storage in input_storages:
+                                # input-input aliasing
+                                msg = f"Input-to-input aliasing detected at nodes {input_storages[storage]} and {node}"
+                                return AliasingInfo(True, msg)
+                            input_storages[storage] = node
             else:
                 break
 
@@ -4635,16 +4635,16 @@ class SubgraphTracer(fx.Tracer):
         out_nodes = self.graph.find_nodes(op="output")[0]
         for out_node in pytree.tree_leaves(out_nodes.args[0]):
             if out_node:
-                example_value = _collect_fake_inputs([out_node])[0]
-                if isinstance(example_value, list):
-                    raise AssertionError("example_value must not be a list")
-                if isinstance(example_value, torch.Tensor):
-                    for storage in get_tensor_storages(example_value):
-                        if storage in output_storages:
-                            # output-output aliasing
-                            msg = f"Output-to-output aliasing detected at nodes {output_storages[storage]} and {out_node}"
-                            return AliasingInfo(True, msg)
-                        output_storages[storage] = out_node
+                for example_value in _collect_fake_inputs([out_node]):
+                    if isinstance(example_value, list):
+                        raise AssertionError("example_value must not be a list")
+                    if isinstance(example_value, torch.Tensor):
+                        for storage in get_tensor_storages(example_value):
+                            if storage in output_storages:
+                                # output-output aliasing
+                                msg = f"Output-to-output aliasing detected at nodes {output_storages[storage]} and {out_node}"
+                                return AliasingInfo(True, msg)
+                            output_storages[storage] = out_node
 
         intersected_storages = input_storages.keys() & output_storages.keys()
         if len(intersected_storages) > 0:

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -478,8 +478,8 @@ def get_tensor_storages(tensor: torch.Tensor) -> set[StorageWeakRef]:
     """
     Get storage references from a tensor.
 
-    Handles regular tensors. Raises NotImplementedError for sparse tensors
-    and traceable wrapper subclasses.
+    Handles regular tensors and traceable wrapper subclasses. Raises
+    NotImplementedError for sparse tensors.
 
     Args:
         tensor: The tensor to extract storages from
@@ -499,9 +499,10 @@ def get_tensor_storages(tensor: torch.Tensor) -> set[StorageWeakRef]:
         raise NotImplementedError("get_tensor_storages does not support sparse tensors")
 
     if is_traceable_wrapper_subclass(tensor):
-        raise NotImplementedError(
-            "get_tensor_storages does not support traceable wrapper subclasses"
-        )
+        for attr_name in tensor.__tensor_flatten__()[0]:
+            inner_tensor = getattr(tensor, attr_name)
+            if isinstance(inner_tensor, torch.Tensor):
+                storages.update(get_tensor_storages(inner_tensor))
     else:
         storages.add(StorageWeakRef(tensor._typed_storage()))
 
@@ -529,9 +530,9 @@ class StorageAliasingTracker:
 
         for node in tx.output.graph.nodes:
             if node.op == "placeholder":
-                example_value = _collect_fake_inputs([node])[0]
-                if isinstance(example_value, torch.Tensor):
-                    self._collect_storages_from_tensor(example_value)
+                for example_value in _collect_fake_inputs([node]):
+                    if isinstance(example_value, torch.Tensor):
+                        self._collect_storages_from_tensor(example_value)
             else:
                 break
 
@@ -541,9 +542,9 @@ class StorageAliasingTracker:
 
         for vt in graph_output_vts:
             proxy = vt.as_proxy()
-            example_value = _collect_fake_inputs([proxy.node])[0]
-            if isinstance(example_value, torch.Tensor):
-                self._collect_storages_from_tensor(example_value)
+            for example_value in _collect_fake_inputs([proxy.node]):
+                if isinstance(example_value, torch.Tensor):
+                    self._collect_storages_from_tensor(example_value)
 
     def check_and_track(self, proxy_node: Proxy) -> bool:
         """
@@ -561,26 +562,19 @@ class StorageAliasingTracker:
             False if it aliases (should be filtered out).
         """
         from torch._higher_order_ops.utils import _collect_fake_inputs
-        from torch.multiprocessing.reductions import StorageWeakRef
-        from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
-        example_value = _collect_fake_inputs([proxy_node])[0]
+        tensor_storages: set[StorageWeakRef] = set()
+        for example_value in _collect_fake_inputs([proxy_node]):
+            if isinstance(example_value, torch.Tensor):
+                tensor_storages.update(get_tensor_storages(example_value))
 
         # Non-tensor outputs (e.g., symints) don't have aliasing concerns
-        if not isinstance(example_value, torch.Tensor):
+        if not tensor_storages:
             return True
-
-        # Check if any storage aliases with existing inputs/outputs
-        tensor_storages = get_tensor_storages(example_value)
         if tensor_storages & self.excluded_storages:
             return False
 
-        # Track this tensor's storage (for wrapper subclasses, inner storages were already checked)
-        if not is_traceable_wrapper_subclass(example_value):
-            if not (example_value.is_sparse or example_value.is_sparse_csr):
-                self.excluded_storages.add(
-                    StorageWeakRef(example_value._typed_storage())
-                )
+        self.excluded_storages.update(tensor_storages)
 
         return True
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185191

HOP subgraph aliasing checks assumed each FX node contributed one fake tensor. For traceable wrapper subclasses, _collect_fake_inputs returns the flattened inner fake tensors for a single node, so callers that indexed [0] ignored later inner tensors. That let aliasing through when only a non-first inner tensor shared storage, and get_tensor_storages rejected wrapper subclasses outright.

Fix this by teaching get_tensor_storages to recurse through traceable wrapper subclass tensor attributes and by making the HOP aliasing helpers inspect every fake tensor leaf returned for a node. This keeps the safety check at the storage layer instead of special-casing any one HOP.

Fixes #161456

Generated by my agent

Test Plan:
- python test/dynamo/test_higher_order_ops.py -k test_hop_aliasing_checks_all_subclass_inner_tensors
- python test/dynamo/test_higher_order_ops.py -k test_non_aliasing_util
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98