### PR TITLE
[TMA] Fix NameError in combo kernel when TMA enabled

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -235,7 +235,10 @@ class ComboKernelTests(TestCase):
         self.assertEqual(out_eager, out_compiled)
 
     @requires_cuda_and_triton
-    @unittest.skipIf(not SM90OrLater, "TMA requires SM90 or later (Hopper+)")
+    @unittest.skipIf(
+        not SM90OrLater or torch.version.hip,
+        "TMA requires SM90 or later (Hopper+), not supported on ROCm",
+    )
     @torch._inductor.config.patch(
         {
             "triton.use_tensor_descriptor": True,

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -234,6 +234,28 @@ class ComboKernelTests(TestCase):
         ).run(code[0])
         self.assertEqual(out_eager, out_compiled)
 
+    @requires_cuda_and_triton
+    @unittest.skipIf(not SM90OrLater, "TMA requires SM90 or later (Hopper+)")
+    @torch._inductor.config.patch(
+        {
+            "triton.use_tensor_descriptor": True,
+            "assume_aligned_inputs": True,
+        }
+    )
+    def test_combo_kernel_tma_descriptor_block_name(self):
+        def fn(a, b):
+            return a.sum(dim=-1), b.sum(dim=-1)
+
+        inps = [
+            torch.randn(1024, 128, device=GPU_TYPE),
+            torch.randn(1024, 256, device=GPU_TYPE),
+        ]
+
+        out_eager = fn(*inps)
+        out_compiled, code = run_and_get_code(torch.compile(fn), *inps)
+        torch.testing.assert_close(out_eager, out_compiled, atol=1e-4, rtol=1e-4)
+        FileCheck().check("make_tensor_descriptor").run(code[0])
+
     @requires_gpu_and_triton
     def test_sort_in_combo_kernel_forces_persistent_reduction(self):
         # ops.sort only works under persistent reduction. Combo kernel codegen

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -21,12 +21,11 @@ from ..runtime.triton_heuristics import (
 )
 from ..scheduler import BaseSchedulerNode
 from ..stream_utils import get_raw_stream_name
-from ..utils import Placeholder, triton_version_uses_attrs_dict
+from ..utils import DeferredLineBase, Placeholder, triton_version_uses_attrs_dict
 from ..virtualized import V
 from .common import (
     ArgName,
     ConstexprArg,
-    DeferredLine,
     IndentedBuffer,
     InplacedBuffer,
     Kernel,
@@ -988,6 +987,7 @@ class ComboKernel(Kernel):
                     uniquify = self.codegen_static_numels_sub_kernel(
                         code, sub_kernel, num
                     )
+                    sub_kernel.codegen_prologue(sub_kernel.body)
                     sub_kernel.codegen_body()
                     sub_kernel._filter_pdl(sub_kernel.body)
                     uniquified_body = self.uniquify_block_sizes(
@@ -1134,7 +1134,7 @@ class ComboKernel(Kernel):
                         block, f"{block}_{num_kernel}"
                     )
                 modified.writeline(modified_line)
-            elif isinstance(line, DeferredLine) and (
+            elif isinstance(line, DeferredLineBase) and (
                 blocks := [e for e in uniquify if e in line.line]
             ):
                 modified_line = line.line
@@ -1142,7 +1142,7 @@ class ComboKernel(Kernel):
                     modified_line = modified_line.replace(
                         block, f"{block}_{num_kernel}"
                     )
-                new_line = DeferredLine(line.name, modified_line)
+                new_line = line._new_line(modified_line)
                 modified.writeline(new_line)
             else:
                 modified.writeline(line)


### PR DESCRIPTION
Fixes: #185513

Root cause: `uniquify_block_sizes()` in `triton_combo_kernel.py` only handled `str` and `DeferredLine` objects in the body buffer, but TMA load expressions are stored as `DelayReplaceLine` objects (a different subclass of `DeferredLineBase`). These were passed through unmodified, leaving `R0_BLOCK` unrenamed.

Fix: Changed the isinstance check from `DeferredLine` to `DeferredLineBase` and use `_new_line()` to create the replacement — this handles all deferred line types generically (DeferredLine, DelayReplaceLine, and any future subclasses).

cc: @kshitij12345 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos