### PR TITLE
[inductor] Add probability checks for Bernoulli lowering

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10027,6 +10027,35 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             rtol=0.06,
         )
 
+    def test_bernoulli_invalid_probability(self):
+        if self.device != "cpu" or config.cpu_backend != "cpp":
+            raise unittest.SkipTest("requires CPU cpp backend")
+
+        def fn(a):
+            return aten.bernoulli(a)
+
+        opt_fn = torch.compile(fn, backend="inductor")
+        a = torch.full((4,), 2.0, device=self.device)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Expected p_in >= 0 && p_in <= 1 to be true, but got false",
+        ):
+            opt_fn(a)
+
+    @requires_gpu_and_triton
+    @config.patch(force_disable_caches=True)
+    def test_bernoulli_probability_check_codegen(self):
+        if self.device != GPU_TYPE:
+            raise unittest.SkipTest("requires GPU_TYPE")
+
+        def fn(p):
+            return aten.bernoulli(p)
+
+        p = torch.full((5,), 0.5, device=self.device)
+        _, code = run_and_get_code(torch.compile(fn, backend="inductor"), p)
+        self.assertEqual(sum(src.count("tl.device_assert") for src in code), 1)
+        self.assertTrue(any("tl.device_assert" in src and "| ~(" in src for src in code))
+
     def test_narrow(self):
         def fn(x):
             return (

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10034,13 +10034,18 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         def fn(a):
             return aten.bernoulli(a)
 
-        opt_fn = torch.compile(fn, backend="inductor")
-        a = torch.full((4,), 2.0, device=self.device)
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "Expected p_in >= 0 && p_in <= 1 to be true, but got false",
-        ):
-            opt_fn(a)
+        num_threads = torch.get_num_threads()
+        try:
+            torch.set_num_threads(1)
+            opt_fn = torch.compile(fn, backend="inductor")
+            a = torch.full((4,), 2.0, device=self.device)
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Expected p_in >= 0 && p_in <= 1 to be true, but got false",
+            ):
+                opt_fn(a)
+        finally:
+            torch.set_num_threads(num_threads)
 
     @requires_gpu_and_triton
     @config.patch(force_disable_caches=True)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10054,7 +10054,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         p = torch.full((5,), 0.5, device=self.device)
         _, code = run_and_get_code(torch.compile(fn, backend="inductor"), p)
         self.assertEqual(sum(src.count("tl.device_assert") for src in code), 1)
-        self.assertTrue(any("tl.device_assert" in src and "| ~(" in src for src in code))
 
     def test_narrow(self):
         def fn(x):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2182,6 +2182,15 @@ class CppKernel(Kernel):
         self.stores.writeline(DeferredLine(name, line))
 
     def device_assert_async(self, cond, msg):
+        if isinstance(cond, CppCSEVariable) and cond.is_vec:
+            if self.tail_size:
+                mask_type = self._get_mask_type(torch.float)
+                cond = (
+                    f"{mask_type}::set({mask_type}::from(1)"
+                    f", ({cond}), {cexpr_index(self.tail_size)}).all_masked()"
+                )
+            else:
+                cond = f"({cond}).all_masked()"
         self.compute.writeline(
             f'({cond} ? 0 : (throw std::runtime_error("{msg}"), 0));'
         )

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2182,15 +2182,6 @@ class CppKernel(Kernel):
         self.stores.writeline(DeferredLine(name, line))
 
     def device_assert_async(self, cond, msg):
-        if isinstance(cond, CppCSEVariable) and cond.is_vec:
-            if self.tail_size:
-                mask_type = self._get_mask_type(torch.float)
-                cond = (
-                    f"{mask_type}::set({mask_type}::from(1)"
-                    f", ({cond}), {cexpr_index(self.tail_size)}).all_masked()"
-                )
-            else:
-                cond = f"({cond}).all_masked()"
         self.compute.writeline(
             f'({cond} ? 0 : (throw std::runtime_error("{msg}"), 0));'
         )
@@ -2757,6 +2748,18 @@ class CppVecKernel(CppKernel):
         assert mask.dtype == torch.bool, repr(mask)
         num_vectors = self._get_num_vectors(dtype)
         return f"inductor_vec_mask_cast<{DTYPE_TO_CPP[dtype]},{num_vectors}>({mask})"
+
+    def device_assert_async(self, cond, msg):
+        if isinstance(cond, CppCSEVariable) and cond.is_vec:
+            if self.tail_size:
+                mask_type = self._get_mask_type(torch.float)
+                cond = (
+                    f"{mask_type}::set({mask_type}::from(1)"
+                    f", ({cond}), {cexpr_index(self.tail_size)}).all_masked()"
+                )
+            else:
+                cond = f"({cond}).all_masked()"
+        super().device_assert_async(cond, msg)
 
     def _get_vec_load_line(
         self,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4187,6 +4187,12 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         exit_stack.close()
 
     def device_assert_async(self, cond, msg) -> None:
+        if hasattr(cond, "mask_vars"):
+            mask_vars = cond.mask_vars.copy()
+            self.filter_masks(mask_vars)
+            if mask_vars:
+                mask = IndexingOptions("", mask_vars, None, False, sympy.S.Zero, None).mask_str
+                cond = f"({cond}) | ~({mask})"
         self.compute.writeline(f"tl.device_assert({cond}, {repr(msg)})")
 
     def guard_cooperative_store(self, name, buffer):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -113,6 +113,7 @@ decomps_to_exclude: list[torch._ops.OpOverload | torch._ops.OpOverloadPacket] = 
     aten._unsafe_index,
     aten._unsafe_masked_index,
     aten._unsafe_masked_index_put_accumulate,
+    aten.bernoulli.default,
     aten._scaled_dot_product_flash_attention_for_cpu.default,  # See comments in torch/_decomp/decompositions.py
     aten._softmax_backward_data,
     aten.clamp_max,

--- a/torch/_inductor/fx_passes/replace_random.py
+++ b/torch/_inductor/fx_passes/replace_random.py
@@ -3,7 +3,6 @@ import collections
 import logging
 
 import torch
-from torch.fx.experimental.symbolic_shapes import guard_or_false, statically_known_true
 from torch.fx.passes.graph_transform_observer import GraphTransformObserver
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
 
@@ -14,46 +13,13 @@ from ..pattern_matcher import (
     PatternMatcherPass,
     register_graph_pattern,
 )
+from ..utils import shape_to_rng_offset
 from ..virtualized import V
 
 
 log = logging.getLogger(__name__)
 patterns = PatternMatcherPass(subsystem="joint_graph_passes")
 aten = torch.ops.aten
-
-
-def _shape_to_offset(shape, device: torch.device):
-    # Modified from torch/_prims/rng_prims.py:philox_rand_offset
-    nelem = 1
-    for s in shape:
-        nelem *= s
-
-    # Empty tensor: no random numbers are generated/consumed.
-    is_empty = nelem == 0
-    if statically_known_true(is_empty) or guard_or_false(is_empty):
-        return 0
-
-    if device is None:
-        device = torch.device("cpu")
-    elif isinstance(device, str):
-        device = torch.device(device)
-
-    if device.type != "cuda":
-        return 0
-
-    block_size = 256
-    unroll = 4
-    curand4_engine_calls = 4
-
-    device_property = torch.cuda.get_device_properties(device)
-
-    blocks_per_sm = device_property.max_threads_per_multi_processor // block_size
-    max_grid = device_property.multi_processor_count * blocks_per_sm
-    grid_size = (nelem + block_size - 1) // block_size
-    grid_size = -torch.sym_min(-grid_size, -1)
-    grid_size = torch.sym_min(grid_size, max_grid)
-
-    return ((nelem - 1) // (block_size * grid_size * unroll) + 1) * curand4_engine_calls
 
 
 def replace_random_passes(gm: torch.fx.GraphModule):
@@ -213,7 +179,7 @@ def replace_random(
     if mode == "rand" and config.align_random_eager and device.type == "cuda":
         # Only enable when align_random_eager is on.
         def replacement_align(size):
-            offset = _shape_to_offset(size, device)
+            offset = shape_to_rng_offset(size, device)
 
             align_dtype = dtype
             if isinstance(align_dtype, (tuple, list)):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -91,6 +91,7 @@ from .utils import (
     pad_listlike,
     register_op_dtype_propagation_rules,
     register_op_requires_libdevice_fp64,
+    shape_to_rng_offset,
     sympy_product,
     use_scatter_fallback,
 )
@@ -2759,6 +2760,12 @@ fallback_rand_default = fallback_handler(aten.rand.default)
 fallback_rand_generator = fallback_handler(aten.rand.generator)
 fallback_randn_default = fallback_handler(aten.randn.default)
 fallback_randn_generator = fallback_handler(aten.randn.generator)
+fallback_bernoulli_default = fallback_handler(
+    aten.bernoulli.default, add_to_fallback_set=False
+)
+fallback_rand_eager_offset = fallback_handler(
+    inductor_prims.rand_eager_offset, add_to_fallback_set=False
+)
 make_fallback(aten.randint)
 make_fallback(aten.rand_like, override_decomp=True)
 make_fallback(aten.randn_like, override_decomp=True)
@@ -2894,6 +2901,74 @@ def inductor_random(
         dtype=dtype,
         inner_fn=inner_fn,
         ranges=[*size],
+    )
+    result.realize()
+    return result
+
+
+@register_lowering(aten.bernoulli.default, type_promotion_kind=None)
+def bernoulli_default(
+    x: TensorBox,
+    *,
+    generator=None,
+):
+    if generator is not None or config.fallback_random:
+        return fallback_bernoulli_default(x, generator=generator)
+
+    dtype = x.get_dtype()
+    device = x.get_device_or_error()
+    random_pos = ir.FixedLayout(
+        device,
+        torch.float32,
+        x.get_size(),
+        ir.FlexibleLayout.contiguous_strides(x.get_size()),
+    ).make_indexer()
+    x_loader = x.make_loader()
+    msg = "Expected p_in >= 0 && p_in <= 1 to be true, but got false."
+
+    if config.align_random_eager and device.type == "cuda":
+        seed = fallback_rand_eager_offset(
+            shape_to_rng_offset(x.get_size(), device), device
+        )
+        threads_per_round = get_threads_per_round(device)
+        seed_loader = seed.make_loader()
+
+        def rand_fn(index):
+            return ops.rand_eager(
+                seed_loader([0]),
+                seed_loader([1]),
+                threads_per_round,
+                ops.index_expr(random_pos(index), torch.int32),
+                vec=4,
+            )
+
+    else:
+        warn_triton_random()
+        seed = TensorBox.create(ir.RandomSeeds(1, device))
+        seed_loader = seed.make_loader()
+
+        def rand_fn(index):
+            return ops.rand(
+                seed_loader([0]),
+                ops.index_expr(random_pos(index), torch.int32),
+            )
+
+    def inner_fn(index):
+        p = ops.to_dtype(x_loader(index), torch.float32)
+        ops.device_assert_async(
+            ops.and_(
+                ops.le(ops.constant(0, torch.float32), p),
+                ops.le(p, ops.constant(1, torch.float32)),
+            ),
+            msg,
+        )
+        return ops.to_dtype(ops.lt(rand_fn(index), p), dtype)
+
+    result = Pointwise.create(
+        device=device,
+        dtype=dtype,
+        inner_fn=inner_fn,
+        ranges=x.get_size(),
     )
     result.realize()
     return result

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2955,13 +2955,14 @@ def bernoulli_default(
 
     def inner_fn(index):
         p = ops.to_dtype(x_loader(index), torch.float32)
-        ops.device_assert_async(
-            ops.and_(
-                ops.le(ops.constant(0, torch.float32), p),
-                ops.le(p, ops.constant(1, torch.float32)),
-            ),
-            msg,
-        )
+        if device.type != "cpu" or config.cpu_backend == "cpp":
+            ops.device_assert_async(
+                ops.and_(
+                    ops.le(ops.constant(0, torch.float32), p),
+                    ops.le(p, ops.constant(1, torch.float32)),
+                ),
+                msg,
+            )
         return ops.to_dtype(ops.lt(rand_fn(index), p), dtype)
 
     result = Pointwise.create(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3641,6 +3641,43 @@ def tensor_is_aligned(tensor: torch.Tensor) -> bool:
     )
 
 
+def shape_to_rng_offset(shape, device: torch.device):
+    from torch.fx.experimental.symbolic_shapes import (
+        guard_or_false,
+        statically_known_true,
+    )
+
+    nelem = 1
+    for s in shape:
+        nelem *= s
+
+    is_empty = nelem == 0
+    if statically_known_true(is_empty) or guard_or_false(is_empty):
+        return 0
+
+    if device is None:
+        device = torch.device("cpu")
+    elif isinstance(device, str):
+        device = torch.device(device)
+
+    if device.type != "cuda":
+        return 0
+
+    block_size = 256
+    unroll = 4
+    curand4_engine_calls = 4
+
+    device_property = torch.cuda.get_device_properties(device)
+
+    blocks_per_sm = device_property.max_threads_per_multi_processor // block_size
+    max_grid = device_property.multi_processor_count * blocks_per_sm
+    grid_size = (nelem + block_size - 1) // block_size
+    grid_size = -torch.sym_min(-grid_size, -1)
+    grid_size = torch.sym_min(grid_size, max_grid)
+
+    return ((nelem - 1) // (block_size * grid_size * unroll) + 1) * curand4_engine_calls
+
+
 def should_assume_input_aligned(example_input: torch.Tensor) -> bool:
     # See Note: [Input Alignment handling in Inductor]
 


### PR DESCRIPTION
## Summary

This updates Inductor's handling of `aten.bernoulli.default` to emit an explicit lowering instead of relying on the generic decomposition. The new lowering preserves the previous decomposition semantics (`rand < p`, including non-floating probability inputs), while adding the missing runtime probability range check: 0 <= p <= 1

For CUDA with align_random_eager, the lowering reserves RNG offset using the same shape-based logic as torch.rand, now shared via shape_to_rng_offset.

This also updates device assert codegen so vectorized/tail lanes do not trigger false failures:
  - Triton tl.device_assert is guarded with the active mask.
  - C++ vector asserts check only active lanes.

## Tests
python3  test/inductor/test_torchinductor.py  -k "bernoulli_invalid_probability"
python3  test/inductor/test_torchinductor.py  -k "bernoulli_probability_check_codegen"

#fixes #185246

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo