### PR TITLE
[Test] Decouple test_type_promotion.py from specific hardware backends

### DIFF
--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -9,7 +9,7 @@ import torch
 from torch.testing._internal.common_utils import (TestCase, run_tests, load_tests, make_tensor,
                                                   TEST_NUMPY, set_default_dtype, torch_to_numpy_dtype_dict,
                                                   numpy_to_torch_dtype_dict, skipIfTorchDynamo)
-from torch.testing._internal.common_device_type import (instantiate_device_type_tests, onlyNativeDeviceTypes,
+from torch.testing._internal.common_device_type import (instantiate_device_type_tests,
                                                         dtypes, onlyCPU, expectedFailureMeta, skipMeta)
 from torch.testing._internal.common_dtype import (
     all_types_and_complex_and, get_all_math_dtypes, floating_types, get_all_dtypes,
@@ -147,9 +147,14 @@ class TestTypePromotion(TestCase):
             self.assertEqual(torch.result_type(s, t), expected_dtype)
             self.assertEqual(torch.result_type(t, s), expected_dtype)
 
-        if torch.device(device).type != 'xla':
-            # chalf is not supported on XLA
+        try:
             s = make_scalar_tensor(dtype=torch.chalf)
+        except RuntimeError as e:
+            if "not supported" not in str(e) and "not implemented" not in str(e):
+                raise
+            s = None
+
+        if s is not None:
             # Same Value type
             t = make_1d_tensor(dtype=torch.half)
             # 0-D Tensor X 1-D Tensor
@@ -171,6 +176,8 @@ class TestTypePromotion(TestCase):
             t = make_1d_tensor(dtype=torch.long)
             complex_scalar_tensor_test(s, t)
             complex_scalar_tensor_test(s.item(), t)
+        else:
+            self.skipTest("chalf not supported on this device")
 
         # CFloat Scalar
         s = make_scalar_tensor(dtype=torch.cfloat)
@@ -287,10 +294,13 @@ class TestTypePromotion(TestCase):
             self.assertEqual(torch.promote_types(torch.bfloat16, dtype), expected_dtype)
             self.assertEqual((bf + t).dtype, expected_dtype)
 
-    @onlyNativeDeviceTypes
     def test_complex_half(self, device):
-        # with scalar
-        chalf = torch.tensor(5.5, dtype=torch.chalf, device=device)
+        try:
+            chalf = torch.tensor(5.5, dtype=torch.chalf, device=device)
+        except RuntimeError as e:
+            if "not supported" not in str(e) and "not implemented" not in str(e):
+                raise
+            self.skipTest("chalf not supported on this device")
         for scalar in (2.2, 5, 100000):   # chalf + 100000 is inf
             self.assertEqual((chalf * scalar).dtype, torch.chalf)
             self.assertEqual(scalar * chalf, chalf * scalar)
@@ -348,7 +358,7 @@ class TestTypePromotion(TestCase):
         # RuntimeError: Function SubBackward0 returned an invalid gradient at index 0 - expected type \
         # torch.FloatTensor but got torch.DoubleTensor
         f_dtypes = [torch.float, torch.double]
-        if self.device_type == 'cuda':
+        if self.device_type != 'cpu':
             f_dtypes = f_dtypes + [torch.half]
         i_dtypes = [torch.int, torch.long]
         for func in [torch.add, torch.sub, torch.rsub, torch.mul, torch.div]:
@@ -530,11 +540,6 @@ class TestTypePromotion(TestCase):
         _test_spot(torch.tensor([1, 1], dtype=torch.bool, device=device), 1., torch.get_default_dtype())
 
     @float_double_default_dtype
-    def test_can_cast(self, device):
-        self.assertTrue(torch.can_cast(torch.double, torch.float))
-        self.assertFalse(torch.can_cast(torch.float, torch.int))
-
-    @float_double_default_dtype
     def test_comparison_ops_with_type_promotion(self, device):
         value_for_type = {
             torch.uint8: (1 << 5),
@@ -626,8 +631,6 @@ class TestTypePromotion(TestCase):
                     self.assertTrue(t1.dtype == dt1)
                     self.assertTrue(t2.dtype == dt2)
 
-    # XLA tests fail for self.assertRaises for complex dtypes
-    @onlyNativeDeviceTypes
     def test_complex_assertraises(self, device):
         comparison_ops = [
             dict(name="lt", compare_op=operator.lt, ),
@@ -638,8 +641,8 @@ class TestTypePromotion(TestCase):
             dict(name="ne", compare_op=operator.ne, ),
         ]
         for op in comparison_ops:
-            is_cuda = torch.device(device).type == 'cuda'
-            dtypes = get_all_dtypes(include_half=is_cuda,
+            is_accelerator = self.device_type != 'cpu'
+            dtypes = get_all_dtypes(include_half=is_accelerator,
                                     include_bfloat16=False, include_bool=False,
                                     include_complex32=True)
 
@@ -675,22 +678,6 @@ class TestTypePromotion(TestCase):
             actual = x < torch.tensor(0.5, device=device)
             self.assertTrue(actual, expected)
             self.assertTrue(actual.dtype == torch.bool)
-
-    @float_double_default_dtype
-    def test_promote_types(self, device):
-        self.assertEqual(torch.promote_types(torch.float, torch.int), torch.float)
-        self.assertEqual(torch.promote_types(torch.float, torch.double), torch.double)
-        self.assertEqual(torch.promote_types(torch.int, torch.uint8), torch.int)
-        with self.assertRaisesRegex(RuntimeError, "Promotion for Float8 Types is not supported"):
-            self.assertEqual(torch.promote_types(torch.float8_e5m2, torch.float), torch.float)
-        with self.assertRaisesRegex(RuntimeError, "Promotion for Float8 Types is not supported"):
-            self.assertEqual(torch.promote_types(torch.float, torch.float8_e4m3fn), torch.float)
-
-    @float_double_default_dtype
-    def test_promote_self(self, device):
-        for dtype in all_types_and_complex_and(torch.half, torch.bfloat16, torch.chalf, torch.bool,
-                                               torch.float8_e5m2, torch.float8_e4m3fn):
-            self.assertEqual(torch.promote_types(dtype, dtype), dtype)
 
     @expectedFailureMeta
     @float_double_default_dtype
@@ -738,7 +725,6 @@ class TestTypePromotion(TestCase):
             casting_result = dividend.to(torch.get_default_dtype()) / 2
             self.assertEqual(casting_result, op(dividend, 2.))
 
-    @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double,
             torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
     def test_div_promotion_out(self, device, dtype):
@@ -896,28 +882,23 @@ class TestTypePromotion(TestCase):
             for inplace, coalesced in itertools.product([True, False], [True, False]):
                 self._test_sparse_op(op_name, inplace, dtype1, dtype2, device, coalesced)
 
-    @onlyNativeDeviceTypes
     def test_sparse_add(self, device):
         self._run_all_tests_for_sparse_op('add', device,
                                           dtypes=get_all_math_dtypes(device))
 
-    @onlyNativeDeviceTypes
     def test_sparse_mul(self, device):
         self._run_all_tests_for_sparse_op('mul', device,
                                           dtypes=get_all_math_dtypes(device))
 
-    @onlyNativeDeviceTypes
     def test_sparse_div(self, device):
         self._run_all_tests_for_sparse_op('div', device,
                                           dtypes=(torch.float32, torch.float64,
                                                   torch.complex64, torch.complex128))
 
-    @onlyNativeDeviceTypes
     def test_sparse_sub(self, device):
         self._run_all_tests_for_sparse_op('sub', device,
                                           dtypes=get_all_math_dtypes(device))
 
-    @onlyNativeDeviceTypes
     @dtypes(torch.bool, torch.short, torch.uint8, torch.int, torch.long)
     @float_double_default_dtype
     def test_sparse_div_promotion(self, device, dtype):
@@ -927,7 +908,6 @@ class TestTypePromotion(TestCase):
             casting_result = dividend.to(torch.get_default_dtype()) / 2
             self.assertEqual(casting_result, op(dividend_sparse, 2).to_dense())
 
-    @onlyNativeDeviceTypes
     @dtypes(torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64)
     def test_integer_addcdiv_deprecated(self, device, dtype):
         t = torch.tensor(1, device=device, dtype=dtype)
@@ -1009,7 +989,6 @@ class TestTypePromotion(TestCase):
                     self.fail(msg)
 
 
-    @onlyNativeDeviceTypes
     def test_cat_different_dtypes(self, device):
         dtypes = all_types_and_complex_and(torch.half, torch.bool)
         for x_dtype, y_dtype in itertools.product(dtypes, dtypes):
@@ -1035,7 +1014,6 @@ class TestTypePromotion(TestCase):
             res = torch.cat([x, y])
             self.assertEqual(res, expected_res, exact_dtype=True)
 
-    @onlyNativeDeviceTypes
     def test_cat_out_different_dtypes(self, device):
         dtypes = all_types_and_complex_and(torch.half)
         for x_dtype, y_dtype, out_dtype in itertools.product(dtypes, dtypes, dtypes):
@@ -1054,7 +1032,6 @@ class TestTypePromotion(TestCase):
                 self.assertEqual(out, expected_out, exact_dtype=True)
 
     # Verifies that unary ops require matching out types
-    @onlyNativeDeviceTypes
     @dtypes(*itertools.product((torch.int64,
                                 torch.float32, torch.float64,
                                 torch.complex64, torch.complex128),
@@ -1089,7 +1066,6 @@ class TestTypePromotion(TestCase):
 
     # Verifies that the out= argument doesn't affect the computation, that
     # is, out = op(...) and op(..., out=out) produce the same result.
-    @onlyNativeDeviceTypes
     @skipMeta
     def test_computation_ignores_out(self, device):
         t = torch.tensor(33000, dtype=torch.float16, device=device)
@@ -1110,7 +1086,6 @@ class TestTypePromotion(TestCase):
         self.assertEqual(result, a - b, exact_dtype=False)
         self.assertNotEqual(result, a.double() - b, exact_dtype=False)
 
-    @onlyNativeDeviceTypes
     @dtypes(*itertools.product((torch.bool, torch.int, torch.float, torch.double), repeat=3))
     def test_clamp_type_promotion(self, device, dtypes):
         dtype0, dtype1, dtype2 = dtypes
@@ -1171,7 +1146,6 @@ class TestTypePromotion(TestCase):
                     actual = torch.clamp_max_(inp, val)
                     self.assertEqual(actual, expected, exact_dtype=False)
 
-    @onlyNativeDeviceTypes
     def test_ternary_out_promotion(self, device):
         for op in [torch.addcdiv, torch.addcmul]:
             for dtype in [torch.float32, torch.cfloat]:
@@ -1184,6 +1158,29 @@ class TestTypePromotion(TestCase):
                 self.assertEqual(y, y_promo.to(dtype=dtype))
 
 
+class TestTypePromotionCPU(TestCase):
+    """Pure dtype-algebra tests that don't require any accelerator."""
+
+    @float_double_default_dtype
+    def test_can_cast(self):
+        self.assertTrue(torch.can_cast(torch.double, torch.float))
+        self.assertFalse(torch.can_cast(torch.float, torch.int))
+
+    @float_double_default_dtype
+    def test_promote_types(self):
+        self.assertEqual(torch.promote_types(torch.float, torch.int), torch.float)
+        self.assertEqual(torch.promote_types(torch.float, torch.double), torch.double)
+        self.assertEqual(torch.promote_types(torch.int, torch.uint8), torch.int)
+        with self.assertRaisesRegex(RuntimeError, "Promotion for Float8 Types is not supported"):
+            self.assertEqual(torch.promote_types(torch.float8_e5m2, torch.float), torch.float)
+        with self.assertRaisesRegex(RuntimeError, "Promotion for Float8 Types is not supported"):
+            self.assertEqual(torch.promote_types(torch.float, torch.float8_e4m3fn), torch.float)
+
+    @float_double_default_dtype
+    def test_promote_self(self):
+        for dtype in all_types_and_complex_and(torch.half, torch.bfloat16, torch.chalf, torch.bool,
+                                               torch.float8_e5m2, torch.float8_e4m3fn):
+            self.assertEqual(torch.promote_types(dtype, dtype), dtype)
 
 
 instantiate_device_type_tests(TestTypePromotion, globals())


### PR DESCRIPTION
## Summary

Break the tight coupling between type promotion tests and specific hardware accelerators (CUDA, XLA) to enable new backends to seamlessly reuse PyTorch's existing test suite.

### What changed

**Accelerator-unrelated tests → CPU-only class**
- Extracted `test_can_cast`, `test_promote_types`, `test_promote_self` into a new `TestTypePromotionCPU` class. These test pure dtype algebra (`torch.promote_types`, `torch.can_cast`) with no tensor computation, so they don't need device parameterization.

**Removed `@onlyNativeDeviceTypes` from 13 tests**
- 8 generic type promotion tests: `test_div_promotion_out`, `test_integer_addcdiv_deprecated`, `test_cat_different_dtypes`,  `test_cat_out_different_dtypes`, `test_unary_op_out_casting`,   `test_computation_ignores_out`, `test_clamp_type_promotion`,  `test_ternary_out_promotion`
- 5 sparse type promotion tests: `test_sparse_add`, `test_sparse_mul`,`test_sparse_div`, `test_sparse_sub`, `test_sparse_div_promotion` (CPU-specific half-precision guards in the helper are kept as-is)

**Replaced hardcoded device checks with capability-based patterns**
- `test_complex_promotion`: `if device != 'xla'` → `try/except RuntimeError`  for chalf support
- `test_complex_half`: `@onlyNativeDeviceTypes` → runtime `try/except` with `self.skipTest()` for chalf support
- `test_mixed_type_backward`: `if device == 'cuda'` → `if device != 'cpu'`  for half-precision autograd
- `test_complex_assertraises`: `@onlyNativeDeviceTypes` + `is_cuda` →  `is_accelerator = self.device_type != 'cpu'`

**Cleanup**
- Removed unused `onlyNativeDeviceTypes` import

### Motivation

This is part of the effort to systematically categorize PyTorch's test suite into three dimensions:
1. **Accelerator-unrelated** - runs on CPU only (pure framework logic)
2. **Accelerator-agnostic** - runs on all backends via device parameterization
3. **Accelerator-specific** - uses capability-based guards instead of hardcoded device names

The goal is to allow new hardware backends (e.g. via OpenReg) to reuse PyTorch's extensive test suite without modification.

## Test plan
- [x] `python test/test_type_promotion.py TestTypePromotionCPU -v` passes
- [x] `python test/test_type_promotion.py -v` passes on CPU

cc: @fffrog @albanD @jbschlosser @mansiag05 