### PR TITLE
[Test] Make dynamo test_streams.py device-agnostic for out-of-tree backends

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -56,13 +56,13 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         super().tearDownClass()
 
     @onlyAccelerator
-    def test_stream_weakref(self):
-        s = torch.Stream()
+    def test_stream_weakref(self, device):
+        s = torch.Stream(device=device)
         weakref.ref(s)
 
     @onlyAccelerator
-    def test_event_weakref(self):
-        e = torch.Event()
+    def test_event_weakref(self, device):
+        e = torch.Event(device=device)
         weakref.ref(e)
 
     def _assert_weakref_callback_fires(self, factory):
@@ -125,7 +125,7 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         reset_user_object_tracking()
 
         def fn(x):
-            return torch.accelerator.current_stream().stream_id
+            return torch.accelerator.current_stream(device).stream_id
 
         x = torch.zeros(1, device=device)
         compiled = torch.compile(fn, backend="eager", fullgraph=True)
@@ -157,7 +157,7 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         )
 
     @onlyAccelerator
-    def test_stream_enter_exit(self):
+    def test_stream_enter_exit(self, device):
         def fn(x, y, s1, s2):
             with s1:
                 z1 = torch.add(x, y)
@@ -167,7 +167,12 @@ class TestStreams(torch._dynamo.test_case.TestCase):
 
             return y
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2), torch.Stream(), torch.Stream())
+        inp = (
+            torch.ones(2, 2) + 1,
+            torch.ones(2, 2),
+            torch.Stream(device=device),
+            torch.Stream(device=device),
+        )
         expected = fn(*inp)
         (
             actual,
@@ -197,10 +202,10 @@ class <lambda>(torch.nn.Module):
 
     @onlyAccelerator
     @unittest.skip("Needs graph break support with annotation context")
-    def test_stream_context_graph_break(self):
+    def test_stream_context_graph_break(self, device):
         def fn(x, y):
-            s2 = torch.Stream()
-            s1 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
             with s1:
                 z1 = torch.add(x, y)
             with s2:
@@ -211,7 +216,7 @@ class <lambda>(torch.nn.Module):
 
             return y
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2))
+        inp = (torch.ones(2, 2, device=device) + 1, torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -238,14 +243,14 @@ class <lambda>(torch.nn.Module):
         self.assertEqual(expected, actual)
 
     @onlyAccelerator
-    def test_local_stream_return(self):
+    def test_local_stream_return(self, device):
         def fn(x, y):
-            s = torch.Stream()
+            s = torch.Stream(device=device)
             z = torch.add(x, y)
             y = z + 2
             return y, s
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2))
+        inp = (torch.ones(2, 2, device=device) + 1, torch.ones(2, 2, device=device))
         fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         _, s0 = fn_opt(*inp)
         _, s1 = fn_opt(*inp)
@@ -269,7 +274,7 @@ class <lambda>(torch.nn.Module):
     def test_get_current_stream_return(self, device):
         def fn(x, s):
             with s:
-                s0 = torch.accelerator.current_stream()
+                s0 = torch.accelerator.current_stream(device)
             return x, s0
 
         s_inp = torch.Stream(device=device)
@@ -286,7 +291,7 @@ class <lambda>(torch.nn.Module):
         under torch.compile and match eager behavior."""
 
         def fn_stream(x):
-            return torch.accelerator.current_stream().stream_id
+            return torch.accelerator.current_stream(device).stream_id
 
         x = torch.zeros(1, device=device)
         compiled = torch.compile(fn_stream, backend="eager", fullgraph=True)
@@ -299,7 +304,7 @@ class <lambda>(torch.nn.Module):
 
         def fn(x, s):
             with s:
-                return torch.accelerator.current_stream().stream_id
+                return torch.accelerator.current_stream(device).stream_id
 
         s = torch.Stream(device=device)
         x = torch.zeros(1, device=device)
@@ -307,7 +312,7 @@ class <lambda>(torch.nn.Module):
         self.assertEqual(compiled(x, s), fn(x, s))
 
     @onlyAccelerator
-    def test_nested_stream_enter_exit(self):
+    def test_nested_stream_enter_exit(self, device):
         def fn(x, y, s0, s1, s2):
             with s1:
                 with s2:
@@ -322,9 +327,9 @@ class <lambda>(torch.nn.Module):
         inp = (
             torch.ones(2, 2) + 1,
             torch.ones(2, 2),
-            torch.Stream(),
-            torch.Stream(),
-            torch.Stream(),
+            torch.Stream(device=device),
+            torch.Stream(device=device),
+            torch.Stream(device=device),
         )
         expected = fn(*inp)
         (
@@ -361,7 +366,7 @@ class <lambda>(torch.nn.Module):
         pass
 
     @onlyAccelerator
-    def test_local_stream_enter_exit(self):
+    def test_local_stream_enter_exit(self, device):
         def fn(x, y):
             s2 = torch.Stream()
             s1 = torch.Stream()
@@ -402,7 +407,7 @@ class <lambda>(torch.nn.Module):
         )
 
     @onlyAccelerator
-    def test_local_stream_nested_enter_exit(self):
+    def test_local_stream_nested_enter_exit(self, device):
         def fn(x, y):
             s2 = torch.Stream()
             s1 = torch.Stream()
@@ -474,7 +479,7 @@ class <lambda>(torch.nn.Module):
         from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
         from torch._dynamo.variables.streams import get_current_stream
 
-        cur_stream = torch.accelerator.current_stream()
+        cur_stream = torch.accelerator.current_stream(device)
         s0 = None
 
         def stream_generation_backend(gm, *args, **kwargs):  # type: ignore[no-untyped-def]
@@ -501,7 +506,7 @@ class <lambda>(torch.nn.Module):
         fn(torch.ones(2, 2, device=device))
 
     @onlyAccelerator
-    def test_stream_with_mutation(self):
+    def test_stream_with_mutation(self, device):
         def fn(x, y):
             s2 = torch.Stream()
             s1 = torch.Stream()
@@ -551,7 +556,7 @@ class <lambda>(torch.nn.Module):
         )
 
     @onlyAccelerator
-    def test_stream_backward_simple(self) -> None:
+    def test_stream_backward_simple(self, device) -> None:
         def fn(x, y):
             s2 = torch.Stream()
             s0 = torch.Stream()
@@ -755,7 +760,7 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_tracing(self, device):
         def fn(x) -> None:
-            e = torch.Event()
+            e = torch.Event(device=device)
             e.record()
             x.add_(1)
             return x
@@ -819,10 +824,10 @@ class <lambda>(torch.nn.Module):
         from torch._dynamo.variables.streams import fork_stream, join_stream
         from torch.library import opcheck
 
-        original_stream = torch.accelerator.current_stream()
+        original_stream = torch.accelerator.current_stream(device)
         try:
-            s0 = torch.Stream()
-            s1 = torch.Stream()
+            s0 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
             store_user_object_weakrefs(s0, s1)
 
             sample_inputs = [
@@ -837,16 +842,16 @@ class <lambda>(torch.nn.Module):
             reset_user_object_tracking()
 
     @onlyAccelerator
-    def test_run_opcheck_wait_record(self):
+    def test_run_opcheck_wait_record(self, device):
         from torch._dynamo.variables.streams import record_event, wait_event
         from torch.library import opcheck
 
-        original_stream = torch.accelerator.current_stream()
+        original_stream = torch.accelerator.current_stream(device)
         try:
-            s0 = torch.Stream()
-            s1 = torch.Stream()
-            e0 = torch.Event()
-            e1 = torch.Event()
+            s0 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
+            e0 = torch.Event(device=device)
+            e1 = torch.Event(device=device)
             store_user_object_weakrefs(s0, s1, e0, e1)
 
             sample_inputs = [
@@ -861,14 +866,14 @@ class <lambda>(torch.nn.Module):
             reset_user_object_tracking()
 
     @onlyAccelerator
-    def test_run_opcheck_wait_record_stream(self):
+    def test_run_opcheck_wait_record_stream(self, device):
         from torch._dynamo.variables.streams import wait_stream
         from torch.library import opcheck
 
         try:
-            s0 = torch.Stream()
-            s1 = torch.Stream()
-            s2 = torch.Stream()
+            s0 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
             store_user_object_weakrefs(s0, s1, s2)
 
             sample_inputs = [
@@ -887,7 +892,7 @@ class <lambda>(torch.nn.Module):
         # We expect there to be a sync_dealloc op added to the graph for y
         # synchronizing the first stream w/ the second stream after the second stream is finished
         def fn(x):
-            e = torch.Event()
+            e = torch.Event(device=device)
             with torch.Stream(device=device):
                 y = torch.ones(2, 2, device=device)
                 e.record()
@@ -982,7 +987,7 @@ class GraphModule(torch.nn.Module):
         # first allocated on the first stream used on the second stream
         # used on the first stream again then finally used on the last stream
         def fn(x):
-            e = torch.Event()
+            e = torch.Event(device=device)
             with torch.Stream(device=device):
                 y = torch.ones(2, 2, device=device)
                 z = y * x
@@ -1290,7 +1295,7 @@ class <lambda>(torch.nn.Module):
         def fn(x) -> torch.Tensor:
             s1 = torch.Stream(device=device)
             s2 = torch.Stream(device=device)
-            e = torch.Event()
+            e = torch.Event(device=device)
 
             with s1:
                 y = x + 1
@@ -1356,7 +1361,7 @@ class <lambda>(torch.nn.Module):
         def fn(x) -> torch.Tensor:
             s1 = torch.Stream(device=device)
             s2 = torch.Stream(device=device)
-            e = torch.Event()
+            e = torch.Event(device=device)
 
             with s1:
                 y = x + 1
@@ -1408,7 +1413,7 @@ class <lambda>(torch.nn.Module):
         def fn(x) -> torch.Tensor:
             s1 = torch.Stream(device=device)
             s2 = torch.Stream(device=device)
-            e = torch.Event()
+            e = torch.Event(device=device)
 
             with s1:
                 y = x + 1
@@ -1489,8 +1494,8 @@ class <lambda>(torch.nn.Module):
             s1 = torch.Stream(device=device)
             s2 = torch.Stream(device=device)
             s3 = torch.Stream(device=device)
-            e1 = torch.Event()
-            e2 = torch.Event()
+            e1 = torch.Event(device=device)
+            e2 = torch.Event(device=device)
 
             with s1:
                 y = x + 1
@@ -1581,7 +1586,7 @@ class <lambda>(torch.nn.Module):
         def fn(x) -> torch.Tensor:
             s1 = torch.Stream(device=device)
             s2 = torch.Stream(device=device)
-            e = torch.Event()
+            e = torch.Event(device=device)
 
             with s1:
                 y = x + 1
@@ -2161,7 +2166,7 @@ class GraphModule(torch.nn.Module):
 
             @torch.compile()  # noqa: UNSPECIFIED_BACKEND
             def fn(x):
-                e = torch.Event()
+                e = torch.Event(device=device)
                 x += x + 1
                 e.record()
                 return x
@@ -2202,8 +2207,8 @@ class GraphModule(torch.nn.Module):
         from torch._inductor.fx_passes.control_dependencies import control_deps
 
         def fn(x, y):
-            s0 = torch.Stream()
-            s1 = torch.Stream()
+            s0 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
             with s0:
                 z0 = 2 * x + y
             with s1:
@@ -2267,7 +2272,7 @@ class GraphModule(torch.nn.Module):
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
 
         def fn(x):
-            s = torch.Stream()
+            s = torch.Stream(device=device)
             x.record_stream(s)
             return x
 
@@ -2284,8 +2289,8 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_after_input_mutation_errors(self, device):
         def fn(x):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s:
                 x.add_(1)
                 e.record()
@@ -2299,8 +2304,8 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_after_input_mutation_stack_traces(self, device):
         def fn(x):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s:
                 x.add_(1)
                 e.record()
@@ -2321,7 +2326,7 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_after_input_mutation_record_event(self, device):
         def fn(x):
-            s = torch.Stream()
+            s = torch.Stream(device=device)
             with s:
                 x.add_(1)
                 e = s.record_event()
@@ -2335,8 +2340,8 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_after_input_mutation_through_view(self, device):
         def fn(x):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             v = x.view(-1)
             with s:
                 v.add_(1)
@@ -2351,7 +2356,7 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_after_input_mutation_input_event(self, device):
         def fn(x, e):
-            s = torch.Stream()
+            s = torch.Stream(device=device)
             with s:
                 x.add_(1)
                 e.record()
@@ -2360,14 +2365,14 @@ class GraphModule(torch.nn.Module):
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
                 torch.ones(2, 2, device=device),
-                torch.Event(),
+                torch.Event(device=device),
             )
 
     @onlyAccelerator
     def test_event_record_before_input_mutation_no_error(self, device):
         def fn(x):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s:
                 e.record()
                 x.add_(1)
@@ -2380,9 +2385,9 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_on_different_stream_no_error(self, device):
         def fn(x):
-            s0 = torch.Stream()
-            s1 = torch.Stream()
-            e = torch.Event()
+            s0 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s0:
                 x.add_(1)
             with s1:
@@ -2396,8 +2401,8 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_not_returned_no_error(self, device):
         def fn(x):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s:
                 x.add_(1)
                 e.record()
@@ -2426,7 +2431,7 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_synchronize_tracing(self, device):
         def fn(x):
-            e = torch.Event()
+            e = torch.Event(device=device)
             e.record()
             x = x + 1
             e.synchronize()
@@ -2470,7 +2475,7 @@ class <lambda>(torch.nn.Module):
 
             @torch.compile()  # noqa: UNSPECIFIED_BACKEND
             def fn(x):
-                e = torch.Event()
+                e = torch.Event(device=device)
                 x = x + 1
                 e.record()
                 e.synchronize()
@@ -2489,7 +2494,7 @@ class <lambda>(torch.nn.Module):
         """
 
         def fn(x) -> torch.Tensor:
-            e = torch.Event()
+            e = torch.Event(device=device)
             y = x + 1
             e.record()
             e.synchronize()
@@ -2602,7 +2607,7 @@ class <lambda>(torch.nn.Module):
         """When the event was recorded externally, synchronize threads graph inputs through."""
 
         def fn(x):
-            e = torch.Event()
+            e = torch.Event(device=device)
             y = x + 1
             e.record()
             e.synchronize()
@@ -2668,7 +2673,7 @@ class <lambda>(torch.nn.Module):
         """E2E: compute → record → synchronize → use result through torch.compile."""
 
         def f(x):
-            e = torch.Event()
+            e = torch.Event(device=device)
             y = x + 1
             e.record()
             e.synchronize()
@@ -2687,7 +2692,7 @@ class <lambda>(torch.nn.Module):
             a_to_cpu_event_list = []
             for a in a_list:
                 a_cpu = a.to(device="cpu", non_blocking=True)
-                e = torch.Event()
+                e = torch.Event(device=device)
                 e.record()
                 a_cpu_list.append(a_cpu)
                 a_to_cpu_event_list.append(e)

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     requires_cuda,
     TEST_WITH_ROCM,
+    TEST_XPU,
 )
 
 
@@ -99,62 +100,6 @@ class TestStreams(torch._dynamo.test_case.TestCase):
             self.skipTest(f"No backend-specific Stream/Event for {device}")
         self._assert_weakref_callback_fires(device_mod.Stream)
         self._assert_weakref_callback_fires(device_mod.Event)
-
-    @onlyAccelerator
-    def test_dynamo_registry_no_dangling_weakref(self, device):
-        """Natural repro of the original UAF pattern.
-
-        `torch.compile(fn, backend="eager")` with `fn` referencing
-        `torch.accelerator.current_stream()` causes dynamo to register a
-        weakref to the captured stream in
-        `index_to_external_object_weakref` (via
-        `store_user_object_weakrefs`, which does NOT pin via
-        `keep_alive`).  As soon as `fn` returns, the captured wrapper
-        has no strong references and is freed via tp_dealloc.
-
-        At that point the patched tp_dealloc must call
-        `PyObject_ClearWeakRefs`, otherwise the registry now holds a
-        weakref whose `wr_object` is a dangling pointer to freed
-        memory.  Later, when `_PyModule_ClearDict` tears down the
-        registry at interpreter finalization, dereferencing that
-        dangling pointer to clear the weakref hits a use-after-free.
-        """
-        # Start from a known-clean registry so the assertion below is
-        # a statement about what happened in *this* test, not residue
-        # from earlier tests in the same process.
-        reset_user_object_tracking()
-
-        def fn(x):
-            return torch.accelerator.current_stream(device).stream_id
-
-        x = torch.zeros(1, device=device)
-        compiled = torch.compile(fn, backend="eager", fullgraph=True)
-        compiled(x)
-        del compiled
-        gc.collect()
-
-        # Tripwire: torch.compile of a function referencing
-        # current_stream() must still register under
-        # CURRENT_STREAM_INDEX.  If this fails, the production code
-        # path that originally surfaced the UAF has moved and this
-        # regression test no longer covers it.
-        self.assertIn(
-            CURRENT_STREAM_INDEX,
-            index_to_external_object_weakref,
-            "torch.compile of a function referencing current_stream() must "
-            "register a weakref under CURRENT_STREAM_INDEX",
-        )
-
-        # The captured stream wrapper was freed when fn returned.  The
-        # patched tp_dealloc must have cleared the registry's weakref;
-        # dereferencing it now must return None rather than a dangling
-        # pointer into freed memory.
-        self.assertIsNone(
-            index_to_external_object_weakref[CURRENT_STREAM_INDEX](),
-            "dynamo registry holds a weakref to a Stream wrapper that has "
-            "been freed; tp_dealloc must call PyObject_ClearWeakRefs to "
-            "clear it, otherwise the registry retains a dangling pointer",
-        )
 
     @onlyAccelerator
     def test_stream_enter_exit(self, device):
@@ -236,7 +181,11 @@ class <lambda>(torch.nn.Module):
             y = z + 2
             return y, s
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2), torch.Stream(device=device))
+        inp = (
+            torch.ones(2, 2) + 1,
+            torch.ones(2, 2),
+            torch.Stream(device=device),
+        )
         expected = fn(*inp)
         fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         actual = fn_opt(*inp)
@@ -269,47 +218,6 @@ class <lambda>(torch.nn.Module):
 
         res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent())
         self.assertEqual(res, torch.ones(2))
-
-    @onlyAccelerator
-    def test_get_current_stream_return(self, device):
-        def fn(x, s):
-            with s:
-                s0 = torch.accelerator.current_stream(device)
-            return x, s0
-
-        s_inp = torch.Stream(device=device)
-        inp = (torch.ones(2, 2) + 1, s_inp)
-        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
-        _, s0 = fn_opt(*inp)
-        _, s1 = fn_opt(*inp)
-        self.assertEqual(s_inp, s0)
-        self.assertEqual(s0, s1)
-
-    @onlyAccelerator
-    def test_current_stream_attrs(self, device):
-        """Verify that accelerator current_stream() attributes are accessible
-        under torch.compile and match eager behavior."""
-
-        def fn_stream(x):
-            return torch.accelerator.current_stream(device).stream_id
-
-        x = torch.zeros(1, device=device)
-        compiled = torch.compile(fn_stream, backend="eager", fullgraph=True)
-        self.assertEqual(compiled(x), fn_stream(x))
-
-    @onlyAccelerator
-    def test_current_stream_with_entered_stream(self, device):
-        """Verify that current_stream().stream_id returns the correct value
-        when inside a stream context for a user-created stream."""
-
-        def fn(x, s):
-            with s:
-                return torch.accelerator.current_stream(device).stream_id
-
-        s = torch.Stream(device=device)
-        x = torch.zeros(1, device=device)
-        compiled = torch.compile(fn, backend="eager", fullgraph=True)
-        self.assertEqual(compiled(x, s), fn(x, s))
 
     @onlyAccelerator
     def test_nested_stream_enter_exit(self, device):
@@ -368,8 +276,8 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_local_stream_enter_exit(self, device):
         def fn(x, y):
-            s2 = torch.Stream()
-            s1 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
             with s1:
                 z1 = torch.add(x, y)
             with s2:
@@ -409,9 +317,9 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_local_stream_nested_enter_exit(self, device):
         def fn(x, y):
-            s2 = torch.Stream()
-            s1 = torch.Stream()
-            s0 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
+            s0 = torch.Stream(device=device)
             with s1:
                 with s2:
                     z1 = torch.add(x, y)
@@ -480,10 +388,8 @@ class <lambda>(torch.nn.Module):
         from torch._dynamo.variables.streams import get_current_stream
 
         cur_stream = torch.accelerator.current_stream(device)
-        s0 = None
 
         def stream_generation_backend(gm, *args, **kwargs):  # type: ignore[no-untyped-def]
-            nonlocal s0
             s0_ind = get_current_stream(torch.device(device))
             self.assertEqual(get_external_object_by_index(s0_ind), cur_stream)
             with gm.graph.inserting_after(next(iter(gm.graph.nodes))):
@@ -508,9 +414,9 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_stream_with_mutation(self, device):
         def fn(x, y):
-            s2 = torch.Stream()
-            s1 = torch.Stream()
-            s0 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
+            s0 = torch.Stream(device=device)
             with s1:
                 with s2:
                     x.add_(y)
@@ -558,8 +464,8 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_stream_backward_simple(self, device) -> None:
         def fn(x, y):
-            s2 = torch.Stream()
-            s0 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s0 = torch.Stream(device=device)
             with s0:
                 y0 = 2 * x + y
             with s2:
@@ -639,8 +545,8 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_stream_backward_sync(self, device) -> None:
         def fn(x, y):
-            s2 = torch.Stream()
-            s0 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s0 = torch.Stream(device=device)
             with s0:
                 y0 = 2 * x + y
             with s2:
@@ -787,37 +693,6 @@ class <lambda>(torch.nn.Module):
         return (copy_,)
 """,
         )
-
-    @requires_cuda
-    def test_recorded_cuda_events_append_runtime_objects(self):
-        events = []
-
-        def fn(x):
-            start_event = torch.cuda.Event(enable_timing=True)
-            end_event = torch.cuda.Event(enable_timing=True)
-
-            start_event.record()
-            out = torch.matmul(x, x)
-            end_event.record()
-
-            events.append(start_event)
-            events.append(end_event)
-            return out
-
-        x = torch.randn(16, 16, device="cuda")
-        expected = fn(x)
-        torch.cuda.synchronize()
-        events[0].elapsed_time(events[1])
-        events.clear()
-
-        actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
-        torch.cuda.synchronize()
-
-        self.assertEqual(expected, actual)
-        self.assertEqual(len(events), 2)
-        self.assertIsInstance(events[0], torch.Event)
-        self.assertIsInstance(events[1], torch.Event)
-        self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
 
     @onlyAccelerator
     def test_run_opcheck_fork_join(self, device):
@@ -2757,8 +2632,8 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_del_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             z0 = x + 1
             with s:
                 z = torch.add(x, y)
@@ -2784,8 +2659,8 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_del_same_stream_no_sync_dealloc(self, device):
         def fn(x, y):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s:
                 z = torch.add(x, y)
                 del x
@@ -2832,8 +2707,8 @@ class <lambda>(torch.nn.Module):
             pass
 
         def fn(x, y):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             h = Holder()
             h.tensor = x
             z0 = x + 1
@@ -2861,8 +2736,8 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_del_subscr_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             d = {"t": x}
             z0 = x + 1
             with s:
@@ -2887,8 +2762,130 @@ class <lambda>(torch.nn.Module):
         self.assertIn("record_event", graph_str)
 
 
+instantiate_device_type_tests(TestStreams, globals(), allow_xpu=True)
+
+_TestStreamsCUDA = globals().get("TestStreamsCUDA", object)
+
+
 @requires_cuda
-class TestStreamsCUDA(torch._dynamo.test_case.TestCase):
+class TestStreamsCUDA(_TestStreamsCUDA):
+    @requires_cuda
+    def test_dynamo_registry_no_dangling_weakref(self):
+        """Natural repro of the original UAF pattern.
+
+        `torch.compile(fn, backend="eager")` with `fn` referencing
+        `torch.cuda.current_stream()` causes dynamo to register a
+        weakref to the captured stream in
+        `index_to_external_object_weakref` (via
+        `store_user_object_weakrefs`, which does NOT pin via
+        `keep_alive`).  As soon as `fn` returns, the captured wrapper
+        has no strong references and is freed via tp_dealloc.
+
+        At that point the patched tp_dealloc must call
+        `PyObject_ClearWeakRefs`, otherwise the registry now holds a
+        weakref whose `wr_object` is a dangling pointer to freed
+        memory.  Later, when `_PyModule_ClearDict` tears down the
+        registry at interpreter finalization, dereferencing that
+        dangling pointer to clear the weakref hits a use-after-free.
+        """
+        reset_user_object_tracking()
+
+        def fn(x):
+            return torch.cuda.current_stream().cuda_stream
+
+        x = torch.zeros(1, device="cuda")
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        compiled(x)
+        del compiled
+        gc.collect()
+
+        self.assertIn(
+            CURRENT_STREAM_INDEX,
+            index_to_external_object_weakref,
+            "torch.compile of a function referencing current_stream() must "
+            "register a weakref under CURRENT_STREAM_INDEX",
+        )
+
+        self.assertIsNone(
+            index_to_external_object_weakref[CURRENT_STREAM_INDEX](),
+            "dynamo registry holds a weakref to a Stream wrapper that has "
+            "been freed; tp_dealloc must call PyObject_ClearWeakRefs to "
+            "clear it, otherwise the registry retains a dangling pointer",
+        )
+
+    @requires_cuda
+    def test_get_current_stream_return(self):
+        def fn(x, s):
+            with s:
+                s0 = torch.cuda.current_stream()
+            return x, s0
+
+        s_inp = torch.Stream(device="cuda")
+        inp = (torch.ones(2, 2, device="cuda") + 1, s_inp)
+        fn_opt = torch.compile(fn, fullgraph=True)
+        _, s0 = fn_opt(*inp)
+        _, s1 = fn_opt(*inp)
+        self.assertEqual(s_inp, s0)
+        self.assertEqual(s0, s1)
+
+    @requires_cuda
+    def test_cuda_current_stream_attrs(self):
+        """Verify that torch.cuda.current_stream() attributes are accessible
+        under torch.compile and match eager behavior."""
+
+        def fn_cuda_stream(x):
+            return torch.cuda.current_stream().cuda_stream
+
+        x = torch.zeros(1, device="cuda")
+        compiled = torch.compile(fn_cuda_stream, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x), fn_cuda_stream(x))
+
+    @requires_cuda
+    def test_cuda_current_stream_with_entered_stream(self):
+        """Verify that torch.cuda.current_stream().cuda_stream returns the
+        correct value when inside a stream context for a user-created stream."""
+
+        def fn(x, s):
+            with s:
+                return torch.cuda.current_stream().cuda_stream
+
+        s = torch.cuda.Stream()
+        x = torch.zeros(1, device="cuda")
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x, s), fn(x, s))
+
+    @requires_cuda
+    def test_recorded_cuda_events_append_runtime_objects(self):
+        events = []
+
+        def fn(x):
+            start_event = torch.cuda.Event(enable_timing=True)
+            end_event = torch.cuda.Event(enable_timing=True)
+
+            start_event.record()
+            out = torch.matmul(x, x)
+            end_event.record()
+
+            events.append(start_event)
+            events.append(end_event)
+            return out
+
+        x = torch.randn(16, 16, device="cuda")
+        expected = fn(x)
+        torch.cuda.synchronize()
+        events[0].elapsed_time(events[1])
+        events.clear()
+
+        actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
+        torch.cuda.synchronize()
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(len(events), 2)
+        self.assertIsInstance(events[0], torch.Event)
+        self.assertIsInstance(events[1], torch.Event)
+        self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
+
+    @requires_cuda
     def test_stream_pointer_extraction_edge_cases(self):
         def get_ptrs(stream_a, stream_b, default_stream):
             return (
@@ -2996,7 +2993,132 @@ class TestStreamsCUDA(torch._dynamo.test_case.TestCase):
         self.assertIn(new_gi, add_node.all_input_nodes)
 
 
-instantiate_device_type_tests(TestStreams, globals())
+del _TestStreamsCUDA
+
+if TEST_XPU:
+    _TestStreamsXPU = TestStreamsXPU  # noqa: F821
+
+    class TestStreamsXPU(_TestStreamsXPU):
+        def test_dynamo_registry_no_dangling_weakref(self):
+            reset_user_object_tracking()
+
+            def fn(x):
+                return torch.xpu.current_stream().sycl_queue
+
+            x = torch.zeros(1, device="xpu")
+            compiled = torch.compile(fn, backend="eager", fullgraph=True)
+            compiled(x)
+            del compiled
+            gc.collect()
+
+            self.assertIn(
+                CURRENT_STREAM_INDEX,
+                index_to_external_object_weakref,
+                "torch.compile of a function referencing current_stream() must "
+                "register a weakref under CURRENT_STREAM_INDEX",
+            )
+
+            self.assertIsNone(
+                index_to_external_object_weakref[CURRENT_STREAM_INDEX](),
+                "dynamo registry holds a weakref to a Stream wrapper that has "
+                "been freed; tp_dealloc must call PyObject_ClearWeakRefs to "
+                "clear it, otherwise the registry retains a dangling pointer",
+            )
+
+        def test_get_current_stream_return(self):
+            def fn(x, s):
+                with s:
+                    s0 = torch.xpu.current_stream()
+                return x, s0
+
+            s_inp = torch.Stream(device="xpu")
+            inp = (torch.ones(2, 2, device="xpu") + 1, s_inp)
+            fn_opt = torch.compile(fn, fullgraph=True)
+            _, s0 = fn_opt(*inp)
+            _, s1 = fn_opt(*inp)
+            self.assertEqual(s_inp, s0)
+            self.assertEqual(s0, s1)
+
+        def test_xpu_current_stream_attrs(self):
+            """Verify that torch.xpu.current_stream() attributes are accessible
+            under torch.compile and match eager behavior."""
+
+            def fn_xpu_stream(x):
+                return torch.xpu.current_stream().sycl_queue
+
+            x = torch.zeros(1, device="xpu")
+            compiled = torch.compile(fn_xpu_stream, backend="eager", fullgraph=True)
+            self.assertEqual(compiled(x), fn_xpu_stream(x))
+
+        def test_xpu_current_stream_with_entered_stream(self):
+            """Verify that torch.xpu.current_stream().sycl_queue returns the
+            correct value when inside a stream context for a user-created stream."""
+
+            def fn(x, s):
+                with s:
+                    return torch.xpu.current_stream().sycl_queue
+
+            s = torch.xpu.Stream()
+            x = torch.zeros(1, device="xpu")
+            compiled = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertEqual(compiled(x, s), fn(x, s))
+
+        def test_recorded_xpu_events_append_runtime_objects(self):
+            events = []
+
+            def fn(x):
+                start_event = torch.xpu.Event(enable_timing=True)
+                end_event = torch.xpu.Event(enable_timing=True)
+
+                start_event.record()
+                out = torch.matmul(x, x)
+                end_event.record()
+
+                events.append(start_event)
+                events.append(end_event)
+                return out
+
+            x = torch.randn(16, 16, device="xpu")
+            expected = fn(x)
+            torch.xpu.synchronize()
+            events[0].elapsed_time(events[1])
+            events.clear()
+
+            actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
+            torch.xpu.synchronize()
+
+            self.assertEqual(expected, actual)
+            self.assertEqual(len(events), 2)
+            self.assertIsInstance(events[0], torch.Event)
+            self.assertIsInstance(events[1], torch.Event)
+            self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
+
+        def test_stream_pointer_extraction_edge_cases(self):
+            def get_ptrs(stream_a, stream_b, default_stream):
+                return (
+                    stream_a.sycl_queue,
+                    stream_b.sycl_queue,
+                    default_stream.sycl_queue,
+                )
+
+            s1, s2 = torch.xpu.Stream(), torch.xpu.Stream()
+            default_s = torch.xpu.current_stream()
+            expected_s1, expected_s2 = s1.sycl_queue, s2.sycl_queue
+
+            self.assertNotEqual(expected_s1, expected_s2)
+
+            opt_get_ptrs = torch.compile(get_ptrs, backend="inductor")
+
+            s3 = torch.xpu.Stream()
+            with torch.xpu.stream(s3):
+                actual_s1, actual_s2, actual_default = opt_get_ptrs(s1, s2, default_s)
+
+            self.assertEqual(actual_s1, expected_s1)
+            self.assertEqual(actual_s2, expected_s2)
+            self.assertEqual(actual_default, default_s.sycl_queue)
+
+    del _TestStreamsXPU
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -113,8 +113,8 @@ class TestStreams(torch._dynamo.test_case.TestCase):
             return y
 
         inp = (
-            torch.ones(2, 2) + 1,
-            torch.ones(2, 2),
+            torch.ones(2, 2, device=device) + 1,
+            torch.ones(2, 2, device=device),
             torch.Stream(device=device),
             torch.Stream(device=device),
         )
@@ -182,8 +182,8 @@ class <lambda>(torch.nn.Module):
             return y, s
 
         inp = (
-            torch.ones(2, 2) + 1,
-            torch.ones(2, 2),
+            torch.ones(2, 2, device=device) + 1,
+            torch.ones(2, 2, device=device),
             torch.Stream(device=device),
         )
         expected = fn(*inp)
@@ -233,8 +233,8 @@ class <lambda>(torch.nn.Module):
             return z0, y
 
         inp = (
-            torch.ones(2, 2) + 1,
-            torch.ones(2, 2),
+            torch.ones(2, 2, device=device) + 1,
+            torch.ones(2, 2, device=device),
             torch.Stream(device=device),
             torch.Stream(device=device),
             torch.Stream(device=device),
@@ -286,7 +286,7 @@ class <lambda>(torch.nn.Module):
 
             return y
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2))
+        inp = (torch.ones(2, 2, device=device) + 1, torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -330,7 +330,7 @@ class <lambda>(torch.nn.Module):
 
             return z0, y
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2))
+        inp = (torch.ones(2, 2, device=device) + 1, torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -428,7 +428,7 @@ class <lambda>(torch.nn.Module):
 
             return z0, y
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2))
+        inp = (torch.ones(2, 2, device=device) + 1, torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -2761,15 +2761,57 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
+    @onlyAccelerator
+    def test_current_stream_with_entered_stream(self, device):
+        """Verify that torch.accelerator.current_stream().stream_id returns the
+        correct value when inside a stream context for a user-created stream."""
+
+        def fn(x, s):
+            with s:
+                return torch.accelerator.current_stream(device).stream_id
+
+        s = torch.Stream(device=device)
+        x = torch.zeros(1, device=device)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x, s), fn(x, s))
+
+    @onlyAccelerator
+    def test_recorded_events_append_runtime_objects(self, device):
+        events = []
+
+        def fn(x):
+            start_event = torch.Event(device=device, enable_timing=True)
+            end_event = torch.Event(device=device, enable_timing=True)
+
+            start_event.record()
+            out = torch.matmul(x, x)
+            end_event.record()
+
+            events.append(start_event)
+            events.append(end_event)
+            return out
+
+        x = torch.randn(16, 16, device=device)
+        expected = fn(x)
+        torch.accelerator.synchronize()
+        events[0].elapsed_time(events[1])
+        events.clear()
+
+        actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
+        torch.accelerator.synchronize()
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(len(events), 2)
+        self.assertIsInstance(events[0], torch.Event)
+        self.assertIsInstance(events[1], torch.Event)
+        self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
+
 
 instantiate_device_type_tests(TestStreams, globals(), allow_xpu=True)
 
-_TestStreamsCUDA = globals().get("TestStreamsCUDA", object)
-
 
 @requires_cuda
-class TestStreamsCUDA(_TestStreamsCUDA):
-    @requires_cuda
+class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
     def test_dynamo_registry_no_dangling_weakref(self):
         """Natural repro of the original UAF pattern.
 
@@ -2813,7 +2855,6 @@ class TestStreamsCUDA(_TestStreamsCUDA):
             "clear it, otherwise the registry retains a dangling pointer",
         )
 
-    @requires_cuda
     def test_get_current_stream_return(self):
         def fn(x, s):
             with s:
@@ -2822,13 +2863,12 @@ class TestStreamsCUDA(_TestStreamsCUDA):
 
         s_inp = torch.Stream(device="cuda")
         inp = (torch.ones(2, 2, device="cuda") + 1, s_inp)
-        fn_opt = torch.compile(fn, fullgraph=True)
+        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         _, s0 = fn_opt(*inp)
         _, s1 = fn_opt(*inp)
         self.assertEqual(s_inp, s0)
         self.assertEqual(s0, s1)
 
-    @requires_cuda
     def test_cuda_current_stream_attrs(self):
         """Verify that torch.cuda.current_stream() attributes are accessible
         under torch.compile and match eager behavior."""
@@ -2840,7 +2880,6 @@ class TestStreamsCUDA(_TestStreamsCUDA):
         compiled = torch.compile(fn_cuda_stream, backend="eager", fullgraph=True)
         self.assertEqual(compiled(x), fn_cuda_stream(x))
 
-    @requires_cuda
     def test_cuda_current_stream_with_entered_stream(self):
         """Verify that torch.cuda.current_stream().cuda_stream returns the
         correct value when inside a stream context for a user-created stream."""
@@ -2854,38 +2893,6 @@ class TestStreamsCUDA(_TestStreamsCUDA):
         compiled = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(compiled(x, s), fn(x, s))
 
-    @requires_cuda
-    def test_recorded_cuda_events_append_runtime_objects(self):
-        events = []
-
-        def fn(x):
-            start_event = torch.cuda.Event(enable_timing=True)
-            end_event = torch.cuda.Event(enable_timing=True)
-
-            start_event.record()
-            out = torch.matmul(x, x)
-            end_event.record()
-
-            events.append(start_event)
-            events.append(end_event)
-            return out
-
-        x = torch.randn(16, 16, device="cuda")
-        expected = fn(x)
-        torch.cuda.synchronize()
-        events[0].elapsed_time(events[1])
-        events.clear()
-
-        actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
-        torch.cuda.synchronize()
-
-        self.assertEqual(expected, actual)
-        self.assertEqual(len(events), 2)
-        self.assertIsInstance(events[0], torch.Event)
-        self.assertIsInstance(events[1], torch.Event)
-        self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
-
-    @requires_cuda
     def test_stream_pointer_extraction_edge_cases(self):
         def get_ptrs(stream_a, stream_b, default_stream):
             return (
@@ -2993,131 +3000,95 @@ class TestStreamsCUDA(_TestStreamsCUDA):
         self.assertIn(new_gi, add_node.all_input_nodes)
 
 
-del _TestStreamsCUDA
+@unittest.skipUnless(TEST_XPU, "xpu only")
+class TestStreamsXPUSpecific(torch._dynamo.test_case.TestCase):
+    def test_dynamo_registry_no_dangling_weakref(self):
+        reset_user_object_tracking()
 
-if TEST_XPU:
-    _TestStreamsXPU = TestStreamsXPU  # noqa: F821
+        def fn(x):
+            return torch.xpu.current_stream().sycl_queue
 
-    class TestStreamsXPU(_TestStreamsXPU):
-        def test_dynamo_registry_no_dangling_weakref(self):
-            reset_user_object_tracking()
+        x = torch.zeros(1, device="xpu")
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        compiled(x)
+        del compiled
+        gc.collect()
 
-            def fn(x):
+        self.assertIn(
+            CURRENT_STREAM_INDEX,
+            index_to_external_object_weakref,
+            "torch.compile of a function referencing current_stream() must "
+            "register a weakref under CURRENT_STREAM_INDEX",
+        )
+
+        self.assertIsNone(
+            index_to_external_object_weakref[CURRENT_STREAM_INDEX](),
+            "dynamo registry holds a weakref to a Stream wrapper that has "
+            "been freed; tp_dealloc must call PyObject_ClearWeakRefs to "
+            "clear it, otherwise the registry retains a dangling pointer",
+        )
+
+    def test_get_current_stream_return(self):
+        def fn(x, s):
+            with s:
+                s0 = torch.xpu.current_stream()
+            return x, s0
+
+        s_inp = torch.Stream(device="xpu")
+        inp = (torch.ones(2, 2, device="xpu") + 1, s_inp)
+        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
+        _, s0 = fn_opt(*inp)
+        _, s1 = fn_opt(*inp)
+        self.assertEqual(s_inp, s0)
+        self.assertEqual(s0, s1)
+
+    def test_xpu_current_stream_attrs(self):
+        """Verify that torch.xpu.current_stream() attributes are accessible
+        under torch.compile and match eager behavior."""
+
+        def fn_xpu_stream(x):
+            return torch.xpu.current_stream().sycl_queue
+
+        x = torch.zeros(1, device="xpu")
+        compiled = torch.compile(fn_xpu_stream, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x), fn_xpu_stream(x))
+
+    def test_xpu_current_stream_with_entered_stream(self):
+        """Verify that torch.xpu.current_stream().sycl_queue returns the
+        correct value when inside a stream context for a user-created stream."""
+
+        def fn(x, s):
+            with s:
                 return torch.xpu.current_stream().sycl_queue
 
-            x = torch.zeros(1, device="xpu")
-            compiled = torch.compile(fn, backend="eager", fullgraph=True)
-            compiled(x)
-            del compiled
-            gc.collect()
+        s = torch.xpu.Stream()
+        x = torch.zeros(1, device="xpu")
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x, s), fn(x, s))
 
-            self.assertIn(
-                CURRENT_STREAM_INDEX,
-                index_to_external_object_weakref,
-                "torch.compile of a function referencing current_stream() must "
-                "register a weakref under CURRENT_STREAM_INDEX",
+    def test_stream_pointer_extraction_edge_cases(self):
+        def get_ptrs(stream_a, stream_b, default_stream):
+            return (
+                stream_a.sycl_queue,
+                stream_b.sycl_queue,
+                default_stream.sycl_queue,
             )
 
-            self.assertIsNone(
-                index_to_external_object_weakref[CURRENT_STREAM_INDEX](),
-                "dynamo registry holds a weakref to a Stream wrapper that has "
-                "been freed; tp_dealloc must call PyObject_ClearWeakRefs to "
-                "clear it, otherwise the registry retains a dangling pointer",
-            )
+        s1, s2 = torch.xpu.Stream(), torch.xpu.Stream()
+        default_s = torch.xpu.current_stream()
+        expected_s1, expected_s2 = s1.sycl_queue, s2.sycl_queue
 
-        def test_get_current_stream_return(self):
-            def fn(x, s):
-                with s:
-                    s0 = torch.xpu.current_stream()
-                return x, s0
+        self.assertNotEqual(expected_s1, expected_s2)
 
-            s_inp = torch.Stream(device="xpu")
-            inp = (torch.ones(2, 2, device="xpu") + 1, s_inp)
-            fn_opt = torch.compile(fn, fullgraph=True)
-            _, s0 = fn_opt(*inp)
-            _, s1 = fn_opt(*inp)
-            self.assertEqual(s_inp, s0)
-            self.assertEqual(s0, s1)
+        opt_get_ptrs = torch.compile(get_ptrs, backend="inductor")
 
-        def test_xpu_current_stream_attrs(self):
-            """Verify that torch.xpu.current_stream() attributes are accessible
-            under torch.compile and match eager behavior."""
+        s3 = torch.xpu.Stream()
+        with torch.xpu.stream(s3):
+            actual_s1, actual_s2, actual_default = opt_get_ptrs(s1, s2, default_s)
 
-            def fn_xpu_stream(x):
-                return torch.xpu.current_stream().sycl_queue
-
-            x = torch.zeros(1, device="xpu")
-            compiled = torch.compile(fn_xpu_stream, backend="eager", fullgraph=True)
-            self.assertEqual(compiled(x), fn_xpu_stream(x))
-
-        def test_xpu_current_stream_with_entered_stream(self):
-            """Verify that torch.xpu.current_stream().sycl_queue returns the
-            correct value when inside a stream context for a user-created stream."""
-
-            def fn(x, s):
-                with s:
-                    return torch.xpu.current_stream().sycl_queue
-
-            s = torch.xpu.Stream()
-            x = torch.zeros(1, device="xpu")
-            compiled = torch.compile(fn, backend="eager", fullgraph=True)
-            self.assertEqual(compiled(x, s), fn(x, s))
-
-        def test_recorded_xpu_events_append_runtime_objects(self):
-            events = []
-
-            def fn(x):
-                start_event = torch.xpu.Event(enable_timing=True)
-                end_event = torch.xpu.Event(enable_timing=True)
-
-                start_event.record()
-                out = torch.matmul(x, x)
-                end_event.record()
-
-                events.append(start_event)
-                events.append(end_event)
-                return out
-
-            x = torch.randn(16, 16, device="xpu")
-            expected = fn(x)
-            torch.xpu.synchronize()
-            events[0].elapsed_time(events[1])
-            events.clear()
-
-            actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
-            torch.xpu.synchronize()
-
-            self.assertEqual(expected, actual)
-            self.assertEqual(len(events), 2)
-            self.assertIsInstance(events[0], torch.Event)
-            self.assertIsInstance(events[1], torch.Event)
-            self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
-
-        def test_stream_pointer_extraction_edge_cases(self):
-            def get_ptrs(stream_a, stream_b, default_stream):
-                return (
-                    stream_a.sycl_queue,
-                    stream_b.sycl_queue,
-                    default_stream.sycl_queue,
-                )
-
-            s1, s2 = torch.xpu.Stream(), torch.xpu.Stream()
-            default_s = torch.xpu.current_stream()
-            expected_s1, expected_s2 = s1.sycl_queue, s2.sycl_queue
-
-            self.assertNotEqual(expected_s1, expected_s2)
-
-            opt_get_ptrs = torch.compile(get_ptrs, backend="inductor")
-
-            s3 = torch.xpu.Stream()
-            with torch.xpu.stream(s3):
-                actual_s1, actual_s2, actual_default = opt_get_ptrs(s1, s2, default_s)
-
-            self.assertEqual(actual_s1, expected_s1)
-            self.assertEqual(actual_s2, expected_s2)
-            self.assertEqual(actual_default, default_s.sycl_queue)
-
-    del _TestStreamsXPU
+        self.assertEqual(actual_s1, expected_s1)
+        self.assertEqual(actual_s2, expected_s2)
+        self.assertEqual(actual_default, default_s.sycl_queue)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -2142,6 +2142,87 @@ class GraphModule(torch.nn.Module):
             # Should not raise due to signature mismatch
             torch.ops.streams.record_stream.default(t, 0)
 
+    def test_expand_dict_returning_deps_triton_kernel(self) -> None:
+        """Triton kernel dicts must not be passed through control_deps.
+
+        triton_kernel_wrapper_functional returns a dict.  If the dict node is
+        threaded through control_deps as a pass-through value,
+        decompose_triton_kernel_wrapper_functional later replaces it with a
+        raw Python dict (via replace_with_graph -> replace_all_uses_with),
+        corrupting the graph and causing KeyError during lowering.
+
+        _expand_dict_returning_deps should insert per-key getitem nodes
+        *before* the sync so that only tensor-valued nodes are passed through.
+        """
+        import operator
+
+        from torch._functorch._aot_autograd.streams import _expand_dict_returning_deps
+
+        graph = torch.fx.Graph()
+        # Placeholder input
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.empty(4, 4)
+
+        # Simulate a triton_kernel_wrapper_functional call returning a dict
+        triton_func = graph.call_function(
+            torch.ops.higher_order.triton_kernel_wrapper_functional,
+            kwargs={
+                "kernel_idx": 0,
+                "constant_args_idx": 0,
+                "grid": [(1, 1, 1)],
+                "tma_descriptor_metadata": {},
+                "kwargs": {"Out": x},
+                "tensors_to_clone": ["Out"],
+            },
+        )
+        triton_func.meta["val"] = {"Out": torch.empty(4, 4)}
+
+        # Simulate a sync node (record_event) between triton_func and getitem
+        sync_node = graph.call_function(
+            torch.ops.streams.record_event.default,
+            args=(0, 0),
+        )
+
+        # getitem user AFTER the sync -- this is the problematic pattern
+        getitem_out = graph.call_function(
+            operator.getitem,
+            args=(triton_func, "Out"),
+        )
+        getitem_out.meta["val"] = torch.empty(4, 4)
+
+        # Use getitem_out so it's live
+        add_node = graph.call_function(torch.ops.aten.add.Tensor, args=(getitem_out, x))
+        graph.output(add_node)
+
+        # Build visited set: everything at or before sync_node
+        visited: set[torch.fx.Node] = set()
+        for n in graph.nodes:
+            visited.add(n)
+            if n is sync_node:
+                break
+
+        # deps_with_uses_after_sync: triton_func has getitem_out as after-sync user
+        deps = [triton_func]
+
+        expanded = _expand_dict_returning_deps(deps, visited, graph, sync_node)
+
+        # The triton_func dict should NOT be in the expanded list
+        self.assertNotIn(triton_func, expanded)
+
+        # Instead, we should have a new getitem node for key "Out"
+        self.assertEqual(len(expanded), 1)
+        new_gi = expanded[0]
+        self.assertEqual(new_gi.target, operator.getitem)
+        self.assertEqual(new_gi.args, (triton_func, "Out"))
+
+        # The new getitem should be BEFORE the sync in graph order
+        node_order = list(graph.nodes)
+        self.assertLess(node_order.index(new_gi), node_order.index(sync_node))
+
+        # The old getitem_out should have been erased; add_node now uses new_gi
+        self.assertNotIn(getitem_out, set(graph.nodes))
+        self.assertIn(new_gi, add_node.all_input_nodes)
+
     @onlyAccelerator
     def test_record_stream(self, device):
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
@@ -2794,7 +2875,12 @@ class <lambda>(torch.nn.Module):
         x = torch.randn(16, 16, device=device)
         expected = fn(x)
         torch.accelerator.synchronize()
-        events[0].elapsed_time(events[1])
+        try:
+            events[0].elapsed_time(events[1])
+        except RuntimeError as e:
+            if "doesn't support elapsedTime" not in str(e):
+                raise
+            self.skipTest(f"{device} does not support Event timing")
         events.clear()
 
         actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
@@ -2917,87 +3003,6 @@ class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
         self.assertEqual(actual_s1, expected_s1)
         self.assertEqual(actual_s2, expected_s2)
         self.assertEqual(actual_default, default_s.cuda_stream)
-
-    def test_expand_dict_returning_deps_triton_kernel(self) -> None:
-        """Triton kernel dicts must not be passed through control_deps.
-
-        triton_kernel_wrapper_functional returns a dict.  If the dict node is
-        threaded through control_deps as a pass-through value,
-        decompose_triton_kernel_wrapper_functional later replaces it with a
-        raw Python dict (via replace_with_graph -> replace_all_uses_with),
-        corrupting the graph and causing KeyError during lowering.
-
-        _expand_dict_returning_deps should insert per-key getitem nodes
-        *before* the sync so that only tensor-valued nodes are passed through.
-        """
-        import operator
-
-        from torch._functorch._aot_autograd.streams import _expand_dict_returning_deps
-
-        graph = torch.fx.Graph()
-        # Placeholder input
-        x = graph.placeholder("x")
-        x.meta["val"] = torch.empty(4, 4)
-
-        # Simulate a triton_kernel_wrapper_functional call returning a dict
-        triton_func = graph.call_function(
-            torch.ops.higher_order.triton_kernel_wrapper_functional,
-            kwargs={
-                "kernel_idx": 0,
-                "constant_args_idx": 0,
-                "grid": [(1, 1, 1)],
-                "tma_descriptor_metadata": {},
-                "kwargs": {"Out": x},
-                "tensors_to_clone": ["Out"],
-            },
-        )
-        triton_func.meta["val"] = {"Out": torch.empty(4, 4)}
-
-        # Simulate a sync node (record_event) between triton_func and getitem
-        sync_node = graph.call_function(
-            torch.ops.streams.record_event.default,
-            args=(0, 0),
-        )
-
-        # getitem user AFTER the sync -- this is the problematic pattern
-        getitem_out = graph.call_function(
-            operator.getitem,
-            args=(triton_func, "Out"),
-        )
-        getitem_out.meta["val"] = torch.empty(4, 4)
-
-        # Use getitem_out so it's live
-        add_node = graph.call_function(torch.ops.aten.add.Tensor, args=(getitem_out, x))
-        graph.output(add_node)
-
-        # Build visited set: everything at or before sync_node
-        visited: set[torch.fx.Node] = set()
-        for n in graph.nodes:
-            visited.add(n)
-            if n is sync_node:
-                break
-
-        # deps_with_uses_after_sync: triton_func has getitem_out as after-sync user
-        deps = [triton_func]
-
-        expanded = _expand_dict_returning_deps(deps, visited, graph, sync_node)
-
-        # The triton_func dict should NOT be in the expanded list
-        self.assertNotIn(triton_func, expanded)
-
-        # Instead, we should have a new getitem node for key "Out"
-        self.assertEqual(len(expanded), 1)
-        new_gi = expanded[0]
-        self.assertEqual(new_gi.target, operator.getitem)
-        self.assertEqual(new_gi.args, (triton_func, "Out"))
-
-        # The new getitem should be BEFORE the sync in graph order
-        node_order = list(graph.nodes)
-        self.assertLess(node_order.index(new_gi), node_order.index(sync_node))
-
-        # The old getitem_out should have been erased; add_node now uses new_gi
-        self.assertNotIn(getitem_out, set(graph.nodes))
-        self.assertIn(new_gi, add_node.all_input_nodes)
 
 
 @unittest.skipUnless(TEST_XPU, "xpu only")

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -177,6 +177,251 @@ class TestStreamsGeneric(torch._dynamo.test_case.TestCase):
         self.assertNotIn(getitem_out, set(graph.nodes))
         self.assertIn(new_gi, add_node.all_input_nodes)
 
+    def test_full_barrier_forward_deps_respect_partition(self) -> None:
+        from torch._functorch._aot_autograd.streams import _collect_sync_forward_deps
+
+        graph = torch.fx.Graph()
+        fw_input = graph.placeholder("fw_input")
+        fw_input.meta["val"] = torch.ones(1)
+        bw_input = graph.placeholder("bw_input")
+        bw_input.meta["val"] = torch.ones(1)
+        barrier = graph.call_function(
+            torch.ops.streams.synchronize_stream.default, (0,)
+        )
+        fw_node = graph.call_function(torch.ops.aten.add.Tensor, (fw_input, 1))
+        fw_node.meta["val"] = torch.ones(1)
+        bw_node = graph.call_function(torch.ops.aten.add.Tensor, (bw_input, 1))
+        bw_node.meta["val"] = torch.ones(1)
+        bw_node.meta["partitioner_tag"] = "is_backward"
+        graph.output((fw_node, bw_node))
+
+        _, deps = _collect_sync_forward_deps(graph)
+        self.assertEqual(list(deps[barrier]), [fw_input])
+
+    def test_backward_full_barrier_filters_forward_sync_deps(self) -> None:
+        from torch._functorch._aot_autograd.streams import _collect_full_barrier_deps
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        fw_compute = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
+        fw_sync = graph.call_function(torch.ops.streams.record_event.default, (0, 0))
+        bw_sync = graph.call_function(torch.ops.streams.record_event.default, (1, 0))
+        bw_sync.meta["partitioner_tag"] = "is_backward"
+        graph.output(fw_compute)
+
+        deps = _collect_full_barrier_deps(
+            {0: [fw_compute]}, {0: [fw_sync, bw_sync]}, bwd=True
+        )
+        self.assertEqual(deps, [fw_compute, bw_sync])
+
+    def test_wait_stream_forward_deps_are_transitive(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            _collect_sync_forward_deps,
+            set_stream,
+        )
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        inp.meta["val"] = torch.ones(1)
+        wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
+        producer = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
+        producer.meta["val"] = torch.ones(1)
+        set_stream(producer, 0)
+        consumer = graph.call_function(torch.ops.aten.mul.Tensor, (producer, 2))
+        consumer.meta["val"] = torch.ones(1)
+        set_stream(consumer, 1)
+        graph.output(consumer)
+
+        wait_deps, _ = _collect_sync_forward_deps(graph)
+        self.assertEqual(list(wait_deps[wait]), [inp])
+
+    def test_wait_stream_forward_deps_respect_partition(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            _collect_sync_forward_deps,
+            set_stream,
+        )
+
+        graph = torch.fx.Graph()
+        fw_input = graph.placeholder("fw_input")
+        fw_input.meta["val"] = torch.ones(1)
+        bw_input = graph.placeholder("bw_input")
+        bw_input.meta["val"] = torch.ones(1)
+        fw_wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
+        fw_node = graph.call_function(torch.ops.aten.add.Tensor, (fw_input, 1))
+        fw_node.meta["val"] = torch.ones(1)
+        set_stream(fw_node, 1)
+        bw_wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
+        bw_wait.meta["partitioner_tag"] = "is_backward"
+        bw_node = graph.call_function(torch.ops.aten.add.Tensor, (bw_input, 1))
+        bw_node.meta["val"] = torch.ones(1)
+        bw_node.meta["partitioner_tag"] = "is_backward"
+        set_stream(bw_node, 1)
+        graph.output((fw_node, bw_node))
+
+        wait_deps, _ = _collect_sync_forward_deps(graph)
+        self.assertEqual(list(wait_deps[fw_wait]), [fw_input])
+        self.assertEqual(list(wait_deps[bw_wait]), [bw_input])
+
+    def _assert_empty_sync_anchors_record(
+        self, sync_target: torch._ops.OpOverload, sync_args: tuple[int, ...]
+    ) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        sync = graph.call_function(sync_target, sync_args)
+        graph.call_function(torch.ops.streams.record_event.default, (1, 1))
+        graph.output(inp)
+        gm = torch.fx.GraphModule({}, graph)
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
+        self.assertEqual(len(ctrl_nodes), 1)
+        self.assertIn(sync, ctrl_nodes[0].args[0])
+        graph.lint()
+
+    def test_empty_synchronize_stream_anchors_record(self) -> None:
+        self._assert_empty_sync_anchors_record(
+            torch.ops.streams.synchronize_stream.default, (0,)
+        )
+
+    def test_empty_synchronize_device_anchors_record(self) -> None:
+        self._assert_empty_sync_anchors_record(
+            torch.ops.streams.synchronize_device.default, ()
+        )
+
+    def test_empty_wait_stream_anchors_record(self) -> None:
+        self._assert_empty_sync_anchors_record(
+            torch.ops.streams.wait_stream.default, (1, 0)
+        )
+
+    def test_external_wait_event_anchors_record(self) -> None:
+        self._assert_empty_sync_anchors_record(
+            torch.ops.streams.wait_event.default, (0, 1)
+        )
+
+    def test_external_wait_event_orders_following_work(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            set_stream,
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        inp.meta["val"] = torch.ones(1)
+        graph.call_function(torch.ops.streams.wait_event.default, (0, 1))
+        add = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
+        add.meta["val"] = torch.ones(1)
+        set_stream(add, 1)
+        graph.output(add)
+        gm = torch.fx.GraphModule({}, graph)
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
+        self.assertEqual(len(ctrl_nodes), 1)
+        self.assertIs(add.args[0].args[0], ctrl_nodes[0])
+        graph.lint()
+
+    def test_external_wait_event_preserves_copy_destination(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            set_stream,
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        graph = torch.fx.Graph()
+        dst = graph.placeholder("dst")
+        dst.meta["val"] = torch.ones(1)
+        src = graph.placeholder("src")
+        src.meta["val"] = torch.ones(1)
+        graph.call_function(torch.ops.streams.wait_event.default, (0, 1))
+        copy = graph.call_function(torch.ops.aten.copy_.default, (dst, src))
+        copy.meta["val"] = torch.ones(1)
+        set_stream(copy, 1)
+        graph.output(copy)
+        gm = torch.fx.GraphModule({}, graph)
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        ctrl = graph.find_nodes(op="call_function", target=control_deps)[0]
+        self.assertIs(copy.args[0], dst)
+        self.assertIs(copy.args[1].args[0], ctrl)
+        graph.lint()
+
+    def test_empty_synchronize_event_anchors_record(self) -> None:
+        self._assert_empty_sync_anchors_record(
+            torch.ops.streams.synchronize_event.default, (0,)
+        )
+
+    def test_wait_stream_depends_on_prior_waiting_stream_work(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            set_stream,
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        inp.meta["val"] = torch.ones(1)
+        prior_work = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
+        prior_work.meta["val"] = torch.ones(1)
+        set_stream(prior_work, 1)
+        graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
+        graph.output(prior_work)
+        gm = torch.fx.GraphModule({}, graph)
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
+        self.assertEqual(len(ctrl_nodes), 1)
+        self.assertIn(prior_work, ctrl_nodes[0].args[0])
+        graph.lint()
+
+    def test_wait_stream_self_wait_orders_work_once(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            set_stream,
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.ones(1)
+        y = graph.placeholder("y")
+        y.meta["val"] = torch.ones(1)
+        prior_work = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
+        prior_work.meta["val"] = torch.ones(1)
+        set_stream(prior_work, 1)
+        graph.call_function(torch.ops.streams.wait_stream.default, (1, 1))
+        following_work = graph.call_function(torch.ops.aten.mul.Tensor, (y, 2))
+        following_work.meta["val"] = torch.ones(1)
+        set_stream(following_work, 1)
+        graph.output((prior_work, following_work))
+        gm = torch.fx.GraphModule({}, graph)
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        ctrl = graph.find_nodes(op="call_function", target=control_deps)[0]
+        self.assertEqual(ctrl.args[0].count(prior_work), 1)
+        self.assertIs(following_work.args[0].args[0], ctrl)
+        graph.lint()
+
+    def test_event_subclass_python_type(self):
+        class MyEvent(torch.Event):
+            pass
+
+        def fn(e):
+            return torch.ones(2) if type(e) is MyEvent else torch.zeros(2)
+
+        res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent(device="cpu"))
+        self.assertEqual(res, torch.ones(2))
+
 
 @requires_accelerator
 class TestStreams(torch._dynamo.test_case.TestCase):
@@ -333,16 +578,6 @@ class <lambda>(torch.nn.Module):
         self.assertIsInstance(s0, torch.Stream)
         # Stream should be newly allocated on each call
         self.assertNotEqual(s0, s1)
-
-    def test_event_subclass_python_type(self):
-        class MyEvent(torch.Event):
-            pass
-
-        def fn(e):
-            return torch.ones(2) if type(e) is MyEvent else torch.zeros(2)
-
-        res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent())
-        self.assertEqual(res, torch.ones(2))
 
     def test_nested_stream_enter_exit(self, device):
         def fn(x, y, s0, s1, s2):
@@ -1603,241 +1838,6 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    def test_full_barrier_forward_deps_respect_partition(self) -> None:
-        from torch._functorch._aot_autograd.streams import _collect_sync_forward_deps
-
-        graph = torch.fx.Graph()
-        fw_input = graph.placeholder("fw_input")
-        fw_input.meta["val"] = torch.ones(1)
-        bw_input = graph.placeholder("bw_input")
-        bw_input.meta["val"] = torch.ones(1)
-        barrier = graph.call_function(
-            torch.ops.streams.synchronize_stream.default, (0,)
-        )
-        fw_node = graph.call_function(torch.ops.aten.add.Tensor, (fw_input, 1))
-        fw_node.meta["val"] = torch.ones(1)
-        bw_node = graph.call_function(torch.ops.aten.add.Tensor, (bw_input, 1))
-        bw_node.meta["val"] = torch.ones(1)
-        bw_node.meta["partitioner_tag"] = "is_backward"
-        graph.output((fw_node, bw_node))
-
-        _, deps = _collect_sync_forward_deps(graph)
-        self.assertEqual(list(deps[barrier]), [fw_input])
-
-    def test_backward_full_barrier_filters_forward_sync_deps(self) -> None:
-        from torch._functorch._aot_autograd.streams import _collect_full_barrier_deps
-
-        graph = torch.fx.Graph()
-        inp = graph.placeholder("inp")
-        fw_compute = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
-        fw_sync = graph.call_function(torch.ops.streams.record_event.default, (0, 0))
-        bw_sync = graph.call_function(torch.ops.streams.record_event.default, (1, 0))
-        bw_sync.meta["partitioner_tag"] = "is_backward"
-        graph.output(fw_compute)
-
-        deps = _collect_full_barrier_deps(
-            {0: [fw_compute]}, {0: [fw_sync, bw_sync]}, bwd=True
-        )
-        self.assertEqual(deps, [fw_compute, bw_sync])
-
-    def test_wait_stream_forward_deps_are_transitive(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            _collect_sync_forward_deps,
-            set_stream,
-        )
-
-        graph = torch.fx.Graph()
-        inp = graph.placeholder("inp")
-        inp.meta["val"] = torch.ones(1)
-        wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
-        producer = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
-        producer.meta["val"] = torch.ones(1)
-        set_stream(producer, 0)
-        consumer = graph.call_function(torch.ops.aten.mul.Tensor, (producer, 2))
-        consumer.meta["val"] = torch.ones(1)
-        set_stream(consumer, 1)
-        graph.output(consumer)
-
-        wait_deps, _ = _collect_sync_forward_deps(graph)
-        self.assertEqual(list(wait_deps[wait]), [inp])
-
-    def test_wait_stream_forward_deps_respect_partition(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            _collect_sync_forward_deps,
-            set_stream,
-        )
-
-        graph = torch.fx.Graph()
-        fw_input = graph.placeholder("fw_input")
-        fw_input.meta["val"] = torch.ones(1)
-        bw_input = graph.placeholder("bw_input")
-        bw_input.meta["val"] = torch.ones(1)
-        fw_wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
-        fw_node = graph.call_function(torch.ops.aten.add.Tensor, (fw_input, 1))
-        fw_node.meta["val"] = torch.ones(1)
-        set_stream(fw_node, 1)
-        bw_wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
-        bw_wait.meta["partitioner_tag"] = "is_backward"
-        bw_node = graph.call_function(torch.ops.aten.add.Tensor, (bw_input, 1))
-        bw_node.meta["val"] = torch.ones(1)
-        bw_node.meta["partitioner_tag"] = "is_backward"
-        set_stream(bw_node, 1)
-        graph.output((fw_node, bw_node))
-
-        wait_deps, _ = _collect_sync_forward_deps(graph)
-        self.assertEqual(list(wait_deps[fw_wait]), [fw_input])
-        self.assertEqual(list(wait_deps[bw_wait]), [bw_input])
-
-    def _assert_empty_sync_anchors_record(
-        self, sync_target: torch._ops.OpOverload, sync_args: tuple[int, ...]
-    ) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            wrap_all_sync_nodes_with_control_deps,
-        )
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        graph = torch.fx.Graph()
-        inp = graph.placeholder("inp")
-        sync = graph.call_function(sync_target, sync_args)
-        graph.call_function(torch.ops.streams.record_event.default, (1, 1))
-        graph.output(inp)
-        gm = torch.fx.GraphModule({}, graph)
-
-        wrap_all_sync_nodes_with_control_deps(gm)
-
-        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
-        self.assertEqual(len(ctrl_nodes), 1)
-        self.assertIn(sync, ctrl_nodes[0].args[0])
-        graph.lint()
-
-    def test_empty_synchronize_stream_anchors_record(self) -> None:
-        self._assert_empty_sync_anchors_record(
-            torch.ops.streams.synchronize_stream.default, (0,)
-        )
-
-    def test_empty_synchronize_device_anchors_record(self) -> None:
-        self._assert_empty_sync_anchors_record(
-            torch.ops.streams.synchronize_device.default, ()
-        )
-
-    def test_empty_wait_stream_anchors_record(self) -> None:
-        self._assert_empty_sync_anchors_record(
-            torch.ops.streams.wait_stream.default, (1, 0)
-        )
-
-    def test_external_wait_event_anchors_record(self) -> None:
-        self._assert_empty_sync_anchors_record(
-            torch.ops.streams.wait_event.default, (0, 1)
-        )
-
-    def test_external_wait_event_orders_following_work(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            set_stream,
-            wrap_all_sync_nodes_with_control_deps,
-        )
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        graph = torch.fx.Graph()
-        inp = graph.placeholder("inp")
-        inp.meta["val"] = torch.ones(1)
-        graph.call_function(torch.ops.streams.wait_event.default, (0, 1))
-        add = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
-        add.meta["val"] = torch.ones(1)
-        set_stream(add, 1)
-        graph.output(add)
-        gm = torch.fx.GraphModule({}, graph)
-
-        wrap_all_sync_nodes_with_control_deps(gm)
-
-        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
-        self.assertEqual(len(ctrl_nodes), 1)
-        self.assertIs(add.args[0].args[0], ctrl_nodes[0])
-        graph.lint()
-
-    def test_external_wait_event_preserves_copy_destination(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            set_stream,
-            wrap_all_sync_nodes_with_control_deps,
-        )
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        graph = torch.fx.Graph()
-        dst = graph.placeholder("dst")
-        dst.meta["val"] = torch.ones(1)
-        src = graph.placeholder("src")
-        src.meta["val"] = torch.ones(1)
-        graph.call_function(torch.ops.streams.wait_event.default, (0, 1))
-        copy = graph.call_function(torch.ops.aten.copy_.default, (dst, src))
-        copy.meta["val"] = torch.ones(1)
-        set_stream(copy, 1)
-        graph.output(copy)
-        gm = torch.fx.GraphModule({}, graph)
-
-        wrap_all_sync_nodes_with_control_deps(gm)
-
-        ctrl = graph.find_nodes(op="call_function", target=control_deps)[0]
-        self.assertIs(copy.args[0], dst)
-        self.assertIs(copy.args[1].args[0], ctrl)
-        graph.lint()
-
-    def test_empty_synchronize_event_anchors_record(self) -> None:
-        self._assert_empty_sync_anchors_record(
-            torch.ops.streams.synchronize_event.default, (0,)
-        )
-
-    def test_wait_stream_depends_on_prior_waiting_stream_work(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            set_stream,
-            wrap_all_sync_nodes_with_control_deps,
-        )
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        graph = torch.fx.Graph()
-        inp = graph.placeholder("inp")
-        inp.meta["val"] = torch.ones(1)
-        prior_work = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
-        prior_work.meta["val"] = torch.ones(1)
-        set_stream(prior_work, 1)
-        graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
-        graph.output(prior_work)
-        gm = torch.fx.GraphModule({}, graph)
-
-        wrap_all_sync_nodes_with_control_deps(gm)
-
-        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
-        self.assertEqual(len(ctrl_nodes), 1)
-        self.assertIn(prior_work, ctrl_nodes[0].args[0])
-        graph.lint()
-
-    def test_wait_stream_self_wait_orders_work_once(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            set_stream,
-            wrap_all_sync_nodes_with_control_deps,
-        )
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        graph = torch.fx.Graph()
-        x = graph.placeholder("x")
-        x.meta["val"] = torch.ones(1)
-        y = graph.placeholder("y")
-        y.meta["val"] = torch.ones(1)
-        prior_work = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
-        prior_work.meta["val"] = torch.ones(1)
-        set_stream(prior_work, 1)
-        graph.call_function(torch.ops.streams.wait_stream.default, (1, 1))
-        following_work = graph.call_function(torch.ops.aten.mul.Tensor, (y, 2))
-        following_work.meta["val"] = torch.ones(1)
-        set_stream(following_work, 1)
-        graph.output((prior_work, following_work))
-        gm = torch.fx.GraphModule({}, graph)
-
-        wrap_all_sync_nodes_with_control_deps(gm)
-
-        ctrl = graph.find_nodes(op="call_function", target=control_deps)[0]
-        self.assertEqual(ctrl.args[0].count(prior_work), 1)
-        self.assertIs(following_work.args[0].args[0], ctrl)
-        graph.lint()
-
     def test_epilogue_copy_stream_tracking(self, device):
         """
         Test that epilogue copies for mutated inputs use the correct stream.
@@ -2628,15 +2628,7 @@ class <lambda>(torch.nn.Module):
         self.assertIsInstance(events[1], torch.Event)
         self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
 
-
-instantiate_device_type_tests(
-    TestStreams, globals(), allow_xpu=True, except_for=("cpu",)
-)
-
-
-@requires_cuda
-class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
-    def test_same_stream_record_ordering(self) -> None:
+    def test_same_stream_record_ordering(self, device) -> None:
         """Two record_events on one stream must be ordered relative to each other.
 
         The second record's per-stream work was reset by the first, so without
@@ -2648,10 +2640,10 @@ class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
         """
 
         def fn(x) -> torch.Tensor:
-            s = torch.Stream(device="cuda")
-            e1 = torch.Event()
-            e2 = torch.Event()
-            e3 = torch.Event()
+            s = torch.Stream(device=device)
+            e1 = torch.Event(device=device)
+            e2 = torch.Event(device=device)
+            e3 = torch.Event(device=device)
             with s:
                 a = x + 1
                 e1.record()
@@ -2659,7 +2651,7 @@ class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
                 e3.record()
             return a
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         # extract_graph already runs wrap_all_sync_nodes_with_control_deps, so
         # assert on its output directly (re-running the pass would wrap the bare
         # e2 a second time and mask the bug).
@@ -2687,6 +2679,14 @@ class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
 
         graph.lint()
 
+
+instantiate_device_type_tests(
+    TestStreams, globals(), allow_xpu=True, except_for=("cpu",)
+)
+
+
+@requires_cuda
+class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
     def test_wait_stream_anchors_following_record(self) -> None:
         """A record_event on the WAITING stream after a wait_stream must chain to
         the wait_stream (which runs on that stream), not float above it as a bare

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -15,17 +15,15 @@ from torch._dynamo.graph_bytecode_inputs import (
     store_user_object_weakrefs,
 )
 from torch._dynamo.testing import extract_graph, remove_trailing_space
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    onlyAccelerator,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     IS_LINUX,
     IS_MACOS,
     IS_WINDOWS,
+    requires_accelerator,
     requires_cuda,
+    requires_xpu,
     TEST_WITH_ROCM,
-    TEST_XPU,
 )
 
 
@@ -47,6 +45,140 @@ def strip_annotation_desc(gm_str: str) -> str:
     return re.sub(r"(# Annotation: \{[^}]*\}).*", r"\1", gm_str)
 
 
+class TestStreamsGeneric(torch._dynamo.test_case.TestCase):
+    @unittest.skip("Needs graph break support with annotation context")
+    def test_stream_enter_exit_graph_break(self):
+        pass
+
+    @unittest.skip("Needs graph break support with annotation context")
+    def test_nested_stream_enter_exit_graph_break(self):
+        pass
+
+    def test_is_marked_side_effectful(self):
+        self.assertIn(
+            torch.ops.streams.fork.default, torch.fx.node._side_effectful_functions
+        )
+        self.assertIn(
+            torch.ops.streams.join.default, torch.fx.node._side_effectful_functions
+        )
+        self.assertIn(
+            torch.ops.streams.wait_event.default,
+            torch.fx.node._side_effectful_functions,
+        )
+        self.assertIn(
+            torch.ops.streams.record_event.default,
+            torch.fx.node._side_effectful_functions,
+        )
+        self.assertIn(
+            torch.ops.streams.synchronize_event.default,
+            torch.fx.node._side_effectful_functions,
+        )
+
+    def test_sync_dealloc_has_fake_impl(self):
+        """Test that sync_dealloc has a registered fake impl.
+
+        Without a fake impl, Inductor's backward compilation crashes when the
+        backward graph contains cross-stream sync_dealloc ops.
+        """
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            t = torch.randn(4)
+            # Should not raise "no fake impl registered"
+            torch.ops.streams.sync_dealloc.default(0, 1, t)
+
+    def test_record_stream_has_fake_impl(self):
+        """Test that record_stream's fake impl has the correct signature."""
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            t = torch.randn(4)
+            # Should not raise due to signature mismatch
+            torch.ops.streams.record_stream.default(t, 0)
+
+    def test_expand_dict_returning_deps_triton_kernel(self) -> None:
+        """Triton kernel dicts must not be passed through control_deps.
+
+        triton_kernel_wrapper_functional returns a dict.  If the dict node is
+        threaded through control_deps as a pass-through value,
+        decompose_triton_kernel_wrapper_functional later replaces it with a
+        raw Python dict (via replace_with_graph -> replace_all_uses_with),
+        corrupting the graph and causing KeyError during lowering.
+
+        _expand_dict_returning_deps should insert per-key getitem nodes
+        *before* the sync so that only tensor-valued nodes are passed through.
+        """
+        import operator
+
+        from torch._functorch._aot_autograd.streams import _expand_dict_returning_deps
+
+        graph = torch.fx.Graph()
+        # Placeholder input
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.empty(4, 4)
+
+        # Simulate a triton_kernel_wrapper_functional call returning a dict
+        triton_func = graph.call_function(
+            torch.ops.higher_order.triton_kernel_wrapper_functional,
+            kwargs={
+                "kernel_idx": 0,
+                "constant_args_idx": 0,
+                "grid": [(1, 1, 1)],
+                "tma_descriptor_metadata": {},
+                "kwargs": {"Out": x},
+                "tensors_to_clone": ["Out"],
+            },
+        )
+        triton_func.meta["val"] = {"Out": torch.empty(4, 4)}
+
+        # Simulate a sync node (record_event) between triton_func and getitem
+        sync_node = graph.call_function(
+            torch.ops.streams.record_event.default,
+            args=(0, 0),
+        )
+
+        # getitem user AFTER the sync -- this is the problematic pattern
+        getitem_out = graph.call_function(
+            operator.getitem,
+            args=(triton_func, "Out"),
+        )
+        getitem_out.meta["val"] = torch.empty(4, 4)
+
+        # Use getitem_out so it's live
+        add_node = graph.call_function(torch.ops.aten.add.Tensor, args=(getitem_out, x))
+        graph.output(add_node)
+
+        # Build visited set: everything at or before sync_node
+        visited: set[torch.fx.Node] = set()
+        for n in graph.nodes:
+            visited.add(n)
+            if n is sync_node:
+                break
+
+        # deps_with_uses_after_sync: triton_func has getitem_out as after-sync user
+        deps = [triton_func]
+
+        expanded = _expand_dict_returning_deps(deps, visited, graph, sync_node)
+
+        # The triton_func dict should NOT be in the expanded list
+        self.assertNotIn(triton_func, expanded)
+
+        # Instead, we should have a new getitem node for key "Out"
+        self.assertEqual(len(expanded), 1)
+        new_gi = expanded[0]
+        self.assertEqual(new_gi.target, operator.getitem)
+        self.assertEqual(new_gi.args, (triton_func, "Out"))
+
+        # The new getitem should be BEFORE the sync in graph order
+        node_order = list(graph.nodes)
+        self.assertLess(node_order.index(new_gi), node_order.index(sync_node))
+
+        # The old getitem_out should have been erased; add_node now uses new_gi
+        self.assertNotIn(getitem_out, set(graph.nodes))
+        self.assertIn(new_gi, add_node.all_input_nodes)
+
+
+@requires_accelerator
 class TestStreams(torch._dynamo.test_case.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -56,12 +188,10 @@ class TestStreams(torch._dynamo.test_case.TestCase):
     def tearDownClass(cls):
         super().tearDownClass()
 
-    @onlyAccelerator
     def test_stream_weakref(self, device):
         s = torch.Stream(device=device)
         weakref.ref(s)
 
-    @onlyAccelerator
     def test_event_weakref(self, device):
         e = torch.Event(device=device)
         weakref.ref(e)
@@ -89,7 +219,6 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         self.assertEqual(called, [True])
         del _weakref_keepalive
 
-    @onlyAccelerator
     def test_backend_stream_event_weakref_callback(self, device):
         device_mod = getattr(torch, torch.device(device).type, None)
         if (
@@ -101,7 +230,6 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         self._assert_weakref_callback_fires(device_mod.Stream)
         self._assert_weakref_callback_fires(device_mod.Event)
 
-    @onlyAccelerator
     def test_stream_enter_exit(self, device):
         def fn(x, y, s1, s2):
             with s1:
@@ -145,7 +273,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     @unittest.skip("Needs graph break support with annotation context")
     def test_stream_context_graph_break(self, device):
         def fn(x, y):
@@ -174,7 +301,6 @@ class <lambda>(torch.nn.Module):
         self.assertExpectedInline(print_graph(fw_graphs[0]), """""")
         self.assertExpectedInline(print_graph(fw_graphs[1]), """""")
 
-    @onlyAccelerator
     def test_stream_input(self, device):
         def fn(x, y, s):
             z = torch.add(x, y)
@@ -191,7 +317,6 @@ class <lambda>(torch.nn.Module):
         actual = fn_opt(*inp)
         self.assertEqual(expected, actual)
 
-    @onlyAccelerator
     def test_local_stream_return(self, device):
         def fn(x, y):
             s = torch.Stream(device=device)
@@ -219,7 +344,6 @@ class <lambda>(torch.nn.Module):
         res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent())
         self.assertEqual(res, torch.ones(2))
 
-    @onlyAccelerator
     def test_nested_stream_enter_exit(self, device):
         def fn(x, y, s0, s1, s2):
             with s1:
@@ -265,15 +389,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @unittest.skip("Needs graph break support with annotation context")
-    def test_stream_enter_exit_graph_break(self):
-        pass
-
-    @unittest.skip("Needs graph break support with annotation context")
-    def test_nested_stream_enter_exit_graph_break(self):
-        pass
-
-    @onlyAccelerator
     def test_local_stream_enter_exit(self, device):
         def fn(x, y):
             s2 = torch.Stream(device=device)
@@ -314,7 +429,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_local_stream_nested_enter_exit(self, device):
         def fn(x, y):
             s2 = torch.Stream(device=device)
@@ -357,7 +471,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_new_stream_api(self, device) -> None:
         from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
         from torch._dynamo.variables.streams import new_stream
@@ -382,7 +495,6 @@ class <lambda>(torch.nn.Module):
 
         fn(torch.ones(2, 2, device=device))
 
-    @onlyAccelerator
     def test_current_stream_api(self, device) -> None:
         from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
         from torch._dynamo.variables.streams import get_current_stream
@@ -411,7 +523,6 @@ class <lambda>(torch.nn.Module):
 
         fn(torch.ones(2, 2, device=device))
 
-    @onlyAccelerator
     def test_stream_with_mutation(self, device):
         def fn(x, y):
             s2 = torch.Stream(device=device)
@@ -461,7 +572,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_stream_backward_simple(self, device) -> None:
         def fn(x, y):
             s2 = torch.Stream(device=device)
@@ -542,7 +652,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_stream_backward_sync(self, device) -> None:
         def fn(x, y):
             s2 = torch.Stream(device=device)
@@ -663,7 +772,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_event_tracing(self, device):
         def fn(x) -> None:
             e = torch.Event(device=device)
@@ -694,7 +802,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_run_opcheck_fork_join(self, device):
         from torch._dynamo.variables.streams import fork_stream, join_stream
         from torch.library import opcheck
@@ -716,7 +823,6 @@ class <lambda>(torch.nn.Module):
             torch.accelerator.set_stream(original_stream)
             reset_user_object_tracking()
 
-    @onlyAccelerator
     def test_run_opcheck_wait_record(self, device):
         from torch._dynamo.variables.streams import record_event, wait_event
         from torch.library import opcheck
@@ -740,7 +846,6 @@ class <lambda>(torch.nn.Module):
             torch.accelerator.set_stream(original_stream)
             reset_user_object_tracking()
 
-    @onlyAccelerator
     def test_run_opcheck_wait_record_stream(self, device):
         from torch._dynamo.variables.streams import wait_stream
         from torch.library import opcheck
@@ -760,7 +865,6 @@ class <lambda>(torch.nn.Module):
         finally:
             reset_user_object_tracking()
 
-    @onlyAccelerator
     def test_record_stream_problem_basic(self, device):
         # see https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html#torch.Tensor.record_stream
         # for what this tests/solves for
@@ -854,7 +958,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_record_stream_problem_interleaved(self, device):
         # see https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html#torch.Tensor.record_stream
         # for what this tests/solves for
@@ -1111,7 +1214,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_epilogue_copy_streams_inference(self, device):
         def fn(x):
             with torch.Stream(device=device):
@@ -1143,7 +1245,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_epilogue_copy_streams_external(self, device):
         @torch.compile(backend="eager")
         def fn(x):
@@ -1159,7 +1260,6 @@ class <lambda>(torch.nn.Module):
         ):
             extract_graph(fn, *inp)
 
-    @onlyAccelerator
     def test_control_deps_wrapping_record_event(self, device) -> None:
         """Test wrapping record_event with control_deps on a two-stream graph.
 
@@ -1225,7 +1325,6 @@ class <lambda>(torch.nn.Module):
         wait_ctrl_node = control_deps_nodes[1]
         self.assertIn(record_ctrl_node, wait_ctrl_node.args[0])
 
-    @onlyAccelerator
     def test_control_deps_wrapping_wait_event(self, device) -> None:
         """Test wrapping wait_event with control_deps on a two-stream graph.
 
@@ -1274,7 +1373,6 @@ class <lambda>(torch.nn.Module):
         )
         self.assertEqual(len(control_deps_nodes), 2)
 
