### PR TITLE
Fix "its'" typos to "its" across AOT autograd and JIT frontend

### DIFF
--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -459,7 +459,7 @@ class _AnalyzeCustomOpInputOutputMode(TorchDispatchMode):
 class _FirstInvocationContext:
     """
     Context manager that tracks first invocation and conditionally enables _AnalyzeCustomOpInputOutputMode.
-    This is useful when we have a custom op where we want to analyze its' input
+    This is useful when we have a custom op where we want to analyze its input
     and output during cold start.
     """
 

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -84,7 +84,7 @@ def get_subclass_typing_container(
 ) -> dict[type[torch.Tensor], list[type[torch.Tensor]]]:
     """
     Given a subclass, returns a recursive dictionary mapping each
-    inner tensors to its' subclass types.
+    inner tensors to its subclass types.
     """
 
     def _get_types_for_subclass(tensor_subclass: torch.Tensor) -> None:

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -669,7 +669,7 @@ struct to_ir {
 
     // At this point, we might have received a graph that is compiled with
     // old operator schemas that might not exist in the system anymore.
-    // Therefore, we replace such ops with its' valid upgrader.
+    // Therefore, we replace such ops with its valid upgrader.
     ReplaceOldOperatorsWithUpgraders(graph);
 
     // NB ORDERING: SSA conversion has to occur before


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185242

The possessive "its" does not take an apostrophe. Fix three instances of
the incorrect "its'" in comments and docstrings.

Authored with Claude (typo_terminator2).