### PR TITLE
[RFC][dynamo] Narrow GB6297 to only graph-break on differentiable duplicate tensor inputs

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -1926,6 +1926,29 @@ class GraphModule(torch.nn.Module):
             out = torch.compile(fn, backend="eager", fullgraph=True)(x)
             out.backward()
 
+    def test_duplicate_nondifferentiable_input_no_graph_break(self):
+        class Bar(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, idx_a, idx_b):
+                ctx.save_for_backward(x)
+                return x[idx_a:idx_b]
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                (x,) = ctx.saved_tensors
+                grad = torch.zeros_like(x)
+                return grad, None, None
+
+        def fn(x, idx):
+            return Bar.apply(x, idx, idx).sum()
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        x = torch.randn(10, requires_grad=True)
+        idx = torch.tensor(3)
+        out = torch.compile(fn, backend=cnt, fullgraph=True)(x, idx)
+        out.backward()
+        self.assertEqual(cnt.frame_count, 1)
+
     def test_udf_output(self):
         class Foo:
             def __init__(self, a, b):

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -5256,15 +5256,22 @@ class AutogradFunctionApplyVariable(VariableTracker):
             if arg.is_tensor():
                 fake_tensor = _get_fake_value(arg)
                 if any(fake_tensor is seen for seen in tensor_args_seen):
-                    unimplemented(
-                        gb_type="autograd.Function.apply: duplicate tensor input",
-                        context="",
-                        explanation="Dynamo does not support tracing autograd.Function.apply "
-                        "when the same tensor is passed to multiple forward inputs.",
-                        hints=[
-                            *graph_break_hints.SUPPORTABLE,
-                        ],
-                    )
+                    # Only graph-break when the duplicate could affect gradient
+                    # correctness. The deduplication bug (lifting the same proxy
+                    # once and overwriting one backward slot) only matters when
+                    # both slots carry real gradients. Non-differentiable tensors
+                    # (integer dtype or requires_grad=False) always get None
+                    # gradients, so deduplication is harmless for them.
+                    if fake_tensor.requires_grad or fake_tensor.dtype.is_floating_point:
+                        unimplemented(
+                            gb_type="autograd.Function.apply: duplicate tensor input",
+                            context="",
+                            explanation="Dynamo does not support tracing autograd.Function.apply "
+                            "when the same tensor is passed to multiple forward inputs.",
+                            hints=[
+                                *graph_break_hints.SUPPORTABLE,
+                            ],
+                        )
                 tensor_args_seen.append(fake_tensor)
 
         # Find the mapping between orig_fwd_args and bwd_out


### PR DESCRIPTION
Summary:
D105712843 added GB6297 which graph-breaks whenever the same tensor is passed to multiple forward inputs of `autograd.Function.apply()`. This was a correctness fix for a real gradient-loss bug where Dynamo's HOP deduplication silently drops one backward gradient contribution.

However, the check is overly broad -- it fires on ALL duplicate tensor inputs regardless of differentiability. Non-differentiable tensors (integer dtype, `requires_grad=False`) always receive `None` gradients in backward, so deduplicating them is harmless. The overwrite in `outer_fwd_proxy_to_bwd_node` is `None -> None`, which is idempotent.

This causes a significant regression in production Ads training models (ATLAS) where `cu_seqlens` (an int32 index tensor) is passed as both `cu_seqlens_q` and `cu_seqlens_k` to `FlashAttnVarlenFunc.apply()` in the self-attention path. The graph break cascades: GB6297 inside a `for layer in self.layers` loop triggers GB7000 (graph break in loop), which skips the entire `Transformer.forward` frame. This disables both PT2 compilation and AutoAC activation checkpointing for 88 transformer layers, causing peak GPU memory to spike from 85% to 99%.

This diff narrows the check to only fire when `fake_tensor.requires_grad or fake_tensor.dtype.is_floating_point`. The condition is intentionally conservative:
- `requires_grad=True`: gradient flows through this tensor, deduplication loses a contribution
- `is_floating_point` (even with `requires_grad=False`): could require grad at runtime with different inputs
- Integer/boolean tensors: can never carry gradients, deduplication is always safe

Authored with Claude.

Test Plan:
Existing test `test_duplicate_input_accumulates_grad` continues to pass -- differentiable duplicate (float, `requires_grad=True`) still graph-breaks with `fullgraph=True` and falls back correctly with `fullgraph=False`.

New test `test_duplicate_nondifferentiable_input_no_graph_break` -- integer duplicate tensor compiles with `fullgraph=True` without graph break.

```
buck2 test mode/opt fbcode//caffe2/test/dynamo:test_autograd_function -- -r test_duplicate_input_accumulates_grad
buck2 test mode/opt fbcode//caffe2/test/dynamo:test_autograd_function -- -r test_duplicate_nondifferentiable_input_no_graph_break
```

E2E validation pending: rerun ATLAS training job with this fix to confirm memory returns from 99% to ~85%.

Differential Revision: D106449323




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98