### PR TITLE
[DTensor] Fix backward support for cumprod, cummax, cummin

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -648,10 +648,6 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     return are_inputs_tensors_sublcass ? grad.new_zeros_symint(sizes)
                                        : at::zeros_symint(sizes, grad.options());
   };
-  auto make_subclass_aware_ones = [&](c10::SymIntArrayRef sizes) {
-    return are_inputs_tensors_sublcass ? grad.new_ones_symint(sizes)
-                                       : at::ones({1}, grad.options()).expand_symint(sizes);
-  };
 
   const auto w = output_conj * grad;
   const auto is_zero = input == 0;
@@ -685,7 +681,7 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     // there is no first zero:
     // indices = (cumsum == 1).max(dim, keepdim=True).indices
     // The mask for the first zero:
-    // zeros_like(indices).scatter_(dim, indices, 1.) & cumsum == 1
+    // zeros_like(indices).scatter(dim, indices, true).logical_and(cumsum == 1)
     // Note that the logic_and with cumsum == 1 accounts
     // for the case when there is no first zero
     Tensor grad_input = make_subclass_aware_zeros(input.sym_sizes());
@@ -778,6 +774,28 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     Tensor prods_from_k_plus_1;
     Tensor omitted_products;
     for (const auto k : c10::irange(dim_size)) {
+      if (are_inputs_tensors_sublcass) {
+        Tensor grad_slice;
+        if (k == 0) {
+          prods_from_k_plus_1 = at::cumprod(input_conj.slice(dim, k + 1), dim);
+          grad_slice = grad.select(dim, k) + at::sum(grad.slice(dim, k + 1) * prods_from_k_plus_1, dim);
+        } else {
+          // Avoid at::prod here: its backward uses cat internally and breaks
+          // higher-order DTensor gradients by mixing Tensor and DTensor inputs.
+          const Tensor prods_until_k =
+              at::cumprod(input_conj.slice(dim, 0, k), dim).slice(dim, k - 1, k);
+          grad_slice = grad.select(dim, k) * prods_until_k.squeeze(dim);
+          if (k != dim_size - 1) {
+            prods_from_k_plus_1 = at::cumprod(input_conj.slice(dim, k + 1), dim);
+            const Tensor omitted_products_tail =
+                prods_until_k.expand_as(prods_from_k_plus_1) * prods_from_k_plus_1;
+            grad_slice = grad_slice + at::sum(grad.slice(dim, k + 1) * omitted_products_tail, dim);
+          }
+        }
+        grad_inputs.push_back(grad_slice);
+        continue;
+      }
+
       if (k == 0) {
         prods_from_k_plus_1 = at::cumprod(input_conj.slice(dim, k + 1), dim);
         omitted_products = at::cat({ones, std::move(prods_from_k_plus_1)}, dim);
@@ -797,11 +815,7 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
       TORCH_CHECK(omitted_products.sym_size(dim) == dim_size - k);
 
       auto grad_slice = at::sum(grad.slice(dim, k) * omitted_products, dim);
-      if (are_inputs_tensors_sublcass) {
-        grad_inputs.push_back(grad_slice);
-      } else {
-        grad_input.select(dim, k).copy_(grad_slice);
-      }
+      grad_input.select(dim, k).copy_(grad_slice);
     }
 
     return are_inputs_tensors_sublcass ? at::stack(grad_inputs, dim) : std::move(grad_input);

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -770,7 +770,7 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     }
     auto ones_size = input.sym_sizes().vec();
     ones_size[dim] = 1;
-    const Tensor ones = make_subclass_aware_ones(ones_size);
+    const Tensor ones = at::ones({1}, grad.options()).expand_symint(ones_size);
     Tensor prods_from_k_plus_1;
     Tensor omitted_products;
     for (const auto k : c10::irange(dim_size)) {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -792,7 +792,7 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
             grad_slice = grad_slice + at::sum(grad.slice(dim, k + 1) * omitted_products_tail, dim);
           }
         }
-        grad_inputs.push_back(grad_slice);
+        grad_inputs.push_back(std::move(grad_slice));
         continue;
       }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -643,15 +643,15 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
   auto output_conj = output.conj();
 
   // For Composite Compliance, we always choose the slower but composite compliant path.
-  bool are_inputs_tensors_sublcass = areAnyTensorSubclassLike({input, grad, output});
+  bool are_inputs_tensors_subclass = areAnyTensorSubclassLike({input, grad, output});
   auto make_subclass_aware_zeros = [&](c10::SymIntArrayRef sizes) {
-    return are_inputs_tensors_sublcass ? grad.new_zeros_symint(sizes)
-                                       : at::zeros_symint(sizes, grad.options());
+    return are_inputs_tensors_subclass ? grad.new_zeros_symint(sizes)
+        : at::zeros_symint(sizes, grad.options());
   };
 
   const auto w = output_conj * grad;
   const auto is_zero = input == 0;
-  if (!are_inputs_tensors_sublcass) {
+  if (!are_inputs_tensors_subclass) {
     if (is_zero.any().item<uint8_t>() == 0) {
       return reversed_cumsum(w, dim).div(input_conj);
     }
@@ -693,7 +693,7 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     // Compute gradient for positions before the first zero
     // Using at::where instead of masked_scatter_ for composite compliance
     auto grad_before_first_zero = reversed_cumsum(w.masked_fill(~mask, 0.), dim);
-    if (!are_inputs_tensors_sublcass) {
+    if (!are_inputs_tensors_subclass) {
       grad_before_first_zero = grad_before_first_zero.div_(input_conj);
     } else {
       grad_before_first_zero = grad_before_first_zero.div(input_conj);
@@ -726,7 +726,7 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     const auto grad_masked = grad.masked_fill(cumsum != 1, 0.);
     const auto output_before_zero = at::gather(output_conj, dim, (first_zero_index - 1).relu_())
                                       .masked_fill_(first_zero_index == 0, 1.);
-    if (!are_inputs_tensors_sublcass) {
+    if (!are_inputs_tensors_subclass) {
       grad_at_first_zero = grad_at_first_zero.mul_(grad_masked)
                              .sum(dim, /*keepdim*/true)
                              .mul_(output_before_zero);
@@ -763,7 +763,7 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     // For Composite Compliance, we will use
     // at::stack on the grad slices, hence the vector.
     std::vector<Tensor> grad_inputs;
-    if (are_inputs_tensors_sublcass) {
+    if (are_inputs_tensors_subclass) {
       grad_inputs.reserve(dim_size);
     } else {
       grad_input = make_subclass_aware_zeros(input.sym_sizes());
@@ -774,7 +774,7 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     Tensor prods_from_k_plus_1;
     Tensor omitted_products;
     for (const auto k : c10::irange(dim_size)) {
-      if (are_inputs_tensors_sublcass) {
+      if (are_inputs_tensors_subclass) {
         Tensor grad_slice;
         if (k == 0) {
           prods_from_k_plus_1 = at::cumprod(input_conj.slice(dim, k + 1), dim);
@@ -818,7 +818,7 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
       grad_input.select(dim, k).copy_(grad_slice);
     }
 
-    return are_inputs_tensors_sublcass ? at::stack(grad_inputs, dim) : std::move(grad_input);
+    return are_inputs_tensors_subclass ? at::stack(grad_inputs, dim) : std::move(grad_input);
   }
 }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -644,6 +644,14 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
 
   // For Composite Compliance, we always choose the slower but composite compliant path.
   bool are_inputs_tensors_sublcass = areAnyTensorSubclassLike({input, grad, output});
+  auto make_subclass_aware_zeros = [&](c10::SymIntArrayRef sizes) {
+    return are_inputs_tensors_sublcass ? grad.new_zeros_symint(sizes)
+                                       : at::zeros_symint(sizes, grad.options());
+  };
+  auto make_subclass_aware_ones = [&](c10::SymIntArrayRef sizes) {
+    return are_inputs_tensors_sublcass ? grad.new_ones_symint(sizes)
+                                       : at::ones({1}, grad.options()).expand_symint(sizes);
+  };
 
   const auto w = output_conj * grad;
   const auto is_zero = input == 0;
@@ -680,7 +688,7 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     // zeros_like(indices).scatter_(dim, indices, 1.) & cumsum == 1
     // Note that the logic_and with cumsum == 1 accounts
     // for the case when there is no first zero
-    Tensor grad_input = at::zeros_symint(input.sym_sizes(), grad.options());
+    Tensor grad_input = make_subclass_aware_zeros(input.sym_sizes());
     const auto cumsum = is_zero.cumsum(dim);
 
     // case k < z1
@@ -708,8 +716,8 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     // which is true in the range [z1, z2)
     const auto first_zero_index = std::get<1>(mask.max(dim, /*keepdim*/ true));
     const auto first_zero_mask = at::zeros_like(mask)
-                                  .scatter_(dim, first_zero_index, /*src*/ 1)
-                                  .logical_and_(mask);
+                                  .scatter(dim, first_zero_index, /*value*/ true)
+                                  .logical_and(mask);
 
     // select everything between the first zero and the second zero (z1, z2)
     mask &= ~first_zero_mask;
@@ -762,11 +770,11 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     if (are_inputs_tensors_sublcass) {
       grad_inputs.reserve(dim_size);
     } else {
-      grad_input = at::zeros(input.sizes(), grad.options());
+      grad_input = make_subclass_aware_zeros(input.sym_sizes());
     }
     auto ones_size = input.sym_sizes().vec();
     ones_size[dim] = 1;
-    const Tensor ones = at::ones({1}, grad.options()).expand_symint(ones_size);
+    const Tensor ones = make_subclass_aware_ones(ones_size);
     Tensor prods_from_k_plus_1;
     Tensor omitted_products;
     for (const auto k : c10::irange(dim_size)) {
@@ -912,13 +920,15 @@ Tensor cummaxmin_backward(const Tensor& grad, const Tensor& input, const Tensor&
   if (input.sym_numel() == 0) {
     return input;
   }
-  auto result = at::zeros_symint(input.sym_sizes(), input.options());
 
-  // for composite compliance, use out-of-place variant of
-  // `scatter_add` if `indices` or `grad` is a Tensor Subclass.
+  // for composite compliance and tensor subclasses (e.g. DTensor), create the
+  // scatter destination via the subclass so subsequent scatter_add stays in the
+  // same tensor subclass.
   if (areAnyTensorSubclassLike({indices, grad})) {
+    auto result = grad.new_zeros_symint(input.sym_sizes());
     return result.scatter_add(dim, indices, grad);
   }
+  auto result = at::zeros_symint(input.sym_sizes(), input.options());
   return result.scatter_add_(dim, indices, grad);
 }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -711,9 +711,7 @@ Tensor cumprod_backward(const Tensor& grad, const Tensor& input, int64_t dim, co
     // To account for this, we need to do an intersection with mask,
     // which is true in the range [z1, z2)
     const auto first_zero_index = std::get<1>(mask.max(dim, /*keepdim*/ true));
-    const auto first_zero_mask = at::zeros_like(mask)
-                                  .scatter(dim, first_zero_index, /*value*/ true)
-                                  .logical_and(mask);
+    const auto first_zero_mask = mask.logical_and(is_zero);
 
     // select everything between the first zero and the second zero (z1, z2)
     mask &= ~first_zero_mask;

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1192,6 +1192,70 @@ class DistMathOpsTest(DTensorTestBase):
                 self.assertEqual(output_dtensor.full_tensor(), output)
 
     @with_comms
+    def test_scan_ops_backward(self):
+        device_mesh = self.build_device_mesh()
+
+        for op, placements in itertools.product(
+            [torch.cumprod, torch.logcumsumexp],
+            [[Shard(0)], [Shard(1)], [Replicate()]],
+        ):
+            for dim in [0, 1]:
+                has_zero_cases = [False, True] if op is torch.cumprod else [False]
+                for has_zero in has_zero_cases:
+                    with self.subTest(
+                        op=op.__name__,
+                        placements=placements,
+                        dim=dim,
+                        has_zero=has_zero,
+                    ):
+                        x = torch.rand(12, 8, device=self.device_type).add_(0.1)
+                        if has_zero:
+                            x.select(dim, x.size(dim) // 2).zero_()
+                        x.requires_grad_()
+                        ref_out = op(x, dim=dim)
+                        ref_out.sum().backward()
+
+                        dist_x = distribute_tensor(
+                            x.detach().clone().requires_grad_(True),
+                            device_mesh,
+                            placements,
+                        )
+                        dist_out = op(dist_x, dim=dim)
+                        dist_out.sum().backward()
+
+                        self.assertEqual(dist_out.full_tensor(), ref_out)
+                        self.assertEqual(dist_x.grad.full_tensor(), x.grad)
+
+    @with_comms
+    def test_masked_cumprod_backward(self):
+        device_mesh = self.build_device_mesh()
+        row_idx = torch.arange(12, device=self.device_type).unsqueeze(1)
+        col_idx = torch.arange(8, device=self.device_type).unsqueeze(0)
+        mask = (row_idx + col_idx) % 2 == 0
+
+        for placements, dim in itertools.product(
+            [[Shard(0)], [Shard(1)], [Replicate()]],
+            [0, 1],
+        ):
+            with self.subTest(placements=placements, dim=dim):
+                x = torch.rand(12, 8, device=self.device_type).add_(0.1)
+                x.requires_grad_()
+                ref_out = torch.masked.cumprod(x, mask=mask, dim=dim)
+                ref_out.sum().backward()
+
+                dist_x = distribute_tensor(
+                    x.detach().clone().requires_grad_(True),
+                    device_mesh,
+                    placements,
+                )
+                dist_mask = distribute_tensor(mask, device_mesh, [Replicate()])
+                dist_out = torch.masked.cumprod(dist_x, mask=dist_mask, dim=dim)
+                dist_out.sum().backward()
+
+                self.assertEqual(dist_out.full_tensor(), ref_out)
+                self.assertEqual(dist_x.grad.full_tensor(), x.grad)
+
+    @with_comms
     def test_scan_ops_with_indices(self):
         mesh = self.build_device_mesh()
         comm_mode = CommDebugMode()
@@ -1212,6 +1276,32 @@ class DistMathOpsTest(DTensorTestBase):
                 else:
                     self.assertTrue(dt_values.placements[0].is_shard(shard_dim))
                 self.assertEqual(dt_values.full_tensor(), values)
+
+    @with_comms
+    def test_scan_ops_with_indices_backward(self):
+        device_mesh = self.build_device_mesh()
+
+        for op, placements in itertools.product(
+            [torch.cummax, torch.cummin],
+            [[Shard(0)], [Shard(1)], [Replicate()]],
+        ):
+            for dim in [0, 1]:
+                with self.subTest(op=op.__name__, placements=placements, dim=dim):
+                    x = torch.randn(12, 8, device=self.device_type, requires_grad=True)
+                    ref_values, ref_indices = op(x, dim=dim)
+                    ref_values.sum().backward()
+
+                    dist_x = distribute_tensor(
+                        x.detach().clone().requires_grad_(True),
+                        device_mesh,
+                        placements,
+                    )
+                    dist_values, dist_indices = op(dist_x, dim=dim)
+                    dist_values.sum().backward()
+
+                    self.assertEqual(dist_values.full_tensor(), ref_values)
+                    self.assertEqual(dist_indices.full_tensor(), ref_indices)
+                    self.assertEqual(dist_x.grad.full_tensor(), x.grad)
 
     @with_comms
     def test_median(self):

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1227,6 +1227,31 @@ class DistMathOpsTest(DTensorTestBase):
                         self.assertEqual(dist_x.grad.full_tensor(), x.grad)
 
     @with_comms
+    def test_cumprod_backward_higher_order(self):
+        device_mesh = self.build_device_mesh()
+        dim = 0
+        x = torch.rand(4, 3, device=self.device_type).add_(0.1)
+        x.select(dim, x.size(dim) // 2).zero_()
+        x.requires_grad_()
+
+        ref_out = torch.cumprod(x, dim=dim)
+        ref_grad = torch.autograd.grad(ref_out.sum(), x, create_graph=True)[0]
+        ref_grad.sum().backward()
+
+        dist_x = distribute_tensor(
+            x.detach().clone().requires_grad_(True),
+            device_mesh,
+            [Shard(0)],
+        )
+        dist_out = torch.cumprod(dist_x, dim=dim)
+        dist_grad = torch.autograd.grad(dist_out.sum(), dist_x, create_graph=True)[0]
+        dist_grad.full_tensor().sum().backward()
+
+        self.assertEqual(dist_out.full_tensor(), ref_out)
+        self.assertEqual(dist_grad.full_tensor(), ref_grad)
+        self.assertEqual(dist_x.grad.full_tensor(), x.grad)
+
+    @with_comms
     def test_masked_cumprod_backward(self):
         device_mesh = self.build_device_mesh()
         row_idx = torch.arange(12, device=self.device_type).unsqueeze(1)


### PR DESCRIPTION
Fixes #185362 

`cumprod_backward` and `cummaxmin_backward` were creating plain tensors inside tensor subclass paths, causing mixed tensor error during backward. this change switches those helper allocations to subclass aware functions and changes some ops to out of place for where `DTensor` need composite compliance. also added tests 