### PR TITLE
Update ARM64 Graviton2 ARC runner labels

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -75,8 +75,8 @@ runner_mapping:
 
   # ---- ARM64 — Graviton ----
 
-  linux.arm64.2xlarge: l-arm64g2-6-32                            # t4g.2xlarge
-  linux.arm64.2xlarge.ephemeral: l-arm64g2-6-32                  # t4g.2xlarge
+  linux.arm64.2xlarge: l-arm64g2-6-25                            # t4g.2xlarge
+  linux.arm64.2xlarge.ephemeral: l-arm64g2-6-25                  # t4g.2xlarge
   linux.arm64.m7g.4xlarge: l-arm64g3-16-62                       # m7g.4xlarge
   linux.arm64.m8g.4xlarge: l-arm64g4-16-62                       # m8g.4xlarge
   linux.arm64.r7g.12xlarge.memory: l-arm64g3-61-463              # r7g.12xlarge

--- a/.github/scripts/test_map_ec2_to_arc.py
+++ b/.github/scripts/test_map_ec2_to_arc.py
@@ -145,7 +145,7 @@ def test_mixed_runners():
         == [
             "l-x86iavx512-16-128",
             "l-x86aavx2-29-113-a10g",
-            "l-arm64g2-6-32",
+            "l-arm64g2-6-25",
         ]
     )
 


### PR DESCRIPTION
- Change linux.arm64.2xlarge runner label from l-arm64g2-6-32 to l-arm64g2-6-25
- Change linux.arm64.2xlarge.ephemeral runner label to match

The t4g.2xlarge Graviton2 runners are remapped to a new label reflecting a reduced memory allocation (32 GB -> 25 GB).