### PR TITLE
Fix AOTI CUDA device copy allocation

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6723,6 +6723,30 @@ class AOTInductorTestsTemplate:
         all_ops = [event.key for event in prof.key_averages()]
         self.assertTrue(not any("aten::contiguous" in op for op in all_ops))
 
+    @requires_multigpu()
+    def test_cuda_to_cuda_device_copy(self):
+        if self.device != GPU_TYPE or GPU_TYPE != "cuda" or TEST_WITH_ROCM:
+            raise unittest.SkipTest("This test requires CUDA")
+
+        device0 = torch.device(type=GPU_TYPE, index=0)
+        device1 = torch.device(type=GPU_TYPE, index=1)
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x, x.to(device1)
+
+        model = Model().to(device0)
+        x = torch.randn(10, device=device0)
+        package_path = AOTIRunnerUtil.compile(model, (x,))
+        aoti_model = torch._inductor.aoti_load_package(package_path, device_index=0)
+
+        expected = model(x)
+        actual = aoti_model(x)
+
+        self.assertEqual(actual[0].device, device0)
+        self.assertEqual(actual[1].device, device1)
+        self.assertEqual(actual, expected)
+
     def test_so_without_weight(self):
         class Model(torch.nn.Module):
             def __init__(self, n, k, device):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2118,6 +2118,20 @@ class CppWrapperCpu(PythonWrapperCodegen):
         self.used_cached_devices.add(device_str)
         return f"cached_torch_device_type_{device_str}, {device.index if device.index else 0}"
 
+    def codegen_device_idx(self, device, device_id):
+        device_id = device_id.strip()
+        if not V.graph.aot_mode:
+            return device_id
+
+        if device.type == V.graph.device_type and device.index is not None:
+            # The primary compile-time device is relocatable via device_index at load.
+            # Other explicit device indices must stay intact for cross-device copies.
+            primary_device_idx = next(iter(V.graph.device_idxs), None)
+            if primary_device_idx is not None and device.index != primary_device_idx:
+                return device_id
+
+        return "this->device_idx_"
+
     def codegen_dtype(self, dtype):
         dtype_str = str(dtype).split(".")[-1]
         self.used_cached_dtypes.add(dtype_str)
@@ -2245,7 +2259,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
             graph=self.get_codegened_graph(),
         )
         device_type, device_id = device_str.split(",")
-        device_idx = "this->device_idx_" if V.graph.aot_mode else device_id
+        device_idx = self.codegen_device_idx(device, device_id)
 
         handle_name = f"{name}_handle"
         args = [

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -849,7 +849,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             graph=self.get_codegened_graph(),
         )
         device_type, device_id = device_str.split(",")
-        device_idx = "this->device_idx_" if V.graph.aot_mode else device_id
+        device_idx = self.codegen_device_idx(device, device_id)
         if buffer_if_can_stack_allocate is not None:
             self.stack_allocated_buffers[name] = buffer_if_can_stack_allocate
             cpp_type = DTYPE_TO_CPP[dtype]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185634

AOTInductor's DeviceCopy IR keeps the destination device in the
output layout, but the AOTI C++ wrapper used this->device_idx_ for every
allocation in AOT mode. For a graph compiled on cuda:0 with x.to(cuda:1),
that allocated the destination buffer on the package primary device
(cuda:0). aoti_torch_copy_ then copied into the already-created cuda:0
buffer, so the result stayed on the wrong device.

Fix this by centralizing AOTI allocation device-index codegen. The primary
compile-time device still uses this->device_idx_, preserving package
relocation through aoti_load_package(..., device_index=...). Explicit
non-primary devices in the same backend keep their literal indices, so
cross-device DeviceCopy outputs are allocated on the requested device. The
same helper is used by the arrayref wrapper allocation path.

I considered fixing this in the copy shim, but that would leave allocation
on the wrong device and make copy_ responsible for changing tensor identity.
The root cause is the generated destination allocation, so the wrapper
codegen is the right layer.

Fixes #152130
Generated by my agent

Test Plan:
- CUDA_VISIBLE_DEVICES=4,5 python <direct issue repro>; reproduced before
  the fix and passed after the fix with AOTI outputs on cuda:0 and cuda:1.
- CUDA_VISIBLE_DEVICES=4,5 python <to cuda:1 then add repro>; passed with
  cuda:1 output matching eager.
- CUDA_VISIBLE_DEVICES=4,5 PYTHONPATH=test/inductor python <AOTIRunnerUtil
  focused repro>; passed with actual devices cuda:0 and cuda:1.
- python -m py_compile torch/_inductor/codegen/cpp_wrapper_cpu.py
  torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
  test/inductor/test_aot_inductor.py
- lintrunner -a
- CUDA_VISIBLE_DEVICES=4,5 python test/inductor/test_aot_inductor.py
  AOTInductorTestABICompatibleGpu.test_cuda_to_cuda_device_copy -v was
  blocked before collection by the local torchvision import failure:
  RuntimeError: operator torchvision::nms does not exist

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo