### PR TITLE
[Test] Improve test reuse in test/ao/sparsity/test_structured_sparsifier.py for out-of-tree backends

### DIFF
--- a/test/ao/sparsity/test_structured_sparsifier.py
+++ b/test/ao/sparsity/test_structured_sparsifier.py
@@ -12,6 +12,7 @@ from torch.ao.pruning._experimental.pruner import (
     SaliencyPruner,
 )
 from torch.nn.utils import parametrize
+from torch.testing._internal.common_device_type import dtypes, onlyCPU
 from torch.testing._internal.common_pruning import (
     Conv2dActivation,
     Conv2dBias,
@@ -33,12 +34,6 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TestCase,
 )
-
-
-DEVICES = {
-    torch.device("cpu"),
-    torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu"),
-}
 
 
 class SimplePruner(BaseStructuredSparsifier):
@@ -73,12 +68,17 @@ class BottomHalfLSTMPruner(BaseStructuredSparsifier):
 
 
 class TestSaliencyPruner(TestCase):
-    def test_saliency_pruner_update_mask(self):
+    @dtypes(torch.float)
+    def test_saliency_pruner_update_mask(self, device, dtype):
         """Test that we prune out the row with the lowest saliency (first row)"""
-        model = SimpleLinear()
+        model = SimpleLinear().to(device)
         with torch.no_grad():
             model.linear1.weight = nn.Parameter(
-                torch.Tensor([[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]])
+                torch.tensor(
+                    [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]],
+                    dtype=dtype,
+                    device=device,
+                )
             )
         pruning_config = [{"tensor_fqn": "linear1.weight", "sparsity_level": 0.5}]
         pruner = SaliencyPruner({})
@@ -88,7 +88,9 @@ class TestSaliencyPruner(TestCase):
         pruner.step()
         pruned_model = pruner.prune()
 
-        expected = torch.Tensor([[3, 3, 3, 3], [4, 4, 4, 4]])
+        expected = torch.tensor(
+            [[3, 3, 3, 3], [4, 4, 4, 4]], dtype=dtype, device=device
+        )
         pruned = pruned_model.linear1.weight
 
         if expected.shape != pruned.shape:
@@ -96,21 +98,24 @@ class TestSaliencyPruner(TestCase):
         if not torch.isclose(expected, pruned, rtol=1e-05, atol=1e-07).all():
             raise AssertionError("Expected and pruned tensors are not close")
 
-    def test_lstm_saliency_pruner_update_mask(self):
+    @dtypes(torch.float)
+    def test_lstm_saliency_pruner_update_mask(self, device, dtype):
         model = LSTMLinearModel(
             input_dim=2,
             hidden_dim=2,
             output_dim=2,
             num_layers=1,
-        )
+        ).to(device)
 
-        manual_weights = torch.Tensor(
-            [[1, 1], [2, 2], [2, 2], [1, 1], [-1, -1], [-2, -2], [-2, -2], [-1, -1]]
+        manual_weights = torch.tensor(
+            [[1, 1], [2, 2], [2, 2], [1, 1], [-1, -1], [-2, -2], [-2, -2], [-1, -1]],
+            dtype=dtype,
+            device=device,
         )
 
         with torch.no_grad():
             model.lstm.weight_ih_l0 = nn.Parameter(manual_weights)
-            model.lstm.weight_hh_l0 = nn.Parameter(torch.Tensor(manual_weights))
+            model.lstm.weight_hh_l0 = nn.Parameter(manual_weights.clone())
             model.lstm.bias_ih_l0 = nn.Parameter(manual_weights[:, 0])
             model.lstm.bias_hh_l0 = nn.Parameter(manual_weights[:, 0])
 
@@ -118,7 +123,7 @@ class TestSaliencyPruner(TestCase):
             {"tensor_fqn": "lstm.weight_ih_l0"},
             {"tensor_fqn": "lstm.weight_hh_l0"},
         ]
-        lstm_input = torch.ones((1, 2))
+        lstm_input = torch.ones((1, 2), device=device)
         fx_pruner = LSTMSaliencyPruner({"sparsity_level": 0.5})
         fx_pruner.prepare(model, config)
         fx_pruner.enable_mask_update = True
@@ -133,21 +138,23 @@ class TestSaliencyPruner(TestCase):
         pruned_model(lstm_input)
 
         # make sure lowest saliency rows are pruned
-        expected = torch.Tensor([[2, 2], [2, 2], [-2, -2], [-2, -2]])
+        expected = torch.tensor(
+            [[2, 2], [2, 2], [-2, -2], [-2, -2]], dtype=dtype, device=device
+        )
         pruned = model.lstm.weight_ih_l0
         if expected.shape != pruned.shape:
             raise AssertionError(f"Expected shape {expected.shape}, got {pruned.shape}")
         if not torch.isclose(expected, pruned, rtol=1e-05, atol=1e-07).all():
             raise AssertionError("Expected and pruned tensors are not close")
 
-        expected = torch.Tensor([[2], [2], [-2], [-2]])
+        expected = torch.tensor([[2], [2], [-2], [-2]], dtype=dtype, device=device)
         pruned = model.lstm.weight_hh_l0
         if expected.shape != pruned.shape:
             raise AssertionError(f"Expected shape {expected.shape}, got {pruned.shape}")
         if not torch.isclose(expected, pruned, rtol=1e-05, atol=1e-07).all():
             raise AssertionError("Expected and pruned tensors are not close")
 
-        expected = torch.Tensor([2, 2, -2, -2])
+        expected = torch.tensor([2, 2, -2, -2], dtype=dtype, device=device)
         for pruned in [model.lstm.bias_ih_l0, model.lstm.bias_hh_l0]:
             if expected.shape != pruned.shape:
                 raise AssertionError(
@@ -256,10 +263,9 @@ class TestBaseStructuredSparsifier(TestCase):
                 f"Expected test value 3, got {pruner.groups[0]['test']}"
             )
 
-    def test_constructor(self):
+    def test_constructor(self, device):
         model = SimpleLinear()
-        for device in DEVICES:
-            self._test_constructor_on_device(model, torch.device(device))
+        self._test_constructor_on_device(model, torch.device(device))
 
     def _test_prepare_linear_on_device(self, model, device):
         model = copy.deepcopy(model).to(device)
@@ -270,16 +276,15 @@ class TestBaseStructuredSparsifier(TestCase):
         if model(x).shape != (128, 10):
             raise AssertionError(f"Expected shape (128, 10), got {model(x).shape}")
 
-    def test_prepare_linear(self):
+    def test_prepare_linear(self, device):
         models = [
             SimpleLinear(),
             LinearBias(),
             LinearActivation(),
             LinearActivationFunctional(),
         ]  # without and with bias
-        for device in DEVICES:
-            for model in models:
-                self._test_prepare_linear_on_device(model, torch.device(device))
+        for model in models:
+            self._test_prepare_linear_on_device(model, torch.device(device))
 
     def _test_prepare_conv2d_on_device(self, model, expected_shape, config, device):
         x = torch.ones((1, 1, 28, 28), device=device)
@@ -291,7 +296,7 @@ class TestBaseStructuredSparsifier(TestCase):
                 f"Expected shape {expected_shape}, got {model(x).shape}"
             )
 
-    def test_prepare_conv2d(self):
+    def test_prepare_conv2d(self, device):
         models = [
             SimpleConv2d(),
             Conv2dBias(),
@@ -307,12 +312,11 @@ class TestBaseStructuredSparsifier(TestCase):
             (1, 52, 3, 3),
         ]
         configs = [None, None, None, None, None]
-        for device in DEVICES:
-            for model, shape, config in zip(models, shapes, configs):
-                model = model.to(device)
-                self._test_prepare_conv2d_on_device(
-                    model, shape, config, torch.device(device)
-                )
+        for model, shape, config in zip(models, shapes, configs):
+            model = model.to(device)
+            self._test_prepare_conv2d_on_device(
+                model, shape, config, torch.device(device)
+            )
 
     def _test_step_linear_on_device(self, model, device):
         model = model.to(device)
@@ -323,16 +327,15 @@ class TestBaseStructuredSparsifier(TestCase):
         pruner.step()
         self._check_pruner_valid_after_step(model, pruner, 1, device)
 
