### PR TITLE
[ROCm] Add gfx110X and gfx1151 to preferred hipBLASLt architectures list

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -556,7 +556,7 @@ const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
 #if ROCM_VERSION >= 70000
     "gfx950"
 #endif
-#if ROCM_VERSION > 70200
+#if ROCM_VERSION >= 71300
     "gfx1100", "gfx1101", "gfx1151"
 #endif
   };

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -554,7 +554,7 @@ const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
     "gfx1200", "gfx1201",
 #endif
 #if ROCM_VERSION >= 70000
-    "gfx950"
+    "gfx950",
 #endif
 #if ROCM_VERSION >= 71300
     "gfx1100", "gfx1101", "gfx1151"

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -556,7 +556,7 @@ const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
 #if ROCM_VERSION >= 70000
     "gfx950"
 #endif
-#if ROCM_VERSION >= 70200
+#if ROCM_VERSION > 70200
     "gfx1100", "gfx1101", "gfx1151"
 #endif
   };

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -554,7 +554,10 @@ const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
     "gfx1200", "gfx1201",
 #endif
 #if ROCM_VERSION >= 70000
-    "gfx950", "gfx1110", "gfx1101", "gfx1151"
+    "gfx950"
+#endif
+#if ROCM_VERSION >= 70200
+    "gfx1100", "gfx1101", "gfx1151"
 #endif
   };
   return archs;

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -554,7 +554,7 @@ const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
     "gfx1200", "gfx1201",
 #endif
 #if ROCM_VERSION >= 70000
-    "gfx950"
+    "gfx950", "gfx1110", "gfx1101", "gfx1151"
 #endif
   };
   return archs;

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -811,19 +811,20 @@ print(t.is_pinned())
                 self.assertTrue(default == torch._C._BlasBackend.Cublas)
             else:
                 # ROCm logic is less so, it's cublaslt for some Instinct, cublas for all else
-                gcn_arch = str(
-                    torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
+                # Mirror CUDAHooks::getHipblasltPreferredArchs in CUDAHooks.cpp
+                ROCM_VERSION = tuple(
+                    int(v) for v in torch.version.hip.split(".")[:2]
                 )
-                if gcn_arch in [
-                    "gfx90a",
-                    "gfx942",
-                    "gfx950",
-                    "gfx1110",
-                    "gfx1101",
-                    "gfx1151",
-                    "gfx1200",
-                    "gfx1201",
-                ]:
+                archs = ["gfx90a", "gfx942"]
+                if ROCM_VERSION >= (6, 4):
+                    archs.extend(["gfx1200", "gfx1201"])
+                if ROCM_VERSION >= (7, 0):
+                    archs.append("gfx950")
+                if ROCM_VERSION >= (7, 13):
+                    archs.extend(["gfx1100", "gfx1101", "gfx1151"])
+                gcn_arch_name = torch.cuda.get_device_properties(0).gcnArchName
+                hipblaslt_preferred = any(arch in gcn_arch_name for arch in archs)
+                if hipblaslt_preferred:
                     self.assertTrue(default == torch._C._BlasBackend.Cublaslt)
                 else:
                     self.assertTrue(default == torch._C._BlasBackend.Cublas)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -812,9 +812,7 @@ print(t.is_pinned())
             else:
                 # ROCm logic is less so, it's cublaslt for some Instinct, cublas for all else
                 # Mirror CUDAHooks::getHipblasltPreferredArchs in CUDAHooks.cpp
-                ROCM_VERSION = tuple(
-                    int(v) for v in torch.version.hip.split(".")[:2]
-                )
+                ROCM_VERSION = tuple(int(v) for v in torch.version.hip.split(".")[:2])
                 archs = ["gfx90a", "gfx942"]
                 if ROCM_VERSION >= (6, 4):
                     archs.extend(["gfx1200", "gfx1201"])

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -814,7 +814,16 @@ print(t.is_pinned())
                 gcn_arch = str(
                     torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
                 )
-                if gcn_arch in ["gfx90a", "gfx942", "gfx950", "gfx1200", "gfx1201"]:
+                if gcn_arch in [
+                    "gfx90a",
+                    "gfx942",
+                    "gfx950",
+                    "gfx1110",
+                    "gfx1101",
+                    "gfx1151",
+                    "gfx1200",
+                    "gfx1201",
+                ]:
                     self.assertTrue(default == torch._C._BlasBackend.Cublaslt)
                 else:
                     self.assertTrue(default == torch._C._BlasBackend.Cublas)


### PR DESCRIPTION
## Summary

Add **gfx1100**, **gfx1101**, and **gfx1151** to `getHipblasltPreferredArchs()` so PyTorch defaults to **hipBLASLt** on these architectures.

## Test plan

- `torch.backends.cuda.preferred_blas_library()` returns `Cublaslt` on gfx1100 / gfx1101 / gfx1151
- `test_preferred_blas_library_settings` passes

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang