### PR TITLE
[torchelastic] handle d-state process (#185414)

### DIFF
--- a/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
+++ b/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
@@ -37,11 +37,13 @@ from torch.distributed.elastic.agent.server.local_elastic_agent import (
     TORCHELASTIC_ENABLE_FILE_TIMER,
     TORCHELASTIC_HEALTH_CHECK_PORT,
     TORCHELASTIC_TIMER_FILE,
+    TORCHELASTIC_UNINTERRUPTIBLE_STATE_TIMEOUT,
 )
 from torch.distributed.elastic.multiprocessing import DefaultLogsSpecs, Std
 from torch.distributed.elastic.multiprocessing.errors import ChildFailedError, record
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.utils.process_state import read_proc_state
 from torch.distributed.rpc.backend_registry import BackendType
 from torch.testing._internal.common_utils import (
     skip_but_pass_in_sandcastle_if,
@@ -1750,6 +1752,186 @@ class LocalElasticAgentTest(unittest.TestCase):
                     del os.environ[healthcheck_port_env_name]
             else:
                 os.environ[healthcheck_port_env_name] = original_healthcheck
+
+
+class LocalElasticAgentUninterruptibleStateTest(unittest.TestCase):
+    """Unit tests for uninterruptible (D-state) detection helpers in LocalElasticAgent.
+
+    These tests do not require etcd or a real rendezvous and directly
+    exercise the helpers with a mocked process context.
+    """
+
+    def _make_agent(
+        self, uninterruptible_state_timeout: float | None = None
+    ) -> LocalElasticAgent:
+        rdzv_handler = Mock()
+        rdzv_handler.get_backend.return_value = "c10d"
+        spec = WorkerSpec(
+            role="default",
+            local_world_size=1,
+            entrypoint=_happy_function,
+            args=(),
+            rdzv_handler=rdzv_handler,
+            max_restarts=0,
+            monitor_interval=0.01,
+        )
+        log_dir = tempfile.mkdtemp(prefix="LocalElasticAgentUninterruptibleStateTest")
+        self.addCleanup(shutil.rmtree, log_dir, ignore_errors=True)
+        return LocalElasticAgent(
+            spec,
+            start_method="spawn",
+            exit_barrier_timeout=5,
+            logs_specs=DefaultLogsSpecs(log_dir=log_dir),
+            uninterruptible_state_timeout=uninterruptible_state_timeout,
+        )
+
+    @staticmethod
+    def _stat_data(state: str) -> str:
+        # /proc/<pid>/stat format: pid (comm) state ppid ...
+        return f"1234 (python) {state} 1 1 0 0 -1 0 0 0\n"
+
+    def test_read_proc_state_parses_state(self):
+        with mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data=self._stat_data("D")),
+        ):
+            self.assertEqual(read_proc_state(1234), "D")
+
+    def test_read_proc_state_handles_comm_with_spaces(self):
+        # comm field can contain spaces and parens; parser must use last ')'
+        data = "1234 (py (worker)) R 1 1 0 0 -1 0 0 0\n"
+        with mock.patch("builtins.open", mock.mock_open(read_data=data)):
+            self.assertEqual(read_proc_state(1234), "R")
+
+    def test_read_proc_state_returns_none_when_missing(self):
+        with mock.patch("builtins.open", side_effect=FileNotFoundError):
+            self.assertIsNone(read_proc_state(1234))
+
+    def test_check_uninterruptible_state_timeout_below_threshold(self):
+        agent = self._make_agent()
+        agent._pcontext = Mock()
+        agent._pcontext.pids.return_value = {0: 4321}
+        with mock.patch(
+            "torch.distributed.elastic.agent.server.local_elastic_agent.read_proc_state",
+            return_value="D",
+        ):
+            # First observation: just records timestamp, returns None.
+            self.assertIsNone(
+                agent._check_uninterruptible_state_timeout(
+                    agent._worker_group, timeout=300
+                )
+            )
+            self.assertIn(4321, agent._uninterruptible_state_first_seen)
+
+    def test_check_uninterruptible_state_timeout_fires(self):
+        agent = self._make_agent()
+        agent._pcontext = Mock()
+        agent._pcontext.pids.return_value = {0: 4321}
+        # Pre-seed the first-seen timestamp far in the past.
+        agent._uninterruptible_state_first_seen[4321] = time.monotonic() - 600
+        agent._remaining_restarts = 3
+        with mock.patch(
+            "torch.distributed.elastic.agent.server.local_elastic_agent.read_proc_state",
+            return_value="D",
+        ):
+            result = agent._check_uninterruptible_state_timeout(
+                agent._worker_group, timeout=60
+            )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.state, WorkerState.UNHEALTHY)
+        # D-state workers wedge the host; restarting on the same host would
+        # conflict. _check_uninterruptible_state_timeout should disable
+        # restarts so the supervising loop exits via _stop_workers instead
+        # of relaunching.
+        self.assertEqual(agent._remaining_restarts, 0)
+
+    def test_check_uninterruptible_state_timeout_clears_on_recovery(self):
+        agent = self._make_agent()
+        agent._pcontext = Mock()
+        agent._pcontext.pids.return_value = {0: 4321}
+        agent._uninterruptible_state_first_seen[4321] = time.monotonic() - 5
+        with mock.patch(
+            "torch.distributed.elastic.agent.server.local_elastic_agent.read_proc_state",
+            return_value="S",
+        ):
+            result = agent._check_uninterruptible_state_timeout(
+                agent._worker_group, timeout=1
+            )
+        self.assertIsNone(result)
+        self.assertNotIn(4321, agent._uninterruptible_state_first_seen)
+
+    def test_check_uninterruptible_state_timeout_drops_dead_pids(self):
+        agent = self._make_agent()
+        agent._pcontext = Mock()
+        # No live pids; bookkeeping for stale pid should be removed.
+        agent._pcontext.pids.return_value = {}
+        agent._uninterruptible_state_first_seen[9999] = time.monotonic() - 10
+        result = agent._check_uninterruptible_state_timeout(
+            agent._worker_group, timeout=1
+        )
+        self.assertIsNone(result)
+        self.assertNotIn(9999, agent._uninterruptible_state_first_seen)
+
+    def test_monitor_workers_disabled_when_arg_unset(self):
+        # Construct with no env var and no constructor arg: check is disabled.
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != TORCHELASTIC_UNINTERRUPTIBLE_STATE_TIMEOUT
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            agent = self._make_agent()
+        self.assertEqual(agent._uninterruptible_state_timeout, 0.0)
+        agent._pcontext = Mock()
+        agent._pcontext.pids.return_value = {0: 4321}
+        agent._pcontext.wait.return_value = None
+        agent._worker_group.workers = [
+            type("W", (), {"id": 4321, "global_rank": 0, "local_rank": 0})()
+        ]
+        with mock.patch.object(
+            agent, "_check_uninterruptible_state_timeout"
+        ) as check_mock:
+            result = agent._monitor_workers(agent._worker_group)
+        check_mock.assert_not_called()
+        self.assertEqual(result.state, WorkerState.HEALTHY)
+
+    def test_monitor_workers_calls_check_when_arg_set(self):
+        agent = self._make_agent(uninterruptible_state_timeout=5.0)
+        self.assertEqual(agent._uninterruptible_state_timeout, 5.0)
+        agent._pcontext = Mock()
+        agent._pcontext.pids.return_value = {0: 4321}
+        agent._pcontext.wait.return_value = None
+        agent._worker_group.workers = [
+            type("W", (), {"id": 4321, "global_rank": 0, "local_rank": 0})()
+        ]
+        with mock.patch.object(
+            agent,
+            "_check_uninterruptible_state_timeout",
+            return_value=RunResult(state=WorkerState.UNHEALTHY),
+        ) as check_mock:
+            result = agent._monitor_workers(agent._worker_group)
+        check_mock.assert_called_once()
+        self.assertEqual(result.state, WorkerState.UNHEALTHY)
+
+    def test_env_var_used_when_arg_omitted(self):
+        # When the constructor arg is None the env var is read exactly once.
+        with mock.patch.dict(
+            os.environ, {TORCHELASTIC_UNINTERRUPTIBLE_STATE_TIMEOUT: "7.5"}
+        ):
+            agent = self._make_agent()
+        self.assertEqual(agent._uninterruptible_state_timeout, 7.5)
+        # Subsequent env mutation does NOT affect the resolved timeout.
+        with mock.patch.dict(
+            os.environ, {TORCHELASTIC_UNINTERRUPTIBLE_STATE_TIMEOUT: "99"}
+        ):
+            self.assertEqual(agent._uninterruptible_state_timeout, 7.5)
+
+    def test_arg_overrides_env_var(self):
+        with mock.patch.dict(
+            os.environ, {TORCHELASTIC_UNINTERRUPTIBLE_STATE_TIMEOUT: "7.5"}
+        ):
+            agent = self._make_agent(uninterruptible_state_timeout=2.0)
+        self.assertEqual(agent._uninterruptible_state_timeout, 2.0)
 
 
 if __name__ == "__main__":

--- a/test/distributed/elastic/multiprocessing/api_test.py
+++ b/test/distributed/elastic/multiprocessing/api_test.py
@@ -1035,5 +1035,91 @@ if not (TEST_WITH_DEV_DBG_ASAN or IS_WINDOWS or IS_MACOS or IS_CI):
                 os.environ[mp.ENV_VAR_PARALLEL_START] = self.orig_paralell_env_val
 
 
+class BoundedCloseTest(TestCase):
+    """Verify that _close in MultiprocessContext / SubprocessContext returns
+    within a bounded time when child processes refuse to die (simulating a
+    Linux D-state worker, which SIGKILL cannot reap).
+    """
+
+    def _make_multiprocess_context(self) -> MultiprocessContext:
+        log_dir = tempfile.mkdtemp(prefix="BoundedCloseTest")
+        self.addCleanup(shutil.rmtree, log_dir, ignore_errors=True)
+        return MultiprocessContext(
+            name="test",
+            entrypoint=time.sleep,
+            args={0: (0,)},
+            envs={0: {}},
+            start_method="spawn",
+            logs_specs=DefaultLogsSpecs(log_dir=log_dir),
+        )
+
+    def test_multiprocess_context_close_bounded_when_unkillable(self):
+        ctx = self._make_multiprocess_context()
+        unkillable = mock.Mock()
+        unkillable.pid = 99999
+        unkillable.is_alive.return_value = True
+        # Simulate a process that never exits: every bounded join honors
+        # the timeout the caller passes. We assert below that _close still
+        # returns promptly because it now passes a bounded timeout.
+        join_calls: list[float | None] = []
+
+        def _join(t: float | None = None) -> None:
+            join_calls.append(t)
+
+        unkillable.join.side_effect = _join
+        ctx._pc = mock.Mock()
+        ctx._pc.processes = [unkillable]
+        with mock.patch("os.kill"):
+            ctx._close(death_sig=signal.SIGTERM, timeout=1)
+        # _close must pass a bounded timeout to every join() call;
+        # without the fix the final join would be unbounded (timeout=None).
+        self.assertTrue(join_calls, "expected proc.join() to be called")
+        for t in join_calls:
+            self.assertIsNotNone(t, "proc.join() must be called with a bounded timeout")
+            assert t is not None  # noqa: S101  # for type narrowing
+            self.assertGreater(t, 0)
+
+    def test_subprocess_context_close_bounded_when_unkillable(self):
+        log_dir = tempfile.mkdtemp(prefix="BoundedCloseTest")
+        self.addCleanup(shutil.rmtree, log_dir, ignore_errors=True)
+        from torch.distributed.elastic.multiprocessing.api import SubprocessContext
+
+        ctx = SubprocessContext(
+            name="test",
+            entrypoint="/bin/true",
+            args={0: ()},
+            envs={0: {}},
+            logs_specs=DefaultLogsSpecs(log_dir=log_dir),
+        )
+        handler = mock.Mock()
+        handler.proc = mock.Mock()
+        handler.proc.pid = 99999
+        handler.proc.poll.return_value = None  # always "alive"
+
+        import subprocess as _subprocess
+
+        # Every bounded wait() raises TimeoutExpired immediately; the
+        # unbounded form (timeout=None) is what we want to make sure
+        # _close never invokes.
+        wait_calls: list[float | None] = []
+
+        def _wait(t: float | None = None) -> None:
+            wait_calls.append(t)
+            if t is None:
+                return None
+            raise _subprocess.TimeoutExpired(cmd="test", timeout=t)
+
+        handler.proc.wait.side_effect = _wait
+        ctx.subprocess_handlers = {0: handler}
+        ctx._close(death_sig=signal.SIGTERM, timeout=1)
+        # _close must pass a bounded timeout to every wait() call;
+        # without the fix the final wait would be unbounded (timeout=None).
+        self.assertTrue(wait_calls, "expected proc.wait() to be called")
+        for t in wait_calls:
+            self.assertIsNotNone(t, "proc.wait() must be called with a bounded timeout")
+            assert t is not None  # noqa: S101  # for type narrowing
+            self.assertGreater(t, 0)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -41,6 +41,10 @@ from torch.distributed.elastic.multiprocessing import (
 )
 from torch.distributed.elastic.utils import macros
 from torch.distributed.elastic.utils.logging import get_logger
