### PR TITLE
Pre-compute igates for XPU LSTM to reduce per-step kernel launches

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -745,7 +745,7 @@ struct LSTMCell : Cell<std::tuple<Tensor, Tensor>, cell_params> {
       bool pre_compute_input = false) const override {
     const auto& [hx, cx] = hidden;
 
-    if (input.is_cuda() || input.is_xpu() || input.is_privateuseone()) {
+    if (input.is_cuda() || input.is_privateuseone()) {
       TORCH_CHECK(!pre_compute_input);
       auto igates = params.matmul_ih(input);
       auto hgates = params.matmul_hh(hx);
@@ -754,6 +754,15 @@ struct LSTMCell : Cell<std::tuple<Tensor, Tensor>, cell_params> {
       // applying projections if w_hr is defined
       auto hy = params.matmul_hr(std::get<0>(result));
       // Slice off the workspace argument (it's needed only for AD).
+      return std::make_tuple(std::move(hy), std::move(std::get<1>(result)));
+    }
+
+    if (input.is_xpu()) {
+      auto igates = pre_compute_input ? input : params.linear_ih(input);
+      auto hgates = params.matmul_hh(hx);
+      auto result = at::_thnn_fused_lstm_cell(
+          igates, hgates, cx, {}, params.b_hh());
+      auto hy = params.matmul_hr(std::get<0>(result));
       return std::make_tuple(std::move(hy), std::move(std::get<1>(result)));
     }
 
@@ -781,13 +790,21 @@ struct GRUCell : Cell<Tensor, cell_params> {
       const hidden_type& hidden,
       const cell_params& params,
       bool pre_compute_input = false) const override {
-    if (input.is_cuda() || input.is_xpu() || input.is_privateuseone()) {
+    if (input.is_cuda() || input.is_privateuseone()) {
       TORCH_CHECK(!pre_compute_input);
       auto igates = params.matmul_ih(input);
       auto hgates = params.matmul_hh(hidden);
       auto result = at::_thnn_fused_gru_cell(
           igates, hgates, hidden, params.b_ih(), params.b_hh());
       // Slice off the workspace argument (it's needed only for AD).
+      return std::move(std::get<0>(result));
+    }
+
+    if (input.is_xpu()) {
+      auto igates = pre_compute_input ? input : params.linear_ih(input);
+      auto hgates = params.matmul_hh(hidden);
+      auto result = at::_thnn_fused_gru_cell(
+          igates, hgates, hidden, {}, params.b_hh());
       return std::move(std::get<0>(result));
     }
     const auto chunked_igates = pre_compute_input
@@ -860,7 +877,7 @@ struct FullLayer : Layer<Tensor, hidden_type, cell_params> {
       const Tensor& inputs,
       const hidden_type& input_hidden,
       const cell_params& params) const override {
-    if (inputs.device().is_cpu()) {
+    if (inputs.device().is_cpu() || inputs.is_xpu()) {
       const auto inputs_w = params.linear_ih(inputs);
       auto unstacked_output =
           (*this)(inputs_w.unbind(0), input_hidden, params, true);
@@ -892,7 +909,7 @@ struct FullBidirectionalLayer
       const hidden_type& input_hidden,
       const param_type& params) const override {
     std::vector<Tensor> step_inputs;
-    if (input.device().is_cpu()) {
+    if (input.device().is_cpu() || input.is_xpu()) {
       auto input_w = params.first.linear_ih(input);
       step_inputs = input_w.unbind(0);
       auto fw_result = layer_(
@@ -954,7 +971,7 @@ struct PackedLayer : Layer<PackedSequence, hidden_type, cell_params> {
     const Tensor* input_ptr = &input.data;
     bool pre_compute_input = false;
     Tensor input_w;
-    if (input.data.device().is_cpu()) {
+    if (input.data.device().is_cpu() || input.data.is_xpu()) {
       input_w = params.linear_ih(input.data);
       input_ptr = &input_w;
       pre_compute_input = true;
@@ -1013,7 +1030,7 @@ struct ReversedPackedLayer : Layer<PackedSequence, hidden_type, cell_params> {
     const Tensor* input_ptr = &input.data;
     bool pre_compute_input = false;
     Tensor input_w;
-    if (input.data.device().is_cpu()) {
+    if (input.data.device().is_cpu() || input.data.is_xpu()) {
       input_w = params.linear_ih(input.data);
       input_ptr = &input_w;
       pre_compute_input = true;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -340,7 +340,8 @@ bool is_onednn_matmul_strides(const at::Tensor& tensor) {
   // the src and weight must have at least one of the axes
   // m or k and n or k contiguous (i.e., stride=1) respectively.
   if (strides[tensor_dim - 1] != 1 && strides[tensor_dim - 2] != 1)
-    return false;
+    if (!(tensor_dim == 2 && (sizes[0] == 1 || sizes[1] == 1)))
+      return false;
 
   if (!onednn_strides_check(tensor))
     return false;


### PR DESCRIPTION
## Summary

On XPU, batch-compute input gates (`linear_ih`) for the entire sequence upfront, then pass pre-computed results to `_thnn_fused_lstm_cell` per time step. This reduces kernel launch overhead from O(T) GEMM launches to a single large GEMM.

## Correctness

Standard LSTM formula per time step:

```
gates_t = W_ih @ x_t + b_ih + W_hh @ h_{t-1} + b_hh
```

The input transform `W_ih @ x_t + b_ih` depends only on `x_t`, not on the hidden state `h_{t-1}`. Since all `x_t` are known at sequence start, we can batch them:

```
igates = X @ W_ih.T + b_ih    # X is [T, batch, input_size], computed once
```

Then per step:
```
gates_t = igates[t] + W_hh @ h_{t-1} + b_hh
```

This is mathematically equivalent. Since `b_ih` is already in `igates`, we pass `b_ih=None` and `b_hh=b_hh` to the fused cell kernel.

## Dependencies

- Requires intel/torch-xpu-ops#3770 to correctly handle `(None, b_hh)` bias combination in the fused LSTM cell kernel.

## Scope

- Only affects XPU path. CUDA and CPU paths are unchanged.
- Applies to `FullLayer`, `FullBidirectionalLayer`, `PackedLayer`, and `ReversedPackedLayer`.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01