### PR TITLE
[TMA] Skips the types that are not in _TMA_SUPPORTED_DTYPES when enabling TMA

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1695,44 +1695,17 @@ class TritonTensorDescriptorTestCUDA(BlockDescriptorTestBase):
         actual = torch.compile(f)(x)
         self.assertEqual(actual, expected)
 
-    def test_bool_dtype_pointwise_skips_tma(self):
-        """
-        Pointwise op on bool tensors should skip TMA and still work.
-        """
-
-        def fn(a, b):
-            return a & b
-
-        a = torch.randint(0, 2, (4096,), dtype=torch.bool, device=self.device)
-        b = torch.randint(0, 2, (4096,), dtype=torch.bool, device=self.device)
-
-        result, (code,) = self._run_and_compare(
-            fn,
-            a,
-            b,
-            expected_num_block_pointers=0,
-            expected_num_triton_kernels=1,
-        )
-
-    def test_bool_dtype_scan_skips_tma(self):
+    def test_bool_dtype_skips_tma(self):
         """
         torch.bool maps to Triton tl.int1 which has no CUtensorMapDataType
-        entry. Verify that TMA is skipped for a scan (cumsum) kernel and
-        the result is still correct.
+        entry, so it should skip TMA.
         """
 
         def fn(a):
             return torch.cumsum(a, -1)
 
-        inp = torch.zeros(2048, dtype=torch.bool, device=self.device)
-        inp[100:200] = True
-
-        compiled = torch.compile(fn, backend="inductor")
-        result, code = run_and_get_code(compiled, inp)
-        expected = fn(inp)
-        self.assertTrue(torch.equal(result, expected))
-        tma_count = sum(prog.count("tl.make_tensor_descriptor") for prog in code)
-        self.assertEqual(tma_count, 0)
+        inp = torch.zeros(16, dtype=torch.bool, device=GPU_TYPE)
+        self._run_and_compare(fn, inp, expected_num_block_pointers=0)
 
 
 test_torchinductor.copy_tests(

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1695,6 +1695,45 @@ class TritonTensorDescriptorTestCUDA(BlockDescriptorTestBase):
         actual = torch.compile(f)(x)
         self.assertEqual(actual, expected)
 
+    def test_bool_dtype_pointwise_skips_tma(self):
+        """
+        Pointwise op on bool tensors should skip TMA and still work.
+        """
+
+        def fn(a, b):
+            return a & b
+
+        a = torch.randint(0, 2, (4096,), dtype=torch.bool, device=self.device)
+        b = torch.randint(0, 2, (4096,), dtype=torch.bool, device=self.device)
+
+        result, (code,) = self._run_and_compare(
+            fn,
+            a,
+            b,
+            expected_num_block_pointers=0,
+            expected_num_triton_kernels=1,
+        )
+
+    def test_bool_dtype_scan_skips_tma(self):
+        """
+        torch.bool maps to Triton tl.int1 which has no CUtensorMapDataType
+        entry. Verify that TMA is skipped for a scan (cumsum) kernel and
+        the result is still correct.
+        """
+
+        def fn(a):
+            return torch.cumsum(a, -1)
+
+        inp = torch.zeros(2048, dtype=torch.bool, device=self.device)
+        inp[100:200] = True
+
+        compiled = torch.compile(fn, backend="inductor")
+        result, code = run_and_get_code(compiled, inp)
+        expected = fn(inp)
+        self.assertTrue(torch.equal(result, expected))
+        tma_count = sum(prog.count("tl.make_tensor_descriptor") for prog in code)
+        self.assertEqual(tma_count, 0)
+
 
 test_torchinductor.copy_tests(
     CommonTemplate,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2786,6 +2786,21 @@ class TMACompatibilityChecker:
             )
             return False
 
+        # CUtensorMapDataType has no entry for `bool` / Triton `tl.int1`
+        # (Triton reports `sizeof(int1) == 0`). PyTorch's `bool.itemsize == 1`
+        # so the per-load `block_shape × element_size ≥ 16` check below would
+        # incorrectly pass; refuse early using the same dtype registry the
+        # matmul-side TMA helper consults (`_TMA_SUPPORTED_DTYPES`).
+        from ..utils import _TMA_SUPPORTED_DTYPES
+
+        if self.dtype not in _TMA_SUPPORTED_DTYPES:
+            log.debug(
+                "%s dtype %s has no CUtensorMapDataType mapping.",
+                self.failed_debug_prefix,
+                self.dtype,
+            )
+            return False
+
         return True
 
     def are_block_parameters_compatible(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -70,6 +70,7 @@ from ..scheduler import (
 from ..shape_propagation import get_broadcasted_shape
 from ..stream_utils import get_raw_stream_name
 from ..utils import (
+    _TMA_SUPPORTED_DTYPES,
     cache_on_self,
     DelayReplaceLine,
     device_supports_fp64,
@@ -2785,13 +2786,6 @@ class TMACompatibilityChecker:
                 self.failed_debug_prefix,
             )
             return False
-
-        # CUtensorMapDataType has no entry for `bool` / Triton `tl.int1`
-        # (Triton reports `sizeof(int1) == 0`). PyTorch's `bool.itemsize == 1`
-        # so the per-load `block_shape × element_size ≥ 16` check below would
-        # incorrectly pass; refuse early using the same dtype registry the
-        # matmul-side TMA helper consults (`_TMA_SUPPORTED_DTYPES`).
-        from ..utils import _TMA_SUPPORTED_DTYPES
 
         if self.dtype not in _TMA_SUPPORTED_DTYPES:
             log.debug(


### PR DESCRIPTION
Fixes #185222
Dtypes that lack a CUtensorMapDataType enum entry (e.g. torch.bool / tl.int1) cannot be used with TMA tensor descriptors. This PR skips TMA codegen for such dtypes, falling back to regular block pointers instead of crashing at runtime.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo