### PR TITLE
Allow debug mode with context_fn in checkpoint()

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7930,6 +7930,46 @@ for shape in [(1,), ()]:
         self.assertEqual(context.exc_type, ValueError)
         self.assertEqual(str(context.exc_value), "forward failed")
 
+    def test_checkpoint_debug_with_context_fn(self):
+        # debug=True should compose with a user-provided context_fn
+        class VerboseTorchDispatchMode(TorchDispatchMode):
+            def __init__(self) -> None:
+                self.operators = []
+
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                if kwargs is None:
+                    kwargs = {}
+                self.operators.append(func.__name__)
+                return func(*args, **kwargs)
+
+        x = torch.tensor(1.0, requires_grad=True)
+        verbose_mode = VerboseTorchDispatchMode()
+
+        def context_fn():
+            return verbose_mode, contextlib.nullcontext()
+
+        # Non-deterministic function to trigger the debug error
+        counter = [0]
+
+        def fn(x):
+            counter[0] += 1
+            if counter[0] == 1:
+                return x.sin().exp()
+            else:
+                return x.sin() * torch.tensor([1.0, 2.0])
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "You are seeing this error because you passed `debug=True` to checkpoint",
+        ):
+            out = checkpoint(
+                fn, x, use_reentrant=False, debug=True, context_fn=context_fn
+            )
+            out.backward()
+
+        # The user's context_fn should still have run during forward
+        self.assertIn("sin.default", verbose_mode.operators)
+
     def test_checkpoint_warns_if_use_reentrant_not_passed_explcitly(self):
         a = torch.randn(1, requires_grad=True)
 

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -343,6 +343,30 @@ class CheckpointFunction(torch.autograd.Function):
 def noop_context_fn():
     return contextlib.nullcontext(), contextlib.nullcontext()
 
+
+def _compose_context_fns(*context_fns):
+    """Compose multiple context_fns into one that stacks all their contexts."""
+    def composed():
+        fwd_and_recomp = [fn() for fn in context_fns]
+
+        @contextlib.contextmanager
+        def combined_fwd():
+            with contextlib.ExitStack() as stack:
+                for fwd, _ in fwd_and_recomp:
+                    stack.enter_context(fwd)
+                yield
+
+        @contextlib.contextmanager
+        def combined_recomp():
+            with contextlib.ExitStack() as stack:
+                for _, recomp in fwd_and_recomp:
+                    stack.enter_context(recomp)
+                yield
+
+        return combined_fwd(), combined_recomp()
+    return composed
+
+
 # Note: [torch.compile and checkpoint]
 # TorchDynamo does not step inside utils.checkpoint function.  The flow
 # looks likes this
@@ -1677,11 +1701,11 @@ def _checkpoint_without_reentrant_generator(
     unpack_error_cb = None
 
     if _checkpoint_debug_enabled if _checkpoint_debug_enabled is not None else debug:
+        debug_context_fn, unpack_error_cb = _get_debug_context_and_cb()
         if context_fn is not noop_context_fn:
-            raise ValueError(
-                "debug=True is incompatible with non-default context_fn"
-            )
-        context_fn, unpack_error_cb = _get_debug_context_and_cb()
+            context_fn = _compose_context_fns(context_fn, debug_context_fn)
+        else:
+            context_fn = debug_context_fn
 
     if determinism_check in _allowed_determinism_checks_to_fns:
         metadata_fn = _allowed_determinism_checks_to_fns[determinism_check]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #185287
* #185286
* __->__ #185285
* #185284
* #185283
* #185282

Previously, passing both `debug=True` and a custom `context_fn` to
`torch.utils.checkpoint` raised a ValueError. This composes the two
by stacking the debug logging contexts on top of the user's contexts
via a new `_compose_context_fns` utility.

Authored with Claude.