### PR TITLE
Add XPU kernels and autocast registrations for TorchScriptTesting que…

### DIFF
--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -769,6 +769,11 @@ TORCH_LIBRARY_IMPL(_TorchScriptTesting, CUDA, m) {
   m.impl("queue_pop", queue_pop);
 }
 
+TORCH_LIBRARY_IMPL(_TorchScriptTesting, XPU, m) {
+  m.impl("queue_push", queue_push);
+  m.impl("queue_pop", queue_pop);
+}
+
 TORCH_LIBRARY_IMPL(_TorchScriptTesting, Meta, m) {
   m.impl("takes_foo", &takes_foo);
   m.impl("takes_foo_list_return", takes_foo_list_return);

--- a/torch/testing/_internal/torchbind_impls.py
+++ b/torch/testing/_internal/torchbind_impls.py
@@ -51,12 +51,18 @@ def register_fake_operators():
     torch.library.register_autocast(
         "_TorchScriptTesting::queue_push", "cuda", torch.float32
     )
+    torch.library.register_autocast(
+        "_TorchScriptTesting::queue_push", "xpu", torch.float32
+    )
 
     torch.library.register_autocast(
         "_TorchScriptTesting::queue_pop", "cpu", torch.float32
     )
     torch.library.register_autocast(
         "_TorchScriptTesting::queue_pop", "cuda", torch.float32
+    )
+    torch.library.register_autocast(
+        "_TorchScriptTesting::queue_pop", "xpu", torch.float32
     )
 
     @torch.library.register_fake("_TorchScriptTesting::queue_size")


### PR DESCRIPTION
…ue ops

Adding XPU autocast registrations for both queue ops in torchbind test Python impls, matching existing CPU/CUDA behavior fixes XPU export/compile torchbind paths that call queue_push/queue_pop under autocast by removing the missing-XPU-kernel NotImplementedError at runtime.