### PR TITLE
Enabling TLX user-defined kernel epilogue fusion (partially) (#185302)

### DIFF
--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -245,9 +245,12 @@ def generate_ttir(
     kernel: "TritonKernelType",
     kwargs: dict[str, Any],
     tma_descriptor_metadata: TMADescriptorMetadata,
-) -> tuple["TritonIRModule", list[str]]:
+) -> tuple["TritonIRModule", list[str], Any, Any, Any]:
     """
-    Uses Triton's internal code generation to create TTIR
+    Uses Triton's internal code generation to create TTIR.
+
+    Returns (ttir_module, ordered_arg_names, backend, target, options).
+    The extra return values are needed to optionally generate TTGIR later.
     """
     import sympy
     import triton
@@ -339,6 +342,26 @@ def generate_ttir(
         param_idx = kernel.arg_names.index(name)
         return kernel.params[param_idx].is_constexpr or arg is None
 
+    # Identify non-constexpr params with value 1 that should be treated as
+    # compile-time constants, matching Triton JIT specialization behavior.
+    # This is needed for kernels using tl.make_tensor_descriptor, where the
+    # semantic function compares stride values against 1 using Python operators.
+    # Without this, stride params like stride_ak=1 become IR tensor values, and
+    # the comparison `stride != 1` triggers a Triton builtin call that fails
+    # outside the JIT context.
+    # Only enabled when TORCHINDUCTOR_FORCE_TLX_EPILOGUE_FUSION is set to avoid
+    # changing behavior for existing kernels.
+    _specialized_constants: set[str] = set()
+    import os
+    if os.environ.get("TORCHINDUCTOR_FORCE_TLX_EPILOGUE_FUSION"):
+        for name, arg in ordered_args.items():
+            if (
+                not _is_constexpr_or_none(name, arg)
+                and isinstance(arg, int)
+                and arg == 1
+            ):
+                _specialized_constants.add(name)
+
     # Note: one would expect that each input to the triton kernel maps to
     # one input parameter in the TTIR. This is _not_ true for TMA descriptors:
     # one TMA descriptor gets converted into:
@@ -353,7 +376,7 @@ def generate_ttir(
     # scalars and tensors as this matters for "odd" ordering,
     # eg. [tensor, scalar, tensor].
     def get_arg_names(name: str, arg: Any) -> list[str]:
-        if _is_constexpr_or_none(name, arg):
+        if _is_constexpr_or_none(name, arg) or name in _specialized_constants:
             return []
 
         if is_stable_tensor_descriptor_arg(arg):
@@ -468,7 +491,7 @@ def generate_ttir(
     constants = {
         name: arg
         for name, arg in ordered_args.items()
-        if _is_constexpr_or_none(name, arg)
+        if _is_constexpr_or_none(name, arg) or name in _specialized_constants
     }
 
     if (mangle_type := getattr(triton.runtime.jit, "mangle_type", None)) is not None:
@@ -494,16 +517,16 @@ def generate_ttir(
     if triton_version_uses_attrs_dict():
         # In newer versions of Triton, the signature includes constexpr args
         signature = {
-            name: get_signature_value(i, arg)
+            name: ("constexpr" if name in constants else get_signature_value(i, arg))
             for i, (name, arg) in enumerate(ordered_args.items())
         }
     else:
         # In older versions of Triton, the signature does not include constexpr args
         constexprs = [p.num for p in kernel.params if p.is_constexpr]
         signature = {
-            name: get_signature_value(i, arg)
+            name: ("constexpr" if name in constants else get_signature_value(i, arg))
             for i, (name, arg) in enumerate(ordered_args.items())
-            if i not in constexprs
+            if i not in constexprs and name not in constants
         }
 
     triton._C.libtriton.ir.load_dialects(context)
@@ -540,7 +563,168 @@ def generate_ttir(
     if not ttir_module.verify():
         raise RuntimeError("Verification for TTIR module has failed")
 
-    return ttir_module, ordered_arg_names
+    return ttir_module, ordered_arg_names, backend, target, options
+
+
+def generate_ttgir(
+    ttir_module: "TritonIRModule",
+    backend: Any,
+    target: Any,
+    options: Any,
+) -> "TritonIRModule":
+    """
+    Converts a TTIR module to TTGIR by applying GPU-specific lowering passes.
+    NOTE: This mutates the module in-place. The TTIR module should not be used
+    for TTIR-level analysis after this call.
+    """
+    capability = backend._parse_arch(options.arch)
+    metadata: dict[str, Any] = {"target": target, **options.__dict__}
+    return backend.make_ttgir(ttir_module, metadata, options, capability)
+
+
+def _analyze_ttgir_for_epilogue(
+    ttgir_module: "TritonIRModule | str",
+) -> bool:
+    """
+    Check if the kernel is eligible for epilogue fusion
+    based on async TMA store patterns in TTGIR.
+
+    Accepts either an MLIR module (with .walk()) or a TTGIR string.
+    Returns True if there is exactly one ttng.async_tma_copy_local_to_global op.
+    """
+    if isinstance(ttgir_module, str):
+        # String-based analysis: count occurrences in the TTGIR text
+        store_count = ttgir_module.count("ttng.async_tma_copy_local_to_global")
+        return store_count == 1
+
+    # MLIR module-based analysis: walk the module
+    store_count = 0
+
+    def _walk_op(op: Any) -> None:
+        nonlocal store_count
+        if op.get_name() == "ttng.async_tma_copy_local_to_global":
+            store_count += 1
+
+    ttgir_module.walk(_walk_op)
+    return store_count == 1
+
+
+def _compile_kernel_to_ttgir(
+    kernel: "TritonKernelType",
+    kwargs: dict[str, Any],
+) -> str | None:
+    """
+    Try to compile a Triton kernel through Triton's full compilation pipeline
+    to get the TTGIR string. This handles kernels that generate_ttir cannot
+    process (e.g. TLX kernels with tl.make_tensor_descriptor).
+
+    Returns the TTGIR string if successful, None otherwise.
+    """
+    try:
+        import triton
+        from triton.runtime.autotuner import Autotuner
+
+        if isinstance(kernel, Autotuner):
+            if len(kernel.configs) > 0:
+                kwargs = {**kwargs, **kernel.configs[0].kwargs}
+            kernel = kernel.fn
+
+        # Build the grid and launch args needed for compilation.
+        # We compile by calling kernel.run() which triggers JIT compilation.
+        # Instead, use triton.compile() with an ASTSource.
+        from triton.compiler.compiler import ASTSource, compile as triton_compile
+
+        target = triton.runtime.driver.active.get_current_target()
+        backend = triton.compiler.compiler.make_backend(target)
+        options = backend.parse_options({})
+
+        import sympy
+        from torch._subclasses.fake_tensor import FakeTensor
+        import torch._inductor.ir
+
+        ordered_args: dict[str, Any] = {}
+        for name in kernel.arg_names:
+            a = kwargs[name]
+            if isinstance(a, (torch.SymInt, torch.SymFloat, torch.SymBool, sympy.Expr)):
+                ordered_args[name] = 2
+            elif isinstance(a, (FakeTensor, torch._inductor.ir.TensorBox)):
+                with torch._C._DisableTorchDispatch():
+                    ordered_args[name] = torch.empty(2, dtype=a.dtype)
+            else:
+                ordered_args[name] = a
+
+        # Build signature and constants
+        def _is_constexpr_or_none(name: str, arg: Any) -> bool:
+            param_idx = kernel.arg_names.index(name)
+            return kernel.params[param_idx].is_constexpr or arg is None
+
+        constants = {
+            name: arg
+            for name, arg in ordered_args.items()
+            if _is_constexpr_or_none(name, arg)
+        }
+
+        from torch._inductor.utils import (
+            get_triton_attrs_descriptor_version,
+            triton_version_uses_attrs_dict,
+            TritonAttrsDescriptorVersion,
+        )
+
+        triton_version = get_triton_attrs_descriptor_version()
+
+        if (mangle_type := getattr(triton.runtime.jit, "mangle_type", None)) is not None:
+            def get_signature_value(idx: int, arg: Any) -> str:
+                if kernel.params[idx].is_constexpr:
+                    return "constexpr"
+                result = mangle_type(arg)
+                if result in ("*i1", "*u1"):
+                    result = "*u8"
+                return result
+        else:
+            def get_signature_value(idx: int, arg: Any) -> str:
+                return kernel._type_of(kernel.key_of(arg))
+
+        if triton_version_uses_attrs_dict():
+            signature = {
+                name: get_signature_value(i, arg)
+                for i, (name, arg) in enumerate(ordered_args.items())
+            }
+        else:
+            constexprs = [p.num for p in kernel.params if p.is_constexpr]
+            signature = {
+                name: get_signature_value(i, arg)
+                for i, (name, arg) in enumerate(ordered_args.items())
+                if i not in constexprs
+            }
+
+        # Get specialization attrs
+        if triton_version in {
+            TritonAttrsDescriptorVersion.V1_COMPILER,
+        }:
+            specialization = kernel._get_config(*ordered_args.values())
+        elif triton_version in {
+            TritonAttrsDescriptorVersion.V2_BACKENDS,
+            TritonAttrsDescriptorVersion.V3_BACKENDS_TUPLE,
+        }:
+            specialization = backend.get_attrs_descriptor(
+                ordered_args.values(), kernel.params
+            )
+        else:
+            # For V4_DICT and above, use empty dict as fallback
+            specialization = {}
+
+        src = ASTSource(kernel, signature, constants, specialization)
+        compiled = triton_compile(src, target=target, options=options)
+        ttgir_str = compiled.asm.get("ttgir")
+        if ttgir_str:
+            log.warning("_compile_kernel_to_ttgir: successfully compiled kernel, got TTGIR (%d chars)", len(ttgir_str))
+        return ttgir_str
+    except Exception:
+        log.warning(
+            "_compile_kernel_to_ttgir: failed to compile kernel to TTGIR",
+            exc_info=True,
+        )
+        return None
 
 
 def ttir_to_functions(
@@ -1072,18 +1256,22 @@ def analyze_kernel_access(
     def _decide_can_fuse_epilogue():
         # only do epilogue fusion if the kernel has a single output tensor
         if len(write_count) != 1:
+            log.warning("_decide_can_fuse_epilogue: BLOCKED write_count=%s (expected 1 entry)", dict(write_count))
             return False
 
         written_arg_index = next(iter(write_count))
         # only do epilogue fusion if the written tensor is written exactly once
         if write_count[written_arg_index] != 1:
+            log.warning("_decide_can_fuse_epilogue: BLOCKED write_count[%d]=%d (expected 1)", written_arg_index, write_count[written_arg_index])
             return False
 
         written_arg_name = next(iter(writes)).name
         #  cannot fuse if the kernel also reads from the output buffer
         if any(read_dep.name == written_arg_name for read_dep in reads):
+            log.warning("_decide_can_fuse_epilogue: BLOCKED kernel reads from output buffer '%s'", written_arg_name)
             return False
 
+        log.warning("_decide_can_fuse_epilogue: PASSED (writes=%s, reads=%s)", writes, reads)
         return True
 
     can_fuse_epilogue = _decide_can_fuse_epilogue()
@@ -1108,8 +1296,11 @@ def identify_accessed_tensors(
 
     ttir_module = None
     functions = None
+    backend = None
+    target = None
+    options = None
     try:
-        ttir_module, ordered_arg_names = generate_ttir(
+        ttir_module, ordered_arg_names, backend, target, options = generate_ttir(
             kernel, kwargs, tma_descriptor_metadata
         )
 
@@ -1141,13 +1332,82 @@ def identify_accessed_tensors(
             if isinstance(kwargs.get(name), (Tensor, TensorBox))
         )
 
-        return analyze_kernel_access(
+        result = analyze_kernel_access(
             functions,
             kernel_name,
             len(ordered_arg_names),
             tuple(ordered_arg_names),
             tensor_arg_indices,
         )
+
+        # TTGIR fallback: if TTIR analysis says can_fuse_epilogue=False,
+        # try TTGIR analysis for TLX kernels with async TMA stores.
+        # make_ttgir mutates ttir_module in-place, but TTIR analysis is done.
+        if not result.can_fuse_epilogue:
+            log.warning("identify_accessed_tensors: TTIR says can_fuse_epilogue=False, trying TTGIR fallback...")
+            ttgir_succeeded = False
+            try:
+                ttgir_module = generate_ttgir(ttir_module, backend, target, options)
+                ttgir_result = _analyze_ttgir_for_epilogue(ttgir_module)
+                log.warning("identify_accessed_tensors: TTGIR _analyze_ttgir_for_epilogue=%s", ttgir_result)
+                if ttgir_result:
+                    result = TensorAccesses(
+                        read_writes=result.read_writes,
+                        can_fuse_epilogue=True,
+                    )
+                    ttgir_succeeded = True
+            except Exception:
+                log.warning(
+                    "TTGIR epilogue analysis failed",
+                    exc_info=True,
+                )
+
+            # AST fallback: if both TTIR and TTGIR analysis failed to enable fusion,
+            # use Python AST store analysis for TMA descriptor kernels.
+            import os
+            if not ttgir_succeeded and not result.can_fuse_epilogue and os.environ.get("TORCHINDUCTOR_FORCE_TLX_EPILOGUE_FUSION"):
+                try:
+                    import ast as _ast
+                    # pyrefly: ignore [missing-attribute]
+                    kernel_src = None
+                    if hasattr(kernel, "src"):
+                        kernel_src = kernel.src
+                    elif hasattr(kernel, "fn") and hasattr(kernel.fn, "src"):
+                        kernel_src = kernel.fn.src
+                    if kernel_src is not None:
+                        kernel_ast = _ast.parse(kernel_src)
+                        stores = identify_triton_stores(kernel_ast)
+                        log.warning("AST fallback (inside try): found %d stores", len(stores.stores))
+                        if len(stores.stores) == 1 and stores.stores[0].is_tma_descriptor_store:
+                            store = stores.stores[0]
+                            output_arg_name = _ast.unparse(store.store_pointer_node).strip()
+                            log.warning("AST fallback: single TMA store to '%s', enabling fusion", output_arg_name)
+
+                            # Build accurate read/write sets from ordered_arg_names
+                            read_deps: OrderedSet[Dep] = OrderedSet(
+                                StarDep(name)
+                                for name in ordered_arg_names
+                                if isinstance(kwargs.get(name), (Tensor, TensorBox)) and name != output_arg_name
+                            )
+                            read_deps = typing.cast(OrderedSet[Dep], read_deps)
+                            write_deps: OrderedSet[Dep] = OrderedSet([StarDep(output_arg_name)])
+                            write_deps = typing.cast(OrderedSet[Dep], write_deps)
+
+                            result = TensorAccesses(
+                                ReadWrites(
+                                    reads=read_deps,
+                                    writes=write_deps,
+                                    index_exprs=OrderedSet(),
+                                ),
+                                can_fuse_epilogue=True,
+                            )
+                except Exception:
+                    log.warning("AST fallback failed", exc_info=True)
+        else:
+            log.warning("identify_accessed_tensors: TTIR says can_fuse_epilogue=True, skipping TTGIR fallback")
+
+        log.warning("identify_accessed_tensors: FINAL result.can_fuse_epilogue=%s, read_writes=%s", result.can_fuse_epilogue, result.read_writes)
+        return result
     except Exception:
         log.warning(
             "Encountered an exception in identify_accessed_tensors, assuming every input is mutated",
@@ -1169,13 +1429,99 @@ def identify_accessed_tensors(
         ]
         all_deps = OrderedSet(StarDep(name) for name in all_tensor_names)
         all_deps = typing.cast(OrderedSet[Dep], all_deps)
+
+        # AST-based fallback for TMA descriptor kernels:
+        # When generate_ttir fails (e.g. for TLX kernels with tl.make_tensor_descriptor),
+        # use the Python AST store analysis to determine which arg is the output,
+        # then validate with _analyze_ttgir_for_epilogue if possible.
+        can_fuse = False
+        import os
+        if os.environ.get("TORCHINDUCTOR_FORCE_TLX_EPILOGUE_FUSION"):
+            try:
+                import ast as _ast
+
+                # Get kernel source: JITFunction has .src directly,
+                # Autotuner wraps a JITFunction in .fn
+                # pyrefly: ignore [missing-attribute]
+                kernel_src = None
+                if hasattr(kernel, "src"):
+                    kernel_src = kernel.src
+                elif hasattr(kernel, "fn") and hasattr(kernel.fn, "src"):
+                    kernel_src = kernel.fn.src
+                if kernel_src is not None:
+                    kernel_ast = _ast.parse(kernel_src)
+                    stores = identify_triton_stores(kernel_ast)
+                    log.warning(
+                        "AST fallback: found %d stores in kernel source",
+                        len(stores.stores),
+                    )
+
+                    # Use _analyze_ttgir_for_epilogue as the authoritative store count check.
+                    # Try to compile the kernel to get TTGIR for analysis.
+                    ttgir_eligible = False
+                    ttgir_str = _compile_kernel_to_ttgir(kernel, kwargs)
+                    if ttgir_str is not None:
+                        ttgir_eligible = _analyze_ttgir_for_epilogue(ttgir_str)
+                        log.warning(
+                            "TTGIR analysis: _analyze_ttgir_for_epilogue=%s",
+                            ttgir_eligible,
+                        )
+                    else:
+                        # If we can't get TTGIR either, fall back to AST store count
+                        # as a proxy for TTGIR analysis.
+                        log.warning(
+                            "TTGIR compilation failed, using AST store count as proxy"
+                        )
+                        ttgir_eligible = (
+                            len(stores.stores) == 1
+                            and stores.stores[0].is_tma_descriptor_store
+                        )
+
+                    if ttgir_eligible and len(stores.stores) >= 1:
+                        # Use AST to find the output arg name
+                        store = stores.stores[0]
+                        if store.is_tma_descriptor_store:
+                            output_arg_name = _ast.unparse(store.store_pointer_node).strip()
+                            log.warning(
+                                "Epilogue fusion enabled: TMA descriptor store to '%s'",
+                                output_arg_name,
+                            )
+
+                            # Build accurate read/write sets:
+                            # - writes: only the output arg
+                            # - reads: all tensor args except the output
+                            write_deps: OrderedSet[Dep] = OrderedSet(
+                                [StarDep(output_arg_name)]
+                            )
+                            write_deps = typing.cast(OrderedSet[Dep], write_deps)
+                            read_deps: OrderedSet[Dep] = OrderedSet(
+                                StarDep(name)
+                                for name in all_tensor_names
+                                if name != output_arg_name
+                            )
+                            read_deps = typing.cast(OrderedSet[Dep], read_deps)
+
+                            return TensorAccesses(
+                                ReadWrites(
+                                    reads=read_deps,
+                                    writes=write_deps,
+                                    index_exprs=OrderedSet(),
+                                ),
+                                can_fuse_epilogue=True,
+                            )
+            except Exception:
+                log.warning(
+                    "Epilogue fusion fallback failed",
+                    exc_info=True,
+                )
+
         return TensorAccesses(
             ReadWrites(
                 reads=all_deps,
                 writes=all_deps,
                 index_exprs=OrderedSet(),
             ),
-            can_fuse_epilogue=False,
+            can_fuse_epilogue=can_fuse,
         )
 
 
@@ -1184,6 +1530,13 @@ class TritonStore:
     store_node: ast.Call
     store_pointer_node: ast.Expr
     store_value_node: ast.Expr
+    # For TMA descriptor stores, the value goes through SMEM:
+    #   local_store(smem, value)  →  async_descriptor_store(desc, smem, offsets)
+    # In this case, store_value_node points to the value arg of local_store,
+    # and local_store_node points to the local_store call whose value arg
+    # should be replaced for epilogue fusion.
+    local_store_node: ast.Call | None = None
+    is_tma_descriptor_store: bool = False
 
 
 @dataclasses.dataclass
@@ -1191,53 +1544,176 @@ class TritonStores:
     stores: list[TritonStore]
 
 
-@functools.cache
-def identify_triton_stores(source_code: str) -> TritonStores:
+def _extract_arg(
+    node: ast.Call, arg_name: str, positional_index: int
+) -> ast.expr | None:
     """
-    Parse Python source code of triton kernel and find all tl.store calls.
-    Returns a TritonStores object containing information about pointer, value, and mask.
-
-    tl.store signature: store(pointer, value, mask=None, boundary_check=(), ...)
+    Extract an argument from a Call node, checking both positional and keyword args.
+    Returns the AST node for the argument, or None if not found.
     """
-    return identify_triton_stores_from_ast(ast.parse(source_code))
+    if len(node.args) > positional_index:
+        return node.args[positional_index]
+    for keyword in node.keywords:
+        if keyword.arg == arg_name:
+            return keyword.value
+    return None
 
 
-def identify_triton_stores_from_ast(tree: ast.Module) -> TritonStores:
-    stores = []
+def _is_call_to(node: ast.Call, module: str, func_name: str) -> bool:
+    """Check if an AST Call node is a call to module.func_name (e.g. tl.store)."""
+    return (
+        isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == module
+        and node.func.attr == func_name
+    )
 
-    def _extract_arg(node, arg_name, positional_index):
-        """
-        Extract an argument from a Call node, checking both positional and keyword args.
-        Returns the AST node for the argument, or None if not found.
-        """
-        # Check positional args first
-        if len(node.args) > positional_index:
-            return node.args[positional_index]
 
-        # Check keyword args
-        for keyword in node.keywords:
-            if keyword.arg == arg_name:
-                return keyword.value
+def _find_tma_descriptor_stores(tree: ast.AST) -> list[TritonStore]:
+    """
+    Find TMA descriptor store patterns in a triton kernel AST.
 
-        return None
+    TMA descriptor stores use a two-step pattern:
+        tlx.local_store(smem_buf, value)
+        tlx.async_descriptor_store(desc, smem_buf, offsets)
+    or:
+        tl.descriptor_store(desc, value, offsets)
+
+    For the tlx.async_descriptor_store pattern, we trace back from the
+    async_descriptor_store to find the preceding local_store that writes
+    the actual value to the SMEM buffer, and return the value arg of
+    local_store as the store_value_node for epilogue fusion.
+    """
+    stores: list[TritonStore] = []
+
+    # Collect all tlx.local_store and tlx.async_descriptor_store calls
+    local_stores: list[ast.Call] = []
+    async_desc_stores: list[ast.Call] = []
+    direct_desc_stores: list[ast.Call] = []
+    # Map descriptor variable name -> base pointer arg from tl.make_tensor_descriptor
+    desc_to_base_ptr: dict[str, ast.expr] = {}
 
     for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if _is_call_to(node, "tlx", "local_store"):
+            local_stores.append(node)
+        elif _is_call_to(node, "tlx", "async_descriptor_store"):
+            async_desc_stores.append(node)
+        elif _is_call_to(node, "tl", "descriptor_store"):
+            direct_desc_stores.append(node)
+
+    # Build desc_to_base_ptr mapping from assignments like:
+    #   desc_c = tl.make_tensor_descriptor(c_ptr, ...)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and isinstance(node.value, ast.Call)
+            and _is_call_to(node.value, "tl", "make_tensor_descriptor")
+        ):
+            base_ptr = _extract_arg(node.value, "base", 0)
+            if base_ptr is not None:
+                desc_to_base_ptr[node.targets[0].id] = base_ptr
+
+    # Handle direct tl.descriptor_store(desc, value, offsets) pattern
+    for desc_store in direct_desc_stores:
+        pointer_node = _extract_arg(desc_store, "desc", 0)
+        value_node = _extract_arg(desc_store, "value", 1)
+        if pointer_node is not None and value_node is not None:
+            stores.append(
+                TritonStore(
+                    store_node=desc_store,
+                    store_pointer_node=pointer_node,
+                    store_value_node=value_node,
+                    is_tma_descriptor_store=True,
+                )
+            )
+
+    # Handle tlx.async_descriptor_store(desc, smem_buf, offsets) pattern
+    # by tracing back to the preceding tlx.local_store(smem_buf, value)
+    for desc_store in async_desc_stores:
+        desc_node = _extract_arg(desc_store, "desc", 0)
+        smem_node = _extract_arg(desc_store, "src", 1)
+        if desc_node is None or smem_node is None:
+            continue
+
+        # Resolve desc variable to the base pointer arg from make_tensor_descriptor
+        # e.g. desc_c -> c_ptr
+        resolved_ptr_node = desc_node
+        if isinstance(desc_node, ast.Name) and desc_node.id in desc_to_base_ptr:
+            resolved_ptr_node = desc_to_base_ptr[desc_node.id]
+
+        # Find the smem buffer name used in async_descriptor_store
+        smem_name = ast.unparse(smem_node).strip() if smem_node else None
+        if smem_name is None:
+            continue
+
+        # Find the matching local_store that writes to the same smem buffer
+        matched_local_store = None
+        for ls in local_stores:
+            ls_dest = _extract_arg(ls, "dest", 0)
+            if ls_dest is not None and ast.unparse(ls_dest).strip() == smem_name:
+                matched_local_store = ls
+
+        if matched_local_store is not None:
+            value_node = _extract_arg(matched_local_store, "value", 1)
+            if value_node is not None:
+                stores.append(
+                    TritonStore(
+                        store_node=desc_store,
+                        store_pointer_node=resolved_ptr_node,
+                        store_value_node=value_node,
+                        local_store_node=matched_local_store,
+                        is_tma_descriptor_store=True,
+                    )
+                )
+
+    return stores
+
+
+def identify_triton_stores(source_code: str | ast.AST) -> TritonStores:
+    """
+    Parse Python source code of triton kernel and find all store calls,
+    including both tl.store() and TMA descriptor store patterns.
+
+    Supported store patterns:
+    1. tl.store(pointer, value, mask=None, ...)
+    2. tl.descriptor_store(desc, value, offsets, ...)
+    3. tlx.local_store(smem, value) + tlx.async_descriptor_store(desc, smem, offsets)
+       (traces back through SMEM to find the actual value)
+
+    Accepts either a source code string or a pre-parsed AST.
+    Note: caching only works for string inputs (AST objects are not hashable).
+    """
+
+    if isinstance(source_code, str):
+        tree = ast.parse(source_code)
+    else:
+        tree = source_code
+    stores = []
+
+    # 1. Find standard tl.store() calls
+    for node in ast.walk(tree):
         if isinstance(node, ast.Call):
-            # Check if this is a tl.store call
-            if (
-                isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "tl"
-                and node.func.attr == "store"
-            ):
-                # Extract required arguments
+            if _is_call_to(node, "tl", "store"):
                 pointer_node = _extract_arg(node, "pointer", 0)
                 value_node = _extract_arg(node, "value", 1)
+                if pointer_node is not None and value_node is not None:
+                    stores.append(TritonStore(node, pointer_node, value_node))
 
-                if pointer_node is None or value_node is None:
-                    continue
+    # 2. Find TMA descriptor store patterns
+    tma_stores = _find_tma_descriptor_stores(tree)
+    stores.extend(tma_stores)
 
-                stores.append(TritonStore(node, pointer_node, value_node))
+    log.warning(
+        "identify_triton_stores: found %d tl.store, %d TMA stores, %d total stores. Details: %s",
+        len(stores) - len(tma_stores),
+        len(tma_stores),
+        len(stores),
+        [(s.is_tma_descriptor_store, s.local_store_node is not None, ast.unparse(s.store_value_node) if s.store_value_node else "None") for s in stores],
+    )
 
     return TritonStores(stores=stores)
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6879,9 +6879,16 @@ class FusedUserDefinedTritonKernel(TritonKernel):
                 if keyword.arg == arg_name:
                     keyword.value = new_arg
 
-        _replace_arg(
-            kernel_stores.stores[0].store_node, "value", 1, new_store_value_node
-        )
+        store = kernel_stores.stores[0]
+        if store.is_tma_descriptor_store and store.local_store_node is not None:
+            # For TMA descriptor stores with the pattern:
+            #   tlx.local_store(smem, value)
+            #   tlx.async_descriptor_store(desc, smem, offsets)
+            # Replace the value arg of the local_store call
+            _replace_arg(store.local_store_node, "value", 1, new_store_value_node)
+        else:
+            # For standard tl.store(ptr, value, ...) or tl.descriptor_store(desc, value, ...)
+            _replace_arg(store.store_node, "value", 1, new_store_value_node)
 
         src_with_store_replaced = ast.unparse(new_ast)
 
@@ -6891,19 +6898,26 @@ class FusedUserDefinedTritonKernel(TritonKernel):
 
         # identify the store again, because the previous parse-modify-unparse could've change its location
         kernel_stores = identify_triton_stores(src_with_store_replaced)
-        # python ast lineno is 1-indexed
-        store_line_index = kernel_stores.stores[0].store_node.lineno - 1
+        store = kernel_stores.stores[0]
 
-        indentations = " " * kernel_stores.stores[0].store_node.col_offset
+        # For TMA stores, inject epilogue code before the local_store (not the async_descriptor_store)
+        if store.is_tma_descriptor_store and store.local_store_node is not None:
+            # python ast lineno is 1-indexed
+            inject_line_index = store.local_store_node.lineno - 1
+            indentations = " " * store.local_store_node.col_offset
+        else:
+            # python ast lineno is 1-indexed
+            inject_line_index = store.store_node.lineno - 1
+            indentations = " " * store.store_node.col_offset
 
         load_lines = [indentations + l for l in self.loads.get_lines_ref()]
         compute_lines = [indentations + l for l in self.compute.get_lines_ref()]
 
         new_src_lines = (
-            src_lines[:store_line_index]
+            src_lines[:inject_line_index]
             + load_lines
             + compute_lines
-            + src_lines[store_line_index:]
+            + src_lines[inject_line_index:]
         )
         return "\n".join(new_src_lines)
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -282,6 +282,9 @@ epilogue_fusion_first = False
 # do epilogue fusions for user defined triton kernels
 epilogue_fusion_user_defined_triton_kernel = False
 
+# do epilogue fusions for fx.wrap-wrapped triton kernels (FallbackKernel)
+epilogue_fusion_fallback_triton_kernel = False
+
 # enable pattern match+replace optimizations
 pattern_matcher = True
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -20,6 +20,7 @@ from sympy import Expr
 import torch
 import torch._logging
 import torch.fx
+import torch.utils._pytree as pytree
 from torch import device, Tensor
 from torch._decomp import get_decompositions
 from torch._dynamo.utils import defake, dynamo_timed
@@ -1540,6 +1541,10 @@ class GraphLowering(torch.fx.Interpreter):
             self.constant_reprs[target] = ""
             return TorchBindObject(name=target, value=value)
         elif is_opaque_type(type(value)):
+            self.torchbind_constants[target] = value  # type: ignore[arg-type]
+            self.constant_reprs[target] = ""
+            return TorchBindObject(name=target, value=value)  # type: ignore[arg-type]
+        elif isinstance(value, pytree.TreeSpec):
             self.torchbind_constants[target] = value  # type: ignore[arg-type]
             self.constant_reprs[target] = ""
             return TorchBindObject(name=target, value=value)  # type: ignore[arg-type]

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -9192,6 +9192,7 @@ class FallbackKernel(ExternKernelAlloc):
         if not device and (
             isinstance(kernel, torch._higher_order_ops.torchbind.CallTorchBind)
             or kernel is torch.ops.higher_order.print
+            or kernel is torch.ops.higher_order.invoke_leaf_function
         ):
             device = torch.device("cpu")
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7,6 +7,7 @@ import functools
 import itertools
 import logging
 import operator
+import os
 import textwrap
 import traceback
 from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
@@ -7813,10 +7814,15 @@ class UserDefinedTritonKernel(ExternKernel):
         We do this by pruning the `out` tensor allocation and directly writing the relu-output.
         """
 
-        if not config.epilogue_fusion_user_defined_triton_kernel:
+        _debug_tlx = os.environ.get("TORCHINDUCTOR_FORCE_TLX_EPILOGUE_FUSION")
+
+        if not config.epilogue_fusion_user_defined_triton_kernel and not _debug_tlx:
+            if _debug_tlx is not None:
+                log.warning("can_fuse_epilogue: BLOCKED by config gate (config=%s, env=%s)", config.epilogue_fusion_user_defined_triton_kernel, _debug_tlx)
             return False
 
         if not self.arg_accesses.can_fuse_epilogue:
+            log.warning("can_fuse_epilogue: BLOCKED by arg_accesses.can_fuse_epilogue=False (read_writes=%s)", self.arg_accesses.read_writes)
             return False
 
         # We achieve fusion by parsing the original src into a python AST,
@@ -7824,6 +7830,7 @@ class UserDefinedTritonKernel(ExternKernel):
         # We generate an expr for the value after the epilogue and replace that into the tl.store.
         # So far we only support the simple case where there is a single tl.store in the kernel.
         if len(self.kernel_stores.stores) != 1:
+            log.warning("can_fuse_epilogue: BLOCKED by kernel_stores count=%d (expected 1). Stores: %s", len(self.kernel_stores.stores), [(type(s).__name__, s.is_tma_descriptor_store, getattr(s, 'local_store_node', None) is not None) for s in self.kernel_stores.stores])
             return False
 
         # Only fuse if the mutated arg is originally an "empty" tensor.
@@ -7831,18 +7838,29 @@ class UserDefinedTritonKernel(ExternKernel):
         # If the kernel only writes to a subset of the tensor, then we only apply the epilogue to that subset.
         # In these edge cases, our fusion is only correct if the original tensor is empty,
         # where the semantics is that content values are UB, and we can rely on the fact that `epilogue(UB) == UB`.
+        #
+        # When TORCHINDUCTOR_FORCE_TLX_EPILOGUE_FUSION is set, skip this check:
+        # the output buffer may come from a different AOT module (graph split) and
+        # appear as an InputBuffer rather than a ComputedBuffer(Pointwise).
         assert len(self.mutable_args) == 1
-        if not isinstance(self.mutable_args[0], TensorBox):
-            return False
-        if not isinstance(self.mutable_args[0].data, StorageBox):
-            return False
-        if not isinstance(self.mutable_args[0].data.data, ComputedBuffer):
-            return False
-        if not isinstance(self.mutable_args[0].data.data.data, Pointwise):
-            return False
-        if not all(r == 0 for r in self.mutable_args[0].data.data.data.ranges):
-            return False
+        if not _debug_tlx:
+            if not isinstance(self.mutable_args[0], TensorBox):
+                log.warning("can_fuse_epilogue: BLOCKED mutable_args[0] is %s, not TensorBox", type(self.mutable_args[0]).__name__)
+                return False
+            if not isinstance(self.mutable_args[0].data, StorageBox):
+                log.warning("can_fuse_epilogue: BLOCKED mutable_args[0].data is %s, not StorageBox", type(self.mutable_args[0].data).__name__)
+                return False
+            if not isinstance(self.mutable_args[0].data.data, ComputedBuffer):
+                log.warning("can_fuse_epilogue: BLOCKED mutable_args[0].data.data is %s, not ComputedBuffer", type(self.mutable_args[0].data.data).__name__)
+                return False
+            if not isinstance(self.mutable_args[0].data.data.data, Pointwise):
+                log.warning("can_fuse_epilogue: BLOCKED mutable_args[0].data.data.data is %s, not Pointwise", type(self.mutable_args[0].data.data.data).__name__)
+                return False
+            if not all(r == 0 for r in self.mutable_args[0].data.data.data.ranges):
+                log.warning("can_fuse_epilogue: BLOCKED mutable_args[0] ranges=%s (not all zero)", self.mutable_args[0].data.data.data.ranges)
+                return False
 
+        log.warning("can_fuse_epilogue: PASSED all checks, returning True")
         return True
 
     @override
@@ -8053,6 +8071,59 @@ class UserDefinedTritonKernel(ExternKernel):
         ]
         V.graph.register_operation(self)
 
+    @override
+    def get_read_writes(self) -> dependencies.ReadWrites:
+        # Limit the new `get_read_writes` to `epilogue_fusion_user_defined_triton_kernel`
+        # to avoid potential regression to existing models.
+        if not config.epilogue_fusion_user_defined_triton_kernel and not os.environ.get(
+            "TORCHINDUCTOR_FORCE_TLX_EPILOGUE_FUSION"
+        ):
+            result = super().get_read_writes()
+            if os.environ.get("TORCHINDUCTOR_FORCE_TLX_EPILOGUE_FUSION") is not None:
+                log.warning(
+                    "get_read_writes: using GENERIC (super) path. reads=%s, writes=%s",
+                    result.reads,
+                    result.writes,
+                )
+            return result
+
+        # maps formal arg name to actual arg name
+        read_renames = {
+            formal_arg_dep.name: self.kernel_args[formal_arg_dep.name].get_name()
+            for formal_arg_dep in self.arg_accesses.read_writes.reads
+        }
+
+        formal_arg_writes = list(self.arg_accesses.read_writes.writes)
+        write_renames = {
+            formal_arg_dep.name: mut_output.get_name()
+            for formal_arg_dep, mut_output in zip(
+                formal_arg_writes, self.mutation_outputs
+            )
+        }
+
+        read_writes = dependencies.ReadWrites(
+            reads=OrderedSet(
+                [
+                    dep.rename(read_renames)
+                    for dep in self.arg_accesses.read_writes.reads
+                ]
+            ),
+            writes=OrderedSet(
+                [
+                    dep.rename(write_renames)
+                    for dep in self.arg_accesses.read_writes.writes
+                ]
+            ),
+            index_exprs=OrderedSet(),
+        )
+        log.warning(
+            "get_read_writes: using DETAILED path. reads=%s, writes=%s, read_renames=%s, write_renames=%s",
+            read_writes.reads,
+            read_writes.writes,
+            read_renames,
+            write_renames,
+        )
+        return read_writes
     def get_outputs(self) -> list[Buffer]:
         return list(self.mutation_outputs)
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2135,6 +2135,9 @@ class ExternKernelSchedulerNode(BaseSchedulerNode):
             device = node.get_device_or_error()
             # pyrefly: ignore [bad-assignment]
             self.group = (device, (numel, rnumel))
+            log.warning("ExternKernelSchedulerNode.__init__: set group=(device=%s, numel=%s, rnumel=%s) for fusable kernel", device, numel, rnumel)
+        elif isinstance(node, ir.UserDefinedTritonKernel):
+            log.warning("ExternKernelSchedulerNode.__init__: kernel can_fuse_epilogue=False, not setting group")
 
     def debug_str_extra(self) -> str:
         return f"{self.get_name()}.node.kernel = {getattr(self.node, 'python_kernel_name', None)}"
@@ -3068,11 +3071,23 @@ class FusedExternTritonKernelSchedulerNode(FusedSchedulerNode):
         assert len(node1.node.mutation_outputs) == 1
         # pyrefly: ignore[bad-assignment]
         mutated_name: str = node1.node.mutation_outputs[0].name
-        # Node1's mutated tensor becomes an intermediary tensor.
-        # Thus, remove node1 from the respective allocated buffer's users
-        # for `Scheduler.dead_node_elimination` to remove.
-        real_name = scheduler.mutation_real_name.get(mutated_name, mutated_name)
-        scheduler.name_to_buf[real_name].users.remove(NodeUser(node1))
+
+        if len(node1.unmet_dependencies) == 1:
+            # Standard path: the only unmet dep is the empty output buffer.
+            original_mutated_buffer = scheduler.name_to_buf[
+                next(iter(node1.unmet_dependencies)).name
+            ]
+            original_mutated_buffer.users.remove(NodeUser(node1))
+        else:
+            # TMA kernel path: output buffer may be a graph input (0 unmet deps)
+            # or there may be multiple unmet deps from read inputs.
+            real_name = scheduler.mutation_real_name.get(mutated_name, mutated_name)
+            if real_name in scheduler.name_to_buf:
+                original_mutated_buffer = scheduler.name_to_buf[real_name]
+                node_user = NodeUser(node1)
+                if node_user in original_mutated_buffer.users:
+                    original_mutated_buffer.users.remove(node_user)
+
         return cls(scheduler, node1, node2)
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
@@ -7299,14 +7314,18 @@ class Scheduler:
                 why("node1's triton kernel doesn't support epilogue fusion")
                 return False
 
+            log.warning("can_fuse: PASSED ExternKernel checks for node1=%s, checking node2=%s (type=%s)", node1.get_name(), node2.get_name(), type(node2).__name__)
+
             if not isinstance(node2, SchedulerNode):
                 why("node1 is extern but node2 is not SchedulerNode")
                 return False
             if not isinstance(node2.node, ComputedBuffer):
                 why("node1 is extern but node2.node is not SchedulerNode")
+                log.warning("can_fuse: BLOCKED node2.node type=%s (expected ComputedBuffer)", type(node2.node).__name__)
                 return False
             if not isinstance(node2.node.data, Pointwise):
                 why("node1 is extern but node2.node.data is not Pointwise")
+                log.warning("can_fuse: BLOCKED node2.node.data type=%s (expected Pointwise)", type(node2.node.data).__name__)
                 return False
 
             assert len(node1.node.mutation_outputs) == 1
@@ -7850,7 +7869,9 @@ class Scheduler:
         read_name = self.mutation_renames.get(read.name, read.name)
         write_name = self.mutation_renames.get(write.name, write.name)
         if isinstance(write, StarDep) and read_name == write_name:
+            log.warning("fusable_stardep_write_and_read_on_empty_tensor: MATCHED read=%s write=%s (renamed: read=%s write=%s)", read.name, write.name, read_name, write_name)
             return True
+        log.warning("fusable_stardep_write_and_read_on_empty_tensor: NOT MATCHED read=%s write=%s (renamed: read=%s write=%s)", read.name, write.name, read_name, write_name)
         return False
 
     @staticmethod


### PR DESCRIPTION
Summary:

Enabled the fusion of TLX user-defined kernel in the epilogue in inductor.
Added a new "TORCHINDUCTOR_FORCE_TLX_EPILOGUE_FUSION" flag. Turn it on to allow the fusion of TLX user-defined kernels using tlx.async_descriptor_store or tl.store. Will add support for kernels with desc.store() later.

Test Plan:
buck run mode/opt -c fbcode.platform010_cuda_version=12.8 //caffe2/test/inductor/fb/tlx:test_fusions -- -r test_async_tma_store_matmul_relu_epilogue_is_fused_float16

Inductor output here:

https://www.internalfb.com/phabricator/paste/view/P2284910677

Differential Revision: D102080949


