### PR TITLE
[BE] Modernize free function == templates in OptionalArrayRef to be hidden friends

### DIFF
--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -279,48 +279,6 @@ ArrayRef<T> makeArrayRef(const T (&Arr)[N]) {
   return ArrayRef<T>(Arr);
 }
 
-// These ArrayRef-specific overloads cannot be removed in favor of the
-// HeaderOnlyArrayRef hidden friends: comparing two ArrayRefs through those
-// friends requires a derived-to-base conversion on *both* arguments, which
-// per-argument ties against the C++20-reversed candidate of
-// operator==(IntArrayRef, OptionalIntArrayRef) in OptionalArrayRef.h (exact
-// match on one arg, user-defined conversion on the other) and produces an
-// ambiguity. Keeping ArrayRef-typed overloads gives an exact match on both
-// args, which wins unambiguously.
-//
-// WARNING: Template instantiation will NOT be willing to do an implicit
-// conversions to get you to an c10::ArrayRef, which is why we need so
-// many overloads.
-template <typename T>
-bool operator==(c10::ArrayRef<T> a1, c10::ArrayRef<T> a2) {
-  return a1.equals(a2);
-}
-
-template <typename T>
-bool operator!=(c10::ArrayRef<T> a1, c10::ArrayRef<T> a2) {
-  return !a1.equals(a2);
-}
-
-template <typename T>
-bool operator==(const std::vector<T>& a1, c10::ArrayRef<T> a2) {
-  return c10::ArrayRef<T>(a1).equals(a2);
-}
-
-template <typename T>
-bool operator!=(const std::vector<T>& a1, c10::ArrayRef<T> a2) {
-  return !c10::ArrayRef<T>(a1).equals(a2);
-}
-
-template <typename T>
-bool operator==(c10::ArrayRef<T> a1, const std::vector<T>& a2) {
-  return a1.equals(c10::ArrayRef<T>(a2));
-}
-
-template <typename T>
-bool operator!=(c10::ArrayRef<T> a1, const std::vector<T>& a2) {
-  return !a1.equals(c10::ArrayRef<T>(a2));
-}
-
 using IntArrayRef = ArrayRef<int64_t>;
 
 using IntList [[deprecated(

--- a/c10/util/OptionalArrayRef.h
+++ b/c10/util/OptionalArrayRef.h
@@ -42,29 +42,34 @@ class OptionalArrayRef final {
   constexpr OptionalArrayRef(const T& value) noexcept
       : wrapped_opt_array_ref(value) {}
 
-  template <
-      typename U = ArrayRef<T>,
-      std::enable_if_t<
-          !std::is_same_v<std::decay_t<U>, OptionalArrayRef> &&
-              !std::is_same_v<std::decay_t<U>, std::in_place_t> &&
-              std::is_constructible_v<ArrayRef<T>, U&&> &&
-              std::is_convertible_v<U&&, ArrayRef<T>> &&
-              !std::is_convertible_v<U&&, T>,
-          bool> = false>
-  constexpr OptionalArrayRef(U&& value) noexcept(
-      std::is_nothrow_constructible_v<ArrayRef<T>, U&&>)
+  template <typename U = ArrayRef<T>>
+  requires(
+      !std::is_same_v<std::decay_t<U>, OptionalArrayRef> &&
+      !std::is_same_v<std::decay_t<U>, std::in_place_t> &&
+      std::is_constructible_v<ArrayRef<T>, U&&> &&
+      std::is_convertible_v<U&&, ArrayRef<T>> &&
+      !std::is_convertible_v<
+          U&&,
+          T>) constexpr OptionalArrayRef(U&& value) noexcept(std::
+                                                                 is_nothrow_constructible_v<
+                                                                     ArrayRef<
+                                                                         T>,
+                                                                     U&&>)
       : wrapped_opt_array_ref(std::forward<U>(value)) {}
 
-  template <
-      typename U = ArrayRef<T>,
-      std::enable_if_t<
-          !std::is_same_v<std::decay_t<U>, OptionalArrayRef> &&
-              !std::is_same_v<std::decay_t<U>, std::in_place_t> &&
-              std::is_constructible_v<ArrayRef<T>, U&&> &&
-              !std::is_convertible_v<U&&, ArrayRef<T>>,
-          bool> = false>
-  constexpr explicit OptionalArrayRef(U&& value) noexcept(
-      std::is_nothrow_constructible_v<ArrayRef<T>, U&&>)
+  template <typename U = ArrayRef<T>>
+  requires(
+      !std::is_same_v<std::decay_t<U>, OptionalArrayRef> &&
+      !std::is_same_v<std::decay_t<U>, std::in_place_t> &&
+      std::is_constructible_v<ArrayRef<T>, U&&> &&
+      !std::is_convertible_v<
+          U&&,
+          ArrayRef<
+              T>>) constexpr explicit OptionalArrayRef(U&& value) noexcept(std::
+                                                                               is_nothrow_constructible_v<
+                                                                                   ArrayRef<
+                                                                                       T>,
+                                                                                   U&&>)
       : wrapped_opt_array_ref(std::forward<U>(value)) {}
 
   template <typename... Args>
@@ -110,13 +115,12 @@ class OptionalArrayRef final {
     return *this;
   }
 
-  template <
-      typename U = ArrayRef<T>,
-      typename = std::enable_if_t<
-          !std::is_same_v<std::decay_t<U>, OptionalArrayRef> &&
-          std::is_constructible_v<ArrayRef<T>, U&&> &&
-          std::is_assignable_v<ArrayRef<T>&, U&&>>>
-  constexpr OptionalArrayRef& operator=(U&& value) noexcept(
+  template <typename U = ArrayRef<T>>
+  requires(
+      !std::is_same_v<std::decay_t<U>, OptionalArrayRef> &&
+      std::is_constructible_v<ArrayRef<T>, U&&> &&
+      std::is_assignable_v<ArrayRef<T>&, U&&>) constexpr OptionalArrayRef&
+  operator=(U&& value) noexcept(
       std::is_nothrow_constructible_v<ArrayRef<T>, U&&> &&
       std::is_nothrow_assignable_v<ArrayRef<T>&, U&&>) {
     wrapped_opt_array_ref = std::forward<U>(value);
@@ -175,16 +179,14 @@ class OptionalArrayRef final {
   }
 
   template <typename U>
-  constexpr std::
-      enable_if_t<std::is_convertible_v<U&&, ArrayRef<T>>, ArrayRef<T>>
-      value_or(U&& default_value) const& {
+  requires std::is_convertible_v<U&&, ArrayRef<T>> constexpr ArrayRef<T>
+  value_or(U&& default_value) const& {
     return wrapped_opt_array_ref.value_or(std::forward<U>(default_value));
   }
 
   template <typename U>
-  constexpr std::
-      enable_if_t<std::is_convertible_v<U&&, ArrayRef<T>>, ArrayRef<T>>
-      value_or(U&& default_value) && {
+  requires std::is_convertible_v<U&&, ArrayRef<T>> constexpr ArrayRef<T>
+  value_or(U&& default_value) && {
     return wrapped_opt_array_ref.value_or(std::forward<U>(default_value));
   }
 
@@ -199,10 +201,10 @@ class OptionalArrayRef final {
   }
 
   template <typename... Args>
-  constexpr std::
-      enable_if_t<std::is_constructible_v<ArrayRef<T>, Args&&...>, ArrayRef<T>&>
-      emplace(Args&&... args) noexcept(
-          std::is_nothrow_constructible_v<ArrayRef<T>, Args&&...>) {
+  requires std::is_constructible_v<ArrayRef<T>, Args&&...> constexpr ArrayRef<
+      T>&
+  emplace(Args&&... args) noexcept(
+      std::is_nothrow_constructible_v<ArrayRef<T>, Args&&...>) {
     return wrapped_opt_array_ref.emplace(std::forward<Args>(args)...);
   }
 
@@ -213,25 +215,17 @@ class OptionalArrayRef final {
     return wrapped_opt_array_ref.emplace(il, std::forward<Args>(args)...);
   }
 
+  friend bool operator==(OptionalArrayRef a1, ArrayRef<T> other) {
+    if (!a1.has_value()) {
+      return false;
+    }
+    return a1.value() == other;
+  }
+
  private:
   std::optional<ArrayRef<T>> wrapped_opt_array_ref;
 };
 
 using OptionalIntArrayRef = OptionalArrayRef<int64_t>;
-
-inline bool operator==(
-    const OptionalIntArrayRef& a1,
-    const IntArrayRef& other) {
-  if (!a1.has_value()) {
-    return false;
-  }
-  return a1.value() == other;
-}
-
-inline bool operator==(
-    const c10::IntArrayRef& a1,
-    const c10::OptionalIntArrayRef& a2) {
-  return a2 == a1;
-}
 
 } // namespace c10


### PR DESCRIPTION
In the prev PR, we needed to keep around redundant == templates in ArrayRef because of overload resolution with OptionalArrayRef. In this PR, we get to delete those by fixing OptionalArrayRef. We fix by moving the free functions in OptionalArrayRef.h to be hidden friends as well, simplifying the overload resolution and removing the ambiguity warnings we were seeing.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #185421
* #185379

