### PR TITLE
[Test] Make test_compile_benchmark_util device-agnostic and fix bench_all inductor bug

### DIFF
--- a/test/test_compile_benchmark_util.py
+++ b/test/test_compile_benchmark_util.py
@@ -4,7 +4,8 @@ import unittest
 
 import torch
 import torch._dynamo as torchdynamo
-from torch.testing._internal.common_utils import run_tests, TEST_CUDA, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 try:
@@ -17,10 +18,9 @@ except ImportError:
     HAS_TABULATE = False
 
 
-@unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
 @unittest.skipIf(not HAS_TABULATE, "tabulate not available")
 class TestCompileBenchmarkUtil(TestCase):
-    def test_training_and_inference(self):
+    def test_training_and_inference(self, device):
         class ToyModel(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -30,9 +30,9 @@ class TestCompileBenchmarkUtil(TestCase):
                 return x * self.weight
 
         torchdynamo.reset()
-        model = ToyModel().cuda()
+        model = ToyModel().to(device)
 
-        inference_table = bench_all(model, torch.ones(1024, 2, 2).cuda(), 5)
+        inference_table = bench_all(model, torch.ones(1024, 2, 2, device=device), 5)
         self.assertTrue(
             "Inference" in inference_table
             and "Eager" in inference_table
@@ -41,7 +41,7 @@ class TestCompileBenchmarkUtil(TestCase):
 
         training_table = bench_all(
             model,
-            torch.ones(1024, 2, 2).cuda(),
+            torch.ones(1024, 2, 2, device=device),
             5,
             optimizer=torch.optim.SGD(model.parameters(), lr=0.01),
         )
@@ -51,6 +51,8 @@ class TestCompileBenchmarkUtil(TestCase):
             and "-" in training_table
         )
 
+
+instantiate_device_type_tests(TestCompileBenchmarkUtil, globals(), except_for="cpu")
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/utils/benchmark/utils/compile.py
+++ b/torch/utils/benchmark/utils/compile.py
@@ -168,14 +168,13 @@ if HAS_TABULATE:
                     finally:
                         if torch.cuda.is_available():
                             _disable_tensor_cores()
-                            table.append([
-                                ("Training" if optimizer else "Inference"),
-                                # pyrefly: ignore [redundant-condition]
-                                backend if backend else "-",
-                                mode if mode is not None else "-",
-                                f"{compilation_time} ms " if compilation_time else "-",
-                                f"{running_time} ms " if running_time else "-",
-                            ])
+                    table.append([
+                        ("Training" if optimizer else "Inference"),
+                        backend if backend else "-",
+                        mode if mode is not None else "-",
+                        f"{compilation_time} ms " if compilation_time else "-",
+                        f"{running_time} ms " if running_time else "-",
+                    ])
 
             else:
                 torch._dynamo.reset()


### PR DESCRIPTION
## Summary

- Convert `TestCompileBenchmarkUtil` to use `instantiate_device_type_tests` (with `except_for="cpu"`) instead of hardcoding `.cuda()` calls and `@unittest.skipIf(not TEST_CUDA, ...)`. The test now runs on any available accelerator (CUDA, PrivateUse1/OpenReg, XPU, etc.).
- Fix a bug in `torch/utils/benchmark/utils/compile.py` where inductor benchmark results were silently dropped on non-CUDA accelerators. The `table.append(...)` call was incorrectly nested inside an `if torch.cuda.is_available():` guard, so it only recorded results when CUDA was present.

## Changes

**`test/test_compile_benchmark_util.py`**
- Removed `TEST_CUDA` import and class-level CUDA skip decorator
- Added `instantiate_device_type_tests` with `except_for="cpu"`
- Added `device` parameter to test method
- Replaced `.cuda()` → `.to(device)` and `torch.ones(...).cuda()` → `torch.ones(..., device=device)`

**`torch/utils/benchmark/utils/compile.py`**
- Moved `table.append(...)` for inductor results outside the `if torch.cuda.is_available():` block so results are recorded regardless of accelerator type

## Test plan

- [x] `TEST_CONFIG=cuda python3 test/run_test.py -i test_compile_benchmark_util` `TestCompileBenchmarkUtilCUDA::test_training_and_inference_cuda PASSED`


cc @fffrog @albanD @jbschlosser @mansiag05 