### PR TITLE
Refactor subprocess call for cpp compiler help in _is_msvc_cl()

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -561,11 +561,9 @@ def _is_msvc_cl(cpp_compiler: str) -> bool:
 
         return bool(lines) and "Microsoft" in lines[0]
 
-    except FileNotFoundError:
+    except (FileNotFoundError, OSError):
         return False
 
-    # pyrefly: ignore [unreachable]
-    return False
 
 @functools.cache
 def _is_intel_compiler(cpp_compiler: str) -> bool:

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -550,19 +550,22 @@ def _is_msvc_cl(cpp_compiler: str) -> bool:
 
     try:
         result = subprocess.run(
-            [cpp_compiler, "/help"], 
-            stdout=subprocess.PIPE, 
+            [cpp_compiler, "/help"],
+            stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            check=False 
+            check=False
         )
-        
+
         output_msg = result.stdout.strip().decode(*SUBPROCESS_DECODE_ARGS)
         lines = output_msg.splitlines()
-        
+
         return bool(lines) and "Microsoft" in lines[0]
-        
+
     except FileNotFoundError:
         return False
+
+    # pyrefly: ignore [unreachable]
+    return False
 
 @functools.cache
 def _is_intel_compiler(cpp_compiler: str) -> bool:

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -561,7 +561,7 @@ def _is_msvc_cl(cpp_compiler: str) -> bool:
 
         return bool(lines) and "Microsoft" in lines[0]
 
-    except (FileNotFoundError, OSError):
+    except OSError:
         return False
 
 

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -549,18 +549,20 @@ def _is_msvc_cl(cpp_compiler: str) -> bool:
         return False
 
     try:
-        output_msg = (
-            subprocess.check_output([cpp_compiler, "/help"], stderr=subprocess.STDOUT)
-            .strip()
-            .decode(*SUBPROCESS_DECODE_ARGS)
+        result = subprocess.run(
+            [cpp_compiler, "/help"], 
+            stdout=subprocess.PIPE, 
+            stderr=subprocess.STDOUT,
+            check=False 
         )
-        return "Microsoft" in output_msg.splitlines()[0]
+        
+        output_msg = result.stdout.strip().decode(*SUBPROCESS_DECODE_ARGS)
+        lines = output_msg.splitlines()
+        
+        return bool(lines) and "Microsoft" in lines[0]
+        
     except FileNotFoundError:
         return False
-
-    # pyrefly: ignore [unreachable]
-    return False
-
 
 @functools.cache
 def _is_intel_compiler(cpp_compiler: str) -> bool:

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -553,7 +553,7 @@ def _is_msvc_cl(cpp_compiler: str) -> bool:
             [cpp_compiler, "/help"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            check=False
+            check=False,
         )
 
         output_msg = result.stdout.strip().decode(*SUBPROCESS_DECODE_ARGS)


### PR DESCRIPTION
Replaced subprocess.check_output with subprocess.run. subprocess.run is safer as it won't raise CalledProcessError on non-zero exits. Python can also crash when unintentionally using gcc compiler.

At the end, check if lines exist to prevent IndexError, then evaluate the first line. In case of 0 lines output.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @nkhasbag-nv @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos