### PR TITLE
[dtensor] Disable FxGraphCache for run_dtensor_rng_op (#185520)

### DIFF
--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -24,7 +24,7 @@ from torch.distributed.tensor._random import (
 from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.parallel import ColwiseParallel, parallelize_module
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import run_tests, skipIfRocm
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -24,7 +24,7 @@ from torch.distributed.tensor._random import (
 from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.parallel import ColwiseParallel, parallelize_module
-from torch.testing._internal.common_utils import run_tests, skipIfRocm
+from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -835,7 +835,6 @@ class DistTensorRandomOpCompileTest(DTensorTestBase):
             eager_results, eager_rng_states, inductor_results, inductor_rng_states
         )
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179985")
     @with_comms
     @skip_unless_torch_gpu
     def test_compile_native_dropout(self):
@@ -847,7 +846,6 @@ class DistTensorRandomOpCompileTest(DTensorTestBase):
         for placements in ([Shard(0)], [Replicate()]):
             self._test_compile_random_op(fn, device_mesh, placements=placements)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179973")
     @with_comms
     @skip_unless_torch_gpu
     def test_compile_normal_(self):
@@ -859,7 +857,6 @@ class DistTensorRandomOpCompileTest(DTensorTestBase):
         for placements in ([Shard(0)], [Replicate()]):
             self._test_compile_random_op(fn, device_mesh, placements=placements)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179977")
     @with_comms
     @skip_unless_torch_gpu
     def test_compile_rand_like(self):
@@ -871,7 +868,6 @@ class DistTensorRandomOpCompileTest(DTensorTestBase):
         for placements in ([Shard(0)], [Replicate()]):
             self._test_compile_random_op(fn, device_mesh, placements=placements)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179963")
     @with_comms
     @skip_unless_torch_gpu
     def test_compile_randn_like(self):
@@ -883,7 +879,6 @@ class DistTensorRandomOpCompileTest(DTensorTestBase):
         for placements in ([Shard(0)], [Replicate()]):
             self._test_compile_random_op(fn, device_mesh, placements=placements)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179984")
     @with_comms
     @skip_unless_torch_gpu
     def test_compile_randint_like(self):
@@ -895,7 +890,6 @@ class DistTensorRandomOpCompileTest(DTensorTestBase):
         for placements in ([Shard(0)], [Replicate()]):
             self._test_compile_random_op(fn, device_mesh, placements=placements)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179964")
     @with_comms
     @skip_unless_torch_gpu
     def test_compile_uniform_(self):
@@ -907,7 +901,6 @@ class DistTensorRandomOpCompileTest(DTensorTestBase):
         for placements in ([Shard(0)], [Replicate()]):
             self._test_compile_random_op(fn, device_mesh, placements=placements)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179981")
     @with_comms
     @skip_unless_torch_gpu
     def test_compile_bernoulli(self):
@@ -929,7 +922,6 @@ class DistTensorRandomOpCompileTest(DTensorTestBase):
                 fn, device_mesh, create_input=create_input, placements=placements
             )
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179987")
     @with_comms
     @skip_unless_torch_gpu
     def test_compile_bernoulli_float(self):

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -933,7 +933,6 @@ class DistTensorRandomOpCompileTest(DTensorTestBase):
         for placements in ([Shard(0)], [Replicate()]):
             self._test_compile_random_op(fn, device_mesh, placements=placements)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/185520")
     @with_comms
     @skip_unless_torch_gpu
     def test_compile_multiple_random_ops(self):

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -24,7 +24,7 @@ from torch.distributed.tensor._random import (
 from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.parallel import ColwiseParallel, parallelize_module
-from torch.testing._internal.common_utils import run_tests, skipIfRocm
+from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -445,7 +445,12 @@ def register_run_dtensor_rng_op():
 
     class RunDTensorRngOp(HigherOrderOperator):
         def __init__(self):
-            super().__init__("run_dtensor_rng_op", cacheable=True)
+            # Not cacheable: the compiled wrapper bakes in the current device
+            # (torch.cuda.set_device(N)) and the rank-dependent start/end offset
+            # ints; sharing the cached graph across ranks routes every rank's
+            # set_rng_state to one rank's device and offsets, leaving the other
+            # ranks' generators unchanged (#185520).
+            super().__init__("run_dtensor_rng_op", cacheable=False)
 
         def __call__(self, start_offset_incr, end_offset_incr, op, *args, **kwargs):
             # pyrefly: ignore [missing-attribute]


### PR DESCRIPTION
The DistTensorRandomOpCompileTest family failed reliably on gfx950 with "RNG state did not change between call 0 and 1". Eight of the nine tests were already @skipIfRocm; this fix re-enables all of them. Note the bug is not ROCm-specific -- it just had the right timing to repro reliably on gfx950. Any multi-rank single-host run with a shared FxGraphCache directory is exposed.

Root cause: the run_dtensor_rng_op HOP was declared cacheable=True, so inductor's FxGraphCache stored its compiled wrapper under a key that did not distinguish per-rank state. The wrapper bakes both `cuda.set_device(N)` and the rank-dependent `start_offset_incr` / `end_offset_incr` integer arguments in as Python constants:

    with torch.cuda._DeviceGuard(N):
        torch.cuda.set_device(N)
        buf0 = torch.ops.higher_order.run_dtensor_rng_op(
            START_OFFSET_INCR, END_OFFSET_INCR, aten.uniform_.default, arg0_1)

When the 4-rank test ran on a single host, all four ranks hashed to the same cache key and reused whichever rank's wrapper landed first. Every rank ended up calling `set_device(2)` and the host-side `set_rng_state` inside `impl_cuda` mutated the wrong device's generator, leaving each rank's own RNG offset unchanged. Confirmed by capturing TORCH_LOGS=output_code on a failing run: all four ranks showed identical wrapper code with `torch.cuda.set_device(2)` baked in.

The fix flips `cacheable=True` -> `cacheable=False` on RunDTensorRngOp. Inductor now bypasses the cache for any graph containing this HOP, so each rank compiles its own wrapper with the correct device and offsets. Empirically `TORCHINDUCTOR_FX_GRAPH_CACHE=0` makes the failure go away, which matches.

Alternative considered: keep cacheable=True and either (a) include the HOP's integer args in the cache key, or (b) avoid baking the runtime device into the wrapper. Both are deeper inductor changes with broader blast radius; flipping cacheable is a minimal, targeted opt-out that matches what `run_with_rng_state` does for the cudagraphs case.

This work was authored with Claude as an AI assistant.

Test Plan:

20x in-a-row on gfx950 (linux-jammy-rocm-py3.10-mi355 equivalent):

    for i in $(seq 1 20); do
      HIP_VISIBLE_DEVICES=4,5,6,7 PYTORCH_TEST_WITH_ROCM=1 \
        python test/distributed/tensor/test_random_ops.py \
        DistTensorRandomOpCompileTest.test_compile_multiple_random_ops
    done
    # 20/20 PASS (was 20/20 FAIL before the fix)

Full DistTensorRandomOpCompileTest class 10x:

    for i in $(seq 1 10); do
      HIP_VISIBLE_DEVICES=4,5,6,7 PYTORCH_TEST_WITH_ROCM=1 \
        python test/distributed/tensor/test_random_ops.py \
        DistTensorRandomOpCompileTest
    done
    # 10/10 PASS (90 individual tests across the family, 0 failures)

Fixes #185520.