### PR TITLE
[Inductor][TEST][CuTeDSL] Fix kwargs in test_cutedsl_subprocess_precompile_invoked

### DIFF
--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -88,7 +88,7 @@ def {{kernel_name}}_precompile(precompile_shapes, precompile_strides=None,
                                 device_capability=None, hw_info=None):
     with open(_PRECOMPILE_SENTINEL, "w") as f:
         import json
-        f.write(json.dumps({"shapes": precompile_shapes, "dtypes": precompile_dtypes}))
+        json.dump({"shapes": precompile_shapes, "strides": precompile_strides, "dtypes": precompile_dtypes}, f)
 """
 )
 


### PR DESCRIPTION
Per title. Without these changes it fails with:
```
TypeError: cutedsl_fused_add_69c3dc94_precompile() got an unexpected keyword argument 'precompile_strides'
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo