### PR TITLE
Add @requires_gpu decorator to user_defined_triton_kernel_autotune test

### DIFF
--- a/test/dynamo/test_fx_graph_runnable.py
+++ b/test/dynamo/test_fx_graph_runnable.py
@@ -203,6 +203,7 @@ class FxGraphRunnableTest(TestCase):
         self._exec_and_verify_payload()
 
     @unittest.skipUnless(has_triton(), "Triton not available")
+    @requires_gpu
     @torch._dynamo.config.patch(nested_graph_breaks=False)
     def test_user_defined_triton_kernel_autotune(self):
         def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary

`test_user_defined_triton_kernel_autotune` in `test_fx_graph_runnable.py` creates tensors on `GPU_TYPE` but only guards on `has_triton()`, missing the `@requires_gpu` decorator that the other 4 Triton kernel tests in the same class all have. This would cause a crash on CPU-only machines where Triton is importable.

**Change:** Add `@requires_gpu` decorator to match the pattern of sibling tests.

## Test plan

- All 5 Triton kernel tests still pass on GPU
- CPU-only runs correctly skip the test instead of crashing

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98