### PR TITLE
Error out when getting symmetric memory device pointers for NCCL < 2.28

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -291,7 +291,9 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
-    @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
+    @requires_nccl_version(
+        (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
+    )
     @skip_if_lt_x_gpu(2)
     def test_nccl_symmem_rendezvous_many_allocations(self):
         symm_mem.set_backend("NCCL")
@@ -552,6 +554,9 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_if_lt_x_gpu(2)
+    @requires_nccl_version(
+        (2, 28), "NCCL Symmetric Memory multicast support from nccl 2.28"
+    )
     def test_nccl_symmem_get(self):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
@@ -941,6 +946,9 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version(
+        (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
+    )
     @skip_if_lt_x_gpu(2)
     def test_mempool_tensor_factory(self):
         symm_mem.set_backend("NCCL")
@@ -969,6 +977,9 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version(
+        (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
+    )
     @skip_if_lt_x_gpu(2)
     def test_mempool_compute_ops(self):
         symm_mem.set_backend("NCCL")

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -303,7 +303,9 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
-    @requires_nccl_version((2, 27), "NCCL Symmetric Memory support from nccl 2.27")
+    @requires_nccl_version(
+        (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
+    )
     @skip_if_lt_x_gpu(2)
     def test_nccl_symmem_rendezvous_many_allocations(self):
         symm_mem.set_backend("NCCL")
@@ -669,6 +671,9 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_if_lt_x_gpu(2)
+    @requires_nccl_version(
+        (2, 28), "NCCL Symmetric Memory multicast support from nccl 2.28"
+    )
     def test_nccl_symmem_get(self):
         symm_mem.set_backend("NCCL")
         torch.cuda.set_device(self.rank)
@@ -1058,6 +1063,9 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version(
+        (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
+    )
     @skip_if_lt_x_gpu(2)
     def test_mempool_tensor_factory(self):
         symm_mem.set_backend("NCCL")
@@ -1086,6 +1094,9 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version(
+        (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
+    )
     @skip_if_lt_x_gpu(2)
     def test_mempool_compute_ops(self):
         symm_mem.set_backend("NCCL")

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -3,6 +3,7 @@
 #ifdef NCCL_HAS_SYMMEM_SUPPORT
 
 #include <algorithm>
+#include <stdexcept>
 #include <vector_types.h>
 #include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
 #include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
@@ -355,10 +356,16 @@ std::vector<void*> NCCLSymmetricMemory::get_signal_pad_ptrs() {
 }
 
 void** NCCLSymmetricMemory::get_buffer_ptrs_dev() {
+  #ifndef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+    TORCH_CHECK(false, "Device pointers are not available in NCCL < 2.28");
+  #endif
   return pai_->buffers_dev_;
 }
 
 void** NCCLSymmetricMemory::get_signal_pad_ptrs_dev() {
+  #ifndef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+    TORCH_CHECK(false, "Device pointers are not available in NCCL < 2.28");
+  #endif
   return pai_->signal_pads_dev_;
 }
 

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -3,6 +3,7 @@
 #ifdef NCCL_HAS_SYMMEM_SUPPORT
 
 #include <algorithm>
+#include <stdexcept>
 #include <vector_types.h>
 #include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
 #include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
@@ -348,10 +349,16 @@ std::vector<void*> NCCLSymmetricMemory::get_signal_pad_ptrs() {
 }
 
 void** NCCLSymmetricMemory::get_buffer_ptrs_dev() {
+  #ifndef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+    TORCH_CHECK(false, "Device pointers are not available in NCCL < 2.28");
+  #endif
   return pai_->buffers_dev_;
 }
 
 void** NCCLSymmetricMemory::get_signal_pad_ptrs_dev() {
+  #ifndef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+    TORCH_CHECK(false, "Device pointers are not available in NCCL < 2.28");
+  #endif
   return pai_->signal_pads_dev_;
 }
 


### PR DESCRIPTION
Those pointers are never set and hence stay NULL.
Using them in CUDA kernels causes `CUDA_ERROR_ILLEGAL_ADDRESS`. Instead throw a descriptive error at the place of the issue.

Skip all tests that made use of this.

Fixes #185216