### PR TITLE
[Test] Support dtype-aware device test exclusions

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 import torch
 import torch.distributed as dist
 from torch.testing._internal.common_device_type import (
+    dtypes,
     instantiate_device_type_tests,
     onlyCUDA,
     onlyOn,
@@ -177,6 +178,38 @@ class TestSkippedWholeTestClass(TestCase):
         self.fail("This class should not be instantiated for openreg")
 
 
+class TestDtypeAwareExclusions(TestCase):
+    executed_dtypes: dict = defaultdict(list)
+
+    @classmethod
+    def tearDownClass(cls):
+        expected = {
+            "test_dtype_filter": [torch.float64],
+            "test_dtype_tuple_filter": [(torch.float64, torch.int64)],
+        }
+        if cls.executed_dtypes != expected:
+            raise AssertionError(
+                f"Dtype-aware exclusions failed: expected {expected}, "
+                f"got {cls.executed_dtypes}"
+            )
+        super().tearDownClass()
+
+    @dtypes(torch.float32, torch.float64)
+    def test_dtype_filter(self, device, dtype):
+        self.assertEqual(torch.device(device).type, "openreg")
+        type(self).executed_dtypes["test_dtype_filter"].append(dtype)
+
+    @dtypes(torch.float32, torch.float64)
+    def test_all_dtypes_excluded(self, device, dtype):
+        self.assertEqual(torch.device(device).type, "openreg")
+        self.fail("This method should not have any dtype variants for openreg")
+
+    @dtypes((torch.float64, torch.int32), (torch.float64, torch.int64))
+    def test_dtype_tuple_filter(self, device, dtypes):
+        self.assertEqual(torch.device(device).type, "openreg")
+        type(self).executed_dtypes["test_dtype_tuple_filter"].append(dtypes)
+
+
 class TestSupportedOpsWithOverrides(TestCase):
     """Verify that op_allowlist filtering works together with op_overrides.
 
@@ -234,6 +267,26 @@ with _temp_test_configs(PrivateUse1TestBase, test_exclusions=OPENREG_TEST_EXCLUS
     )
     instantiate_device_type_tests(
         TestSkippedWholeTestClass, globals(), only_for="openreg"
+    )
+
+OPENREG_DTYPE_TEST_EXCLUSIONS = {
+    "TestDtypeAwareExclusions": {
+        "test_dtype_filter": {
+            "dtypes": [torch.float32],
+        },
+        "test_all_dtypes_excluded": {
+            "dtypes": [torch.float32, torch.float64],
+        },
+        "test_dtype_tuple_filter": {
+            "dtypes": [torch.int32],
+        },
+    },
+}
+with _temp_test_configs(
+    PrivateUse1TestBase, test_exclusions=OPENREG_DTYPE_TEST_EXCLUSIONS
+):
+    instantiate_device_type_tests(
+        TestDtypeAwareExclusions, globals(), only_for="openreg"
     )
 
 with _temp_test_configs(

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -10,7 +10,7 @@ import sys
 import threading
 import unittest
 from collections import namedtuple
-from collections.abc import Callable, Collection, Iterable, Sequence
+from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from enum import Enum
 from functools import partial, wraps
 from typing import Any, ClassVar, TypeVar
@@ -348,15 +348,44 @@ class DeviceTypeTestBase(TestCase):
     op_allowlist = None  # type: Optional[Collection[str]]
 
     # An optional skip mechanism built upon instantiate_device_type_tests(),
-    # designed to facilitate skipping either an entire class or specific test cases
-    # within a class.
+    # designed to filter generated tests at different granularities.
+    #
+    # Supported exclusions:
+    #   - Exclude an entire test class
+    #   - Exclude specific test methods within a class
+    #   - Exclude specific @dtypes/@dtypesIf-generated dtype variants of a
+    #     test method
     #
     # Format:
+    #
     #   test_exclusions = {
-    #       "TestClassA": ["test_a", "test_b"],   # Selective: Skips specific
-    #       "TestClassB": "*",                    # Global: Skips the entire class
+    #       # Exclude all generated variants in the class.
+    #       "TestClassA": "*",
+    #
+    #       # Backward-compatible shorthand: exclude all generated variants
+    #       # of specific methods.
+    #       "TestClassB": ["test_a", "test_b"],
+    #
+    #       # Unified form: supports unconditional method exclusions and
+    #       # dtype-specific generated variant exclusions.
+    #       "TestClassC": {
+    #           "test_a": "*",
+    #           "test_b": {
+    #               "dtypes": [torch.float32],
+    #           },
+    #       },
     #   }
-    test_exclusions: ClassVar[dict[str, Collection[str]] | None] = None
+    #
+    # Note:
+    #   Conditional filtering currently only supports per-method dtype-based
+    #   filtering for variants generated from @dtypes and @dtypesIf decorators
+    #   in the unified mapping form. Class-level dtype exclusions are not
+    #   supported.
+    #   A tuple/list dtype variant is excluded if any dtype in the variant is
+    #   listed in the method's excluded dtypes.
+    #   @ops-generated dtype variants and other parametrized arguments are
+    #   ignored for now.
+    test_exclusions: ClassVar[dict[str, Any] | None] = None
 
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
@@ -430,7 +459,65 @@ class DeviceTypeTestBase(TestCase):
         test_exclusions = getattr(cls, "test_exclusions", None)
         if test_exclusions is not None and test_class_name in test_exclusions:
             return test_exclusions[test_class_name]
-        return []
+        return None
+
+    @classmethod
+    def _should_exclude_test(cls, test_class_name, test_name=None):
+        exclusion_rule = cls._get_test_exclusions(test_class_name)
+
+        if exclusion_rule is None:
+            return False
+
+        # Exclude the entire test class.
+        if exclusion_rule == "*":
+            return True
+
+        # test_name is None means we are only checking class-level exclusion.
+        if test_name is None:
+            return False
+
+        # Unified form: "test_a": "*" excludes all generated variants of
+        # the method. Conditional mapping entries are handled separately.
+        if isinstance(exclusion_rule, Mapping):
+            return exclusion_rule.get(test_name) == "*"
+
+        # Backward-compatible shorthand: ["test_a", "test_b"].
+        if isinstance(exclusion_rule, Collection) and not isinstance(
+            exclusion_rule, (str, bytes)
+        ):
+            return test_name in exclusion_rule
+
+        return False
+
+    @classmethod
+    def _should_exclude_test_conditionally(
+        cls, test_class_name, test_name, *, dtypes=None
+    ):
+        return cls._should_exclude_dtype_variant(
+            test_class_name, test_name, dtypes=dtypes
+        )
+
+    @classmethod
+    def _should_exclude_dtype_variant(cls, test_class_name, test_name, *, dtypes=None):
+        if dtypes is None:
+            return False
+
+        exclusion_rule = cls._get_test_exclusions(test_class_name)
+
+        if not isinstance(exclusion_rule, Mapping):
+            return False
+
+        method_exclusion = exclusion_rule.get(test_name)
+        if not isinstance(method_exclusion, Mapping):
+            return False
+
+        excluded_dtypes = set(method_exclusion.get("dtypes", ()))
+        if not excluded_dtypes:
+            return False
+
+        if isinstance(dtypes, (list, tuple)):
+            return any(component_dtype in excluded_dtypes for component_dtype in dtypes)
+        return dtypes in excluded_dtypes
 
     @classmethod
     def _apply_op_allowlist(cls, ops):
@@ -523,6 +610,10 @@ class DeviceTypeTestBase(TestCase):
     # Creates device-specific tests.
     @classmethod
     def instantiate_test(cls, name, test, *, generic_cls=None):
+        test_class_name = (
+            generic_cls.__name__ if generic_cls is not None else cls.__name__
+        )
+
         def instantiate_test_helper(
             cls, name, *, test, param_kwargs=None, decorator_fn=lambda _: []
         ):
@@ -589,6 +680,16 @@ class DeviceTypeTestBase(TestCase):
         # If one of the @dtypes* decorators is present, also parametrize over the dtypes set by it.
         dtypes = cls._get_dtypes(test)
         if dtypes is not None:
+            dtypes = tuple(
+                dtype
+                for dtype in dtypes
+                if not cls._should_exclude_test_conditionally(
+                    test_class_name, name, dtypes=dtype
+                )
+            )
+
+            if not dtypes:
+                return
 
             def dtype_parametrize_fn(test, generic_cls, device_cls, dtypes=dtypes):
                 for dtype in dtypes:
@@ -1027,9 +1128,8 @@ def instantiate_device_type_tests(
     for base in get_desired_device_type_test_bases(
         except_for, only_for, include_lazy, allow_mps, allow_xpu
     ):
-        skipped = base._get_test_exclusions(generic_test_class.__name__)
         # Skip the entire class
-        if "*" in skipped:
+        if base._should_exclude_test(generic_test_class.__name__):
             continue
 
         class_name = generic_test_class.__name__ + base.device_type.upper()
@@ -1064,7 +1164,7 @@ def instantiate_device_type_tests(
         for name in generic_members:
             if name in generic_tests:  # Instantiates test member
                 # Skip the specified methods.
-                if name in skipped:
+                if base._should_exclude_test(generic_test_class.__name__, name):
                     continue
                 test = getattr(generic_test_class, name)
                 # XLA-compat shim (XLA's instantiate_test takes doesn't take generic_cls)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -491,15 +491,32 @@ class DeviceTypeTestBase(TestCase):
 
     @classmethod
     def _should_exclude_test_conditionally(
-        cls, test_class_name, test_name, *, dtypes=None
+        cls, test_class_name, test_name, *, dtype_variant=None
     ):
+        """Entry point for conditional test variant exclusion.
+
+        Currently only supports dtype-based exclusion (delegating to
+        _should_exclude_dtype_variant), but is designed as a separate
+        method so that future non-dtype conditional exclusions (e.g.
+        based on device capabilities or other test parameters) can
+        be added here without changing the call site in instantiate_test.
+        """
         return cls._should_exclude_dtype_variant(
-            test_class_name, test_name, dtypes=dtypes
+            test_class_name, test_name, dtype_variant=dtype_variant
         )
 
     @classmethod
-    def _should_exclude_dtype_variant(cls, test_class_name, test_name, *, dtypes=None):
-        if dtypes is None:
+    def _should_exclude_dtype_variant(
+        cls, test_class_name, test_name, *, dtype_variant=None
+    ):
+        """Check whether a dtype variant should be excluded.
+
+        Args:
+            dtype_variant: Either a single torch.dtype (e.g. torch.float32) or
+                a tuple of dtypes (e.g. (torch.float64, torch.int32)) from a
+                @dtypes decorator with tuple variants.
+        """
+        if dtype_variant is None:
             return False
 
         exclusion_rule = cls._get_test_exclusions(test_class_name)
@@ -515,9 +532,11 @@ class DeviceTypeTestBase(TestCase):
         if not excluded_dtypes:
             return False
 
-        if isinstance(dtypes, (list, tuple)):
-            return any(component_dtype in excluded_dtypes for component_dtype in dtypes)
-        return dtypes in excluded_dtypes
+        if isinstance(dtype_variant, (list, tuple)):
+            return any(
+                component_dtype in excluded_dtypes for component_dtype in dtype_variant
+            )
+        return dtype_variant in excluded_dtypes
 
     @classmethod
     def _apply_op_allowlist(cls, ops):
@@ -684,7 +703,7 @@ class DeviceTypeTestBase(TestCase):
                 dtype
                 for dtype in dtypes
                 if not cls._should_exclude_test_conditionally(
-                    test_class_name, name, dtypes=dtype
+                    test_class_name, name, dtype_variant=dtype
                 )
             )
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -362,12 +362,11 @@ class DeviceTypeTestBase(TestCase):
     #       # Exclude all generated variants in the class.
     #       "TestClassA": "*",
     #
-    #       # Backward-compatible shorthand: exclude all generated variants
-    #       # of specific methods.
+    #       # Simple form: exclude all generated variants of specific methods.
     #       "TestClassB": ["test_a", "test_b"],
     #
-    #       # Unified form: supports unconditional method exclusions and
-    #       # dtype-specific generated variant exclusions.
+    #       # Advanced form: supports both unconditional method exclusions
+    #       # and fine-grained generated variant exclusions (e.g. by dtype).
     #       "TestClassC": {
     #           "test_a": "*",
     #           "test_b": {
@@ -462,81 +461,54 @@ class DeviceTypeTestBase(TestCase):
         return None
 
     @classmethod
-    def _should_exclude_test(cls, test_class_name, test_name=None):
-        exclusion_rule = cls._get_test_exclusions(test_class_name)
+    def _should_exclude(cls, test_class_name, *, test_name=None, dtype_variant=None):
+        if test_name is None and dtype_variant is not None:
+            raise AssertionError("dtype_variant requires test_name")
 
+        exclusion_rule = cls._get_test_exclusions(test_class_name)
         if exclusion_rule is None:
             return False
 
-        # Exclude the entire test class.
-        if exclusion_rule == "*":
-            return True
+        def _check_class():
+            # "TestClassA": "*" — exclude all generated variants in the class.
+            return exclusion_rule == "*"
 
-        # test_name is None means we are only checking class-level exclusion.
+        def _check_method():
+            # "TestClassC": {"test_a": "*"} — exclude all generated variants of
+            # a specific method.
+            if isinstance(exclusion_rule, Mapping):
+                return exclusion_rule.get(test_name) == "*"
+            # "TestClassB": ["test_a", "test_b"] — simple form, exclude all
+            # generated variants of specific methods.
+            if isinstance(exclusion_rule, Collection) and not isinstance(
+                exclusion_rule, (str, bytes)
+            ):
+                return test_name in exclusion_rule
+            return False
+
+        def _check_dtype():
+            # "TestClassC": {"test_b": {"dtypes": [torch.float32]}} — exclude
+            # specific dtype-generated variants of a method.
+            if not isinstance(exclusion_rule, Mapping):
+                return False
+            method_exclusion = exclusion_rule.get(test_name)
+            if not isinstance(method_exclusion, Mapping):
+                return False
+            excluded_dtypes = set(method_exclusion.get("dtypes", ()))
+            if not excluded_dtypes:
+                return False
+            if isinstance(dtype_variant, (list, tuple)):
+                return any(
+                    component_dtype in excluded_dtypes
+                    for component_dtype in dtype_variant
+                )
+            return dtype_variant in excluded_dtypes
+
         if test_name is None:
-            return False
-
-        # Unified form: "test_a": "*" excludes all generated variants of
-        # the method. Conditional mapping entries are handled separately.
-        if isinstance(exclusion_rule, Mapping):
-            return exclusion_rule.get(test_name) == "*"
-
-        # Backward-compatible shorthand: ["test_a", "test_b"].
-        if isinstance(exclusion_rule, Collection) and not isinstance(
-            exclusion_rule, (str, bytes)
-        ):
-            return test_name in exclusion_rule
-
-        return False
-
-    @classmethod
-    def _should_exclude_test_conditionally(
-        cls, test_class_name, test_name, *, dtype_variant=None
-    ):
-        """Entry point for conditional test variant exclusion.
-
-        Currently only supports dtype-based exclusion (delegating to
-        _should_exclude_dtype_variant), but is designed as a separate
-        method so that future non-dtype conditional exclusions (e.g.
-        based on device capabilities or other test parameters) can
-        be added here without changing the call site in instantiate_test.
-        """
-        return cls._should_exclude_dtype_variant(
-            test_class_name, test_name, dtype_variant=dtype_variant
-        )
-
-    @classmethod
-    def _should_exclude_dtype_variant(
-        cls, test_class_name, test_name, *, dtype_variant=None
-    ):
-        """Check whether a dtype variant should be excluded.
-
-        Args:
-            dtype_variant: Either a single torch.dtype (e.g. torch.float32) or
-                a tuple of dtypes (e.g. (torch.float64, torch.int32)) from a
-                @dtypes decorator with tuple variants.
-        """
+            return _check_class()
         if dtype_variant is None:
-            return False
-
-        exclusion_rule = cls._get_test_exclusions(test_class_name)
-
-        if not isinstance(exclusion_rule, Mapping):
-            return False
-
-        method_exclusion = exclusion_rule.get(test_name)
-        if not isinstance(method_exclusion, Mapping):
-            return False
-
-        excluded_dtypes = set(method_exclusion.get("dtypes", ()))
-        if not excluded_dtypes:
-            return False
-
-        if isinstance(dtype_variant, (list, tuple)):
-            return any(
-                component_dtype in excluded_dtypes for component_dtype in dtype_variant
-            )
-        return dtype_variant in excluded_dtypes
+            return _check_method()
+        return _check_dtype()
 
     @classmethod
     def _apply_op_allowlist(cls, ops):
@@ -629,10 +601,6 @@ class DeviceTypeTestBase(TestCase):
     # Creates device-specific tests.
     @classmethod
     def instantiate_test(cls, name, test, *, generic_cls=None):
-        test_class_name = (
-            generic_cls.__name__ if generic_cls is not None else cls.__name__
-        )
-
         def instantiate_test_helper(
             cls, name, *, test, param_kwargs=None, decorator_fn=lambda _: []
         ):
@@ -702,8 +670,8 @@ class DeviceTypeTestBase(TestCase):
             dtypes = tuple(
                 dtype
                 for dtype in dtypes
-                if not cls._should_exclude_test_conditionally(
-                    test_class_name, name, dtype_variant=dtype
+                if not cls._should_exclude(
+                    generic_cls.__name__, test_name=name, dtype_variant=dtype
                 )
             )
 
@@ -1148,7 +1116,7 @@ def instantiate_device_type_tests(
         except_for, only_for, include_lazy, allow_mps, allow_xpu
     ):
         # Skip the entire class
-        if base._should_exclude_test(generic_test_class.__name__):
+        if base._should_exclude(generic_test_class.__name__):
             continue
 
         class_name = generic_test_class.__name__ + base.device_type.upper()
@@ -1183,7 +1151,7 @@ def instantiate_device_type_tests(
         for name in generic_members:
             if name in generic_tests:  # Instantiates test member
                 # Skip the specified methods.
-                if base._should_exclude_test(generic_test_class.__name__, name):
+                if base._should_exclude(generic_test_class.__name__, test_name=name):
                     continue
                 test = getattr(generic_test_class, name)
                 # XLA-compat shim (XLA's instantiate_test takes doesn't take generic_cls)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -10,7 +10,7 @@ import sys
 import threading
 import unittest
 from collections import namedtuple
-from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import Enum
 from functools import partial, wraps
 from typing import Any, ClassVar, TypeVar
@@ -480,9 +480,7 @@ class DeviceTypeTestBase(TestCase):
                 return exclusion_rule.get(test_name) == "*"
             # "TestClassB": ["test_a", "test_b"] — simple form, exclude all
             # generated variants of specific methods.
-            if isinstance(exclusion_rule, Collection) and not isinstance(
-                exclusion_rule, (str, bytes)
-            ):
+            if isinstance(exclusion_rule, list):
                 return test_name in exclusion_rule
             return False
 
@@ -667,13 +665,14 @@ class DeviceTypeTestBase(TestCase):
         # If one of the @dtypes* decorators is present, also parametrize over the dtypes set by it.
         dtypes = cls._get_dtypes(test)
         if dtypes is not None:
-            dtypes = tuple(
-                dtype
-                for dtype in dtypes
-                if not cls._should_exclude(
-                    generic_cls.__name__, test_name=name, dtype_variant=dtype
+            if generic_cls is not None:
+                dtypes = tuple(
+                    dtype
+                    for dtype in dtypes
+                    if not cls._should_exclude(
+                        generic_cls.__name__, test_name=name, dtype_variant=dtype
+                    )
                 )
-            )
 
             if not dtypes:
                 return


### PR DESCRIPTION
## Summary
Add dtype-aware `test_exclusions` support to `DeviceTypeTestBase`.

This PR extends the existing exclusion mechanism while preserving current behavior:

- Class-level exclusion remains supported via:
  - `"TestClass": "*"`

- Method-level exclusion remains supported via:
  - `["test_a", "test_b"]`

- The unified mapping form now additionally supports:
  - unconditional method exclusion via:
    - `"test_a": "*"`
  - dtype-specific exclusion via:
    - `"test_b": {"dtypes": [...]}`

The dtype-aware filtering currently applies only to dtype variants generated by
`@dtypes` / `@dtypesIf...` decorators.

`@ops`-generated dtype variants and other parametrized arguments are intentionally
out of scope for this change.