### PR TITLE
Support small FlexAttention score_mod reductions

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -3,6 +3,7 @@
 import functools
 import gc
 import json
+import math
 import os
 import random
 import string
@@ -4608,6 +4609,123 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             return inv_dist * score
 
         self.run_test(euclidean_dist_pos_embed, torch.bfloat16, device=device)
+
+    @supported_platform
+    @skip_on_cpu
+    def test_score_mod_rbf_bias_trainable_reductions(self, device):
+        B_local, H_local, S_local, D_local = 1, 2, 32, 32
+        D_s, num_basis = 2, 5
+        dtype = torch.float32
+
+        query = torch.randn(
+            B_local,
+            H_local,
+            S_local,
+            D_local,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        key = torch.randn(
+            B_local,
+            H_local,
+            S_local,
+            D_local,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        value = torch.randn(
+            B_local,
+            H_local,
+            S_local,
+            D_local,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        query_pos = torch.randn(B_local, S_local, D_s, device=device)
+        key_pos = torch.randn(B_local, S_local, D_s, device=device)
+        alpha = nn.Parameter(torch.randn(H_local, num_basis, device=device) * 0.1)
+        beta = nn.Parameter(torch.rand(H_local, num_basis, device=device) * 0.05 + 0.05)
+        alpha_ref = nn.Parameter(alpha.detach().clone())
+        beta_ref = nn.Parameter(beta.detach().clone())
+
+        def make_rbf_bias(alpha, beta):
+            def rbf_bias(score, b, h, q_idx, kv_idx):
+                d_sq = torch.square(query_pos[b, q_idx] - key_pos[b, kv_idx]).sum()
+                d_rbf = alpha[h] * torch.exp(-beta[h] * d_sq)
+                return score + d_rbf.sum()
+
+            return rbf_bias
+
+        query_ref, key_ref, value_ref = query_key_value_clones(query, key, value)
+        score_mod = make_rbf_bias(alpha, beta)
+
+        compiled_flex_attention = torch.compile(flex_attention, fullgraph=True)
+        out = compiled_flex_attention(
+            query,
+            key,
+            value,
+            score_mod=score_mod,
+            kernel_options={"BACKEND": "TRITON"},
+        )
+        scores = (query_ref @ key_ref.transpose(-2, -1)) * (
+            1 / math.sqrt(query_ref.size(-1))
+        )
+        d_sq = torch.square(query_pos[:, :, None, :] - key_pos[:, None, :, :]).sum(
+            dim=-1
+        )
+        bias = (
+            alpha_ref[None, :, None, None, :]
+            * torch.exp(-beta_ref[None, :, None, None, :] * d_sq[:, None, :, :, None])
+        ).sum(dim=-1)
+        ref = torch.softmax(scores + bias, dim=-1) @ value_ref
+
+        torch.testing.assert_close(out, ref, atol=3e-2, rtol=3e-2)
+
+        grad_out = torch.randn_like(out)
+        out.backward(grad_out)
+        ref.backward(grad_out)
+        torch.testing.assert_close(query.grad, query_ref.grad, atol=4e-2, rtol=4e-2)
+        torch.testing.assert_close(key.grad, key_ref.grad, atol=4e-2, rtol=4e-2)
+        torch.testing.assert_close(value.grad, value_ref.grad, atol=4e-2, rtol=4e-2)
+        torch.testing.assert_close(alpha.grad, alpha_ref.grad, atol=4e-2, rtol=4e-2)
+        torch.testing.assert_close(beta.grad, beta_ref.grad, atol=4e-2, rtol=4e-2)
+
+    @supported_platform
+    @skip_on_cpu
+    def test_score_mod_captured_grad_slice_unroll_limit(self, device):
+        B_local, H_local, S_local, D_local = 1, 1, 16, 16
+        basis = config.unroll_reductions_threshold - 3
+        query = torch.randn(
+            B_local,
+            H_local,
+            S_local,
+            D_local,
+            device=device,
+            dtype=torch.float32,
+            requires_grad=True,
+        )
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+        alpha = nn.Parameter(torch.randn(H_local, basis, basis, device=device))
+
+        def score_mod(score, b, h, q_idx, kv_idx):
+            # Each reduction is small enough to be unrolled in the forward
+            # score_mod, but the captured-gradient scatter slice is basis**2.
+            return score + (alpha[h] * (q_idx - kv_idx)).sum(dim=-1).sum(dim=-1)
+
+        out = torch.compile(flex_attention, fullgraph=True)(
+            query,
+            key,
+            value,
+            score_mod=score_mod,
+            kernel_options={"BACKEND": "TRITON"},
+        )
+        expected_error_message = "Captured score_mod gradient slices with"
+        with self.assertRaisesRegex(RuntimeError, expected_error_message):
+            out.sum().backward()
 
     @supported_platform
     @skip_on_cpu

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -9867,6 +9867,8 @@ class StorageBox(MutableBox):
         return False
 
     def mark_reuse(self, users: int) -> None:
+        if getattr(V.graph, "suppress_buffer_realization_heuristics", False):
+            return
         if self.should_realize_on_reuse(users):
             self.realize()
 

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -17,7 +17,8 @@ from torch._inductor.virtualized import V
 from torch.nn.attention.flex_attention import _Backend
 from torch.utils._sympy.functions import FloorDiv, Mod
 
-from ...ir import ComputedBuffer, ExternKernel, FixedLayout, TensorBox
+from ... import config
+from ...ir import ComputedBuffer, ExternKernel, FixedLayout, Scatter, TensorBox
 from ...lowering import empty, empty_strided, lowerings, register_lowering, to_dtype
 from ...select_algorithm import (
     autotune_select_algorithm,
@@ -581,6 +582,22 @@ class JointOutputResult:
     mutated_grads: list[TensorBox]
 
 
+def validate_captured_grad_scatter_unrolling(grads_compute: list[ComputedBuffer]):
+    for buf in grads_compute:
+        if not isinstance(buf.data, Scatter) or not buf.data.get_size():
+            continue
+        scatter_ranges = V.graph.sizevars.guard_int_seq(buf.data.get_size())
+        scatter_numel = math.prod(scatter_ranges)
+        if scatter_numel >= config.unroll_reductions_threshold:
+            raise NotImplementedError(
+                "Captured score_mod gradient slices with "
+                f"{scatter_numel} elements are not supported. "
+                "Only slices smaller than "
+                f"config.unroll_reductions_threshold="
+                f"{config.unroll_reductions_threshold} can be unrolled."
+            )
+
+
 def process_joint_outputs(
     all_joint_outputs: SubgraphResults, num_placeholders: int
 ) -> JointOutputResult:
@@ -604,6 +621,7 @@ def process_joint_outputs(
     # outer_grads has the structure: Len(other_buffer_grads) if buffer doesn't require grad than it will be None
     # We only grab the buffers that require grad for inlining into kernel
     grads_compute = [buf for buf in other_grads if buf is not None]
+    validate_captured_grad_scatter_unrolling(grads_compute)
 
     def get_out(buf):
         if buf is None:

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1058,9 +1058,36 @@ class TritonTemplateKernel(TritonKernel):
                 x_i * stride for x_i, stride in zip(x, scatter_graph.get_stride())
             )
 
-        return scatter_graph.data.store_output(  # type: ignore[attr-defined]
-            scatter_graph.name, contiguous_strides, []
-        )
+        scatter_data = scatter_graph.data
+        if not scatter_data.get_size():
+            return [
+                scatter_data.store_output(  # type: ignore[attr-defined]
+                    scatter_graph.name, contiguous_strides, []
+                )
+            ]
+
+        # Captured-buffer gradients may scatter a small slice per score_mod
+        # invocation, e.g. alpha[h, :] in an RBF basis.  The score tile already
+        # occupies the template's vector dimensions, so unroll the extra static
+        # slice dimensions into separate vectorized atomic adds.
+        scatter_ranges = V.graph.sizevars.guard_int_seq(scatter_data.get_size())
+        scatter_numel = math.prod(scatter_ranges)
+        if scatter_numel >= config.unroll_reductions_threshold:
+            raise NotImplementedError(
+                "Captured score_mod gradient slices with "
+                f"{scatter_numel} elements are not supported. "
+                "Only slices smaller than "
+                f"config.unroll_reductions_threshold="
+                f"{config.unroll_reductions_threshold} can be unrolled."
+            )
+        return [
+            scatter_data.store_output(  # type: ignore[attr-defined]
+                scatter_graph.name,
+                contiguous_strides,
+                [sympy.Integer(i) for i in index],
+            )
+            for index in itertools.product(*(range(r) for r in scatter_ranges))
+        ]
 
     def modification(
         self,
@@ -1098,7 +1125,7 @@ class TritonTemplateKernel(TritonKernel):
                 # Handle scatter stores
                 if isinstance(subgraph, list):
                     for scatter_graph in subgraph:
-                        scatters.append(self._handle_scatter_graph(scatter_graph))
+                        scatters.extend(self._handle_scatter_graph(scatter_graph))
                 elif isinstance(subgraph.data, ir.InputBuffer):
                     out = subgraph.data.make_loader()(())
                 else:

--- a/torch/_inductor/subgraph_lowering.py
+++ b/torch/_inductor/subgraph_lowering.py
@@ -42,6 +42,9 @@ class PointwiseSubgraphLowering(torch.fx.Interpreter):
     additional_lowerings: LoweringDict | None
     buffers: list[ir.Buffer]
     mutated_buffers: OrderedSet[str]
+    # Pointwise subgraphs are inlined into their caller; heuristic realization
+    # would try to create a temporary buffer, which this lowering mode forbids.
+    suppress_buffer_realization_heuristics = True
 
     def __init__(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185611

FlexAttention lowers score_mod as a pointwise subgraph that is inlined into the surrounding template, so that lowering path cannot create temporary buffers. Small reductions are already converted into inline Pointwise IR, but the RBF-bias pattern broadcasts one of those reduced scalar expressions into a basis-vector expression. The generic reuse heuristic then tried to realize the inline expression as a ComputedBuffer, and PointwiseSubgraphLowering rejected the buffer allocation.

For trainable RBF bias parameters, backward hit a second related limitation. The captured-gradient scatter for alpha[h, :] and beta[h, :] produces a small vector slice per score_mod invocation, but the FlexAttention backward template only emitted scalar captured-gradient stores.

Fix this by suppressing heuristic mark_reuse realization while lowering pointwise subgraphs, while leaving explicit realize paths intact so large non-unrolled reductions still fail normally. Also teach the FlexAttention backward template to unroll small static captured-gradient scatter slices, and reject larger slices before template selection using the same strict-below unroll threshold policy as reductions.

Fixes #152593
Generated by my agent

Benchmark Results:
Before the fix, the RBF score_mod benchmark failed during compilation with `SubgraphLoweringException: Buffers cannot be created while lowering a pointwise subgraph`, so no steady-state timing was available.

After the fix, a trainable RBF fwd+bwd smoke benchmark on the local NVIDIA B200 with `B=2 H=2 L=256 D=32 D_s=2 basis=5` produced:

```
warmup_compile_plus_first_s=5.026798
iter_s=0.003430,0.002700,0.002532,0.002438,0.002419
mean_s=0.002704
peak_allocated_mib=1.02
grad_means=0.000001,0.000001,0.000003,0.000093,0.000057
```

Test Plan:
```
python test/inductor/test_flex_attention.py -k test_score_mod_rbf_bias_trainable_reductions -v
python test/inductor/test_flex_attention.py -k test_score_mod_captured_grad_slice_unroll_limit -v
python test/inductor/test_flex_attention.py -k test_captured_scalar_grad -v
python test/inductor/test_flex_attention.py -k test_reduction_unrolled -v
python test/inductor/test_flex_attention.py -k test_cant_lower_error_message -v
python test/inductor/test_flex_attention.py -k test_captured_wrong_device_error_message -v
python test/inductor/test_flex_attention.py -k test_bf16_score_mod_captured_grad_dtype -v
lintrunner -a
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos