### PR TITLE
Register functionalization for non-mutating prim views

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -20,6 +20,7 @@ from torch._dynamo.testing import (
 from torch._functorch.aot_autograd import _aot_export_function, create_functional_call
 from torch._guards import CompileContext, StorageOverlap, TracingContext
 from torch._subclasses.fake_tensor import FakeTensorMode
+from torch._subclasses.functional_tensor import dispatch_functionalize
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.profiler import profile
 from torch.testing import FileCheck
@@ -90,6 +91,52 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
         aot_fn = torch.compile(fn, backend="aot_eager")
         # This should not error: we mutated an autograd leaf under no_grad mode.
         aot_fn(x, y)
+
+    def test_prims_broadcast_in_dim_functionalize(self):
+        def fn(x):
+            return torch.ops.prims.broadcast_in_dim.default(
+                x, [x.shape[0], x.shape[1], 1], [0, 1]
+            )
+
+        x = torch.randn(3, 4)
+        expected = fn(x)
+        actual = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual.stride(), expected.stride())
+        self.assertEqual(
+            actual.untyped_storage().data_ptr(), x.untyped_storage().data_ptr()
+        )
+
+    def test_prims_view_functionalize_preserves_meta_validation(self):
+        def fn(x):
+            return torch.ops.prims.squeeze.default(x, [1])
+
+        x = torch.randn(2, 3)
+        msg = "Cannot squeeze dimension 1 with size 3"
+
+        with self.assertRaisesRegex(AssertionError, msg):
+            fn(x)
+        with self.assertRaisesRegex(AssertionError, msg):
+            dispatch_functionalize(fn)(x)
+
+    def test_prims_as_strided_functionalize_not_silent_wrong_result(self):
+        def fn(x):
+            return torch.ops.prims.as_strided.default(x, [2, 2], [3, 1], 1)
+
+        x = torch.randn(8)
+        expected = fn(x)
+
+        # prims.as_strided uses mutable alias annotations, so it is deliberately
+        # excluded from the generic non-mutating view Functionalize rule.
+        try:
+            actual = torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+        except torch._dynamo.exc.BackendCompilerFailed as e:
+            self.assertIn("alias annotations: prims::as_strided", str(e))
+            return
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual.stride(), expected.stride())
 
     def test_mutation1(self):
         def fn(_stack0: torch.Tensor, diagonal_chunked_attention_scores: torch.Tensor):

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -38,6 +38,7 @@ prim = torch.library.Library("prims", "DEF")
 prim_impl = torch.library.Library("prims", "IMPL", "CompositeExplicitAutograd")
 prim_backend_select_impl = torch.library.Library("prims", "IMPL", "BackendSelect")
 prim_autograd_impl = torch.library.Library("prims", "IMPL", "Autograd")
+prim_functionalize_impl = torch.library.Library("prims", "IMPL", "Functionalize")
 prim_meta_impl = torch.library.Library("prims", "IMPL", "Meta")
 
 # Experimental module containing prototype "primitive" operations.
@@ -343,6 +344,23 @@ def _make_prim(
         if return_type == RETURN_TYPE.VIEW or register_conj_neg_fallthrough:
             prim_def._lib.impl(name, torch.library.fallthrough_kernel, "Conjugate")
             prim_def._lib.impl(name, torch.library.fallthrough_kernel, "Negative")
+
+    if return_type == RETURN_TYPE.VIEW and is_functional_schema(
+        cpp_schema, allow_valid_view=True
+    ):
+
+        def _functionalize_impl(*args, **kwargs):
+            meta(*args, **kwargs)
+            return impl_aten(*args, **kwargs)
+
+        # The Functionalize fallback cannot handle custom ops with view alias
+        # annotations. Non-mutating view prims can reuse their ATen view
+        # implementation after prim meta validation; schemas with mutable alias
+        # annotations need a custom rule because alias correction will otherwise
+        # treat them as mutations.
+        # In particular, prims.as_strided has Tensor(a!) -> Tensor(a!) schema
+        # annotations and must not use this generic non-mutating view rule.
+        prim_functionalize_impl.impl(name, _functionalize_impl)
 
     _prim_packet = getattr(torch._ops.ops.prims, name)
     _prim = _prim_packet.default


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185445

AOTAutograd enables functionalization while tracing compiled graphs. When a graph
contains `prims.broadcast_in_dim`, dispatch currently reaches the generic custom
operator Functionalize fallback. That fallback rejects custom operators whose
outputs carry alias annotations, so `torch.compile` fails even though
`broadcast_in_dim` is a valid non-mutating view primitive.

Register Functionalize kernels for prim view operators whose schemas are valid
non-mutating one-input/one-output view schemas. The registered kernel preserves
prim semantics by running the prim meta validation before redispatching through
the existing ATen view implementation. The schema gate deliberately excludes
mutable-alias view schemas such as `prims.as_strided`; registering those through
the generic wrapper can let alias correction treat the result as a mutated input
and return a silent wrong result. Those schemas need dedicated functionalization
rules if we want to support them later.

Fixes #157610
Generated by my agent

Test Plan:
- python test/dynamo/test_aot_autograd.py AotAutogradFallbackTests.test_prims_broadcast_in_dim_functionalize AotAutogradFallbackTests.test_prims_view_functionalize_preserves_meta_validation AotAutogradFallbackTests.test_prims_as_strided_functionalize_not_silent_wrong_result
- python test/test_prims.py -k broadcast_in_dim
- lintrunner -a

Benchmark Results:
- Command: Python microbenchmark with 1,000 warmup calls and seven 20,000-call samples of `torch.ops.prims.broadcast_in_dim.default(torch.randn(16, 16), [16, 16, 1], [0, 1])`.
- main (536474ecda7f): samples 0.860611, 0.863911, 0.863571, 0.931457, 0.865168, 0.866762, 0.878284 s; median 43.258 us/call.
- fix-157610: samples 0.912291, 0.863946, 0.866196, 0.932999, 0.922190, 0.868976, 0.866985 s; median 43.449 us/call.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos