### PR TITLE
Use safe softmax for masked MHA weights

### DIFF
--- a/test/nn/test_multihead_attention.py
+++ b/test/nn/test_multihead_attention.py
@@ -106,8 +106,11 @@ class TestMultiheadAttentionNN(NNTestCase):
                 for j in range(x.shape[1]):
                     for k in range(x.shape[2]):
                         x_curr = x[i, j, k, :]
-                        e_x = np.exp(x_curr - np.amax(x_curr))
-                        output[i, j, k, :] = e_x / np.sum(e_x)
+                        if np.isneginf(x_curr).all():
+                            output[i, j, k, :] = 0
+                        else:
+                            e_x = np.exp(x_curr - np.amax(x_curr))
+                            output[i, j, k, :] = e_x / np.sum(e_x)
             return output
 
         def _split_heads_ref(X, dims, nheads, d_head):
@@ -504,6 +507,74 @@ class TestMultiheadAttentionNN(NNTestCase):
 
             # output_2d in shape of [T, 1, D]
             self.assertEqual(output_3d[i].unsqueeze(0).transpose(0, 1), output_2d)
+
+    def test_multihead_attn_fully_masked_head_need_weights(self):
+        torch.manual_seed(0)
+        src_len = 5
+        embed_dim = 3
+        num_heads = 3
+        query = torch.randn(1, src_len, embed_dim)
+        attn_mask = (
+            torch.tensor([False, False, True])
+            .view(num_heads, 1, 1)
+            .expand(num_heads, src_len, src_len)
+        )
+        mha = torch.nn.MultiheadAttention(embed_dim, num_heads, batch_first=True)
+
+        output_ref, _ = mha(
+            query,
+            query,
+            query,
+            attn_mask=attn_mask,
+            average_attn_weights=False,
+            need_weights=False,
+        )
+        output, weights = mha(
+            query,
+            query,
+            query,
+            attn_mask=attn_mask,
+            average_attn_weights=False,
+            need_weights=True,
+        )
+
+        self.assertFalse(torch.isnan(output).any())
+        self.assertFalse(torch.isnan(weights).any())
+        self.assertEqual(output, output_ref)
+        self.assertEqual(weights[:, 2], torch.zeros_like(weights[:, 2]))
+
+    def test_multihead_attn_fully_masked_row_need_weights(self):
+        torch.manual_seed(0)
+        batch_size = 2
+        src_len = 4
+        embed_dim = 8
+        num_heads = 2
+        query = torch.randn(batch_size, src_len, embed_dim)
+        attn_mask = torch.zeros(src_len, src_len, dtype=torch.bool)
+        attn_mask[1] = True
+        mha = torch.nn.MultiheadAttention(embed_dim, num_heads, batch_first=True)
+
+        output_ref, _ = mha(
+            query,
+            query,
+            query,
+            attn_mask=attn_mask,
+            average_attn_weights=False,
+            need_weights=False,
+        )
+        output, weights = mha(
+            query,
+            query,
+            query,
+            attn_mask=attn_mask,
+            average_attn_weights=False,
+            need_weights=True,
+        )
+
+        self.assertFalse(torch.isnan(output).any())
+        self.assertFalse(torch.isnan(weights).any())
+        self.assertEqual(output, output_ref)
+        self.assertEqual(weights[:, :, 1], torch.zeros_like(weights[:, :, 1]))
 
     def test_multihead_attn_no_bias(self):
         embed_dim = 8

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6833,7 +6833,10 @@ def multi_head_attention_forward(
             attn_output_weights = torch.bmm(q_scaled, k.transpose(-2, -1))
         if not torch.jit.is_scripting():
             del q_scaled, k
-        attn_output_weights = softmax(attn_output_weights, dim=-1)
+        if attn_mask is not None:
+            attn_output_weights = torch._safe_softmax(attn_output_weights, dim=-1)
+        else:
+            attn_output_weights = softmax(attn_output_weights, dim=-1)
         if dropout_p > 0.0:
             attn_output_weights = dropout(attn_output_weights, p=dropout_p)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185338

When MultiheadAttention runs with need_weights=True, it uses the Python
bmm/baddbmm attention path instead of scaled_dot_product_attention. Boolean
attention masks and key padding masks are canonicalized into additive -inf
scores before this branch. If a mask fully hides a query row or a whole head,
the old plain softmax saw an all--inf row and produced NaNs, which then
poisoned both the returned weights and the projected output.

The need_weights=False path already goes through SDPA, whose math backend uses
safe softmax and returns zero weights for all--inf rows. Mirror that behavior
in the need_weights=True path when a mask is present by using torch._safe_softmax
for masked scores. Leave unmasked scores on the existing softmax path to avoid
changing behavior or cost for the common unmasked case.

I used the existing safe softmax primitive rather than manually checking
isneginf rows in Python, since this keeps the semantics aligned with SDPA. An
unconditional replacement was considered, but the microbenchmarks below showed
that it would slow unmasked need_weights=True calls unnecessarily.

Fixes #160064
Generated by my agent

Benchmark Results:
Direct CPU softmax microbenchmark on masked score tensors:
- shape=(8, 128, 128): plain softmax 85.78 us, _safe_softmax 293.46 us
- shape=(32, 256, 256): plain softmax 1.26 ms, _safe_softmax 4.76 ms

End-to-end CPU MultiheadAttention need_weights=True masked-path benchmark:
- issue shape, batch=1 seq=5 embed=3 heads=3: old 88.61 us, new 98.22 us
- larger case, batch=8 seq=128 embed=128 heads=8: old 4.38 ms, new 7.35 ms

Test Plan:
python - <<'PY'
import torch
from torch import nn

torch.manual_seed(0)
x = torch.randn(1, 5, 3)
mask = torch.tensor([False, False, True]).view(-1, 1, 1).expand(-1, 5, 5)
att = nn.MultiheadAttention(3, 3, batch_first=True)
y1, _ = att(x, x, x, attn_mask=mask, average_attn_weights=False, need_weights=False)
y2, weights = att(x, x, x, attn_mask=mask, average_attn_weights=False, need_weights=True)
print(torch.isnan(y1).any().item(), torch.isnan(y2).any().item(), torch.isnan(weights).any().item())
print(torch.allclose(y1, y2))
print(torch.equal(weights[0, 2], torch.zeros_like(weights[0, 2])))
PY
python test/nn/test_multihead_attention.py TestMultiheadAttentionNN.test_multihead_attn_fully_masked_head_need_weights TestMultiheadAttentionNN.test_multihead_attn_fully_masked_row_need_weights
python test/nn/test_multihead_attention.py -k test_multihead_attention
lintrunner -a