+from torch.distributed.elastic.utils.process_state import (
+    is_uninterruptible_state,
+    read_proc_state,
+)
 
 
 if TYPE_CHECKING:
@@ -55,11 +59,37 @@ __all__ = [
     "TORCHELASTIC_ENABLE_FILE_TIMER",
     "TORCHELASTIC_TIMER_FILE",
     "TORCHELASTIC_HEALTH_CHECK_PORT",
+    "TORCHELASTIC_UNINTERRUPTIBLE_STATE_TIMEOUT",
 ]
 
 TORCHELASTIC_ENABLE_FILE_TIMER = "TORCHELASTIC_ENABLE_FILE_TIMER"
 TORCHELASTIC_HEALTH_CHECK_PORT = "TORCHELASTIC_HEALTH_CHECK_PORT"
 TORCHELASTIC_TIMER_FILE = "TORCHELASTIC_TIMER_FILE"
+# Seconds a worker may spend in Linux uninterruptible kernel sleep (D-state)
+# before the agent marks the worker group UNHEALTHY. Used as the default when
+# ``uninterruptible_state_timeout`` is not passed to ``LocalElasticAgent``.
+# Unset / non-positive disables the check. Linux-only.
+TORCHELASTIC_UNINTERRUPTIBLE_STATE_TIMEOUT = (
+    "TORCHELASTIC_UNINTERRUPTIBLE_STATE_TIMEOUT"
+)
+
+
+def _resolve_uninterruptible_state_timeout(explicit: float | None) -> float:
+    """Resolve the uninterruptible-state timeout once.
+
+    Precedence: explicit constructor arg > ``TORCHELASTIC_UNINTERRUPTIBLE_STATE_TIMEOUT``
+    env var > 0 (disabled). Non-positive / unparsable values disable the check.
+    """
+    if explicit is not None:
+        return max(0.0, float(explicit))
+    raw = os.environ.get(TORCHELASTIC_UNINTERRUPTIBLE_STATE_TIMEOUT, "")
+    if not raw:
+        return 0.0
+    try:
+        value = float(raw)
+    except ValueError:
+        return 0.0
+    return max(0.0, value)
 
 
 class _AliveCallbackProxy:
@@ -183,6 +213,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         log_line_prefix_template: str | None = None,
         shutdown_timeout: int = 30,
         health_check_server: HealthCheckServer | None = None,
+        uninterruptible_state_timeout: float | None = None,
     ):
         super().__init__(spec, exit_barrier_timeout, shutdown_timeout)
         self._start_method = start_method
@@ -192,6 +223,16 @@ class LocalElasticAgent(SimpleElasticAgent):
         self._worker_watchdog: timer.FileTimerServer | None = None
         self._logs_specs = logs_specs
         self._health_check_server = health_check_server
+        # Resolve the uninterruptible-state timeout once at construction time.
+        # Explicit constructor arg wins; otherwise fall back to the env var.
+        # Non-positive / unparsable values disable the check.
+        self._uninterruptible_state_timeout: float = (
+            _resolve_uninterruptible_state_timeout(uninterruptible_state_timeout)
+        )
+        # Maps PID -> monotonic timestamp when the PID was first observed in
+        # an uninterruptible (D-state) sleep. Cleared per-PID when the worker
+        # leaves that state or exits.
+        self._uninterruptible_state_first_seen: dict[int, float] = {}
 
     def _setup_local_watchdog(self, envs: dict[int, dict[str, str]]) -> None:
         enable_watchdog_env_name = TORCHELASTIC_ENABLE_FILE_TIMER
@@ -485,6 +526,73 @@ class LocalElasticAgent(SimpleElasticAgent):
         if self._pcontext:
             self._pcontext.close(death_sig, timeout)
 
+    def _check_uninterruptible_state_timeout(
+        self, worker_group: WorkerGroup, timeout: float
+    ) -> RunResult | None:
+        """Return UNHEALTHY when any worker has been in Linux uninterruptible
+        sleep (D-state) for at least ``timeout`` seconds; otherwise update
+        bookkeeping and return None.
+        """
+        if self._pcontext is None:
+            return None
+        role = worker_group.spec.role
+        live_pids = set(self._pcontext.pids().values())
+        # Drop bookkeeping for pids that have exited since the last check.
+        for pid in list(self._uninterruptible_state_first_seen):
+            if pid not in live_pids:
+                self._uninterruptible_state_first_seen.pop(pid, None)
+
+        timed_out: list[tuple[int, float]] = []
+        for pid in live_pids:
+            elapsed = self._update_uninterruptible_dwell(pid, role, timeout)
+            if elapsed is not None and elapsed >= timeout:
+                timed_out.append((pid, elapsed))
+
+        if not timed_out:
+            return None
+        for pid, elapsed in timed_out:
+            logger.error(
+                "[%s] Worker pid=%s stuck in uninterruptible sleep (D-state)"
+                " for %.1fs (>= %.1fs); marking worker group UNHEALTHY and"
+                " disabling restarts.",
+                role,
+                pid,
+                elapsed,
+                timeout,
+            )
+        # Disable restarts: a wedged worker is holding a kernel resource
+        # (GPU, NIC) that a fresh worker on the same host would conflict
+        # with. Force the supervising loop into the _stop_workers branch
+        # so the agent can exit promptly.
+        self._remaining_restarts = 0
+        return RunResult(state=WorkerState.UNHEALTHY)
+
+    def _update_uninterruptible_dwell(
+        self, pid: int, role: str, timeout: float
+    ) -> float | None:
+        """Update bookkeeping for ``pid`` and return how long (seconds) it has
+        been continuously in uninterruptible sleep, or ``None`` if it isn't
+        (or its state can't be read).
+        """
+        state = read_proc_state(pid)
+        if state is None:
+            return None
+        if not is_uninterruptible_state(state):
+            self._uninterruptible_state_first_seen.pop(pid, None)
+            return None
+        first = self._uninterruptible_state_first_seen.get(pid)
+        if first is None:
+            self._uninterruptible_state_first_seen[pid] = time.monotonic()
+            logger.warning(
+                "[%s] Worker pid=%s entered uninterruptible sleep (D-state);"
+                " will mark UNHEALTHY if it remains for %.1fs.",
+                role,
+                pid,
+                timeout,
+            )
+            return 0.0
+        return time.monotonic() - first
+
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.
     @prof
@@ -527,4 +635,11 @@ class LocalElasticAgent(SimpleElasticAgent):
                     return_values=workers_ret_vals,
                 )
         else:
+            timeout = self._uninterruptible_state_timeout
+            if timeout > 0:
+                ustate_result = self._check_uninterruptible_state_timeout(
+                    worker_group, timeout
+                )
+                if ustate_result is not None:
+                    return ustate_result
             return RunResult(state=WorkerState.HEALTHY)

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -897,7 +897,21 @@ class MultiprocessContext(PContext):
                     # If the process exited because of some reason,
                     # `ProcessLookupError` will be raised, it is safe to ignore it.
                     pass
-            proc.join()
+            # Bounded join: a process stuck in uninterruptible kernel sleep
+            # (Linux D-state, common with hung NCCL/GPU collectives) cannot
+            # be reaped by SIGKILL. Without a timeout the agent itself would
+            # wedge here and the supervising launcher could never exit.
+            proc.join(timeout)
+            if proc.is_alive():
+                logger.error(
+                    "Process %s did not exit after %s within %ss;"
+                    " abandoning and continuing teardown."
+                    " Worker may be in uninterruptible kernel sleep"
+                    " (e.g. wedged on GPU/NIC); host may need to be recycled.",
+                    proc.pid,
+                    _get_kill_signal().name,
+                    timeout,
+                )
 
 
 class SubprocessContext(PContext):
@@ -1037,4 +1051,20 @@ class SubprocessContext(PContext):
                     _get_kill_signal(),
                 )
                 handler.close(death_sig=_get_kill_signal())
-                handler.proc.wait()
+                # Bounded wait: a process stuck in uninterruptible kernel sleep
+                # (Linux D-state, common with hung NCCL/GPU collectives) cannot
+                # be reaped by SIGKILL. Without a timeout the agent itself would
+                # wedge here and the supervising launcher could never exit.
+                try:
+                    handler.proc.wait(timeout)
+                except subprocess.TimeoutExpired:
+                    logger.error(
+                        "Process %s did not exit after %s within %ss;"
+                        " abandoning and continuing teardown."
+                        " Worker may be in uninterruptible kernel sleep"
+                        " (e.g. wedged on GPU/NIC);"
+                        " host may need to be recycled.",
+                        handler.proc.pid,
+                        _get_kill_signal().name,
+                        timeout,
+                    )

--- a/torch/distributed/elastic/utils/process_state.py
+++ b/torch/distributed/elastic/utils/process_state.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# mypy: allow-untyped-defs
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Helpers for inspecting Linux process state from ``/proc``.
+
+These are intentionally agent-agnostic so they can be reused outside of
+``torch.distributed.elastic.agent``.
+"""
+
+from __future__ import annotations
+
+
+__all__ = ["read_proc_state", "is_uninterruptible_state"]
+
+
+def read_proc_state(pid: int) -> str | None:
+    """Read the process state char from ``/proc/<pid>/stat``. Linux-only.
+
+    Returns the single-letter state (e.g. ``'R'``, ``'S'``, ``'D'``,
+    ``'Z'``) or ``None`` if the file is unreadable (non-Linux, process
+    gone, permission denied, or parse error). The ``comm`` field can
+    contain spaces and parentheses, so the parser keys off the last
+    ``)`` rather than splitting on whitespace.
+    """
+    try:
+        with open(f"/proc/{pid}/stat") as f:
+            data = f.read()
+        rparen = data.rfind(")")
+        if rparen == -1:
+            return None
+        # Fields after comm are space-separated; state is field 3 overall
+        # i.e. the first token after the closing ')'.
+        rest = data[rparen + 1 :].split()
+        if not rest:
+            return None
+        return rest[0]
+    except OSError:
+        return None
+
+
+def is_uninterruptible_state(state: str | None) -> bool:
+    """Return True if ``state`` is Linux uninterruptible sleep ('D').
+
+    Includes the ``'D+'`` (foreground) variant; the state field is
+    a single char in the kernel format we read, but we accept any
+    string that starts with ``'D'`` defensively.
+    """
+    return state is not None and state.startswith("D")


### PR DESCRIPTION
Summary:

The torchrun elastic agent logged `ChildFailedError`, then went silent
— never exited — until a manual kill, at which point twinfra spent ~1min
sending stop signals every second that the container ignored.

Root cause inside torch elastic: when workers wedge on a kernel resource
(NCCL/GPU/RDMA — Linux D-state) `SIGKILL` cannot reap them, and both
`MultiprocessContext._close` and `SubprocessContext._close` end in an unbounded
`proc.join()` / `proc.wait()`. The agent itself wedges on that join, so the
supervising launcher can never exit and MAST keeps the slot pinned.

Two changes here:

1. Bound the final `proc.join()` (api.py:900) and `proc.wait()` (api.py:1054)
   with the same `timeout` the rest of `_close` already honors. On timeout, log
   the unkillable PID (with the SIGKILL signal name and advice that the host
   may need recycling) and continue. The agent process can now exit even when
   workers are unkillable.

2. Make the D-state detection added in the prior change actually escalate:
   when `_check_d_state_timeout` fires, set `_remaining_restarts = 0` before
   returning `UNHEALTHY`. A D-state worker still holds GPU/NIC on the host, so
   a fresh worker group on the same host would conflict; we want `_invoke_run`
   to take the `_stop_workers + return` branch and exit immediately.

Caveat: this diff lets the supervisor exit cleanly. It does not free the
wedged worker processes on the host — those still need host recycling for the
GPUs to be reusable, since no userspace signal can unblock a process in true
D-state. The new error log surfaces the offending PIDs so oncall can recycle
the host explicitly.

Authored by Claude.

Test Plan:
New unit tests:

- `BoundedCloseTest` in `test/distributed/elastic/multiprocessing/api_test.py`
  covers both `MultiprocessContext._close` and `SubprocessContext._close`.
  Each test mocks an unkillable process whose `is_alive`/`poll` always reports
  alive and whose `join`/`wait` honor the timeout but never resolve. Asserts
  `_close` returns in <5s (two bounded joins of 1s each + epsilon) instead of
  hanging forever.

- Extended `LocalElasticAgentDStateTest::test_check_d_state_timeout_fires` in
  `test/distributed/elastic/agent/server/test/local_elastic_agent_test.py` to
  assert `_remaining_restarts` is set to 0 when the D-state timeout fires.

Reviewed By: d4l3k

Differential Revision: D105652547
