### PR TITLE
[pytorch] Nested custom Python process groups (experimental) (#185475)

### DIFF
--- a/test/distributed/test_custom_pg.py
+++ b/test/distributed/test_custom_pg.py
@@ -1,0 +1,1098 @@
+# Owner(s): ["oncall: distributed"]
+
+"""Tests for custom Python process groups (PassthroughProcessGroup, _pg_bypass)."""
+
+import os
+
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_utils import run_tests
+
+
+class CustomProcessGroupTest(MultiProcessTestCase):
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self):
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    @property
+    def world_size(self):
+        return 4
+
+    def test_pg_bypass_delegates_collective(self):
+        """@_pg_bypass forwards dist.all_reduce to pg.all_reduce if defined."""
+
+        calls = []
+
+        class _CollectivePG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "collective_bypass"
+
+            def all_reduce(self, tensor, op=None, async_op=False):
+                calls.append(
+                    {
+                        "tensor_shape": list(tensor.shape),
+                        "op": op,
+                        "async_op": async_op,
+                    }
+                )
+                return None
+
+        dist.Backend.register_backend(
+            "collective_bypass",
+            lambda *args, **kwargs: _CollectivePG(
+                args[0].group_rank, args[0].group_size
+            ),
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "collective_bypass", rank=self.rank, world_size=self.world_size
+        )
+
+        try:
+            tensor = torch.zeros(4)
+            dist.all_reduce(tensor, op=dist.ReduceOp.MAX)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0]["tensor_shape"], [4])
+            self.assertEqual(calls[0]["op"], dist.ReduceOp.MAX)
+            self.assertFalse(calls[0]["async_op"])
+        finally:
+            dist.destroy_process_group()
+
+    def test_pg_bypass_falls_through_when_not_overridden(self):
+        """@_pg_bypass falls through when PG doesn't override the method."""
+
+        class _MinimalPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "minimal_bypass"
+
+        dist.Backend.register_backend(
+            "minimal_bypass",
+            lambda *args, **kwargs: _MinimalPG(args[0].group_rank, args[0].group_size),
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "minimal_bypass", rank=self.rank, world_size=self.world_size
+        )
+
+        try:
+            # all_reduce is not overridden on _MinimalPG, so _pg_bypass
+            # falls through to the original dist.all_reduce implementation.
+            # _MinimalPG has no C++ backend, so this raises RuntimeError.
+            tensor = torch.zeros(4)
+            with self.assertRaises(RuntimeError):
+                dist.all_reduce(tensor)
+        finally:
+            dist.destroy_process_group()
+
+    def test_pg_bypass_extracts_group_positionally(self):
+        """@_pg_bypass handles group passed as a positional argument."""
+
+        calls = []
+
+        class _PositionalPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "positional_bypass"
+
+            def broadcast(self, tensor, src=None, async_op=False, group_src=None):
+                calls.append({"src": src, "async_op": async_op})
+                return None
+
+        dist.Backend.register_backend(
+            "positional_bypass",
+            lambda *args, **kwargs: _PositionalPG(
+                args[0].group_rank, args[0].group_size
+            ),
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "positional_bypass", rank=self.rank, world_size=self.world_size
+        )
+
+        try:
+            tensor = torch.zeros(4)
+            # Pass group as keyword
+            dist.broadcast(tensor, src=0, group=dist.group.WORLD)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0]["src"], 0)
+        finally:
+            dist.destroy_process_group()
+
+    def test_getattr_forwards_custom_collective(self):
+        """Module __getattr__ forwards unknown functions to the PG."""
+
+        calls = []
+
+        class _CustomPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "custom_collective"
+
+            def my_custom_collective(self, tensor, scale=1.0):
+                calls.append({"shape": list(tensor.shape), "scale": scale})
+                return None
+
+        dist.Backend.register_backend(
+            "custom_collective",
+            lambda *args, **kwargs: _CustomPG(args[0].group_rank, args[0].group_size),
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "custom_collective", rank=self.rank, world_size=self.world_size
+        )
+
+        try:
+            tensor = torch.zeros(8)
+            dist.my_custom_collective(tensor, scale=2.0, group=dist.group.WORLD)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0]["shape"], [8])
+            self.assertEqual(calls[0]["scale"], 2.0)
+        finally:
+            dist.destroy_process_group()
+
+    def test_getattr_raises_for_nonexistent(self):
+        """Module __getattr__ raises AttributeError for unknown methods."""
+
+        class _EmptyPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "empty_getattr"
+
+        dist.Backend.register_backend(
+            "empty_getattr",
+            lambda *args, **kwargs: _EmptyPG(args[0].group_rank, args[0].group_size),
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "empty_getattr", rank=self.rank, world_size=self.world_size
+        )
+
+        try:
+            tensor = torch.zeros(4)
+            with self.assertRaises(AttributeError):
+                dist.nonexistent_function(tensor, group=dist.group.WORLD)
+        finally:
+            dist.destroy_process_group()
+
+    def test_passthrough_delegates_to_inner(self):
+        """PassthroughProcessGroup delegates unhandled calls to inner PG."""
+
+        inner_calls = []
+
+        class _InnerPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "inner_terminal"
+
+            def all_reduce(self, tensor, op=None, async_op=False):
+                inner_calls.append({"op": "all_reduce"})
+                tensor.add_(1)
+                return None
+
+            def my_custom_op(self, tensor, scale=1.0):
+                inner_calls.append({"op": "my_custom_op", "scale": scale})
+                tensor.mul_(scale)
+                return None
+
+        outer_calls = []
+
+        class _OuterPG(dist.distributed_c10d.PassthroughProcessGroup):
+            def broadcast(self, tensor, src=None, async_op=False, **kwargs):
+                outer_calls.append({"op": "broadcast"})
+                tensor.fill_(42)
+                return None
+
+        def create_inner(dist_opts, pg_options=None):
+            return _InnerPG(dist_opts.group_rank, dist_opts.group_size)
+
+        def create_outer(dist_opts, pg_options=None):
+            pg = _OuterPG(dist_opts.group_rank, dist_opts.group_size)
+            dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+            return pg
+
+        dist.Backend.register_backend(
+            "inner_terminal",
+            create_inner,
+            extended_api=True,
+        )
+        dist.Backend.register_backend(
+            "outer_passthrough",
+            create_outer,
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "outer_passthrough(inner_terminal)",
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        try:
+            # broadcast is overridden on _OuterPG
+            tensor = torch.zeros(4)
+            dist.broadcast(tensor, src=0)
+            self.assertEqual(len(outer_calls), 1)
+            self.assertEqual(outer_calls[0]["op"], "broadcast")
+            self.assertEqual(tensor, torch.full((4,), 42.0))
+
+            # all_reduce is NOT on _OuterPG; delegates to _InnerPG
+            tensor = torch.zeros(4)
+            dist.all_reduce(tensor)
+            self.assertEqual(len(inner_calls), 1)
+            self.assertEqual(inner_calls[0]["op"], "all_reduce")
+            self.assertEqual(tensor, torch.ones(4))
+
+            # custom op defined only on _InnerPG, forwarded via
+            # __getattr__ on PassthroughProcessGroup
+            tensor = torch.full((4,), 3.0)
+            dist.my_custom_op(tensor, scale=2.0, group=dist.group.WORLD)
+            self.assertEqual(len(inner_calls), 2)
+            self.assertEqual(inner_calls[1]["op"], "my_custom_op")
+            self.assertEqual(tensor, torch.full((4,), 6.0))
+        finally:
+            dist.destroy_process_group()
+
+    def test_passthrough_fallback(self):
+        """Passthrough PG can fall back to inner PG."""
+
+        calls = []
+
+        class _InnerPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "fb_inner"
+
+            def all_reduce(self, tensor, op=None, async_op=False):
+                calls.append("inner")
+                tensor.add_(10)
+                return None
+
+        class _OuterPG(dist.distributed_c10d.PassthroughProcessGroup):
+            def all_reduce(self, tensor, op=None, async_op=False):
+                if tensor.shape[0] > 8:
+                    calls.append("outer_custom")
+                    tensor.fill_(99)
+                    return None
+                calls.append("outer_fallback")
+                return self._inner_pg.all_reduce(
+                    tensor,
+                    op=op,
+                    async_op=async_op,
+                )
+
+        def create_inner(dist_opts, pg_options=None):
+            return _InnerPG(dist_opts.group_rank, dist_opts.group_size)
+
+        def create_outer(dist_opts, pg_options=None):
+            pg = _OuterPG(dist_opts.group_rank, dist_opts.group_size)
+            dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+            return pg
+
+        dist.Backend.register_backend(
+            "fb_inner",
+            create_inner,
+            extended_api=True,
+        )
+        dist.Backend.register_backend(
+            "fb_outer",
+            create_outer,
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "fb_outer(fb_inner)",
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        try:
+            # Small tensor: outer falls back to inner
+            tensor = torch.zeros(4)
+            dist.all_reduce(tensor)
+            self.assertEqual(calls, ["outer_fallback", "inner"])
+            self.assertEqual(tensor, torch.full((4,), 10.0))
+
+            # Large tensor: outer handles it directly
+            calls.clear()
+            tensor = torch.zeros(16)
+            dist.all_reduce(tensor)
+            self.assertEqual(calls, ["outer_custom"])
+            self.assertEqual(tensor, torch.full((16,), 99.0))
+        finally:
+            dist.destroy_process_group()
+
+    def test_passthrough_kwargs_forwarding(self):
+        """Subset PG with **kwargs forwards extra params to inner PG."""
+
+        calls = []
+
+        class _InnerPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "kw_inner"
+
+            def broadcast(self, tensor, src=None, async_op=False, group_src=None):
+                calls.append(
+                    {
+                        "op": "inner_broadcast",
+                        "src": src,
+                        "group_src": group_src,
+                    }
+                )
+                tensor.fill_(7)
+                return None
+
+        class _OuterPG(dist.distributed_c10d.PassthroughProcessGroup):
+            def broadcast(self, tensor, src=None, async_op=False, **kwargs):
+                calls.append({"op": "outer_broadcast"})
+                return self._inner_pg.broadcast(
+                    tensor,
+                    src=src,
+                    async_op=async_op,
+                    **kwargs,
+                )
+
+        def create_inner(dist_opts, pg_options=None):
+            return _InnerPG(dist_opts.group_rank, dist_opts.group_size)
+
+        def create_outer(dist_opts, pg_options=None):
+            pg = _OuterPG(dist_opts.group_rank, dist_opts.group_size)
+            dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+            return pg
+
+        dist.Backend.register_backend(
+            "kw_inner",
+            create_inner,
+            extended_api=True,
+        )
+        dist.Backend.register_backend(
+            "kw_outer",
+            create_outer,
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "kw_outer(kw_inner)",
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        try:
+            tensor = torch.zeros(4)
+            dist.broadcast(tensor, src=0, group_src=42)
+            self.assertEqual(len(calls), 2)
+            self.assertEqual(calls[0]["op"], "outer_broadcast")
+            self.assertEqual(calls[1]["op"], "inner_broadcast")
+            self.assertEqual(calls[1]["src"], 0)
+            self.assertEqual(calls[1]["group_src"], 42)
+            self.assertEqual(tensor, torch.full((4,), 7.0))
+        finally:
+            dist.destroy_process_group()
+
+    def test_passthrough_pg_options_dict(self):
+        """pg_options dict dispatches per-layer options to each creator."""
+
+        received_opts = {}
+
+        class _InnerPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "opts_inner"
+
+        class _OuterPG(dist.distributed_c10d.PassthroughProcessGroup):
+            pass
+
+        def create_inner(dist_opts, pg_options=None):
+            received_opts["inner"] = pg_options
+            received_opts["inner_dist"] = dist_opts.pg_options
+            return _InnerPG(dist_opts.group_rank, dist_opts.group_size)
+
+        def create_outer(dist_opts, pg_options=None):
+            received_opts["outer"] = pg_options
+            received_opts["outer_dist"] = dist_opts.pg_options
+            pg = _OuterPG(dist_opts.group_rank, dist_opts.group_size)
+            dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+            return pg
+
+        dist.Backend.register_backend(
+            "opts_inner",
+            create_inner,
+            extended_api=True,
+        )
+        dist.Backend.register_backend(
+            "opts_outer",
+            create_outer,
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+
+        outer_opts = {"compression": True}
+        inner_opts = {"batch_size": 64}
+        dist_pg_opts = "nccl_options_placeholder"
+
+        dist.init_process_group(
+            "opts_outer(opts_inner)",
+            rank=self.rank,
+            world_size=self.world_size,
+            pg_options={
+                "opts_outer": outer_opts,
+                "opts_inner": inner_opts,
+                "dist": dist_pg_opts,
+            },
+        )
+
+        try:
+            # Outer creator got its own options and dist options
+            self.assertEqual(received_opts["outer"], outer_opts)
+            self.assertEqual(received_opts["outer_dist"], dist_pg_opts)
+
+            # Inner creator got its own options and dist options
+            self.assertEqual(received_opts["inner"], inner_opts)
+            self.assertEqual(received_opts["inner_dist"], dist_pg_opts)
+        finally:
+            dist.destroy_process_group()
+
+    def test_passthrough_pg_options_non_dict(self):
+        """Non-dict pg_options passes through to dist as-is."""
+
+        received_opts = {}
+
+        class _InnerPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "ndopt_inner"
+
+        class _OuterPG(dist.distributed_c10d.PassthroughProcessGroup):
+            pass
+
+        def create_inner(dist_opts, pg_options=None):
+            received_opts["inner"] = pg_options
+            received_opts["inner_dist"] = dist_opts.pg_options
+            return _InnerPG(dist_opts.group_rank, dist_opts.group_size)
+
+        def create_outer(dist_opts, pg_options=None):
+            received_opts["outer"] = pg_options
+            received_opts["outer_dist"] = dist_opts.pg_options
+            pg = _OuterPG(dist_opts.group_rank, dist_opts.group_size)
+            dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+            return pg
+
+        dist.Backend.register_backend(
+            "ndopt_inner",
+            create_inner,
+            extended_api=True,
+        )
+        dist.Backend.register_backend(
+            "ndopt_outer",
+            create_outer,
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+
+        raw_opts = "some_nccl_options"
+        dist.init_process_group(
+            "ndopt_outer(ndopt_inner)",
+            rank=self.rank,
+            world_size=self.world_size,
+            pg_options=raw_opts,
+        )
+
+        try:
+            # Non-dict: creators get pg_options=None,
+            # dist_opts.pg_options carries the raw value
+            self.assertIsNone(received_opts["outer"])
+            self.assertEqual(received_opts["outer_dist"], raw_opts)
+            self.assertIsNone(received_opts["inner"])
+            self.assertEqual(received_opts["inner_dist"], raw_opts)
+        finally:
+            dist.destroy_process_group()
+
+    def test_passthrough_pg_options_invalid_key(self):
+        """pg_options dict with unknown keys raises ValueError."""
+
+        class _SimplePG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "valopt_simple"
+
+        dist.Backend.register_backend(
+            "valopt_simple",
+            lambda *args, **kwargs: _SimplePG(args[0].group_rank, args[0].group_size),
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+
+        with self.assertRaises(ValueError):
+            dist.init_process_group(
+                "valopt_simple",
+                rank=self.rank,
+                world_size=self.world_size,
+                pg_options={"bogus_key": "value"},
+            )
+
+    def test_nested_three_layers(self):
+        """Three-layer nesting: outer(middle(inner))."""
+
+        calls = []
+
+        class _Layer(dist.distributed_c10d.PassthroughProcessGroup):
+            pass
+
+        class _InnerPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "layer_inner"
+
+            def all_reduce(self, tensor, op=None, async_op=False):
+                calls.append("inner")
+                tensor.add_(1)
+                return None
+
+        class _MiddlePG(_Layer):
+            def broadcast(self, tensor, src=None, async_op=False, **kwargs):
+                calls.append("middle")
+                tensor.add_(10)
+                return None
+
+        class _OuterPG(_Layer):
+            def barrier(self, async_op=False, **kwargs):
+                calls.append("outer_barrier")
+                return None
+
+        def create_inner(dist_opts, pg_options=None):
+            return _InnerPG(dist_opts.group_rank, dist_opts.group_size)
+
+        def create_middle(dist_opts, pg_options=None):
+            pg = _MiddlePG(dist_opts.group_rank, dist_opts.group_size)
+            dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+            return pg
+
+        def create_outer(dist_opts, pg_options=None):
+            pg = _OuterPG(dist_opts.group_rank, dist_opts.group_size)
+            dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+            return pg
+
+        dist.Backend.register_backend(
+            "layer_inner",
+            create_inner,
+            extended_api=True,
+        )
+        dist.Backend.register_backend(
+            "layer_middle",
+            create_middle,
+            extended_api=True,
+        )
+        dist.Backend.register_backend(
+            "layer_outer",
+            create_outer,
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "layer_outer(layer_middle(layer_inner))",
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        try:
+            # barrier: defined on _OuterPG
+            dist.barrier()
+            self.assertEqual(calls, ["outer_barrier"])
+
+            # broadcast: not on _OuterPG, delegates to _MiddlePG
+            calls.clear()
+            tensor = torch.zeros(4)
+            dist.broadcast(tensor, src=0)
+            self.assertEqual(calls, ["middle"])
+            self.assertEqual(tensor, torch.full((4,), 10.0))
+
+            # all_reduce: not on _OuterPG or _MiddlePG,
+            # delegates to _InnerPG
+            calls.clear()
+            tensor = torch.zeros(4)
+            dist.all_reduce(tensor)
+            self.assertEqual(calls, ["inner"])
+            self.assertEqual(tensor, torch.ones(4))
+        finally:
+            dist.destroy_process_group()
+
+    def test_passthrough_custom_work(self):
+        """Passthrough PG can return a custom Work object."""
+
+        calls = []
+
+        class _CustomWork:
+            def __init__(self, inner_work, op_name):
+                self._inner = inner_work
+                self._op_name = op_name
+
+            def wait(self):
+                calls.append(f"wait:{self._op_name}")
+                if self._inner is not None:
+                    return self._inner.wait()
+                return True
+
+        class _InnerPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "work_inner"
+
+            def all_reduce(self, tensor, op=None, async_op=False):
+                calls.append("inner_all_reduce")
+                tensor.add_(5)
+                return None
+
+        class _OuterPG(dist.distributed_c10d.PassthroughProcessGroup):
+            def all_reduce(self, tensor, op=None, async_op=False, **kwargs):
+                inner_work = self._inner_pg.all_reduce(
+                    tensor,
+                    op=op,
+                    async_op=async_op,
+                    **kwargs,
+                )
+                calls.append("outer_wrapped")
+                return _CustomWork(inner_work, "all_reduce")
+
+        def create_inner(dist_opts, pg_options=None):
+            return _InnerPG(dist_opts.group_rank, dist_opts.group_size)
+
+        def create_outer(dist_opts, pg_options=None):
+            pg = _OuterPG(dist_opts.group_rank, dist_opts.group_size)
+            dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+            return pg
+
+        dist.Backend.register_backend(
+            "work_inner",
+            create_inner,
+            extended_api=True,
+        )
+        dist.Backend.register_backend(
+            "work_outer",
+            create_outer,
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "work_outer(work_inner)",
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        try:
+            tensor = torch.zeros(4)
+            work = dist.all_reduce(tensor, async_op=True)
+            self.assertIsInstance(work, _CustomWork)
+            work.wait()
+            self.assertEqual(
+                calls,
+                ["inner_all_reduce", "outer_wrapped", "wait:all_reduce"],
+            )
+            self.assertEqual(tensor, torch.full((4,), 5.0))
+        finally:
+            dist.destroy_process_group()
+
+    def test_passthrough_new_group_wraps_subgroup(self):
+        """Passthrough PG can override new_group to wrap subgroups."""
+
+        calls = []
+
+        class _InnerPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "ng_inner"
+
+            def all_reduce(self, tensor, op=None, async_op=False):
+                calls.append("inner_all_reduce")
+                tensor.add_(1)
+                return None
+
+        class _OuterPG(dist.distributed_c10d.PassthroughProcessGroup):
+            def all_reduce(self, tensor, op=None, async_op=False, **kwargs):
+                calls.append("outer_all_reduce")
+                return self._inner_pg.all_reduce(
+                    tensor,
+                    op=op,
+                    async_op=async_op,
+                    **kwargs,
+                )
+
+            def new_group(
+                self,
+                ranks,
+                timeout=None,
+                pg_options=None,
+                group_name=None,
+                group_desc=None,
+            ):
+                calls.append("outer_new_group")
+                my_rank = self.rank()
+                if my_rank not in ranks:
+                    return None
+                inner_sub = _InnerPG(
+                    ranks.index(my_rank),
+                    len(ranks),
+                )
+                sub = _OuterPG(
+                    ranks.index(my_rank),
+                    len(ranks),
+                )
+                sub._inner_pg = inner_sub
+                sub._dist = self._dist
+                dist.register_process_group(sub, group_name, ranks)
+                return sub
+
+        def create_inner(dist_opts, pg_options=None):
+            return _InnerPG(
+                dist_opts.group_rank,
+                dist_opts.group_size,
+            )
+
+        def create_outer(dist_opts, pg_options=None):
+            pg = _OuterPG(
+                dist_opts.group_rank,
+                dist_opts.group_size,
+            )
+            dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+            return pg
+
+        dist.Backend.register_backend(
+            "ng_inner",
+            create_inner,
+            extended_api=True,
+        )
+        dist.Backend.register_backend(
+            "ng_outer",
+            create_outer,
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "ng_outer(ng_inner)",
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        try:
+            sub_pg = dist.new_group(ranks=[0, 1])
+            self.assertIn("outer_new_group", calls)
+
+            if self.rank in [0, 1]:
+                self.assertIsNotNone(sub_pg)
+                self.assertNotEqual(
+                    sub_pg,
+                    dist.distributed_c10d.GroupMember.NON_GROUP_MEMBER,
+                )
+                self.assertIsInstance(
+                    sub_pg,
+                    _OuterPG,
+                )
+
+                calls.clear()
+                tensor = torch.zeros(4)
+                dist.all_reduce(tensor, group=sub_pg)
+                self.assertIn("outer_all_reduce", calls)
+                self.assertIn("inner_all_reduce", calls)
+                self.assertEqual(tensor, torch.ones(4))
+            else:
+                self.assertTrue(
+                    sub_pg is None
+                    or sub_pg == dist.distributed_c10d.GroupMember.NON_GROUP_MEMBER
+                )
+        finally:
+            dist.destroy_process_group()
+
+    def test_terminal_split_group_with_register(self):
+        """Terminal PG can override split_group and register subgroups."""
+
+        calls = []
+
+        class _TerminalPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "sg_terminal"
+
+            def all_reduce(self, tensor, op=None, async_op=False):
+                calls.append("all_reduce")
+                tensor.fill_(float(self.size()))
+                return None
+
+            def split_group(
+                self,
+                split_ranks=None,
+                timeout=None,
+                pg_options=None,
+                group_desc=None,
+                **kwargs,
+            ):
+                calls.append("split_group")
+                my_rank = self.rank()
+                my_ranks = None
+                for rank_list in split_ranks:
+                    if my_rank in rank_list:
+                        my_ranks = rank_list
+                        break
+                if my_ranks is None:
+                    return None
+                child_name = group_desc or "split"
+                sub = _TerminalPG(
+                    my_ranks.index(my_rank),
+                    len(my_ranks),
+                )
+                dist.register_process_group(sub, child_name, my_ranks)
+                return sub
+
+        dist.Backend.register_backend(
+            "sg_terminal",
+            lambda *args, **kwargs: _TerminalPG(args[0].group_rank, args[0].group_size),
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "sg_terminal",
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        try:
+            sub_pg = dist.split_group(
+                split_ranks=[[0, 1], [2, 3]],
+                group_desc="test_split",
+            )
+            self.assertIn("split_group", calls)
+            self.assertIsNotNone(sub_pg)
+            self.assertEqual(sub_pg.size(), 2)
+
+            calls.clear()
+            tensor = torch.zeros(4)
+            dist.all_reduce(tensor, group=sub_pg)
+            self.assertIn("all_reduce", calls)
+            self.assertEqual(tensor, torch.full((4,), 2.0))
+        finally:
+            dist.destroy_process_group()
+
+    def test_terminal_new_group_with_register(self):
+        """Terminal PG can override new_group and register subgroups."""
+
+        calls = []
+
+        class _TerminalPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "ngt_terminal"
+
+            def all_reduce(self, tensor, op=None, async_op=False):
+                calls.append("all_reduce")
+                tensor.fill_(float(self.size()))
+                return None
+
+            def new_group(
+                self,
+                ranks,
+                timeout=None,
+                pg_options=None,
+                group_name=None,
+                group_desc=None,
+            ):
+                calls.append("new_group")
+                my_rank = self.rank()
+                if my_rank not in ranks:
+                    return None
+                sub = _TerminalPG(
+                    ranks.index(my_rank),
+                    len(ranks),
+                )
+                dist.register_process_group(sub, group_name, ranks)
+                return sub
+
+        dist.Backend.register_backend(
+            "ngt_terminal",
+            lambda *args, **kwargs: _TerminalPG(args[0].group_rank, args[0].group_size),
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "ngt_terminal",
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        try:
+            sub_pg = dist.new_group(ranks=[0, 1])
+            self.assertIn("new_group", calls)
+
+            if self.rank in [0, 1]:
+                self.assertIsNotNone(sub_pg)
+                self.assertEqual(sub_pg.size(), 2)
+
+                calls.clear()
+                tensor = torch.zeros(4)
+                dist.all_reduce(tensor, group=sub_pg)
+                self.assertIn("all_reduce", calls)
+                self.assertEqual(tensor, torch.full((4,), 2.0))
+            else:
+                self.assertTrue(
+                    sub_pg is None
+                    or sub_pg == dist.distributed_c10d.GroupMember.NON_GROUP_MEMBER
+                )
+        finally:
+            dist.destroy_process_group()
+
+    def test_pg_bypass_isend_irecv(self):
+        """@_pg_bypass forwards dist.isend/irecv to pg.isend/irecv."""
+
+        calls = []
+
+        class _P2PPG(dist.ProcessGroup):
+            def __init__(self, rank, size):
+                super().__init__(rank, size)
+
+            def getBackendName(self):
+                return "p2p_bypass"
+
+            def isend(self, tensor, dst=0, tag=0, group_dst=None, **kwargs):
+                calls.append(
+                    {
+                        "op": "isend",
+                        "shape": list(tensor.shape),
+                        "dst": dst,
+                    }
+                )
+
+                class _FakeWork:
+                    def wait(self):
+                        return True
+
+                return _FakeWork()
+
+            def irecv(self, tensor, src=None, tag=0, group_src=None, **kwargs):
+                calls.append(
+                    {
+                        "op": "irecv",
+                        "shape": list(tensor.shape),
+                        "src": src,
+                    }
+                )
+                tensor.fill_(99.0)
+
+                class _FakeWork:
+                    def wait(self):
+                        return True
+
+                return _FakeWork()
+
+        dist.Backend.register_backend(
+            "p2p_bypass",
+            lambda *args, **kwargs: _P2PPG(args[0].group_rank, args[0].group_size),
+            extended_api=True,
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "p2p_bypass",
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        try:
+            tensor = torch.zeros(4)
+            if self.rank == 0:
+                work = dist.isend(tensor, dst=1)
+                self.assertIsNotNone(work)
+                work.wait()
+                self.assertEqual(len(calls), 1)
+                self.assertEqual(calls[0]["op"], "isend")
+                self.assertEqual(calls[0]["dst"], 1)
+            else:
+                work = dist.irecv(tensor, src=0)
+                self.assertIsNotNone(work)
+                work.wait()
+                self.assertEqual(len(calls), 1)
+                self.assertEqual(calls[0]["op"], "irecv")
+                self.assertEqual(calls[0]["src"], 0)
+                self.assertEqual(tensor, torch.full((4,), 99.0))
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/CUSTOM_PG.md
+++ b/torch/distributed/CUSTOM_PG.md
@@ -1,0 +1,428 @@
+# Custom Python Process Groups (Experimental)
+
+> **Note:** This is an experimental feature and subject to change.
+
+## Overview
+
+Distributed training code is full of calls like `dist.all_reduce`,
+`dist.broadcast`, and `dist.barrier`.  When end users need to add cross-cutting
+behavior -- logging every collective, timing them, compressing tensors before
+sending, or injecting fault tolerance -- they typically have to modify every
+call site throughout their codebase. This is tedious, error-prone, and hard to
+maintain.
+
+Custom Python process groups solve this by letting you customize behavior at the
+process group level, not the call site level.  All of the custom logic sits in a
+centralized location -- the custom PG class and its creator function. The only
+changes at the user callsite are:
+
+1. Register the custom PG backend (one-time setup).
+2. Update the backend string in `dist.init_process_group`.
+
+After that, every `dist.*` call in the entire codebase automatically goes
+through the custom logic.  No other code changes needed.
+
+Here are some common use cases:
+
+**Logging and monitoring.** You want to log every collective operation, track
+latency, count bytes transferred, or emit metrics to a dashboard. With a
+passthrough PG, you override the collectives you care about, add your logging,
+and delegate to the inner PG. Every `dist.*` call in your training loop is
+automatically instrumented.
+
+**Timing and profiling.** You want to measure how long each collective takes
+without modifying your training code.  A passthrough PG can wrap each
+collective's Work object to record start/end times, then return the wrapped Work
+to the caller transparently.
+
+**Compression and quantization.** You want to compress tensors
+before sending and decompress after receiving to reduce
+communication bandwidth. A passthrough PG overrides `all_gather`
+or `all_to_all` to compress the input, call the inner PG's
+collective, and decompress the output.
+
+**Custom collective implementations.** You have a specialized implementation of
+a subset of collectives optimized for your infrastructure -- for example, a
+hierarchical all-reduce that exploits your network topology. You can use either
+a passthrough PG (overriding specific collectives while delegating the rest to
+NCCL) or a terminal PG (implementing everything from scratch).
+
+**Custom collective functions.** You want to define entirely new collective
+operations like `my_special_all_reduce` that don't exist in PyTorch. You can
+define these as methods on your custom PG and call them as
+`dist.my_special_all_reduce(tensor, group=pg)` without modifying PyTorch. The
+module-level `__getattr__` on `torch.distributed` forwards unknown function
+names to the PG automatically.
+
+**Composing multiple customizations.** You want logging AND compression, each as
+a separate reusable module.  Passthrough PGs can be stacked:
+`"logging(compression(cuda:nccl))"`.  Each layer handles its concern and
+delegates to the next.  The layers are independent and can be mixed and matched.
+
+The key idea: a custom PG intercepts `dist.*` calls at the Python level and
+receives the original Python arguments.  It can implement collectives from
+scratch (terminal PG), selectively override some and delegate the rest
+(passthrough PG), or stack multiple layers of custom behavior on top of a
+standard backend.
+
+## Quick Start
+
+There are three steps to creating a custom PG:
+
+1. Define a class that extends `ProcessGroup` (terminal) or
+   `PassthroughProcessGroup` (passthrough).
+2. Define a creator function that constructs the PG.
+3. Register the backend with `dist.Backend.register_backend`.
+
+Then use it with `dist.init_process_group("my_backend")` or, for passthrough
+backends, `dist.init_process_group("my_backend(cuda:nccl)")`.
+
+## Terminal Process Groups
+
+A terminal PG extends `ProcessGroup` directly and implements
+collectives from scratch.  To intercept `dist.*` calls like
+`dist.all_reduce(tensor)`, define the method with the Python
+dist.* API signature (e.g., `all_reduce(self, tensor, op,
+async_op)`).  You can also override C++ virtual methods (e.g.,
+`allreduce(self, tensor_list, opts)`) for code that calls them
+directly on the PG instance.
+
+```python
+import torch.distributed as dist
+
+class MyPG(dist.ProcessGroup):
+    def __init__(self, rank, size):
+        super().__init__(rank, size)
+
+    def getBackendName(self):
+        return "my_pg"
+
+    def all_reduce(self, tensor, op=None, async_op=False):
+        # custom implementation
+        ...
+
+def create_my_pg(dist_opts, pg_options=None):
+    return MyPG(dist_opts.group_rank, dist_opts.group_size)
+
+dist.Backend.register_backend(
+    "my_pg", create_my_pg, extended_api=True,
+)
+dist.init_process_group("my_pg")
+```
+
+After `init_process_group`, calls like `dist.all_reduce(tensor)` are forwarded
+directly to `MyPG.all_reduce` with the original Python arguments. Collectives
+not defined on `MyPG` fall through to the standard C++ path (which will fail if
+there is no C++ backend).
+
+## Passthrough Process Groups
+
+A passthrough PG wraps an inner PG, intercepts some collectives, and delegates
+everything else to the inner PG.  This is the common pattern for adding
+monitoring, compression, quantization, or other middleware on top of a standard
+backend like NCCL.
+
+```python
+import torch.distributed as dist
+
+class MyWrapper(dist.PassthroughProcessGroup):
+    def all_reduce(self, tensor, op=None, async_op=False, **kwargs):
+        if self._should_customize(tensor):
+            # custom path
+            ...
+        else:
+            # fall back to the inner PG
+            return self._inner_pg.all_reduce(
+                tensor, op=op, async_op=async_op, **kwargs,
+            )
+
+def create(dist_opts, pg_options=None):
+    pg = MyWrapper(dist_opts.group_rank, dist_opts.group_size)
+    dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+    return pg
+
+dist.Backend.register_backend(
+    "my_wrapper", create, extended_api=True,
+)
+dist.init_process_group("my_wrapper(cuda:nccl,cpu:gloo)")
+```
+
+Key points:
+
+- Call `setup_inner_pg(pg, dist_opts)` in the creator to create and
+  attach the inner PG.  Do NOT set `_inner_pg` directly.
+- Methods that accept a subset of the `dist.*` parameters should
+  include `**kwargs` so unhandled parameters are forwarded.
+- `PassthroughProcessGroup` provides default forwarding methods for
+  ALL `dist.*` collectives, so you only override what you need.
+- C++ virtual methods (`allreduce`, `allgather`, etc.) are also
+  forwarded to `self._inner_pg` for code that calls them directly.
+- Custom collectives not in the `dist.*` API are delegated via
+  `__getattr__`.
+- Custom PGs can override `new_group` and `split_group` to
+  control how sub-process-groups are created. Without this,
+  subgroups created via `dist.new_group()` or
+  `dist.split_group()` will be standard ProcessGroup instances
+  that do NOT have the custom PG's overrides. If the custom
+  behavior should apply to subgroups too, the custom PG must
+  override `new_group` and/or `split_group` to wrap the
+  resulting subgroup in another instance of itself.
+  See the **Subgroup Creation** section below for details.
+
+## Nesting / Stacking
+
+Passthrough backends can be stacked using nested backend strings. The nesting
+syntax uses parentheses to indicate which backend wraps which:
+
+```python
+dist.init_process_group("outer(inner(cuda:nccl,cpu:gloo))")
+```
+
+This creates three layers:
+- `outer` wraps `inner`, which wraps the standard NCCL/Gloo PG.
+- When `dist.broadcast` is called, `outer` gets first shot.  If it
+  doesn't override `broadcast`, `PassthroughProcessGroup`'s default
+  forwarding calls `dist.broadcast(group=inner_pg)`, which gives
+  `inner` a shot, and so on down to NCCL.
+
+Each layer's creator receives `dist_opts.inner` with the next level's
+spec.  `setup_inner_pg(pg, dist_opts)` handles the recursion automatically.
+
+The nesting is parsed left-to-right.  The outermost backend
+name comes first, followed by its inner in parentheses.
+The inner is opaque to PyTorch -- it is simply passed as
+a string to the custom process group via `dist_opts.inner`.
+The custom process group decides how to interpret it. Examples:
+
+```
+"my_logger(cuda:nccl)"
+    -- inner "cuda:nccl" passed to my_logger
+
+"compressor(my_logger(cuda:nccl))"
+    -- inner "my_logger(cuda:nccl)" passed to compressor
+
+"my_custom_backend"
+    -- no inner (dist_opts.inner is None)
+
+"my_custom_backend(cuda,cpu)"
+    -- inner "cuda,cpu" passed to my_custom_backend
+
+"my_custom_backend(cuda:nccl,cpu:gloo)"
+    -- inner "cuda:nccl,cpu:gloo" passed to
+       my_custom_backend
+```
+
+Each passthrough creator function looks the same regardless of nesting depth.
+The creator does not need to know or care what the inner backend is -- it just
+calls `setup_inner_pg(pg, dist_opts)` and the framework handles the rest:
+
+```python
+def create_my_logger(dist_opts, pg_options=None):
+    pg = MyLoggerPG(dist_opts.group_rank, dist_opts.group_size)
+    dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+    return pg
+
+def create_compressor(dist_opts, pg_options=None):
+    pg = CompressorPG(dist_opts.group_rank, dist_opts.group_size)
+    dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+    return pg
+```
+
+Both creators are identical in structure.  To compose them:
+
+```python
+dist.Backend.register_backend(
+    "my_logger", create_my_logger, extended_api=True, )
+dist.Backend.register_backend(
+    "compressor", create_compressor, extended_api=True, )
+
+# Use them individually:
+dist.init_process_group("my_logger(cuda:nccl)")
+
+# Or stack them:
+dist.init_process_group("compressor(my_logger(cuda:nccl))")
+```
+
+The layers are independent and reusable.  You can add, remove, or reorder them
+by changing only the backend string.
+
+## Custom Work Objects
+
+Custom PGs can return their own Work objects from collective methods for
+monitoring, logging, or custom async behavior:
+
+```python
+class MonitoredWork:
+    def __init__(self, inner_work, op_name):
+        self._inner = inner_work
+        self._op_name = op_name
+
+    def wait(self):
+        start = time.time()
+        result = self._inner.wait() if self._inner else True
+        log_latency(self._op_name, time.time() - start)
+        return result
+
+class MonitoredPG(dist.PassthroughProcessGroup):
+    def all_reduce(self, tensor, op=None, async_op=False, **kwargs):
+        work = self._inner_pg.all_reduce(
+            tensor, op=op, async_op=async_op, **kwargs,
+        )
+        return MonitoredWork(work, "all_reduce")
+```
+
+The caller receives the custom Work object and `.wait()` works transparently.
+This enables per-collective latency tracking, profiling, or custom
+synchronization behavior.
+
+## pg_options
+
+`pg_options` can be passed as a dict keyed by backend name to provide per-layer
+options:
+
+```python
+dist.init_process_group(
+    "outer(inner(cuda:nccl,cpu:gloo))",
+    pg_options={
+        "outer": OuterOpts(...),
+        "inner": InnerOpts(...),
+        "dist": ProcessGroupNCCL.Options(...),
+    }, )
+```
+
+- Each layer's creator receives its own entry as the `pg_options`
+  argument.  For example, `outer`'s creator gets `OuterOpts(...)`.
+- The `"dist"` entry carries terminal C++ backend options (e.g.,
+  `ProcessGroupNCCL.Options`) and is available to every layer via
+  `dist_opts.pg_options`.
+- Keys must be either registered backend names or `"dist"`. Unknown
+  keys raise `ValueError`.
+- If `pg_options` is not a dict, it is treated as dist/terminal
+  options: each custom layer's creator receives `pg_options=None`,
+  and the value passes through to the C++ backend at the bottom.
+
+## Subgroup Creation
+
+When `dist.new_group()` or `dist.split_group()` is called, the default
+process group's `new_group` or `split_group` method is invoked via
+`@_pg_bypass`.  The custom PG is responsible for creating and registering
+the subgroup.
+
+### `new_group`
+
+Override `new_group` on your PG class to create subgroups:
+
+```python
+class MyPG(dist.ProcessGroup):
+    def new_group(self, ranks, timeout=None, pg_options=None,
+                  group_name=None, group_desc=None):
+        # Create the subgroup however you need to.
+        sub_pg = MyPG(...)
+
+        # Register the subgroup so dist.* calls on it work.
+        dist.register_process_group(sub_pg, group_name, ranks)
+
+        return sub_pg  # or None if this rank is not a member
+```
+
+`dist.new_group()` calls `pg.new_group(ranks, timeout, pg_options,
+group_name, group_desc)` on the default PG.  The `group_name` is
+generated by PyTorch and must be passed to `register_process_group`
+as-is.  If this rank is not a member, return `None`.
+
+### `split_group`
+
+Override `split_group` to handle `dist.split_group()`:
+
+```python
+class MyPG(dist.ProcessGroup):
+    def split_group(self, split_ranks=None, timeout=None,
+                    pg_options=None, group_desc=None, **kwargs):
+        # Find which split this rank belongs to.
+        my_rank = self.rank()
+        my_ranks = None
+        for rank_list in split_ranks:
+            if my_rank in rank_list:
+                my_ranks = rank_list
+                break
+
+        if my_ranks is None:
+            return None  # not a member of any split
+
+        # Create the subgroup.
+        child_name = group_desc or "split_%d" % self._split_counter
+        sub_pg = MyPG(...)
+
+        # Register the subgroup.
+        dist.register_process_group(sub_pg, child_name, my_ranks)
+
+        return sub_pg
+```
+
+`dist.split_group()` calls `pg.split_group(split_ranks, timeout,
+pg_options, group_desc)` on the parent PG.  The `split_ranks` is a
+list of lists -- each inner list is one subgroup's ranks.  All ranks
+in the parent PG must participate in the call.
+
+### `register_process_group`
+
+Both `new_group` and `split_group` must call
+`dist.register_process_group(pg, group_name, ranks)` to register
+the newly created subgroup.  This is required so that subsequent
+`dist.*` calls on the subgroup pass PyTorch's internal validation.
+
+```python
+dist.register_process_group(
+    pg,          # the new ProcessGroup
+    group_name,  # unique name (from group_name arg or self-generated)
+    ranks,       # global ranks of members, in group-rank order
+)
+```
+
+Without registration, calls like `dist.all_reduce(tensor, group=sub_pg)`
+will fail with "Group is not registered".
+
+## File Organization
+
+- `torch/distributed/custom_pg.py`: `PassthroughProcessGroup`,
+  `setup_inner_pg`, `_pg_bypass`, and internal helpers.
+- `torch/distributed/CUSTOM_PG.md`: this documentation.
+- `torch/distributed/distributed_c10d.py`: imports from
+  `custom_pg.py`, `@_pg_bypass`-decorated `dist.*` functions,
+  `_new_process_group_helper` integration for nested backend strings.
+- `test/distributed/test_custom_pg.py`: all custom PG tests.
+
+## Implementation Details
+
+- `@_pg_bypass` decorator on `dist.*` collective functions walks
+  the MRO (stopping at `ProcessGroup`) to find methods with
+  matching parameter names.  The signature check (subset match,
+  ignoring `*args`/`**kwargs`) distinguishes `dist.*` API overrides
+  from C++ virtual method overrides.  Results are cached per class.
+- `PassthroughProcessGroup` forwarding methods call
+  `self._dist.<fn>(group=self._inner_pg)`, re-entering the
+  `_pg_bypass` mechanism on the inner PG.  This is how collectives
+  chain through nested layers without explicit inner-PG walking.
+- `_parse_nested_backend()` parses `"outer(inner(...))"` backend
+  strings into `(outermost, inner)` tuples.
+- `_DistributedBackendOpts` wraps the C++
+  `_DistributedBackendOptions` to add `inner`, `pg_options`,
+  and `_remaining_pg_options`.
+- `_pop_pg_options()` splits a `pg_options` dict into per-layer,
+  dist, and remaining entries.
+- `_create_process_group()` uses a unique inner group name to avoid
+  registration conflicts with the outer PG.
+- `register_process_group(pg, group_name, ranks)` is the public API
+  for registering custom-created subgroups in PyTorch's global state.
+  It wraps `_register_pg_in_world` with sensible defaults so custom
+  PGs don't need to manipulate `_world` internals directly.
+- `@_pg_bypass` on `dist.new_group` and `dist.split_group` delegates
+  subgroup creation to the custom PG's `new_group`/`split_group`
+  methods.  The custom PG is responsible for calling
+  `register_process_group` on the newly created subgroup.  For
+  functions like `new_group` that have no `group` parameter,
+  `@_pg_bypass` uses the default PG (group_pos=-1 path).
+- Module-level `__getattr__` on `torch.distributed` forwards custom
+  collectives defined on PG subclasses.  Guarded by
+  `is_initialized()` so submodule imports (e.g.,
+  `torch.distributed.fsdp`) are not intercepted during startup.

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -174,3 +174,38 @@ else:
 
     sys.modules["torch.distributed"].GroupName = _Stub  # type: ignore[attr-defined]
     sys.modules["torch.distributed"].ProcessGroup = _Stub  # type: ignore[attr-defined]
+
+
+def __getattr__(name):
+    """Forward unknown function calls to the default ProcessGroup.
+
+    Enables custom collectives defined on a ProcessGroup subclass
+    to be called as ``dist.<fn>(..., group=pg)`` without modifying
+    this module.  ``group`` must be passed as a keyword argument;
+    defaults to WORLD.
+
+    Only active after ``init_process_group`` has been called, so
+    submodule imports (e.g., ``torch.distributed.fsdp``) are not
+    intercepted during startup.
+    """
+    try:
+        from .distributed_c10d import _get_default_group
+
+        default_pg = _get_default_group()
+    except (ValueError, ImportError):
+        raise AttributeError(
+            f"module 'torch.distributed' has no attribute '{name}'"
+        ) from None
+
+    def _forward(*args, group=None, **kwargs):
+        group = group or default_pg
+        pg_fn = getattr(group, name, None)
+        if pg_fn is None:
+            raise AttributeError(
+                f"'{type(group)}' process group has no attribute '{name}'"
+            )
+        return pg_fn(*args, **kwargs)
+
+    _forward.__name__ = name
+    _forward.__qualname__ = f"torch.distributed.{name}"
+    return _forward

--- a/torch/distributed/custom_pg.py
+++ b/torch/distributed/custom_pg.py
@@ -1,0 +1,444 @@
+"""Custom Python process groups.
+
+See CUSTOM_PG.md for full documentation and usage examples.
+"""
+
+import inspect
+import weakref
+from functools import wraps
+
+from torch._C._distributed_c10d import ProcessGroup
+
+
+__all__ = [
+    "PassthroughProcessGroup",
+    "setup_inner_pg",
+]
+
+
+# =====================================================================
+# Internal helpers
+# =====================================================================
+
+
+class _DistributedBackendOpts:
+    """Python wrapper around C++ ``_DistributedBackendOptions``.
+
+    Extra fields for custom Python process groups:
+    ``inner``, ``pg_options``, ``_remaining_pg_options``.
+    """
+
+    _extra_fields = frozenset(
+        {
+            "inner",
+            "pg_options",
+            "_remaining_pg_options",
+        }
+    )
+
+    def __init__(self, base):
+        object.__setattr__(self, "_base", base)
+        object.__setattr__(self, "inner", None)
+        object.__setattr__(self, "pg_options", None)
+        object.__setattr__(self, "_remaining_pg_options", None)
+
+    def __getattr__(self, name: str):
+        return getattr(self._base, name)
+
+    def __setattr__(self, name: str, value):
+        if name in _DistributedBackendOpts._extra_fields:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._base, name, value)
+
+
+def _pop_pg_options(pg_options, backend_name: str):
+    """Extract per-layer and dist pg_options from *pg_options*.
+
+    Returns ``(this_layer_opts, dist_opts, remaining_dict)``.
+    """
+    if not isinstance(pg_options, dict):
+        return None, pg_options, None
+    from torch.distributed.distributed_c10d import Backend
+
+    valid_keys = {"dist"} | {k.lower() for k in Backend._plugins}
+    unknown = set(pg_options) - valid_keys
+    if unknown:
+        raise ValueError(
+            f"Unknown keys in pg_options dict: {unknown}. "
+            f"Valid keys are registered backend names or 'dist'."
+        )
+    rest = dict(pg_options)
+    this_layer = rest.pop(backend_name, None)
+    dist = rest.pop("dist", None)
+    remaining = rest if rest else None
+    return this_layer, dist, remaining
+
+
+def _create_process_group(dist_opts):
+    """Create a process group from the backend string in *dist_opts*.
+
+    Called internally by ``setup_inner_pg``.
+    """
+    from torch.distributed.distributed_c10d import _new_process_group_helper, GroupName
+
+    inner = dist_opts.inner
+    if inner is None:
+        raise ValueError(
+            "_create_process_group called with no inner in dist_opts. "
+            "This is only for passthrough backends with a nested backend spec."
+        )
+
+    remaining = dist_opts._remaining_pg_options
+    dist_pg_options = dist_opts.pg_options
+    if remaining is not None:
+        backend_options = dict(remaining)
+        if dist_pg_options is not None:
+            backend_options["dist"] = dist_pg_options
+    else:
+        backend_options = dist_pg_options
+
+    store = dist_opts.store
+    group_rank = dist_opts.group_rank
+    group_size = dist_opts.group_size
+    timeout = dist_opts.timeout
+    group_name = dist_opts.group_id
+    global_ranks_in_group = dist_opts.global_ranks_in_group
+
+    inner_name = f"{group_name}/inner"
+    pg, _ = _new_process_group_helper(
+        group_size,
+        group_rank,
+        global_ranks_in_group,
+        inner,
+        store,
+        GroupName(inner_name),
+        backend_options=backend_options,
+        timeout=timeout,
+    )
+    return pg
+
+
+def _pg_bypass(group_param="group"):
+    """Decorator: if the ProcessGroup overrides the function, forward directly.
+
+    Walks the MRO (stopping at ProcessGroup) to find methods with
+    matching parameter names.  The signature check (subset match,
+    ignoring *args/**kwargs) distinguishes dist.* API overrides from
+    C++ virtual method overrides.  Cached per class.
+    """
+
+    def decorator(fn):
+        sig = inspect.signature(fn)
+        params = list(sig.parameters)
+        group_pos = params.index(group_param) if group_param in params else -1
+        fn_param_names = {p for p in sig.parameters if p != group_param}
+
+        _sig_cache: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+        def _has_matching_sig(cls):
+            if cls not in _sig_cache:
+                method = cls.__dict__.get(fn.__name__)
+                if method is None:
+                    _sig_cache[cls] = False
+                elif not fn_param_names:
+                    _sig_cache[cls] = True
+                else:
+                    try:
+                        pg_sig = inspect.signature(method)
+                        pg_params = {
+                            p
+                            for p, v in pg_sig.parameters.items()
+                            if p != "self"
+                            and v.kind
+                            not in (
+                                inspect.Parameter.VAR_POSITIONAL,
+                                inspect.Parameter.VAR_KEYWORD,
+                            )
+                        }
+                        _sig_cache[cls] = bool(pg_params) and pg_params.issubset(
+                            fn_param_names
+                        )
+                    except (ValueError, TypeError):
+                        _sig_cache[cls] = False
+            return _sig_cache[cls]
+
+        def _find_bypass(group):
+            for cls in type(group).__mro__:
+                if cls is ProcessGroup or cls is object:
+                    break
+                if _has_matching_sig(cls):
+                    return cls.__dict__[fn.__name__], group
+            return None, None
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            from torch.distributed.distributed_c10d import _get_default_group
+            if group_pos < 0:
+                group = None
+            elif group_param in kwargs:
+                group = kwargs.pop(group_param)
+            elif len(args) > group_pos:
+                group = args[group_pos]
+                args = args[:group_pos] + args[group_pos + 1 :]
+            else:
+                group = None
+            group = group or _get_default_group()
+            pg_fn, target_pg = _find_bypass(group)
+            if pg_fn is not None:
+                return pg_fn(target_pg, *args, **kwargs)
+            if group_pos < 0:
+                return fn(*args, **kwargs)
+            return fn(*args, **{group_param: group, **kwargs})
+
+        return wrapper
+
+    return decorator
+
+
+# =====================================================================
+# Public API
+# =====================================================================
+
+
+class PassthroughProcessGroup(ProcessGroup):
+    """Base class for custom backends that wrap an inner ProcessGroup.
+
+    See CUSTOM_PG.md for full documentation and usage examples.
+    Use setup_inner_pg(pg, dist_opts) in the creator to attach
+    the inner PG.  Do NOT set _inner_pg directly.
+    """
+
+    def __init__(self, rank: int, size: int):
+        super().__init__(rank, size)  # pyrefly: ignore[missing-argument, bad-argument-type]
+        self._inner_pg = None
+        import torch.distributed as _dist
+
+        self._dist = _dist
+
+    def getBackendName(self) -> str:
+        return type(self).__name__
+
+    def __getattr__(self, name: str):
+        inner = self.__dict__.get("_inner_pg")
+        if inner is None:
+            raise AttributeError(name)
+        fn = getattr(inner, name, None)
+        if fn is not None:
+            return fn
+        raise AttributeError(name)
+
+    # -- C++ virtual method overrides (forward to inner PG) -----------
+    # These ensure that direct C++ calls like group.allreduce(...)
+    # are forwarded to the inner PG rather than failing with
+    # "No backend type associated with device type".
+
+    def allreduce(self, tensors, opts=None):  # pyrefly: ignore[bad-override]
+        return self._inner_pg.allreduce(tensors, opts)  # pyrefly: ignore[missing-attribute]
+
+    def allreduce_coalesced(self, tensors, opts=None):  # pyrefly: ignore[bad-override]
+        return self._inner_pg.allreduce_coalesced(tensors, opts)  # pyrefly: ignore[missing-attribute]
+
+    def allgather(  # pyrefly: ignore[bad-override]
+        self, output_tensors, input_tensors, opts=None
+    ):
+        return self._inner_pg.allgather(output_tensors, input_tensors, opts)  # pyrefly: ignore[missing-attribute]
+
+    def _allgather_base(
+        self, output, input, opts=None
+    ):  # pyrefly: ignore[bad-override]
+        return self._inner_pg._allgather_base(output, input, opts)  # pyrefly: ignore[missing-attribute]
+
+    def allgather_coalesced(
+        self, output_lists, input_list, opts=None
+    ):  # pyrefly: ignore[bad-override]
+        return self._inner_pg.allgather_coalesced(output_lists, input_list, opts)  # pyrefly: ignore[missing-attribute]
+
+    def allgather_into_tensor_coalesced(
+        self, outputs, inputs, opts=None
+    ):  # pyrefly: ignore[bad-override]
+        return self._inner_pg.allgather_into_tensor_coalesced(outputs, inputs, opts)  # pyrefly: ignore[missing-attribute]
+
+    def reduce_scatter_tensor_coalesced(
+        self, outputs, inputs, opts=None
+    ):  # pyrefly: ignore[bad-override]
+        return self._inner_pg.reduce_scatter_tensor_coalesced(outputs, inputs, opts)  # pyrefly: ignore[missing-attribute]
+
+    def _reduce_scatter_base(
+        self, output, input, opts=None
+    ):  # pyrefly: ignore[bad-override]
+        return self._inner_pg._reduce_scatter_base(output, input, opts)  # pyrefly: ignore[missing-attribute]
+
+    def alltoall_base(  # pyrefly: ignore[bad-override]
+        self, output, input, output_split_sizes=None,
+        input_split_sizes=None, opts=None,
+    ):
+        return self._inner_pg.alltoall_base(  # pyrefly: ignore[missing-attribute]
+            output, input, output_split_sizes, input_split_sizes, opts)
+
+    def alltoall(  # pyrefly: ignore[bad-override]
+        self, output_tensors, input_tensors, opts=None
+    ):
+        return self._inner_pg.alltoall(output_tensors, input_tensors, opts)  # pyrefly: ignore[missing-attribute]
+
+    # -- Python dist.* forwarding methods ------------------------------
+    # These are found by _pg_bypass's MRO walk and call back into
+    # dist.<fn>(group=self._inner_pg) so the bypass mechanism handles
+    # the inner PG correctly.
+
+    def send(self, tensor, dst=0, tag=0, group_dst=None, **kwargs):  # pyrefly: ignore[bad-override]
+        return self._dist.send(tensor, dst=dst, group=self._inner_pg,
+                               tag=tag, group_dst=group_dst, **kwargs)
+
+    def isend(self, tensor, dst=0, tag=0, group_dst=None, **kwargs):
+        return self._dist.isend(tensor, dst=dst, group=self._inner_pg,
+                                tag=tag, group_dst=group_dst, **kwargs)
+
+    def recv(self, tensor, src=None, tag=0, group_src=None, **kwargs):  # pyrefly: ignore[bad-override]
+        return self._dist.recv(tensor, src=src, group=self._inner_pg,
+                               tag=tag, group_src=group_src, **kwargs)
+
+    def irecv(self, tensor, src=None, tag=0, group_src=None, **kwargs):
+        return self._dist.irecv(tensor, src=src, group=self._inner_pg,
+                                tag=tag, group_src=group_src, **kwargs)
+
+    def broadcast(self, tensor, src=None, async_op=False,  # pyrefly: ignore[bad-override]
+                  group_src=None, **kwargs):
+        return self._dist.broadcast(
+            tensor, src=src, group=self._inner_pg,
+            async_op=async_op, group_src=group_src, **kwargs)
+
+    def all_reduce(self, tensor, op=None, async_op=False, **kwargs):
+        return self._dist.all_reduce(
+            tensor, op=op, group=self._inner_pg,
+            async_op=async_op, **kwargs)
+
+    def all_reduce_coalesced(self, tensors, op=None, async_op=False,
+                             **kwargs):
+        return self._dist.all_reduce_coalesced(
+            tensors, op=op, group=self._inner_pg,
+            async_op=async_op, **kwargs)
+
+    def reduce(self, tensor, dst=0, op=None, async_op=False,  # pyrefly: ignore[bad-override]
+               group_dst=None, **kwargs):
+        return self._dist.reduce(
+            tensor, dst=dst, op=op, group=self._inner_pg,
+            async_op=async_op, group_dst=group_dst, **kwargs)
+
+    def all_gather_object(self, object_list, obj, **kwargs):
+        return self._dist.all_gather_object(
+            object_list, obj, group=self._inner_pg, **kwargs)
+
+    def gather_object(self, obj, object_gather_list=None, dst=0,
+                      group_dst=None, **kwargs):
+        return self._dist.gather_object(
+            obj, object_gather_list=object_gather_list, dst=dst,
+            group=self._inner_pg, group_dst=group_dst, **kwargs)
+
+    def send_object_list(self, object_list, dst=0, device=None,
+                         group_dst=None, use_batch=False, **kwargs):
+        return self._dist.send_object_list(
+            object_list, dst=dst, group=self._inner_pg, device=device,
+            group_dst=group_dst, use_batch=use_batch, **kwargs)
+
+    def recv_object_list(self, object_list, src=0, device=None,
+                         group_src=None, use_batch=False, **kwargs):
+        return self._dist.recv_object_list(
+            object_list, src=src, group=self._inner_pg, device=device,
+            group_src=group_src, use_batch=use_batch, **kwargs)
+
+    def broadcast_object_list(self, object_list, src=None, device=None,
+                              group_src=None, **kwargs):
+        return self._dist.broadcast_object_list(
+            object_list, src=src, group=self._inner_pg, device=device,
+            group_src=group_src, **kwargs)
+
+    def scatter_object_list(self, scatter_object_output_list,
+                            scatter_object_input_list, src=0,
+                            group_src=None, **kwargs):
+        return self._dist.scatter_object_list(
+            scatter_object_output_list, scatter_object_input_list,
+            src=src, group=self._inner_pg, group_src=group_src, **kwargs)
+
+    def all_gather(self, tensor_list, tensor, async_op=False, **kwargs):
+        return self._dist.all_gather(
+            tensor_list, tensor, group=self._inner_pg,
+            async_op=async_op, **kwargs)
+
+    def all_gather_into_tensor(self, output_tensor, input_tensor,
+                               async_op=False, **kwargs):
+        return self._dist.all_gather_into_tensor(
+            output_tensor, input_tensor, group=self._inner_pg,
+            async_op=async_op, **kwargs)
+
+    def all_gather_coalesced(self, output_tensor_lists,
+                             input_tensor_list, async_op=False, **kwargs):
+        return self._dist.all_gather_coalesced(
+            output_tensor_lists, input_tensor_list,
+            group=self._inner_pg, async_op=async_op, **kwargs)
+
+    def gather(self, tensor, gather_list=None, dst=0, async_op=False,  # pyrefly: ignore[bad-override]
+               group_dst=None, **kwargs):
+        return self._dist.gather(
+            tensor, gather_list=gather_list, dst=dst,
+            group=self._inner_pg, async_op=async_op,
+            group_dst=group_dst, **kwargs)
+
+    def scatter(self, tensor, scatter_list=None, src=0, async_op=False,  # pyrefly: ignore[bad-override]
+                group_src=None, **kwargs):
+        return self._dist.scatter(
+            tensor, scatter_list=scatter_list, src=src,
+            group=self._inner_pg, async_op=async_op,
+            group_src=group_src, **kwargs)
+
+    def reduce_scatter(self, output, input_list, op=None, async_op=False,  # pyrefly: ignore[bad-override]
+                       **kwargs):
+        return self._dist.reduce_scatter(
+            output, input_list, op=op, group=self._inner_pg,
+            async_op=async_op, **kwargs)
+
+    def reduce_scatter_tensor(self, output, input, op=None,
+                              async_op=False, **kwargs):
+        return self._dist.reduce_scatter_tensor(
+            output, input, op=op, group=self._inner_pg,
+            async_op=async_op, **kwargs)
+
+    def all_to_all_single(self, output, input, output_split_sizes=None,
+                          input_split_sizes=None, async_op=False,
+                          **kwargs):
+        return self._dist.all_to_all_single(
+            output, input, output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+            group=self._inner_pg, async_op=async_op, **kwargs)
+
+    def all_to_all(self, output_tensor_list, input_tensor_list,
+                   async_op=False, **kwargs):
+        return self._dist.all_to_all(
+            output_tensor_list, input_tensor_list,
+            group=self._inner_pg, async_op=async_op, **kwargs)
+
+    def barrier(self, async_op=False, device_ids=None, timeout=None,  # pyrefly: ignore[bad-override]
+                **kwargs):
+        return self._dist.barrier(
+            group=self._inner_pg, async_op=async_op,
+            device_ids=device_ids, timeout=timeout, **kwargs)
+
+    def monitored_barrier(self, timeout=None, wait_all_ranks=False,
+                          **kwargs):
+        return self._dist.monitored_barrier(
+            group=self._inner_pg, timeout=timeout,
+            wait_all_ranks=wait_all_ranks, **kwargs)
+
+
+def setup_inner_pg(pg: PassthroughProcessGroup, dist_opts):
+    """Create the inner PG from *dist_opts* and attach it to *pg*.
+
+    This is called in a passthrough creator function after constructing
+    the custom PG::
+
+        def create_my_passthrough(dist_opts, pg_options=None):
+            pg = MyPassthroughPG(dist_opts.group_rank, dist_opts.group_size)
+            dist.distributed_c10d.setup_inner_pg(pg, dist_opts)
+            return pg
+    """
+    pg._inner_pg = _create_process_group(dist_opts)

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -135,6 +135,7 @@ __all__ = [
     "split_group",
     "shrink_group",
     "record_comm",
+    "register_process_group",
 ]
 
 _MPI_AVAILABLE = True
@@ -414,7 +415,12 @@ class BackendConfig:
         # pyrefly: ignore [bad-assignment]
         backend = str(backend)
 
-        if backend == Backend.UNDEFINED:
+        if "(" in backend:
+            outer, _ = _parse_nested_backend(backend)
+            supported_devices = Backend.backend_capability[outer.lower()]
+            backend_val = Backend(backend)
+            self.device_backend_map = dict.fromkeys(supported_devices, backend_val)
+        elif backend == Backend.UNDEFINED:
             # Detect the accelerator on the machine. If no accelerator is
             # available, it returns CPU.
             device_type = torch._C._get_accelerator().type
@@ -1428,6 +1434,34 @@ def _get_default_group() -> ProcessGroup:
         return GroupMember.WORLD
 
 
+from torch.distributed.custom_pg import (  # noqa: F401
+    _create_process_group,
+    _DistributedBackendOpts,
+    _pg_bypass,
+    _pop_pg_options,
+    PassthroughProcessGroup,
+    setup_inner_pg,
+)
+
+
+def _parse_nested_backend(backend_str: str) -> tuple[str, str | None]:
+    """Parse a possibly nested backend string.
+
+    Returns ``(outer, inner)`` where *inner* is ``None`` for
+    terminal backends.
+    """
+    paren = backend_str.find("(")
+    if paren == -1:
+        return backend_str, None
+    if not backend_str.endswith(")"):
+        raise ValueError(
+            f"Malformed nested backend string: {backend_str!r}. Expected closing ')'."
+        )
+    outer = backend_str[:paren]
+    inner = backend_str[paren + 1 : -1]
+    return outer, inner
+
+
 def _get_default_store() -> Store:
     """Get the default store created by init_process_group."""
     if not is_initialized():
@@ -2065,8 +2099,9 @@ def _new_process_group_helper(
     )
     backend_config = BackendConfig(backend)
     # Set the default backend when single backend is passed in.
+    outer, _ = _parse_nested_backend(str(backend))
     if "," not in str(backend) and ":" not in str(backend):
-        if backend not in Backend.backend_type_map:
+        if outer not in Backend.backend_type_map:
             raise AssertionError(f"Unknown backend type {backend}")
         if backend == Backend.UNDEFINED:
             # Currently when backend is UNDEFINED, only one backend will be initialized
@@ -2077,7 +2112,7 @@ def _new_process_group_helper(
             else:
                 pg._set_default_backend(ProcessGroup.BackendType.GLOO)
         else:
-            pg._set_default_backend(Backend.backend_type_map[backend])
+            pg._set_default_backend(Backend.backend_type_map[outer])
     # In order to correctly call pg._has_hooks(), we should set the default backend
     # when multi backend is passed in
     else:
@@ -2232,10 +2267,12 @@ def _new_process_group_helper(
             )
             backend_type = ProcessGroup.BackendType.XCCL
         else:
-            if backend_str.upper() not in Backend._plugins:
-                raise AssertionError(f"Unknown c10d backend type {backend_str.upper()}")
+            outer, inner = _parse_nested_backend(backend_str)
 
-            backend_plugin = Backend._plugins[backend_str.upper()]
+            if outer.upper() not in Backend._plugins:
+                raise AssertionError(f"Unknown c10d backend type {outer.upper()}")
+
+            backend_plugin = Backend._plugins[outer.upper()]
             creator_fn = backend_plugin.creator_fn
             extended_api = backend_plugin.extended_api
             backend_type = ProcessGroup.BackendType.CUSTOM
@@ -2245,7 +2282,9 @@ def _new_process_group_helper(
                     backend_prefix_store, group_rank, group_size, timeout
                 )
             else:
-                dist_backend_opts = _DistributedBackendOptions()
+                dist_backend_opts = _DistributedBackendOpts(
+                    _DistributedBackendOptions()
+                )
                 dist_backend_opts.store = backend_prefix_store
                 dist_backend_opts.group_rank = group_rank
                 dist_backend_opts.group_size = group_size
@@ -2253,8 +2292,15 @@ def _new_process_group_helper(
                 dist_backend_opts.timeout = timeout
                 dist_backend_opts.group_id = group_name
                 dist_backend_opts.global_ranks_in_group = global_ranks_in_group
+                dist_backend_opts.inner = inner
 
-                backend_class = creator_fn(dist_backend_opts, backend_options)
+                this_opts, dist_opts, remaining = _pop_pg_options(
+                    backend_options, outer.lower()
+                )
+                dist_backend_opts.pg_options = dist_opts
+                dist_backend_opts._remaining_pg_options = remaining
+
+                backend_class = creator_fn(dist_backend_opts, this_opts)
 
         # Set sequence numbers for gloo and nccl backends.
         if backend_str == Backend.GLOO and not _use_torchcomms_enabled():
@@ -2356,6 +2402,7 @@ def _new_process_group_helper(
     return pg, prefix_store
 
 
+@_pg_bypass()
 def destroy_process_group(group: ProcessGroup | None = None):
     """
     Destroy a given process group, and deinitialize the distributed package.
@@ -2593,6 +2640,7 @@ def get_world_size(group: ProcessGroup | None = None) -> int:
     return _get_group_size(group)
 
 
+@_pg_bypass()
 def isend(
     tensor: torch.Tensor,
     dst: int | None = None,
@@ -2650,6 +2698,7 @@ def isend(
     return group.send([tensor], group_dst, tag)
 
 
+@_pg_bypass()
 def irecv(
     tensor: torch.Tensor,
     src: int | None = None,
@@ -2707,6 +2756,7 @@ def irecv(
         return group.recv([tensor], group_src, tag)
 
 
+@_pg_bypass()
 @_exception_logger
 def send(
     tensor: torch.Tensor,
@@ -2751,6 +2801,7 @@ def send(
         work.wait()
 
 
+@_pg_bypass()
 @_exception_logger
 def recv(
     tensor: torch.Tensor,
@@ -3082,6 +3133,7 @@ def _is_fp8(tensor):
     )
 
 
+@_pg_bypass()
 @_exception_logger
 def broadcast(
     tensor: torch.Tensor,
@@ -3152,6 +3204,7 @@ def broadcast(
     # Otherwise, the backend has sync'ed at CPP level
 
 
+@_pg_bypass()
 @_exception_logger
 def all_reduce(tensor, op=ReduceOp.SUM, group=None, async_op: bool = False):
     """
@@ -3253,6 +3306,7 @@ def all_reduce(tensor, op=ReduceOp.SUM, group=None, async_op: bool = False):
     # Otherwise, the backend has sync'ed at CPP level
 
 
+@_pg_bypass()
 @_exception_logger
 @deprecated(
     "`torch.distributed.all_reduce_coalesced` will be deprecated. If you must "
@@ -3333,6 +3387,7 @@ def all_reduce_coalesced(tensors, op=ReduceOp.SUM, group=None, async_op: bool = 
     # Otherwise, the backend has sync'ed at CPP level
 
 
+@_pg_bypass()
 @_exception_logger
 def reduce(
     tensor: torch.Tensor,
@@ -3435,6 +3490,7 @@ def _tensor_to_object(tensor, tensor_size, group):
         return _unpickler(io.BytesIO(buf)).load()
 
 
+@_pg_bypass()
 @_exception_logger
 def all_gather_object(object_list, obj, group=None):
     """
@@ -3530,6 +3586,7 @@ def all_gather_object(object_list, obj, group=None):
         object_list[i] = _tensor_to_object(tensor, tensor_size, group)
 
 
+@_pg_bypass()
 @_exception_logger
 def gather_object(
     obj: Any,
@@ -3661,6 +3718,7 @@ def gather_object(
         object_gather_list[i] = _tensor_to_object(tensor, tensor_size, group)
 
 
+@_pg_bypass()
 @_exception_logger
 def send_object_list(
     object_list: list[Any],
@@ -3779,6 +3837,7 @@ def send_object_list(
         send(object_tensor, group_dst=group_dst, group=group)
 
 
+@_pg_bypass()
 @_exception_logger
 def recv_object_list(
     object_list: list[Any],
@@ -3921,6 +3980,7 @@ def recv_object_list(
     return rank_objects
 
 
+@_pg_bypass()
 @_exception_logger
 def broadcast_object_list(
     object_list: list[Any],
@@ -4053,6 +4113,7 @@ def broadcast_object_list(
             object_list[i] = _tensor_to_object(obj_view, obj_size, group)
 
 
+@_pg_bypass()
 @_exception_logger
 def scatter_object_list(
     scatter_object_output_list: list[Any],
@@ -4188,6 +4249,7 @@ def scatter_object_list(
     )
 
 
+@_pg_bypass()
 @_exception_logger
 def all_gather(tensor_list, tensor, group=None, async_op=False):
     """
@@ -4288,6 +4350,7 @@ def all_gather(tensor_list, tensor, group=None, async_op=False):
     # Otherwise, the backend has sync'ed at CPP level
 
 
+@_pg_bypass()
 @_exception_logger
 def all_gather_into_tensor(output_tensor, input_tensor, group=None, async_op=False):
     """
@@ -4425,6 +4488,7 @@ def _all_gather_base(output_tensor, input_tensor, group=None, async_op: bool = F
     return all_gather_into_tensor(output_tensor, input_tensor, group, async_op)
 
 
+@_pg_bypass()
 @_exception_logger
 @deprecated(
     "`torch.distributed.all_gather_coalesced` will be deprecated. If you must use it, "
@@ -4546,6 +4610,7 @@ def _validate_output_list_for_rank(my_rank: int, dst: int, gather_list):
         )
 
 
+@_pg_bypass()
 @_exception_logger
 def gather(
     tensor: torch.Tensor,
@@ -4650,6 +4715,7 @@ def gather(
     # Otherwise, the backend has sync'ed at CPP level
 
 
+@_pg_bypass()
 @_exception_logger
 def scatter(
     tensor: torch.Tensor,
@@ -4768,6 +4834,7 @@ def scatter(
     # Otherwise, the backend has sync'ed at CPP level
 
 
+@_pg_bypass()
 @_exception_logger
 def reduce_scatter(
     output, input_list, op=ReduceOp.SUM, group=None, async_op: bool = False
@@ -4825,6 +4892,7 @@ def reduce_scatter(
     # Otherwise, the backend has sync'ed at CPP level
 
 
+@_pg_bypass()
 @_exception_logger
 def reduce_scatter_tensor(output, input, op=ReduceOp.SUM, group=None, async_op=False):
     """
@@ -4956,6 +5024,7 @@ def _reduce_scatter_base(
     return reduce_scatter_tensor(output, input, op, group, async_op)
 
 
+@_pg_bypass()
 @_exception_logger
 def all_to_all_single(
     output,
@@ -5105,6 +5174,7 @@ def all_to_all_single(
     # Otherwise, the backend has sync'ed at CPP level
 
 
+@_pg_bypass()
 @_exception_logger
 def all_to_all(
     output_tensor_list, input_tensor_list, group=None, async_op: bool = False
@@ -5244,6 +5314,7 @@ def all_to_all(
     # Otherwise, the backend has sync'ed at CPP level
 
 
+@_pg_bypass()
 @_exception_logger
 def barrier(
     group: ProcessGroup | None = GroupMember.WORLD,
@@ -5321,6 +5392,7 @@ def barrier(
     # Otherwise, the backend has sync'ed at CPP level
 
 
+@_pg_bypass()
 def monitored_barrier(
     group: ProcessGroup | None = GroupMember.WORLD,
     timeout=None,
@@ -5477,6 +5549,7 @@ def _is_safe_to_split() -> bool:
     return _get_default_group().bound_device_id is not None
 
 
+@_pg_bypass(group_param="parent_pg")
 @_time_logger
 def split_group(
     parent_pg: ProcessGroup | None = None,
@@ -5697,6 +5770,7 @@ def split_group(
     return split_pg
 
 
+@_pg_bypass()
 @_time_logger
 def new_group(
     ranks=None,
@@ -5879,34 +5953,6 @@ def _new_group_with_tag(
 
     group_name = _process_group_name(ranks, use_hashed_name=use_local_synchronization)
 
-    # If the default PG implements new_group, delegate to it. This allows
-    # custom Python PG subclasses to handle subgroup creation in a single
-    # call, avoiding the per-device creator iteration in
-    # _new_process_group_helper.
-    if hasattr(default_pg, "new_group") and callable(default_pg.new_group):
-        pg_or_none = default_pg.new_group(
-            ranks,
-            timeout=timeout,
-            pg_options=backend_options,
-            group_name=group_name,
-            group_desc=group_desc,
-        )
-        if pg_or_none is None:
-            return GroupMember.NON_GROUP_MEMBER
-
-        pg: ProcessGroup = pg_or_none  # pyrefly: ignore[bad-assignment]
-        _register_pg_in_world(
-            pg,
-            backend_name=backend,
-            store=PrefixStore(f"{group_name}/", default_store),
-            group_name=group_name,
-            backend_config=str(BackendConfig(backend)),
-            rank_mapping={
-                global_rank: group_rank for group_rank, global_rank in enumerate(ranks)
-            },
-        )
-        return pg
-
     pg, pg_store = _new_process_group_helper(
         group_world_size,
         group_rank,
@@ -5954,6 +6000,7 @@ def _new_group_with_tag(
     return pg
 
 
+@_pg_bypass()
 def new_subgroups(
     group_size=None,
     group=None,
@@ -6671,6 +6718,36 @@ def _cleanup_process_group_global_state(pg: ProcessGroup) -> None:
         logger.warning(
             "Failed to fully clean up global state for process group", exc_info=True
         )
+
+
+def register_process_group(
+    pg: ProcessGroup,
+    group_name: str,
+    ranks: list[int],
+) -> None:
+    """Register a custom-created process group in the global state.
+
+    Custom PG backends that create subgroups (via new_group, split_group,
+    or manual construction) must register them so that ``dist.*`` calls
+    on the subgroup pass validation.
+
+    Args:
+        pg: The process group to register.
+        group_name: A unique name for this group.
+        ranks: Global ranks of the members, in group-rank order.
+            ``ranks[i]`` is the global rank of group rank ``i``.
+    """
+    default_store = _get_default_store()
+    _register_pg_in_world(
+        pg,
+        backend_name="",
+        store=PrefixStore(f"{group_name}/", default_store),
+        group_name=GroupName(group_name),
+        backend_config="",
+        rank_mapping={
+            global_rank: group_rank for group_rank, global_rank in enumerate(ranks)
+        },
+    )
 
 
 def _register_pg_in_world(


### PR DESCRIPTION
Summary:

Add experimental infrastructure for custom Python process
groups that can intercept dist.* collective calls with the
original Python arguments. See CUSTOM_PG.md for full
documentation.

Two kinds of custom PGs are supported:

1. Terminal -- extends ProcessGroup directly, implements
   collectives with the dist.* API signature.
2. Passthrough -- extends PassthroughProcessGroup, wraps an
   inner PG, intercepts some collectives, delegates the rest.
   Supports nesting: "outer(inner(cuda:nccl,cpu:gloo))".

Key features:

- PassthroughProcessGroup provides forwarding methods for all
  dist.* collectives and C++ virtual methods.
- setup_inner_pg(pg, dist_opts) creates and attaches the inner
  PG. Subclasses should NOT set _inner_pg directly.
- Custom Work objects can be returned from collective methods.
- pg_options can be a dict keyed by backend name for per-layer
  options, with "dist" for terminal C++ backend options.
- _pg_bypass decorator walks the MRO with signature-based
  subset matching to distinguish dist.* overrides from C++
  virtual methods.
- Module-level __getattr__ on torch.distributed forwards
  custom collectives, guarded by is_initialized().

File organization:

- torch/distributed/custom_pg.py: PassthroughProcessGroup,
  setup_inner_pg, _pg_bypass, and internal helpers.
- torch/distributed/CUSTOM_PG.md: full documentation.
- torch/distributed/distributed_c10d.py: imports from
  custom_pg.py, _pg_bypass-decorated dist.* functions.
- test/distributed/test_custom_pg.py: all custom PG tests.

Test Plan: CI

Differential Revision: D106611088


