### PR TITLE
Fix Inductor MKL-DNN to_dense handling

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -406,6 +406,103 @@ class CPUReproTests(TestCase):
 
     @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
     @patch("torch.cuda.is_available", lambda: False)
+    def test_mkldnn_input_to_dense(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x.to_dense() + 1
+
+        mod = Model().eval()
+        x = torch.randn(4, 4).to_mkldnn()
+        expected = mod(x)
+
+        actual = torch.compile(mod, backend="inductor", fullgraph=True)(x)
+
+        self.assertFalse(actual.is_mkldnn)
+        torch.testing.assert_close(actual, expected)
+
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
+    @patch("torch.cuda.is_available", lambda: False)
+    def test_mkldnn_input_to_dense_with_requires_grad(self):
+        def fn(x):
+            return (x.to_dense() * 2).sum()
+
+        x = torch.randn(4, 4, requires_grad=True).to_mkldnn()
+        expected = fn(x)
+
+        actual = torch.compile(fn, backend="inductor", fullgraph=True)(x)
+
+        torch.testing.assert_close(actual, expected)
+
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
+    @patch("torch.cuda.is_available", lambda: False)
+    def test_mkldnn_input_detach_to_dense(self):
+        def fn(x):
+            return x.detach().to_dense() + 1
+
+        x = torch.randn(4, 4).to_mkldnn()
+        expected = fn(x)
+
+        actual = torch.compile(fn, backend="inductor", fullgraph=True)(x)
+
+        self.assertFalse(actual.is_mkldnn)
+        torch.testing.assert_close(actual, expected)
+
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
+    @patch("torch.cuda.is_available", lambda: False)
+    def test_mkldnn_input_aten_to_dense(self):
+        dtype = (
+            torch.bfloat16
+            if torch.ops.mkldnn._is_mkldnn_bf16_supported()
+            else torch.float32
+        )
+
+        def fn(x):
+            return torch.ops.aten.to_dense.default(x, dtype=dtype) + 1
+
+        x = torch.randn(4, 4).to_mkldnn()
+        expected = fn(x)
+
+        actual = torch.compile(fn, backend="inductor", fullgraph=True)(x)
+
+        self.assertFalse(actual.is_mkldnn)
+        self.assertEqual(actual.dtype, dtype)
+        if dtype is not torch.float32:
+            self.assertNotEqual(actual.dtype, x.dtype)
+        torch.testing.assert_close(actual, expected)
+
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
+    @patch("torch.cuda.is_available", lambda: False)
+    def test_mkldnn_input_repeated_to_dense(self):
+        def fn(x):
+            y = torch.ops.aten.to_dense.default(x, dtype=torch.float32)
+            z = torch.ops.aten.to_dense.default(y, dtype=torch.float32)
+            return z + 1
+
+        x = torch.randn(4, 4).to_mkldnn()
+        expected = fn(x)
+
+        actual = torch.compile(fn, backend="inductor", fullgraph=True)(x)
+
+        self.assertFalse(actual.is_mkldnn)
+        torch.testing.assert_close(actual, expected)
+
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
+    @patch("torch.cuda.is_available", lambda: False)
+    def test_mkldnn_input_aten_to_dense_without_pre_grad_passes(self):
+        def fn(x):
+            return torch.ops.aten.to_dense.default(x, dtype=torch.float32) + 1
+
+        x = torch.randn(4, 4).to_mkldnn()
+        expected = fn(x)
+
+        with config.patch(use_pre_grad_passes=False):
+            actual = torch.compile(fn, backend="inductor", fullgraph=True)(x)
+
+        self.assertFalse(actual.is_mkldnn)
+        torch.testing.assert_close(actual, expected)
+
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "MKLDNN is not enabled")
+    @patch("torch.cuda.is_available", lambda: False)
     def test_unsupported_conv_transpose(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -117,7 +117,7 @@ from .decomposition import select_decomp_table
 from .exc import InductorError
 from .fx_passes.joint_graph import joint_graph_passes
 from .fx_passes.post_grad import post_grad_passes, view_to_reshape
-from .fx_passes.pre_grad import pre_grad_passes
+from .fx_passes.pre_grad import canonicalize_mkldnn_to_dense, pre_grad_passes
 from .graph import GraphLowering
 from .ir import get_device_type, IRNode
 from .triton_bundler import TritonBundler
@@ -511,6 +511,7 @@ def _recursive_pre_grad_passes(
         log_pt2_compile_event=True,
         dynamo_compile_column_us="pre_grad_pass_time_us",
     ):
+        canonicalize_mkldnn_to_dense(gm, example_inputs)
         if not config.use_pre_grad_passes:
             return gm
 

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -20,6 +20,7 @@ from torch.fx.passes.graph_transform_observer import (
 from torch.fx.passes.shape_prop import ShapeProp
 from torch.nn import functional as F
 from torch.nn.utils.fusion import fuse_conv_bn_eval, fuse_conv_bn_weights
+from torch.utils._ordered_set import OrderedSet
 
 from .. import config
 from ..custom_graph_pass import get_custom_graph_passes
@@ -124,6 +125,54 @@ def fuse_chunk_reshape_concat_pass(graph):
 
 def remove_noop_pass(graph):
     return None
+
+
+def _is_mkldnn_value(value: object) -> bool:
+    return bool(
+        getattr(value, "_fake_is_mkldnn", False)
+        or (isinstance(value, torch.Tensor) and value.is_mkldnn)
+    )
+
+
+def canonicalize_mkldnn_to_dense(gm, example_inputs):
+    placeholders = [node for node in gm.graph.nodes if node.op == "placeholder"]
+    mkldnn_nodes = OrderedSet(
+        [
+            node
+            for node, value in zip(placeholders, example_inputs)
+            if _is_mkldnn_value(value)
+        ]
+    )
+
+    def is_mkldnn_node(node):
+        if not isinstance(node, torch.fx.Node):
+            return False
+        if node in mkldnn_nodes:
+            return True
+        return _is_mkldnn_value(node.meta.get("val")) or _is_mkldnn_value(
+            node.meta.get("example_value")
+        )
+
+    changed = False
+    for node in gm.graph.nodes:
+        if (
+            node.op == "call_function"
+            and node.target is torch.ops.aten.to_dense.default
+            and node.args
+            and is_mkldnn_node(node.args[0])
+        ):
+            node.target = torch.ops.aten._to_dense.default
+            node.meta.pop("val", None)
+            node.meta.pop("example_value", None)
+            changed = True
+        elif _is_mkldnn_value(node.meta.get("val")) or _is_mkldnn_value(
+            node.meta.get("example_value")
+        ):
+            mkldnn_nodes.add(node)
+
+    if changed:
+        gm.graph.lint()
+        gm.recompile()
 
 
 def stack_to_unsqueeze_pass(graph):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3570,6 +3570,8 @@ make_fallback(aten._efficientzerotensor)
 make_fallback(aten._sparse_coo_tensor_with_dims_and_tensors)
 make_fallback(aten.to_sparse)
 make_fallback(aten._to_sparse)
+make_fallback(aten.to_dense)
+make_fallback(aten._to_dense)
 
 # Needs dimname support
 make_fallback(aten.zeros.names)

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -205,6 +205,38 @@ def dispatch_to_op_implementations_dict(
     return op_implementations_dict[func](fake_mode, func, *args, **kwargs)
 
 
+def _is_sparse_any(x: FakeTensor) -> bool:
+    return x.is_sparse or x.layout in {
+        torch.sparse_csr,
+        torch.sparse_csc,
+        torch.sparse_bsr,
+        torch.sparse_bsc,
+    }
+
+
+@register_op_impl([aten.to_dense.default, aten._to_dense.default])
+def dense_from_mkldnn(
+    fake_mode: FakeTensorMode,
+    func: OpOverload,
+    self: FakeTensor,
+    dtype: torch.dtype | None = None,
+    masked_grad: bool | None = None,
+) -> FakeTensor:
+    if not getattr(self, "_fake_is_mkldnn", False):
+        if func is not aten._to_dense.default or _is_sparse_any(self):
+            return NotImplemented
+        # AOT can canonicalize MKL-DNN densify to aten._to_dense, then later
+        # propagate that graph with a plain strided fake input.
+        # The runtime fallback still enforces the real input layout.
+
+    out_dtype = self.dtype if dtype is None else dtype
+    shape = tuple(self.shape)
+    strides = make_contiguous_strides_for(shape)
+    with in_kernel_invocation_manager(fake_mode):
+        out = torch.empty_strided(shape, strides, dtype=out_dtype, device="meta")
+    return FakeTensor(fake_mode, out, self.fake_device)
+
+
 @register_op_impl(_is_tensor_constructor)
 @register_op_impl([*_like_tensor_constructors])
 def constructors(
@@ -1878,9 +1910,11 @@ def fast_detach(
 ) -> FakeTensor:
     with no_python_dispatcher(), in_kernel_invocation_manager(fake_mode):
         out = torch.ops.aten.detach.default(x)
-    if include_real:
-        return FakeTensor(fake_mode, out, x.device, real_tensor=x.real_tensor)
-    return FakeTensor(fake_mode, out, x.device)
+    real_tensor = x.real_tensor if include_real else None
+    fake_out = FakeTensor(fake_mode, out, x.device, real_tensor=real_tensor)
+    if getattr(x, "_fake_is_mkldnn", False):
+        fake_out._fake_is_mkldnn = True
+    return fake_out
 
 
 @functools.cache

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -714,6 +714,7 @@ class FakeTensor(Tensor):
     fake_mode: FakeTensorMode
     constant: Tensor | None
     real_tensor: Tensor | None
+    _fake_is_mkldnn: bool = False
 
     # TODO: Generalize this as needed, e.g., into a trie of memos, if
     # you do something like x[0].item()  (x[0] is fresh each time, so
@@ -889,6 +890,13 @@ class FakeTensor(Tensor):
     @staticmethod
     def from_tensor(t: Tensor, fake_mode: FakeTensorMode) -> FakeTensor:
         return fake_mode.from_tensor(t)
+
+    def to_dense(
+        self, dtype: torch.dtype | None = None, *, masked_grad: bool | None = None
+    ) -> Tensor:
+        if getattr(self, "_fake_is_mkldnn", False):
+            return torch.ops.aten._to_dense.default(self, dtype, masked_grad)
+        return torch.Tensor.to_dense(self, dtype=dtype, masked_grad=masked_grad)
 
     @classmethod
     @count
@@ -2812,6 +2820,21 @@ class FakeTensorMode(TorchDispatchMode):
             if fast_impl is not None:
                 return maybe_propagate_real_tensors(fast_impl(self, *args, **kwargs))
 
+        if (
+            func is aten.to_dense.default
+            and args
+            and isinstance(args[0], FakeTensor)
+            and getattr(args[0], "_fake_is_mkldnn", False)
+        ):
+            # MKL-DNN fakes are backed by strided meta tensors, so redirect
+            # before aten.to_dense decomposes to identity.
+            dtype = kwargs.get("dtype", args[1] if len(args) > 1 else None)
+            masked_grad = kwargs.get("masked_grad", args[2] if len(args) > 2 else None)
+            with self:
+                return maybe_propagate_real_tensors(
+                    aten._to_dense.default(args[0], dtype, masked_grad)
+                )
+
         # If there's a Python meta, prefer that over the decomposition
         from torch._decomp import meta_table
 
@@ -3056,6 +3079,13 @@ class FakeTensorMode(TorchDispatchMode):
         device: torch.device,
     ) -> PyTree:
         converter = self.fake_tensor_converter
+        propagate_fake_mkldnn = func in (
+            aten.alias.default,
+            aten.detach.default,
+        ) and any(
+            isinstance(arg, FakeTensor) and getattr(arg, "_fake_is_mkldnn", False)
+            for arg in flat_args
+        )
 
         # Lazily initialized, in case there are no tensor returns
         common_device = None
@@ -3080,17 +3110,22 @@ class FakeTensorMode(TorchDispatchMode):
                     e.device == common_device,
                     lambda: f"FakeTensor is wrapped to wrong device, found {e.device}, expected {common_device}",
                 )
+                if propagate_fake_mkldnn:
+                    e._fake_is_mkldnn = True
                 return cast(T, e)
             elif converter is not None:
                 if has_scalar_only_inputs:
                     # Under FakeTensorMode, op accepts scalar only inputs, such as aten.add/sub/mul/div,
                     # returns a real scalar tensor on CPU. See TensorMeta() in _prims/__init__.py for details.
                     # We thus directly convert real tensor to fake tensor.
-                    return converter.from_real_tensor(self, e)
+                    out = converter.from_real_tensor(self, e)
                 else:
-                    return converter.from_meta_and_device(
+                    out = converter.from_meta_and_device(
                         self, e, device or common_device
                     )
+                if propagate_fake_mkldnn:
+                    out._fake_is_mkldnn = True
+                return out
             else:
                 # pyrefly: ignore [bad-return]
                 return e

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -382,7 +382,9 @@ class FunctionalTensor(torch.Tensor):
         *,
         masked_grad: builtins.bool | None = None,
     ) -> torch.Tensor:
-        return self.elem.to_dense()
+        if getattr(torch._from_functional_tensor(self.elem), "_fake_is_mkldnn", False):
+            return torch.ops.aten._to_dense.default(self, dtype, masked_grad)
+        return self.elem.to_dense(dtype=dtype, masked_grad=masked_grad)
 
     @property
     # pyrefly: ignore[bad-override]

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -286,11 +286,12 @@ class MetaTensorDescriber:
         is_leaf = safe_is_leaf(t)
         is_view = t._is_view()
         is_sparse = t.is_sparse
+        is_fake_mkldnn = bool(getattr(t, "_fake_is_mkldnn", False))
         layout = t.layout
         is_nested = t.is_nested
         is_traceable_wrapper_subclass_v = is_traceable_wrapper_subclass(t)
         is_functorch_wrapped = is_functorch_wrapped_tensor(t)
-        is_mkldnn = t.is_mkldnn
+        is_mkldnn = t.is_mkldnn or is_fake_mkldnn
         is_batchedtensor_v = is_batchedtensor(t)
         is_legacy_batchedtensor_v = is_legacy_batchedtensor(t)
         is_gradtrackingtensor_v = is_gradtrackingtensor(t)
@@ -1599,20 +1600,20 @@ class MetaConverter(Generic[_TensorT]):
                         explanation="This is not supported.",
                         hints=[],
                     )
-                elif t.is_mkldnn:
+                elif t.is_mkldnn or getattr(t, "_fake_is_mkldnn", False):
                     is_leaf = t.is_leaf
                     (
                         sizes,
                         strides,
                         _storage_offset,
                     ) = sym_sizes_strides_storage_offset(t, source)
-                    # TODO: This doesn't seem right, where's the MKLDNN'ness
-                    # lol
                     r = callback(
                         lambda: torch.empty_strided(
                             sizes, strides, dtype=t.dtype, device="meta"
                         )
                     )
+                    if _is_fake_tensor(r):
+                        r._fake_is_mkldnn = True
                     if self.copy_data:
                         with torch.no_grad(), no_dispatch():
                             if t.size is None:
@@ -1642,6 +1643,8 @@ class MetaConverter(Generic[_TensorT]):
                         r.requires_grad = True
                     if t.requires_grad and not is_leaf:
                         r = self._backward_error(r)
+                        if _is_fake_tensor(r):
+                            r._fake_is_mkldnn = True
                 elif t.is_functorch_wrapped:
                     if t.is_view:
                         from torch._dynamo.exc import unimplemented


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185311

MKL-DNN tensors cannot be represented as MKL-DNN layout meta tensors, so fakification used an ordinary strided fake tensor with MKL-DNN-like metadata. AOT/functionalization could then treat `to_dense()` as an identity and drop the layout conversion. Inductor would compile kernels that read the opaque MKL-DNN runtime tensor directly, which fails with `Cannot access data pointer of Tensor that doesn't have storage`.

Preserve an internal fake MKL-DNN marker during fakification and through aliasing paths such as detach, and use it to keep MKL-DNN `to_dense` as a real `_to_dense` operation. Inductor also canonicalizes pre-grad `aten.to_dense.default` nodes that consume known MKL-DNN graph inputs to `aten._to_dense.default`, clears stale fake value metadata on the rewritten node, and falls back to eager for the real densify before generated kernels consume the dense tensor.

I considered relying only on FakeTensor method shims, but direct `aten.to_dense.default` can be decomposed before the shim path sees it. I also avoided rewriting all `to_dense` calls: the canonicalization is limited to values still proven to be MKL-DNN so repeated `to_dense` on the newly dense value remains valid eager behavior.

Fixes #160873
Generated by my agent

Test Plan:
- `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` direct repro for `x.to_dense() + 1` on MKL-DNN input: passed.
- `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` direct `aten.to_dense.default(x, dtype=torch.float32) + 1` repro: passed.
- `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` non-leaf `requires_grad` repro `(x.to_dense() * 2).sum()`: passed.
- `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` `x.detach().to_dense() + 1` repro: passed.
- `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` repeated `to_dense` repro: passed.
- `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` direct `aten.to_dense.default` with `torch._inductor.config.patch(use_pre_grad_passes=False)`: passed.
- `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` local unittest wrapper for `CPUReproTests.test_mkldnn_input_to_dense`, `test_mkldnn_input_to_dense_with_requires_grad`, `test_mkldnn_input_detach_to_dense`, `test_mkldnn_input_aten_to_dense`, `test_mkldnn_input_repeated_to_dense`, and `test_mkldnn_input_aten_to_dense_without_pre_grad_passes`: passed. The wrapper stubs an incompatible local `torchvision` import.
- `python -m py_compile torch/_inductor/compile_fx.py torch/_inductor/fx_passes/pre_grad.py torch/_subclasses/meta_utils.py torch/_subclasses/fake_tensor.py torch/_subclasses/fake_impls.py torch/_subclasses/functional_tensor.py torch/_inductor/lowering.py test/inductor/test_cpu_repro.py`: passed.
- `python test/inductor/test_cpu_repro.py CPUReproTests.test_mkldnn_input_to_dense`: blocked locally by incompatible installed `torchvision` raising `RuntimeError: operator torchvision::nms does not exist` during collection.
- `python -m pytest test/inductor/test_cpu_repro.py -k test_mkldnn_input_to_dense -q`: blocked locally by the same incompatible installed `torchvision` import.
- `python test/run_test.py -i inductor/test_cpu_repro -- TestCPURepro.test_mkldnn_input_to_dense`: blocked locally because `pytest-rerunfailures` is missing.
- `lintrunner -a`: passed with `ok No lint issues.` It printed the existing warning that `lintrunner init` may be needed.

Benchmark Results:
Compared compile time for a dense CPU graph with the new canonicalizer active versus monkeypatched to a no-op, using `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` and alternating post-warm samples in the same process.

No-op canonicalizer raw seconds: `[0.4936808860002202, 0.4866723800005275, 0.5101479299992207, 0.4982140799984336, 0.5020959150024282, 0.5014094739999564, 0.491620968998177, 0.49936055400030455]`
No-op canonicalizer mean/median: `0.497900s / 0.498787s`

Active canonicalizer raw seconds: `[0.4978512050001882, 0.4793518149999727, 0.5172312379982031, 0.5169351330005156, 0.5274919729999965, 0.49402191799890716, 0.4951389569978346, 0.5081143530005647]`
Active canonicalizer mean/median: `0.504517s / 0.502983s`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos