### PR TITLE
docs: clean up multilabel soft margin loss args

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4312,15 +4312,14 @@ def multilabel_soft_margin_loss(
     Args:
        input (Tensor): Predicted values.
        target (Tensor): Ground truth values.
-       size_average (bool, optional): Deprecated (see :attr:`reduction`).
-       reduce (bool, optional): Deprecated (see :attr:`reduction`).
+       weight (Tensor, optional): A manual rescaling weight given to each class.
        reduction (str, optional): Specifies the reduction to apply to the output:
                                   'none' | 'mean' | 'sum'. 'mean': the mean of the output is taken.
                                   'sum': the output will be summed. 'none': no reduction will be applied.
                                   Default: 'mean'.
 
     Returns:
-       Tensor: Mutilabel soft margin loss.
+       Tensor: Multilabel soft margin loss.
     """
     if has_torch_function_variadic(input, target, weight):
         return handle_torch_function(

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4538,15 +4538,14 @@ def multilabel_soft_margin_loss(
     Args:
        input (Tensor): Predicted values.
        target (Tensor): Ground truth values.
-       size_average (bool, optional): Deprecated (see :attr:`reduction`).
-       reduce (bool, optional): Deprecated (see :attr:`reduction`).
+       weight (Tensor, optional): A manual rescaling weight given to each class.
        reduction (str, optional): Specifies the reduction to apply to the output:
                                   'none' | 'mean' | 'sum'. 'mean': the mean of the output is taken.
                                   'sum': the output will be summed. 'none': no reduction will be applied.
                                   Default: 'mean'.
 
     Returns:
-       Tensor: Mutilabel soft margin loss.
+       Tensor: Multilabel soft margin loss.
     """
     if has_torch_function_variadic(input, target, weight):
         return handle_torch_function(


### PR DESCRIPTION
Fixes #67969

Summary:
- Stop listing the deprecated `size_average` and `reduce` arguments in `torch.nn.functional.multilabel_soft_margin_loss` docs.
- Document the existing `weight` argument and fix the return description typo.

Test Plan:
- `python3 -m py_compile torch/nn/functional.py`
- `git diff --check`