### PR TITLE
Fix FakeTensor module.to conversion under export

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -17219,13 +17219,13 @@ def forward(self, x):
         pytree._deregister_pytree_node(torch.FunctionSchema)
 
     @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
-    def test_exception(self):
+    def test_module_to_in_non_strict_export(self):
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
                 self.embedding = torch.nn.Embedding(num_embeddings=10, embedding_dim=8)
-                self.register_buffer("buffer", torch.ones(4, 4))
-                self.register_buffer("param", torch.ones(4, 4))
+                self.register_buffer("buffer", torch.ones(()))
+                self.param = torch.nn.Parameter(torch.ones(()))
 
             def forward(self, x):
                 token_ids = torch.randint(0, 10, (4,), device=x.device)
@@ -17244,24 +17244,16 @@ def forward(self, x):
                 else:
                     return x.sum()
 
-        class BarBar(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.mod = BarModel()
-
-            def forward(self, x):
-                with torch.amp.autocast(device_type="cuda"):
-                    y = self.mod(x)
-                return y
-
         with torch.no_grad():
-            with self.assertRaisesRegex(RuntimeError, "Couldn't swap Embedding.weight"):
-                _ = torch.export.export(
-                    BarBar(),
-                    (),
-                    {"x": torch.randn(4, 4, 4, device="cuda")},
-                    strict=False,
-                ).module()
+            ep = torch.export.export(
+                BarModel(),
+                (),
+                {"x": torch.randn(4, 4, 4, device="cuda")},
+                strict=False,
+            ).module()
+
+            out = ep(x=torch.randn(4, 4, 4, device="cuda"))
+            self.assertEqual(out.device.type, "cuda")
 
     def test_export_for_training_with_state_dict_hooks(self):
         def _state_dict_pre_hook(mod, prefix, keep_vars):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -2123,6 +2123,26 @@ class FakeTensorOperatorInvariants(TestCase):
         self.assertTrue(isinstance(out, FakeTensor))
         self.assertEqual(out.device, gpu_device)
 
+    @unittest.skipIf(not torch.backends.cuda.is_built(), "requires CUDA build")
+    def test_move_module_under_fake_with_swap_future(self):
+        if torch._functorch.config.fake_tensor_propagate_real_tensors:
+            self.skipTest("Propagate real tensor not supported")
+
+        gpu_device = torch.device(GPU_TYPE, 0)
+        old_swap = torch.__future__.get_swap_module_params_on_conversion()
+
+        try:
+            torch.__future__.set_swap_module_params_on_conversion(True)
+            with FakeTensorMode():
+                m = torch.nn.Linear(2, 2)
+                m.to(device=gpu_device)
+        finally:
+            torch.__future__.set_swap_module_params_on_conversion(old_swap)
+
+        for p in m.parameters():
+            self.assertTrue(isinstance(p, FakeTensor))
+            self.assertEqual(p.device, gpu_device)
+
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_move_meta_tensor(self):
         if torch._functorch.config.fake_tensor_propagate_real_tensors:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -963,12 +963,17 @@ class Module:
             with torch.no_grad():
                 param_applied = fn(param)
             p_should_use_set_data = compute_should_use_set_data(param, param_applied)
+            is_fake_param = isinstance(param, FakeTensor)
+            is_fake_param_applied = isinstance(param_applied, FakeTensor)
 
             # subclasses may have multiple child tensors so we need to use swap_tensors
             p_should_use_swap_tensors = (
-                should_use_swap_tensors
-                or is_traceable_wrapper_subclass(param_applied)
-                or isinstance(param, FakeTensor)
+                not is_fake_param
+                and not is_fake_param_applied
+                and (
+                    should_use_swap_tensors
+                    or is_traceable_wrapper_subclass(param_applied)
+                )
             )
 
             param_grad = param.grad


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185595

Non-strict export fakifies module state, and the reported repro calls Module.to(x.device) while tracing. Module._apply forced FakeTensor parameters through swap_tensors. Export/proxy-traced FakeTensors can carry weakrefs, so swap_tensors rejects them before the CUDA device move is modeled. With the swap future flag enabled, the same invalid path was still reachable.

This changes the swap predicate to skip swap_tensors whenever the original parameter or converted parameter is a FakeTensor. FakeTensor conversions then use the existing replacement path, which already avoids .data for FakeTensor outputs, while ordinary tensors and non-fake traceable wrapper subclasses keep their swap behavior. The alternative would be to special-case export or catch the weakref failure, but the bug is in the general FakeTensor _apply predicate.

Fixes #153056

Generated by my agent

Test Plan:
- python test/export/test_export.py -k test_module_to_in_non_strict_export
- python test/test_fake_tensor.py -k test_move_module_under_fake_with_swap_future
- python test/test_fake_tensor.py -k test_move_module_under_fake
- python test/test_fake_tensor.py -k test_module_to
- python test/export/test_export.py -k test_module_to_with_shared_weights
- lintrunner -a