### PR TITLE
[inductor] Setting align_random_eager to True

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -888,8 +888,15 @@ delay_realize_cheap_outputs: bool = Config(
 # fallback to eager for random/dropout, this is slow but useful for debugging
 fallback_random = False
 
-# align random/dropout as eager mode(aten) behavior, maintaining fused possibility and faster gpu kernel
-align_random_eager = False
+# align random/dropout as eager mode(aten) behavior, maintaining fused possibility and faster gpu kernel.
+# Enabled by default: makes inductor-lowered dropout produce bit-identical masks to eager
+# aten.native_dropout for the same (seed, offset). Without this, the element-to-Philox-counter
+# mapping in the lowered Triton kernel (flat element-index) differs from the eager CUDA kernel's
+# (subseq, lane, offblk) layout, so eager and compile produce different dropout masks despite
+# identical torch.manual_seed(). The aligned codegen lives in
+# torch/_inductor/runtime/triton_helpers.py:rand_eager_kernel and is fully fusion-compatible;
+# perf parity verified on distilgpt2 training/amp (MI350X gfx950).
+align_random_eager = True
 
 # fallback embedding_bag_byte_unpack to eager
 fallback_embedding_bag_byte_unpack = False


### PR DESCRIPTION
Summary:                                                  
  Flip torch._inductor.config.align_random_eager from False to True so that inductor-lowered dropout (and other random ops) produce bit-identical masks to eager aten.native_dropout for the same (seed, offset).                                                                                                                        
   
  Why:                                                                                                                                                                    
  The eager CUDA dropout kernel maps elements to Philox counters via (thread_id, intra_thread_iter), while inductor's lowered Triton kernel uses a flat element-linear
  index. Same torch.manual_seed(...) → different masks → eager-vs-compile divergence. On MI350X (gfx950) this caused DistillGPT2 --training --amp to fail the dynamo      
  accuracy harness, even though the underlying numerics are fine.
                                                                                                                                                                          
  Fix:                                                      
  The aligned codegen already exists at torch/_inductor/runtime/triton_helpers.py:rand_eager_kernel and is gated by align_random_eager
  (torch/_inductor/fx_passes/replace_random.py). It is fusion-compatible, so we lose neither the fused-kernel path nor perf. Verified perf parity on distilgpt2           
  training+AMP (2.016× default vs 2.023× aligned — within noise).
                                                                                                                                                                          
  Verification:                                                                                                                                                           
  - DistillGPT2 training+AMP: fail_accuracy → pass
  - No new test failures expected since the path was already opt-in and exercised. 
       
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo