### PR TITLE
[XPU] Unskip test_float16_reduction_with_int_output

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -3128,7 +3128,6 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
 
         self.assertEqual(compile_decimal, Decimal(0))
 
-    @skipIfXpu(msg="AssertionError: torch-xpu-ops: #3006")
     @config.patch(
         {"triton.use_block_ptr": True, "triton.codegen_upcast_to_fp32": False}
     )


### PR DESCRIPTION
## Summary

Removes the `@skipIfXpu` decorator from `CudaReproTests::test_float16_reduction_with_int_output` in `test/inductor/test_cuda_repro.py`. The skip referenced [intel/torch-xpu-ops#3006](https://github.com/intel/torch-xpu-ops/issues/3006), where Triton codegen for `argmax` over float16 inputs was emitting a spurious `.to(tl.float16)` downcast on the int64 index result. That bug was fixed upstream by #174321 (`[inductor] Fix incorrect Triton reduction output dtype`), which is already in `main`, so the XPU skip is no longer needed.

## Verification

Verified on Intel Data Center GPU Max 1550 (PVC) with `torch==2.13.0.dev20260525+xpu`:

```bash
source /home/gta/intel/oneapi/setvars.sh
export LD_PRELOAD=/home/gta/intel/oneapi/ccl/2022.0/lib/libccl.so.1
export PYTORCH_TEST_WITH_SLOW=1
pytest -v test/inductor/test_cuda_repro.py \
  -k test_float16_reduction_with_int_output -rs
```

Result:

```
test/inductor/test_cuda_repro.py::CudaReproTests::test_float16_reduction_with_int_output PASSED [16.3236s] [100%]
====================== 1 passed, 110 deselected in 26.62s ======================
```

Fixes intel/torch-xpu-ops#3006.

Authored by Claude (opencode).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo