### PR TITLE
[Test] Improve test reuse in test/nn/test_pooling.py for out-of-tree backends

### DIFF
--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -2181,7 +2181,7 @@ torch.cuda.synchronize()
         F.adaptive_max_pool3d(imgs, (Od, Oh, Ow))
 
 
-instantiate_device_type_tests(TestAvgPoolDeviceType, globals(), except_for=("cpu"))
+instantiate_device_type_tests(TestAvgPoolDeviceType, globals())
 instantiate_device_type_tests(TestPoolingNNDeviceType, globals(), allow_mps=True)
 instantiate_parametrized_tests(TestPoolingNN)
 

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -2121,6 +2121,7 @@ torch.cuda.synchronize()
                         fn(x, 6, stride=2, padding=0)
 
     @onlyAccelerator
+    @expectedFailureMPS  # MPS adaptive avg pool requires divisible input/output sizes
     def test_pooling_bfloat16(self, device):
         _test_bfloat16_ops(
             self,

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -358,6 +358,7 @@ class TestPoolingNN(NNTestCase):
 
 
 class TestPoolingNNDeviceType(NNTestCase):
+    @expectedFailureMPS  # MPS adaptive avg pool requires divisible input/output sizes
     def test_adaptive_pooling_avg_nhwc(self, device):
         input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
         input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
@@ -378,6 +379,7 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(out, ref_out)
         self.assertEqual(input.grad, ref_input.grad)
 
+    @expectedFailureMPS  # MPS adaptive avg pool requires divisible input/output sizes
     def test_adaptive_pooling_avg_nhwc_non_contiguous(self, device):
         input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
         input = input.contiguous(memory_format=torch.channels_last)
@@ -401,6 +403,7 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(input.grad, ref_input.grad)
 
     @onlyAccelerator
+    @expectedFailureMPS  # MPS adaptive avg pool requires divisible input/output sizes
     @largeTensorTest("12GB")
     def test_adaptive_pooling_avg_nhwc_launch_config_backward(self, device):
         input = torch.randint(
@@ -426,6 +429,7 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(input.grad, ref_input.grad)
 
     @onlyAccelerator
+    @expectedFailureMPS  # MPS adaptive avg pool requires divisible input/output sizes
     @largeTensorTest("12GB")
     def test_adaptive_pooling_avg_nhwc_launch_config_forward(self, device):
         input = torch.randint(
@@ -1250,7 +1254,7 @@ torch.cuda.synchronize()
     def test_max_pool2d(self, device):
         def helper(n, c, h, w, ks):
             x = torch.randn(
-                n, c, h, w, device="cuda", dtype=torch.float, requires_grad=True
+                n, c, h, w, device=device, dtype=torch.float, requires_grad=True
             )
             ref_x = x.detach().clone().cpu().requires_grad_()
 
@@ -1470,11 +1474,11 @@ torch.cuda.synchronize()
         def helper(n, c, h, w, ks):
             if n is None:
                 x = torch.randn(
-                    c, h, w, device="cuda", dtype=torch.float, requires_grad=True
+                    c, h, w, device=device, dtype=torch.float, requires_grad=True
                 )
             else:
                 x = torch.randn(
-                    n, c, h, w, device="cuda", dtype=torch.float, requires_grad=True
+                    n, c, h, w, device=device, dtype=torch.float, requires_grad=True
                 )
 
             ref_x = x.detach().clone().cpu().requires_grad_()
@@ -1691,9 +1695,9 @@ torch.cuda.synchronize()
         )
         y = torch.nn.functional.max_pool3d(x, 5)
         g = torch.randn_like(y, dtype=torch.half)
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         y.backward(g)
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         ref_x = x.detach().cpu().float()  # max_pool3d_cpu is not implemented for half
         ref_x.requires_grad = True
@@ -2083,11 +2087,11 @@ torch.cuda.synchronize()
     def test_pooling_large(self, device):
         def helper(pool):
             inp = torch.randn(
-                2**7 + 10, 2**8, 2**8, 2**8, dtype=torch.half, device="cuda"
+                2**7 + 10, 2**8, 2**8, 2**8, dtype=torch.half, device=device
             )
             self.assertTrue(inp.numel() > 2**31 - 1)
             pool(inp)
-            torch.cuda.synchronize()  # asserts test finishes normally without raising errors
+            torch.accelerator.synchronize()  # asserts test finishes normally without raising errors
 
         helper(nn.MaxPool2d(4, 4))
         helper(nn.AvgPool2d(4, 4))

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -2083,6 +2083,7 @@ torch.cuda.synchronize()
                 self.assertEqual(x.shape[2], res.shape[2])
 
     @onlyAccelerator
+    @expectedFailureMPS  # Not implemented
     @largeTensorTest("6GB")
     def test_pooling_large(self, device):
         def helper(pool):

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -17,7 +17,6 @@ import torch.nn.functional as F
 from torch import inf, nan
 from torch.autograd import gradcheck, gradgradcheck
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfCUDA,
@@ -30,6 +29,7 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     onlyMPS,
     onlyNativeDeviceTypes,
+    onlyOn,
     TEST_WITH_ROCM,
 )
 from torch.testing._internal.common_dtype import floating_types_and
@@ -127,27 +127,19 @@ class TestAvgPool(TestCase):
                         expected = self._sum_pool3d(input, (i, j, k)) / divisor
                         self.assertEqual(actual, expected, rtol=0, atol=1e-5)
 
-    def test_avg_pool1d_ceil_mode(self):
+
+class TestAvgPoolDeviceType(TestCase):
+    def test_avg_pool1d_ceil_mode(self, device):
         # Regression test for gh-36977
-        x = 10 * torch.randn((1, 16, 4))
+        x = 10 * torch.randn((1, 16, 4), device=device)
         y = torch.nn.functional.avg_pool1d(
             x, ceil_mode=True, count_include_pad=True, kernel_size=1, stride=2
         )
         self.assertTrue(not torch.isnan(y).any())
 
-        if TEST_CUDA:
-            y = torch.nn.functional.avg_pool1d(
-                x.to("cuda"),
-                ceil_mode=True,
-                count_include_pad=True,
-                kernel_size=1,
-                stride=2,
-            )
-            self.assertTrue(not torch.isnan(y).any())
-
-    def test_avg_pool2d_ceil_mode(self):
+    def test_avg_pool2d_ceil_mode(self, device):
         # Regression test for gh-36977
-        x = 10 * torch.randn((1, 16, 4, 4))
+        x = 10 * torch.randn((1, 16, 4, 4), device=device)
         y = torch.nn.functional.avg_pool2d(
             x,
             ceil_mode=True,
@@ -158,34 +150,13 @@ class TestAvgPool(TestCase):
         )
         self.assertTrue(not torch.isnan(y).any())
 
-        if TEST_CUDA:
-            y = torch.nn.functional.avg_pool2d(
-                x.to("cuda"),
-                ceil_mode=True,
-                count_include_pad=True,
-                kernel_size=(1, 2),
-                padding=(0, 1),
-                stride=2,
-            )
-            self.assertTrue(not torch.isnan(y).any())
-
-    def test_avg_pool3d_ceil_mode(self):
+    def test_avg_pool3d_ceil_mode(self, device):
         # Regression test for gh-36977
-        x = 10 * torch.randn((1, 16, 4, 4, 4))
+        x = 10 * torch.randn((1, 16, 4, 4, 4), device=device)
         y = torch.nn.functional.avg_pool3d(
             x, ceil_mode=True, count_include_pad=True, kernel_size=(1, 2, 3), stride=2
         )
         self.assertTrue(not torch.isnan(y).any())
-
-        if TEST_CUDA:
-            y = torch.nn.functional.avg_pool3d(
-                x.to("cuda"),
-                ceil_mode=True,
-                count_include_pad=True,
-                kernel_size=(1, 2, 3),
-                stride=2,
-            )
-            self.assertTrue(not torch.isnan(y).any())
 
 
 class TestPoolingNN(NNTestCase):
@@ -214,58 +185,6 @@ class TestPoolingNN(NNTestCase):
                 torch.empty([2, 2, 2])
             ),
         )
-
-    def test_adaptive_pooling_avg_nhwc(self):
-        device_list = ["cpu"]
-        if TEST_CUDA:
-            device_list.append("cuda")
-
-        for device in device_list:
-            input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
-            input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
-            grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32).to(device)
-            pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
-
-            ref_input = input.detach().clone().contiguous().requires_grad_(True)
-            ref_grad = grad.detach().clone().contiguous()
-            ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
-
-            out = pool(input)
-            out.backward(grad)
-            ref_out = ref_pool(ref_input)
-            ref_out.backward(ref_grad)
-
-            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-            self.assertTrue(ref_out.is_contiguous())
-            self.assertEqual(out, ref_out)
-            self.assertEqual(input.grad, ref_input.grad)
-
-    def test_adaptive_pooling_avg_nhwc_non_contiguous(self):
-        device_list = ["cpu"]
-        if TEST_CUDA:
-            device_list.append("cuda")
-
-        for device in device_list:
-            input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
-            input = input.contiguous(memory_format=torch.channels_last)
-            input = input[:, ::2, :, :].requires_grad_()
-            grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32).to(device)
-            grad = grad[:, ::2, :, :]
-            pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
-
-            ref_input = input.detach().clone().contiguous().requires_grad_(True)
-            ref_grad = grad.detach().clone().contiguous()
-            ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
-
-            out = pool(input)
-            out.backward(grad)
-            ref_out = ref_pool(ref_input)
-            ref_out.backward(ref_grad)
-
-            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-            self.assertTrue(ref_out.is_contiguous())
-            self.assertEqual(out, ref_out)
-            self.assertEqual(input.grad, ref_input.grad)
 
     def test_adaptive_pooling_lower_precision(self):
         def _test_adaptive_pooling_lower_precision(
@@ -311,71 +230,6 @@ class TestPoolingNN(NNTestCase):
                 _test_adaptive_pooling_lower_precision(
                     self, device, dtype, torch.nn.AdaptiveMaxPool2d, torch.channels_last
                 )
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    @largeTensorTest("12GB", device="cuda")
-    def test_adaptive_pooling_avg_nhwc_launch_config_backward(self):
-        input = torch.randint(
-            1, 10, (1, 32, 2**17 + 1, 32), dtype=torch.float32, device="cuda"
-        )
-        input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
-        grad = torch.randint(1, 10, (1, 32, 10, 32), dtype=torch.float32, device="cuda")
-
-        pool = torch.nn.AdaptiveAvgPool2d((10, 32)).cuda()
-
-        ref_input = input.detach().clone().contiguous().requires_grad_(True)
-        ref_grad = grad.detach().clone().contiguous()
-        ref_pool = torch.nn.AdaptiveAvgPool2d((10, 32)).cuda()
-
-        out = pool(input)
-        out.backward(grad)
-        ref_out = ref_pool(ref_input)
-        ref_out.backward(ref_grad)
-
-        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-        self.assertTrue(ref_out.is_contiguous())
-        self.assertEqual(out, ref_out)
-        self.assertEqual(input.grad, ref_input.grad)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    @largeTensorTest("12GB", device="cuda")
-    def test_adaptive_pooling_avg_nhwc_launch_config_forward(self):
-        input = torch.randint(
-            1, 10, (1, 32, 16, 16), dtype=torch.float32, device="cuda"
-        )
-        input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
-        pool = torch.nn.AdaptiveAvgPool2d((2**17 + 1, 32)).cuda()
-
-        ref_input = input.detach().clone().contiguous().requires_grad_(True)
-        ref_pool = torch.nn.AdaptiveAvgPool2d((2**17 + 1, 32)).cuda()
-
-        out = pool(input)
-        ref_out = ref_pool(ref_input)
-
-        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-        self.assertTrue(ref_out.is_contiguous())
-        self.assertEqual(out, ref_out)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_adaptive_avg_pooling_overflow(self):
-        input = torch.randint(
-            -256, 256, (20, 32, 256, 256), dtype=torch.half, device="cuda"
-        )
-        avg_pool = torch.nn.AdaptiveAvgPool2d((2, 2))
-        out = avg_pool(input)
-        self.assertFalse(torch.isinf(out).any())
-        self.assertFalse(torch.isnan(out).any())
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_adaptive_avg_pooling_nhwc_overflow(self):
-        input = torch.randint(
-            -256, 256, (20, 32, 256, 256), dtype=torch.half, device="cuda"
-        )
-        input = input.contiguous(memory_format=torch.channels_last)
-        avg_pool = torch.nn.AdaptiveAvgPool2d((2, 2))
-        out = avg_pool(input)
-        self.assertFalse(torch.isinf(out).any())
-        self.assertFalse(torch.isnan(out).any())
 
     def test_MaxUnpool2d_output_size(self):
         m = nn.MaxPool2d(3, stride=2, return_indices=True)
@@ -505,6 +359,115 @@ class TestPoolingNN(NNTestCase):
 
 
 class TestPoolingNNDeviceType(NNTestCase):
+    @onlyOn(["cpu", "cuda"])
+    def test_adaptive_pooling_avg_nhwc(self, device):
+        input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
+        input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
+        grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32).to(device)
+        pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
+
+        ref_input = input.detach().clone().contiguous().requires_grad_(True)
+        ref_grad = grad.detach().clone().contiguous()
+        ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
+
+        out = pool(input)
+        out.backward(grad)
+        ref_out = ref_pool(ref_input)
+        ref_out.backward(ref_grad)
+
+        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+        self.assertTrue(ref_out.is_contiguous())
+        self.assertEqual(out, ref_out)
+        self.assertEqual(input.grad, ref_input.grad)
+
+    @onlyOn(["cpu", "cuda"])
+    def test_adaptive_pooling_avg_nhwc_non_contiguous(self, device):
+        input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
+        input = input.contiguous(memory_format=torch.channels_last)
+        input = input[:, ::2, :, :].requires_grad_()
+        grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32).to(device)
+        grad = grad[:, ::2, :, :]
+        pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
+
+        ref_input = input.detach().clone().contiguous().requires_grad_(True)
+        ref_grad = grad.detach().clone().contiguous()
+        ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
+
+        out = pool(input)
+        out.backward(grad)
+        ref_out = ref_pool(ref_input)
+        ref_out.backward(ref_grad)
+
+        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+        self.assertTrue(ref_out.is_contiguous())
+        self.assertEqual(out, ref_out)
+        self.assertEqual(input.grad, ref_input.grad)
+
+    @onlyCUDA
+    @largeTensorTest("12GB")
+    def test_adaptive_pooling_avg_nhwc_launch_config_backward(self, device):
+        input = torch.randint(
+            1, 10, (1, 32, 2**17 + 1, 32), dtype=torch.float32, device=device
+        )
+        input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
+        grad = torch.randint(1, 10, (1, 32, 10, 32), dtype=torch.float32, device=device)
+
+        pool = torch.nn.AdaptiveAvgPool2d((10, 32)).to(device)
+
+        ref_input = input.detach().clone().contiguous().requires_grad_(True)
+        ref_grad = grad.detach().clone().contiguous()
+        ref_pool = torch.nn.AdaptiveAvgPool2d((10, 32)).to(device)
+
+        out = pool(input)
+        out.backward(grad)
+        ref_out = ref_pool(ref_input)
+        ref_out.backward(ref_grad)
+
+        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+        self.assertTrue(ref_out.is_contiguous())
+        self.assertEqual(out, ref_out)
+        self.assertEqual(input.grad, ref_input.grad)
+
+    @onlyCUDA
+    @largeTensorTest("12GB")
+    def test_adaptive_pooling_avg_nhwc_launch_config_forward(self, device):
+        input = torch.randint(
+            1, 10, (1, 32, 16, 16), dtype=torch.float32, device=device
+        )
+        input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
+        pool = torch.nn.AdaptiveAvgPool2d((2**17 + 1, 32)).to(device)
+
+        ref_input = input.detach().clone().contiguous().requires_grad_(True)
+        ref_pool = torch.nn.AdaptiveAvgPool2d((2**17 + 1, 32)).to(device)
+
+        out = pool(input)
+        ref_out = ref_pool(ref_input)
+
+        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+        self.assertTrue(ref_out.is_contiguous())
+        self.assertEqual(out, ref_out)
+
+    @onlyCUDA
+    def test_adaptive_avg_pooling_overflow(self, device):
+        input = torch.randint(
+            -256, 256, (20, 32, 256, 256), dtype=torch.half, device=device
+        )
+        avg_pool = torch.nn.AdaptiveAvgPool2d((2, 2))
+        out = avg_pool(input)
+        self.assertFalse(torch.isinf(out).any())
+        self.assertFalse(torch.isnan(out).any())
+
+    @onlyCUDA
+    def test_adaptive_avg_pooling_nhwc_overflow(self, device):
+        input = torch.randint(
+            -256, 256, (20, 32, 256, 256), dtype=torch.half, device=device
+        )
+        input = input.contiguous(memory_format=torch.channels_last)
+        avg_pool = torch.nn.AdaptiveAvgPool2d((2, 2))
+        out = avg_pool(input)
+        self.assertFalse(torch.isinf(out).any())
+        self.assertFalse(torch.isnan(out).any())
+
     @expectedFailureMPS  # No double, float shape prop does not work
     @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double)
@@ -2250,6 +2213,9 @@ torch.cuda.synchronize()
         F.adaptive_max_pool3d(imgs, (Od, Oh, Ow))
 
 
+instantiate_device_type_tests(
+    TestAvgPoolDeviceType, globals(), only_for=("cpu", "cuda")
+)
 instantiate_device_type_tests(TestPoolingNNDeviceType, globals(), allow_mps=True)
 instantiate_parametrized_tests(TestPoolingNN)
 

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -23,13 +23,12 @@ from torch.testing._internal.common_device_type import (
     dtypesIfMPS,
     expectedFailureMeta,
     expectedFailureMPS,
+    expectedFailureXLA,
     instantiate_device_type_tests,
     largeTensorTest,
+    onlyAccelerator,
     onlyCPU,
-    onlyCUDA,
     onlyMPS,
-    onlyNativeDeviceTypes,
-    onlyOn,
     TEST_WITH_ROCM,
 )
 from torch.testing._internal.common_dtype import floating_types_and
@@ -359,7 +358,6 @@ class TestPoolingNN(NNTestCase):
 
 
 class TestPoolingNNDeviceType(NNTestCase):
-    @onlyOn(["cpu", "cuda"])
     def test_adaptive_pooling_avg_nhwc(self, device):
         input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
         input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
