### PR TITLE
Fix wait_stream reordering in inductor codegen

### DIFF
--- a/test/inductor/test_user_streams.py
+++ b/test/inductor/test_user_streams.py
@@ -1299,6 +1299,56 @@ class TestUserStreamCompile(InductorTestCase):
         # wait_stream(0, 1) must come after wait_stream(1, 0)
         self.assertGreater(wait_0_1_pos, wait_1_0_pos)
 
+    def test_wait_stream_ordering_independent_inputs(self):
+        """wait_stream must order subsequent waiting-stream work even with independent inputs."""
+        from torch._inductor.utils import run_and_get_code
+
+        side = torch.cuda.Stream()
+
+        def fn(x, y):
+            a = x * 2
+            side.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(side):
+                b = y + 1
+            torch.cuda.current_stream().wait_stream(side)
+            return a + b
+
+        x = torch.randn(1024, device="cuda")
+        y = torch.randn(1024, device="cuda")
+        expected = fn(x, y)
+        compiled_fn = torch.compile(fn)
+        result, (code,) = run_and_get_code(compiled_fn, x, y)
+        self.assertTrue(torch.allclose(result, expected, atol=1e-5, rtol=1e-5))
+
+        # Search within the call method only to avoid matching kernel
+        # definitions at the top of the generated file.
+        call_code = code[code.find("def call(") :]
+
+        # wait_stream(1, 0) must come BEFORE the add kernel on stream 1.
+        # This tests that even when the waiting-stream computation (y + 1)
+        # uses an independent input (y), it is still ordered after wait_stream.
+        wait_1_0_pos = call_code.find("wait_stream.default(1, 0)")
+        wait_0_1_pos = call_code.find("wait_stream.default(0, 1)")
+        self.assertGreater(wait_1_0_pos, -1, "wait_stream(1, 0) not found")
+        self.assertGreater(wait_0_1_pos, -1, "wait_stream(0, 1) not found")
+
+        # Find the stream1 add kernel call (fused_add*.run)
+        add_kernel_pos = call_code.find("fused_add")
+        self.assertGreater(add_kernel_pos, -1, "add kernel not found")
+
+        # Correct ordering: wait_stream(1,0) before add kernel (on stream 1),
+        # add kernel before wait_stream(0,1)
+        self.assertGreater(
+            add_kernel_pos,
+            wait_1_0_pos,
+            "add kernel (stream 1) must come after wait_stream(1, 0)",
+        )
+        self.assertGreater(
+            wait_0_1_pos,
+            add_kernel_pos,
+            "wait_stream(0, 1) must come after add kernel (stream 1)",
+        )
+
     def test_codegen_structure_single_stream(self):
         """Verify wrapper structure for pointwise ops with one side stream."""
         from torch._inductor.utils import run_and_get_code
@@ -2521,6 +2571,31 @@ class TestStreamCudagraphInteraction(InductorTestCase):
         for _ in range(3):
             result = compiled_fn(x)
         self.assertEqual(result, expected)
+
+    def test_wait_stream_independent_inputs_with_cudagraphs(self):
+        """wait_stream with independent inputs must work under cudagraph capture.
+
+        When the waiting-stream computation uses an input independent of the
+        waited-on stream, it must still be ordered after wait_stream.
+        """
+        side = torch.cuda.Stream()
+
+        def fn(x, y):
+            a = x * 2
+            side.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(side):
+                b = y + 1
+            torch.cuda.current_stream().wait_stream(side)
+            return a + b
+
+        x = torch.randn(1024, device="cuda")
+        y = torch.randn(1024, device="cuda")
+        expected = fn(x, y)
+        compiled_fn = torch.compile(fn, mode="reduce-overhead")
+        # Warmup + capture + replay
+        for _ in range(3):
+            result = compiled_fn(x, y)
+        self.assertTrue(torch.allclose(result, expected, atol=1e-5, rtol=1e-5))
 
 
 instantiate_parametrized_tests(TestStreamUtils)

--- a/test/inductor/test_user_streams.py
+++ b/test/inductor/test_user_streams.py
@@ -1263,6 +1263,42 @@ class TestUserStreamCompile(InductorTestCase):
         self.assertIn("wait_stream", code)
         self.assertIn("synchronize_stream", code)
 
+    def test_wait_stream_ordering_preserved(self):
+        """wait_stream must not be reordered before the work it synchronizes."""
+        from torch._inductor.utils import run_and_get_code
+
+        side = torch.cuda.Stream()
+
+        def fn(x):
+            a = x * 2
+            side.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(side):
+                b = a + 1
+            torch.cuda.current_stream().wait_stream(side)
+            return b
+
+        x = torch.randn(1024, device="cuda")
+        expected = fn(x)
+        compiled_fn = torch.compile(fn)
+        result, (code,) = run_and_get_code(compiled_fn, x)
+        self.assertEqual(result, expected)
+
+        # Both wait_stream calls must survive
+        self.assertIn("wait_stream", code)
+
+        # The first wait_stream(1, 0) must appear AFTER the mul kernel,
+        # not before it. Find positions in the generated code.
+        mul_pos = code.find("fused_mul")
+        wait_1_0_pos = code.find("wait_stream.default(1, 0)")
+        wait_0_1_pos = code.find("wait_stream.default(0, 1)")
+        self.assertGreater(mul_pos, -1, "mul kernel not found in code")
+        self.assertGreater(wait_1_0_pos, -1, "wait_stream(1, 0) not found")
+        self.assertGreater(wait_0_1_pos, -1, "wait_stream(0, 1) not found")
+        # wait_stream(1, 0) must come after mul (side waits for default's work)
+        self.assertGreater(wait_1_0_pos, mul_pos)
+        # wait_stream(0, 1) must come after wait_stream(1, 0)
+        self.assertGreater(wait_0_1_pos, wait_1_0_pos)
+
     def test_codegen_structure_single_stream(self):
         """Verify wrapper structure for pointwise ops with one side stream."""
         from torch._inductor.utils import run_and_get_code
@@ -2458,6 +2494,32 @@ class TestStreamCudagraphInteraction(InductorTestCase):
         compiled_fn = torch.compile(fn)
         for _ in range(3):
             result = compiled_fn(x, y)
+        self.assertEqual(result, expected)
+
+    def test_wait_stream_fork_join_with_cudagraphs(self):
+        """wait_stream fork-join pattern must work under cudagraph capture.
+
+        Regression test for https://github.com/pytorch/pytorch/issues/185546.
+        CUDA graph capture requires all forked streams to be rejoined before
+        capture ends. If wait_stream(default, side) is incorrectly reordered
+        before the side-stream work, capture fails with StreamCaptureUnjoined.
+        """
+        side = torch.cuda.Stream()
+
+        def fn(x):
+            a = x * 2
+            side.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(side):
+                b = a + 1
+            torch.cuda.current_stream().wait_stream(side)
+            return b
+
+        x = torch.randn(1024, device="cuda")
+        expected = fn(x)
+        compiled_fn = torch.compile(fn)
+        # Warmup + capture + replay
+        for _ in range(3):
+            result = compiled_fn(x)
         self.assertEqual(result, expected)
 
 

--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -29,6 +29,7 @@ Graph: TypeAlias = torch.fx.Graph
 _SYNC_OPS = (
     torch.ops.streams.record_event.default,
     torch.ops.streams.wait_event.default,
+    torch.ops.streams.wait_stream.default,
     torch.ops.streams.synchronize_event.default,
     torch.ops.streams.synchronize_device.default,
     torch.ops.streams.synchronize_stream.default,
@@ -503,6 +504,23 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
                         found_sync = True
                         _wrap_sync_node(gm, node, all_stream_deps, visited)
                     stream_to_nodes.clear()
+                    node = next_node
+                    continue
+
+                # wait_stream(waiting, waited_on) creates a dependency on
+                # the waited_on stream: all prior work there must complete
+                # before the waiting stream proceeds.
+                if node.target is torch.ops.streams.wait_stream.default:
+                    waited_on_stream: int = node.args[1]  # type: ignore[assignment]
+                    deps_before_sync = list(stream_to_nodes.get(waited_on_stream, ()))
+                    if None in stream_to_nodes and waited_on_stream is not None:
+                        deps_before_sync.extend(stream_to_nodes[None])
+                    if deps_before_sync:
+                        found_sync = True
+                        _wrap_sync_node(gm, node, deps_before_sync, visited)
+                    stream_to_nodes[waited_on_stream] = []
+                    if None in stream_to_nodes:
+                        stream_to_nodes[None] = []
                     node = next_node
                     continue
 

--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -456,6 +456,44 @@ def _wrap_sync_node(
     return control_deps_node, list(replacements.values())
 
 
+def _collect_wait_stream_forward_deps(graph: torch.fx.Graph) -> dict[Node, list[Node]]:
+    """
+    Pre-pass: for each wait_stream(waiting, waited_on) node, find tensor inputs
+    of subsequent compute nodes on the waiting stream that are defined before
+    the wait_stream. These must be threaded through the control_deps so that
+    the waiting-stream work is ordered after the wait_stream operation.
+    """
+    result: dict[Node, list[Node]] = {}
+    nodes_before: set[Node] = set()
+    for node in graph.nodes:
+        if (
+            node.op == "call_function"
+            and node.target is torch.ops.streams.wait_stream.default
+        ):
+            waiting_stream: int = node.args[0]  # type: ignore[assignment]
+            extra_deps: set[Node] = set()
+            forward_node = node.next
+            while forward_node.op != "root":
+                if (
+                    forward_node.op == "call_function"
+                    and forward_node.target not in _SYNC_OPS
+                    and (get_stream(forward_node) or 0) == waiting_stream
+                ):
+
+                    def _collect(n: torch.fx.Node) -> torch.fx.Node:
+                        if n in nodes_before and "val" in n.meta:
+                            extra_deps.add(n)
+                        return n
+
+                    map_arg(forward_node.args, _collect)
+                    map_arg(forward_node.kwargs, _collect)
+                forward_node = forward_node.next
+            if extra_deps:
+                result[node] = list(extra_deps)
+        nodes_before.add(node)
+    return result
+
+
 def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
     """
     Single-pass wrap of all sync nodes in control_deps.
@@ -468,6 +506,11 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
     graph = gm.graph
     if len(graph.nodes) == 0:
         raise RuntimeError("Expected a non-empty graph")
+
+    # Pre-pass: find inputs of waiting-stream nodes that need to be threaded
+    # through wait_stream's control_deps for forward ordering.
+    wait_stream_forward_deps = _collect_wait_stream_forward_deps(graph)
+
     stream_to_nodes: dict[int | None, list[Node]] = {}
     # Maps event_index -> control_deps node that wrapped its record_event,
     # so the corresponding wait_event/synchronize_event can depend on the record.
@@ -515,6 +558,15 @@ def wrap_all_sync_nodes_with_control_deps(gm: torch.fx.GraphModule) -> None:
                     deps_before_sync = list(stream_to_nodes.get(waited_on_stream, ()))
                     if None in stream_to_nodes and waited_on_stream is not None:
                         deps_before_sync.extend(stream_to_nodes[None])
+                    # Also include inputs of subsequent waiting-stream nodes
+                    # so they get threaded through control_deps, creating a
+                    # forward ordering constraint (waiting-stream work must
+                    # come after wait_stream).
+                    existing_ids = {id(d) for d in deps_before_sync}
+                    for dep in wait_stream_forward_deps.get(node, ()):
+                        if id(dep) not in existing_ids:
+                            deps_before_sync.append(dep)
+                            existing_ids.add(id(dep))
                     if deps_before_sync:
                         found_sync = True
                         _wrap_sync_node(gm, node, deps_before_sync, visited)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8738,6 +8738,43 @@ def control_deps_op_lowering(additional_deps, subgraph_fn, *args):
             assert op_name is not None
             V.graph.additional_buffer_deps[op_name].add(dep_name)
 
+    # For void ops (e.g. wait_stream) that don't produce tensor outputs,
+    # passthrough args returned by control_deps are the same IR nodes as
+    # their inputs. This means downstream consumers have no scheduling
+    # dependency on the void op. Create MutationOutput entries to force
+    # the scheduler to order subsequent readers after the void op.
+    # Only apply this for wait_stream, which needs forward ordering on the
+    # waiting stream. Other sync ops (synchronize_stream, record_event) are
+    # full barriers or have event-based cross-sync tracking.
+    void_ops = [
+        op
+        for op in new_ops
+        if isinstance(op, ir.Buffer)
+        and op.name is not None
+        and isinstance(op.layout, ir.NoneLayout)
+        and not isinstance(op, ir.MutationOutput)
+    ]
+    if void_ops and args:
+        # Check if the subgraph contains a wait_stream call
+        has_wait_stream = any(
+            n.op == "call_function"
+            and n.target is torch.ops.streams.wait_stream.default
+            for n in subgraph_fn.graph_module.graph.nodes
+        )
+        if has_wait_stream:
+            for void_op in void_ops:
+                for arg in args:
+                    for arg_leaf in pytree.tree_leaves(arg):
+                        if not isinstance(arg_leaf, IRNode):
+                            continue
+                        device = arg_leaf.get_device()
+                        if device is None:
+                            continue
+                        mut_out = ir.MutationOutput(
+                            ir.NoneLayout(device=device), arg_leaf, void_op
+                        )
+                        void_op.mutation_outputs.append(mut_out)
+
     return output
 
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8763,6 +8763,7 @@ def control_deps_op_lowering(additional_deps, subgraph_fn, *args):
         )
         if has_wait_stream:
             for void_op in void_ops:
+                assert isinstance(void_op, ir.ExternKernel)
                 for arg in args:
                     for arg_leaf in pytree.tree_leaves(arg):
                         if not isinstance(arg_leaf, IRNode):


### PR DESCRIPTION
Fixes #185546 

The root cause is that torch.ops.streams.wait_stream was missing from _SYNC_OPS in torch/_functorch/_aot_autograd/streams.py. The wrap_all_sync_nodes_with_control_deps() pass uses _SYNC_OPS to identify synchronization ops that need control_deps wrapping to preserve ordering. Without this wrapping, wait_stream nodes have no tensor dependencies (their args are just integer stream indices), so the inductor scheduler treats them as zero-dependency nodes and schedules them first.

The fix adds wait_stream to _SYNC_OPS and handles it in the control_deps wrapping pass. The semantics of wait_stream(waiting, waited_on) are: the waiting stream depends on all prior work on the waited_on stream. So we collect deps from the waited_on stream's node list and wrap them with control_deps, matching the pattern used by record_event/wait_event.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo