### PR TITLE
Disable XNNPACK by default in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ option(USE_VULKAN_FP16_INFERENCE "Vulkan - Use fp16 inference" OFF)
 option(USE_VULKAN_RELAXED_PRECISION
        "Vulkan - Use relaxed precision math in the kernels (mediump)" OFF)
 # option USE_XNNPACK: try to enable xnnpack by default.
-option(USE_XNNPACK "Use XNNPACK" ON)
+option(USE_XNNPACK "Use XNNPACK" OFF)
 option(USE_ROCM_KERNEL_ASSERT "Use Kernel Assert for ROCm" OFF)
 # Ensure that an ITT build is the default for x86 CPUs
 cmake_dependent_option(USE_ITT "Use Intel(R) VTune Profiler ITT functionality"

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -19,6 +19,12 @@ from torch.testing._internal.torchbind_impls import (
 
 requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "requires cuda")
 
+# prepacked linear requires XNNPACK support.
+requires_prepacked_linear = unittest.skipIf(
+    not hasattr(torch.ops.prepacked, "linear_clamp_prepack"),
+    "requires XNNPACK (prepacked linear ops)",
+)
+
 
 class TestConverter(TestCase):
     def setUp(self):
@@ -1455,6 +1461,7 @@ class TestConverter(TestCase):
     # and
     # torch.ops.prepacked.linear_clamp_run
     @xfailIfS390X
+    @requires_prepacked_linear
     def test_ts2ep_convert_quantized_model_with_opcontext(self):
         class M(torch.nn.Module):
             def __init__(self, linear_op):
@@ -1478,6 +1485,7 @@ class TestConverter(TestCase):
     # and
     # torch.ops.prepacked.linear_clamp_run
     @xfailIfS390X
+    @requires_prepacked_linear
     def test_ts2ep_convert_quantized_model_with_opcontext_and_constant(self):
         class M(torch.nn.Module):
             def __init__(self, linear_op):

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -104,8 +104,8 @@ ALLOW_LIST = [
     ("aten::miopen_depthwise_convolution_backward_input", datetime.date(9999, 1, 1)),
     ("aten::miopen_depthwise_convolution_backward_weight", datetime.date(9999, 1, 1)),
     ("aten::_nested_tensor", datetime.date(9999, 1, 1)),
-    ("prepacked::unpack_prepacked_sizes_conv2d", datetime.date(9999, 1, 1)),
-    ("prepacked::unpack_prepacked_sizes_linear", datetime.date(9999, 1, 1)),
+    ("prepacked::unpack_prepacked_sizes_conv2d", datetime.date(9999, 1, 1), None, True),
+    ("prepacked::unpack_prepacked_sizes_linear", datetime.date(9999, 1, 1), None, True),
     ("aten::_symeig_helper", datetime.date(9999, 1, 1)),
     ("aten::symeig", datetime.date(9999, 1, 1)),
     ("aten::symeig.e", datetime.date(9999, 1, 1)),
@@ -174,6 +174,7 @@ dont_parse_list = [
     ("test_backend", datetime.date(2099, 9, 17)),
     ("dist_c10d", datetime.date(2099, 9, 17)),
     ("__backends__.nnc", datetime.date(2099, 9, 17)),
+    ("xnnpack", datetime.date(2099, 9, 17)),
 ]
 
 


### PR DESCRIPTION
XNNPACK is primarily used for deprecated PyTorch Mobile. Disable by default in CMake. ExecuTorch is the recommended replacement.

Note that this change is intentionally BC breaking for existing torchscript artifacts with prepacked XNNPACK operators, as per @malfet's recommendation. I've also updated the TS2EP converter to skip tests that require XNNPACK when not available.