### PR TITLE
Type Dynamo compiler config accessors

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -72,6 +72,7 @@ from torch._C._dynamo.eval_frame import (  # noqa: F401
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.types import (
     CompilerConfig,
+    CompilerConfigProvider,
     ConvertFrameReturn,
     FrameAction,
     FrameExecStrategy,
@@ -1816,7 +1817,11 @@ def _optimize(
         error_on_graph_break=error_on_graph_break
         and not config.debug_force_graph_break_on_leaf_return,
         dynamic=dynamic,
-        compiler_config=backend.get_compiler_config(),
+        compiler_config=(
+            backend.get_compiler_config()
+            if isinstance(backend, CompilerConfigProvider)
+            else None
+        ),
         rebuild_ctx=rebuild_ctx,
         package=package,
         isolate_recompiles=isolate_recompiles,

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -44,7 +44,7 @@ from collections.abc import Generator, Sized
 from dataclasses import dataclass
 from enum import Enum
 from os.path import dirname, join
-from typing import Any, Literal, NamedTuple, TYPE_CHECKING
+from typing import Any, cast, Literal, NamedTuple, TYPE_CHECKING
 from unittest.mock import patch
 
 import sympy
@@ -1818,8 +1818,8 @@ def _optimize(
         and not config.debug_force_graph_break_on_leaf_return,
         dynamic=dynamic,
         compiler_config=(
-            backend.get_compiler_config()
-            if isinstance(backend, CompilerConfigProvider)
+            cast(CompilerConfigProvider, backend).get_compiler_config()
+            if hasattr(backend, "get_compiler_config")
             else None
         ),
         rebuild_ctx=rebuild_ctx,

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -72,7 +72,6 @@ from torch._C._dynamo.eval_frame import (  # noqa: F401
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.types import (
     CompilerConfig,
-    CompilerConfigProvider,
     ConvertFrameReturn,
     FrameAction,
     FrameExecStrategy,
@@ -1817,11 +1816,7 @@ def _optimize(
         error_on_graph_break=error_on_graph_break
         and not config.debug_force_graph_break_on_leaf_return,
         dynamic=dynamic,
-        compiler_config=(
-            backend.get_compiler_config()
-            if isinstance(backend, CompilerConfigProvider)
-            else None
-        ),
+        compiler_config=backend.get_compiler_config(),
         rebuild_ctx=rebuild_ctx,
         package=package,
         isolate_recompiles=isolate_recompiles,

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -70,7 +70,13 @@ from torch._C._dynamo.eval_frame import (  # noqa: F401
     unsupported,
 )
 from torch._dispatch.python import enable_python_dispatcher
-from torch._dynamo.types import ConvertFrameReturn, FrameAction, FrameExecStrategy
+from torch._dynamo.types import (
+    CompilerConfig,
+    CompilerConfigProvider,
+    ConvertFrameReturn,
+    FrameAction,
+    FrameExecStrategy,
+)
 from torch._export.utils import _compiling_state_context
 from torch._library.opaque_object import is_opaque_type
 from torch._subclasses.fake_tensor import unset_fake_temporarily
@@ -451,7 +457,7 @@ class OptimizedModule(torch.nn.Module):
     """
 
     _torchdynamo_orig_callable: Callable[..., Any]
-    get_compiler_config: Callable[[], Any]
+    get_compiler_config: Callable[[], CompilerConfig | None]
 
     _opt_mod_attributes = {
         "_orig_mod",
@@ -828,7 +834,7 @@ class _TorchDynamoContext:
         error_on_graph_break: bool | None = None,
         export: bool = False,
         dynamic: bool | None = None,
-        compiler_config: Any | None = None,
+        compiler_config: CompilerConfig | None = None,
         package: CompilePackage | None = None,
         hooks: Hooks | None = None,
         isolate_recompiles: bool = False,
@@ -929,7 +935,7 @@ class _TorchDynamoContext:
 
     def __call__(self, fn: Any) -> Any:
         # public api for compiler config/options
-        def get_compiler_config() -> Any:
+        def get_compiler_config() -> CompilerConfig | None:
             return self.compiler_config
 
         from .package import DynamoCache
@@ -1317,7 +1323,7 @@ class OptimizeContext(_TorchDynamoContext):
         error_on_graph_break: bool | None = None,
         export: bool = False,
         dynamic: bool | None = None,
-        compiler_config: Any | None = None,
+        compiler_config: CompilerConfig | None = None,
         rebuild_ctx: Callable[[], OptimizeContext | _NullDecorator] | None = None,
         package: CompilePackage | None = None,
         hooks: Hooks | None = None,
@@ -1499,7 +1505,7 @@ def _optimize_catch_errors(
     error_on_graph_break: bool | None = None,
     export: bool = False,
     dynamic: bool | None = None,
-    compiler_config: Any | None = None,
+    compiler_config: CompilerConfig | None = None,
     rebuild_ctx: Callable[[], OptimizeContext | _NullDecorator] | None = None,
     package: CompilePackage | None = None,
     isolate_recompiles: bool = False,
@@ -1813,7 +1819,7 @@ def _optimize(
         dynamic=dynamic,
         compiler_config=(
             backend.get_compiler_config()
-            if hasattr(backend, "get_compiler_config")
+            if isinstance(backend, CompilerConfigProvider)
             else None
         ),
         rebuild_ctx=rebuild_ctx,

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -96,6 +96,8 @@ class WrapBackendDebug:
             self.__name__ = unconfigured_compiler_fn.compiler_name  # type: ignore[attr-defined]
         if isinstance(unconfigured_compiler_fn, CompilerConfigProvider):
             self.get_compiler_config = unconfigured_compiler_fn.get_compiler_config
+        else:
+            self.get_compiler_config = lambda: None
 
     def __call__(
         self, gm: torch.fx.GraphModule, example_inputs: list[Any], **kwargs: Any

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -53,6 +53,7 @@ from torch.hub import tqdm
 from .. import config
 from ..backends.registry import CompilerFn, lookup_backend, register_debug_backend
 from ..debug_utils import clone_inputs_retaining_gradness
+from ..types import CompilerConfig, CompilerConfigProvider
 
 
 log = logging.getLogger(__name__)
@@ -81,6 +82,8 @@ def _accuracy_fails(
 
 
 class WrapBackendDebug:
+    get_compiler_config: Callable[[], CompilerConfig | None]
+
     def __init__(
         self, unconfigured_compiler_fn: CompilerFn, compiler_name: str | None
     ) -> None:
@@ -91,8 +94,8 @@ class WrapBackendDebug:
             self.__name__ = unconfigured_compiler_fn.__name__
         if hasattr(unconfigured_compiler_fn, "compiler_name"):
             self.__name__ = unconfigured_compiler_fn.compiler_name  # type: ignore[attr-defined]
-        if hasattr(unconfigured_compiler_fn, "get_compiler_config"):
-            self.get_compiler_config = unconfigured_compiler_fn.get_compiler_config  # type: ignore[attr-defined]
+        if isinstance(unconfigured_compiler_fn, CompilerConfigProvider):
+            self.get_compiler_config = unconfigured_compiler_fn.get_compiler_config
 
     def __call__(
         self, gm: torch.fx.GraphModule, example_inputs: list[Any], **kwargs: Any

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -62,6 +62,11 @@ log = logging.getLogger(__name__)
 inductor_config = import_module("torch._inductor.config")
 use_buck = inductor_config.is_fbcode()
 
+
+def _no_compiler_config() -> CompilerConfig | None:
+    return None
+
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 #                           MAIN ENTRY POINT
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
@@ -97,7 +102,7 @@ class WrapBackendDebug:
         if isinstance(unconfigured_compiler_fn, CompilerConfigProvider):
             self.get_compiler_config = unconfigured_compiler_fn.get_compiler_config
         else:
-            self.get_compiler_config = lambda: None
+            self.get_compiler_config = _no_compiler_config
 
     def __call__(
         self, gm: torch.fx.GraphModule, example_inputs: list[Any], **kwargs: Any

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -53,7 +53,7 @@ from torch.hub import tqdm
 from .. import config
 from ..backends.registry import CompilerFn, lookup_backend, register_debug_backend
 from ..debug_utils import clone_inputs_retaining_gradness
-from ..types import CompilerConfig, CompilerConfigProvider
+from ..types import CompilerConfigProvider
 
 
 log = logging.getLogger(__name__)
@@ -61,11 +61,6 @@ log = logging.getLogger(__name__)
 
 inductor_config = import_module("torch._inductor.config")
 use_buck = inductor_config.is_fbcode()
-
-
-def _no_compiler_config() -> CompilerConfig | None:
-    return None
-
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 #                           MAIN ENTRY POINT
@@ -87,8 +82,6 @@ def _accuracy_fails(
 
 
 class WrapBackendDebug:
-    get_compiler_config: Callable[[], CompilerConfig | None]
-
     def __init__(
         self, unconfigured_compiler_fn: CompilerFn, compiler_name: str | None
     ) -> None:
@@ -100,9 +93,7 @@ class WrapBackendDebug:
         if hasattr(unconfigured_compiler_fn, "compiler_name"):
             self.__name__ = unconfigured_compiler_fn.compiler_name  # type: ignore[attr-defined]
         if isinstance(unconfigured_compiler_fn, CompilerConfigProvider):
-            self.get_compiler_config = unconfigured_compiler_fn.get_compiler_config
-        else:
-            self.get_compiler_config = _no_compiler_config
+            self.get_compiler_config = unconfigured_compiler_fn.get_compiler_config  # type: ignore[attr-defined]
 
     def __call__(
         self, gm: torch.fx.GraphModule, example_inputs: list[Any], **kwargs: Any

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -26,7 +26,7 @@ import sys
 import textwrap
 from collections.abc import Callable, Sequence
 from importlib import import_module
-from typing import Any
+from typing import Any, cast
 
 import torch
 import torch.fx as fx
@@ -92,8 +92,10 @@ class WrapBackendDebug:
             self.__name__ = unconfigured_compiler_fn.__name__
         if hasattr(unconfigured_compiler_fn, "compiler_name"):
             self.__name__ = unconfigured_compiler_fn.compiler_name  # type: ignore[attr-defined]
-        if isinstance(unconfigured_compiler_fn, CompilerConfigProvider):
-            self.get_compiler_config = unconfigured_compiler_fn.get_compiler_config  # type: ignore[attr-defined]
+        if hasattr(unconfigured_compiler_fn, "get_compiler_config"):
+            self.get_compiler_config = cast(
+                CompilerConfigProvider, unconfigured_compiler_fn
+            ).get_compiler_config
 
     def __call__(
         self, gm: torch.fx.GraphModule, example_inputs: list[Any], **kwargs: Any

--- a/torch/_dynamo/types.py
+++ b/torch/_dynamo/types.py
@@ -13,8 +13,8 @@ ensuring type safety and clear contracts between different components of the sys
 
 import dataclasses
 import types
-from collections.abc import Callable
-from typing import Any, NamedTuple, Protocol
+from collections.abc import Callable, Iterator
+from typing import Any, NamedTuple, Protocol, runtime_checkable
 
 # CacheEntry has a `guard_manager` field for the guard, and a `code` field for the code object.
 from torch._C._dynamo.eval_frame import (
@@ -103,6 +103,19 @@ class DynamoCallbackFn(Protocol):
 
 
 DynamoCallback = DynamoCallbackFn | None | bool
+
+
+class CompilerConfig(Protocol):
+    def __getitem__(self, key: str) -> Any: ...
+
+    def __iter__(self) -> Iterator[str]: ...
+
+    def __len__(self) -> int: ...
+
+
+@runtime_checkable
+class CompilerConfigProvider(Protocol):
+    def get_compiler_config(self) -> CompilerConfig | None: ...
 
 
 class DynamoGuardHook(Protocol):

--- a/torch/_dynamo/types.py
+++ b/torch/_dynamo/types.py
@@ -13,7 +13,7 @@ ensuring type safety and clear contracts between different components of the sys
 
 import dataclasses
 import types
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Mapping
 from typing import Any, NamedTuple, Protocol, runtime_checkable
 
 # CacheEntry has a `guard_manager` field for the guard, and a `code` field for the code object.
@@ -105,12 +105,7 @@ class DynamoCallbackFn(Protocol):
 DynamoCallback = DynamoCallbackFn | None | bool
 
 
-class CompilerConfig(Protocol):
-    def __getitem__(self, key: str) -> Any: ...
-
-    def __iter__(self) -> Iterator[str]: ...
-
-    def __len__(self) -> int: ...
+CompilerConfig = Mapping[str, Any]
 
 
 @runtime_checkable


### PR DESCRIPTION
## Summary

Define a Dynamo `CompilerConfig` protocol for compiler configuration snapshots and a runtime-checkable `CompilerConfigProvider` protocol for backends that expose them. Thread the config type through `OptimizedModule`, `_TorchDynamoContext`, `OptimizeContext`, `_optimize_catch_errors`, and the after-Dynamo repro backend wrapper so `get_compiler_config()` no longer returns `Any`.

## Root cause problem

`compiler_config` was passed through Dynamo as `Any | None` even though the value is only stored and retrieved as either `None` or a mapping-like compiler configuration snapshot. Backend wrappers that preserve `get_compiler_config()` also relied on `hasattr`, which left the accessor untyped.

## Proposed fix

Add explicit structural protocols in `torch._dynamo.types`:

- `CompilerConfig` for mapping-like config snapshots
- `CompilerConfigProvider` for objects exposing `get_compiler_config()`

Use those protocols at the Dynamo storage/accessor sites and when preserving backend config accessors.

## Why this is the right long term fix

A protocol captures the small contract Dynamo actually depends on without coupling Dynamo to inductor's concrete config representation. This keeps the public accessor flexible for future compiler backends while removing the local `Any` escape hatch.

## Testing

- `python3 -m py_compile torch/_dynamo/types.py torch/_dynamo/eval_frame.py torch/_dynamo/repro/after_dynamo.py`
- `PATH=/root/.local/bin:$PATH lintrunner --take FLAKE8,PYFMT torch/_dynamo/types.py torch/_dynamo/eval_frame.py torch/_dynamo/repro/after_dynamo.py`

Attempted but could not complete in this fresh checkout:

- `PYTHONPATH=. python3 test/inductor/test_config.py -k test_get_compiler_config` initially failed because the checkout was not built (`torch/lib/libtorch_global_deps.so` missing).
- CPU-only `python3 setup.py develop` was attempted after installing Python requirements and `build-essential`; reduced CPU build configuration still failed during CMake prebuild because required third-party submodules were incomplete (`third_party/python-peachpy` after earlier missing `pybind11`, `protobuf`, and `psimd`).

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98