### PR TITLE
[dynamo] Add dynamic_values config to mark int sources / tensor dims dynamic by value

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10040,6 +10040,92 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         self.assertEqual(counter.frame_count, 1)
 
+    @torch.compiler.config.patch(dynamic_values="1111")
+    def test_dynamic_values_int(self):
+        builder._DYNAMIC_VALUES = None
+        counter = CompileCounter()
+
+        @torch.compile(backend=counter)
+        def fn(x):
+            return torch.randn(5) * x
+
+        # Warm up with the sentinel value 1111 → the int gets marked dynamic.
+        fn(1111)
+        fn(2)
+        fn(3)
+
+        self.assertEqual(counter.frame_count, 1)
+
+    @torch.compiler.config.patch(dynamic_values="1111")
+    def test_dynamic_values_tensor(self):
+        builder._DYNAMIC_VALUES = None
+        counter = CompileCounter()
+
+        @torch.compile(backend=counter)
+        def fn(x):
+            return x * x
+
+        # Warm up with a tensor whose dim equals 1111 → that dim becomes dynamic.
+        fn(torch.randn(1111))
+        fn(torch.randn(3))
+        fn(torch.randn(4))
+
+        self.assertEqual(counter.frame_count, 1)
+
+    @torch.compiler.config.patch(dynamic_values="1111")
+    def test_dynamic_values_no_match_specializes(self):
+        builder._DYNAMIC_VALUES = None
+        counter = CompileCounter()
+
+        @torch.compile(backend=counter)
+        def fn(x):
+            return torch.randn(5) * x
+
+        fn(2)
+        fn(3)
+        fn(4)
+
+        self.assertEqual(counter.frame_count, 2)
+
+    @torch.compiler.config.patch(dynamic_values="1111")
+    def test_dynamic_values_graph_break(self):
+        """Motivating use case: graph breaks drop dynamic-ness in eager code,
+        but the sentinel value lets the second compiled region re-mark dynamic."""
+        builder._DYNAMIC_VALUES = None
+        counter = CompileCounter()
+
+        def foo(x):
+            return x * x
+
+        @torch.compile(backend=counter)
+        def fn(x):
+            x = x * x
+            torch._dynamo.graph_break()
+            return foo(x)
+
+        fn(torch.randn(1111))
+        fn(torch.randn(3))
+        fn(torch.randn(4))
+
+        # 2 frames (one per side of the graph break), no recompiles on either.
+        self.assertEqual(counter.frame_count, 2)
+
+    @torch.compiler.config.patch(dynamic_values="1111, 2222")
+    def test_dynamic_values_multiple(self):
+        builder._DYNAMIC_VALUES = None
+        counter = CompileCounter()
+
+        @torch.compile(backend=counter)
+        def fn(x):
+            return x * x
+
+        # Both sentinel values trigger dynamic marking.
+        fn(torch.randn(2222))
+        fn(torch.randn(7))
+        fn(torch.randn(9))
+
+        self.assertEqual(counter.frame_count, 1)
+
     @torch.compiler.config.patch(unbacked_sources="L['x']")
     def test_unbacked_sources_tensor(self):
         counter = CompileCounter()

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10072,6 +10072,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         self.assertEqual(counter.frame_count, 1)
 
+    @torch._dynamo.config.patch(assume_static_by_default=True)
     @torch.compiler.config.patch(dynamic_values="1111")
     def test_dynamic_values_no_match_specializes(self):
         builder._DYNAMIC_VALUES = None

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -4230,10 +4230,10 @@ def is_dynamic_value(value: int) -> bool:
     dynamic_values = get_dynamic_values()
     if not dynamic_values:
         return False
-    # bool is a subclass of int; treat True/False as not-an-int-value to avoid
-    # accidentally marking 0/1 dynamic when users include them in the list.
     if isinstance(value, bool):
-        return False
+        raise TypeError(
+            f"is_dynamic_value got a bool ({value}); callers must pass an int"
+        )
     return value in dynamic_values
 
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2523,6 +2523,14 @@ class VariableBuilder:
                 )
                 return self.wrap_symint(value, dynamism=DimDynamic.DYNAMIC)
 
+            if is_dynamic_value(value):
+                log.debug(
+                    "%s marked dynamic via dynamic-values list (value=%s)",
+                    self.source.name,
+                    value,
+                )
+                return self.wrap_symint(value, dynamism=DimDynamic.DYNAMIC)
+
             if is_unbacked_source(self.source.name):
                 log.debug(
                     "%s marked unbacked via unbacked-sources list", self.source.name
@@ -4194,6 +4202,41 @@ def is_unbacked_source(source_name: str, dim: int | None = None) -> bool:
     return False
 
 
+# Cache for the parsed `torch.compiler.config.dynamic_values` config.
+_DYNAMIC_VALUES: set[int] | None = None
+_DYNAMIC_VALUES_CONFIG_HASH: int | None = None
+
+
+def get_dynamic_values() -> set[int]:
+    global _DYNAMIC_VALUES, _DYNAMIC_VALUES_CONFIG_HASH
+
+    current_hash = hash(torch.compiler.config.dynamic_values)
+
+    if _DYNAMIC_VALUES is not None and _DYNAMIC_VALUES_CONFIG_HASH == current_hash:
+        return _DYNAMIC_VALUES
+
+    _DYNAMIC_VALUES = {
+        int(s)
+        for s in torch.compiler.config.dynamic_values.replace(" ", "").split(",")
+        if s
+    }
+    _DYNAMIC_VALUES_CONFIG_HASH = current_hash
+
+    return _DYNAMIC_VALUES
+
+
+def is_dynamic_value(value: int) -> bool:
+    """Return True if ``value`` matches an entry in the dynamic-values list."""
+    dynamic_values = get_dynamic_values()
+    if not dynamic_values:
+        return False
+    # bool is a subclass of int; treat True/False as not-an-int-value to avoid
+    # accidentally marking 0/1 dynamic when users include them in the list.
+    if isinstance(value, bool):
+        return False
+    return value in dynamic_values
+
+
 def _symbolic_context_from_shapes_spec(
     e: Any,
     source: Source,
@@ -4462,6 +4505,15 @@ def _automatic_dynamic(
 
         if is_dynamic_source(name, i):
             log.debug("%s dim %d marked dynamic via dynamic-sources list", name, i)
+            automatic_dynamic_size = True
+
+        if is_dynamic_value(e.size(i)):
+            log.debug(
+                "%s dim %d marked dynamic via dynamic-values list (value=%s)",
+                name,
+                i,
+                e.size(i),
+            )
             automatic_dynamic_size = True
 
         if is_unbacked_source(name, i):

--- a/torch/compiler/config.py
+++ b/torch/compiler/config.py
@@ -136,6 +136,29 @@ Entries in this list are dominant over all other flags dynamic=False, force_nn_m
 and force_parameter_static_shapes.
 """
 
+dynamic_values: str = Config(
+    env_name_default="TORCH_COMPILE_DYNAMIC_VALUES", default=""
+)
+"""
+Comma delimited list of integer values that should cause any matching int source or
+tensor dim to be marked dynamic.
+
+This is useful for JIT workflows with graph breaks where you don't know up-front which
+sources need to be dynamic, but you can warm up the model with a distinctive "sentinel"
+value (e.g. an odd batch size like 1111) and have any int or tensor dim that equals one
+of those values be marked dynamic automatically. This is needed because with graph
+breaks we do not propagate dynamic properties through eager code, so an int or tensor
+derived in eager between two compiled regions cannot inherit the dynamic-ness of its
+source — matching on the sentinel value lets us recover it on the next compiled region.
+
+Example::
+
+    TORCH_COMPILE_DYNAMIC_VALUES="1111,2222"
+
+unlike ``dynamic_sources``, ``dynamic_values`` does NOT override
+``force_parameter_static_shapes`` or ``force_nn_module_property_static_shapes``.
+"""
+
 unbacked_sources: str = Config(
     env_name_default="TORCH_COMPILE_UNBACKED_SOURCES", default=""
 )

--- a/torch/compiler/config.py
+++ b/torch/compiler/config.py
@@ -155,6 +155,11 @@ Example::
 
     TORCH_COMPILE_DYNAMIC_VALUES="1111,2222"
 
+Pick sentinel values unlikely to occur as legitimate shapes/ints in your
+workload (e.g. 1111, 2222) — matching is purely by value, so any int source
+or tensor dim equal to a listed value anywhere in the program will be
+marked dynamic.
+
 unlike ``dynamic_sources``, ``dynamic_values`` does NOT override
 ``force_parameter_static_shapes`` or ``force_nn_module_property_static_shapes``.
 """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #185570
* __->__ #185292

This is useful for JIT workflows with graph breaks where you don't know up-front which
sources need to be dynamic, but you can warm up the model with a distinctive "sentinel"
value (e.g. an odd batch size like 1111) and have any int or tensor dim that equals one
of those values be marked dynamic automatically. This is needed because with graph
breaks we do not propagate dynamic properties through eager code, so an int or tensor
derived in eager between two compiled regions cannot inherit the dynamic-ness of its
source — matching on the sentinel value lets us recover it on the next compiled region.


Addressing compile time for internal users that do warmup with multiple batch sized and want to minimize compile time in warm up.

this is easier approach than
1) warm up with fake. 
2) special subclass that propagates dynamic shapes in eager. 

both ran into many issues, and this fix compile time in much simpler way.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98