### PR TITLE
Remove "good first issue" from triage bot label allowlist

### DIFF
--- a/.claude/skills/triaging-issues/labels.json
+++ b/.claude/skills/triaging-issues/labels.json
@@ -1,7 +1,7 @@
 {
   "description": "Labels suitable for issue triage. Excludes CI triggers, test configs, release notes, deprecated, PR-only labels, and labels requiring human decision.",
   "repo": "pytorch/pytorch",
-  "count": 285,
+  "count": 284,
   "labels": [
     {
       "name": "better-on-discuss-forum",
@@ -30,10 +30,6 @@
     {
       "name": "fx",
       "description": ""
-    },
-    {
-      "name": "good first issue",
-      "description": "Good for new open source contributors"
     },
     {
       "name": "has workaround",


### PR DESCRIPTION
## Author Notes

Written with Claude. This label means you're ready to review the PR, which the bot cannot do.

## Agent Notes

The triage bot should not be applying the "good first issue" label --
that decision requires human judgment about whether an issue is actually
approachable for newcomers. Removing the label from the allowlist in
`labels.json` means the validation hook will automatically strip it if
the bot ever tries to add it.