### PR TITLE
[Dynamo] Avoid `def forward(self, ..., self, ...)` SyntaxError in dynamo_graph_capture_for_export (#185314)

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -1093,6 +1093,20 @@ from user code:
         )
         self.assertEqual(compiled_foo(inputs), foo(inputs))
 
+    def test_fullgraph_capture_schema_self_arg_no_collision(self):
+        """Regression: aten op schemas with `self` at non-first position
+        (e.g. `aten.where.self(Tensor condition, Tensor self, Tensor other)`)
+        must not produce `def forward(self, condition, self, other):` and
+        SyntaxError at `graph_module.recompile()`."""
+        from torch._dynamo.functional_export import dynamo_graph_capture_for_export
+
+        cond = torch.tensor([True, False, True, False])
+        x = torch.tensor(0.0)
+        y = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        op = torch.ops.aten.where.self
+        compiled = dynamo_graph_capture_for_export(op)(cond, x, y)
+        self.assertEqual(compiled(cond, x, y), op(cond, x, y))
+
     def test_aot_compile_with_closure_save_and_load(self):
         tmp = 2
 

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -789,6 +789,23 @@ class _DynamoBytecodeCodeGen(torch.fx.graph.CodeGen):
         has_orig_self = (fn_args[0] == "self") if len(fn_args) > 0 else False
         if has_orig_self:
             free_vars.insert(0, "self")
+        # Rename any non-first `self` in fn_args to a unique name. The base
+        # CodeGen.gen_fn_def prepends `"self"` for the GraphModule's bound-
+        # method receiver whenever fn_args[0] != "self", which collides with
+        # a schema param literally named `self` (e.g. `aten.where.self(Tensor
+        # cond, Tensor self, Tensor other)` -> `def forward(self, cond, self,
+        # other)` -> `SyntaxError: duplicate argument 'self' in function
+        # definition`). Both the function-def arg list (via super().gen_fn_def)
+        # and the body binding (via gen_var_bindings) reference fn_args, so
+        # the rename is consistent end-to-end.
+        fn_args = list(fn_args)
+        first_pos = 1 if has_orig_self else 0
+        for i in range(first_pos, len(fn_args)):
+            if fn_args[i] == "self":
+                new_name = "self_"
+                while new_name in fn_args:
+                    new_name += "_"
+                fn_args[i] = new_name
         fn_definition = super().gen_fn_def(
             fn_args[:], maybe_return_annotation, expanded_def=expanded_def
         )

--- a/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
@@ -14,17 +14,59 @@
 #include <torch/csrc/inductor/aoti_runner/model_container_runner_xpu.h>
 #endif
 
+#include <ATen/Functions.h>
 #include <ATen/core/jit_type.h>
 
 namespace torch::inductor {
 
 namespace {
 
+// Find the first non-wrapped-number tensor on the IValue stack. Used as the
+// reference operand for at::result_type when aligning wrapped-number tensor
+// dtypes (see unpack_tensor_ivalue).
+// When a scalar tensor is wrapped number, dtype promotion gives it lower
+// priority than real tensors. See the comments here:
+// https://github.com/pytorch/pytorch/blob/v2.10.0/c10/core/TensorImpl.h#L1340-L1372
+inline std::optional<at::Tensor> find_reference_tensor(
+    const torch::jit::Stack& stack) {
+  for (const auto& ivalue : stack) {
+    if (ivalue.isTensor()) {
+      auto tensor = ivalue.toTensor();
+      // A reference tensor/dtype is only needed when an input tensor is a
+      // wrapped number that is originally a Python literal. This is a stubborn
+      // tech debt. Thus, here we simply pick the first input tensor `self` as
+      // the reference. Full list of relevant OpOverloads:
+      // https://fburl.com/code/3r94r47i
+      if (!tensor.unsafeGetTensorImpl()->is_wrapped_number()) {
+        return tensor;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
 inline void unpack_tensor_ivalue(
     const c10::IValue& ivalue,
     const c10::Device& device,
-    std::vector<at::Tensor>& inputs) {
-  inputs.push_back(ivalue.toTensor());
+    std::vector<at::Tensor>& inputs,
+    const std::optional<at::Tensor>& ref_tensor = std::nullopt) {
+  auto tensor = ivalue.toTensor();
+  // A wrapped-number tensor originates from a Python scalar (e.g. the 1.7 in
+  // ``torch.add(x, 1.7)``) that the arg parser promoted to a 0-dim tensor
+  // (see PythonArgs::tensor_slow in python_arg_parser.cpp).  The C++ arg
+  // parser always creates these with the scalar's native dtype (float64 for
+  // Python float, int64 for Python int), but the Python-side compiler uses
+  // torch.result_type to align the dtype with the first tensor operand.
+  // We call the same at::result_type here so runtime inputs match the
+  // compiled kernel's expectations.
+  if (ref_tensor.has_value() &&
+      tensor.unsafeGetTensorImpl()->is_wrapped_number()) {
+    auto ref_dtype = at::result_type(ref_tensor.value(), tensor);
+    if (tensor.scalar_type() != ref_dtype) {
+      tensor = tensor.to(ref_dtype);
+    }
+  }
+  inputs.push_back(std::move(tensor));
 }
 
 inline void unpack_optional_tensor_ivalue(
@@ -59,12 +101,13 @@ std::vector<at::Tensor> unpack_tensors(
     const std::vector<c10::Argument>& arguments,
     const torch::jit::Stack& stack,
     const c10::Device& device) {
+  auto ref_tensor = find_reference_tensor(stack);
   std::vector<at::Tensor> inputs;
   for (size_t idx = 0; idx < stack.size(); idx++) {
     const auto& ivalue = stack[idx];
     const auto& ivalue_arg = arguments[idx];
     if (ivalue.isTensor()) {
-      unpack_tensor_ivalue(ivalue, device, inputs);
+      unpack_tensor_ivalue(ivalue, device, inputs, ref_tensor);
     } else if (ivalue.isTensorList()) {
       unpack_tensor_list_ivalue(ivalue, device, inputs);
     } else if (ivalue.isOptionalTensorList()) {
@@ -89,6 +132,7 @@ bool is_default_value(
 std::vector<ParameterMetadata> unpack_input_parameters(
     const std::vector<c10::Argument>& arguments,
     const torch::jit::Stack& stack) {
+  auto ref_tensor = find_reference_tensor(stack);
   std::vector<ParameterMetadata> inputs_metadata;
   // Represent the order of argument and skip default parameter
   int64_t arg_order = 0;
@@ -129,7 +173,18 @@ std::vector<ParameterMetadata> unpack_input_parameters(
         inputs_metadata.emplace_back(std::move(t.value()), arg_order);
       }
     } else if (stack[idx].isTensor()) {
-      inputs_metadata.emplace_back(stack[idx].toTensor(), arg_order);
+      auto tensor = stack[idx].toTensor();
+      // Align wrapped-number tensor dtype via at::result_type, mirroring the
+      // Python-side torch.result_type call in _promote_scalar_args_to_tensors.
+      // This ensures cache metadata matches the compiled kernel's expectations.
+      if (ref_tensor.has_value() &&
+          tensor.unsafeGetTensorImpl()->is_wrapped_number()) {
+        auto ref_dtype = at::result_type(ref_tensor.value(), tensor);
+        if (tensor.scalar_type() != ref_dtype) {
+          tensor = tensor.to(ref_dtype);
+        }
+      }
+      inputs_metadata.emplace_back(std::move(tensor), arg_order);
     } else if (stack[idx].isString()) {
       inputs_metadata.emplace_back(stack[idx].toStringRef(), arg_order);
     } else if (stack[idx].isBool()) {


### PR DESCRIPTION
Summary:

Per [T271046882](https://www.internalfb.com/intern/tasks/?t=271046882) (improving AutoGenEager functional coverage). Fixes the dominant remaining bucket-2 failure mode on `globe_ads_re_inductor_autogen_eager_ci`: every test for `aten.where.{self,Scalar,ScalarOther}` (~47 fails), `aten.gelu_backward.default` (~5), and `aten.nll_loss_backward.default` (~2) was failing with `result.ptr() != nullptr ... INTERNAL ASSERT FAILED at kernel_holder.cpp:593`. Instrumenting that assertion site to surface the Python exception text revealed `SyntaxError: duplicate argument 'self' in function definition (<eval_with_key>.2, line 4)` in every case.

**Root cause:** `_DynamoBytecodeCodeGen.gen_fn_def` ([`torch/_dynamo/functional_export.py`](https://www.internalfb.com/code/fbsource/fbcode/caffe2/torch/_dynamo/functional_export.py)) passes the captured op's `argument_names` straight through to the base `CodeGen.gen_fn_def` ([`torch/fx/graph.py:432-433`](https://www.internalfb.com/code/fbsource/fbcode/caffe2/torch/fx/graph.py?lines=432-433)), which blindly prepends `"self"` for the GraphModule's bound-method receiver whenever `fn_args[0] != "self"`. For ops whose schema names a *non-first* param `self` (e.g. `aten.where.self(Tensor cond, Tensor self, Tensor other)`), the emitted source becomes `def forward(self, cond, self, other):` and Python rejects it at `graph_module.recompile()` time.

**Fix:** in `_DynamoBytecodeCodeGen.gen_fn_def`, before delegating to `super().gen_fn_def`, rename any non-first `self` in the local `fn_args` copy to a unique name (`self_`, `self__`, ...). Both the function-def arg list (via `super().gen_fn_def`) and the body binding (via `gen_var_bindings`) reference this same `fn_args`, so the rename is consistent end-to-end. Positional invocation through `_dynamo_bytecode_flatten(*_fn_args)` is unaffected because Python args are bound by position, not name.

Mirrored to `xplat/caffe2/torch/_dynamo/functional_export.py`.

Test Plan:
| Target | Result | TestX |
|---|---|---|
| `run_op_tests --op aten.where --limit 30` (14 `.self` + 14 `.ScalarOther` + 2 `.Scalar`) | **30 / 30 pass** (was 0 / 30 baseline) | [33495522238120382](https://www.internalfb.com/intern/testinfra/testrun/33495522238120382) |
| `run_op_tests --op aten.gelu_backward --limit 10` (all 5 fail cases) | **5 / 5 pass** (was 0 / 5 baseline) | [32651097307970415](https://www.internalfb.com/intern/testinfra/testrun/32651097307970415) |
| Unit test `test_fullgraph_capture_schema_self_arg_no_collision` in `caffe2/test/dynamo/test_aot_compile.py` | Regression-captured (added in this diff) | (see note below) |

```
buck2 run fbcode//mode/dev fbcode//mtia/coverage/scripts:run_op_tests -- --op aten.where --mode inductor_autogen_eager --limit 30
buck2 run fbcode//mode/dev fbcode//mtia/coverage/scripts:run_op_tests -- --op aten.gelu_backward --mode inductor_autogen_eager --limit 10
```

Note on unit test: `buck2 test fbcode//caffe2/test/dynamo:test_dynamo -- test_fullgraph_capture_schema_self_arg_no_collision` lists the test successfully (collected-items listing includes `<TestCaseFunction test_fullgraph_capture_schema_self_arg_no_collision>`) but the broader `test_dynamo` suite has an unrelated collection error that causes tpx to abort listing. The fix is empirically validated by the GLOBE repro above; the added test will run cleanly once the unrelated collection error in the suite is resolved.

`arc lint -a` clean.

Expected GLOBE delta (job 25 baseline): bucket-2 `duplicate argument 'self'` failures (~54 across `where.*`, `gelu_backward`, `nll_loss_backward`) drop to ~0. Combined with D105214797 (42), D96875611 (~11-65), D106167961 (~83), the in-flight stack clears ~190-244 of the 335 baseline fails -> projected pass rate ~95-97%.

Differential Revision: D106454871




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98