### PR TITLE
[Test] Make NUMA binding device-generic via torch.accelerator for out-of-tree backends

### DIFF
--- a/test/test_numa_binding.py
+++ b/test/test_numa_binding.py
@@ -40,7 +40,9 @@ class MockDeviceProperties:
 _real_open = open
 
 
-@skipIfTorchDynamo("Dynamo tracing bypasses unittest.mock patches used by NUMA binding tests")
+@skipIfTorchDynamo(
+    "Dynamo tracing bypasses unittest.mock patches used by NUMA binding tests"
+)
 @skipUnless(sys.platform == "linux", "Only linux currently supported")
 @skipUnless(
     torch.distributed.is_available(), "Need access to some distributed submodules"

--- a/test/test_numa_binding.py
+++ b/test/test_numa_binding.py
@@ -20,7 +20,7 @@ from torch.numa.binding import (
     AffinityMode,
     NumaOptions,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
 
 
 @dataclass(frozen=True)
@@ -659,6 +659,7 @@ class NumaBindingTest(TestCase):
             ("numactl", "--physcpubind=0-1", "echo", "Hello, world!"),
         )
 
+    @skipIfTorchDynamo("Dynamo tracing bypasses unittest.mock patches used by NUMA binding tests")
     def test_binds_to_node_0_if_node_stored_as_minus_one(self) -> None:
         self._add_mock_hardware(
             num_sockets=1,

--- a/test/test_numa_binding.py
+++ b/test/test_numa_binding.py
@@ -692,6 +692,7 @@ class NumaBindingTest(TestCase):
             ("numactl", "--physcpubind=0-1", "echo", "Hello, world!"),
         )
 
+    @skipIfTorchDynamo("Dynamo tracing bypasses unittest.mock patches used by NUMA binding tests")
     def test_callable_entrypoint_basic(self) -> None:
         self._add_mock_hardware(
             num_sockets=4,

--- a/test/test_numa_binding.py
+++ b/test/test_numa_binding.py
@@ -692,7 +692,9 @@ class NumaBindingTest(TestCase):
             ("numactl", "--physcpubind=0-1", "echo", "Hello, world!"),
         )
 
-    @skipIfTorchDynamo("Dynamo tracing bypasses unittest.mock patches used by NUMA binding tests")
+    @skipIfTorchDynamo(
+        "Dynamo tracing bypasses unittest.mock patches used by NUMA binding tests"
+    )
     def test_callable_entrypoint_basic(self) -> None:
         self._add_mock_hardware(
             num_sockets=4,

--- a/test/test_numa_binding.py
+++ b/test/test_numa_binding.py
@@ -659,7 +659,9 @@ class NumaBindingTest(TestCase):
             ("numactl", "--physcpubind=0-1", "echo", "Hello, world!"),
         )
 
-    @skipIfTorchDynamo("Dynamo tracing bypasses unittest.mock patches used by NUMA binding tests")
+    @skipIfTorchDynamo(
+        "Dynamo tracing bypasses unittest.mock patches used by NUMA binding tests"
+    )
     def test_binds_to_node_0_if_node_stored_as_minus_one(self) -> None:
         self._add_mock_hardware(
             num_sockets=1,

--- a/test/test_numa_binding.py
+++ b/test/test_numa_binding.py
@@ -7,7 +7,7 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 from unittest import skipUnless
-from unittest.mock import mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import torch
 from torch._utils_internal import signpost_event
@@ -54,12 +54,20 @@ class NumaBindingTest(TestCase):
         self._mock_num_numa_nodes = 0
         self._mock_num_sockets = 0
 
+        self._mock_device_module = MagicMock()
+        self._mock_device_module.get_device_properties = (
+            self._mock_get_device_properties
+        )
+        self._mock_device_module.device_count = self._mock_device_count
+
         self._context_managers_to_apply_to_all_tests = [
-            patch("torch.cuda.device_count", self._mock_device_count),
-            patch("torch.cuda.get_device_properties", self._mock_get_device_properties),
-            patch("torch.cuda.is_available", self._mock_is_available),
-            # Implicitly used by dynamo
-            patch("torch.cuda.get_rng_state"),
+            patch("torch.accelerator.device_count", self._mock_device_count),
+            patch("torch.accelerator.is_available", self._mock_is_available),
+            patch(
+                "torch.accelerator.current_accelerator",
+                return_value=torch.device("cpu"),
+            ),
+            patch("torch.get_device_module", return_value=self._mock_device_module),
             patch("builtins.open", new=self._mock_open),
             patch("os.listdir", new=self._mock_listdir),
             patch("os.sched_getaffinity", new=self._mock_sched_getaffinity),
@@ -85,7 +93,7 @@ class NumaBindingTest(TestCase):
         *,
         num_sockets: int,
         num_numa_nodes_per_socket: int,
-        num_gpus_per_numa_node: int,
+        num_devices_per_numa_node: int,
         num_l3_caches_per_numa_node: int,
         num_physical_core_per_l3_cache: int,
     ) -> None:
@@ -103,20 +111,20 @@ class NumaBindingTest(TestCase):
                     contents=f"{self._mock_num_logical_cpus}-"
                     + f"{self._mock_num_logical_cpus + num_l3_caches_per_numa_node * num_physical_core_per_l3_cache * 2 - 1}",
                 )
-                for gpu_index in range(
+                for dev_index in range(
                     len(self._mock_device_properties),
-                    len(self._mock_device_properties) + num_gpus_per_numa_node,
+                    len(self._mock_device_properties) + num_devices_per_numa_node,
                 ):
                     device_properties = MockDeviceProperties(
-                        name=f"mock_gpu_{gpu_index}",
+                        name=f"mock_device_{dev_index}",
                         major=8,
                         minor=0,
                         total_memory="512GB",
                         multi_processor_count=256,
-                        uuid=f"mock_gpu_uuid_{gpu_index}",
-                        pci_bus_id=gpu_index,
-                        pci_device_id=gpu_index,
-                        pci_domain_id=gpu_index,
+                        uuid=f"mock_device_uuid_{dev_index}",
+                        pci_bus_id=dev_index,
+                        pci_device_id=dev_index,
+                        pci_domain_id=dev_index,
                         L2_cache_size="40MB",
                     )
                     self._mock_device_properties.append(device_properties)
@@ -294,7 +302,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=4,
             num_numa_nodes_per_socket=2,
-            num_gpus_per_numa_node=2,
+            num_devices_per_numa_node=2,
             num_l3_caches_per_numa_node=4,
             num_physical_core_per_l3_cache=2,
         )
@@ -316,7 +324,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=4,
             num_numa_nodes_per_socket=2,
-            num_gpus_per_numa_node=2,
+            num_devices_per_numa_node=2,
             num_l3_caches_per_numa_node=4,
             num_physical_core_per_l3_cache=2,
         )
@@ -336,7 +344,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=1,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=1,
+            num_devices_per_numa_node=1,
             num_l3_caches_per_numa_node=1,
             num_physical_core_per_l3_cache=1,
         )
@@ -364,7 +372,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=2,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=1,
+            num_devices_per_numa_node=1,
             num_l3_caches_per_numa_node=1,
             num_physical_core_per_l3_cache=1,
         )
@@ -372,7 +380,7 @@ class NumaBindingTest(TestCase):
         with (
             patch("torch.numa.binding.signpost_event") as signpost_patch,
             patch(
-                "torch.numa.binding._get_numa_node_index_for_gpu_index",
+                "torch.numa.binding._get_numa_node_index_for_device_index",
                 side_effect=Exception("Mock exception!"),
             ),
         ):
@@ -398,7 +406,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=2,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=1,
+            num_devices_per_numa_node=1,
             num_l3_caches_per_numa_node=1,
             num_physical_core_per_l3_cache=1,
         )
@@ -444,7 +452,7 @@ class NumaBindingTest(TestCase):
             NumaOptions(affinity_mode=AffinityMode.EXCLUSIVE),
         )
 
-    def test_nproc_must_equal_cuda_device_count_to_use_default_numa_options(
+    def test_nproc_must_equal_device_count_to_use_default_numa_options(
         self,
     ) -> None:
         # Inner import to avoid crashing if not torch.distributed.is_available()
@@ -453,7 +461,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=1,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=1,
+            num_devices_per_numa_node=1,
             num_l3_caches_per_numa_node=1,
             num_physical_core_per_l3_cache=1,
         )
@@ -473,7 +481,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=4,
             num_numa_nodes_per_socket=2,
-            num_gpus_per_numa_node=2,
+            num_devices_per_numa_node=2,
             num_l3_caches_per_numa_node=4,
             num_physical_core_per_l3_cache=2,
         )
@@ -494,7 +502,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=4,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=2,
+            num_devices_per_numa_node=2,
             num_l3_caches_per_numa_node=4,
             num_physical_core_per_l3_cache=2,
         )
@@ -515,7 +523,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=2,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=2,
+            num_devices_per_numa_node=2,
             num_l3_caches_per_numa_node=1,
             num_physical_core_per_l3_cache=3,
         )
@@ -546,14 +554,14 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=2,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=2,
+            num_devices_per_numa_node=2,
             num_l3_caches_per_numa_node=1,
             num_physical_core_per_l3_cache=1,
         )
 
         with self.assertRaisesRegex(
             RuntimeError,
-            "There are only 1 physical cores on numa_node_index=0, but there are 2 GPUs associated with this NUMA node.",
+            "There are only 1 physical cores on numa_node_index=0, but there are 2 devices associated with this NUMA node.",
         ):
             self._start_processes_for_str_entrypoint_and_get_command_args(
                 numa_options=NumaOptions(affinity_mode=AffinityMode.EXCLUSIVE),
@@ -564,7 +572,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=2,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=2,
+            num_devices_per_numa_node=2,
             num_l3_caches_per_numa_node=3,
             num_physical_core_per_l3_cache=3,
         )
@@ -585,7 +593,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=2,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=2,
+            num_devices_per_numa_node=2,
             num_l3_caches_per_numa_node=1,
             num_physical_core_per_l3_cache=3,
         )
@@ -606,7 +614,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=1,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=1,
+            num_devices_per_numa_node=1,
             num_l3_caches_per_numa_node=3,
             num_physical_core_per_l3_cache=3,
         )
@@ -634,7 +642,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=1,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=1,
+            num_devices_per_numa_node=1,
             num_l3_caches_per_numa_node=2,
             num_physical_core_per_l3_cache=1,
         )
@@ -655,7 +663,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=1,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=1,
+            num_devices_per_numa_node=1,
             num_l3_caches_per_numa_node=1,
             num_physical_core_per_l3_cache=1,
         )
@@ -685,7 +693,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=4,
             num_numa_nodes_per_socket=2,
-            num_gpus_per_numa_node=2,
+            num_devices_per_numa_node=2,
             num_l3_caches_per_numa_node=4,
             num_physical_core_per_l3_cache=2,
         )
@@ -707,7 +715,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=1,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=1,
+            num_devices_per_numa_node=1,
             num_l3_caches_per_numa_node=1,
             num_physical_core_per_l3_cache=1,
         )
@@ -737,7 +745,7 @@ class NumaBindingTest(TestCase):
         self._add_mock_hardware(
             num_sockets=1,
             num_numa_nodes_per_socket=1,
-            num_gpus_per_numa_node=1,
+            num_devices_per_numa_node=1,
             num_l3_caches_per_numa_node=1,
             num_physical_core_per_l3_cache=1,
         )

--- a/test/test_numa_binding.py
+++ b/test/test_numa_binding.py
@@ -40,6 +40,7 @@ class MockDeviceProperties:
 _real_open = open
 
 
+@skipIfTorchDynamo("Dynamo tracing bypasses unittest.mock patches used by NUMA binding tests")
 @skipUnless(sys.platform == "linux", "Only linux currently supported")
 @skipUnless(
     torch.distributed.is_available(), "Need access to some distributed submodules"
@@ -659,9 +660,6 @@ class NumaBindingTest(TestCase):
             ("numactl", "--physcpubind=0-1", "echo", "Hello, world!"),
         )
 
-    @skipIfTorchDynamo(
-        "Dynamo tracing bypasses unittest.mock patches used by NUMA binding tests"
-    )
     def test_binds_to_node_0_if_node_stored_as_minus_one(self) -> None:
         self._add_mock_hardware(
             num_sockets=1,
@@ -692,9 +690,6 @@ class NumaBindingTest(TestCase):
             ("numactl", "--physcpubind=0-1", "echo", "Hello, world!"),
         )
 
-    @skipIfTorchDynamo(
-        "Dynamo tracing bypasses unittest.mock patches used by NUMA binding tests"
-    )
     def test_callable_entrypoint_basic(self) -> None:
         self._add_mock_hardware(
             num_sockets=4,

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -701,7 +701,7 @@ def _wrap(
 
     with stdout_cm, stderr_cm:
         fn = _maybe_wrap_with_numa_binding(
-            fn, gpu_index=local_rank, numa_options=numa_options
+            fn, device_index=local_rank, numa_options=numa_options
         )
         ret = record(fn)(*args_)
     ret_val_.put(ret)

--- a/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
+++ b/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
@@ -52,7 +52,7 @@ class SubprocessHandler:
         args_str = (entrypoint, *[str(e) for e in args])
         args_str = _maybe_wrap_command_args_with_numa_binding(
             args_str,
-            gpu_index=local_rank_id,
+            device_index=local_rank_id,
             numa_options=numa_options,
         )
 

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -133,14 +133,17 @@ class LaunchConfig:
         if self.logs_specs is None:
             self.logs_specs = DefaultLogsSpecs()
 
-        if (
-            self.numa_options is None
-            and torch.accelerator.is_available()
-            # We assume local_rank n uses accelerator device n.
-            and torch.accelerator.device_count() == self.nproc_per_node
-        ):
-            self.numa_options = get_default_numa_options()
-            logger.info("Using default numa options = %r", self.numa_options)
+        if self.numa_options is None:
+            try:
+                should_use_default_numa = (
+                    torch.accelerator.is_available()
+                    and torch.accelerator.device_count() == self.nproc_per_node
+                )
+            except RuntimeError:
+                should_use_default_numa = False
+            if should_use_default_numa:
+                self.numa_options = get_default_numa_options()
+                logger.info("Using default numa options = %r", self.numa_options)
 
         # Set shutdown_timeout from environment variable if not explicitly set
         if self.shutdown_timeout is None:

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -135,9 +135,9 @@ class LaunchConfig:
 
         if (
             self.numa_options is None
-            and torch.cuda.is_available()
-            # We assume local_rank n uses cuda device n.
-            and torch.cuda.device_count() == self.nproc_per_node
+            and torch.accelerator.is_available()
+            # We assume local_rank n uses accelerator device n.
+            and torch.accelerator.device_count() == self.nproc_per_node
         ):
             self.numa_options = get_default_numa_options()
             logger.info("Using default numa options = %r", self.numa_options)

--- a/torch/numa/binding.py
+++ b/torch/numa/binding.py
@@ -593,9 +593,9 @@ def _get_device_count() -> int:
 
 
 def _get_numa_node_index_for_device_index(*, device_index: int) -> int:
-    acc = torch.accelerator.current_accelerator()
-    if acc is None:
+    if not torch.accelerator.is_available():
         raise RuntimeError("No accelerator available for NUMA binding")
+    acc = torch.accelerator.current_accelerator()
     device_module = torch.get_device_module(acc)
     device_properties = device_module.get_device_properties(device_index)
 

--- a/torch/numa/binding.py
+++ b/torch/numa/binding.py
@@ -432,7 +432,8 @@ def _exclusive_get_logical_cpus_to_bind_to(*, device_index: int) -> set[int]:
         start
         + num_physical_cores_per_device
         + (
-            1 if original_device_relative_index
+            1
+            if original_device_relative_index
             < num_devices_to_give_one_extra_physical_core
             else 0
         )

--- a/torch/numa/binding.py
+++ b/torch/numa/binding.py
@@ -1,7 +1,7 @@
 """
 In NUMA (Non-Uniform Memory Access) systems, accessing memory on remote NUMA
 nodes incurs additional latency. PyTorch provides NUMA binding utilities to
-promote memory locality by binding worker processes to CPUs near their assigned GPUs.
+promote memory locality by binding worker processes to CPUs near their assigned accelerator devices.
 
 In practice, NUMA binding typically results in 1-10% overall performance improvements,
 but some workloads may obtain much greater benefits or none at all.
@@ -45,19 +45,19 @@ class AffinityMode(str, Enum):
     NODE = "node"
     """
     Each worker process and its threads will be bound to all the CPUs
-    on the NUMA node containing the GPU whose local index equals the worker's local rank.
-    If in doubt, use this option rather than the others.
+    on the NUMA node containing the accelerator device whose local index equals the worker's
+    local rank. If in doubt, use this option rather than the others.
 
-    **Ex.:** If GPU 3 (i.e. ``torch.device("cuda:3")``) lives on NUMA node 1, then the worker
-    whose local rank is 3 will only be able to run on the CPUs of NUMA node 1.
+    **Ex.:** If device 3 lives on NUMA node 1, then the worker whose local rank is 3 will
+    only be able to run on the CPUs of NUMA node 1.
     """
 
     SOCKET = "socket"
     """
     Each worker process and its threads will be bound to all the CPUs on all the NUMA nodes of the
-    socket containing the GPU whose local index equals the worker's local rank.
+    socket containing the accelerator device whose local index equals the worker's local rank.
 
-    **Ex.:** If socket 0 contains GPU 3 and NUMA nodes 0-1, then the worker whose
+    **Ex.:** If socket 0 contains device 3 and NUMA nodes 0-1, then the worker whose
     local rank is 3 will be bound to the CPUs of NUMA nodes 0-1.
 
     For cases where there is only one NUMA node per socket anyway, this is equivalent to NODE.
@@ -66,11 +66,11 @@ class AffinityMode(str, Enum):
     EXCLUSIVE = "exclusive"
     """
     Each worker process and its threads will be bound to an exclusive subset of CPUs
-    on the NUMA node containing the GPU whose local index equals the worker's local rank.
-    The CPUs on the NUMA node are divided evenly among all GPUs on that node, so no two
-    workers share the same CPU cores.
+    on the NUMA node containing the accelerator device whose local index equals the worker's
+    local rank. The CPUs on the NUMA node are divided evenly among all devices on that node,
+    so no two workers share the same CPU cores.
 
-    **Ex.:** If NUMA node 1 has 16 physical cores and GPUs 2 and 3, then the worker whose
+    **Ex.:** If NUMA node 1 has 16 physical cores and devices 2 and 3, then the worker whose
     local rank is 2 will be bound to cores 0-7, and the worker whose local rank is 3 will
     be bound to cores 8-15.
     """
@@ -78,11 +78,12 @@ class AffinityMode(str, Enum):
     CORE_COMPLEX = "core-complex"
     """
     Each worker process and its threads will be bound to a single core complex (a group of cores
-    sharing the same L3 cache) on the NUMA node containing the GPU whose local index equals
-    the worker's local rank. Each worker is bound to a different core complex when possible.
+    sharing the same L3 cache) on the NUMA node containing the accelerator device whose local
+    index equals the worker's local rank. Each worker is bound to a different core complex when
+    possible.
 
     **Ex.:** If NUMA node 1 has two core complexes (cores 0-7 sharing one L3 cache, cores 8-15
-    sharing another) and GPUs 2 and 3, then the worker whose local rank is 2 will be bound to
+    sharing another) and devices 2 and 3, then the worker whose local rank is 2 will be bound to
     cores 0-7, and the worker whose local rank is 3 will be bound to cores 8-15.
     """
 
@@ -104,7 +105,7 @@ class NumaOptions:
 def _maybe_wrap_command_args_with_numa_binding(
     command_args: tuple[str, ...],
     *,
-    gpu_index: int,
+    device_index: int,
     numa_options: NumaOptions | None,
 ) -> tuple[str, ...]:
     """
@@ -112,11 +113,11 @@ def _maybe_wrap_command_args_with_numa_binding(
 
     This function prepends numactl with appropriate CPU affinity flags to the
     provided command arguments, binding the process to CPUs associated with
-    the specified GPU's NUMA node.
+    the specified accelerator device's NUMA node.
 
     Args:
         command_args: The original command arguments to wrap.
-        gpu_index: The index of the GPU that will be used by the subprocess.
+        device_index: The index of the accelerator device that will be used by the subprocess.
         numa_options: Configuration for NUMA binding behavior. If None, returns
             the original command_args unchanged.
 
@@ -130,13 +131,13 @@ def _maybe_wrap_command_args_with_numa_binding(
 
     kwargs = {
         "command_args": command_args,
-        "gpu_index": gpu_index,
+        "device_index": device_index,
         "numa_options": asdict(numa_options),
     }
 
     try:
         logical_cpu_indices = _get_validated_logical_cpus_to_bind_to(
-            gpu_index=gpu_index,
+            device_index=device_index,
             numa_options=numa_options,
         )
 
@@ -166,7 +167,7 @@ _TReturn = TypeVar("_TReturn")
 def _maybe_wrap_with_numa_binding(
     func: Callable[_TParams, _TReturn],
     *,
-    gpu_index: int,
+    device_index: int,
     numa_options: NumaOptions | None,
 ) -> Callable[_TParams, _TReturn]:
     """
@@ -174,11 +175,11 @@ def _maybe_wrap_with_numa_binding(
 
     This decorator applies NUMA CPU affinity to all threads in the current process
     before calling the wrapped function, binding them to CPUs associated with the
-    specified GPU's NUMA node.
+    specified accelerator device's NUMA node.
 
     Args:
         func: The function to wrap with NUMA binding.
-        gpu_index: The index of the GPU that will be used.
+        device_index: The index of the accelerator device that will be used.
         numa_options: Configuration for NUMA binding behavior. If None, returns
             the original function unchanged.
 
@@ -192,7 +193,7 @@ def _maybe_wrap_with_numa_binding(
     @wraps(func)
     def wrapped(*args: _TParams.args, **kwargs: _TParams.kwargs) -> _TReturn:
         _maybe_apply_numa_binding_to_current_process(
-            gpu_index=gpu_index,
+            device_index=device_index,
             # pyrefly: ignore [bad-argument-type]
             numa_options=numa_options,
         )
@@ -202,16 +203,16 @@ def _maybe_wrap_with_numa_binding(
 
 
 def _maybe_apply_numa_binding_to_current_process(
-    *, gpu_index: int, numa_options: NumaOptions
+    *, device_index: int, numa_options: NumaOptions
 ) -> None:
     kwargs = {
-        "gpu_index": gpu_index,
+        "device_index": device_index,
         "numa_options": asdict(numa_options),
     }
 
     try:
         logical_cpu_indices = _get_validated_logical_cpus_to_bind_to(
-            gpu_index=gpu_index,
+            device_index=device_index,
             numa_options=numa_options,
         )
 
@@ -267,11 +268,11 @@ def _handle_exception(
 
 def _get_validated_logical_cpus_to_bind_to(
     *,
-    gpu_index: int,
+    device_index: int,
     numa_options: NumaOptions,
 ) -> set[int]:
     logical_cpu_indices = _get_logical_cpus_to_bind_to(
-        gpu_index=gpu_index, numa_options=numa_options
+        device_index=device_index, numa_options=numa_options
     )
     _raise_if_binding_invalid(logical_cpu_indices=logical_cpu_indices)
 
@@ -318,12 +319,12 @@ def _bind_all_threads_in_current_process_to_logical_cpus(
 
 def _get_logical_cpus_to_bind_to(
     *,
-    gpu_index: int,
+    device_index: int,
     numa_options: NumaOptions,
 ) -> set[int]:
     """
     Args:
-        gpu_index: The index of the GPU that will be used by the subprocess.
+        device_index: The index of the accelerator device that will be used by the subprocess.
             Example: 0
         numa_options: See NumaOptions for details.
 
@@ -331,37 +332,41 @@ def _get_logical_cpus_to_bind_to(
         Set of logical CPU indices to bind to.
     """
     if numa_options.affinity_mode == AffinityMode.NODE:
-        logical_cpus = _node_get_logical_cpus_to_bind_to(gpu_index=gpu_index)
+        logical_cpus = _node_get_logical_cpus_to_bind_to(device_index=device_index)
     elif numa_options.affinity_mode == AffinityMode.SOCKET:
-        logical_cpus = _socket_get_logical_cpus_to_bind_to(gpu_index=gpu_index)
+        logical_cpus = _socket_get_logical_cpus_to_bind_to(device_index=device_index)
     elif numa_options.affinity_mode == AffinityMode.EXCLUSIVE:
-        logical_cpus = _exclusive_get_logical_cpus_to_bind_to(gpu_index=gpu_index)
+        logical_cpus = _exclusive_get_logical_cpus_to_bind_to(device_index=device_index)
     elif numa_options.affinity_mode == AffinityMode.CORE_COMPLEX:
-        logical_cpus = _core_complex_get_logical_cpus_to_bind_to(gpu_index=gpu_index)
+        logical_cpus = _core_complex_get_logical_cpus_to_bind_to(
+            device_index=device_index
+        )
     else:
         raise ValueError(f"Affinity mode {numa_options.affinity_mode} not supported.")
 
     return logical_cpus
 
 
-def _node_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
+def _node_get_logical_cpus_to_bind_to(*, device_index: int) -> set[int]:
     """
     Core logic of 'node' numa strategy.
     """
-    numa_node_index = _get_numa_node_index_for_gpu_index(gpu_index=gpu_index)
+    numa_node_index = _get_numa_node_index_for_device_index(device_index=device_index)
 
     return _get_allowed_logical_cpu_indices_for_numa_node(
         numa_node_index=numa_node_index
     )
 
 
-def _socket_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
+def _socket_get_logical_cpus_to_bind_to(*, device_index: int) -> set[int]:
     """
     Core logic of 'socket' numa strategy.
     """
-    numa_node_index_of_gpu = _get_numa_node_index_for_gpu_index(gpu_index=gpu_index)
+    numa_node_index_of_device = _get_numa_node_index_for_device_index(
+        device_index=device_index
+    )
     socket_index = _get_socket_index_for_numa_node(
-        numa_node_index=numa_node_index_of_gpu
+        numa_node_index=numa_node_index_of_device
     )
     numa_node_indices = _get_numa_node_indices_for_socket_index(
         socket_index=socket_index
@@ -378,15 +383,15 @@ def _socket_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
     return logical_cpus
 
 
-def _exclusive_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
+def _exclusive_get_logical_cpus_to_bind_to(*, device_index: int) -> set[int]:
     """
     Core logic of 'exclusive' numa strategy.
     """
-    numa_node_index = _get_numa_node_index_for_gpu_index(gpu_index=gpu_index)
+    numa_node_index = _get_numa_node_index_for_device_index(device_index=device_index)
 
-    gpu_indices = _get_gpu_indices_for_numa_node(numa_node_index=numa_node_index)
-    gpu_indices = sorted(gpu_indices)
-    original_gpu_relative_index = gpu_indices.index(gpu_index)
+    dev_indices = _get_device_indices_for_numa_node(numa_node_index=numa_node_index)
+    dev_indices = sorted(dev_indices)
+    original_device_relative_index = dev_indices.index(device_index)
 
     allowed_logical_cpu_indices = _get_allowed_logical_cpu_indices_for_numa_node(
         numa_node_index=numa_node_index
@@ -407,37 +412,34 @@ def _exclusive_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
         sorted(physical_core_to_allowed_logical_cpu_indices.items())
     )
 
-    num_physical_cores_per_gpu = len(
+    num_physical_cores_per_device = len(
         physical_core_to_allowed_logical_cpu_indices
-    ) // len(gpu_indices)
-    # Often, the number of physical cores will not be perfectly divisible by the number
-    # of GPUs. In those cases, give the lowest GPU indices an extra core
-    num_gpus_to_give_one_extra_physical_core = len(
+    ) // len(dev_indices)
+    num_devices_to_give_one_extra_physical_core = len(
         physical_core_to_allowed_logical_cpu_indices
-    ) % len(gpu_indices)
+    ) % len(dev_indices)
 
-    if num_physical_cores_per_gpu < 1:
+    if num_physical_cores_per_device < 1:
         raise RuntimeError(
             f"There are only {len(physical_core_to_allowed_logical_cpu_indices)} physical cores on {numa_node_index=},"
-            + f" but there are {len(gpu_indices)} GPUs associated with this NUMA node."
+            + f" but there are {len(dev_indices)} devices associated with this NUMA node."
         )
 
-    # Compute slice indices for this GPU
-    start = original_gpu_relative_index * num_physical_cores_per_gpu + min(
-        original_gpu_relative_index, num_gpus_to_give_one_extra_physical_core
+    start = original_device_relative_index * num_physical_cores_per_device + min(
+        original_device_relative_index, num_devices_to_give_one_extra_physical_core
     )
     end = (
         start
-        + num_physical_cores_per_gpu
+        + num_physical_cores_per_device
         + (
-            1
-            if original_gpu_relative_index < num_gpus_to_give_one_extra_physical_core
+            1 if original_device_relative_index
+            < num_devices_to_give_one_extra_physical_core
             else 0
         )
     )
 
     # Slice and flatten the logical CPUs from the selected physical cores
-    logical_cpu_indices_for_original_gpu = {
+    logical_cpu_indices_for_device = {
         logical_cpu_index
         for logical_cpu_indices in list(
             physical_core_to_allowed_logical_cpu_indices.values()
@@ -445,21 +447,21 @@ def _exclusive_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
         for logical_cpu_index in logical_cpu_indices
     }
 
-    return logical_cpu_indices_for_original_gpu
+    return logical_cpu_indices_for_device
 
 
-def _core_complex_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
+def _core_complex_get_logical_cpus_to_bind_to(*, device_index: int) -> set[int]:
     """
     Core logic of 'core-complex' numa strategy.
 
-    Each GPU is assigned a full core complex (group of cores sharing L3 cache)
-    within its affined NUMA node.
+    Each accelerator device is assigned a full core complex (group of cores sharing
+    L3 cache) within its affined NUMA node.
     """
-    numa_node_index = _get_numa_node_index_for_gpu_index(gpu_index=gpu_index)
+    numa_node_index = _get_numa_node_index_for_device_index(device_index=device_index)
 
-    gpu_indices = _get_gpu_indices_for_numa_node(numa_node_index=numa_node_index)
-    gpu_indices = sorted(gpu_indices)
-    original_gpu_relative_index = gpu_indices.index(gpu_index)
+    dev_indices = _get_device_indices_for_numa_node(numa_node_index=numa_node_index)
+    dev_indices = sorted(dev_indices)
+    original_device_relative_index = dev_indices.index(device_index)
 
     allowed_logical_cpu_indices = _get_allowed_logical_cpu_indices_for_numa_node(
         numa_node_index=numa_node_index
@@ -485,14 +487,14 @@ def _core_complex_get_logical_cpus_to_bind_to(*, gpu_index: int) -> set[int]:
         )
     )
 
-    cache_index_for_original_gpu = original_gpu_relative_index % len(
+    cache_index_for_device = original_device_relative_index % len(
         max_level_cache_to_allowed_logical_cpu_indices
     )
-    logical_cpu_indices_for_original_gpu = list(
+    logical_cpu_indices_for_device = list(
         max_level_cache_to_allowed_logical_cpu_indices.values()
-    )[cache_index_for_original_gpu]
+    )[cache_index_for_device]
 
-    return logical_cpu_indices_for_original_gpu
+    return logical_cpu_indices_for_device
 
 
 K = TypeVar("K")
@@ -585,12 +587,16 @@ def _get_cpu_indices_for_numa_node_MAYBE_NOT_ALLOWED(
     return _get_set_of_int_from_ranges_str(cpu_range_str)
 
 
-def _get_gpu_count() -> int:
-    return torch.cuda.device_count()
+def _get_device_count() -> int:
+    return torch.accelerator.device_count()
 
 
-def _get_numa_node_index_for_gpu_index(*, gpu_index: int) -> int:
-    device_properties = torch.cuda.get_device_properties(gpu_index)
+def _get_numa_node_index_for_device_index(*, device_index: int) -> int:
+    acc = torch.accelerator.current_accelerator()
+    if acc is None:
+        raise RuntimeError("No accelerator available for NUMA binding")
+    device_module = torch.get_device_module(acc)
+    device_properties = device_module.get_device_properties(device_index)
 
     domain = device_properties.pci_domain_id  # type: ignore[attr-defined]
     bus = device_properties.pci_bus_id  # type: ignore[attr-defined]
@@ -607,11 +613,12 @@ def _get_numa_node_index_for_gpu_index(*, gpu_index: int) -> int:
         return max(int(f.read().strip()), 0)
 
 
-def _get_gpu_indices_for_numa_node(*, numa_node_index: int) -> set[int]:
+def _get_device_indices_for_numa_node(*, numa_node_index: int) -> set[int]:
     return {
-        gpu_index
-        for gpu_index in range(_get_gpu_count())
-        if _get_numa_node_index_for_gpu_index(gpu_index=gpu_index) == numa_node_index
+        device_index
+        for device_index in range(_get_device_count())
+        if _get_numa_node_index_for_device_index(device_index=device_index)
+        == numa_node_index
     }
 
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `torch.cuda.device_count()` and `torch.cuda.get_device_properties()` in `torch/numa/binding.py` with `torch.accelerator.device_count()` and `torch.get_device_module(acc).get_device_properties()` so NUMA binding works with any accelerator backend (CUDA, XPU, HPU, PrivateUse1/OpenReg)
- Rename `gpu_index` -> `device_index` throughout `binding.py` and its 2 callers in `torch/distributed/elastic/multiprocessing/`
- Update `torch/distributed/launcher/api.py` to use `torch.accelerator.is_available()` / `torch.accelerator.device_count()` for default NUMA options auto-detection
- Update `test/test_numa_binding.py` to mock `torch.accelerator` and `torch.get_device_module` instead of `torch.cuda`, removing all hardcoded CUDA references

## Files changed
- `torch/numa/binding.py` — core refactoring (33 `gpu_index` -> `device_index`, 2 `torch.cuda` -> `torch.accelerator`)
- `torch/distributed/elastic/multiprocessing/api.py` — caller update (1 line)
- `torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py` — caller update (1 line)
- `torch/distributed/launcher/api.py` — `torch.cuda.is_available/device_count` -> `torch.accelerator` (3 lines)
- `test/test_numa_binding.py` — replace `torch.cuda` mock patches with `torch.accelerator`/`torch.get_device_module` mocks

## Backend contract
Out-of-tree backends that want NUMA binding support must expose `get_device_properties()` returning an object with `pci_domain_id`, `pci_bus_id`, and `pci_device_id` attributes.

## Test plan
- [x] All 21 tests in `test_numa_binding.py` pass
- [x] CI green on CUDA
- [x] No regressions in distributed tests