### PR TITLE
Lazy Module to have concrete shapes on dynamic shapes active

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1511,8 +1511,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnt.op_count, 1)
         self.assertTrue(torch._dynamo.testing.same(out1, out2))
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module1(self):
         input_shape = (16, 3, 6, 7, 8)
 
@@ -1691,8 +1689,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         with self.assertRaises(AttributeError):
             exp_res = opt_m(x, y)
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module_speculation_log_divergence(self):
         class ModWithOneLazyLinear(torch.nn.Module):
             def __init__(self) -> None:
@@ -1729,6 +1725,29 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         expect_res = mod(x)
         self.assertTrue(torch.allclose(expect_res, actual_res))
         self.assertEqual(cnt.frame_count, 1)
+
+    def test_lazy_module_dynamic_shapes(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.bn = torch.nn.LazyBatchNorm2d()
+                self.fc = torch.nn.LazyLinear(10)
+
+            def forward(self, x):
+                x = self.bn(x)
+                x = x.flatten(1)
+                x = self.fc(x)
+                return x
+
+        m = M()
+        opt_m = torch.compile(m, backend="eager", dynamic=True)
+        inp = torch.randn(1, 3, 16, 16)
+        result = opt_m(inp)
+        self.assertEqual(result.shape, (1, 10))
+        self.assertIsInstance(m.bn, torch.nn.BatchNorm2d)
+        self.assertIsInstance(m.fc, torch.nn.Linear)
+        self.assertEqual(m.bn.num_features, 3)
+        self.assertEqual(m.fc.in_features, 768)
 
     def test_call_fn_with_non_const_inputs_safe(self):
         class ModuleSpecialFwd(torch.nn.Module):

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -107,7 +107,31 @@ def initialize_lazy_module(
             elif isinstance(x, (list, tuple, set)):
                 return type(x)(convert_to_fake(elem) for elem in x)
             elif isinstance(x, torch.fx.Proxy):
-                return get_fake_value(x.node, tx)
+                fake_value = get_fake_value(x.node, tx)
+                if isinstance(fake_value, torch.Tensor):
+                    concrete_shape = tuple(
+                        s.node.hint if isinstance(s, torch.SymInt) else s
+                        for s in fake_value.shape
+                    )
+                    empty_tensor = torch.empty(
+                        concrete_shape,
+                        dtype=fake_value.dtype,
+                        device=fake_value.device,
+                        layout=fake_value.layout,
+                        requires_grad=fake_value.requires_grad,
+                    )
+                    fake_value = tx.output.fake_mode.from_tensor(
+                        empty_tensor, static_shapes=True
+                    )
+                elif isinstance(
+                    fake_value, (torch.SymInt, torch.SymFloat, torch.SymBool)
+                ):
+                    fake_value = (
+                        fake_value.node.hint
+                        if fake_value.node.hint is not None
+                        else fake_value.node.constant
+                    )
+                return fake_value
             else:
                 return x
 


### PR DESCRIPTION
Fixes #185494 

When dynamic=True, Dynamo traces with fake tensors whose shape dimensions are SymInts. During lazy module initialization, _infer_parameters reads input.shape to determine parameter sizes (e.g. num_features for BatchNorm), then passes those SymInts to torch.empty() inside materialize(), which requires concrete integers.

Fix by concretizing fake tensor args in initialize_lazy_module before calling _infer_parameters: extract concrete shapes from SymInt hints, create a real tensor via torch.empty  then convert back to a static-shaped FakeTensor for consistency. This runs once per lazy module at first compilation and does not affect tracing, guards, or recompilation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98