### PR TITLE
Check torch.monitor.Stat windowSize

### DIFF
--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -60,6 +60,11 @@ class TestMonitor(TestCase):
         self.assertEqual(s.count, 0)
         self.assertEqual(s.get(), {Aggregation.SUM: 6.0, Aggregation.COUNT: 3})
 
+    def test_invalid_stat_window_size(self) -> None:
+        for window_size in (timedelta(milliseconds=0), timedelta(milliseconds=-1)):
+            with self.assertRaisesRegex(ValueError, "windowSize must be greater than 0"):
+                Stat("asdf", (Aggregation.SUM, Aggregation.COUNT), window_size)
+
     def test_log_event(self) -> None:
         e = Event(
             name="torch.monitor.TestEvent",

--- a/torch/csrc/monitor/counters.h
+++ b/torch/csrc/monitor/counters.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <c10/macros/Macros.h>
+#include <c10/util/Exception.h>
 
 #include <torch/csrc/monitor/events.h>
 
@@ -107,6 +108,8 @@ class Stat {
         aggregations_(merge(aggregations)),
         windowSize_(windowSize),
         maxSamples_(maxSamples) {
+    TORCH_CHECK_VALUE(
+        windowSize.count() > 0, "windowSize must be greater than 0");
     detail::registerStat(this);
   }
 
@@ -119,6 +122,8 @@ class Stat {
         aggregations_(merge(aggregations)),
         windowSize_(windowSize),
         maxSamples_(maxSamples) {
+    TORCH_CHECK_VALUE(
+        windowSize.count() > 0, "windowSize must be greater than 0");
     detail::registerStat(this);
   }
   Stat(const Stat&) = delete;


### PR DESCRIPTION
## Summary  

  Add a constructor check in `torch.monitor.Stat` to reject non-positive `windowSize` values before          
  registration. This prevents `windowSize=0` from reaching the window ID calculation where it is used as a
  divisor.                                                                                                   
                  
  ## Test Plan                                                                                               
   
  ```bash                                                                                                    
  python3 test/test_monitor.py -k invalid_stat_window_size
 ```
fixes #184878

cc @malfet