### PR TITLE
Inline decomposed quantization helpers in Dynamo

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7528,6 +7528,83 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
 
         self.assertEqual(model(*inputs), compiled_model(*inputs))
 
+    # https://github.com/pytorch/pytorch/issues/152307
+    def test_fp8_qdq_repeated_modules_no_recompile(self):
+        class FP8QDQLinear(torch.nn.Module):
+            def __init__(self, in_features, out_features):
+                super().__init__()
+                weight = torch.randn(out_features, in_features).abs().add(0.01)
+                scale = weight.amax() / torch.finfo(torch.float8_e4m3fn).max
+                self.register_buffer(
+                    "qweight",
+                    torch.clamp(
+                        weight / scale,
+                        torch.finfo(torch.float8_e4m3fn).min,
+                        torch.finfo(torch.float8_e4m3fn).max,
+                    ).to(torch.float8_e4m3fn),
+                )
+                self.register_buffer("weight_scale", scale)
+                self.register_buffer("bias", torch.randn(out_features))
+                self.scale = 1 / torch.finfo(torch.float8_e4m3fn).max
+
+            def forward(self, x):
+                from torch.ao.quantization.fx._decomposed import (
+                    dequantize_per_tensor,
+                    quantize_per_tensor,
+                )
+
+                weight = dequantize_per_tensor(
+                    self.qweight,
+                    self.weight_scale,
+                    0,
+                    torch.finfo(torch.float8_e4m3fn).min,
+                    torch.finfo(torch.float8_e4m3fn).max,
+                    self.qweight.dtype,
+                    out_dtype=torch.float,
+                )
+                qx = quantize_per_tensor(
+                    x,
+                    self.scale,
+                    0,
+                    torch.finfo(torch.float8_e4m3fn).min,
+                    torch.finfo(torch.float8_e4m3fn).max,
+                    torch.float8_e4m3fn,
+                )
+                dx = dequantize_per_tensor(
+                    qx,
+                    self.scale,
+                    0,
+                    torch.finfo(torch.float8_e4m3fn).min,
+                    torch.finfo(torch.float8_e4m3fn).max,
+                    qx.dtype,
+                    out_dtype=torch.float,
+                )
+                return torch.nn.functional.linear(dx, weight, self.bias)
+
+        class Block(torch.nn.Module):
+            def __init__(self, in_features, out_features):
+                super().__init__()
+                self.linear = FP8QDQLinear(in_features, out_features)
+
+            def forward(self, input):
+                return torch.relu(self.linear(input))
+
+        model = torch.nn.Sequential(
+            Block(13, 512),
+            Block(512, 256),
+            Block(256, 128),
+        ).eval()
+        x = torch.randn(8, 13)
+
+        with torch.no_grad(), torch._dynamo.config.patch(error_on_recompile=True):
+            expected = model(x)
+            opt_model = torch.compile(model, backend="eager")
+            result = opt_model(x)
+            result_second_call = opt_model(x)
+
+        self.assertEqual(result, expected)
+        self.assertEqual(result_second_call, expected)
+
     # https://github.com/pytorch/pytorch/issues/144080
     def test_pad_sequence_mixed_dtype_padding_value(self):
         class RNNPadSequence(torch.nn.Module):

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3503,6 +3503,7 @@ MOD_INLINELIST = [
     "torch._tensor",
     "torch.amp.autocast_mode",
     "torch.ao.nn",
+    "torch.ao.quantization.fx._decomposed",
     "torch.autograd.function",
     "torch.backends.cuda",
     "torch.cuda.amp.autocast_mode",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185628

Dynamo skip-lists the broader torch.ao package. Direct calls into
`torch.ao.quantization.fx._decomposed` therefore hit the skip rule and graph
break, even though these helpers are PyTorch decomposed quantization functions
that Dynamo should trace through.

That graph break exposed repeated module `forward` code objects from an MLP as
separate Dynamo frame compilations. The first layer specialized the frame input
shape to `[*, 13]`; the second layer then reached the same `forward` code object
with `[*, 512]`, which surfaced as a false recompile when
`error_on_recompile=True`.

Add the decomposed quantization module to `MOD_INLINELIST` so calls to
`quantize_per_tensor` and `dequantize_per_tensor` are traced instead of skipped.
I chose the trace-rule fix over changing general graph-break cache behavior
because the reported functions are traceable torch decompositions and the
existing trace-rule contract explicitly uses `MOD_INLINELIST` for supported
submodules under a skipped package.

Fixes #152307
Generated by my agent

Test Plan:
- OMP_NUM_THREADS=1 TORCHINDUCTOR_FREEZING=1 TORCHDYNAMO_PRINT_GUARD_FAILS=1 python - <<'PY' ... PY
  - issue-derived repro now exits 0 and prints `OK`
- python test/dynamo/test_repros.py -k test_fp8_qdq_repeated_modules_no_recompile
  - passed, Ran 1 test in 1.094s
- python test/dynamo/test_trace_rules.py -k test_skipfiles_inlinelist
  - passed, Ran 1 test in 2.246s
- lintrunner -a
  - passed, `ok No lint issues. Successfully applied all patches.`

Benchmark Results:
- Command: OMP_NUM_THREADS=1 python - <<'PY' ... PY, comparing the issue-shaped
  backend=eager compile+two-call path with the inlinelist entry removed at
  runtime versus present.
- without inlinelist: samples_sec=[1.096908, 0.523763, 0.495201, 0.512599, 0.506565]
  median_sec=0.512599 mean_sec=0.627007
- with inlinelist: samples_sec=[0.155078, 0.097191, 0.094781, 0.287944, 0.104605]
  median_sec=0.104605 mean_sec=0.147920

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos