### PR TITLE
[BE][Ez]: Fix missing reserve calls on std::vector

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -702,6 +702,10 @@ static void check_shape_forward(const at::Tensor& input,
   if (!transposed) {
     std::vector<T> input_shape;
     std::vector<T> kernel_shape;
+    if (k > 2) {
+      input_shape.reserve(k - 2);
+      kernel_shape.reserve(k - 2);
+    }
     bool kernel_size_correct = true;
 
     if constexpr (std::is_same_v<T, c10::SymInt>) {

--- a/aten/src/ATen/native/DilatedConvolutionUtils.h
+++ b/aten/src/ATen/native/DilatedConvolutionUtils.h
@@ -42,6 +42,7 @@ std::vector<int64_t> get_output_size(
     IntArrayRef pad_size,
     IntArrayRef dilation_size) {
   std::vector<int64_t> sizes;
+  sizes.reserve(dim);
   for (const auto index : c10::irange(dim)) {
     sizes.push_back(
         div_rtn<int64_t>(

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -240,6 +240,7 @@ inline std::vector<c10::Scalar> convert_tensor_to_scalar_list(
             " but got ",
             scalarList_.size(0),
             " instead.");
+        scalarList.reserve(scalarList_.size(0));
         for (int64_t i = 0; i < scalarList_.size(0); i++) {
           scalarList.emplace_back(scalar_data[i]);
         }

--- a/aten/src/ATen/native/IndexingUtils.h
+++ b/aten/src/ATen/native/IndexingUtils.h
@@ -129,6 +129,7 @@ inline torch::List<std::optional<Tensor>> toListOfOptionalTensors(ArrayRef<IValu
   std::vector<int64_t> dims;
   std::vector<Tensor> transposedIndices;
   dims.reserve(self.dim());
+  transposedIndices.reserve(self.dim());
   for (const auto i : c10::irange(self.dim())) {
     if (indices[i].defined()) {
       dims.push_back(i);
@@ -151,6 +152,7 @@ transposeToFrontAndInvPerm(const Tensor& self, TensorList indices) {
   std::vector<Tensor> transposedIndices;
   dims.reserve(self.dim());
   invPerm.resize(self.dim());
+  transposedIndices.reserve(self.dim());
   for (const auto i : c10::irange(self.dim())) {
     if (indices[i].defined()) {
       dims.push_back(i);

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -686,6 +686,7 @@ Tensor _trilinear(const Tensor& i1_, const Tensor& i2_, const Tensor& i3_,
   Tensor i3 = i3_;
   std::vector<c10::SymInt> output_size;
   std::vector<int64_t> sum_dims_12, sum_dims_23;
+  output_size.reserve(total_dim);
   int64_t unroll_size = -1;
   // asserts...
   for (const auto i : c10::irange(total_dim)) {
@@ -791,6 +792,7 @@ Tensor bilinear(const Tensor& input1, const Tensor& input2, const Tensor& weight
 
   std::vector<c10::SymInt> output_size;
   auto size1 = input1.sym_sizes();
+  output_size.reserve(size1.size());
   output_size.insert(output_size.end(), size1.begin(), size1.end() - 1);
   output_size.push_back(weight.sym_size(0));
   auto input1_flattened = input1.reshape_symint({-1, input1.sym_size(-1)});

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -608,11 +608,13 @@ std::vector<CellParams> gather_params(TensorList params, bool has_biases, bool h
   if (has_biases) {
     if (has_projections) {
       TORCH_CHECK(params.size() % 5 == 0, "got an incorrect number of RNN parameters");
+      result.reserve(params.size() / 5);
       for (size_t i = 0; i < params.size(); i += 5) {
         result.emplace_back(params[i], params[i + 1], params[i + 2], params[i + 3], params[i + 4]);
       }
     } else {
       TORCH_CHECK(params.size() % 4 == 0, "got an incorrect number of RNN parameters");
+      result.reserve(params.size() / 4);
       for (size_t i = 0; i < params.size(); i += 4) {
         result.emplace_back(params[i], params[i + 1], params[i + 2], params[i + 3], undefined);
       }
@@ -620,11 +622,13 @@ std::vector<CellParams> gather_params(TensorList params, bool has_biases, bool h
   } else {
     if (has_projections) {
       TORCH_CHECK(params.size() % 3 == 0, "got an incorrect number of RNN parameters");
+      result.reserve(params.size() / 3);
       for (size_t i = 0; i < params.size(); i += 3) {
         result.emplace_back(params[i], params[i + 1], undefined, undefined, params[i + 2]);
       }
     } else {
       TORCH_CHECK(params.size() % 2 == 0, "got an incorrect number of RNN parameters");
+      result.reserve(params.size() / 2);
       for (size_t i = 0; i < params.size(); i += 2) {
         result.emplace_back(params[i], params[i + 1], undefined, undefined, undefined);
       }

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -308,6 +308,7 @@ inline std::vector<int64_t> get_zero_numel_tensor_size(
     sizes[dim] = 1;
   }
   else {
+    sizes.reserve(self.dim() - 1);
     for (const auto d : c10::irange(self.dim())) {
       if (d != dim) {
         sizes.push_back(self.sizes()[d]);

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -585,6 +585,7 @@ Tensor to(
 // across tensors.
 std::vector<Tensor> _to_cpu(TensorList tensors) {
   std::vector<Tensor> cpu_tensors;
+  cpu_tensors.reserve(tensors.size());
   for (const auto& t : tensors) {
     cpu_tensors.push_back(t.cpu());
   }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -356,6 +356,7 @@ DEFINE_DISPATCH(stack_serial_stub);
 Tensor _reshape_from_tensor(const Tensor& self, const Tensor& shape_tensor) {
   TORCH_CHECK(shape_tensor.dim() == 1);
   std::vector<int64_t> shape;
+  shape.reserve(shape_tensor.numel());
   auto accessor = shape_tensor.accessor<int64_t, 1>();
   for (const auto i : c10::irange(shape_tensor.numel())) {
     shape.push_back(accessor[i]);
@@ -872,6 +873,8 @@ static Tensor cat_sparse_impl(
   int64_t dense_dim = tensors[0].get().dense_dim();
   IntArrayRef sizes = tensors[0].get().sizes();
   if (wrapped < sparse_dim) {
+    indices.reserve(tensors.size());
+    values.reserve(tensors.size());
     for (const auto i : c10::irange(tensors.size())) {
       const Tensor& t = tensors[i];
       check_cat_sparse_dims(t, i, sizes, wrapped, sparse_dim, dense_dim);
@@ -946,6 +949,8 @@ static Tensor cat_sparse_impl(
     int64_t cumulative_size = 0;
     std::vector<Tensor> vals_pieces;
     std::vector<Tensor> idxs_pieces;
+    vals_pieces.reserve(tensors.size());
+    idxs_pieces.reserve(tensors.size());
     for (const auto i : c10::irange(tensors.size())) {
       const Tensor& t = tensors[i];
       check_cat_sparse_dims(t, i, sizes, wrapped, sparse_dim, dense_dim);

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -79,6 +79,7 @@ std::vector<Tensor> quantize_per_tensor_list_cpu(
     const Tensor& zero_points,
     ScalarType dtype) {
   std::vector<Tensor> quantized_tensors;
+  quantized_tensors.reserve(tensors.size());
   for (const auto i : c10::irange(tensors.size())) {
     quantized_tensors.push_back(at::quantize_per_tensor(
         tensors[i],
@@ -109,6 +110,7 @@ Tensor dequantize_quantized(const Tensor& self) {
 
 std::vector<Tensor> dequantize_tensors_quantized_cpu(TensorList tensors) {
   std::vector<Tensor> dequantized_tensors;
+  dequantized_tensors.reserve(tensors.size());
   for (const auto & tensor : tensors) {
     dequantized_tensors.push_back(tensor.dequantize());
   }

--- a/aten/src/ATen/native/vulkan/ops/Stack.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Stack.cpp
@@ -46,6 +46,7 @@ Tensor stack(const at::TensorList tensors, const int64_t dim) {
 
   // Unsqueeze each tensor in the list
   std::vector<Tensor> unsqueezed_outputs;
+  unsqueezed_outputs.reserve(tensors.size());
   for (const auto& t : tensors) {
     unsqueezed_outputs.push_back(at::unsqueeze(t, dim));
   }


### PR DESCRIPTION
Adds more missing reserve calls that can reduce unnecessary reallocations of std::vectors

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01