### PR TITLE
[ROCm][CI] Restore workspace owner after ROCm test container runs for navi31s

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -175,7 +175,8 @@ jobs:
           env | grep '^GITHUB' >> "/tmp/github_env_${GITHUB_RUN_ID}"
           env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
 
-      - name: Start test container
+      - name: Test
+        id: test
         env:
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -204,9 +205,17 @@ jobs:
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
-        shell: bash
+        timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
         run: |
           set -x
+
+          if [[ $TEST_CONFIG == 'multigpu' ]]; then
+            TEST_COMMAND=.ci/pytorch/multigpu-test.sh
+          elif [[ $BUILD_ENVIRONMENT == *onnx* ]]; then
+            TEST_COMMAND=.ci/caffe2/test.sh
+          else
+            TEST_COMMAND=.ci/pytorch/test.sh
+          fi
 
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
@@ -259,33 +268,11 @@ jobs:
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"
           )
+          # save container name for later step
           echo "CONTAINER_NAME=${container_name}" >> "$GITHUB_ENV"
-
-      - name: Record workspace owner
-        shell: bash
-        run: |
-          OWNER_ID=$(docker exec -t "${CONTAINER_NAME}" stat -c '%u' /var/lib/jenkins/workspace | tr -d '\r')
-          echo "WORKSPACE_ORIGINAL_OWNER_ID=${OWNER_ID}" >> "$GITHUB_ENV"
-
-      - name: Run tests
-        id: test
-        env:
-          BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
-          TEST_CONFIG: ${{ matrix.config }}
-        timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
-        shell: bash
-        run: |
-          set -x
-
-          if [[ $TEST_CONFIG == 'multigpu' ]]; then
-            TEST_COMMAND=.ci/pytorch/multigpu-test.sh
-          elif [[ $BUILD_ENVIRONMENT == *onnx* ]]; then
-            TEST_COMMAND=.ci/caffe2/test.sh
-          else
-            TEST_COMMAND=.ci/pytorch/test.sh
-          fi
-
-          docker exec -t "${CONTAINER_NAME}" sh -c "pip install dist/*.whl && ${TEST_COMMAND}"
+          WORKSPACE_ORIGINAL_OWNER_ID=$(docker exec -t "${container_name}" stat -c '%u' /var/lib/jenkins/workspace | tr -d '\r')
+          echo "WORKSPACE_ORIGINAL_OWNER_ID=${WORKSPACE_ORIGINAL_OWNER_ID}" >> "$GITHUB_ENV"
+          docker exec -t "${container_name}" sh -c "pip install dist/*.whl && ${TEST_COMMAND}"
 
       - name: Restore workspace owner
         if: always() && contains(matrix.runner, 'gfx1100')

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -274,7 +274,7 @@ jobs:
           echo "WORKSPACE_ORIGINAL_OWNER_ID=${WORKSPACE_ORIGINAL_OWNER_ID}" >> "$GITHUB_ENV"
           docker exec -t "${container_name}" sh -c "pip install dist/*.whl && ${TEST_COMMAND}"
 
-      - name: Restore workspace owner
+      - name: Restore workspace owner (for gfx1100 only)
         if: always() && contains(matrix.runner, 'gfx1100')
         shell: bash
         run: |

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -175,8 +175,7 @@ jobs:
           env | grep '^GITHUB' >> "/tmp/github_env_${GITHUB_RUN_ID}"
           env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
 
-      - name: Test
-        id: test
+      - name: Start test container
         env:
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -205,17 +204,9 @@ jobs:
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
-        timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
+        shell: bash
         run: |
           set -x
-
-          if [[ $TEST_CONFIG == 'multigpu' ]]; then
-            TEST_COMMAND=.ci/pytorch/multigpu-test.sh
-          elif [[ $BUILD_ENVIRONMENT == *onnx* ]]; then
-            TEST_COMMAND=.ci/caffe2/test.sh
-          else
-            TEST_COMMAND=.ci/pytorch/test.sh
-          fi
 
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
@@ -268,9 +259,40 @@ jobs:
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"
           )
-          # save container name for later step
           echo "CONTAINER_NAME=${container_name}" >> "$GITHUB_ENV"
-          docker exec -t "${container_name}" sh -c "pip install dist/*.whl && ${TEST_COMMAND}"
+
+      - name: Record workspace owner
+        shell: bash
+        run: |
+          OWNER_ID=$(docker exec -t "${CONTAINER_NAME}" stat -c '%u' /var/lib/jenkins/workspace | tr -d '\r')
+          echo "WORKSPACE_ORIGINAL_OWNER_ID=${OWNER_ID}" >> "$GITHUB_ENV"
+
+      - name: Run tests
+        id: test
+        env:
+          BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
+          TEST_CONFIG: ${{ matrix.config }}
+        timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
+        shell: bash
+        run: |
+          set -x
+
+          if [[ $TEST_CONFIG == 'multigpu' ]]; then
+            TEST_COMMAND=.ci/pytorch/multigpu-test.sh
+          elif [[ $BUILD_ENVIRONMENT == *onnx* ]]; then
+            TEST_COMMAND=.ci/caffe2/test.sh
+          else
+            TEST_COMMAND=.ci/pytorch/test.sh
+          fi
+
+          docker exec -t "${CONTAINER_NAME}" sh -c "pip install dist/*.whl && ${TEST_COMMAND}"
+
+      - name: Restore workspace owner
+        if: always() && contains(matrix.runner, 'gfx1100')
+        shell: bash
+        run: |
+          docker exec -t "${CONTAINER_NAME}" sh -c \
+            'sudo chown -R '"${WORKSPACE_ORIGINAL_OWNER_ID}"' /var/lib/jenkins/workspace'
 
       - name: Print remaining test logs
         shell: bash


### PR DESCRIPTION
## Summary

Record the bind-mounted workspace owner UID inside the existing `Test` step in `_rocm-test.yml` (before running tests) and add a `Restore workspace owner` step after tests on gfx1100 (navi31) runners to reset `/var/lib/jenkins/workspace` permissions.

## Test plan

- [ ] Trigger a workflow that calls `_rocm-test.yml` on a gfx1100 (navi31) runner
- [ ] Confirm `WORKSPACE_ORIGINAL_OWNER_ID` is recorded in the Test step before tests run
- [ ] Confirm restore step runs on success and failure for gfx1100 runners
- [ ] Confirm `Print remaining test logs` and `Upload test artifacts` still succeed

Authored w/ assistance from cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang