### PR TITLE
[cuda] Add built-in UVM allocator context manager for numerics testing

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -8424,6 +8424,31 @@ class TestMemPool(TestCase):
             torch.cuda.empty_cache()
             torch.cuda.memory._set_allocator_settings("")
 
+    def test_use_uvm(self):
+        with torch.cuda._use_uvm():
+            x = torch.randn(256, 256, device="cuda")
+            y = torch.randn(256, 256, device="cuda")
+            z = x @ y
+        self.assertEqual(z.shape, (256, 256))
+        self.assertTrue(z.is_cuda)
+
+    def test_use_uvm_numerics(self):
+        torch.manual_seed(42)
+        with torch.cuda._use_uvm():
+            a_uvm = torch.randn(128, 128, device="cuda")
+        torch.manual_seed(42)
+        a_reg = torch.randn(128, 128, device="cuda")
+        self.assertEqual(a_uvm, a_reg)
+
+    def test_use_uvm_backward(self):
+        with torch.cuda._use_uvm():
+            with torch.autograd.set_multithreading_enabled(False):
+                model = torch.nn.Linear(512, 512, device="cuda")
+                out = model(torch.randn(16, 512, device="cuda"))
+                out.sum().backward()
+        self.assertIsNotNone(model.weight.grad)
+        self.assertEqual(model.weight.grad.shape, (512, 512))
+
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -2091,6 +2091,7 @@ __all__ = [
     "memory_usage",
     "MemPool",
     "use_mem_pool",
+    "_use_uvm",
     "temperature",
     "power_draw",
     "clock_rate",

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -62,6 +62,7 @@ __all__ = [
     "change_current_allocator",
     "MemPool",
     "use_mem_pool",
+    "_use_uvm",
 ]
 
 
@@ -1357,3 +1358,93 @@ def use_mem_pool(pool: MemPool, device: "Device" = None):
     finally:
         _cuda_endAllocateToPool(device_index, pool.id)
         _cuda_releasePool(device_index, pool.id)
+
+
+@contextlib.contextmanager
+def _use_uvm(device: "Device" = None):
+    r"""A context manager that routes CUDA allocations through ``cudaMallocManaged`` (UVM).
+
+    All tensors allocated inside this context use CUDA Unified Virtual Memory,
+    which allows oversubscribing GPU device memory by transparently paging to
+    system RAM on demand. Numerics are identical to regular device allocations;
+    only performance is affected due to page migration overhead.
+
+    This is useful for running models or artifacts that were compiled for more
+    GPUs than are locally available (e.g., validating numerics of a 64-GPU
+    precompile artifact on a single 8-GPU node).
+
+    Args:
+        device (torch.device or int, optional): selected device. Uses the
+            current device, given by :func:`~torch.cuda.current_device`,
+            if :attr:`device` is ``None`` (default).
+
+    Example::
+
+        >>> with torch.cuda._use_uvm():
+        ...     x = torch.randn(1024, 1024, device="cuda")
+        ...     y = x @ x.T  # computed on GPU, pages in/out as needed
+
+    .. note::
+        Only the current thread's allocations are routed to managed memory.
+        Allocations in threads spawned inside this context (e.g. by backward)
+        will use the default allocator.
+
+    .. note::
+        Requires ``cuda.bindings`` package (``pip install cuda-python``).
+    """
+    try:
+        from cuda.bindings import (  # pyrefly: ignore[missing-import]
+            runtime as cuda_runtime,
+        )
+    except ImportError:
+        raise ImportError(
+            "torch.cuda._use_uvm() requires the 'cuda-python' package for "
+            "cuda.bindings.runtime (cudaMallocManaged, cudaMemAdvise, cudaFree).\n"
+            "Install it with: pip install cuda-python"
+        ) from None
+
+    ALLOC_FN = ctypes.CFUNCTYPE(
+        ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_void_p
+    )
+    FREE_FN = ctypes.CFUNCTYPE(
+        None, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_void_p
+    )
+
+    def _uvm_alloc(size, device, stream):
+        err, ptr = cuda_runtime.cudaMallocManaged(
+            size, cuda_runtime.cudaMemAttachGlobal
+        )
+        if err != cuda_runtime.cudaError_t.cudaSuccess:
+            return 0
+        if device >= 0:
+            location = cuda_runtime.cudaMemLocation()
+            location.type = cuda_runtime.cudaMemLocationType.cudaMemLocationTypeDevice
+            location.id = device
+            cuda_runtime.cudaMemAdvise(
+                ptr,
+                size,
+                cuda_runtime.cudaMemoryAdvise.cudaMemAdviseSetPreferredLocation,
+                location,
+            )
+            cuda_runtime.cudaMemAdvise(
+                ptr,
+                size,
+                cuda_runtime.cudaMemoryAdvise.cudaMemAdviseSetAccessedBy,
+                location,
+            )
+        return ptr
+
+    def _uvm_free(ptr, size, device, stream):
+        if ptr:
+            cuda_runtime.cudaFree(ptr)
+
+    c_alloc = ALLOC_FN(_uvm_alloc)
+    c_free = FREE_FN(_uvm_free)
+    alloc_ptr = ctypes.cast(c_alloc, ctypes.c_void_p).value
+    free_ptr = ctypes.cast(c_free, ctypes.c_void_p).value
+
+    # pyrefly: ignore[bad-argument-type]
+    allocator = torch._C._cuda_customAllocator(alloc_ptr, free_ptr)
+    pool = MemPool(allocator=allocator)
+    with use_mem_pool(pool, device=device):
+        yield pool


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185413

Add `torch.cuda._use_uvm()`, a context manager that routes CUDA
allocations through `cudaMallocManaged` (Unified Virtual Memory). UVM
transparently pages between GPU device memory and host RAM, allowing a
single GPU to run workloads that exceed its physical VRAM. Numerics are
identical to regular device allocations.

The primary use case is numerics validation of precompiled graph trainer
artifacts. When testing precompile artifacts from large multi-node jobs
(e.g., Llama3-70B on 64 GPUs with TP=8 DP=8), we run the artifact
single-process with FakePG simulating the full world. The traced FX
graph materializes all layers' FSDP-allgathered weights at once (no
per-layer resharding in the flat graph), peaking at ~141 GB -- well
beyond a single H100's 95 GB.

To verify correctness, we compare the precompile artifact against the
eager DTensor reference path. The eager path can consume even more
memory than precompile (101+ GB in practice) because it materializes
full allgathered weights during forward and retains activations for
backward. Without UVM, the eager reference OOMs on a single GPU, making
the comparison impossible. With UVM, both paths run to completion and we
can verify bitwise-identical loss and gradient hashes, confirming the
precompile artifact is numerically faithful.

This is a correctness tool, not a performance tool -- UVM page migration
adds 5-10x overhead. The allocator is thread-local: only the calling
thread's allocations go through managed memory. For eager models where
autograd backward runs on a separate C++ thread, pair with
`torch.autograd.set_multithreading_enabled(False)` so backward
allocations also use UVM.

The implementation is pure Python: uses ctypes callbacks with
cuda.bindings.runtime (cudaMallocManaged/cudaFree/cudaMemAdvise) passed
to the existing `torch._C._cuda_customAllocator` pluggable allocator
infrastructure. The context manager wraps this in a MemPool via
use_mem_pool. No C++ changes needed.

Authored by Claude.

Test Plan:

Added three unit tests in TestMemPool (test/test_cuda.py):
- test_use_uvm: allocate + matmul under UVM, verify result
- test_use_uvm_numerics: same seed produces identical tensors in UVM vs regular
- test_use_uvm_backward: forward + backward through nn.Linear with
  single-threaded autograd

```
python test/test_cuda.py -k test_use_uvm
```

Validated on devgpu (H100 95GB) with Llama3-70B precompile artifact
(141.5 GB peak, ~46 GB paged to host) and eager DTensor reference
(101+ GB peak). Both paths produced bitwise-identical loss and gradient
hashes across all training steps.