-    def test_step_linear(self):
+    def test_step_linear(self, device):
         models = [
             SimpleLinear(),
             LinearBias(),
             LinearActivation(),
             LinearActivationFunctional(),
         ]
-        for device in DEVICES:
-            for model in models:
-                self._test_step_linear_on_device(model, torch.device(device))
+        for model in models:
+            self._test_step_linear_on_device(model, torch.device(device))
 
     def _test_step_conv2d_on_device(self, model, expected_shape, config, device):
         model = model.to(device)
@@ -349,7 +352,7 @@ class TestBaseStructuredSparsifier(TestCase):
             )
 
     @skipIfTorchDynamo("TorchDynamo fails with unknown reason")
-    def test_step_conv2d(self):
+    def test_step_conv2d(self, device):
         models = [
             SimpleConv2d(),
             Conv2dBias(),
@@ -365,11 +368,8 @@ class TestBaseStructuredSparsifier(TestCase):
             (1, 52, 3, 3),
         ]
         configs = [None, None, None, None, None]
-        for device in DEVICES:
-            for model, shape, config in zip(models, shapes, configs):
-                self._test_step_conv2d_on_device(
-                    model, shape, config, torch.device(device)
-                )
+        for model, shape, config in zip(models, shapes, configs):
+            self._test_step_conv2d_on_device(model, shape, config, torch.device(device))
 
     def _check_pruner_pruned(self, model, pruner, device):
         for config in pruner.groups:
@@ -418,7 +418,7 @@ class TestBaseStructuredSparsifier(TestCase):
                     f"Expected pruned params ({num_pruned_params}) < original ({num_original_params})"
                 )
 
-    def test_prune_linear_linear(self):
+    def test_prune_linear_linear(self, device):
         r"""test pruning linear-> linear modules"""
         configs, shapes = [], []
         configs.append(
@@ -447,18 +447,17 @@ class TestBaseStructuredSparsifier(TestCase):
             ]
         )
         shapes.append((128, 10))
-        for device in DEVICES:
-            for also_prune_bias in [True, False]:
-                for config, shape in zip(configs, shapes):
-                    self._test_linear_on_device(
-                        SimpleLinear(),
-                        config,
-                        shape,
-                        torch.device(device),
-                        also_prune_bias,
-                    )
+        for also_prune_bias in [True, False]:
+            for config, shape in zip(configs, shapes):
+                self._test_linear_on_device(
+                    SimpleLinear(),
+                    config,
+                    shape,
+                    torch.device(device),
+                    also_prune_bias,
+                )
 
-    def test_prune_linear_bias_linear(self):
+    def test_prune_linear_bias_linear(self, device):
         # linear(bias) -> linear(no bias)
         configs, shapes = [], []
         configs.append(
@@ -488,18 +487,17 @@ class TestBaseStructuredSparsifier(TestCase):
         )
         shapes.append((128, 10))
 
-        for device in DEVICES:
-            for also_prune_bias in [True, False]:
-                for config, shape in zip(configs, shapes):
-                    self._test_linear_on_device(
-                        LinearBias(),
-                        config,
-                        shape,
-                        torch.device(device),
-                        also_prune_bias,
-                    )
+        for also_prune_bias in [True, False]:
+            for config, shape in zip(configs, shapes):
+                self._test_linear_on_device(
+                    LinearBias(),
+                    config,
+                    shape,
+                    torch.device(device),
+                    also_prune_bias,
+                )
 
-    def test_prune_linear_activation_linear(self):
+    def test_prune_linear_activation_linear(self, device):
         config = [
             {"tensor_fqn": "seq.0.weight"},
             {"tensor_fqn": "seq.2.weight"},
@@ -508,24 +506,23 @@ class TestBaseStructuredSparsifier(TestCase):
         ]
         shape = (128, 10)
 
-        for device in DEVICES:
-            for also_prune_bias in [True, False]:
-                # test version with nn.Modules
-                self._test_linear_on_device(
-                    LinearActivation(),
-                    config,
-                    shape,
-                    torch.device(device),
-                    also_prune_bias,
-                )
-                # test functional version
-                self._test_linear_on_device(
-                    LinearActivationFunctional(),
-                    config,
-                    shape,
-                    torch.device(device),
-                    also_prune_bias,
-                )
+        for also_prune_bias in [True, False]:
+            # test version with nn.Modules
+            self._test_linear_on_device(
+                LinearActivation(),
+                config,
+                shape,
+                torch.device(device),
+                also_prune_bias,
+            )
+            # test functional version
+            self._test_linear_on_device(
+                LinearActivationFunctional(),
+                config,
+                shape,
+                torch.device(device),
+                also_prune_bias,
+            )
 
     def _test_conv2d_on_device(
         self, model, config, x, expected_shape, device, also_prune_bias
@@ -567,7 +564,7 @@ class TestBaseStructuredSparsifier(TestCase):
                     f"Expected pruned params ({num_pruned_params}) <= original ({num_original_params})"
                 )
 
-    def test_prune_conv2d_conv2d(self):
+    def test_prune_conv2d_conv2d(self, device):
         configs, shapes = [], []
         # all within sequential blocks
         configs.append(
@@ -586,20 +583,19 @@ class TestBaseStructuredSparsifier(TestCase):
         )
         shapes.append((1, 52, 20, 20))
 
-        for device in DEVICES:
-            x = torch.ones((1, 1, 28, 28), device=device)
-            for also_prune_bias in [True, False]:
-                for config, shape in zip(configs, shapes):
-                    self._test_conv2d_on_device(
-                        SimpleConv2d(),
-                        config,
-                        x,
-                        shape,
-                        torch.device(device),
-                        also_prune_bias,
-                    )
+        x = torch.ones((1, 1, 28, 28), device=device)
+        for also_prune_bias in [True, False]:
+            for config, shape in zip(configs, shapes):
+                self._test_conv2d_on_device(
+                    SimpleConv2d(),
+                    config,
+                    x,
+                    shape,
+                    torch.device(device),
+                    also_prune_bias,
+                )
 
-    def test_prune_conv2d_bias_conv2d(self):
+    def test_prune_conv2d_bias_conv2d(self, device):
         # Conv2d with Bias and no Activation
         configs, shapes = [], []
         # conv2d(bias) -> conv2d(bias)
@@ -631,20 +627,19 @@ class TestBaseStructuredSparsifier(TestCase):
         )
         shapes.append((1, 52, 18, 18))
 
-        for device in DEVICES:
-            x = torch.ones((1, 1, 28, 28), device=device)
-            for also_prune_bias in [True, False]:
-                for config, shape in zip(configs, shapes):
-                    self._test_conv2d_on_device(
-                        Conv2dBias(),
-                        config,
-                        x,
-                        shape,
-                        torch.device(device),
-                        also_prune_bias,
-                    )
+        x = torch.ones((1, 1, 28, 28), device=device)
+        for also_prune_bias in [True, False]:
+            for config, shape in zip(configs, shapes):
+                self._test_conv2d_on_device(
+                    Conv2dBias(),
+                    config,
+                    x,
+                    shape,
+                    torch.device(device),
+                    also_prune_bias,
+                )
 
-    def test_prune_conv2d_activation_conv2d(self):
+    def test_prune_conv2d_activation_conv2d(self, device):
         # Conv2d with Activation and no Bias
         configs, shapes = [], []
 
@@ -682,20 +677,19 @@ class TestBaseStructuredSparsifier(TestCase):
         )
         shapes.append((1, 52, 18, 18))
 
-        for device in DEVICES:
-            x = torch.ones((1, 1, 28, 28), device=device)
-            for also_prune_bias in [True, False]:
-                for config, shape in zip(configs, shapes):
-                    self._test_conv2d_on_device(
-                        Conv2dActivation(),
-                        config,
-                        x,
-                        shape,
-                        torch.device(device),
-                        also_prune_bias,
-                    )
+        x = torch.ones((1, 1, 28, 28), device=device)
+        for also_prune_bias in [True, False]:
+            for config, shape in zip(configs, shapes):
+                self._test_conv2d_on_device(
+                    Conv2dActivation(),
+                    config,
+                    x,
+                    shape,
+                    torch.device(device),
+                    also_prune_bias,
+                )
 
