### PR TITLE
docs: add generated pages for torch constants

### DIFF
--- a/docs/source/torch.md
+++ b/docs/source/torch.md
@@ -409,6 +409,15 @@ False
 ### Constants
 
 ```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    e
+    pi
+```
+
+```{eval-rst}
 ======================================= ===========================================
 ``e``                                       Euler's number, the base of natural logarithms (~2.7183). Alias for :attr:`math.e`.
 ``inf``                                     A floating-point positive infinity. Alias for :attr:`math.inf`.


### PR DESCRIPTION
Fixes #134964

Summary:
- Add `torch.e` and `torch.pi` to the constants autosummary so dedicated API pages are generated.
- Keep the existing constants table descriptions unchanged.

Test Plan:
- `git diff --check`