### PR TITLE
Use `atomic<shared_ptr>` for current RPC agent

### DIFF
--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -253,14 +253,14 @@ const WorkerInfo& RpcAgent::getWorkerInfo() const {
   return workerInfo_;
 }
 
-std::shared_ptr<RpcAgent> RpcAgent::currentRpcAgent_ = nullptr;
+std::atomic<std::shared_ptr<RpcAgent>> RpcAgent::currentRpcAgent_{nullptr};
 
 bool RpcAgent::isCurrentRpcAgentSet() {
-  return std::atomic_load(&currentRpcAgent_) != nullptr;
+  return currentRpcAgent_.load() != nullptr;
 }
 
 std::shared_ptr<RpcAgent> RpcAgent::getCurrentRpcAgent() {
-  std::shared_ptr<RpcAgent> agent = std::atomic_load(&currentRpcAgent_);
+  std::shared_ptr<RpcAgent> agent = currentRpcAgent_.load();
   TORCH_CHECK(
       agent,
       "Current RPC agent is not set! Did you initialize the RPC "
@@ -273,9 +273,9 @@ void RpcAgent::setCurrentRpcAgent(std::shared_ptr<RpcAgent> rpcAgent) {
     std::shared_ptr<RpcAgent> previousAgent;
     // Use compare_exchange so that we don't actually perform the exchange if
     // that would trigger the assert just below. See:
-    // https://en.cppreference.com/w/cpp/atomic/atomic_compare_exchange
-    std::atomic_compare_exchange_strong(
-        &currentRpcAgent_, &previousAgent, std::move(rpcAgent));
+    // https://en.cppreference.com/w/cpp/atomic/atomic/compare_exchange
+    currentRpcAgent_.compare_exchange_strong(
+        previousAgent, std::move(rpcAgent));
     TORCH_INTERNAL_ASSERT(
         previousAgent == nullptr, "Current RPC agent is set!");
   } else {
@@ -283,7 +283,7 @@ void RpcAgent::setCurrentRpcAgent(std::shared_ptr<RpcAgent> rpcAgent) {
     // don't need to, as the only case that would trigger the assert is if we
     // replaced nullptr with nullptr, which we can just do as it has no effect.
     std::shared_ptr<RpcAgent> previousAgent =
-        std::atomic_exchange(&currentRpcAgent_, std::move(rpcAgent));
+        currentRpcAgent_.exchange(std::move(rpcAgent));
     TORCH_INTERNAL_ASSERT(
         previousAgent != nullptr, "Current RPC agent is not set!");
   }

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -253,14 +253,26 @@ const WorkerInfo& RpcAgent::getWorkerInfo() const {
   return workerInfo_;
 }
 
+#if defined(TORCH_RPC_HAS_ATOMIC_SHARED_PTR)
 std::atomic<std::shared_ptr<RpcAgent>> RpcAgent::currentRpcAgent_{nullptr};
+#else
+std::shared_ptr<RpcAgent> RpcAgent::currentRpcAgent_ = nullptr;
+#endif
 
 bool RpcAgent::isCurrentRpcAgentSet() {
+#if defined(TORCH_RPC_HAS_ATOMIC_SHARED_PTR)
   return currentRpcAgent_.load() != nullptr;
+#else
+  return std::atomic_load(&currentRpcAgent_) != nullptr;
+#endif
 }
 
 std::shared_ptr<RpcAgent> RpcAgent::getCurrentRpcAgent() {
+#if defined(TORCH_RPC_HAS_ATOMIC_SHARED_PTR)
   std::shared_ptr<RpcAgent> agent = currentRpcAgent_.load();
+#else
+  std::shared_ptr<RpcAgent> agent = std::atomic_load(&currentRpcAgent_);
+#endif
   TORCH_CHECK(
       agent,
       "Current RPC agent is not set! Did you initialize the RPC "
@@ -273,17 +285,28 @@ void RpcAgent::setCurrentRpcAgent(std::shared_ptr<RpcAgent> rpcAgent) {
     std::shared_ptr<RpcAgent> previousAgent;
     // Use compare_exchange so that we don't actually perform the exchange if
     // that would trigger the assert just below. See:
+#if defined(TORCH_RPC_HAS_ATOMIC_SHARED_PTR)
     // https://en.cppreference.com/w/cpp/atomic/atomic/compare_exchange
     currentRpcAgent_.compare_exchange_strong(
         previousAgent, std::move(rpcAgent));
+#else
+    // https://en.cppreference.com/w/cpp/atomic/atomic_compare_exchange
+    std::atomic_compare_exchange_strong(
+        &currentRpcAgent_, &previousAgent, std::move(rpcAgent));
+#endif
     TORCH_INTERNAL_ASSERT(
         previousAgent == nullptr, "Current RPC agent is set!");
   } else {
     // We can't use compare_exchange (we don't know what value to expect) but we
     // don't need to, as the only case that would trigger the assert is if we
     // replaced nullptr with nullptr, which we can just do as it has no effect.
+#if defined(TORCH_RPC_HAS_ATOMIC_SHARED_PTR)
     std::shared_ptr<RpcAgent> previousAgent =
         currentRpcAgent_.exchange(std::move(rpcAgent));
+#else
+    std::shared_ptr<RpcAgent> previousAgent =
+        std::atomic_exchange(&currentRpcAgent_, std::move(rpcAgent));
+#endif
     TORCH_INTERNAL_ASSERT(
         previousAgent != nullptr, "Current RPC agent is not set!");
   }

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -274,7 +274,7 @@ class TORCH_API RpcAgent {
   std::atomic<bool> rpcAgentRunning_;
 
  private:
-  static std::shared_ptr<RpcAgent> currentRpcAgent_;
+  static std::atomic<std::shared_ptr<RpcAgent>> currentRpcAgent_;
   // Add GIL wait time data point to metrics
   virtual void addGilWaitTime(const std::chrono::microseconds gilWaitTime) = 0;
   friend class PythonRpcHandler;

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -10,6 +10,11 @@
 #include <mutex>
 #include <thread>
 
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+#define TORCH_RPC_HAS_ATOMIC_SHARED_PTR 1
+#endif
+
 namespace torch::distributed::rpc {
 
 using DeviceMap = std::unordered_map<c10::Device, c10::Device>;
@@ -274,7 +279,11 @@ class TORCH_API RpcAgent {
   std::atomic<bool> rpcAgentRunning_;
 
  private:
+#if defined(TORCH_RPC_HAS_ATOMIC_SHARED_PTR)
   static std::atomic<std::shared_ptr<RpcAgent>> currentRpcAgent_;
+#else
+  static std::shared_ptr<RpcAgent> currentRpcAgent_;
+#endif
   // Add GIL wait time data point to metrics
   virtual void addGilWaitTime(const std::chrono::microseconds gilWaitTime) = 0;
   friend class PythonRpcHandler;


### PR DESCRIPTION
`std::atomic_load`, `std::atomic_exchange`, and `std::atomic_compare_exchange_*` overloads for `std::shared_ptr<T>` are deprecated since C++20 ([ref](https://en.cppreference.com/cpp/memory/shared_ptr/atomic)). Newer GCC/libstdc++ warns on these deprecated overloads, and warning-as-error builds can turn this into a build failure, as encountered in #182016.

This PR updates `RpcAgent::currentRpcAgent_` from a plain `std::shared_ptr<RpcAgent>` accessed through the deprecated free-function atomic API to `std::atomic<std::shared_ptr<RpcAgent>>` accessed through the modern member API when `__cpp_lib_atomic_shared_ptr` is available.

The implementation keeps the legacy free-function path on older standard libraries that do not provide the C++20 `std::atomic<std::shared_ptr<T>>` specialization.

cc. @aditew01 @malfet