### PR TITLE
Fix FX subgraph rewrite of adjacent aggregate matches

### DIFF
--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -38,6 +38,11 @@ def wrapped_gemm_bias_mul_with_c(a, b, bias, c):
     return lin_res, mul_res
 
 
+@torch.fx.wrap
+def wrapped_cat(tensors, dim):
+    return torch.cat(tensors, dim=dim)
+
+
 class TestSubgraphRewriter(JitTestCase):
     def test_subgraph_rewriter_preserves_logic(self):
         class M(torch.nn.Module):
@@ -548,6 +553,38 @@ class TestSubgraphRewriter(JitTestCase):
         ref_outs = comparison_fn(x)
         test_outs = traced.forward(x)
         self.assertEqual(ref_outs, test_outs)
+
+    def test_subgraph_rewriter_replace_back_to_back_list_arg_matches(self):
+        class M(torch.nn.Module):
+            def forward(self, x1, x2, x3):
+                y1 = torch.cat([x1, x2], dim=1)
+                return torch.cat([y1, x3], dim=2)
+
+        def pattern(tensors, dim):
+            return torch.cat(tensors, dim=dim)
+
+        def replacement(tensors, dim):
+            return wrapped_cat(tensors, dim)
+
+        traced = symbolic_trace(M())
+
+        matches = subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+
+        traced.graph.lint()
+
+        self.assertEqual(len(matches), 2)
+        replacement_nodes = [
+            node
+            for node in traced.graph.nodes
+            if node.op == "call_function" and node.target is wrapped_cat
+        ]
+        self.assertEqual(len(replacement_nodes), 2)
+        self.assertIs(replacement_nodes[1].args[0][0], replacement_nodes[0])
+
+        x1 = torch.randn(1, 30, 16)
+        x2 = torch.randn(1, 10, 16)
+        x3 = torch.randn(1, 40, 16)
+        self.assertEqual(M()(x1, x2, x3), traced.forward(x1, x2, x3))
 
     def test_subgraph_rewriter_with_overlapping_matches(self):
         def f(x):

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -9,7 +9,7 @@ from ._compatibility import compatibility
 from ._symbolic_trace import symbolic_trace
 from .graph import Graph
 from .graph_module import GraphModule
-from .node import Node
+from .node import map_arg, Node
 
 
 if TYPE_CHECKING:
@@ -347,20 +347,14 @@ def _replace_pattern(
                 f"Placeholder count mismatch: {len(match.placeholder_nodes)} vs "
                 f"{len(replacement_placeholders)}"
             )
-        val_map: dict[Node, Node] = {}
-        for rn, gn in zip(replacement_placeholders, match.placeholder_nodes):
-            if isinstance(gn, Node):
-                val_map[rn] = match_changed_node.get(gn, gn)
-                if gn != val_map[rn]:
-                    # Update match.placeholder_nodes and match.nodes_map with the node that replaced gn
-                    gn_ind = match.placeholder_nodes.index(gn)
-                    match.placeholder_nodes[gn_ind] = match_changed_node[gn]
-                    map_key = list(match.nodes_map.keys())[
-                        list(match.nodes_map.values()).index(gn)
-                    ]
-                    match.nodes_map[map_key] = match_changed_node[gn]
-            else:
-                val_map[rn] = gn
+        val_map: dict[Node, Any] = {}
+        pattern_placeholders = [n for n in pattern_graph.nodes if n.op == "placeholder"]
+        for i, (rn, gn) in enumerate(
+            zip(replacement_placeholders, match.placeholder_nodes)
+        ):
+            val_map[rn] = map_arg(gn, lambda node: match_changed_node.get(node, node))
+            match.placeholder_nodes[i] = val_map[rn]
+            match.nodes_map[pattern_placeholders[i]] = val_map[rn]
 
         # Copy the replacement graph over
         user_nodes: set[Node] = set()
@@ -406,7 +400,9 @@ def _replace_pattern(
 
         # Get a list of nodes that have been replaced into the graph
         replacement_nodes: list[Node] = [
-            v for v in val_map.values() if v not in match.placeholder_nodes
+            v
+            for v in val_map.values()
+            if isinstance(v, Node) and v not in match.placeholder_nodes
         ]
 
         # Hook the output Node of the replacement subgraph in to the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* __->__ #185365

`replace_pattern` computes all matches before it starts mutating the graph, so later matches may contain references to nodes that earlier replacements erase. The existing bookkeeping handled this only when a later pattern placeholder directly matched a replaced `Node`.

For aggregate placeholders, such as a `torch.cat(tensors, dim)` pattern where `tensors` matches `[cat, x3]`, the stale node was hidden inside the list. Copying the replacement graph then preserved that erased `cat` reference and left the graph topologically invalid.

Fix this by using FX's existing `map_arg` helper when building the replacement value map. This recursively remaps any previously replaced nodes inside placeholder aggregate values while preserving the original argument structure. The match metadata is kept in sync with the remapped placeholders so subsequent replacement bookkeeping sees the current graph nodes.

The alternative would be to special-case lists or cat arguments, but the bug is in generic placeholder remapping and can affect any supported FX aggregate argument shape.

Fixes #159613
Generated by my agent

Test Plan:
- git diff --cached --check
- pytest -q test/fx/test_subgraph_rewriter.py::TestSubgraphRewriter::test_subgraph_rewriter_replace_back_to_back_list_arg_matches
- pytest -q test/fx/test_subgraph_rewriter.py
- lintrunner -a