### PR TITLE
[ROCm] - Link ck_sdpa ONLY if it exists

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1465,7 +1465,7 @@ if(USE_ROCM)
   if(USE_MEM_EFF_ATTENTION)
     target_compile_definitions(torch_hip PRIVATE USE_MEM_EFF_ATTENTION)
   endif()
-  if(USE_ROCM_CK_SDPA)
+  if(TARGET ck_sdpa)
     target_compile_definitions(torch_hip PRIVATE USE_ROCM_CK_SDPA)
   endif()
 
@@ -1850,7 +1850,7 @@ if(USE_ROCM)
   target_link_libraries(torch_hip PUBLIC torch_cpu_library ${Caffe2_PUBLIC_HIP_DEPENDENCY_LIBS})
   target_link_libraries(torch_hip PRIVATE ${Caffe2_HIP_DEPENDENCY_LIBS})
 
-  if(USE_ROCM_CK_SDPA)
+  if(TARGET ck_sdpa)
     target_link_libraries(torch_hip PRIVATE ck_sdpa)
   endif()
 


### PR DESCRIPTION
As of turning ck_sdpa on by default, builds for early architectures that do not support ck_sdpa have been broken. This is due to the link step only caring about USE_ROCM_CK_SDPA which is now on, but the ck_sdpa target depends on USE_FLASH_ATTENTION and USE_MEM_EFF_ATTENTION, both of which are off in the failing builds. This change makes the link step depend on whether the ck_sdpa target was ever created.

fixes https://github.com/ROCm/TheRock/issues/5178

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang