### PR TITLE
FIx serialization truncated

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1204,6 +1204,17 @@ class TestSerialization(TestCase, SerializationMixin):
             f.seek(0)
             state = torch.load(f)
 
+
+        gc.collect()
+        if IS_FILESYSTEM_UTF8_ENCODING:
+            with TemporaryDirectoryName(suffix='\u975eASCII\u30d1\u30b9') as dname:
+                with TemporaryFileName(dir=dname) as fname:
+                    # https://github.com/pytorch/pytorch/issues/185098
+                    data = torch.rand(200, 2048, 2048, dtype=torch.float32)  # ~3.13 GiB storage
+                    torch.save(data, fname)
+                    loaded_data = torch.load(fname)
+                    self.assertEqual(loaded_data, data)
+
     @serialTest()
     def test_serialization_4gb_file(self):
         '''

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -817,8 +817,7 @@ class _open_zipfile_writer_file(_opener[torch._C.PyTorchFileWriter]):
             # PyTorchFileWriter only supports ascii filename.
             # For filenames with non-ascii characters, we rely on Python
             # for writing out the file.
-            # pyrefly: ignore [bad-assignment]
-            self.file_stream = io.FileIO(self.name, mode="w")
+            self.file_stream = open(self.name, mode="wb")  # noqa: SIM115
             super().__init__(
                 torch._C.PyTorchFileWriter(  # pyrefly: ignore  # no-matching-overload
                     self.file_stream, get_crc32_options(), _get_storage_alignment()


### PR DESCRIPTION
The write() system call on a linux system can at most write 2GB of data into the disk per call. This PR replaces the raw data stream with buffered data stream to automatically handle the data with size greater than 2GB.

There is a similar limit on windows so using a buffered data stream is safer for both platforms.

fixes #185098