### PR TITLE
Add XPU dispatch for _fused_adagrad_ operator

### DIFF
--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -1611,7 +1611,7 @@ optim_db: list[OptimizerInfo] = [
             "maximize",
             "capturable",
         ),
-        supports_fused_on=("cpu", "cuda"),
+        supports_fused_on=("cpu", "cuda", "xpu"),
         supports_sparse=True,
         metadata_for_sparse=(
             {"lr": 0.1, "weight_decay": 0, "lr_decay": 0},


### PR DESCRIPTION
- Register XPU dispatch key in native_functions.yaml for both scalar and tensor lr overloads of _fused_adagrad_
- Add 'xpu' to Adagrad's supports_fused_on tuple in common_optimizers.py

Fixes: https://github.com/pytorch/pytorch/issues/185477