### PR TITLE
[c10d] Make FakeProcessGroup reduce collectives numerically consistent

### DIFF
--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -245,16 +245,22 @@ class TestFakePG(TestCase):
     @parametrize("rank", [0, 1])
     def test_reduce_scatter_copy_semantics(self, rank):
         store = FakeStore()
-        dist.init_process_group(backend="fake", rank=rank, world_size=2, store=store)
+        world_size = 2
+        dist.init_process_group(
+            backend="fake", rank=rank, world_size=world_size, store=store
+        )
 
-        to_reduce_scatter = [torch.ones(3, 3) * r for r in range(2)]
+        to_reduce_scatter = [torch.ones(3, 3) * r for r in range(world_size)]
         output = torch.empty(3, 3)
         dist.reduce_scatter(output, to_reduce_scatter)
-        self.assertEqual(output, to_reduce_scatter[rank])
+        self.assertEqual(output, to_reduce_scatter[rank] * world_size)
 
     def test_reduce_scatter_requires_grad(self):
         store = FakeStore()
-        dist.init_process_group(backend="fake", rank=1, world_size=2, store=store)
+        world_size = 2
+        dist.init_process_group(
+            backend="fake", rank=1, world_size=world_size, store=store
+        )
 
         inputs = [
             torch.ones(3, 3).requires_grad_(True),
@@ -262,7 +268,7 @@ class TestFakePG(TestCase):
         ]
         output = torch.empty(3, 3)
         dist.reduce_scatter(output, inputs)
-        self.assertEqual(output, inputs[1])
+        self.assertEqual(output, inputs[1] * world_size)
         self.assertFalse(output.requires_grad)
 
     @parametrize("rank", [0, 1])
@@ -296,41 +302,53 @@ class TestFakePG(TestCase):
     @parametrize("rank", [0, 1])
     def test_reduce_scatter_base_copy_semantics(self, rank):
         store = FakeStore()
-        dist.init_process_group(backend="fake", rank=rank, world_size=2, store=store)
+        world_size = 2
+        dist.init_process_group(
+            backend="fake", rank=rank, world_size=world_size, store=store
+        )
 
         in_buf = torch.arange(12.0).reshape(6, 2)
         out_buf = torch.empty(3, 2)
-        dist._reduce_scatter_base(out_buf, in_buf)
-        self.assertEqual(out_buf, in_buf.chunk(2)[rank])
+        dist.reduce_scatter_tensor(out_buf, in_buf)
+        self.assertEqual(out_buf, in_buf.chunk(world_size)[rank] * world_size)
 
     @parametrize("rank", [0, 1])
     def test_reduce_scatter_tensor_copy_semantics(self, rank):
         store = FakeStore()
-        dist.init_process_group(backend="fake", rank=rank, world_size=2, store=store)
+        world_size = 2
+        dist.init_process_group(
+            backend="fake", rank=rank, world_size=world_size, store=store
+        )
 
         in_tensor = torch.arange(8.0).reshape(4, 2)
         out_tensor = torch.empty(2, 2)
         dist.reduce_scatter_tensor(out_tensor, in_tensor)
-        self.assertEqual(out_tensor, in_tensor.chunk(2)[rank])
+        self.assertEqual(out_tensor, in_tensor.chunk(world_size)[rank] * world_size)
 
     def test_reduce_scatter_base_requires_grad(self):
         store = FakeStore()
-        dist.init_process_group(backend="fake", rank=1, world_size=2, store=store)
+        world_size = 2
+        dist.init_process_group(
+            backend="fake", rank=1, world_size=world_size, store=store
+        )
 
         in_tensor = torch.arange(4.0).reshape(4, 1).requires_grad_(True)
         out_tensor = torch.empty(2, 1)
-        dist._reduce_scatter_base(out_tensor, in_tensor)
-        self.assertEqual(out_tensor, in_tensor.chunk(2)[1])
+        dist.reduce_scatter_tensor(out_tensor, in_tensor)
+        self.assertEqual(out_tensor, in_tensor.chunk(world_size)[1] * world_size)
 
     def test_reduce_scatter_tensor_coalesced_requires_grad(self):
         store = FakeStore()
-        dist.init_process_group(backend="fake", rank=1, world_size=2, store=store)
+        world_size = 2
+        dist.init_process_group(
+            backend="fake", rank=1, world_size=world_size, store=store
+        )
 
         in_tensor = torch.arange(4.0).reshape(4, 1).requires_grad_(True)
         out_tensor = torch.empty(2, 1)
         with dist._coalescing_manager():
             dist.reduce_scatter_tensor(out_tensor, in_tensor)
-        self.assertEqual(out_tensor, in_tensor.chunk(2)[1])
+        self.assertEqual(out_tensor, in_tensor.chunk(world_size)[1] * world_size)
 
     @parametrize("rank", [0, 1])
     def test_allgather_copy_semantics(self, rank):
@@ -708,7 +726,7 @@ class TestFakePG(TestCase):
             RuntimeError,
             "input tensor must be the same size as output size times world size",
         ):
-            dist._reduce_scatter_base(out_buf, in_buf)
+            dist.reduce_scatter_tensor(out_buf, in_buf)
 
     def test_allgather_coalesced_wrong_inner_list_size(self):
         store = FakeStore()
@@ -718,6 +736,78 @@ class TestFakePG(TestCase):
         inputs = [torch.ones(3, 3)]
         with self.assertRaisesRegex(RuntimeError, "invalid output size"):
             dist.all_gather_coalesced(output, inputs)
+
+    def test_reduce_numerics_all_ranks_identical(self):
+        world_size = 64
+        dist.init_process_group(backend="fake", rank=0, world_size=world_size)
+        pg = dist.distributed_c10d._get_default_group()
+
+        x = torch.randn(32)
+
+        shard = x[:4].clone()
+        gathered = torch.empty(4 * world_size)
+        dist.all_gather_into_tensor(gathered, shard)
+        for chunk in gathered.chunk(world_size):
+            self.assertEqual(chunk, shard)
+
+        shard_data = torch.randn(4)
+        inp = shard_data.repeat(world_size)
+        out = torch.empty(4)
+        dist.reduce_scatter_tensor(out, inp)
+        self.assertEqual(out, shard_data * world_size)
+
+        ar = x.clone()
+        dist.all_reduce(ar)
+        self.assertEqual(ar, x * world_size)
+
+        ar_max = x.clone()
+        dist.all_reduce(ar_max, op=dist.ReduceOp.MAX)
+        self.assertEqual(ar_max, x)
+
+        ar_avg = x.clone()
+        dist.all_reduce(ar_avg, op=dist.ReduceOp.AVG)
+        self.assertEqual(ar_avg, x)
+
+        pos = x.abs() + 0.1
+        ar_prod = pos.clone()
+        dist.all_reduce(ar_prod, op=dist.ReduceOp.PRODUCT)
+        self.assertEqual(ar_prod, pos.pow(world_size))
+
+        factor = 0.5
+        ar_premul = x.clone()
+        dist.all_reduce(ar_premul, op=dist._make_nccl_premul_sum(factor))
+        self.assertEqual(ar_premul, x * factor * world_size)
+
+        t_factor = torch.tensor(0.25)
+        ar_premul_t = x.clone()
+        dist.all_reduce(ar_premul_t, op=dist._make_nccl_premul_sum(t_factor))
+        self.assertEqual(ar_premul_t, x * t_factor * world_size)
+
+        r = x.clone()
+        dist.reduce(r, dst=0)
+        self.assertEqual(r, x * world_size)
+
+        t1, t2 = x[:16].clone(), x[16:].clone()
+        tensors = [t1, t2]
+        dist.all_reduce_coalesced(tensors)
+        self.assertEqual(tensors[0], x[:16] * world_size)
+        self.assertEqual(tensors[1], x[16:] * world_size)
+
+        fg = funcol.all_gather_tensor(shard, 0, pg)
+        for chunk in fg.chunk(world_size):
+            self.assertEqual(chunk, shard)
+
+        inp2 = torch.randn(4).repeat(world_size)
+        rs = funcol.reduce_scatter_tensor(inp2, "sum", 0, pg)
+        self.assertEqual(rs, inp2.chunk(world_size)[0] * world_size)
+
+        ar2 = x.clone()
+        ar2 = funcol.all_reduce(ar2, "sum", pg)
+        self.assertEqual(ar2, x * world_size)
+
+        ar3 = x.clone()
+        ar3 = funcol.all_reduce(ar3, "max", pg)
+        self.assertEqual(ar3, x)
 
 
 instantiate_parametrized_tests(TestFakePG)

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -55,38 +55,55 @@ class FakeProcessGroup : public Backend {
   }
 
   c10::intrusive_ptr<Work> allreduce(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceOptions& /* opts */ = AllreduceOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override {
     checkCollectiveError();
+    at::AutoDispatchBelowAutograd guard;
+    for (auto& tensor : tensors) {
+      applyReduceScaling_(tensor, opts.reduceOp);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> allreduce_sparse(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceOptions& /* opts */ = AllreduceOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override {
     checkCollectiveError();
+    at::AutoDispatchBelowAutograd guard;
+    for (auto& tensor : tensors) {
+      applyReduceScaling_(tensor, opts.reduceOp);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> allreduce_coalesced(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceCoalescedOptions& /* opts */ =
+      std::vector<at::Tensor>& tensors,
+      const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override {
     checkCollectiveError();
+    at::AutoDispatchBelowAutograd guard;
+    for (auto& tensor : tensors) {
+      applyReduceScaling_(tensor, opts.reduceOp);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> reduce(
-      std::vector<at::Tensor>& /* tensors */,
-      const ReduceOptions& /* opts */ = ReduceOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) override {
     checkCollectiveError();
+    at::AutoDispatchBelowAutograd guard;
+    for (auto& tensor : tensors) {
+      applyReduceScaling_(tensor, opts.reduceOp);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
   // NOTE [FakeProcessGroup collective semantics]
-  // Collectives use deterministic single-process approximations. When output
-  // can be derived from local inputs, fake collectives copy those values into
-  // local outputs so tests do not consume uninitialized memory. For scatter on
+  // Collectives simulate a multi-rank run where every rank holds identical
+  // data. Gather-style ops (allgather) replicate the local input. Reduce-style
+  // ops (allreduce, reduce_scatter) apply the reduction scaling factor: e.g.
+  // SUM multiplies by world_size, AVG/MIN/MAX are identity. For scatter on
   // non-root ranks, the root's input list is unavailable in this single-process
   // simulation, so the output tensor is left unchanged.
   c10::intrusive_ptr<Work> allgather(
@@ -205,8 +222,7 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> reduce_scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
-      const ReduceScatterOptions& /* opts */ =
-          ReduceScatterOptions()) override {
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
     checkCollectiveError();
     auto invalidArgument = [](const std::string& msg) {
       TORCH_CHECK(false, "FakeProcessGroup::reduce_scatter: ", msg);
@@ -219,6 +235,7 @@ class FakeProcessGroup : public Backend {
       assertInputTensorListSizeEqualsWorldSize(
           invalidArgument, inputTensors[i].size(), size_);
       outputTensors[i].copy_(inputTensors[i][rank_]);
+      applyReduceScaling_(outputTensors[i], opts.reduceOp);
     }
     return c10::make_intrusive<FakeWork>();
   }
@@ -226,8 +243,7 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> _reduce_scatter_base(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
-      const ReduceScatterOptions& /* opts */ =
-          ReduceScatterOptions()) override {
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
     checkCollectiveError();
     TORCH_CHECK(
         inputBuffer.numel() == outputBuffer.numel() * size_,
@@ -236,14 +252,14 @@ class FakeProcessGroup : public Backend {
     at::AutoDispatchBelowAutograd guard;
     auto chunks = inputBuffer.chunk(size_);
     outputBuffer.copy_(chunks[rank_]);
+    applyReduceScaling_(outputBuffer, opts.reduceOp);
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
-      const ReduceScatterOptions& /* opts */ =
-          ReduceScatterOptions()) override {
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
     checkCollectiveError();
     auto invalidArgument = [](const std::string& msg) {
       TORCH_CHECK(
@@ -259,6 +275,7 @@ class FakeProcessGroup : public Backend {
           "input tensor must be the same size as output size times world size");
       auto chunks = inputs[i].chunk(size_);
       outputs[i].copy_(chunks[rank_]);
+      applyReduceScaling_(outputs[i], opts.reduceOp);
     }
     return c10::make_intrusive<FakeWork>();
   }
@@ -381,6 +398,39 @@ class FakeProcessGroup : public Backend {
     TORCH_CHECK(
         !options_ || !options_->error_on_collective,
         "FakeProcessGroup collective operation error (error_on_collective=true)");
+  }
+
+  // Scale reduce output assuming all ranks hold identical data.
+  // SUM of N identical values = N*x, PREMUL_SUM = f*x*N, AVG = x,
+  // MIN/MAX = x, PRODUCT = x^N.
+  void applyReduceScaling_(at::Tensor& tensor, const ReduceOp& op) const {
+    switch (op.op_) {
+      case ReduceOp::SUM:
+        tensor.mul_(size_);
+        break;
+      case ReduceOp::PREMUL_SUM: {
+        const auto* supp =
+            static_cast<PreMulSumSupplement*>(op.supplement_.get());
+        if (supp && supp->tensor_factor.defined()) {
+          tensor.mul_(supp->tensor_factor);
+        } else if (supp) {
+          tensor.mul_(supp->double_factor);
+        }
+        tensor.mul_(size_);
+        break;
+      }
+      case ReduceOp::PRODUCT:
+        tensor.pow_(size_);
+        break;
+      case ReduceOp::AVG:
+      case ReduceOp::MIN:
+      case ReduceOp::MAX:
+      case ReduceOp::BAND:
+      case ReduceOp::BOR:
+      case ReduceOp::BXOR:
+      case ReduceOp::UNUSED:
+        break;
+    }
   }
 };
 

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -18,9 +18,10 @@ def _create_fake_pg(common_opts, backend_opts):
     communication.  You can run a single rank with a fake process group
     without needing multiple processes (simulates per-rank behavior)
 
-    NOTE: This is not a real process group, and it would produce wrong results
-    for every collective. It should be used as a convenient tool when playing
-    with distributed but don't care about the actual data.
+    NOTE: Under the assumption that all ranks hold identical data,
+    reduce collectives (allreduce, reduce_scatter, etc.) now produce
+    numerically correct results (e.g. SUM multiplies by world_size).
+    Gather-style collectives replicate the local input.
     """
     return FakeProcessGroup._create_internal(
         common_opts.group_rank, common_opts.group_size, backend_opts


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185253

FakeProcessGroup previously produced wrong numerical results for reduce
collectives: allreduce was a no-op and reduce_scatter just copied a chunk
without any reduction. This made FakePG unsuitable for single-process
numerics verification of distributed training graphs.

Under the assumption that all ranks hold identical data (valid for
single-process simulation), the correct result for reduce collectives is:
- SUM: output = input * world_size (N identical values summed)
- PREMUL_SUM: output = input * prescale_factor * world_size
- AVG/MIN/MAX: output = input (identity for identical values)
- PRODUCT: output = input ^ world_size

This change adds an `applyReduceScaling_` helper that applies the correct
scaling factor after the existing copy logic for allreduce, allreduce_sparse,
allreduce_coalesced, reduce, reduce_scatter, _reduce_scatter_base, and
reduce_scatter_tensor_coalesced. Gather-style ops (allgather, broadcast)
were already correct. PREMUL_SUM correctly extracts the user-supplied
prescale factor (scalar or tensor) from ReduceOp::supplement_.

Also migrates test calls from the deprecated `dist._reduce_scatter_base`
to `dist.reduce_scatter_tensor`, and updates the FakePG docstring to
reflect the new numerics contract.

Authored by Claude.

Test Plan:

Updated existing reduce_scatter tests to expect the new (correct) scaled
values. Added `test_reduce_numerics_all_ranks_identical` that verifies
all collective patterns found in a Llama3-70B TP=8 DP=8 precompile graph
(1926x all_gather, 404x reduce_scatter SUM, 159x allreduce SUM,
1x allreduce MAX) at world_size=64, using both `dist.*` and `funcol.*` APIs.
Also covers AVG, PRODUCT, PREMUL_SUM (scalar and tensor factor), reduce,
and allreduce_coalesced.

```
CUDA_VISIBLE_DEVICES="" python test/distributed/test_fake_pg.py -v  # 61 tests, all pass
```