### PR TITLE
Adding a test case using fx.wrap to test whether TLX user-defined kernel is visible in the inductor output (#185301)

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -20,6 +20,7 @@ from sympy import Expr
 import torch
 import torch._logging
 import torch.fx
+import torch.utils._pytree as pytree
 from torch import device, Tensor
 from torch._decomp import get_decompositions
 from torch._dynamo.utils import defake, dynamo_timed
@@ -1540,6 +1541,10 @@ class GraphLowering(torch.fx.Interpreter):
             self.constant_reprs[target] = ""
             return TorchBindObject(name=target, value=value)
         elif is_opaque_type(type(value)):
+            self.torchbind_constants[target] = value  # type: ignore[arg-type]
+            self.constant_reprs[target] = ""
+            return TorchBindObject(name=target, value=value)  # type: ignore[arg-type]
+        elif isinstance(value, pytree.TreeSpec):
             self.torchbind_constants[target] = value  # type: ignore[arg-type]
             self.constant_reprs[target] = ""
             return TorchBindObject(name=target, value=value)  # type: ignore[arg-type]

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -9185,6 +9185,7 @@ class FallbackKernel(ExternKernelAlloc):
         if not device and (
             isinstance(kernel, torch._higher_order_ops.torchbind.CallTorchBind)
             or kernel is torch.ops.higher_order.print
+            or kernel is torch.ops.higher_order.invoke_leaf_function
         ):
             device = torch.device("cpu")
 


### PR DESCRIPTION
Summary:

This diff is dependent on [D96405491](https://www.internalfb.com/diff/D96405491), where I added a test case to check whether customized kernel is fused in inductor. This diff added one more test case to it but instead of using torch.library.custom\_op to wrap the kernel, it uses fx.wrap to make the kernel visible in inductor output.

Test Plan:
With the changes in this diff, generated code now contains "matmul_kernel_tma_pipelined_blackwell_0" which means the customized kernel is visible in the indcutor output. However, at this stage it is not yet fused with relu. So the next step we'll be working on enabling the kernel to be fused in epilogue.

The inductor output is here:
https://www.internalfb.com/phabricator/paste/view/P2262168046

Reviewed By: dshi7

Differential Revision: D99210723




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo