### PR TITLE
[inductor] Fix missing libtorch_python symbols in FBCODE when using cpp-wrapper (#185551)

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -56,6 +56,40 @@ class GpuWrapperTemplate:
     pass
 
 
+def _register_fbcode_cpp_wrapper_arg_helper_op(m, device):
+    def impl(xs, dtype, device_arg, layout, memory_format):
+        if dtype != torch.float32:
+            raise AssertionError(f"Unexpected dtype: {dtype}")
+        if torch.device(device_arg).type != device:
+            raise AssertionError(f"Unexpected device: {device_arg}")
+        if layout != torch.strided:
+            raise AssertionError(f"Unexpected layout: {layout}")
+        if memory_format != torch.contiguous_format:
+            raise AssertionError(f"Unexpected memory_format: {memory_format}")
+        return (
+            xs[0]
+            .to(device=device_arg, dtype=dtype)
+            .contiguous(memory_format=memory_format)
+        )
+
+    def meta(xs, dtype, _device_arg, layout, memory_format):
+        return torch.empty_like(
+            xs[0],
+            dtype=dtype,
+            layout=layout,
+            memory_format=memory_format,
+        )
+
+    m.define(
+        "arg_helpers("
+        "Tensor[] xs, ScalarType dtype, Device device, "
+        "Layout layout, MemoryFormat memory_format"
+        ") -> Tensor"
+    )
+    m.impl("arg_helpers", impl, GPU_TYPE.upper())
+    m.impl("arg_helpers", meta, "Meta")
+
+
 class TestGpuWrapper(InductorTestCase):
     device = GPU_TYPE
 
@@ -92,6 +126,34 @@ class TestGpuWrapper(InductorTestCase):
         with torch.utils._device.DeviceContext(self.device):
             _, code = test_torchinductor.run_and_get_cpp_code(compiled, x, 3)
         self.assertIn("torch.tensor(arg, device='cpu')", code)
+
+    @config.patch(implicit_fallbacks=True)
+    def test_fbcode_custom_op_fallback_python_arg_helpers(self):
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+        if not config.is_fbcode():
+            self.skipTest("fbcode-only cpp_wrapper symbol visibility test")
+
+        device = self.device
+        with torch.library._scoped_library(
+            "fbcode_cpp_wrapper_arg_helpers", "FRAGMENT"
+        ) as m:
+            _register_fbcode_cpp_wrapper_arg_helper_op(m, device)
+
+            def fn(x):
+                y = x.sin()
+                return torch.ops.fbcode_cpp_wrapper_arg_helpers.arg_helpers(
+                    [y],
+                    torch.float32,
+                    torch.device(device),
+                    torch.strided,
+                    torch.contiguous_format,
+                ).cos()
+
+            x = torch.randn(4, 4, device=device)
+            expected = fn(x)
+            actual = torch.compile(fullgraph=True, options={"cpp_wrapper": True})(fn)(x)
+            self.assertEqual(actual, expected)
 
     def test_cpp_scratch_scales_with_grid_size_for_tma(self):
         if GPU_TYPE != "cuda" or torch.version.hip:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3069,20 +3069,16 @@ if (!custom_op_wrapper) {
                 # torch/_prims_common/__init__.py
                 return handle_scalar(raw_arg)
             elif isinstance(raw_arg, torch.device):
-                self.include_extra_header("torch/csrc/Device.h")
                 device_str, device_index = self.codegen_device(raw_arg).split(", ")
-                return f"THPDevice_New(c10::Device(static_cast<c10::DeviceType>({device_str}), {device_index}))"
+                return f"torch_python_thp_device_new({device_str}, {device_index})"
             elif isinstance(raw_arg, torch.dtype):
-                self.include_extra_header("torch/csrc/DynamicTypes.h")
-                return f"Py_NewRef(torch::getTHPDtype(static_cast<c10::ScalarType>({self.codegen_dtype(raw_arg)})))"
+                return f"torch_python_get_thp_dtype({self.codegen_dtype(raw_arg)})"
             elif isinstance(raw_arg, torch.layout):
-                self.include_extra_header("torch/csrc/DynamicTypes.h")
-                return f"Py_NewRef(torch::getTHPLayout(static_cast<c10::Layout>({self.codegen_layout(raw_arg)})))"
+                return f"torch_python_get_thp_layout({self.codegen_layout(raw_arg)})"
             elif isinstance(raw_arg, torch.memory_format):
-                self.include_extra_header("torch/csrc/utils/tensor_memoryformats.h")
                 return (
-                    "Py_NewRef(torch::utils::getTHPMemoryFormat(static_cast<c10::MemoryFormat>("
-                    f"{self.codegen_memory_format(raw_arg)})))"
+                    "torch_python_get_thp_memory_format("
+                    f"{self.codegen_memory_format(raw_arg)})"
                 )
             else:
                 raise NotImplementedError(

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -9,6 +9,8 @@
 #include <c10/util/Synchronized.h>
 #include <c10/util/flat_hash_map.h>
 #include <fmt/format.h>
+#include <torch/csrc/Device.h>
+#include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/autograd/grad_mode.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
 #include <torch/csrc/dynamo/guards.h>
@@ -20,6 +22,7 @@
 #include <torch/csrc/utils/python_strings.h>
 #include <torch/csrc/utils/python_symnode.h>
 #include <torch/csrc/utils/pythoncapi_compat.h>
+#include <torch/csrc/utils/tensor_memoryformats.h>
 #include <torch/extension.h>
 #include <cstdint>
 
@@ -7262,11 +7265,34 @@ double profile_guard_manager(
 
 } // namespace
 
+// These helpers are exported to Python as raw function pointers on the
+// torch._C._dynamo.guards module; see the grouped PyModule_AddObject calls in
+// torch_c_dynamo_guards_init below for the rationale.
 static void* _torchinductor_pyobject_tensor_data_ptr(PyObject* obj) {
   TORCH_CHECK(
       obj != nullptr && (THPVariable_CheckExact(obj) || THPVariable_Check(obj)),
       "_torchinductor_pyobject_tensor_data_ptr: non-tensor input");
   return THPVariable_Unpack(obj).data_ptr();
+}
+
+static PyObject* _torchinductor_thp_device_new(
+    int device_type,
+    int device_index) {
+  return THPDevice_New(
+      c10::Device(static_cast<c10::DeviceType>(device_type), device_index));
+}
+
+static PyObject* _torchinductor_get_thp_dtype(int dtype) {
+  return Py_NewRef(torch::getTHPDtype(static_cast<c10::ScalarType>(dtype)));
+}
+
+static PyObject* _torchinductor_get_thp_layout(int layout) {
+  return Py_NewRef(torch::getTHPLayout(static_cast<c10::Layout>(layout)));
+}
+
+static PyObject* _torchinductor_get_thp_memory_format(int memory_format) {
+  return Py_NewRef(torch::utils::getTHPMemoryFormat(
+      static_cast<c10::MemoryFormat>(memory_format)));
 }
 
 void* convert_to_root_guard_manager(py::object root) {
@@ -7343,40 +7369,37 @@ PyObject* torch_c_dynamo_guards_init() {
     return nullptr;
   }
 
-  // We expose the address of _torchinductor_pyobject_tensor_data_ptr in order
-  // to allow manual linking in our generated TorchInductor Python bindings.
-  // While regular linking works in most cases, it does not work properly in
-  // fbcode due to janky build setup there.
-  if (PyModule_AddObject(
-          m,
+  // Expose helper function pointers on the torch._C._dynamo.guards module so
+  // TorchInductor cpp_wrapper generated code can resolve these libtorch_python
+  // helpers at runtime instead of at link time. This is required in fbcode,
+  // where libtorch_python symbols are absent from the executable's dynamic
+  // symbol table, so the generated JIT .so cannot link them directly; it reads
+  // the pointers back via PyLong_AsVoidPtr (see the torch_python_* wrappers in
+  // torch/csrc/inductor/cpp_wrapper/common.h).
+  const auto expose_inductor_symbol = [&](const char* name, auto fn) {
+    return PyModule_AddObject(
+               m, name, PyLong_FromVoidPtr(reinterpret_cast<void*>(fn))) >= 0;
+  };
+  if (!expose_inductor_symbol(
           "_torchinductor_pyobject_tensor_data_ptr",
-          PyLong_FromVoidPtr(reinterpret_cast<void*>(
-              &_torchinductor_pyobject_tensor_data_ptr))) < 0) {
+          &_torchinductor_pyobject_tensor_data_ptr) ||
+      !expose_inductor_symbol(
+          "_torchinductor_thp_device_new", &_torchinductor_thp_device_new) ||
+      !expose_inductor_symbol(
+          "_torchinductor_get_thp_dtype", &_torchinductor_get_thp_dtype) ||
+      !expose_inductor_symbol(
+          "_torchinductor_get_thp_layout", &_torchinductor_get_thp_layout) ||
+      !expose_inductor_symbol(
+          "_torchinductor_get_thp_memory_format",
+          &_torchinductor_get_thp_memory_format) ||
+      !expose_inductor_symbol(
+          "_torchinductor_thp_variable_wrap",
+          static_cast<PyObject* (*)(const at::TensorBase&)>(
+              &THPVariable_Wrap)) ||
+      !expose_inductor_symbol(
+          "_torchinductor_thputils_unpack_int",
+          static_cast<int32_t (*)(PyObject*)>(&THPUtils_unpackInt))) {
     return nullptr;
-  }
-
-  // Expose THPVariable_Wrap for cpp_wrapper inductor, for fbcode
-  {
-    using WrapFn = PyObject* (*)(const at::TensorBase&);
-    WrapFn fn = &THPVariable_Wrap;
-    if (PyModule_AddObject(
-            m,
-            "_torchinductor_thp_variable_wrap",
-            PyLong_FromVoidPtr(reinterpret_cast<void*>(fn))) < 0) {
-      return nullptr;
-    }
-  }
-
-  // Expose THPUtils_unpackInt for cpp_wrapper inductor, for fbcode
-  {
-    using UnpackFn = int32_t (*)(PyObject*);
-    UnpackFn fn = &THPUtils_unpackInt;
-    if (PyModule_AddObject(
-            m,
-            "_torchinductor_thputils_unpack_int",
-            PyLong_FromVoidPtr(reinterpret_cast<void*>(fn))) < 0) {
-      return nullptr;
-    }
   }
 
   auto py_m = py::handle(m).cast<py::module>();

--- a/torch/csrc/inductor/cpp_wrapper/common.h
+++ b/torch/csrc/inductor/cpp_wrapper/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <filesystem>
 #include <optional>
 #include <utility>
@@ -88,3 +89,123 @@ using namespace torch::aot_inductor;
 [[maybe_unused]] inline int64_t align(int64_t nbytes) {
   return (nbytes + 64 - 1) & -64;
 }
+
+// Helpers backed by function pointers exported from the torch._C._dynamo.guards
+// Python module. Defined at the end of this header so they can use RAIIPyObject
+// and AOTI_TORCH_CHECK, both established above.
+//
+// Inductor-generated wrappers cannot always link the libtorch_python THP
+// symbols directly (notably in fbcode, where libtorch_python symbols are absent
+// from the executable's dynamic symbol table; see torch_c_dynamo_guards_init in
+// torch/csrc/dynamo/guards.cpp). Instead we resolve the corresponding
+// _torchinductor_* function pointers from the guards module at runtime, lazily
+// on first use, and expose typed torch_python_* wrappers around them.
+
+// Forward-declared rather than including the heavy <ATen/Tensor.h>:
+// at::TensorBase is used below only in reference parameters and
+// function-pointer types.
+namespace at {
+class TensorBase;
+}
+
+namespace torch::aot_inductor {
+
+static PyObject* (*_torchinductor_thp_device_new)(int, int) = nullptr;
+static PyObject* (*_torchinductor_get_thp_dtype)(int) = nullptr;
+static PyObject* (*_torchinductor_get_thp_layout)(int) = nullptr;
+static PyObject* (*_torchinductor_get_thp_memory_format)(int) = nullptr;
+static PyObject* (*_torchinductor_thp_variable_wrap)(const at::TensorBase&) =
+    nullptr;
+static int32_t (*_torchinductor_thputils_unpack_int)(PyObject*) = nullptr;
+
+// Guards the lazy init below; set true only once all pointers resolve.
+static bool _torchinductor_pointers_initialized = false;
+
+static inline void* torch_python_get_pointer_attr(
+    PyObject* module,
+    const char* attr) {
+  RAIIPyObject value(PyObject_GetAttrString(module, attr));
+  AOTI_TORCH_CHECK(
+      value, "Failed to load torch._C._dynamo.guards function pointer");
+  void* ptr = PyLong_AsVoidPtr(value.get());
+  AOTI_TORCH_CHECK(
+      ptr && !PyErr_Occurred(),
+      "Failed to parse torch._C._dynamo.guards function pointer");
+  return ptr;
+}
+
+// Resolves every _torchinductor_* pointer in one shot; the guards module
+// registers them all together. _torchinductor_pointers_initialized is set only
+// after all resolutions succeed, so a partial failure leaves it false and the
+// next call retries instead of leaving some pointers null behind a satisfied
+// early-return.
+static inline void torch_python_init_guards_pointers() {
+  if (_torchinductor_pointers_initialized) {
+    return;
+  }
+
+  RAIIPyObject guards_mod(PyImport_ImportModule("torch._C._dynamo.guards"));
+  AOTI_TORCH_CHECK(guards_mod, "Failed to import torch._C._dynamo.guards");
+
+  _torchinductor_thp_device_new =
+      reinterpret_cast<decltype(_torchinductor_thp_device_new)>(
+          torch_python_get_pointer_attr(
+              guards_mod.get(), "_torchinductor_thp_device_new"));
+  _torchinductor_get_thp_dtype =
+      reinterpret_cast<decltype(_torchinductor_get_thp_dtype)>(
+          torch_python_get_pointer_attr(
+              guards_mod.get(), "_torchinductor_get_thp_dtype"));
+  _torchinductor_get_thp_layout =
+      reinterpret_cast<decltype(_torchinductor_get_thp_layout)>(
+          torch_python_get_pointer_attr(
+              guards_mod.get(), "_torchinductor_get_thp_layout"));
+  _torchinductor_get_thp_memory_format =
+      reinterpret_cast<decltype(_torchinductor_get_thp_memory_format)>(
+          torch_python_get_pointer_attr(
+              guards_mod.get(), "_torchinductor_get_thp_memory_format"));
+  _torchinductor_thp_variable_wrap =
+      reinterpret_cast<decltype(_torchinductor_thp_variable_wrap)>(
+          torch_python_get_pointer_attr(
+              guards_mod.get(), "_torchinductor_thp_variable_wrap"));
+  _torchinductor_thputils_unpack_int =
+      reinterpret_cast<decltype(_torchinductor_thputils_unpack_int)>(
+          torch_python_get_pointer_attr(
+              guards_mod.get(), "_torchinductor_thputils_unpack_int"));
+
+  _torchinductor_pointers_initialized = true;
+}
+
+static inline PyObject* torch_python_thp_device_new(
+    int device_type,
+    int device_index) {
+  torch_python_init_guards_pointers();
+  return _torchinductor_thp_device_new(device_type, device_index);
+}
+
+static inline PyObject* torch_python_get_thp_dtype(int dtype) {
+  torch_python_init_guards_pointers();
+  return _torchinductor_get_thp_dtype(dtype);
+}
+
+static inline PyObject* torch_python_get_thp_layout(int layout) {
+  torch_python_init_guards_pointers();
+  return _torchinductor_get_thp_layout(layout);
+}
+
+static inline PyObject* torch_python_get_thp_memory_format(int memory_format) {
+  torch_python_init_guards_pointers();
+  return _torchinductor_get_thp_memory_format(memory_format);
+}
+
+static inline PyObject* torch_python_thp_variable_wrap(
+    const at::TensorBase& tensor) {
+  torch_python_init_guards_pointers();
+  return _torchinductor_thp_variable_wrap(tensor);
+}
+
+static inline int32_t torch_python_thputils_unpack_int(PyObject* obj) {
+  torch_python_init_guards_pointers();
+  return _torchinductor_thputils_unpack_int(obj);
+}
+
+} // namespace torch::aot_inductor

--- a/torch/csrc/inductor/cpp_wrapper/lazy_triton_compile.h
+++ b/torch/csrc/inductor/cpp_wrapper/lazy_triton_compile.h
@@ -12,9 +12,6 @@
 #include <torch/csrc/inductor/cpp_wrapper/device_internal/cuda.h>
 #endif
 
-static PyObject* (*_THPVariable_Wrap)(const at::TensorBase&) = nullptr;
-static int32_t (*_THPUtils_unpackInt)(PyObject*) = nullptr;
-
 // Cached module and function references
 static PyObject* triton_lazy_compile_module = nullptr;
 static PyObject* start_kernel_compile = nullptr;
@@ -42,25 +39,6 @@ static inline void loadLazyCompileFuncs() {
     AOTI_TORCH_CHECK(
         run_triton_kernel_with_autotune,
         "Failed to get run_triton_kernel_with_autotune");
-
-    RAIIPyObject guards_mod = PyImport_ImportModule("torch._C._dynamo.guards");
-    AOTI_TORCH_CHECK(guards_mod, "Failed to import torch._C._dynamo.guards");
-
-    RAIIPyObject wrap_addr =
-        PyObject_GetAttrString(guards_mod, "_torchinductor_thp_variable_wrap");
-    AOTI_TORCH_CHECK(
-        wrap_addr, "Failed to get _torchinductor_thp_variable_wrap");
-    _THPVariable_Wrap = reinterpret_cast<decltype(_THPVariable_Wrap)>(
-        PyLong_AsVoidPtr(wrap_addr));
-    AOTI_TORCH_CHECK(_THPVariable_Wrap, "THPVariable_Wrap not resolved");
-
-    RAIIPyObject unpack_addr = PyObject_GetAttrString(
-        guards_mod, "_torchinductor_thputils_unpack_int");
-    AOTI_TORCH_CHECK(
-        unpack_addr, "Failed to get _torchinductor_thputils_unpack_int");
-    _THPUtils_unpackInt = reinterpret_cast<decltype(_THPUtils_unpackInt)>(
-        PyLong_AsVoidPtr(unpack_addr));
-    AOTI_TORCH_CHECK(_THPUtils_unpackInt, "THPUtils_unpackInt not resolved");
   }
 }
 
@@ -73,7 +51,7 @@ static inline std::string getStringAttr(PyObject* obj, const char* attr) {
 static inline int getIntAttr(PyObject* obj, const char* attr) {
   RAIIPyObject val = PyObject_GetAttrString(obj, attr);
   AOTI_TORCH_CHECK(val, "Failed to get attribute");
-  return _THPUtils_unpackInt(val);
+  return torch_python_thputils_unpack_int(val);
 }
 
 static inline int getOptionalIntAttr(
@@ -82,7 +60,8 @@ static inline int getOptionalIntAttr(
     int sentinel = -1) {
   RAIIPyObject val = PyObject_GetAttrString(obj, attr);
   AOTI_TORCH_CHECK(val, "Failed to get attribute");
-  return (!Py_IsNone(val.get())) ? _THPUtils_unpackInt(val) : sentinel;
+  return (!Py_IsNone(val.get())) ? torch_python_thputils_unpack_int(val)
+                                 : sentinel;
 }
 
 static inline std::vector<int> getIntListAttr(PyObject* obj, const char* attr) {
@@ -92,7 +71,7 @@ static inline std::vector<int> getIntListAttr(PyObject* obj, const char* attr) {
   std::vector<int> result;
   result.reserve(size);
   for (Py_ssize_t i = 0; i < size; i++) {
-    result.push_back(_THPUtils_unpackInt(PyList_GetItem(val, i)));
+    result.push_back(torch_python_thputils_unpack_int(PyList_GetItem(val, i)));
   }
   return result;
 }
@@ -122,13 +101,13 @@ static inline PyObject* convertArgToPython(const T& arg) {
   if constexpr (std::is_same_v<DecayedT, AtenTensorHandle>) {
     at::Tensor* tensor_ptr =
         torch::aot_inductor::tensor_handle_to_tensor_pointer(arg);
-    return _THPVariable_Wrap(*tensor_ptr);
+    return torch_python_thp_variable_wrap(*tensor_ptr);
   } else if constexpr (std::is_same_v<
                            DecayedT,
                            torch::aot_inductor::RAIIAtenTensorHandle>) {
     at::Tensor* tensor_ptr =
         torch::aot_inductor::tensor_handle_to_tensor_pointer(arg.get());
-    return _THPVariable_Wrap(*tensor_ptr);
+    return torch_python_thp_variable_wrap(*tensor_ptr);
   } else if constexpr (std::is_same_v<DecayedT, bool>) {
     PyObject* py_arg = arg ? Py_True : Py_False;
     return Py_NewRef(py_arg);


### PR DESCRIPTION
Summary:

In fbcode, cpp-wrapper generated modules cannot directly resolve several `libtorch_python` helpers from the executable dynamic symbol table. Route generated Python argument construction for `torch.device`, `torch.dtype`, `torch.layout`, and `torch.memory_format` through helper function pointers exported on `torch._C._dynamo.guards` instead.

Reviewed By: Microve

Differential Revision: D106591087




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98