### PR TITLE
[inductor] Fold small-row expanded bmm to mm in post-grad

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -689,6 +689,50 @@ class TestPatternMatcher(TestCase):
 
         FileCheck().check("extern_kernels.bmm(").run(code_multi)
 
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    @inductor_config.patch(
+        {
+            "max_autotune_gemm_backends": "ATEN",
+        }
+    )
+    def test_transposed_linear_dynamic_batch_uses_guarded_mm(self):
+        def fn(x, w, b):
+            return F.linear(x.transpose(0, 1), w, b)
+
+        def make_x(batch):
+            return (
+                torch.randn(
+                    batch, seq, in_features, device=GPU_TYPE, dtype=torch.float16
+                )
+                * 0.1
+            )
+
+        seq, in_features, out_features = 512, 2048, 2048
+        w = (
+            torch.randn(out_features, in_features, device=GPU_TYPE, dtype=torch.float16)
+            * 0.1
+        )
+        b = torch.randn(out_features, device=GPU_TYPE, dtype=torch.float16) * 0.1
+
+        compiled = torch.compile(fn, dynamic=True, fullgraph=True)
+        x_large = make_x(128)
+        result, (code,) = run_and_get_code(compiled, x_large, w, b)
+        expected = fn(x_large, w, b)
+        torch.testing.assert_close(result, expected, rtol=2e-2, atol=2e-2)
+        self.assertEqual(result.stride(), expected.stride())
+        FileCheck().check("extern_kernels.bmm(").check_not("extern_kernels.mm(").run(
+            code
+        )
+
+        x_small = make_x(4)
+        result, (code,) = run_and_get_code(compiled, x_small, w, b)
+        expected = fn(x_small, w, b)
+        torch.testing.assert_close(result, expected, rtol=2e-2, atol=2e-2)
+        self.assertEqual(result.stride(), expected.stride())
+        FileCheck().check("extern_kernels.mm(").check_not("extern_kernels.bmm(").run(
+            code
+        )
+
     def test_cat_mm(self):
         def fn(a, b, c):
             return torch.cat(

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -14,7 +14,7 @@ import torch._inductor as inductor
 import torch.utils._pytree as pytree
 from torch import fx
 from torch._decomp import register_decomposition
-from torch._dynamo.utils import counters
+from torch._dynamo.utils import counters, is_node_meta_valid
 from torch._inductor.custom_graph_pass import (
     CustomInferenceAwareGraphPass,
     get_custom_graph_passes,
@@ -22,7 +22,11 @@ from torch._inductor.custom_graph_pass import (
 from torch._inductor.virtualized import ops  # noqa: F401
 from torch._logging import trace_structured
 from torch._prims_common import is_boolean_dtype, is_expandable_to, is_integer_dtype
-from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
+from torch.fx.experimental.symbolic_shapes import (
+    guard_or_false,
+    statically_known_true,
+    sym_eq,
+)
 from torch.utils._ordered_set import OrderedSet
 
 from .. import config, ir, pattern_matcher  # noqa: F401
@@ -87,6 +91,10 @@ pass_patterns = [
     PatternMatcherPass(),
     PatternMatcherPass(),
 ]
+
+FOLD_EXPANDED_BMM_TO_MM_MAX_ROW_DIM = 64
+FOLD_EXPANDED_BMM_TO_MM_MIN_OUTER_DIM = 512
+FOLD_EXPANDED_BMM_TO_MM_MIN_GEMM_DIM = 2048
 
 
 def _remove_profiler_ops(graph: torch.fx.Graph) -> None:
@@ -888,12 +896,135 @@ def register_lowering_pattern(
     )
 
 
+def _guarded_ge(value: int | torch.SymInt, minimum: int) -> bool:
+    return guard_or_false(value >= minimum)
+
+
+def _guarded_in_range(
+    value: int | torch.SymInt,
+    *,
+    min_value: int | None = None,
+    max_value: int | None = None,
+) -> bool:
+    if min_value is not None and not _guarded_ge(value, min_value):
+        return False
+    if max_value is not None and not guard_or_false(value <= max_value):
+        return False
+    return True
+
+
+def _is_batch_first_transpose_layout(tensor: torch.Tensor) -> bool:
+    if tensor.dim() != 3:
+        return False
+
+    m, _b, k = tensor.shape
+    stride_m, stride_b, stride_k = tensor.stride()
+    return (
+        statically_known_true(sym_eq(stride_m, k))
+        and statically_known_true(sym_eq(stride_b, m * k))
+        and statically_known_true(sym_eq(stride_k, 1))
+    )
+
+
+def _is_valid_expanded_bmm_to_mm(match: Match) -> bool:
+    mat1_node = match.kwargs["mat1"]
+    mat2_node = match.kwargs["mat2"]
+    bmm_node = match.output_node()
+    if (
+        not is_node_meta_valid(mat1_node)
+        or not is_node_meta_valid(mat2_node)
+        or not is_node_meta_valid(bmm_node)
+    ):
+        return False
+
+    mat1 = mat1_node.meta["val"]
+    mat2 = mat2_node.meta["val"]
+    bmm = bmm_node.meta["val"]
+    if (
+        not isinstance(mat1, torch.Tensor)
+        or not isinstance(mat2, torch.Tensor)
+        or not isinstance(bmm, torch.Tensor)
+    ):
+        return False
+    if mat1.dim() != 3 or mat2.dim() != 2 or bmm.dim() != 3:
+        return False
+    if mat1.device != mat2.device or not is_gpu(mat1.device.type):
+        return False
+    if mat1.dtype != mat2.dtype or mat1.dtype not in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ):
+        return False
+    if not _is_batch_first_transpose_layout(mat1):
+        return False
+
+    m, b, k = mat1.shape
+    k2, n = mat2.shape
+    if not (
+        statically_known_true(sym_eq(k, k2))
+        and statically_known_true(sym_eq(m, bmm.shape[0]))
+        and statically_known_true(sym_eq(b, bmm.shape[1]))
+        and statically_known_true(sym_eq(n, bmm.shape[2]))
+    ):
+        return False
+
+    # Guard dynamic dimensions so the fold decision is stable for cache reuse.
+    return (
+        _guarded_in_range(b, max_value=FOLD_EXPANDED_BMM_TO_MM_MAX_ROW_DIM)
+        and _guarded_in_range(m, min_value=FOLD_EXPANDED_BMM_TO_MM_MIN_OUTER_DIM)
+        and _guarded_in_range(k, min_value=FOLD_EXPANDED_BMM_TO_MM_MIN_GEMM_DIM)
+        and _guarded_in_range(n, min_value=FOLD_EXPANDED_BMM_TO_MM_MIN_GEMM_DIM)
+    )
+
+
 ################################################################################
 # Actual patterns below this point.
 # Priority of patterns is:
 #   - later output nodes first
 #   - order patterns are defined in
 ################################################################################
+
+
+_expanded_bmm_rhs_2d = CallFunction(
+    aten.expand.default,
+    KeywordArg("mat2"),
+    Ignored(),
+)
+
+
+@register_graph_pattern(
+    CallFunction(
+        aten.bmm.default,
+        KeywordArg("mat1"),
+        _expanded_bmm_rhs_2d,
+    ),
+    extra_check=_is_valid_expanded_bmm_to_mm,
+    # pyrefly: ignore [bad-argument-type]
+    pass_dict=pass_patterns[1],
+)
+@register_graph_pattern(
+    CallFunction(
+        aten.bmm.default,
+        CallFunction(
+            aten.expand.default,
+            KeywordArg("mat1"),
+            Ignored(),
+        ),
+        _expanded_bmm_rhs_2d,
+    ),
+    extra_check=_is_valid_expanded_bmm_to_mm,
+    # pyrefly: ignore [bad-argument-type]
+    pass_dict=pass_patterns[1],
+)
+def fold_expanded_bmm_to_mm(match: Match, mat1, mat2):
+    def repl(mat1, mat2):
+        mat1_2d = mat1.reshape(mat1.shape[0] * mat1.shape[1], mat1.shape[2])
+        mm = torch.ops.aten.mm.default(mat1_2d, mat2)
+        return mm.reshape(mat1.shape[0], mat1.shape[1], mat2.shape[1])
+
+    counters["inductor"]["fold_expanded_bmm_to_mm"] += 1
+    match.replace_by_example(repl, [mat1, mat2])
 
 
 def is_valid_mm_plus_mm(match: Match):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185404

A dynamic linear on batch-first transposed activations can reach post-grad as
an expanded batched matmul:

    [T, B, K] @ expand([K, N], [T, K, N])

For small B this produces many small-row GEMMs. On CUDA fp16 this path can be
much slower than flattening the transposed activation to [T * B, K] and using
one mm. The issue shows up in AOTInductor autocast because the fp16 cast drops
requires_grad, so the existing matmul folding heuristic no longer takes the
requires_grad escape hatch that the fp32 graph happened to use.

Add a post-grad Inductor pattern for the specific expanded-bmm shape generated
by transposed linear. This keeps eager and general decomposition stride behavior
unchanged, addressing the concern from the abandoned decomposition-only PR. The
pattern is deliberately narrow: GPU fp16/bf16/fp32, batch-first transpose
layout, large T/K/N, and B <= 64. Dynamic dimensions are checked with guards so
cache reuse is stable: large batches keep the original bmm path, while small
batches compile to the mm path.

I considered a runtime torch.cond between bmm and mm, but tracing cond inside
this post-grad replacement currently nests torch.compile and trips Inductor's
compile event stack. Guarded specialization is the simpler established path and
keeps large-batch behavior on the original implementation.

Benchmark Results:
On NVIDIA B200, fp16, T=1000, K=2048, N=6144, max_autotune_gemm_backends=ATEN,
5 warmup iterations and 20 timed CUDA-event iterations:

Before:
- B=1: current bmm 0.0721 ms, manual folded mm 0.0724 ms
- B=2: current bmm 1.3912 ms, manual folded mm 0.0841 ms
- B=4: current bmm 1.4169 ms, manual folded mm 0.1524 ms

After:
- generated code uses mm for the small-batch guarded graph
- B=1: 0.0772 ms
- B=2: 0.0903 ms
- B=4: 0.1531 ms

Test Plan:
- python test/inductor/test_pattern_matcher.py -k test_transposed_linear_dynamic_batch_uses_guarded_mm
- python test/inductor/test_pattern_matcher.py -k test_bmm_to_mm
- lintrunner -a torch/_inductor/fx_passes/post_grad.py test/inductor/test_pattern_matcher.py
- git diff --check

Fixes #159346
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos