### PR TITLE
Allow register_constant for enum subclasses

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -15498,6 +15498,24 @@ def forward(self, x, y):
             FooModel(), (Foo(torch.ones(4, 4), torch.ones(4, 4)),), strict=False
         )
 
+    def test_register_constant_enum(self):
+        class Color(enum.Enum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+
+        class Foo(torch.nn.Module):
+            def forward(self, x, col):
+                return x + col.value
+
+        register_constant(Color)
+        try:
+            x = torch.ones(4, 4)
+            ep = torch.export.export(Foo(), (x, Color.RED), strict=False)
+            self.assertEqual(ep.module()(x, Color.RED), Foo()(x, Color.RED))
+        finally:
+            pytree._deregister_pytree_node(Color)
+
     def test_custom_pytree_run_decompositions(self):
         class MyContainer:
             def __init__(self, t1, t2):

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -1356,6 +1356,20 @@ if "optree" in sys.modules:
         self.assertEqual(elements, [])
         self.assertEqual(spec.context.value, config)
 
+    def test_constant_enum(self):
+        class Color(enum.Enum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+
+        python_pytree.register_constant(Color)
+        try:
+            elements, spec = python_pytree.tree_flatten(Color.RED)
+            self.assertEqual(elements, [])
+            self.assertIs(python_pytree.tree_unflatten(elements, spec), Color.RED)
+        finally:
+            python_pytree._deregister_pytree_node(Color)
+
     def test_constant_default_eq_error(self):
         class Config:
             def __init__(self, norm: str):

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -433,6 +433,8 @@ def register_constant(cls: type[Any]) -> None:
 
     Args:
         cls: the type to register as a constant. This type must be hashable.
+            Enum subclasses are accepted even if they use the default
+            identity-based `__eq__`.
 
     Example:
 
@@ -450,7 +452,8 @@ def register_constant(cls: type[Any]) -> None:
         >>> assert len(values) == 0
 
     """
-    if cls.__eq__ is object.__eq__:  # type: ignore[comparison-overlap]
+    is_enum_subclass = isinstance(cls, type) and issubclass(cls, Enum)
+    if cls.__eq__ is object.__eq__ and not is_enum_subclass:  # type: ignore[comparison-overlap]
         raise TypeError(
             "register_constant(cls) expects `cls` to have a non-default `__eq__` implementation."
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185593

Enum subclasses intentionally inherit object identity equality because enum members are singletons. register_constant previously rejected any class whose __eq__ was object.__eq__, so enum classes failed before reaching the existing enum allowance in _private_register_pytree_node. This made the issue repro fail at registration even though enum values are already handled as guard-safe opaque value constants.

This change exempts Enum subclasses from the default-equality rejection while preserving the validation for ordinary mutable objects. The pytree registration path can then use the existing constant-node behavior and emit the current deprecation warning for enum registration.

Fixes #153061

Generated by my agent

Test Plan:
- python test/export/test_export.py -k test_register_constant_enum
- PYTORCH_TEST_FBCODE=1 python test/test_pytree.py -k test_constant_enum
- python - <<'PY' ... issue repro script ... PY
- python - <<'PY' ... non-enum default __eq__ rejection check ... PY
- lintrunner -a torch/utils/_pytree.py test/test_pytree.py test/export/test_export.py

Plain python test/test_pytree.py -k test_constant_enum was blocked before test selection by missing optree>=0.13.0 in this environment.