### PR TITLE
Canonicalize avg_pool2d singleton lists during export

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -589,6 +589,89 @@ class TestExport(TestCase):
         #     exported_program.module()(*args, **reversed_kwargs), f(*args, **reversed_kwargs)
         # )
 
+    def _get_avg_pool2d_node(self, ep):
+        nodes = [
+            node
+            for node in ep.graph_module.graph.nodes
+            if node.op == "call_function"
+            and node.target == torch.ops.aten.avg_pool2d.default
+        ]
+        self.assertEqual(len(nodes), 1)
+        return nodes[0]
+
+    def test_avg_pool2d_export_single_element_args(self):
+        class FunctionalAvgPool2d(torch.nn.Module):
+            def forward(self, x):
+                return F.avg_pool2d(x, kernel_size=(2,))
+
+        class FunctionalAvgPool2dWithListArgs(torch.nn.Module):
+            def forward(self, x):
+                return F.avg_pool2d(x, kernel_size=[2], stride=[1], padding=[1])
+
+        class ModuleAvgPool2d(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = torch.nn.AvgPool2d(kernel_size=(2,))
+
+            def forward(self, x):
+                return self.pool(x)
+
+        class DirectAtenAvgPool2d(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.avg_pool2d.default(x, [2])
+
+        class DirectAtenAvgPool2dWithPadding(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.avg_pool2d.default(x, [2], [], [1])
+
+        class DirectCAvgPool2d(torch.nn.Module):
+            def forward(self, x):
+                return torch._C._nn.avg_pool2d(x, [2])
+
+        x = torch.randn(1, 1, 8, 8)
+
+        functional_ep = export(FunctionalAvgPool2d(), (x,))
+        functional_node = self._get_avg_pool2d_node(functional_ep)
+        self.assertEqual(functional_node.args[1], [2, 2])
+        self.assertEqual(len(functional_node.args), 2)
+        self.assertEqual(functional_ep.module()(x), FunctionalAvgPool2d()(x))
+
+        functional_list_ep = export(FunctionalAvgPool2dWithListArgs(), (x,))
+        functional_list_node = self._get_avg_pool2d_node(functional_list_ep)
+        self.assertEqual(functional_list_node.args[1], [2, 2])
+        self.assertEqual(functional_list_node.args[2], [1, 1])
+        self.assertEqual(functional_list_node.args[3], [1, 1])
+        self.assertEqual(
+            functional_list_ep.module()(x), FunctionalAvgPool2dWithListArgs()(x)
+        )
+
+        module_ep = export(ModuleAvgPool2d(), (x,))
+        module_node = self._get_avg_pool2d_node(module_ep)
+        self.assertEqual(module_node.args[1], [2, 2])
+        self.assertEqual(module_node.args[2], [2, 2])
+        self.assertEqual(module_ep.module()(x), ModuleAvgPool2d()(x))
+
+        direct_aten_ep = export(DirectAtenAvgPool2d(), (x,))
+        direct_aten_node = self._get_avg_pool2d_node(direct_aten_ep)
+        self.assertEqual(direct_aten_node.args[1], [2, 2])
+        self.assertEqual(len(direct_aten_node.args), 2)
+        self.assertEqual(direct_aten_ep.module()(x), DirectAtenAvgPool2d()(x))
+
+        direct_aten_padding_ep = export(DirectAtenAvgPool2dWithPadding(), (x,))
+        direct_aten_padding_node = self._get_avg_pool2d_node(direct_aten_padding_ep)
+        self.assertEqual(direct_aten_padding_node.args[1], [2, 2])
+        self.assertEqual(direct_aten_padding_node.args[2], [])
+        self.assertEqual(direct_aten_padding_node.args[3], [1, 1])
+        self.assertEqual(
+            direct_aten_padding_ep.module()(x), DirectAtenAvgPool2dWithPadding()(x)
+        )
+
+        direct_c_ep = export(DirectCAvgPool2d(), (x,))
+        direct_c_node = self._get_avg_pool2d_node(direct_c_ep)
+        self.assertEqual(direct_c_node.args[1], [2, 2])
+        self.assertEqual(len(direct_c_node.args), 2)
+        self.assertEqual(direct_c_ep.module()(x), DirectCAvgPool2d()(x))
+
     def _check_dynamic_shapes_specs_and_shapes(
         self,
         model,

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1128,6 +1128,30 @@ def _fetch_proxies_and_all_constant_flag(
     return f_flat_args_kwargs, tuple(proxy_flat_args_kwargs), all_constant
 
 
+def _expand_singleton_int_list(arg: object) -> object:
+    if isinstance(arg, (list, tuple)) and len(arg) == 1:
+        return [arg[0], arg[0]]
+    return arg
+
+
+def _normalize_avg_pool2d_args(
+    func: OpOverload,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> tuple[tuple[object, ...], dict[str, object]]:
+    if func is not torch.ops.aten.avg_pool2d.default:
+        return args, kwargs
+
+    args_list = list(args)
+    kwargs = dict(kwargs)
+    for idx, name in ((1, "kernel_size"), (2, "stride"), (3, "padding")):
+        if idx < len(args_list):
+            args_list[idx] = _expand_singleton_int_list(args_list[idx])
+        elif name in kwargs:
+            kwargs[name] = _expand_singleton_int_list(kwargs[name])
+    return tuple(args_list), kwargs
+
+
 def proxy_call(
     proxy_mode: ProxyTorchDispatchMode,
     func: OpOverload,
@@ -1215,6 +1239,9 @@ def proxy_call(
             )
 
     proxy_args, proxy_kwargs = pytree.tree_unflatten(proxy_flat_args_kwargs, spec)
+    proxy_args, proxy_kwargs = _normalize_avg_pool2d_args(
+        func, proxy_args, proxy_kwargs
+    )
 
     # When we trace through a torch.tensor invocation, you never actually
     # see a torch.ops.aten.tensor call. Instead, the way this function is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185591

`aten.avg_pool2d` accepts `int[2]` arguments for `kernel_size`, `stride`,
and `padding`, and eager execution permits a single-element list or tuple by
expanding it internally. `torch.export` records the proxy node before the
native/meta implementation performs that expansion, so models using
`kernel_size=(2,)` or `[2]` could produce an ExportedProgram containing
`aten.avg_pool2d.default(x, [2])`. That IR disagrees with the operator schema
and breaks downstream consumers that expect the recorded argument to already be
the canonical two-element form.

The fix canonicalizes only the proxy arguments used to create FX nodes for
`aten.avg_pool2d.default`, expanding singleton list/tuple values for
`kernel_size`, `stride`, and `padding` while preserving empty stride as the
operator default. The actual eager call still receives the original arguments,
so runtime behavior is unchanged. Earlier PR #154353 documented the eager
behavior; this patch fixes the exported IR side.

Fixes #153149
Generated by my agent

Benchmark Results
- Command: microbenchmark repeated `torch.export.export` calls for a 100-op
  relu chain and a direct `aten.avg_pool2d.default(x, [2])` module, 3 warmup
  iterations and 12 timed iterations per case.
- Before (main): relu_chain_100_ops median 0.071131s; avg_pool2d_singleton
  median 0.005553s.
- After (fix-153149): relu_chain_100_ops median 0.060361s;
  avg_pool2d_singleton median 0.005231s.
- Raw timings are recorded in state/153149/notes.

Test Plan:
- python test/export/test_export.py TestExport.test_avg_pool2d_export_single_element_args
- python test/test_nn.py TestNNDeviceTypeCPU.test_avg_pool2d_invalid_parameters_cpu
- lintrunner -a