### PR TITLE
[inductor] Codegen backed SymInt input runtime asserts

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -143,6 +143,20 @@ class LstmModule(torch.nn.Module):
 class CPUReproTests(TestCase):
     common = check_model
 
+    @torch._dynamo.config.patch(prefer_deferred_runtime_asserts_over_guards=True)
+    def test_prefer_deferred_runtime_asserts_backed_symint_compile(self):
+        def fn(x):
+            y = x.reshape(100, -1).clone()
+            return y + 10
+
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=True)
+
+        x = torch.rand(100, 100)
+        self.assertEqual(compiled(x), fn(x))
+
+        with self.assertRaisesRegex(RuntimeError, "to be True"):
+            compiled(torch.rand(101, 101))
+
     @skipIfNoLapack
     def test_torch_linalg_qr_tuple_slice(self):
         def fn(x):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -2219,6 +2219,9 @@ class GraphLowering(torch.fx.Interpreter):
     def create_deferred_runtime_asserts(
         self, n: torch.fx.Node, new_unbacked_defs: OrderedSet[sympy.Symbol]
     ) -> None:
+        """
+        Register wrapper-level runtime asserts after their symbolic inputs are bound.
+        """
         if config.do_not_emit_runtime_assertions:
             return
         # [NOTE] Codegen runtime asserts in Inductor
@@ -2257,14 +2260,19 @@ class GraphLowering(torch.fx.Interpreter):
             self.register_buffer(assert_op, set_name=True)
             self.register_operation(assert_op)
 
-        if (
-            full_aoti_runtime_assert()
-            and n.target is torch.ops.aten._assert_scalar.default
-            and self.aot_mode
-        ):
+        codegen_input_assert = False
+        assert_expr: Any = None
+        if n.target is torch.ops.aten._assert_scalar.default:
             node_args, _ = self.fetch_args_kwargs_from_env(n)
-            if node_args[0] != True:  # noqa: E712
-                make_assert(node_args[0], f"{node_args[0]} to be True")
+            assert_expr = node_args[0]
+            codegen_input_assert = (full_aoti_runtime_assert() and self.aot_mode) or (
+                has_free_symbols(assert_expr)
+                and not bool(free_unbacked_symbols(assert_expr))
+            )
+
+        if codegen_input_assert:
+            if assert_expr != True:  # noqa: E712
+                make_assert(assert_expr, f"{assert_expr} to be True")
         else:
             # bound_unbacked_symbols tracks the symbols that are created so far,
             # we use it to make sure that runtime assertions are added after all


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185588

When prefer_deferred_runtime_asserts_over_guards=True, Dynamo records backed-SymInt shape checks as deferred runtime asserts instead of guards. FX materializes those backed-only checks as input-graph aten._assert_scalar nodes, but regular Inductor lowering dropped those nodes. Only the AOTI full-runtime-assert path converted input-graph _assert_scalar nodes into wrapper AssertScalar operations, and the unbacked-symbol deferred assert path had no binding point for backed-only expressions.

This teaches Inductor to codegen input-graph _assert_scalar nodes when the assertion expression has backed free symbols and no unbacked symbols. Assertions with unbacked symbols continue to use the existing deferred path so they are emitted only after their unbacked inputs are bound. The fix preserves the existing AOTI full-runtime-assert behavior while covering the regular torch.compile path from the issue.

The alternative was to reject prefer_deferred_runtime_asserts_over_guards under torch.compile, but that would leave the underlying assert codegen gap in place. Emitting the missing wrapper assert fixes the root cause and keeps the config usable.

Benchmark Results:
- Command: CPU microbenchmark of the issue function under prefer_deferred_runtime_asserts_over_guards=True, comparing valid-input compiled runtime with torch._inductor.config.scalar_asserts=False versus True, 7 repeats x 2000 iterations.
- scalar_asserts=False: raw_us=[22.461562999524176, 22.525724009028636, 23.39909749571234, 23.2970344950445, 22.4234054912813, 22.69597048871219, 22.82404799188953], median_us=22.696, mean_us=22.804, stdev_us=0.398
- scalar_asserts=True: raw_us=[22.668353994959034, 22.598629002459347, 22.41791199776344, 22.698774497257546, 23.04643249954097, 22.65578499645926, 22.364952499629], median_us=22.656, mean_us=22.636, stdev_us=0.222

Test Plan:
- CUDA repro before fix: compiled bad 101x101 input returned shape (100, 102) with no error while eager reshape raised.
- CUDA repro after fix: compiled bad 101x101 input raises RuntimeError "Eq(Mod(s27*s77, 100), 0) to be True".
- python test/inductor/test_cpu_repro.py CPUReproTests.test_prefer_deferred_runtime_asserts_backed_symint_compile (local environment failed during import due torchvision::nms mismatch before running tests)
- python runpy workaround blocking torchvision import for test/inductor/test_cpu_repro.py CPUReproTests.test_prefer_deferred_runtime_asserts_backed_symint_compile (Ran 1 test, OK)
- git diff --cached --check
- lintrunner -a torch/_inductor/graph.py test/inductor/test_cpu_repro.py

Fixes #153175
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos