### PR TITLE
Improve error message in linalg.eigh for large matrices

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2818,12 +2818,27 @@ DEFINE_DISPATCH(linalg_eigh_stub);
 */
 
 TORCH_IMPL_FUNC(_linalg_eigh_out)(const Tensor& A,
-                                  std::string_view uplo,
-                                  bool compute_v,
-                                  const Tensor& L,
-                                  const Tensor& V) {
+                                 std::string_view uplo,
+                                 bool compute_v,
+                                 const Tensor& L,
+                                 const Tensor& V) {
   if (A.numel() == 0) {
     return;
+  }
+
+  const auto n = A.size(-1);
+  // LAPACK's syevd uses int internally for workspace and dimension parameters.
+  // For large matrices (e.g., 53000 x 53000), the workspace computation
+  // 1 + 6*n + 2*n*n overflows INT32_MAX, causing a cryptic MKL error:
+  // "Intel MKL ERROR: Parameter 8 was incorrect on entry to SSYEVD".
+  // Emit a clear error message instead.
+  // See https://github.com/pytorch/pytorch/issues/92141
+  if (n * n > static_cast<int64_t>(std::numeric_limits<int>::max())) {
+    TORCH_CHECK(false, "linalg.eigh: The matrix of size ", n,
+        " is too large for the LAPACK backend. "
+        "The workspace size for the eigenvalue decomposition would overflow "
+        "a 32-bit integer, which causes a cryptic internal error. "
+        "Consider using a smaller matrix.");
   }
 
   auto uplo_uppercase = static_cast<char>(std::toupper(static_cast<unsigned char>(uplo[0])));


### PR DESCRIPTION
When calling `linalg.eigh` on a large matrix (e.g., 53000 x 53000), the LAPACK workspace size computation `1 + 6*n + 2*n*n` overflows int32, causing a cryptic MKL error:

```
Intel MKL ERROR: Parameter 8 was incorrect on entry to SSYEVD.
RuntimeError: false INTERNAL ASSERT FAILED at .../BatchLinearAlgebra.cpp:...
  linalg.eigh: Argument 8 has illegal value. Most certainly there is a bug in the implementation calling the backend library.
```

This change adds an explicit size check in the `_linalg_eigh_out` implementation that catches this case and emits a clear, actionable error message explaining the issue and suggesting a workaround.

**Root cause:** LAPACKs syevd uses `int` (32-bit) internally for workspace and dimension parameters. For matrices with dimension `n` where `n^2 > INT32_MAX` (roughly n > 46340), the workspace size `1 + 6*n + 2*n*n` exceeds `INT32_MAX`, causing an integer overflow. The overflowed value is passed as `lwork` (Parameter 8) to SSYEVD, which MKL rejects with a cryptic error.

**The fix:** Added a validation check in `TORCH_IMPL_FUNC(_linalg_eigh_out)` (aten/src/ATen/native/BatchLinearAlgebra.cpp) that checks `if (n * n > static_cast<int64_t>(std::numeric_limits<int>::max()))` and raises a clear error if the matrix is too large.

Fixes https://github.com/pytorch/pytorch/issues/92141

Co-authored-by: El Williams <thechyeahhh@gmail.com>