### PR TITLE
Add == overloads for HeaderOnlyArrayRef

### DIFF
--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -281,6 +281,14 @@ ArrayRef<T> makeArrayRef(const T (&Arr)[N]) {
 // WARNING: Template instantiation will NOT be willing to do an implicit
 // conversions to get you to an c10::ArrayRef, which is why we need so
 // many overloads.
+//
+// NOTE: ArrayRef inherits operator==/!= from HeaderOnlyArrayRef via
+// derived-to-base deduction, so these ArrayRef-specific overloads are
+// technically redundant. We keep them because they are an *exact* match
+// for ArrayRef arguments, which makes overload resolution pick them over
+// the C++20 reversed candidates of cross-type operators like
+// operator==(OptionalIntArrayRef, IntArrayRef) — otherwise comparing two
+// ArrayRefs becomes ambiguous.
 
 template <typename T>
 bool operator==(c10::ArrayRef<T> a1, c10::ArrayRef<T> a2) {

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -147,16 +147,16 @@ class ArrayRef : public HeaderOnlyArrayRef<T> {
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  std::enable_if_t<std::is_same_v<U, T>, ArrayRef<T>>& operator=(
+  requires std::is_same_v<U, T>
       // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
-      U&& Temporary) = delete;
+      ArrayRef<T>& operator=(U&& Temporary) = delete;
 
   /// Disallow accidental assignment from a temporary.
   ///
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  std::enable_if_t<std::is_same_v<U, T>, ArrayRef<T>>& operator=(
+  requires std::is_same_v<U, T> ArrayRef<T>& operator=(
       std::initializer_list<U>) = delete;
 
   /// @}
@@ -193,6 +193,7 @@ ArrayRef(const std::array<T, N>&) -> ArrayRef<T>;
 
 // C array constructor
 template <typename T, size_t N>
+// NOLINTNEXTLINE(*c-arrays*)
 ArrayRef(const T (&)[N]) -> ArrayRef<T>;
 
 // std::initializer_list constructor
@@ -278,18 +279,18 @@ ArrayRef<T> makeArrayRef(const T (&Arr)[N]) {
   return ArrayRef<T>(Arr);
 }
 
+// These ArrayRef-specific overloads cannot be removed in favor of the
+// HeaderOnlyArrayRef hidden friends: comparing two ArrayRefs through those
+// friends requires a derived-to-base conversion on *both* arguments, which
+// per-argument ties against the C++20-reversed candidate of
+// operator==(IntArrayRef, OptionalIntArrayRef) in OptionalArrayRef.h (exact
+// match on one arg, user-defined conversion on the other) and produces an
+// ambiguity. Keeping ArrayRef-typed overloads gives an exact match on both
+// args, which wins unambiguously.
+//
 // WARNING: Template instantiation will NOT be willing to do an implicit
 // conversions to get you to an c10::ArrayRef, which is why we need so
 // many overloads.
-//
-// NOTE: ArrayRef inherits operator==/!= from HeaderOnlyArrayRef via
-// derived-to-base deduction, so these ArrayRef-specific overloads are
-// technically redundant. We keep them because they are an *exact* match
-// for ArrayRef arguments, which makes overload resolution pick them over
-// the C++20 reversed candidates of cross-type operators like
-// operator==(OptionalIntArrayRef, IntArrayRef) — otherwise comparing two
-// ArrayRefs becomes ambiguous.
-
 template <typename T>
 bool operator==(c10::ArrayRef<T> a1, c10::ArrayRef<T> a2) {
   return a1.equals(a2);

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -147,16 +147,18 @@ class ArrayRef : public HeaderOnlyArrayRef<T> {
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  requires std::is_same_v<U, T>
+  // NOLINTNEXTLINE(modernize-use-constraints)
+  std::enable_if_t<std::is_same_v<U, T>, ArrayRef<T>>& operator=(
       // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
-      ArrayRef<T>& operator=(U&& Temporary) = delete;
+      U&& Temporary) = delete;
 
   /// Disallow accidental assignment from a temporary.
   ///
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  requires std::is_same_v<U, T> ArrayRef<T>& operator=(
+  // NOLINTNEXTLINE(modernize-use-constraints)
+  std::enable_if_t<std::is_same_v<U, T>, ArrayRef<T>>& operator=(
       std::initializer_list<U>) = delete;
 
   /// @}

--- a/test/cpp/aoti_abi_check/test_headeronlyarrayref.cpp
+++ b/test/cpp/aoti_abi_check/test_headeronlyarrayref.cpp
@@ -50,3 +50,38 @@ TEST(TestHeaderOnlyArrayRef, TestFromRange) {
     EXPECT_EQ(vec[i + 3], res_vec[i]);
   }
 }
+
+TEST(TestHeaderOnlyArrayRef, TestEqualityOperators) {
+  std::vector<int> vec = {1, 2, 3, 4};
+  std::vector<int> same_vec = {1, 2, 3, 4};
+  std::vector<int> diff_vec = {1, 2, 3, 5};
+  std::vector<int> short_vec = {1, 2, 3};
+
+  HeaderOnlyArrayRef<int> arr(vec);
+  HeaderOnlyArrayRef<int> same_arr(same_vec);
+  HeaderOnlyArrayRef<int> diff_arr(diff_vec);
+  HeaderOnlyArrayRef<int> short_arr(short_vec);
+
+  // HeaderOnlyArrayRef vs HeaderOnlyArrayRef
+  EXPECT_TRUE(arr == same_arr);
+  EXPECT_FALSE(arr != same_arr);
+  EXPECT_FALSE(arr == diff_arr);
+  EXPECT_TRUE(arr != diff_arr);
+  EXPECT_FALSE(arr == short_arr);
+  EXPECT_TRUE(arr != short_arr);
+
+  // HeaderOnlyArrayRef should agree with .equals()
+  EXPECT_EQ(arr == same_arr, arr.equals(same_arr));
+  EXPECT_EQ(arr == diff_arr, arr.equals(diff_arr));
+
+  // HeaderOnlyArrayRef vs std::vector (both orderings)
+  EXPECT_TRUE(arr == same_vec);
+  EXPECT_TRUE(same_vec == arr);
+  EXPECT_FALSE(arr != same_vec);
+  EXPECT_FALSE(same_vec != arr);
+
+  EXPECT_FALSE(arr == diff_vec);
+  EXPECT_FALSE(diff_vec == arr);
+  EXPECT_TRUE(arr != diff_vec);
+  EXPECT_TRUE(diff_vec != arr);
+}

--- a/torch/headeronly/util/HeaderOnlyArrayRef.h
+++ b/torch/headeronly/util/HeaderOnlyArrayRef.h
@@ -240,6 +240,40 @@ class HeaderOnlyArrayRef {
   /// @}
 };
 
+// WARNING: Template instantiation will NOT be willing to do an implicit
+// conversions to get you to an c10::HeaderOnlyArrayRef, which is why we need so
+// many overloads.
+
+template <typename T>
+bool operator==(c10::HeaderOnlyArrayRef<T> a1, c10::HeaderOnlyArrayRef<T> a2) {
+  return a1.equals(a2);
+}
+
+template <typename T>
+bool operator!=(c10::HeaderOnlyArrayRef<T> a1, c10::HeaderOnlyArrayRef<T> a2) {
+  return !a1.equals(a2);
+}
+
+template <typename T>
+bool operator==(const std::vector<T>& a1, c10::HeaderOnlyArrayRef<T> a2) {
+  return c10::HeaderOnlyArrayRef<T>(a1).equals(a2);
+}
+
+template <typename T>
+bool operator!=(const std::vector<T>& a1, c10::HeaderOnlyArrayRef<T> a2) {
+  return !c10::HeaderOnlyArrayRef<T>(a1).equals(a2);
+}
+
+template <typename T>
+bool operator==(c10::HeaderOnlyArrayRef<T> a1, const std::vector<T>& a2) {
+  return a1.equals(c10::HeaderOnlyArrayRef<T>(a2));
+}
+
+template <typename T>
+bool operator!=(c10::HeaderOnlyArrayRef<T> a1, const std::vector<T>& a2) {
+  return !a1.equals(c10::HeaderOnlyArrayRef<T>(a2));
+}
+
 } // namespace c10
 
 namespace torch::headeronly {

--- a/torch/headeronly/util/HeaderOnlyArrayRef.h
+++ b/torch/headeronly/util/HeaderOnlyArrayRef.h
@@ -66,9 +66,11 @@ class HeaderOnlyArrayRef {
 
   template <
       typename Container,
-      typename U = decltype(std::declval<Container>().data())>
-  requires(std::is_same_v<U, T*> || std::is_same_v<U, T const*>)
-      /* implicit */ HeaderOnlyArrayRef(const Container& container)
+      typename U = decltype(std::declval<Container>().data()),
+      // NOLINTNEXTLINE(modernize-use-constraints)
+      typename = std::enable_if_t<
+          (std::is_same_v<U, T*> || std::is_same_v<U, T const*>)>>
+  /* implicit */ HeaderOnlyArrayRef(const Container& container)
       : Data(container.data()), Length(container.size()) {}
 
   /// Construct a HeaderOnlyArrayRef from a std::vector.
@@ -217,16 +219,18 @@ class HeaderOnlyArrayRef {
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  requires std::is_same_v<U, T>
+  // NOLINTNEXTLINE(modernize-use-constraints)
+  std::enable_if_t<std::is_same_v<U, T>, HeaderOnlyArrayRef<T>>& operator=(
       // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
-      HeaderOnlyArrayRef<T>& operator=(U&& Temporary) = delete;
+      U&& Temporary) = delete;
 
   /// Disallow accidental assignment from a temporary.
   ///
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  requires std::is_same_v<U, T> HeaderOnlyArrayRef<T>& operator=(
+  // NOLINTNEXTLINE(modernize-use-constraints)
+  std::enable_if_t<std::is_same_v<U, T>, HeaderOnlyArrayRef<T>>& operator=(
       std::initializer_list<U>) = delete;
 
   /// @}

--- a/torch/headeronly/util/HeaderOnlyArrayRef.h
+++ b/torch/headeronly/util/HeaderOnlyArrayRef.h
@@ -66,10 +66,9 @@ class HeaderOnlyArrayRef {
 
   template <
       typename Container,
-      typename U = decltype(std::declval<Container>().data()),
-      typename = std::enable_if_t<
-          (std::is_same_v<U, T*> || std::is_same_v<U, T const*>)>>
-  /* implicit */ HeaderOnlyArrayRef(const Container& container)
+      typename U = decltype(std::declval<Container>().data())>
+  requires(std::is_same_v<U, T*> || std::is_same_v<U, T const*>)
+      /* implicit */ HeaderOnlyArrayRef(const Container& container)
       : Data(container.data()), Length(container.size()) {}
 
   /// Construct a HeaderOnlyArrayRef from a std::vector.
@@ -218,16 +217,16 @@ class HeaderOnlyArrayRef {
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  std::enable_if_t<std::is_same_v<U, T>, HeaderOnlyArrayRef<T>>& operator=(
+  requires std::is_same_v<U, T>
       // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
-      U&& Temporary) = delete;
+      HeaderOnlyArrayRef<T>& operator=(U&& Temporary) = delete;
 
   /// Disallow accidental assignment from a temporary.
   ///
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  std::enable_if_t<std::is_same_v<U, T>, HeaderOnlyArrayRef<T>>& operator=(
+  requires std::is_same_v<U, T> HeaderOnlyArrayRef<T>& operator=(
       std::initializer_list<U>) = delete;
 
   /// @}
@@ -238,41 +237,21 @@ class HeaderOnlyArrayRef {
   }
 
   /// @}
+  /// @name Equality operators
+  /// @{
+  ///
+  /// When migrating these over from ArrayRef.h, we changed these from
+  /// free functions outside the class to be hidden friends which is the
+  /// modern C++ recommendation for various reasons including being more
+  /// precisely scoped and being non-templates after class instantiation.
+  friend bool operator==(HeaderOnlyArrayRef a1, HeaderOnlyArrayRef a2) {
+    return a1.equals(a2);
+  }
+  friend bool operator!=(HeaderOnlyArrayRef a1, HeaderOnlyArrayRef a2) {
+    return !a1.equals(a2);
+  }
+  /// @}
 };
-
-// WARNING: Template instantiation will NOT be willing to do an implicit
-// conversions to get you to an c10::HeaderOnlyArrayRef, which is why we need so
-// many overloads.
-
-template <typename T>
-bool operator==(c10::HeaderOnlyArrayRef<T> a1, c10::HeaderOnlyArrayRef<T> a2) {
-  return a1.equals(a2);
-}
-
-template <typename T>
-bool operator!=(c10::HeaderOnlyArrayRef<T> a1, c10::HeaderOnlyArrayRef<T> a2) {
-  return !a1.equals(a2);
-}
-
-template <typename T>
-bool operator==(const std::vector<T>& a1, c10::HeaderOnlyArrayRef<T> a2) {
-  return c10::HeaderOnlyArrayRef<T>(a1).equals(a2);
-}
-
-template <typename T>
-bool operator!=(const std::vector<T>& a1, c10::HeaderOnlyArrayRef<T> a2) {
-  return !c10::HeaderOnlyArrayRef<T>(a1).equals(a2);
-}
-
-template <typename T>
-bool operator==(c10::HeaderOnlyArrayRef<T> a1, const std::vector<T>& a2) {
-  return a1.equals(c10::HeaderOnlyArrayRef<T>(a2));
-}
-
-template <typename T>
-bool operator!=(c10::HeaderOnlyArrayRef<T> a1, const std::vector<T>& a2) {
-  return !a1.equals(c10::HeaderOnlyArrayRef<T>(a2));
-}
 
 } // namespace c10
 


### PR DESCRIPTION
I noticed during migration of ArrayRef to HeaderOnlyArrayRef that we had to change == usages to .equals, which felt silly. This is a UX improvement.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #185421
* __->__ #185379

