### PR TITLE
[torchfuzz] Add elementwise math operators (#185389)

### DIFF
--- a/tools/experimental/torchfuzz/README.md
+++ b/tools/experimental/torchfuzz/README.md
@@ -561,18 +561,22 @@ class MyOperator(Operator):
         return f"{output_name} = torch.my_op({', '.join(input_names)})"
 ```
 
-### Step 2: Register Operator
+### Step 2: Register Your Module
 
-Add your operator to `operators/registry.py`:
+Add your module name to the `_OPERATOR_MODULES` list in `operators/registry.py`:
 
 ```python
-from torchfuzz.operators.my_op import MyOperator
-
-class OperatorRegistry:
-    def _register_default_operators(self):
-        # ... existing registrations ...
-        self.register(MyOperator())
+_OPERATOR_MODULES: list[str] = [
+    # ... existing modules ...
+    "my_op",
+]
 ```
+
+The registry automatically discovers all concrete `Operator` subclasses in each listed module using introspection. Your operator class must:
+- Be a concrete (non-abstract) subclass of `Operator`
+- Be defined in the module (not re-exported from elsewhere)
+- NOT have a class name ending with `Base` (reserved for abstract bases)
+- Have a parameterless constructor (or all-defaulted parameters)
 
 ### Step 3: Add to Template (Optional)
 

--- a/tools/experimental/torchfuzz/operators/LIMITATIONS.md
+++ b/tools/experimental/torchfuzz/operators/LIMITATIONS.md
@@ -1,0 +1,53 @@
+# Operator Coverage Limitations
+
+Known gaps between what these operator definitions exercise and what
+PyTorch allows. Each section is maintained by the diff that introduced
+the operators it describes.
+
+## Cross-Cutting
+
+These limitations stem from the fuzzer's top-down graph construction
+model and affect all or most operators.
+
+- **Non-contiguous inputs** — Input strides are always copied from
+  `output_spec.stride` or computed via `contiguous_stride()`.
+  Non-contiguous inputs (transposed, sliced, expanded) are never
+  independently generated.
+
+- **In-place variants** — Codegen always assigns to a new variable.
+  In-place forms (`.cos_()`, `inplace=True`) are never emitted.
+
+- **`out=` parameter** — Pre-allocated output tensors are never passed.
+
+- **Empty tensors** — Shape generators use `randint(1, 6)`, so
+  size-0 dimensions are never produced.
+
+- **Rank-0 broadcast** — `random_broadcast_shape` cannot produce a
+  rank-0 (scalar) tensor input. The `while len(result) > 1` guard
+  prevents dropping below rank 1.
+
+- **Complex dtypes** — `FLOAT_DTYPES` contains no complex types.
+  Particularly impacts `torch.angle`, `torch.real`, and any binary
+  op that supports complex inputs.
+
+- **Max rank** — `max_dims=3` caps tensor rank. 4-D (NCHW) and 5-D
+  tensors common in ML workloads are never generated.
+
+- **Single-input broadcast** — When broadcasting is applied, only one
+  of N inputs is shrunk. Simultaneous broadcasting of multiple inputs
+  (e.g., `(3,1) + (1,4)` → `(3,4)`) is never tested.
+
+- **Broadcast stride** — Broadcast inputs always get contiguous strides.
+  Non-contiguous broadcast inputs are valid but never generated.
+
+- **Float8 dtypes** — `torch.float8_e4m3fn` etc. are excluded.
+
+- **Half-precision edge cases** — No targeted generation of denormals,
+  near-max values, or bf16 precision boundaries.
+
+## Tensor Creation
+
+- `_like` operators: the non-contiguous output path creates a
+  contiguous intermediate via the `_like` call and `.copy_()` into
+  `torch.empty_strided`. This does not test the op's native stride
+  handling.

--- a/tools/experimental/torchfuzz/operators/LIMITATIONS.md
+++ b/tools/experimental/torchfuzz/operators/LIMITATIONS.md
@@ -45,6 +45,23 @@ model and affect all or most operators.
 - **Half-precision edge cases** — No targeted generation of denormals,
   near-max values, or bf16 precision boundaries.
 
+## Elementwise Math
+
+- `torch.angle` and `torch.real` are no-ops on real-valued tensors;
+  their interesting behavior requires complex dtypes (excluded above).
+
+- `torch.clamp_max` / `torch.clamp_min` randomize scalar bounds but
+  never test tensor bounds (`torch.clamp_max(input, max=other_tensor)`).
+
+- `torch.heaviside` second arg is always a 0-d scalar tensor; never
+  tests a broadcastable `values` tensor of higher rank.
+
+- `torch.lerp` always uses 3 tensor inputs; the scalar weight variant
+  `torch.lerp(start, end, weight=0.5)` is never tested.
+
+- `torch.addcmul` integer inputs are valid in PyTorch but excluded by
+  `requires_float = True`.
+
 ## Tensor Creation
 
 - `_like` operators: the non-contiguous output path creates a

--- a/tools/experimental/torchfuzz/operators/__init__.py
+++ b/tools/experimental/torchfuzz/operators/__init__.py
@@ -46,7 +46,7 @@ from torchfuzz.operators.scalar_pointwise import (
     ScalarAddOperator,
     ScalarDivOperator,
     ScalarMulOperator,
-    ScalarPointwiseOperator,
+    ScalarPointwiseOperatorBase,
     ScalarSubOperator,
 )
 from torchfuzz.operators.tensor_pointwise import (
@@ -54,20 +54,20 @@ from torchfuzz.operators.tensor_pointwise import (
     ClampOperator,
     DivOperator,
     MulOperator,
-    PointwiseOperator,
+    PointwiseOperatorBase,
     SubOperator,
 )
 
 
 __all__ = [
     "Operator",
-    "PointwiseOperator",
+    "PointwiseOperatorBase",
     "AddOperator",
     "MulOperator",
     "SubOperator",
     "DivOperator",
     "ClampOperator",
-    "ScalarPointwiseOperator",
+    "ScalarPointwiseOperatorBase",
     "ScalarAddOperator",
     "ScalarMulOperator",
     "ScalarSubOperator",

--- a/tools/experimental/torchfuzz/operators/_dtypes.py
+++ b/tools/experimental/torchfuzz/operators/_dtypes.py
@@ -1,0 +1,63 @@
+# pyre-strict
+"""Shared dtype constants and utilities for torchfuzz operator modules."""
+
+from __future__ import annotations
+
+import math
+import random
+
+import torch
+
+
+FLOAT_DTYPES: tuple[torch.dtype, ...] = (
+    torch.float16,
+    torch.float32,
+    torch.float64,
+    torch.bfloat16,
+)
+
+
+def is_float_dtype(dt: torch.dtype) -> bool:
+    return dt in FLOAT_DTYPES
+
+
+def contiguous_stride(size: tuple[int, ...]) -> tuple[int, ...]:
+    """Row-major contiguous strides for ``size``."""
+    if not size:
+        return ()
+    strides: list[int] = [1]
+    for dim in reversed(size[1:]):
+        strides.append(strides[-1] * dim)
+    return tuple(reversed(strides))
+
+
+def scalar_repr(value: object) -> str:
+    """Format a scalar for embedding in codegen, handling inf/nan."""
+    if isinstance(value, float):
+        if math.isinf(value):
+            return f"float('{'-' if value < 0 else ''}inf')"
+        if math.isnan(value):
+            return "float('nan')"
+    return repr(value)
+
+
+def random_broadcast_shape(output_size: tuple[int, ...]) -> tuple[int, ...]:
+    """Return a shape that broadcasts to ``output_size``.
+
+    Each dimension has a 30% chance of shrinking to 1. Leading size-1
+    dims may then be dropped (50% chance each) to produce a lower-rank
+    input. Returns ``output_size`` unchanged if no dims were shrunk.
+    """
+    if not output_size:
+        return ()
+    result = list(output_size)
+    changed = False
+    for i in range(len(result)):
+        if random.random() < 0.3:
+            result[i] = 1
+            changed = True
+    if not changed:
+        return output_size
+    while len(result) > 1 and result[0] == 1 and random.random() < 0.5:
+        result.pop(0)
+    return tuple(result)

--- a/tools/experimental/torchfuzz/operators/elementwise_math.py
+++ b/tools/experimental/torchfuzz/operators/elementwise_math.py
@@ -1,0 +1,736 @@
+# pyre-strict
+"""Elementwise math Operator subclasses.
+
+Covers unary, bool-output unary, binary, ternary, and a handful of special-case
+elementwise ops (clamp_max, clamp_min, heaviside, ldexp, logcumsumexp). Op
+classes that overlap upstream torchfuzz (add, sub, mul, div, clamp) are NOT
+defined here — they remain registered by upstream.
+
+Subclasses are generated via small factory helpers to avoid hundreds of lines
+of near-identical boilerplate. Each generated class is assigned to a
+module-level name and has ``__module__`` set so the introspection-based
+registry discovers it.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+import torch
+
+from torchfuzz.operators._dtypes import (
+    contiguous_stride,
+    FLOAT_DTYPES,
+    is_float_dtype,
+    random_broadcast_shape,
+)
+from torchfuzz.operators.base import Operator
+from torchfuzz.operators.tensor_pointwise import PointwiseOperatorBase
+from torchfuzz.tensor_fuzzer import Spec, TensorSpec
+
+
+# ---------------------------------------------------------------------------
+# Base classes (excluded from introspection by the ``Base`` suffix)
+# ---------------------------------------------------------------------------
+
+
+class UnaryElementwiseOperatorBase(Operator):
+    """Base for one-tensor-in / one-tensor-out elementwise math (same dtype)."""
+
+    requires_float: bool = False
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        if not isinstance(output_spec, TensorSpec):
+            return False
+        if output_spec.dtype == torch.bool:
+            return False
+        if self.requires_float and not is_float_dtype(output_spec.dtype):
+            return False
+        return True
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError(
+                f"{self.__class__.__name__} can only produce TensorSpec outputs"
+            )
+        return [
+            TensorSpec(
+                size=output_spec.size,  # pyrefly: ignore[missing-argument]
+                stride=output_spec.stride,
+                dtype=output_spec.dtype,
+            )
+        ]
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        if len(input_names) != 1:
+            raise ValueError(
+                f"{self.__class__.__name__} requires exactly 1 input tensor"
+            )
+        return f"{output_name} = {self.torch_op_name}({input_names[0]})"
+
+
+class BoolUnaryElementwiseOperatorBase(Operator):
+    """Base for one-numeric-tensor-in / one-bool-tensor-out (isfinite/isnan/...)."""
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        return isinstance(output_spec, TensorSpec) and output_spec.dtype == torch.bool
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError(
+                f"{self.__class__.__name__} can only produce TensorSpec outputs"
+            )
+        # Pick a random float dtype at spec-fuzz time
+        return [
+            TensorSpec(
+                size=output_spec.size,  # pyrefly: ignore[missing-argument]
+                stride=output_spec.stride,
+                dtype=random.choice(
+                    FLOAT_DTYPES + (torch.int8, torch.int16, torch.int32, torch.int64)
+                ),
+            )
+        ]
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        if len(input_names) != 1:
+            raise ValueError(
+                f"{self.__class__.__name__} requires exactly 1 input tensor"
+            )
+        return f"{output_name} = {self.torch_op_name}({input_names[0]})"
+
+
+class FloatOnlyPointwiseOperatorBase(PointwiseOperatorBase):
+    """PointwiseOperatorBase restricted to float dtypes."""
+
+    _scalar_input_positions = ()
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        if not isinstance(output_spec, TensorSpec):
+            return False
+        if output_spec.dtype == torch.bool:
+            return False
+        return is_float_dtype(output_spec.dtype)
+
+
+class TernaryElementwiseOperatorBase(Operator):
+    """Base for three-tensor-in / one-tensor-out elementwise math (float-only)."""
+
+    requires_float: bool = True
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        if not isinstance(output_spec, TensorSpec):
+            return False
+        if output_spec.dtype == torch.bool:
+            return False
+        if self.requires_float and not is_float_dtype(output_spec.dtype):
+            return False
+        return True
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError(
+                f"{self.__class__.__name__} can only produce TensorSpec outputs"
+            )
+        spec = TensorSpec(
+            size=output_spec.size,
+            stride=output_spec.stride,
+            dtype=output_spec.dtype,
+        )
+        specs: list[Spec] = [spec, spec, spec]
+        if random.random() < 0.3:
+            idx = random.randint(0, 2)
+            bcast_size = random_broadcast_shape(tuple(output_spec.size))
+            if bcast_size != tuple(output_spec.size):
+                specs[idx] = TensorSpec(
+                    size=bcast_size,
+                    stride=contiguous_stride(bcast_size),
+                    dtype=output_spec.dtype,
+                )
+        return specs
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        if len(input_names) != 3:
+            raise ValueError(
+                f"{self.__class__.__name__} requires exactly 3 input tensors"
+            )
+        return (
+            f"{output_name} = {self.torch_op_name}("
+            f"{input_names[0]}, {input_names[1]}, {input_names[2]})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Subclass factories
+# ---------------------------------------------------------------------------
+
+
+def _class_name_from_op(op_name: str) -> str:
+    """Convert ``"torch.nan_to_num"`` -> ``"NanToNumOperator"``."""
+    suffix = op_name.replace("torch.", "")
+    return "".join(p.capitalize() for p in suffix.split("_")) + "Operator"
+
+
+def _make_subclass(
+    base: type[Operator],
+    op_name: str,
+    extra_attrs: dict[str, Any] | None = None,
+) -> type[Operator]:
+    """Build a concrete Operator subclass for ``op_name`` deriving from ``base``."""
+    cls_name = _class_name_from_op(op_name)
+
+    def _init(self: Operator) -> None:
+        base.__init__(self, op_name)
+
+    attrs: dict[str, Any] = {
+        "__init__": _init,
+    }
+    if extra_attrs:
+        attrs.update(extra_attrs)
+    cls = type(cls_name, (base,), attrs)
+    cls.__module__ = __name__
+    return cls
+
+
+# ---------------------------------------------------------------------------
+# Unary subclasses
+# ---------------------------------------------------------------------------
+
+# Float-only unary ops (per plan filtering rules).
+_UNARY_FLOAT_OPS: tuple[str, ...] = (
+    "torch.acos",
+    "torch.acosh",
+    "torch.angle",
+    "torch.arccos",
+    "torch.arccosh",
+    "torch.arcsin",
+    "torch.arcsinh",
+    "torch.arctan",
+    "torch.arctanh",
+    "torch.asin",
+    "torch.asinh",
+    "torch.atan",
+    "torch.atanh",
+    "torch.cos",
+    "torch.cosh",
+    "torch.deg2rad",
+    "torch.erf",
+    "torch.erfc",
+    "torch.erfinv",
+    "torch.exp",
+    "torch.exp2",
+    "torch.expm1",
+    "torch.fix",
+    "torch.frac",
+    "torch.log",
+    "torch.log10",
+    "torch.log1p",
+    "torch.log2",
+    "torch.rad2deg",
+    "torch.reciprocal",
+    "torch.rsqrt",
+    "torch.sin",
+    "torch.sinh",
+    "torch.sqrt",
+    "torch.tan",
+)
+
+# Numeric unary ops that work on int + float (no bool).
+_UNARY_NUMERIC_OPS: tuple[str, ...] = (
+    "torch.abs",
+    "torch.absolute",
+    "torch.ceil",
+    "torch.floor",
+    "torch.neg",
+    "torch.negative",
+    "torch.real",
+    "torch.sgn",
+    "torch.sign",
+    "torch.square",
+    "torch.trunc",
+)
+
+
+for _op in _UNARY_FLOAT_OPS:
+    globals()[_class_name_from_op(_op)] = _make_subclass(
+        UnaryElementwiseOperatorBase, _op, {"requires_float": True}
+    )
+
+for _op in _UNARY_NUMERIC_OPS:
+    globals()[_class_name_from_op(_op)] = _make_subclass(
+        UnaryElementwiseOperatorBase, _op
+    )
+
+
+class LogitOperator(UnaryElementwiseOperatorBase):
+    requires_float = True
+
+    def __init__(self) -> None:
+        super().__init__("torch.logit")
+        self._eps: float | None = None
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        self._eps = round(random.uniform(1e-7, 1e-2), 8)
+        return super().fuzz_inputs_specs(output_spec)
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        eps = self._eps
+        self._eps = None
+        return f"{output_name} = torch.logit({input_names[0]}, eps={eps!r})"
+
+
+class NanToNumOperator(UnaryElementwiseOperatorBase):
+    requires_float = True
+
+    def __init__(self) -> None:
+        super().__init__("torch.nan_to_num")
+        self._nan: float | None = None
+        self._posinf: float | None = None
+        self._neginf: float | None = None
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        self._nan = round(random.uniform(-10.0, 10.0), 4)
+        self._posinf = round(random.uniform(0.0, 100.0), 4)
+        self._neginf = round(random.uniform(-100.0, 0.0), 4)
+        return super().fuzz_inputs_specs(output_spec)
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        nan, posinf, neginf = self._nan, self._posinf, self._neginf
+        self._nan = self._posinf = self._neginf = None
+        return (
+            f"{output_name} = torch.nan_to_num({input_names[0]}, "
+            f"nan={nan!r}, posinf={posinf!r}, neginf={neginf!r})"
+        )
+
+
+class RoundOperator(UnaryElementwiseOperatorBase):
+    requires_float = True
+
+    def __init__(self) -> None:
+        super().__init__("torch.round")
+        self._decimals: int | None = None
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        self._decimals = random.randint(0, 4)
+        return super().fuzz_inputs_specs(output_spec)
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        decimals = self._decimals
+        self._decimals = None
+        return f"{output_name} = torch.round({input_names[0]}, decimals={decimals})"
+
+
+# ---------------------------------------------------------------------------
+# Bool-output unary subclasses
+# ---------------------------------------------------------------------------
+
+_BOOL_UNARY_OPS: tuple[str, ...] = (
+    "torch.isfinite",
+    "torch.isinf",
+    "torch.isnan",
+    "torch.isneginf",
+    "torch.isposinf",
+    "torch.signbit",
+)
+
+for _op in _BOOL_UNARY_OPS:
+    globals()[_class_name_from_op(_op)] = _make_subclass(
+        BoolUnaryElementwiseOperatorBase, _op
+    )
+
+
+# ---------------------------------------------------------------------------
+# Binary subclasses
+# ---------------------------------------------------------------------------
+
+# Float-only binary ops — both args must be tensors.
+_BINARY_FLOAT_TENSOR_ONLY_OPS: tuple[str, ...] = (
+    "torch.arctan2",
+    "torch.atan2",
+    "torch.hypot",
+    "torch.logaddexp",
+    "torch.logaddexp2",
+    "torch.nextafter",
+)
+
+# Float-only binary ops — scalar allowed in position 1 (the `other` arg).
+_BINARY_FLOAT_SCALAR_OTHER_OPS: tuple[str, ...] = ("torch.copysign",)
+
+# Float-only binary ops — scalar allowed in either position.
+_BINARY_FLOAT_SCALAR_BOTH_OPS: tuple[str, ...] = ("torch.xlogy",)
+
+# Numeric binary ops — scalar allowed in either position.
+_BINARY_NUMERIC_OPS: tuple[str, ...] = (
+    "torch.floor_divide",
+    "torch.multiply",
+    "torch.remainder",
+    "torch.subtract",
+)
+
+# Numeric binary ops — both args must be tensors.
+_BINARY_NUMERIC_TENSOR_ONLY_OPS: tuple[str, ...] = (
+    "torch.fmax",
+    "torch.fmin",
+    "torch.maximum",
+    "torch.minimum",
+)
+
+# Numeric binary ops — scalar allowed in position 1 only.
+_BINARY_NUMERIC_SCALAR_OTHER_OPS: tuple[str, ...] = ("torch.fmod",)
+
+for _op in _BINARY_FLOAT_TENSOR_ONLY_OPS:
+    globals()[_class_name_from_op(_op)] = _make_subclass(
+        FloatOnlyPointwiseOperatorBase, _op
+    )
+
+for _op in _BINARY_FLOAT_SCALAR_OTHER_OPS:
+    globals()[_class_name_from_op(_op)] = _make_subclass(
+        FloatOnlyPointwiseOperatorBase, _op, {"_scalar_input_positions": (1,)}
+    )
+
+for _op in _BINARY_FLOAT_SCALAR_BOTH_OPS:
+    globals()[_class_name_from_op(_op)] = _make_subclass(
+        FloatOnlyPointwiseOperatorBase, _op, {"_scalar_input_positions": (0, 1)}
+    )
+
+for _op in _BINARY_NUMERIC_OPS:
+    globals()[_class_name_from_op(_op)] = _make_subclass(PointwiseOperatorBase, _op)
+
+for _op in _BINARY_NUMERIC_TENSOR_ONLY_OPS:
+    globals()[_class_name_from_op(_op)] = _make_subclass(
+        PointwiseOperatorBase, _op, {"_scalar_input_positions": ()}
+    )
+
+for _op in _BINARY_NUMERIC_SCALAR_OTHER_OPS:
+    globals()[_class_name_from_op(_op)] = _make_subclass(
+        PointwiseOperatorBase, _op, {"_scalar_input_positions": (1,)}
+    )
+
+
+class PowOperator(PointwiseOperatorBase):
+    """torch.pow with non-negative exponents for integer bases.
+
+    Negative integer exponents produce fractions that cannot be
+    represented in integer dtypes; PyTorch raises RuntimeError.
+    Uses Python abs() instead of torch.abs() so scalar exponents work.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("torch.pow")
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        if (
+            isinstance(output_spec, TensorSpec)
+            and output_spec.dtype not in FLOAT_DTYPES
+        ):
+            return f"{output_name} = torch.pow({input_names[0]}, abs({input_names[1]}))"
+        return super().codegen(output_name, input_names, output_spec)
+
+
+class DivideOperator(PointwiseOperatorBase):
+    def __init__(self) -> None:
+        super().__init__("torch.divide")
+        self._rounding_mode: str | None = None
+
+    def fuzz_inputs_specs(self, output_spec: Spec, num_inputs: int = 2) -> list[Spec]:
+        self._rounding_mode = random.choice(["default", "trunc", "floor"])
+        return super().fuzz_inputs_specs(output_spec, num_inputs)
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        rm = self._rounding_mode
+        self._rounding_mode = None
+        base = super().codegen(output_name, input_names, output_spec)
+        if rm != "default":
+            base = base[:-1] + f", rounding_mode={rm!r})"
+        return base
+
+
+class TrueDivideOperator(PointwiseOperatorBase):
+    def __init__(self) -> None:
+        super().__init__("torch.true_divide")
+
+
+class RsubOperator(PointwiseOperatorBase):
+    _scalar_input_positions = (1,)
+
+    def __init__(self) -> None:
+        super().__init__("torch.rsub")
+        self._alpha: float | int | None = None
+
+    def fuzz_inputs_specs(self, output_spec: Spec, num_inputs: int = 2) -> list[Spec]:
+        if random.random() < 0.3:
+            alpha = round(random.uniform(-5.0, 5.0), 4)
+            if (
+                isinstance(output_spec, TensorSpec)
+                and output_spec.dtype not in FLOAT_DTYPES
+            ):
+                alpha = int(alpha)
+            self._alpha = alpha
+        else:
+            self._alpha = None
+        return super().fuzz_inputs_specs(output_spec, num_inputs)
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        alpha = self._alpha
+        self._alpha = None
+        base = super().codegen(output_name, input_names, output_spec)
+        if alpha is not None:
+            base = base[:-1] + f", alpha={alpha!r})"
+        return base
+
+
+# ---------------------------------------------------------------------------
+# Ternary subclasses (float-only)
+# ---------------------------------------------------------------------------
+
+_TERNARY_OPS: tuple[str, ...] = ("torch.lerp",)
+
+for _op in _TERNARY_OPS:
+    globals()[_class_name_from_op(_op)] = _make_subclass(
+        TernaryElementwiseOperatorBase, _op
+    )
+
+
+class AddcdivOperator(TernaryElementwiseOperatorBase):
+    def __init__(self) -> None:
+        super().__init__("torch.addcdiv")
+        self._value: float | None = None
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        self._value = (
+            round(random.uniform(-5.0, 5.0), 4) if random.random() < 0.3 else None
+        )
+        return super().fuzz_inputs_specs(output_spec)
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        value = self._value
+        self._value = None
+        if len(input_names) != 3:
+            raise ValueError("AddcdivOperator requires exactly 3 input tensors")
+        base = (
+            f"{output_name} = torch.addcdiv("
+            f"{input_names[0]}, {input_names[1]}, {input_names[2]}"
+        )
+        if value is not None:
+            return f"{base}, value={value!r})"
+        return f"{base})"
+
+
+class AddcmulOperator(TernaryElementwiseOperatorBase):
+    def __init__(self) -> None:
+        super().__init__("torch.addcmul")
+        self._value: float | None = None
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        self._value = (
+            round(random.uniform(-5.0, 5.0), 4) if random.random() < 0.3 else None
+        )
+        return super().fuzz_inputs_specs(output_spec)
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        value = self._value
+        self._value = None
+        if len(input_names) != 3:
+            raise ValueError("AddcmulOperator requires exactly 3 input tensors")
+        base = (
+            f"{output_name} = torch.addcmul("
+            f"{input_names[0]}, {input_names[1]}, {input_names[2]}"
+        )
+        if value is not None:
+            return f"{base}, value={value!r})"
+        return f"{base})"
+
+
+# ---------------------------------------------------------------------------
+# Special-case operators
+# ---------------------------------------------------------------------------
+
+
+class ClampMaxOperator(Operator):
+    """``torch.clamp_max(input, max)`` — random scalar bound."""
+
+    def __init__(self) -> None:
+        super().__init__("torch.clamp_max")
+        self._max: float | int | None = None
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        if not isinstance(output_spec, TensorSpec):
+            return False
+        return output_spec.dtype != torch.bool
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        assert isinstance(output_spec, TensorSpec)  # noqa: S101
+        bound = round(random.uniform(-10.0, 10.0), 4)
+        if output_spec.dtype not in FLOAT_DTYPES:
+            bound = int(bound)
+        self._max = bound
+        return [
+            TensorSpec(
+                size=output_spec.size,
+                stride=output_spec.stride,
+                dtype=output_spec.dtype,
+            )
+        ]
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        max_val = self._max
+        self._max = None
+        return f"{output_name} = torch.clamp_max({input_names[0]}, max={max_val!r})"
+
+
+class ClampMinOperator(Operator):
+    """``torch.clamp_min(input, min)`` — random scalar bound."""
+
+    def __init__(self) -> None:
+        super().__init__("torch.clamp_min")
+        self._min: float | int | None = None
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        if not isinstance(output_spec, TensorSpec):
+            return False
+        return output_spec.dtype != torch.bool
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        assert isinstance(output_spec, TensorSpec)  # noqa: S101
+        bound = round(random.uniform(-10.0, 10.0), 4)
+        if output_spec.dtype not in FLOAT_DTYPES:
+            bound = int(bound)
+        self._min = bound
+        return [
+            TensorSpec(
+                size=output_spec.size,
+                stride=output_spec.stride,
+                dtype=output_spec.dtype,
+            )
+        ]
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        min_val = self._min
+        self._min = None
+        return f"{output_name} = torch.clamp_min({input_names[0]}, min={min_val!r})"
+
+
+class HeavisideOperator(Operator):
+    """``torch.heaviside(input, values)`` — second arg is a 0-d tensor."""
+
+    def __init__(self) -> None:
+        super().__init__("torch.heaviside")
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        if not isinstance(output_spec, TensorSpec):
+            return False
+        if output_spec.dtype == torch.bool:
+            return False
+        return is_float_dtype(output_spec.dtype)
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError("HeavisideOperator can only produce TensorSpec outputs")
+        return [
+            TensorSpec(
+                size=output_spec.size,
+                stride=output_spec.stride,
+                dtype=output_spec.dtype,
+            ),
+            TensorSpec(size=(), stride=(), dtype=output_spec.dtype),
+        ]
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        if len(input_names) != 2:
+            raise ValueError("HeavisideOperator requires exactly 2 input tensors")
+        return f"{output_name} = torch.heaviside({input_names[0]}, {input_names[1]})"
+
+
+class LdexpOperator(Operator):
+    """``torch.ldexp(input, other)`` — second arg is an integer exponent."""
+
+    _EXP_DTYPES: tuple[torch.dtype, ...] = (
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+    )
+
+    def __init__(self) -> None:
+        super().__init__("torch.ldexp")
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        if not isinstance(output_spec, TensorSpec):
+            return False
+        return is_float_dtype(output_spec.dtype)
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        assert isinstance(output_spec, TensorSpec)  # noqa: S101
+        return [
+            TensorSpec(
+                size=output_spec.size,
+                stride=output_spec.stride,
+                dtype=output_spec.dtype,
+            ),
+            TensorSpec(
+                size=output_spec.size,
+                stride=output_spec.stride,
+                dtype=random.choice(self._EXP_DTYPES),
+            ),
+        ]
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        return f"{output_name} = torch.ldexp({input_names[0]}, {input_names[1]})"

--- a/tools/experimental/torchfuzz/operators/matrix_multiply.py
+++ b/tools/experimental/torchfuzz/operators/matrix_multiply.py
@@ -11,7 +11,7 @@ from torchfuzz.tensor_fuzzer import Spec, TensorSpec
 # Type promotion imports removed since we now use explicit casting in codegen
 
 
-class MatrixMultiplyOperator(Operator):
+class MatrixMultiplyOperatorBase(Operator):
     """Base class for matrix multiplication operations."""
 
     def __init__(self, name: str):
@@ -43,7 +43,7 @@ class MatrixMultiplyOperator(Operator):
         return [output_dtype, output_dtype]
 
 
-class MMOperator(MatrixMultiplyOperator):
+class MMOperator(MatrixMultiplyOperatorBase):
     """Operator for matrix multiplication (torch.mm)."""
 
     def __init__(self):
@@ -128,7 +128,7 @@ class MMOperator(MatrixMultiplyOperator):
             return f"{output_name} = torch.mm({input_names[0]}, {input_names[1]})"
 
 
-class AddmmOperator(MatrixMultiplyOperator):
+class AddmmOperator(MatrixMultiplyOperatorBase):
     """Operator for additive matrix multiplication (torch.addmm)."""
 
     def __init__(self):
@@ -221,7 +221,7 @@ class AddmmOperator(MatrixMultiplyOperator):
             return f"{output_name} = torch.addmm({input_names[0]}, {input_names[1]}, {input_names[2]})"
 
 
-class BmmOperator(MatrixMultiplyOperator):
+class BmmOperator(MatrixMultiplyOperatorBase):
     """Operator for batch matrix multiplication (torch.bmm)."""
 
     def __init__(self):
@@ -306,7 +306,7 @@ class BmmOperator(MatrixMultiplyOperator):
             return f"{output_name} = torch.bmm({input_names[0]}, {input_names[1]})"
 
 
-class MatmulOperator(MatrixMultiplyOperator):
+class MatmulOperator(MatrixMultiplyOperatorBase):
     """Operator for general matrix multiplication (torch.matmul)."""
 
     def __init__(self):

--- a/tools/experimental/torchfuzz/operators/nn_functional.py
+++ b/tools/experimental/torchfuzz/operators/nn_functional.py
@@ -543,7 +543,8 @@ class GELUOperator(Operator):
             raise ValueError("GELU requires exactly 1 input")
 
         input_name = input_names[0]
-        return f"{output_name} = torch.nn.functional.gelu({input_name})"
+        approx = random.choice(["none", "tanh"])
+        return f"{output_name} = torch.nn.functional.gelu({input_name}, approximate={approx!r})"
 
 
 class SigmoidOperator(Operator):
@@ -877,7 +878,8 @@ class LeakyReLUOperator(Operator):
             raise ValueError("LeakyReLU requires exactly 1 input")
 
         input_name = input_names[0]
-        return f"{output_name} = torch.nn.functional.leaky_relu({input_name}, negative_slope=0.01)"
+        slope = round(random.uniform(0.001, 0.5), 4)
+        return f"{output_name} = torch.nn.functional.leaky_relu({input_name}, negative_slope={slope!r})"
 
 
 class ELUOperator(Operator):
@@ -919,7 +921,8 @@ class ELUOperator(Operator):
             raise ValueError("ELU requires exactly 1 input")
 
         input_name = input_names[0]
-        return f"{output_name} = torch.nn.functional.elu({input_name})"
+        alpha = round(random.uniform(0.1, 3.0), 4)
+        return f"{output_name} = torch.nn.functional.elu({input_name}, alpha={alpha!r})"
 
 
 class SiLUOperator(Operator):

--- a/tools/experimental/torchfuzz/operators/registry.py
+++ b/tools/experimental/torchfuzz/operators/registry.py
@@ -20,6 +20,7 @@ _OPERATOR_MODULES: list[str] = [
     "nn_functional",
     "nonzero",
     "scalar_pointwise",
+    "tensor_creation",
     "tensor_pointwise",
     "unique",
 ]

--- a/tools/experimental/torchfuzz/operators/registry.py
+++ b/tools/experimental/torchfuzz/operators/registry.py
@@ -1,64 +1,54 @@
 """Operator registry for mapping operation names to operator instances."""
 
-from torchfuzz.operators.arg import ArgOperator
-from torchfuzz.operators.argsort import ArgsortOperator
+import importlib
+import inspect
+from types import ModuleType
+
 from torchfuzz.operators.base import Operator
-from torchfuzz.operators.constant import ConstantOperator
-from torchfuzz.operators.gather import GatherOperator
-from torchfuzz.operators.index_select import IndexSelectOperator
-from torchfuzz.operators.item import ItemOperator
-from torchfuzz.operators.layout import (
-    CatOperator,
-    ChunkOperator,
-    FlattenOperator,
-    ReshapeOperator,
-    SqueezeOperator,
-    StackOperator,
-    UnsqueezeOperator,
-    ViewOperator,
-)
-from torchfuzz.operators.masked_select import MaskedSelectOperator
-from torchfuzz.operators.matrix_multiply import (
-    AddmmOperator,
-    BmmOperator,
-    MatmulOperator,
-    MMOperator,
-)
-from torchfuzz.operators.nn_functional import (
-    BatchNormOperator,
-    DropoutOperator,
-    ELUOperator,
-    EmbeddingOperator,
-    GELUOperator,
-    GroupNormOperator,
-    LayerNormOperator,
-    LeakyReLUOperator,
-    LinearOperator,
-    MultiHeadAttentionForwardOperator,
-    ReLUOperator,
-    RMSNormOperator,
-    ScaledDotProductAttentionOperator,
-    SigmoidOperator,
-    SiLUOperator,
-    SoftmaxOperator,
-    TanhOperator,
-)
-from torchfuzz.operators.nonzero import NonzeroOperator
-from torchfuzz.operators.scalar_pointwise import (
-    ScalarAddOperator,
-    ScalarDivOperator,
-    ScalarMulOperator,
-    ScalarSubOperator,
-)
-from torchfuzz.operators.tensor_pointwise import (
-    AddOperator,
-    ClampOperator,
-    CumsumOperator,
-    DivOperator,
-    MulOperator,
-    SubOperator,
-)
-from torchfuzz.operators.unique import UniqueOperator
+
+
+_OPERATOR_MODULES: list[str] = [
+    "arg",
+    "argsort",
+    "constant",
+    "gather",
+    "index_select",
+    "item",
+    "layout",
+    "masked_select",
+    "matrix_multiply",
+    "nn_functional",
+    "nonzero",
+    "scalar_pointwise",
+    "tensor_pointwise",
+    "unique",
+]
+
+
+def _concrete_operator_classes(module: ModuleType) -> list[type[Operator]]:
+    """Discover all concrete Operator subclasses defined in a module.
+
+    Filters out:
+    - Non-Operator classes
+    - The Operator ABC itself
+    - Re-exported classes (whose __module__ doesn't match)
+    - Abstract classes
+    - Classes with names ending in "Base" (reserved for abstract bases)
+    """
+    out: list[type[Operator]] = []
+    for _name, cls in inspect.getmembers(module, inspect.isclass):
+        if not issubclass(cls, Operator):
+            continue
+        if cls is Operator:
+            continue
+        if cls.__module__ != module.__name__:
+            continue
+        if inspect.isabstract(cls):
+            continue
+        if cls.__name__.endswith("Base"):
+            continue
+        out.append(cls)
+    return out
 
 
 class OperatorRegistry:
@@ -70,74 +60,13 @@ class OperatorRegistry:
         self._register_default_operators()
 
     def _register_default_operators(self):
-        """Register the default set of operators."""
-        # Individual tensor pointwise operators (preferred)
-        self.register(AddOperator())
-        self.register(MulOperator())
-        self.register(SubOperator())
-        self.register(DivOperator())
-        self.register(ClampOperator())
-        self.register(CumsumOperator())
-
-        # Individual scalar pointwise operators (preferred)
-        self.register(ScalarAddOperator())
-        self.register(ScalarMulOperator())
-        self.register(ScalarSubOperator())
-        self.register(ScalarDivOperator())
-
-        # Leaf Input operators
-        self.register(ConstantOperator())
-        self.register(ArgOperator())
-
-        # # Data-dependent operators
-        self.register(NonzeroOperator())
-        self.register(MaskedSelectOperator())
-        self.register(GatherOperator())
-        self.register(IndexSelectOperator())
-        self.register(ArgsortOperator())
-        self.register(ItemOperator())
-        self.register(UniqueOperator())
-
-        # Tensor layout operators
-        self.register(ViewOperator())
-        self.register(ReshapeOperator())
-        self.register(FlattenOperator())
-        self.register(SqueezeOperator())
-        self.register(UnsqueezeOperator())
-        self.register(CatOperator())
-        self.register(StackOperator())
-        self.register(ChunkOperator())
-
-        # Matrix multiplication operators
-        self.register(MMOperator())
-        self.register(AddmmOperator())
-        self.register(BmmOperator())
-        self.register(MatmulOperator())
-
-        # Neural network functional operators
-        self.register(EmbeddingOperator())
-        self.register(LinearOperator())
-        self.register(ScaledDotProductAttentionOperator())
-        self.register(MultiHeadAttentionForwardOperator())
-
-        # Activation functions
-        self.register(ReLUOperator())
-        self.register(LeakyReLUOperator())
-        self.register(ELUOperator())
-        self.register(GELUOperator())
-        self.register(SiLUOperator())
-        self.register(SigmoidOperator())
-        self.register(TanhOperator())
-        self.register(SoftmaxOperator())
-
-        # Normalization layers
-        self.register(LayerNormOperator())
-        self.register(RMSNormOperator())
-        self.register(BatchNormOperator())
-        self.register(GroupNormOperator())
-
-        # Regularization
-        self.register(DropoutOperator())
+        """Register the default set of operators via introspection."""
+        for module_name in _OPERATOR_MODULES:
+            module = importlib.import_module(
+                f".{module_name}", package="torchfuzz.operators"
+            )
+            for cls in _concrete_operator_classes(module):
+                self.register(cls())  # pyrefly: ignore[missing-argument]
 
     def register(self, operator: Operator):
         """Register an operator in the registry."""

--- a/tools/experimental/torchfuzz/operators/registry.py
+++ b/tools/experimental/torchfuzz/operators/registry.py
@@ -11,6 +11,7 @@ _OPERATOR_MODULES: list[str] = [
     "arg",
     "argsort",
     "constant",
+    "elementwise_math",
     "gather",
     "index_select",
     "item",

--- a/tools/experimental/torchfuzz/operators/scalar_pointwise.py
+++ b/tools/experimental/torchfuzz/operators/scalar_pointwise.py
@@ -8,7 +8,7 @@ from torchfuzz.operators.base import Operator
 from torchfuzz.tensor_fuzzer import ScalarSpec, Spec
 
 
-class ScalarPointwiseOperator(Operator):
+class ScalarPointwiseOperatorBase(Operator):
     """Base class for scalar pointwise operations."""
 
     def __init__(self, name: str, symbol: str):
@@ -51,28 +51,28 @@ class ScalarPointwiseOperator(Operator):
         return f"{output_name} = {input_names[0]} {self.symbol} {input_names[1]}"
 
 
-class ScalarAddOperator(ScalarPointwiseOperator):
+class ScalarAddOperator(ScalarPointwiseOperatorBase):
     """Operator for scalar addition."""
 
     def __init__(self):
         super().__init__("scalar_add", "+")
 
 
-class ScalarMulOperator(ScalarPointwiseOperator):
+class ScalarMulOperator(ScalarPointwiseOperatorBase):
     """Operator for scalar multiplication."""
 
     def __init__(self):
         super().__init__("scalar_mul", "*")
 
 
-class ScalarSubOperator(ScalarPointwiseOperator):
+class ScalarSubOperator(ScalarPointwiseOperatorBase):
     """Operator for scalar subtraction."""
 
     def __init__(self):
         super().__init__("scalar_sub", "-")
 
 
-class ScalarDivOperator(ScalarPointwiseOperator):
+class ScalarDivOperator(ScalarPointwiseOperatorBase):
     """Operator for scalar division."""
 
     def __init__(self):

--- a/tools/experimental/torchfuzz/operators/tensor_creation.py
+++ b/tools/experimental/torchfuzz/operators/tensor_creation.py
@@ -1,0 +1,461 @@
+# pyre-strict
+"""Tensor creation & initialization Operator subclasses.
+
+These operators model torch factory functions (``torch.ones``, ``torch.full``,
+``torch.arange``, ``torch.Tensor.new_full``, etc.) for the upstream torchfuzz
+framework.  All factories are non-leaf operators: they may take zero or one
+prototype tensor input but always produce a fresh ``TensorSpec`` output.
+
+When ``output_spec.stride`` is non-contiguous, factories emit
+``torch.empty_strided(...).fill_(...)`` (or a copy from a freshly-allocated
+strided buffer for the ``_like`` family) so the requested layout is honored
+without aliasing into another tensor's storage (see plan note [H19]).
+"""
+
+from __future__ import annotations
+
+import random
+
+import torch
+
+from torchfuzz.operators._dtypes import FLOAT_DTYPES
+from torchfuzz.operators.base import Operator
+from torchfuzz.tensor_fuzzer import Spec, TensorSpec
+
+
+_ARANGE_ALLOWED_DTYPES: frozenset[torch.dtype] = frozenset(
+    {
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.uint8,
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.bfloat16,
+    }
+)
+
+_NON_BOOL_DTYPES: tuple[torch.dtype, ...] = (
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+    torch.uint8,
+    torch.float16,
+    torch.float32,
+    torch.float64,
+    torch.bfloat16,
+)
+
+
+def _contiguous_stride(size: tuple[int, ...]) -> tuple[int, ...]:
+    """Return the contiguous (row-major) stride for ``size``."""
+    if not size:
+        return ()
+    strides: list[int] = [1]
+    for dim in reversed(size[1:]):
+        strides.append(strides[-1] * dim)
+    return tuple(reversed(strides))
+
+
+def _default_fill_value(dtype: torch.dtype) -> object:
+    """Canonical fill value for full/full_like/new_full per dtype.
+
+    Centralized so FullOperator, FullLikeOperator, and NewFullOperator cannot
+    drift in their fill-value selection (per plan note [H4]).
+    """
+    if dtype == torch.bool:
+        return True
+    if dtype in FLOAT_DTYPES:
+        return 1.0
+    return 1
+
+
+_UNSIGNED_INT_DTYPES: frozenset[torch.dtype] = frozenset(
+    {
+        torch.uint8,
+    }
+)
+
+
+def _random_fill_value(dtype: torch.dtype) -> object:
+    """Random fill value appropriate for ``dtype``.
+
+    Used by Full/FullLike/NewFull operators to exercise a wider range of
+    constant values than the fixed ``_default_fill_value``.
+    """
+    if dtype == torch.bool:
+        return random.choice([True, False])
+    if dtype in FLOAT_DTYPES:
+        return round(random.uniform(-10.0, 10.0), 4)
+    if dtype in _UNSIGNED_INT_DTYPES:
+        return random.randint(0, 100)
+    return random.randint(-100, 100)
+
+
+def _dtype_str(dt: torch.dtype) -> str:
+    """Mirror the formatting used by upstream operators/constant.py."""
+    return str(dt)
+
+
+def _is_contiguous(output_spec: TensorSpec) -> bool:
+    return tuple(output_spec.stride) == _contiguous_stride(tuple(output_spec.size))
+
+
+# ---------------------------------------------------------------------------
+# Base classes
+# ---------------------------------------------------------------------------
+
+
+class TensorCreationFromSizeOperatorBase(Operator):
+    """Base for factories that take no input tensor (ones, zeros, full)."""
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        return isinstance(output_spec, TensorSpec)
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        return []
+
+    def _fill_value(self, output_spec: TensorSpec) -> object:
+        """Subclasses override to provide the constant the factory writes."""
+        raise NotImplementedError
+
+    def _factory_args(self, output_spec: TensorSpec) -> str:
+        """Args to pass after size for the contiguous-path factory call."""
+        return f"dtype={_dtype_str(output_spec.dtype)}"
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError(
+                f"{self.__class__.__name__} can only produce TensorSpec outputs"
+            )
+        size = tuple(output_spec.size)
+        if _is_contiguous(output_spec):
+            return (
+                f"{output_name} = {self.torch_op_name}({size}, "
+                f"{self._factory_args(output_spec)})"
+            )
+        stride = tuple(output_spec.stride)
+        return (
+            f"{output_name} = torch.empty_strided({size}, {stride}, "
+            f"dtype={_dtype_str(output_spec.dtype)}).fill_("
+            f"{self._fill_value(output_spec)!r})"
+        )
+
+
+class TensorCreationFromPrototypeOperatorBase(Operator):
+    """Base for factories that take one prototype tensor (ones_like, etc.)."""
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        return isinstance(output_spec, TensorSpec)
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError(
+                f"{self.__class__.__name__} can only produce TensorSpec outputs"
+            )
+        proto_dtype = output_spec.dtype
+        # 30% chance: use a different prototype dtype to exercise the
+        # dtype-override path (codegen passes dtype= explicitly).
+        if proto_dtype != torch.bool and random.random() < 0.3:
+            candidates = [dt for dt in _NON_BOOL_DTYPES if dt != proto_dtype]
+            if candidates:
+                proto_dtype = random.choice(candidates)
+        return [
+            TensorSpec(
+                size=output_spec.size,
+                stride=output_spec.stride,
+                dtype=proto_dtype,
+            )
+        ]
+
+    def _like_extra_args(self, output_spec: TensorSpec) -> str:
+        """Extra positional args after the prototype (e.g. fill value for full_like)."""
+        return ""
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError(
+                f"{self.__class__.__name__} can only produce TensorSpec outputs"
+            )
+        if len(input_names) != 1:
+            raise ValueError(
+                f"{self.__class__.__name__} requires exactly 1 input tensor"
+            )
+        prototype = input_names[0]
+        extra = self._like_extra_args(output_spec)
+        dtype_kwarg = f", dtype={_dtype_str(output_spec.dtype)}"
+        like_call = f"{self.torch_op_name}({prototype}{extra}{dtype_kwarg})"
+        if _is_contiguous(output_spec):
+            return f"{output_name} = {like_call}"
+        size = tuple(output_spec.size)
+        stride = tuple(output_spec.stride)
+        tmp = f"_tmp_{output_name}"
+        return (
+            f"{tmp} = {like_call}; "
+            f"{output_name} = torch.empty_strided({size}, {stride}, "
+            f"dtype={_dtype_str(output_spec.dtype)}); "
+            f"{output_name}.copy_({tmp})"
+        )
+
+
+class TensorMethodNewOperatorBase(Operator):
+    """Base for ``Tensor.new_X(size, ...)`` methods (new_ones, new_zeros, ...)."""
+
+    method_name: str = ""
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        return isinstance(output_spec, TensorSpec)
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError(
+                f"{self.__class__.__name__} can only produce TensorSpec outputs"
+            )
+        return [TensorSpec(size=(1,), stride=(1,), dtype=output_spec.dtype)]
+
+    def _fill_value(self, output_spec: TensorSpec) -> object:
+        raise NotImplementedError
+
+    def _new_extra_args(self, output_spec: TensorSpec) -> str:
+        """Extra positional args after the size for the contiguous-path call."""
+        return ""
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError(
+                f"{self.__class__.__name__} can only produce TensorSpec outputs"
+            )
+        if len(input_names) != 1:
+            raise ValueError(
+                f"{self.__class__.__name__} requires exactly 1 prototype tensor"
+            )
+        prototype = input_names[0]
+        size = tuple(output_spec.size)
+        if _is_contiguous(output_spec):
+            extra = self._new_extra_args(output_spec)
+            return (
+                f"{output_name} = {prototype}.{self.method_name}({size}{extra}, "
+                f"dtype={_dtype_str(output_spec.dtype)})"
+            )
+        stride = tuple(output_spec.stride)
+        return (
+            f"{output_name} = torch.empty_strided({size}, {stride}, "
+            f"dtype={_dtype_str(output_spec.dtype)}).fill_("
+            f"{self._fill_value(output_spec)!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Concrete factories without a prototype input
+# ---------------------------------------------------------------------------
+
+
+class OnesOperator(TensorCreationFromSizeOperatorBase):
+    def __init__(self) -> None:
+        super().__init__("torch.ones")
+
+    def _fill_value(self, output_spec: TensorSpec) -> object:
+        return 1
+
+
+class ZerosOperator(TensorCreationFromSizeOperatorBase):
+    def __init__(self) -> None:
+        super().__init__("torch.zeros")
+
+    def _fill_value(self, output_spec: TensorSpec) -> object:
+        return 0
+
+
+class FullOperator(TensorCreationFromSizeOperatorBase):
+    def __init__(self) -> None:
+        super().__init__("torch.full")
+        self._stashed_fill: object | None = None
+
+    def _fill_value(self, output_spec: TensorSpec) -> object:
+        return self._stashed_fill
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError(
+                f"{self.__class__.__name__} can only produce TensorSpec outputs"
+            )
+        self._stashed_fill = _random_fill_value(output_spec.dtype)
+        return []
+
+    def _factory_args(self, output_spec: TensorSpec) -> str:
+        return f"{self._stashed_fill!r}, dtype={_dtype_str(output_spec.dtype)}"
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        result = super().codegen(output_name, input_names, output_spec)
+        self._stashed_fill = None
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Concrete factories with a prototype input
+# ---------------------------------------------------------------------------
+
+
+class OnesLikeOperator(TensorCreationFromPrototypeOperatorBase):
+    def __init__(self) -> None:
+        super().__init__("torch.ones_like")
+
+
+class ZerosLikeOperator(TensorCreationFromPrototypeOperatorBase):
+    def __init__(self) -> None:
+        super().__init__("torch.zeros_like")
+
+
+class FullLikeOperator(TensorCreationFromPrototypeOperatorBase):
+    def __init__(self) -> None:
+        super().__init__("torch.full_like")
+        self._stashed_fill: object | None = None
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError(
+                f"{self.__class__.__name__} can only produce TensorSpec outputs"
+            )
+        self._stashed_fill = _random_fill_value(output_spec.dtype)
+        return super().fuzz_inputs_specs(output_spec)
+
+    def _like_extra_args(self, output_spec: TensorSpec) -> str:
+        return f", {self._stashed_fill!r}"
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        result = super().codegen(output_name, input_names, output_spec)
+        self._stashed_fill = None
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Concrete Tensor.new_X factories
+# ---------------------------------------------------------------------------
+
+
+class NewOnesOperator(TensorMethodNewOperatorBase):
+    method_name: str = "new_ones"
+
+    def __init__(self) -> None:
+        super().__init__("torch.Tensor.new_ones")
+
+    def _fill_value(self, output_spec: TensorSpec) -> object:
+        return 1
+
+
+class NewZerosOperator(TensorMethodNewOperatorBase):
+    method_name: str = "new_zeros"
+
+    def __init__(self) -> None:
+        super().__init__("torch.Tensor.new_zeros")
+
+    def _fill_value(self, output_spec: TensorSpec) -> object:
+        return 0
+
+
+class NewFullOperator(TensorMethodNewOperatorBase):
+    method_name: str = "new_full"
+
+    def __init__(self) -> None:
+        super().__init__("torch.Tensor.new_full")
+        self._stashed_fill: object | None = None
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError(
+                f"{self.__class__.__name__} can only produce TensorSpec outputs"
+            )
+        self._stashed_fill = _random_fill_value(output_spec.dtype)
+        return super().fuzz_inputs_specs(output_spec)
+
+    def _fill_value(self, output_spec: TensorSpec) -> object:
+        return self._stashed_fill
+
+    def _new_extra_args(self, output_spec: TensorSpec) -> str:
+        return f", {self._stashed_fill!r}"
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        result = super().codegen(output_name, input_names, output_spec)
+        self._stashed_fill = None
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Special-case: torch.arange (always 1-D, contiguous)
+# ---------------------------------------------------------------------------
+
+
+class ArangeOperator(Operator):
+    def __init__(self) -> None:
+        super().__init__("torch.arange")
+        self._start: int | None = None
+        self._step: int | None = None
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
+
+    def can_produce(self, output_spec: Spec) -> bool:
+        if not isinstance(output_spec, TensorSpec):
+            return False
+        if len(output_spec.size) != 1:
+            return False
+        if tuple(output_spec.stride) != (1,):
+            return False
+        return output_spec.dtype in _ARANGE_ALLOWED_DTYPES
+
+    def fuzz_inputs_specs(self, output_spec: Spec) -> list[Spec]:
+        if random.random() < 0.5:
+            self._start = random.randint(-10, 10)
+            self._step = random.randint(1, 3)
+        else:
+            self._start = None
+            self._step = None
+        return []
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        if not isinstance(output_spec, TensorSpec):
+            raise ValueError("ArangeOperator can only produce TensorSpec outputs")
+        n = output_spec.size[0]
+        dtype_arg = f"dtype={_dtype_str(output_spec.dtype)}"
+        if self._start is not None and self._step is not None:
+            start = self._start
+            step = self._step
+            end = start + step * n
+            result = (
+                f"{output_name} = torch.arange({start}, {end}, {step}, {dtype_arg})"
+            )
+        else:
+            result = f"{output_name} = torch.arange({n}, {dtype_arg})"
+        self._start = None
+        self._step = None
+        return result

--- a/tools/experimental/torchfuzz/operators/tensor_pointwise.py
+++ b/tools/experimental/torchfuzz/operators/tensor_pointwise.py
@@ -5,7 +5,7 @@ import random
 import torch
 
 from torchfuzz.operators.base import Operator
-from torchfuzz.tensor_fuzzer import Spec, TensorSpec
+from torchfuzz.tensor_fuzzer import ScalarSpec, Spec, TensorSpec
 from torchfuzz.type_promotion import (
     get_dtype_map,
     get_dtype_name,
@@ -13,12 +13,43 @@ from torchfuzz.type_promotion import (
 )
 
 
+def _contiguous_stride(size: tuple[int, ...]) -> tuple[int, ...]:
+    if not size:
+        return ()
+    strides: list[int] = [1]
+    for dim in reversed(size[1:]):
+        strides.append(strides[-1] * dim)
+    return tuple(reversed(strides))
+
+
+def _random_broadcast_shape(output_size: tuple[int, ...]) -> tuple[int, ...]:
+    if not output_size:
+        return ()
+    result = list(output_size)
+    changed = False
+    for i in range(len(result)):
+        if random.random() < 0.3:
+            result[i] = 1
+            changed = True
+    if not changed:
+        return output_size
+    while len(result) > 1 and result[0] == 1 and random.random() < 0.5:
+        result.pop(0)
+    return tuple(result)
+
+
 class PointwiseOperator(Operator):
     """Base class for element-wise pointwise operations."""
 
-    def __init__(self, name: str, symbol: str):
+    _scalar_input_positions: tuple[int, ...] = (0, 1)
+
+    def __init__(self, name: str, symbol: str = ""):
         super().__init__(name)
         self.symbol = symbol
+
+    @property
+    def torch_op_name(self) -> str:
+        return self.name
 
     def can_produce(self, output_spec: Spec) -> bool:
         """Tensor pointwise operations can produce tensors but not scalars."""
@@ -53,7 +84,7 @@ class PointwiseOperator(Operator):
         # Convert dtype strings back to torch dtypes
         dtype_map = get_dtype_map()
 
-        return [
+        input_specs: list[Spec] = [
             TensorSpec(
                 size=output_spec.size,
                 stride=output_spec.stride,
@@ -61,6 +92,23 @@ class PointwiseOperator(Operator):
             )
             for dt in dtypes
         ]
+
+        if num_inputs >= 2:
+            r = random.random()
+            if self._scalar_input_positions and r < 0.3:
+                idx = random.choice(self._scalar_input_positions)
+                input_specs[idx] = ScalarSpec(dtype=input_specs[idx].dtype)
+            elif r < 0.5:
+                idx = random.randint(0, 1)
+                bcast_size = _random_broadcast_shape(tuple(output_spec.size))
+                if bcast_size != tuple(output_spec.size):
+                    input_specs[idx] = TensorSpec(
+                        size=bcast_size,
+                        stride=_contiguous_stride(bcast_size),
+                        dtype=input_specs[idx].dtype,
+                    )
+
+        return input_specs
 
     def codegen(
         self, output_name: str, input_names: list[str], output_spec: Spec
@@ -84,6 +132,24 @@ class AddOperator(PointwiseOperator):
     @property
     def torch_op_name(self) -> str:
         return "torch.add"
+
+    def codegen(
+        self, output_name: str, input_names: list[str], output_spec: Spec
+    ) -> str:
+        if len(input_names) == 2 and random.random() < 0.3:
+            alpha = round(random.uniform(-5.0, 5.0), 4)
+            if isinstance(output_spec, TensorSpec) and output_spec.dtype not in (
+                torch.float16,
+                torch.float32,
+                torch.float64,
+                torch.bfloat16,
+            ):
+                alpha = int(alpha)
+            return (
+                f"{output_name} = torch.add("
+                f"{input_names[0]}, {input_names[1]}, alpha={alpha!r})"
+            )
+        return super().codegen(output_name, input_names, output_spec)
 
 
 class MulOperator(PointwiseOperator):

--- a/tools/experimental/torchfuzz/operators/tensor_pointwise.py
+++ b/tools/experimental/torchfuzz/operators/tensor_pointwise.py
@@ -38,7 +38,7 @@ def _random_broadcast_shape(output_size: tuple[int, ...]) -> tuple[int, ...]:
     return tuple(result)
 
 
-class PointwiseOperator(Operator):
+class PointwiseOperatorBase(Operator):
     """Base class for element-wise pointwise operations."""
 
     _scalar_input_positions: tuple[int, ...] = (0, 1)
@@ -122,7 +122,7 @@ class PointwiseOperator(Operator):
             return f"{output_name} = {expr}"
 
 
-class AddOperator(PointwiseOperator):
+class AddOperator(PointwiseOperatorBase):
     """Operator for element-wise addition."""
 
     def __init__(self, weight: float = 1.0):
@@ -152,7 +152,7 @@ class AddOperator(PointwiseOperator):
         return super().codegen(output_name, input_names, output_spec)
 
 
-class MulOperator(PointwiseOperator):
+class MulOperator(PointwiseOperatorBase):
     """Operator for element-wise multiplication."""
 
     def __init__(self):
@@ -163,7 +163,7 @@ class MulOperator(PointwiseOperator):
         return "torch.mul"
 
 
-class SubOperator(PointwiseOperator):
+class SubOperator(PointwiseOperatorBase):
     """Operator for element-wise subtraction."""
 
     def __init__(self):
@@ -174,7 +174,7 @@ class SubOperator(PointwiseOperator):
         return "torch.sub"
 
 
-class DivOperator(PointwiseOperator):
+class DivOperator(PointwiseOperatorBase):
     """Operator for element-wise division."""
 
     def __init__(self):

--- a/tools/experimental/torchfuzz/operators/tensor_pointwise.py
+++ b/tools/experimental/torchfuzz/operators/tensor_pointwise.py
@@ -4,6 +4,7 @@ import random
 
 import torch
 
+from torchfuzz.operators._dtypes import FLOAT_DTYPES
 from torchfuzz.operators.base import Operator
 from torchfuzz.tensor_fuzzer import ScalarSpec, Spec, TensorSpec
 from torchfuzz.type_promotion import (
@@ -237,14 +238,22 @@ class ClampOperator(Operator):
         if not use_min and not use_max:
             use_min = True
 
+        # For integer-dtype tensors, emit integer bounds so the fuzzer doesn't
+        # generate float-bound + int-tensor mismatches between CPU and MTIA.
+        assert isinstance(output_spec, TensorSpec)  # noqa: S101
+        if output_spec.dtype in FLOAT_DTYPES:
+            min_literal, max_literal = "-1.0", "1.0"
+        else:
+            min_literal, max_literal = "-1", "1"
+
         args = [input_name]
         if use_min:
-            args.append("min=-1.0")
+            args.append(f"min={min_literal}")
         else:
             args.append("min=None")
 
         if use_max:
-            args.append("max=1.0")
+            args.append(f"max={max_literal}")
         else:
             args.append("max=None")
 

--- a/tools/experimental/torchfuzz/tensor_fuzzer.py
+++ b/tools/experimental/torchfuzz/tensor_fuzzer.py
@@ -390,7 +390,12 @@ def fuzz_tensor(
             elif dtype == torch.bool:
                 base_tensor = torch.randint(0, 2, (required_storage,), dtype=torch.bool)
             else:  # integer types
-                base_tensor = torch.randint(-100, 100, (required_storage,), dtype=dtype)
+                # torch.randint requires `low` to be within the dtype's
+                # representable range. Unsigned dtypes (uint8/16/32/64)
+                # cannot represent negative values, so clamp `low` to 0;
+                # signed dtypes keep the default of -100.
+                low = -100 if torch.iinfo(dtype).min < 0 else 0
+                base_tensor = torch.randint(low, 100, (required_storage,), dtype=dtype)
         else:
             # Use zeros (default behavior)
             base_tensor = torch.ones(required_storage, dtype=dtype)


### PR DESCRIPTION
Summary:

Adds the Elementwise Math operator category from `inductor-operators.csv` to upstream torchfuzz: 88 ops (5 of which reuse upstream-registered classes).

**New module:**

- `operators/elementwise_math.py` — four base classes and ~70 concrete subclasses:
  - `UnaryElementwiseOperatorBase` — 1 input, same dtype in/out. 47 subclasses (35 float-only + 12 numeric) generated via `_make_subclass` factory.
  - `BoolUnaryElementwiseOperatorBase` — 1 float input, bool output. 6 subclasses (`isfinite`, `isinf`, `isnan`, etc.).
  - `FloatOnlyPointwiseOperatorBase(PointwiseOperator)` — inherits upstream `PointwiseOperator` (gets type promotion, scalar operands, and broadcasting for free), restricted to float dtypes. 8 subclasses (`atan2`, `copysign`, `hypot`, etc.).
  - `TernaryElementwiseOperatorBase` — 3 same-dtype inputs with 30% probability of broadcasting one input. 3 subclasses (`addcdiv`, `addcmul`, `lerp`).
  - 13 numeric binary ops subclass upstream `PointwiseOperator` directly (`divide`, `floor_divide`, `fmax`, `pow`, etc.).
  - 4 special-case standalone operators (`ClampMaxOperator`, `ClampMinOperator`, `HeavisideOperator`, `LdexpOperator`).

**Updated:**

- `operators/LIMITATIONS.md` — adds elementwise math coverage gaps section.

Test Plan:
Operator definitions in this commit were validated end-to-end using a downstream torchfuzz device plugin for a non-GPU architecture. A test harness ran the fuzzer across all operators in the plugin's template, testing each operator in isolation (`--max-depth 1 --supported-ops '<op>'`) so that failures are attributable to a single operator definition. Per-operator seed counts were derived from coupon-collector analysis: for each operator, the rarest discrete random outcome in `fuzz_inputs_specs` is identified (probability `p_min`), then `N = ceil(ln(0.05) / ln(1 - p_min))` gives 95% confidence of exercising that path at least once; `N` is then doubled for margin. This produced tiered counts from 10 seeds (operators with no discrete choices) to 70 seeds (operators with complex mode/dim/dtype interactions). 5830 total invocations across all operator categories.

Failures were automatically classified: "investigate" (fuzzer crashed before generating a program — likely a bug in the operator's `fuzz_inputs_specs` or `codegen`) vs "triage" (program was generated but failed at compile or execution time — could be a definition bug or a legitimate backend issue the fuzzer is designed to surface). Three iterative triage-and-fix rounds were completed until all operator-definition bugs were resolved. Remaining triage failures are legitimate backend compilation/execution issues.

Differential Revision: D106518330


