### PR TITLE
[Test]Make test/dynamo/test_reconstruct.py device agnostic

### DIFF
--- a/test/dynamo/test_reconstruct.py
+++ b/test/dynamo/test_reconstruct.py
@@ -8,7 +8,7 @@ import unittest
 import torch
 import torch._dynamo.test_case
 from torch.testing._internal.common_utils import IS_FBCODE
-from torch.testing._internal.inductor_utils import GPU_TYPE, requires_triton
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 from torch.utils._triton import (
     has_triton_experimental_host_tma,
     has_triton_tensor_descriptor_host_tma,
@@ -501,7 +501,7 @@ class ReconstructTest(torch._dynamo.test_case.TestCase):
         inp = torch.randn(3)
         self.assertEqual(gn(inp), inp + 3)
 
-    @requires_triton()
+    @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
     @unittest.skipIf(
         not has_triton_experimental_host_tma(),
         "Test requires triton.tools.experimental_descriptor API",
@@ -526,7 +526,7 @@ class ReconstructTest(torch._dynamo.test_case.TestCase):
         res = torch.compile(create_tma, backend="eager")(x)
         self.assertEqual(ref[1].desc, res[1].desc)
 
-    @requires_triton()
+    @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
     @unittest.skipIf(
         not has_triton_tensor_descriptor_host_tma(),
         "Test requires triton.tools.tensor_descriptor API",


### PR DESCRIPTION
Replace @requires_triton() decorator with @unittest.skipIf(not HAS_GPU) to enable tests on all GPU accelerators (CUDA, XPU, HPU, etc.).

  Changes:
  - Import: requires_triton -> HAS_GPU
  - Decorator: @requires_triton() -> @unittest.skipIf(not HAS_GPU, \"requires GPU and Triton\")
  - Affects: test_tma_experimental_reconstruct, test_tma_stable_reconstruct

  Both tests already use GPU_TYPE for device-agnostic tensor creation.

  **Test plan:**
  TEST_CONFIG=cpu python test/dynamo/test_reconstruct.py -v
  TEST_CONFIG=cuda python test/dynamo/test_reconstruct.py -v
  
  **All tests pass.**



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98