### PR TITLE
Dynamo: avoid wrapping overridden argument defaults

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -4859,6 +4859,53 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 3)
         self.assertEqual(cnts.op_count, 6)
 
+    def test_dataclass_constructor_overrides_tensor_defaults(self):
+        @dataclass
+        class CacheParams:
+            conv_state: torch.Tensor = torch.Tensor()
+            ssm_state: torch.Tensor = torch.Tensor()
+            state_indices_tensor: torch.Tensor = torch.Tensor()
+
+            def at_layer_idx(self, layer_idx):
+                return CacheParams(
+                    self.conv_state[layer_idx],
+                    self.ssm_state[layer_idx],
+                    self.state_indices_tensor,
+                )
+
+        params = CacheParams(torch.randn(2, 3), torch.randn(2, 3), torch.arange(3))
+        compiled_fn = torch.compile(
+            params.at_layer_idx, fullgraph=True, backend="eager"
+        )
+
+        expected = params.at_layer_idx(1)
+        actual = compiled_fn(1)
+
+        self.assertEqual(expected.conv_state, actual.conv_state)
+        self.assertEqual(expected.ssm_state, actual.ssm_state)
+        self.assertEqual(expected.state_indices_tensor, actual.state_indices_tensor)
+
+        def make_cache_with_keywords(conv_state, ssm_state, state_indices_tensor):
+            return CacheParams(
+                conv_state=conv_state[1],
+                ssm_state=ssm_state[1],
+                state_indices_tensor=state_indices_tensor,
+            )
+
+        compiled_keyword_fn = torch.compile(
+            make_cache_with_keywords, fullgraph=True, backend="eager"
+        )
+        expected = make_cache_with_keywords(
+            params.conv_state, params.ssm_state, params.state_indices_tensor
+        )
+        actual = compiled_keyword_fn(
+            params.conv_state, params.ssm_state, params.state_indices_tensor
+        )
+
+        self.assertEqual(expected.conv_state, actual.conv_state)
+        self.assertEqual(expected.ssm_state, actual.ssm_state)
+        self.assertEqual(expected.state_indices_tensor, actual.state_indices_tensor)
+
     @torch._dynamo.config.patch(assume_dunder_attributes_remain_unchanged=False)
     def test_meth_default_tensor_args(self):
         """

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -216,8 +216,15 @@ def bind_args_cached(
     rem_kw = dict(kwargs)
 
     # 1) Bind all positional (pos-only + pos-or-kw)
-    # 1.1) Apply pos-defaults first (maybe overridden later)
+    # 1.1) Apply pos-defaults that are actually used. Defaults may be objects
+    # that cannot be represented sourcelessly, so do not wrap values that the
+    # call overrides with explicit arguments.
+    provided_positional_names = set(spec.all_pos_names[: len(args)])
     for name, idx in spec.pos_default_map.items():
+        if name in provided_positional_names or (
+            name in rem_kw and name not in spec.posonly_names
+        ):
+            continue
         default_source = None
         if fn_source and not (
             ConstantVariable.is_literal(spec.defaults[idx])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185279

Fixes #161120

When Dynamo inlines a user-defined constructor, bind_args_cached used to eagerly wrap every positional default before explicit call arguments were applied. Dataclass-generated __init__ methods can have default values like torch.Tensor(). In the vLLM MambaCacheParams pattern, all of those defaults are overridden, but the unused eager tensor defaults still went through wrap_bound_arg without a source and reached SourcelessBuilder.create, which intentionally does not wrap raw eager tensors. That produced Unsupported: Unexpected type in sourceless builder torch.Tensor.

This fixes the binder to only wrap positional defaults that CPython would actually bind for the call. Parameters supplied positionally or by keyword skip their defaults, so overridden tensor defaults never need a sourceless representation. I kept the fix in argument binding instead of adding eager tensor support to SourcelessBuilder, since used defaults already have DefaultsSource handling and unused defaults should not affect tracing at all.

Benchmark Results:
- bind_args_cached positional overrides: old 2.167906s, new 1.282225s, ratio 0.591 (200000 calls, median of 7)
- bind_args_cached keyword overrides: old 2.248614s, new 1.349610s, ratio 0.600 (200000 calls, median of 7)
- bind_args_cached defaults used: old 1.262218s, new 1.309172s, ratio 1.037 (200000 calls, median of 7)

Test Plan:
- python test/dynamo/test_functions.py DefaultsTests.test_dataclass_constructor_overrides_tensor_defaults
- python test/dynamo/test_functions.py DefaultsTests
- lintrunner -a torch/_dynamo/variables/functions.py test/dynamo/test_functions.py

Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos