### PR TITLE
Include node.meta["custom"] in AOTAutograd cache key

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -2727,6 +2727,122 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
                 self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 2)
                 self.assertEqual(counters["aot_autograd"]["autograd_cache_bypass"], 0)
 
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_per_node_memory_budget_meta_does_not_cause_cache_miss(self):
+        """Demonstrate that per-node memory_budget set via node.meta is invisible
+        to the AOTAutograd cache key, so changing it gets a stale cache hit."""
+
+        def make_backend(budget):
+            def backend(gm, example_inputs):
+                for node in gm.graph.nodes:
+                    if node.op == "call_function":
+                        node.meta["memory_budget"] = budget
+                return torch._inductor.compile_fx.compile_fx(gm, example_inputs)
+
+            return backend
+
+        def fn(x, y):
+            return torch.mm(x, y) + 1
+
+        def run_with_budget(budget):
+            compiled_fn = torch.compile(fn, backend=make_backend(budget))
+            x = torch.randn(10, 10, requires_grad=True)
+            y = torch.randn(10, 10, requires_grad=True)
+            result = compiled_fn(x, y)
+            result.sum().backward()
+
+        run_with_budget(0.3)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+
+        self._clear_dynamo_and_codecache()
+
+        # Different per-node budget, but we get a stale cache hit (bug)
+        run_with_budget(0.8)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_custom_node_metadata_causes_cache_miss(self):
+        """Custom annotations set via fx_traceback.annotate inside a compiled
+        function are included in the AOTAutograd cache key."""
+        import torch.fx.traceback as fx_traceback
+
+        def fn1(x):
+            with fx_traceback.annotate({"blah": 1}):
+                return x.sin().cos()
+
+        compiled = torch.compile(fn1, backend="inductor")
+        x = torch.randn(10, requires_grad=True)
+        compiled(x).sum().backward()
+
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+        self._clear_dynamo_and_codecache()
+
+        # Same annotation value should hit cache
+        def fn2(x):
+            with fx_traceback.annotate({"blah": 1}):
+                return x.sin().cos()
+
+        compiled2 = torch.compile(fn2, backend="inductor")
+        x2 = torch.randn(10, requires_grad=True)
+        compiled2(x2).sum().backward()
+
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+        self._clear_dynamo_and_codecache()
+
+        # Different annotation value should miss cache
+        def fn3(x):
+            with fx_traceback.annotate({"blah": 2}):
+                return x.sin().cos()
+
+        compiled3 = torch.compile(fn3, backend="inductor")
+        x3 = torch.randn(10, requires_grad=True)
+        compiled3(x3).sum().backward()
+
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_different_activation_memory_budget_causes_cache_miss(self):
+        def fn(x, y):
+            return torch.mm(x, y) + 1
+
+        with functorch_config.patch({"activation_memory_budget": 0.5}):
+            compiled_fn = torch.compile(fn, backend="inductor")
+            x = torch.randn(10, 10, requires_grad=True)
+            y = torch.randn(10, 10, requires_grad=True)
+            result = compiled_fn(x, y)
+            result.sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+
+        self._clear_dynamo_and_codecache()
+
+        with functorch_config.patch({"activation_memory_budget": 0.7}):
+            compiled_fn2 = torch.compile(fn, backend="inductor")
+            x2 = torch.randn(10, 10, requires_grad=True)
+            y2 = torch.randn(10, 10, requires_grad=True)
+            result2 = compiled_fn2(x2, y2)
+            result2.sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 2)
+
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -365,6 +365,29 @@ def _collect_context_fn_hashes(gm: torch.fx.GraphModule) -> list[str]:
     return hashes
 
 
+def _collect_custom_node_metadata(
+    gm: torch.fx.GraphModule,
+) -> list[tuple[int, dict[str, Any]]]:
+    """
+    Collect custom annotations (node.meta["custom"]) set via fx_traceback.annotate.
+
+    These annotations can affect compilation behavior (e.g., memory_budget
+    controls the min-cut partitioner, sparsity_hint affects runtime cost
+    estimation). We include them in the cache key so that changing an
+    annotation invalidates the cache.
+
+    Returns a list of (node_index, custom_dict) for nodes that have custom
+    metadata, using node position index as a stable identifier.
+    """
+    result: list[tuple[int, dict[str, Any]]] = []
+    for module in _iter_graph_modules(gm):
+        for i, node in enumerate(module.graph.nodes):
+            custom = node.meta.get("custom")
+            if custom:
+                result.append((i, custom))
+    return result
+
+
 def _collect_wrapped_user_cache_hashes(gm: torch.fx.GraphModule) -> list[str]:
     wrapped_user_cache_hashes = []
     for node in gm.graph.nodes:
@@ -509,6 +532,7 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
             _collect_saved_tensors_hooks_fx_wrap_cache_hashes(gm)
         )
         self.sac_context_fn_hashes = _collect_context_fn_hashes(gm)
+        self.custom_node_metadata = _collect_custom_node_metadata(gm)
 
         # Note: We use the live config module, not self.autograd_config (the
         # saved config), because activation_memory_budget_runtime_estimator and


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #185287
* #185286
* #185285
* #185284
* #185283
* #185282
* __->__ #185370

Custom annotations set via fx_traceback.annotate (e.g., memory_budget,
sparsity_hint) can affect compilation behavior in the min-cut
partitioner and runtime cost estimation, but were invisible to the
AOTAutograd cache key. This meant changing an annotation between
compilations would silently reuse a stale cached result.

The fix collects node.meta["custom"] from all nodes in the graph and
stores it as a field on AOTAutogradCacheDetails, so it gets pickled
into the cache key hash. Same annotations produce the same key (cache
hit), different annotations produce a different key (cache miss).

Authored by Claude.

Test Plan:

```
python -m pytest test/dynamo/test_aot_autograd_cache.py -xvs -k "test_custom_node_metadata_causes_cache_miss"
python -m pytest test/dynamo/test_aot_autograd_cache.py -xvs -k "test_per_node_memory_budget or test_different_activation_memory_budget"
```