### PR TITLE
[MPS] 2D dispatch for strided unary kernels

### DIFF
--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       sync-tag: macos-py3-arm64-build
       build-environment: macos-py3-arm64
-      runner-type: macos-m2-15
+      runner-type: macos-m1-stable
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
       python-version: 3.12.7

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       sync-tag: macos-py3-arm64-build
       build-environment: macos-py3-arm64
-      runner-type: macos-m1-stable
+      runner-type: macos-m2-15
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
       python-version: 3.12.7

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -698,7 +698,13 @@ void MetalShaderLibrary::exec_unary_kernel_with_params(TensorIteratorBase& iter,
             computeEncoder, iter.shape(), iter.strides(1), iter.strides(0), static_cast<uint32_t>(iter.ndim()));
       }
       detail::mtl_setArg(computeEncoder, params, iter.is_contiguous() ? 2 : 6);
-      mtl_dispatch1DJob(computeEncoder, cplState, length);
+      if (!iter.is_contiguous()) {
+        const auto inner = static_cast<NSUInteger>(iter.shape()[0]);
+        const auto outer = static_cast<NSUInteger>(length) / inner;
+        mtl_dispatch2DJob(computeEncoder, cplState, inner, outer);
+      } else {
+        mtl_dispatch1DJob(computeEncoder, cplState, length);
+      }
 
       getMPSProfiler().endProfileKernel(cplState);
     });

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -574,6 +574,28 @@ static inline void mtl_dispatch1DJob(id<MTLComputeCommandEncoder> encoder,
   [encoder dispatchThreads:size threadsPerThreadgroup:threadGroupSize];
 }
 
+// Dispatch a 2D grid (x = inner, y = outer). The kernel receives `uint2
+// thread_position_in_grid` and can use `.x` directly as the innermost coord,
+// avoiding one div/mod in the index decomposition. If inner_len is smaller
+// than the kernel's maxThreadsPerGroup, pack multiple outer rows into one TG
+// along y so we keep TG occupancy high and don't pay extra TG-launch overhead
+// vs the 1D dispatch. The kernel reads thread_position_in_grid as uint
+// per-axis, so each dim must fit in uint32; the product can exceed UINT32_MAX
+// (i.e. >4G total threads are fine as long as neither inner nor outer alone
+// overflow). Like mtl_dispatch1DJob, caller is responsible for the per-axis
+// bound; TensorIterator's 32-bit decomposition keeps both within range today.
+static inline void mtl_dispatch2DJob(id<MTLComputeCommandEncoder> encoder,
+                                     id<MTLComputePipelineState> cplState,
+                                     NSUInteger inner_len,
+                                     NSUInteger outer_len) {
+  const auto maxThreadsPerGroup = [cplState maxTotalThreadsPerThreadgroup];
+  auto size = MTLSizeMake(inner_len, outer_len, 1);
+  auto tg_x = std::min(maxThreadsPerGroup, inner_len);
+  auto tg_y = std::max(NSUInteger(1), std::min(outer_len, maxThreadsPerGroup / tg_x));
+  auto threadGroupSize = MTLSizeMake(tg_x, tg_y, 1);
+  [encoder dispatchThreads:size threadsPerThreadgroup:threadGroupSize];
+}
+
 id<MTLBuffer> generateKernelDataOffsets(id<MTLComputeCommandEncoder> commandEncoder,
                                         const TensorIteratorBase& iter,
                                         bool use_64bit_index = false);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1076,6 +1076,14 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
 
       [computeEncoder setComputePipelineState:cplState];
       bind_iter_tensors(computeEncoder, iter);
+      // Strided kernels use a 2D dispatch (grid.x = innermost dim, grid.y = product of outer dims) so the kernel can
+      // read pos[0] directly from thread_position_in_grid.x and skip one div/mod per element. shape()[0] is the
+      // innermost dim after TensorIterator's reorder+coalesce.
+      const auto dispatch_strided_2d = [&]() {
+        const auto inner = static_cast<NSUInteger>(iter.shape()[0]);
+        const auto outer = static_cast<NSUInteger>(length) / inner;
+        mtl_dispatch2DJob(computeEncoder, cplState, inner, outer);
+      };
       if (cast_needed) {
         // {dense,strided}_castout take the output dtype at runtime via the ScalarType in the trailing constant buffer;
         // input is read at compile-time Tin.
@@ -1084,11 +1092,12 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
           std::array<uint32_t, 2> size_outtype = {static_cast<uint32_t>(c10::elementSize(outputTensor.scalar_type())),
                                                   out_type};
           mtl_setBytes(computeEncoder, size_outtype, 2);
+          mtl_dispatch1DJob(computeEncoder, cplState, length);
         } else {
           std::array<uint32_t, 2> ndim_outtype = {static_cast<uint32_t>(iter.ndim()), out_type};
           mtl_setArgs<2>(computeEncoder, iter.shape(), iter.strides(1), iter.strides(0), ndim_outtype);
+          dispatch_strided_2d();
         }
-        mtl_dispatch1DJob(computeEncoder, cplState, length);
       } else if (dense_ilp) {
         mtl_setBytes(computeEncoder, length, 2);
         mtl_dispatch1DJob(
@@ -1101,7 +1110,11 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
         if (alpha) {
           mtl_setBytes(computeEncoder, getMPSScalar(*alpha, alpha_type), is_contiguous ? 2 : 6);
         }
-        mtl_dispatch1DJob(computeEncoder, cplState, length);
+        if (!is_contiguous) {
+          dispatch_strided_2d();
+        } else {
+          mtl_dispatch1DJob(computeEncoder, cplState, length);
+        }
       }
 
       getMPSProfiler().endProfileKernel(cplState);

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -251,11 +251,11 @@ kernel void unary_alpha_strided(
     constant long* output_strides [[buffer(4)]],
     constant uint& ndim [[buffer(5)]],
     constant T2& alpha [[buffer(6)]],
-    uint index [[thread_position_in_grid]]) {
+    uint2 thread_pos [[thread_position_in_grid]]) {
   F f;
   using res_t = result_of<F, T, T2>;
   int pos[max_ndim];
-  pos_from_thread_index(int(index), pos, sizes, ndim);
+  pos_from_thread_index(thread_pos, pos, sizes, ndim);
   const auto input_offs = offset_from_coord(pos, input_strides, ndim);
   const auto output_offs = offset_from_coord(pos, output_strides, ndim);
   ref_at_offs<res_t>(output, output_offs) =
@@ -286,7 +286,7 @@ kernel void unary_alpha_strided(
           constant long* output_strides,                                   \
           constant uint& ndim,                                             \
           constant DTYPEA& alpha,                                          \
-          uint index)
+          uint2 thread_pos)
 
 // Value at offset with dynamic cast from provided type
 template <typename T, typename P>

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -34,6 +34,20 @@ inline void pos_from_thread_index(
   }
 }
 
+// 2D dispatch overload: thread_pos.x maps directly to pos[0] (innermost dim),
+// thread_pos.y is decomposed across the remaining outer dims. Skips one
+// div/mod per element vs the 1D form.
+template <typename T>
+inline void pos_from_thread_index(
+    uint2 thread_pos,
+    thread T pos[max_ndim],
+    constant long* sizes,
+    uint ndim) {
+  pos[0] = static_cast<T>(thread_pos.x);
+  pos_from_thread_index(
+      static_cast<T>(thread_pos.y), pos + 1, sizes + 1, ndim - 1);
+}
+
 inline long offset_from_thread_index(
     long idx,
     constant long* sizes,
@@ -104,6 +118,10 @@ kernel void unary_dense(
   }
 }
 
+// 2D-grid variant: grid.x = thread_pos.x runs along the fastest-varying
+// (innermost) dim, grid.y enumerates the product of the remaining outer dims.
+// Saves one div+mod per thread vs the 1D form, and lets the SIMD-group walk
+// consecutive elements on the dense side (better memory coalescing).
 template <typename T, typename F>
 kernel void unary_strided(
     device void* output [[buffer(0)]],
@@ -112,11 +130,11 @@ kernel void unary_strided(
     constant long* input_strides [[buffer(3)]],
     constant long* output_strides [[buffer(4)]],
     constant uint& ndim [[buffer(5)]],
-    uint index [[thread_position_in_grid]]) {
+    uint2 thread_pos [[thread_position_in_grid]]) {
   F f;
   using res_t = result_of<F, T>;
   int pos[max_ndim];
-  pos_from_thread_index(int(index), pos, sizes, ndim);
+  pos_from_thread_index(thread_pos, pos, sizes, ndim);
   const auto input_offs = offset_from_coord(pos, input_strides, ndim);
   const auto output_offs = offset_from_coord(pos, output_strides, ndim);
   ref_at_offs<res_t>(output, output_offs) =
@@ -141,7 +159,7 @@ kernel void unary_strided_castout(
     constant long* input_strides,
     constant long* output_strides,
     constant uint2& ndim_outtype,
-    uint index);
+    uint2 thread_pos);
 
 // Registers the direct per-(out,in) unary kernels and the castout variants
 // keyed on the input dtype. Castout kernels compute the functor in DTYPE0
@@ -175,7 +193,7 @@ kernel void unary_strided_castout(
           constant long* input_strides,                                        \
           constant long* output_strides,                                       \
           constant uint& ndim,                                                 \
-          uint index);                                                         \
+          uint2 thread_pos);                                                   \
   template [[host_name(#NAME "_dense_castout_" #DTYPE0)]] kernel void ::c10::  \
       metal::unary_dense_castout<DTYPE0, NAME##_functor>(                      \
           device void* output,                                                 \
@@ -190,7 +208,7 @@ kernel void unary_strided_castout(
           constant long* input_strides,                                        \
           constant long* output_strides,                                       \
           constant uint2& ndim_outtype,                                        \
-          uint index)
+          uint2 thread_pos)
 
 #define DEFINE_UNARY_FLOATING_FUNCTOR(NAME)                                     \
   struct NAME##_functor {                                                       \
@@ -331,11 +349,11 @@ kernel void unary_strided_castout(
     constant long* input_strides [[buffer(3)]],
     constant long* output_strides [[buffer(4)]],
     constant uint2& ndim_outtype [[buffer(5)]],
-    uint index [[thread_position_in_grid]]) {
+    uint2 thread_pos [[thread_position_in_grid]]) {
   F f;
   using res_t = result_of<F, Tin>;
   int pos[max_ndim];
-  pos_from_thread_index(int(index), pos, sizes, ndim_outtype.x);
+  pos_from_thread_index(thread_pos, pos, sizes, ndim_outtype.x);
   const auto input_offs = offset_from_coord(pos, input_strides, ndim_outtype.x);
   const auto output_offs =
       offset_from_coord(pos, output_strides, ndim_outtype.x);

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -44,8 +44,11 @@ inline void pos_from_thread_index(
     constant long* sizes,
     uint ndim) {
   pos[0] = static_cast<T>(thread_pos.x);
-  pos_from_thread_index(
-      static_cast<T>(thread_pos.y), pos + 1, sizes + 1, ndim - 1);
+  auto idx = static_cast<T>(thread_pos.y);
+  for (uint i = 1; i < ndim; ++i) {
+    pos[i] = idx % T(sizes[i]);
+    idx /= T(sizes[i]);
+  }
 }
 
 inline long offset_from_thread_index(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #185422
* __->__ #185291

Dispatch `unary_strided*`  as a 2D grid (`grid.x` = innermost dim after TensorIterator reorder, `grid.y` = product of outer dims) instead of a flat 1D grid. Kernel reads `pos[0]` straight from `thread_position_in_grid.x` and skip one div/mod per element in the coord decomposition. Adds a `uint2` overload of `pos_from_thread_index` so the kernels stay one-liners.

TG sizing matters: when `inner < maxThreadsPerThreadgroup` we pack several outer rows per TG along `y` (`tg_y = maxTG/tg_x`). Without that, small inner dims (e.g. transposed 256x256) regress because TG count goes up and SIMD occupancy drops; with it, occupancy matches the 1D path and the saved div/mod is pure profit.

The kernel reads `thread_position_in_grid` as `uint`-per-axis so each dim must fit in uint32, but the product can exceed UINT32_MAX -- 2D dispatch addresses >4G total threads natively as long as neither axis alone overflows. TensorIterator's `with_32bit_indexing()` still decomposes when `iter.numel() > INT32_MAX`, so today the wider envelope isn't exercised, but a >4 GiB strided unary op already runs correctly end-to-end through the split path. Per-axis range is the caller's responsibility (mtl_dispatch1DJob trusts the same way).

Authored with Claude.

Test plan: `torch.abs(x, out=y)` on a permuted 256x256x256 float tensor:

```python
import time, torch
x = torch.randn(256, 256, 256, device='mps').permute(1, 0, 2)
out = torch.empty(x.shape, device='mps')
for _ in range(20):
    torch.abs(x, out=out)
torch.mps.synchronize()
t = time.perf_counter()
for _ in range(300):
    torch.abs(x, out=out)
torch.mps.synchronize()
print(f"{(time.perf_counter()-t)/300*1e6:.1f} us")
```

Before: ~651 us. After: ~380 us (~1.7x). Also re-ran the MPS test_copy / test_slice / test_view sweep -- all pass.

<details>
<summary>Full perf sweep across 3D permute patterns (abs into preallocated out)</summary>

\`\`\`
pattern                                    old_us     new_us   speedup
----------------------------------------------------------------------
abs_p(1, 0, 2)|1024x1024x4                 167.55      84.06     1.99x
abs_p(1, 0, 2)|128x128x128                  87.32      45.30     1.93x
abs_p(1, 0, 2)|256x256x256                 651.46     380.48     1.71x
abs_p(1, 0, 2)|256x256x32                   88.03      45.03     1.96x
abs_p(1, 0, 2)|256x32x256                   87.27      45.19     1.93x
abs_p(1, 0, 2)|32x256x256                   87.52      47.67     1.84x
abs_p(1, 0, 2)|4x1024x1024                 167.82      84.31     1.99x
abs_p(1, 0, 2)|512x512x8                    87.93      46.25     1.90x
abs_p(1, 0, 2)|64x64x64                     15.01       8.66     1.73x
abs_p(1, 0, 2)|8x512x512                    87.46      45.51     1.92x
abs_p(2, 0, 1)|1024x1024x4                 116.71      57.15     2.04x
abs_p(2, 0, 1)|128x128x128                  61.78      55.86     1.11x
abs_p(2, 0, 1)|256x256x256                 633.08     456.48     1.39x
abs_p(2, 0, 1)|256x256x32                   68.86      55.73     1.24x
abs_p(2, 0, 1)|256x32x256                   60.52      55.93     1.08x
abs_p(2, 0, 1)|32x256x256                   61.29      59.31     1.03x
abs_p(2, 0, 1)|4x1024x1024                 117.15     109.07     1.07x
abs_p(2, 0, 1)|512x512x8                    67.96      33.10     2.05x
abs_p(2, 0, 1)|64x64x64                     10.70      10.16     1.05x
abs_p(2, 0, 1)|8x512x512                    60.73      55.68     1.09x
abs_p(2, 1, 0)|1024x1024x4                 167.52     116.02     1.44x
abs_p(2, 1, 0)|128x128x128                  87.07      58.02     1.50x
abs_p(2, 1, 0)|256x256x256                 813.28     610.72     1.33x
abs_p(2, 1, 0)|256x256x32                   91.84      65.53     1.40x
abs_p(2, 1, 0)|256x32x256                   87.27      55.90     1.56x
abs_p(2, 1, 0)|32x256x256                   87.07      56.14     1.55x
abs_p(2, 1, 0)|4x1024x1024                 167.15     112.05     1.49x
abs_p(2, 1, 0)|512x512x8                    91.22      55.07     1.66x
abs_p(2, 1, 0)|64x64x64                     14.23      11.70     1.22x
abs_p(2, 1, 0)|8x512x512                    86.99      56.32     1.54x
\`\`\`

Binary strided kernels follow the same 1D-dispatch pattern and are unchanged here; the same treatment would likely yield a comparable win and is a natural follow-up.

</details>