### PR TITLE
[Test] Make dynamo/test_interop.py device-agnostic for out-of-tree backends

### DIFF
--- a/test/dynamo/test_interop.py
+++ b/test/dynamo/test_interop.py
@@ -1,7 +1,15 @@
 # Owner(s): ["module: dynamo"]
+from functools import wraps
+
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
+from torch._dynamo import allow_in_graph
+
+
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
 
 
 def fn(a, b):
@@ -10,7 +18,10 @@ def fn(a, b):
 
 class InteropTests(torch._dynamo.test_case.TestCase):
     def _common(self, fn):
-        inputs = [torch.randn(10), torch.randn(10)]
+        inputs = [
+            torch.randn(10, device=device_type),
+            torch.randn(10, device=device_type),
+        ]
         ref = fn(*inputs)
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         res = opt_fn(*inputs)
@@ -25,7 +36,10 @@ class InteropTests(torch._dynamo.test_case.TestCase):
         self._common(lambda a, b: script_fn(a, b) + 1)
 
     def test_trace_fn(self):
-        trace_fn = torch.jit.trace(fn, [torch.zeros(10), torch.zeros(10)])
+        trace_fn = torch.jit.trace(
+            fn,
+            [torch.zeros(10, device=device_type), torch.zeros(10, device=device_type)],
+        )
         self._common(lambda a, b: trace_fn(a, b) + 1)
 
     def test_staticmethod_script_fn(self):
@@ -42,10 +56,6 @@ class InteropTests(torch._dynamo.test_case.TestCase):
         self._common(lambda a, b: foo.g(a, b) + 1)
 
     def test_vmap_in_graph(self):
-        from functools import wraps
-
-        from torch._dynamo import allow_in_graph
-
         def traceable(f):
             f = allow_in_graph(f)
 
@@ -56,7 +66,7 @@ class InteropTests(torch._dynamo.test_case.TestCase):
             return wrapper
 
         cnts = torch._dynamo.testing.CompileCounter()
-        x = torch.randn(3, 5, 3)
+        x = torch.randn(3, 5, 3, device=device_type)
 
         def fn(x):
             return torch.vmap(torch.Tensor.t)(x)


### PR DESCRIPTION
## Summary
- Detect the available accelerator at module level using `torch.accelerator.current_accelerator()`, falling back to `"cpu"` when no accelerator is present. This follows the same pattern established in `test_logging.py`.
- Update all tensor creation sites (`_common` helper, `test_trace_fn` trace inputs, `test_vmap_in_graph`) to use `device=device_type` so tests automatically run on CPU, CUDA, XPU, or any other available backend.
- Hoist inline imports (`functools.wraps`, `torch._dynamo.allow_in_graph`) from `test_vmap_in_graph` to module level.

## Test plan
- `TEST_CONFIG=cpu python3 test/run_test.py -i dynamo/test_interop` — all 5 tests pass.
- CI will validate on CUDA/XPU configurations.

cc: @guilhermeleobas @Lucaskabela @fffrog @albanD @mansiag05 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98