### PR TITLE
Fix reinplace alias checks for index_put

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -11,6 +11,7 @@ from torch._higher_order_ops.auto_functionalize import (
     auto_functionalized,
     auto_functionalized_v2,
 )
+from torch._inductor import inductor_prims
 from torch._inductor.fx_passes.reinplace import reinplace_inplaceable_ops_core
 from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
 from torch.testing._internal.common_utils import (
@@ -129,6 +130,112 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             return x
 
         self._test(f)
+
+    def test_index_put_source_alias_should_not_reinplace(self):
+        def f(x, y):
+            x = x.cos()
+            source = aten.alias(x)
+            return aten.index_put.default(x, [y], source)
+
+        x = torch.randn(4, 4, device=device)
+        y = torch.tensor([3, 1, 0, 2], device=device)
+        gm = make_fx(f, tracing_mode="fake")(x, y)
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertIn(aten.index_put.default, targets)
+        self.assertNotIn(aten.index_put_.default, targets)
+        self.assertEqual(gm(x, y), f(x, y))
+
+    def test_index_put_indices_alias_should_not_reinplace(self):
+        def f(x):
+            x = x.clone()
+            index = aten.alias(x)
+            values = torch.zeros_like(x)
+            return aten.index_put.default(x, [index], values)
+
+        x = torch.tensor([3, 1, 0, 2], device=device)
+        gm = make_fx(f, tracing_mode="fake")(x)
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertIn(aten.index_put.default, targets)
+        self.assertNotIn(aten.index_put_.default, targets)
+        self.assertEqual(gm(x), f(x))
+
+    def test_unsafe_index_put_source_alias_should_not_reinplace(self):
+        def f(x, y):
+            x = x.cos()
+            source = aten.alias(x)
+            return aten._unsafe_index_put.default(x, [y], source)
+
+        x = torch.randn(4, 4, device=device)
+        y = torch.tensor([3, 1, 0, 2], device=device)
+        gm = make_fx(f, tracing_mode="fake")(x, y)
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertIn(aten._unsafe_index_put.default, targets)
+        self.assertNotIn(inductor_prims._unsafe_index_put_, targets)
+        self.assertEqual(gm(x, y), f(x, y))
+
+    def test_with_effects_index_put_source_alias_should_not_reinplace(self):
+        from torch._higher_order_ops.effects import with_effects
+
+        def f(x, y):
+            x = x.cos()
+            source = aten.alias(x)
+            token = torch.ops.aten._make_dep_token()
+            _, result = with_effects(token, aten.index_put.default, x, [y], source)
+            return result
+
+        x = torch.randn(4, 4, device=device)
+        y = torch.tensor([3, 1, 0, 2], device=device)
+        gm = make_fx(f, tracing_mode="fake")(x, y)
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        with_effects_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.target is torch.ops.higher_order.with_effects
+        ]
+        self.assertEqual(len(with_effects_nodes), 1)
+        self.assertEqual(with_effects_nodes[0].args[1], aten.index_put.default)
+        self.assertEqual(gm(x, y), f(x, y))
+
+    def test_with_effects_index_put_indices_alias_should_not_reinplace(self):
+        from torch._higher_order_ops.effects import with_effects
+
+        def f(x):
+            x = x.clone()
+            index = aten.alias(x)
+            values = torch.zeros_like(x)
+            token = torch.ops.aten._make_dep_token()
+            _, result = with_effects(token, aten.index_put.default, x, [index], values)
+            return result
+
+        x = torch.tensor([3, 1, 0, 2], device=device)
+        gm = make_fx(f, tracing_mode="fake")(x)
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        with_effects_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.target is torch.ops.higher_order.with_effects
+        ]
+        self.assertEqual(len(with_effects_nodes), 1)
+        self.assertEqual(with_effects_nodes[0].args[1], aten.index_put.default)
+        self.assertEqual(gm(x), f(x))
 
     def test_should_modify_input(self):
         def f(x, y):

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -370,9 +370,54 @@ def canonicalize_view_scatter_ops(graph: torch.fx.Graph) -> None:
             handle_view_scatter(node)
 
 
+def _may_overlap(lhs: Any, rhs: Any) -> bool:
+    if not isinstance(lhs, torch.fx.Node) or not isinstance(rhs, torch.fx.Node):
+        return False
+
+    lhs_storage = get_node_storage(lhs)
+    rhs_storage = get_node_storage(rhs)
+    if lhs_storage is None or lhs_storage != rhs_storage:
+        return False
+
+    try:
+        return len(compute_overlapping_tensors([lhs.meta["val"], rhs.meta["val"]])) != 0
+    except GuardOnDataDependentSymNode:
+        return True
+
+
+def _may_overlap_with_any(lhs: Any, rhs: Any) -> bool:
+    if _may_overlap(lhs, rhs):
+        return True
+    if isinstance(rhs, (list, tuple, immutable_list)):
+        return any(_may_overlap_with_any(lhs, arg) for arg in rhs)
+    return False
+
+
+def _node_arg(node: torch.fx.Node, index: int, name: str) -> Any:
+    if node.target is torch.ops.higher_order.with_effects:
+        index += 2
+    if len(node.args) > index:
+        return node.args[index]
+    return node.kwargs.get(name)
+
+
+def _index_put_no_read_overlap(node: torch.fx.Node) -> bool:
+    self_arg = _node_arg(node, 0, "self")
+    return not (
+        _may_overlap_with_any(self_arg, _node_arg(node, 1, "indices"))
+        or _may_overlap_with_any(self_arg, _node_arg(node, 2, "values"))
+    )
+
+
 inplaceable_ops: dict[Callable[..., Any], InplaceableOp] = {
-    aten.index_put.default: InplaceableOp(aten.index_put_.default, 0),
-    aten._unsafe_index_put.default: InplaceableOp(inductor_prims._unsafe_index_put_, 0),
+    aten.index_put.default: InplaceableOp(
+        aten.index_put_.default, 0, extra_check=_index_put_no_read_overlap
+    ),
+    aten._unsafe_index_put.default: InplaceableOp(
+        inductor_prims._unsafe_index_put_,
+        0,
+        extra_check=_index_put_no_read_overlap,
+    ),
     _generalized_scatter: InplaceableOp(
         _inplace_generalized_scatter,
         0,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185450

Inductor's reinplace pass can rewrite functional index_put into its in-place variant when the destination has no later observable uses. That check was only reasoning about later uses of the destination tensor. It did not account for operands that index_put reads during the operation.

When self aliases either the values tensor or a tensor entry in the indices list, rewriting aten.index_put.default to aten.index_put_.default changes a functional update into an in-place read/write overlap. That is unsafe: eager either needs functional clone semantics or raises the usual overlap error for the in-place form. The same hazard applies to the _unsafe_index_put mapping, and the extra_check hook also has to handle with_effects nodes where inner op arguments are shifted by the token and op operands.

This adds an index_put-specific reinplace eligibility check that rejects overlap between self and all read tensor operands: values plus every tensor nested in indices. The check is shared by aten.index_put.default and aten._unsafe_index_put.default, and it accounts for with_effects positional argument offsets.

An older abandoned draft PR for #156786 only checked the last positional argument, which misses schemas with an accumulate argument and does not cover indices. This version keys off the operator schema positions instead.

Fixes #156786
Generated by my agent

Test Plan:
- python -m pytest test/inductor/test_inplacing_pass.py -k 'index_put_source_alias_should_not_reinplace or index_put_indices_alias_should_not_reinplace or unsafe_index_put_source_alias_should_not_reinplace' -q
- python -m pytest test/inductor/test_inplacing_pass.py -q
- lintrunner -a

Benchmark Results:
Microbenchmark measured reinplace_inplaceable_ops_core on a non-aliasing index_put FX graph, using 7 samples of 3000 pass runs after warmup.

main:
- samples_us_per_pass= [443.35, 394.77, 411.03, 398.33, 398.33, 458.74, 404.95]
- median_us_per_pass= 404.95

fix:
- samples_us_per_pass= [429.71, 412.25, 414.45, 415.83, 417.07, 489.16, 418.41]
- median_us_per_pass= 417.07

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos