### PR TITLE
[Test] Remove useless `gpus_for_rank()`

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -57,22 +57,6 @@ torch.backends.cuda.matmul.allow_tf32 = False
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
-def gpus_for_rank(world_size):
-    """Multigpu tests are designed to simulate the multi nodes with multi
-    GPUs on each node. Nccl backend requires equal #GPUs in each process.
-    On a single node, all visible GPUs are evenly
-    divided to subsets, each process only uses a subset.
-    """
-    visible_devices = list(range(torch.accelerator.device_count()))
-    gpus_per_process = torch.accelerator.device_count() // world_size
-    gpus_for_rank = []
-    for rank in range(world_size):
-        gpus_for_rank.append(
-            visible_devices[rank * gpus_per_process : (rank + 1) * gpus_per_process]
-        )
-    return gpus_for_rank
-
-
 class StoreTestBase:
     def _create_store(self, i):
         raise RuntimeError("not implemented")


### PR DESCRIPTION
`gpus_for_rank()` in `test_store.py` has 0 references. 
Other tests all use `gpus_for_rank()` from `test_c10d_common.py` (same name, same function)

cc @mruberry