@@ -380,7 +378,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(out, ref_out)
         self.assertEqual(input.grad, ref_input.grad)
 
-    @onlyOn(["cpu", "cuda"])
     def test_adaptive_pooling_avg_nhwc_non_contiguous(self, device):
         input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
         input = input.contiguous(memory_format=torch.channels_last)
@@ -403,7 +400,7 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(out, ref_out)
         self.assertEqual(input.grad, ref_input.grad)
 
-    @onlyCUDA
+    @onlyAccelerator
     @largeTensorTest("12GB")
     def test_adaptive_pooling_avg_nhwc_launch_config_backward(self, device):
         input = torch.randint(
@@ -428,7 +425,7 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(out, ref_out)
         self.assertEqual(input.grad, ref_input.grad)
 
-    @onlyCUDA
+    @onlyAccelerator
     @largeTensorTest("12GB")
     def test_adaptive_pooling_avg_nhwc_launch_config_forward(self, device):
         input = torch.randint(
@@ -447,7 +444,7 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertTrue(ref_out.is_contiguous())
         self.assertEqual(out, ref_out)
 
-    @onlyCUDA
+    @onlyAccelerator
     def test_adaptive_avg_pooling_overflow(self, device):
         input = torch.randint(
             -256, 256, (20, 32, 256, 256), dtype=torch.half, device=device
@@ -457,7 +454,7 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertFalse(torch.isinf(out).any())
         self.assertFalse(torch.isnan(out).any())
 
-    @onlyCUDA
+    @onlyAccelerator
     def test_adaptive_avg_pooling_nhwc_overflow(self, device):
         input = torch.randint(
             -256, 256, (20, 32, 256, 256), dtype=torch.half, device=device
@@ -469,7 +466,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertFalse(torch.isnan(out).any())
 
     @expectedFailureMPS  # No double, float shape prop does not work
-    @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double)
     def test_adaptive_pooling_zero_batch(self, dtype, device):
         inp = torch.ones(0, 10, dtype=dtype, device=device)
@@ -489,7 +485,6 @@ class TestPoolingNNDeviceType(NNTestCase):
     # These tests are explicitly written because ErrorInputs does not support backward calls
     # Issue: https://github.com/pytorch/pytorch/issues/78868
     @expectedFailureMPS  # No double, float shape prop does not work
-    @onlyNativeDeviceTypes
     @dtypes(torch.float32, torch.float64)
     @dtypesIfCUDA(torch.float32, torch.float64, torch.bfloat16, torch.float16)
     def test_adaptive_pooling_empty_output_size(self, dtype, device):
@@ -523,7 +518,6 @@ class TestPoolingNNDeviceType(NNTestCase):
                 fn(input2, output_size).sum().backward()
 
     @expectedFailureMPS  # Error message does not match
-    @onlyNativeDeviceTypes
     def test_adaptive_avg_pooling_backward_fails(self, device):
         grad_output = torch.randn(1, 2, 7, device=device)
         input = torch.randn(1, 2, 3, 3, device=device)
@@ -535,7 +529,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "Expected dimensions"):
             torch.ops.aten._adaptive_avg_pool3d_backward(grad_output, input)
 
-    @onlyNativeDeviceTypes
     def test_adaptive_max_pooling_backward_fails(self, device):
         grad_output = torch.randn(1, 2, 7, 7, device=device)
         input = torch.randn(1, 2, 7, 7, device=device)
@@ -550,7 +543,6 @@ class TestPoolingNNDeviceType(NNTestCase):
             torch.ops.aten.adaptive_max_pool3d_backward(grad_output, input, indices)
 
     @expectedFailureMPS  # Op not implemented
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool2d_zero_batch(self, device):
         mod = nn.FractionalMaxPool2d(3, output_ratio=(0.5, 0.5))
         inp = torch.ones(0, 16, 50, 32, device=device)
@@ -561,7 +553,6 @@ class TestPoolingNNDeviceType(NNTestCase):
             mod(inp)
 
     @expectedFailureMPS  # Op not implemented
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool3d_zero_batch(self, device):
         mod = nn.FractionalMaxPool3d(3, output_ratio=(0.5, 0.5, 0.5)).to(device)
         inp = torch.ones(0, 16, 50, 32, 32, device=device)
@@ -572,7 +563,6 @@ class TestPoolingNNDeviceType(NNTestCase):
             mod(inp)
 
     @expectedFailureMPS  # Op not implemented
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool2d_zero_out_size(self, device):
         mod = nn.FractionalMaxPool2d([2, 2], output_size=[0, 1])
         inp = torch.rand([16, 50, 32, 32], device=device)
@@ -580,7 +570,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(out, torch.empty((16, 50, 0, 1), device=device))
 
     @expectedFailureMPS  # Op not implemented
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool3d_zero_out_size(self, device):
         mod = nn.FractionalMaxPool3d([3, 2, 2], output_size=[0, 1, 1])
         inp = torch.rand([16, 50, 32, 32], device=device)
@@ -588,7 +577,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(out, torch.empty((16, 0, 1, 1), device=device))
 
     @expectedFailureMPS  # Op not implemented
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool2d_zero_samples(self, device):
         samples = torch.rand([0, 16, 2], device=device)
         mod = nn.FractionalMaxPool2d(
@@ -603,7 +591,6 @@ class TestPoolingNNDeviceType(NNTestCase):
             mod(inp1)
 
     @expectedFailureMPS  # Op not implemented
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool3d_zero_samples(self, device):
         samples = torch.rand([0, 16, 3], device=device)
         mod = nn.FractionalMaxPool3d(
@@ -617,7 +604,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "Expect _random_samples"):
             mod(inp1)
 
-    @onlyNativeDeviceTypes
     def test_FractionalMaxPool3d_errors(self, device):
         samples = torch.rand([0, 16, 3], device=device)
         with self.assertRaisesRegex(ValueError, "kernel_size must be greater than 0"):
@@ -638,7 +624,6 @@ class TestPoolingNNDeviceType(NNTestCase):
                 output_size=[1, 1, 1],
             )(samples)
 
-    @onlyNativeDeviceTypes
     def test_MaxPool3d_errors(self, device):
         samples = torch.randn(1, 3, 10, 10, 10)
         with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
@@ -652,7 +637,6 @@ class TestPoolingNNDeviceType(NNTestCase):
                 kernel_size=-1,
             )(samples)
 
-    @onlyNativeDeviceTypes
     def test_MaxPool_zero_batch_dim(self, device):
         inp = torch.randn(0, 16, 50, device=device)
         mod = torch.nn.MaxPool1d(3, stride=2).to(device)
@@ -677,7 +661,6 @@ class TestPoolingNNDeviceType(NNTestCase):
             inp = torch.ones(1, 0, 50, 44, 31, device=device)
             mod(inp)
 
-    @onlyNativeDeviceTypes
     def test_MaxUnpool_zero_batch_dim(self, device):
         pool = torch.nn.MaxPool1d(2, stride=2, return_indices=True).to(device)
         unpool = torch.nn.MaxUnpool1d(2, stride=2).to(device)
@@ -712,7 +695,6 @@ class TestPoolingNNDeviceType(NNTestCase):
         self.assertEqual(unpool_out, torch.zeros_like(unpool_out))
 
     @slowTest
-    @onlyNativeDeviceTypes
     @parametrize_test(
         "module_name,module_size,output_size,test_index,should_error",
         [
@@ -832,7 +814,6 @@ torch.cuda.synchronize()
                 unpool(output, indices)
 
     # https://github.com/pytorch/pytorch/issues/163409
-    @onlyNativeDeviceTypes
     def test_MaxUnpool_invalid_output_size(self, device):
         input2d = torch.randn(1, 1, 1)
         input3d = torch.randn(1, 1, 1, 1, 1)
@@ -846,7 +827,6 @@ torch.cuda.synchronize()
             unpool3d(input3d, torch.zeros_like(input3d, dtype=torch.int64))
 
     @expectedFailureMPS
-    @onlyNativeDeviceTypes
     def test_AdaptiveMaxPool_zero_batch_dim(self, device):
         inp = torch.randn(0, 16, 50, device=device)
         mod = torch.nn.AdaptiveMaxPool1d(3).to(device)
@@ -882,7 +862,6 @@ torch.cuda.synchronize()
         with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
             avgpool(inp)
 
-    @onlyNativeDeviceTypes
     def test_AvgPool2d_empty(self, device):
         avgpool = torch.nn.AvgPool2d(3, stride=2).to(device)
         inp = torch.randn(0, 16, 20, 32, device=device)
@@ -948,7 +927,6 @@ torch.cuda.synchronize()
         )
         self.assertEqual(y.size(), (1, 1, 3, 4))
 
-    @onlyNativeDeviceTypes  # TODO: fix on XLA
     def test_adaptive_avg_pool2d_output_size_one(self, device):
         def helper(size, memory_format):
             x = torch.randint(
@@ -978,7 +956,6 @@ torch.cuda.synchronize()
         for mf in (torch.contiguous_format, torch.channels_last, "non_contiguous"):
             helper((2, 3, 6, 6), mf)
 
-    @onlyNativeDeviceTypes
     def test_adaptive_avg_pool3d_output_size_one(self, device):
         x = torch.randn(
             (2, 3, 6, 6, 6), dtype=torch.float, device=device, requires_grad=True
@@ -996,7 +973,6 @@ torch.cuda.synchronize()
         self.assertEqual(out.stride(), [c, 1, 1, 1, 1])
 
     @expectedFailureMeta  # Runtime Error not raised for meta
-    @onlyNativeDeviceTypes
     @dtypes(torch.uint8, torch.int8, torch.short, torch.int, torch.long)
     def test_adaptive_pooling_no_suppot_input(self, device, dtype):
         for numel in (2, 3):
@@ -1027,7 +1003,6 @@ torch.cuda.synchronize()
         self.assertEqual(out, expected)
 
     @expectedFailureMPS  # TODO: fixme
-    @onlyNativeDeviceTypes
     @gcIfJetson
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
@@ -1095,7 +1070,6 @@ torch.cuda.synchronize()
         helper(10, 512, 31, 31, 3, stride=2)
         helper(1, 129, 8, 8, 3, stride=2)
 
-    @onlyNativeDeviceTypes
     @gcIfJetson
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
@@ -1271,7 +1245,7 @@ torch.cuda.synchronize()
         check(tensor, 3, 2, 1, 2, ceil_mode=True)
         check(tensor.transpose(1, 2), 3, 2, 1, 2, ceil_mode=True)
 
-    @onlyCUDA
+    @onlyAccelerator
     @gcIfJetson
     def test_max_pool2d(self, device):
         def helper(n, c, h, w, ks):
@@ -1296,7 +1270,6 @@ torch.cuda.synchronize()
         helper(1, 100000, 1, 4, ks=(1, 4))  # test for max_pool1d
 
     @expectedFailureMPS  # TODO: Fixme
-    @onlyNativeDeviceTypes
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @gcIfJetson
@@ -1372,7 +1345,6 @@ torch.cuda.synchronize()
         )
 
     @expectedFailureMPS  # TODO: Fixme
-    @onlyNativeDeviceTypes
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @gcIfJetson
@@ -1492,7 +1464,7 @@ torch.cuda.synchronize()
         helper((4, 10, 3, 8, 8), 3, 1, torch.contiguous_format, dtype)
         helper((4, 10, 8, 8, 8), 7, 1, torch.channels_last_3d, dtype)
 
-    @onlyCUDA
+    @onlyAccelerator
     @gcIfJetson
     def test_max_pool2d_indices(self, device):
         def helper(n, c, h, w, ks):
@@ -1524,7 +1496,6 @@ torch.cuda.synchronize()
         helper(2, 8, 4, 4, ks=2)
         helper(None, 3, 50, 50, ks=5)
 
-    @onlyNativeDeviceTypes
     def test_max_pool2d_with_indices_backward_fails(self, device):
         grad_output = torch.randn(1, 2, 7, 7, device=device)
         input = torch.randn(1, 2, 7, 7, device=device)
@@ -1691,7 +1662,7 @@ torch.cuda.synchronize()
             helper(4, 8, 9, 14, (2, 2), (1, 1), (1, 1), (2, 2), contig, device)
             helper(4, 8, 11, 11, (4, 4), (2, 2), (2, 2), (2, 2), contig, device)
 
-    @onlyCUDA
+    @onlyAccelerator
     def test_pool3d_size_one_feature_dim(self, device):
         # Tests crazy strides for feature dim of size 1
         x = torch.randn(7, 1, 5, 3, 2, device=device)
@@ -1710,7 +1681,7 @@ torch.cuda.synchronize()
             out_x = fn(x)
             self.assertEqual(out_y, out_x.to(device), msg=test)
 
-    @onlyCUDA
+    @onlyAccelerator
     @largeTensorTest("18GB")
     @largeTensorTest("180GB", "cpu")
     def test_pool3d_large_size_int64(self, device):
@@ -1733,7 +1704,7 @@ torch.cuda.synchronize()
         self.assertEqual(y, ref_y, exact_dtype=False)
         self.assertEqual(x.grad, ref_x.grad, exact_dtype=False)
 
-    @onlyCUDA
+    @onlyAccelerator
     def test_AvgPool3d_backward_after_cat_dim1_device(self, device):
         # x has to have batch_size 1 to test contiguous checks
         x = torch.randn(1, 3, 4, 4, 4, device=device, requires_grad=True)
@@ -1897,7 +1868,7 @@ torch.cuda.synchronize()
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float)
     @expectedFailureMPS  # Exception not raise
-    @onlyNativeDeviceTypes  # TODO: Fails on XLA
+    @expectedFailureXLA
     @gcIfJetson
     def test_max_pool_nan_inf(self, device, dtype):
         for adaptive in ["", "adaptive_"]:
@@ -1935,7 +1906,6 @@ torch.cuda.synchronize()
 
     @expectedFailureMPS  # float64
     @expectedFailureMeta  # RuntimeError: Unrecognized tensor type ID: Meta
-    @onlyNativeDeviceTypes
     def test_fractional_max_pool2d(self, device):
         with set_default_dtype(torch.double):
             x = torch.randn(1, 2, 7, 7, requires_grad=True, device=device)
@@ -1983,7 +1953,6 @@ torch.cuda.synchronize()
                         x, (2, 2), output_size=output_size, _random_samples=samples
                     )
 
-    @onlyNativeDeviceTypes
     def test_fractional_max_pool2d_backward_fails(self, device):
         grad_output = torch.randn(1, 1, 2, 3, 3, device=device)
         input = torch.randn(1, 2, 7, 7, device=device)
@@ -1998,7 +1967,6 @@ torch.cuda.synchronize()
 
     @expectedFailureMPS  # float64
     @expectedFailureMeta  # RuntimeError: Unrecognized tensor type ID: Meta
-    @onlyNativeDeviceTypes
     def test_fractional_max_pool3d(self, device):
         with set_default_dtype(torch.double):
             x = torch.randn(1, 2, 7, 7, 7, requires_grad=True, device=device)
@@ -2047,7 +2015,7 @@ torch.cuda.synchronize()
     @expectedFailureMPS  # Not implemented
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float)
-    @onlyNativeDeviceTypes  # TODO: Fails on XLA
+    @expectedFailureXLA
     def test_fractional_max_pool_nan_inf(self, device, dtype):
         for num_dim in [2, 3]:
             fn_name = f"FractionalMaxPool{num_dim}d"
@@ -2074,7 +2042,7 @@ torch.cuda.synchronize()
             res2.backward(torch.randn_like(res2))
             self.assertTrue(math.isinf(res2.item()))
 
-    @onlyNativeDeviceTypes  # TODO: RuntimeError message different on XLA
+    @expectedFailureXLA
     def test_pooling_zero_stride(self, device):
         for op in ("max", "avg"):
             for num_dim in [1, 2, 3]:
@@ -2110,7 +2078,7 @@ torch.cuda.synchronize()
                 # check if the output shape was still computed correctly
                 self.assertEqual(x.shape[2], res.shape[2])
 
-    @onlyCUDA
+    @onlyAccelerator
     @largeTensorTest("6GB")
     def test_pooling_large(self, device):
         def helper(pool):
@@ -2148,7 +2116,7 @@ torch.cuda.synchronize()
                         # some implementations do not support dilation
                         fn(x, 6, stride=2, padding=0)
 
-    @onlyCUDA
+    @onlyAccelerator
     def test_pooling_bfloat16(self, device):
         _test_bfloat16_ops(
             self,
@@ -2213,9 +2181,7 @@ torch.cuda.synchronize()
         F.adaptive_max_pool3d(imgs, (Od, Oh, Ow))
 
 
-instantiate_device_type_tests(
-    TestAvgPoolDeviceType, globals(), only_for=("cpu", "cuda")
-)
+instantiate_device_type_tests(TestAvgPoolDeviceType, globals(), except_for=("cpu"))
 instantiate_device_type_tests(TestPoolingNNDeviceType, globals(), allow_mps=True)
 instantiate_parametrized_tests(TestPoolingNN)
 


### PR DESCRIPTION
## Summary
Improve test reuse in `test/nn/test_pooling.py` for out-of-tree backends by replacing hardcoded device-specific test logic with device-type test patterns.

## Changes
- Added a new `TestAvgPoolDeviceType` class and moved 3 `ceil_mode` tests from `TestAvgPool` to use injected `device`.

- Moved the following methods from `TestPoolingNN` to `TestPoolingNNDeviceType`:
  - `test_adaptive_pooling_avg_nhwc`
  - `test_adaptive_pooling_avg_nhwc_non_contiguous`
  - `test_adaptive_pooling_avg_nhwc_launch_config_backward`
  - `test_adaptive_pooling_avg_nhwc_launch_config_forward`
  - `test_adaptive_avg_pooling_overflow`
  - `test_adaptive_avg_pooling_nhwc_overflow`

- Replaced `TEST_CUDA` checks and manual `device_list` branching with injected `device` usage.
- Removed `@onlyCUDA` and `@onlyNativeDeviceTypes` where they were unnecessarily restrictive.
- Replaced them with `@onlyAccelerator` where accelerator-only behavior is required.

## Test Plan

Verified on CUDA with:
- `python test/nn/test_pooling.py -v`

Ran 266 tests in 30.543s                                                                                                                
                                                                                                                                        
OK (skipped=59)  

cc: @fffrog @albanD @jbschlosser

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD