### PR TITLE
[ROCm][Distributed] Add synthesized test for sac_milp to ensure numerical correctness

### DIFF
--- a/test/distributed/_tools/test_sac_ilp.py
+++ b/test/distributed/_tools/test_sac_ilp.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 import copy
 import unittest
+from unittest.mock import patch
 
 import pytest
 
@@ -226,6 +227,52 @@ class TestSACILP(TestCase):
         self.assertEqual(ac_decisions, {})
         self.assertEqual(recomputation_time, 0)
         self.assertEqual(peak_mem, -1)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(not HAS_PULP, "pulp package not installed")
+    @patch(
+        "torch.utils._runtime_estimation.get_gpu_dram_gbps",
+        return_value=2039,
+    )
+    @patch(
+        "torch.utils._runtime_estimation.get_device_tflops",
+        side_effect=lambda dtype: {
+            torch.bfloat16: 312.5,
+            torch.float16: 312.5,
+            torch.int8: 624.0,
+        }.get(dtype, 19.5),
+    )
+    def test_sac_ilp_case1_with_pinned_hw(self, _mock_tflops, _mock_gbps):
+        """
+        Same scenario as test_sac_ilp_case1 but with the roofline cost
+        model's hardware oracles pinned to the NVIDIA A100 SXM datasheet
+        (from torch/_inductor/analysis/device_info.py), so the MILP output
+        is exact on every host. Restores the numerical assertions that
+        case1 had to drop to be portable across A100/H100/MI300/MI350.
+        """
+        mod_info = self._collect_module_info_with_fake_tensor_mode()
+        g = parse_module_info(mod_info)
+
+        memory_budget = 1.6
+        budget_bytes = round(memory_budget * (2**30))
+
+        baseline_peak_mem, _ = get_peak_memory_runtime_baseline(g)
+        self.assertEqual(baseline_peak_mem, 2583888896)
+
+        ac_decisions, recomputation_time, peak_mem = sac_milp(
+            g, memory_budget=memory_budget, world_size=4
+        )
+
+        self.assertEqual(
+            set(ac_decisions.keys()),
+            {f"Transformer.layers.{i}" for i in range(4)},
+        )
+        self.assertEqual(
+            sorted(ac_decisions.values()),
+            [0.5225, 0.5225, 0.5225, 0.7983],
+        )
+        self.assertEqual(peak_mem, budget_bytes)
+        self.assertEqual(recomputation_time, 6.92)
 
 
 class TestOptimalCheckpointingPolicy(TestCase):

--- a/test/distributed/_tools/test_sac_ilp.py
+++ b/test/distributed/_tools/test_sac_ilp.py
@@ -37,6 +37,14 @@ except ImportError:
     get_optimal_checkpointing_policy_per_module = None  # type: ignore[assignment, misc]
     sac_milp = None  # type: ignore[assignment]
 
+# A100 SXM datasheet values, mirrored from the "NVIDIA A100" entry in
+# torch/_inductor/analysis/device_info.py. Keep in sync with that entry; they
+# exist only to make the roofline cost model host-independent in
+# test_sac_ilp_case1_with_pinned_hw.
+_A100_TFLOPS = {torch.bfloat16: 312.5, torch.float16: 312.5, torch.int8: 624.0}
+_A100_DEFAULT_TFLOPS = 19.5  # fp32 / fp64
+_A100_DRAM_GBPS = 2039.0
+
 
 # TODO(multigpu-marker): These tests are single-process but their AC-decision
 # assertions depend on RuntimeEstimator's roofline runtime estimates, which read
@@ -232,23 +240,27 @@ class TestSACILP(TestCase):
     @unittest.skipIf(not HAS_PULP, "pulp package not installed")
     @patch(
         "torch.utils._runtime_estimation.get_gpu_dram_gbps",
-        return_value=2039,
+        return_value=_A100_DRAM_GBPS,
     )
     @patch(
         "torch.utils._runtime_estimation.get_device_tflops",
-        side_effect=lambda dtype: {
-            torch.bfloat16: 312.5,
-            torch.float16: 312.5,
-            torch.int8: 624.0,
-        }.get(dtype, 19.5),
+        side_effect=lambda dtype: _A100_TFLOPS.get(dtype, _A100_DEFAULT_TFLOPS),
     )
     def test_sac_ilp_case1_with_pinned_hw(self, _mock_tflops, _mock_gbps):
         """
         Same scenario as test_sac_ilp_case1 but with the roofline cost
         model's hardware oracles pinned to the NVIDIA A100 SXM datasheet
-        (from torch/_inductor/analysis/device_info.py), so the MILP output
-        is exact on every host. Restores the numerical assertions that
-        case1 had to drop to be portable across A100/H100/MI300/MI350.
+        (the "NVIDIA A100" entry in torch/_inductor/analysis/device_info.py),
+        so the MILP inputs are identical on every GPU host. Restores the
+        numerical assertions that case1 had to drop to be portable across
+        A100/H100/MI300/MI350.
+
+        Still requires a CUDA/ROCm device (setUp uses current_device()). The
+        AC ratios and recomputation_time asserted below are golden values:
+        sac_milp solves with PULP_CBC_CMD(gapRel=0.05), which accepts any
+        solution within 5% of optimal, so they are pinned to the bundled CBC
+        build and may need re-capturing after a pulp/CBC upgrade. The memory
+        assertions (baseline_peak_mem, peak_mem) are solver-version robust.
         """
         mod_info = self._collect_module_info_with_fake_tensor_mode()
         g = parse_module_info(mod_info)


### PR DESCRIPTION
## Summary

Adds `TestSACILP.test_sac_ilp_case1_with_pinned_hw`, a synthesized variant of `test_sac_ilp_case1` that restores the exact numerical assertions which #182670 had to drop in order to make `test_sac_ilp_case1` portable across A100/H100/MI300/MI350.

## Background

https://github.com/pytorch/pytorch/pull/182670#pullrequestreview-4285832421

`test_sac_ilp_case1` feeds the SAC MILP with runtime estimates produced by the `operator-level-cost-model` roofline estimator. That estimator's compute/transfer times depend on the host GPU's TFLOPS and DRAM bandwidth (`get_device_tflops` / `get_gpu_dram_gbps`), so the MILP solution differs per host. To stay portable, #182670 replaced the exact-value checks with structural/inequality checks, losing numerical-correctness coverage.

## What this does

The new test pins the roofline cost model's hardware oracles to the **NVIDIA A100 SXM** datasheet values (the `"NVIDIA A100"` entry in `torch/_inductor/analysis/device_info.py`) by patching them at their point of use in `torch.utils._runtime_estimation`:

- `get_device_tflops`: bf16/fp16 = 312.5, int8 = 624.0, default (fp32/fp64) = 19.5
- `get_gpu_dram_gbps` = 2039

With the hardware-dependent inputs fixed, the MILP inputs become host-independent, so the test can assert the exact baseline peak memory, AC decision set, per-module discard ratios, peak memory, and recomputation time. The scenario (memory budget 1.6 GiB, `world_size=4`) is identical to `test_sac_ilp_case1`.

## Test plan

```
python test/distributed/_tools/test_sac_ilp.py -k test_sac_ilp_case1_with_pinned_hw
```

Requires a CUDA/ROCm device to be present and the `pulp` package installed (otherwise the test is skipped).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