-    @onlyAccelerator
     def test_control_deps_prevents_invalid_reordering(self, device) -> None:
         """
         Test that control_deps creates proper data dependencies that prevent invalid reordering.
@@ -1351,7 +1449,6 @@ class <lambda>(torch.nn.Module):
         with self.assertRaises(RuntimeError):
             graph.lint()
 
-    @onlyAccelerator
     def test_cross_event_deps_multiple_events(self, device) -> None:
         """Stress test: multiple events across three streams.
 
@@ -1449,7 +1546,6 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    @onlyAccelerator
     def test_cross_event_deps_event_reuse(self, device) -> None:
         """Test that reusing an event updates the cross-event dependency.
 
@@ -1951,7 +2047,6 @@ class <lambda>(torch.nn.Module):
         self.assertIs(following_work.args[0].args[0], ctrl)
         graph.lint()
 
-    @onlyAccelerator
     def test_epilogue_copy_stream_tracking(self, device):
         """
         Test that epilogue copies for mutated inputs use the correct stream.
@@ -2035,7 +2130,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_inductor_lowering(self, device):
         with patch("torch._inductor.config.implicit_fallbacks", False):
 
@@ -2049,27 +2143,6 @@ class GraphModule(torch.nn.Module):
             inp = (torch.ones(2, 2, device=device),)
             fn(*inp)
 
-    def test_is_marked_side_effectful(self):
-        self.assertIn(
-            torch.ops.streams.fork.default, torch.fx.node._side_effectful_functions
-        )
-        self.assertIn(
-            torch.ops.streams.join.default, torch.fx.node._side_effectful_functions
-        )
-        self.assertIn(
-            torch.ops.streams.wait_event.default,
-            torch.fx.node._side_effectful_functions,
-        )
-        self.assertIn(
-            torch.ops.streams.record_event.default,
-            torch.fx.node._side_effectful_functions,
-        )
-        self.assertIn(
-            torch.ops.streams.synchronize_event.default,
-            torch.fx.node._side_effectful_functions,
-        )
-
-    @onlyAccelerator
     def test_backward_sync_control_deps_e2e(self, device) -> None:
         """
         End-to-end test verifying that backward sync nodes are wrapped with control_deps.
@@ -2120,110 +2193,6 @@ class GraphModule(torch.nn.Module):
             "Expected control_deps nodes in backward graph for stream synchronization",
         )
 
-    def test_sync_dealloc_has_fake_impl(self):
-        """Test that sync_dealloc has a registered fake impl.
-
-        Without a fake impl, Inductor's backward compilation crashes when the
-        backward graph contains cross-stream sync_dealloc ops.
-        """
-        from torch._subclasses.fake_tensor import FakeTensorMode
-
-        with FakeTensorMode():
-            t = torch.randn(4)
-            # Should not raise "no fake impl registered"
-            torch.ops.streams.sync_dealloc.default(0, 1, t)
-
-    def test_record_stream_has_fake_impl(self):
-        """Test that record_stream's fake impl has the correct signature."""
-        from torch._subclasses.fake_tensor import FakeTensorMode
-
-        with FakeTensorMode():
-            t = torch.randn(4)
-            # Should not raise due to signature mismatch
-            torch.ops.streams.record_stream.default(t, 0)
-
-    def test_expand_dict_returning_deps_triton_kernel(self) -> None:
-        """Triton kernel dicts must not be passed through control_deps.
-
-        triton_kernel_wrapper_functional returns a dict.  If the dict node is
-        threaded through control_deps as a pass-through value,
-        decompose_triton_kernel_wrapper_functional later replaces it with a
-        raw Python dict (via replace_with_graph -> replace_all_uses_with),
-        corrupting the graph and causing KeyError during lowering.
-
-        _expand_dict_returning_deps should insert per-key getitem nodes
-        *before* the sync so that only tensor-valued nodes are passed through.
-        """
-        import operator
-
-        from torch._functorch._aot_autograd.streams import _expand_dict_returning_deps
-
-        graph = torch.fx.Graph()
-        # Placeholder input
-        x = graph.placeholder("x")
-        x.meta["val"] = torch.empty(4, 4)
-
-        # Simulate a triton_kernel_wrapper_functional call returning a dict
-        triton_func = graph.call_function(
-            torch.ops.higher_order.triton_kernel_wrapper_functional,
-            kwargs={
-                "kernel_idx": 0,
-                "constant_args_idx": 0,
-                "grid": [(1, 1, 1)],
-                "tma_descriptor_metadata": {},
-                "kwargs": {"Out": x},
-                "tensors_to_clone": ["Out"],
-            },
-        )
-        triton_func.meta["val"] = {"Out": torch.empty(4, 4)}
-
-        # Simulate a sync node (record_event) between triton_func and getitem
-        sync_node = graph.call_function(
-            torch.ops.streams.record_event.default,
-            args=(0, 0),
-        )
-
-        # getitem user AFTER the sync -- this is the problematic pattern
-        getitem_out = graph.call_function(
-            operator.getitem,
-            args=(triton_func, "Out"),
-        )
-        getitem_out.meta["val"] = torch.empty(4, 4)
-
-        # Use getitem_out so it's live
-        add_node = graph.call_function(torch.ops.aten.add.Tensor, args=(getitem_out, x))
-        graph.output(add_node)
-
-        # Build visited set: everything at or before sync_node
-        visited: set[torch.fx.Node] = set()
-        for n in graph.nodes:
-            visited.add(n)
-            if n is sync_node:
-                break
-
-        # deps_with_uses_after_sync: triton_func has getitem_out as after-sync user
-        deps = [triton_func]
-
-        expanded = _expand_dict_returning_deps(deps, visited, graph, sync_node)
-
-        # The triton_func dict should NOT be in the expanded list
-        self.assertNotIn(triton_func, expanded)
-
-        # Instead, we should have a new getitem node for key "Out"
-        self.assertEqual(len(expanded), 1)
-        new_gi = expanded[0]
-        self.assertEqual(new_gi.target, operator.getitem)
-        self.assertEqual(new_gi.args, (triton_func, "Out"))
-
-        # The new getitem should be BEFORE the sync in graph order
-        node_order = list(graph.nodes)
-        self.assertLess(node_order.index(new_gi), node_order.index(sync_node))
-
-        # The old getitem_out should have been erased; add_node now uses new_gi
-        self.assertNotIn(getitem_out, set(graph.nodes))
-        self.assertIn(new_gi, add_node.all_input_nodes)
-
-    @onlyAccelerator
     def test_record_stream(self, device):
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
 
@@ -2242,7 +2211,6 @@ class GraphModule(torch.nn.Module):
         )
         self.assertTrue(found, "record_stream op not found in graph")
 
-    @onlyAccelerator
     def test_event_record_after_input_mutation_errors(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2257,7 +2225,6 @@ class GraphModule(torch.nn.Module):
                 torch.ones(2, 2, device=device)
             )
 
-    @onlyAccelerator
     def test_event_record_after_input_mutation_stack_traces(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2279,7 +2246,6 @@ class GraphModule(torch.nn.Module):
             self.assertIn("Event record occurred here:", msg)
             self.assertIn("e.record()", msg)
 
-    @onlyAccelerator
     def test_event_record_after_input_mutation_record_event(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2293,7 +2259,6 @@ class GraphModule(torch.nn.Module):
                 torch.ones(2, 2, device=device)
             )
 
-    @onlyAccelerator
     def test_event_record_after_input_mutation_through_view(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2309,7 +2274,6 @@ class GraphModule(torch.nn.Module):
                 torch.ones(2, 2, device=device)
             )
 
-    @onlyAccelerator
     def test_event_record_after_input_mutation_input_event(self, device):
         def fn(x, e):
             s = torch.Stream(device=device)
@@ -2324,7 +2288,6 @@ class GraphModule(torch.nn.Module):
                 torch.Event(device=device),
             )
 
-    @onlyAccelerator
     def test_event_record_before_input_mutation_no_error(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2338,7 +2301,6 @@ class GraphModule(torch.nn.Module):
             torch.ones(2, 2, device=device)
         )
 
-    @onlyAccelerator
     def test_event_record_on_different_stream_no_error(self, device):
         def fn(x):
             s0 = torch.Stream(device=device)
@@ -2354,7 +2316,6 @@ class GraphModule(torch.nn.Module):
             torch.ones(2, 2, device=device)
         )
 
-    @onlyAccelerator
     def test_event_not_returned_no_error(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2373,7 +2334,6 @@ class GraphModule(torch.nn.Module):
         IS_LINUX or IS_MACOS or TEST_WITH_ROCM or IS_WINDOWS,
         "https://github.com/pytorch/pytorch/issues/178155",
     )
-    @onlyAccelerator
     @unittest.skip("https://github.com/pytorch/pytorch/issues/177771")
     def test_backend_event_record_on_stream(self, device):
         """Backend Event should be accepted by torch.Stream.record_event (C++ type check)."""
@@ -2384,7 +2344,6 @@ class GraphModule(torch.nn.Module):
         e = device_mod.Event()
         s.record_event(e)
 
-    @onlyAccelerator
     def test_event_synchronize_tracing(self, device):
         def fn(x):
             e = torch.Event(device=device)
@@ -2425,7 +2384,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_event_synchronize_inductor_lowering(self, device):
         with patch("torch._inductor.config.implicit_fallbacks", False):
 
@@ -2440,7 +2398,6 @@ class <lambda>(torch.nn.Module):
             inp = (torch.ones(2, 2, device=device),)
             fn(*inp)
 
-    @onlyAccelerator
     def test_control_deps_wrapping_synchronize_event(self, device) -> None:
         """Test that synchronize_event threads recorded ops' values through.
 
@@ -2558,7 +2515,6 @@ class <lambda>(torch.nn.Module):
             "mul should depend on synchronize_event's getitem, not record_event's",
         )
 
-    @onlyAccelerator
     def test_external_event_synchronize_threads_inputs(self, device) -> None:
         """When the event was recorded externally, synchronize threads graph inputs through."""
 
@@ -2624,7 +2580,6 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    @onlyAccelerator
     def test_event_synchronize_control_deps_e2e(self, device):
         """E2E: compute → record → synchronize → use result through torch.compile."""
 
@@ -2641,7 +2596,6 @@ class <lambda>(torch.nn.Module):
         compiled_result = torch.compile(f)(inp)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(eager_result, compiled_result)
 
-    @onlyAccelerator
     def test_event_synchronize_e2e(self, device):
         def f(a_list):
             a_cpu_list = []
@@ -2666,7 +2620,6 @@ class <lambda>(torch.nn.Module):
         compiled_result = f_compiled(inputs)
         self.assertEqual(eager_result, compiled_result)
 
-    @onlyAccelerator
     def test_event_record_wait_on_default_stream(self, device):
         device_mod = getattr(torch, torch.device(device).type, None)
         if device_mod is None or not hasattr(device_mod, "Event"):
@@ -2685,7 +2638,6 @@ class <lambda>(torch.nn.Module):
         compiled_result = f_compiled(x)
         self.assertEqual(eager_result, compiled_result)
 
-    @onlyAccelerator
     def test_record_stream_inductor_output_code(self, device) -> None:
         """Verify record_stream is ordered between the producing kernel and the
         consuming kernel in inductor-generated wrapper code."""
@@ -2710,7 +2662,6 @@ class <lambda>(torch.nn.Module):
             "torch.ops.streams.record_stream.default("
         ).check("return").run(code)
 
-    @onlyAccelerator
     def test_del_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream(device=device)
@@ -2737,7 +2688,6 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @onlyAccelerator
     def test_del_same_stream_no_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream(device=device)
@@ -2762,7 +2712,6 @@ class <lambda>(torch.nn.Module):
         graph_str = print_graph(fw_graphs[0])
         self.assertNotIn("sync_dealloc", graph_str)
 
-    @onlyAccelerator
     def test_del_single_stream_no_sync_dealloc(self, device):
         def fn(x, y):
             z = torch.add(x, y)
@@ -2782,7 +2731,6 @@ class <lambda>(torch.nn.Module):
         graph_str = print_graph(fw_graphs[0])
         self.assertNotIn("sync_dealloc", graph_str)
 
-    @onlyAccelerator
     def test_del_attr_multi_stream_sync_dealloc(self, device):
         class Holder:
             pass
@@ -2814,7 +2762,6 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @onlyAccelerator
     def test_del_subscr_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream(device=device)
@@ -2842,7 +2789,6 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @onlyAccelerator
     def test_current_stream_with_entered_stream(self, device):
         """Verify that torch.accelerator.current_stream().stream_id returns the
         correct value when inside a stream context for a user-created stream."""
@@ -2856,7 +2802,6 @@ class <lambda>(torch.nn.Module):
         compiled = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(compiled(x, s), fn(x, s))
 
-    @onlyAccelerator
     def test_recorded_events_append_runtime_objects(self, device):
         events = []
 
@@ -2893,7 +2838,9 @@ class <lambda>(torch.nn.Module):
         self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
 
 
-instantiate_device_type_tests(TestStreams, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestStreams, globals(), allow_xpu=True, except_for=("cpu",)
+)
 
 
 @requires_cuda
@@ -3005,7 +2952,7 @@ class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
         self.assertEqual(actual_default, default_s.cuda_stream)
 
 
-@unittest.skipUnless(TEST_XPU, "xpu only")
+@requires_xpu
 class TestStreamsXPUSpecific(torch._dynamo.test_case.TestCase):
     def test_dynamo_registry_no_dangling_weakref(self):
         reset_user_object_tracking()

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -2881,7 +2881,9 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @requires_cuda
+
+@requires_cuda
+class TestStreamsCUDA(torch._dynamo.test_case.TestCase):
     def test_stream_pointer_extraction_edge_cases(self):
         def get_ptrs(stream_a, stream_b, default_stream):
             return (

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -15,13 +15,16 @@ from torch._dynamo.graph_bytecode_inputs import (
     store_user_object_weakrefs,
 )
 from torch._dynamo.testing import extract_graph, remove_trailing_space
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     IS_LINUX,
     IS_MACOS,
     IS_WINDOWS,
     requires_cuda,
     TEST_WITH_ROCM,
-    TEST_XPU,
 )
 
 
@@ -52,12 +55,12 @@ class TestStreams(torch._dynamo.test_case.TestCase):
     def tearDownClass(cls):
         super().tearDownClass()
 
-    @requires_cuda
+    @onlyAccelerator
     def test_stream_weakref(self):
         s = torch.Stream()
         weakref.ref(s)
 
-    @requires_cuda
+    @onlyAccelerator
     def test_event_weakref(self):
         e = torch.Event()
         weakref.ref(e)
@@ -85,27 +88,29 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         self.assertEqual(called, [True])
         del _weakref_keepalive
 
-    @requires_cuda
-    def test_cuda_stream_event_weakref_callback(self):
-        self._assert_weakref_callback_fires(torch.cuda.Stream)
-        self._assert_weakref_callback_fires(torch.cuda.Event)
+    @onlyAccelerator
+    def test_backend_stream_event_weakref_callback(self, device):
+        device_mod = getattr(torch, torch.device(device).type, None)
+        if (
+            device_mod is None
+            or not hasattr(device_mod, "Stream")
+            or not hasattr(device_mod, "Event")
+        ):
+            self.skipTest(f"No backend-specific Stream/Event for {device}")
+        self._assert_weakref_callback_fires(device_mod.Stream)
+        self._assert_weakref_callback_fires(device_mod.Event)
 
-    @unittest.skipUnless(TEST_XPU, "xpu only")
-    def test_xpu_stream_event_weakref_callback(self):
-        self._assert_weakref_callback_fires(torch.xpu.Stream)
-        self._assert_weakref_callback_fires(torch.xpu.Event)
-
-    @requires_cuda
-    def test_dynamo_registry_no_dangling_weakref(self):
+    @onlyAccelerator
+    def test_dynamo_registry_no_dangling_weakref(self, device):
         """Natural repro of the original UAF pattern.
 
         `torch.compile(fn, backend="eager")` with `fn` referencing
-        `torch.cuda.current_stream()` causes dynamo to register a
+        `torch.accelerator.current_stream()` causes dynamo to register a
         weakref to the captured stream in
         `index_to_external_object_weakref` (via
         `store_user_object_weakrefs`, which does NOT pin via
         `keep_alive`).  As soon as `fn` returns, the captured wrapper
-        has no strong references and is freed via `THCPStream_dealloc`.
+        has no strong references and is freed via tp_dealloc.
 
         At that point the patched tp_dealloc must call
         `PyObject_ClearWeakRefs`, otherwise the registry now holds a
@@ -120,9 +125,9 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         reset_user_object_tracking()
 
         def fn(x):
-            return torch.cuda.current_stream().cuda_stream
+            return torch.accelerator.current_stream().stream_id
 
-        x = torch.zeros(1, device="cuda")
+        x = torch.zeros(1, device=device)
         compiled = torch.compile(fn, backend="eager", fullgraph=True)
         compiled(x)
         del compiled
@@ -151,7 +156,7 @@ class TestStreams(torch._dynamo.test_case.TestCase):
             "clear it, otherwise the registry retains a dangling pointer",
         )
 
-    @requires_cuda
+    @onlyAccelerator
     def test_stream_enter_exit(self):
         def fn(x, y, s1, s2):
             with s1:
@@ -190,7 +195,7 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
+    @onlyAccelerator
     @unittest.skip("Needs graph break support with annotation context")
     def test_stream_context_graph_break(self):
         def fn(x, y):
@@ -219,20 +224,20 @@ class <lambda>(torch.nn.Module):
         self.assertExpectedInline(print_graph(fw_graphs[0]), """""")
         self.assertExpectedInline(print_graph(fw_graphs[1]), """""")
 
-    @requires_cuda
-    def test_stream_input(self):
+    @onlyAccelerator
+    def test_stream_input(self, device):
         def fn(x, y, s):
             z = torch.add(x, y)
             y = z + 2
             return y, s
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2), torch.Stream(device="cuda"))
+        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2), torch.Stream(device=device))
         expected = fn(*inp)
         fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         actual = fn_opt(*inp)
         self.assertEqual(expected, actual)
 
-    @requires_cuda
+    @onlyAccelerator
     def test_local_stream_return(self):
         def fn(x, y):
             s = torch.Stream()
@@ -260,14 +265,14 @@ class <lambda>(torch.nn.Module):
         res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent())
         self.assertEqual(res, torch.ones(2))
 
-    @requires_cuda
-    def test_get_current_stream_return(self):
+    @onlyAccelerator
+    def test_get_current_stream_return(self, device):
         def fn(x, s):
             with s:
                 s0 = torch.accelerator.current_stream()
             return x, s0
 
-        s_inp = torch.Stream(device="cuda")
+        s_inp = torch.Stream(device=device)
         inp = (torch.ones(2, 2) + 1, s_inp)
         fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         _, s0 = fn_opt(*inp)
@@ -275,59 +280,33 @@ class <lambda>(torch.nn.Module):
         self.assertEqual(s_inp, s0)
         self.assertEqual(s0, s1)
 
-    @requires_cuda
-    def test_cuda_current_stream_attrs(self):
-        """Verify that torch.cuda.current_stream() attributes are accessible
+    @onlyAccelerator
+    def test_current_stream_attrs(self, device):
+        """Verify that accelerator current_stream() attributes are accessible
         under torch.compile and match eager behavior."""
 
-        def fn_cuda_stream(x):
-            return torch.cuda.current_stream().cuda_stream
+        def fn_stream(x):
+            return torch.accelerator.current_stream().stream_id
 
-        x = torch.zeros(1, device="cuda")
-        compiled = torch.compile(fn_cuda_stream, backend="eager", fullgraph=True)
-        self.assertEqual(compiled(x), fn_cuda_stream(x))
+        x = torch.zeros(1, device=device)
+        compiled = torch.compile(fn_stream, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x), fn_stream(x))
 
-    @unittest.skipIf(not TEST_XPU, "XPU is not available")
-    def test_xpu_current_stream_attrs(self):
-        """Verify that torch.xpu.current_stream() attributes are accessible
-        under torch.compile and match eager behavior."""
-
-        def fn_xpu_stream(x):
-            return torch.xpu.current_stream().sycl_queue
-
-        x = torch.zeros(1, device="xpu")
-        compiled = torch.compile(fn_xpu_stream, backend="eager", fullgraph=True)
-        self.assertEqual(compiled(x), fn_xpu_stream(x))
-
-    @requires_cuda
-    def test_cuda_current_stream_with_entered_stream(self):
-        """Verify that torch.cuda.current_stream().cuda_stream returns the
-        correct value when inside a stream context for a user-created stream."""
+    @onlyAccelerator
+    def test_current_stream_with_entered_stream(self, device):
+        """Verify that current_stream().stream_id returns the correct value
+        when inside a stream context for a user-created stream."""
 
         def fn(x, s):
             with s:
-                return torch.cuda.current_stream().cuda_stream
+                return torch.accelerator.current_stream().stream_id
 
-        s = torch.cuda.Stream()
-        x = torch.zeros(1, device="cuda")
+        s = torch.Stream(device=device)
+        x = torch.zeros(1, device=device)
         compiled = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(compiled(x, s), fn(x, s))
 
-    @unittest.skipIf(not TEST_XPU, "XPU is not available")
-    def test_xpu_current_stream_with_entered_stream(self):
-        """Verify that torch.xpu.current_stream().sycl_queue returns the
-        correct value when inside a stream context for a user-created stream."""
-
-        def fn(x, s):
-            with s:
-                return torch.xpu.current_stream().sycl_queue
-
-        s = torch.xpu.Stream()
-        x = torch.zeros(1, device="xpu")
-        compiled = torch.compile(fn, backend="eager", fullgraph=True)
-        self.assertEqual(compiled(x, s), fn(x, s))
-
-    @requires_cuda
+    @onlyAccelerator
     def test_nested_stream_enter_exit(self):
         def fn(x, y, s0, s1, s2):
             with s1:
@@ -381,7 +360,7 @@ class <lambda>(torch.nn.Module):
     def test_nested_stream_enter_exit_graph_break(self):
         pass
 
-    @requires_cuda
+    @onlyAccelerator
     def test_local_stream_enter_exit(self):
         def fn(x, y):
             s2 = torch.Stream()
@@ -422,7 +401,7 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
+    @onlyAccelerator
     def test_local_stream_nested_enter_exit(self):
         def fn(x, y):
             s2 = torch.Stream()
@@ -465,8 +444,8 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_new_stream_api(self) -> None:
+    @onlyAccelerator
+    def test_new_stream_api(self, device) -> None:
         from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
         from torch._dynamo.variables.streams import new_stream
 
@@ -488,10 +467,10 @@ class <lambda>(torch.nn.Module):
         def fn(x):
             return x + 1
 
-        fn(torch.ones(2, 2, device="cuda:0"))
+        fn(torch.ones(2, 2, device=device))
 
-    @requires_cuda
-    def test_current_stream_api(self) -> None:
+    @onlyAccelerator
+    def test_current_stream_api(self, device) -> None:
         from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
         from torch._dynamo.variables.streams import get_current_stream
 
@@ -500,7 +479,7 @@ class <lambda>(torch.nn.Module):
 
         def stream_generation_backend(gm, *args, **kwargs):  # type: ignore[no-untyped-def]
             nonlocal s0
-            s0_ind = get_current_stream(torch.device("cuda:0"))
+            s0_ind = get_current_stream(torch.device(device))
             self.assertEqual(get_external_object_by_index(s0_ind), cur_stream)
             with gm.graph.inserting_after(next(iter(gm.graph.nodes))):
                 gm.graph.call_function(
@@ -519,9 +498,9 @@ class <lambda>(torch.nn.Module):
         def fn(x):
             return x + 1
 
-        fn(torch.ones(2, 2, device="cuda:0"))
+        fn(torch.ones(2, 2, device=device))
 
-    @requires_cuda
+    @onlyAccelerator
     def test_stream_with_mutation(self):
         def fn(x, y):
             s2 = torch.Stream()
@@ -571,7 +550,7 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
+    @onlyAccelerator
     def test_stream_backward_simple(self) -> None:
         def fn(x, y):
             s2 = torch.Stream()
@@ -652,8 +631,8 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_stream_backward_sync(self) -> None:
+    @onlyAccelerator
+    def test_stream_backward_sync(self, device) -> None:
         def fn(x, y):
             s2 = torch.Stream()
             s0 = torch.Stream()
@@ -665,8 +644,8 @@ class GraphModule(torch.nn.Module):
             return y0, z
 
         inp = (
-            torch.ones(2, 2, device="cuda:0", requires_grad=True) + 1,
-            torch.ones(2, 2, device="cuda:0", requires_grad=True),
+            torch.ones(2, 2, device=device, requires_grad=True) + 1,
+            torch.ones(2, 2, device=device, requires_grad=True),
         )
         torch.cuda.synchronize()
         expected = fn(*inp)
@@ -773,15 +752,15 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_event_tracing(self):
+    @onlyAccelerator
+    def test_event_tracing(self, device):
         def fn(x) -> None:
             e = torch.Event()
             e.record()
             x.add_(1)
             return x
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -835,8 +814,8 @@ class <lambda>(torch.nn.Module):
         self.assertIsInstance(events[1], torch.Event)
         self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
 
-    @requires_cuda
-    def test_run_opcheck_fork_join(self):
+    @onlyAccelerator
+    def test_run_opcheck_fork_join(self, device):
         from torch._dynamo.variables.streams import fork_stream, join_stream
         from torch.library import opcheck
 
@@ -857,7 +836,7 @@ class <lambda>(torch.nn.Module):
             torch.accelerator.set_stream(original_stream)
             reset_user_object_tracking()
 
-    @requires_cuda
+    @onlyAccelerator
     def test_run_opcheck_wait_record(self):
         from torch._dynamo.variables.streams import record_event, wait_event
         from torch.library import opcheck
@@ -881,7 +860,7 @@ class <lambda>(torch.nn.Module):
             torch.accelerator.set_stream(original_stream)
             reset_user_object_tracking()
 
-    @requires_cuda
+    @onlyAccelerator
     def test_run_opcheck_wait_record_stream(self):
         from torch._dynamo.variables.streams import wait_stream
         from torch.library import opcheck
@@ -901,26 +880,26 @@ class <lambda>(torch.nn.Module):
         finally:
             reset_user_object_tracking()
 
-    @requires_cuda
-    def test_record_stream_problem_basic(self):
+    @onlyAccelerator
+    def test_record_stream_problem_basic(self, device):
         # see https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html#torch.Tensor.record_stream
         # for what this tests/solves for
         # We expect there to be a sync_dealloc op added to the graph for y
         # synchronizing the first stream w/ the second stream after the second stream is finished
         def fn(x):
             e = torch.Event()
-            with torch.Stream(device="cuda:0"):
-                y = torch.ones(2, 2, device="cuda:0")
+            with torch.Stream(device=device):
+                y = torch.ones(2, 2, device=device)
                 e.record()
                 z = y * x
 
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 e.wait()
                 z0 = y * 2 * x
 
             return z0, z
 
-        inp = (torch.ones(2, 2, device="cuda", requires_grad=True),)
+        inp = (torch.ones(2, 2, device=device, requires_grad=True),)
         (
             actual,
             _,
@@ -995,8 +974,8 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_record_stream_problem_interleaved(self):
+    @onlyAccelerator
+    def test_record_stream_problem_interleaved(self, device):
         # see https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html#torch.Tensor.record_stream
         # for what this tests/solves for
         # This will have interleaved computation where y is
@@ -1004,22 +983,22 @@ class GraphModule(torch.nn.Module):
         # used on the first stream again then finally used on the last stream
         def fn(x):
             e = torch.Event()
-            with torch.Stream(device="cuda:0"):
-                y = torch.ones(2, 2, device="cuda:0")
+            with torch.Stream(device=device):
+                y = torch.ones(2, 2, device=device)
                 z = y * x
                 e.record()
 
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 e.wait()
                 z0 = y * 2 * z
                 e.record()
 
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 e.wait()
                 z1 = y * x * z0
                 e.record()
 
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 e.wait()
                 z2 = y * 4 * z1
                 e.record()
@@ -1027,7 +1006,7 @@ class GraphModule(torch.nn.Module):
             e.wait()
             return z, z1, z2
 
-        inp = (torch.ones(2, 2, device="cuda", requires_grad=True),)
+        inp = (torch.ones(2, 2, device=device, requires_grad=True),)
         (
             actual,
             _,
@@ -1252,16 +1231,16 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_epilogue_copy_streams_inference(self):
+    @onlyAccelerator
+    def test_epilogue_copy_streams_inference(self, device):
         def fn(x):
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 with torch.no_grad():
                     x.add_(2)
 
             return x
 
-        x = torch.ones(2, 2, requires_grad=True, device="cuda:0")
+        x = torch.ones(2, 2, requires_grad=True, device=device)
 
         inp = (x,)
         (
@@ -1284,15 +1263,15 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_epilogue_copy_streams_external(self):
+    @onlyAccelerator
+    def test_epilogue_copy_streams_external(self, device):
         @torch.compile(backend="eager")
         def fn(x):
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 x.mul_(3)
             return x.sin()
 
-        x = torch.ones(2, 2, requires_grad=True, device="cuda:0")
+        x = torch.ones(2, 2, requires_grad=True, device=device)
         inp = (x.clone(),)
         with self.assertRaisesRegex(
             RuntimeError,
@@ -1300,8 +1279,8 @@ class <lambda>(torch.nn.Module):
         ):
             extract_graph(fn, *inp)
 
-    @requires_cuda
-    def test_control_deps_wrapping_record_event(self) -> None:
+    @onlyAccelerator
+    def test_control_deps_wrapping_record_event(self, device) -> None:
         """Test wrapping record_event with control_deps on a two-stream graph.
 
         The producer stream has work before the record_event, so control_deps
@@ -1309,8 +1288,8 @@ class <lambda>(torch.nn.Module):
         """
 
         def fn(x) -> torch.Tensor:
-            s1 = torch.Stream(device="cuda")
-            s2 = torch.Stream(device="cuda")
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
             e = torch.Event()
 
             with s1:
@@ -1324,7 +1303,7 @@ class <lambda>(torch.nn.Module):
 
             return w
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -1366,8 +1345,8 @@ class <lambda>(torch.nn.Module):
         wait_ctrl_node = control_deps_nodes[1]
         self.assertIn(record_ctrl_node, wait_ctrl_node.args[0])
 
-    @requires_cuda
-    def test_control_deps_wrapping_wait_event(self) -> None:
+    @onlyAccelerator
+    def test_control_deps_wrapping_wait_event(self, device) -> None:
         """Test wrapping wait_event with control_deps on a two-stream graph.
 
         The consumer stream has the wait_event, and there should be same-stream
@@ -1375,8 +1354,8 @@ class <lambda>(torch.nn.Module):
         """
 
         def fn(x) -> torch.Tensor:
-            s1 = torch.Stream(device="cuda")
-            s2 = torch.Stream(device="cuda")
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
             e = torch.Event()
 
             with s1:
@@ -1390,7 +1369,7 @@ class <lambda>(torch.nn.Module):
 
             return z
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -1415,8 +1394,8 @@ class <lambda>(torch.nn.Module):
         )
         self.assertEqual(len(control_deps_nodes), 2)
 
-    @requires_cuda
-    def test_control_deps_prevents_invalid_reordering(self) -> None:
+    @onlyAccelerator
+    def test_control_deps_prevents_invalid_reordering(self, device) -> None:
         """
         Test that control_deps creates proper data dependencies that prevent invalid reordering.
 
@@ -1427,8 +1406,8 @@ class <lambda>(torch.nn.Module):
         """
 
         def fn(x) -> torch.Tensor:
-            s1 = torch.Stream(device="cuda")
-            s2 = torch.Stream(device="cuda")
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
             e = torch.Event()
 
             with s1:
@@ -1442,7 +1421,7 @@ class <lambda>(torch.nn.Module):
 
             return w
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -1492,8 +1471,8 @@ class <lambda>(torch.nn.Module):
         with self.assertRaises(RuntimeError):
             graph.lint()
 
-    @requires_cuda
-    def test_cross_event_deps_multiple_events(self) -> None:
+    @onlyAccelerator
+    def test_cross_event_deps_multiple_events(self, device) -> None:
         """Stress test: multiple events across three streams.
 
         Verifies that each wait_event's control_deps node depends on exactly
@@ -1507,9 +1486,9 @@ class <lambda>(torch.nn.Module):
         """
 
         def fn(x) -> torch.Tensor:
-            s1 = torch.Stream(device="cuda")
-            s2 = torch.Stream(device="cuda")
-            s3 = torch.Stream(device="cuda")
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
+            s3 = torch.Stream(device=device)
             e1 = torch.Event()
             e2 = torch.Event()
 
@@ -1529,7 +1508,7 @@ class <lambda>(torch.nn.Module):
 
             return a + b + y + z
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         # Patch out wrapping so we get the raw graph to manually wrap below.
         with patch(
             "torch._functorch._aot_autograd.graph_capture.wrap_all_sync_nodes_with_control_deps"
@@ -1590,18 +1569,18 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    @requires_cuda
-    def test_cross_event_deps_event_reuse(self) -> None:
+    @onlyAccelerator
+    def test_cross_event_deps_event_reuse(self, device) -> None:
         """Test that reusing an event updates the cross-event dependency.
 
         When the same event is recorded twice with work in between, the wait
-        should depend on the LAST record's control_deps node (matching CUDA
+        should depend on the LAST record's control_deps node (matching stream
         semantics where record() overwrites the event).
         """
 
         def fn(x) -> torch.Tensor:
-            s1 = torch.Stream(device="cuda")
-            s2 = torch.Stream(device="cuda")
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
             e = torch.Event()
 
             with s1:
@@ -1616,7 +1595,7 @@ class <lambda>(torch.nn.Module):
 
             return w + z
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -2092,8 +2071,8 @@ class <lambda>(torch.nn.Module):
         self.assertIs(following_work.args[0].args[0], ctrl)
         graph.lint()
 
-    @requires_cuda
-    def test_epilogue_copy_stream_tracking(self):
+    @onlyAccelerator
+    def test_epilogue_copy_stream_tracking(self, device):
         """
         Test that epilogue copies for mutated inputs use the correct stream.
         This verifies that ViewAndMutationMeta.mutated_inp_stream_indices is
@@ -2106,8 +2085,8 @@ class <lambda>(torch.nn.Module):
             @staticmethod
             def forward(ctx, x, y):
                 ctx.save_for_backward(x)
-                ctx.s1 = torch.Stream(device="cuda:0")
-                ctx.s2 = torch.Stream(device="cuda:0")
+                ctx.s1 = torch.Stream(device=x.device)
+                ctx.s2 = torch.Stream(device=x.device)
                 # Do computation on stream s2
                 with ctx.s2:
                     result = x * 2 + y
@@ -2129,8 +2108,8 @@ class <lambda>(torch.nn.Module):
             result = BwMutationWithStream.apply(x, y)
             return result
 
-        x = torch.ones(2, 2, requires_grad=True, device="cuda:0")
-        y = torch.ones(2, 2, requires_grad=True, device="cuda:0")
+        x = torch.ones(2, 2, requires_grad=True, device=device)
+        y = torch.ones(2, 2, requires_grad=True, device=device)
         (
             actual,
             _,
@@ -2176,8 +2155,8 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_inductor_lowering(self):
+    @onlyAccelerator
+    def test_inductor_lowering(self, device):
         with patch("torch._inductor.config.implicit_fallbacks", False):
 
             @torch.compile()  # noqa: UNSPECIFIED_BACKEND
@@ -2187,7 +2166,7 @@ class GraphModule(torch.nn.Module):
                 e.record()
                 return x
 
-            inp = (torch.ones(2, 2, device="cuda"),)
+            inp = (torch.ones(2, 2, device=device),)
             fn(*inp)
 
     def test_is_marked_side_effectful(self):
@@ -2210,8 +2189,8 @@ class GraphModule(torch.nn.Module):
             torch.fx.node._side_effectful_functions,
         )
 
-    @requires_cuda
-    def test_backward_sync_control_deps_e2e(self) -> None:
+    @onlyAccelerator
+    def test_backward_sync_control_deps_e2e(self, device) -> None:
         """
         End-to-end test verifying that backward sync nodes are wrapped with control_deps.
 
@@ -2232,8 +2211,8 @@ class GraphModule(torch.nn.Module):
             return z0, z1
 
         inp = (
-            torch.ones(2, 2, device="cuda:0", requires_grad=True) + 1,
-            torch.ones(2, 2, device="cuda:0", requires_grad=True),
+            torch.ones(2, 2, device=device, requires_grad=True) + 1,
+            torch.ones(2, 2, device=device, requires_grad=True),
         )
 
         (
@@ -2283,8 +2262,8 @@ class GraphModule(torch.nn.Module):
             # Should not raise due to signature mismatch
             torch.ops.streams.record_stream.default(t, 0)
 
-    @requires_cuda
-    def test_record_stream(self):
+    @onlyAccelerator
+    def test_record_stream(self, device):
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
 
         def fn(x):
@@ -2293,7 +2272,7 @@ class GraphModule(torch.nn.Module):
             return x
 
         compiled = torch.compile(fn, backend=backend, fullgraph=True)
-        compiled(torch.randn(4, device="cuda"))
+        compiled(torch.randn(4, device=device))
 
         self.assertEqual(len(backend.graphs), 1)
         found = any(
@@ -2302,8 +2281,8 @@ class GraphModule(torch.nn.Module):
         )
         self.assertTrue(found, "record_stream op not found in graph")
 
-    @requires_cuda
-    def test_event_record_after_input_mutation_errors(self):
+    @onlyAccelerator
+    def test_event_record_after_input_mutation_errors(self, device):
         def fn(x):
             s = torch.Stream()
             e = torch.Event()
@@ -2314,11 +2293,11 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda")
+                torch.ones(2, 2, device=device)
             )
 
-    @requires_cuda
-    def test_event_record_after_input_mutation_stack_traces(self):
+    @onlyAccelerator
+    def test_event_record_after_input_mutation_stack_traces(self, device):
         def fn(x):
             s = torch.Stream()
             e = torch.Event()
@@ -2329,7 +2308,7 @@ class GraphModule(torch.nn.Module):
 
         try:
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda")
+                torch.ones(2, 2, device=device)
             )
             self.fail("Expected RuntimeError")
         except RuntimeError as e:
@@ -2339,8 +2318,8 @@ class GraphModule(torch.nn.Module):
             self.assertIn("Event record occurred here:", msg)
             self.assertIn("e.record()", msg)
 
-    @requires_cuda
-    def test_event_record_after_input_mutation_record_event(self):
+    @onlyAccelerator
+    def test_event_record_after_input_mutation_record_event(self, device):
         def fn(x):
             s = torch.Stream()
             with s:
@@ -2350,11 +2329,11 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda")
+                torch.ones(2, 2, device=device)
             )
 
-    @requires_cuda
-    def test_event_record_after_input_mutation_through_view(self):
+    @onlyAccelerator
+    def test_event_record_after_input_mutation_through_view(self, device):
         def fn(x):
             s = torch.Stream()
             e = torch.Event()
@@ -2366,11 +2345,11 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda")
+                torch.ones(2, 2, device=device)
             )
 
-    @requires_cuda
-    def test_event_record_after_input_mutation_input_event(self):
+    @onlyAccelerator
+    def test_event_record_after_input_mutation_input_event(self, device):
         def fn(x, e):
             s = torch.Stream()
             with s:
@@ -2380,12 +2359,12 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda"),
+                torch.ones(2, 2, device=device),
                 torch.Event(),
             )
 
-    @requires_cuda
-    def test_event_record_before_input_mutation_no_error(self):
+    @onlyAccelerator
+    def test_event_record_before_input_mutation_no_error(self, device):
         def fn(x):
             s = torch.Stream()
             e = torch.Event()
@@ -2395,11 +2374,11 @@ class GraphModule(torch.nn.Module):
             return e
 
         torch.compile(fn, backend="eager", fullgraph=True)(
-            torch.ones(2, 2, device="cuda")
+            torch.ones(2, 2, device=device)
         )
 
-    @requires_cuda
-    def test_event_record_on_different_stream_no_error(self):
+    @onlyAccelerator
+    def test_event_record_on_different_stream_no_error(self, device):
         def fn(x):
             s0 = torch.Stream()
             s1 = torch.Stream()
@@ -2411,11 +2390,11 @@ class GraphModule(torch.nn.Module):
             return e
 
         torch.compile(fn, backend="eager", fullgraph=True)(
-            torch.ones(2, 2, device="cuda")
+            torch.ones(2, 2, device=device)
         )
 
-    @requires_cuda
-    def test_event_not_returned_no_error(self):
+    @onlyAccelerator
+    def test_event_not_returned_no_error(self, device):
         def fn(x):
             s = torch.Stream()
             e = torch.Event()
@@ -2426,24 +2405,26 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda")
+                torch.ones(2, 2, device=device)
             )
 
     @unittest.skipIf(
         IS_LINUX or IS_MACOS or TEST_WITH_ROCM or IS_WINDOWS,
         "https://github.com/pytorch/pytorch/issues/178155",
     )
-    @requires_cuda
+    @onlyAccelerator
     @unittest.skip("https://github.com/pytorch/pytorch/issues/177771")
-    def test_cuda_event_record_on_stream(self):
-        """torch.cuda.Event should be accepted by torch.Stream.record_event (C++ type check)."""
-        s = torch.Stream(device="cuda")
-        e = torch.cuda.Event()
-        # This hits THPStream_record_event in Stream.cpp which does a type check
+    def test_backend_event_record_on_stream(self, device):
+        """Backend Event should be accepted by torch.Stream.record_event (C++ type check)."""
+        device_mod = getattr(torch, torch.device(device).type, None)
+        if device_mod is None or not hasattr(device_mod, "Event"):
+            self.skipTest(f"No backend-specific Event for {device}")
+        s = torch.Stream(device=device)
+        e = device_mod.Event()
         s.record_event(e)
 
-    @requires_cuda
-    def test_event_synchronize_tracing(self):
+    @onlyAccelerator
+    def test_event_synchronize_tracing(self, device):
         def fn(x):
             e = torch.Event()
             e.record()
@@ -2451,7 +2432,7 @@ class GraphModule(torch.nn.Module):
             e.synchronize()
             return x
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -2483,8 +2464,8 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_event_synchronize_inductor_lowering(self):
+    @onlyAccelerator
+    def test_event_synchronize_inductor_lowering(self, device):
         with patch("torch._inductor.config.implicit_fallbacks", False):
 
             @torch.compile()  # noqa: UNSPECIFIED_BACKEND
@@ -2495,11 +2476,11 @@ class <lambda>(torch.nn.Module):
                 e.synchronize()
                 return x
 
-            inp = (torch.ones(2, 2, device="cuda"),)
+            inp = (torch.ones(2, 2, device=device),)
             fn(*inp)
 
-    @requires_cuda
-    def test_control_deps_wrapping_synchronize_event(self) -> None:
+    @onlyAccelerator
+    def test_control_deps_wrapping_synchronize_event(self, device) -> None:
         """Test that synchronize_event threads recorded ops' values through.
 
         After record_event wraps ops in control_deps and produces getitem
@@ -2517,7 +2498,7 @@ class <lambda>(torch.nn.Module):
             z = y * 2
             return z
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         # Patch out wrapping so we get the raw graph to manually wrap below.
         with patch(
             "torch._functorch._aot_autograd.graph_capture.wrap_all_sync_nodes_with_control_deps"
@@ -2616,8 +2597,8 @@ class <lambda>(torch.nn.Module):
             "mul should depend on synchronize_event's getitem, not record_event's",
         )
 
-    @requires_cuda
-    def test_external_event_synchronize_threads_inputs(self) -> None:
+    @onlyAccelerator
+    def test_external_event_synchronize_threads_inputs(self, device) -> None:
         """When the event was recorded externally, synchronize threads graph inputs through."""
 
         def fn(x):
@@ -2628,7 +2609,7 @@ class <lambda>(torch.nn.Module):
             z = y * 2
             return z
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         # Patch out wrapping so we get the raw graph to manually wrap below.
         with patch(
             "torch._functorch._aot_autograd.graph_capture.wrap_all_sync_nodes_with_control_deps"
@@ -2682,8 +2663,8 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    @requires_cuda
-    def test_event_synchronize_control_deps_e2e(self):
+    @onlyAccelerator
+    def test_event_synchronize_control_deps_e2e(self, device):
         """E2E: compute → record → synchronize → use result through torch.compile."""
 
         def f(x):
@@ -2694,13 +2675,13 @@ class <lambda>(torch.nn.Module):
             z = y * 2
             return z
 
-        inp = torch.ones(2, 2, device="cuda")
+        inp = torch.ones(2, 2, device=device)
         eager_result = f(inp)
         compiled_result = torch.compile(f)(inp)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(eager_result, compiled_result)
 
-    @requires_cuda
-    def test_event_synchronize_e2e(self):
+    @onlyAccelerator
+    def test_event_synchronize_e2e(self, device):
         def f(a_list):
             a_cpu_list = []
             a_to_cpu_event_list = []
@@ -2718,15 +2699,18 @@ class <lambda>(torch.nn.Module):
 
         f_compiled = torch.compile(f)  # noqa: UNSPECIFIED_BACKEND
         inputs = [
-            torch.rand(100, dtype=torch.float16, device="cuda") for _ in range(10)
+            torch.rand(100, dtype=torch.float16, device=device) for _ in range(10)
         ]
         eager_result = f(inputs)
         compiled_result = f_compiled(inputs)
         self.assertEqual(eager_result, compiled_result)
 
-    @requires_cuda
-    def test_event_record_wait_on_default_stream(self):
-        e = torch.cuda.Event()
+    @onlyAccelerator
+    def test_event_record_wait_on_default_stream(self, device):
+        device_mod = getattr(torch, torch.device(device).type, None)
+        if device_mod is None or not hasattr(device_mod, "Event"):
+            self.skipTest(f"No backend-specific Event for {device}")
+        e = device_mod.Event()
 
         def f(x):
             y = x + 1
@@ -2735,27 +2719,27 @@ class <lambda>(torch.nn.Module):
             return y + 1
 
         f_compiled = torch.compile(f)  # noqa: UNSPECIFIED_BACKEND
-        x = torch.randn(10, device="cuda")
+        x = torch.randn(10, device=device)
         eager_result = f(x)
         compiled_result = f_compiled(x)
         self.assertEqual(eager_result, compiled_result)
 
-    @requires_cuda
-    def test_record_stream_inductor_output_code(self) -> None:
+    @onlyAccelerator
+    def test_record_stream_inductor_output_code(self, device) -> None:
         """Verify record_stream is ordered between the producing kernel and the
         consuming kernel in inductor-generated wrapper code."""
         from torch._inductor.utils import run_and_get_code
         from torch.testing import FileCheck
 
         def fn(x):
-            s = torch.Stream(device="cuda")
+            s = torch.Stream(device=device)
             y = x + 1
             y.record_stream(s)
             z = y * 2
             return z
 
         compiled = torch.compile(fn, backend="inductor", fullgraph=True)
-        x = torch.randn(1024, device="cuda")
+        x = torch.randn(1024, device=device)
         result, (code,) = run_and_get_code(compiled, x)
         self.assertEqual(result, (x + 1) * 2)
 
@@ -2765,8 +2749,8 @@ class <lambda>(torch.nn.Module):
             "torch.ops.streams.record_stream.default("
         ).check("return").run(code)
 
-    @requires_cuda
-    def test_del_multi_stream_sync_dealloc(self):
+    @onlyAccelerator
+    def test_del_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream()
             e = torch.Event()
@@ -2778,7 +2762,7 @@ class <lambda>(torch.nn.Module):
             del x
             return z0, z
 
-        inp = (torch.ones(2, 2, device="cuda"), torch.ones(2, 2, device="cuda"))
+        inp = (torch.ones(2, 2, device=device), torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -2792,8 +2776,8 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @requires_cuda
-    def test_del_same_stream_no_sync_dealloc(self):
+    @onlyAccelerator
+    def test_del_same_stream_no_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream()
             e = torch.Event()
@@ -2804,7 +2788,7 @@ class <lambda>(torch.nn.Module):
             e.wait()
             return z
 
-        inp = (torch.ones(2, 2, device="cuda"), torch.ones(2, 2, device="cuda"))
+        inp = (torch.ones(2, 2, device=device), torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -2817,14 +2801,14 @@ class <lambda>(torch.nn.Module):
         graph_str = print_graph(fw_graphs[0])
         self.assertNotIn("sync_dealloc", graph_str)
 
-    @requires_cuda
-    def test_del_single_stream_no_sync_dealloc(self):
+    @onlyAccelerator
+    def test_del_single_stream_no_sync_dealloc(self, device):
         def fn(x, y):
             z = torch.add(x, y)
             del x
             return z
 
-        inp = (torch.ones(2, 2, device="cuda"), torch.ones(2, 2, device="cuda"))
+        inp = (torch.ones(2, 2, device=device), torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -2837,8 +2821,8 @@ class <lambda>(torch.nn.Module):
         graph_str = print_graph(fw_graphs[0])
         self.assertNotIn("sync_dealloc", graph_str)
 
-    @requires_cuda
-    def test_del_attr_multi_stream_sync_dealloc(self):
+    @onlyAccelerator
+    def test_del_attr_multi_stream_sync_dealloc(self, device):
         class Holder:
             pass
 
@@ -2855,7 +2839,7 @@ class <lambda>(torch.nn.Module):
             del h.tensor
             return z0, z
 
-        inp = (torch.ones(2, 2, device="cuda"), torch.ones(2, 2, device="cuda"))
+        inp = (torch.ones(2, 2, device=device), torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -2869,8 +2853,8 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @requires_cuda
-    def test_del_subscr_multi_stream_sync_dealloc(self):
+    @onlyAccelerator
+    def test_del_subscr_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream()
             e = torch.Event()
@@ -2883,7 +2867,7 @@ class <lambda>(torch.nn.Module):
             del d["t"]
             return z0, z
 
-        inp = (torch.ones(2, 2, device="cuda"), torch.ones(2, 2, device="cuda"))
+        inp = (torch.ones(2, 2, device=device), torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -3004,6 +2988,8 @@ class <lambda>(torch.nn.Module):
         self.assertNotIn(getitem_out, set(graph.nodes))
         self.assertIn(new_gi, add_node.all_input_nodes)
 
+
+instantiate_device_type_tests(TestStreams, globals())
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -667,7 +667,7 @@ class GraphModule(torch.nn.Module):
             torch.ones(2, 2, device=device, requires_grad=True) + 1,
             torch.ones(2, 2, device=device, requires_grad=True),
         )
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         expected = fn(*inp)
         (
             actual,
@@ -675,7 +675,7 @@ class GraphModule(torch.nn.Module):
             fw_graphs,
             bw_graphs,
         ) = extract_graph(fn, *inp)
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         self.assertEqual(len(fw_graphs), 1)
         self.assertEqual(expected, actual)
         self.assertExpectedInline(
@@ -1603,192 +1603,6 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    @requires_cuda
-    def test_same_stream_record_ordering(self) -> None:
-        """Two record_events on one stream must be ordered relative to each other.
-
-        The second record's per-stream work was reset by the first, so without
-        an explicit edge it is emitted bare (no control_deps) and can float above
-        the compute, capturing nothing -- the same 'bare side-effectful sync
-        floats' bug as an unanchored synchronize_stream. Each record must depend
-        on the prior sync on its own stream, so the second record's control_deps
-        depends on the first record's control_deps node.
-        """
-
-        def fn(x) -> torch.Tensor:
-            s = torch.Stream(device="cuda")
-            e1 = torch.Event()
-            e2 = torch.Event()
-            e3 = torch.Event()
-            with s:
-                a = x + 1
-                e1.record()
-                e2.record()  # deps reset by e1 -> would be bare without the fix
-                e3.record()
-            return a
-
-        inp = (torch.ones(2, 2, device="cuda"),)
-        # extract_graph already runs wrap_all_sync_nodes_with_control_deps, so
-        # assert on its output directly (re-running the pass would wrap the bare
-        # e2 a second time and mask the bug).
-        (
-            _,
-            _,
-            fw_graphs,
-            _,
-        ) = extract_graph(fn, *inp)
-
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        # All records must be wrapped -- e2/e3 must not be left bare nodes.
-        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
-        self.assertEqual(len(ctrl_nodes), 3)
-        record1_ctrl, record2_ctrl, record3_ctrl = ctrl_nodes
-
-        # Each record depends only on its immediate predecessor, keeping the
-        # per-stream sync ordering a linear chain rather than its full history.
-        self.assertIn(record1_ctrl, record2_ctrl.args[0])
-        self.assertIn(record2_ctrl, record3_ctrl.args[0])
-        self.assertNotIn(record1_ctrl, record3_ctrl.args[0])
-
-        graph.lint()
-
-    @requires_cuda
-    def test_wait_stream_anchors_following_record(self) -> None:
-        """A record_event on the WAITING stream after a wait_stream must chain to
-        the wait_stream (which runs on that stream), not float above it as a bare
-        node. Regression: wait_stream's control_deps was keyed under the waited-on
-        stream, so a later record on the waiting stream never found it.
-        """
-
-        def fn(x) -> torch.Tensor:
-            default = torch.cuda.current_stream()
-            side = torch.cuda.Stream()
-            ready = torch.cuda.Event()
-            e = torch.cuda.Event()
-            a = x @ x
-            ready.record(default)
-            with torch.cuda.stream(side):
-                side.wait_stream(default)
-                e.record()  # bare on the waiting stream without the fix
-            e.wait()
-            return a
-
-        inp = (torch.ones(4, 4, device="cuda"),)
-        (
-            _,
-            _,
-            fw_graphs,
-            _,
-        ) = extract_graph(fn, *inp)
-
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        # The record must be wrapped, not left as a bare (floatable) node in the
-        # main graph -- wrapped record_events live inside control_deps subgraphs.
-        bare_records = graph.find_nodes(
-            op="call_function", target=torch.ops.streams.record_event.default
-        )
-        self.assertEqual(
-            list(bare_records), [], "record_event on the waiting stream floated bare"
-        )
-
-        # The wait must depend on the waited-on stream's retained record dependency,
-        # and the following record must depend on the wait on its own stream.
-        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
-        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
-        wait_ctrl = [n for n in ctrl_nodes if "wait_stream" in n.args[1].name]
-        self.assertEqual(len(record_ctrl), 2)
-        self.assertEqual(len(wait_ctrl), 1)
-        self.assertIn(record_ctrl[0], wait_ctrl[0].args[0])
-        self.assertIn(wait_ctrl[0], record_ctrl[1].args[0])
-
-        graph.lint()
-
-    @requires_cuda
-    def test_cross_stream_event_rerecord_without_work(self) -> None:
-        def fn(x) -> torch.Tensor:
-            s1 = torch.cuda.Stream()
-            s2 = torch.cuda.Stream()
-            s3 = torch.cuda.Stream()
-            e = torch.cuda.Event()
-            with torch.cuda.stream(s1):
-                y = x + 1
-                e.record()
-            with torch.cuda.stream(s2):
-                e.record()
-            with torch.cuda.stream(s3):
-                e.wait()
-                z = x + 2
-            return y + z
-
-        inp = (torch.ones(2, 2, device="cuda"),)
-        _, _, fw_graphs, _ = extract_graph(fn, *inp)
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
-        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
-        wait_ctrl = [n for n in ctrl_nodes if "wait_event" in n.args[1].name]
-        self.assertEqual(len(record_ctrl), 2)
-        self.assertEqual(len(wait_ctrl), 1)
-        self.assertIn(record_ctrl[0], record_ctrl[1].args[0])
-        self.assertIn(record_ctrl[1], wait_ctrl[0].args[0])
-        self.assertNotIn(record_ctrl[0], wait_ctrl[0].args[0])
-
-        graph.lint()
-
-    @requires_cuda
-    def test_wait_stream_preserves_waited_on_work(self) -> None:
-        def fn(x) -> torch.Tensor:
-            default = torch.cuda.current_stream()
-            side = torch.cuda.Stream()
-            a = x @ x
-            side.wait_stream(default)
-            torch.cuda.Event().record(default)
-            return a
-
-        inp = (torch.ones(4, 4, device="cuda"),)
-        _, _, fw_graphs, _ = extract_graph(fn, *inp)
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
-        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
-        self.assertEqual(len(record_ctrl), 1)
-        self.assertTrue(record_ctrl[0].args[0])
-
-        graph.lint()
-
-    @requires_cuda
-    def test_leading_synchronize_stream_orders_following_work(self) -> None:
-        def fn(x) -> torch.Tensor:
-            torch.cuda.current_stream().synchronize()
-            return x + 1
-
-        inp = (torch.ones(4, 4, device="cuda"),)
-        _, _, fw_graphs, _ = extract_graph(fn, *inp)
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
-        sync_ctrl = [n for n in ctrl_nodes if "synchronize_stream" in n.args[1].name]
-        self.assertEqual(len(sync_ctrl), 1)
-        adds = list(
-            graph.find_nodes(op="call_function", target=torch.ops.aten.add.Tensor)
-        )
-        self.assertEqual(len(adds), 1)
-        self.assertIs(adds[0].args[0].args[0], sync_ctrl[0])
-
-        graph.lint()
-
     def test_full_barrier_forward_deps_respect_partition(self) -> None:
         from torch._functorch._aot_autograd.streams import _collect_sync_forward_deps
 
@@ -1938,29 +1752,6 @@ class <lambda>(torch.nn.Module):
         ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
         self.assertEqual(len(ctrl_nodes), 1)
         self.assertIs(add.args[0].args[0], ctrl_nodes[0])
-        graph.lint()
-
-    @requires_cuda
-    def test_captured_external_wait_event_orders_following_work(self) -> None:
-        event = torch.cuda.Event()
-        stream = torch.cuda.Stream()
-        event.record()
-
-        def fn(x: torch.Tensor) -> torch.Tensor:
-            with torch.cuda.stream(stream):
-                event.wait()
-                return x + 1
-
-        _, _, fw_graphs, _ = extract_graph(fn, torch.ones(2, device="cuda"))
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
-        wait_ctrl = [n for n in ctrl_nodes if "wait_event" in n.args[1].name]
-        self.assertEqual(len(wait_ctrl), 1)
-        add = graph.find_nodes(op="call_function", target=torch.ops.aten.add.Tensor)[0]
-        self.assertIs(add.args[0].args[0], wait_ctrl[0])
         graph.lint()
 
     def test_external_wait_event_preserves_copy_destination(self) -> None:
@@ -2845,6 +2636,209 @@ instantiate_device_type_tests(
 
 @requires_cuda
 class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
+    def test_same_stream_record_ordering(self) -> None:
+        """Two record_events on one stream must be ordered relative to each other.
+
+        The second record's per-stream work was reset by the first, so without
+        an explicit edge it is emitted bare (no control_deps) and can float above
+        the compute, capturing nothing -- the same 'bare side-effectful sync
+        floats' bug as an unanchored synchronize_stream. Each record must depend
+        on the prior sync on its own stream, so the second record's control_deps
+        depends on the first record's control_deps node.
+        """
+
+        def fn(x) -> torch.Tensor:
+            s = torch.Stream(device="cuda")
+            e1 = torch.Event()
+            e2 = torch.Event()
+            e3 = torch.Event()
+            with s:
+                a = x + 1
+                e1.record()
+                e2.record()  # deps reset by e1 -> would be bare without the fix
+                e3.record()
+            return a
+
+        inp = (torch.ones(2, 2, device="cuda"),)
+        # extract_graph already runs wrap_all_sync_nodes_with_control_deps, so
+        # assert on its output directly (re-running the pass would wrap the bare
+        # e2 a second time and mask the bug).
+        (
+            _,
+            _,
+            fw_graphs,
+            _,
+        ) = extract_graph(fn, *inp)
+
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        # All records must be wrapped -- e2/e3 must not be left bare nodes.
+        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
+        self.assertEqual(len(ctrl_nodes), 3)
+        record1_ctrl, record2_ctrl, record3_ctrl = ctrl_nodes
+
+        # Each record depends only on its immediate predecessor, keeping the
+        # per-stream sync ordering a linear chain rather than its full history.
+        self.assertIn(record1_ctrl, record2_ctrl.args[0])
+        self.assertIn(record2_ctrl, record3_ctrl.args[0])
+        self.assertNotIn(record1_ctrl, record3_ctrl.args[0])
+
+        graph.lint()
+
+    def test_wait_stream_anchors_following_record(self) -> None:
+        """A record_event on the WAITING stream after a wait_stream must chain to
+        the wait_stream (which runs on that stream), not float above it as a bare
+        node. Regression: wait_stream's control_deps was keyed under the waited-on
+        stream, so a later record on the waiting stream never found it.
+        """
+
+        def fn(x) -> torch.Tensor:
+            default = torch.cuda.current_stream()
+            side = torch.cuda.Stream()
+            ready = torch.cuda.Event()
+            e = torch.cuda.Event()
+            a = x @ x
+            ready.record(default)
+            with torch.cuda.stream(side):
+                side.wait_stream(default)
+                e.record()  # bare on the waiting stream without the fix
+            e.wait()
+            return a
+
+        inp = (torch.ones(4, 4, device="cuda"),)
+        (
+            _,
+            _,
+            fw_graphs,
+            _,
+        ) = extract_graph(fn, *inp)
+
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        # The record must be wrapped, not left as a bare (floatable) node in the
+        # main graph -- wrapped record_events live inside control_deps subgraphs.
+        bare_records = graph.find_nodes(
+            op="call_function", target=torch.ops.streams.record_event.default
+        )
+        self.assertEqual(
+            list(bare_records), [], "record_event on the waiting stream floated bare"
+        )
+
+        # The wait must depend on the waited-on stream's retained record dependency,
+        # and the following record must depend on the wait on its own stream.
+        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
+        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
+        wait_ctrl = [n for n in ctrl_nodes if "wait_stream" in n.args[1].name]
+        self.assertEqual(len(record_ctrl), 2)
+        self.assertEqual(len(wait_ctrl), 1)
+        self.assertIn(record_ctrl[0], wait_ctrl[0].args[0])
+        self.assertIn(wait_ctrl[0], record_ctrl[1].args[0])
+
+        graph.lint()
+
+    def test_cross_stream_event_rerecord_without_work(self) -> None:
+        def fn(x) -> torch.Tensor:
+            s1 = torch.cuda.Stream()
+            s2 = torch.cuda.Stream()
+            s3 = torch.cuda.Stream()
+            e = torch.cuda.Event()
+            with torch.cuda.stream(s1):
+                y = x + 1
+                e.record()
+            with torch.cuda.stream(s2):
+                e.record()
+            with torch.cuda.stream(s3):
+                e.wait()
+                z = x + 2
+            return y + z
+
+        inp = (torch.ones(2, 2, device="cuda"),)
+        _, _, fw_graphs, _ = extract_graph(fn, *inp)
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
+        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
+        wait_ctrl = [n for n in ctrl_nodes if "wait_event" in n.args[1].name]
+        self.assertEqual(len(record_ctrl), 2)
+        self.assertEqual(len(wait_ctrl), 1)
+        self.assertIn(record_ctrl[0], record_ctrl[1].args[0])
+        self.assertIn(record_ctrl[1], wait_ctrl[0].args[0])
+        self.assertNotIn(record_ctrl[0], wait_ctrl[0].args[0])
+
+        graph.lint()
+
+    def test_wait_stream_preserves_waited_on_work(self) -> None:
+        def fn(x) -> torch.Tensor:
+            default = torch.cuda.current_stream()
+            side = torch.cuda.Stream()
+            a = x @ x
+            side.wait_stream(default)
+            torch.cuda.Event().record(default)
+            return a
+
+        inp = (torch.ones(4, 4, device="cuda"),)
+        _, _, fw_graphs, _ = extract_graph(fn, *inp)
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
+        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
+        self.assertEqual(len(record_ctrl), 1)
+        self.assertTrue(record_ctrl[0].args[0])
+
+        graph.lint()
+
+    def test_leading_synchronize_stream_orders_following_work(self) -> None:
+        def fn(x) -> torch.Tensor:
+            torch.cuda.current_stream().synchronize()
+            return x + 1
+
+        inp = (torch.ones(4, 4, device="cuda"),)
+        _, _, fw_graphs, _ = extract_graph(fn, *inp)
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
+        sync_ctrl = [n for n in ctrl_nodes if "synchronize_stream" in n.args[1].name]
+        self.assertEqual(len(sync_ctrl), 1)
+        adds = list(
+            graph.find_nodes(op="call_function", target=torch.ops.aten.add.Tensor)
+        )
+        self.assertEqual(len(adds), 1)
+        self.assertIs(adds[0].args[0].args[0], sync_ctrl[0])
+
+        graph.lint()
+
+    def test_captured_external_wait_event_orders_following_work(self) -> None:
+        event = torch.cuda.Event()
+        stream = torch.cuda.Stream()
+        event.record()
+
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            with torch.cuda.stream(stream):
+                event.wait()
+                return x + 1
+
+        _, _, fw_graphs, _ = extract_graph(fn, torch.ones(2, device="cuda"))
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
+        wait_ctrl = [n for n in ctrl_nodes if "wait_event" in n.args[1].name]
+        self.assertEqual(len(wait_ctrl), 1)
+        add = graph.find_nodes(op="call_function", target=torch.ops.aten.add.Tensor)[0]
+        self.assertIs(add.args[0].args[0], wait_ctrl[0])
+        graph.lint()
+
     def test_dynamo_registry_no_dangling_weakref(self):
         """Natural repro of the original UAF pattern.
 

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -21,17 +21,15 @@ from torch._dynamo.graph_bytecode_inputs import (
 )
 from torch._dynamo.testing import extract_graph, remove_trailing_space
 from torch._dynamo.variables.user_defined import UserDefinedClassVariable
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    onlyAccelerator,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     IS_LINUX,
     IS_MACOS,
     IS_WINDOWS,
+    requires_accelerator,
     requires_cuda,
+    requires_xpu,
     TEST_WITH_ROCM,
-    TEST_XPU,
 )
 
 
@@ -53,14 +51,137 @@ def strip_annotation_desc(gm_str: str) -> str:
     return re.sub(r"(# Annotation: \{[^}]*\}).*", r"\1", gm_str)
 
 
-class TestStreams(torch._dynamo.test_case.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+class TestStreamsGeneric(torch._dynamo.test_case.TestCase):
+    @unittest.skip("Needs graph break support with annotation context")
+    def test_stream_enter_exit_graph_break(self):
+        pass
 
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
+    @unittest.skip("Needs graph break support with annotation context")
+    def test_nested_stream_enter_exit_graph_break(self):
+        pass
+
+    def test_is_marked_side_effectful(self):
+        self.assertIn(
+            torch.ops.streams.fork.default, torch.fx.node._side_effectful_functions
+        )
+        self.assertIn(
+            torch.ops.streams.join.default, torch.fx.node._side_effectful_functions
+        )
+        self.assertIn(
+            torch.ops.streams.wait_event.default,
+            torch.fx.node._side_effectful_functions,
+        )
+        self.assertIn(
+            torch.ops.streams.record_event.default,
+            torch.fx.node._side_effectful_functions,
+        )
+        self.assertIn(
+            torch.ops.streams.synchronize_event.default,
+            torch.fx.node._side_effectful_functions,
+        )
+
+    def test_sync_dealloc_has_fake_impl(self):
+        """Test that sync_dealloc has a registered fake impl.
+
+        Without a fake impl, Inductor's backward compilation crashes when the
+        backward graph contains cross-stream sync_dealloc ops.
+        """
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            t = torch.randn(4)
+            # Should not raise "no fake impl registered"
+            torch.ops.streams.sync_dealloc.default(0, 1, t)
+
+    def test_record_stream_has_fake_impl(self):
+        """Test that record_stream's fake impl has the correct signature."""
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            t = torch.randn(4)
+            # Should not raise due to signature mismatch
+            torch.ops.streams.record_stream.default(t, 0)
+
+    def test_expand_dict_returning_deps_triton_kernel(self) -> None:
+        """Triton kernel dicts must not be passed through control_deps.
+
+        triton_kernel_wrapper_functional returns a dict.  If the dict node is
+        threaded through control_deps as a pass-through value,
+        decompose_triton_kernel_wrapper_functional later replaces it with a
+        raw Python dict (via replace_with_graph -> replace_all_uses_with),
+        corrupting the graph and causing KeyError during lowering.
+
+        _expand_dict_returning_deps should insert per-key getitem nodes
+        *before* the sync so that only tensor-valued nodes are passed through.
+        """
+        import operator
+
+        from torch._functorch._aot_autograd.streams import _expand_dict_returning_deps
+
+        graph = torch.fx.Graph()
+        # Placeholder input
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.empty(4, 4)
+
+        # Simulate a triton_kernel_wrapper_functional call returning a dict
+        triton_func = graph.call_function(
+            torch.ops.higher_order.triton_kernel_wrapper_functional,
+            kwargs={
+                "kernel_idx": 0,
+                "constant_args_idx": 0,
+                "grid": [(1, 1, 1)],
+                "tma_descriptor_metadata": {},
+                "kwargs": {"Out": x},
+                "tensors_to_clone": ["Out"],
+            },
+        )
+        triton_func.meta["val"] = {"Out": torch.empty(4, 4)}
+
+        # Simulate a sync node (record_event) between triton_func and getitem
+        sync_node = graph.call_function(
+            torch.ops.streams.record_event.default,
+            args=(0, 0),
+        )
+
+        # getitem user AFTER the sync -- this is the problematic pattern
+        getitem_out = graph.call_function(
+            operator.getitem,
+            args=(triton_func, "Out"),
+        )
+        getitem_out.meta["val"] = torch.empty(4, 4)
+
+        # Use getitem_out so it's live
+        add_node = graph.call_function(torch.ops.aten.add.Tensor, args=(getitem_out, x))
+        graph.output(add_node)
+
+        # Build visited set: everything at or before sync_node
+        visited: set[torch.fx.Node] = set()
+        for n in graph.nodes:
+            visited.add(n)
+            if n is sync_node:
+                break
+
+        # deps_with_uses_after_sync: triton_func has getitem_out as after-sync user
+        deps = [triton_func]
+
+        expanded = _expand_dict_returning_deps(deps, visited, graph, sync_node)
+
+        # The triton_func dict should NOT be in the expanded list
+        self.assertNotIn(triton_func, expanded)
+
+        # Instead, we should have a new getitem node for key "Out"
+        self.assertEqual(len(expanded), 1)
+        new_gi = expanded[0]
+        self.assertEqual(new_gi.target, operator.getitem)
+        self.assertEqual(new_gi.args, (triton_func, "Out"))
+
+        # The new getitem should be BEFORE the sync in graph order
+        node_order = list(graph.nodes)
+        self.assertLess(node_order.index(new_gi), node_order.index(sync_node))
+
+        # The old getitem_out should have been erased; add_node now uses new_gi
+        self.assertNotIn(getitem_out, set(graph.nodes))
+        self.assertIn(new_gi, add_node.all_input_nodes)
 
     def test_registered_device_stream_event_in_graph_classes(self):
         class TestStream(torch.Stream):
@@ -100,12 +221,21 @@ class TestStreams(torch._dynamo.test_case.TestCase):
             self.assertNotIn(DeviceInterface.Stream, in_graph_classes)
             self.assertNotIn(DeviceInterface.Event, in_graph_classes)
 
-    @onlyAccelerator
+
+@requires_accelerator
+class TestStreams(torch._dynamo.test_case.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
     def test_stream_weakref(self, device):
         s = torch.Stream(device=device)
         weakref.ref(s)
 
-    @onlyAccelerator
     def test_event_weakref(self, device):
         e = torch.Event(device=device)
         weakref.ref(e)
@@ -133,7 +263,6 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         self.assertEqual(called, [True])
         del _weakref_keepalive
 
-    @onlyAccelerator
     def test_backend_stream_event_weakref_callback(self, device):
         device_mod = getattr(torch, torch.device(device).type, None)
         if (
@@ -145,7 +274,6 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         self._assert_weakref_callback_fires(device_mod.Stream)
         self._assert_weakref_callback_fires(device_mod.Event)
 
-    @onlyAccelerator
     def test_stream_enter_exit(self, device):
         def fn(x, y, s1, s2):
             with s1:
@@ -189,7 +317,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     @unittest.skip("Needs graph break support with annotation context")
     def test_stream_context_graph_break(self, device):
         def fn(x, y):
@@ -218,7 +345,6 @@ class <lambda>(torch.nn.Module):
         self.assertExpectedInline(print_graph(fw_graphs[0]), """""")
         self.assertExpectedInline(print_graph(fw_graphs[1]), """""")
 
-    @onlyAccelerator
     def test_stream_input(self, device):
         def fn(x, y, s):
             z = torch.add(x, y)
@@ -235,7 +361,6 @@ class <lambda>(torch.nn.Module):
         actual = fn_opt(*inp)
         self.assertEqual(expected, actual)
 
-    @onlyAccelerator
     def test_local_stream_return(self, device):
         def fn(x, y):
             s = torch.Stream(device=device)
@@ -263,7 +388,6 @@ class <lambda>(torch.nn.Module):
         res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent())
         self.assertEqual(res, torch.ones(2))
 
-    @onlyAccelerator
     def test_nested_stream_enter_exit(self, device):
         def fn(x, y, s0, s1, s2):
             with s1:
@@ -309,15 +433,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @unittest.skip("Needs graph break support with annotation context")
-    def test_stream_enter_exit_graph_break(self):
-        pass
-
-    @unittest.skip("Needs graph break support with annotation context")
-    def test_nested_stream_enter_exit_graph_break(self):
-        pass
-
-    @onlyAccelerator
     def test_local_stream_enter_exit(self, device):
         def fn(x, y):
             s2 = torch.Stream(device=device)
@@ -358,7 +473,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_local_stream_nested_enter_exit(self, device):
         def fn(x, y):
             s2 = torch.Stream(device=device)
@@ -401,7 +515,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_new_stream_api(self, device) -> None:
         from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
         from torch._dynamo.variables.streams import new_stream
@@ -426,7 +539,6 @@ class <lambda>(torch.nn.Module):
 
         fn(torch.ones(2, 2, device=device))
 
-    @onlyAccelerator
     def test_current_stream_api(self, device) -> None:
         from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
         from torch._dynamo.variables.streams import get_current_stream
@@ -455,7 +567,6 @@ class <lambda>(torch.nn.Module):
 
         fn(torch.ones(2, 2, device=device))
 
-    @onlyAccelerator
     def test_stream_with_mutation(self, device):
         def fn(x, y):
             s2 = torch.Stream(device=device)
@@ -505,7 +616,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_stream_backward_simple(self, device) -> None:
         def fn(x, y):
             s2 = torch.Stream(device=device)
@@ -586,7 +696,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_stream_backward_sync(self, device) -> None:
         def fn(x, y):
             s2 = torch.Stream(device=device)
@@ -707,7 +816,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_event_tracing(self, device):
         def fn(x) -> None:
             e = torch.Event(device=device)
@@ -738,7 +846,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_run_opcheck_fork_join(self, device):
         from torch._dynamo.variables.streams import fork_stream, join_stream
         from torch.library import opcheck
@@ -760,7 +867,6 @@ class <lambda>(torch.nn.Module):
             torch.accelerator.set_stream(original_stream)
             reset_user_object_tracking()
 
-    @onlyAccelerator
     def test_run_opcheck_wait_record(self, device):
         from torch._dynamo.variables.streams import record_event, wait_event
         from torch.library import opcheck
@@ -784,7 +890,6 @@ class <lambda>(torch.nn.Module):
             torch.accelerator.set_stream(original_stream)
             reset_user_object_tracking()
 
-    @onlyAccelerator
     def test_run_opcheck_wait_record_stream(self, device):
         from torch._dynamo.variables.streams import wait_stream
         from torch.library import opcheck
@@ -804,7 +909,6 @@ class <lambda>(torch.nn.Module):
         finally:
             reset_user_object_tracking()
 
-    @onlyAccelerator
     def test_record_stream_problem_basic(self, device):
         # see https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html#torch.Tensor.record_stream
         # for what this tests/solves for
@@ -898,7 +1002,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_record_stream_problem_interleaved(self, device):
         # see https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html#torch.Tensor.record_stream
         # for what this tests/solves for
@@ -1155,7 +1258,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_epilogue_copy_streams_inference(self, device):
         def fn(x):
             with torch.Stream(device=device):
@@ -1187,7 +1289,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_epilogue_copy_streams_external(self, device):
         @torch.compile(backend="eager")
         def fn(x):
@@ -1203,7 +1304,6 @@ class <lambda>(torch.nn.Module):
         ):
             extract_graph(fn, *inp)
 
-    @onlyAccelerator
     def test_control_deps_wrapping_record_event(self, device) -> None:
         """Test wrapping record_event with control_deps on a two-stream graph.
 
@@ -1269,7 +1369,6 @@ class <lambda>(torch.nn.Module):
         wait_ctrl_node = control_deps_nodes[1]
         self.assertIn(record_ctrl_node, wait_ctrl_node.args[0])
 
-    @onlyAccelerator
     def test_control_deps_wrapping_wait_event(self, device) -> None:
         """Test wrapping wait_event with control_deps on a two-stream graph.
 
@@ -1318,7 +1417,6 @@ class <lambda>(torch.nn.Module):
         )
         self.assertEqual(len(control_deps_nodes), 2)
 
-    @onlyAccelerator
     def test_control_deps_prevents_invalid_reordering(self, device) -> None:
         """
         Test that control_deps creates proper data dependencies that prevent invalid reordering.
@@ -1395,7 +1493,6 @@ class <lambda>(torch.nn.Module):
         with self.assertRaises(RuntimeError):
             graph.lint()
 
-    @onlyAccelerator
     def test_cross_event_deps_multiple_events(self, device) -> None:
         """Stress test: multiple events across three streams.
 
@@ -1493,7 +1590,6 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    @onlyAccelerator
     def test_cross_event_deps_event_reuse(self, device) -> None:
         """Test that reusing an event updates the cross-event dependency.
 
@@ -1995,7 +2091,6 @@ class <lambda>(torch.nn.Module):
         self.assertIs(following_work.args[0].args[0], ctrl)
         graph.lint()
 
-    @onlyAccelerator
     def test_epilogue_copy_stream_tracking(self, device):
         """
         Test that epilogue copies for mutated inputs use the correct stream.
@@ -2079,7 +2174,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_inductor_lowering(self, device):
         with patch("torch._inductor.config.implicit_fallbacks", False):
 
@@ -2093,27 +2187,6 @@ class GraphModule(torch.nn.Module):
             inp = (torch.ones(2, 2, device=device),)
             fn(*inp)
 
-    def test_is_marked_side_effectful(self):
-        self.assertIn(
-            torch.ops.streams.fork.default, torch.fx.node._side_effectful_functions
-        )
-        self.assertIn(
-            torch.ops.streams.join.default, torch.fx.node._side_effectful_functions
-        )
-        self.assertIn(
-            torch.ops.streams.wait_event.default,
-            torch.fx.node._side_effectful_functions,
-        )
-        self.assertIn(
-            torch.ops.streams.record_event.default,
-            torch.fx.node._side_effectful_functions,
-        )
-        self.assertIn(
-            torch.ops.streams.synchronize_event.default,
-            torch.fx.node._side_effectful_functions,
-        )
-
-    @onlyAccelerator
     def test_backward_sync_control_deps_e2e(self, device) -> None:
         """
         End-to-end test verifying that backward sync nodes are wrapped with control_deps.
@@ -2164,110 +2237,6 @@ class GraphModule(torch.nn.Module):
             "Expected control_deps nodes in backward graph for stream synchronization",
         )
 
-    def test_sync_dealloc_has_fake_impl(self):
-        """Test that sync_dealloc has a registered fake impl.
-
-        Without a fake impl, Inductor's backward compilation crashes when the
-        backward graph contains cross-stream sync_dealloc ops.
-        """
-        from torch._subclasses.fake_tensor import FakeTensorMode
-
-        with FakeTensorMode():
-            t = torch.randn(4)
-            # Should not raise "no fake impl registered"
-            torch.ops.streams.sync_dealloc.default(0, 1, t)
-
-    def test_record_stream_has_fake_impl(self):
-        """Test that record_stream's fake impl has the correct signature."""
-        from torch._subclasses.fake_tensor import FakeTensorMode
-
-        with FakeTensorMode():
-            t = torch.randn(4)
-            # Should not raise due to signature mismatch
-            torch.ops.streams.record_stream.default(t, 0)
-
-    def test_expand_dict_returning_deps_triton_kernel(self) -> None:
-        """Triton kernel dicts must not be passed through control_deps.
-
-        triton_kernel_wrapper_functional returns a dict.  If the dict node is
-        threaded through control_deps as a pass-through value,
-        decompose_triton_kernel_wrapper_functional later replaces it with a
-        raw Python dict (via replace_with_graph -> replace_all_uses_with),
-        corrupting the graph and causing KeyError during lowering.
-
-        _expand_dict_returning_deps should insert per-key getitem nodes
-        *before* the sync so that only tensor-valued nodes are passed through.
-        """
-        import operator
-
-        from torch._functorch._aot_autograd.streams import _expand_dict_returning_deps
-
-        graph = torch.fx.Graph()
-        # Placeholder input
-        x = graph.placeholder("x")
-        x.meta["val"] = torch.empty(4, 4)
-
-        # Simulate a triton_kernel_wrapper_functional call returning a dict
-        triton_func = graph.call_function(
-            torch.ops.higher_order.triton_kernel_wrapper_functional,
-            kwargs={
-                "kernel_idx": 0,
-                "constant_args_idx": 0,
-                "grid": [(1, 1, 1)],
-                "tma_descriptor_metadata": {},
-                "kwargs": {"Out": x},
-                "tensors_to_clone": ["Out"],
-            },
-        )
-        triton_func.meta["val"] = {"Out": torch.empty(4, 4)}
-
-        # Simulate a sync node (record_event) between triton_func and getitem
-        sync_node = graph.call_function(
-            torch.ops.streams.record_event.default,
-            args=(0, 0),
-        )
-
-        # getitem user AFTER the sync -- this is the problematic pattern
-        getitem_out = graph.call_function(
-            operator.getitem,
-            args=(triton_func, "Out"),
-        )
-        getitem_out.meta["val"] = torch.empty(4, 4)
-
-        # Use getitem_out so it's live
-        add_node = graph.call_function(torch.ops.aten.add.Tensor, args=(getitem_out, x))
-        graph.output(add_node)
-
-        # Build visited set: everything at or before sync_node
-        visited: set[torch.fx.Node] = set()
-        for n in graph.nodes:
-            visited.add(n)
-            if n is sync_node:
-                break
-
-        # deps_with_uses_after_sync: triton_func has getitem_out as after-sync user
-        deps = [triton_func]
-
-        expanded = _expand_dict_returning_deps(deps, visited, graph, sync_node)
-
-        # The triton_func dict should NOT be in the expanded list
-        self.assertNotIn(triton_func, expanded)
-
-        # Instead, we should have a new getitem node for key "Out"
-        self.assertEqual(len(expanded), 1)
-        new_gi = expanded[0]
-        self.assertEqual(new_gi.target, operator.getitem)
-        self.assertEqual(new_gi.args, (triton_func, "Out"))
-
-        # The new getitem should be BEFORE the sync in graph order
-        node_order = list(graph.nodes)
-        self.assertLess(node_order.index(new_gi), node_order.index(sync_node))
-
-        # The old getitem_out should have been erased; add_node now uses new_gi
-        self.assertNotIn(getitem_out, set(graph.nodes))
-        self.assertIn(new_gi, add_node.all_input_nodes)
-
-    @onlyAccelerator
     def test_record_stream(self, device):
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
 
@@ -2286,7 +2255,6 @@ class GraphModule(torch.nn.Module):
         )
         self.assertTrue(found, "record_stream op not found in graph")
 
-    @onlyAccelerator
     def test_event_record_after_input_mutation_errors(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2301,7 +2269,6 @@ class GraphModule(torch.nn.Module):
                 torch.ones(2, 2, device=device)
             )
 
-    @onlyAccelerator
     def test_event_record_after_input_mutation_stack_traces(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2323,7 +2290,6 @@ class GraphModule(torch.nn.Module):
             self.assertIn("Event record occurred here:", msg)
             self.assertIn("e.record()", msg)
 
-    @onlyAccelerator
     def test_event_record_after_input_mutation_record_event(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2337,7 +2303,6 @@ class GraphModule(torch.nn.Module):
                 torch.ones(2, 2, device=device)
             )
 
-    @onlyAccelerator
     def test_event_record_after_input_mutation_through_view(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2353,7 +2318,6 @@ class GraphModule(torch.nn.Module):
                 torch.ones(2, 2, device=device)
             )
 
-    @onlyAccelerator
     def test_event_record_after_input_mutation_input_event(self, device):
         def fn(x, e):
             s = torch.Stream(device=device)
@@ -2368,7 +2332,6 @@ class GraphModule(torch.nn.Module):
                 torch.Event(device=device),
             )
 
-    @onlyAccelerator
     def test_event_record_before_input_mutation_no_error(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2382,7 +2345,6 @@ class GraphModule(torch.nn.Module):
             torch.ones(2, 2, device=device)
         )
 
-    @onlyAccelerator
     def test_event_record_on_different_stream_no_error(self, device):
         def fn(x):
             s0 = torch.Stream(device=device)
@@ -2398,7 +2360,6 @@ class GraphModule(torch.nn.Module):
             torch.ones(2, 2, device=device)
         )
 
-    @onlyAccelerator
     def test_event_not_returned_no_error(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -2417,7 +2378,6 @@ class GraphModule(torch.nn.Module):
         IS_LINUX or IS_MACOS or TEST_WITH_ROCM or IS_WINDOWS,
         "https://github.com/pytorch/pytorch/issues/178155",
     )
-    @onlyAccelerator
     @unittest.skip("https://github.com/pytorch/pytorch/issues/177771")
     def test_backend_event_record_on_stream(self, device):
         """Backend Event should be accepted by torch.Stream.record_event (C++ type check)."""
@@ -2428,7 +2388,6 @@ class GraphModule(torch.nn.Module):
         e = device_mod.Event()
         s.record_event(e)
 
-    @onlyAccelerator
     def test_event_synchronize_tracing(self, device):
         def fn(x):
             e = torch.Event(device=device)
@@ -2469,7 +2428,6 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @onlyAccelerator
     def test_event_synchronize_inductor_lowering(self, device):
         with patch("torch._inductor.config.implicit_fallbacks", False):
 
@@ -2484,7 +2442,6 @@ class <lambda>(torch.nn.Module):
             inp = (torch.ones(2, 2, device=device),)
             fn(*inp)
 
-    @onlyAccelerator
     def test_control_deps_wrapping_synchronize_event(self, device) -> None:
         """Test that synchronize_event threads recorded ops' values through.
 
@@ -2602,7 +2559,6 @@ class <lambda>(torch.nn.Module):
             "mul should depend on synchronize_event's getitem, not record_event's",
         )
 
-    @onlyAccelerator
     def test_external_event_synchronize_threads_inputs(self, device) -> None:
         """When the event was recorded externally, synchronize threads graph inputs through."""
 
@@ -2668,7 +2624,6 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    @onlyAccelerator
     def test_event_synchronize_control_deps_e2e(self, device):
         """E2E: compute → record → synchronize → use result through torch.compile."""
 
@@ -2685,7 +2640,6 @@ class <lambda>(torch.nn.Module):
         compiled_result = torch.compile(f)(inp)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(eager_result, compiled_result)
 
-    @onlyAccelerator
     def test_event_synchronize_e2e(self, device):
         def f(a_list):
             a_cpu_list = []
@@ -2710,7 +2664,6 @@ class <lambda>(torch.nn.Module):
         compiled_result = f_compiled(inputs)
         self.assertEqual(eager_result, compiled_result)
 
-    @onlyAccelerator
     def test_event_record_wait_on_default_stream(self, device):
         device_mod = getattr(torch, torch.device(device).type, None)
         if device_mod is None or not hasattr(device_mod, "Event"):
@@ -2729,7 +2682,6 @@ class <lambda>(torch.nn.Module):
         compiled_result = f_compiled(x)
         self.assertEqual(eager_result, compiled_result)
 
-    @onlyAccelerator
     def test_record_stream_inductor_output_code(self, device) -> None:
         """Verify record_stream is ordered between the producing kernel and the
         consuming kernel in inductor-generated wrapper code."""
@@ -2754,7 +2706,6 @@ class <lambda>(torch.nn.Module):
             "torch.ops.streams.record_stream.default("
         ).check("return").run(code)
 
-    @onlyAccelerator
     def test_del_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream(device=device)
@@ -2781,7 +2732,6 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @onlyAccelerator
     def test_del_same_stream_no_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream(device=device)
@@ -2806,7 +2756,6 @@ class <lambda>(torch.nn.Module):
         graph_str = print_graph(fw_graphs[0])
         self.assertNotIn("sync_dealloc", graph_str)
 
-    @onlyAccelerator
     def test_del_single_stream_no_sync_dealloc(self, device):
         def fn(x, y):
             z = torch.add(x, y)
@@ -2826,7 +2775,6 @@ class <lambda>(torch.nn.Module):
         graph_str = print_graph(fw_graphs[0])
         self.assertNotIn("sync_dealloc", graph_str)
 
-    @onlyAccelerator
     def test_del_attr_multi_stream_sync_dealloc(self, device):
         class Holder:
             pass
@@ -2858,7 +2806,6 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @onlyAccelerator
     def test_del_subscr_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream(device=device)
@@ -2886,7 +2833,6 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @onlyAccelerator
     def test_current_stream_with_entered_stream(self, device):
         """Verify that torch.accelerator.current_stream().stream_id returns the
         correct value when inside a stream context for a user-created stream."""
@@ -2900,7 +2846,6 @@ class <lambda>(torch.nn.Module):
         compiled = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(compiled(x, s), fn(x, s))
 
-    @onlyAccelerator
     def test_recorded_events_append_runtime_objects(self, device):
         events = []
 
@@ -2937,7 +2882,9 @@ class <lambda>(torch.nn.Module):
         self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
 
 
-instantiate_device_type_tests(TestStreams, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestStreams, globals(), allow_xpu=True, except_for=("cpu",)
+)
 
 
 @requires_cuda
@@ -3049,7 +2996,7 @@ class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
         self.assertEqual(actual_default, default_s.cuda_stream)
 
 
-@unittest.skipUnless(TEST_XPU, "xpu only")
+@requires_xpu
 class TestStreamsXPUSpecific(torch._dynamo.test_case.TestCase):
     def test_dynamo_registry_no_dangling_weakref(self):
         reset_user_object_tracking()

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -21,13 +21,16 @@ from torch._dynamo.graph_bytecode_inputs import (
 )
 from torch._dynamo.testing import extract_graph, remove_trailing_space
 from torch._dynamo.variables.user_defined import UserDefinedClassVariable
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     IS_LINUX,
     IS_MACOS,
     IS_WINDOWS,
     requires_cuda,
     TEST_WITH_ROCM,
-    TEST_XPU,
 )
 
 
@@ -96,12 +99,12 @@ class TestStreams(torch._dynamo.test_case.TestCase):
             self.assertNotIn(DeviceInterface.Stream, in_graph_classes)
             self.assertNotIn(DeviceInterface.Event, in_graph_classes)
 
-    @requires_cuda
+    @onlyAccelerator
     def test_stream_weakref(self):
         s = torch.Stream()
         weakref.ref(s)
 
-    @requires_cuda
+    @onlyAccelerator
     def test_event_weakref(self):
         e = torch.Event()
         weakref.ref(e)
@@ -129,27 +132,29 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         self.assertEqual(called, [True])
         del _weakref_keepalive
 
-    @requires_cuda
-    def test_cuda_stream_event_weakref_callback(self):
-        self._assert_weakref_callback_fires(torch.cuda.Stream)
-        self._assert_weakref_callback_fires(torch.cuda.Event)
+    @onlyAccelerator
+    def test_backend_stream_event_weakref_callback(self, device):
+        device_mod = getattr(torch, torch.device(device).type, None)
+        if (
+            device_mod is None
+            or not hasattr(device_mod, "Stream")
+            or not hasattr(device_mod, "Event")
+        ):
+            self.skipTest(f"No backend-specific Stream/Event for {device}")
+        self._assert_weakref_callback_fires(device_mod.Stream)
+        self._assert_weakref_callback_fires(device_mod.Event)
 
-    @unittest.skipUnless(TEST_XPU, "xpu only")
-    def test_xpu_stream_event_weakref_callback(self):
-        self._assert_weakref_callback_fires(torch.xpu.Stream)
-        self._assert_weakref_callback_fires(torch.xpu.Event)
-
-    @requires_cuda
-    def test_dynamo_registry_no_dangling_weakref(self):
+    @onlyAccelerator
+    def test_dynamo_registry_no_dangling_weakref(self, device):
         """Natural repro of the original UAF pattern.
 
         `torch.compile(fn, backend="eager")` with `fn` referencing
-        `torch.cuda.current_stream()` causes dynamo to register a
+        `torch.accelerator.current_stream()` causes dynamo to register a
         weakref to the captured stream in
         `index_to_external_object_weakref` (via
         `store_user_object_weakrefs`, which does NOT pin via
         `keep_alive`).  As soon as `fn` returns, the captured wrapper
-        has no strong references and is freed via `THCPStream_dealloc`.
+        has no strong references and is freed via tp_dealloc.
 
         At that point the patched tp_dealloc must call
         `PyObject_ClearWeakRefs`, otherwise the registry now holds a
@@ -164,9 +169,9 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         reset_user_object_tracking()
 
         def fn(x):
-            return torch.cuda.current_stream().cuda_stream
+            return torch.accelerator.current_stream().stream_id
 
-        x = torch.zeros(1, device="cuda")
+        x = torch.zeros(1, device=device)
         compiled = torch.compile(fn, backend="eager", fullgraph=True)
         compiled(x)
         del compiled
@@ -195,7 +200,7 @@ class TestStreams(torch._dynamo.test_case.TestCase):
             "clear it, otherwise the registry retains a dangling pointer",
         )
 
-    @requires_cuda
+    @onlyAccelerator
     def test_stream_enter_exit(self):
         def fn(x, y, s1, s2):
             with s1:
@@ -234,7 +239,7 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
+    @onlyAccelerator
     @unittest.skip("Needs graph break support with annotation context")
     def test_stream_context_graph_break(self):
         def fn(x, y):
@@ -263,20 +268,20 @@ class <lambda>(torch.nn.Module):
         self.assertExpectedInline(print_graph(fw_graphs[0]), """""")
         self.assertExpectedInline(print_graph(fw_graphs[1]), """""")
 
-    @requires_cuda
-    def test_stream_input(self):
+    @onlyAccelerator
+    def test_stream_input(self, device):
         def fn(x, y, s):
             z = torch.add(x, y)
             y = z + 2
             return y, s
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2), torch.Stream(device="cuda"))
+        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2), torch.Stream(device=device))
         expected = fn(*inp)
         fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         actual = fn_opt(*inp)
         self.assertEqual(expected, actual)
 
-    @requires_cuda
+    @onlyAccelerator
     def test_local_stream_return(self):
         def fn(x, y):
             s = torch.Stream()
@@ -304,14 +309,14 @@ class <lambda>(torch.nn.Module):
         res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent())
         self.assertEqual(res, torch.ones(2))
 
-    @requires_cuda
-    def test_get_current_stream_return(self):
+    @onlyAccelerator
+    def test_get_current_stream_return(self, device):
         def fn(x, s):
             with s:
                 s0 = torch.accelerator.current_stream()
             return x, s0
 
-        s_inp = torch.Stream(device="cuda")
+        s_inp = torch.Stream(device=device)
         inp = (torch.ones(2, 2) + 1, s_inp)
         fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         _, s0 = fn_opt(*inp)
@@ -319,59 +324,33 @@ class <lambda>(torch.nn.Module):
         self.assertEqual(s_inp, s0)
         self.assertEqual(s0, s1)
 
-    @requires_cuda
-    def test_cuda_current_stream_attrs(self):
-        """Verify that torch.cuda.current_stream() attributes are accessible
+    @onlyAccelerator
+    def test_current_stream_attrs(self, device):
+        """Verify that accelerator current_stream() attributes are accessible
         under torch.compile and match eager behavior."""
 
-        def fn_cuda_stream(x):
-            return torch.cuda.current_stream().cuda_stream
+        def fn_stream(x):
+            return torch.accelerator.current_stream().stream_id
 
-        x = torch.zeros(1, device="cuda")
-        compiled = torch.compile(fn_cuda_stream, backend="eager", fullgraph=True)
-        self.assertEqual(compiled(x), fn_cuda_stream(x))
+        x = torch.zeros(1, device=device)
+        compiled = torch.compile(fn_stream, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x), fn_stream(x))
 
-    @unittest.skipIf(not TEST_XPU, "XPU is not available")
-    def test_xpu_current_stream_attrs(self):
-        """Verify that torch.xpu.current_stream() attributes are accessible
-        under torch.compile and match eager behavior."""
-
-        def fn_xpu_stream(x):
-            return torch.xpu.current_stream().sycl_queue
-
-        x = torch.zeros(1, device="xpu")
-        compiled = torch.compile(fn_xpu_stream, backend="eager", fullgraph=True)
-        self.assertEqual(compiled(x), fn_xpu_stream(x))
-
-    @requires_cuda
-    def test_cuda_current_stream_with_entered_stream(self):
-        """Verify that torch.cuda.current_stream().cuda_stream returns the
-        correct value when inside a stream context for a user-created stream."""
+    @onlyAccelerator
+    def test_current_stream_with_entered_stream(self, device):
+        """Verify that current_stream().stream_id returns the correct value
+        when inside a stream context for a user-created stream."""
 
         def fn(x, s):
             with s:
-                return torch.cuda.current_stream().cuda_stream
+                return torch.accelerator.current_stream().stream_id
 
-        s = torch.cuda.Stream()
-        x = torch.zeros(1, device="cuda")
+        s = torch.Stream(device=device)
+        x = torch.zeros(1, device=device)
         compiled = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(compiled(x, s), fn(x, s))
 
-    @unittest.skipIf(not TEST_XPU, "XPU is not available")
-    def test_xpu_current_stream_with_entered_stream(self):
-        """Verify that torch.xpu.current_stream().sycl_queue returns the
-        correct value when inside a stream context for a user-created stream."""
-
-        def fn(x, s):
-            with s:
-                return torch.xpu.current_stream().sycl_queue
-
-        s = torch.xpu.Stream()
-        x = torch.zeros(1, device="xpu")
-        compiled = torch.compile(fn, backend="eager", fullgraph=True)
-        self.assertEqual(compiled(x, s), fn(x, s))
-
-    @requires_cuda
+    @onlyAccelerator
     def test_nested_stream_enter_exit(self):
         def fn(x, y, s0, s1, s2):
             with s1:
@@ -425,7 +404,7 @@ class <lambda>(torch.nn.Module):
     def test_nested_stream_enter_exit_graph_break(self):
         pass
 
-    @requires_cuda
+    @onlyAccelerator
     def test_local_stream_enter_exit(self):
         def fn(x, y):
             s2 = torch.Stream()
@@ -466,7 +445,7 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
+    @onlyAccelerator
     def test_local_stream_nested_enter_exit(self):
         def fn(x, y):
             s2 = torch.Stream()
@@ -509,8 +488,8 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_new_stream_api(self) -> None:
+    @onlyAccelerator
+    def test_new_stream_api(self, device) -> None:
         from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
         from torch._dynamo.variables.streams import new_stream
 
@@ -532,10 +511,10 @@ class <lambda>(torch.nn.Module):
         def fn(x):
             return x + 1
 
-        fn(torch.ones(2, 2, device="cuda:0"))
+        fn(torch.ones(2, 2, device=device))
 
-    @requires_cuda
-    def test_current_stream_api(self) -> None:
+    @onlyAccelerator
+    def test_current_stream_api(self, device) -> None:
         from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
         from torch._dynamo.variables.streams import get_current_stream
 
@@ -544,7 +523,7 @@ class <lambda>(torch.nn.Module):
 
         def stream_generation_backend(gm, *args, **kwargs):  # type: ignore[no-untyped-def]
             nonlocal s0
-            s0_ind = get_current_stream(torch.device("cuda:0"))
+            s0_ind = get_current_stream(torch.device(device))
             self.assertEqual(get_external_object_by_index(s0_ind), cur_stream)
             with gm.graph.inserting_after(next(iter(gm.graph.nodes))):
                 gm.graph.call_function(
@@ -563,9 +542,9 @@ class <lambda>(torch.nn.Module):
         def fn(x):
             return x + 1
 
-        fn(torch.ones(2, 2, device="cuda:0"))
+        fn(torch.ones(2, 2, device=device))
 
-    @requires_cuda
+    @onlyAccelerator
     def test_stream_with_mutation(self):
         def fn(x, y):
             s2 = torch.Stream()
@@ -615,7 +594,7 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
+    @onlyAccelerator
     def test_stream_backward_simple(self) -> None:
         def fn(x, y):
             s2 = torch.Stream()
@@ -696,8 +675,8 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_stream_backward_sync(self) -> None:
+    @onlyAccelerator
+    def test_stream_backward_sync(self, device) -> None:
         def fn(x, y):
             s2 = torch.Stream()
             s0 = torch.Stream()
@@ -709,8 +688,8 @@ class GraphModule(torch.nn.Module):
             return y0, z
 
         inp = (
-            torch.ones(2, 2, device="cuda:0", requires_grad=True) + 1,
-            torch.ones(2, 2, device="cuda:0", requires_grad=True),
+            torch.ones(2, 2, device=device, requires_grad=True) + 1,
+            torch.ones(2, 2, device=device, requires_grad=True),
         )
         torch.cuda.synchronize()
         expected = fn(*inp)
@@ -817,15 +796,15 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_event_tracing(self):
+    @onlyAccelerator
+    def test_event_tracing(self, device):
         def fn(x) -> None:
             e = torch.Event()
             e.record()
             x.add_(1)
             return x
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -879,8 +858,8 @@ class <lambda>(torch.nn.Module):
         self.assertIsInstance(events[1], torch.Event)
         self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
 
-    @requires_cuda
-    def test_run_opcheck_fork_join(self):
+    @onlyAccelerator
+    def test_run_opcheck_fork_join(self, device):
         from torch._dynamo.variables.streams import fork_stream, join_stream
         from torch.library import opcheck
 
@@ -901,7 +880,7 @@ class <lambda>(torch.nn.Module):
             torch.accelerator.set_stream(original_stream)
             reset_user_object_tracking()
 
-    @requires_cuda
+    @onlyAccelerator
     def test_run_opcheck_wait_record(self):
         from torch._dynamo.variables.streams import record_event, wait_event
         from torch.library import opcheck
@@ -925,7 +904,7 @@ class <lambda>(torch.nn.Module):
             torch.accelerator.set_stream(original_stream)
             reset_user_object_tracking()
 
-    @requires_cuda
+    @onlyAccelerator
     def test_run_opcheck_wait_record_stream(self):
         from torch._dynamo.variables.streams import wait_stream
         from torch.library import opcheck
@@ -945,26 +924,26 @@ class <lambda>(torch.nn.Module):
         finally:
             reset_user_object_tracking()
 
-    @requires_cuda
-    def test_record_stream_problem_basic(self):
+    @onlyAccelerator
+    def test_record_stream_problem_basic(self, device):
         # see https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html#torch.Tensor.record_stream
         # for what this tests/solves for
         # We expect there to be a sync_dealloc op added to the graph for y
         # synchronizing the first stream w/ the second stream after the second stream is finished
         def fn(x):
             e = torch.Event()
-            with torch.Stream(device="cuda:0"):
-                y = torch.ones(2, 2, device="cuda:0")
+            with torch.Stream(device=device):
+                y = torch.ones(2, 2, device=device)
                 e.record()
                 z = y * x
 
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 e.wait()
                 z0 = y * 2 * x
 
             return z0, z
 
-        inp = (torch.ones(2, 2, device="cuda", requires_grad=True),)
+        inp = (torch.ones(2, 2, device=device, requires_grad=True),)
         (
             actual,
             _,
@@ -1039,8 +1018,8 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_record_stream_problem_interleaved(self):
+    @onlyAccelerator
+    def test_record_stream_problem_interleaved(self, device):
         # see https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html#torch.Tensor.record_stream
         # for what this tests/solves for
         # This will have interleaved computation where y is
@@ -1048,22 +1027,22 @@ class GraphModule(torch.nn.Module):
         # used on the first stream again then finally used on the last stream
         def fn(x):
             e = torch.Event()
-            with torch.Stream(device="cuda:0"):
-                y = torch.ones(2, 2, device="cuda:0")
+            with torch.Stream(device=device):
+                y = torch.ones(2, 2, device=device)
                 z = y * x
                 e.record()
 
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 e.wait()
                 z0 = y * 2 * z
                 e.record()
 
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 e.wait()
                 z1 = y * x * z0
                 e.record()
 
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 e.wait()
                 z2 = y * 4 * z1
                 e.record()
@@ -1071,7 +1050,7 @@ class GraphModule(torch.nn.Module):
             e.wait()
             return z, z1, z2
 
-        inp = (torch.ones(2, 2, device="cuda", requires_grad=True),)
+        inp = (torch.ones(2, 2, device=device, requires_grad=True),)
         (
             actual,
             _,
@@ -1296,16 +1275,16 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_epilogue_copy_streams_inference(self):
+    @onlyAccelerator
+    def test_epilogue_copy_streams_inference(self, device):
         def fn(x):
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 with torch.no_grad():
                     x.add_(2)
 
             return x
 
-        x = torch.ones(2, 2, requires_grad=True, device="cuda:0")
+        x = torch.ones(2, 2, requires_grad=True, device=device)
 
         inp = (x,)
         (
@@ -1328,15 +1307,15 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_epilogue_copy_streams_external(self):
+    @onlyAccelerator
+    def test_epilogue_copy_streams_external(self, device):
         @torch.compile(backend="eager")
         def fn(x):
-            with torch.Stream(device="cuda:0"):
+            with torch.Stream(device=device):
                 x.mul_(3)
             return x.sin()
 
-        x = torch.ones(2, 2, requires_grad=True, device="cuda:0")
+        x = torch.ones(2, 2, requires_grad=True, device=device)
         inp = (x.clone(),)
         with self.assertRaisesRegex(
             RuntimeError,
@@ -1344,8 +1323,8 @@ class <lambda>(torch.nn.Module):
         ):
             extract_graph(fn, *inp)
 
-    @requires_cuda
-    def test_control_deps_wrapping_record_event(self) -> None:
+    @onlyAccelerator
+    def test_control_deps_wrapping_record_event(self, device) -> None:
         """Test wrapping record_event with control_deps on a two-stream graph.
 
         The producer stream has work before the record_event, so control_deps
@@ -1353,8 +1332,8 @@ class <lambda>(torch.nn.Module):
         """
 
         def fn(x) -> torch.Tensor:
-            s1 = torch.Stream(device="cuda")
-            s2 = torch.Stream(device="cuda")
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
             e = torch.Event()
 
             with s1:
@@ -1368,7 +1347,7 @@ class <lambda>(torch.nn.Module):
 
             return w
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -1410,8 +1389,8 @@ class <lambda>(torch.nn.Module):
         wait_ctrl_node = control_deps_nodes[1]
         self.assertIn(record_ctrl_node, wait_ctrl_node.args[0])
 
-    @requires_cuda
-    def test_control_deps_wrapping_wait_event(self) -> None:
+    @onlyAccelerator
+    def test_control_deps_wrapping_wait_event(self, device) -> None:
         """Test wrapping wait_event with control_deps on a two-stream graph.
 
         The consumer stream has the wait_event, and there should be same-stream
@@ -1419,8 +1398,8 @@ class <lambda>(torch.nn.Module):
         """
 
         def fn(x) -> torch.Tensor:
-            s1 = torch.Stream(device="cuda")
-            s2 = torch.Stream(device="cuda")
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
             e = torch.Event()
 
             with s1:
@@ -1434,7 +1413,7 @@ class <lambda>(torch.nn.Module):
 
             return z
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -1459,8 +1438,8 @@ class <lambda>(torch.nn.Module):
         )
         self.assertEqual(len(control_deps_nodes), 2)
 
-    @requires_cuda
-    def test_control_deps_prevents_invalid_reordering(self) -> None:
+    @onlyAccelerator
+    def test_control_deps_prevents_invalid_reordering(self, device) -> None:
         """
         Test that control_deps creates proper data dependencies that prevent invalid reordering.
 
@@ -1471,8 +1450,8 @@ class <lambda>(torch.nn.Module):
         """
 
         def fn(x) -> torch.Tensor:
-            s1 = torch.Stream(device="cuda")
-            s2 = torch.Stream(device="cuda")
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
             e = torch.Event()
 
             with s1:
@@ -1486,7 +1465,7 @@ class <lambda>(torch.nn.Module):
 
             return w
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -1536,8 +1515,8 @@ class <lambda>(torch.nn.Module):
         with self.assertRaises(RuntimeError):
             graph.lint()
 
-    @requires_cuda
-    def test_cross_event_deps_multiple_events(self) -> None:
+    @onlyAccelerator
+    def test_cross_event_deps_multiple_events(self, device) -> None:
         """Stress test: multiple events across three streams.
 
         Verifies that each wait_event's control_deps node depends on exactly
@@ -1551,9 +1530,9 @@ class <lambda>(torch.nn.Module):
         """
 
         def fn(x) -> torch.Tensor:
-            s1 = torch.Stream(device="cuda")
-            s2 = torch.Stream(device="cuda")
-            s3 = torch.Stream(device="cuda")
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
+            s3 = torch.Stream(device=device)
             e1 = torch.Event()
             e2 = torch.Event()
 
@@ -1573,7 +1552,7 @@ class <lambda>(torch.nn.Module):
 
             return a + b + y + z
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         # Patch out wrapping so we get the raw graph to manually wrap below.
         with patch(
             "torch._functorch._aot_autograd.graph_capture.wrap_all_sync_nodes_with_control_deps"
@@ -1634,18 +1613,18 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    @requires_cuda
-    def test_cross_event_deps_event_reuse(self) -> None:
+    @onlyAccelerator
+    def test_cross_event_deps_event_reuse(self, device) -> None:
         """Test that reusing an event updates the cross-event dependency.
 
         When the same event is recorded twice with work in between, the wait
-        should depend on the LAST record's control_deps node (matching CUDA
+        should depend on the LAST record's control_deps node (matching stream
         semantics where record() overwrites the event).
         """
 
         def fn(x) -> torch.Tensor:
-            s1 = torch.Stream(device="cuda")
-            s2 = torch.Stream(device="cuda")
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
             e = torch.Event()
 
             with s1:
@@ -1660,7 +1639,7 @@ class <lambda>(torch.nn.Module):
 
             return w + z
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -2136,8 +2115,8 @@ class <lambda>(torch.nn.Module):
         self.assertIs(following_work.args[0].args[0], ctrl)
         graph.lint()
 
-    @requires_cuda
-    def test_epilogue_copy_stream_tracking(self):
+    @onlyAccelerator
+    def test_epilogue_copy_stream_tracking(self, device):
         """
         Test that epilogue copies for mutated inputs use the correct stream.
         This verifies that ViewAndMutationMeta.mutated_inp_stream_indices is
@@ -2150,8 +2129,8 @@ class <lambda>(torch.nn.Module):
             @staticmethod
             def forward(ctx, x, y):
                 ctx.save_for_backward(x)
-                ctx.s1 = torch.Stream(device="cuda:0")
-                ctx.s2 = torch.Stream(device="cuda:0")
+                ctx.s1 = torch.Stream(device=x.device)
+                ctx.s2 = torch.Stream(device=x.device)
                 # Do computation on stream s2
                 with ctx.s2:
                     result = x * 2 + y
@@ -2173,8 +2152,8 @@ class <lambda>(torch.nn.Module):
             result = BwMutationWithStream.apply(x, y)
             return result
 
-        x = torch.ones(2, 2, requires_grad=True, device="cuda:0")
-        y = torch.ones(2, 2, requires_grad=True, device="cuda:0")
+        x = torch.ones(2, 2, requires_grad=True, device=device)
+        y = torch.ones(2, 2, requires_grad=True, device=device)
         (
             actual,
             _,
@@ -2220,8 +2199,8 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_inductor_lowering(self):
+    @onlyAccelerator
+    def test_inductor_lowering(self, device):
         with patch("torch._inductor.config.implicit_fallbacks", False):
 
             @torch.compile()  # noqa: UNSPECIFIED_BACKEND
@@ -2231,7 +2210,7 @@ class GraphModule(torch.nn.Module):
                 e.record()
                 return x
 
-            inp = (torch.ones(2, 2, device="cuda"),)
+            inp = (torch.ones(2, 2, device=device),)
             fn(*inp)
 
     def test_is_marked_side_effectful(self):
@@ -2254,8 +2233,8 @@ class GraphModule(torch.nn.Module):
             torch.fx.node._side_effectful_functions,
         )
 
-    @requires_cuda
-    def test_backward_sync_control_deps_e2e(self) -> None:
+    @onlyAccelerator
+    def test_backward_sync_control_deps_e2e(self, device) -> None:
         """
         End-to-end test verifying that backward sync nodes are wrapped with control_deps.
 
@@ -2276,8 +2255,8 @@ class GraphModule(torch.nn.Module):
             return z0, z1
 
         inp = (
-            torch.ones(2, 2, device="cuda:0", requires_grad=True) + 1,
-            torch.ones(2, 2, device="cuda:0", requires_grad=True),
+            torch.ones(2, 2, device=device, requires_grad=True) + 1,
+            torch.ones(2, 2, device=device, requires_grad=True),
         )
 
         (
@@ -2327,8 +2306,8 @@ class GraphModule(torch.nn.Module):
             # Should not raise due to signature mismatch
             torch.ops.streams.record_stream.default(t, 0)
 
-    @requires_cuda
-    def test_record_stream(self):
+    @onlyAccelerator
+    def test_record_stream(self, device):
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
 
         def fn(x):
@@ -2337,7 +2316,7 @@ class GraphModule(torch.nn.Module):
             return x
 
         compiled = torch.compile(fn, backend=backend, fullgraph=True)
-        compiled(torch.randn(4, device="cuda"))
+        compiled(torch.randn(4, device=device))
 
         self.assertEqual(len(backend.graphs), 1)
         found = any(
@@ -2346,8 +2325,8 @@ class GraphModule(torch.nn.Module):
         )
         self.assertTrue(found, "record_stream op not found in graph")
 
-    @requires_cuda
-    def test_event_record_after_input_mutation_errors(self):
+    @onlyAccelerator
+    def test_event_record_after_input_mutation_errors(self, device):
         def fn(x):
             s = torch.Stream()
             e = torch.Event()
@@ -2358,11 +2337,11 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda")
+                torch.ones(2, 2, device=device)
             )
 
-    @requires_cuda
-    def test_event_record_after_input_mutation_stack_traces(self):
+    @onlyAccelerator
+    def test_event_record_after_input_mutation_stack_traces(self, device):
         def fn(x):
             s = torch.Stream()
             e = torch.Event()
@@ -2373,7 +2352,7 @@ class GraphModule(torch.nn.Module):
 
         try:
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda")
+                torch.ones(2, 2, device=device)
             )
             self.fail("Expected RuntimeError")
         except RuntimeError as e:
@@ -2383,8 +2362,8 @@ class GraphModule(torch.nn.Module):
             self.assertIn("Event record occurred here:", msg)
             self.assertIn("e.record()", msg)
 
-    @requires_cuda
-    def test_event_record_after_input_mutation_record_event(self):
+    @onlyAccelerator
+    def test_event_record_after_input_mutation_record_event(self, device):
         def fn(x):
             s = torch.Stream()
             with s:
@@ -2394,11 +2373,11 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda")
+                torch.ones(2, 2, device=device)
             )
 
-    @requires_cuda
-    def test_event_record_after_input_mutation_through_view(self):
+    @onlyAccelerator
+    def test_event_record_after_input_mutation_through_view(self, device):
         def fn(x):
             s = torch.Stream()
             e = torch.Event()
@@ -2410,11 +2389,11 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda")
+                torch.ones(2, 2, device=device)
             )
 
-    @requires_cuda
-    def test_event_record_after_input_mutation_input_event(self):
+    @onlyAccelerator
+    def test_event_record_after_input_mutation_input_event(self, device):
         def fn(x, e):
             s = torch.Stream()
             with s:
@@ -2424,12 +2403,12 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda"),
+                torch.ones(2, 2, device=device),
                 torch.Event(),
             )
 
-    @requires_cuda
-    def test_event_record_before_input_mutation_no_error(self):
+    @onlyAccelerator
+    def test_event_record_before_input_mutation_no_error(self, device):
         def fn(x):
             s = torch.Stream()
             e = torch.Event()
@@ -2439,11 +2418,11 @@ class GraphModule(torch.nn.Module):
             return e
 
         torch.compile(fn, backend="eager", fullgraph=True)(
-            torch.ones(2, 2, device="cuda")
+            torch.ones(2, 2, device=device)
         )
 
-    @requires_cuda
-    def test_event_record_on_different_stream_no_error(self):
+    @onlyAccelerator
+    def test_event_record_on_different_stream_no_error(self, device):
         def fn(x):
             s0 = torch.Stream()
             s1 = torch.Stream()
@@ -2455,11 +2434,11 @@ class GraphModule(torch.nn.Module):
             return e
 
         torch.compile(fn, backend="eager", fullgraph=True)(
-            torch.ones(2, 2, device="cuda")
+            torch.ones(2, 2, device=device)
         )
 
-    @requires_cuda
-    def test_event_not_returned_no_error(self):
+    @onlyAccelerator
+    def test_event_not_returned_no_error(self, device):
         def fn(x):
             s = torch.Stream()
             e = torch.Event()
@@ -2470,24 +2449,26 @@ class GraphModule(torch.nn.Module):
 
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
-                torch.ones(2, 2, device="cuda")
+                torch.ones(2, 2, device=device)
             )
 
     @unittest.skipIf(
         IS_LINUX or IS_MACOS or TEST_WITH_ROCM or IS_WINDOWS,
         "https://github.com/pytorch/pytorch/issues/178155",
     )
-    @requires_cuda
+    @onlyAccelerator
     @unittest.skip("https://github.com/pytorch/pytorch/issues/177771")
-    def test_cuda_event_record_on_stream(self):
-        """torch.cuda.Event should be accepted by torch.Stream.record_event (C++ type check)."""
-        s = torch.Stream(device="cuda")
-        e = torch.cuda.Event()
-        # This hits THPStream_record_event in Stream.cpp which does a type check
+    def test_backend_event_record_on_stream(self, device):
+        """Backend Event should be accepted by torch.Stream.record_event (C++ type check)."""
+        device_mod = getattr(torch, torch.device(device).type, None)
+        if device_mod is None or not hasattr(device_mod, "Event"):
+            self.skipTest(f"No backend-specific Event for {device}")
+        s = torch.Stream(device=device)
+        e = device_mod.Event()
         s.record_event(e)
 
-    @requires_cuda
-    def test_event_synchronize_tracing(self):
+    @onlyAccelerator
+    def test_event_synchronize_tracing(self, device):
         def fn(x):
             e = torch.Event()
             e.record()
@@ -2495,7 +2476,7 @@ class GraphModule(torch.nn.Module):
             e.synchronize()
             return x
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         (
             _,
             _,
@@ -2527,8 +2508,8 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
-    @requires_cuda
-    def test_event_synchronize_inductor_lowering(self):
+    @onlyAccelerator
+    def test_event_synchronize_inductor_lowering(self, device):
         with patch("torch._inductor.config.implicit_fallbacks", False):
 
             @torch.compile()  # noqa: UNSPECIFIED_BACKEND
@@ -2539,11 +2520,11 @@ class <lambda>(torch.nn.Module):
                 e.synchronize()
                 return x
 
-            inp = (torch.ones(2, 2, device="cuda"),)
+            inp = (torch.ones(2, 2, device=device),)
             fn(*inp)
 
-    @requires_cuda
-    def test_control_deps_wrapping_synchronize_event(self) -> None:
+    @onlyAccelerator
+    def test_control_deps_wrapping_synchronize_event(self, device) -> None:
         """Test that synchronize_event threads recorded ops' values through.
 
         After record_event wraps ops in control_deps and produces getitem
@@ -2561,7 +2542,7 @@ class <lambda>(torch.nn.Module):
             z = y * 2
             return z
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         # Patch out wrapping so we get the raw graph to manually wrap below.
         with patch(
             "torch._functorch._aot_autograd.graph_capture.wrap_all_sync_nodes_with_control_deps"
@@ -2660,8 +2641,8 @@ class <lambda>(torch.nn.Module):
             "mul should depend on synchronize_event's getitem, not record_event's",
         )
 
-    @requires_cuda
-    def test_external_event_synchronize_threads_inputs(self) -> None:
+    @onlyAccelerator
+    def test_external_event_synchronize_threads_inputs(self, device) -> None:
         """When the event was recorded externally, synchronize threads graph inputs through."""
 
         def fn(x):
@@ -2672,7 +2653,7 @@ class <lambda>(torch.nn.Module):
             z = y * 2
             return z
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         # Patch out wrapping so we get the raw graph to manually wrap below.
         with patch(
             "torch._functorch._aot_autograd.graph_capture.wrap_all_sync_nodes_with_control_deps"
@@ -2726,8 +2707,8 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    @requires_cuda
-    def test_event_synchronize_control_deps_e2e(self):
+    @onlyAccelerator
+    def test_event_synchronize_control_deps_e2e(self, device):
         """E2E: compute → record → synchronize → use result through torch.compile."""
 
         def f(x):
@@ -2738,13 +2719,13 @@ class <lambda>(torch.nn.Module):
             z = y * 2
             return z
 
-        inp = torch.ones(2, 2, device="cuda")
+        inp = torch.ones(2, 2, device=device)
         eager_result = f(inp)
         compiled_result = torch.compile(f)(inp)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(eager_result, compiled_result)
 
-    @requires_cuda
-    def test_event_synchronize_e2e(self):
+    @onlyAccelerator
+    def test_event_synchronize_e2e(self, device):
         def f(a_list):
             a_cpu_list = []
             a_to_cpu_event_list = []
@@ -2762,15 +2743,18 @@ class <lambda>(torch.nn.Module):
 
         f_compiled = torch.compile(f)  # noqa: UNSPECIFIED_BACKEND
         inputs = [
-            torch.rand(100, dtype=torch.float16, device="cuda") for _ in range(10)
+            torch.rand(100, dtype=torch.float16, device=device) for _ in range(10)
         ]
         eager_result = f(inputs)
         compiled_result = f_compiled(inputs)
         self.assertEqual(eager_result, compiled_result)
 
-    @requires_cuda
-    def test_event_record_wait_on_default_stream(self):
-        e = torch.cuda.Event()
+    @onlyAccelerator
+    def test_event_record_wait_on_default_stream(self, device):
+        device_mod = getattr(torch, torch.device(device).type, None)
+        if device_mod is None or not hasattr(device_mod, "Event"):
+            self.skipTest(f"No backend-specific Event for {device}")
+        e = device_mod.Event()
 
         def f(x):
             y = x + 1
@@ -2779,27 +2763,27 @@ class <lambda>(torch.nn.Module):
             return y + 1
 
         f_compiled = torch.compile(f)  # noqa: UNSPECIFIED_BACKEND
-        x = torch.randn(10, device="cuda")
+        x = torch.randn(10, device=device)
         eager_result = f(x)
         compiled_result = f_compiled(x)
         self.assertEqual(eager_result, compiled_result)
 
-    @requires_cuda
-    def test_record_stream_inductor_output_code(self) -> None:
+    @onlyAccelerator
+    def test_record_stream_inductor_output_code(self, device) -> None:
         """Verify record_stream is ordered between the producing kernel and the
         consuming kernel in inductor-generated wrapper code."""
         from torch._inductor.utils import run_and_get_code
         from torch.testing import FileCheck
 
         def fn(x):
-            s = torch.Stream(device="cuda")
+            s = torch.Stream(device=device)
             y = x + 1
             y.record_stream(s)
             z = y * 2
             return z
 
         compiled = torch.compile(fn, backend="inductor", fullgraph=True)
-        x = torch.randn(1024, device="cuda")
+        x = torch.randn(1024, device=device)
         result, (code,) = run_and_get_code(compiled, x)
         self.assertEqual(result, (x + 1) * 2)
 
@@ -2809,8 +2793,8 @@ class <lambda>(torch.nn.Module):
             "torch.ops.streams.record_stream.default("
         ).check("return").run(code)
 
-    @requires_cuda
-    def test_del_multi_stream_sync_dealloc(self):
+    @onlyAccelerator
+    def test_del_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream()
             e = torch.Event()
@@ -2822,7 +2806,7 @@ class <lambda>(torch.nn.Module):
             del x
             return z0, z
 
-        inp = (torch.ones(2, 2, device="cuda"), torch.ones(2, 2, device="cuda"))
+        inp = (torch.ones(2, 2, device=device), torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -2836,8 +2820,8 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @requires_cuda
-    def test_del_same_stream_no_sync_dealloc(self):
+    @onlyAccelerator
+    def test_del_same_stream_no_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream()
             e = torch.Event()
@@ -2848,7 +2832,7 @@ class <lambda>(torch.nn.Module):
             e.wait()
             return z
 
-        inp = (torch.ones(2, 2, device="cuda"), torch.ones(2, 2, device="cuda"))
+        inp = (torch.ones(2, 2, device=device), torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -2861,14 +2845,14 @@ class <lambda>(torch.nn.Module):
         graph_str = print_graph(fw_graphs[0])
         self.assertNotIn("sync_dealloc", graph_str)
 
-    @requires_cuda
-    def test_del_single_stream_no_sync_dealloc(self):
+    @onlyAccelerator
+    def test_del_single_stream_no_sync_dealloc(self, device):
         def fn(x, y):
             z = torch.add(x, y)
             del x
             return z
 
-        inp = (torch.ones(2, 2, device="cuda"), torch.ones(2, 2, device="cuda"))
+        inp = (torch.ones(2, 2, device=device), torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -2881,8 +2865,8 @@ class <lambda>(torch.nn.Module):
         graph_str = print_graph(fw_graphs[0])
         self.assertNotIn("sync_dealloc", graph_str)
 
-    @requires_cuda
-    def test_del_attr_multi_stream_sync_dealloc(self):
+    @onlyAccelerator
+    def test_del_attr_multi_stream_sync_dealloc(self, device):
         class Holder:
             pass
 
@@ -2899,7 +2883,7 @@ class <lambda>(torch.nn.Module):
             del h.tensor
             return z0, z
 
-        inp = (torch.ones(2, 2, device="cuda"), torch.ones(2, 2, device="cuda"))
+        inp = (torch.ones(2, 2, device=device), torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -2913,8 +2897,8 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @requires_cuda
-    def test_del_subscr_multi_stream_sync_dealloc(self):
+    @onlyAccelerator
+    def test_del_subscr_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
             s = torch.Stream()
             e = torch.Event()
@@ -2927,7 +2911,7 @@ class <lambda>(torch.nn.Module):
             del d["t"]
             return z0, z
 
-        inp = (torch.ones(2, 2, device="cuda"), torch.ones(2, 2, device="cuda"))
+        inp = (torch.ones(2, 2, device=device), torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -3048,6 +3032,8 @@ class <lambda>(torch.nn.Module):
         self.assertNotIn(getitem_out, set(graph.nodes))
         self.assertIn(new_gi, add_node.all_input_nodes)
 
+
+instantiate_device_type_tests(TestStreams, globals())
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -157,8 +157,8 @@ class TestStreams(torch._dynamo.test_case.TestCase):
             return y
 
         inp = (
-            torch.ones(2, 2) + 1,
-            torch.ones(2, 2),
+            torch.ones(2, 2, device=device) + 1,
+            torch.ones(2, 2, device=device),
             torch.Stream(device=device),
             torch.Stream(device=device),
         )
@@ -226,8 +226,8 @@ class <lambda>(torch.nn.Module):
             return y, s
 
         inp = (
-            torch.ones(2, 2) + 1,
-            torch.ones(2, 2),
+            torch.ones(2, 2, device=device) + 1,
+            torch.ones(2, 2, device=device),
             torch.Stream(device=device),
         )
         expected = fn(*inp)
@@ -277,8 +277,8 @@ class <lambda>(torch.nn.Module):
             return z0, y
 
         inp = (
-            torch.ones(2, 2) + 1,
-            torch.ones(2, 2),
+            torch.ones(2, 2, device=device) + 1,
+            torch.ones(2, 2, device=device),
             torch.Stream(device=device),
             torch.Stream(device=device),
             torch.Stream(device=device),
@@ -330,7 +330,7 @@ class <lambda>(torch.nn.Module):
 
             return y
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2))
+        inp = (torch.ones(2, 2, device=device) + 1, torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -374,7 +374,7 @@ class <lambda>(torch.nn.Module):
 
             return z0, y
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2))
+        inp = (torch.ones(2, 2, device=device) + 1, torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -472,7 +472,7 @@ class <lambda>(torch.nn.Module):
 
             return z0, y
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2))
+        inp = (torch.ones(2, 2, device=device) + 1, torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -2805,15 +2805,57 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
+    @onlyAccelerator
+    def test_current_stream_with_entered_stream(self, device):
+        """Verify that torch.accelerator.current_stream().stream_id returns the
+        correct value when inside a stream context for a user-created stream."""
+
+        def fn(x, s):
+            with s:
+                return torch.accelerator.current_stream(device).stream_id
+
+        s = torch.Stream(device=device)
+        x = torch.zeros(1, device=device)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x, s), fn(x, s))
+
+    @onlyAccelerator
+    def test_recorded_events_append_runtime_objects(self, device):
+        events = []
+
+        def fn(x):
+            start_event = torch.Event(device=device, enable_timing=True)
+            end_event = torch.Event(device=device, enable_timing=True)
+
+            start_event.record()
+            out = torch.matmul(x, x)
+            end_event.record()
+
+            events.append(start_event)
+            events.append(end_event)
+            return out
+
+        x = torch.randn(16, 16, device=device)
+        expected = fn(x)
+        torch.accelerator.synchronize()
+        events[0].elapsed_time(events[1])
+        events.clear()
+
+        actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
+        torch.accelerator.synchronize()
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(len(events), 2)
+        self.assertIsInstance(events[0], torch.Event)
+        self.assertIsInstance(events[1], torch.Event)
+        self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
+
 
 instantiate_device_type_tests(TestStreams, globals(), allow_xpu=True)
 
-_TestStreamsCUDA = globals().get("TestStreamsCUDA", object)
-
 
 @requires_cuda
-class TestStreamsCUDA(_TestStreamsCUDA):
-    @requires_cuda
+class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
     def test_dynamo_registry_no_dangling_weakref(self):
         """Natural repro of the original UAF pattern.
 
@@ -2857,7 +2899,6 @@ class TestStreamsCUDA(_TestStreamsCUDA):
             "clear it, otherwise the registry retains a dangling pointer",
         )
 
-    @requires_cuda
     def test_get_current_stream_return(self):
         def fn(x, s):
             with s:
@@ -2866,13 +2907,12 @@ class TestStreamsCUDA(_TestStreamsCUDA):
 
         s_inp = torch.Stream(device="cuda")
         inp = (torch.ones(2, 2, device="cuda") + 1, s_inp)
-        fn_opt = torch.compile(fn, fullgraph=True)
+        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         _, s0 = fn_opt(*inp)
         _, s1 = fn_opt(*inp)
         self.assertEqual(s_inp, s0)
         self.assertEqual(s0, s1)
 
-    @requires_cuda
     def test_cuda_current_stream_attrs(self):
         """Verify that torch.cuda.current_stream() attributes are accessible
         under torch.compile and match eager behavior."""
@@ -2884,7 +2924,6 @@ class TestStreamsCUDA(_TestStreamsCUDA):
         compiled = torch.compile(fn_cuda_stream, backend="eager", fullgraph=True)
         self.assertEqual(compiled(x), fn_cuda_stream(x))
 
-    @requires_cuda
     def test_cuda_current_stream_with_entered_stream(self):
         """Verify that torch.cuda.current_stream().cuda_stream returns the
         correct value when inside a stream context for a user-created stream."""
@@ -2898,38 +2937,6 @@ class TestStreamsCUDA(_TestStreamsCUDA):
         compiled = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(compiled(x, s), fn(x, s))
 
-    @requires_cuda
-    def test_recorded_cuda_events_append_runtime_objects(self):
-        events = []
-
-        def fn(x):
-            start_event = torch.cuda.Event(enable_timing=True)
-            end_event = torch.cuda.Event(enable_timing=True)
-
-            start_event.record()
-            out = torch.matmul(x, x)
-            end_event.record()
-
-            events.append(start_event)
-            events.append(end_event)
-            return out
-
-        x = torch.randn(16, 16, device="cuda")
-        expected = fn(x)
-        torch.cuda.synchronize()
-        events[0].elapsed_time(events[1])
-        events.clear()
-
-        actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
-        torch.cuda.synchronize()
-
-        self.assertEqual(expected, actual)
-        self.assertEqual(len(events), 2)
-        self.assertIsInstance(events[0], torch.Event)
-        self.assertIsInstance(events[1], torch.Event)
-        self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
-
-    @requires_cuda
     def test_stream_pointer_extraction_edge_cases(self):
         def get_ptrs(stream_a, stream_b, default_stream):
             return (
@@ -3037,131 +3044,95 @@ class TestStreamsCUDA(_TestStreamsCUDA):
         self.assertIn(new_gi, add_node.all_input_nodes)
 
 
-del _TestStreamsCUDA
+@unittest.skipUnless(TEST_XPU, "xpu only")
+class TestStreamsXPUSpecific(torch._dynamo.test_case.TestCase):
+    def test_dynamo_registry_no_dangling_weakref(self):
+        reset_user_object_tracking()
 
-if TEST_XPU:
-    _TestStreamsXPU = TestStreamsXPU  # noqa: F821
+        def fn(x):
+            return torch.xpu.current_stream().sycl_queue
 
-    class TestStreamsXPU(_TestStreamsXPU):
-        def test_dynamo_registry_no_dangling_weakref(self):
-            reset_user_object_tracking()
+        x = torch.zeros(1, device="xpu")
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        compiled(x)
+        del compiled
+        gc.collect()
 
-            def fn(x):
+        self.assertIn(
+            CURRENT_STREAM_INDEX,
+            index_to_external_object_weakref,
+            "torch.compile of a function referencing current_stream() must "
+            "register a weakref under CURRENT_STREAM_INDEX",
+        )
+
+        self.assertIsNone(
+            index_to_external_object_weakref[CURRENT_STREAM_INDEX](),
+            "dynamo registry holds a weakref to a Stream wrapper that has "
+            "been freed; tp_dealloc must call PyObject_ClearWeakRefs to "
+            "clear it, otherwise the registry retains a dangling pointer",
+        )
+
+    def test_get_current_stream_return(self):
+        def fn(x, s):
+            with s:
+                s0 = torch.xpu.current_stream()
+            return x, s0
+
+        s_inp = torch.Stream(device="xpu")
+        inp = (torch.ones(2, 2, device="xpu") + 1, s_inp)
+        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
+        _, s0 = fn_opt(*inp)
+        _, s1 = fn_opt(*inp)
+        self.assertEqual(s_inp, s0)
+        self.assertEqual(s0, s1)
+
+    def test_xpu_current_stream_attrs(self):
+        """Verify that torch.xpu.current_stream() attributes are accessible
+        under torch.compile and match eager behavior."""
+
+        def fn_xpu_stream(x):
+            return torch.xpu.current_stream().sycl_queue
+
+        x = torch.zeros(1, device="xpu")
+        compiled = torch.compile(fn_xpu_stream, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x), fn_xpu_stream(x))
+
+    def test_xpu_current_stream_with_entered_stream(self):
+        """Verify that torch.xpu.current_stream().sycl_queue returns the
+        correct value when inside a stream context for a user-created stream."""
+
+        def fn(x, s):
+            with s:
                 return torch.xpu.current_stream().sycl_queue
 
-            x = torch.zeros(1, device="xpu")
-            compiled = torch.compile(fn, backend="eager", fullgraph=True)
-            compiled(x)
-            del compiled
-            gc.collect()
+        s = torch.xpu.Stream()
+        x = torch.zeros(1, device="xpu")
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x, s), fn(x, s))
 
-            self.assertIn(
-                CURRENT_STREAM_INDEX,
-                index_to_external_object_weakref,
-                "torch.compile of a function referencing current_stream() must "
-                "register a weakref under CURRENT_STREAM_INDEX",
+    def test_stream_pointer_extraction_edge_cases(self):
+        def get_ptrs(stream_a, stream_b, default_stream):
+            return (
+                stream_a.sycl_queue,
+                stream_b.sycl_queue,
+                default_stream.sycl_queue,
             )
 
-            self.assertIsNone(
-                index_to_external_object_weakref[CURRENT_STREAM_INDEX](),
-                "dynamo registry holds a weakref to a Stream wrapper that has "
-                "been freed; tp_dealloc must call PyObject_ClearWeakRefs to "
-                "clear it, otherwise the registry retains a dangling pointer",
-            )
+        s1, s2 = torch.xpu.Stream(), torch.xpu.Stream()
+        default_s = torch.xpu.current_stream()
+        expected_s1, expected_s2 = s1.sycl_queue, s2.sycl_queue
 
-        def test_get_current_stream_return(self):
-            def fn(x, s):
-                with s:
-                    s0 = torch.xpu.current_stream()
-                return x, s0
+        self.assertNotEqual(expected_s1, expected_s2)
 
-            s_inp = torch.Stream(device="xpu")
-            inp = (torch.ones(2, 2, device="xpu") + 1, s_inp)
-            fn_opt = torch.compile(fn, fullgraph=True)
-            _, s0 = fn_opt(*inp)
-            _, s1 = fn_opt(*inp)
-            self.assertEqual(s_inp, s0)
-            self.assertEqual(s0, s1)
+        opt_get_ptrs = torch.compile(get_ptrs, backend="inductor")
 
-        def test_xpu_current_stream_attrs(self):
-            """Verify that torch.xpu.current_stream() attributes are accessible
-            under torch.compile and match eager behavior."""
+        s3 = torch.xpu.Stream()
+        with torch.xpu.stream(s3):
+            actual_s1, actual_s2, actual_default = opt_get_ptrs(s1, s2, default_s)
 
-            def fn_xpu_stream(x):
-                return torch.xpu.current_stream().sycl_queue
-
-            x = torch.zeros(1, device="xpu")
-            compiled = torch.compile(fn_xpu_stream, backend="eager", fullgraph=True)
-            self.assertEqual(compiled(x), fn_xpu_stream(x))
-
-        def test_xpu_current_stream_with_entered_stream(self):
-            """Verify that torch.xpu.current_stream().sycl_queue returns the
-            correct value when inside a stream context for a user-created stream."""
-
-            def fn(x, s):
-                with s:
-                    return torch.xpu.current_stream().sycl_queue
-
-            s = torch.xpu.Stream()
-            x = torch.zeros(1, device="xpu")
-            compiled = torch.compile(fn, backend="eager", fullgraph=True)
-            self.assertEqual(compiled(x, s), fn(x, s))
-
-        def test_recorded_xpu_events_append_runtime_objects(self):
-            events = []
-
-            def fn(x):
-                start_event = torch.xpu.Event(enable_timing=True)
-                end_event = torch.xpu.Event(enable_timing=True)
-
-                start_event.record()
-                out = torch.matmul(x, x)
-                end_event.record()
-
-                events.append(start_event)
-                events.append(end_event)
-                return out
-
-            x = torch.randn(16, 16, device="xpu")
-            expected = fn(x)
-            torch.xpu.synchronize()
-            events[0].elapsed_time(events[1])
-            events.clear()
-
-            actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
-            torch.xpu.synchronize()
-
-            self.assertEqual(expected, actual)
-            self.assertEqual(len(events), 2)
-            self.assertIsInstance(events[0], torch.Event)
-            self.assertIsInstance(events[1], torch.Event)
-            self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
-
-        def test_stream_pointer_extraction_edge_cases(self):
-            def get_ptrs(stream_a, stream_b, default_stream):
-                return (
-                    stream_a.sycl_queue,
-                    stream_b.sycl_queue,
-                    default_stream.sycl_queue,
-                )
-
-            s1, s2 = torch.xpu.Stream(), torch.xpu.Stream()
-            default_s = torch.xpu.current_stream()
-            expected_s1, expected_s2 = s1.sycl_queue, s2.sycl_queue
-
-            self.assertNotEqual(expected_s1, expected_s2)
-
-            opt_get_ptrs = torch.compile(get_ptrs, backend="inductor")
-
-            s3 = torch.xpu.Stream()
-            with torch.xpu.stream(s3):
-                actual_s1, actual_s2, actual_default = opt_get_ptrs(s1, s2, default_s)
-
-            self.assertEqual(actual_s1, expected_s1)
-            self.assertEqual(actual_s2, expected_s2)
-            self.assertEqual(actual_default, default_s.sycl_queue)
-
-    del _TestStreamsXPU
+        self.assertEqual(actual_s1, expected_s1)
+        self.assertEqual(actual_s2, expected_s2)
+        self.assertEqual(actual_default, default_s.sycl_queue)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -2925,7 +2925,9 @@ class <lambda>(torch.nn.Module):
         self.assertIn("sync_dealloc", graph_str)
         self.assertIn("record_event", graph_str)
 
-    @requires_cuda
+
+@requires_cuda
+class TestStreamsCUDA(torch._dynamo.test_case.TestCase):
     def test_stream_pointer_extraction_edge_cases(self):
         def get_ptrs(stream_a, stream_b, default_stream):
             return (

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -31,6 +31,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     requires_cuda,
     TEST_WITH_ROCM,
+    TEST_XPU,
 )
 
 
@@ -145,62 +146,6 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         self._assert_weakref_callback_fires(device_mod.Event)
 
     @onlyAccelerator
-    def test_dynamo_registry_no_dangling_weakref(self, device):
-        """Natural repro of the original UAF pattern.
-
-        `torch.compile(fn, backend="eager")` with `fn` referencing
-        `torch.accelerator.current_stream()` causes dynamo to register a
-        weakref to the captured stream in
-        `index_to_external_object_weakref` (via
-        `store_user_object_weakrefs`, which does NOT pin via
-        `keep_alive`).  As soon as `fn` returns, the captured wrapper
-        has no strong references and is freed via tp_dealloc.
-
-        At that point the patched tp_dealloc must call
-        `PyObject_ClearWeakRefs`, otherwise the registry now holds a
-        weakref whose `wr_object` is a dangling pointer to freed
-        memory.  Later, when `_PyModule_ClearDict` tears down the
-        registry at interpreter finalization, dereferencing that
-        dangling pointer to clear the weakref hits a use-after-free.
-        """
-        # Start from a known-clean registry so the assertion below is
-        # a statement about what happened in *this* test, not residue
-        # from earlier tests in the same process.
-        reset_user_object_tracking()
-
-        def fn(x):
-            return torch.accelerator.current_stream(device).stream_id
-
-        x = torch.zeros(1, device=device)
-        compiled = torch.compile(fn, backend="eager", fullgraph=True)
-        compiled(x)
-        del compiled
-        gc.collect()
-
-        # Tripwire: torch.compile of a function referencing
-        # current_stream() must still register under
-        # CURRENT_STREAM_INDEX.  If this fails, the production code
-        # path that originally surfaced the UAF has moved and this
-        # regression test no longer covers it.
-        self.assertIn(
-            CURRENT_STREAM_INDEX,
-            index_to_external_object_weakref,
-            "torch.compile of a function referencing current_stream() must "
-            "register a weakref under CURRENT_STREAM_INDEX",
-        )
-
-        # The captured stream wrapper was freed when fn returned.  The
-        # patched tp_dealloc must have cleared the registry's weakref;
-        # dereferencing it now must return None rather than a dangling
-        # pointer into freed memory.
-        self.assertIsNone(
-            index_to_external_object_weakref[CURRENT_STREAM_INDEX](),
-            "dynamo registry holds a weakref to a Stream wrapper that has "
-            "been freed; tp_dealloc must call PyObject_ClearWeakRefs to "
-            "clear it, otherwise the registry retains a dangling pointer",
-        )
-
-    @onlyAccelerator
     def test_stream_enter_exit(self, device):
         def fn(x, y, s1, s2):
             with s1:
@@ -280,7 +225,11 @@ class <lambda>(torch.nn.Module):
             y = z + 2
             return y, s
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2), torch.Stream(device=device))
+        inp = (
+            torch.ones(2, 2) + 1,
+            torch.ones(2, 2),
+            torch.Stream(device=device),
+        )
         expected = fn(*inp)
         fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         actual = fn_opt(*inp)
@@ -313,47 +262,6 @@ class <lambda>(torch.nn.Module):
 
         res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent())
         self.assertEqual(res, torch.ones(2))
-
-    @onlyAccelerator
-    def test_get_current_stream_return(self, device):
-        def fn(x, s):
-            with s:
-                s0 = torch.accelerator.current_stream(device)
-            return x, s0
-
-        s_inp = torch.Stream(device=device)
-        inp = (torch.ones(2, 2) + 1, s_inp)
-        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
-        _, s0 = fn_opt(*inp)
-        _, s1 = fn_opt(*inp)
-        self.assertEqual(s_inp, s0)
-        self.assertEqual(s0, s1)
-
-    @onlyAccelerator
-    def test_current_stream_attrs(self, device):
-        """Verify that accelerator current_stream() attributes are accessible
-        under torch.compile and match eager behavior."""
-
-        def fn_stream(x):
-            return torch.accelerator.current_stream(device).stream_id
-
-        x = torch.zeros(1, device=device)
-        compiled = torch.compile(fn_stream, backend="eager", fullgraph=True)
-        self.assertEqual(compiled(x), fn_stream(x))
-
-    @onlyAccelerator
-    def test_current_stream_with_entered_stream(self, device):
-        """Verify that current_stream().stream_id returns the correct value
-        when inside a stream context for a user-created stream."""
-
-        def fn(x, s):
-            with s:
-                return torch.accelerator.current_stream(device).stream_id
-
-        s = torch.Stream(device=device)
-        x = torch.zeros(1, device=device)
-        compiled = torch.compile(fn, backend="eager", fullgraph=True)
-        self.assertEqual(compiled(x, s), fn(x, s))
 
     @onlyAccelerator
     def test_nested_stream_enter_exit(self, device):
@@ -412,8 +320,8 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_local_stream_enter_exit(self, device):
         def fn(x, y):
-            s2 = torch.Stream()
-            s1 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
             with s1:
                 z1 = torch.add(x, y)
             with s2:
@@ -453,9 +361,9 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_local_stream_nested_enter_exit(self, device):
         def fn(x, y):
-            s2 = torch.Stream()
-            s1 = torch.Stream()
-            s0 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
+            s0 = torch.Stream(device=device)
             with s1:
                 with s2:
                     z1 = torch.add(x, y)
@@ -524,10 +432,8 @@ class <lambda>(torch.nn.Module):
         from torch._dynamo.variables.streams import get_current_stream
 
         cur_stream = torch.accelerator.current_stream(device)
-        s0 = None
 
         def stream_generation_backend(gm, *args, **kwargs):  # type: ignore[no-untyped-def]
-            nonlocal s0
             s0_ind = get_current_stream(torch.device(device))
             self.assertEqual(get_external_object_by_index(s0_ind), cur_stream)
             with gm.graph.inserting_after(next(iter(gm.graph.nodes))):
@@ -552,9 +458,9 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_stream_with_mutation(self, device):
         def fn(x, y):
-            s2 = torch.Stream()
-            s1 = torch.Stream()
-            s0 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
+            s0 = torch.Stream(device=device)
             with s1:
                 with s2:
                     x.add_(y)
@@ -602,8 +508,8 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_stream_backward_simple(self, device) -> None:
         def fn(x, y):
-            s2 = torch.Stream()
-            s0 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s0 = torch.Stream(device=device)
             with s0:
                 y0 = 2 * x + y
             with s2:
@@ -683,8 +589,8 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_stream_backward_sync(self, device) -> None:
         def fn(x, y):
-            s2 = torch.Stream()
-            s0 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s0 = torch.Stream(device=device)
             with s0:
                 y0 = 2 * x + y
             with s2:
@@ -831,37 +737,6 @@ class <lambda>(torch.nn.Module):
         return (copy_,)
 """,
         )
-
-    @requires_cuda
-    def test_recorded_cuda_events_append_runtime_objects(self):
-        events = []
-
-        def fn(x):
-            start_event = torch.cuda.Event(enable_timing=True)
-            end_event = torch.cuda.Event(enable_timing=True)
-
-            start_event.record()
-            out = torch.matmul(x, x)
-            end_event.record()
-
-            events.append(start_event)
-            events.append(end_event)
-            return out
-
-        x = torch.randn(16, 16, device="cuda")
-        expected = fn(x)
-        torch.cuda.synchronize()
-        events[0].elapsed_time(events[1])
-        events.clear()
-
-        actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
-        torch.cuda.synchronize()
-
-        self.assertEqual(expected, actual)
-        self.assertEqual(len(events), 2)
-        self.assertIsInstance(events[0], torch.Event)
-        self.assertIsInstance(events[1], torch.Event)
-        self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
 
     @onlyAccelerator
     def test_run_opcheck_fork_join(self, device):
@@ -2801,8 +2676,8 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_del_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             z0 = x + 1
             with s:
                 z = torch.add(x, y)
@@ -2828,8 +2703,8 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_del_same_stream_no_sync_dealloc(self, device):
         def fn(x, y):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s:
                 z = torch.add(x, y)
                 del x
@@ -2876,8 +2751,8 @@ class <lambda>(torch.nn.Module):
             pass
 
         def fn(x, y):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             h = Holder()
             h.tensor = x
             z0 = x + 1
@@ -2905,8 +2780,8 @@ class <lambda>(torch.nn.Module):
     @onlyAccelerator
     def test_del_subscr_multi_stream_sync_dealloc(self, device):
         def fn(x, y):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             d = {"t": x}
             z0 = x + 1
             with s:
@@ -2931,8 +2806,130 @@ class <lambda>(torch.nn.Module):
         self.assertIn("record_event", graph_str)
 
 
+instantiate_device_type_tests(TestStreams, globals(), allow_xpu=True)
+
+_TestStreamsCUDA = globals().get("TestStreamsCUDA", object)
+
+
 @requires_cuda
-class TestStreamsCUDA(torch._dynamo.test_case.TestCase):
+class TestStreamsCUDA(_TestStreamsCUDA):
+    @requires_cuda
+    def test_dynamo_registry_no_dangling_weakref(self):
+        """Natural repro of the original UAF pattern.
+
+        `torch.compile(fn, backend="eager")` with `fn` referencing
+        `torch.cuda.current_stream()` causes dynamo to register a
+        weakref to the captured stream in
+        `index_to_external_object_weakref` (via
+        `store_user_object_weakrefs`, which does NOT pin via
+        `keep_alive`).  As soon as `fn` returns, the captured wrapper
+        has no strong references and is freed via tp_dealloc.
+
+        At that point the patched tp_dealloc must call
+        `PyObject_ClearWeakRefs`, otherwise the registry now holds a
+        weakref whose `wr_object` is a dangling pointer to freed
+        memory.  Later, when `_PyModule_ClearDict` tears down the
+        registry at interpreter finalization, dereferencing that
+        dangling pointer to clear the weakref hits a use-after-free.
+        """
+        reset_user_object_tracking()
+
+        def fn(x):
+            return torch.cuda.current_stream().cuda_stream
+
+        x = torch.zeros(1, device="cuda")
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        compiled(x)
+        del compiled
+        gc.collect()
+
+        self.assertIn(
+            CURRENT_STREAM_INDEX,
+            index_to_external_object_weakref,
+            "torch.compile of a function referencing current_stream() must "
+            "register a weakref under CURRENT_STREAM_INDEX",
+        )
+
+        self.assertIsNone(
+            index_to_external_object_weakref[CURRENT_STREAM_INDEX](),
+            "dynamo registry holds a weakref to a Stream wrapper that has "
+            "been freed; tp_dealloc must call PyObject_ClearWeakRefs to "
+            "clear it, otherwise the registry retains a dangling pointer",
+        )
+
+    @requires_cuda
+    def test_get_current_stream_return(self):
+        def fn(x, s):
+            with s:
+                s0 = torch.cuda.current_stream()
+            return x, s0
+
+        s_inp = torch.Stream(device="cuda")
+        inp = (torch.ones(2, 2, device="cuda") + 1, s_inp)
+        fn_opt = torch.compile(fn, fullgraph=True)
+        _, s0 = fn_opt(*inp)
+        _, s1 = fn_opt(*inp)
+        self.assertEqual(s_inp, s0)
+        self.assertEqual(s0, s1)
+
+    @requires_cuda
+    def test_cuda_current_stream_attrs(self):
+        """Verify that torch.cuda.current_stream() attributes are accessible
+        under torch.compile and match eager behavior."""
+
+        def fn_cuda_stream(x):
+            return torch.cuda.current_stream().cuda_stream
+
+        x = torch.zeros(1, device="cuda")
+        compiled = torch.compile(fn_cuda_stream, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x), fn_cuda_stream(x))
+
+    @requires_cuda
+    def test_cuda_current_stream_with_entered_stream(self):
+        """Verify that torch.cuda.current_stream().cuda_stream returns the
+        correct value when inside a stream context for a user-created stream."""
+
+        def fn(x, s):
+            with s:
+                return torch.cuda.current_stream().cuda_stream
+
+        s = torch.cuda.Stream()
+        x = torch.zeros(1, device="cuda")
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x, s), fn(x, s))
+
+    @requires_cuda
+    def test_recorded_cuda_events_append_runtime_objects(self):
+        events = []
+
+        def fn(x):
+            start_event = torch.cuda.Event(enable_timing=True)
+            end_event = torch.cuda.Event(enable_timing=True)
+
+            start_event.record()
+            out = torch.matmul(x, x)
+            end_event.record()
+
+            events.append(start_event)
+            events.append(end_event)
+            return out
+
+        x = torch.randn(16, 16, device="cuda")
+        expected = fn(x)
+        torch.cuda.synchronize()
+        events[0].elapsed_time(events[1])
+        events.clear()
+
+        actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
+        torch.cuda.synchronize()
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(len(events), 2)
+        self.assertIsInstance(events[0], torch.Event)
+        self.assertIsInstance(events[1], torch.Event)
+        self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
+
+    @requires_cuda
     def test_stream_pointer_extraction_edge_cases(self):
         def get_ptrs(stream_a, stream_b, default_stream):
             return (
@@ -3040,7 +3037,132 @@ class TestStreamsCUDA(torch._dynamo.test_case.TestCase):
         self.assertIn(new_gi, add_node.all_input_nodes)
 
 
-instantiate_device_type_tests(TestStreams, globals())
+del _TestStreamsCUDA
+
+if TEST_XPU:
+    _TestStreamsXPU = TestStreamsXPU  # noqa: F821
+
+    class TestStreamsXPU(_TestStreamsXPU):
+        def test_dynamo_registry_no_dangling_weakref(self):
+            reset_user_object_tracking()
+
+            def fn(x):
+                return torch.xpu.current_stream().sycl_queue
+
+            x = torch.zeros(1, device="xpu")
+            compiled = torch.compile(fn, backend="eager", fullgraph=True)
+            compiled(x)
+            del compiled
+            gc.collect()
+
+            self.assertIn(
+                CURRENT_STREAM_INDEX,
+                index_to_external_object_weakref,
+                "torch.compile of a function referencing current_stream() must "
+                "register a weakref under CURRENT_STREAM_INDEX",
+            )
+
+            self.assertIsNone(
+                index_to_external_object_weakref[CURRENT_STREAM_INDEX](),
+                "dynamo registry holds a weakref to a Stream wrapper that has "
+                "been freed; tp_dealloc must call PyObject_ClearWeakRefs to "
+                "clear it, otherwise the registry retains a dangling pointer",
+            )
+
+        def test_get_current_stream_return(self):
+            def fn(x, s):
+                with s:
+                    s0 = torch.xpu.current_stream()
+                return x, s0
+
+            s_inp = torch.Stream(device="xpu")
+            inp = (torch.ones(2, 2, device="xpu") + 1, s_inp)
+            fn_opt = torch.compile(fn, fullgraph=True)
+            _, s0 = fn_opt(*inp)
+            _, s1 = fn_opt(*inp)
+            self.assertEqual(s_inp, s0)
+            self.assertEqual(s0, s1)
+
+        def test_xpu_current_stream_attrs(self):
+            """Verify that torch.xpu.current_stream() attributes are accessible
+            under torch.compile and match eager behavior."""
+
+            def fn_xpu_stream(x):
+                return torch.xpu.current_stream().sycl_queue
+
+            x = torch.zeros(1, device="xpu")
+            compiled = torch.compile(fn_xpu_stream, backend="eager", fullgraph=True)
+            self.assertEqual(compiled(x), fn_xpu_stream(x))
+
+        def test_xpu_current_stream_with_entered_stream(self):
+            """Verify that torch.xpu.current_stream().sycl_queue returns the
+            correct value when inside a stream context for a user-created stream."""
+
+            def fn(x, s):
+                with s:
+                    return torch.xpu.current_stream().sycl_queue
+
+            s = torch.xpu.Stream()
+            x = torch.zeros(1, device="xpu")
+            compiled = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertEqual(compiled(x, s), fn(x, s))
+
+        def test_recorded_xpu_events_append_runtime_objects(self):
+            events = []
+
+            def fn(x):
+                start_event = torch.xpu.Event(enable_timing=True)
+                end_event = torch.xpu.Event(enable_timing=True)
+
+                start_event.record()
+                out = torch.matmul(x, x)
+                end_event.record()
+
+                events.append(start_event)
+                events.append(end_event)
+                return out
+
+            x = torch.randn(16, 16, device="xpu")
+            expected = fn(x)
+            torch.xpu.synchronize()
+            events[0].elapsed_time(events[1])
+            events.clear()
+
+            actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
+            torch.xpu.synchronize()
+
+            self.assertEqual(expected, actual)
+            self.assertEqual(len(events), 2)
+            self.assertIsInstance(events[0], torch.Event)
+            self.assertIsInstance(events[1], torch.Event)
+            self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
+
+        def test_stream_pointer_extraction_edge_cases(self):
+            def get_ptrs(stream_a, stream_b, default_stream):
+                return (
+                    stream_a.sycl_queue,
+                    stream_b.sycl_queue,
+                    default_stream.sycl_queue,
+                )
+
+            s1, s2 = torch.xpu.Stream(), torch.xpu.Stream()
+            default_s = torch.xpu.current_stream()
+            expected_s1, expected_s2 = s1.sycl_queue, s2.sycl_queue
+
+            self.assertNotEqual(expected_s1, expected_s2)
+
+            opt_get_ptrs = torch.compile(get_ptrs, backend="inductor")
+
+            s3 = torch.xpu.Stream()
+            with torch.xpu.stream(s3):
+                actual_s1, actual_s2, actual_default = opt_get_ptrs(s1, s2, default_s)
+
+            self.assertEqual(actual_s1, expected_s1)
+            self.assertEqual(actual_s2, expected_s2)
+            self.assertEqual(actual_default, default_s.sycl_queue)
+
+    del _TestStreamsXPU
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -221,6 +221,251 @@ class TestStreamsGeneric(torch._dynamo.test_case.TestCase):
             self.assertNotIn(DeviceInterface.Stream, in_graph_classes)
             self.assertNotIn(DeviceInterface.Event, in_graph_classes)
 
+    def test_full_barrier_forward_deps_respect_partition(self) -> None:
+        from torch._functorch._aot_autograd.streams import _collect_sync_forward_deps
+
+        graph = torch.fx.Graph()
+        fw_input = graph.placeholder("fw_input")
+        fw_input.meta["val"] = torch.ones(1)
+        bw_input = graph.placeholder("bw_input")
+        bw_input.meta["val"] = torch.ones(1)
+        barrier = graph.call_function(
+            torch.ops.streams.synchronize_stream.default, (0,)
+        )
+        fw_node = graph.call_function(torch.ops.aten.add.Tensor, (fw_input, 1))
+        fw_node.meta["val"] = torch.ones(1)
+        bw_node = graph.call_function(torch.ops.aten.add.Tensor, (bw_input, 1))
+        bw_node.meta["val"] = torch.ones(1)
+        bw_node.meta["partitioner_tag"] = "is_backward"
+        graph.output((fw_node, bw_node))
+
+        _, deps = _collect_sync_forward_deps(graph)
+        self.assertEqual(list(deps[barrier]), [fw_input])
+
+    def test_backward_full_barrier_filters_forward_sync_deps(self) -> None:
+        from torch._functorch._aot_autograd.streams import _collect_full_barrier_deps
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        fw_compute = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
+        fw_sync = graph.call_function(torch.ops.streams.record_event.default, (0, 0))
+        bw_sync = graph.call_function(torch.ops.streams.record_event.default, (1, 0))
+        bw_sync.meta["partitioner_tag"] = "is_backward"
+        graph.output(fw_compute)
+
+        deps = _collect_full_barrier_deps(
+            {0: [fw_compute]}, {0: [fw_sync, bw_sync]}, bwd=True
+        )
+        self.assertEqual(deps, [fw_compute, bw_sync])
+
+    def test_wait_stream_forward_deps_are_transitive(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            _collect_sync_forward_deps,
+            set_stream,
+        )
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        inp.meta["val"] = torch.ones(1)
+        wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
+        producer = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
+        producer.meta["val"] = torch.ones(1)
+        set_stream(producer, 0)
+        consumer = graph.call_function(torch.ops.aten.mul.Tensor, (producer, 2))
+        consumer.meta["val"] = torch.ones(1)
+        set_stream(consumer, 1)
+        graph.output(consumer)
+
+        wait_deps, _ = _collect_sync_forward_deps(graph)
+        self.assertEqual(list(wait_deps[wait]), [inp])
+
+    def test_wait_stream_forward_deps_respect_partition(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            _collect_sync_forward_deps,
+            set_stream,
+        )
+
+        graph = torch.fx.Graph()
+        fw_input = graph.placeholder("fw_input")
+        fw_input.meta["val"] = torch.ones(1)
+        bw_input = graph.placeholder("bw_input")
+        bw_input.meta["val"] = torch.ones(1)
+        fw_wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
+        fw_node = graph.call_function(torch.ops.aten.add.Tensor, (fw_input, 1))
+        fw_node.meta["val"] = torch.ones(1)
+        set_stream(fw_node, 1)
+        bw_wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
+        bw_wait.meta["partitioner_tag"] = "is_backward"
+        bw_node = graph.call_function(torch.ops.aten.add.Tensor, (bw_input, 1))
+        bw_node.meta["val"] = torch.ones(1)
+        bw_node.meta["partitioner_tag"] = "is_backward"
+        set_stream(bw_node, 1)
+        graph.output((fw_node, bw_node))
+
+        wait_deps, _ = _collect_sync_forward_deps(graph)
+        self.assertEqual(list(wait_deps[fw_wait]), [fw_input])
+        self.assertEqual(list(wait_deps[bw_wait]), [bw_input])
+
+    def _assert_empty_sync_anchors_record(
+        self, sync_target: torch._ops.OpOverload, sync_args: tuple[int, ...]
+    ) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        sync = graph.call_function(sync_target, sync_args)
+        graph.call_function(torch.ops.streams.record_event.default, (1, 1))
+        graph.output(inp)
+        gm = torch.fx.GraphModule({}, graph)
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
+        self.assertEqual(len(ctrl_nodes), 1)
+        self.assertIn(sync, ctrl_nodes[0].args[0])
+        graph.lint()
+
+    def test_empty_synchronize_stream_anchors_record(self) -> None:
+        self._assert_empty_sync_anchors_record(
+            torch.ops.streams.synchronize_stream.default, (0,)
+        )
+
+    def test_empty_synchronize_device_anchors_record(self) -> None:
+        self._assert_empty_sync_anchors_record(
+            torch.ops.streams.synchronize_device.default, ()
+        )
+
+    def test_empty_wait_stream_anchors_record(self) -> None:
+        self._assert_empty_sync_anchors_record(
+            torch.ops.streams.wait_stream.default, (1, 0)
+        )
+
+    def test_external_wait_event_anchors_record(self) -> None:
+        self._assert_empty_sync_anchors_record(
+            torch.ops.streams.wait_event.default, (0, 1)
+        )
+
+    def test_external_wait_event_orders_following_work(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            set_stream,
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        inp.meta["val"] = torch.ones(1)
+        graph.call_function(torch.ops.streams.wait_event.default, (0, 1))
+        add = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
+        add.meta["val"] = torch.ones(1)
+        set_stream(add, 1)
+        graph.output(add)
+        gm = torch.fx.GraphModule({}, graph)
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
+        self.assertEqual(len(ctrl_nodes), 1)
+        self.assertIs(add.args[0].args[0], ctrl_nodes[0])
+        graph.lint()
+
+    def test_external_wait_event_preserves_copy_destination(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            set_stream,
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        graph = torch.fx.Graph()
+        dst = graph.placeholder("dst")
+        dst.meta["val"] = torch.ones(1)
+        src = graph.placeholder("src")
+        src.meta["val"] = torch.ones(1)
+        graph.call_function(torch.ops.streams.wait_event.default, (0, 1))
+        copy = graph.call_function(torch.ops.aten.copy_.default, (dst, src))
+        copy.meta["val"] = torch.ones(1)
+        set_stream(copy, 1)
+        graph.output(copy)
+        gm = torch.fx.GraphModule({}, graph)
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        ctrl = graph.find_nodes(op="call_function", target=control_deps)[0]
+        self.assertIs(copy.args[0], dst)
+        self.assertIs(copy.args[1].args[0], ctrl)
+        graph.lint()
+
+    def test_empty_synchronize_event_anchors_record(self) -> None:
+        self._assert_empty_sync_anchors_record(
+            torch.ops.streams.synchronize_event.default, (0,)
+        )
+
+    def test_wait_stream_depends_on_prior_waiting_stream_work(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            set_stream,
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        inp.meta["val"] = torch.ones(1)
+        prior_work = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
+        prior_work.meta["val"] = torch.ones(1)
+        set_stream(prior_work, 1)
+        graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
+        graph.output(prior_work)
+        gm = torch.fx.GraphModule({}, graph)
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
+        self.assertEqual(len(ctrl_nodes), 1)
+        self.assertIn(prior_work, ctrl_nodes[0].args[0])
+        graph.lint()
+
+    def test_wait_stream_self_wait_orders_work_once(self) -> None:
+        from torch._functorch._aot_autograd.streams import (
+            set_stream,
+            wrap_all_sync_nodes_with_control_deps,
+        )
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.ones(1)
+        y = graph.placeholder("y")
+        y.meta["val"] = torch.ones(1)
+        prior_work = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
+        prior_work.meta["val"] = torch.ones(1)
+        set_stream(prior_work, 1)
+        graph.call_function(torch.ops.streams.wait_stream.default, (1, 1))
+        following_work = graph.call_function(torch.ops.aten.mul.Tensor, (y, 2))
+        following_work.meta["val"] = torch.ones(1)
+        set_stream(following_work, 1)
+        graph.output((prior_work, following_work))
+        gm = torch.fx.GraphModule({}, graph)
+
+        wrap_all_sync_nodes_with_control_deps(gm)
+
+        ctrl = graph.find_nodes(op="call_function", target=control_deps)[0]
+        self.assertEqual(ctrl.args[0].count(prior_work), 1)
+        self.assertIs(following_work.args[0].args[0], ctrl)
+        graph.lint()
+
+    def test_event_subclass_python_type(self):
+        class MyEvent(torch.Event):
+            pass
+
+        def fn(e):
+            return torch.ones(2) if type(e) is MyEvent else torch.zeros(2)
+
+        res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent(device="cpu"))
+        self.assertEqual(res, torch.ones(2))
+
 
 @requires_accelerator
 class TestStreams(torch._dynamo.test_case.TestCase):
@@ -377,16 +622,6 @@ class <lambda>(torch.nn.Module):
         self.assertIsInstance(s0, torch.Stream)
         # Stream should be newly allocated on each call
         self.assertNotEqual(s0, s1)
-
-    def test_event_subclass_python_type(self):
-        class MyEvent(torch.Event):
-            pass
-
-        def fn(e):
-            return torch.ones(2) if type(e) is MyEvent else torch.zeros(2)
-
-        res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent())
-        self.assertEqual(res, torch.ones(2))
 
     def test_nested_stream_enter_exit(self, device):
         def fn(x, y, s0, s1, s2):
@@ -1647,241 +1882,6 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    def test_full_barrier_forward_deps_respect_partition(self) -> None:
-        from torch._functorch._aot_autograd.streams import _collect_sync_forward_deps
-
-        graph = torch.fx.Graph()
-        fw_input = graph.placeholder("fw_input")
-        fw_input.meta["val"] = torch.ones(1)
-        bw_input = graph.placeholder("bw_input")
-        bw_input.meta["val"] = torch.ones(1)
-        barrier = graph.call_function(
-            torch.ops.streams.synchronize_stream.default, (0,)
-        )
-        fw_node = graph.call_function(torch.ops.aten.add.Tensor, (fw_input, 1))
-        fw_node.meta["val"] = torch.ones(1)
-        bw_node = graph.call_function(torch.ops.aten.add.Tensor, (bw_input, 1))
-        bw_node.meta["val"] = torch.ones(1)
-        bw_node.meta["partitioner_tag"] = "is_backward"
-        graph.output((fw_node, bw_node))
-
-        _, deps = _collect_sync_forward_deps(graph)
-        self.assertEqual(list(deps[barrier]), [fw_input])
-
-    def test_backward_full_barrier_filters_forward_sync_deps(self) -> None:
-        from torch._functorch._aot_autograd.streams import _collect_full_barrier_deps
-
-        graph = torch.fx.Graph()
-        inp = graph.placeholder("inp")
-        fw_compute = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
-        fw_sync = graph.call_function(torch.ops.streams.record_event.default, (0, 0))
-        bw_sync = graph.call_function(torch.ops.streams.record_event.default, (1, 0))
-        bw_sync.meta["partitioner_tag"] = "is_backward"
-        graph.output(fw_compute)
-
-        deps = _collect_full_barrier_deps(
-            {0: [fw_compute]}, {0: [fw_sync, bw_sync]}, bwd=True
-        )
-        self.assertEqual(deps, [fw_compute, bw_sync])
-
-    def test_wait_stream_forward_deps_are_transitive(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            _collect_sync_forward_deps,
-            set_stream,
-        )
-
-        graph = torch.fx.Graph()
-        inp = graph.placeholder("inp")
-        inp.meta["val"] = torch.ones(1)
-        wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
-        producer = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
-        producer.meta["val"] = torch.ones(1)
-        set_stream(producer, 0)
-        consumer = graph.call_function(torch.ops.aten.mul.Tensor, (producer, 2))
-        consumer.meta["val"] = torch.ones(1)
-        set_stream(consumer, 1)
-        graph.output(consumer)
-
-        wait_deps, _ = _collect_sync_forward_deps(graph)
-        self.assertEqual(list(wait_deps[wait]), [inp])
-
-    def test_wait_stream_forward_deps_respect_partition(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            _collect_sync_forward_deps,
-            set_stream,
-        )
-
-        graph = torch.fx.Graph()
-        fw_input = graph.placeholder("fw_input")
-        fw_input.meta["val"] = torch.ones(1)
-        bw_input = graph.placeholder("bw_input")
-        bw_input.meta["val"] = torch.ones(1)
-        fw_wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
-        fw_node = graph.call_function(torch.ops.aten.add.Tensor, (fw_input, 1))
-        fw_node.meta["val"] = torch.ones(1)
-        set_stream(fw_node, 1)
-        bw_wait = graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
-        bw_wait.meta["partitioner_tag"] = "is_backward"
-        bw_node = graph.call_function(torch.ops.aten.add.Tensor, (bw_input, 1))
-        bw_node.meta["val"] = torch.ones(1)
-        bw_node.meta["partitioner_tag"] = "is_backward"
-        set_stream(bw_node, 1)
-        graph.output((fw_node, bw_node))
-
-        wait_deps, _ = _collect_sync_forward_deps(graph)
-        self.assertEqual(list(wait_deps[fw_wait]), [fw_input])
-        self.assertEqual(list(wait_deps[bw_wait]), [bw_input])
-
-    def _assert_empty_sync_anchors_record(
-        self, sync_target: torch._ops.OpOverload, sync_args: tuple[int, ...]
-    ) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            wrap_all_sync_nodes_with_control_deps,
-        )
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        graph = torch.fx.Graph()
-        inp = graph.placeholder("inp")
-        sync = graph.call_function(sync_target, sync_args)
-        graph.call_function(torch.ops.streams.record_event.default, (1, 1))
-        graph.output(inp)
-        gm = torch.fx.GraphModule({}, graph)
-
-        wrap_all_sync_nodes_with_control_deps(gm)
-
-        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
-        self.assertEqual(len(ctrl_nodes), 1)
-        self.assertIn(sync, ctrl_nodes[0].args[0])
-        graph.lint()
-
-    def test_empty_synchronize_stream_anchors_record(self) -> None:
-        self._assert_empty_sync_anchors_record(
-            torch.ops.streams.synchronize_stream.default, (0,)
-        )
-
-    def test_empty_synchronize_device_anchors_record(self) -> None:
-        self._assert_empty_sync_anchors_record(
-            torch.ops.streams.synchronize_device.default, ()
-        )
-
-    def test_empty_wait_stream_anchors_record(self) -> None:
-        self._assert_empty_sync_anchors_record(
-            torch.ops.streams.wait_stream.default, (1, 0)
-        )
-
-    def test_external_wait_event_anchors_record(self) -> None:
-        self._assert_empty_sync_anchors_record(
-            torch.ops.streams.wait_event.default, (0, 1)
-        )
-
-    def test_external_wait_event_orders_following_work(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            set_stream,
-            wrap_all_sync_nodes_with_control_deps,
-        )
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        graph = torch.fx.Graph()
-        inp = graph.placeholder("inp")
-        inp.meta["val"] = torch.ones(1)
-        graph.call_function(torch.ops.streams.wait_event.default, (0, 1))
-        add = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
-        add.meta["val"] = torch.ones(1)
-        set_stream(add, 1)
-        graph.output(add)
-        gm = torch.fx.GraphModule({}, graph)
-
-        wrap_all_sync_nodes_with_control_deps(gm)
-
-        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
-        self.assertEqual(len(ctrl_nodes), 1)
-        self.assertIs(add.args[0].args[0], ctrl_nodes[0])
-        graph.lint()
-
-    def test_external_wait_event_preserves_copy_destination(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            set_stream,
-            wrap_all_sync_nodes_with_control_deps,
-        )
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        graph = torch.fx.Graph()
-        dst = graph.placeholder("dst")
-        dst.meta["val"] = torch.ones(1)
-        src = graph.placeholder("src")
-        src.meta["val"] = torch.ones(1)
-        graph.call_function(torch.ops.streams.wait_event.default, (0, 1))
-        copy = graph.call_function(torch.ops.aten.copy_.default, (dst, src))
-        copy.meta["val"] = torch.ones(1)
-        set_stream(copy, 1)
-        graph.output(copy)
-        gm = torch.fx.GraphModule({}, graph)
-
-        wrap_all_sync_nodes_with_control_deps(gm)
-
-        ctrl = graph.find_nodes(op="call_function", target=control_deps)[0]
-        self.assertIs(copy.args[0], dst)
-        self.assertIs(copy.args[1].args[0], ctrl)
-        graph.lint()
-
-    def test_empty_synchronize_event_anchors_record(self) -> None:
-        self._assert_empty_sync_anchors_record(
-            torch.ops.streams.synchronize_event.default, (0,)
-        )
-
-    def test_wait_stream_depends_on_prior_waiting_stream_work(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            set_stream,
-            wrap_all_sync_nodes_with_control_deps,
-        )
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        graph = torch.fx.Graph()
-        inp = graph.placeholder("inp")
-        inp.meta["val"] = torch.ones(1)
-        prior_work = graph.call_function(torch.ops.aten.add.Tensor, (inp, 1))
-        prior_work.meta["val"] = torch.ones(1)
-        set_stream(prior_work, 1)
-        graph.call_function(torch.ops.streams.wait_stream.default, (1, 0))
-        graph.output(prior_work)
-        gm = torch.fx.GraphModule({}, graph)
-
-        wrap_all_sync_nodes_with_control_deps(gm)
-
-        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
-        self.assertEqual(len(ctrl_nodes), 1)
-        self.assertIn(prior_work, ctrl_nodes[0].args[0])
-        graph.lint()
-
-    def test_wait_stream_self_wait_orders_work_once(self) -> None:
-        from torch._functorch._aot_autograd.streams import (
-            set_stream,
-            wrap_all_sync_nodes_with_control_deps,
-        )
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        graph = torch.fx.Graph()
-        x = graph.placeholder("x")
-        x.meta["val"] = torch.ones(1)
-        y = graph.placeholder("y")
-        y.meta["val"] = torch.ones(1)
-        prior_work = graph.call_function(torch.ops.aten.add.Tensor, (x, 1))
-        prior_work.meta["val"] = torch.ones(1)
-        set_stream(prior_work, 1)
-        graph.call_function(torch.ops.streams.wait_stream.default, (1, 1))
-        following_work = graph.call_function(torch.ops.aten.mul.Tensor, (y, 2))
-        following_work.meta["val"] = torch.ones(1)
-        set_stream(following_work, 1)
-        graph.output((prior_work, following_work))
-        gm = torch.fx.GraphModule({}, graph)
-
-        wrap_all_sync_nodes_with_control_deps(gm)
-
-        ctrl = graph.find_nodes(op="call_function", target=control_deps)[0]
-        self.assertEqual(ctrl.args[0].count(prior_work), 1)
-        self.assertIs(following_work.args[0].args[0], ctrl)
-        graph.lint()
-
     def test_epilogue_copy_stream_tracking(self, device):
         """
         Test that epilogue copies for mutated inputs use the correct stream.
@@ -2672,15 +2672,7 @@ class <lambda>(torch.nn.Module):
         self.assertIsInstance(events[1], torch.Event)
         self.assertGreaterEqual(events[0].elapsed_time(events[1]), 0.0)
 
-
-instantiate_device_type_tests(
-    TestStreams, globals(), allow_xpu=True, except_for=("cpu",)
-)
-
-
-@requires_cuda
-class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
-    def test_same_stream_record_ordering(self) -> None:
+    def test_same_stream_record_ordering(self, device) -> None:
         """Two record_events on one stream must be ordered relative to each other.
 
         The second record's per-stream work was reset by the first, so without
@@ -2692,10 +2684,10 @@ class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
         """
 
         def fn(x) -> torch.Tensor:
-            s = torch.Stream(device="cuda")
-            e1 = torch.Event()
-            e2 = torch.Event()
-            e3 = torch.Event()
+            s = torch.Stream(device=device)
+            e1 = torch.Event(device=device)
+            e2 = torch.Event(device=device)
+            e3 = torch.Event(device=device)
             with s:
                 a = x + 1
                 e1.record()
@@ -2703,7 +2695,7 @@ class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
                 e3.record()
             return a
 
-        inp = (torch.ones(2, 2, device="cuda"),)
+        inp = (torch.ones(2, 2, device=device),)
         # extract_graph already runs wrap_all_sync_nodes_with_control_deps, so
         # assert on its output directly (re-running the pass would wrap the bare
         # e2 a second time and mask the bug).
@@ -2731,6 +2723,14 @@ class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
 
         graph.lint()
 
+
+instantiate_device_type_tests(
+    TestStreams, globals(), allow_xpu=True, except_for=("cpu",)
+)
+
+
+@requires_cuda
+class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
     def test_wait_stream_anchors_following_record(self) -> None:
         """A record_event on the WAITING stream after a wait_stream must chain to
         the wait_stream (which runs on that stream), not float above it as a bare

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -100,13 +100,13 @@ class TestStreams(torch._dynamo.test_case.TestCase):
             self.assertNotIn(DeviceInterface.Event, in_graph_classes)
 
     @onlyAccelerator
-    def test_stream_weakref(self):
-        s = torch.Stream()
+    def test_stream_weakref(self, device):
+        s = torch.Stream(device=device)
         weakref.ref(s)
 
     @onlyAccelerator
-    def test_event_weakref(self):
-        e = torch.Event()
+    def test_event_weakref(self, device):
+        e = torch.Event(device=device)
         weakref.ref(e)
 
     def _assert_weakref_callback_fires(self, factory):
@@ -169,7 +169,7 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         reset_user_object_tracking()
 
         def fn(x):
-            return torch.accelerator.current_stream().stream_id
+            return torch.accelerator.current_stream(device).stream_id
 
         x = torch.zeros(1, device=device)
         compiled = torch.compile(fn, backend="eager", fullgraph=True)
@@ -201,7 +201,7 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         )
 
     @onlyAccelerator
-    def test_stream_enter_exit(self):
+    def test_stream_enter_exit(self, device):
         def fn(x, y, s1, s2):
             with s1:
                 z1 = torch.add(x, y)
@@ -211,7 +211,12 @@ class TestStreams(torch._dynamo.test_case.TestCase):
 
             return y
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2), torch.Stream(), torch.Stream())
+        inp = (
+            torch.ones(2, 2) + 1,
+            torch.ones(2, 2),
+            torch.Stream(device=device),
+            torch.Stream(device=device),
+        )
         expected = fn(*inp)
         (
             actual,
@@ -241,10 +246,10 @@ class <lambda>(torch.nn.Module):
 
     @onlyAccelerator
     @unittest.skip("Needs graph break support with annotation context")
-    def test_stream_context_graph_break(self):
+    def test_stream_context_graph_break(self, device):
         def fn(x, y):
-            s2 = torch.Stream()
-            s1 = torch.Stream()
+            s2 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
             with s1:
                 z1 = torch.add(x, y)
             with s2:
@@ -255,7 +260,7 @@ class <lambda>(torch.nn.Module):
 
             return y
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2))
+        inp = (torch.ones(2, 2, device=device) + 1, torch.ones(2, 2, device=device))
         expected = fn(*inp)
         (
             actual,
@@ -282,14 +287,14 @@ class <lambda>(torch.nn.Module):
         self.assertEqual(expected, actual)
 
     @onlyAccelerator
-    def test_local_stream_return(self):
+    def test_local_stream_return(self, device):
         def fn(x, y):
-            s = torch.Stream()
+            s = torch.Stream(device=device)
             z = torch.add(x, y)
             y = z + 2
             return y, s
 
-        inp = (torch.ones(2, 2) + 1, torch.ones(2, 2))
+        inp = (torch.ones(2, 2, device=device) + 1, torch.ones(2, 2, device=device))
         fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         _, s0 = fn_opt(*inp)
         _, s1 = fn_opt(*inp)
@@ -313,7 +318,7 @@ class <lambda>(torch.nn.Module):
     def test_get_current_stream_return(self, device):
         def fn(x, s):
             with s:
-                s0 = torch.accelerator.current_stream()
+                s0 = torch.accelerator.current_stream(device)
             return x, s0
 
         s_inp = torch.Stream(device=device)
@@ -330,7 +335,7 @@ class <lambda>(torch.nn.Module):
         under torch.compile and match eager behavior."""
 
         def fn_stream(x):
-            return torch.accelerator.current_stream().stream_id
+            return torch.accelerator.current_stream(device).stream_id
 
         x = torch.zeros(1, device=device)
         compiled = torch.compile(fn_stream, backend="eager", fullgraph=True)
@@ -343,7 +348,7 @@ class <lambda>(torch.nn.Module):
 
         def fn(x, s):
             with s:
-                return torch.accelerator.current_stream().stream_id
+                return torch.accelerator.current_stream(device).stream_id
 
         s = torch.Stream(device=device)
         x = torch.zeros(1, device=device)
@@ -351,7 +356,7 @@ class <lambda>(torch.nn.Module):
         self.assertEqual(compiled(x, s), fn(x, s))
 
     @onlyAccelerator
-    def test_nested_stream_enter_exit(self):
+    def test_nested_stream_enter_exit(self, device):
         def fn(x, y, s0, s1, s2):
             with s1:
                 with s2:
@@ -366,9 +371,9 @@ class <lambda>(torch.nn.Module):
         inp = (
             torch.ones(2, 2) + 1,
             torch.ones(2, 2),
-            torch.Stream(),
-            torch.Stream(),
-            torch.Stream(),
+            torch.Stream(device=device),
+            torch.Stream(device=device),
+            torch.Stream(device=device),
         )
         expected = fn(*inp)
         (
@@ -405,7 +410,7 @@ class <lambda>(torch.nn.Module):
         pass
 
     @onlyAccelerator
-    def test_local_stream_enter_exit(self):
+    def test_local_stream_enter_exit(self, device):
         def fn(x, y):
             s2 = torch.Stream()
             s1 = torch.Stream()
@@ -446,7 +451,7 @@ class <lambda>(torch.nn.Module):
         )
 
     @onlyAccelerator
-    def test_local_stream_nested_enter_exit(self):
+    def test_local_stream_nested_enter_exit(self, device):
         def fn(x, y):
             s2 = torch.Stream()
             s1 = torch.Stream()
@@ -518,7 +523,7 @@ class <lambda>(torch.nn.Module):
         from torch._dynamo.graph_bytecode_inputs import get_external_object_by_index
         from torch._dynamo.variables.streams import get_current_stream
 
-        cur_stream = torch.accelerator.current_stream()
+        cur_stream = torch.accelerator.current_stream(device)
         s0 = None
 
         def stream_generation_backend(gm, *args, **kwargs):  # type: ignore[no-untyped-def]
@@ -545,7 +550,7 @@ class <lambda>(torch.nn.Module):
         fn(torch.ones(2, 2, device=device))
 
     @onlyAccelerator
-    def test_stream_with_mutation(self):
+    def test_stream_with_mutation(self, device):
         def fn(x, y):
             s2 = torch.Stream()
             s1 = torch.Stream()
@@ -595,7 +600,7 @@ class <lambda>(torch.nn.Module):
         )
 
     @onlyAccelerator
-    def test_stream_backward_simple(self) -> None:
+    def test_stream_backward_simple(self, device) -> None:
         def fn(x, y):
             s2 = torch.Stream()
             s0 = torch.Stream()
@@ -799,7 +804,7 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_tracing(self, device):
         def fn(x) -> None:
-            e = torch.Event()
+            e = torch.Event(device=device)
             e.record()
             x.add_(1)
             return x
@@ -863,10 +868,10 @@ class <lambda>(torch.nn.Module):
         from torch._dynamo.variables.streams import fork_stream, join_stream
         from torch.library import opcheck
 
-        original_stream = torch.accelerator.current_stream()
+        original_stream = torch.accelerator.current_stream(device)
         try:
-            s0 = torch.Stream()
-            s1 = torch.Stream()
+            s0 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
             store_user_object_weakrefs(s0, s1)
 
             sample_inputs = [
@@ -881,16 +886,16 @@ class <lambda>(torch.nn.Module):
             reset_user_object_tracking()
 
     @onlyAccelerator
-    def test_run_opcheck_wait_record(self):
+    def test_run_opcheck_wait_record(self, device):
         from torch._dynamo.variables.streams import record_event, wait_event
         from torch.library import opcheck
 
-        original_stream = torch.accelerator.current_stream()
+        original_stream = torch.accelerator.current_stream(device)
         try:
-            s0 = torch.Stream()
-            s1 = torch.Stream()
-            e0 = torch.Event()
-            e1 = torch.Event()
+            s0 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
+            e0 = torch.Event(device=device)
+            e1 = torch.Event(device=device)
             store_user_object_weakrefs(s0, s1, e0, e1)
 
             sample_inputs = [
@@ -905,14 +910,14 @@ class <lambda>(torch.nn.Module):
             reset_user_object_tracking()
 
     @onlyAccelerator
-    def test_run_opcheck_wait_record_stream(self):
+    def test_run_opcheck_wait_record_stream(self, device):
         from torch._dynamo.variables.streams import wait_stream
         from torch.library import opcheck
 
         try:
-            s0 = torch.Stream()
-            s1 = torch.Stream()
-            s2 = torch.Stream()
+            s0 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
             store_user_object_weakrefs(s0, s1, s2)
 
             sample_inputs = [
@@ -931,7 +936,7 @@ class <lambda>(torch.nn.Module):
         # We expect there to be a sync_dealloc op added to the graph for y
         # synchronizing the first stream w/ the second stream after the second stream is finished
         def fn(x):
-            e = torch.Event()
+            e = torch.Event(device=device)
             with torch.Stream(device=device):
                 y = torch.ones(2, 2, device=device)
                 e.record()
@@ -1026,7 +1031,7 @@ class GraphModule(torch.nn.Module):
         # first allocated on the first stream used on the second stream
         # used on the first stream again then finally used on the last stream
         def fn(x):
-            e = torch.Event()
+            e = torch.Event(device=device)
             with torch.Stream(device=device):
                 y = torch.ones(2, 2, device=device)
                 z = y * x
@@ -1334,7 +1339,7 @@ class <lambda>(torch.nn.Module):
         def fn(x) -> torch.Tensor:
             s1 = torch.Stream(device=device)
             s2 = torch.Stream(device=device)
-            e = torch.Event()
+            e = torch.Event(device=device)
 
             with s1:
                 y = x + 1
@@ -1400,7 +1405,7 @@ class <lambda>(torch.nn.Module):
         def fn(x) -> torch.Tensor:
             s1 = torch.Stream(device=device)
             s2 = torch.Stream(device=device)
-            e = torch.Event()
+            e = torch.Event(device=device)
 
             with s1:
                 y = x + 1
@@ -1452,7 +1457,7 @@ class <lambda>(torch.nn.Module):
         def fn(x) -> torch.Tensor:
             s1 = torch.Stream(device=device)
             s2 = torch.Stream(device=device)
-            e = torch.Event()
+            e = torch.Event(device=device)
 
             with s1:
                 y = x + 1
@@ -1533,8 +1538,8 @@ class <lambda>(torch.nn.Module):
             s1 = torch.Stream(device=device)
             s2 = torch.Stream(device=device)
             s3 = torch.Stream(device=device)
-            e1 = torch.Event()
-            e2 = torch.Event()
+            e1 = torch.Event(device=device)
+            e2 = torch.Event(device=device)
 
             with s1:
                 y = x + 1
@@ -1625,7 +1630,7 @@ class <lambda>(torch.nn.Module):
         def fn(x) -> torch.Tensor:
             s1 = torch.Stream(device=device)
             s2 = torch.Stream(device=device)
-            e = torch.Event()
+            e = torch.Event(device=device)
 
             with s1:
                 y = x + 1
@@ -2205,7 +2210,7 @@ class GraphModule(torch.nn.Module):
 
             @torch.compile()  # noqa: UNSPECIFIED_BACKEND
             def fn(x):
-                e = torch.Event()
+                e = torch.Event(device=device)
                 x += x + 1
                 e.record()
                 return x
@@ -2246,8 +2251,8 @@ class GraphModule(torch.nn.Module):
         from torch._inductor.fx_passes.control_dependencies import control_deps
 
         def fn(x, y):
-            s0 = torch.Stream()
-            s1 = torch.Stream()
+            s0 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
             with s0:
                 z0 = 2 * x + y
             with s1:
@@ -2311,7 +2316,7 @@ class GraphModule(torch.nn.Module):
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
 
         def fn(x):
-            s = torch.Stream()
+            s = torch.Stream(device=device)
             x.record_stream(s)
             return x
 
@@ -2328,8 +2333,8 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_after_input_mutation_errors(self, device):
         def fn(x):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s:
                 x.add_(1)
                 e.record()
@@ -2343,8 +2348,8 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_after_input_mutation_stack_traces(self, device):
         def fn(x):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s:
                 x.add_(1)
                 e.record()
@@ -2365,7 +2370,7 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_after_input_mutation_record_event(self, device):
         def fn(x):
-            s = torch.Stream()
+            s = torch.Stream(device=device)
             with s:
                 x.add_(1)
                 e = s.record_event()
@@ -2379,8 +2384,8 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_after_input_mutation_through_view(self, device):
         def fn(x):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             v = x.view(-1)
             with s:
                 v.add_(1)
@@ -2395,7 +2400,7 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_after_input_mutation_input_event(self, device):
         def fn(x, e):
-            s = torch.Stream()
+            s = torch.Stream(device=device)
             with s:
                 x.add_(1)
                 e.record()
@@ -2404,14 +2409,14 @@ class GraphModule(torch.nn.Module):
         with self.assertRaisesRegex(RuntimeError, "An event was recorded on a stream"):
             torch.compile(fn, backend="eager", fullgraph=True)(
                 torch.ones(2, 2, device=device),
-                torch.Event(),
+                torch.Event(device=device),
             )
 
     @onlyAccelerator
     def test_event_record_before_input_mutation_no_error(self, device):
         def fn(x):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s:
                 e.record()
                 x.add_(1)
@@ -2424,9 +2429,9 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_record_on_different_stream_no_error(self, device):
         def fn(x):
-            s0 = torch.Stream()
-            s1 = torch.Stream()
-            e = torch.Event()
+            s0 = torch.Stream(device=device)
+            s1 = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s0:
                 x.add_(1)
             with s1:
@@ -2440,8 +2445,8 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_not_returned_no_error(self, device):
         def fn(x):
-            s = torch.Stream()
-            e = torch.Event()
+            s = torch.Stream(device=device)
+            e = torch.Event(device=device)
             with s:
                 x.add_(1)
                 e.record()
@@ -2470,7 +2475,7 @@ class GraphModule(torch.nn.Module):
     @onlyAccelerator
     def test_event_synchronize_tracing(self, device):
         def fn(x):
-            e = torch.Event()
+            e = torch.Event(device=device)
             e.record()
             x = x + 1
             e.synchronize()
@@ -2514,7 +2519,7 @@ class <lambda>(torch.nn.Module):
 
             @torch.compile()  # noqa: UNSPECIFIED_BACKEND
             def fn(x):
-                e = torch.Event()
+                e = torch.Event(device=device)
                 x = x + 1
                 e.record()
                 e.synchronize()
@@ -2533,7 +2538,7 @@ class <lambda>(torch.nn.Module):
         """
 
         def fn(x) -> torch.Tensor:
-            e = torch.Event()
+            e = torch.Event(device=device)
             y = x + 1
             e.record()
             e.synchronize()
@@ -2646,7 +2651,7 @@ class <lambda>(torch.nn.Module):
         """When the event was recorded externally, synchronize threads graph inputs through."""
 
         def fn(x):
-            e = torch.Event()
+            e = torch.Event(device=device)
             y = x + 1
             e.record()
             e.synchronize()
@@ -2712,7 +2717,7 @@ class <lambda>(torch.nn.Module):
         """E2E: compute → record → synchronize → use result through torch.compile."""
 
         def f(x):
-            e = torch.Event()
+            e = torch.Event(device=device)
             y = x + 1
             e.record()
             e.synchronize()
@@ -2731,7 +2736,7 @@ class <lambda>(torch.nn.Module):
             a_to_cpu_event_list = []
             for a in a_list:
                 a_cpu = a.to(device="cpu", non_blocking=True)
-                e = torch.Event()
+                e = torch.Event(device=device)
                 e.record()
                 a_cpu_list.append(a_cpu)
                 a_to_cpu_event_list.append(e)

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -711,7 +711,7 @@ class GraphModule(torch.nn.Module):
             torch.ones(2, 2, device=device, requires_grad=True) + 1,
             torch.ones(2, 2, device=device, requires_grad=True),
         )
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         expected = fn(*inp)
         (
             actual,
@@ -719,7 +719,7 @@ class GraphModule(torch.nn.Module):
             fw_graphs,
             bw_graphs,
         ) = extract_graph(fn, *inp)
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         self.assertEqual(len(fw_graphs), 1)
         self.assertEqual(expected, actual)
         self.assertExpectedInline(
@@ -1647,192 +1647,6 @@ class <lambda>(torch.nn.Module):
 
         graph.lint()
 
-    @requires_cuda
-    def test_same_stream_record_ordering(self) -> None:
-        """Two record_events on one stream must be ordered relative to each other.
-
-        The second record's per-stream work was reset by the first, so without
-        an explicit edge it is emitted bare (no control_deps) and can float above
-        the compute, capturing nothing -- the same 'bare side-effectful sync
-        floats' bug as an unanchored synchronize_stream. Each record must depend
-        on the prior sync on its own stream, so the second record's control_deps
-        depends on the first record's control_deps node.
-        """
-
-        def fn(x) -> torch.Tensor:
-            s = torch.Stream(device="cuda")
-            e1 = torch.Event()
-            e2 = torch.Event()
-            e3 = torch.Event()
-            with s:
-                a = x + 1
-                e1.record()
-                e2.record()  # deps reset by e1 -> would be bare without the fix
-                e3.record()
-            return a
-
-        inp = (torch.ones(2, 2, device="cuda"),)
-        # extract_graph already runs wrap_all_sync_nodes_with_control_deps, so
-        # assert on its output directly (re-running the pass would wrap the bare
-        # e2 a second time and mask the bug).
-        (
-            _,
-            _,
-            fw_graphs,
-            _,
-        ) = extract_graph(fn, *inp)
-
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        # All records must be wrapped -- e2/e3 must not be left bare nodes.
-        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
-        self.assertEqual(len(ctrl_nodes), 3)
-        record1_ctrl, record2_ctrl, record3_ctrl = ctrl_nodes
-
-        # Each record depends only on its immediate predecessor, keeping the
-        # per-stream sync ordering a linear chain rather than its full history.
-        self.assertIn(record1_ctrl, record2_ctrl.args[0])
-        self.assertIn(record2_ctrl, record3_ctrl.args[0])
-        self.assertNotIn(record1_ctrl, record3_ctrl.args[0])
-
-        graph.lint()
-
-    @requires_cuda
-    def test_wait_stream_anchors_following_record(self) -> None:
-        """A record_event on the WAITING stream after a wait_stream must chain to
-        the wait_stream (which runs on that stream), not float above it as a bare
-        node. Regression: wait_stream's control_deps was keyed under the waited-on
-        stream, so a later record on the waiting stream never found it.
-        """
-
-        def fn(x) -> torch.Tensor:
-            default = torch.cuda.current_stream()
-            side = torch.cuda.Stream()
-            ready = torch.cuda.Event()
-            e = torch.cuda.Event()
-            a = x @ x
-            ready.record(default)
-            with torch.cuda.stream(side):
-                side.wait_stream(default)
-                e.record()  # bare on the waiting stream without the fix
-            e.wait()
-            return a
-
-        inp = (torch.ones(4, 4, device="cuda"),)
-        (
-            _,
-            _,
-            fw_graphs,
-            _,
-        ) = extract_graph(fn, *inp)
-
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        # The record must be wrapped, not left as a bare (floatable) node in the
-        # main graph -- wrapped record_events live inside control_deps subgraphs.
-        bare_records = graph.find_nodes(
-            op="call_function", target=torch.ops.streams.record_event.default
-        )
-        self.assertEqual(
-            list(bare_records), [], "record_event on the waiting stream floated bare"
-        )
-
-        # The wait must depend on the waited-on stream's retained record dependency,
-        # and the following record must depend on the wait on its own stream.
-        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
-        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
-        wait_ctrl = [n for n in ctrl_nodes if "wait_stream" in n.args[1].name]
-        self.assertEqual(len(record_ctrl), 2)
-        self.assertEqual(len(wait_ctrl), 1)
-        self.assertIn(record_ctrl[0], wait_ctrl[0].args[0])
-        self.assertIn(wait_ctrl[0], record_ctrl[1].args[0])
-
-        graph.lint()
-
-    @requires_cuda
-    def test_cross_stream_event_rerecord_without_work(self) -> None:
-        def fn(x) -> torch.Tensor:
-            s1 = torch.cuda.Stream()
-            s2 = torch.cuda.Stream()
-            s3 = torch.cuda.Stream()
-            e = torch.cuda.Event()
-            with torch.cuda.stream(s1):
-                y = x + 1
-                e.record()
-            with torch.cuda.stream(s2):
-                e.record()
-            with torch.cuda.stream(s3):
-                e.wait()
-                z = x + 2
-            return y + z
-
-        inp = (torch.ones(2, 2, device="cuda"),)
-        _, _, fw_graphs, _ = extract_graph(fn, *inp)
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
-        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
-        wait_ctrl = [n for n in ctrl_nodes if "wait_event" in n.args[1].name]
-        self.assertEqual(len(record_ctrl), 2)
-        self.assertEqual(len(wait_ctrl), 1)
-        self.assertIn(record_ctrl[0], record_ctrl[1].args[0])
-        self.assertIn(record_ctrl[1], wait_ctrl[0].args[0])
-        self.assertNotIn(record_ctrl[0], wait_ctrl[0].args[0])
-
-        graph.lint()
-
-    @requires_cuda
-    def test_wait_stream_preserves_waited_on_work(self) -> None:
-        def fn(x) -> torch.Tensor:
-            default = torch.cuda.current_stream()
-            side = torch.cuda.Stream()
-            a = x @ x
-            side.wait_stream(default)
-            torch.cuda.Event().record(default)
-            return a
-
-        inp = (torch.ones(4, 4, device="cuda"),)
-        _, _, fw_graphs, _ = extract_graph(fn, *inp)
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
-        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
-        self.assertEqual(len(record_ctrl), 1)
-        self.assertTrue(record_ctrl[0].args[0])
-
-        graph.lint()
-
-    @requires_cuda
-    def test_leading_synchronize_stream_orders_following_work(self) -> None:
-        def fn(x) -> torch.Tensor:
-            torch.cuda.current_stream().synchronize()
-            return x + 1
-
-        inp = (torch.ones(4, 4, device="cuda"),)
-        _, _, fw_graphs, _ = extract_graph(fn, *inp)
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
-        sync_ctrl = [n for n in ctrl_nodes if "synchronize_stream" in n.args[1].name]
-        self.assertEqual(len(sync_ctrl), 1)
-        adds = list(
-            graph.find_nodes(op="call_function", target=torch.ops.aten.add.Tensor)
-        )
-        self.assertEqual(len(adds), 1)
-        self.assertIs(adds[0].args[0].args[0], sync_ctrl[0])
-
-        graph.lint()
-
     def test_full_barrier_forward_deps_respect_partition(self) -> None:
         from torch._functorch._aot_autograd.streams import _collect_sync_forward_deps
 
@@ -1982,29 +1796,6 @@ class <lambda>(torch.nn.Module):
         ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
         self.assertEqual(len(ctrl_nodes), 1)
         self.assertIs(add.args[0].args[0], ctrl_nodes[0])
-        graph.lint()
-
-    @requires_cuda
-    def test_captured_external_wait_event_orders_following_work(self) -> None:
-        event = torch.cuda.Event()
-        stream = torch.cuda.Stream()
-        event.record()
-
-        def fn(x: torch.Tensor) -> torch.Tensor:
-            with torch.cuda.stream(stream):
-                event.wait()
-                return x + 1
-
-        _, _, fw_graphs, _ = extract_graph(fn, torch.ones(2, device="cuda"))
-        graph = fw_graphs[0].graph
-
-        from torch._inductor.fx_passes.control_dependencies import control_deps
-
-        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
-        wait_ctrl = [n for n in ctrl_nodes if "wait_event" in n.args[1].name]
-        self.assertEqual(len(wait_ctrl), 1)
-        add = graph.find_nodes(op="call_function", target=torch.ops.aten.add.Tensor)[0]
-        self.assertIs(add.args[0].args[0], wait_ctrl[0])
         graph.lint()
 
     def test_external_wait_event_preserves_copy_destination(self) -> None:
@@ -2889,6 +2680,209 @@ instantiate_device_type_tests(
 
 @requires_cuda
 class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
+    def test_same_stream_record_ordering(self) -> None:
+        """Two record_events on one stream must be ordered relative to each other.
+
+        The second record's per-stream work was reset by the first, so without
+        an explicit edge it is emitted bare (no control_deps) and can float above
+        the compute, capturing nothing -- the same 'bare side-effectful sync
+        floats' bug as an unanchored synchronize_stream. Each record must depend
+        on the prior sync on its own stream, so the second record's control_deps
+        depends on the first record's control_deps node.
+        """
+
+        def fn(x) -> torch.Tensor:
+            s = torch.Stream(device="cuda")
+            e1 = torch.Event()
+            e2 = torch.Event()
+            e3 = torch.Event()
+            with s:
+                a = x + 1
+                e1.record()
+                e2.record()  # deps reset by e1 -> would be bare without the fix
+                e3.record()
+            return a
+
+        inp = (torch.ones(2, 2, device="cuda"),)
+        # extract_graph already runs wrap_all_sync_nodes_with_control_deps, so
+        # assert on its output directly (re-running the pass would wrap the bare
+        # e2 a second time and mask the bug).
+        (
+            _,
+            _,
+            fw_graphs,
+            _,
+        ) = extract_graph(fn, *inp)
+
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        # All records must be wrapped -- e2/e3 must not be left bare nodes.
+        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
+        self.assertEqual(len(ctrl_nodes), 3)
+        record1_ctrl, record2_ctrl, record3_ctrl = ctrl_nodes
+
+        # Each record depends only on its immediate predecessor, keeping the
+        # per-stream sync ordering a linear chain rather than its full history.
+        self.assertIn(record1_ctrl, record2_ctrl.args[0])
+        self.assertIn(record2_ctrl, record3_ctrl.args[0])
+        self.assertNotIn(record1_ctrl, record3_ctrl.args[0])
+
+        graph.lint()
+
+    def test_wait_stream_anchors_following_record(self) -> None:
+        """A record_event on the WAITING stream after a wait_stream must chain to
+        the wait_stream (which runs on that stream), not float above it as a bare
+        node. Regression: wait_stream's control_deps was keyed under the waited-on
+        stream, so a later record on the waiting stream never found it.
+        """
+
+        def fn(x) -> torch.Tensor:
+            default = torch.cuda.current_stream()
+            side = torch.cuda.Stream()
+            ready = torch.cuda.Event()
+            e = torch.cuda.Event()
+            a = x @ x
+            ready.record(default)
+            with torch.cuda.stream(side):
+                side.wait_stream(default)
+                e.record()  # bare on the waiting stream without the fix
+            e.wait()
+            return a
+
+        inp = (torch.ones(4, 4, device="cuda"),)
+        (
+            _,
+            _,
+            fw_graphs,
+            _,
+        ) = extract_graph(fn, *inp)
+
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        # The record must be wrapped, not left as a bare (floatable) node in the
+        # main graph -- wrapped record_events live inside control_deps subgraphs.
+        bare_records = graph.find_nodes(
+            op="call_function", target=torch.ops.streams.record_event.default
+        )
+        self.assertEqual(
+            list(bare_records), [], "record_event on the waiting stream floated bare"
+        )
+
+        # The wait must depend on the waited-on stream's retained record dependency,
+        # and the following record must depend on the wait on its own stream.
+        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
+        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
+        wait_ctrl = [n for n in ctrl_nodes if "wait_stream" in n.args[1].name]
+        self.assertEqual(len(record_ctrl), 2)
+        self.assertEqual(len(wait_ctrl), 1)
+        self.assertIn(record_ctrl[0], wait_ctrl[0].args[0])
+        self.assertIn(wait_ctrl[0], record_ctrl[1].args[0])
+
+        graph.lint()
+
+    def test_cross_stream_event_rerecord_without_work(self) -> None:
+        def fn(x) -> torch.Tensor:
+            s1 = torch.cuda.Stream()
+            s2 = torch.cuda.Stream()
+            s3 = torch.cuda.Stream()
+            e = torch.cuda.Event()
+            with torch.cuda.stream(s1):
+                y = x + 1
+                e.record()
+            with torch.cuda.stream(s2):
+                e.record()
+            with torch.cuda.stream(s3):
+                e.wait()
+                z = x + 2
+            return y + z
+
+        inp = (torch.ones(2, 2, device="cuda"),)
+        _, _, fw_graphs, _ = extract_graph(fn, *inp)
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
+        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
+        wait_ctrl = [n for n in ctrl_nodes if "wait_event" in n.args[1].name]
+        self.assertEqual(len(record_ctrl), 2)
+        self.assertEqual(len(wait_ctrl), 1)
+        self.assertIn(record_ctrl[0], record_ctrl[1].args[0])
+        self.assertIn(record_ctrl[1], wait_ctrl[0].args[0])
+        self.assertNotIn(record_ctrl[0], wait_ctrl[0].args[0])
+
+        graph.lint()
+
+    def test_wait_stream_preserves_waited_on_work(self) -> None:
+        def fn(x) -> torch.Tensor:
+            default = torch.cuda.current_stream()
+            side = torch.cuda.Stream()
+            a = x @ x
+            side.wait_stream(default)
+            torch.cuda.Event().record(default)
+            return a
+
+        inp = (torch.ones(4, 4, device="cuda"),)
+        _, _, fw_graphs, _ = extract_graph(fn, *inp)
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
+        record_ctrl = [n for n in ctrl_nodes if "record_event" in n.args[1].name]
+        self.assertEqual(len(record_ctrl), 1)
+        self.assertTrue(record_ctrl[0].args[0])
+
+        graph.lint()
+
+    def test_leading_synchronize_stream_orders_following_work(self) -> None:
+        def fn(x) -> torch.Tensor:
+            torch.cuda.current_stream().synchronize()
+            return x + 1
+
+        inp = (torch.ones(4, 4, device="cuda"),)
+        _, _, fw_graphs, _ = extract_graph(fn, *inp)
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        ctrl_nodes = list(graph.find_nodes(op="call_function", target=control_deps))
+        sync_ctrl = [n for n in ctrl_nodes if "synchronize_stream" in n.args[1].name]
+        self.assertEqual(len(sync_ctrl), 1)
+        adds = list(
+            graph.find_nodes(op="call_function", target=torch.ops.aten.add.Tensor)
+        )
+        self.assertEqual(len(adds), 1)
+        self.assertIs(adds[0].args[0].args[0], sync_ctrl[0])
+
+        graph.lint()
+
+    def test_captured_external_wait_event_orders_following_work(self) -> None:
+        event = torch.cuda.Event()
+        stream = torch.cuda.Stream()
+        event.record()
+
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            with torch.cuda.stream(stream):
+                event.wait()
+                return x + 1
+
+        _, _, fw_graphs, _ = extract_graph(fn, torch.ones(2, device="cuda"))
+        graph = fw_graphs[0].graph
+
+        from torch._inductor.fx_passes.control_dependencies import control_deps
+
+        ctrl_nodes = graph.find_nodes(op="call_function", target=control_deps)
+        wait_ctrl = [n for n in ctrl_nodes if "wait_event" in n.args[1].name]
+        self.assertEqual(len(wait_ctrl), 1)
+        add = graph.find_nodes(op="call_function", target=torch.ops.aten.add.Tensor)[0]
+        self.assertIs(add.args[0].args[0], wait_ctrl[0])
+        graph.lint()
+
     def test_dynamo_registry_no_dangling_weakref(self):
         """Natural repro of the original UAF pattern.
 

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -2186,6 +2186,87 @@ class GraphModule(torch.nn.Module):
             # Should not raise due to signature mismatch
             torch.ops.streams.record_stream.default(t, 0)
 
+    def test_expand_dict_returning_deps_triton_kernel(self) -> None:
+        """Triton kernel dicts must not be passed through control_deps.
+
+        triton_kernel_wrapper_functional returns a dict.  If the dict node is
+        threaded through control_deps as a pass-through value,
+        decompose_triton_kernel_wrapper_functional later replaces it with a
+        raw Python dict (via replace_with_graph -> replace_all_uses_with),
+        corrupting the graph and causing KeyError during lowering.
+
+        _expand_dict_returning_deps should insert per-key getitem nodes
+        *before* the sync so that only tensor-valued nodes are passed through.
+        """
+        import operator
+
+        from torch._functorch._aot_autograd.streams import _expand_dict_returning_deps
+
+        graph = torch.fx.Graph()
+        # Placeholder input
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.empty(4, 4)
+
+        # Simulate a triton_kernel_wrapper_functional call returning a dict
+        triton_func = graph.call_function(
+            torch.ops.higher_order.triton_kernel_wrapper_functional,
+            kwargs={
+                "kernel_idx": 0,
+                "constant_args_idx": 0,
+                "grid": [(1, 1, 1)],
+                "tma_descriptor_metadata": {},
+                "kwargs": {"Out": x},
+                "tensors_to_clone": ["Out"],
+            },
+        )
+        triton_func.meta["val"] = {"Out": torch.empty(4, 4)}
+
+        # Simulate a sync node (record_event) between triton_func and getitem
+        sync_node = graph.call_function(
+            torch.ops.streams.record_event.default,
+            args=(0, 0),
+        )
+
+        # getitem user AFTER the sync -- this is the problematic pattern
+        getitem_out = graph.call_function(
+            operator.getitem,
+            args=(triton_func, "Out"),
+        )
+        getitem_out.meta["val"] = torch.empty(4, 4)
+
+        # Use getitem_out so it's live
+        add_node = graph.call_function(torch.ops.aten.add.Tensor, args=(getitem_out, x))
+        graph.output(add_node)
+
+        # Build visited set: everything at or before sync_node
+        visited: set[torch.fx.Node] = set()
+        for n in graph.nodes:
+            visited.add(n)
+            if n is sync_node:
+                break
+
+        # deps_with_uses_after_sync: triton_func has getitem_out as after-sync user
+        deps = [triton_func]
+
+        expanded = _expand_dict_returning_deps(deps, visited, graph, sync_node)
+
+        # The triton_func dict should NOT be in the expanded list
+        self.assertNotIn(triton_func, expanded)
+
+        # Instead, we should have a new getitem node for key "Out"
+        self.assertEqual(len(expanded), 1)
+        new_gi = expanded[0]
+        self.assertEqual(new_gi.target, operator.getitem)
+        self.assertEqual(new_gi.args, (triton_func, "Out"))
+
+        # The new getitem should be BEFORE the sync in graph order
+        node_order = list(graph.nodes)
+        self.assertLess(node_order.index(new_gi), node_order.index(sync_node))
+
+        # The old getitem_out should have been erased; add_node now uses new_gi
+        self.assertNotIn(getitem_out, set(graph.nodes))
+        self.assertIn(new_gi, add_node.all_input_nodes)
+
     @onlyAccelerator
     def test_record_stream(self, device):
         backend = torch._dynamo.testing.EagerAndRecordGraphs()
@@ -2838,7 +2919,12 @@ class <lambda>(torch.nn.Module):
         x = torch.randn(16, 16, device=device)
         expected = fn(x)
         torch.accelerator.synchronize()
-        events[0].elapsed_time(events[1])
+        try:
+            events[0].elapsed_time(events[1])
+        except RuntimeError as e:
+            if "doesn't support elapsedTime" not in str(e):
+                raise
+            self.skipTest(f"{device} does not support Event timing")
         events.clear()
 
         actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
@@ -2961,87 +3047,6 @@ class TestStreamsCUDASpecific(torch._dynamo.test_case.TestCase):
         self.assertEqual(actual_s1, expected_s1)
         self.assertEqual(actual_s2, expected_s2)
         self.assertEqual(actual_default, default_s.cuda_stream)
-
-    def test_expand_dict_returning_deps_triton_kernel(self) -> None:
-        """Triton kernel dicts must not be passed through control_deps.
-
-        triton_kernel_wrapper_functional returns a dict.  If the dict node is
-        threaded through control_deps as a pass-through value,
-        decompose_triton_kernel_wrapper_functional later replaces it with a
-        raw Python dict (via replace_with_graph -> replace_all_uses_with),
-        corrupting the graph and causing KeyError during lowering.
-
-        _expand_dict_returning_deps should insert per-key getitem nodes
-        *before* the sync so that only tensor-valued nodes are passed through.
-        """
-        import operator
-
-        from torch._functorch._aot_autograd.streams import _expand_dict_returning_deps
-
-        graph = torch.fx.Graph()
-        # Placeholder input
-        x = graph.placeholder("x")
-        x.meta["val"] = torch.empty(4, 4)
-
-        # Simulate a triton_kernel_wrapper_functional call returning a dict
-        triton_func = graph.call_function(
-            torch.ops.higher_order.triton_kernel_wrapper_functional,
-            kwargs={
-                "kernel_idx": 0,
-                "constant_args_idx": 0,
-                "grid": [(1, 1, 1)],
-                "tma_descriptor_metadata": {},
-                "kwargs": {"Out": x},
-                "tensors_to_clone": ["Out"],
-            },
-        )
-        triton_func.meta["val"] = {"Out": torch.empty(4, 4)}
-
-        # Simulate a sync node (record_event) between triton_func and getitem
-        sync_node = graph.call_function(
-            torch.ops.streams.record_event.default,
-            args=(0, 0),
-        )
-
-        # getitem user AFTER the sync -- this is the problematic pattern
-        getitem_out = graph.call_function(
-            operator.getitem,
-            args=(triton_func, "Out"),
-        )
-        getitem_out.meta["val"] = torch.empty(4, 4)
-
-        # Use getitem_out so it's live
-        add_node = graph.call_function(torch.ops.aten.add.Tensor, args=(getitem_out, x))
-        graph.output(add_node)
-
-        # Build visited set: everything at or before sync_node
-        visited: set[torch.fx.Node] = set()
-        for n in graph.nodes:
-            visited.add(n)
-            if n is sync_node:
-                break
-
-        # deps_with_uses_after_sync: triton_func has getitem_out as after-sync user
-        deps = [triton_func]
-
-        expanded = _expand_dict_returning_deps(deps, visited, graph, sync_node)
-
-        # The triton_func dict should NOT be in the expanded list
-        self.assertNotIn(triton_func, expanded)
-
-        # Instead, we should have a new getitem node for key "Out"
-        self.assertEqual(len(expanded), 1)
-        new_gi = expanded[0]
-        self.assertEqual(new_gi.target, operator.getitem)
-        self.assertEqual(new_gi.args, (triton_func, "Out"))
-
-        # The new getitem should be BEFORE the sync in graph order
-        node_order = list(graph.nodes)
-        self.assertLess(node_order.index(new_gi), node_order.index(sync_node))
-
-        # The old getitem_out should have been erased; add_node now uses new_gi
-        self.assertNotIn(getitem_out, set(graph.nodes))
-        self.assertIn(new_gi, add_node.all_input_nodes)
 
 
 @unittest.skipUnless(TEST_XPU, "xpu only")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1944,6 +1944,8 @@ if TEST_CUDA and 'NUM_PARALLEL_PROCS' in os.environ:
     torch.cuda.set_per_process_memory_fraction(round((gb_available - num_procs * .85) / gb_available / num_procs, 2))
 
 requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "Requires CUDA")
+requires_xpu = unittest.skipUnless(torch.xpu.is_available(), "Requires XPU")
+requires_accelerator = unittest.skipUnless(torch.accelerator.is_available(), "requires accelerator")
 
 
 def lazy_skip_if(condition_fn, reason):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1922,6 +1922,8 @@ if TEST_CUDA and 'NUM_PARALLEL_PROCS' in os.environ:
     torch.cuda.set_per_process_memory_fraction(round((gb_available - num_procs * .85) / gb_available / num_procs, 2))
 
 requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "Requires CUDA")
+requires_xpu = unittest.skipUnless(torch.xpu.is_available(), "Requires XPU")
+requires_accelerator = unittest.skipUnless(torch.accelerator.is_available(), "requires accelerator")
 
 
 def lazy_skip_if(condition_fn, reason):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1944,8 +1944,7 @@ if TEST_CUDA and 'NUM_PARALLEL_PROCS' in os.environ:
     torch.cuda.set_per_process_memory_fraction(round((gb_available - num_procs * .85) / gb_available / num_procs, 2))
 
 requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "Requires CUDA")
-requires_xpu = unittest.skipUnless(torch.xpu.is_available(), "Requires XPU")
-requires_accelerator = unittest.skipUnless(torch.accelerator.is_available(), "requires accelerator")
+requires_xpu = unittest.skipUnless(TEST_XPU, "Requires XPU")
 
 
 def lazy_skip_if(condition_fn, reason):
@@ -1977,6 +1976,11 @@ def lazy_skip_if(condition_fn, reason):
             return fn(*args, **kwargs)
         return wrapper
     return decorator
+
+requires_accelerator = lazy_skip_if(
+    lambda: not torch.accelerator.is_available(),
+    "requires accelerator",
+)
 
 
 def skipIfCrossRef(fn):


### PR DESCRIPTION
Refactor `test/dynamo/test_streams.py` to use `instantiate_device_type_tests` with `@requires_accelerator` so stream and event tests automatically run on any registered accelerator backend.

## Changes

### Infrastructure
- Add `requires_accelerator` and `requires_xpu` to `common_utils.py` mirroring the existing `requires_cuda` named decorator
- Add `instantiate_device_type_tests` with `except_for=("cpu",)` so future accelerator backends are included automatically without editing this file
- Replace 56 per-method `@onlyAccelerator` decorators with a single `@requires_accelerator` at the `TestStreams` class level

### Test organization
- Create `TestStreamsGeneric` for 6 device-agnostic tests (side-effect registry checks, FakeTensorMode, FX graph tests) so they run on CPU-only machines
- Convert 58 tests from `@requires_cuda` to device-generic via `instantiate_device_type_tests`
- Replace `@unittest.skipUnless(TEST_XPU, "xpu only")` on `TestStreamsXPUSpecific` with `@requires_xpu`
- Remove unused `TEST_XPU` import

### Device-agnostic conversion
- Replace all hardcoded `device="cuda"` / `device="cuda:0"` with `device=device`
- Merge CUDA/XPU test pairs into single device-generic tests:
  - `test_cuda_stream_event_weakref_callback` + `test_xpu_stream_event_weakref_callback` → `test_backend_stream_event_weakref_callback`
  - `test_cuda_current_stream_with_entered_stream` + `test_xpu_current_stream_with_entered_stream` → `test_current_stream_with_entered_stream`
  - `test_cuda_event_record_on_stream` → `test_backend_event_record_on_stream`
- Use `torch.accelerator.current_stream().stream_id` instead of backend-specific `.cuda_stream` / `.sycl_queue`
- Add `skipTest` guards for backends without `torch.<backend>.Stream` / `torch.<backend>.Event`

**Test count: 82 → 83 passing** (1 new test from `TestStreamsGeneric` running on CPU; 2 additional XPU tests now properly collected and skipped when no XPU is present)

## Not Changed
- `test_stream_pointer_extraction_edge_cases` — deeply tied to `.cuda_stream` pointer values, `torch.cuda.default_stream()`, and `torch.cuda.stream()` context manager

cc @albanD @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98