### PR TITLE
Add checkpoint_name() API for explicit tensor naming in SAC

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16506,6 +16506,46 @@ class TestSelectiveActivationCheckpoint(TestCase):
         with self.assertRaisesRegex(RuntimeError, "Trying to backward an extra time"):
             out.sum().backward(retain_graph=True)
 
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_checkpoint_name_skips_recomputation(self):
+        from torch.utils.checkpoint import checkpoint_name
+
+        with (
+            _counter_op("name_a") as (op_a, counts_a, _),
+            _counter_op("name_b") as (op_b, counts_b, _),
+        ):
+
+            def policy_fn(ctx, op, *args, **kwargs):
+                if ctx.tensor_name == "keep_this":
+                    return CheckpointPolicy.MUST_SAVE
+                return CheckpointPolicy.PREFER_RECOMPUTE
+
+            def fn(x):
+                y = op_a(x, 0)
+                checkpoint_name(y, "keep_this")
+                return op_b(y, 0)
+
+            x = torch.randn(4, requires_grad=True)
+            context_fn = functools.partial(
+                create_selective_checkpoint_contexts, policy_fn
+            )
+            out = checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
+            self.assertEqual(counts_a[0], 1)
+            self.assertEqual(counts_b[0], 1)
+
+            out.sum().backward()
+            # op_a was named "keep_this" and policy returned MUST_SAVE: not recomputed
+            self.assertEqual(counts_a[0], 1)
+            # op_b was not named: recomputed
+            self.assertEqual(counts_b[0], 2)
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_checkpoint_name_no_sac_is_noop(self):
+        from torch.utils.checkpoint import checkpoint_name
+
+        x = torch.randn(4)
+        checkpoint_name(x, "foo")  # should not raise
+
     @skipIfTorchDynamo("torch dispatch modes don't support compile")
     def test_auto_naming_mode_names(self):
         with _counter_op("my_op") as (my_op, my_count, idx_log):

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -391,6 +391,7 @@ manual_torch_name_rule_map: dict[
     "torch.fx.experimental.symbolic_shapes.has_static_value": TorchInGraphFunctionVariable,
     "torch.fx.experimental.symbolic_shapes.has_free_unbacked_symbols": TorchInGraphFunctionVariable,
     "torch.cuda._get_device_properties": TorchInGraphFunctionVariable,
+    "torch.utils.checkpoint.checkpoint_name": TorchInGraphFunctionVariable,
     "torch.utils.hooks.BackwardHook": TorchInGraphFunctionVariable,
     "torch.set_default_device": UserFunctionVariable,
     "torch.sparse_bsc_tensor": SparseTensorCreationSkipVariable,

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -7,7 +7,7 @@ import platform
 import uuid
 import warnings
 import weakref
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from typing import *  # noqa: F403
 from typing_extensions import Self
 import enum
@@ -19,6 +19,8 @@ from torch.utils._pytree import tree_map
 from torch.testing._internal.logging_tensor import capture_logs, LoggingTensorMode
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch._C._autograd import _make_saved_tensor, SavedTensor
+from torch.utils.hooks import RemovableHandle
+from torch.utils.weak import WeakTensorKeyDictionary
 from typing import NoReturn
 
 __all__ = [
@@ -38,6 +40,7 @@ __all__ = [
     "SelectiveCheckpointContext",
     "create_selective_checkpoint_contexts",
     "SAC_IGNORED_OPS",
+    "checkpoint_name",
     "GraphExecGroup",
 ]
 
@@ -1282,9 +1285,10 @@ class SelectiveCheckpointContext:
         >>>     context_fn=context_fn,
         >>> )
     """
-    def __init__(self, *, is_recompute, op_output=None) -> None:
+    def __init__(self, *, is_recompute, op_output=None, tensor_name=None) -> None:
         self.is_recompute = is_recompute
         self.op_output = op_output
+        self.tensor_name = tensor_name
 
 
 class CheckpointPolicy(enum.Enum):
@@ -1352,6 +1356,35 @@ def _sac_storage_key(func, args):
     return func
 
 
+_tensor_naming_hooks: Dict[int, Callable] = OrderedDict()
+
+
+def _register_tensor_naming_hook(hook: Callable) -> RemovableHandle:
+    handle = RemovableHandle(_tensor_naming_hooks)
+    _tensor_naming_hooks[handle.id] = hook
+    return handle
+
+
+def checkpoint_name(tensor: torch.Tensor, name: Any) -> None:
+    """Name a tensor for selective activation checkpointing.
+
+    Call this inside a checkpointed function to associate a name with a
+    tensor.  The policy function receives the name via
+    ``ctx.tensor_name`` and can decide whether to save or recompute.
+
+    Outside of a selective activation checkpoint context, this is a no-op.
+
+    Args:
+        tensor: The tensor to name.
+        name: An arbitrary name (typically a string).
+    """
+    # During recompute (backward), checkpoint_name() is a no-op
+    if torch._C._current_graph_task_id() != -1:
+        return
+    for hook in _tensor_naming_hooks.values():
+        hook(tensor, name)
+
+
 class _CachingTorchDispatchMode(TorchDispatchMode):
     @classmethod
     def ignore_compile_internals(cls):
@@ -1363,6 +1396,35 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
         self.storage = storage
         self.ac_graph_id = ac_graph_id
         self.func_counter: Dict[Any, int] = defaultdict(int)
+        self.tensor_tracker: WeakTensorKeyDictionary = WeakTensorKeyDictionary()
+        self._naming_hook_handle: Optional[RemovableHandle] = None
+
+    def __enter__(self):
+        self._naming_hook_handle = _register_tensor_naming_hook(self._on_tensor_named)
+        return super().__enter__()
+
+    def __exit__(self, *args):
+        if self._naming_hook_handle is not None:
+            self._naming_hook_handle.remove()
+            self._naming_hook_handle = None
+        return super().__exit__(*args)
+
+    def _on_tensor_named(self, tensor, name):
+        info = self.tensor_tracker.get(tensor)
+        if info is None:
+            return
+        func, idx, any_ret_has_alias_info = info
+        policy = self.policy_fn(
+            SelectiveCheckpointContext(is_recompute=False, tensor_name=name),
+            func,
+        )
+        if isinstance(policy, bool):
+            policy = _policy_from_bool(policy)
+        if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE):
+            self.storage[func][idx] = tree_map(
+                lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)),
+                tensor,
+            )
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         kwargs = {} if kwargs is None else kwargs
@@ -1396,6 +1458,14 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
         key = _sac_storage_key(func, args)
         idx = self.func_counter[key]
         self.func_counter[key] += 1
+
+        # Track outputs so checkpoint_name() can retroactively trigger saving.
+        if isinstance(out, torch.Tensor):
+            self.tensor_tracker[out] = (func, idx, any_ret_has_alias_info)
+        elif isinstance(out, (tuple, list)):
+            for o in out:
+                if isinstance(o, torch.Tensor):
+                    self.tensor_tracker[o] = (func, idx, any_ret_has_alias_info)
 
         policy = self.policy_fn(SelectiveCheckpointContext(is_recompute=False, op_output=out),
                                 func, *args, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #185287
* #185286
* #185285
* __->__ #185284
* #185283
* #185282

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98