### PR TITLE
[BE] Use `std::clamp`

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -570,7 +570,7 @@ static inline void mtl_dispatch1DJob(id<MTLComputeCommandEncoder> encoder,
   static_assert(sizeof(NSUInteger) == sizeof(uint64_t));
   const auto maxThreadsPerGroup = [cplState maxTotalThreadsPerThreadgroup];
   auto size = MTLSizeMake(length, 1, 1);
-  auto threadGroupSize = MTLSizeMake(std::min(maxThreadsPerGroup, length), 1, 1);
+  auto threadGroupSize = MTLSizeMake(std::clamp(length, 1UL, maxThreadsPerGroup), 1, 1);
   [encoder dispatchThreads:size threadsPerThreadgroup:threadGroupSize];
 }
 
@@ -591,7 +591,7 @@ static inline void mtl_dispatch2DJob(id<MTLComputeCommandEncoder> encoder,
   const auto maxThreadsPerGroup = [cplState maxTotalThreadsPerThreadgroup];
   auto size = MTLSizeMake(inner_len, outer_len, 1);
   auto tg_x = std::min(maxThreadsPerGroup, inner_len);
-  auto tg_y = std::max(NSUInteger(1), std::min(outer_len, maxThreadsPerGroup / tg_x));
+  auto tg_y = std::clamp(outer_len, 1UL, maxThreadsPerGroup / tg_x);
   auto threadGroupSize = MTLSizeMake(tg_x, tg_y, 1);
   [encoder dispatchThreads:size threadsPerThreadgroup:threadGroupSize];
 }

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -233,7 +233,7 @@ static void lerp_tensor_mps_kernel(at::TensorIteratorBase& iter) {
       auto tg_x = std::min(static_cast<NSUInteger>(sizes[0]), maxTg);
       auto tg_y = std::min(static_cast<NSUInteger>(sizes[1]), maxTg / tg_x);
       auto grid_z = ndim > 2 ? static_cast<NSUInteger>(sizes[2]) : 1;
-      auto tg_z = std::min(grid_z, std::max(maxTg / (tg_x * tg_y), (NSUInteger)1));
+      auto tg_z = std::clamp(grid_z, 1UL, maxTg / (tg_x * tg_y));
       [computeEncoder dispatchThreads:MTLSizeMake(sizes[0], sizes[1], grid_z)
                 threadsPerThreadgroup:MTLSizeMake(tg_x, tg_y, tg_z)];
     });

--- a/aten/src/ATen/native/mps/operations/Eye.mm
+++ b/aten/src/ATen/native/mps/operations/Eye.mm
@@ -59,7 +59,7 @@ Tensor& eye_out_mps(int64_t n, int64_t m, Tensor& result) {
 
         auto maxTg = [pso maxTotalThreadsPerThreadgroup];
         auto tg_x = std::min(grid_x, maxTg);
-        auto tg_y = std::min(grid_y, std::max(maxTg / tg_x, static_cast<NSUInteger>(1)));
+        auto tg_y = std::clamp(grid_y, 1UL, maxTg / tg_x);
         [computeEncoder dispatchThreads:MTLSizeMake(grid_x, grid_y, 1)
                   threadsPerThreadgroup:MTLSizeMake(tg_x, tg_y, 1)];
       }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #185422
* #185291

Instead of min/max pair, addresses feedback from https://github.com/pytorch/pytorch/pull/185291/changes#r3312183923