### PR TITLE
[Test] Replace torch.cuda.empty_cache with torch.accelerator.empty_cache in test/test_scatter_gather_ops.py 

### DIFF
--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -74,7 +74,8 @@ class TestScatterGather(TestCase):
     def test_gather_large(self, device, dtype):
         # test larger shapes to check vectorized implementation
         for (m, n, k) in ((4096, 3072, 4096), (4096, 3072, 4100), (4, 4, 16384 * 8192)):
-            torch.accelerator.empty_cache()
+            if device != "cpu":
+                torch.accelerator.empty_cache()
             src = make_tensor((m, k), device=device, dtype=dtype)
             alloc0 = torch.empty(src.nelement() * 2, device=device, dtype=dtype)
             discontig = alloc0.view(m, 2 * k)[:, ::2].copy_(src)
@@ -303,7 +304,8 @@ class TestScatterGather(TestCase):
         else:
             shapes.append((4, 4, 16384 * 256))
         for (m, n, k) in shapes:
-            torch.accelerator.empty_cache()
+            if device != "cpu":
+                torch.accelerator.empty_cache()
             self_tensor = torch.zeros(m, k, device=device, dtype=dtype)
             src = make_tensor((n, k), device=device, dtype=dtype)
             # contiguous + aligned (should hit fast path on dim=0)

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -74,7 +74,7 @@ class TestScatterGather(TestCase):
     def test_gather_large(self, device, dtype):
         # test larger shapes to check vectorized implementation
         for (m, n, k) in ((4096, 3072, 4096), (4096, 3072, 4100), (4, 4, 16384 * 8192)):
-            torch.cuda.empty_cache()
+            torch.accelerator.empty_cache()
             src = make_tensor((m, k), device=device, dtype=dtype)
             alloc0 = torch.empty(src.nelement() * 2, device=device, dtype=dtype)
             discontig = alloc0.view(m, 2 * k)[:, ::2].copy_(src)
@@ -303,7 +303,7 @@ class TestScatterGather(TestCase):
         else:
             shapes.append((4, 4, 16384 * 256))
         for (m, n, k) in shapes:
-            torch.cuda.empty_cache()
+            torch.accelerator.empty_cache()
             self_tensor = torch.zeros(m, k, device=device, dtype=dtype)
             src = make_tensor((n, k), device=device, dtype=dtype)
             # contiguous + aligned (should hit fast path on dim=0)


### PR DESCRIPTION
## Summary
Replace hardcoded `torch.cuda.empty_cache()` calls in `TestScatterGather` class with `torch.accelerator.empty_cache()` to avoid CUDA-specific assumptions.

## Test Plan
`pytest test/test_scatter_gather_ops.py -v -k "test_gather_large or test_scatter_add_large"`

- 7 passed, 3 skipped, 220 deselected