-    def test_prune_conv2d_padding_conv2d(self):
+    def test_prune_conv2d_padding_conv2d(self, device):
         # Conv2d with Padded layers after Bias layers
         configs, shapes = [], []
 
@@ -737,20 +731,19 @@ class TestBaseStructuredSparsifier(TestCase):
         )
         shapes.append((1, 52, 24, 24))
 
-        for device in DEVICES:
-            x = torch.ones((1, 1, 28, 28), device=device)
-            for also_prune_bias in [True, False]:
-                for config, shape in zip(configs, shapes):
-                    self._test_conv2d_on_device(
-                        Conv2dPadBias(),
-                        config,
-                        x,
-                        shape,
-                        torch.device(device),
-                        also_prune_bias,
-                    )
+        x = torch.ones((1, 1, 28, 28), device=device)
+        for also_prune_bias in [True, False]:
+            for config, shape in zip(configs, shapes):
+                self._test_conv2d_on_device(
+                    Conv2dPadBias(),
+                    config,
+                    x,
+                    shape,
+                    torch.device(device),
+                    also_prune_bias,
+                )
 
-    def test_prune_conv2d_pool_conv2d(self):
+    def test_prune_conv2d_pool_conv2d(self, device):
         # Conv2d with Pooling layers
         config = [
             {"tensor_fqn": "seq.0.weight"},
@@ -760,20 +753,19 @@ class TestBaseStructuredSparsifier(TestCase):
         ]
         shape = (1, 52, 3, 3)
 
-        for device in DEVICES:
-            x = torch.ones((1, 1, 28, 28), device=device)
-            for also_prune_bias in [True, False]:
-                self._test_conv2d_on_device(
-                    Conv2dPool(),
-                    config,
-                    x,
-                    shape,
-                    torch.device(device),
-                    also_prune_bias,
-                )
+        x = torch.ones((1, 1, 28, 28), device=device)
+        for also_prune_bias in [True, False]:
+            self._test_conv2d_on_device(
+                Conv2dPool(),
+                config,
+                x,
+                shape,
+                torch.device(device),
+                also_prune_bias,
+            )
 
     @skipIfTorchDynamo("TorchDynamo fails with unknown reason")
-    def test_complex_conv2d(self):
+    def test_complex_conv2d(self, device):
         """Test fusion for models that contain Conv2d & Linear modules.
         Currently supports: Conv2d-Pool2d-Flatten-Linear, Skip-add"""
         config = [
@@ -784,27 +776,27 @@ class TestBaseStructuredSparsifier(TestCase):
         ]
         shape = (1, 13)
 
-        for device in DEVICES:
-            x = torch.ones((1, 1, 28, 28), device=device)
-            for also_prune_bias in [True, False]:
-                self._test_conv2d_on_device(
-                    Conv2dPoolFlattenFunctional(),
-                    config,
-                    x,
-                    shape,
-                    torch.device(device),
-                    also_prune_bias,
-                )
-                self._test_conv2d_on_device(
-                    Conv2dPoolFlatten(),
-                    config,
-                    x,
-                    shape,
-                    torch.device(device),
-                    also_prune_bias,
-                )
+        x = torch.ones((1, 1, 28, 28), device=device)
+        for also_prune_bias in [True, False]:
+            self._test_conv2d_on_device(
+                Conv2dPoolFlattenFunctional(),
+                config,
+                x,
+                shape,
+                torch.device(device),
+                also_prune_bias,
+            )
+            self._test_conv2d_on_device(
+                Conv2dPoolFlatten(),
+                config,
+                x,
+                shape,
+                torch.device(device),
+                also_prune_bias,
+            )
 
-    def test_prune_lstm_linear_multiple_layer(self):
+    @onlyCPU
+    def test_prune_lstm_linear_multiple_layer(self, device):
         """
         Test fusion support for LSTM(multi-layer) -> Linear
         """
@@ -813,7 +805,7 @@ class TestBaseStructuredSparsifier(TestCase):
             hidden_dim=8,
             output_dim=8,
             num_layers=2,
-        )
+        ).to(device)
 
         config = [
             {"tensor_fqn": "lstm.weight_ih_l0"},
@@ -822,7 +814,7 @@ class TestBaseStructuredSparsifier(TestCase):
             {"tensor_fqn": "lstm.weight_hh_l1"},
         ]
 
-        lstm_input = torch.ones((1, 8))
+        lstm_input = torch.ones((1, 8), device=device)
         fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
         fx_pruner.prepare(model, config)
 
@@ -852,7 +844,8 @@ class TestBaseStructuredSparsifier(TestCase):
                 f"Expected all params deleted, but {len(expected_params)} remain"
             )
 
-    def test_prune_lstm_linear_single_layer(self):
+    @onlyCPU
+    def test_prune_lstm_linear_single_layer(self, device):
         """
         Test fusion support for LSTM (single-layer) -> Linear
         """
@@ -861,14 +854,14 @@ class TestBaseStructuredSparsifier(TestCase):
             hidden_dim=8,
             output_dim=8,
             num_layers=1,
-        )
+        ).to(device)
 
         config = [
             {"tensor_fqn": "lstm.weight_ih_l0"},
             {"tensor_fqn": "lstm.weight_hh_l0"},
         ]
 
-        lstm_input = torch.ones((1, 8))
+        lstm_input = torch.ones((1, 8), device=device)
         fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
         fx_pruner.prepare(model, config)
         fx_pruner.enable_mask_update = True
@@ -896,7 +889,8 @@ class TestBaseStructuredSparsifier(TestCase):
                 f"Expected shape {out_expected.shape}, got {out_pruned.shape}"
             )
 
-    def test_prune_lstm_layernorm_linear_multiple_layer(self):
+    @onlyCPU
+    def test_prune_lstm_layernorm_linear_multiple_layer(self, device):
         """
         Test fusion support for LSTM(multi-layer) -> Linear
         """
@@ -905,7 +899,7 @@ class TestBaseStructuredSparsifier(TestCase):
             output_dim=8,
             hidden_dim=8,
             num_layers=2,
-        )
+        ).to(device)
 
         config = [
             {"tensor_fqn": "lstm.weight_ih_l0"},
@@ -914,7 +908,7 @@ class TestBaseStructuredSparsifier(TestCase):
             {"tensor_fqn": "lstm.weight_hh_l1"},
         ]
 
-        lstm_input = torch.ones((1, 8))
+        lstm_input = torch.ones((1, 8), device=device)
         fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
         fx_pruner.prepare(model, config)
 
@@ -944,7 +938,8 @@ class TestBaseStructuredSparsifier(TestCase):
                 f"Expected all params deleted, but {len(expected_params)} remain"
             )
 
-    def test_prune_lstm_layernorm_linear_single_layer(self):
+    @onlyCPU
+    def test_prune_lstm_layernorm_linear_single_layer(self, device):
         """
         Test fusion support for LSTM (single-layer) -> Linear
         """
@@ -953,14 +948,14 @@ class TestBaseStructuredSparsifier(TestCase):
             hidden_dim=8,
             output_dim=8,
             num_layers=1,
-        )
+        ).to(device)
 
         config = [
             {"tensor_fqn": "lstm.weight_ih_l0"},
             {"tensor_fqn": "lstm.weight_hh_l0"},
         ]
 
-        lstm_input = torch.ones((1, 8))
+        lstm_input = torch.ones((1, 8), device=device)
         fx_pruner = BottomHalfLSTMPruner({"sparsity_level": 0.5})
         fx_pruner.prepare(model, config)
         fx_pruner.enable_mask_update = True
@@ -1028,14 +1023,15 @@ class TestFPGMPruner(TestCase):
             x = self.conv2d2(x)
             return x
 
-    def test_compute_distance(self, device="cpu"):
+    @onlyCPU
+    def test_compute_distance(self, device):
         """Test the distance computation function"""
         model = TestFPGMPruner.SimpleConvFPGM().to(device)
         pruner = FPGMPruner(0.3)
         dist_conv1 = pruner._compute_distance(model.conv2d1.weight)
 
         # compute the distance matrix using torch.cdist
-        flattened_filters = torch.Tensor(
+        flattened_filters = torch.tensor(
             [
                 [
                     3.0000,
@@ -1070,7 +1066,8 @@ class TestFPGMPruner(TestCase):
                     0.1000,
                     0.1000,
                 ],
-            ]
+            ],
+            device=device,
         )
 
         """
@@ -1175,18 +1172,15 @@ class TestFPGMPruner(TestCase):
         ).all():
             raise AssertionError("conv2d2 weight does not match expected")
 
-    def test_update_mask(self):
+    def test_update_mask(self, device):
         weights = torch.tensor([3.0, 0.1])
         expected_conv1 = torch.ones((2, 1, 3, 3)) * weights[:, None, None, None]
 
         weights = torch.tensor([7.0, 0.4])
         expected_conv2 = torch.ones((2, 2, 3, 3)) * weights[:, None, None, None]
 
-        for device in DEVICES:
-            self._test_update_mask_on_single_layer(expected_conv1, device)
-            self._test_update_mask_on_multiple_layer(
-                expected_conv1, expected_conv2, device
-            )
+        self._test_update_mask_on_single_layer(expected_conv1, device)
+        self._test_update_mask_on_multiple_layer(expected_conv1, expected_conv2, device)
 
 
 if __name__ == "__main__":

--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -57,11 +57,9 @@ from ao.sparsity.test_data_sparsifier import (  # noqa: F401
 from ao.sparsity.test_sparsity_utils import TestSparsityUtilFunctions  # noqa: F401
 
 
-instantiate_device_type_tests(TestSaliencyPruner, globals(), only_for=("cpu",))
-instantiate_device_type_tests(
-    TestBaseStructuredSparsifier, globals(), only_for=("cpu", "cuda")
-)
-instantiate_device_type_tests(TestFPGMPruner, globals(), only_for=("cpu", "cuda"))
+instantiate_device_type_tests(TestSaliencyPruner, globals())
+instantiate_device_type_tests(TestBaseStructuredSparsifier, globals())
+instantiate_device_type_tests(TestFPGMPruner, globals())
 
 
 if __name__ == "__main__":

--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -21,12 +21,13 @@ from ao.sparsity.test_sparsifier import (  # noqa: F401
 )
 
 # Structured Pruning
-from ao.sparsity.test_structured_sparsifier import (  # noqa: F401
+from ao.sparsity.test_structured_sparsifier import (
     TestBaseStructuredSparsifier,
     TestFPGMPruner,
     TestSaliencyPruner,
 )
 
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import IS_ARM64, run_tests
 
 
@@ -54,6 +55,13 @@ from ao.sparsity.test_data_sparsifier import (  # noqa: F401
 
 # Utilities
 from ao.sparsity.test_sparsity_utils import TestSparsityUtilFunctions  # noqa: F401
+
+
+instantiate_device_type_tests(TestSaliencyPruner, globals(), only_for=("cpu",))
+instantiate_device_type_tests(
+    TestBaseStructuredSparsifier, globals(), only_for=("cpu", "cuda")
+)
+instantiate_device_type_tests(TestFPGMPruner, globals(), only_for=("cpu", "cuda"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Improve test reuse in `test/ao/sparsity/test_structured_sparsifier.py` for out-of-tree backends by migrating the tests to device-type test patterns and removing manual device handling.

## Changes

- Converted structured sparsifier tests to use the injected `device` argument from `instantiate_device_type_tests`.
- Removed manual `DEVICES` iteration and replaced hardcoded device placement with injected device usage for models and tensors.
- Added device-type test instantiation in  `test/test_ao_sparsity.py` for:
  - `TestSaliencyPruner`
  - `TestBaseStructuredSparsifier`
  - `TestFPGMPruner`
- Replaced hardcoded `torch.float` tensor construction in saliency pruner tests with `@dtypes(torch.float)` and injected `dtype`.

## Test Plan

```
pytest test/test_ao_sparsity.py \
  -k "TestSaliencyPruner or TestBaseStructuredSparsifier or TestFPGMPruner" -v
```
- 39 passed, 5 skipped, 66 deselected


cc @bdhirsh