### PR TITLE
[Inductor] Avoid poisoning forks in `pre_fork_setup`

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -8,6 +8,7 @@ import textwrap
 import unittest
 from threading import Event
 
+import torch
 import torch._inductor.config as config
 from torch._inductor.compile_worker.subproc_pool import (
     raise_testexc,
@@ -45,6 +46,15 @@ class TestCompileWorker(TestCase):
                 "torch._inductor.compile_worker.subproc_pool.TestException",
             ):
                 a.result()
+        finally:
+            pool.shutdown()
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available.")
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
+    def test_cuda_init_in_forked_worker(self):
+        pool = self.make_pool(1)
+        try:
+            self.assertIsNone(pool.submit(torch.cuda.set_device, 0).result())
         finally:
             pool.shutdown()
 

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -90,10 +90,6 @@ def pre_fork_setup():
     """
     Setup that must be done prior to forking with a process pool.
     """
-    # ensure properties have been calculated before processes
-    # are forked
-    caching_device_properties()
-
     # Computing the triton key can be slow. If we call it before fork,
     # it will be cached for the forked subprocesses.
     from torch._inductor.runtime.triton_compat import HAS_TRITON, triton_key
@@ -300,6 +296,8 @@ class AsyncCompile:
             if config.worker_start_method == "spawn":
                 # Avoid creating pools in the spawned subprocs themselves:
                 os.environ["TORCH_WARM_POOL"] = "0"
+            # Preserve the eager device-property cache for direct process pools.
+            caching_device_properties()
             pre_fork_setup()
             ctx = multiprocessing.get_context(config.worker_start_method)
             pool = TrackedProcessPoolExecutor(


### PR DESCRIPTION
Getting device properties can initialize a CUDA context, leading to failures like
```Name=cutedsl_fused__grouped_mm_8b85b949
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_worker/subproc_pool.py", line 475, in do_job
    result = job()
             ^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/runtime/compile_tasks.py", line 164, in _worker_compile_pycodecache_kernel
    precompile_fn(**precompile_metadata)
  File "/tmp/tmpcprwivph/vt/cvtfkpn3jdz3x23dfbppswmt5yjiokr5ldwf64ezqarrq3ia6yg7.py", line 371, in cutedsl_fused__grouped_mm_8b85b949_precompile
    torch.cuda.set_device(device_index)
  File "/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py", line 685, in set_device
    torch._C._cuda_setDevice(device)
  File "/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py", line 513, in _lazy_init
    raise RuntimeError(
RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method


Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"


To execute this test, run the following from the base repo dir:
    python test/inductor/test_async_compile.py TestCuteDSLSubprocessGroupedGemm.test_grouped_gemm_subprocess_e2e
 
```

authored with codex

cc @ptrblck @msaroufim @tinglvv @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo