### PR TITLE
Fix typos in optimizer, distribution, and utility modules

### DIFF
--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -46,7 +46,7 @@ __all__ = [
 
 class Transform:
     """
-    Abstract class for invertable transformations with computable log
+    Abstract class for invertible transformations with computable log
     det jacobians. They are primarily used in
     :class:`torch.distributions.TransformedDistribution`.
 

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -273,7 +273,7 @@ Adagrad.__doc__ = (
         {_differentiable_doc}
         fused (bool, optional): whether the fused implementation (CPU and CUDA only) is used.
             Currently, `torch.float64`, `torch.float32`, `torch.float16`, and `torch.bfloat16`
-            are supported. (default: None). Please note that the fused implementations does not
+            are supported. (default: None). Please note that the fused implementation does not
             support sparse or complex gradients.
     .. _Adaptive Subgradient Methods for Online Learning and Stochastic
         Optimization: http://jmlr.org/papers/v12/duchi11a.html

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -415,7 +415,7 @@ def _single_tensor_adam(
 
         if weight_decay != 0:
             if decoupled_weight_decay:
-                # Perform stepweight decay
+                # Perform step weight decay
                 param.mul_(1 - lr * weight_decay)
             else:
                 # Nested if is necessary to bypass jitscript rules
@@ -687,7 +687,7 @@ def _multi_tensor_adam(
 
         if weight_decay != 0:
             if decoupled_weight_decay:
-                # Perform stepweight decay
+                # Perform step weight decay
                 torch._foreach_mul_(device_params, 1 - lr * weight_decay)
             else:
                 # Reuse the intermediate memory (device_grads) already allocated for maximize

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -497,7 +497,7 @@ class Optimizer:
 
         When python tracing is enabled the profiler will hook into this
         function at the CPython level to inspect the optimizer's parameters and
-        param groups. It is called it after `step()` since many optimizers
+        param groups. It is called after `step()` since many optimizers
         lazily initialize state.
 
         This is a workaround due to lack of a proper step hook on the optimizer,

--- a/torch/utils/bundled_inputs.py
+++ b/torch/utils/bundled_inputs.py
@@ -54,7 +54,7 @@ def bundle_inputs(
 
     If inputs is passed in as a list then the inputs will be bundled for 'forward'.
     If inputs is instead passed in as a map then all the methods specified in the map
-    will have their corresponding inputs bundled. Info should match watchever type is
+    will have their corresponding inputs bundled. Info should match whatever type is
     chosen for the inputs.
 
     The returned model will support the following methods:

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -169,7 +169,7 @@ class IterableDataset(Dataset[_T_co], Iterable[_T_co]):
         ...     dataset.end = min(dataset.start + per_worker, overall_end)
         ...
 
-        >>> # Mult-process loading with the custom `worker_init_fn`
+        >>> # Multi-process loading with the custom `worker_init_fn`
         >>> # Worker 0 fetched [3, 4].  Worker 1 fetched [5, 6].
         >>> print(list(torch.utils.data.DataLoader(ds, num_workers=2, worker_init_fn=worker_init_fn)))
         [3, 5, 4, 6]

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -531,7 +531,7 @@ def sdpa_backward_flop_count(grad_out_shape, query_shape, key_shape, value_shape
     # scores: [b, h_q, s_k, s_q] @ gradOut: [b, h_q, s_q, d_v] -> gradV: [b, h_q, s_k, d_v]
     total_flops += bmm_flop((b * h_q, s_k, s_q), (b * h_q, s_q, d_v))
 
-    # Step 3: We propagate th gradients through the k @ v operation
+    # Step 3: We propagate the gradients through the k @ v operation
     # gradScores: [b, h_q, s_q, s_k] @ k: [b, h_q, s_k, d_q] -> gradQ: [b, h_q, s_q, d_q]
     total_flops += bmm_flop((b * h_q, s_q, s_k), (b * h_q, s_k, d_q))
     # q: [b, h_q, d_q, s_q] @ gradScores: [b, h_q, s_q, s_k] -> gradK: [b, h_q, d_q, s_k]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185620

Fix spelling and grammar errors in comments and docstrings across
several torch modules: "invertable" → "invertible", "stepweight" →
"step weight", "implementations does" → "implementation does",
"is called it after" → "is called after", "watchever" → "whatever",
"Mult-process" → "Multi-process", and "th gradients" →
"the gradients".

Authored with Claude (typo_terminator2).