### PR TITLE
[TEST] Fix key construction in `test_corrupt_cache_recompile_end_to_end`

### DIFF
--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -1416,7 +1416,15 @@ class TestCuteDSLSubprocessCompile(TestCase):
 
                 key, path = codecache.PyCodeCache.write(source)
                 config_key = ("test_corrupt_e2e",)
-                runtime_key = ((8, 4), torch.float32, (8, 4), torch.float32)
+                x = torch.randn(8, 4, device=device, dtype=torch.float32)
+                y = torch.randn(8, 4, device=device, dtype=torch.float32)
+                out = torch.empty(8, 4, device=device, dtype=torch.float32)
+                runtime_key = (
+                    tuple(x.shape),
+                    x.dtype,
+                    tuple(y.shape),
+                    y.dtype,
+                )
                 h = _make_disk_key(path, config_key, runtime_key, device_index=dev_idx)
                 obj_path = cache_dir / f"{h}.o"
 
@@ -1428,9 +1436,6 @@ class TestCuteDSLSubprocessCompile(TestCase):
                 mod = codecache.PyCodeCache.load_by_key_path(key, path)
                 self.assertEqual(mod.compile_count, 0)
 
-                x = torch.randn(8, 4, device=device, dtype=torch.float32)
-                y = torch.randn(8, 4, device=device, dtype=torch.float32)
-                out = torch.empty(8, 4, device=device, dtype=torch.float32)
                 mod.test_kernel_main(x, y, out)
 
                 self.assertEqual(


### PR DESCRIPTION
Otherwise seems to fail with e.g., 
```
  File "/opt/pytorch/pytorch/torch/_inductor/runtime/compile_tasks.py", line 35, in _reload_python_module                                                                                                                                                                                  
    exec(code, mod.__dict__, mod.__dict__)                                                                                                   
  File "/tmp/tmp4vip_irp/kh/ckh7p34aorayopzureuxjxhyvkve6nzlpfm44pf4ck2emgl3qgle.py", line 116, in <module>                                                                                                                                                                                
    async_compile.wait(globals())                                                                                                            
  File "/opt/pytorch/pytorch/torch/_inductor/async_compile.py", line 797, in wait                                                                                                                                                                                                          
    self._wait_futures(scope)                                                                                                                
  File "/opt/pytorch/pytorch/torch/_inductor/async_compile.py", line 827, in _wait_futures                                                                                                                                                                                                 
    kernel = result.result(timeout=wait_timeout)                                                                                                                                                                                                                                           
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                           
  File "/opt/pytorch/pytorch/torch/_inductor/codecache.py", line 5086, in result                                                             
    return self.result_fn()                                                                                                                  
           ^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                
  File "/opt/pytorch/pytorch/torch/_inductor/async_compile.py", line 650, in get_result                                                                                                                                                                                                    
    raise e.with_name(kernel_name) from e                                                                                                    
torch._inductor.exc.InductorError: SubprocException: An exception occurred in a subprocess:                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                           
Name=cutedsl_fused_add_fc760305                                                                                                                                                                                                                                                            
Traceback (most recent call last):                                                                                                                                                                                                                                                         
  File "/opt/pytorch/pytorch/torch/_inductor/compile_worker/subproc_pool.py", line 475, in do_job                                            
    result = job()                                                                                                                           
             ^^^^^                                                                                                                           
  File "/opt/pytorch/pytorch/torch/_inductor/runtime/compile_tasks.py", line 164, in _worker_compile_pycodecache_kernel                                                                                                                                                                    
    precompile_fn(**precompile_metadata)                                                                                                     
TypeError: cutedsl_fused_add_fc760305_precompile() got an unexpected keyword argument 'precompile_strides' 
```

authored with codex

cc @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo