### PR TITLE
[ROCm] Fix skipIfRocm erroring instead of skipping on continuous tests

### DIFF
--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -3,6 +3,7 @@ import contextlib
 import itertools
 import math
 import sys
+import unittest
 from typing import Any
 
 import torch
@@ -31,8 +32,8 @@ from torch.testing._internal.common_fsdp import (
 )
 from torch.testing._internal.common_utils import (
     run_tests,
-    skipIfRocm,
     TEST_WITH_DEV_DBG_ASAN,
+    TEST_WITH_ROCM,
 )
 
 
@@ -259,7 +260,7 @@ class TestUnshardParams(TestUnshardParamsBase):
         else:  # wrote to padding
             self.assertEqual(self.rank + 2, flat_param[0])
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/159348")
+    @unittest.skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/159348")
     @skip_if_lt_x_gpu(2)
     def test_unshard_params_respects_reshard(self):
         """

--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -48,7 +48,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
-    skipIfRocm,
+    TEST_WITH_ROCM,
     TestCase,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -1410,7 +1410,7 @@ class DistributeWithDeviceOrderTest(DTensorContinuousTestBase):
             expected_total_combination *= math.factorial(N)
             self.assertEqual(len(all_combinations), expected_total_combination)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/168197")
+    @unittest.skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/168197")
     def test_ordered_distribute_all_combination(self):
         """Exhaustively test all possible sharding combinations and verify correctness"""
         torch.manual_seed(21)

--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -21,12 +21,10 @@ from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
-    MI200_ARCH,
     parametrize,
     run_tests,
     serialTest,
-    skipIfRocm,
-    skipIfRocmArch,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
@@ -639,8 +637,7 @@ class DistTensorOpsTest(DTensorContinuousTestBase):
             self.assertEqual(output_dt.placements, [Shard(gather_dim)])
             self.assertEqual(output_dt.full_tensor(), global_output)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/175064")
-    @skipIfRocmArch(MI200_ARCH)
+    @unittest.skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/175064")
     @serialTest()  # heavy combinatorial _test_op calls, serialize to avoid OOM
     def test_index(self):
         meshes = [

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -34,8 +34,8 @@ from torch.testing._internal.common_utils import (
     IS_LINUX,
     run_tests,
     skip_but_pass_in_sandcastle_if,
-    skipIfRocm,
     TEST_WITH_DEV_DBG_ASAN,
+    TEST_WITH_ROCM,
 )
 
 
@@ -320,7 +320,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
             expected_val *= self.world_size
             self.assertEqual(xs.item(), expected_val)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/157896")
+    @unittest.skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/157896")
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_nccl_watchdog_cudagraph(self):

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -49,7 +49,7 @@ from torch.testing._internal.common_utils import (
     requires_cuda,
     requires_cuda_p2p_access,
     run_tests,
-    skipIfRocm,
+    TEST_WITH_ROCM,
     TestCase,
 )
 
@@ -1890,7 +1890,7 @@ class SymmMemPoolTest(MultiProcContinuousTest):
         torch.cuda.set_device(self.device)
         torch.manual_seed(42 + self.rank)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/180464")
+    @skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/180464")
     @skipIf(
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )


### PR DESCRIPTION
Commit #185013 inlined the auto-disabler JSON entries as in-source skip decorators. For five tests whose class derives from MultiProcContinuousTest it used @skipIfRocm, which is built on lazy_skip_if and raises unittest.SkipTest from inside the test body at call time. In MultiProcContinuousTest the body runs in a spawned worker subprocess whose loop (common_distributed.py _worker_loop) only treats a SystemExit carrying a registered TEST_SKIPS exit code as a skip; a bare SkipTest raised in the worker is wrapped as RuntimeError and reported as a failure, which also trips the poison_pill that skips the rest of the class. So on ROCm these tests fail instead of being skipped.

This is specific to MultiProcContinuousTest. MultiProcessTestCase (the child catches SkipTest and exits with the generic skip code, the parent remaps it) and MultiThreadedTestCase both handle a worker-raised SkipTest correctly, which is why the many other @skipIfRocm/@skipIf* sites added by #185013 on FSDPTest/DTensorTestBase classes are fine.

The fix replaces @skipIfRocm(...) with
@unittest.skipIf(TEST_WITH_ROCM, <issue-url>), which sets __unittest_skip__ at decoration time. unittest honors that on the dispatcher (main) process before setUp dispatches to the workers, so the test is skipped cleanly and never reaches the worker. The original issue URLs are preserved as the skip reason.

In test_tensor_ops.py the inlined @skipIfRocm sat on top of a pre-existing @skipIfRocmArch(MI200_ARCH), which has the same call-time SkipTest flaw (latent on MI200). TEST_WITH_ROCM subsumes MI200, so that arch decorator is now dead and is removed along with its unused imports.

Affected tests (class / issue):
  test_fsdp_unshard_params  TestUnshardParams.test_unshard_params_respects_reshard  #159348
  test_redistribute         DistributeWithDeviceOrderTest.test_ordered_distribute_all_combination  #168197
  test_tensor_ops           DistTensorOpsTest.test_index  #175064
  test_c10d_ops_nccl        ProcessGroupNCCLOpTest.test_nccl_watchdog_cudagraph  #157896
  test_symmetric_memory     SymmMemPoolTest.test_mempool_tensor_factory  #180464

Authored by Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil