### PR TITLE
Fix subclass static input remapping for SymInt args

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -2469,8 +2469,19 @@ class GraphModule(torch.nn.Module):
             extern_node_serializer: Callable[[list[Any]], Any] | None = None,
             **kwargs: Any,
         ):
+            placeholders = list(gm.graph.find_nodes(op="placeholder"))
+            symint_idxs = [
+                i
+                for i, placeholder in enumerate(placeholders)
+                if isinstance(placeholder.meta.get("val"), torch.SymInt)
+            ]
+            self.assertTrue(set(symint_idxs).isdisjoint(static_input_idxs or ()))
+            for idx in static_input_idxs or ():
+                self.assertIsInstance(placeholders[idx].meta.get("val"), torch.Tensor)
+
             if dynamic:
-                self.assertEqual(static_input_idxs, [2, 3, 4])
+                self.assertTrue(symint_idxs)
+                self.assertEqual(static_input_idxs, [2, 3])
             else:
                 self.assertEqual(static_input_idxs, [1, 2])
             return gm

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -434,16 +434,23 @@ def remap_unwrapped_subclass_arg_indices(
     new_ind = 0
     remapped_static_indices = []
     for i, arg in enumerate(wrapped_args):
-        num_indices = 1
-        if is_traceable_wrapper_subclass(arg):
-            num_indices = (
-                len(get_plain_tensors(arg, out=[]))
-                + len(enumerate_filter_symints(arg.size()))
-                + len(enumerate_filter_symints(arg.stride()))
+        if not is_traceable_wrapper_subclass(arg):
+            if i in static_input_indices_set and isinstance(arg, Tensor):
+                remapped_static_indices.append(new_ind)
+            new_ind += 1
+            continue
+
+        if not isinstance(arg, Tensor):
+            raise AssertionError(
+                f"expected Tensor for traceable wrapper subclass, got {type(arg)}"
             )
 
-        for _ in range(num_indices):
-            if i in static_input_indices_set:
+        unwrapped_args, _ = unwrap_tensor_subclasses(
+            [arg], [DummyAOTInput(i)], append_symints=True
+        )
+
+        for unwrapped_arg in unwrapped_args:
+            if i in static_input_indices_set and isinstance(unwrapped_arg, Tensor):
                 remapped_static_indices.append(new_ind)
 
             new_ind += 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185624

AOTAutograd remapped a static wrapper subclass input by counting every
unwrapped component of the subclass. With dynamic shapes, subclass unwrapping
also appends symbolic size/stride placeholders, so those SymInt graph args were
included in fw_metadata.static_input_indices even though static input indices
are meant to identify tensor inputs whose memory address is stable.

Remap static subclass inputs through the same subclass unwrapping helper used
for tracing, but only preserve tensor-valued unwrapped components as static.
Plain non-subclass inputs also remain static only when they are tensors. This
keeps the static tensor leaves from a wrapper subclass while excluding appended
SymInt size/stride graph args at the AOTAutograd metadata boundary, where the
forward graph input convention is defined.

Fixing this in AOTAutograd is preferable to filtering later in Inductor because
Inductor should receive static indices that already correspond to the generated
forward graph's tensor inputs, rather than repairing an inconsistent calling
convention downstream.

Benchmark Results:
A synthetic compile-time microbenchmark compared the previous remapping logic
against the patched implementation for `[Tensor, TwoTensor(Tensor, Tensor,
outer_size=(unbacked SymInt,)), Tensor]` with the subclass marked static.

Before: old result `[1, 2, 3]`; 0.040025s total, 4.003 us/call, n=10000.
After: new result `[1, 2]`; 0.100217s total, 10.022 us/call, n=10000.

This adds about 6 us per remapping call in the synthetic compile-time path and
does not affect compiled model runtime.

Test Plan:
python test/dynamo/test_subclasses.py -k test_mark_static_with_subclass_desugaring
python test/dynamo/test_subclasses.py -k test_subclass_parameters_are_static_under_training
lintrunner -a

Fixes #152343
Generated by my agent

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98