### PR TITLE
Add memory_budget() context manager for per-region activation memory budgets

### DIFF
--- a/test/functorch/test_memory_budget.py
+++ b/test/functorch/test_memory_budget.py
@@ -1,0 +1,152 @@
+# Owner(s): ["module: activation checkpointing"]
+
+import torch
+import torch.nn as nn
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch._functorch._activation_checkpointing.memory_budget import memory_budget
+
+
+class TestMemoryBudgetValidation(TestCase):
+    def test_rejects_invalid_type(self):
+        with self.assertRaises(TypeError):
+            with memory_budget("0.5"):
+                pass
+
+    def test_rejects_out_of_range(self):
+        with self.assertRaises(ValueError):
+            with memory_budget(1.5):
+                pass
+        with self.assertRaises(ValueError):
+            with memory_budget(-0.1):
+                pass
+
+    def test_boundary_values(self):
+        with memory_budget(0.0):
+            pass
+        with memory_budget(1.0):
+            pass
+        with memory_budget(1):
+            pass
+
+
+def _get_budgets_by_target(gm):
+    """Extract {op_name: [budgets]} from a GraphModule."""
+    result = {}
+    for node in gm.graph.nodes:
+        if node.op not in ("call_function", "call_method"):
+            continue
+        b = node.meta.get("custom", {}).get("memory_budget", None)
+        if b is not None:
+            name = getattr(node.target, "__name__", str(node.target))
+            result.setdefault(name, []).append(b)
+    return result
+
+
+class TestMemoryBudgetCompile(TestCase):
+    def test_single_budget(self):
+        budgets = {}
+
+        def capture(gm, example_inputs):
+            budgets.update(_get_budgets_by_target(gm))
+            return gm.forward
+
+        @torch.compile(backend=capture)
+        def fn(x):
+            with memory_budget(0.3):
+                return x.sin().cos()
+
+        fn(torch.randn(4))
+        self.assertEqual(budgets["sin"], [0.3])
+        self.assertEqual(budgets["cos"], [0.3])
+
+    def test_nesting(self):
+        budgets = {}
+
+        def capture(gm, example_inputs):
+            budgets.update(_get_budgets_by_target(gm))
+            return gm.forward
+
+        @torch.compile(backend=capture)
+        def fn(x):
+            with memory_budget(0.3):
+                x = x.sin()
+                with memory_budget(0.8):
+                    x = x.cos()
+                x = x.relu()
+            return x
+
+        fn(torch.randn(4))
+        self.assertEqual(budgets["sin"], [0.3])
+        self.assertEqual(budgets["cos"], [0.8])
+        self.assertEqual(budgets["relu"], [0.3])
+
+    def test_graph_break(self):
+        graphs = []
+
+        def capture(gm, example_inputs):
+            graphs.append(_get_budgets_by_target(gm))
+            return gm.forward
+
+        @torch.compile(backend=capture)
+        def fn(x):
+            with memory_budget(0.3):
+                x = x.sin()
+            torch._dynamo.graph_break()
+            with memory_budget(0.8):
+                x = x.cos()
+            return x
+
+        fn(torch.randn(4))
+        self.assertEqual(len(graphs), 2)
+        self.assertEqual(graphs[0]["sin"], [0.3])
+        self.assertEqual(graphs[1]["cos"], [0.8])
+
+    def test_propagates_to_joint_graph(self):
+        from functorch.compile import nop
+        from torch._dynamo.backends.common import aot_autograd
+
+        joint_budgets = {}
+
+        def my_partition(joint_module, _joint_inputs, *, num_fwd_outputs, **kwargs):
+            for node in joint_module.graph.nodes:
+                b = node.meta.get("custom", {}).get("memory_budget", None)
+                if b is not None:
+                    joint_budgets.setdefault(getattr(node.target, "__name__", str(node.target)), []).append(b)
+            from torch._functorch.partitioners import (
+                min_cut_rematerialization_partition,
+            )
+            return min_cut_rematerialization_partition(
+                joint_module, _joint_inputs, num_fwd_outputs=num_fwd_outputs, **kwargs
+            )
+
+        backend = aot_autograd(
+            fw_compiler=nop, bw_compiler=nop, partition_fn=my_partition,
+        )
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = nn.Linear(16, 16)
+                self.linear2 = nn.Linear(16, 16)
+
+            def forward(self, x):
+                with memory_budget(0.3):
+                    x = self.linear1(x).sin()
+                with memory_budget(0.8):
+                    x = self.linear2(x).cos()
+                return x
+
+        model = Model()
+        compiled = torch.compile(model, backend=backend)
+        x = torch.randn(4, 16, requires_grad=True)
+        compiled(x).sum().backward()
+
+        budget_values = set()
+        for vals in joint_budgets.values():
+            budget_values.update(vals)
+        self.assertIn(0.3, budget_values)
+        self.assertIn(0.8, budget_values)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3489,6 +3489,7 @@ MOD_INLINELIST = [
     "torch._dynamo.polyfills",
     "torch._dynamo.test_case",
     "torch._export.non_strict_utils",
+    "torch._functorch._activation_checkpointing.memory_budget",
     "torch._functorch._aot_autograd.subclass_parametrization",
     "torch._functorch.autograd_function",
     "torch._functorch.eager_transforms",

--- a/torch/_functorch/_activation_checkpointing/memory_budget.py
+++ b/torch/_functorch/_activation_checkpointing/memory_budget.py
@@ -1,0 +1,39 @@
+import torch.fx.traceback as fx_traceback
+
+
+def _validate_budget(budget: object) -> float:
+    if not isinstance(budget, (int, float)):
+        raise TypeError(
+            f"memory_budget must be a float between 0 and 1, got {type(budget).__name__}"
+        )
+    budget = float(budget)
+    if not (0.0 <= budget <= 1.0):
+        raise ValueError(
+            f"memory_budget must be between 0 and 1, got {budget}"
+        )
+    return budget
+
+
+def memory_budget(budget: float):
+    """Context manager that sets the activation memory budget for a region.
+
+    Controls the recomputation vs. memory trade-off in the min-cut
+    partitioner when used under ``torch.compile``. A budget of 0 means
+    "recompute everything" (minimum memory), while 1 means "save
+    everything" (maximum memory, no recomputation). Values in between
+    interpolate via the knapsack solver.
+
+    The budget is stored in ``node.meta["custom"]["memory_budget"]``
+    on every FX node traced inside the ``with`` block, overriding
+    ``torch._functorch.config.activation_memory_budget`` on a
+    per-region basis.
+
+    Example::
+
+        with memory_budget(0.3):
+            x = layer1(x)   # aggressive recomputation
+        with memory_budget(0.8):
+            x = layer2(x)   # save most activations
+    """
+    budget = _validate_budget(budget)
+    return fx_traceback.annotate({"memory_budget": budget})

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -3793,8 +3793,9 @@ def min_cut_rematerialization_partition(
 
     memory_budget = config.activation_memory_budget
     for node in joint_graph.nodes:
-        if isinstance(node.meta.get("memory_budget", None), float):
-            memory_budget = node.meta["memory_budget"]
+        custom_budget = node.meta.get("custom", {}).get("memory_budget", None)
+        if isinstance(custom_budget, float):
+            memory_budget = custom_budget
             break
     saved_values = choose_saved_values_set(
         joint_graph,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185287
* #185286
* #185285
* #185284
* #185283
* #185282

Adds a `memory_budget(budget)` context manager that controls the
recomputation vs. memory trade-off in the min-cut partitioner on a
per-region basis under `torch.compile`.

The implementation delegates to `fx_traceback.annotate`, which stores
the budget in `node.meta["custom"]["memory_budget"]` via the existing
`_COPY_META_FIELDS` mechanism. This avoids the need for marker ops,
post-passes, or `allow_in_graph` -- the metadata propagates naturally
through both Dynamo tracing and AOTAutograd's `make_fx` re-tracing.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98