### PR TITLE
[Test] Make test/test_accelerator.py device-agnostic for out-of-tree backends

### DIFF
--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -6,6 +6,7 @@ import unittest
 from contextlib import nullcontext
 
 import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     NoTest,
     run_tests,
@@ -27,17 +28,12 @@ if not TEST_ACCELERATOR:
 class TestAccelerator(TestCase):
     def test_current_accelerator(self):
         self.assertTrue(torch.accelerator.is_available())
-        accelerators = ["cuda", "xpu", "mps"]
-        for accelerator in accelerators:
-            if torch.get_device_module(accelerator).is_available():
-                self.assertEqual(
-                    torch.accelerator.current_accelerator().type, accelerator
-                )
-                self.assertIsNone(torch.accelerator.current_accelerator().index)
-                with self.assertRaisesRegex(
-                    ValueError, "doesn't match the current accelerator"
-                ):
-                    torch.accelerator.set_device_index("cpu")
+        self.assertEqual(torch.accelerator.current_accelerator().type, self.device_type)
+        self.assertIsNone(torch.accelerator.current_accelerator().index)
+        with self.assertRaisesRegex(
+            ValueError, "doesn't match the current accelerator"
+        ):
+            torch.accelerator.set_device_index("cpu")
 
     @unittest.skipIf(not TEST_MULTIACCELERATOR, "only one accelerator detected")
     def test_generic_multi_device_behavior(self):
@@ -307,6 +303,19 @@ class TestAccelerator(TestCase):
                     t = torch.empty(16, dtype=dtype, device=acc)
                     t = t.to(reference_dtype)
                     t = t.to(dtype)
+
+
+instantiate_device_type_tests(
+    TestAccelerator,
+    globals(),
+    only_for=(
+        "cuda",
+        "xpu",
+        "mps",
+    ),
+    allow_mps=True,
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -308,11 +308,7 @@ class TestAccelerator(TestCase):
 instantiate_device_type_tests(
     TestAccelerator,
     globals(),
-    only_for=(
-        "cuda",
-        "xpu",
-        "mps",
-    ),
+    except_for=("cpu",),
     allow_mps=True,
     allow_xpu=True,
 )


### PR DESCRIPTION
## Summary
Make `test_accelerator.py` device-generic by using `instantiate_device_type_tests`.

## Changes
- Use `instantiate_device_type_tests` to generate device-specific test subclasses.
- Use `self.device_type` instead of hardcoded iteration over `["cuda", "xpu", "mps"]`.

## Test Plan
` TEST_CONFIG=cuda python test/test_accelerator.py -v `
```bash
test_current_accelerator_cuda (__main__.TestAcceleratorCUDA.test_current_accelerator_cuda) ... ok
test_current_stream_query_cuda (__main__.TestAcceleratorCUDA.test_current_stream_query_cuda) ... ok
test_device_capability_supported_dtypes_cuda (__main__.TestAcceleratorCUDA.test_device_capability_supported_dtypes_cuda) ... skipped "Backend doesn't support get_device_capability"
test_device_context_manager_cuda (__main__.TestAcceleratorCUDA.test_device_context_manager_cuda) ... ok
test_device_index_fullgraph_cuda (__main__.TestAcceleratorCUDA.test_device_index_fullgraph_cuda) ... ok
test_generic_event_behavior_cuda (__main__.TestAcceleratorCUDA.test_generic_event_behavior_cuda) ... ok
test_generic_multi_device_behavior_cuda (__main__.TestAcceleratorCUDA.test_generic_multi_device_behavior_cuda) ... skipped 'only one accelerator detected'
test_generic_stream_behavior_cuda (__main__.TestAcceleratorCUDA.test_generic_stream_behavior_cuda) ... ok
test_get_memory_info_cuda (__main__.TestAcceleratorCUDA.test_get_memory_info_cuda) ... ok
test_memory_stats_cuda (__main__.TestAcceleratorCUDA.test_memory_stats_cuda) ... ok
test_multi_device_context_manager_cuda (__main__.TestAcceleratorCUDA.test_multi_device_context_manager_cuda) ... skipped 'only one accelerator detected'
test_multi_device_stream_context_manager_cuda (__main__.TestAcceleratorCUDA.test_multi_device_stream_context_manager_cuda) ... skipped 'only one accelerator detected'
test_pin_memory_on_non_blocking_copy_cuda (__main__.TestAcceleratorCUDA.test_pin_memory_on_non_blocking_copy_cuda) ... ok
test_stream_context_manager_cuda (__main__.TestAcceleratorCUDA.test_stream_context_manager_cuda) ... ok
test_stream_context_manager_reentrance_cuda (__main__.TestAcceleratorCUDA.test_stream_context_manager_reentrance_cuda) ... ok

----------------------------------------------------------------------
Ran 15 tests in 1.180s

OK (skipped=4)
```
