### PR TITLE
[torch._native] Skip CuTeDSL op registration on ROCm/HIP builds

### DIFF
--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -44,6 +44,14 @@ def _check_runtime_available() -> tuple[bool, Version | None]:
     if not _cuda.is_built():
         return (False, None)
 
+    # CuTeDSL kernels require genuine NVIDIA GPUs; on ROCm/HIP builds the
+    # CUDA compatibility layer reports is_built()=True but cuInit() will fail
+    # because no NVIDIA driver is present.
+    import torch
+
+    if torch.version.hip is not None:
+        return (False, None)
+
     deps = [
         ("nvidia_cutlass_dsl", "cutlass"),
         ("apache_tvm_ffi", "tvm_ffi"),


### PR DESCRIPTION
Summary:
D106105718 (PyTorch DiffTrain, May 22-24) changed `torch/_native/ops/__init__.py ` from 
`from . import bmm_outer_product, scatter_add` to
`from . import bmm_outer_product, norm, scatter_add`
  2. That new norm import triggers `norm/__init__.py` which calls `register_rmsnorm_overrides()`. This registers a CuTeDSL-backed RMSNorm kernel at the CUDA dispatch key — meaning whenever `aten::_fused_rms_norm` is called on a CUDA tensor, PyTorch will check this override first.
  3. The registration gate in `cutedsl_utils.py` checks `_cuda.is_built()` — but on ROCm/AMD builds, this returns True because HIP implements the CUDA API. So the override gets registered on MI350X.
  4. During training, the model calls `_fused_rms_norm`. The  function `_fused_rms_norm_cond` checks `torch.cuda.get_device_capability()` — MI350X is gfx950, which reports major=9, matching the major in (9, 10) check. So the cond returns True.
  5. The impl function runs and lazily imports `from torch._vendor.quack.rmsnorm import _compile_rmsnorm_fwd → quack imports cutlass → cutlass.base_dsl imports cuda.bindings.driver → calls cuInit(0) → crash`. There's no NVIDIA driver on an AMD machine, so `cuInit`  fails immediately with CudaDriverDependencyError.

**Fix:** add a `torch.version.hip` guard in `_check_runtime_available()` so that
CuTeDSL ops are never registered on ROCm builds.

Test Plan:
```
import torch
print("hip:", torch.version.hip)
print("cuda.is_built:", torch.backends.cuda.is_built())

from torch._native.cutedsl_utils import _check_runtime_available
available, version = _check_runtime_available()
print("cutedsl available:", available)
print("cutedsl version:", version)
```

Without fix (control):
```
  hip: 7.0.51831
  cuda.is_built: True
  cutedsl available: True        ← BUG: CuTeDSL registered on AMD
  cutedsl version: 4.4.2
  FAIL: CuTeDSL should be disabled on ROCm/HIP!
```

 With fix (treatment):
```
  hip: 7.0.51831
  cuda.is_built: True
  cutedsl available: False       ← FIXED: CuTeDSL blocked on AMD
  cutedsl version: None
  PASS: CuTeDSL correctly disabled on ROCm/HIP
```

Reviewed By: wdvr

Differential Revision: D106426428




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang