### PR TITLE
[pooling] Reject negative divisor_override in avg_pool2d/3d

### DIFF
--- a/aten/src/ATen/native/AveragePool2d.cpp
+++ b/aten/src/ATen/native/AveragePool2d.cpp
@@ -42,8 +42,8 @@ TORCH_PRECOMPUTE_META_FUNC(avg_pool2d)
   const int padH = c10::checked_convert<int>(padding[0], "int");
   const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
 
-  TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0,
-    "divisor must be not zero");
+  TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() > 0,
+    "divisor must be greater than zero");
 
   const int64_t nbatch = input.ndimension() == 4 ? input.size(-4) : 1;
   const int64_t nInputPlane = input.size(-3);
@@ -127,7 +127,7 @@ TORCH_META_FUNC(avg_pool2d_backward) (
   const int padH = c10::checked_convert<int>(padding[0], "int");
   const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
 
-  TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0, "divisor must be not zero");
+  TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() > 0, "divisor must be greater than zero");
 
   /* sizes */
   const int64_t nbatch = input.ndimension() == 4 ? input.size(-4) : 1;
@@ -203,7 +203,7 @@ TORCH_IMPL_FUNC(avg_pool2d_backward_out_cpu) (
   const int padH = c10::checked_convert<int>(padding[0], "int");
   const int padW = padding.size() == 1 ? padH : c10::checked_convert<int>(padding[1], "int");
 
-  TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0, "divisor must be not zero");
+  TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() > 0, "divisor must be greater than zero");
 
   TORCH_CHECK(input.dtype() == gradOutput.dtype(),
     "expected dtype ", input.dtype(), " for `gradOutput` but got dtype ", gradOutput.dtype());

--- a/aten/src/ATen/native/AveragePool3d.cpp
+++ b/aten/src/ATen/native/AveragePool3d.cpp
@@ -50,8 +50,8 @@ TORCH_META_FUNC(avg_pool3d) (
   TORCH_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
     "non-empty 4D or 5D (batch mode) tensor expected for input");
 
-  TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0,
-    "divisor must be not zero");
+  TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() > 0,
+    "divisor must be greater than zero");
 
   /* sizes */
   const int64_t nbatch = input.size(0);
@@ -119,7 +119,7 @@ TORCH_META_FUNC(avg_pool3d_backward) (
   TORCH_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
     "non-empty 4D or 5D (batch mode) tensor expected for input");
 
-  TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0, "divisor must be not zero");
+  TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() > 0, "divisor must be greater than zero");
 
   const int64_t nslices = input.size(-4);
   const int64_t itime = input.size(-3);

--- a/aten/src/ATen/native/quantized/cpu/AveragePool2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/AveragePool2d.cpp
@@ -190,8 +190,8 @@ Tensor q_avg_pool2d(
   const int64_t inputWidth = input.size(-1);
 
   TORCH_CHECK(
-      !divisor_override.has_value() || divisor_override.value() != 0,
-      "divisor must be not zero");
+      !divisor_override.has_value() || divisor_override.value() > 0,
+      "divisor must be greater than zero");
 
   auto output_shape =
       get_output_shape(input, kW, kH, dW, dH, padW, padH, ceil_mode);

--- a/aten/src/ATen/native/quantized/cpu/AveragePool3d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/AveragePool3d.cpp
@@ -111,8 +111,8 @@ Tensor q_avg_pool3d(
   const int64_t inputWidth = input.size(-1);
 
   TORCH_CHECK(
-      !divisor_override.has_value() || divisor_override.value() != 0,
-      "divisor must be not zero");
+      !divisor_override.has_value() || divisor_override.value() > 0,
+      "divisor must be greater than zero");
 
   auto output_shape =
       get_output_shape(input, kW, kH, kD, dW, dH, dD, padW, padH, padD, ceil_mode);

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -187,6 +187,21 @@ class TestAvgPool(TestCase):
             )
             self.assertTrue(not torch.isnan(y).any())
 
+    def test_avg_pool2d_with_negative_divisor(self):
+        self.assertRaisesRegex(
+            RuntimeError,
+            "divisor must be greater than zero",
+            lambda: F.avg_pool2d(torch.zeros(3, 3, 3), (2, 2), divisor_override=-1),
+        )
+
+    def test_avg_pool3d_with_negative_divisor(self):
+        x = torch.rand([1, 1, 16, 8, 8], dtype=torch.float32)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "divisor must be greater than zero",
+            lambda: F.avg_pool3d(x, [1, 1, 1], divisor_override=-1),
+        )
+
 
 class TestPoolingNN(NNTestCase):
     _do_cuda_memory_leak_check = True

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -775,7 +775,7 @@ class TestAvgPool(TestCaseMPS):
         return self._sum_pool3d(x, kernel_size) / size
 
     def test_avg_pool2d_with_zero_divisor(self):
-        self.assertRaisesRegex(RuntimeError, "divisor must be not zero",
+        self.assertRaisesRegex(RuntimeError, "divisor must be greater than zero",
                                lambda: F.avg_pool2d(torch.zeros(3, 3, 3), (2, 2), divisor_override=0))
 
     def test_doubletensor_avg_pool2d_with_divisor(self):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6205,6 +6205,9 @@ def _avg_poolnd(
     divisor_override,
     dim,
 ):
+    assert divisor_override is None or divisor_override > 0, (
+        "divisor must be greater than zero"
+    )
     if not stride:
         stride = kernel_size
     if not padding:
@@ -6343,7 +6346,9 @@ def avg_pool2d_backward(
     count_include_pad,
     divisor_override=None,
 ):
-    assert divisor_override is None or divisor_override != 0, "divisor must be not zero"
+    assert divisor_override is None or divisor_override > 0, (
+        "divisor must be greater than zero"
+    )
     if not stride:
         stride = kernel_size
     if not padding:
@@ -6514,7 +6519,9 @@ def avg_pool3d_backward(
     count_include_pad,
     divisor_override=None,
 ):
-    assert divisor_override is None or divisor_override != 0, "divisor must be not zero"
+    assert divisor_override is None or divisor_override > 0, (
+        "divisor must be greater than zero"
+    )
     if not stride:
         stride = kernel_size
     if not padding:

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3119,8 +3119,8 @@ def meta_avg_pool2d(
     padH, padW = unpack("padding", padding)
 
     torch._check(
-        divisor_override is None or divisor_override != 0,
-        lambda: "divisor must be not zero",
+        divisor_override is None or divisor_override > 0,
+        lambda: "divisor must be greater than zero",
     )
 
     nbatch = input.size(-4) if input.dim() == 4 else 1
@@ -3239,8 +3239,8 @@ def meta_avg_pool2d_backward(
     padW = padH if len(padding) == 1 else padding[1]
 
     torch._check(
-        divisor_override is None or divisor_override != 0,
-        lambda: "divisor must be not zero",
+        divisor_override is None or divisor_override > 0,
+        lambda: "divisor must be greater than zero",
     )
 
     input_size = input.shape
@@ -3325,8 +3325,8 @@ def meta_avg_pool3d(
     )
 
     torch._check(
-        divisor_override is None or divisor_override != 0,
-        lambda: "divisor must be not zero",
+        divisor_override is None or divisor_override > 0,
+        lambda: "divisor must be greater than zero",
     )
 
     nbatch = input.size(0)
@@ -3412,8 +3412,8 @@ def meta_avg_pool3d_backward(
     )
 
     torch._check(
-        divisor_override is None or divisor_override != 0,
-        lambda: "divisor must be not zero",
+        divisor_override is None or divisor_override > 0,
+        lambda: "divisor must be greater than zero",
     )
 
     nslices = input.size(-4)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5225,7 +5225,7 @@ def sample_inputs_avgpool2d(op_info, device, dtype, requires_grad, **kwargs):
              ((1, 3, 9, 9), (4, 4), (2, 3), 1, True, False, 2),
              ((1, 3, 9, 9), (6, 6), (3, 3), (2, 3), True, True, 2),
              ((2, 3, 9, 9), (3, 3), (1, 1), (1, ), True, False, 2),
-             ((1, 1, 4, 4), (2, 2), (), (0, ), False, True, -2),
+             ((1, 1, 4, 4), (2, 2), (), (0, ), False, True, 2),
              ((1, 2, 6, 6), (4, 4), (2, 2), (2, ), True, True, None))
 
     for input_shape, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override in cases:
@@ -5267,7 +5267,7 @@ def sample_inputs_avgpool3d(op_info, device, dtype, requires_grad, **kwargs):
         ((1, 1, 7, 5, 7), (6, 3, 4), dict(stride=(2, 3, 2), padding=(3, 1, 0), ceil_mode=False,
                                           count_include_pad=False, divisor_override=2)),
         ((1, 1, 4, 5, 4), (2, 2, 3), dict(stride=(2, 2, 1), padding=0, ceil_mode=False,
-                                          count_include_pad=True, divisor_override=-2)),
+                                          count_include_pad=True, divisor_override=2)),
         ((1, 1, 6, 5, 6), (4, 5, 6), dict(stride=(2, 3, 2), padding=2, ceil_mode=True,
                                           count_include_pad=True, divisor_override=None)),
         ((0, 1, 4, 5, 4), (2, 3, 1), dict(stride=(2, 1, 2), padding=0, ceil_mode=False,
@@ -5306,7 +5306,7 @@ def error_inputs_avg_pool2d(op_info, device, **kwargs):
     # error inputs for zero divisor
     x = torch.zeros(3, 3, 3)
     yield ErrorInput(SampleInput(x, kwargs={'kernel_size': (2, 2), 'divisor_override': 0}),
-                     error_regex='divisor must be not zero')
+                     error_regex='divisor must be greater than zero')
 
 def error_inputs_avg_pool3d(op_info, device, **kwargs):
     # error inputs when pad is negative
@@ -5327,7 +5327,7 @@ def error_inputs_avg_pool3d(op_info, device, **kwargs):
     # error inputs for zero divisor
     x = torch.zeros(3, 3, 3, 3)
     yield ErrorInput(SampleInput(x, kwargs={'kernel_size': (2, 2, 2), 'divisor_override': 0}),
-                     error_regex='divisor must be not zero')
+                     error_regex='divisor must be greater than zero')
 
     # error inputs for invalid input dimension
     x = torch.rand([0, 1, 49], dtype=torch.float32)


### PR DESCRIPTION
## What does this PR do?
Fix segmentation fault in torch.linalg.eigvals triggered by invalid avg_pool3d divisor.

### Root Cause
1. F.avg_pool3d creates Negative Values:
When passing divisor_override=-1, PyTorch's pooling kernel sums the values in the window and divides them by -1. Because there is no check preventing negative divisor_override values, the output pooled silently becomes a tensor of strictly negative numbers.
2. torch.log2 creates NaNs:
Taking the real-valued logarithm of negative numbers is undefined. PyTorch standard behavior here is to return NaN (Not a Number). The logged tensor is now completely filled with NaNs.
3. torch.linalg.eigvals passes NaNs to Intel oneMKL:
PyTorch’s linalg operations are generally thin wrappers around LAPACK routines provided by backends like Intel oneMKL or OpenBLAS. PyTorch does not check tensors for NaNs or Infs before passing them to MKL, because doing so would incur a massive performance penalty on every linear algebra operation.
When oneMKL's sgebal (Single-precision GEneral matrix BALancing) routine receives a matrix full of NaNs, it violates the internal mathematical assumptions of the Fortran/C code. Instead of returning an error code gracefully, oneMKL encounters a memory/parameter violation and segfaults, crashing the entire Python process.

### Solution
Update TORCH_CHECK in the ATen backend to check if divisor_override is negative.

### Related Issue
Fixes #185247

## Test Cases
Added unit tests to verify the fix (in `test/nn/test_pooling.py/TestAvgPool`):
```
    def test_avg_pool2d_with_negative_divisor(self):
        self.assertRaisesRegex(
            RuntimeError,
            "divisor must be greater than zero",
            lambda: F.avg_pool2d(torch.zeros(3, 3, 3), (2, 2), divisor_override=-1),
        )

    def test_avg_pool3d_with_negative_divisor(self):
        x = torch.rand([1, 1, 16, 8, 8], dtype=torch.float32)
        self.assertRaisesRegex(
            RuntimeError,
            "divisor must be greater than zero",
            lambda: F.avg_pool3d(x, [1, 1, 1], divisor_override=-1),
        )
```
```
import faulthandler
import torch
import torch.nn.functional as F

faulthandler.enable()

def model():
    x = torch.rand([1, 16, 8, 8], dtype=torch.float32)
    pooled = F.avg_pool3d(
        x,
        [1, 1, 1],
        stride=(1, 1, 1),
        padding=(0, 0, 0),
        ceil_mode=False,
        count_include_pad=False,
        divisor_override=-1,
    )
    logged = torch.log2(pooled)
    return torch.linalg.eigvals(logged)

if __name__ == "__main__":
    print("torch", torch.__version__, flush=True)
    torch.manual_seed(0)
    out = model()
    print("returned", out.shape, out.dtype, flush=True)
```
<img width="639" height="87" alt="result" src="https://github.com/user-attachments/assets/af8e3907-e16d-4bb3-b62a-5a433f41d6db" />


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo