### PR TITLE
Add pickle protocol 5 support to memory visualizer JS unpickler

### DIFF
--- a/test/profiler/test_memory_viz.js
+++ b/test/profiler/test_memory_viz.js
@@ -1455,6 +1455,82 @@ function test_per_pool_summarization_interleaved() {
 }
 
 // ============================================================
+// unpickleData tests
+// ============================================================
+
+// Load unpickleData from MemoryViz.js
+const memvizPath = path.resolve(__dirname, '../../torch/utils/viz/MemoryViz.js');
+let memvizSrc = fs.readFileSync(memvizPath, 'utf-8');
+const funcStart = memvizSrc.indexOf('function unpickleData(buffer)');
+const funcEnd = memvizSrc.indexOf('\nfunction ', funcStart + 1);
+const unpickleDataSrc = memvizSrc.slice(funcStart, funcEnd);
+const { unpickleData } = vm.runInThisContext(
+  `(function() { ${unpickleDataSrc}\nreturn { unpickleData }; })()`,
+  { filename: memvizPath });
+
+function makePickle(proto_version, opcodes) {
+  const bytes = [0x80, proto_version, ...opcodes, '.'.charCodeAt(0)];
+  return new Uint8Array(bytes).buffer;
+}
+
+function test_unpickle_protocol5_accepted() {
+  console.log('test_unpickle_protocol5_accepted');
+  // Protocol 5 pickle containing EMPTY_DICT + STOP
+  const buf = makePickle(5, ['}'.charCodeAt(0)]);
+  const result = unpickleData(buf);
+  assert(typeof result === 'object' && result !== null, 'protocol 5 dict parsed');
+  assertEqual(Object.keys(result).length, 0, 'empty dict');
+}
+
+function test_unpickle_protocol4_still_works() {
+  console.log('test_unpickle_protocol4_still_works');
+  const buf = makePickle(4, ['}'.charCodeAt(0)]);
+  const result = unpickleData(buf);
+  assert(typeof result === 'object' && result !== null, 'protocol 4 still works');
+}
+
+function test_unpickle_protocol6_rejected() {
+  console.log('test_unpickle_protocol6_rejected');
+  const buf = makePickle(6, ['}'.charCodeAt(0)]);
+  let threw = false;
+  try {
+    unpickleData(buf);
+  } catch (e) {
+    threw = true;
+    assertContains(e.message, 'Unhandled version 6', 'error message mentions version 6');
+  }
+  assert(threw, 'protocol 6 should throw');
+}
+
+function test_unpickle_bytearray8() {
+  console.log('test_unpickle_bytearray8');
+  // Build a protocol 5 pickle with BYTEARRAY8 opcode
+  // BYTEARRAY8 = 0x96, followed by 8-byte LE length, then raw bytes
+  const data = [0xDE, 0xAD, 0xBE, 0xEF];
+  const len_bytes = [data.length, 0, 0, 0, 0, 0, 0, 0]; // 4 as uint64 LE
+  const opcodes = [0x96, ...len_bytes, ...data];
+  const buf = makePickle(5, opcodes);
+  const result = unpickleData(buf);
+  assert(result instanceof Uint8Array, 'BYTEARRAY8 produces Uint8Array');
+  assertEqual(result.length, 4, 'bytearray length is 4');
+  assertEqual(result[0], 0xDE, 'first byte');
+  assertEqual(result[3], 0xEF, 'last byte');
+}
+
+function test_unpickle_protocol5_dict_with_values() {
+  console.log('test_unpickle_protocol5_dict_with_values');
+  // Build a protocol 5 pickle for {"a": 42}:
+  // PROTO 5, EMPTY_DICT, SHORT_BINUNICODE "a", BININT1 42, SETITEM, STOP
+  const key = [0x8C, 1, 'a'.charCodeAt(0)]; // SHORT_BINUNICODE len=1 "a"
+  const val = ['K'.charCodeAt(0), 42];       // BININT1 42
+  const setitem = ['s'.charCodeAt(0)];       // SETITEM
+  const opcodes = ['}'.charCodeAt(0), ...key, ...val, ...setitem];
+  const buf = makePickle(5, opcodes);
+  const result = unpickleData(buf);
+  assertEqual(result.a, 42, 'dict value parsed correctly');
+}
+
+// ============================================================
 // Run all tests
 // ============================================================
 
@@ -1505,6 +1581,11 @@ test_per_pool_summarization();
 test_per_pool_summarization_with_frees();
 test_per_pool_summarization_initially_allocated();
 test_per_pool_summarization_interleaved();
+test_unpickle_protocol5_accepted();
+test_unpickle_protocol4_still_works();
+test_unpickle_protocol6_rejected();
+test_unpickle_bytearray8();
+test_unpickle_protocol5_dict_with_values();
 
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -1319,6 +1319,9 @@ function unpickleData(buffer) {
   const LIST = 'l'.charCodeAt(0);
   const DICT = 'd'.charCodeAt(0);
   const SETITEM = 's'.charCodeAt(0);
+  const BYTEARRAY8 = 0x96;
+  const NEXT_BUFFER = 0x97;
+  const READONLY_BUFFER = 0x98;
 
   const scratch_buffer = new ArrayBuffer(8);
   const scratch_bytes = new Uint8Array(scratch_buffer);
@@ -1334,6 +1337,15 @@ function unpickleData(buffer) {
     offset += 4;
     return n;
   }
+  function read_uint64() {
+    const lo = read_uint4();
+    const hi = read_uint4();
+    const n = lo + hi * 0x100000000;
+    if (!Number.isSafeInteger(n)) {
+      throw new Error('Pickle length exceeds safe integer range');
+    }
+    return n;
+  }
   function setitems(d, mark) {
     for (let i = mark; i < stack.length; i += 2) {
       d[stack[i]] = stack[i + 1];
@@ -1347,7 +1359,7 @@ function unpickleData(buffer) {
       case PROTO:
         {
           const version = bytebuffer[offset++];
-          if (version < 2 || version > 4) {
+          if (version < 2 || version > 5) {
             throw new Error(`Unhandled version ${version}`);
           }
         }
@@ -1527,6 +1539,16 @@ function unpickleData(buffer) {
         }
         stack.push(float64[0]);
         break;
+      case BYTEARRAY8:
+        {
+          const n = read_uint64();
+          stack.push(new Uint8Array(buffer.slice(offset, offset + n)));
+          offset += n;
+        }
+        break;
+      case NEXT_BUFFER:
+      case READONLY_BUFFER:
+        throw new Error('Out-of-band buffer opcodes are not supported');
       default:
         throw new Error(`UNKNOWN OPCODE: ${opcode}`);
     }


### PR DESCRIPTION
Summary:
The JavaScript pickle unpickler in `MemoryViz.js` only accepted pickle protocols 2-4. Python 3.8+ defaults to protocol 5 (`pickle.DEFAULT_PROTOCOL`), and free-threaded Python (3.13t/3.14t) also uses protocol 5. GPU memory snapshots pickled on these versions fail to load in the browser with `Error: Unhandled version 5`.

Protocol 5 (PEP 574) adds three new opcodes. Only `BYTEARRAY8` is relevant for in-band deserialization — the other two (`NEXT_BUFFER`, `READONLY_BUFFER`) are for out-of-band buffer passing which memory snapshots do not use. The snapshot data is pure dicts/lists/strings/ints/floats, so `BYTEARRAY8` is also unlikely to appear in practice, but is added for correctness.

Changes:
- Bump version check from `version > 4` to `version > 5`
- Add `BYTEARRAY8` (0x96) handler with `read_uint64()` helper and safe-integer guard
- Add `NEXT_BUFFER` (0x97) / `READONLY_BUFFER` (0x98) handlers that throw explicitly
- Add 5 new tests for the unpickler covering protocol acceptance, rejection, and `BYTEARRAY8`

Test Plan:
```
node fbcode/caffe2/test/profiler/test_memory_viz.js
# 209 passed, 0 failed
```

Also verified with real protocol-5 pickle files generated by Python 3.12.

Differential Revision: D106536158


