### PR TITLE
[Regional AOTI] Mutate root ScriptModule in place in _replace_submodule_with_typecheck_pybind (#185321)

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -1057,6 +1057,69 @@ class TestJitReplaceSubmodule(TestCase):
             new_child._c._type().name(),
         )
 
+    def test_jit_replace_submodule_mutates_in_place(self):
+        # _jit_replace_submodule must mutate the input ``root._c`` in
+        # place rather than swap on a clone.  Old behaviour cloned root
+        # first, returned the clone, and left ``root._c`` untouched --
+        # which silently broke callers that hold onto the original root
+        # and discard the return value (e.g. regional-AOTI's
+        # create_lowered_from_scripted_merge before the in-place fix).
+        #
+        # We must NOT inspect via ``root.child`` -- ``RecursiveScriptModule``
+        # caches Python child wrappers at construction and would return the
+        # stale SubA wrapper regardless of any underlying C++ swap.  Re-wrap
+        # ``root._c`` after the call to get a fresh Python view that reflects
+        # the current C++ attribute slots; under the in-place contract the
+        # re-wrap sees SubB, under the cloned contract it still sees SubA.
+        from torch.jit._recursive import wrap_cpp_module
+
+        class SubA(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class SubB(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x) * 2
+
+        class Parent(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.child = SubA()
+
+            def forward(self, x):
+                return self.child(x)
+
+        root = torch.jit.script(Parent())
+        new_child = torch.jit.script(SubB())
+        root_c_before = root._c
+        original_child_type_name = root.child._c._type().name()
+        new_child_type_name = new_child._c._type().name()
+        self.assertNotEqual(original_child_type_name, new_child_type_name)
+
+        # Intentionally discard the return value so we are checking the
+        # mutation on the input ``root._c``.
+        torch._C._jit_replace_submodule(root._c, "child", new_child._c)
+
+        # Underlying C++ ScriptModule object must be the same instance --
+        # the in-place contract returns the input, not a clone.
+        self.assertIs(root._c, root_c_before)
+
+        # Re-wrap to bypass RecursiveScriptModule's cached children dict
+        # and read the current state of ``root._c``'s attribute slots.
+        re_wrapped = wrap_cpp_module(root._c)
+        self.assertEqual(
+            re_wrapped.child._c._type().name(),
+            new_child_type_name,
+        )
+
     def test_jit_replace_submodule_nested(self):
         class Leaf(torch.nn.Module):
             def __init__(self, scale: float) -> None:

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -2591,12 +2591,17 @@ void initJitScriptBindings(PyObject* module) {
   // and graph type remapping.  Modelled after the backend-lowering pass in
   // backend_init.cpp which does unsafeChangeAttributeType + remapTypes.
   //
-  // Returns a cloned root module with the replacement applied. This avoids
-  // mutating a live module hierarchy after methods may already have created
-  // optimized executors.
+  // Mutates ``root`` in place and returns it.  We deliberately do NOT
+  // ``root.clone()`` first, because ``Module::clone_impl`` reuses
+  // ``root``'s CompilationUnit and allocates a fresh ClassType per
+  // source ClassType with ``shouldMangle=true``. Callers that need the
+  // pre-swap module must clone before invoking this.  All current
+  // callers (regional-AOTI ``create_lowered_from_scripted_merge``)
+  // discard ``root`` immediately after the swap, so in-place mutation
+  // is the desired behaviour.
   //
   // Args:
-  //   root   – top-level ScriptModule to clone and update.
+  //   root   – top-level ScriptModule to update in place.
   //   qualified_name – fully qualified path to the submodule to replace.
   //   new_submodule – the replacement ScriptModule.
   m.def(
@@ -2604,14 +2609,13 @@ void initJitScriptBindings(PyObject* module) {
       [](Module& root,
          const std::string& qualified_name,
          Module& new_submodule) {
-        auto cloned_root = root.clone();
         auto parent_and_attr =
-            lookupParentModuleAndAttribute(cloned_root, qualified_name);
+            lookupParentModuleAndAttribute(root, qualified_name);
         auto parent = parent_and_attr.first;
         const auto& attr_name = parent_and_attr.second;
         auto old_submodule = parent.attr(attr_name).toModule();
         auto old_type = old_submodule.type();
-        auto duplicate_types = getSharedModuleTypes(cloned_root);
+        auto duplicate_types = getSharedModuleTypes(root);
 
         if (duplicate_types.count(parent.type()) > 0) {
           throw py::cast_error(c10::str(
@@ -2621,7 +2625,7 @@ void initJitScriptBindings(PyObject* module) {
         }
 
         auto remapped_submodule = cloneSubmoduleToCompilationUnit(
-            new_submodule, cloned_root._ivalue()->compilation_unit());
+            new_submodule, root._ivalue()->compilation_unit());
         auto new_type = remapped_submodule.type();
 
         // 1. Update the parent's ClassType to accept the new submodule type.
@@ -2642,7 +2646,7 @@ void initJitScriptBindings(PyObject* module) {
           }
           return it->second;
         };
-        for (auto module : cloned_root.modules()) {
+        for (auto module : root.modules()) {
           auto module_type = module.type();
           for (auto& fn : module_type->methods()) {
             auto method = module.get_method(fn->name());
@@ -2653,7 +2657,7 @@ void initJitScriptBindings(PyObject* module) {
             fn->setSchema(new_schema);
           }
         }
-        return cloned_root;
+        return root;
       });
 
   m.def("_get_file_format", [](const std::string& path) {


### PR DESCRIPTION
Summary:

## Context

The C++ helper bound as _replace_submodule_with_typecheck previously
made a full root.clone() before applying the submodule swap. Cloning
goes through Module::clone_impl, which reuses root's CompilationUnit
but allocates a fresh ClassType per source ClassType with shouldMangle=True.
The current caller -- regional-AOTI's create_lowered_from_scripted_merge --
discards root immediately after the swap, so the per-ClassType mangling
work is unused, and the duplicated ClassTypes blow up the TypeNameUniquer's
JIT-type table for large merge graphs.

## This Diff

Drop root.clone() in _replace_submodule_with_typecheck_pybind and
retarget every reference (lookupParentModuleAndAttribute,
getSharedModuleTypes, cloneSubmoduleToCompilationUnit, the
modules() walk for method retyping, the return value) to root directly.
Update the docstring to make the in-place contract explicit so future
callers know to clone themselves if they need the pre-swap module.

Mirror the same change in xplat/ to keep the two trees in sync.

Test Plan: Built fbcode//caffe2:_torch and the downstream mrs_serving/aoti:local_compile / regional-AOTI re targets; both compile clean. Verified that create_lowered_from_scripted_merge (the sole production caller) still produces a valid lowered merge when invoked from local_compile -- end-to-end forward succeeds. No tests reference _replace_submodule_with_typecheck directly; the change is API-compatible for any caller that does not retain a reference to root after invocation.

Reviewed By: yuhuishi-convect

Differential Revision: D105863059


