### PR TITLE
Mark graphsafe_run_with_rng_state as cacheable for FxGraphCache

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1742,8 +1742,8 @@ class TestFxGraphCache(TestCase):
         self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 2)
         self.assertEqual(counters["inductor"]["fxgraph_cache_bypass"], 0)
 
-        torch.testing.assert_close(out1, out2)
-        torch.testing.assert_close(grad1, grad2)
+        self.assertEqual(out1, out2)
+        self.assertEqual(grad1, grad2)
 
         # Different seed through cached code must produce different output —
         # proves the cached artifact is parameterized by runtime RNG state

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1692,6 +1692,70 @@ class TestFxGraphCache(TestCase):
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
+    def test_graphsafe_rng_cache_hit(self):
+        """graphsafe_run_with_rng_state must not bypass FxGraphCache.
+
+        Activation checkpointing with preserve_rng_state=True inserts
+        graphsafe_run_with_rng_state into post-partition graphs when the
+        wrapped region contains nondeterministic ops (e.g. SDPA dropout).
+        The sibling RNG HOPs (run_and_save_rng_state, run_with_rng_state,
+        run_dtensor_rng_op) are all cacheable; this one must be too.
+        """
+        import torch.nn.functional as F
+        from torch.utils.checkpoint import checkpoint
+
+        class SDPADrop(torch.nn.Module):
+            def forward(self, q, k, v):
+                return F.scaled_dot_product_attention(q, k, v, dropout_p=0.1)
+
+        inner = SDPADrop()
+        q = torch.randn(2, 4, 16, 16, device=GPU_TYPE, requires_grad=True)
+        k = torch.randn(2, 4, 16, 16, device=GPU_TYPE)
+        v = torch.randn(2, 4, 16, 16, device=GPU_TYPE)
+
+        def model(q, k, v):
+            return checkpoint(
+                inner, q, k, v, use_reentrant=False, preserve_rng_state=True
+            )
+
+        def run(q):
+            torch.manual_seed(99)
+            out = torch.compile(model, fullgraph=True)(q, k, v).sum()
+            out.backward()
+            return out.detach(), q.grad.clone()
+
+        # Cold compile — fwd and bwd graphs each miss once
+        out1, grad1 = run(q)
+        q.grad = None
+
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_bypass"], 0)
+
+        # Warm compile — fwd and bwd graphs each hit
+        counters.clear()
+        self.reset()
+
+        out2, grad2 = run(q)
+
+        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 2)
+        self.assertEqual(counters["inductor"]["fxgraph_cache_bypass"], 0)
+
+        torch.testing.assert_close(out1, out2)
+        torch.testing.assert_close(grad1, grad2)
+
+        # Different seed through cached code must produce different output —
+        # proves the cached artifact is parameterized by runtime RNG state
+        q.grad = None
+        torch.manual_seed(0)
+        out3 = torch.compile(model, fullgraph=True)(q, k, v).sum()
+        self.assertFalse(torch.allclose(out1, out3))
+
+    @requires_gpu()
+    @requires_triton()
+    @config.patch({"fx_graph_cache": True})
+    @config.patch({"fx_graph_remote_cache": False})
     @parametrize("bundle_triton", (False, True))
     def test_triton_higher_order_op(self, bundle_triton):
         """

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -336,7 +336,7 @@ def _impl_graphsafe_rng(op, *args, rng_state=None, **kwargs):
 def register_graphsafe_run_with_rng_state_op():
     class GraphSafeRunWithRngState(HigherOrderOperator):
         def __init__(self):
-            super().__init__("graphsafe_run_with_rng_state")
+            super().__init__("graphsafe_run_with_rng_state", cacheable=True)
 
         def __call__(self, op, *args, rng_state=None, **kwargs):
             # pyrefly: ignore [missing-attribute]


### PR DESCRIPTION
#169959 marked run_and_save_rng_state and run_with_rng_state as cacheable but did not include graphsafe_run_with_rng_state, which uses a different generator interface (graphsafe_get/set_state). Since then, the opaque generator work (#179661) has landed and stabilized that interface, so this HOP can be marked cacheable too.

Without this, FxGraphCache bypasses entirely for any graph containing activation checkpointing with preserve_rng_state=True, forcing a cold recompile every time.  The RNG state is a runtime tensor input, so the cached artifact remains correctly parameterized.

Test Plan: test_graphsafe_rng_cache_hit verifies cold miss → warm hit progression and that cached code respects runtime RNG state changes.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo