### PR TITLE
docs: note expand materialization costs

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -6323,8 +6323,7 @@ memory.
 
     Operations on an expanded view may still allocate memory if they need to
     materialize the expanded values. For example, changing dtype after
-    :meth:`expand` can allocate memory for the full expanded shape. To control
-    peak memory, perform such operations before expanding where possible.
+    :meth:`expand` can allocate memory for the full expanded shape.
 
 Args:
     *size (torch.Size or int...): the desired expanded size

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -6319,6 +6319,13 @@ expanded to a larger size by setting the ``stride`` to 0. Any dimension
 of size 1 can be expanded to an arbitrary value without allocating new
 memory.
 
+.. note::
+
+    Operations on an expanded view may still allocate memory if they need to
+    materialize the expanded values. For example, changing dtype after
+    :meth:`expand` can allocate memory for the full expanded shape. To control
+    peak memory, perform such operations before expanding where possible.
+
 Args:
     *size (torch.Size or int...): the desired expanded size
 


### PR DESCRIPTION
Fixes #116142

Summary:
- Add a note to `Tensor.expand` explaining that expand itself is a view, but later operations can materialize the expanded shape.
- Mention dtype conversion after `expand` as a concrete example and suggest doing such operations before expanding when possible.

Test Plan:
- `python3 -m py_compile torch/_tensor_docs.py`
- `git diff --check`