### PR TITLE
 [inductor] Validate Bernoulli probabilities in decomposition to match eager mode (#185544)

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -143,6 +143,32 @@ class LstmModule(torch.nn.Module):
 class CPUReproTests(TestCase):
     common = check_model
 
+    def test_bernoulli_compiled_invalid_probabilities(self):
+        def model():
+            p = torch.full((4,), 2.0, dtype=torch.float32)
+            return torch.bernoulli(p)
+
+        with self.assertRaises(RuntimeError):
+            torch.compile(model, backend="inductor")()
+
+    def test_bernoulli_compiled_negative_probabilities(self):
+        def model():
+            p = torch.full((4,), -0.5, dtype=torch.float32)
+            return torch.bernoulli(p)
+
+        with self.assertRaises(RuntimeError):
+            torch.compile(model, backend="inductor")()
+
+    def test_bernoulli_compiled_valid_probabilities(self):
+        def model():
+            p = torch.full((4,), 0.3, dtype=torch.float32)
+            return torch.bernoulli(p)
+
+        torch._dynamo.reset()
+        result = torch.compile(model, backend="inductor")()
+        self.assertEqual(result.shape, (4,))
+        self.assertTrue(torch.all((result == 0) | (result == 1)))
+
     @skipIfNoLapack
     def test_torch_linalg_qr_tuple_slice(self):
         def fn(x):

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -658,6 +658,29 @@ class TestDecomp(TestCase):
         res_p = res.sum() / torch.prod(torch.tensor(res.size()))
         self.assertEqual(ref_p, res_p, atol=0.06 * p, rtol=0.06)
 
+    def test_bernoulli_invalid_probabilities(self, device):
+        p_t = torch.full((4,), 2.0, dtype=torch.float32, device=device)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "bernoulli expects all probabilities to be in \\[0, 1\\]",
+        ):
+            torch._decomp.decompositions.bernoulli(p_t)
+
+        p_t_neg = torch.full((4,), -0.5, dtype=torch.float32, device=device)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "bernoulli expects all probabilities to be in \\[0, 1\\]",
+        ):
+            torch._decomp.decompositions.bernoulli(p_t_neg)
+
+    def test_bernoulli_compile_invalid_probabilities(self, device):
+        def model():
+            p = torch.full((4,), 2.0, dtype=torch.float32, device=device)
+            return torch.bernoulli(p)
+
+        with self.assertRaises(RuntimeError):
+            torch.compile(model, backend="inductor")()
+
     def test_broadcasting_index_copy(self, device):
         x = torch.zeros([1, 10], device=device)
         xs = torch.ones([2, 10], device=device)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5815,6 +5815,11 @@ def bernoulli(
     *,
     generator: torch.Generator | None = None,
 ) -> torch.Tensor:
+    torch._check_tensor_all(
+        (self >= 0) & (self <= 1),
+        lambda: "bernoulli expects all probabilities to be in [0, 1],"
+        " got out-of-range values",
+    )
     if generator is None:
         raw_p = torch.rand(self.size(), dtype=torch.float32, device=self.device)
     else:

--- a/torch/_decomp/decompositions_for_rng.py
+++ b/torch/_decomp/decompositions_for_rng.py
@@ -257,6 +257,17 @@ register_extra_random_decomp = functools.partial(
 def bernoulli_(self, p=0.5):
     if self.device == torch.device("cpu"):
         return NotImplemented
+    if isinstance(p, torch.Tensor):
+        torch._check_tensor_all(
+            (p >= 0) & (p <= 1),
+            lambda: "bernoulli_ expects all probabilities to be"
+            " in [0, 1], got out-of-range values",
+        )
+    else:
+        torch._check(
+            0 <= p <= 1,
+            lambda: f"bernoulli_ expects p to be in [0, 1], but got p={p}",
+        )
     return self.copy_(torch.rand_like(self, dtype=torch.float32) < p)
 
 
@@ -266,6 +277,17 @@ def bernoulli_p(self, p=0.5, *, generator=None):
         return NotImplemented
     if generator is not None:
         raise AssertionError(f"generator must be None, got {generator}")
+    if isinstance(p, torch.Tensor):
+        torch._check_tensor_all(
+            (p >= 0) & (p <= 1),
+            lambda: "bernoulli expects all probabilities to be"
+            " in [0, 1], got out-of-range values",
+        )
+    else:
+        torch._check(
+            0 <= p <= 1,
+            lambda: f"bernoulli expects p to be in [0, 1], but got p={p}",
+        )
     return torch.rand_like(self, dtype=torch.float32) < p
 
 


### PR DESCRIPTION
Summary:
## Context

`torch.bernoulli()` in eager mode validates that all probability values are in [0, 1], raising `RuntimeError` for out-of-range inputs. The C++ kernel checks this per-element via `TORCH_CHECK_IF_NOT_ON_CUDA(p_in >= 0 && p_in <= 1)` in `DistributionsHelper.h`. However, `torch.compile` with the inductor backend uses a Python decomposition (`aten.bernoulli.default`) that bypasses this validation entirely, silently producing incorrect results (e.g., `p=2.0` always yields 1.0 since `rand() < 2.0` is always true).

Fixes https://github.com/pytorch/pytorch/issues/185246

## This diff

Adds `torch._check_tensor_all` validation to the Bernoulli decompositions to match eager mode behavior:
- `aten.bernoulli.default` in `decompositions.py`: validates tensor probabilities are in [0, 1]
- `aten.bernoulli_` and `aten.bernoulli.p` in `decompositions_for_rng.py`: validates both scalar and tensor probability arguments

Uses `torch._check_tensor_all` (not `torch._check`) for tensor conditions, as `torch._check` only accepts `bool`/`SymBool` arguments.


Test Plan:
New tests added in `test_cpu_repro.py` and `test_decomp.py`:
- `test_bernoulli_compiled_invalid_probabilities` -- verifies `torch.compile` raises `RuntimeError` for p=2.0
- `test_bernoulli_compiled_negative_probabilities` -- verifies `torch.compile` raises `RuntimeError` for p=-0.5
- `test_bernoulli_compiled_valid_probabilities` -- verifies valid probabilities still work correctly
- `test_bernoulli_invalid_probabilities` -- unit test for decomposition with p>1 and p<0
- `test_bernoulli_compile_invalid_probabilities` -- end-to-end compile test

Authored with Claude Code.

Differential Revision: D106471031

Pulled By: tanpuresiddhant


