### PR TITLE
[fix] Generalize test_compiler_bisector.py

### DIFF
--- a/test/dynamo/_test_compiler_bisector_run_helper.py
+++ b/test/dynamo/_test_compiler_bisector_run_helper.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 
 import torch
 import torch._prims_common as utils
+from torch.testing._internal.inductor_utils import GPU_TYPE
 
 
 aten = torch.ops.aten
@@ -48,7 +49,7 @@ def vq(x):
 def test_fn():
     with patch_exp_decomp():
         vq_compiled = torch.compile(vq)
-        x = torch.randn(4, 400, 256).cuda()
+        x = torch.randn(4, 400, 256, device=GPU_TYPE)
         out_compiled = vq_compiled(x)
 
     return 1 if out_compiled.isnan().any() else 0

--- a/test/dynamo/test_compiler_bisector.py
+++ b/test/dynamo/test_compiler_bisector.py
@@ -12,7 +12,8 @@ from torch._inductor.compiler_bisector import CompilerBisector
 from torch._inductor.custom_graph_pass import CustomGraphPass
 from torch._inductor.test_case import TestCase
 from torch.library import _scoped_library, Library
-from torch.testing._internal.inductor_utils import HAS_GPU
+from torch.testing._internal.common_utils import requires_cuda
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
 aten = torch.ops.aten
@@ -84,7 +85,7 @@ class TestCompilerBisector(TestCase):
             torch._dynamo.reset()
             with patch_exp_decomp():
                 vq_compiled = torch.compile(vq)
-                x = torch.randn(4, 400, 256).cuda()
+                x = torch.randn(4, 400, 256, device=GPU_TYPE)
                 with torch._dynamo.utils.preserve_rng_state():
                     vq(x)
                 out_compiled = vq_compiled(x)
@@ -158,7 +159,7 @@ class TestCompilerBisector(TestCase):
         def test_fn():
             torch._dynamo.reset()
 
-            inp = torch.rand([10], device="cuda")
+            inp = torch.rand([10], device=GPU_TYPE)
 
             out = foo(inp)
             out_c = torch.compile(foo)(inp)
@@ -174,7 +175,7 @@ class TestCompilerBisector(TestCase):
 
     def test_rng(self):
         def foo():
-            return torch.rand([10], device="cuda") + 1
+            return torch.rand([10], device=GPU_TYPE) + 1
 
         def test_fn():
             torch._dynamo.reset()
@@ -248,7 +249,7 @@ class TestCompilerBisector(TestCase):
 
             dtype = torch.bfloat16
             torch.manual_seed(0)
-            inp = torch.randn(16, 16, 768, dtype=dtype, device="cuda")
+            inp = torch.randn(16, 16, 768, dtype=dtype, device=GPU_TYPE)
             eager_scale = calculate_scale(inp)
             compile_scale = torch.compile(calculate_scale)(inp)
 
@@ -266,7 +267,7 @@ class TestCompilerBisector(TestCase):
                 def my_func(x):
                     return ((x * -1) - 0.01).relu()
 
-                inp = torch.rand([100], device="cuda")
+                inp = torch.rand([100], device=GPU_TYPE)
 
                 return torch.allclose(torch.compile(my_func)(inp), my_func(inp))
 
@@ -328,7 +329,7 @@ class TestCompilerBisector(TestCase):
         def test_fn():
             torch._dynamo.reset()
 
-            x = torch.randn(1024, device="cuda")
+            x = torch.randn(1024, device=GPU_TYPE)
             with config.patch("triton.inject_relu_bug_TESTING_ONLY", "accuracy"):
                 opt_f = torch.compile(f, backend=MyBackend())
                 return torch.allclose(opt_f(x), f(x))
@@ -338,6 +339,7 @@ class TestCompilerBisector(TestCase):
         self.assertEqual(out.subsystem, "pre_grad_graph")
         self.assertEqual(out.bisect_number, 1)
 
+    @requires_cuda
     def test_cudagraph_bisect_max(self):
         """Test that cudagraph bisector can limit number of cudagraphed graphs."""
         import os
@@ -367,7 +369,7 @@ class TestCompilerBisector(TestCase):
             try:
                 foo_c = torch.compile(foo, mode="reduce-overhead")
                 bar_c = torch.compile(bar, mode="reduce-overhead")
-                x = torch.randn(10, device="cuda")
+                x = torch.randn(10, device=GPU_TYPE)
                 foo_c(x)
                 bar_c(x)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #185326

# Motivation
PR #185131 refactored this test file to be device-agnostic, but there are still some CUDA-specific hardcoded paths remaining. This PR updates those parts to make the test fully device-agnostic.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98