### PR TITLE
[pipelining] Fix backward hook accumulation on recv buffer activations

### DIFF
--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -9,6 +9,7 @@ from torch.distributed.pipelining import (
     build_stage,
     pipeline,
     PipelineStage,
+    Schedule1F1B,
     ScheduleGPipe,
 )
 from torch.distributed.pipelining._utils import PipeliningMetadataError
@@ -332,6 +333,83 @@ class StageTest(MultiProcContinuousTest):
             self.assertEqual(
                 len(stage.output_chunks), 0, "Last stage should store output chunks"
             )
+
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+    )
+    def test_recv_buffer_hooks_do_not_accumulate(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/185331
+        # Backward hooks on stage-boundary activations must not accumulate across
+        # training steps. Before the fix, requires_grad_() was in-place and returned
+        # self, aliasing the persistent recv buffer directly as the stage activation.
+        # Hooks registered in step N persisted into step N+1 causing fired counts to
+        # grow: 2, 4, 6, 8, 10. detach() gives a fresh tensor identity each step
+        # (zero-copy, preserves pinned/custom allocator properties) so hooks are
+        # discarded naturally when the activation goes out of scope.
+        n_microbatches = 2
+        n_steps = 5
+
+        full_mod = MultiMLP(d_hid, n_layers=self.world_size)
+        full_mod.to(self.device)
+        x = torch.randn(batch_size, d_hid, device=self.device)
+        split_spec = full_mod.split_spec if hasattr(full_mod, "split_spec") else None
+        pipe = pipeline(module=full_mod, mb_args=(x,), split_spec=split_spec)
+        stage = pipe.build_stage(self.rank, self.device, None)
+
+        fired_hook_ids = []
+        next_hook_id = [0]
+
+        def add_tensor_hook(module):
+            def pre_hook(_module, inputs):
+                inp = inputs[0]
+                hook_id = next_hook_id[0]
+                next_hook_id[0] += 1
+
+                def tensor_hook(_grad):
+                    fired_hook_ids.append(hook_id)
+
+                inp.register_hook(tensor_hook)
+
+            module.register_forward_pre_hook(pre_hook)
+
+        if self.rank == self.world_size - 1:
+            first_submod = next(stage.submod.children())
+            add_tensor_hook(first_submod)
+
+        loss_fn = torch.nn.MSELoss()
+        hooks_per_step = []
+
+        for _step in range(n_steps):
+            fired_hook_ids.clear()
+            inp = torch.randn(batch_size, d_hid, device=self.device)
+            target = torch.randn(batch_size, d_hid, device=self.device)
+            schedule = Schedule1F1B(
+                stage,
+                n_microbatches=n_microbatches,
+                loss_fn=loss_fn,
+            )
+            if self.rank == 0:
+                schedule.step(inp)
+            else:
+                schedule.step(target=target)
+            if self.rank == self.world_size - 1:
+                hooks_per_step.append(len(fired_hook_ids))
+
+        if self.rank == self.world_size - 1:
+            # Before fix (buffer aliased as activation): [2, 4, 6, 8, 10]
+            # After fix  (detach gives fresh identity):  [2, 2, 2, 2,  2]
+            for step, count in enumerate(hooks_per_step):
+                self.assertEqual(
+                    count,
+                    n_microbatches,
+                    msg=(
+                        f"Step {step}: expected {n_microbatches} hooks "
+                        f"(== n_microbatches), got {count}. "
+                        f"Hook accumulation regression on recv buffer. "
+                        f"All steps: {hooks_per_step}"
+                    ),
+                )
 
 
 instantiate_parametrized_tests(StageTest)

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -630,7 +630,13 @@ class _PipelineStageBase(ABC):
                         run_check=False,
                     ).requires_grad_(effective_requires_grad)
                 else:
-                    activation = info.buffer.requires_grad_(effective_requires_grad)
+                    # Detach instead of aliasing the buffer directly: requires_grad_()
+                    # is in-place and returns self, so hooks attached to the activation
+                    # would accumulate on the persistent recv buffer across steps.
+                    # See https://github.com/pytorch/pytorch/issues/185331
+                    activation = info.buffer.detach().requires_grad_(
+                        effective_requires_grad
+                    )
                 # Activation must be a leaf so backward terminates here.
                 if effective_requires_grad and not activation.is_leaf:
                     warnings.warn(


### PR DESCRIPTION
Fixes #185331

**Root cause:**
`_retrieve_recv_activations` passed `info.buffer` directly as the stage
activation via `requires_grad_()`, which is in-place and returns `self`.
This aliased the persistent recv buffer as the activation tensor, so
backward hooks attached by user code (e.g. via module forward pre-hooks
for gradient collection or debugging) accumulated on the buffer across
steps rather than being discarded — causing hook fired counts to grow
as 2, 4, 6, 8, 10 instead of staying constant at 2.

**Fix:**
Clone the recv buffer before use as the stage activation. The clone is a
fresh leaf tensor each step, giving stage-boundary activations the same
lifecycle as normal non-pipelined activations. The recv buffer itself
remains untouched and continues to serve as the `irecv` target.

**Test:**
`test/distributed/pipelining/test_recv_buffer_hooks.py` — runs
Schedule1F1B with 2 processes, attaches a forward pre-hook that
registers tensor backward hooks, and asserts hook fired count stays
constant (== n_microbatches) across 5 steps.