### PR TITLE
[torch][fx] Skip GraphModule construction in CSEPass when nothing changed

### DIFF
--- a/torch/fx/passes/dialect/common/cse_pass.py
+++ b/torch/fx/passes/dialect/common/cse_pass.py
@@ -153,5 +153,7 @@ class CSEPass(PassBase):
                     hash_env[hash_val] = new_node
                     token_map[hash_val] = token
 
+        if not modified:
+            return PassResult(graph_module, False)
         csed_gm = GraphModule(graph_module, new_graph)
-        return PassResult(csed_gm, modified)
+        return PassResult(csed_gm, True)


### PR DESCRIPTION
Summary: CSEPass always constructed a new GraphModule (triggering recompile) even when no common subexpressions were eliminated. Now returns the original graph_module directly when modified is False, avoiding unnecessary graph copying and code generation.

Test Plan: Should be NFC.

Differential Revision: D106613141


