### PR TITLE
Make AOTAutograd metadata repr subclass-safe

### DIFF
--- a/test/functorch/test_subclass_codegen.py
+++ b/test/functorch/test_subclass_codegen.py
@@ -124,6 +124,116 @@ def inner_fn(args):
     return (_out_15,)""",
         )
 
+    def test_view_and_mutation_meta_repr_handles_bad_subclass_repr(self):
+        from torch._functorch._aot_autograd.schemas import (
+            PlainTensorMeta,
+            SubclassCreationMeta,
+            SubclassMeta,
+            ViewAndMutationMeta,
+        )
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torchgen.utils import dataclass_repr
+
+        class ReprHostileTensor(torch.Tensor):
+            @staticmethod
+            def __new__(cls, elem):
+                out = torch.Tensor._make_wrapper_subclass(
+                    cls,
+                    elem.shape,
+                    dtype=elem.dtype,
+                    device=elem.device,
+                    requires_grad=elem.requires_grad,
+                )
+                out.elem = elem
+                return out
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                raise RuntimeError(f"dispatch during tensor repr: {func}")
+
+        class BadReprTensor(ReprHostileTensor):
+            def __repr__(self):
+                raise RuntimeError("bad subclass repr")
+
+        class MissingReprTensor(ReprHostileTensor):
+            pass
+
+        for tensor_type in (BadReprTensor, MissingReprTensor):
+            with self.subTest(tensor_type=tensor_type):
+                meta = ViewAndMutationMeta(
+                    [],
+                    [],
+                    0,
+                    False,
+                    [tensor_type(torch.ones(2))],
+                    [],
+                    [],
+                    [],
+                    [],
+                )
+
+                meta_repr = repr(meta)
+
+                self.assertIn("ViewAndMutationMeta(", meta_repr)
+                self.assertIn(f"<unprintable {tensor_type.__name__}", meta_repr)
+
+        class BadReprTwoTensor(TwoTensor):
+            def __repr__(self):
+                raise RuntimeError("bad subclass repr")
+
+        with FakeTensorMode() as fake_mode:
+            fake_inner = fake_mode.from_tensor(torch.ones(2))
+            bad_subclass = BadReprTwoTensor(fake_inner, fake_inner.clone())
+            subclass_creation_meta = SubclassCreationMeta(
+                0,
+                2,
+                False,
+                {"a": PlainTensorMeta(0), "b": PlainTensorMeta(1)},
+                bad_subclass.size(),
+                bad_subclass.stride(),
+                None,
+                bad_subclass,
+            )
+
+        meta = ViewAndMutationMeta(
+            [],
+            [],
+            0,
+            False,
+            [],
+            [],
+            [subclass_creation_meta],
+            [],
+            [],
+        )
+
+        meta_repr = repr(meta)
+
+        self.assertIn("ViewAndMutationMeta(", meta_repr)
+        self.assertIn("<unprintable BadReprTwoTensor", meta_repr)
+
+        subclass_meta = SubclassMeta()
+        subclass_meta.fw_metadata = ViewAndMutationMeta(
+            [],
+            [],
+            0,
+            False,
+            [],
+            [],
+            [],
+            [],
+            [],
+        )
+        subclass_meta.grad_input_metas = [subclass_creation_meta]
+
+        subclass_meta_repr = dataclass_repr(subclass_meta)
+        subclass_creation_meta_repr = dataclass_repr(subclass_creation_meta)
+
+        self.assertIn("SubclassMeta(", subclass_meta_repr)
+        self.assertIn("<unprintable BadReprTwoTensor", subclass_meta_repr)
+        self.assertIn("SubclassCreationMeta(", subclass_creation_meta_repr)
+        self.assertIn("<unprintable BadReprTwoTensor", subclass_creation_meta_repr)
+
     def test_trailing_args_forwarded(self):
         """Extra trailing args (e.g. rng seed/offset) are forwarded to compiled_fn."""
         # Build SubclassCreationMeta manually to avoid __post_init__ fake tensor check

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import collections
 import functools
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, is_dataclass, replace
 from enum import Enum
 from typing import Any, NewType, Protocol, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
@@ -42,6 +42,83 @@ if TYPE_CHECKING:
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 zip = strict_zip
+
+
+def _safe_metadata_repr(obj: object, visited: set[int] | None = None) -> str:
+    if visited is None:
+        visited = set()
+
+    obj_id = id(obj)
+    if obj_id in visited:
+        return "..."
+
+    if is_dataclass(obj) and not isinstance(obj, type):
+        visited.add(obj_id)
+        try:
+            field_reprs = []
+            for obj_field in fields(obj):
+                if obj_field.repr:
+                    try:
+                        field_value = getattr(obj, obj_field.name)
+                    except AttributeError:
+                        field_reprs.append(f"{obj_field.name}=<missing>")
+                        continue
+                    except Exception as e:
+                        try:
+                            exc_str = str(e)
+                        except Exception:
+                            exc_str = "<exception str() failed>"
+                        field_reprs.append(
+                            f"{obj_field.name}=<unprintable field: "
+                            f"{type(e).__name__}: {exc_str}>"
+                        )
+                        continue
+                    field_reprs.append(
+                        f"{obj_field.name}={_safe_metadata_repr(field_value, visited)}"
+                    )
+            return f"{type(obj).__name__}({', '.join(field_reprs)})"
+        finally:
+            visited.remove(obj_id)
+
+    if isinstance(obj, list):
+        visited.add(obj_id)
+        try:
+            return f"[{', '.join(_safe_metadata_repr(x, visited) for x in obj)}]"
+        finally:
+            visited.remove(obj_id)
+
+    if isinstance(obj, tuple):
+        visited.add(obj_id)
+        try:
+            elems = [_safe_metadata_repr(x, visited) for x in obj]
+            if len(elems) == 1:
+                return f"({elems[0]},)"
+            return f"({', '.join(elems)})"
+        finally:
+            visited.remove(obj_id)
+
+    if isinstance(obj, dict):
+        visited.add(obj_id)
+        try:
+            return (
+                "{"
+                + ", ".join(
+                    f"{_safe_metadata_repr(k, visited)}: {_safe_metadata_repr(v, visited)}"
+                    for k, v in obj.items()
+                )
+                + "}"
+            )
+        finally:
+            visited.remove(obj_id)
+
+    try:
+        return repr(obj)
+    except Exception as e:
+        try:
+            exc_str = str(e)
+        except Exception:
+            exc_str = "<exception str() failed>"
+        return f"<unprintable {type(obj).__name__}: {type(e).__name__}: {exc_str}>"
 
 
 OutputType = Enum(
@@ -279,6 +356,9 @@ class SubclassCreationMeta:
     # Used at runtime to determine the subclass type, so we don't need to save the original subclass
     original_subclass_type: type | None = None
     memory_format: MemoryFormatMeta | None = None
+
+    def __repr__(self) -> str:
+        return _safe_metadata_repr(self)
 
     def compute_outer_size_and_stride(
         self,
@@ -553,6 +633,9 @@ class ViewAndMutationMeta:
 
     # help users identify where to add .detach() in their code
     tangent_source_stack_traces: list[str | None] | None = None
+
+    def __repr__(self) -> str:
+        return _safe_metadata_repr(self)
 
     def __post_init__(self) -> None:
         # pre-compute the indices of the inputs that are mutated.
@@ -885,6 +968,9 @@ class SubclassMeta:
     def __init__(self) -> None:
         # The fields in this class get set after its construction.
         pass
+
+    def __repr__(self) -> str:
+        return _safe_metadata_repr(self)
 
 
 # This class exists because:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185632

ViewAndMutationMeta and related subclass metadata are included in AOTAutograd structured logging for tlparse. These dataclasses can hold tensor subclasses in traced_tangents and SubclassCreationMeta.original_subclass. The generated dataclass repr recursively calls those objects' repr implementations, so a tensor subclass with no PT2-friendly repr or with fake-tensor-hostile repr could crash compilation while formatting logging artifacts.

This adds a safe metadata repr used by ViewAndMutationMeta, SubclassCreationMeta, and SubclassMeta. It preserves dataclass field rendering for metadata but catches terminal repr failures and prints <unprintable ...>, so logging still records useful context without letting subclass repr failures escape the logging path. SubclassMeta is covered because it is logged separately from ViewAndMutationMeta via dataclass_repr(maybe_subclass_meta).

Fixes #152183

Generated by my agent

Test Plan:
- python test/functorch/test_subclass_codegen.py TestSubclassCodegen.test_view_and_mutation_meta_repr_handles_bad_subclass_repr
- python test/functorch/test_subclass_codegen.py
- lintrunner -a torch/_functorch/_aot_autograd/schemas.py test/functorch/test_subclass_codegen.py