### PR TITLE
[MPS] fix bucketization speed

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Bucketization.metal
+++ b/aten/src/ATen/native/mps/kernels/Bucketization.metal
@@ -98,8 +98,10 @@ kernel void searchsorted_sorter(
     constant int64_t* data_sort [[buffer(8)]],
     uint2 tgid [[threadgroup_position_in_grid]],
     uint2 tid2 [[thread_position_in_threadgroup]],
-    uint2 tptg [[threads_per_threadgroup]]) {
-  for (int64_t tid = tgid.x * tptg.x + tid2.x; tid < numel_in; tid += tptg.x) {
+    uint2 tptg [[threads_per_threadgroup]],
+    uint2 tgpg [[threadgroups_per_grid]]) {
+  for (int64_t tid = tgid.x * tptg.x + tid2.x; tid < numel_in;
+       tid += tptg.x * tgpg.x) {
     // If boundaries tensor is 1d, we always search the entire boundary tensor
     int64_t start_bd = is_1d_boundaries ? 0 : tid / idim_in * idim_bd;
     int64_t end_bd = start_bd + idim_bd;
@@ -129,8 +131,10 @@ kernel void searchsorted(
     constant int64_t& is_1d_boundaries [[buffer(7)]],
     uint2 tgid [[threadgroup_position_in_grid]],
     uint2 tid2 [[thread_position_in_threadgroup]],
-    uint2 tptg [[threads_per_threadgroup]]) {
-  for (int64_t tid = tgid.x * tptg.x + tid2.x; tid < numel_in; tid += tptg.x) {
+    uint2 tptg [[threads_per_threadgroup]],
+    uint2 tgpg [[threadgroups_per_grid]]) {
+  for (int64_t tid = tgid.x * tptg.x + tid2.x; tid < numel_in;
+       tid += tptg.x * tgpg.x) {
     // If boundaries tensor is 1d, we always search the entire boundary tensor
     int64_t start_bd = is_1d_boundaries ? 0 : tid / idim_in * idim_bd;
     int64_t end_bd = start_bd + idim_bd;
@@ -161,7 +165,8 @@ kernel void searchsorted(
       constant int64_t* data_sort [[buffer(8)]],                             \
       uint2 tgid [[threadgroup_position_in_grid]],                           \
       uint2 tid2 [[thread_position_in_threadgroup]],                         \
-      uint2 tptg [[threads_per_threadgroup]]);                               \
+      uint2 tptg [[threads_per_threadgroup]],                                \
+      uint2 tgpg [[threadgroups_per_grid]]);                                 \
   template [[host_name("searchsorted_" #INPUT_T "_" #OUTPUT_T)]] kernel void \
   searchsorted<INPUT_T, OUTPUT_T>(                                           \
       constant INPUT_T * data_in [[buffer(0)]],                              \
@@ -174,7 +179,8 @@ kernel void searchsorted(
       constant int64_t& is_1d_boundaries [[buffer(7)]],                      \
       uint2 tgid [[threadgroup_position_in_grid]],                           \
       uint2 tid2 [[thread_position_in_threadgroup]],                         \
-      uint2 tptg [[threads_per_threadgroup]]);
+      uint2 tptg [[threads_per_threadgroup]],                                \
+      uint2 tgpg [[threadgroups_per_grid]]);
 
 REGISTER_SEARCHSORTED_OP(float, int);
 REGISTER_SEARCHSORTED_OP(float, long);


### PR DESCRIPTION
thread should have jumped `threadgroup_size * num_tid_in_threadgroup`, instead it jumped just `threadgroup_size` which killed perf.
Numbers:
| dtype    | shape   | old_ms   | new_ms | speedup |
|----------|---------|----------|--------|---------|
| float32  | 1048576 | 27.9118  | 0.2327 | 119.97x |
| bfloat16 | 1048576 | 26.2353  | 0.0692 | 379.08x |
| float16  | 1048576 | 26.3862  | 0.0674 | 391.39x |
| bfloat16 | 2097152 | 79.2882  | 0.1372 | 577.91x |
| float16  | 2097152 | 81.8492  | 0.1372 | 596.46x |
| float32  | 2097152 | 81.5274  | 0.1330 | 612.89x |
| float16  | 4194304 | 187.7229 | 0.2333 | 804.59x |
| float32  | 4194304 | 193.2925 | 0.2373 | 814.56x |
| bfloat16 | 4194304 | 187.9809 | 0.2271 | 827.81x |