### PR TITLE
[pytorch] Validate system gloo GPU flavour at configure time

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1239,6 +1239,40 @@ if(USE_GLOO)
       endif()
       message("Found gloo: ${Gloo_NATIVE_LIBRARY}, cuda lib: ${Gloo_CUDA_LIBRARY}, hip lib: ${Gloo_HIP_LIBRARY}")
       message("Found gloo include directories: ${Gloo_INCLUDE_DIRS}")
+
+      # Validate that the system-installed gloo was built with the GPU flavor
+      # PyTorch is requesting. A mismatch (e.g. a CUDA-only gloo used in a
+      # ROCm build) causes cryptic compile errors deep in the build; catch it
+      # here with a clear message instead.
+      set(_gloo_config_h "${Gloo_INCLUDE_DIRS}/gloo/config.h")
+      if(EXISTS "${_gloo_config_h}")
+        file(READ "${_gloo_config_h}" _gloo_config_contents)
+        if(USE_CUDA)
+          string(REGEX MATCH "#define GLOO_USE_CUDA ([01])" _match "${_gloo_config_contents}")
+          if(NOT "${CMAKE_MATCH_1}" STREQUAL "1")
+            message(FATAL_ERROR
+              "USE_SYSTEM_GLOO: the gloo found at ${Gloo_INCLUDE_DIRS} was not "
+              "built with CUDA support (GLOO_USE_CUDA=${CMAKE_MATCH_1} in "
+              "${_gloo_config_h}). Rebuild gloo with -DUSE_CUDA=ON or point "
+              "CMAKE_PREFIX_PATH at a CUDA-enabled gloo installation.")
+          endif()
+        elseif(USE_ROCM)
+          string(REGEX MATCH "#define GLOO_USE_ROCM ([01])" _match "${_gloo_config_contents}")
+          if(NOT "${CMAKE_MATCH_1}" STREQUAL "1")
+            message(FATAL_ERROR
+              "USE_SYSTEM_GLOO: the gloo found at ${Gloo_INCLUDE_DIRS} was not "
+              "built with ROCm support (GLOO_USE_ROCM=${CMAKE_MATCH_1} in "
+              "${_gloo_config_h}). Rebuild gloo with -DUSE_ROCM=ON or point "
+              "CMAKE_PREFIX_PATH at a ROCm-enabled gloo installation.")
+          endif()
+        endif()
+      else()
+        message(WARNING
+          "USE_SYSTEM_GLOO: could not find ${_gloo_config_h} to verify GPU "
+          "flavor; proceeding, but the build may fail if gloo was compiled "
+          "for a different GPU backend.")
+      endif()
+
       add_library(gloo SHARED IMPORTED)
       set_target_properties(gloo PROPERTIES IMPORTED_LOCATION ${Gloo_NATIVE_LIBRARY})
       if(USE_CUDA)


### PR DESCRIPTION
Summary:
When PyTorch is built with `USE_SYSTEM_GLOO=ON`, `find_package(Gloo)` locates a pre-installed gloo but never checks whether that installation was compiled with the GPU backend PyTorch actually needs. If, for example, gloo was built with CUDA support but PyTorch is doing a ROCm/HIP build (or vice-versa), the mismatch surfaces as a cryptic `#error` deep in `gloo/cuda.h` during compilation — far from the root cause.

This diff adds a configure-time validation step in `cmake/Dependencies.cmake` immediately after `find_package(Gloo)` succeeds in the `USE_SYSTEM_GLOO` branch. It reads the installed `gloo/config.h`, extracts the `GLOO_USE_CUDA` / `GLOO_USE_ROCM` macro values (which are always `0` or `1` due to `#cmakedefine01`), and compares them against PyTorch's `USE_CUDA` / `USE_ROCM` settings. On mismatch, CMake emits a `FATAL_ERROR` that names the exact config file, the mismatched value, and tells the user how to fix it (rebuild gloo with the right flag or point `CMAKE_PREFIX_PATH` elsewhere). If `config.h` is missing entirely, a warning is emitted so the build can still proceed rather than failing silently.

No changes to gloo's own headers — the fix is entirely on the PyTorch consumer side.

Authored by Claude.

Test Plan:
before:
```
/usr/include/gloo/hip.h:24:2: error: #error "Expected GLOO_USE_ROCM to be defined"
     24 | #error "Expected GLOO_USE_ROCM to be defined"
```
after:
```
CMake Error at cmake/Dependencies.cmake:1262 (message):
    USE_SYSTEM_GLOO: the gloo found at /usr/include was not built with ROCm
    support (GLOO_USE_ROCM=0 in /usr/include/gloo/config.h).  Rebuild gloo with
    -DUSE_ROCM=ON or point CMAKE_PREFIX_PATH at a ROCm-enabled gloo
```

Reviewed By: d4l3k

Differential Revision: D106397943


