### PR TITLE
Use oneDNN for int8 quantization AArch64 with x86 engine

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -435,16 +435,21 @@ inline bool should_use_onednn_quant(
 #if !defined(__linux__)
   return false;
 #else
-#if defined(__powerpc__)
+#if defined(__powerpc__) || defined(__aarch64__) || defined(_M_ARM64)
   constexpr auto vnni_available = true;
 #else
   const auto vnni_available = cpuinfo_has_x86_avx512vnni();
+#endif
+#if defined(__aarch64__) || defined(_M_ARM64)
+  const auto valid_type = weight.scalar_type() == at::kQInt8;
+#else
+  constexpr auto valid_type = true;
 #endif
   bool w_sym_quant =
       is_weight_symmetric_quant(weight, is_transposed_conv);
   bool opad_all_zero =
       std::all_of(output_padding.begin(), output_padding.end(), [](int i) { return i==0; });
-  return vnni_available && (groups <= 100) && w_sym_quant && opad_all_zero;
+  return vnni_available && (groups <= 100) && w_sym_quant && opad_all_zero && valid_type;
 #endif
 }
 

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -436,7 +436,9 @@ int register_linear_params() {
                     at::globalContext().qEngine() == at::QEngine::X86) {
                   const auto& weight = std::get<0>(state);
                   if (weight.scalar_type() == at::kQInt8) {
+#if !defined(__aarch64__) && !defined(_M_ARM64)
                     return std::apply(PackedLinearWeight::prepack, std::move(state));
+#endif
                   } else if (weight.scalar_type() == at::kFloat) {
                     // NB: fp16 weight is serialized as float
                     return std::apply(PackedLinearWeightFp16::prepack, std::move(state));
@@ -460,7 +462,8 @@ int register_linear_params() {
                 }
 #endif // USE_PYTORCH_QNNPACK
 #if AT_MKLDNN_ENABLED()
-                if (at::globalContext().qEngine() == at::QEngine::ONEDNN) {
+                if (at::globalContext().qEngine() == at::QEngine::ONEDNN ||
+                    at::globalContext().qEngine() == at::QEngine::X86) {
                   const auto& weight = std::get<0>(state);
                   TORCH_CHECK(
                       weight.scalar_type() == at::kQInt8,

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -590,8 +590,11 @@ class QLinearPackWeightInt8 final {
     auto& ctx = at::globalContext();
 
 #ifdef USE_FBGEMM
-    if (ctx.qEngine() == at::QEngine::FBGEMM ||
-        ctx.qEngine() == at::QEngine::X86) {
+    if (ctx.qEngine() == at::QEngine::FBGEMM
+#if !defined(__aarch64__) && !defined(_M_ARM64)
+        || ctx.qEngine() == at::QEngine::X86
+#endif
+    ) {
       return PackedLinearWeight::prepack(std::move(weight), std::move(bias));
     }
 #endif
@@ -602,7 +605,8 @@ class QLinearPackWeightInt8 final {
     }
 #endif
 #if AT_MKLDNN_ENABLED()
-    if (ctx.qEngine() == at::QEngine::ONEDNN) {
+    if (ctx.qEngine() == at::QEngine::ONEDNN ||
+        ctx.qEngine() == at::QEngine::X86) {
       return PackedLinearWeightsOnednn::prepack(std::move(weight), std::move(bias));
     }
 #endif // #if AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/quantized/qconv_unpack.cpp
+++ b/aten/src/ATen/native/quantized/qconv_unpack.cpp
@@ -49,8 +49,11 @@ class QConvUnpackWeightsInt8 final {
     auto& ctx = at::globalContext();
 
 #ifdef USE_FBGEMM
-    if (ctx.qEngine() == at::QEngine::FBGEMM ||
-        ctx.qEngine() == at::QEngine::X86) {
+    if (ctx.qEngine() == at::QEngine::FBGEMM
+#if !defined(__aarch64__) && !defined(_M_ARM64)
+        || ctx.qEngine() == at::QEngine::X86
+#endif
+    ) {
       return packed_weight->unpack();
     }
 #endif
@@ -66,7 +69,8 @@ class QConvUnpackWeightsInt8 final {
 #endif
 
 #if AT_MKLDNN_ENABLED()
-    if (ctx.qEngine() == at::QEngine::ONEDNN) {
+    if (ctx.qEngine() == at::QEngine::ONEDNN
+        || ctx.qEngine() == at::QEngine::X86) {
       return packed_weight->unpack();
     }
 #endif
@@ -86,8 +90,11 @@ class QConv1dUnpackWeightsInt8 final {
     at::Tensor weight;
     std::optional<at::Tensor> bias;
 #ifdef USE_FBGEMM
-    if (ctx.qEngine() == at::QEngine::FBGEMM ||
-        ctx.qEngine() == at::QEngine::X86) {
+    if (ctx.qEngine() == at::QEngine::FBGEMM
+#if !defined(__aarch64__) && !defined(_M_ARM64)
+        || ctx.qEngine() == at::QEngine::X86
+#endif
+    ) {
       std::tie(weight, bias) = packed_weight->unpack();
       weight = weight.squeeze_(quant_utils::kConv1dSqueezeDim + 2);
       return std::tuple<at::Tensor, std::optional<at::Tensor>>(
@@ -106,7 +113,8 @@ class QConv1dUnpackWeightsInt8 final {
 #endif
 
 #if AT_MKLDNN_ENABLED()
-    if (ctx.qEngine() == at::QEngine::ONEDNN) {
+    if (ctx.qEngine() == at::QEngine::ONEDNN ||
+        ctx.qEngine() == at::QEngine::X86) {
       std::tie(weight, bias) = packed_weight->unpack();
       at::Tensor new_weight = weight.clone();
       new_weight.squeeze_(quant_utils::kConv1dSqueezeDim + 2);

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -89,7 +89,6 @@ from torch.testing._internal.common_utils import (
     skipIfXpu,
     TEST_MPS,
     TEST_WITH_ROCM,
-    xfailIf,
 )
 from torch.testing._internal.custom_tensor import CustomTensorPlainOut
 from torch.testing._internal.inductor_utils import (

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -73,7 +73,6 @@ from torch.testing._internal.common_quantization import (
 )
 from torch.testing._internal.common_utils import (
     DeterministicGuard,
-    IS_ARM64,
     IS_CI,
     IS_FBCODE,
     IS_MACOS,
@@ -2068,8 +2067,6 @@ class AOTInductorTestsTemplate:
         with config.patch({"aot_inductor.use_runtime_constant_folding": True}):
             self.check_model(Model(self.device), example_inputs)
 
-    @xfailIf(IS_ARM64)
-    # see https://github.com/pytorch/pytorch/issues/177254
     @skipIfNoFBGEMM
     def test_quanatized_int8_linear(self):
         class Model(torch.nn.Module):


### PR DESCRIPTION
This change ensures that oneDNN is used for int8 quantization on AArch64 when using the x86 quantization engine.

This fixes the failing test seen in #180546, as well as other untracked tests under `test_quantization.py`.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jerryzh168