### PR TITLE
[torchfuzz] Enhance PointwiseOperator with scalar/broadcast inputs and randomized hyperparameters (#185383)

### DIFF
--- a/tools/experimental/torchfuzz/operators/nn_functional.py
+++ b/tools/experimental/torchfuzz/operators/nn_functional.py
@@ -543,7 +543,8 @@ class GELUOperator(Operator):
             raise ValueError("GELU requires exactly 1 input")
 
         input_name = input_names[0]
-        return f"{output_name} = torch.nn.functional.gelu({input_name})"
+        approx = random.choice(["none", "tanh"])
+        return f"{output_name} = torch.nn.functional.gelu({input_name}, approximate={approx!r})"
 
 
 class SigmoidOperator(Operator):
@@ -877,7 +878,8 @@ class LeakyReLUOperator(Operator):
             raise ValueError("LeakyReLU requires exactly 1 input")
 
         input_name = input_names[0]
-        return f"{output_name} = torch.nn.functional.leaky_relu({input_name}, negative_slope=0.01)"
+        slope = round(random.uniform(0.001, 0.5), 4)
+        return f"{output_name} = torch.nn.functional.leaky_relu({input_name}, negative_slope={slope!r})"
 
 
 class ELUOperator(Operator):
@@ -919,7 +921,8 @@ class ELUOperator(Operator):
             raise ValueError("ELU requires exactly 1 input")
 
         input_name = input_names[0]
-        return f"{output_name} = torch.nn.functional.elu({input_name})"
+        alpha = round(random.uniform(0.1, 3.0), 4)
+        return f"{output_name} = torch.nn.functional.elu({input_name}, alpha={alpha!r})"
 
 
 class SiLUOperator(Operator):

--- a/tools/experimental/torchfuzz/operators/tensor_pointwise.py
+++ b/tools/experimental/torchfuzz/operators/tensor_pointwise.py
@@ -5,7 +5,7 @@ import random
 import torch
 
 from torchfuzz.operators.base import Operator
-from torchfuzz.tensor_fuzzer import Spec, TensorSpec
+from torchfuzz.tensor_fuzzer import ScalarSpec, Spec, TensorSpec
 from torchfuzz.type_promotion import (
     get_dtype_map,
     get_dtype_name,
@@ -13,12 +13,43 @@ from torchfuzz.type_promotion import (
 )
 
 
+def _contiguous_stride(size: tuple[int, ...]) -> tuple[int, ...]:
+    if not size:
+        return ()
+    strides: list[int] = [1]
+    for dim in reversed(size[1:]):
+        strides.append(strides[-1] * dim)
+    return tuple(reversed(strides))
+
+
+def _random_broadcast_shape(output_size: tuple[int, ...]) -> tuple[int, ...]:
+    if not output_size:
+        return ()
+    result = list(output_size)
+    changed = False
+    for i in range(len(result)):
+        if random.random() < 0.3:
+            result[i] = 1
+            changed = True
+    if not changed:
+        return output_size
+    while len(result) > 1 and result[0] == 1 and random.random() < 0.5:
+        result.pop(0)
+    return tuple(result)
+
+
 class PointwiseOperator(Operator):
     """Base class for element-wise pointwise operations."""
 
-    def __init__(self, name: str, symbol: str):
+    _scalar_input_positions: tuple[int, ...] = (0, 1)
+
+    def __init__(self, name: str, symbol: str = ""):
         super().__init__(name)
         self.symbol = symbol
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
 
     def can_produce(self, output_spec: Spec) -> bool:
         """Tensor pointwise operations can produce tensors but not scalars."""
@@ -53,7 +84,7 @@ class PointwiseOperator(Operator):
         # Convert dtype strings back to torch dtypes
         dtype_map = get_dtype_map()
 
-        return [
+        input_specs: list[Spec] = [
             TensorSpec(
                 size=output_spec.size,
                 stride=output_spec.stride,
@@ -61,6 +92,23 @@ class PointwiseOperator(Operator):
             )
             for dt in dtypes
         ]
+
+        if num_inputs >= 2:
+            r = random.random()
+            if self._scalar_input_positions and r < 0.3:
+                idx = random.choice(self._scalar_input_positions)
+                input_specs[idx] = ScalarSpec(dtype=input_specs[idx].dtype)
+            elif r < 0.5:
+                idx = random.randint(0, 1)
+                bcast_size = _random_broadcast_shape(tuple(output_spec.size))
+                if bcast_size != tuple(output_spec.size):
+                    input_specs[idx] = TensorSpec(
+                        size=bcast_size,
+                        stride=_contiguous_stride(bcast_size),
+                        dtype=input_specs[idx].dtype,
+                    )
+
+        return input_specs
 
     def codegen(
         self, output_name: str, input_names: list[str], output_spec: Spec
@@ -84,6 +132,24 @@ class AddOperator(PointwiseOperator):
     @property
     def torch_op_name(self) -> str:
         return "torch.add"
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        if len(input_names) == 2 and random.random() < 0.3:
+            alpha = round(random.uniform(-5.0, 5.0), 4)
+            if isinstance(output_spec, TensorSpec) and output_spec.dtype not in (
+                torch.float16,
+                torch.float32,
+                torch.float64,
+                torch.bfloat16,
+            ):
+                alpha = int(alpha)
+            return (
+                f"{output_name} = torch.add("
+                f"{input_names[0]}, {input_names[1]}, alpha={alpha!r})"
+            )
+        return super().codegen(output_name, input_names, output_spec)
 
 
 class MulOperator(PointwiseOperator):


### PR DESCRIPTION
Summary:

Backward-compatible enhancements to `PointwiseOperator` and three upstream activation operators:

**`PointwiseOperator` changes (`tensor_pointwise.py`):**

1. `fuzz_inputs_specs` now randomly replaces one of the two inputs with a `ScalarSpec` (30% probability). This exercises the `torch.add(tensor, scalar)` dispatch path that is ubiquitous in real models but was never tested by the fuzzer.

2. `fuzz_inputs_specs` has a secondary 20% probability path that replaces one input's shape with a broadcast-compatible shape (via `_random_broadcast_shape`). This exercises PyTorch's implicit broadcast semantics for binary ops.

3. `symbol` parameter defaults to `""` (was required). This allows subclasses that represent named-function ops (e.g. `torch.maximum`) to skip the symbol without passing a dummy string.

4. Default `torch_op_name` property returns `self.name`. This eliminates the need for every subclass to define the same one-liner property.

5. `AddOperator.codegen` now has a 30% probability of emitting `alpha=<random>` to exercise the `torch.add(a, b, alpha=...)` path. For integer output dtypes, the alpha is truncated to `int`.

**Activation operator changes (`nn_functional.py`):**

6. `GELUOperator.codegen` now randomizes `approximate=` between `"none"` and `"tanh"` (was always `"none"`).

7. `LeakyReLUOperator.codegen` now draws `negative_slope` from `Uniform(0.001, 0.5)` (was hardcoded `0.01`).

8. `ELUOperator.codegen` now draws `alpha` from `Uniform(0.1, 3.0)` (was always the PyTorch default `1.0`).

Test Plan:
These changes were tested as part of a collection of changes to add operator coverage to torchfuzz.

Operator definitions were validated end-to-end using a downstream torchfuzz device plugin for a non-GPU architecture. A test harness ran the fuzzer across all operators in the plugin's template, testing each operator in isolation (--max-depth 1 --supported-ops '<op>') so that failures are attributable to a single operator definition. Per-operator seed counts were derived from coupon-collector analysis: for each operator, the rarest discrete random outcome in fuzz_inputs_specs is identified (probability p_min), then N = ceil(ln(0.05) / ln(1 - p_min)) gives 95% confidence of exercising that path at least once; N is then doubled for margin. This produced tiered counts from 10 seeds (operators with no discrete choices) to 70 seeds (operators with complex mode/dim/dtype interactions). 5830 total invocations across all operator categories.

Failures were automatically classified: "investigate" (fuzzer crashed before generating a program — likely a bug in the operator's fuzz_inputs_specs or codegen) vs "triage" (program was generated but failed at compile or execution time — could be a definition bug or a legitimate backend issue the fuzzer is designed to surface). Three iterative triage-and-fix rounds were completed until all operator-definition bugs were resolved. Remaining triage failures are legitimate backend compilation/execution issues.

Differential Revision: D106395651


