### PR TITLE
[pytorch] add environment variable to enable line tables in aoti wrapper.so

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2176,6 +2176,9 @@ class aot_inductor:
         os.environ.get("AOT_INDUCTOR_ENABLE_FRAME_POINTER", "1") == "1"
     )
 
+    # Enable lightweight line tables for profiling tools (e.g. strobelight)
+    enable_line_tables = os.environ.get("AOT_INDUCTOR_ENABLE_LINE_TABLES", "1") == "1"
+
     # Annotate generated main wrapper function, i.e. AOTInductorModel::run_impl,
     # to use which cpp compiler optimization level, default to O1
     compile_wrapper_opt_level = os.environ.get(

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1060,6 +1060,13 @@ def _get_optimization_cflags(
         else:
             cflags.append("fno-omit-frame-pointer")
 
+    if config.aot_inductor.enable_line_tables and not should_add_debug_symbol_flags:
+        if not _IS_WINDOWS:
+            if _is_clang(cpp_compiler):
+                cflags.append("gline-tables-only")
+            else:
+                cflags.append("g1")
+
     cflags += _get_ffast_math_flags()
 
     if _IS_WINDOWS:


### PR DESCRIPTION
Summary:
Add a new `config.aot_inductor.enable_line_tables` option that passes `-gline-tables-only` (Clang) or `-g1` (GCC) to the C++ compiler when building AOTInductor shared libraries. This generates DWARF line tables without full debug info, allowing profiling tools like Strobelight to resolve source line numbers in stack traces (the `stack_linenums` column) through AOTInductor-compiled code.

Previously, D99431656 added `-fno-omit-frame-pointer` which enabled Strobelight to walk the stack and see `.wrapper.cpp` frames, but line numbers were missing because frame pointers only enable stack walking — they do not produce the address-to-line mapping that symbolizers need. That mapping comes from DWARF line tables, which require a `-g` variant flag.

Full `-g` (`AOT_INDUCTOR_DEBUG_SYMBOLS=1`) works but is heavyweight — it emits complete DWARF debug info (types, variables, scopes), significantly increasing `.so` size and compilation time. `-gline-tables-only` / `-g1` is the standard production-profiling compromise: it emits only the line number tables, with much less overhead.

Enabled by default via `AOT_INDUCTOR_ENABLE_LINE_TABLES=1` env var or `torch._inductor.config.aot_inductor.enable_line_tables = True`. Can be disabled with `AOT_INDUCTOR_ENABLE_LINE_TABLES=0`. When full debug symbols are already enabled (`debug_symbols` or `debug_compile`), the line-tables flag is skipped so the stronger `-g` is not downgraded.

Test Plan:
AOT_INDUCTOR_ENABLE_LINE_TABLE is disabled explicitly:

```
[nbeloborodov@devgpu031]% export AOT_INDUCTOR_ENABLE_LINE_TABLE=0
[nbeloborodov@devgpu031]% buck2 run mode/dev-nosan caffe2/test/inductor:provenance_tracing -- -r test_aoti_python_stack_traces
```
```
[nbeloborodov@devgpu031]~% strobe gpuevent --duration-ms=45000 --collect-kernel-events --kernel-sample-interval=0 --attach-to-driver-api --collect-native-stacks --collect-aoti-stacks --log-address-stack --log-module-stack --log-symbolizer-stack --pids 873143
Running "gpuevent" with run id 2265853518695972 and group_trace_id "" on hosts: ["::1"]
Press Ctrl-C to stop the run
> Queuing...	 (00:00:00.001)
> Preparing...	 (00:00:03.171)
> Profiling...	 (00:00:45.458)
> Processing...	 (00:00:02.525)
> Logging...	 (00:00:00.027)
> Finished
| Host | Return Code | Samples | Result Links                                               |
|------|-------------|---------|------------------------------------------------------------|
| ::1  | SUCCESS     | 3       | Icicle view (Kernel Launch Stacks):                        |
|      |             |         | https://fburl.com/scuba/strobelight_gpu/on_demand/rrmc5m3h |
|      |             |         |                                                            |
|      |             |         | Raw samples:                                               |
|      |             |         | https://fburl.com/scuba/strobelight_gpu/on_demand/mcqg9af7 |
|      |             |         |                                                            |
|      |             |         | Run Details:                                               |
|      |             |         | https://fburl.com/scuba/strobelight_runs/qref0gz0          |
```
```
[unknown]
glibc/2.34/src/glibc-2.34/csu/libc-start.c:409
glibc/2.34/src/glibc-2.34/sysdeps/nptl/libc_start_call_main.h:58
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
include/pybind11/pybind11.h:1209
include/pybind11/pybind11.h:540
include/pybind11/pybind11.h:333
caffe2/torch/csrc/inductor/aoti_package/pybind.cpp:38
caffe2/torch/csrc/inductor/aoti_package/model_package_loader.cpp:951
caffe2/torch/csrc/inductor/aoti_runner/model_container_runner.cpp:199
caffe2/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.cpp:28
caffe2/torch/csrc/inductor/aoti_runner/model_container_runner.cpp:157
[unknown]
[unknown]
[unknown]
[unknown]
clnhnkuvkwaob5ez4pwo7zybham2q4vpxh2kcllezjlr355aoryu.wrapper.cpp
clnhnkuvkwaob5ez4pwo7zybham2q4vpxh2kcllezjlr355aoryu.wrapper.cpp
```
AOT_INDUCTOR_ENABLE_LINE_TABLE is enabled explicitly:
```
[nbeloborodov@devgpu031]~/fbsource/fbcode% export AOT_INDUCTOR_ENABLE_LINE_TABLES=1
[nbeloborodov@devgpu031]% buck2 run mode/dev-nosan caffe2/test/inductor:provenance_tracing -- -r test_aoti_python_stack_traces
```
```
[nbeloborodov@devgpu031]~% strobe gpuevent --duration-ms=60000 --collect-kernel-events --kernel-sample-interval=0 --attach-to-driver-api --collect-native-stacks --collect-aoti-stacks --log-address-stack --log-module-stack --log-symbolizer-stack --pids 1289894
Running "gpuevent" with run id -4318367199197358 and group_trace_id "" on hosts: ["::1"]
Press Ctrl-C to stop the run
> Queuing...	 (00:00:00.002)
> Preparing...	 (00:00:03.082)
> Profiling...	 (00:01:01.028)
> Processing...	 (00:00:01.789)
> Logging...	 (00:00:00.030)
> Finished
| Host | Return Code | Samples | Result Links                                               |
|------|-------------|---------|------------------------------------------------------------|
| ::1  | SUCCESS     | 4       | Icicle view (Kernel Launch Stacks):                        |
|      |             |         | https://fburl.com/scuba/strobelight_gpu/on_demand/u2r278h5 |
|      |             |         |                                                            |
|      |             |         | Raw samples:                                               |
|      |             |         | https://fburl.com/scuba/strobelight_gpu/on_demand/hm4tm4do |
|      |             |         |                                                            |
|      |             |         | Run Details:                                               |
|      |             |         | https://fburl.com/scuba/strobelight_runs/pf0tjms2          |
```
```
[unknown]
glibc/2.34/src/glibc-2.34/csu/libc-start.c:409
glibc/2.34/src/glibc-2.34/sysdeps/nptl/libc_start_call_main.h:58
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
include/pybind11/pybind11.h:1209
include/pybind11/pybind11.h:540
include/pybind11/pybind11.h:333
caffe2/torch/csrc/inductor/aoti_package/pybind.cpp:38
caffe2/torch/csrc/inductor/aoti_package/model_package_loader.cpp:951
caffe2/torch/csrc/inductor/aoti_runner/model_container_runner.cpp:199
caffe2/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.cpp:28
caffe2/torch/csrc/inductor/aoti_runner/model_container_runner.cpp:157
/tmp/tmpcglbkkw4/cwhkamk7hukdm5d55b4fxkyyok5x57mzbc2hzfy243x4xp2dcbtz/cjoggitxfwprxh7am27d7hlac4itywodzaldxk2n7fdg2dlokxih.wrapper.cpp:130
/data/users/nbeloborodov/fbsource/buck-out/v2/art/fbcode/5e823f9aee8c9508/caffe2/test/inductor/__provenance_tracing__/provenance_tracing#link-tree/torch/include/torch/csrc/inductor/aoti_runtime/model_container.h:201
/data/users/nbeloborodov/fbsource/buck-out/v2/art/fbcode/5e823f9aee8c9508/caffe2/test/inductor/__provenance_tracing__/provenance_tracing#link-tree/torch/include/torch/csrc/inductor/aoti_runtime/model_base.h:519
/tmp/tmpcglbkkw4/cwhkamk7hukdm5d55b4fxkyyok5x57mzbc2hzfy243x4xp2dcbtz/cjoggitxfwprxh7am27d7hlac4itywodzaldxk2n7fdg2dlokxih.wrapper.cpp:1421
buck-out/v2/art/fbcode/caffe2/__gen_aten__/d32949ec848ae7fd/out/torch/csrc/inductor/aoti_torch/generated/c_shim_cuda.cpp:1345
buck-out/v2/art/fbcode/caffe2/__gen_aten__/d32949ec848ae7fd/out/RegisterCUDA_0.cpp:14923
caffe2/aten/src/ATen/native/cuda/Blas.cpp:648
caffe2/aten/src/ATen/native/cuda/Blas.cpp:322
caffe2/aten/src/ATen/cuda/CUDABlas.cpp:1140
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
```
AOT_INDUCTOR_ENABLE_LINE_TABLE is enabled implicitly:
```
[nbeloborodov@devgpu031]~/fbsource/fbcode% buck2 run mode/dev-nosan fbcode//caffe2/test/inductor:provenance_tracing -- -r test_aoti_python_stack_traces
```
```
[nbeloborodov@devgpu031]~% strobe gpuevent --duration-ms=60000 --collect-kernel-events --kernel-sample-interval=0 --attach-to-driver-api --collect-native-stacks --collect-aoti-stacks --log-address-stack --log-module-stack --log-symbolizer-stack --pids 1840157
Running "gpuevent" with run id -5710665134750513 and group_trace_id "" on hosts: ["::1"]
Press Ctrl-C to stop the run
> Queuing...	 (00:00:00.002)
> Preparing...	 (00:00:03.274)
> Profiling...	 (00:01:00.797)
> Processing...	 (00:00:02.374)
> Logging...	 (00:00:00.029)
> Finished
| Host | Return Code | Samples | Result Links                                               |
|------|-------------|---------|------------------------------------------------------------|
| ::1  | SUCCESS     | 4       | Icicle view (Kernel Launch Stacks):                        |
|      |             |         | https://fburl.com/scuba/strobelight_gpu/on_demand/lhpp1vd8 |
|      |             |         |                                                            |
|      |             |         | Raw samples:                                               |
|      |             |         | https://fburl.com/scuba/strobelight_gpu/on_demand/i9wdvve8 |
|      |             |         |                                                            |
|      |             |         | Run Details:                                               |
|      |             |         | https://fburl.com/scuba/strobelight_runs/98bavw7d          |
```
```
[unknown]
glibc/2.34/src/glibc-2.34/csu/libc-start.c:409
glibc/2.34/src/glibc-2.34/sysdeps/nptl/libc_start_call_main.h:58
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
include/pybind11/pybind11.h:1209
include/pybind11/pybind11.h:540
include/pybind11/pybind11.h:333
caffe2/torch/csrc/inductor/aoti_package/pybind.cpp:38
caffe2/torch/csrc/inductor/aoti_package/model_package_loader.cpp:951
caffe2/torch/csrc/inductor/aoti_runner/model_container_runner.cpp:199
caffe2/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.cpp:28
caffe2/torch/csrc/inductor/aoti_runner/model_container_runner.cpp:157
/tmp/tmpzb8qpii9/cwhkamk7hukdm5d55b4fxkyyok5x57mzbc2hzfy243x4xp2dcbtz/ccmp22uzma5xokzkbg3wdlzmp6jjcyn55b4hdes7wxgbbcqfmrrk.wrapper.cpp:130
/data/users/nbeloborodov/fbsource/buck-out/v2/art/fbcode/5e823f9aee8c9508/caffe2/test/inductor/__provenance_tracing__/provenance_tracing#link-tree/torch/include/torch/csrc/inductor/aoti_runtime/model_container.h:201
/data/users/nbeloborodov/fbsource/buck-out/v2/art/fbcode/5e823f9aee8c9508/caffe2/test/inductor/__provenance_tracing__/provenance_tracing#link-tree/torch/include/torch/csrc/inductor/aoti_runtime/model_base.h:519
/tmp/tmpzb8qpii9/cwhkamk7hukdm5d55b4fxkyyok5x57mzbc2hzfy243x4xp2dcbtz/ccmp22uzma5xokzkbg3wdlzmp6jjcyn55b4hdes7wxgbbcqfmrrk.wrapper.cpp:1366
buck-out/v2/art/fbcode/caffe2/__gen_aten__/d32949ec848ae7fd/out/torch/csrc/inductor/aoti_torch/generated/c_shim_cuda.cpp:1345
buck-out/v2/art/fbcode/caffe2/__gen_aten__/d32949ec848ae7fd/out/RegisterCUDA_0.cpp:14923
caffe2/aten/src/ATen/native/cuda/Blas.cpp:648
caffe2/aten/src/ATen/native/cuda/Blas.cpp:322
caffe2/aten/src/ATen/cuda/CUDABlas.cpp:1140
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
[unknown]
```

Reviewed By: banitag1

Differential Revision: D106384603




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo