### PR TITLE
Fix addmm max-autotune SliceView bias guard

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4544,6 +4544,36 @@ for dtype in (torch.int32, torch.int64):
             ),
         )
 
+    @config.patch(
+        {
+            "max_autotune": True,
+            "max_autotune_gemm_backends": "ATEN",
+            "triton.autotune_cublasLt": True,
+        }
+    )
+    def test_addmm_unrealized_bias_view_max_autotune(self):
+        if self.device != "cpu":
+            self.skipTest("CPU regression test")
+
+        def fn(x, weight, bias):
+            flat = torch.cat([weight.view(-1), bias.view(-1)], dim=0)
+            flat_div = flat / 4.0
+
+            new_weight = flat_div.narrow(0, 0, weight.numel()).view_as(weight)
+            new_bias = flat_div.narrow(0, weight.numel(), bias.numel()).view_as(bias)
+
+            return F.linear(x, new_weight, new_bias)
+
+        self.common(
+            fn,
+            (
+                torch.randn(4, 64, device=self.device),
+                torch.randn(32, 64, device=self.device),
+                torch.randn(32, device=self.device),
+            ),
+            check_lowp=False,
+        )
+
     def test_addmv(self):
         def fn(a, b, c):
             return torch.addmv(a, b, c)

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -672,9 +672,11 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
 
     if use_aten_gemm_kernels():
         aten_templates: list[ExternKernelChoice | KernelTemplate] = [aten_addmm]
+        inp_stride = inp.maybe_get_stride()
         if (
-            inp.get_stride()[0] == 0
+            inp_stride is not None
             and len(inp.get_size()) == 2
+            and inp_stride[0] == 0
             and inductor_config.triton.autotune_cublasLt
             and not V.graph.cpp_wrapper  # bias_addmm only has a Python implementation
         ):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1526,6 +1526,8 @@ class TritonTemplateKernel(TritonKernel):
                         lookup_output = range_tree.lookup(sympy.S.One, lengths[i])
                         old_name = lookup_output.symbol()
                         lookup_output.set_name(name)
+                        V.kernel.range_tree_nodes.pop(old_name, None)
+                        V.kernel.range_tree_nodes[symbol] = lookup_output
                         # Update var_list and var_range
                         range_tree.var_list[range_tree.var_list.index(old_name)] = (
                             symbol


### PR DESCRIPTION
Fixes #185533

Summary:
- Guard the `aten_bias_addmm` max-autotune probe with `maybe_get_stride()` so lazy view inputs that do not expose concrete strides do not crash while checking the optional cuBLASLt bias candidate.
- Keep the bias fast path available for concrete 2D row-broadcast inputs; unrealized views skip that extra candidate and still use the normal ATen addmm choice.
- Add regression coverage for a CPU `F.linear` case where the bias comes from `cat -> narrow -> view_as`.
- Add a follow-up range-symbol registration fix for the H100/B200 TMA-store smoke failure seen during merge validation (`Unregistered range symbol: yindex`).

Test plan:
- `python -m py_compile torch/_inductor/select_algorithm.py torch/_inductor/kernel/mm.py test/inductor/test_torchinductor.py`
- `git diff --check upstream/main...HEAD`
- Inspected the failed H100 smoke job from CI and confirmed the merge-blocking failure was `TestMaxAutotune.test_max_autotune_addmm_persistent_tma_a_transposed_True_b_transposed_False_dynamic_True_tma_store_True` failing with `Unregistered range symbol: yindex`.
- I could not run the target H100/B200 CUDA smoke test locally from this Windows CPU checkout; GitHub CI is still the required runtime validation for that hardware-specific path.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo