### PR TITLE
Tune jemalloc for inductor compile workers to reduce memory fragmentation

### DIFF
--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -177,15 +177,16 @@ class SubprocPool:
             # pyrefly: ignore [bad-assignment]
             self.log_file = open(log_path, "w")  # noqa:SIM115
 
+        subproc_env = {
+            **python_subprocess_env(),
+            "TORCH_WARM_POOL": "0",
+            "LD_LIBRARY_PATH": get_ld_library_path(),
+        }
+        if config.compile_worker_malloc_conf:
+            subproc_env["MALLOC_CONF"] = config.compile_worker_malloc_conf
         self.process = subprocess.Popen(
             cmd,
-            env={
-                **python_subprocess_env(),
-                # Safeguard against creating a SubprocPool in the subprocess.
-                "TORCH_WARM_POOL": "0",
-                # Some internal usages need a modified LD_LIBRARY_PATH.
-                "LD_LIBRARY_PATH": get_ld_library_path(),
-            },
+            env=subproc_env,
             pass_fds=(subproc_read_fd, subproc_write_fd),
             stdout=self.log_file,
             stderr=self.log_file,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1377,6 +1377,16 @@ quiesce_async_compile_time: int = Config(
     default=60,
 )
 
+# MALLOC_CONF to set for the compile worker subprocess. Tuned to reduce
+# memory fragmentation and retention in the jemalloc allocator used by
+# Triton/LLVM compilation. Default reduces RSS ~20% vs stock jemalloc
+# settings by limiting arena count and returning freed pages immediately.
+# Set to empty string to disable.
+compile_worker_malloc_conf: str = Config(
+    env_name_force="TORCHINDUCTOR_COMPILE_WORKER_MALLOC_CONF",
+    default="dirty_decay_ms:0,narenas:4",
+)
+
 # Whether or not to enable statically launching CUDA kernels
 # compiled by triton (instead of using triton's own launcher)
 use_static_cuda_launcher: bool = static_cuda_launcher_default()


### PR DESCRIPTION
Summary:
Inductor jemalloc config isn't optimized and causes a lot of memory footprint. In general, footprint of single compile worker can get to 3GB due to large arenas and large decay timer (10 second by default). Because we compile pretty much all of the time, memory never gets defragmented. 

This change exposes this param and sets more reasonable default. There's no performance or memory penalty related to it.

Test Plan:
GB200 with 4 compile threads, 50 model compilations. By default, there were 500+ arenas, seems excessive

Baseline:     RSS=3223 MB, frag=1695 MB (142%)
`dirty_decay_ms:0,narenas:4`:   RSS=2576 MB, frag=97 MB (8%)
`dirty_decay_ms:0,narenas:1`:   RSS=2562 MB, frag=59 MB (5%)


narenas=1 is too risky. No time in overall compilation, malloc perf is non detrimental than here.

Differential Revision: D106669001




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo