### PR TITLE
Fix typos in comments

### DIFF
--- a/torch/csrc/jit/mobile/compatibility/backport_manager.cpp
+++ b/torch/csrc/jit/mobile/compatibility/backport_manager.cpp
@@ -252,7 +252,7 @@ namespace {
 
 /*
 The following functions needed for backport model from v5 to v4.
-Backport function bytecode v5 that deduplicate constanst table.
+Backport function bytecode v5 that deduplicate constants table.
 Previously, in v4, constant table will be exported twice, in both archive
 bytecode and archive constants, and majority (almost all) are duplicates.
 Currently, in v5, JIT and mobile will share archive constants, and all

--- a/torch/fx/experimental/rewriter.py
+++ b/torch/fx/experimental/rewriter.py
@@ -127,7 +127,7 @@ def _rewrite(
 ) -> torch.nn.Module | Callable[..., Any]:
     if isinstance(fn, torch.nn.Module):
         # Rewrite this module's `forward` as well as the `forward`s of
-        # all of this module's recursive descendents. Return the new,
+        # all of this module's recursive descendants. Return the new,
         # rewritten module hierarchy.
         def rewrite_module(m: torch.nn.Module) -> torch.nn.Module:
             class RewrittenModule(torch.nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185556

Fix "constanst" → "constants" in backport_manager.cpp and
"descendents" → "descendants" in rewriter.py.

Authored with Claude (typo_terminator2).