### PR TITLE
fix(core): support ldexp on custom backends by falling back to decomposition

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1588,7 +1588,8 @@ Tensor& ldexp_out(const Tensor& self, const Tensor& other, Tensor& result) {
               "ldexp can't be cast to the desired output type ", result.scalar_type());
 
   if (isIntegralType(other.scalar_type(), /*includeBool=*/true) &&
-      isFloatingType(self.scalar_type())) {
+      isFloatingType(self.scalar_type()) &&
+      ldexp_stub.is_device_supported(self.device().type())) {
     return _ldexp_int_exponent(self, other, result);
   }
 
@@ -1597,7 +1598,8 @@ Tensor& ldexp_out(const Tensor& self, const Tensor& other, Tensor& result) {
 
 Tensor ldexp(const Tensor& self, const Tensor& other) {
   if (isIntegralType(other.scalar_type(), /*includeBool=*/true) &&
-      isFloatingType(self.scalar_type())) {
+      isFloatingType(self.scalar_type()) &&
+      ldexp_stub.is_device_supported(self.device().type())) {
     Tensor result = at::empty_like(self);
     return _ldexp_int_exponent(self, other, result);
   }

--- a/test/test_privateuseone_python_backend.py
+++ b/test/test_privateuseone_python_backend.py
@@ -3,6 +3,7 @@ import numpy as np
 
 import torch
 import torch._C
+import torch._dynamo
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.utils.backend_registration import _setup_privateuseone_for_python_backend
 
@@ -66,8 +67,9 @@ def detach(self):
 def empty_strided(
     size, stride, *, dtype=None, layout=None, device=None, pin_memory=None
 ):
+    dtype = dtype if dtype is not None else torch.float32
     out = np.empty(size)
-    return wrap(out, out.shape, torch.float32)
+    return wrap(out, out.shape, dtype)
 
 
 @torch.library.impl("aten::_copy_from", "privateuseone")
@@ -89,8 +91,9 @@ def _view(a, b):
 def empty_memory_format(
     size, *, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None
 ):
+    dtype = dtype if dtype is not None else torch.float32
     ans = np.empty(size)
-    return wrap(ans, ans.shape, torch.float32)
+    return wrap(ans, ans.shape, dtype)
 
 
 @torch.library.impl("aten::sum", "privateuseone")
@@ -119,6 +122,12 @@ def as_strided(self, size, stride, storage_offset=None):
     return wrap(ans, ans.shape, torch.float32)
 
 
+@torch.library.impl("aten::pow.Scalar", "privateuseone")
+def pow_scalar(scalar, exponent):
+    ans = np.power(scalar, unwrap(exponent))
+    return wrap(ans, ans.shape, torch.float32)
+
+
 class PrivateUse1BackendTest(TestCase):
     @classmethod
     def setupClass(cls):
@@ -141,6 +150,17 @@ class PrivateUse1BackendTest(TestCase):
         c = (a + b).sum()
         c.backward()
         self.assertTrue(np.allclose(a.grad.raw_data, np.ones((2, 2))))
+
+    def test_ldexp(self):
+        a_cpu = torch.tensor([1.0, 2.0], dtype=torch.float32)
+        b_cpu = torch.tensor([1, 2], dtype=torch.int32)
+        a = a_cpu.to("privateuseone")
+        b = b_cpu.to("privateuseone")
+        res = torch.ldexp(a, b)
+        # Disable Dynamo tracing on test assertions to prevent compile-time FakeTensor crashes
+        torch._dynamo.disable(self.assertTrue)(
+            np.allclose(unwrap(res), np.array([2.0, 8.0]))
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

This PR fixes a critical dispatcher bug that causes eager-mode `torch.ldexp` to crash on all third-party hardware backends (utilizing the `PrivateUse1` dispatch key, such as TPU / `torch_tpu`). 

### Root Cause
The `aten::ldexp` operator is declared as `CompositeExplicitAutograd` in PyTorch core, meaning it should be fully backend-agnostic and fall back to decomposition (`mul` and `pow`) for custom devices. 

However, the C++ implementation in `aten/src/ATen/native/BinaryOps.cpp` optimized integer exponent paths by dispatching directly to a private C++ `ldexp_stub` (which only implements native CPU and CUDA kernels). Since third-party backends cannot register to this private C++ stub, it caused a hard runtime crash with:
`RuntimeError: ... DispatchStub: missing kernel for PrivateUse1/tpu/xla_cpu`

### Solution
We replaced the hardcoded device check with PyTorch's public capability-query API **`ldexp_stub.is_device_supported(device_type)`**. Now, PyTorch dynamically queries the stub itself. If the stub has a compiled kernel (like CPU/CUDA), it runs the optimized path. Otherwise, it safely falls back to the core's math decomposition (`mul` and `pow`), which works out-of-the-box on all custom devices.

---

### Unit Testing & Mock Backend Improvements

To verify the bug and its fix in a lightweight, hardware-agnostic way, we added `test_ldexp` to the generic C++ custom device Python mock test suite under `test/test_privateuseone_python_backend.py`. 

To make this mock backend support this test, we implemented two critical enhancements to the PyTorch mock backend helper:

1.  **Dynamic Dtype Propagation in Mock Allocators**: 
    Previously, `empty` and `empty_strided` bindings in the mock Python backend helper hardcoded the allocated tensor dtype to `torch.float32`, silently ignoring requested dtypes. 
    *   *Why we fixed this*: When the test called `b_cpu.to("privateuseone")` where `b_cpu` was `int32`, it was allocated as `float32`. This masked the dispatcher leak by bypassing the C++ `isIntegralType(exponent)` check. We updated the allocators to respect and propagate the requested `dtype` dynamically.
2.  **Registered `pow.Scalar` Mock Operator**: 
    The math decomposition fallback of `ldexp` calculates `self * at::pow(2.0, other)` (Scalar-Tensor power). We registered a mock implementation for `pow.Scalar` using NumPy's `np.power` so the fallback could execute successfully on the mock backend.

---

### Validation Results
*   **Before C++ Fix**: Running the new `test_ldexp` case failed exactly as expected, exposing the internal leak:
    `RuntimeError: false INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/native/DispatchStub.cpp":268, please report a bug to PyTorch. DispatchStub: missing kernel for npy`
*   **After C++ Fix**: The C++ code compiled successfully, bypassed the `ldexp_stub` crash, triggered the C++ composite decomposition fallback, and the test **successfully passed** returning correct values:
    `OK (Ran 1 test in 2.185s)`
