### PR TITLE
[inductor] Add probability checks for Bernoulli

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10027,6 +10027,21 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             rtol=0.06,
         )
 
+    def test_bernoulli_invalid_probability(self):
+        if self.device != "cpu":
+            raise unittest.SkipTest("requires CPU")
+
+        def fn(a):
+            return aten.bernoulli(a)
+
+        opt_fn = torch.compile(fn, backend="inductor")
+        a = torch.full((4,), 2.0, device=self.device)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Expected p_in >= 0 && p_in <= 1 to be true, but got false",
+        ):
+            opt_fn(a)
+
     def test_narrow(self):
         def fn(x):
             return (

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5653,6 +5653,10 @@ def bernoulli(
     *,
     generator: torch.Generator | None = None,
 ) -> torch.Tensor:
+    aten._assert_async.msg(
+        torch.all(torch.logical_and(self >= 0, self <= 1)),
+        "Expected p_in >= 0 && p_in <= 1 to be true, but got false.",
+    )
     if generator is None:
         raw_p = torch.rand(self.size(), dtype=torch.float32, device=self.device)
     else:


### PR DESCRIPTION
## Summary

  This adds the missing probability range check to the `aten.bernoulli.default`
  decomposition.Before generating Bernoulli samples, the decomposition now checks: 0 <= p <= 1

  using aten._assert_async.msg. This preserves the existing decomposition shape
  and random sampling behavior (rand < p) while matching eager Bernoulli's
  probability validation more closely.

  This is the simpler implementation: the check is expressed at the decomposition
  level and may lower as a separate device check/reduction path instead of being
  fused into the Bernoulli elementwise random kernel.

 ## Test Plan
python3 test/inductor/test_torchinductor.py -k "bernoulli_invalid_probability"


#fixes https://github.com/pytorch/pytorch/issues/185246

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo