### PR TITLE
[Inductor] Fix FallbackKernel out-variant layout with dynamic shapes

### DIFF
--- a/test/inductor/test_custom_op_out_lowering.py
+++ b/test/inductor/test_custom_op_out_lowering.py
@@ -64,6 +64,26 @@ class TestCustomOpOutLowering(InductorTestCase):
 
             FileCheck().check(".out(").check_not(".default(").run(code)
 
+    @parametrize("device", DEVICES)
+    def test_add_one_lowered_to_out_dynamic_shape(self, device):
+        """Out-variant lowering with symbolic output shape (see #185503)."""
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            self._register_add_one_ops(lib)
+
+            def f(x):
+                return torch.ops.mylib.add_one(x)
+
+            x = torch.randn(4, 8, device=device)
+            torch._dynamo.mark_dynamic(x, 0)
+            eager_out = f(x)
+
+            compiled_out, (code,) = run_and_get_code(
+                torch.compile(f, backend="inductor", fullgraph=True, dynamic=True),
+                x,
+            )
+            self.assertEqual(compiled_out, eager_out)
+            FileCheck().check(".out(").check_not(".default(").run(code)
+
     def _register_split_add_ops(self, lib):
         """Register a split_add op returning two tensors with functional + .out overloads."""
         lib.define("split_add(Tensor x, float a, float b) -> (Tensor, Tensor)")

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -9722,12 +9722,7 @@ class FallbackKernel(ExternKernelAlloc):
                 out_op = lookup_manual_out_variant(kernel)
 
             if out_op is not None and len(get_out_arg_names(out_op)) == 1:
-                layout = FixedLayout(
-                    device=example_output.device,
-                    dtype=example_output.dtype,
-                    size=[*example_output.shape],
-                    stride=[*example_output.stride()],
-                )
+                layout = cls.tensor_to_layout(example_output)
                 return ExternKernelOut(  # type: ignore[return-value]
                     layout=layout,
                     inputs=list(tensor_args),


### PR DESCRIPTION
- Use tensor_to_layout in the single-output out-variant lowering path so SymInt shape entries are converted before FixedLayout construction.
- Fixes #185503

Test plan
- `python test/inductor/test_custom_op_out_lowering.py TestCustomOpOutLowering.test_add_one_lowered_to_out_dynamic_shape_device_cpu`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo