### PR TITLE
[Test][distributed] Update entries in `test_backends.py`

### DIFF
--- a/test/distributed/test_backends.py
+++ b/test/distributed/test_backends.py
@@ -27,10 +27,15 @@ class TestMiscCollectiveUtils(TestCase):
                 raise AssertionError(
                     f"Expected gloo, got {dist.get_default_backend_for_device(device)}"
                 )
-        elif "hpu" in device:
-            if dist.get_default_backend_for_device(device) != "hccl":
+        elif "mps" in device:
+            if dist.get_default_backend_for_device(device) != "gloo":
                 raise AssertionError(
-                    f"Expected hccl, got {dist.get_default_backend_for_device(device)}"
+                    f"Expected gloo, got {dist.get_default_backend_for_device(device)}"
+                )
+        elif "xpu" in device:
+            if dist.get_default_backend_for_device(device) != "xccl":
+                raise AssertionError(
+                    f"Expected xccl, got {dist.get_default_backend_for_device(device)}"
                 )
         else:
             with self.assertRaises(ValueError):
@@ -54,8 +59,10 @@ class TestMiscCollectiveUtils(TestCase):
         dist.destroy_process_group()
 
 
-devices = ["cpu", "cuda", "hpu"]
-instantiate_device_type_tests(TestMiscCollectiveUtils, globals(), only_for=devices)
+devices = ["cpu", "cuda", "mps", "xpu"]
+instantiate_device_type_tests(
+    TestMiscCollectiveUtils, globals(), only_for=devices, allow_mps=True, allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Due to updates happened in `Backend.default_device_backend_map`, update `test_backends.py`
https://github.com/pytorch/pytorch/blob/339e39645a25968c7cd3fb81dd7e48ca3a31f9c2/torch/distributed/distributed_c10d.py#L1495-L1515
https://github.com/pytorch/pytorch/blob/339e39645a25968c7cd3fb81dd7e48ca3a31f9c2/torch/distributed/distributed_c10d.py#L302-L307
- Remove `hpu` and `hccl` entries
- Add `xpu` and `mps` related entries

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy @mruberry