### PR TITLE
[BE][Ez]: native RNN missing std::move calls

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -302,9 +302,9 @@ struct QuantizedCellParams : public CellParamsBase {
                                                zero_point_hh.toLong()};
     return CellParamsSerializationType(
         "quantized",
-        tensors_to_serialize,
-        doubles_to_serialize,
-        longs_to_serialize,
+        std::move(tensors_to_serialize),
+        std::move(doubles_to_serialize),
+        std::move(longs_to_serialize),
         {});
   }
   static c10::intrusive_ptr<CellParamsBase> __setstate__(
@@ -444,10 +444,10 @@ struct QuantizedCellParamsDynamic : public CellParamsBase {
     // reduce_range parameter is serialized along with the int field values.
     return CellParamsSerializationType(
         "quantized_dynamic",
-        tensors_to_serialize,
+        std::move(tensors_to_serialize),
         {},
         {reduce_range_},
-        packed_params_to_serialize);
+        std::move(packed_params_to_serialize));
   }
   static c10::intrusive_ptr<CellParamsBase> __setstate__(
       CellParamsSerializationType state) {
@@ -520,7 +520,7 @@ struct QuantizedCellParamsFP16 : public CellParamsBase {
         packed_params_to_serialize{packed_ih, packed_hh};
 
     return CellParamsSerializationType(
-        "quantized_fp16", {}, {}, {}, packed_params_to_serialize);
+        "quantized_fp16", {}, {}, {}, std::move(packed_params_to_serialize));
   }
   static c10::intrusive_ptr<CellParamsBase> __setstate__(
       CellParamsSerializationType state) {
@@ -866,12 +866,12 @@ struct FullLayer : Layer<Tensor, hidden_type, cell_params> {
           (*this)(inputs_w.unbind(0), input_hidden, params, true);
       TORCH_CHECK(unstacked_output.outputs.size()>0, "Expected sequence length to be larger than 0 in RNN");
       return {at::stack(unstacked_output.outputs, 0),
-              unstacked_output.final_hidden};
+              std::move(unstacked_output.final_hidden)};
     }
     auto unstacked_output = (*this)(inputs.unbind(0), input_hidden, params);
     TORCH_CHECK(unstacked_output.outputs.size()>0, "Expected sequence length to be larger than 0 in RNN");
     return {at::stack(unstacked_output.outputs, 0),
-            unstacked_output.final_hidden};
+            std::move(unstacked_output.final_hidden)};
   }
 
   Cell<hidden_type, cell_params>& cell_;
@@ -907,7 +907,9 @@ struct FullBidirectionalLayer
       std::reverse(rev_result.outputs.begin(), rev_result.outputs.end());
       auto rev_output = at::stack(rev_result.outputs, 0);
       return {at::cat({fw_output, rev_output}, fw_output.dim() - 1),
-              std::make_pair(fw_result.final_hidden, rev_result.final_hidden)};
+              std::make_pair(
+                  std::move(fw_result.final_hidden),
+                  std::move(rev_result.final_hidden))};
     }
 
     step_inputs = input.unbind(0);
@@ -920,7 +922,9 @@ struct FullBidirectionalLayer
     std::reverse(rev_result.outputs.begin(), rev_result.outputs.end());
     auto rev_output = at::stack(rev_result.outputs, 0);
     return {at::cat({fw_output, rev_output}, fw_output.dim() - 1),
-            std::make_pair(fw_result.final_hidden, rev_result.final_hidden)};
+            std::make_pair(
+                std::move(fw_result.final_hidden),
+                std::move(rev_result.final_hidden))};
   }
 
   std::vector<Tensor> reverse(std::vector<Tensor>&& x) const {
@@ -1040,7 +1044,7 @@ struct ReversedPackedLayer : Layer<PackedSequence, hidden_type, cell_params> {
     }
     std::reverse(step_outputs.begin(), step_outputs.end());
     return {PackedSequence{at::cat(step_outputs, 0), input.batch_sizes},
-            hidden};
+            std::move(hidden)};
   }
 
   Cell<hidden_type, cell_params>& cell_;
@@ -1066,8 +1070,10 @@ struct PackedBidirectionalLayer
     PackedSequence output{
         at::cat({fw_result.outputs.data, rev_result.outputs.data}, -1),
         input.batch_sizes};
-    return {output,
-            std::make_pair(fw_result.final_hidden, rev_result.final_hidden)};
+    return {std::move(output),
+            std::make_pair(
+                std::move(fw_result.final_hidden),
+                std::move(rev_result.final_hidden))};
   }
 
   PackedLayer<dir_hidden_type, cell_params> layer_;
@@ -1104,8 +1110,8 @@ apply_layer_stack(const Layer<io_type, hidden_type, weight_type>& layer, const i
   std::vector<hidden_type> final_hiddens;
   for (const auto l : c10::irange(num_layers)) {
     auto layer_output = layer(layer_input, *(hidden_it++), *(weight_it++));
-    final_hiddens.push_back(layer_output.final_hidden);
-    layer_input = layer_output.outputs;
+    final_hiddens.push_back(std::move(layer_output.final_hidden));
+    layer_input = std::move(layer_output.outputs);
 
     if (dropout_p != 0 && train && l < num_layers - 1) {
       layer_input = dropout(layer_input, dropout_p);
@@ -1130,7 +1136,7 @@ LayerOutput<io_type, std::vector<typename CellType::hidden_type>> _rnn_impl(
   if (bidirectional) {
     using BidirLayer = BidirLayerT<hidden_type, cell_params>;
     auto bidir_result = apply_layer_stack(BidirLayer{cell}, input, pair_vec(hiddens), pair_vec(params), num_layers, dropout_p, train);
-    return {bidir_result.outputs, unpair_vec(std::move(bidir_result.final_hidden))};
+    return {std::move(bidir_result.outputs), unpair_vec(std::move(bidir_result.final_hidden))};
   } else {
     return apply_layer_stack(LayerT<hidden_type,cell_params>{cell}, input, hiddens, params, num_layers, dropout_p, train);
   }


### PR DESCRIPTION
Add a few missing std::move here, especially for pointers and vectors that can be consumed.