### PR TITLE
[CuTeDSL] Use `get_stride_order` in `cutedsl_mm_grouped.py.jinja`

### DIFF
--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -76,9 +76,7 @@ import tempfile
 
 _PRECOMPILE_SENTINEL = os.path.join(tempfile.gettempdir(), "SENTINEL_PLACEHOLDER")
 
-def {{kernel_name}}_precompile(
-    precompile_shapes, precompile_strides, precompile_dtypes, device_index=0
-):
+def {{kernel_name}}_precompile(precompile_shapes, precompile_dtypes, device_index=0):
     with open(_PRECOMPILE_SENTINEL, "w") as f:
         import json
         f.write(json.dumps({"shapes": precompile_shapes, "dtypes": precompile_dtypes}))

--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -76,7 +76,9 @@ import tempfile
 
 _PRECOMPILE_SENTINEL = os.path.join(tempfile.gettempdir(), "SENTINEL_PLACEHOLDER")
 
-def {{kernel_name}}_precompile(precompile_shapes, precompile_dtypes, device_index=0):
+def {{kernel_name}}_precompile(
+    precompile_shapes, precompile_strides, precompile_dtypes, device_index=0
+):
     with open(_PRECOMPILE_SENTINEL, "w") as f:
         import json
         f.write(json.dumps({"shapes": precompile_shapes, "dtypes": precompile_dtypes}))

--- a/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
+++ b/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
@@ -56,7 +56,7 @@ _TORCH_TO_CUTLASS_DTYPE = {
 }
 
 def _to_fake_cute_tensor(t, assumed_align=16):
-    dyn_shape = tuple(int(dim) for dim in t.shape)
+    dyn_shape = tuple(map(int, t.shape))
     stride_order = tuple(get_stride_order(t.stride()))
     return cute.runtime.make_fake_compact_tensor(
         _TORCH_TO_CUTLASS_DTYPE[t.dtype], dyn_shape,

--- a/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
+++ b/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
@@ -1,5 +1,6 @@
 import functools
 
+from torch._inductor.ir import get_stride_order
 from torch._inductor.runtime.cutedsl_cache import disk_cache_get, disk_cache_set
 from torch._inductor.runtime.runtime_utils import ceildiv
 from cutlass.utils import TensorMapUpdateMode
@@ -54,12 +55,11 @@ _TORCH_TO_CUTLASS_DTYPE = {
     torch.int64: cutlass.Int64,
 }
 
-def _to_fake_cute_tensor(shape, dtype, assumed_align=16):
-    ndim = len(shape)
-    dyn_shape = tuple(cute.sym_int64() for _ in range(ndim))
-    stride_order = tuple(range(ndim - 1, -1, -1))
+def _to_fake_cute_tensor(t, assumed_align=16):
+    dyn_shape = tuple(int(dim) for dim in t.shape)
+    stride_order = tuple(get_stride_order(t.stride()))
     return cute.runtime.make_fake_compact_tensor(
-        _TORCH_TO_CUTLASS_DTYPE[dtype], dyn_shape,
+        _TORCH_TO_CUTLASS_DTYPE[t.dtype], dyn_shape,
         stride_order=stride_order, assumed_align=assumed_align,
     )
 
@@ -230,7 +230,7 @@ def launch_build_group_ptrs_from_bases(
             base_A_u64=base_A_u64,
             base_B_u64=base_B_u64,
             base_C_u64=base_C_u64,
-            offs=_to_fake_cute_tensor(input_a_offs.shape, input_a_offs.dtype, assumed_align=4),
+            offs=_to_fake_cute_tensor(input_a_offs, assumed_align=4),
             G=int(G),
             K=int(K),
             N=int(N),
@@ -242,9 +242,9 @@ def launch_build_group_ptrs_from_bases(
             stride_Bn_elems=sB_n,
             stride_C_m_elems=sC_m,
             stride_C_n_elems=sC_n,
-            out_ptrs=_to_fake_cute_tensor(ptrs_t.shape, ptrs_t.dtype),
-            out_problem=_to_fake_cute_tensor(probs_t.shape, probs_t.dtype, assumed_align=4),
-            out_strides_abc=_to_fake_cute_tensor(strides_t.shape, strides_t.dtype, assumed_align=4),
+            out_ptrs=_to_fake_cute_tensor(ptrs_t),
+            out_problem=_to_fake_cute_tensor(probs_t, assumed_align=4),
+            out_strides_abc=_to_fake_cute_tensor(strides_t, assumed_align=4),
             stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
             options="--enable-tvm-ffi",
         )
@@ -314,15 +314,15 @@ def launch_build_group_ptrs_from_bases(
         c_unsq = {{get_output()}}.unsqueeze(-1)
         gemm_executor = cute.compile(
             grouped_gemm,
-            _to_fake_cute_tensor(a_unsq.shape, a_unsq.dtype),
-            _to_fake_cute_tensor(b_unsq.shape, b_unsq.dtype),
-            _to_fake_cute_tensor(c_unsq.shape, c_unsq.dtype),
+            _to_fake_cute_tensor(a_unsq),
+            _to_fake_cute_tensor(b_unsq),
+            _to_fake_cute_tensor(c_unsq),
             G,
-            _to_fake_cute_tensor(probs_t.shape, probs_t.dtype, assumed_align=4),
-            _to_fake_cute_tensor(strides_t.shape, strides_t.dtype, assumed_align=4),
-            _to_fake_cute_tensor(ptrs_t.shape, ptrs_t.dtype),
+            _to_fake_cute_tensor(probs_t, assumed_align=4),
+            _to_fake_cute_tensor(strides_t, assumed_align=4),
+            _to_fake_cute_tensor(ptrs_t),
             total_num_clusters,
-            _to_fake_cute_tensor(tensormap_workspace_t.shape, tensormap_workspace_t.dtype),
+            _to_fake_cute_tensor(tensormap_workspace_t),
             max_active_clusters,
             cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
             options="--enable-tvm-ffi",


### PR DESCRIPTION
Otherwise seeing failures like
```
  File "/tmp/tmpqt1_p9i5/vt/cvtfkpn3jdz3x23dfbppswmt5yjiokr5ldwf64ezqarrq3ia6yg7.py", line 336, in cutedsl_fused__grouped_mm_8b85b949_main
    gemm_executor = cute.compile(
                    ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/compiler.py", line 582, in __call__
    return self._compile(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/compiler.py", line 661, in _compile
    return func._dsl_object._func(func, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/dsl.py", line 2214, in _func
    result = self.generate_mlir(
             ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/dsl.py", line 1835, in generate_mlir
    module, module_hash, result = self.generate_original_ir(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/dsl.py", line 1599, in generate_original_ir
    module, result = build_ir_module()
                     ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/dsl.py", line 1575, in build_ir_module
    result = funcBody(*ir_args, **ir_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/torch/_inductor/kernel/vendored_templates/cutedsl/kernels/cutedsl_grouped_gemm.py", line 343, in __call__
    self.a_major_mode = utils.LayoutEnum.from_tensor(initial_a).mma_major_mode()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/utils/layout.py", line 65, in from_tensor
    raise ValueError(f"Invalid leading dimension: {tensor.leading_dim}")
ValueError: Invalid leading dimension: 2

To execute this test, run the following from the base repo dir:
    python test/inductor/test_cutedsl_grouped_mm.py TestCuTeDSLGroupedGemm.test_grouped_gemm_assorted_layouts_layout_A_contiguous_layout_B_broadcasted


```
authored with codex

cc @jamesr66a @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo