### PR TITLE
[BE] Stop running mem_leak_check on CI

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -30,30 +30,11 @@ PREFIX = "test-config/"
 logging.basicConfig(level=logging.INFO)
 
 
-def is_cuda_or_rocm_job(
-    job_name: str | None, config: dict[str, Any] | None = None
-) -> bool:
-    if job_name and ("cuda" in job_name or "rocm" in job_name):
-        return True
-
-    # Also check the runner name in the config, since some workflows (e.g.
-    # inductor-unittest) use job names that don't include "cuda" even though
-    # they target CUDA runners.
-    if config:
-        runner = config.get("runner", "")
-        if "nvidia.gpu" in runner or "rocm.gpu" in runner:
-            return True
-
-    return False
-
-
 # Supported modes when running periodically. Only applying the mode when
 # its lambda condition returns true. Each callable receives (job_name, config).
 SUPPORTED_PERIODICAL_MODES: dict[
     str, Callable[[str | None, dict[str, Any] | None], bool]
 ] = {
-    # Memory leak check is only needed for CUDA and ROCm jobs which utilize GPU memory
-    "mem_leak_check": is_cuda_or_rocm_job,
     "rerun_disabled_tests": lambda job_name, config=None: True,
 }
 
@@ -69,7 +50,6 @@ TEST_JOB_NAME = "test"
 BUILD_AND_TEST_JOB_NAME = "build-and-test"
 JOB_NAME_CFG_REGEX = re.compile(r"(?P<job>[\w-]+)\s+\((?P<cfg>[\w-]+)\)")
 EXCLUDED_BRANCHES = ["nightly"]
-MEM_LEAK_LABEL = "enable-mem-leak-check"
 
 
 class IssueType(Enum):
@@ -569,12 +549,6 @@ def perform_misc_tasks(
 
     set_output("reenabled-issues", ",".join(get_reenabled_issues(pr_body=pr_body)))
 
-    if MEM_LEAK_LABEL in labels:
-        # Enable mem leak check if label is added
-        for config in test_matrix.get("include", []):
-            if is_cuda_or_rocm_job(job_name):
-                config["mem_leak_check"] = "mem_leak_check"
-
 
 def main() -> None:
     args = parse_args()
@@ -633,8 +607,8 @@ def main() -> None:
         )
 
     if args.event_name == "schedule" and args.schedule == "29 8 * * *":
-        # we don't want to run the mem leak check or disabled tests on normal
-        # periodically scheduled jobs, only the ones at this time
+        # Only run rerun_disabled_tests on this dedicated periodic schedule,
+        # not on every periodically scheduled job.
         filtered_test_matrix = set_periodic_modes(filtered_test_matrix, args.job_name)
 
     if args.workflow and args.job_name and args.branch not in EXCLUDED_BRANCHES:

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -394,12 +394,10 @@ class TestConfigFilter(TestCase):
         scheduled = set_periodic_modes(test_matrix, "inductor-build / build")
 
         modes_per_config = [
-            entry.get("mem_leak_check") or entry.get("rerun_disabled_tests")
-            for entry in scheduled["include"]
+            entry.get("rerun_disabled_tests") for entry in scheduled["include"]
         ]
-        self.assertIn("mem_leak_check", modes_per_config)
         self.assertIn("rerun_disabled_tests", modes_per_config)
-        self.assertEqual(len(scheduled["include"]), 4)
+        self.assertEqual(len(scheduled["include"]), 2)
 
     @mock.patch("filter_test_configs.download_json")
     def test_remove_disabled_jobs(self, mock_download_json: Any) -> None:

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -143,7 +143,7 @@ jobs:
       fail-fast: false
     environment: ${{ github.ref == 'refs/heads/main' && 'scribe-protected' || startsWith(github.ref, 'refs/heads/release/') && 'scribe-protected' || contains(github.event.pull_request.labels.*.name, 'ci-scribe') && 'scribe-pr' || '' }}
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       id-token: write
       contents: read
@@ -322,7 +322,7 @@ jobs:
         id: test-timeout
         shell: bash
         env:
-          JOB_TIMEOUT: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+          JOB_TIMEOUT: ${{ inputs.timeout-minutes }}
         run: |
           echo "timeout=$((JOB_TIMEOUT-30))" >> "${GITHUB_OUTPUT}"
 
@@ -380,7 +380,6 @@ jobs:
           DOCKER_IMAGE_S390X: ${{ inputs.docker-image }}
           XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
-          PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
@@ -485,7 +484,6 @@ jobs:
             -e SCCACHE_REGION \
             -e XLA_CUDA \
             -e XLA_CLANG_CACHE_S3_BUCKET_NAME \
-            -e PYTORCH_TEST_CUDA_MEM_LEAK_CHECK \
             -e PYTORCH_TEST_RERUN_DISABLED_TESTS \
             -e TESTS_TO_INCLUDE \
             -e SKIP_SCCACHE_INITIALIZATION=1 \
@@ -636,7 +634,7 @@ jobs:
     container:
       image: ${{ inputs.docker-image }}
       options: "--gpus all"
-    timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       id-token: write
       contents: read
@@ -742,7 +740,7 @@ jobs:
         id: test-timeout
         shell: bash
         env:
-          JOB_TIMEOUT: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+          JOB_TIMEOUT: ${{ inputs.timeout-minutes }}
         run: |
           echo "timeout=$((JOB_TIMEOUT-30))" >> "${GITHUB_OUTPUT}"
 
@@ -780,7 +778,6 @@ jobs:
           SCCACHE_S3_NO_CREDENTIALS: ${{ steps.aws-creds.outcome != 'success' && 'true' || 'false' }}
           XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
-          PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -67,7 +67,7 @@ jobs:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
@@ -171,7 +171,7 @@ jobs:
         id: test-timeout
         shell: bash
         env:
-          JOB_TIMEOUT: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+          JOB_TIMEOUT: ${{ inputs.timeout-minutes }}
         run: |
           echo "timeout=$((JOB_TIMEOUT-30))" >> "${GITHUB_OUTPUT}"
 
@@ -179,7 +179,6 @@ jobs:
         id: test
         timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
         env:
-          PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           CONTINUE_THROUGH_ERROR: ${{ steps.keep-going.outputs.keep-going }}
           VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -82,7 +82,7 @@ jobs:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -165,7 +165,7 @@ jobs:
         id: test-timeout
         shell: bash
         env:
-          JOB_TIMEOUT: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+          JOB_TIMEOUT: ${{ inputs.timeout-minutes }}
         run: |
           echo "timeout=$((JOB_TIMEOUT-30))" >> "${GITHUB_OUTPUT}"
 
@@ -201,7 +201,6 @@ jobs:
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
           NO_TD: ${{ steps.keep-going.outputs.ci-no-td }}
           DOCKER_IMAGE: ${{ inputs.docker-image }}
-          PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
@@ -250,7 +249,6 @@ jobs:
             -e NO_TEST_TIMEOUT \
             -e NO_TD \
             -e MAX_JOBS="$(nproc --ignore=2)" \
-            -e PYTORCH_TEST_CUDA_MEM_LEAK_CHECK \
             -e PYTORCH_TEST_RERUN_DISABLED_TESTS \
             -e TESTS_TO_INCLUDE \
             -e HUGGING_FACE_HUB_TOKEN \

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -59,7 +59,7 @@ jobs:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     defaults:
       run:
         shell: bash
@@ -159,7 +159,7 @@ jobs:
         id: test-timeout
         shell: bash
         env:
-          JOB_TIMEOUT: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+          JOB_TIMEOUT: ${{ inputs.timeout-minutes }}
         run: |
           echo "timeout=$((JOB_TIMEOUT-30))" >> "${GITHUB_OUTPUT}"
 
@@ -200,7 +200,6 @@ jobs:
           TEST_CONFIG: ${{ matrix.config }}
           REENABLED_ISSUES: ${{ github.event.pull_request.reenabled-issues }}
           TORCH_CUDA_ARCH_LIST: "8.6"
-          PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
         run: |
           pushd "${PYTORCH_FINAL_PACKAGE_DIR}"

--- a/.github/workflows/_xpu-test.yml
+++ b/.github/workflows/_xpu-test.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
-    timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     runs-on: ${{ matrix.runner }}
     steps:
       # [see note: pytorch repo ref]
@@ -159,7 +159,7 @@ jobs:
         id: test-timeout
         shell: bash
         env:
-          JOB_TIMEOUT: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+          JOB_TIMEOUT: ${{ inputs.timeout-minutes }}
         run: |
           echo "timeout=$((JOB_TIMEOUT-30))" >> "${GITHUB_OUTPUT}"
 
@@ -191,7 +191,6 @@ jobs:
           REENABLED_ISSUES: ${{ steps.keep-going.outputs.reenabled-issues }}
           DOCKER_IMAGE: ${{ inputs.docker-image }}
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
-          PYTORCH_TEST_CUDA_MEM_LEAK_CHECK: ${{ matrix.mem_leak_check && '1' || '0' }}
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
@@ -242,7 +241,6 @@ jobs:
             -e SCCACHE_REGION \
             -e SCCACHE_S3_KEY_PREFIX \
             -e XLA_CLANG_CACHE_S3_BUCKET_NAME \
-            -e PYTORCH_TEST_CUDA_MEM_LEAK_CHECK \
             -e PYTORCH_TEST_RERUN_DISABLED_TESTS \
             -e TESTS_TO_INCLUDE \
             -e ZE_AFFINITY_MASK \


### PR DESCRIPTION
## Summary

`mem_leak_check` is not pulling its weight on CI (10h timeout jobs, mostly flaky/noisy results). This PR removes both ways it gets scheduled:

- `mem_leak_check` in `SUPPORTED_PERIODICAL_MODES` (the `29 8 * * *` schedule).
- The `enable-mem-leak-check` PR label path in `perform_misc_tasks`.

Also cleans up the now-dead `matrix.mem_leak_check` guards in `_{linux,mac,win,rocm,xpu}-test.yml` and the orphaned `is_cuda_or_rocm_job` helper / `MEM_LEAK_LABEL` constant.

`PYTORCH_TEST_CUDA_MEM_LEAK_CHECK` plumbing in `torch/testing/_internal/common_utils.py`, `tools/testing/...`, and the slow-gradcheck branch in `.ci/pytorch/test.sh` are intentionally untouched so local runs still work.

## Test plan

- [x] `python -m pytest .github/scripts/test_filter_test_configs.py -x -q` — all 11 pass.
- [ ] Next `29 8 * * *` `periodic` run no longer schedules mem-leak-check shards.

Authored by Claude.