### PR TITLE
fix clamp and clamp_{min,max} gradient at scalar bound to be 0

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -13010,6 +13010,46 @@ class TestAutogradDeviceType(TestCase):
             (min_val + max_val).backward()
             self.assertEqual(x.grad, torch.tensor([0.5, 0.5, 0.5, 0.5], device=device))
 
+    def test_clamp_saturation_boundary_subgradient(self, device):
+        # Scalar clamp / clamp_min / clamp_max are the same function as
+        # hardtanh / relu, so their gradients must agree.
+        # A value pinned to a clamp bound (e.g. an int4 quantization level)
+        # is then a fixed point of gradient descent and does not drift off.
+        # See pytorch#184572.
+        F = torch.nn.functional
+        qmin, qmax = -8.0, 7.0  # signed int4 range
+
+        xs = torch.tensor(
+            [qmin - 1, qmin, (qmin + qmax) / 2, qmax, qmax + 1], device=device
+        )
+        xc = xs.clone().requires_grad_(True)
+        torch.clamp(xc, qmin, qmax).sum().backward()
+        xh = xs.clone().requires_grad_(True)
+        F.hardtanh(xh, qmin, qmax).sum().backward()
+        self.assertEqual(xc.grad, xh.grad)
+        self.assertEqual(xc.grad[xs == qmin].item(), 0.0)  # saturated at the bounds
+        self.assertEqual(xc.grad[xs == qmax].item(), 0.0)
+
+        # one-sided forms agree with relu (== clamp_min(., 0)) at the bound
+        def grad_at(fn, val):
+            x = torch.tensor(val, device=device, requires_grad=True)
+            fn(x).backward()
+            return x.grad.item()
+
+        self.assertEqual(grad_at(lambda x: x.clamp_min(qmin), qmin), 0.0)
+        self.assertEqual(grad_at(lambda x: x.clamp_max(qmax), qmax), 0.0)
+        self.assertEqual(grad_at(torch.relu, 0.0), 0.0)
+
+        # a value sitting on a bound stays pinned under gradient descent
+        for bound in (qmin, qmax):
+            w = torch.tensor(bound, device=device, requires_grad=True)
+            for _ in range(3):
+                w.clamp(qmin, qmax).backward()
+                with torch.no_grad():
+                    w -= 0.1 * w.grad
+                w.grad = None
+            self.assertEqual(w.item(), bound)
+
     def test_scatter_index_reduce_amin_amax_aminmax_backprops_to_all_values(
         self, device
     ):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -430,7 +430,7 @@
   result: auto_element_wise
 
 - name: clamp_min(Tensor self, Scalar min) -> Tensor
-  self: where(self >= min, grad, at::scalar_tensor(0., grad.options()))
+  self: where(self > min, grad, at::scalar_tensor(0., grad.options()))
   result: auto_element_wise
 
 - name: clamp_min.Tensor(Tensor self, Tensor min) -> Tensor
@@ -439,7 +439,7 @@
   result: where(self_p >= min_p, self_t, min_t)
 
 - name: clamp_max(Tensor self, Scalar max) -> Tensor
-  self: where(self <= max, grad, at::scalar_tensor(0., grad.options()))
+  self: where(self < max, grad, at::scalar_tensor(0., grad.options()))
   result: auto_element_wise
 
 - name: clamp_max.Tensor(Tensor self, Tensor max) -> Tensor

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1238,17 +1238,17 @@ Tensor clamp_backward(
     const Tensor& self,
     const std::optional<Scalar>& min,
     const std::optional<Scalar>& max) {
-  // clamp: gradients not defined on min and max, so we return the subgradient 1
-  // for these cases.
+  // clamp: at a saturation boundary the subgradient is [0, 1]
+  // we return 0 to match hardtanh by using strict inequalities
   if (max && min) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where((self >= *min).logical_and_(self <= *max), grad, zero);
+    return where((self > *min).logical_and_(self < *max), grad, zero);
   } else if (min) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where(self >= *min, grad, zero);
+    return where(self > *min, grad, zero);
   } else if (max) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where(self <= *max, grad, zero);
+    return where(self < *max, grad, zero);
   } else {
     return grad;
   }


### PR DESCRIPTION

## Issue

Fixes #184574 

## Summary

Scalar `clamp` / `clamp_min` / `clamp_max` returned subgradient 1 at their bound, while `relu` / `hardtanh` return 0. The backward used the closed interval (`self >= min`, `self <= max`): switching to strict inequalities (`>`, `<`) puts the boundary on the saturated side, so `clamp(x, lo, hi)` now matches `hardtanh` everywhere.

I deliberately avoided `maximum`/`minimum` and the `*.Tensor` clamp variants as I don't know which conventions PyTorch team adopted in their implementation.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests: `test_clamp_saturation_boundary_subgradient`, gradcheck does not cover this (it avoids the kink)
- [ ] Updated documentation (NA)
- [ ] Included benchmark results (NA)

## BC-breaking?

No. Only the subgradient at the exact clamp bound changes (`1` -> `0`), values strictly inside or outside the bounds are unaffected.

## Changes

- `tools/autograd/derivatives.yaml`: scalar `clamp_min` (`self >= min` -> `self > min`) and
  `clamp_max` (`self <= max` -> `self < max`).
- `torch/csrc/autograd/FunctionsManual.cpp`: scalar `clamp_backward` uses strict inequalities
  in all three branches.
- `test/test_autograd.py`: add `test_clamp_saturation_boundary_subgradient`.