### PR TITLE
Improve scan HOP direct call error

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -213,6 +213,27 @@ class HigherOrderOpTests(torch._dynamo.test_case.TestCase):
         ):
             f(x)
 
+    def test_direct_scan_op_compile_error(self):
+        def fn(x):
+            def combine_fn(carry, element):
+                (total,) = carry
+                return (total + element,), None
+
+            final_carry, _ = torch.ops.higher_order.scan(
+                functools.partial(combine_fn),
+                (torch.zeros((), dtype=x.dtype, device=x.device),),
+                x,
+                (),
+            )
+            (final_sum,) = final_carry
+            return final_sum
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.UncapturedHigherOrderOpError,
+            r"Direct calls to torch\.ops\.higher_order\.scan are not supported",
+        ):
+            torch.compile(fn, backend="eager")(torch.arange(1, 11, dtype=torch.float32))
+
     def test_no_freevars(self):
         def f(x):
             return wrap(lambda x: torch.sin(x), x)

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2110,6 +2110,16 @@
       ]
     }
   ],
+  "GB7190": [
+    {
+      "Gb_type": "torch.scan: direct operator call",
+      "Context": "missing scan partial keywords: {missing_keywords}",
+      "Explanation": "Direct calls to torch.ops.higher_order.scan are not supported. Call the scan frontend instead of the internal lowered operator.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    }
+  ],
   "GB9522": [
     {
       "Gb_type": "hasattr() on unsupported type",

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2980,6 +2980,30 @@ class ScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
                         *graph_break_hints.DIFFICULT,
                     ],
                 )
+            if isinstance(combine_fn_var, variables.FunctoolsPartialVariable):
+                missing_keywords = [
+                    key
+                    for key in (
+                        "combine_fn",
+                        "spec_init",
+                        "spec_xs",
+                        "num_init_leaves",
+                        "num_inp_leaves",
+                    )
+                    if key not in combine_fn_var.keywords
+                ]
+                if missing_keywords:
+                    unimplemented(
+                        gb_type="torch.scan: direct operator call",
+                        context=f"missing scan partial keywords: {missing_keywords}",
+                        explanation=(
+                            "Direct calls to torch.ops.higher_order.scan are not supported. "
+                            "Call the scan frontend instead of the internal lowered operator."
+                        ),
+                        hints=[
+                            *graph_break_hints.USER_ERROR,
+                        ],
+                    )
             return isinstance(
                 combine_fn_var,
                 (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185320

Direct calls to torch.ops.higher_order.scan are not the supported user-facing API. Dynamo's scan HOP path still accepted any functools.partial as if it came from the torch._higher_order_ops.scan frontend, then unconditionally read combine_fn.keywords["combine_fn"]. When user code called the internal operator directly with an ordinary partial, that assumption escaped as InternalTorchDynamoError: KeyError: combine_fn.

Validate the partial schema expected from the scan frontend before using those keywords. If the required scan wrapper metadata is absent, report a user-facing unsupported HOP error that points users at the frontend instead of letting the raw KeyError leak. The alternative would have been to support arbitrary direct torch.ops.higher_order.scan calls, but that bypasses the frontend flattening and metadata contract the Dynamo path relies on.

Fixes #160544
Generated by my agent

Benchmark Results:
Micro-benchmark of the added scan partial validation in isolation:
- before median: 0.018409 us/op
- after median: 0.167151 us/op
- delta median: 0.148742 us/op

Test Plan:
- python test/dynamo/test_higher_order_ops.py HigherOrderOpTests.test_direct_scan_op_compile_error
- git diff --cached --check
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos