### PR TITLE
Sort record names before hashing in writeSerializationId

### DIFF
--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -9,6 +9,7 @@
 #include <ostream>
 #include <sstream>
 #include <thread>
+#include <vector>
 
 #include <c10/core/Allocator.h>
 #include <c10/core/Backend.h>
@@ -908,8 +909,17 @@ void PyTorchStreamWriter::writeSerializationId() {
   // This is best effort to create a fixed-length, unique and deterministic id
   // for the serialized files without incurring additional computation overhead.
   if (files_written_.find(kSerializationIdRecordName) == files_written_.end()) {
+    // Iterate the record names in sorted order so the resulting hash doesn't
+    // depend on the iteration order of ``files_written_`` which is an
+    // ``unordered_set`` and so depends on the standard libary implementation
+    // / build configuration. Without sorting two machines writing the same
+    // set of records can otherwise produce different serialization ids for
+    // bit-identical model weights (see #184219).
+    std::vector<std::string> sorted_record_names(
+        files_written_.begin(), files_written_.end());
+    std::sort(sorted_record_names.begin(), sorted_record_names.end());
     uint64_t combined_record_name_hash = 0;
-    for (const std::string& record_name : files_written_) {
+    for (const std::string& record_name : sorted_record_names) {
       size_t record_name_hash = c10::hash<std::string>{}(record_name);
       combined_record_name_hash =
           c10::hash_combine(combined_record_name_hash, record_name_hash);

--- a/caffe2/serialize/inline_container_test.cc
+++ b/caffe2/serialize/inline_container_test.cc
@@ -402,6 +402,50 @@ TEST(PytorchStreamWriterAndReader, SkipDuplicateSerializationIdRecords) {
   remove(file_name);
 }
 
+TEST(PytorchStreamWriterAndReader, SerializationIdIsInsertionOrderIndependent) {
+  // Regression for #184219: two writers that write the same set of records
+  // in different orders should produce the same serialization_id. The id is
+  // computed from a hash of the record names which used to iterate
+  // ``files_written_`` (an ``unordered_set``) directly and could therfore
+  // differ across machines / std lib implementations.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-avoid-magic-numbers)
+  std::array<char, 32> data1;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-avoid-magic-numbers)
+  std::array<char, 32> data2;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-avoid-magic-numbers)
+  std::array<char, 32> data3;
+  for (auto i : c10::irange(data1.size())) {
+    data1[i] = static_cast<char>(i);
+    data2[i] = static_cast<char>(data1.size() - i);
+    data3[i] = static_cast<char>((i * 7) % 128);
+  }
+
+  std::ostringstream oss1;
+  PyTorchStreamWriter writer1([&](const void* b, size_t n) -> size_t {
+    oss1.write(static_cast<const char*>(b), n);
+    return oss1 ? n : 0;
+  });
+  writer1.writeRecord("alpha.bin", data1.data(), data1.size());
+  writer1.writeRecord("beta.bin", data2.data(), data2.size());
+  writer1.writeRecord("gamma.bin", data3.data(), data3.size());
+  writer1.writeEndOfFile();
+  auto id1 = writer1.serializationId();
+
+  std::ostringstream oss2;
+  PyTorchStreamWriter writer2([&](const void* b, size_t n) -> size_t {
+    oss2.write(static_cast<const char*>(b), n);
+    return oss2 ? n : 0;
+  });
+  // Same records, opposite insertion order.
+  writer2.writeRecord("gamma.bin", data3.data(), data3.size());
+  writer2.writeRecord("beta.bin", data2.data(), data2.size());
+  writer2.writeRecord("alpha.bin", data1.data(), data1.size());
+  writer2.writeEndOfFile();
+  auto id2 = writer2.serializationId();
+
+  EXPECT_EQ(id1, id2);
+}
+
 TEST(PytorchStreamWriterAndReader, LogAPIUsageMetadata) {
   std::map<std::string, std::map<std::string, std::string>> logs;
 


### PR DESCRIPTION
closes #184219

## Summary

`PyTorchStreamWriter::writeSerializationId` builds the `serialization_id` from a hash of the record names plus a CRC. The goal would be  for the value to be deterministic for the same set of files.

The hash combine was previously done while iterating over `files_written_` directly but `files_written_` is a `std::unordered_set<std::string>`. Since `hash_combine` is order-sensitive and `std::unordered_set` iteration order is implementation-defined two machines with different `libstdc++` / `libc++` versions can produce different `serialization_id` values for bit-identical model weights.

this was discussed in the issue and agreed to be worth fixing

## Fix

I followed the suggestion from the issue body:

1. Copy the record names into a vector.
2. Sort the vector.
3. Hash the names in sorted order.

This does not change the serialization format since it only makes the existing hash deterministic across insertion orders and platforms.

There is also no behavior change for any single machine that previously happened to iterate the `unordered_set` in sorted order.

## Local confirmation

I confirmed the order sensitivity locally with a small standalone snippet that mirrors the hash loop:

```text
buggy(insert_order_a) = 0x52284c220db0513f
buggy(insert_order_b) = 0xf4eb650822cb00d0  <- different

fixed(insert_order_a) = 0xa3597b62c25e3b8b
fixed(insert_order_b) = 0xa3597b62c25e3b8b  <- equal
````

This was on the same machine with the same compile only using a different insertion order. So the bug can also affect a single machine if records are written in different orders across runs.

## Test

Added a regression test:

`SerializationIdIsInsertionOrderIndependent` in `caffe2/serialize/inline_container_test.cc`

The test writes the same three records in opposite orders from two writers then asserts that the two `serializationId()` values match.

## AI disclosure

AI helped me double check my code matches pytorch standards + format this PR.