### PR TITLE
Enable TF32 fpmath mode for XPU deconvolution

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
@@ -191,6 +191,8 @@ sycl::event deconvolution(
 
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
+  at::native::onednn::apply_tf32_if_allowed(pattr);
+
   auto deconv_fwd_pd = dnnl::deconvolution_forward::primitive_desc(
       engine,
       dnnl::prop_kind::forward,
@@ -273,6 +275,8 @@ sycl::event deconvolution_backward_data(
       at::globalContext().deterministicMkldnn())
     pattr.set_deterministic(true);
 #endif
+
+  at::native::onednn::apply_tf32_if_allowed(pattr);
 
   dnnl::memory::dims _stride = stride.vec();
   dnnl::memory::dims _padding_l = padding.vec();
@@ -376,6 +380,7 @@ sycl::event deconvolution_backward_weights(
     pattr.set_deterministic(true);
 #endif
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+  at::native::onednn::apply_tf32_if_allowed(pattr);
   auto deconv_fwd_pd = dnnl::deconvolution_forward::primitive_desc(
       engine,
       dnnl::prop_kind::forward,


### PR DESCRIPTION
## Summary

The convolution path already calls `apply_tf32_if_allowed()` to set oneDNN `fpmath_mode::tf32` when the user enables it via `torch.backends.mkldnn.allow_tf32 = True`, but the deconvolution path has not been enabled yet. This caused `ConvTranspose` ops to always run in strict FP32 mode regardless of the user setting.

## Changes

Add `apply_tf32_if_allowed(pattr)` to deconvolution forward and both backward paths in `Deconv.cpp`, consistent with what `Conv.cpp` already does.

Authored by Claude.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01