### PR TITLE
Align subclass output SymInt unwrapping with metadata

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -41,9 +41,11 @@ from torch.distributed.tensor.parallel import (
     ColwiseParallel,
     loss_parallel,
     parallelize_module,
+    ParallelStyle,
     PrepareModuleInput,
     PrepareModuleOutput,
     RowwiseParallel,
+    SequenceParallel,
 )
 from torch.distributed.tensor.placement_types import _StridedShard, Placement
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -160,6 +162,46 @@ class SimpleModel(nn.Module):
 
     def forward(self, input):
         return self.mlp_1(self.mlp_0(input))
+
+
+class _ReplicateParallel(ParallelStyle):
+    @staticmethod
+    def _prepare_input_fn(placement, mod, inputs, device_mesh):
+        x = inputs[0]
+        if not isinstance(x, DTensor):
+            x = DTensor.from_local(x, device_mesh, (placement,), run_check=False)
+        return (x, *inputs[1:])
+
+    @staticmethod
+    def _prepare_output_fn(placement, mod, outputs, device_mesh):
+        def replicate(x):
+            if isinstance(x, DTensor) and x.placements != (placement,):
+                x = x.redistribute(placements=(placement,), async_op=True)
+            return x
+
+        if isinstance(outputs, tuple):
+            return tuple(replicate(x) for x in outputs)
+        return replicate(outputs)
+
+    def _apply(self, module, device_mesh):
+        return distribute_module(
+            module,
+            device_mesh,
+            None,
+            functools.partial(self._prepare_input_fn, Replicate()),
+            functools.partial(self._prepare_output_fn, Replicate()),
+        )
+
+
+class _IdentityFront(nn.Module):
+    def forward(self, x):
+        return x
+
+
+class _ArityRouter(nn.Module):
+    def forward(self, x):
+        y = x.reshape(-1, 8) * 2
+        return y, y + 1
 
 
 def extract_graph(fx_g, _, graph_cell):
@@ -2925,6 +2967,49 @@ class TestDTensorCompileE2E(DTensorTestBase):
                 2,
                 f"Expected ProcessGroup placeholders but only got {len(placeholders)} placeholder(s)",
             )
+
+
+class TestDTensorSubclassOutputCompile(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 2
+
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @patch.object(torch._inductor.config, "compile_threads", 1)
+    def test_dtensor_output_symint_arity_matches_metadata(self):
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+
+        front = parallelize_module(
+            _IdentityFront().to(self.device_type), mesh, SequenceParallel()
+        )
+        router = parallelize_module(
+            _ArityRouter().to(self.device_type), mesh, _ReplicateParallel()
+        )
+
+        front = torch.compile(front, backend="inductor", fullgraph=True)
+        router = torch.compile(router, backend="inductor", fullgraph=True)
+
+        x = torch.randn(
+            1,
+            1,
+            8,
+            device=self.device_type,
+            requires_grad=True,
+        )
+        x = front(x)
+        self.assertIsInstance(x, DTensor)
+
+        x = x.redistribute(placements=(Replicate(),), async_op=False)
+        x = x.to_local(grad_placements=(Partial(),))
+
+        y0, y1 = router(x)
+        out = y0 + y1
+
+        self.assertIsInstance(out, DTensor)
+        self.assertEqual(out.placements, (Replicate(),))
+        self.assertEqual(out.to_local().shape, (self.world_size, 8))
 
 
 class TestDTensorACCompile(DTensorTestBase):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -4828,6 +4828,64 @@ def forward(self, tangents_1):
         self.assertEqual(outer_size, (4, 6))
         self.assertEqual(outer_stride, (6, 1))
 
+    def test_unwrap_subclass_outputs_uses_symints_from_meta(self):
+        from torch._functorch._aot_autograd.descriptors import (
+            PlainAOTOutput,
+            SubclassSizeAOTOutput,
+            SubclassStrideAOTOutput,
+        )
+        from torch._functorch._aot_autograd.schemas import (
+            PlainTensorMeta,
+            SubclassCreationMeta,
+        )
+        from torch._functorch._aot_autograd.subclass_utils import (
+            unwrap_tensor_subclasses,
+        )
+
+        # Simulate metadata that recorded dynamic outer size/stride slots, while
+        # the current wrapper instance reports concrete Python ints.
+        marked_a = torch.randn(4, 6)
+        marked_b = torch.randn(4, 6)
+        torch._dynamo.mark_dynamic(marked_a, 0)
+        torch._dynamo.mark_dynamic(marked_a, 1)
+        torch._dynamo.mark_dynamic(marked_b, 0)
+        torch._dynamo.mark_dynamic(marked_b, 1)
+        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+        with fake_mode:
+            fake_a = fake_mode.from_tensor(marked_a)
+            fake_b = fake_mode.from_tensor(marked_b)
+            fake_two_tensor = TwoTensor(fake_a, fake_b)
+        meta = SubclassCreationMeta(
+            flat_tensor_start_idx=0,
+            arg_count=5,
+            included_subclass_symints=True,
+            attrs={
+                "a": PlainTensorMeta(unwrapped_idx=0),
+                "b": PlainTensorMeta(unwrapped_idx=1),
+            },
+            outer_size=fake_two_tensor.size(),
+            outer_stride=fake_two_tensor.stride(),
+            meta=None,
+            original_subclass=fake_two_tensor,
+        )
+
+        a = torch.randn(4, 6)
+        b = torch.randn(4, 6)
+        out, descs = unwrap_tensor_subclasses(
+            [TwoTensor(a, b)],
+            [PlainAOTOutput(0)],
+            append_symints=True,
+            subclass_metas=[meta],
+        )
+
+        self.assertEqual(out, [a, b, 4, 6, 6])
+        self.assertIsInstance(descs[2], SubclassSizeAOTOutput)
+        self.assertEqual(descs[2].idx, 0)
+        self.assertIsInstance(descs[3], SubclassSizeAOTOutput)
+        self.assertEqual(descs[3].idx, 1)
+        self.assertIsInstance(descs[4], SubclassStrideAOTOutput)
+        self.assertEqual(descs[4].idx, 0)
+
     def test_subclass_dynamic_stride(self):
         @torch.compile(backend="aot_eager", dynamic=True)
         def f(x):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -4787,6 +4787,37 @@ def forward(self, tangents_1):
         counters.clear()
         torch._dynamo.reset()
 
+    def _make_dynamic_twotensor_subclass_meta(self):
+        from torch._functorch._aot_autograd.schemas import (
+            PlainTensorMeta,
+            SubclassCreationMeta,
+        )
+
+        marked_a = torch.randn(4, 6)
+        marked_b = torch.randn(4, 6)
+        torch._dynamo.mark_dynamic(marked_a, 0)
+        torch._dynamo.mark_dynamic(marked_a, 1)
+        torch._dynamo.mark_dynamic(marked_b, 0)
+        torch._dynamo.mark_dynamic(marked_b, 1)
+        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+        with fake_mode:
+            fake_a = fake_mode.from_tensor(marked_a)
+            fake_b = fake_mode.from_tensor(marked_b)
+            fake_two_tensor = TwoTensor(fake_a, fake_b)
+        return SubclassCreationMeta(
+            flat_tensor_start_idx=0,
+            arg_count=5,
+            included_subclass_symints=True,
+            attrs={
+                "a": PlainTensorMeta(unwrapped_idx=0),
+                "b": PlainTensorMeta(unwrapped_idx=1),
+            },
+            outer_size=fake_two_tensor.size(),
+            outer_stride=fake_two_tensor.stride(),
+            meta=None,
+            original_subclass=fake_two_tensor,
+        )
+
     def test_compute_outer_size_and_stride_bug(self):
         import dataclasses
 
@@ -4834,40 +4865,13 @@ def forward(self, tangents_1):
             SubclassSizeAOTOutput,
             SubclassStrideAOTOutput,
         )
-        from torch._functorch._aot_autograd.schemas import (
-            PlainTensorMeta,
-            SubclassCreationMeta,
-        )
         from torch._functorch._aot_autograd.subclass_utils import (
             unwrap_tensor_subclasses,
         )
 
         # Simulate metadata that recorded dynamic outer size/stride slots, while
         # the current wrapper instance reports concrete Python ints.
-        marked_a = torch.randn(4, 6)
-        marked_b = torch.randn(4, 6)
-        torch._dynamo.mark_dynamic(marked_a, 0)
-        torch._dynamo.mark_dynamic(marked_a, 1)
-        torch._dynamo.mark_dynamic(marked_b, 0)
-        torch._dynamo.mark_dynamic(marked_b, 1)
-        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
-        with fake_mode:
-            fake_a = fake_mode.from_tensor(marked_a)
-            fake_b = fake_mode.from_tensor(marked_b)
-            fake_two_tensor = TwoTensor(fake_a, fake_b)
-        meta = SubclassCreationMeta(
-            flat_tensor_start_idx=0,
-            arg_count=5,
-            included_subclass_symints=True,
-            attrs={
-                "a": PlainTensorMeta(unwrapped_idx=0),
-                "b": PlainTensorMeta(unwrapped_idx=1),
-            },
-            outer_size=fake_two_tensor.size(),
-            outer_stride=fake_two_tensor.stride(),
-            meta=None,
-            original_subclass=fake_two_tensor,
-        )
+        meta = self._make_dynamic_twotensor_subclass_meta()
 
         a = torch.randn(4, 6)
         b = torch.randn(4, 6)
@@ -4885,6 +4889,37 @@ def forward(self, tangents_1):
         self.assertEqual(descs[3].idx, 1)
         self.assertIsInstance(descs[4], SubclassStrideAOTOutput)
         self.assertEqual(descs[4].idx, 0)
+
+    def test_static_input_remap_uses_subclass_meta_symints(self):
+        from torch._functorch._aot_autograd.descriptors import PlainAOTInput
+        from torch._functorch._aot_autograd.schemas import PlainTensorMeta
+        from torch._functorch._aot_autograd.subclass_utils import (
+            remap_unwrapped_subclass_arg_indices,
+            unwrap_tensor_subclasses,
+        )
+
+        meta = self._make_dynamic_twotensor_subclass_meta()
+
+        a = torch.randn(4, 6)
+        b = torch.randn(4, 6)
+        static_arg = torch.randn(2)
+        wrapped_args = [TwoTensor(a, b), static_arg]
+        subclass_metas = [meta, PlainTensorMeta(unwrapped_idx=meta.arg_count)]
+
+        unwrapped_args, _ = unwrap_tensor_subclasses(
+            wrapped_args,
+            [PlainAOTInput(0), PlainAOTInput(1)],
+            append_symints=True,
+            subclass_metas=subclass_metas,
+        )
+        remapped_static_indices = remap_unwrapped_subclass_arg_indices(
+            wrapped_args,
+            [1],
+            subclass_metas=subclass_metas,
+        )
+
+        self.assertEqual(remapped_static_indices, [meta.arg_count])
+        self.assertIs(unwrapped_args[remapped_static_indices[0]], static_arg)
 
     def test_subclass_dynamic_stride(self):
         @torch.compile(backend="aot_eager", dynamic=True)

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -79,7 +79,9 @@ from .schemas import (
     JointTraceFn,
     MutationType,
     OutputType,
+    PlainTensorMeta,
     PreppedForAutogradTraceFn,
+    SubclassCreationMeta,
     SubclassMeta,
     SubclassTracingInfo,
     TraceFn,
@@ -1335,6 +1337,20 @@ def aot_dispatch_subclass(
     # NB: doesn't take descs, this is going from the NEW flat_args to the
     # subclasses, we don't need to do bookkeeping here
     def inner_fn(fn: Callable[..., Any], args: Any, *, use_trace_joint: bool) -> Any:
+        def aligned_subclass_metas(
+            wrapped_outs: list[FxValue],
+            subclass_metas: list[PlainTensorMeta | SubclassCreationMeta] | None,
+        ) -> list[PlainTensorMeta | SubclassCreationMeta] | None:
+            if subclass_metas is None:
+                return None
+            if len(wrapped_outs) != len(subclass_metas):
+                raise AssertionError(
+                    "subclass metadata length mismatch: "
+                    f"{len(wrapped_outs)} wrapped values, "
+                    f"{len(subclass_metas)} metadata entries"
+                )
+            return subclass_metas
+
         # Step 1: wrap tensor inputs into subclasses if necessary
         all_args = wrap_tensor_subclasses_maybe_joint(
             args, is_joint_structure=use_trace_joint, meta=meta
@@ -1361,12 +1377,19 @@ def aot_dispatch_subclass(
                 wrapped_outs[0],
                 wrapped_outs_descs[0],
                 append_symints=True,
+                subclass_metas=aligned_subclass_metas(
+                    wrapped_outs[0],
+                    meta.subclass_fw_graph_out_meta,
+                ),
             )
             # ignore nested ints here
             backward_outs, backward_outs_descs = unwrap_tensor_subclasses(
                 wrapped_outs[1],
                 wrapped_outs_descs[1],
                 append_symints=True,
+                subclass_metas=aligned_subclass_metas(
+                    wrapped_outs[1], subclass_meta.grad_input_metas
+                ),
             )
             return (
                 (forward_outs, backward_outs),
@@ -1375,7 +1398,12 @@ def aot_dispatch_subclass(
 
         # Step 3: Unwrap any subclass outputs back into dense tensors
         return unwrap_tensor_subclasses(
-            wrapped_outs, wrapped_outs_descs, append_symints=True
+            wrapped_outs,
+            wrapped_outs_descs,
+            append_symints=True,
+            subclass_metas=aligned_subclass_metas(
+                wrapped_outs, meta.subclass_fw_graph_out_meta
+            ),
         )
 
     def joint_fn(
@@ -1414,6 +1442,7 @@ def aot_dispatch_subclass(
             primals_wrapped,
             primals_wrapped_descs,
             append_symints=True,
+            subclass_metas=meta.subclass_inp_meta,
         )
         # We pass append_symints=False here because the partitioner will
         # capture and add any extra argument.
@@ -1441,6 +1470,7 @@ def aot_dispatch_subclass(
             primals_wrapped,
             primals_wrapped_descs,
             append_symints=True,
+            subclass_metas=meta.subclass_inp_meta,
         )
         remapped_static_indices = remap_unwrapped_subclass_arg_indices(
             primals_wrapped,

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -1457,6 +1457,7 @@ def aot_dispatch_subclass(
         remapped_static_indices = remap_unwrapped_subclass_arg_indices(
             primals_wrapped,
             meta.static_input_indices,  # type: ignore[arg-type]
+            subclass_metas=meta.subclass_inp_meta,
         )
 
         primals_unwrapped = args_unwrapped[0]  # type: ignore[assignment]
@@ -1475,6 +1476,7 @@ def aot_dispatch_subclass(
         remapped_static_indices = remap_unwrapped_subclass_arg_indices(
             primals_wrapped,
             meta.static_input_indices,  # type: ignore[arg-type]
+            subclass_metas=meta.subclass_inp_meta,
         )
 
         primals_unwrapped = args_unwrapped  # type: ignore[assignment]

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -497,19 +497,34 @@ def unwrap_tensor_subclasses_with_indices_to_original(
 
 
 def remap_unwrapped_subclass_arg_indices(
-    wrapped_args: list[Any], static_input_indices: list[int]
+    wrapped_args: list[Any],
+    static_input_indices: list[int],
+    *,
+    subclass_metas: Sequence[PlainTensorMeta | SubclassCreationMeta] | None = None,
 ) -> list[int]:
     static_input_indices_set = set(static_input_indices)
     new_ind = 0
     remapped_static_indices = []
+
+    if subclass_metas is not None and len(wrapped_args) != len(subclass_metas):
+        raise AssertionError(
+            f"subclass_metas length ({len(subclass_metas)}) != wrapped_args length ({len(wrapped_args)})"
+        )
+
     for i, arg in enumerate(wrapped_args):
-        num_indices = 1
-        if is_traceable_wrapper_subclass(arg):
+        subclass_meta = None if subclass_metas is None else subclass_metas[i]
+        if isinstance(subclass_meta, SubclassCreationMeta):
+            num_indices = subclass_meta.arg_count
+        elif subclass_meta is not None:
+            num_indices = 1
+        elif is_traceable_wrapper_subclass(arg):
             num_indices = (
                 len(get_plain_tensors(arg, out=[]))
                 + len(enumerate_filter_symints(arg.size()))
                 + len(enumerate_filter_symints(arg.stride()))
             )
+        else:
+            num_indices = 1
 
         for _ in range(num_indices):
             if i in static_input_indices_set:

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -229,9 +229,21 @@ def enumerate_filter_symints(lst: Iterable[IntLikeType]) -> list[tuple[int, SymI
     return [(i, s) for i, s in enumerate(lst) if symint_check(s)]
 
 
-def compute_symint_placeholders(lst: Iterable[None | int | SymInt]) -> list[bool]:
-    # Non-nested symints are replaced with None in `make_runtime_safe()`
-    return [s is None for s in lst]
+def compute_symint_placeholders(
+    lst: Iterable[None | int | SymInt],
+    *,
+    symints_are_placeholders: bool = False,
+) -> list[bool]:
+    # Non-nested symints are replaced with None in `make_runtime_safe()`.
+    return [
+        s is None
+        or (
+            symints_are_placeholders
+            and isinstance(s, SymInt)
+            and not s.node.is_nested_int()
+        )
+        for s in lst
+    ]
 
 
 # Intended to make it easier to define function that is
@@ -258,6 +270,7 @@ def unwrap_tensor_subclasses(
     wrapped_args_descs: Sequence[AOTDescriptor],
     *,
     append_symints: bool,
+    subclass_metas: Sequence[PlainTensorMeta | SubclassCreationMeta] | None = None,
 ) -> tuple[list[FxValue], list[AOTDescriptor]]:
     def _maybe_fakeify_opaque(v: Any) -> Any:
         # Registered opaque types need to be wrapped as FakeScriptObject for
@@ -275,15 +288,27 @@ def unwrap_tensor_subclasses(
     def flatten_subclass(
         t: FxValue,
         desc: AOTDescriptor,
+        subclass_meta: PlainTensorMeta | SubclassCreationMeta | OpaqueMeta | None,
         *,
         out: tuple[list[FxValue], list[AOTDescriptor]],
     ) -> None:
         # unwrap a subclass into plain tensors and their size/stride if "append_symint"
         # is True
         if not is_traceable_wrapper_subclass(t):
+            if isinstance(subclass_meta, SubclassCreationMeta):
+                raise AssertionError(
+                    f"expected traceable wrapper subclass, got {type(t)}"
+                )
             out[0].append(_maybe_fakeify_opaque(t))
             out[1].append(desc)
             return
+
+        if subclass_meta is not None and not isinstance(
+            subclass_meta, SubclassCreationMeta
+        ):
+            raise AssertionError(
+                f"expected SubclassCreationMeta, got {type(subclass_meta)}"
+            )
 
         attrs, _ = t.__tensor_flatten__()
 
@@ -302,21 +327,65 @@ def unwrap_tensor_subclasses(
         for attr in attrs:
             inner_value = getattr(t, attr)
             n_desc: Any = SubclassGetAttr(desc, attr)
-            flatten_subclass(inner_value, n_desc, out=out)
+            inner_meta = None
+            if subclass_meta is not None:
+                if attr not in subclass_meta.attrs:
+                    raise AssertionError(
+                        f"attr {attr!r} not found in subclass metadata"
+                    )
+                inner_meta = subclass_meta.attrs[attr]
+            flatten_subclass(inner_value, n_desc, inner_meta, out=out)
 
         if append_symints:
-            sizes = enumerate_filter_symints(t.size())
-            strides = enumerate_filter_symints(t.stride())
-            out[0].extend(s for _, s in sizes)
-            out[0].extend(s for _, s in strides)
-            out[1].extend(SubclassSize(desc, i) for i, _ in sizes)
-            out[1].extend(SubclassStride(desc, i) for i, _ in strides)
+            if subclass_meta is None:
+                sizes = enumerate_filter_symints(t.size())
+                strides = enumerate_filter_symints(t.stride())
+                out[0].extend(s for _, s in sizes)
+                out[0].extend(s for _, s in strides)
+                out[1].extend(SubclassSize(desc, i) for i, _ in sizes)
+                out[1].extend(SubclassStride(desc, i) for i, _ in strides)
+            else:
+
+                def append_symints_from_meta(
+                    values: Sequence[IntLikeType],
+                    meta_values: Iterable[None | int | SymInt],
+                    make_desc: Callable[[AOTInput | AOTOutput, int], AOTDescriptor],
+                    label: str,
+                ) -> None:
+                    symint_placeholders = compute_symint_placeholders(
+                        meta_values,
+                        symints_are_placeholders=True,
+                    )
+                    if len(values) != len(symint_placeholders):
+                        raise AssertionError(
+                            f"{label} length mismatch: "
+                            f"{len(values)} != {len(symint_placeholders)}"
+                        )
+                    for i, (s, is_symint) in enumerate(
+                        zip(values, symint_placeholders)
+                    ):
+                        if is_symint:
+                            out[0].append(s)
+                            out[1].append(make_desc(desc, i))
+
+                append_symints_from_meta(
+                    t.size(), subclass_meta.outer_size, SubclassSize, "size"
+                )
+                append_symints_from_meta(
+                    t.stride(), subclass_meta.outer_stride, SubclassStride, "stride"
+                )
 
     xs_inner: list[FxValue] = []
     descs_inner: list[AOTDescriptor] = []
 
-    for x, desc in zip(wrapped_args, wrapped_args_descs):
-        flatten_subclass(x, desc, out=(xs_inner, descs_inner))
+    if subclass_metas is not None and len(wrapped_args) != len(subclass_metas):
+        raise AssertionError(
+            f"subclass_metas length ({len(subclass_metas)}) != wrapped_args length ({len(wrapped_args)})"
+        )
+
+    for idx, (x, desc) in enumerate(zip(wrapped_args, wrapped_args_descs)):
+        subclass_meta = None if subclass_metas is None else subclass_metas[idx]
+        flatten_subclass(x, desc, subclass_meta, out=(xs_inner, descs_inner))
 
     return xs_inner, descs_inner
 


### PR DESCRIPTION
## Agent Report
### Summary
`torch.compile` failed for a DTensor-returning module because AOTAutograd's
metadata pass and joint graph capture disagreed on the flattened output arity
for traceable wrapper subclass outputs. The generated two-rank repro failed
before the fix with:

```text
AssertionError: Node view_3 was invalid, but is output
```

After the fix, the repro compiles and runs successfully.

### Fix
`unwrap_tensor_subclasses()` now accepts optional subclass metadata. When
metadata is provided, compile-time unwrapping uses it as the source of truth for
which outer size and stride slots must be emitted, while taking the actual
values from the current wrapper instance.

`aot_dispatch_subclass()` passes forward-output metadata while unwrapping
subclass outputs during graph capture, and input metadata while unwrapping
subclass inputs. Metadata length/type mismatches now assert immediately instead
of silently falling back to runtime symbolic-size detection.

The pre-`make_runtime_safe()` handling of real `SymInt` metadata is scoped
behind an explicit `symints_are_placeholders=True` flag, so existing runtime
callers keep the prior `None`-placeholder behavior.

### Repro
Run command:

```bash
CUDA_VISIBLE_DEVICES=0,1 TORCHINDUCTOR_COMPILE_THREADS=1 \
 /home/avenkataraman/.ptq_workspace/jobs/20260526-pytorch-185296/.venv/bin/python \
 -m torch.distributed.run --standalone --nproc_per_node=2 \
 /home/avenkataraman/.ptq_workspace/jobs/20260526-pytorch-185296/repro_185296_generated.py
```
Run:

```bash
python repro_185296_generated.py
```

<details>
<summary>Repro Script</summary>

```python
#!/usr/bin/env python3

import os
from functools import partial

import torch
import torch.distributed as dist
import torch.nn as nn
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed.tensor import DTensor, Partial, Replicate, distribute_module
from torch.distributed.tensor.parallel import (
 ParallelStyle,
 SequenceParallel,
 parallelize_module,
)


TP_DEGREE = 2
BATCH_SIZE = 1
LOCAL_SEQ_LEN = 1
HIDDEN_SIZE = 8


class ReplicateParallel(ParallelStyle):
 @staticmethod
 def _prepare_input_fn(placement, mod, inputs, device_mesh):
 x = inputs[0]
 if not isinstance(x, DTensor):
 x = DTensor.from_local(x, device_mesh, (placement,), run_check=False)
 return (x, *inputs[1:])

 @staticmethod
 def _prepare_output_fn(placement, mod, outputs, device_mesh):
 def replicate(x):
 if isinstance(x, DTensor) and x.placements != (placement,):
 x = x.redistribute(placements=(placement,), async_op=True)
 return x

 if isinstance(outputs, tuple):
 return tuple(replicate(x) for x in outputs)
 return replicate(outputs)

 def _apply(self, module, device_mesh):
 return distribute_module(
 module,
 device_mesh,
 None,
 partial(self._prepare_input_fn, Replicate()),
 partial(self._prepare_output_fn, Replicate()),
 )


class IdentityFront(nn.Module):
 def forward(self, x):
 return x


class Router(nn.Module):
 def forward(self, x):
 x = x.reshape(-1, HIDDEN_SIZE)
 y = x * 2
 return y, y + 1


def main():
 local_rank = int(os.environ["LOCAL_RANK"])
 rank = int(os.environ["RANK"])

 torch.cuda.set_device(local_rank)
 dist.init_process_group("nccl")

 mesh = init_device_mesh("cuda", (TP_DEGREE,), mesh_dim_names=("tp",))

 front = IdentityFront().cuda()
 router = Router().cuda()

 parallelize_module(front, mesh, SequenceParallel())
 parallelize_module(router, mesh, ReplicateParallel())

 front = torch.compile(front, backend="inductor", fullgraph=True)
 router = torch.compile(router, backend="inductor", fullgraph=True)

 x = torch.randn(
 BATCH_SIZE,
 LOCAL_SEQ_LEN,
 HIDDEN_SIZE,
 device="cuda",
 requires_grad=True,
 )

 x = front(x)
 assert isinstance(x, DTensor)

 x = x.redistribute(placements=(Replicate(),), async_op=False)
 x = x.to_local(grad_placements=(Partial(),))

 y0, y1 = router(x)
 out = y0 + y1

 dist.barrier()

 if rank == 0:
 print(f"unexpected_success out_norm={out.norm().item():.6f}", flush=True)

 dist.destroy_process_group()


if __name__ == "__main__":
 main()
```

</details>

### Testing
Passed:

```bash
CUDA_VISIBLE_DEVICES=0,1 TORCHINDUCTOR_COMPILE_THREADS=1 \
 /home/avenkataraman/.ptq_workspace/jobs/20260526-pytorch-185296/.venv/bin/python \
 -m torch.distributed.run --standalone --nproc_per_node=2 \
 /home/avenkataraman/.ptq_workspace/jobs/20260526-pytorch-185296/repro_185296_generated.py

/home/avenkataraman/.ptq_workspace/jobs/20260526-pytorch-185296/.venv/bin/python \
 test/functorch/test_aotdispatch.py \
 -k test_unwrap_subclass_outputs_uses_symints_from_meta

CUDA_VISIBLE_DEVICES=0,1 TORCHINDUCTOR_COMPILE_THREADS=1 \
 /home/avenkataraman/.ptq_workspace/jobs/20260526-pytorch-185296/.venv/bin/python \
 test/distributed/tensor/test_dtensor_compile.py \
 TestDTensorSubclassOutputCompile.test_dtensor_output_symint_arity_matches_metadata

/home/avenkataraman/.ptq_workspace/jobs/20260526-pytorch-185296/.venv/bin/python \
 test/dynamo/test_subclasses.py \
 SubclassTests.test_tensor_subclass_TwoTensor_simple \
 SubclassTests.test_tensor_subclass_TwoTensor_mark_dynamic_shapes

git diff --check

uvx --python 3.10 lintrunner@0.12.7 \
 --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a
```

Lint:

```bash
spin fixlint
```

`spin fixlint` failed in the all-files lintrunner phase with:

```text
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.
error: No such file or directory (os error 2)
Lint failed!
```

The later patch-applying lint phase reported `ok No lint issues` and
`Successfully applied all patches`. The narrower lintrunner command above
passed.

## Files Changed
- `torch/_functorch/_aot_autograd/subclass_utils.py`
- `torch/_functorch/_aot_autograd/graph_capture_wrappers.py`
- `test/functorch/test_aotdispatch.py`
- `test/distributed/tensor/test_dtensor_compile.py`


Fixes #185296

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*