### PR TITLE
[AOTInductor][AMD GFX950] Drop all TritonConfigs whose kpack != 1 (#185599)

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -416,6 +416,43 @@ class TestTritonHeuristics(TestCase):
             )
             self.assertEqual(len(configs), expected_count)
 
+    def test_rocm_gfx950_filters_mm_configs_with_non_unit_kpack(self):
+        from torch._inductor.template_heuristics.triton import (
+            ROCmConfigHeuristic,
+            ROCmGemmConfig,
+        )
+
+        device_props = MagicMock()
+        device_props.gcnArchName = "gfx950"
+        mm_configs = [
+            ROCmGemmConfig(32, 32, 16, 1, 4, group_m=8, kpack=1),
+            ROCmGemmConfig(64, 64, 16, 1, 4, group_m=8, kpack=2),
+        ]
+
+        with (
+            patch("torch.version.hip", "7.0"),
+            patch("torch.cuda.get_device_properties", return_value=device_props),
+            patch(
+                "torch._inductor.template_heuristics.triton.get_backend_num_stages",
+                return_value=2,
+            ),
+            patch(
+                "torch._inductor.template_heuristics.triton.get_default_kpack",
+                return_value=1,
+            ),
+            config.patch({"test_configs.max_mm_configs": None}),
+            self.assertLogs(
+                "torch._inductor.template_heuristics.triton", level="WARNING"
+            ) as log_context,
+        ):
+            config_heuristic = ROCmConfigHeuristic()
+            configs = list(config_heuristic._finalize_mm_configs(mm_configs))
+
+        self.assertEqual([cfg.kwargs["kpack"] for cfg in configs], [1])
+        self.assertIn("Invalid TritonConfig has been dropped", log_context.output[0])
+        self.assertIn("ROCmGemmConfig", log_context.output[0])
+        self.assertIn("kpack=2", log_context.output[0])
+
 
 _PLUGIN_FACTORY_PATH = (
     "torch._inductor.runtime.triton_heuristics.get_caching_autotuner_plugins"

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -39,6 +39,7 @@ from ..utils import (
     TMA_DESCRIPTOR_SIZE,
     triton_type,
     using_b200,
+    using_gfx950,
 )
 from ..virtualized import V
 from .gemm import GemmMaxAutotuneTemplateConfigHeuristics
@@ -1767,6 +1768,14 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             # Use explicit kpack if set, otherwise determine optimal value based on
             # architecture and BLOCK_K
             kpack: int = getattr(conf, "kpack", get_default_kpack(conf.block_k))
+            if (kpack != 1) and using_gfx950():
+                log.warning(
+                    "Invalid TritonConfig has been dropped because `kpack` must be 1 on GFX950: "
+                    "conf=%s, kpack=%d",
+                    conf,
+                    kpack,
+                )
+                continue
 
             if matrix_instr_nonkdim != 0 and (
                 conf.block_m % matrix_instr_nonkdim != 0

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1951,6 +1951,17 @@ def using_b200() -> bool:
     return device_properties.major == 10
 
 
+@functools.lru_cache
+def using_gfx950() -> bool:
+    """Returns true if the device is using GFX950 arch, otherwise returns false."""
+    if not torch.cuda.is_available():
+        return False
+    if torch.version.hip is None:
+        return False
+    device_properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return "gfx950" in device_properties.gcnArchName
+
+
 def get_num_sms() -> int:
     """Handle experimental carveout if set otherwise return hardware SM count"""
     # TODO we need to properly guard on this global
@@ -1983,7 +1994,11 @@ def get_tma_workspace_arg(
 def get_default_kpack(block_k: int = 16) -> int:
     if not torch.version.hip:
         return 0
-    if "gfx942" in torch.cuda.get_device_properties(0).gcnArchName and block_k <= 16:
+    arch = torch.cuda.get_device_properties(0).gcnArchName
+    if "gfx950" in arch:
+        # kpack must be 1 on GFX950
+        return 1
+    if "gfx942" in arch and block_k <= 16:
         return 1
     return 2
 


### PR DESCRIPTION
Summary:

GFX950 has deprecated usage of `kpack`.
An error will be raised in AMD compiler if `kpack` is set to a different value than 1 on GFX950.
https://www.internalfb.com/code/fbsource/[b64aeb388c60]/fbcode/triton_mtia/third_party/triton/third_party/amd/backend/compiler.py?lines=82

When auto-tuning in triton on GFX950, drop all TritonConfigs where kpack != 1 to avoid a compiler error.

Test Plan:
```
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:triton_heuristics
```

https://www.internalfb.com/intern/testinfra/testconsole/testrun/34339947169244438/

Differential Revision: D106201997


