### PR TITLE
Fix PendingUnbackedSymbolNotFound for tensor-derived slice bounds

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -15998,6 +15998,49 @@ def forward(self, L_x_ : torch.Tensor):
         opt = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(opt(), "1:2:3")
 
+    def test_compile_tensor_derived_slice_bounds(self):
+        # https://github.com/pytorch/pytorch/issues/185185
+        class TensorDerivedSliceBounds(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer(
+                    "crop_size", torch.tensor(224, dtype=torch.float32)
+                )
+
+            def forward(self, x):
+                h = x.shape[2]
+                w = x.shape[3]
+                h = torch.tensor(h, device=x.device, dtype=torch.float32)
+                w = torch.tensor(w, device=x.device, dtype=torch.float32)
+                h0 = (h - self.crop_size) / 2
+                w0 = (w - self.crop_size) / 2
+                h1 = h0 + self.crop_size
+                w1 = w0 + self.crop_size
+                return x[:, :, h0.long() : h1.long(), w0.long() : w1.long()]
+
+        model = TensorDerivedSliceBounds().eval()
+        x = torch.randn(1, 3, 224, 224)
+
+        with torch.no_grad():
+            eager_out = model(x)
+
+        torch._dynamo.reset()
+        compiled = torch.compile(model, backend="eager", fullgraph=True)
+        with torch.no_grad():
+            compiled_out = compiled(x)
+
+        self.assertEqual(eager_out, compiled_out)
+
+        x2 = torch.randn(1, 3, 256, 300)
+        with torch.no_grad():
+            eager_out2 = model(x2)
+        torch._dynamo.reset()
+        compiled2 = torch.compile(model, backend="eager", fullgraph=True)
+        with torch.no_grad():
+            compiled_out2 = compiled2(x2)
+
+        self.assertEqual(eager_out2, compiled_out2)
+
 
 instantiate_parametrized_tests(MiscTests)
 

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4343,11 +4343,12 @@ def forward(self, causal_mask, fill_value):
             self.assertTrue(torch.allclose(ep.module()(x, xs), mod(x, xs)))
 
         # check unbacked bindings
-        # should be 4 symbols: u0, u1, output size, output storage offset
+        # should be 2 symbols: u0, u1 (output size and storage offset
+        # are derived symbolically from u0/u1 via sym_ite/sym_min/sym_max)
         bound_unbacked = set()
         for node in ep.graph.nodes:
             bound_unbacked |= node.meta.get("unbacked_bindings", {}).keys()
-        self.assertEqual(len(bound_unbacked), 4)
+        self.assertEqual(len(bound_unbacked), 2)
 
     def test_dim_hint_ranges(self):
         class Foo(torch.nn.Module):

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4195,15 +4195,7 @@ def forward(self, arg0_1: "i64[2][1]cpu", arg1_1: "Sym(u2)", arg2_1: "Sym(u3)", 
         _local_scalar_dense: "Sym(u0)" = torch.ops.aten._local_scalar_dense.default(select);  select = None
         select_1: "i64[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 1);  arg0_1 = None
         _local_scalar_dense_1: "Sym(u1)" = torch.ops.aten._local_scalar_dense.default(select_1);  select_1 = None
-        slice_1: "f32[u2][1]cpu" = torch.ops.aten.slice.Tensor(arg1_1, 0, _local_scalar_dense, _local_scalar_dense_1);  arg1_1 = _local_scalar_dense = _local_scalar_dense_1 = None
-        sym_size_int: "Sym(u2)" = torch.ops.aten.sym_size.int(slice_1, 0)
-        ge_1: "Sym(u2 >= 0)" = sym_size_int >= 0
-        _assert_scalar = torch.ops.aten._assert_scalar.default(ge_1, "Runtime assertion failed for expression u2 >= 0 on node 'ge'");  ge_1 = _assert_scalar = None
-        le: "Sym(u2 <= 10)" = sym_size_int <= 10;  sym_size_int = None
-        _assert_scalar_1 = torch.ops.aten._assert_scalar.default(le, "Runtime assertion failed for expression u2 <= 10 on node 'le'");  le = _assert_scalar_1 = None
-        sym_storage_offset_default: "Sym(u3)" = torch.ops.aten.sym_storage_offset.default(slice_1)
-        ge_2: "Sym(u3 >= 0)" = sym_storage_offset_default >= 0;  sym_storage_offset_default = None
-        _assert_scalar_2 = torch.ops.aten._assert_scalar.default(ge_2, "Runtime assertion failed for expression u3 >= 0 on node 'ge_1'");  ge_2 = _assert_scalar_2 = None
+        slice_1: "f32[Max(0, -Max(0, Min(10, Piecewise((u0, u0 >= 0), (u0 + 10, True)))) + Max(0, Min(10, Piecewise((u1, u1 >= 0), (u1 + 10, True)))))][1]cpu" = torch.ops.aten.slice.Tensor(arg1_1, 0, _local_scalar_dense, _local_scalar_dense_1);  arg1_1 = _local_scalar_dense = _local_scalar_dense_1 = None
         return (slice_1,)""",
             ignore_comments=True,
             ignore_empty_lines=True,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1498,7 +1498,10 @@ def slice_(x, dim=0, start=0, end=sys.maxsize, step=1, clamp=True):
         elif fn(sympy.Lt(index, 0)):
             # If index < 0, wrap and clamp: the resolved index is at least 0.
             return Max(index + size, 0)
-        return None
+        # Symbolic fallback for unbacked symbols where sign is unknown.
+        # Mirrors _compute_slice_index in fake_impls.py.
+        adjusted = sympy.Piecewise((index, index >= 0), (index + size, True))
+        return Max(Min(adjusted, size), 0)
 
     start_index, end_index = None, None
     # ambiguous_slice=False means we know what semantics this slice call follows,

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -1138,7 +1138,7 @@ def _padded_dense_to_jagged_forward(
     return padded.new_empty(output_shape)  # type: ignore[return]
 
 
-def _compute_slice_index(size: IntLikeType, index: IntLikeType) -> IntLikeType | None:
+def _compute_slice_index(size: IntLikeType, index: IntLikeType) -> IntLikeType:
     from torch.fx.experimental.symbolic_shapes import guard_or_false, sym_and
 
     if guard_or_false(sym_and(index >= 0, index <= size)):
@@ -1154,7 +1154,8 @@ def _compute_slice_index(size: IntLikeType, index: IntLikeType) -> IntLikeType |
     elif guard_or_false(index < 0):
         return torch.sym_max(index + size, 0)
 
-    return None
+    adjusted = torch.sym_ite(index >= 0, index, index + size)
+    return torch.sym_max(torch.sym_min(adjusted, size), 0)
 
 
 @register_op_impl(torch.ops.aten.slice.Tensor)

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -130,6 +130,11 @@ def _run_sympy_handler(analysis, args, expr, index_dtype=torch.int64):
         return analysis.sqrt(args[0])
     if isinstance(expr, ToFloat):
         return analysis.to_dtype(args[0], torch.float64)
+    # sympy rewrites Piecewise over booleans into ITE (If-Then-Else) internally;
+    # decompose back into primitives the interpreter already handles.
+    if expr.func is sympy.logic.boolalg.ITE:
+        c, t, f = args
+        return analysis.or_(analysis.and_(c, t), analysis.and_(analysis.not_(c), f))
 
     # These handlers are special because they take an extra dtype argument
     # specifying what they should convert to, and we need to appropriately set

--- a/torch/utils/_sympy/printers.py
+++ b/torch/utils/_sympy/printers.py
@@ -367,6 +367,11 @@ class PythonPrinter(ExprPrinter):
                     result = f"({expr_str} if {cond_str} else {result})"
         return result if result else "0"
 
+    def _print_ITE(self, expr: sympy.Expr) -> str:
+        c, t, f = expr.args
+        # pyrefly: ignore [missing-attribute]
+        return f"({self._print(t)} if {self._print(c)} else {self._print(f)})"
+
 
 class CppPrinter(ExprPrinter):
     def _print_Integer(self, expr: sympy.Expr) -> str:
@@ -408,6 +413,12 @@ class CppPrinter(ExprPrinter):
                 else:
                     result = f"{cond_str} ? {expr_str} : {result}"
         return f"({result})" if result else "0"
+
+    def _print_ITE(self, expr: sympy.Expr) -> str:
+        c, t, f = (
+            self.parenthesize(arg, PRECEDENCE["Atom"] - 0.5) for arg in expr.args
+        )
+        return f"({c} ? {t} : {f})"
 
     def _print_ModularIndexing(self, expr: sympy.Expr) -> str:
         x, div, mod = expr.args


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/185185

`_compute_slice_index` returns None for unbacked symbolic integers because no `guard_or_false` check can resolve statically. This forces `slice_forward` to create fresh unbacked symbols for size and storage offset. In chained slices (e.g. x[:, :, h0:h1, w0:w1]), the intermediate storage offset symbol gets superseded but stays in the pending set with no binding site causibg crashes.

**Fix**: replace return `None` with a symbolic fallback mirroring the C++ `at::slice` clamping logic, so the original `.item()` symbols flow through instead of being replaced by orphaned fresh ones and only activates for unbacked symbols. 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98