### PR TITLE
Narrow OpInfo skips from #185013 to per-op entries

### DIFF
--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -32,11 +32,7 @@ from torch.testing._internal.common_device_type import (
     OpDTypes,
     ops,
 )
-from torch.testing._internal.common_utils import (
-    run_tests,
-    TEST_WITH_ASAN,
-    unMarkDynamoStrictTest,
-)
+from torch.testing._internal.common_utils import run_tests, unMarkDynamoStrictTest
 
 
 if TYPE_CHECKING:
@@ -98,15 +94,6 @@ SKIPS = {
     Descriptor(op=aten.transpose, variant=Variant.Distributed): "No scalar support",
     Descriptor(op=aten.view_as_real, variant=Variant.Distributed): "No scalar support",
 }
-if TEST_WITH_ASAN:
-    SKIPS[
-        Descriptor(
-            op=aten.diagonal_scatter,
-            variant=Variant.GradCheck,
-            device_type="cpu",
-            dtype=torch.complex128,
-        )
-    ] = "https://github.com/pytorch/pytorch/issues/168169"
 
 EXTRA_KWARGS = {
     Descriptor(op=aten.asinh, dtype=torch.complex64, variant=Variant.Op): {

--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -1,7 +1,6 @@
 # Owner(s): ["module: complex"]
 from __future__ import annotations
 
-import unittest
 from typing import TYPE_CHECKING
 
 import torch
@@ -99,6 +98,15 @@ SKIPS = {
     Descriptor(op=aten.transpose, variant=Variant.Distributed): "No scalar support",
     Descriptor(op=aten.view_as_real, variant=Variant.Distributed): "No scalar support",
 }
+if TEST_WITH_ASAN:
+    SKIPS[
+        Descriptor(
+            op=aten.diagonal_scatter,
+            variant=Variant.GradCheck,
+            device_type="cpu",
+            dtype=torch.complex128,
+        )
+    ] = "https://github.com/pytorch/pytorch/issues/168169"
 
 EXTRA_KWARGS = {
     Descriptor(op=aten.asinh, dtype=torch.complex64, variant=Variant.Op): {
@@ -167,7 +175,6 @@ class TestComplexTensor(TestCase):
 class TestComplexBwdGradients(TestCase):
     _default_dtype_check_enabled = True
 
-    @unittest.skipIf(TEST_WITH_ASAN, "https://github.com/pytorch/pytorch/issues/168169")
     @ops(
         implemented_op_db,
         dtypes=OpDTypes.supported_backward,

--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -1013,8 +1013,6 @@ class TestSingleDimStrategies(DTensorOpTestBase):
             skip("log_normal"),
             skip("normal", "in_place"),
             skip("uniform"),
-            # https://github.com/pytorch/pytorch/issues/184463
-            skip("nn.functional.max_unpool3d", "grad"),
         },
     )
     def test_single_dim_strategy(self, dtype, op):

--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -5,7 +5,6 @@ import copy
 import random
 import re
 import threading
-import unittest
 import warnings
 
 import torch
@@ -33,7 +32,6 @@ from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_ops_unbacked import ops_dde_xfail, ops_unbacked_skip
 from torch.testing._internal.common_utils import (
     freeze_rng_state,
-    IS_LINUX,
     np,
     run_tests,
     SEED,
@@ -220,6 +218,12 @@ dtensor_multi_threaded_fails = {
     xfail("nn.functional.dropout3d"),
     skip("nn.functional.multi_head_attention_forward"),
     xfail("multinomial"),
+    # Flaky in CI: https://github.com/pytorch/pytorch/issues/167252
+    skip("full_like"),
+    # Flaky in CI: https://github.com/pytorch/pytorch/issues/179779
+    skip("bmm"),
+    # Flaky in CI: https://github.com/pytorch/pytorch/issues/180522
+    skip("baddbmm"),
 }
 
 # Ops that fail to compile with DTensor + torch.compile(fullgraph=True).
@@ -286,6 +290,10 @@ dtensor_compiled_fails = {
     # False positives: these have no sharding strategy and their
     # eager DTensor failure is registered elsewhere.
     xfail("nn.functional.multilabel_soft_margin_loss"),
+    # Flaky in CI: https://github.com/pytorch/pytorch/issues/181204
+    skip("norm", "nuc"),
+    # Flaky in CI: https://github.com/pytorch/pytorch/issues/176973
+    skip("histc"),
 }
 
 # Ops that compile successfully but fail numeric checks in eager DTensor tests.
@@ -681,9 +689,6 @@ class TestMultiThreadedDTensorOps(DTensorOpTestBase, TestDTensorOps):
     _op_db = repurpose_ops(op_db, "TestDTensorOps", "TestMultiThreadedDTensorOps")
     _op_db_sample_lock = threading.Lock()
 
-    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/167252")
-    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/179779")
-    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/180522")
     @suppress_warnings
     @ops(_op_db, allowed_dtypes=(torch.float,))
     @skipOps(
@@ -961,7 +966,6 @@ class TestUnbackedDTensorOps(TestDTensorOps):
                     ) from e
         return rs
 
-    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/179881")
     @suppress_warnings
     @ops(_op_db, allowed_dtypes=(torch.float,))
     @skipOps(
@@ -998,7 +1002,6 @@ class TestSingleDimStrategies(DTensorOpTestBase):
 
         self.skipTest(f"Op {torch_op} failed to extract aten op")
 
-    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/184463")
     @suppress_warnings
     @ops(op_db, allowed_dtypes=(torch.float,))
     @skipOps(
@@ -1010,6 +1013,8 @@ class TestSingleDimStrategies(DTensorOpTestBase):
             skip("log_normal"),
             skip("normal", "in_place"),
             skip("uniform"),
+            # https://github.com/pytorch/pytorch/issues/184463
+            skip("nn.functional.max_unpool3d", "grad"),
         },
     )
     def test_single_dim_strategy(self, dtype, op):
@@ -1164,8 +1169,6 @@ class TestCompiledDTensorOps(TestDTensorOps):
             # Just run - if it compiles and runs without error, we pass
             compiled_func(*dtensor_args, **dtensor_kwargs)
 
-    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/181204")
-    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/176973")
     @suppress_warnings
     @ops(_op_db, allowed_dtypes=(torch.float,))
     @skipOps(

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -561,6 +561,25 @@ comprehensive_failures = {
         "nn.functional.upsample_bilinear", "", dtypes=(torch.uint8,)
     ),  # off by one error
 }
+if IS_LINUX or TEST_WITH_ROCM:
+    # https://github.com/pytorch/pytorch/issues/131050
+    comprehensive_failures.add(
+        skip(
+            "nn.functional.pad",
+            "reflect",
+            device_type="cuda",
+            dtypes=(torch.bfloat16,),
+        )
+    )
+if IS_LINUX:
+    # https://github.com/pytorch/pytorch/issues/76962
+    comprehensive_failures.add(
+        skip(
+            "linalg.ldl_factor_ex",
+            device_type="cuda",
+            dtypes=(torch.complex64, torch.complex128),
+        )
+    )
 
 
 @unMarkDynamoStrictTest
@@ -604,10 +623,6 @@ class TestDecomp(TestCase):
                 torch.autograd.gradcheck(func, args)
             self.check_decomposed(aten_name, mode)
 
-    @unittest.skipIf(
-        IS_LINUX or TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/131050"
-    )
-    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/76962")
     @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @skipIfCrossRef

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -30,13 +30,11 @@ from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.common_utils import (
     is_iterable_of_tensors,
-    IS_LINUX,
     run_tests,
     skipIfCrossRef,
     skipIfTorchDynamo,
     suppress_warnings,
     TEST_WITH_ASAN,
-    TEST_WITH_ROCM,
     TEST_WITH_SLOW,
     TestCase,
     unMarkDynamoStrictTest,
@@ -561,25 +559,6 @@ comprehensive_failures = {
         "nn.functional.upsample_bilinear", "", dtypes=(torch.uint8,)
     ),  # off by one error
 }
-if IS_LINUX or TEST_WITH_ROCM:
-    # https://github.com/pytorch/pytorch/issues/131050
-    comprehensive_failures.add(
-        skip(
-            "nn.functional.pad",
-            "reflect",
-            device_type="cuda",
-            dtypes=(torch.bfloat16,),
-        )
-    )
-if IS_LINUX:
-    # https://github.com/pytorch/pytorch/issues/76962
-    comprehensive_failures.add(
-        skip(
-            "linalg.ldl_factor_ex",
-            device_type="cuda",
-            dtypes=(torch.complex64, torch.complex128),
-        )
-    )
 
 
 @unMarkDynamoStrictTest

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -42,7 +42,7 @@ from torch.testing._internal.common_quantized import (
 )
 from torch.testing._internal.common_utils import (
     make_fullrank_matrices_with_distinct_singular_values,
-    TEST_WITH_ROCM, IS_FBCODE, IS_WINDOWS, IS_MACOS, MACOS_VERSION, TEST_SCIPY,
+    TEST_WITH_ROCM, IS_FBCODE, IS_LINUX, IS_WINDOWS, IS_MACOS, MACOS_VERSION, TEST_SCIPY,
     torch_to_numpy_dtype_dict, numpy_to_torch_dtype, TEST_WITH_ASAN,
     GRADCHECK_NONDET_TOL, slowTest, TEST_WITH_SLOW,
     TEST_WITH_TORCHINDUCTOR, skipIfNoTritonDSL,
@@ -14218,7 +14218,14 @@ op_db: list[OpInfo] = [
            supports_out=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           sample_inputs_func=sample_inputs_diagonal_scatter),
+           sample_inputs_func=sample_inputs_diagonal_scatter,
+           skips=(
+               # https://github.com/pytorch/pytorch/issues/168169
+               DecorateInfo(unittest.skip("Flaky under ASAN"),
+                            'TestComplexBwdGradients', 'test_fn_grad',
+                            device_type='cpu', dtypes=(torch.complex128,),
+                            active_if=TEST_WITH_ASAN),
+           )),
     OpInfo('alias_copy',
            dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16, torch.chalf),
            sample_inputs_func=sample_inputs_alias_copy,
@@ -16795,6 +16802,11 @@ op_db: list[OpInfo] = [
                # RuntimeError: falseINTERNAL ASSERT FAILED at
                # "../torch/csrc/jit/passes/utils/check_alias_annotation.cpp":185, please report a bug to PyTorch.
                DecorateInfo(unittest.skip("Skipped!"), 'TestJit', 'test_variant_consistency_jit', dtypes=(torch.float32,)),
+               # https://github.com/pytorch/pytorch/issues/131050
+               DecorateInfo(unittest.skip("Flaky on Linux/ROCm CUDA"),
+                            'TestDecomp', 'test_comprehensive',
+                            device_type='cuda', dtypes=(torch.bfloat16,),
+                            active_if=IS_LINUX or TEST_WITH_ROCM),
            ),
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
            supports_out=False),
@@ -17454,7 +17466,12 @@ op_db: list[OpInfo] = [
            dtypesIfMPS=floating_types_and(
                torch.float16, torch.bfloat16, torch.int16, torch.int32, torch.int64, torch.uint8, torch.bool, torch.int8
            ),
-           sample_inputs_func=sample_inputs_max_unpool_grad),
+           sample_inputs_func=sample_inputs_max_unpool_grad,
+           skips=(
+               # https://github.com/pytorch/pytorch/issues/184463
+               DecorateInfo(unittest.skip("Flaky in CI"),
+                            'TestSingleDimStrategies', 'test_single_dim_strategy'),
+           )),
     OpInfo('nn.functional.linear',
            aten_name='linear',
            supports_autograd=True,

--- a/torch/testing/_internal/common_ops_unbacked.py
+++ b/torch/testing/_internal/common_ops_unbacked.py
@@ -247,4 +247,6 @@ ops_unbacked_skip = {
     skip("zeros"),
     # Sparse ops that can't be deepcopied
     skip("sparse.sampled_addmm"),
+    # Flaky in CI: https://github.com/pytorch/pytorch/issues/179881
+    skip("norm", "nuc"),
 }

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1547,6 +1547,15 @@ op_db: list[OpInfo] = [
         skips=(
             # NotImplementedError: The operator 'aten::linalg_ldl_factor_ex.out' is not currently implemented for the MPS device
             DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
+            # https://github.com/pytorch/pytorch/issues/76962
+            DecorateInfo(
+                unittest.skip("Flaky on Linux CUDA"),
+                "TestDecomp",
+                "test_comprehensive",
+                device_type="cuda",
+                dtypes=(torch.complex64, torch.complex128),
+                active_if=IS_LINUX,
+            ),
         ),
     ),
     OpInfo(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #185307

#185013 attached `@unittest.skipIf(IS_LINUX, ...)` / `@unittest.skipIf(TEST_WITH_ASAN, ...)` to a handful of `@ops`-decorated test methods, which over-skipped: every OpInfo invocation got skipped, even though the originating issues each
  targeted a single op + dtype.
  
  Replace those broad guards with targeted entries:
  - `test_decomp.py` `comprehensive_failures`: per-op `skip(...)` for #131050, #76962.
  - `complex_tensor/test_complex_tensor.py`: `SKIPS` entry gated on `TEST_WITH_ASAN` for #168169.
  - `distributed/tensor/test_dtensor_ops.py`: per-op skips folded into `dtensor_multi_threaded_fails` (#167252, #179779, #180522), `dtensor_compiled_fails` (#181204, #176973), `ops_unbacked_skip` (#179881), and the inline
  `test_single_dim_strategy` set (#184463). DTensor tests only run on Linux CI so no `IS_LINUX` guard is needed.

Authored by Claude.

Fixes #185294