### PR TITLE
Support torch.compile under user FakeTensorMode

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10960,13 +10960,55 @@ def ___make_guard_fn():
     def test_compile_with_userland_fake_tensor_mode(self):
         # Test that torch.compile works when called inside a user's FakeTensorMode.
         # The user's fake tensors should be "refakified" to Dynamo's fake mode.
-        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 
-        with FakeTensorMode():
+        @torch.compile
+        def fn(x):
+            return x + 1
+
+        backend_fake_modes = []
+
+        def backend(gm, example_inputs):
+            context = torch._guards.TracingContext.try_get()
+            self.assertIsNotNone(context)
+            self.assertIsNotNone(context.fake_mode)
+            for example in example_inputs:
+                if isinstance(example, FakeTensor):
+                    backend_fake_modes.append(example.fake_mode)
+                    self.assertIs(example.fake_mode, context.fake_mode)
+            return gm.forward
+
+        with FakeTensorMode() as fake_mode:
+            out = fn(torch.rand(4, 4))
+            self.assertIsInstance(out, FakeTensor)
+            self.assertIs(out.fake_mode, fake_mode)
+
+            custom_out = torch.compile(lambda x: x.cos(), backend=backend)(
+                torch.rand(4, 4)
+            )
+            self.assertIsInstance(custom_out, FakeTensor)
+            self.assertIs(custom_out.fake_mode, fake_mode)
+            self.assertTrue(backend_fake_modes)
+            self.assertTrue(all(mode is not fake_mode for mode in backend_fake_modes))
+
             model = torch.nn.Linear(4, 4)
             inp = torch.rand(4, 4)
             loss = torch.compile(model, backend="aot_eager")(inp).sum()
             loss.backward()
+
+        real_inp = torch.rand(4, 4)
+        with FakeTensorMode(allow_non_fake_inputs=True) as fake_mode:
+            out = torch.compile(lambda x: x + 1)(real_inp)
+            self.assertIsInstance(out, FakeTensor)
+            self.assertIs(out.fake_mode, fake_mode)
+
+        opt = torch.compile(lambda x: x + 1)
+        first = opt(real_inp)
+        self.assertNotIsInstance(first, FakeTensor)
+        with FakeTensorMode(allow_non_fake_inputs=True) as fake_mode:
+            second = opt(real_inp)
+            self.assertIsInstance(second, FakeTensor)
+            self.assertIs(second.fake_mode, fake_mode)
 
     def test_scalar_tensor_is_equivalent_to_symint_argument(self):
         class GumbelTopKSampler(torch.nn.Module):

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -60,7 +60,14 @@ from torch._C._dynamo.guards import GlobalStateGuard
 from torch._dynamo.callback import CallbackTrigger
 from torch._dynamo.distributed import get_compile_pg
 from torch._dynamo.symbolic_convert import TensorifyState
-from torch._guards import compile_context, CompileContext, CompileId, tracing
+from torch._guards import (
+    active_fake_mode,
+    compile_context,
+    compile_runtime_fake_mode,
+    CompileContext,
+    CompileId,
+    tracing,
+)
 from torch._logging import structured
 from torch._utils_internal import (
     compile_time_strobelight_meta,
@@ -2615,7 +2622,12 @@ class CatchErrorsWrapper:
                         frame,
                     )
 
-        with compile_lock, _disable_current_modes():
+        runtime_fake_mode = active_fake_mode()
+        with (
+            compile_lock,
+            compile_runtime_fake_mode(runtime_fake_mode),
+            _disable_current_modes(),
+        ):
             # skip=1: skip this frame
             result = self._torchdynamo_orig_backend(
                 frame, cache_entry, self.hooks, frame_state, skip=1

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3166,6 +3166,25 @@ class GuardBuilder(GuardBuilderBase):
 
     # Global state guard — not source-specific, checked separately at runtime.
     @skip_guard_check_spec
+    def RUNTIME_FAKE_MODE(self, guard: Guard) -> None:
+        has_runtime_fake_mode = torch._guards.compile_runtime_fake_mode_active()
+        code = [
+            f"torch._guards.compile_runtime_fake_mode_active() == {has_runtime_fake_mode}"
+        ]
+        self._set_guard_export_info(guard, code)
+
+        def fn(x: Any) -> bool:
+            return (
+                torch._guards.compile_runtime_fake_mode_active()
+                == has_runtime_fake_mode
+            )
+
+        self.guard_manager.root.add_lambda_guard(
+            fn, get_verbose_code_parts(code, guard), guard.user_stack
+        )
+
+    # Global state guard — not source-specific, checked separately at runtime.
+    @skip_guard_check_spec
     def DEFAULT_DEVICE(self, guard: Guard) -> None:
         """Guard on CURRENT_DEVICE per torch.utils._device"""
         if guard.source is not GuardSource.GLOBAL:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1118,6 +1118,7 @@ class OutputGraph(OutputGraphCommon):
         self.guards.add(
             GlobalStateSource().make_guard(GuardBuilder.TORCH_FUNCTION_STATE)
         )
+        self.guards.add(GlobalStateSource().make_guard(GuardBuilder.RUNTIME_FAKE_MODE))
 
         ci = torch._C._functorch.peek_interpreter_stack()
         if ci is not None:
@@ -3156,7 +3157,17 @@ class OutputGraph(OutputGraphCommon):
         return next_name
 
     def example_inputs(self) -> list[torch.Tensor]:
-        result = [arg.example for arg in self.graphargs]
+        fake_mode = self.tracing_context.fake_mode
+        result = []
+        for arg in self.graphargs:
+            example = arg.example
+            if (
+                fake_mode is not None
+                and isinstance(example, FakeTensor)
+                and example.fake_mode is not fake_mode
+            ):
+                example = fake_mode.from_tensor(example)
+            result.append(example)
         # pyrefly: ignore[bad-return]
         return result
 

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1005,6 +1005,7 @@ class HopDispatchSetCache:
 
 
 _TLS = threading.local()
+_MISSING = object()
 
 """
 TracingContext is the source of truth for all currently accumulated information
@@ -1584,10 +1585,35 @@ def active_fake_mode() -> FakeTensorMode | None:
     Returns None if no fake mode is active.
     """
     from torch._subclasses.fake_tensor import FakeTensorMode
-    from torch.utils._python_dispatch import _get_current_dispatch_mode_stack
 
-    for _, m in enumerate(reversed(_get_current_dispatch_mode_stack())):
+    for idx in range(torch._C._len_torch_dispatch_stack() - 1, -1, -1):
+        m = torch._C._get_dispatch_stack_at(idx)
         if isinstance(m, FakeTensorMode):
             return m
 
     return None
+
+
+@contextmanager
+def compile_runtime_fake_mode(fake_mode: FakeTensorMode | None) -> Any:
+    """
+    Preserve an active user FakeTensorMode while compilation disables dispatch
+    modes internally.
+    """
+    prior = getattr(_TLS, "compile_runtime_fake_mode", _MISSING)
+    _TLS.compile_runtime_fake_mode = fake_mode
+    try:
+        yield
+    finally:
+        if prior is _MISSING:
+            del _TLS.compile_runtime_fake_mode
+        else:
+            _TLS.compile_runtime_fake_mode = prior
+
+
+def get_compile_runtime_fake_mode() -> FakeTensorMode | None:
+    return getattr(_TLS, "compile_runtime_fake_mode", None)
+
+
+def compile_runtime_fake_mode_active() -> bool:
+    return get_compile_runtime_fake_mode() is not None or active_fake_mode() is not None

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1227,6 +1227,11 @@ class FxGraphHashDetails:
                     self.fx_kwargs[k] = OrderedSetHolder(sorted(v))  # type: ignore[call-overload]
                 else:
                     self.fx_kwargs[k] = v
+        if torch._guards.compile_runtime_fake_mode_active():
+            # Fake-mode runtime calls need the inductor_compiled_code wrapper
+            # and therefore a cached graph that serialized its original FX graph.
+            # Keep those entries separate from ordinary real-input compiles.
+            self.runtime_fake_mode_active = True
 
         from torch._higher_order_ops.triton_kernel_wrap import (
             kernel_side_table,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -99,6 +99,7 @@ from torch._inductor.utils import (
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import is_opaque_type
 from torch._logging import trace_structured
+from torch._subclasses.fake_tensor import FakeTensor
 from torch._utils_internal import compile_time_strobelight_meta
 from torch.fx import GraphModule
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols, SymExprPrinter
@@ -759,6 +760,10 @@ def with_fresh_cache_if_config() -> Generator[None, None, None]:
         yield
 
 
+def _has_fake_tensor(inputs: Sequence[InputType]) -> bool:
+    return any(isinstance(t, FakeTensor) for t in inputs)
+
+
 class _CompileFxKwargs(TypedDict, total=False):
     cudagraphs: BoxedBool | None
     static_input_idxs: Sequence[int]
@@ -772,6 +777,7 @@ class _CompileFxKwargs(TypedDict, total=False):
     boxed_forward_device_index: BoxedDeviceIndex | None
     fx_wrapper: bool
     get_decomp_fn: Callable[..., dict[Any, Callable[..., Any]]]
+    runtime_inputs_are_fake: bool
 
 
 class _CompileFxCallable(Protocol):
@@ -2427,6 +2433,7 @@ def compile_fx_forward(
     compiler_config_extra: CompilerConfigExtra,
     inner_compile: Callable[..., OutputCode] = compile_fx_inner,
     is_inference: bool = False,
+    runtime_inputs_are_fake: bool = False,
 ) -> OutputCode:
     """
     Compile the forward graph of the given graph module.
@@ -2531,16 +2538,18 @@ def compile_fx_forward(
     # original strides
     _recursive_record_user_visible_output_idxs(gm)
 
+    compile_kwargs: _CompileFxKwargs = {
+        "static_input_idxs": get_static_input_idxs(fixed),
+        "cudagraphs": compiler_config_extra.cudagraphs,
+        "graph_id": compiler_config_extra.graph_id,
+        "is_inference": is_inference,
+        "boxed_forward_device_index": compiler_config_extra.forward_device,
+    }
+    if runtime_inputs_are_fake:
+        compile_kwargs["runtime_inputs_are_fake"] = True
+
     with cudagraph_annotation_context(compiler_config_extra.cudagraphs):
-        result = inner_compile(
-            gm,
-            example_inputs,
-            static_input_idxs=get_static_input_idxs(fixed),
-            cudagraphs=compiler_config_extra.cudagraphs,
-            graph_id=compiler_config_extra.graph_id,
-            is_inference=is_inference,
-            boxed_forward_device_index=compiler_config_extra.forward_device,
-        )
+        result = inner_compile(gm, example_inputs, **compile_kwargs)
 
         if (
             not is_inference
@@ -2558,6 +2567,7 @@ def compile_fx_backward(
     example_inputs: Sequence[InputType],
     compiler_config_extra: CompilerConfigExtra,
     inner_compile: Callable[..., OutputCode] = compile_fx_inner,
+    runtime_inputs_are_fake: bool = False,
 ) -> OutputCode:
     """
     Compile the backward graph of the given graph module.
@@ -2604,15 +2614,17 @@ def compile_fx_backward(
             ),
             cudagraph_annotation_context(cudagraphs),
         ):
-            return inner_compile(
-                gm,
-                example_inputs,
-                static_input_idxs=static_input_idxs,
-                cudagraphs=cudagraphs,
-                is_backward=True,
-                graph_id=compiler_config_extra.graph_id,
-                boxed_forward_device_index=compiler_config_extra.forward_device,
-            )
+            compile_kwargs: _CompileFxKwargs = {
+                "static_input_idxs": static_input_idxs,
+                "cudagraphs": cudagraphs,
+                "is_backward": True,
+                "graph_id": compiler_config_extra.graph_id,
+                "boxed_forward_device_index": compiler_config_extra.forward_device,
+            }
+            if runtime_inputs_are_fake:
+                compile_kwargs["runtime_inputs_are_fake"] = True
+
+            return inner_compile(gm, example_inputs, **compile_kwargs)
 
 
 def run_pre_grad_passes(
@@ -2888,6 +2900,10 @@ def _compile_fx_main(
         assert not config._raise_error_for_testing
 
         num_example_inputs = len(example_inputs_)
+        runtime_inputs_are_fake = (
+            _has_fake_tensor(example_inputs_)
+            or torch._guards.compile_runtime_fake_mode_active()
+        )
 
         compiler_config_extra = create_compiler_config_extra(model_)
 
@@ -2912,6 +2928,7 @@ def _compile_fx_main(
                     compiler_config_extra=compiler_config_extra,
                     inner_compile=inner_compile,
                     is_inference=is_inference,
+                    runtime_inputs_are_fake=runtime_inputs_are_fake,
                 )
 
         fw_compiler: Callable[[GraphModule, Sequence[InputType]], OutputCode] = (
@@ -2947,6 +2964,7 @@ def _compile_fx_main(
                     example_inputs,
                     compiler_config_extra=compiler_config_extra,
                     inner_compile=inner_compile,
+                    runtime_inputs_are_fake=runtime_inputs_are_fake,
                 )
 
         bw_compiler = SerializableAOTDispatchCompiler(OutputCode, bw_compiler)

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -78,6 +78,15 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def _copy_stripped_gm(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    import copy
+
+    gm_copy = copy.deepcopy(gm)
+    for node in gm_copy.graph.nodes:
+        node.meta.clear()
+    return gm_copy
+
+
 @dataclasses.dataclass
 class OutputCode:
     # TODO: Remove underscores here
@@ -686,18 +695,17 @@ class CompiledFxGraph(OutputCode):
 
         # Store whether to wrap compiled regions in inductor_compiled_code HOP
         # This is set at compile time to avoid runtime overhead
-        self._wrap_compiled_regions = config.wrap_inductor_compiled_regions
+        self._wrap_compiled_regions = (
+            config.wrap_inductor_compiled_regions
+            or fx_kwargs.get("runtime_inputs_are_fake", False)
+            or torch._guards.compile_runtime_fake_mode_active()
+        )
 
         if self._wrap_compiled_regions:
             # Store a metadata-stripped copy of the FX graph. Running this
             # under FakeTensorMode re-derives output shapes and aliasing
             # from the input fake tensors.
-            import copy
-
-            gm_copy = copy.deepcopy(gm)
-            for node in gm_copy.graph.nodes:
-                node.meta.clear()
-            self._original_gm = gm_copy
+            self._original_gm = _copy_stripped_gm(gm)
 
     def __del__(self) -> None:
         if self.compiled_fn_runner is not None:
@@ -894,6 +902,16 @@ class CompiledFxGraph(OutputCode):
             original_gm.recompile()
             self._original_gm = original_gm
             self._serialized_original_gm = None
+
+        if (
+            graph_kwargs.get("runtime_inputs_are_fake", False)
+            or torch._guards.compile_runtime_fake_mode_active()
+        ):
+            self._wrap_compiled_regions = True
+            if self._original_gm is None and isinstance(
+                constants, CompiledFxGraphConstantsWithGm
+            ):
+                self._original_gm = _copy_stripped_gm(constants.gm)
 
         # Apply inductor_compiled_code HOP wrapper if configured
         # This is done in post_compile to ensure it works with cached artifacts


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185347

Dynamo creates its own FakeTensorMode for tracing and then switches to a fresh backend FakeTensorMode before handing graphs to AOTAutograd/Inductor. When torch.compile was invoked under a user-created FakeTensorMode, backend example inputs could still belong to the user fake mode, which tripped fake-mode consistency checks. Even after refakifying inputs, Inductor could reuse real-input compiled artifacts for later fake-runtime calls and execute generated kernels against FakeTensors instead of using the fake-safe FX fallback path.

Fix this by refakifying fake graph examples into the active Dynamo/backend fake mode before backend handoff, preserving the presence of an active user FakeTensorMode while Dynamo disables dispatch modes during compilation, and guarding Dynamo graphs on runtime fake-mode presence. Inductor now threads that fake-runtime bit through forward/backward compilation, separates fake-runtime FX cache entries from ordinary real-input entries, and enables the existing inductor_compiled_code FX fallback only for fake-runtime compilations or explicit wrap_inductor_compiled_regions users.

The alternative was to always wrap Inductor compiled regions or to key on the specific FakeTensorMode object. Always wrapping would add overhead to ordinary real-input compiles, while keying on identity would over-fragment caches for modes that share the same behavior. A presence guard is sufficient because the compiled graph only needs to distinguish whether runtime dispatch should preserve FakeTensorMode semantics.

Fixes #160057
Fixes #136586

Generated by my agent

Test Plan:

- python test/dynamo/test_misc.py MiscTests.test_compile_with_userland_fake_tensor_mode

- python test/dynamo/test_wrap_inductor_compiled_regions.py TestWrapInductorCompiledRegions.test_wrap_default_disabled

- python - <<'PY' ... cache-order repro: compile once outside FakeTensorMode, then call inside FakeTensorMode(allow_non_fake_inputs=True) ... PY

- python - <<'PY' ... CUDA fake tensor repro from issue ... PY

- lintrunner -a

- git diff --check

- git diff --cached --check

Benchmark Results:

Cached-call microbenchmark using torch.compile(fn, backend='eager') on x + 1, 9 samples of 10,000 calls after warmup.

- main baseline median: 14.576 us/call; min: 14.416 us/call

- patched median: 15.776 us/call; min: 15.681 us/call

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @mlazos