### PR TITLE
Handle symbolic bounds in slice decomposition

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1350,6 +1350,26 @@ class DecompOneOffTests(TestCase):
 instantiate_device_type_tests(DecompOneOffTests, globals())
 
 
+class SliceDecompTest(TestCase):
+    def test_slice_forward_unbacked_dim_size(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import (
+            _constrain_range_for_size,
+            ShapeEnv,
+        )
+
+        shape_env = ShapeEnv()
+        with FakeTensorMode(shape_env=shape_env, allow_non_fake_inputs=True):
+            u0 = shape_env.create_unbacked_symint()
+            _constrain_range_for_size(u0, min=0)
+            x = torch.empty((u0,), device="cpu")
+
+            out = torch._decomp.decompositions.slice_forward(x, 0, 0, 800, 1)
+
+        self.assertEqual(out.storage_offset(), 0)
+        self.assertEqual(str(out.shape), "torch.Size([Min(800, u0)])")
+
+
 class HasDecompTest(TestCase):
     def setUp(self):
         super().setUp()

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -756,8 +756,6 @@ def slice_forward(
     end: int | None = None,
     step: int = 1,
 ):
-    from torch.fx.experimental.symbolic_shapes import statically_known_true
-
     ndim = self.dim()
     if ndim == 0:
         raise RuntimeError("slice() cannot be applied to a 0-dim tensor.")
@@ -771,23 +769,76 @@ def slice_forward(
     start_val = start if start is not None else 0
     end_val = end if end is not None else sys.maxsize  # 2^63 - 1
 
-    if start_val < 0:
-        start_val += sizes[dim]
+    def is_symint(x):
+        return isinstance(x, torch.SymInt)
 
-    if end_val < 0:
-        end_val += sizes[dim]
+    if not (is_symint(sizes[dim]) or is_symint(start_val) or is_symint(end_val)):
+        if start_val < 0:
+            start_val += sizes[dim]
 
-    if start_val < 0:
-        start_val = 0
-    elif start_val > sizes[dim]:
-        start_val = sizes[dim]
+        if end_val < 0:
+            end_val += sizes[dim]
 
-    if statically_known_true(end_val == sys.maxsize):
-        end_val = sizes[dim]
-    elif end_val < start_val:
-        end_val = start_val
-    elif end_val > sizes[dim]:
-        end_val = sizes[dim]
+        if start_val < 0:
+            start_val = 0
+        elif start_val > sizes[dim]:
+            start_val = sizes[dim]
+
+        if end_val == sys.maxsize:
+            end_val = sizes[dim]
+        elif end_val < start_val:
+            end_val = start_val
+        elif end_val > sizes[dim]:
+            end_val = sizes[dim]
+    else:
+        from torch.fx.experimental.symbolic_shapes import (
+            statically_known_false,
+            statically_known_true,
+        )
+
+        def sym_max(a, b):
+            if statically_known_true(a >= b):
+                return a
+            if statically_known_true(a <= b):
+                return b
+            return torch.sym_max(a, b)
+
+        def sym_min(a, b):
+            if statically_known_true(a <= b):
+                return a
+            if statically_known_true(a >= b):
+                return b
+            return torch.sym_min(a, b)
+
+        def sym_ite(pred, true_val, false_val):
+            if statically_known_true(pred):
+                return true_val
+            if statically_known_false(pred):
+                return false_val
+            if is_symint(true_val) and not is_symint(false_val):
+                false_val = true_val * 0 + false_val
+            elif is_symint(false_val) and not is_symint(true_val):
+                true_val = false_val * 0 + true_val
+            return torch.sym_ite(pred, true_val, false_val)
+
+        def clamp_min(val, lower):
+            return sym_max(val, lower)
+
+        def clamp_max(val, upper):
+            return sym_min(val, upper)
+
+        def adjust_negative(val):
+            return sym_ite(val < 0, val + sizes[dim], val)
+
+        start_val = adjust_negative(start_val)
+
+        start_val = clamp_max(clamp_min(start_val, 0), sizes[dim])
+
+        if statically_known_true(end_val == sys.maxsize):
+            end_val = sizes[dim]
+        else:
+            end_val = adjust_negative(end_val)
+            end_val = clamp_max(clamp_min(end_val, start_val), sizes[dim])
 
     storage_offset = self.storage_offset() + start_val * strides[dim]
     len = end_val - start_val


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185545

slice_forward normalized start and end with Python comparisons against the input dimension size. When that size is an unbacked SymInt, as in Detectron2 ImageList copying into a symbolic slice during export, comparisons such as end > size require a data-dependent guard like u0 < 800 and export fails before reaching the model body.

Keep the original concrete Python normalization path for ordinary integer sizes and bounds. When any of the slice size/start/end values is symbolic, normalize with sym_min, sym_max, and sym_ite so clamping and negative-index adjustment remain represented symbolically instead of forcing Python bool guards. This fixes the root cause without adding model-specific handling.

The main alternative was to route all slices through symbolic helpers. I kept a concrete fast path to avoid overhead in the common static decomposition path.

Benchmark Results:

Compared a copied pre-fix slice_forward implementation against the new implementation for 7 repeats of 200000 calls on torch.empty(1024) with slice bounds (0, 800). Raw minimums: old 0.543135s / 2.716 us per call; new 0.479447s / 2.397 us per call.

Test Plan:

python test/test_decomp.py SliceDecompTest.test_slice_forward_unbacked_dim_size

python test/dynamo/test_misc.py MiscTests.test_symint_copy_into_unbacked_slice

python test/export/test_export.py TestExport.test_unbacked_slice_forward TestExport.test_unbacked_slice_simple

lintrunner -a

Fixes #154137

Generated by my agent