### PR TITLE
Type inductor pattern constants

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2503,6 +2503,37 @@ class TestPatternMatcher(TestCase):
         )
         compiled_fn(x, y)
 
+    def test_keyword_arg_matches_constant(self):
+        test_pass = PatternMatcherPass()
+        matched_alphas = []
+
+        @register_graph_pattern(
+            CallFunction(
+                aten.add.Tensor,
+                KeywordArg("x"),
+                KeywordArg("y"),
+                alpha=KeywordArg("alpha"),
+            ),
+            pass_dict=test_pass,
+        )
+        def add_with_alpha(match: Match, x, y, alpha):
+            matched_alphas.append(alpha)
+
+        def custom_pass(graph: torch.fx.Graph):
+            self.assertEqual(test_pass.apply(graph), 1)
+
+        def fn(x, y):
+            return torch.add(x, y, alpha=2)
+
+        x = torch.randn(4, 4, device=GPU_TYPE)
+        y = torch.randn(4, 4, device=GPU_TYPE)
+
+        compiled_fn = torch.compile(
+            fn, options={"post_grad_custom_post_pass": custom_pass}
+        )
+        self.assertEqual(compiled_fn(x, y), fn(x, y))
+        self.assertEqual(matched_alphas, [2])
+
     def test_replace_by_example_returns_inserted_nodes(self):
         test_pass = PatternMatcherPass()
         replacement_targets = []

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -455,8 +455,6 @@ class MatchContext:
 
     def match(self, pattern: PatternExpr, node: NodeOrConstant) -> MatchResult:
         """wrapper to check reused nodes in patterns"""
-        if not isinstance(node, torch.fx.Node):
-            return FailedMatch("pattern expects node")
         if pattern in self.pattern_to_node:
             if self.pattern_to_node[pattern] == node:
                 return Match(self, pattern)  # already checked this node

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -460,9 +460,11 @@ class MatchContext:
                 return Match(self, pattern)  # already checked this node
             else:
                 return FailedMatch("repeated pattern differs")
-        m = pattern._match(node, self)
+        m = pattern._match(typing.cast(Any, node), self)
         assert pattern not in self.pattern_to_node
-        self.pattern_to_node[pattern] = node if m else None
+        self.pattern_to_node[pattern] = typing.cast(
+            torch.fx.Node | None, node if m else None
+        )
         return m
 
     def filter_multi_user_patterns(self) -> dict[PatternExpr, torch.fx.Node]:

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -84,7 +84,7 @@ log = logging.getLogger(__name__)
 aten = torch.ops.aten
 prims = torch.ops.prims
 
-Constant: TypeAlias = int | float | bool | str | None
+Constant: TypeAlias = torch.fx.node.Argument
 NodeOrConstant = Constant | torch.fx.Node
 
 backend = os.environ.get("TORCHINDUCTOR_PATTERN_MATCH_BACKEND", "inductor")

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -52,7 +52,7 @@ from collections import defaultdict
 from collections.abc import Callable, Collection, Generator, Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any, NoReturn, Protocol, TypeVar
-from typing_extensions import Self, TypeIs
+from typing_extensions import Self, TypeAlias, TypeIs
 
 import torch
 import torch._guards
@@ -84,7 +84,7 @@ log = logging.getLogger(__name__)
 aten = torch.ops.aten
 prims = torch.ops.prims
 
-Constant = Any
+Constant: TypeAlias = int | float | bool | str | None
 NodeOrConstant = Constant | torch.fx.Node
 
 backend = os.environ.get("TORCHINDUCTOR_PATTERN_MATCH_BACKEND", "inductor")

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -51,8 +51,8 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Collection, Generator, Iterable, Mapping, Sequence
 from pathlib import Path
-from typing import Any, NoReturn, Protocol, TypeVar
-from typing_extensions import Self, TypeAlias, TypeIs
+from typing import Any, NoReturn, Protocol, TypeAlias, TypeVar
+from typing_extensions import Self, TypeIs
 
 import torch
 import torch._guards
@@ -455,6 +455,8 @@ class MatchContext:
 
     def match(self, pattern: PatternExpr, node: NodeOrConstant) -> MatchResult:
         """wrapper to check reused nodes in patterns"""
+        if not isinstance(node, torch.fx.Node):
+            return FailedMatch("pattern expects node")
         if pattern in self.pattern_to_node:
             if self.pattern_to_node[pattern] == node:
                 return Match(self, pattern)  # already checked this node


### PR DESCRIPTION
Root cause problem:

`torch/_inductor/pattern_matcher.py` used `Constant = Any`, so the public node-or-constant matcher type admitted arbitrary values and hid the actual FX argument contract. A narrower scalar-only alias was too small because FX node arguments can also contain dtype/device/layout/container and symbolic values. A follow-up runtime guard then incorrectly rejected constants before leaf patterns like `KeywordArg`, `Arg`, and `Ignored` could match them.

Proposed fix:

Use `torch.fx.node.Argument` for the `Constant` alias, import `TypeAlias` from `typing`, and keep `MatchContext.match` dispatching to leaf pattern `_match` methods for non-Node constants. Add a regression test covering `KeywordArg` matching a constant `alpha` kwarg.

Why this is the right long term fix:

This keeps the alias aligned with the values FX actually carries while preserving the existing matcher behavior: node-shaped patterns can still reject constants in their own `_match` implementations, but leaf capture patterns continue to accept any FX argument value they are designed to capture.

Testing:

- `python3 -m py_compile torch/_inductor/pattern_matcher.py test/inductor/test_pattern_matcher.py`
- `git diff --check`

Attempted but not run:

- `python3 test/inductor/test_pattern_matcher.py TestPatternMatcher.test_keyword_arg_matches_constant` because this container has no installed `torch` module.
- `python3 scripts/lintrunner.py -a torch/_inductor/pattern_matcher.py test/inductor/test_pattern_matcher.py` because the hook virtualenv is not initialized in this checkout.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

Drafted via Codex, published after manual review by @bobrenjc93
