### PR TITLE
Revert "Forbid Co-authored-by: Claude trailer in commit messages"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,11 +73,7 @@ out succinctly and justify the one you took.
 When describing the testing strategy in a commit message, include the literal
 commands that were run in fenced Markdown code blocks.
 
-Disclose that the PR was authored with an AI assistant. Do this informally in
-the commit body (e.g., "Authored by Claude." or a similar attribution for
-whichever assistant was used). NEVER add a `Co-authored-by:` trailer
-attributing the AI assistant, as it interferes with the Linux Foundation CLA
-bot.
+Disclose that the PR was authored with an AI assistant.
 
 When the user asks you to amend a commit, check whether the commit message
 still accurately describes the changes. If it doesn't and the commit is not a


### PR DESCRIPTION
EasyCLA provides mechanism to allow coding assistants to commit to a project. This has been enabled for the pytorch project so we should not be bypassing the check with this change. If new coding agents need exceptions added we can add them by opening a ticket with the EasyCLA team by following the link provided by the EasyCLA bot.

Reverts 2bece38c198292399fc47014330c75f47ad157e1 (#182207).