### PR TITLE
[dynamo] Refactor generator calling for python 3.11+

### DIFF
--- a/test/dynamo/test_generator.py
+++ b/test/dynamo/test_generator.py
@@ -902,6 +902,17 @@ class GraphModule(torch.nn.Module):
         self.assertRaises(StopIteration, next, g)
         self.assertFalse(3 in whoo())
 
+    def test_raise_immediately(self):
+        # see https://github.com/python/cpython/issues/143493
+        @torch.compile(fullgraph=True, backend="eager")
+        def f(s):
+            return (x for x in s)
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported, "'int' object is not iterable"
+        ):
+            f(1)
+
 
 class TestGeneratorSend(GeneratorTestsBase):
     def test_send(self):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5217,17 +5217,18 @@ class InstructionTranslatorBase(
 
         self.package = package
 
-        from .resume_execution import (
-            CO_ASYNC_GENERATOR,
-            CO_COROUTINE,
-            CO_GENERATOR,
-            CO_ITERABLE_COROUTINE,
-        )
+        if sys.version_info < (3, 11):
+            from .resume_execution import (
+                CO_ASYNC_GENERATOR,
+                CO_COROUTINE,
+                CO_GENERATOR,
+                CO_ITERABLE_COROUTINE,
+            )
 
-        if f_code.co_flags & (
-            CO_GENERATOR | CO_COROUTINE | CO_ITERABLE_COROUTINE | CO_ASYNC_GENERATOR
-        ):
-            self.push(BuiltinVariable(None))
+            if f_code.co_flags & (
+                CO_GENERATOR | CO_COROUTINE | CO_ITERABLE_COROUTINE | CO_ASYNC_GENERATOR
+            ):
+                self.push(BuiltinVariable(None))
 
         self.inline_depth = inline_depth
         self.inconsistent_side_effects = False
@@ -6194,7 +6195,6 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
         self.generated_items.append(top)
         if len(self.generated_items) > MAX_ITERATOR_LIMIT:
             raise exc.InfiniteGeneratorError
-        self.push(ConstantVariable.create(None))
         if (
             config.enable_faithful_generator_behavior
             or self.is_generator_from_ctx_manager
@@ -6209,6 +6209,10 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
             self.pop()
             res = VariableTracker.build(self, iter).call_function(self, [tos], {})  # type: ignore[arg-type]
             self.push(res)
+
+    def RETURN_GENERATOR(self, inst: Instruction):
+        self.symbolic_result = self.funcvar
+        raise ReturnValueOp
 
     def RETURN_VALUE(self, inst: Instruction) -> None:
         self.generator_exhausted = True

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -6213,7 +6213,7 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
             res = VariableTracker.build(self, iter).call_function(self, [tos], {})  # type: ignore[arg-type]
             self.push(res)
 
-    def RETURN_GENERATOR(self, inst: Instruction):
+    def RETURN_GENERATOR(self, inst: Instruction) -> None:
         self.symbolic_result = self.funcvar
         raise ReturnValueOp
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5217,18 +5217,20 @@ class InstructionTranslatorBase(
 
         self.package = package
 
-        if sys.version_info < (3, 11):
-            from .resume_execution import (
-                CO_ASYNC_GENERATOR,
-                CO_COROUTINE,
-                CO_GENERATOR,
-                CO_ITERABLE_COROUTINE,
-            )
+        from .resume_execution import (
+            CO_ASYNC_GENERATOR,
+            CO_COROUTINE,
+            CO_GENERATOR,
+            CO_ITERABLE_COROUTINE,
+        )
 
-            if f_code.co_flags & (
-                CO_GENERATOR | CO_COROUTINE | CO_ITERABLE_COROUTINE | CO_ASYNC_GENERATOR
-            ):
-                self.push(BuiltinVariable(None))
+        # Probably we shouldn't actually push None until the frame actually starts executing, but some tests (and
+        # possibly user code) depends on it.  Generators are handled properly in 3.11+, so we can skip them
+        push_types = CO_COROUTINE | CO_ITERABLE_COROUTINE | CO_ASYNC_GENERATOR
+        if sys.version_info < (3, 11):
+            push_types |= CO_GENERATOR
+        if f_code.co_flags & (push_types):
+            self.push(BuiltinVariable(None))
 
         self.inline_depth = inline_depth
         self.inconsistent_side_effects = False
@@ -6181,6 +6183,7 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
         self.generated_items = []
         self.generator_exhausted = False
         self.is_generator_from_ctx_manager = False
+        self.generator_just_started = True
 
     def inline_call_(self) -> VariableTracker:
         with profile_inline_call(self.output, self.f_code, lambda: self.inline_depth):
@@ -6211,6 +6214,7 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
             self.push(res)
 
     def RETURN_GENERATOR(self, inst: Instruction):
+        self.generator_just_started = False
         self.symbolic_result = self.funcvar
         raise ReturnValueOp
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -6184,7 +6184,6 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
         self.generated_items = []
         self.generator_exhausted = False
         self.is_generator_from_ctx_manager = False
-        self.generator_just_started = True
 
     def inline_call_(self) -> VariableTracker:
         with profile_inline_call(self.output, self.f_code, lambda: self.inline_depth):
@@ -6215,7 +6214,6 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
             self.push(res)
 
     def RETURN_GENERATOR(self, inst: Instruction):
-        self.generator_just_started = False
         self.symbolic_result = self.funcvar
         raise ReturnValueOp
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5224,8 +5224,9 @@ class InstructionTranslatorBase(
             CO_ITERABLE_COROUTINE,
         )
 
-        # Probably we shouldn't actually push None until the frame actually starts executing, but some tests (and
-        # possibly user code) depends on it.  Generators are handled properly in 3.11+, so we can skip them
+        # This isn't really the right place to push None.  But since we treat RETURN_GENERATOR as a no-op for
+        # non-generator frames, there needs to be something on the stack since the first instruction will be POP_TOP,
+        # which would error out with an empty stack
         push_types = CO_COROUTINE | CO_ITERABLE_COROUTINE | CO_ASYNC_GENERATOR
         if sys.version_info < (3, 11):
             push_types |= CO_GENERATOR

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1168,8 +1168,10 @@ class LocalGeneratorObjectVariable(VariableTracker):
     def python_type(self) -> type:
         return types.GeneratorType
 
-    def tp_iternext_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
-        # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/genobject.c#L832
+    def gen_send_ex2(
+        self, tx: "InstructionTranslatorBase", arg: VariableTracker
+    ) -> VariableTracker:
+        # https://github.com/python/cpython/blob/f31a89bb901067dd105b00cfa90523cf7ffdbbdd/Objects/genobject.c#L259
         tracer = self.inline_tracer
 
         if self._is_generator_exhausted():
@@ -1179,6 +1181,7 @@ class LocalGeneratorObjectVariable(VariableTracker):
             # Hierarchically, tx can be seen as the parent of the inline tracer
             # created on call_function. Any exception needs to be propagated to tx
             # for Dynamo to behave correctly
+            tracer.push(arg)
             return tracer.inline_call_()
         except ObservedException as e:
             tracer.generator_exhausted = True
@@ -1201,6 +1204,10 @@ class LocalGeneratorObjectVariable(VariableTracker):
             if not tx.one_graph and not tx.error_on_graph_break:
                 e.msg += "\n\nSkipping frame due to graph break in a generator's next() call."
             raise
+
+    def tp_iternext_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/genobject.c#L832
+        return self.gen_send_ex2(tx, ConstantVariable.create(None))
 
     def call_obj_hasattr(
         self, tx: "InstructionTranslator", name: str
@@ -1273,9 +1280,7 @@ class LocalGeneratorObjectVariable(VariableTracker):
                 # Test: GeneratorCPythonTests.test_send_non_none_to_new_gen
                 if not all(arg.is_constant_none() for arg in args):
                     raise_observed_exception(TypeError, tx)
-            tracer = self.inline_tracer
-            tracer.push_many(args)
-            return self.tp_iternext_impl(tx)
+            return self.gen_send_ex2(tx, args[0])
         elif name == "close":
             # * Raises a GeneratorExit at the point where the generator function was paused.
             # * If the generator function catches the exception and returns a
@@ -1330,7 +1335,7 @@ class LocalGeneratorObjectVariable(VariableTracker):
 
             try:
                 # Raise RuntimeError if the generator yields any other value
-                if self.tp_iternext_impl(tx):
+                if tracer.inline_call_():
                     raise_observed_exception(RuntimeError, tx)
             except ObservedGeneratorExit:
                 tracer.generator_exhausted = True
@@ -1364,7 +1369,7 @@ class LocalGeneratorObjectVariable(VariableTracker):
                 # propagate the exception back to the parent caller
                 raise
 
-            retval = self.tp_iternext_impl(tx)
+            retval = tracer.inline_call_()
 
             # The exception raised before is still active. We need to check the exception
             # table one more time to find the next target. But why? Let's walk
@@ -1430,7 +1435,7 @@ class LocalGeneratorObjectVariable(VariableTracker):
 
             try:
                 self._setup_exception(tx, variables.ExceptionVariable(exc_type, []))
-                self.next_variable(tx)
+                tracer.inline_call_()
             except get_dynamo_observed_exception(exc_type):
                 # We should get back the exception raised before.
                 pass
@@ -1528,6 +1533,8 @@ class LocalGeneratorFunctionVariable(BaseUserFunctionVariable):
         code = self.vt.get_code()
         f_globals = self.vt.get_globals()
 
+        if sys.version_info >= (3, 11):
+            inline_tracer.inline_call_()
         # calling a generator returns a generator object
         return self.generator_cls(
             code,

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1259,7 +1259,11 @@ class LocalGeneratorObjectVariable(VariableTracker):
             tracer.exception_handler(e)
 
     def _is_generator_just_started(self) -> bool:
-        return self.inline_tracer is None or self.inline_tracer.instruction_pointer == 0
+        if sys.version_info < (3, 11):
+            first_inst = 0
+        else:
+            first_inst = 1
+        return self.inline_tracer is None or self.inline_tracer.instruction_pointer == first_inst
 
     def _is_generator_exhausted(self) -> bool:
         return getattr(self.inline_tracer, "generator_exhausted", False)

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1263,7 +1263,10 @@ class LocalGeneratorObjectVariable(VariableTracker):
             first_inst = 0
         else:
             first_inst = 1
-        return self.inline_tracer is None or self.inline_tracer.instruction_pointer == first_inst
+        return (
+            self.inline_tracer is None
+            or self.inline_tracer.instruction_pointer == first_inst
+        )
 
     def _is_generator_exhausted(self) -> bool:
         return getattr(self.inline_tracer, "generator_exhausted", False)

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1342,6 +1342,7 @@ class LocalGeneratorObjectVariable(VariableTracker):
 
             try:
                 # Raise RuntimeError if the generator yields any other value
+                # TODO seems like this should send None
                 if tracer.inline_call_():
                     raise_observed_exception(RuntimeError, tx)
             except ObservedGeneratorExit:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #185566

The main change is to actually call the generator when it's created.  In 3.11-3.14 this immediately returns (via
RETURN_GENERATOR).  Starting in 3.15 there's a short prologue that needs to be executed first (see the added test and
linked issue).  Also changes how objects are sent to the generator to more closely match cpython.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98