### PR TITLE
[PrivateUse1] Add dedicated LSTM dispatch branch for PU1 backends.

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -757,7 +757,7 @@ struct LSTMCell : Cell<std::tuple<Tensor, Tensor>, cell_params> {
       bool pre_compute_input = false) const override {
     const auto& [hx, cx] = hidden;
 
-    if (input.is_cuda() || input.is_xpu() || input.is_privateuseone()) {
+    if (input.is_cuda() || input.is_xpu()) {
       TORCH_CHECK(!pre_compute_input);
       auto igates = params.matmul_ih(input);
       auto hgates = params.matmul_hh(hx);
@@ -793,7 +793,7 @@ struct GRUCell : Cell<Tensor, cell_params> {
       const hidden_type& hidden,
       const cell_params& params,
       bool pre_compute_input = false) const override {
-    if (input.is_cuda() || input.is_xpu() || input.is_privateuseone()) {
+    if (input.is_cuda() || input.is_xpu()) {
       TORCH_CHECK(!pre_compute_input);
       auto igates = params.matmul_ih(input);
       auto hgates = params.matmul_hh(hidden);
@@ -1466,6 +1466,18 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
       TensorList _params, bool has_biases,
       int64_t num_layers, double dropout_p, bool train, bool bidirectional, bool batch_first) {
   TORCH_CHECK(hx.size() == 2, "lstm expects two hidden states");
+  if (_input.is_privateuseone()) {
+    check_attributes(_input, _params, hx);
+    auto input = batch_first ? _input.transpose(0, 1) : _input;
+    bool has_projections = (hx[0].sym_size(2) != hx[1].sym_size(2));
+    auto params = gather_params(_params, has_biases, has_projections);
+    auto results = _lstm_impl<FullLayer, FullBidirectionalLayer>(
+        input, params, hx[0], hx[1], num_layers, dropout_p, train, bidirectional);
+    if (batch_first) {
+      std::get<0>(results) = std::get<0>(results).transpose(0, 1);
+    }
+    return results;
+  }
   if (use_cudnn(_input)) {
     Tensor output, hy, cy;
     lstm_cudnn_stub(_input.device().type(), output, hy, cy, _input, hx, _params, has_biases,
@@ -1530,6 +1542,17 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
       TensorList _params, bool has_biases,
       int64_t num_layers, double dropout_p, bool train, bool bidirectional) {
   TORCH_CHECK(hx.size() == 2, "lstm expects two hidden states");
+  if (data.is_privateuseone()) {
+    bool has_projections = (hx[0].size(2) != hx[1].size(2));
+    PackedSequence input { data, batch_sizes };
+    auto params = gather_params(_params, has_biases, has_projections);
+    auto result = _lstm_impl<PackedLayer, PackedBidirectionalLayer>(
+        input, params, hx[0], hx[1], num_layers, dropout_p, train, bidirectional);
+    auto & packed_output = std::get<0>(result);
+    return std::make_tuple(std::move(packed_output.data),
+                           std::move(std::get<1>(result)),
+                           std::move(std::get<2>(result)));
+  }
   if (use_cudnn(data)) {
     Tensor output, hy, cy;
     lstm_packed_cudnn_stub(data.device().type(), output, hy, cy, data, batch_sizes, hx,

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_rnn.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_rnn.py
@@ -1,0 +1,151 @@
+# Owner(s): ["module: PrivateUse1"]
+
+import torch
+import torch.nn as nn
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestLSTM(TestCase):
+    def test_lstm_basic(self):
+        input_size, hidden_size, num_layers = 10, 20, 1
+        seq_len, batch_size = 5, 2
+
+        lstm = nn.LSTM(input_size=input_size, hidden_size=hidden_size, num_layers=num_layers)
+        lstm_openreg = lstm.to("openreg")
+        x = torch.randn(seq_len, batch_size, input_size, device="openreg")
+
+        output, (h_n, c_n) = lstm_openreg(x)
+
+        self.assertEqual(output.device.type, "openreg")
+        self.assertEqual(h_n.device.type, "openreg")
+        self.assertEqual(c_n.device.type, "openreg")
+        self.assertEqual(output.shape, torch.Size([seq_len, batch_size, hidden_size]))
+        self.assertEqual(h_n.shape, torch.Size([num_layers, batch_size, hidden_size]))
+        self.assertEqual(c_n.shape, torch.Size([num_layers, batch_size, hidden_size]))
+
+    def test_lstm_multi_layer(self):
+        input_size, hidden_size, num_layers = 10, 20, 3
+        seq_len, batch_size = 5, 2
+
+        lstm = nn.LSTM(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+        ).to("openreg")
+        x = torch.randn(seq_len, batch_size, input_size, device="openreg")
+
+        output, (h_n, c_n) = lstm(x)
+
+        self.assertEqual(output.device.type, "openreg")
+        self.assertEqual(output.shape, torch.Size([seq_len, batch_size, hidden_size]))
+        self.assertEqual(h_n.shape, torch.Size([num_layers, batch_size, hidden_size]))
+        self.assertEqual(c_n.shape, torch.Size([num_layers, batch_size, hidden_size]))
+
+    def test_lstm_bidirectional(self):
+        input_size, hidden_size, num_layers = 10, 20, 2
+        seq_len, batch_size = 5, 2
+        num_directions = 2
+
+        lstm = nn.LSTM(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            bidirectional=True,
+        ).to("openreg")
+        x = torch.randn(seq_len, batch_size, input_size, device="openreg")
+
+        output, (h_n, c_n) = lstm(x)
+
+        self.assertEqual(output.device.type, "openreg")
+        self.assertEqual(
+            output.shape,
+            torch.Size([seq_len, batch_size, hidden_size * num_directions]),
+        )
+        self.assertEqual(
+            h_n.shape,
+            torch.Size([num_layers * num_directions, batch_size, hidden_size]),
+        )
+        self.assertEqual(
+            c_n.shape,
+            torch.Size([num_layers * num_directions, batch_size, hidden_size]),
+        )
+
+    def test_lstm_batch_first(self):
+        input_size, hidden_size = 10, 20
+        seq_len, batch_size = 5, 2
+
+        lstm = nn.LSTM(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            batch_first=True,
+        ).to("openreg")
+        x = torch.randn(batch_size, seq_len, input_size, device="openreg")
+
+        output, (h_n, c_n) = lstm(x)
+
+        self.assertEqual(output.device.type, "openreg")
+        self.assertEqual(output.shape, torch.Size([batch_size, seq_len, hidden_size]))
+
+    def test_lstm_with_initial_hidden(self):
+        input_size, hidden_size, num_layers = 10, 20, 1
+        seq_len, batch_size = 5, 2
+
+        lstm = nn.LSTM(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+        ).to("openreg")
+        x = torch.randn(seq_len, batch_size, input_size, device="openreg")
+        h0 = torch.randn(num_layers, batch_size, hidden_size, device="openreg")
+        c0 = torch.randn(num_layers, batch_size, hidden_size, device="openreg")
+
+        output, (h_n, c_n) = lstm(x, (h0, c0))
+
+        self.assertEqual(output.device.type, "openreg")
+        self.assertEqual(h_n.device.type, "openreg")
+        self.assertEqual(c_n.device.type, "openreg")
+
+    def test_lstm_packed_sequence(self):
+        input_size, hidden_size = 10, 20
+
+        lstm = nn.LSTM(input_size=input_size, hidden_size=hidden_size).to("openreg")
+
+        sequences = [
+            torch.randn(5, input_size),
+            torch.randn(3, input_size),
+            torch.randn(1, input_size),
+        ]
+        packed = nn.utils.rnn.pack_sequence(sequences, enforce_sorted=True)
+        packed_openreg = packed.to("openreg")
+
+        output_packed, (h_n, c_n) = lstm(packed_openreg)
+
+        self.assertEqual(output_packed.data.device.type, "openreg")
+        self.assertEqual(h_n.device.type, "openreg")
+        self.assertEqual(c_n.device.type, "openreg")
+
+    def test_lstm_cpu_parity(self):
+        input_size, hidden_size, num_layers = 8, 16, 2
+        seq_len, batch_size = 4, 3
+
+        lstm = nn.LSTM(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            bidirectional=True,
+        )
+
+        x_cpu = torch.randn(seq_len, batch_size, input_size)
+        output_cpu, (h_cpu, c_cpu) = lstm(x_cpu)
+
+        lstm_openreg = lstm.to("openreg")
+        x_openreg = x_cpu.to("openreg")
+        output_openreg, (h_openreg, c_openreg) = lstm_openreg(x_openreg)
+
+        self.assertEqual(output_cpu, output_openreg.cpu())
+        self.assertEqual(h_cpu, h_openreg.cpu())
+        self.assertEqual(c_cpu, c_openreg.cpu())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_rnn.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_rnn.py
@@ -10,7 +10,9 @@ class TestLSTM(TestCase):
         input_size, hidden_size, num_layers = 10, 20, 1
         seq_len, batch_size = 5, 2
 
-        lstm = nn.LSTM(input_size=input_size, hidden_size=hidden_size, num_layers=num_layers)
+        lstm = nn.LSTM(
+            input_size=input_size, hidden_size=hidden_size, num_layers=num_layers
+        )
         lstm_openreg = lstm.to("openreg")
         x = torch.randn(seq_len, batch_size, input_size, device="openreg")
 


### PR DESCRIPTION
Previously, PrivateUse1 tensors in the top-level lstm() functions had no explicit dispatch branch, they fell through all backend-specific checks (cuDNN, MIOpen, oneDNN, MPS) before reaching the generic fallback path. Additionally, LSTMCell and GRUCell unconditionally routed PrivateUse1 tensors to _thnn_fused_lstm_cell / _thnn_fused_gru_cell, which only have CUDA kernels. Meaning, PU1 backends using CPU fallback (like OpenReg) would hit a NotImplementedError at runtime.

This change adds explicit is_privateuseone() branches in both the dense and packed lstm() functions, routing PrivateUse1 tensors directly to the generic _lstm_impl path. It also removes is_privateuseone() from the fused kernel condition in LSTMCell and GRUCell so that PrivateUse1 backends use the generic decomposed path (linear_hh, add_, sigmoid_, tanh_) instead of the CUDA-only fused kernels. The generic path works on any backend since it only uses standard tensor ops. Backends that want a faster fused LSTM can override aten::lstm at the dispatcher level.

**Test Plan:**
OpenReg LSTM tests covering single-layer, multi-layer, bidirectional, batch_first, packed sequence, explicit initial hidden state, and CPU-parity validation:

cd test/cpp_extensions/open_registration_extension/torch_openreg 
python tests/test_rnn.py : 7 tests passed.

Fixes: #170737 

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD