### PR TITLE
fix flash sdpa activation dtype mismatched between meta and cpu implementation

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1896,6 +1896,26 @@ class TestMeta(TestCase):
         else:
             self.assertEqual(out_dtype, [in_dtype,])
 
+    @parametrize("dtype", [torch.float64, torch.float32, torch.float16, torch.bfloat16])
+    def test_scaled_dot_product_flash_attention_for_cpu_logsumexp_dtype(self, dtype):
+        B, H, L, E = 2, 4, 8, 16
+
+        def run(device):
+            query = torch.randn(B, H, L, E, device=device, dtype=dtype)
+            key = torch.randn(B, H, L, E, device=device, dtype=dtype)
+            value = torch.randn(B, H, L, E, device=device, dtype=dtype)
+
+            output, logsumexp = torch.ops.aten._scaled_dot_product_flash_attention_for_cpu(
+                query, key, value
+            )
+            return output.dtype, logsumexp.dtype
+
+        cpu_output_dtype, cpu_logsumexp_dtype = run("cpu")
+        meta_output_dtype, meta_logsumexp_dtype = run("meta")
+
+        self.assertEqual(cpu_output_dtype, meta_output_dtype)
+        self.assertEqual(cpu_logsumexp_dtype, meta_logsumexp_dtype)
+
 class TestMetaKernelConv(TestCase):
     @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
     def test_convolution_backward_meta_kernel_channels_last(self):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6343,7 +6343,7 @@ def meta__scaled_dot_product_flash_attention_for_cpu(
             max_seqlen_batch_q,
             num_heads,
         ),
-        dtype=torch.float,
+        dtype=utils.get_acc_type(query.dtype, torch.device("cpu")),
         device=query.device,
     ).transpose(1, 2)
     return (

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6343,7 +6343,7 @@ def meta__scaled_dot_product_flash_attention_for_cpu(
             max_seqlen_batch_q,
             num_heads,
         ),
-        dtype=utils.get_acc_type(query.dtype, torch.device("cpu")),
+        dtype=utils.get_computation_dtype(query.dtype),
         device=query.device,
     ).transpose(1, 2)
     return (


### PR DESCRIPTION
This PR matches the activation `logsumexp`'s dtype within cpu flash SDPA's meta formula to the one used in the cpu eager implementation.

Eager type mapping:
https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/OpMathType.h

Meta type mapping:
https://github.com/pytorch/pytorch/blob/7ed7ac4802b7a1e1cab54fcd1b2bbb10105f8285/torch/_prims_common/__init__.py#L1493-L1501

Fixes #185539 

cc @mlazos