### PR TITLE
Fix Inductor FX graph cache key for implicit CPU threads

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -39,6 +39,7 @@ from torch._inductor.codecache import (
     BypassFxGraphCache,
     CacheabilityValidator,
     CacheBase,
+    compiled_fx_graph_hash,
     CUDACodeCache,
     FxGraphCache,
     FxGraphCachePickler,
@@ -109,6 +110,17 @@ if HAS_TRITON:
     import triton  # @manual
 
     from torch.testing._internal.triton_utils import add_kernel, sub_kernel
+
+
+@contextmanager
+def set_num_threads(num_threads):
+    orig_num_threads = torch.get_num_threads()
+    torch.set_num_threads(num_threads)
+    try:
+        yield
+    finally:
+        torch.set_num_threads(orig_num_threads)
+
 
 torch._dynamo.config.fake_tensor_cache_enabled = True
 torch._dynamo.config.fake_tensor_cache_crosscheck_enabled = True
@@ -2908,6 +2920,35 @@ class TestCustomPartitionerFn(CustomPartitionerFn):
 
 
 class TestFxGraphCacheHashing(TestCase):
+    def test_ambient_cpp_thread_count_affects_cache_key(self):
+        def fn(x):
+            return x + 1
+
+        gm = torch.fx.symbolic_trace(fn)
+        inp = torch.randn(8)
+
+        with config.patch({"cpp.threads": -1, "cpp.dynamic_threads": False}):
+            with set_num_threads(1):
+                key_1, debug_lines_1 = compiled_fx_graph_hash(gm, [inp], {}, [])
+            with set_num_threads(2):
+                key_2, debug_lines_2 = compiled_fx_graph_hash(gm, [inp], {}, [])
+
+        self.assertNotEqual(key_1, key_2)
+        self.assertTrue(
+            any("cpp_thread_count" in line and ": 1" in line for line in debug_lines_1)
+        )
+        self.assertTrue(
+            any("cpp_thread_count" in line and ": 2" in line for line in debug_lines_2)
+        )
+
+        with config.patch({"cpp.threads": 2, "cpp.dynamic_threads": False}):
+            with set_num_threads(1):
+                explicit_key_1, _ = compiled_fx_graph_hash(gm, [inp], {}, [])
+            with set_num_threads(2):
+                explicit_key_2, _ = compiled_fx_graph_hash(gm, [inp], {}, [])
+
+        self.assertEqual(explicit_key_1, explicit_key_2)
+
     @unittest.skipIf(not torch.backends.mkldnn.is_available(), "requires MKLDNN")
     def test_cacheability_validator_checks_mkldnn_constant(self):
         graph = torch.fx.Graph()

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -102,6 +102,7 @@ from torch._inductor.utils import (
     determine_aoti_mmap_flags,
     is_linux,
     is_windows,
+    parallel_num_threads,
     XPU_KERNEL_FORMAT,
 )
 from torch._library.fake_class_registry import FakeScriptObject
@@ -1334,6 +1335,10 @@ class FxGraphHashDetails:
         self.inductor_config = config.save_config_portable(
             ignore_private_configs=False, readonly_values=True
         )
+        if config.cpp.threads < 1 and not config.cpp.dynamic_threads:
+            # CPU C++ codegen specializes implicit thread count into OpenMP
+            # pragmas, but save_config_portable() only records cpp.threads=-1.
+            self.cpp_thread_count = parallel_num_threads()
         # Custom passes should provide an ID to hash when they run late (after cache lookup).
         if resolve_pre_grad_pass_timing() != "early":
             self.pre_grad_custom_pass = self._get_custom_pass_detail(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185312

CPU C++ codegen resolves the default config.cpp.threads=-1 through torch.get_num_threads() and can specialize that resolved value into OpenMP pragmas such as num_threads(N). The FX graph cache key only included the saved config value, so a graph generated with one ambient torch thread count could be loaded later after torch.set_num_threads() changed and still run stale generated code.

Include the resolved implicit CPU C++ thread count in FxGraphHashDetails when cpp.threads is implicit and dynamic thread mode is disabled. Explicit config.cpp.threads remains represented by the saved config, and dynamic thread mode intentionally stays independent of the ambient count.

A broader alternative would have been forcing dynamic OpenMP pragmas whenever cpp.threads is implicit, but that changes generated code and can regress single-threaded workloads. Keying the cache on the value codegen already specializes preserves existing codegen choices while preventing stale cache reuse.

Fixes #160812

Generated by my agent

Benchmark Results

compiled_fx_graph_hash microbenchmark, median microseconds per hash, 10 samples of 100 hashes each: before 3847.30 us, after 3819.20 us. Raw samples are recorded in state/160812/notes. The change did not add measurable overhead to hash computation.

Test Plan

python -m py_compile torch/_inductor/codecache.py test/inductor/test_codecache.py

python test/inductor/test_codecache.py -k test_ambient_cpp_thread_count_affects_cache_key

python test/inductor/test_codecache.py -k TestFxGraphCacheHashing

git diff --check

lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos