### PR TITLE
Include custom op fake metadata in FX cache key

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -726,6 +726,78 @@ class TestFxGraphCache(TestCase):
             torch.set_default_dtype(old_dtype)
             FxGraphCache.clear()
 
+    @config.patch({"fx_graph_cache": True, "fx_graph_remote_cache": False})
+    @functorch_config.patch({"enable_autograd_cache": False})
+    def test_custom_op_fake_output_metadata_affects_cache_key(self):
+        FxGraphCache.clear()
+
+        @torch.library.custom_op("_test_fx_graph_cache::fake_meta", mutates_args=())
+        def fake_meta(x: torch.Tensor) -> torch.Tensor:
+            return x + 1
+
+        @fake_meta.register_fake
+        def _(x):
+            return x.new_empty((2,))
+
+        def fn(x):
+            return fake_meta(x) * 2
+
+        x = torch.arange(4, dtype=torch.float32)
+        with self.assertRaisesRegex(AssertionError, "expected size 4==2"):
+            torch.compile(fn, fullgraph=True)(x)
+
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        @fake_meta.register_fake
+        def _(x):
+            return x.new_empty(x.shape)
+
+        self.reset()
+        result = torch.compile(fn, fullgraph=True)(x)
+        self.assertEqual(result, (x + 1) * 2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+    @config.patch({"fx_graph_cache": True, "fx_graph_remote_cache": False})
+    @functorch_config.patch({"enable_autograd_cache": False})
+    def test_custom_op_fake_tuple_output_dtype_affects_cache_key(self):
+        FxGraphCache.clear()
+
+        @torch.library.custom_op(
+            "_test_fx_graph_cache::fake_tuple_dtype", mutates_args=()
+        )
+        def fake_tuple_dtype(
+            x: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            return x.to(torch.bfloat16) + 1, torch.ones(x.shape[0], dtype=torch.float32)
+
+        @fake_tuple_dtype.register_fake
+        def _(x):
+            return x.to(torch.float32), torch.empty(x.shape[0], dtype=torch.float32)
+
+        def fn(x):
+            return fake_tuple_dtype(x)[0]
+
+        x = torch.arange(4, dtype=torch.bfloat16)
+        result = torch.compile(fn, fullgraph=True)(x)
+        self.assertEqual(result, fn(x))
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+        @fake_tuple_dtype.register_fake
+        def _(x):
+            return x.new_empty(x.shape, dtype=torch.bfloat16), torch.empty(
+                x.shape[0], dtype=torch.float32
+            )
+
+        self.reset()
+        result = torch.compile(fn, fullgraph=True)(x)
+        self.assertEqual(result, fn(x))
+        self.assertEqual(result.dtype, torch.bfloat16)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
     @requires_triton()
     @config.patch({"fx_graph_remote_cache": True})
     @parametrize("device", (GPU_TYPE, "cpu"))

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -45,7 +45,9 @@ from typing import Any, cast, Generic, Literal, NoReturn, TYPE_CHECKING, TypeVar
 from typing_extensions import NotRequired, override, Self, TypedDict
 
 import torch
+import torch._library.custom_ops as custom_ops
 import torch._library.opaque_object as opaque_object
+import torch._library.simple_registry as simple_registry
 import torch.distributed as dist
 from torch import SymInt, Tensor
 from torch._dynamo.device_interface import get_interface_for_device
@@ -1181,6 +1183,24 @@ class HashableOpaqueValue:
     ordinal: int
 
 
+def _has_torch_library_fake_impl(target: object) -> bool:
+    if not isinstance(target, torch._ops.OpOverload):
+        return False
+
+    if custom_ops._maybe_get_opdef(target) is not None:
+        return True
+
+    entry = simple_registry.singleton.get(target._name)
+    return entry is not None and entry.fake_impl.kernel is not None
+
+
+def _custom_op_meta_for_cache_key(node: torch.fx.Node) -> object:
+    for key in ("val", "example_value", "tensor_meta"):
+        if key in node.meta:
+            return node.meta[key]
+    return None
+
+
 class FxGraphHashDetails:
     """
     Object to capture all the details for a compiled FX graph relevant to computing
@@ -1237,13 +1257,28 @@ class FxGraphHashDetails:
             user_defined_triton_kernel_transitive_closure_source_code,
         )
 
-        # Node meta will not be part of gm's reduce function, so lets remember
-        # the kernel source code separately
+        # Node meta will not be part of gm's reduce function, so remember the
+        # user-provided pieces of metadata/source that affect codegen separately.
         self.user_defined_triton_source: list[Any] = []
+        self.user_custom_op_output_metadata: list[tuple[str, object]] = []
         if gm is not None:
             for module in gm.modules():
                 if not isinstance(module, torch.fx.GraphModule):
                     continue
+                for node in module.graph.nodes:
+                    target = node.target
+                    if (
+                        node.op != "call_function"
+                        or not isinstance(target, torch._ops.OpOverload)
+                        or not _has_torch_library_fake_impl(target)
+                    ):
+                        continue
+                    self.user_custom_op_output_metadata.append(
+                        (
+                            target._name,
+                            _custom_op_meta_for_cache_key(node),
+                        )
+                    )
                 for node in itertools.chain(
                     module.graph.find_nodes(
                         op="call_function", target=triton_kernel_wrapper_functional


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185323

FX graph cache keys are computed from the graph module, example inputs, and
compile/runtime settings. GraphModule pickling intentionally does not include
node metadata, but torch.library custom ops rely on their fake implementations
to populate output metadata such as dtype, shape, and stride. Inductor then
uses those fake output properties when compiling the graph.

That meant changing a custom op fake implementation could leave the FX graph
cache key unchanged. A later compile could reload code compiled with stale fake
metadata, which is the root cause of the PT2 cache issue where correcting a
custom op fake dtype still reused the old cached artifact.

Record output metadata for torch.library custom ops with fake implementations
inside FxGraphHashDetails. This invalidates cached FX graphs when the observed
fake output contract changes, while avoiding source hashing for fake functions
whose edits do not affect the metadata consumed by codegen.

Fixes #160472
Generated by my agent

Test Plan:
- python test/inductor/test_codecache.py TestFxGraphCache.test_custom_op_fake_output_metadata_affects_cache_key TestFxGraphCache.test_custom_op_fake_tuple_output_dtype_affects_cache_key
- lintrunner -a
- git diff --cached --check

Benchmark Results:
Benchmark command: a microbenchmark of compiled_fx_graph_hash over a 64-op plain
FX graph and a 32-call tuple-output custom-op FX graph, 5 repeats of 100 cache-key
computations per graph.

Main (536474ecda7fbb475458262123d58bd6c478668d):
- plain_64_ops: mean=16.341 ms stdev=1.396 raw=18.391,14.544,16.578,15.792,16.398
- custom_tuple_32_ops: mean=20.483 ms stdev=0.602 raw=20.086,20.115,19.981,21.344,20.890

This change:
- plain_64_ops: mean=15.973 ms stdev=1.320 raw=17.662,15.924,16.352,15.951,13.979
- custom_tuple_32_ops: mean=17.439 ms stdev=3.348 raw=23.025,18.131,15.459,15.211,15.370

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos