### PR TITLE
[MPS] Phase 1: Add 'metal' device string alias for MPS backend (#173225)

### DIFF
--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -41,6 +41,18 @@ DeviceType parse_type(const std::string& device_string) {
         "'mkldnn' is no longer used as device type. So torch.device('mkldnn') will be "
         "deprecated and removed in the future. Please use other valid device types instead.");
   }
+  // "metal" is accepted as an alias for "mps" (DeviceType::MPS).  The MPS
+  // backend is increasingly implemented via custom Metal kernels rather than
+  // Metal Performance Shaders, so "metal" is the preferred long-term name.
+  // "mps" remains the canonical string returned by DeviceTypeName() and
+  // device.type during the transition.  See gh-173225.
+  //
+  // NOTE: This string is explicitly intercepted here instead of being added to
+  // the 'types' array below to avoid overflowing COMPILE_TIME_MAX_DEVICE_TYPES
+  // and silently colliding with the dormant DeviceType::Metal enum value.
+  if (device_string == "metal") {
+    return DeviceType::MPS;
+  }
   if (device_string == get_privateuse1_backend()) {
     return DeviceType::PrivateUse1;
   }
@@ -59,6 +71,9 @@ DeviceType parse_type(const std::string& device_string) {
       device_names.push_back(it.first);
     }
   }
+  // Include "metal" in the list of accepted device strings.
+  // Handled explicitly above to avoid over-allocating COMPILE_TIME_MAX_DEVICE_TYPES.
+  device_names.push_back("metal");
   TORCH_CHECK(
       false,
       "Expected one of ",

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -145,8 +145,8 @@ void register_privateuse1_backend(const std::string& backend_name) {
       "torch.register_privateuse1_backend() has already been set! Current backend: ",
       privateuse1_backend_name);
 
-  static const std::array<std::string, 6> types = {
-      "cpu", "cuda", "hip", "mps", "xpu", "mtia"};
+  static const std::array<std::string, 7> types = {
+      "cpu", "cuda", "hip", "metal", "mps", "mtia", "xpu"};
   TORCH_CHECK(
       std::find(types.begin(), types.end(), backend_name) == types.end(),
       "Cannot register privateuse1 backend with in-tree device name: ",

--- a/c10/test/core/Device_test.cpp
+++ b/c10/test/core/Device_test.cpp
@@ -59,7 +59,48 @@ TEST(DeviceTypeTest, PrivateUseOneRegister) {
   ASSERT_THROW(c10::register_privateuse1_backend("cpu"), c10::Error);
   ASSERT_THROW(c10::register_privateuse1_backend("cuda"), c10::Error);
   ASSERT_THROW(c10::register_privateuse1_backend("hip"), c10::Error);
+  ASSERT_THROW(c10::register_privateuse1_backend("metal"), c10::Error);
   ASSERT_THROW(c10::register_privateuse1_backend("mps"), c10::Error);
   ASSERT_THROW(c10::register_privateuse1_backend("xpu"), c10::Error);
   ASSERT_THROW(c10::register_privateuse1_backend("mtia"), c10::Error);
+}
+
+// The canonical printed representation of a device constructed from "metal"
+// remains "mps" for backward compatibility during the transition.
+TEST(DeviceTest, MetalAliasStrReturnsMps) {
+  c10::Device d("metal");
+  ASSERT_EQ(d.str(), "mps");
+
+  // Verify C++ ostream operator<< support
+  std::stringstream ss;
+  ss << d;
+  ASSERT_EQ(ss.str(), "mps");
+}
+
+TEST(DeviceTest, MetalAliasParsesToMPS) {
+  c10::Device device_lowercase("metal");
+  EXPECT_EQ(device_lowercase.type(), c10::DeviceType::MPS);
+  EXPECT_EQ(device_lowercase.index(), -1);
+
+  c10::Device device_with_index("metal:0");
+  EXPECT_EQ(device_with_index.type(), c10::DeviceType::MPS);
+  EXPECT_EQ(device_with_index.index(), 0);
+}
+
+TEST(DeviceTest, ErrorMessageIncludesMetal) {
+  try {
+    c10::Device bad("notadevice");
+    FAIL() << "Expected c10::Error";
+  } catch (const c10::Error& e) {
+    ASSERT_NE(std::string(e.what()).find("metal"), std::string::npos)
+        << "Error message should list 'metal' as an accepted device string";
+  }
+}
+
+TEST(DeviceTest, MetalPrefixedGarbageIsRejected) {
+  auto make = [](const std::string& s) { return c10::Device(s); };
+  EXPECT_THROW(make("metalx"), c10::Error);
+  EXPECT_THROW(make("metal:"), c10::Error);
+  EXPECT_THROW(make("metal:01"), c10::Error);
+  EXPECT_THROW(make("metal:-1"), c10::Error);
 }

--- a/test/test_metal_device_alias.py
+++ b/test/test_metal_device_alias.py
@@ -1,0 +1,69 @@
+import unittest
+import torch
+import pickle
+import copy
+import os
+
+class TestMetalDeviceAlias(unittest.TestCase):
+    def test_metal_parsing(self):
+        # String parsing to mps device type (torch.device("metal") -> mps)
+        d = torch.device("metal")
+        self.assertEqual(d.type, "mps")
+        self.assertEqual(d.index, None)
+
+        d0 = torch.device("metal:0")
+        self.assertEqual(d0.type, "mps")
+        self.assertEqual(d0.index, 0)
+
+    def test_metal_keyword_arguments(self):
+        """Verify keyword-based instantiation routes correctly."""
+        d1 = torch.device(type="metal")
+        self.assertEqual(d1.type, "mps")
+        
+        d2 = torch.device(type="metal", index=1)
+        self.assertEqual(d2.type, "mps")
+        self.assertEqual(d2.index, 1)
+
+    def test_metal_deepcopy_correctly(self):
+        """Verify copy.deepcopy preserves alias routing to canonical mps."""
+        original = torch.device("metal")
+        copied = copy.deepcopy(original)
+        self.assertEqual(copied, original)
+        self.assertEqual(copied.type, "mps")
+
+    def test_semantic_equality(self):
+        # Semantic equality checking (torch.device("metal") == torch.device("mps"))
+        self.assertEqual(torch.device("metal"), torch.device("mps"))
+        self.assertEqual(torch.device("metal:0"), torch.device("mps:0"))
+        self.assertNotEqual(torch.device("metal:0"), torch.device("mps:1"))
+
+    def test_serialization(self):
+        # Pickling/unpickling
+        d = torch.device("metal:0")
+        pickled = pickle.dumps(d)
+        unpickled = pickle.loads(pickled)
+        # Note: Canonical name is still "mps", so it should unpickle to "mps"
+        self.assertEqual(unpickled.type, "mps")
+        self.assertEqual(unpickled.index, 0)
+
+    def test_hashing_and_dict(self):
+        # Hashing and dict-key access
+        d_metal = torch.device("metal:0")
+        d_mps = torch.device("mps:0")
+        self.assertEqual(hash(d_metal), hash(d_mps))
+        
+        d = {d_metal: "value"}
+        self.assertEqual(d[d_mps], "value")
+
+    @unittest.skipUnless(torch.backends.mps.is_available(), "MPS hardware not available")
+    def test_allocation(self):
+        # Hardware-gated execution blocks
+        t = torch.randn(5, device="metal")
+        self.assertEqual(t.device.type, "mps")
+        
+        t0 = torch.randn(5, device="metal:0")
+        self.assertEqual(t0.device.type, "mps")
+        self.assertEqual(t0.device.index, 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR safely implements Phase 1 of the MPS-to-Metal backend alias strategy outlined in #173225. It introduces `"metal"` as a valid device string that maps directly to `DeviceType::MPS` under the hood, while preserving the canonical `"mps"` serialization tags.

## Critical Architectural Safeguards
A naive implementation inserting `"metal"` into the fixed `types` array in `Device.cpp` fails due to `COMPILE_TIME_MAX_DEVICE_TYPES = 21` constraints (the array already contains 20 elements). Attempting to expand or over-allocate this array silently collides with the dormant `DeviceType::Metal = 11` enum definition.

To bypass this safely, this PR uses an early string-interception pattern for `"metal"` inside `parse_type`, modeling it closely after the existing `get_privateuse1_backend()` interception logic.

## Changes Included
- **c10/core/Device.cpp**: Intercepts `"metal"` explicitly and injects it into the typo hint array.
- **c10/core/DeviceType.cpp**: Shifts the `register_privateuse1_backend` blocklist array from 6 to 7 elements to explicitly reserve `"metal"` from being hijacked by third-party backends.
- **c10/test/core/Device_test.cpp**: Added unit tests verifying standard parsing, indexed parsing (`metal:0`), stream formatting (`operator<<`), and prefix rejection safety.
- **test/test_metal_device_alias.py**: Full Python integration coverage spanning pickling, keyword matching (`torch.device(type="metal")`), hashing/dictionary mapping, and hardware-gated tensor tests.

Fixes #173225