### PR TITLE
[Test] Make test_wrap_inductor_compiled_regions.py device-agnostic for out-of-tree backends

### DIFF
--- a/test/dynamo/test_wrap_inductor_compiled_regions.py
+++ b/test/dynamo/test_wrap_inductor_compiled_regions.py
@@ -12,7 +12,7 @@ from torch._functorch import config as functorch_config
 from torch._inductor import config as inductor_config
 from torch.nn.attention.flex_attention import flex_attention, flex_attention_hop
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.triton_utils import requires_gpu_and_triton
 from torch.utils._debug_mode import DebugMode
 from torch.utils.checkpoint import (
     checkpoint,
@@ -74,7 +74,7 @@ def count_ops(
 class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
     """Tests for wrap_inductor_compiled_regions option"""
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_enabled_visible_in_debug_mode(self, device):
         """Test that compiled regions are wrapped when option is enabled"""
 
@@ -101,7 +101,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_name_visible_in_debug_mode(self, device):
         """Test that named compiled regions surface their name in DebugMode"""
 
@@ -128,7 +128,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_disabled_not_visible_in_debug_mode(self, device):
         """Test that compiled regions are not wrapped when option is disabled"""
 
@@ -155,7 +155,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_default_disabled(self, device):
         """Test that wrapping is disabled by default"""
 
@@ -178,7 +178,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_with_backward(self, device):
         """Test that wrapping works correctly with backward pass"""
 
@@ -218,7 +218,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(x.grad, x_eager.grad)
         self.assertEqual(y.grad, y_eager.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_with_multiple_ops(self, device):
         """Test wrapping with a function that has multiple operations"""
 
@@ -250,7 +250,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = b + x
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_option_type_validation(self, device):
         """Test that wrap_inductor_compiled_regions validates type correctly"""
 
@@ -285,7 +285,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         self.assertIn("Unexpected type", str(cm.exception))
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_per_compilation(self, device):
         """Test that wrap option is per-compilation, not global"""
 
@@ -318,7 +318,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             _ = fn_not_wrapped(x, y)
         self.assertNotIn("inductor_compiled_code", debug_mode2.debug_string())
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
@@ -398,7 +398,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result1, expected)
         self.assertEqual(result2, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
@@ -490,7 +490,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         # Unwrapped version should not
         self.assertNotIn("inductor_compiled_code", debug_unwrapped.debug_string())
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_flex_attention_with_wrapper_basic(self, device):
         """Test that flex_attention works with wrap_inductor_compiled_regions=True"""
 
@@ -526,7 +526,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         output_unwrapped = fn_unwrapped(q, k, v)
         torch.testing.assert_close(output, output_unwrapped, rtol=1e-3, atol=1e-3)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_flex_attention_wrapper_visible_in_debug_mode(self, device):
         """Test that inductor_compiled_code HOP is visible to DebugMode when wrapper is enabled"""
 
@@ -576,7 +576,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             "inductor_compiled_code HOP should not be visible when wrapper is disabled",
         )
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_flex_attention_wrapper_with_backward(self, device):
         """Test that wrapper works correctly with backward pass"""
 
@@ -633,7 +633,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(k.grad, k2.grad, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(v.grad, v2.grad, rtol=1e-3, atol=1e-3)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
@@ -702,7 +702,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         # Verify correctness
         torch.testing.assert_close(result1, result2)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_flex_attention_with_sac_must_save(self, device):
         """
         Test that SAC policy MUST_SAVE for flex_attention_hop
@@ -786,7 +786,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(k.grad)
         self.assertIsNotNone(v.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_flex_attention_with_sac_prefer_recompute(self, device):
         """
         Test that SAC policy PREFER_RECOMPUTE for flex_attention_hop
@@ -871,7 +871,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(k.grad)
         self.assertIsNotNone(v.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_sac_outer_compile_inner_basic(self, device):
         """
         Test SAC(compile(foo)) pattern - SAC on eager code with inner compiled region.
@@ -951,7 +951,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(x.grad, x_eager.grad)
         self.assertEqual(y.grad, y_eager.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_sac_outer_compile_inner_name_visible_to_policy(self, device):
         """Test that SAC policies can inspect torch.compile region names"""
 
@@ -1005,7 +1005,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(x.grad, x_eager.grad)
         self.assertEqual(y.grad, y_eager.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_no_dispatch_mode_no_hop_invoked(self, device):
         """
         Test that without TorchDispatchMode, the HOP is NOT invoked.
@@ -1068,7 +1068,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             mock_hop.assert_called()
             self.assertEqual(result_with, expected2)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_sac_outer_compile_inner_flex_attention(self, device):
         """
         Test SAC(compile(foo)) with flex_attention - the key motivating use case.
@@ -1153,7 +1153,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
 
 instantiate_device_type_tests(
-    TestWrapInductorCompiledRegions, globals(), only_for=("cuda", "xpu")
+    TestWrapInductorCompiledRegions, globals(), only_for=("cuda", "xpu"), allow_xpu=True
 )
 
 

--- a/test/dynamo/test_wrap_inductor_compiled_regions.py
+++ b/test/dynamo/test_wrap_inductor_compiled_regions.py
@@ -11,6 +11,7 @@ from torch._dynamo.utils import counters
 from torch._functorch import config as functorch_config
 from torch._inductor import config as inductor_config
 from torch.nn.attention.flex_attention import flex_attention, flex_attention_hop
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 from torch.utils._debug_mode import DebugMode
 from torch.utils.checkpoint import (
@@ -74,7 +75,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
     """Tests for wrap_inductor_compiled_regions option"""
 
     @requires_cuda_and_triton
-    def test_wrap_enabled_visible_in_debug_mode(self):
+    def test_wrap_enabled_visible_in_debug_mode(self, device):
         """Test that compiled regions are wrapped when option is enabled"""
 
         @torch.compile(
@@ -85,8 +86,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -101,7 +102,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, expected)
 
     @requires_cuda_and_triton
-    def test_wrap_name_visible_in_debug_mode(self):
+    def test_wrap_name_visible_in_debug_mode(self, device):
         """Test that named compiled regions surface their name in DebugMode"""
 
         @torch.compile(
@@ -113,8 +114,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -128,7 +129,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, expected)
 
     @requires_cuda_and_triton
-    def test_wrap_disabled_not_visible_in_debug_mode(self):
+    def test_wrap_disabled_not_visible_in_debug_mode(self, device):
         """Test that compiled regions are not wrapped when option is disabled"""
 
         @torch.compile(
@@ -139,8 +140,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -155,15 +156,15 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, expected)
 
     @requires_cuda_and_triton
-    def test_wrap_default_disabled(self):
+    def test_wrap_default_disabled(self, device):
         """Test that wrapping is disabled by default"""
 
         @torch.compile(backend="inductor", fullgraph=True)
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -178,7 +179,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, expected)
 
     @requires_cuda_and_triton
-    def test_wrap_with_backward(self):
+    def test_wrap_with_backward(self, device):
         """Test that wrapping works correctly with backward pass"""
 
         @torch.compile(
@@ -189,8 +190,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
 
         # Clone for eager comparison
         x_eager = x.detach().clone().requires_grad_(True)
@@ -218,7 +219,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(y.grad, y_eager.grad)
 
     @requires_cuda_and_triton
-    def test_wrap_with_multiple_ops(self):
+    def test_wrap_with_multiple_ops(self, device):
         """Test wrapping with a function that has multiple operations"""
 
         @torch.compile(
@@ -232,8 +233,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             c = b + x
             return c
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -250,7 +251,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, expected)
 
     @requires_cuda_and_triton
-    def test_wrap_option_type_validation(self):
+    def test_wrap_option_type_validation(self, device):
         """Test that wrap_inductor_compiled_regions validates type correctly"""
 
         # Should accept bool
@@ -268,7 +269,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn_false(x):
             return x + 1
 
-        x = torch.randn(4, device="cuda")
+        x = torch.randn(4, device=device)
         _ = fn_true(x)
         _ = fn_false(x)
 
@@ -285,7 +286,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIn("Unexpected type", str(cm.exception))
 
     @requires_cuda_and_triton
-    def test_wrap_per_compilation(self):
+    def test_wrap_per_compilation(self, device):
         """Test that wrap option is per-compilation, not global"""
 
         @torch.compile(
@@ -304,8 +305,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn_not_wrapped(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         # First function should be wrapped
         with DebugMode() as debug_mode1:
@@ -321,7 +322,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
-    def test_wrap_with_cache(self):
+    def test_wrap_with_cache(self, device):
         """
         Test that wrap_inductor_compiled_regions works correctly with caching.
         Verify that the wrapper is properly applied when loading from cache by
@@ -333,8 +334,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         # Clear all caches and counters
         counters.clear()
@@ -401,7 +402,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
-    def test_wrap_config_affects_cache_key(self):
+    def test_wrap_config_affects_cache_key(self, device):
         """
         Test that wrap_inductor_compiled_regions is part of the cache key.
         Changing this option should cause a cache miss because it produces
@@ -412,8 +413,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         # Clear all caches and counters
         counters.clear()
@@ -490,7 +491,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertNotIn("inductor_compiled_code", debug_unwrapped.debug_string())
 
     @requires_cuda_and_triton
-    def test_flex_attention_with_wrapper_basic(self):
+    def test_flex_attention_with_wrapper_basic(self, device):
         """Test that flex_attention works with wrap_inductor_compiled_regions=True"""
 
         def causal_score_mod(score, b, h, q_idx, k_idx):
@@ -505,9 +506,9 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             return flex_attention(q, k, v, score_mod=causal_score_mod)
 
         B, H, S, D = 2, 4, 128, 64
-        q = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
+        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
         # Test forward pass
         output = fn(q, k, v)
@@ -526,7 +527,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(output, output_unwrapped, rtol=1e-3, atol=1e-3)
 
     @requires_cuda_and_triton
-    def test_flex_attention_wrapper_visible_in_debug_mode(self):
+    def test_flex_attention_wrapper_visible_in_debug_mode(self, device):
         """Test that inductor_compiled_code HOP is visible to DebugMode when wrapper is enabled"""
 
         def score_mod(score, b, h, q_idx, k_idx):
@@ -549,9 +550,9 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             return flex_attention(q, k, v, score_mod=score_mod)
 
         B, H, S, D = 2, 4, 128, 64
-        q = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
+        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
         # Test with wrapper enabled - should see inductor_compiled_code HOP
         with DebugMode() as debug_wrapped:
@@ -576,7 +577,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         )
 
     @requires_cuda_and_triton
-    def test_flex_attention_wrapper_with_backward(self):
+    def test_flex_attention_wrapper_with_backward(self, device):
         """Test that wrapper works correctly with backward pass"""
 
         def score_mod(score, b, h, q_idx, k_idx):
@@ -592,13 +593,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Forward and backward
@@ -636,7 +637,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
-    def test_flex_attention_wrapper_with_cache(self):
+    def test_flex_attention_wrapper_with_cache(self, device):
         """Test that wrapper works correctly with caching"""
         from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
 
@@ -655,9 +656,9 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             return fn
 
         B, H, S, D = 2, 4, 128, 64
-        q = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
+        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
         # Clear all caches
         counters.clear()
@@ -702,7 +703,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(result1, result2)
 
     @requires_cuda_and_triton
-    def test_flex_attention_with_sac_must_save(self):
+    def test_flex_attention_with_sac_must_save(self, device):
         """
         Test that SAC policy MUST_SAVE for flex_attention_hop
         prevents recomputation during backward when used with wrapper.
@@ -738,13 +739,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Forward compiler: should see flex_attention_hop once
@@ -786,7 +787,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(v.grad)
 
     @requires_cuda_and_triton
-    def test_flex_attention_with_sac_prefer_recompute(self):
+    def test_flex_attention_with_sac_prefer_recompute(self, device):
         """
         Test that SAC policy PREFER_RECOMPUTE for flex_attention_hop
         causes recomputation during backward when used with wrapper.
@@ -823,13 +824,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Forward compiler: should see flex_attention_hop once
@@ -871,7 +872,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(v.grad)
 
     @requires_cuda_and_triton
-    def test_sac_outer_compile_inner_basic(self):
+    def test_sac_outer_compile_inner_basic(self, device):
         """
         Test SAC(compile(foo)) pattern - SAC on eager code with inner compiled region.
 
@@ -908,8 +909,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             b = torch.relu(a)
             return b
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
 
         # Clone for comparison
         x_eager = x.detach().clone().requires_grad_(True)
@@ -951,7 +952,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(y.grad, y_eager.grad)
 
     @requires_cuda_and_triton
-    def test_sac_outer_compile_inner_name_visible_to_policy(self):
+    def test_sac_outer_compile_inner_name_visible_to_policy(self, device):
         """Test that SAC policies can inspect torch.compile region names"""
 
         @torch.compile(
@@ -976,8 +977,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             a = inner_compiled_matmul(x, y)
             return torch.relu(a)
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
 
         x_eager = x.detach().clone().requires_grad_(True)
         y_eager = y.detach().clone().requires_grad_(True)
@@ -1005,7 +1006,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(y.grad, y_eager.grad)
 
     @requires_cuda_and_triton
-    def test_wrap_no_dispatch_mode_no_hop_invoked(self):
+    def test_wrap_no_dispatch_mode_no_hop_invoked(self, device):
         """
         Test that without TorchDispatchMode, the HOP is NOT invoked.
 
@@ -1031,8 +1032,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             def fn(x, y):
                 return torch.matmul(x, y)
 
-            x = torch.randn(4, 4, device="cuda")
-            y = torch.randn(4, 4, device="cuda")
+            x = torch.randn(4, 4, device=device)
+            y = torch.randn(4, 4, device=device)
             expected = torch.matmul(x, y)
 
             result_without = fn(x, y)
@@ -1056,8 +1057,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             def fn2(x, y):
                 return torch.matmul(x, y)
 
-            x2 = torch.randn(4, 4, device="cuda")
-            y2 = torch.randn(4, 4, device="cuda")
+            x2 = torch.randn(4, 4, device=device)
+            y2 = torch.randn(4, 4, device=device)
             expected2 = torch.matmul(x2, y2)
 
             with DebugMode():
@@ -1068,7 +1069,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             self.assertEqual(result_with, expected2)
 
     @requires_cuda_and_triton
-    def test_sac_outer_compile_inner_flex_attention(self):
+    def test_sac_outer_compile_inner_flex_attention(self, device):
         """
         Test SAC(compile(foo)) with flex_attention - the key motivating use case.
 
@@ -1102,13 +1103,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Enable wrapping at the inductor config level so that flex_attention's
@@ -1149,6 +1150,15 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(q.grad, q2.grad, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(k.grad, k2.grad, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(v.grad, v2.grad, rtol=1e-3, atol=1e-3)
+
+
+instantiate_device_type_tests(
+    TestWrapInductorCompiledRegions, globals(), only_for=("cuda", "xpu")
+)
+
+
+class TestWrapInductorCompiledRegionsCPU(torch._dynamo.test_case.TestCase):
+    """Tests that don't require a GPU device"""
 
     def test_fake_tensor_mode_works(self):
         """Test that running compiled code inside FakeTensorMode works with FX graph fallback"""

--- a/test/dynamo/test_wrap_inductor_compiled_regions.py
+++ b/test/dynamo/test_wrap_inductor_compiled_regions.py
@@ -12,6 +12,7 @@ from torch._dynamo.utils import counters
 from torch._functorch import config as functorch_config
 from torch._inductor import config as inductor_config
 from torch.nn.attention.flex_attention import flex_attention, flex_attention_hop
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 from torch.utils._debug_mode import DebugMode
 from torch.utils.checkpoint import (
@@ -75,7 +76,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
     """Tests for wrap_inductor_compiled_regions option"""
 
     @requires_cuda_and_triton
-    def test_wrap_enabled_visible_in_debug_mode(self):
+    def test_wrap_enabled_visible_in_debug_mode(self, device):
         """Test that compiled regions are wrapped when option is enabled"""
 
         @torch.compile(
@@ -86,8 +87,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -102,7 +103,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, expected)
 
     @requires_cuda_and_triton
-    def test_wrap_name_visible_in_debug_mode(self):
+    def test_wrap_name_visible_in_debug_mode(self, device):
         """Test that named compiled regions surface their name in DebugMode"""
 
         @torch.compile(
@@ -114,8 +115,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -129,7 +130,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, expected)
 
     @requires_cuda_and_triton
-    def test_wrap_disabled_not_visible_in_debug_mode(self):
+    def test_wrap_disabled_not_visible_in_debug_mode(self, device):
         """Test that compiled regions are not wrapped when option is disabled"""
 
         @torch.compile(
@@ -140,8 +141,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -156,15 +157,15 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, expected)
 
     @requires_cuda_and_triton
-    def test_wrap_default_disabled(self):
+    def test_wrap_default_disabled(self, device):
         """Test that wrapping is disabled by default"""
 
         @torch.compile(backend="inductor", fullgraph=True)
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -179,7 +180,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, expected)
 
     @requires_cuda_and_triton
-    def test_wrap_with_backward(self):
+    def test_wrap_with_backward(self, device):
         """Test that wrapping works correctly with backward pass"""
 
         @torch.compile(
@@ -190,8 +191,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
 
         # Clone for eager comparison
         x_eager = x.detach().clone().requires_grad_(True)
@@ -219,7 +220,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(y.grad, y_eager.grad)
 
     @requires_cuda_and_triton
-    def test_wrap_with_multiple_ops(self):
+    def test_wrap_with_multiple_ops(self, device):
         """Test wrapping with a function that has multiple operations"""
 
         @torch.compile(
@@ -233,8 +234,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             c = b + x
             return c
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -251,7 +252,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, expected)
 
     @requires_cuda_and_triton
-    def test_wrap_option_type_validation(self):
+    def test_wrap_option_type_validation(self, device):
         """Test that wrap_inductor_compiled_regions validates type correctly"""
 
         # Should accept bool
@@ -269,7 +270,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn_false(x):
             return x + 1
 
-        x = torch.randn(4, device="cuda")
+        x = torch.randn(4, device=device)
         _ = fn_true(x)
         _ = fn_false(x)
 
@@ -286,7 +287,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIn("Unexpected type", str(cm.exception))
 
     @requires_cuda_and_triton
-    def test_wrap_per_compilation(self):
+    def test_wrap_per_compilation(self, device):
         """Test that wrap option is per-compilation, not global"""
 
         @torch.compile(
@@ -305,8 +306,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn_not_wrapped(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         # First function should be wrapped
         with DebugMode() as debug_mode1:
@@ -322,7 +323,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
-    def test_wrap_with_cache(self):
+    def test_wrap_with_cache(self, device):
         """
         Test that wrap_inductor_compiled_regions works correctly with caching.
         Verify that the wrapper is properly applied when loading from cache by
@@ -334,8 +335,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         # Clear all caches and counters
         counters.clear()
@@ -402,7 +403,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
-    def test_wrap_config_affects_cache_key(self):
+    def test_wrap_config_affects_cache_key(self, device):
         """
         Test that wrap_inductor_compiled_regions is part of the cache key.
         Changing this option should cause a cache miss because it produces
@@ -413,8 +414,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         # Clear all caches and counters
         counters.clear()
@@ -491,7 +492,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertNotIn("inductor_compiled_code", debug_unwrapped.debug_string())
 
     @requires_cuda_and_triton
-    def test_flex_attention_with_wrapper_basic(self):
+    def test_flex_attention_with_wrapper_basic(self, device):
         """Test that flex_attention works with wrap_inductor_compiled_regions=True"""
 
         def causal_score_mod(score, b, h, q_idx, k_idx):
@@ -506,9 +507,9 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             return flex_attention(q, k, v, score_mod=causal_score_mod)
 
         B, H, S, D = 2, 4, 128, 64
-        q = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
+        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
         # Test forward pass
         output = fn(q, k, v)
@@ -527,7 +528,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(output, output_unwrapped, rtol=1e-3, atol=1e-3)
 
     @requires_cuda_and_triton
-    def test_flex_attention_wrapper_visible_in_debug_mode(self):
+    def test_flex_attention_wrapper_visible_in_debug_mode(self, device):
         """Test that inductor_compiled_code HOP is visible to DebugMode when wrapper is enabled"""
 
         def score_mod(score, b, h, q_idx, k_idx):
@@ -550,9 +551,9 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             return flex_attention(q, k, v, score_mod=score_mod)
 
         B, H, S, D = 2, 4, 128, 64
-        q = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
+        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
         # Test with wrapper enabled - should see inductor_compiled_code HOP
         with DebugMode() as debug_wrapped:
@@ -577,7 +578,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         )
 
     @requires_cuda_and_triton
-    def test_flex_attention_wrapper_with_backward(self):
+    def test_flex_attention_wrapper_with_backward(self, device):
         """Test that wrapper works correctly with backward pass"""
 
         def score_mod(score, b, h, q_idx, k_idx):
@@ -593,13 +594,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Forward and backward
@@ -637,7 +638,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
-    def test_flex_attention_wrapper_with_cache(self):
+    def test_flex_attention_wrapper_with_cache(self, device):
         """Test that wrapper works correctly with caching"""
         from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
 
@@ -656,9 +657,9 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             return fn
 
         B, H, S, D = 2, 4, 128, 64
-        q = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
+        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
         # Clear all caches
         counters.clear()
@@ -703,7 +704,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(result1, result2)
 
     @requires_cuda_and_triton
-    def test_flex_attention_with_sac_must_save(self):
+    def test_flex_attention_with_sac_must_save(self, device):
         """
         Test that SAC policy MUST_SAVE for flex_attention_hop
         prevents recomputation during backward when used with wrapper.
@@ -739,13 +740,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Forward compiler: should see flex_attention_hop once
@@ -787,7 +788,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(v.grad)
 
     @requires_cuda_and_triton
-    def test_flex_attention_with_sac_prefer_recompute(self):
+    def test_flex_attention_with_sac_prefer_recompute(self, device):
         """
         Test that SAC policy PREFER_RECOMPUTE for flex_attention_hop
         causes recomputation during backward when used with wrapper.
@@ -824,13 +825,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Forward compiler: should see flex_attention_hop once
@@ -872,7 +873,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(v.grad)
 
     @requires_cuda_and_triton
-    def test_sac_outer_compile_inner_basic(self):
+    def test_sac_outer_compile_inner_basic(self, device):
         """
         Test SAC(compile(foo)) pattern - SAC on eager code with inner compiled region.
 
@@ -909,8 +910,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             b = torch.relu(a)
             return b
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
 
         # Clone for comparison
         x_eager = x.detach().clone().requires_grad_(True)
@@ -952,7 +953,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(y.grad, y_eager.grad)
 
     @requires_cuda_and_triton
-    def test_sac_outer_compile_inner_name_visible_to_policy(self):
+    def test_sac_outer_compile_inner_name_visible_to_policy(self, device):
         """Test that SAC policies can inspect torch.compile region names"""
 
         @torch.compile(
@@ -977,8 +978,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             a = inner_compiled_matmul(x, y)
             return torch.relu(a)
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
 
         x_eager = x.detach().clone().requires_grad_(True)
         y_eager = y.detach().clone().requires_grad_(True)
@@ -1006,7 +1007,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(y.grad, y_eager.grad)
 
     @requires_cuda_and_triton
-    def test_wrap_no_dispatch_mode_no_hop_invoked(self):
+    def test_wrap_no_dispatch_mode_no_hop_invoked(self, device):
         """
         Test that without TorchDispatchMode, the HOP is NOT invoked.
 
@@ -1032,8 +1033,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             def fn(x, y):
                 return torch.matmul(x, y)
 
-            x = torch.randn(4, 4, device="cuda")
-            y = torch.randn(4, 4, device="cuda")
+            x = torch.randn(4, 4, device=device)
+            y = torch.randn(4, 4, device=device)
             expected = torch.matmul(x, y)
 
             result_without = fn(x, y)
@@ -1057,8 +1058,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             def fn2(x, y):
                 return torch.matmul(x, y)
 
-            x2 = torch.randn(4, 4, device="cuda")
-            y2 = torch.randn(4, 4, device="cuda")
+            x2 = torch.randn(4, 4, device=device)
+            y2 = torch.randn(4, 4, device=device)
             expected2 = torch.matmul(x2, y2)
 
             with DebugMode():
@@ -1069,7 +1070,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             self.assertEqual(result_with, expected2)
 
     @requires_cuda_and_triton
-    def test_sac_outer_compile_inner_flex_attention(self):
+    def test_sac_outer_compile_inner_flex_attention(self, device):
         """
         Test SAC(compile(foo)) with flex_attention - the key motivating use case.
 
@@ -1103,13 +1104,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Enable wrapping at the inductor config level so that flex_attention's
@@ -1150,6 +1151,15 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(q.grad, q2.grad, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(k.grad, k2.grad, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(v.grad, v2.grad, rtol=1e-3, atol=1e-3)
+
+
+instantiate_device_type_tests(
+    TestWrapInductorCompiledRegions, globals(), only_for=("cuda", "xpu")
+)
+
+
+class TestWrapInductorCompiledRegionsCPU(torch._dynamo.test_case.TestCase):
+    """Tests that don't require a GPU device"""
 
     def test_fake_tensor_mode_works(self):
         """Test that running compiled code inside FakeTensorMode works with FX graph fallback"""

--- a/test/dynamo/test_wrap_inductor_compiled_regions.py
+++ b/test/dynamo/test_wrap_inductor_compiled_regions.py
@@ -13,7 +13,7 @@ from torch._functorch import config as functorch_config
 from torch._inductor import config as inductor_config
 from torch.nn.attention.flex_attention import flex_attention, flex_attention_hop
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.triton_utils import requires_gpu_and_triton
 from torch.utils._debug_mode import DebugMode
 from torch.utils.checkpoint import (
     checkpoint,
@@ -75,7 +75,7 @@ def count_ops(
 class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
     """Tests for wrap_inductor_compiled_regions option"""
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_enabled_visible_in_debug_mode(self, device):
         """Test that compiled regions are wrapped when option is enabled"""
 
@@ -102,7 +102,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_name_visible_in_debug_mode(self, device):
         """Test that named compiled regions surface their name in DebugMode"""
 
@@ -129,7 +129,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_disabled_not_visible_in_debug_mode(self, device):
         """Test that compiled regions are not wrapped when option is disabled"""
 
@@ -156,7 +156,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_default_disabled(self, device):
         """Test that wrapping is disabled by default"""
 
@@ -179,7 +179,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_with_backward(self, device):
         """Test that wrapping works correctly with backward pass"""
 
@@ -219,7 +219,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(x.grad, x_eager.grad)
         self.assertEqual(y.grad, y_eager.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_with_multiple_ops(self, device):
         """Test wrapping with a function that has multiple operations"""
 
@@ -251,7 +251,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = b + x
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_option_type_validation(self, device):
         """Test that wrap_inductor_compiled_regions validates type correctly"""
 
@@ -286,7 +286,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         self.assertIn("Unexpected type", str(cm.exception))
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_per_compilation(self, device):
         """Test that wrap option is per-compilation, not global"""
 
@@ -319,7 +319,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             _ = fn_not_wrapped(x, y)
         self.assertNotIn("inductor_compiled_code", debug_mode2.debug_string())
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
@@ -399,7 +399,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result1, expected)
         self.assertEqual(result2, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
@@ -491,7 +491,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         # Unwrapped version should not
         self.assertNotIn("inductor_compiled_code", debug_unwrapped.debug_string())
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_flex_attention_with_wrapper_basic(self, device):
         """Test that flex_attention works with wrap_inductor_compiled_regions=True"""
 
@@ -527,7 +527,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         output_unwrapped = fn_unwrapped(q, k, v)
         torch.testing.assert_close(output, output_unwrapped, rtol=1e-3, atol=1e-3)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_flex_attention_wrapper_visible_in_debug_mode(self, device):
         """Test that inductor_compiled_code HOP is visible to DebugMode when wrapper is enabled"""
 
@@ -577,7 +577,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             "inductor_compiled_code HOP should not be visible when wrapper is disabled",
         )
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_flex_attention_wrapper_with_backward(self, device):
         """Test that wrapper works correctly with backward pass"""
 
@@ -634,7 +634,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(k.grad, k2.grad, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(v.grad, v2.grad, rtol=1e-3, atol=1e-3)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
@@ -703,7 +703,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         # Verify correctness
         torch.testing.assert_close(result1, result2)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_flex_attention_with_sac_must_save(self, device):
         """
         Test that SAC policy MUST_SAVE for flex_attention_hop
@@ -787,7 +787,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(k.grad)
         self.assertIsNotNone(v.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_flex_attention_with_sac_prefer_recompute(self, device):
         """
         Test that SAC policy PREFER_RECOMPUTE for flex_attention_hop
@@ -872,7 +872,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(k.grad)
         self.assertIsNotNone(v.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_sac_outer_compile_inner_basic(self, device):
         """
         Test SAC(compile(foo)) pattern - SAC on eager code with inner compiled region.
@@ -952,7 +952,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(x.grad, x_eager.grad)
         self.assertEqual(y.grad, y_eager.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_sac_outer_compile_inner_name_visible_to_policy(self, device):
         """Test that SAC policies can inspect torch.compile region names"""
 
@@ -1006,7 +1006,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(x.grad, x_eager.grad)
         self.assertEqual(y.grad, y_eager.grad)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_wrap_no_dispatch_mode_no_hop_invoked(self, device):
         """
         Test that without TorchDispatchMode, the HOP is NOT invoked.
@@ -1069,7 +1069,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             mock_hop.assert_called()
             self.assertEqual(result_with, expected2)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_sac_outer_compile_inner_flex_attention(self, device):
         """
         Test SAC(compile(foo)) with flex_attention - the key motivating use case.
@@ -1154,7 +1154,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
 
 instantiate_device_type_tests(
-    TestWrapInductorCompiledRegions, globals(), only_for=("cuda", "xpu")
+    TestWrapInductorCompiledRegions, globals(), only_for=("cuda", "xpu"), allow_xpu=True
 )
 
 


### PR DESCRIPTION
## Summary

Make `test_wrap_inductor_compiled_regions.py` device-agnostic by using `instantiate_device_type_tests` to generate device-specific test subclasses.

## Changes

- Use `instantiate_device_type_tests` with `only_for=("cuda", "xpu")` to generate device-specific test subclasses.
- Add `device` parameter to 20 accelerator tests and replace 45 hardcoded `device="cuda"` with `device=device`.
- Move 3 CPU-only tests (`test_fake_tensor_mode_works`, `test_proxy_tensor_mode_works`, `test_sac_cached_value_fifo_mismatch`) to a separate `TestWrapInductorCompiledRegionsCPU` class since they don't require a GPU device.
- Keep `@requires_cuda_and_triton` on all 20 accelerator tests since Inductor GPU codegen requires Triton.

## Test plan

- [x] `TEST_CONFIG=cuda python3 test/run_test.py -i dynamo/test_wrap_inductor_compiled_regions` — 22/23 passed
- [x] 1 pre-existing failure (`test_sac_cached_value_fifo_mismatch`) also fails on unmodified main — unrelated to this change

cc: @fffrog @albanD @jbschlosser @guilhermeleobas @Lucaskabela @zou3519 @mansiag05 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98