### PR TITLE
[ROCm] Skip test_compile_multiple_random_ops on ROCm

### DIFF
--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -941,6 +941,7 @@ class DistTensorRandomOpCompileTest(DTensorTestBase):
         for placements in ([Shard(0)], [Replicate()]):
             self._test_compile_random_op(fn, device_mesh, placements=placements)
 
+    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/185520")
     @with_comms
     @skip_unless_torch_gpu
     def test_compile_multiple_random_ops(self):


### PR DESCRIPTION
The DistTensorRandomOpCompileTest family is flaky on ROCm. Eight sibling tests in this class are already @skipIfRocm with individual auto-disabler tracking issues; test_compile_multiple_random_ops is the only member never disabled and is now flaking on linux-jammy-rocm-py3.10-mi355 (gfx950 / MI355) across multiple mainline commits and shards.

The failing assertion is "RNG state did not change between call 0 and 1" at test/distributed/tensor/test_random_ops.py:747. Eager and aot_eager runs of the same fn pass; only the inductor branch fails. The compiled path replaces the eager DTensor _distribute_region offset bump with the run_dtensor_rng_op HOP, which inductor registers as a make_fallback. Its torch.cuda.set_rng_state is a hidden host-side side effect not modeled by the inductor scheduler.

See https://github.com/pytorch/pytorch/issues/185520 for the full analysis and per-sibling table.

Authored by Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang