### PR TITLE
Add sparse COO dispatch for linalg.vector_norm

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -75,6 +75,7 @@
 #include <ATen/ops/imag.h>
 #include <ATen/ops/isnan_native.h>
 #include <ATen/ops/linalg_vector_norm.h>
+#include <ATen/ops/linalg_vector_norm_native.h>
 #include <ATen/ops/logcumsumexp.h>
 #include <ATen/ops/logcumsumexp_native.h>
 #include <ATen/ops/logical_xor.h>
@@ -1643,6 +1644,16 @@ Tensor sparse_dtype_norm(
     bool keepdim,
     ScalarType dtype) {
   return at::native_norm(self, p, dim, keepdim, dtype);
+}
+
+Tensor linalg_vector_norm_sparse(
+    const Tensor& self,
+    const Scalar& ord,
+    OptionalIntArrayRef opt_dim,
+    bool keepdim,
+    std::optional<ScalarType> opt_dtype) {
+  return at::native_norm(
+      self, ord, opt_dim.value_or(IntArrayRef{}), keepdim, opt_dtype);
 }
 
 Tensor norm(const Tensor& self, const std::optional<Scalar>& p, ScalarType dtype) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14550,6 +14550,8 @@
   python_module: linalg
   variants: function
   structured_delegate: linalg_vector_norm.out
+  dispatch:
+    SparseCPU, SparseCUDA, SparseMPS: linalg_vector_norm_sparse
   tags: reduction
 
 - func: linalg_vector_norm.out(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -2031,7 +2031,10 @@ class TestSparse(TestSparseBase):
         def test_shape(sparse_dims, nnz, with_size):
             x, _, _ = self._gen_sparse(sparse_dims, nnz, with_size, dtype, device, coalesced)
             y = x.coalesce()
-            self.assertEqual(x.norm(), y._values().norm())
+            self.assertEqual(
+                torch.linalg.vector_norm(x),
+                torch.linalg.vector_norm(y._values()),
+            )
 
         test_shape(3, 10, 100)
         test_shape(4, 10, [100, 100, 100, 5, 5, 5, 0])
@@ -2043,15 +2046,13 @@ class TestSparse(TestSparseBase):
              RuntimeError, r'norm_sparse currently does not support keepdim=True'),
             ({'dim': 0},
              RuntimeError, r'norm_sparse currently only supports full reductions'),
-            ({'dtype': torch.double, 'p': 'fro'},
-             ValueError, r'dtype argument is not supported in frobenius norm'),
-            ({'dtype': torch.double, 'p': 0},
-             RuntimeError, r"norm_sparse currently does not support 'dtype' argument")
+            ({'dtype': torch.double, 'ord': 0},
+             RuntimeError, r"norm_sparse currently does not support 'dtype' argument"),
         ]
         x = self._gen_sparse(3, 10, 100, dtype, device, coalesced)[0]
         for kwargs, err, msg in kwarg_error_pairs:
             with self.assertRaisesRegex(err, msg):
-                x.norm(**kwargs)
+                torch.linalg.vector_norm(x, **kwargs)
 
     @coalescedonoff
     @dtypes(torch.double)


### PR DESCRIPTION
`torch.linalg.vector_norm` previously lacked SparseCPU/SparseCUDA/SparseMPS dispatch, so substituting it for the deprecated `torch.norm` raised `NotImplementedError` on sparse COO tensors. Adds a thin `linalg_vector_norm_sparse` wrapper that delegates to the existing `norm_sparse` kernel via `aten::native_norm`.
 

