### PR TITLE
Validate forward-mode functional autograd arguments

### DIFF
--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -691,6 +691,12 @@ class TestAutogradFunctional(TestCase):
             return 3 * a.narrow(0, 0, 3), "bar"
 
         inp = ctors.rand(4)
+        with self.assertRaisesRegex(ValueError, "requires `vectorize=True`"):
+        autogradF.jacobian(foo, inp, strategy="forward-mode", vectorize=False)
+
+        with self.assertRaisesRegex(
+        TypeError, "The inputs given to jacobian must be either a Tensor"
+        ):
         with self.assertRaisesRegex(
             TypeError, "The inputs given to jacobian must be either a Tensor"
         ):
@@ -1044,6 +1050,11 @@ class TestAutogradFunctional(TestCase):
             return 3 * a.narrow(0, 0, 3), 3 * a.narrow(0, 0, 3)
 
         inp = ctors.rand(4)
+        with self.assertRaisesRegex(ValueError, "requires `vectorize=True`"):
+            autogradF.hessian(
+                foo, inp, outer_jacobian_strategy="forward-mode", vectorize=False
+            )
+
         with self.assertRaisesRegex(
             TypeError, "The inputs given to hessian must be either a Tensor"
         ):

--- a/torch/autograd/functional.py
+++ b/torch/autograd/functional.py
@@ -684,6 +684,11 @@ def jacobian(
             'Otherwise, prefer to use "reverse-mode".'
         )
     if strategy == "forward-mode":
+        if not vectorize:
+            raise ValueError(
+                'torch.autograd.functional.jacobian: `strategy="forward-mode"` '
+                "requires `vectorize=True`."
+            )
         if create_graph:
             raise NotImplementedError(
                 "torch.autograd.functional.jacobian: `create_graph=True` "
@@ -953,6 +958,11 @@ def hessian(
     ):
         raise AssertionError(
             'Expected strategy to be either "forward-mode" or "reverse-mode".'
+        )
+    if outer_jacobian_strategy == "forward-mode" and not vectorize:
+        raise ValueError(
+            'torch.autograd.functional.hessian: `outer_jacobian_strategy="forward-mode"` '
+            "requires `vectorize=True`."
         )
 
     def ensure_single_output_function(*inp):


### PR DESCRIPTION
Fixes #184842

This PR adds early validation for forward-mode autograd functional APIs that require `vectorize=True`.

Changes:
- Raises `ValueError` in `torch.autograd.functional.jacobian` when `strategy="forward-mode"` is used with `vectorize=False`.
- Raises `ValueError` in `torch.autograd.functional.hessian` when `outer_jacobian_strategy="forward-mode"` is used with `vectorize=False`.
- Adds regression tests for both invalid argument combinations.

This makes the APIs fail during argument validation instead of later with a lower-level `NotImplementedError`.