### PR TITLE
Fix TORCH_COMPILE_DEBUG FX graph cache traces

### DIFF
--- a/test/inductor/test_debug_trace.py
+++ b/test/inductor/test_debug_trace.py
@@ -9,6 +9,8 @@ import unittest
 from pathlib import Path
 
 import torch
+from torch._dynamo.utils import counters
+from torch._functorch import config as functorch_config
 from torch._inductor import config, test_operators
 from torch._inductor.utils import fresh_cache
 from torch.testing._internal.common_utils import skipIfWindows
@@ -249,6 +251,55 @@ op2.node.kernel = extern_kernels.mm""",
         )
         # intentionally only cleanup on success so debugging test is easier
         shutil.rmtree(filename)
+
+    @functorch_config.patch({"enable_autograd_cache": False})
+    def test_debug_trace_bypasses_fx_graph_cache(self):
+        counters.clear()
+
+        def fn(a, b):
+            return torch.matmul(a + 1, b)
+
+        debug_root = tempfile.mkdtemp()
+        debug_paths = []
+        try:
+            with config.patch(
+                {
+                    "trace.debug_dir": debug_root,
+                    "fx_graph_cache": True,
+                    "fx_graph_remote_cache": False,
+                }
+            ):
+                for _ in range(2):
+                    compiled_fn = torch.compile(fn)
+                    with self.assertLogs(
+                        logging.getLogger("torch._inductor.debug"),
+                        level=logging.WARNING,
+                    ) as cm:
+                        compiled_fn(torch.randn(16, 16), torch.randn(16, 16))
+
+                    m = None
+                    for log_line in cm.output:
+                        m = re.match(r"WARNING.* debug trace: (.*)", log_line)
+                        if m:
+                            break
+                    self.assertTrue(m, "debug trace file path not found in logs")
+                    if m is None:
+                        raise AssertionError
+
+                    debug_path = Path(m.group(1))
+                    debug_paths.append(debug_path)
+                    self.assertTrue(debug_path.is_dir())
+                    self.assertGreater(filesize(debug_path / "fx_graph_readable.py"), 0)
+                    self.assertGreater(filesize(debug_path / "output_code.py"), 0)
+
+                    torch.compiler.reset()
+
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 0)
+            self.assertEqual(len(set(debug_paths)), 2)
+        finally:
+            torch.compiler.reset()
+            shutil.rmtree(debug_root, ignore_errors=True)
 
     # AOT compiler have not supported windows yet.
     @skipIfWindows

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -931,6 +931,10 @@ def _compile_fx_inner(
         use_cache = (
             not config.force_disable_caches
             and (config.fx_graph_cache or fx_graph_remote_cache)
+            # Debug tracing writes artifacts during codegen.  Loading a
+            # CompiledFxGraph from cache skips codegen and leaves the freshly
+            # announced debug trace directory empty.
+            and not config.trace.enabled
             and not aot_mode
             and backends_support_caching
             and not torch._functorch.config.bundled_autograd_cache


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185621

TORCH_COMPILE_DEBUG creates a fresh per-compile debug directory before
Inductor looks in the FX graph cache.  If the cache returns a
CompiledFxGraph, Inductor skips fx_codegen_and_compile, which is where the
normal debug trace artifacts are written.  On CUDA this can leave the newly
announced debug trace directory empty on repeated debug runs.

Disable FX graph cache load/save while trace debug mode is enabled.  This
keeps debug runs on the codegen path so each printed trace directory is
populated consistently.  The alternative would be to reconstruct every debug
artifact from a cached CompiledFxGraph on hit, but cached graphs do not retain
all of the scheduler/codegen state needed for the full trace, and debug mode
already prioritizes observability over compile latency.

Fixes #152374
Generated by my agent

Benchmark Results:
Repeated CPU debug compile microbenchmark with fx_graph_cache=True and
fx_graph_remote_cache=False, timing the second compile after a first debug
compile populated the cache:

- Before: mean 0.034383s, median 0.033580s, fxgraph cache hits=1 and misses=1
  per iteration.
- After: mean 0.066796s, median 0.067191s, fxgraph cache hits=0 and misses=0
  per iteration.

The extra debug-mode compile time is expected because trace-enabled runs now
bypass the FX graph cache instead of taking the fast cache-hit path.

Test Plan:
- Reproduced the reported CUDA debug/debug cache behavior before the fix: the
  second debug trace directory was created and logged but contained no trace
  files.
- Verified the same CUDA reproducer after the fix: both debug trace directories
  contained fx_graph_readable.py, fx_graph_runnable.py,
  fx_graph_transformed.py, ir_pre_fusion.txt, ir_post_fusion.txt,
  output_code.py, and provenance JSON.
- python test/inductor/test_debug_trace.py TestDebugTrace.test_debug_trace_bypasses_fx_graph_cache
  (blocked in this local environment by incompatible torchvision import:
  RuntimeError: operator torchvision::nms does not exist)
- Targeted unittest with torchvision import blocked for
  TestDebugTrace.test_debug_trace_bypasses_fx_graph_cache: passed.
- Targeted unittest with torchvision import blocked for TestDebugTrace.test_debug_trace
  and TestDebugTrace.test_debug_trace_bypasses_fx_graph_cache: passed.
- lintrunner -a: passed.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo