### PR TITLE
Make new_group delegate to split_group behind a migration flag

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1156,6 +1156,89 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_new_group_delegates_to_split_group_when_flag_set(self):
+        # When the migration flag is on, new_group should drive ncclCommSplit
+        # rather than constructing a fresh communicator.
+        from torch.distributed import config as dist_config
+
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        pg = self._create_process_group_nccl(store, self.opts(), device_id=device)
+        backend = pg._get_backend(torch.device(device))
+        self.assertEqual(backend.comm_split_count(), 0)
+
+        subg_ranks = [0, 1]
+        with (
+            dist_config.patch(new_group_use_split_group=True),
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always", FutureWarning)
+            ng = c10d.new_group(subg_ranks)
+        migration_warnings = [
+            w for w in caught
+            if issubclass(w.category, FutureWarning)
+            and "new_group_use_split_group" in str(w.message)
+        ]
+        self.assertEqual(migration_warnings, [])
+
+        # split happened eagerly under the split_group path.
+        self.assertEqual(backend.comm_split_count(), 1)
+        self.assertEqual(
+            dist.get_process_group_ranks(ng),
+            subg_ranks if self.rank in subg_ranks else [],
+        )
+
+        if dist.get_rank(ng) >= 0:
+            tensor = torch.full((1,), self.rank).cuda(device)
+            dist.broadcast(tensor, dist.get_global_rank(ng, 0), group=ng)
+            self.assertEqual(tensor, torch.full((1,), 0))
+
+        dist.destroy_process_group()
+
+    @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_new_group_warns_once_when_flag_unset(self):
+        import torch.distributed.distributed_c10d as c10d_module
+
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        self._create_process_group_nccl(store, self.opts(), device_id=device)
+
+        # Reset the per-process latch so this test is order-independent.
+        c10d_module._warned_about_new_group_migration = False
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", FutureWarning)
+            c10d.new_group([0, 1])
+            c10d.new_group([0, 1])
+
+        migration_warnings = [
+            w for w in caught
+            if issubclass(w.category, FutureWarning)
+            and "new_group_use_split_group" in str(w.message)
+        ]
+        self.assertEqual(len(migration_warnings), 1)
+        dist.destroy_process_group()
+
+    @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_new_group_via_split_group_raises_on_unsupported_args(self):
+        from torch.distributed import config as dist_config
+
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        self._create_process_group_nccl(store, self.opts(), device_id=device)
+
+        with dist_config.patch(new_group_use_split_group=True):
+            with self.assertRaisesRegex(NotImplementedError, "use_local_synchronization"):
+                c10d.new_group([0, 1], use_local_synchronization=True)
+            with self.assertRaisesRegex(NotImplementedError, "sort_ranks"):
+                c10d.new_group([0, 1], sort_ranks=False)
+
+        dist.destroy_process_group()
+
+    @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_comm_split_group_mixed_backend(self):
         # Test `ncclCommSplit` for smaller subgroups of the world when
         # we've passed a specific device_id to init_process_group.

--- a/torch/distributed/config.py
+++ b/torch/distributed/config.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from torch.utils._config_module import Config, install_config_module
 
 
-__all__ = ["compile_on_one_rank", "use_torchcomms"]
+__all__ = ["compile_on_one_rank", "new_group_use_split_group", "use_torchcomms"]
 
 # When enabled, coordinates are computed at runtime via a custom op rather
 # than being baked in at compile time. This allows compiling on one rank
@@ -25,6 +25,14 @@ compile_on_one_rank: bool = bool(
 use_torchcomms: bool = Config(
     default=False,
     env_name_default="TORCH_DISTRIBUTED_USE_TORCHCOMMS",
+)
+
+# When enabled, `new_group` delegates to `split_group` instead of the
+# legacy per-backend creator path. The default is False so existing users
+# get a one-time deprecation warning before the migration completes.
+new_group_use_split_group: bool = Config(
+    default=False,
+    env_name_default="TORCH_DIST_NEW_GROUP_USE_SPLIT_GROUP",
 )
 
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -167,6 +167,16 @@ def _use_torchcomms_enabled() -> bool:
     return _TORCHCOMM_AVAILABLE and dist_config.use_torchcomms
 
 
+def _use_split_group_for_new_group() -> bool:
+    """Check if `new_group` should delegate to `split_group`."""
+    return dist_config.new_group_use_split_group
+
+
+# Module-level latch so the new_group -> split_group migration warning is
+# emitted at most once per process.
+_warned_about_new_group_migration: bool = False
+
+
 _pickler = pickle.Pickler
 _unpickler = pickle.Unpickler
 
@@ -5780,7 +5790,41 @@ def new_group(
     N.B. use_local_synchronization=True can lead to deadlocks when each rank creates
     multiple overlapping process groups. To avoid that, make sure all ranks follow the
     same global creation order.
+
+    N.B. When ``torch.distributed.config.new_group_use_split_group`` is True
+    (or ``TORCH_DIST_NEW_GROUP_USE_SPLIT_GROUP=1``), this function delegates to
+    :func:`split_group` instead of running the legacy per-backend creator path.
+    The delegation path raises ``NotImplementedError`` for arguments that
+    :func:`split_group` cannot honor (e.g. ``use_local_synchronization=True``,
+    ``sort_ranks=False``, or an explicit ``backend`` / ``device_id`` that
+    diverges from the default group). When the flag is False, a one-time
+    ``FutureWarning`` is emitted advising callers to opt in.
     """
+    if _use_split_group_for_new_group():
+        return _new_group_via_split_group(
+            ranks=ranks,
+            timeout=timeout,
+            backend=backend,
+            pg_options=pg_options,
+            use_local_synchronization=use_local_synchronization,
+            group_desc=group_desc,
+            device_id=device_id,
+            sort_ranks=sort_ranks,
+        )
+
+    global _warned_about_new_group_migration
+    if not _warned_about_new_group_migration:
+        warnings.warn(
+            "torch.distributed.new_group is being migrated to delegate to "
+            "torch.distributed.split_group. Set "
+            "torch.distributed.config.new_group_use_split_group = True "
+            "(or export TORCH_DIST_NEW_GROUP_USE_SPLIT_GROUP=1) to opt in to "
+            "the new behavior. This warning is shown once per process.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        _warned_about_new_group_migration = True
+
     return _new_group_with_tag(
         ranks,
         timeout,
@@ -5792,6 +5836,65 @@ def new_group(
         device_id=device_id,
         sort_ranks=sort_ranks,
     )
+
+
+def _new_group_via_split_group(
+    ranks,
+    timeout,
+    backend,
+    pg_options,
+    use_local_synchronization,
+    group_desc,
+    device_id,
+    sort_ranks,
+):
+    """Implement `new_group` semantics on top of `split_group`.
+
+    Raises ``NotImplementedError`` (or ``ValueError`` for inconsistent args)
+    when the requested ``new_group`` configuration cannot be expressed through
+    ``split_group``. Backend-level limitations (e.g. Gloo / MPI not supporting
+    splitting) propagate as the ``RuntimeError`` raised by ``split_group``.
+    """
+    if use_local_synchronization:
+        raise NotImplementedError(
+            "new_group -> split_group delegation does not support "
+            "use_local_synchronization=True; split_group requires all ranks "
+            "in the parent group to participate."
+        )
+    if not sort_ranks:
+        raise NotImplementedError(
+            "new_group -> split_group delegation does not support "
+            "sort_ranks=False; split_group always sorts the ranks of each "
+            "subgroup."
+        )
+
+    default_pg = _get_default_group()
+    if device_id is not None:
+        bound = default_pg.bound_device_id
+        if bound is not None and device_id != bound:
+            raise ValueError(
+                f"device_id={device_id} does not match the default process "
+                f"group's bound_device_id={bound}; split_group inherits the "
+                "default group's device binding."
+            )
+
+    global_world_size = default_pg.size()
+    if ranks is None:
+        group_ranks = list(range(global_world_size))
+    else:
+        group_ranks = sorted(ranks)
+
+    split_pg = split_group(
+        parent_pg=default_pg,
+        split_ranks=[group_ranks],
+        timeout=timeout,
+        pg_options=pg_options,
+        group_desc=group_desc,
+        backend=backend,
+    )
+    if split_pg is None:
+        return GroupMember.NON_GROUP_MEMBER
+    return split_pg
 
 
 def _new_group_with_tag(


### PR DESCRIPTION

Summary:

To unblock migrating callers from `new_group` to `split_group`, route
`new_group` through `split_group` under an opt-in flag while keeping
the legacy path as the default and warning users about the upcoming
change. This lets call sites switch over incrementally without
forcing a hard cutover.

Add `torch.distributed.config.new_group_use_split_group` (env var
`TORCH_DIST_NEW_GROUP_USE_SPLIT_GROUP`, default False). When set,
`new_group` routes through a thin adapter that calls `split_group` on
the default process group, preserving `new_group`'s return contract
(`GroupMember.NON_GROUP_MEMBER` for non-members). When unset, the
legacy `_new_group_with_tag` path runs as before and a one-time
`FutureWarning` advises callers to opt in.

`split_group` has a narrower surface than `new_group`, so the adapter
raises `NotImplementedError` for `use_local_synchronization=True` and
`sort_ranks=False`, and `ValueError` if `device_id` conflicts with the
default group's bound device. Backend-level incompatibilities (Gloo,
MPI, mismatched backends) propagate from `split_group`'s existing
checks. Raising (rather than silently falling back) was chosen so
callers learn which call sites still need attention as the migration
progresses.

Test Plan:

Added three tests in `ProcessGroupNCCLGroupTest`:

- `test_new_group_delegates_to_split_group_when_flag_set` verifies that
  `comm_split_count` increments and the resulting subgroup is
  functional, and that no migration warning fires under the flag.
- `test_new_group_warns_once_when_flag_unset` resets the per-process
  latch, calls `new_group` twice, and asserts exactly one
  `FutureWarning` is emitted.
- `test_new_group_via_split_group_raises_on_unsupported_args` asserts
  `NotImplementedError` for `use_local_synchronization=True` and
  `sort_ranks=False` when delegation is enabled.

Run with:

    python test/distributed/test_c10d_nccl.py ProcessGroupNCCLGroupTest \
        -k 'new_group_delegates_to_split_group_when_flag_set or \
            new_group_warns_once_when_flag_unset or \
            new_group_via_split_group_raises_on_unsupported_args'

(Requires NCCL 2.18+ and 2+ GPUs; not executed locally.)

Authored by Claude.
