### PR TITLE
[inductor] Add fallback_batch_norm config to fall back BN to ATen kernel                                                                                                    

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6854,6 +6854,41 @@ class CommonTemplate:
         o2 = torch.compile(mod)(inp)
         self.assertEqual(o1, o2, rtol=1e-3, atol=1e-3)
 
+    @config.patch(fallback_batch_norm=True)
+    def test_fallback_batch_norm_skips_decomp(self):
+        # With fallback_batch_norm on, BN is not decomposed: no welford_reduce
+        # / triton_red_fused__native_batch_norm_* kernel; instead an extern
+        # aten._native_batch_norm_legit_functional call. Output must stay
+        # within standard bf16 autocast tolerance of eager.
+        if self.device == "cpu":
+            raise unittest.SkipTest(f"requires {GPU_TYPE}")
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = torch.nn.Conv2d(1, 64, 3)
+                self.bn = torch.nn.BatchNorm2d(64, momentum=1, affine=True)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.bn(self.conv(x))
+
+        torch.manual_seed(0)
+        eager = M().to(device=self.device).train()
+        compiled_mod = copy.deepcopy(eager)
+        x = torch.randn(5, 1, 28, 28, device=self.device)
+
+        with torch.autocast(self.device, dtype=torch.bfloat16):
+            out_eager = eager(x.clone())
+            compiled = torch.compile(compiled_mod)
+            out_compiled, (fwd_code,) = run_and_get_code(compiled, x.clone())
+
+        self.assertNotIn("welford_reduce", fwd_code)
+        self.assertNotIn("triton_red_fused__native_batch_norm", fwd_code)
+        self.assertIn(
+            "torch.ops.aten._native_batch_norm_legit_functional.default", fwd_code
+        )
+        self.assertEqual(out_eager, out_compiled, atol=1e-2, rtol=1e-2)
+
     @patch.object(config.trace, "enabled", True)
     def test_layer_norm(self):
         m = torch.nn.Sequential(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6856,10 +6856,8 @@ class CommonTemplate:
 
     @config.patch(fallback_batch_norm=True)
     def test_fallback_batch_norm_skips_decomp(self):
-        # With fallback_batch_norm on, BN is not decomposed: no welford_reduce
-        # / triton_red_fused__native_batch_norm_* kernel; instead an extern
-        # aten._native_batch_norm_legit_functional call. Output must stay
-        # within standard bf16 autocast tolerance of eager.
+        # BN should fall back to the extern aten call instead of a fused
+        # Triton var_mean kernel, and stay within bf16 autocast tolerance.
         if self.device == "cpu":
             raise unittest.SkipTest(f"requires {GPU_TYPE}")
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -890,15 +890,9 @@ align_random_eager = False
 # fallback embedding_bag_byte_unpack to eager
 fallback_embedding_bag_byte_unpack = False
 
-# fallback batch_norm ops to eager (calls into the registered ATen kernel:
-# MIOpen on ROCm, cuDNN on CUDA, native otherwise). Without this, inductor
-# decomposes BN to var_mean+sub+mul+rsqrt and fuses with neighbors; the parallel
-# reduction order in the lowered Triton kernel differs from MIOpen's two-stage
-# (PartialMV -> FinalMV) reduction by ~1 fp32 ULP of mean/var, which when
-# re-quantized to bf16 produces ~1 bf16-ULP per-element output drift -- enough
-# to trip tight per-model accuracy bounds (e.g. maml_omniglot on MI350X gfx950
-# under autocast bf16). Enabling this disables BN fusion (perf cost) but makes
-# eager and compile bit-identical on the BN path. Disabled by default.
+# Skip BN decomposition; fall back to the registered ATen kernel. Costs BN
+# fusion. Use when Triton's fused var_mean reduction order drifts enough
+# from eager's to fail tight accuracy bounds.
 fallback_batch_norm = False
 
 # automatically create fallbacks when encountering an unhandled op

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -890,6 +890,17 @@ align_random_eager = False
 # fallback embedding_bag_byte_unpack to eager
 fallback_embedding_bag_byte_unpack = False
 
+# fallback batch_norm ops to eager (calls into the registered ATen kernel:
+# MIOpen on ROCm, cuDNN on CUDA, native otherwise). Without this, inductor
+# decomposes BN to var_mean+sub+mul+rsqrt and fuses with neighbors; the parallel
+# reduction order in the lowered Triton kernel differs from MIOpen's two-stage
+# (PartialMV -> FinalMV) reduction by ~1 fp32 ULP of mean/var, which when
+# re-quantized to bf16 produces ~1 bf16-ULP per-element output drift -- enough
+# to trip tight per-model accuracy bounds (e.g. maml_omniglot on MI350X gfx950
+# under autocast bf16). Enabling this disables BN fusion (perf cost) but makes
+# eager and compile bit-identical on the BN path. Disabled by default.
+fallback_batch_norm = False
+
 # automatically create fallbacks when encountering an unhandled op
 implicit_fallbacks = True
 assume_unaligned_fallback_output = (

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -109,20 +109,25 @@ decompositions = {**core_aten_decompositions(), **inductor_decompositions}
 
 # BN decomps gated by config.fallback_batch_norm. When the flag is set we
 # remove these from the active decomp table so the op survives to inductor as
-# a single node and falls back to its registered ATen kernel (MIOpen on ROCm,
-# cuDNN on CUDA), giving bit-identical numerics to eager at the cost of fusion.
-_batch_norm_decomp_ops = [
-    aten._native_batch_norm_legit,
-    aten._native_batch_norm_legit_functional,
-    aten._native_batch_norm_legit_no_training,
-    aten._batch_norm_with_update,
-    aten._batch_norm_with_update_functional,
-    aten._batch_norm_no_update,
-    aten.batch_norm_backward,
-    aten.native_batch_norm,
-    aten.native_batch_norm_backward,
-]
-extra_batch_norm_decomps = get_decompositions(_batch_norm_decomp_ops)
+# a single node and falls back to its registered ATen kernel, giving
+# bit-identical numerics to eager at the cost of fusion. To actually reach the
+# MIOpen / cuDNN code path that eager uses, every layer of the BN decomp chain
+# must be excluded -- including the backend-specific entry points
+# (cudnn_batch_norm, miopen_batch_norm) whose decomps rewrite them into the
+# generic _native_batch_norm_legit_functional path that doesn't route to the
+# accelerated kernel. Otherwise the fallback lands on the plain native CUDA
+# kernel and still drifts from eager by the same ~1 fp32 ULP.
+#
+# We build the set by name-matching against the assembled decompositions dict
+# rather than hardcoding overloads -- this is robust against new BN ops being
+# added and against the inconsistency between OpOverloadPacket and OpOverload
+# registrations (get_decompositions([packet]) does not always yield every
+# overload that ends up in `decompositions`).
+extra_batch_norm_decomps = {
+    k: v
+    for k, v in decompositions.items()
+    if "batch_norm" in (k.name() if hasattr(k, "name") else str(k))
+}
 
 # Remove unwanted decompositions included via the core ATen decompositions from
 # the Inductor decomp table.
@@ -995,7 +1000,24 @@ def select_decomp_table() -> dict[Any, Callable[..., Any]]:
     else:
         result = fast_random_decomps()
     if config.fallback_batch_norm:
-        result = {k: v for k, v in result.items() if k not in extra_batch_norm_decomps}
+        # Strip every BN entry by name (rather than set-membership against a
+        # precomputed extra_batch_norm_decomps) to catch BN overloads that
+        # land in `result` via paths other than the inductor list -- e.g.
+        # miopen_batch_norm.default/out registered through extra_random_decomps.
+        # Note: we mutate `decompositions` in place too, so any downstream
+        # consumer that reads the global dict directly (e.g. make_fallback's
+        # assertion fallback) also sees the BN ops as absent. Without this the
+        # global dict still advertises BN as decomposable, the fallback path
+        # takes a different shape and the resulting kernel chain stops drifting
+        # only partially.
+        bn_keys = [
+            k
+            for k in result
+            if "batch_norm" in (k.name() if hasattr(k, "name") else str(k))
+        ]
+        for k in bn_keys:
+            decompositions.pop(k, None)
+        result = {k: v for k, v in result.items() if k not in bn_keys}
     return result
 
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -986,16 +986,14 @@ def select_decomp_table() -> dict[Any, Callable[..., Any]]:
     else:
         result = fast_random_decomps()
     if config.fallback_batch_norm:
-        # Strip every BN entry by name. Also mutate `decompositions` so the
-        # global dict (read by make_fallback's assertion fallback) agrees.
-        bn_keys = [
-            k
-            for k in result
-            if "batch_norm" in (k.name() if hasattr(k, "name") else str(k))
-        ]
-        for k in bn_keys:
-            decompositions.pop(k, None)
-        result = {k: v for k, v in result.items() if k not in bn_keys}
+        # Strip every BN entry by name from the returned table only. Do NOT
+        # mutate `decompositions` -- the patch needs to be reversible across
+        # @config.patch entry/exit.
+        result = {
+            k: v
+            for k, v in result.items()
+            if "batch_norm" not in (k.name() if hasattr(k, "name") else str(k))
+        }
     return result
 
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -107,22 +107,8 @@ inductor_decompositions = get_decompositions(
 )
 decompositions = {**core_aten_decompositions(), **inductor_decompositions}
 
-# BN decomps gated by config.fallback_batch_norm. When the flag is set we
-# remove these from the active decomp table so the op survives to inductor as
-# a single node and falls back to its registered ATen kernel, giving
-# bit-identical numerics to eager at the cost of fusion. To actually reach the
-# MIOpen / cuDNN code path that eager uses, every layer of the BN decomp chain
-# must be excluded -- including the backend-specific entry points
-# (cudnn_batch_norm, miopen_batch_norm) whose decomps rewrite them into the
-# generic _native_batch_norm_legit_functional path that doesn't route to the
-# accelerated kernel. Otherwise the fallback lands on the plain native CUDA
-# kernel and still drifts from eager by the same ~1 fp32 ULP.
-#
-# We build the set by name-matching against the assembled decompositions dict
-# rather than hardcoding overloads -- this is robust against new BN ops being
-# added and against the inconsistency between OpOverloadPacket and OpOverload
-# registrations (get_decompositions([packet]) does not always yield every
-# overload that ends up in `decompositions`).
+# Every BN overload in the active decomp table. Filter is name-based so it
+# catches overloads added via other paths (e.g. extra_random_decomps).
 extra_batch_norm_decomps = {
     k: v
     for k, v in decompositions.items()
@@ -1000,16 +986,8 @@ def select_decomp_table() -> dict[Any, Callable[..., Any]]:
     else:
         result = fast_random_decomps()
     if config.fallback_batch_norm:
-        # Strip every BN entry by name (rather than set-membership against a
-        # precomputed extra_batch_norm_decomps) to catch BN overloads that
-        # land in `result` via paths other than the inductor list -- e.g.
-        # miopen_batch_norm.default/out registered through extra_random_decomps.
-        # Note: we mutate `decompositions` in place too, so any downstream
-        # consumer that reads the global dict directly (e.g. make_fallback's
-        # assertion fallback) also sees the BN ops as absent. Without this the
-        # global dict still advertises BN as decomposable, the fallback path
-        # takes a different shape and the resulting kernel chain stops drifting
-        # only partially.
+        # Strip every BN entry by name. Also mutate `decompositions` so the
+        # global dict (read by make_fallback's assertion fallback) agrees.
         bn_keys = [
             k
             for k in result

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -107,6 +107,23 @@ inductor_decompositions = get_decompositions(
 )
 decompositions = {**core_aten_decompositions(), **inductor_decompositions}
 
+# BN decomps gated by config.fallback_batch_norm. When the flag is set we
+# remove these from the active decomp table so the op survives to inductor as
+# a single node and falls back to its registered ATen kernel (MIOpen on ROCm,
+# cuDNN on CUDA), giving bit-identical numerics to eager at the cost of fusion.
+_batch_norm_decomp_ops = [
+    aten._native_batch_norm_legit,
+    aten._native_batch_norm_legit_functional,
+    aten._native_batch_norm_legit_no_training,
+    aten._batch_norm_with_update,
+    aten._batch_norm_with_update_functional,
+    aten._batch_norm_no_update,
+    aten.batch_norm_backward,
+    aten.native_batch_norm,
+    aten.native_batch_norm_backward,
+]
+extra_batch_norm_decomps = get_decompositions(_batch_norm_decomp_ops)
+
 # Remove unwanted decompositions included via the core ATen decompositions from
 # the Inductor decomp table.
 decomps_to_exclude: list[torch._ops.OpOverload | torch._ops.OpOverloadPacket] = [
@@ -970,12 +987,15 @@ def fast_random_decomps() -> dict[Any, Callable[..., Any]]:
 def select_decomp_table() -> dict[Any, Callable[..., Any]]:
     """decomps can change based on config"""
     if config.fallback_random:
-        return decompositions
-    if config.fallback_embedding_bag_byte_unpack:
+        result = decompositions
+    elif config.fallback_embedding_bag_byte_unpack:
         # remove q_embedding_bag_byte_unpack_decomp from decompositions
         decompositions.pop(torch.ops.quantized.embedding_bag_byte_unpack.default, None)
-        return decompositions
-    result = fast_random_decomps()
+        result = decompositions
+    else:
+        result = fast_random_decomps()
+    if config.fallback_batch_norm:
+        result = {k: v for k, v in result.items() if k not in extra_batch_norm_decomps}
     return result
 
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1367,6 +1367,20 @@ class GraphLowering(torch.fx.Interpreter):
                     get_decomp_fn=self.get_decomp_fn,
                     override_decomp=True,
                 )
+            elif (
+                config.fallback_batch_norm
+                and target in torch._inductor.decomposition.extra_batch_norm_decomps
+            ):
+                # Honor fallback_batch_norm even when implicit_fallbacks is off:
+                # the flag's whole purpose is to opt into the ATen kernel for
+                # parity, so it must succeed in environments (e.g. the inductor
+                # test suite) that disable implicit fallbacks by default.
+                make_fallback(
+                    target,
+                    warn=False,
+                    get_decomp_fn=self.get_decomp_fn,
+                    override_decomp=True,
+                )
             elif config.implicit_fallbacks:
                 error = (
                     MissingOperatorWithDecomp

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1371,10 +1371,7 @@ class GraphLowering(torch.fx.Interpreter):
                 config.fallback_batch_norm
                 and target in torch._inductor.decomposition.extra_batch_norm_decomps
             ):
-                # Honor fallback_batch_norm even when implicit_fallbacks is off:
-                # the flag's whole purpose is to opt into the ATen kernel for
-                # parity, so it must succeed in environments (e.g. the inductor
-                # test suite) that disable implicit fallbacks by default.
+                # Honor fallback_batch_norm even when implicit_fallbacks is off.
                 make_fallback(
                     target,
                     warn=False,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2632,6 +2632,11 @@ def make_fallback(
             config.fallback_random
             and op in torch._decomp.decompositions_for_rng.extra_random_decomps
         )
+        # if fallback_batch_norm, we allow not decomposing BN
+        and not (
+            config.fallback_batch_norm
+            and op in torch._inductor.decomposition.extra_batch_norm_decomps
+        )
         and not override_decomp
     ):
         # Note: 'warn' is holdover from when this was a warning, but for ops that previously


### PR DESCRIPTION
                                                            
  Description: Adds opt-in torch._inductor.config.fallback_batch_norm (default False, env TORCHINDUCTOR_FALLBACK_BATCH_NORM). When enabled, BN ops are removed from inductor's         
  decomposition table and survive as single nodes that fall back to the registered ATen kernel (MIOpen on ROCm, cuDNN on CUDA), giving bit-identical numerics to eager at the cost of BN fusion.                                                                                                                                                  
                                                            
  Motivation: Under inductor + autocast bf16, BN decomposes to var_mean + sub + mul + rsqrt and gets fused with neighbors. The parallel reduction order in the lowered Triton kernel differs from MIOpen's two-stage (PartialMV → FinalMV) reduction by ~1 fp32 ULP of mean/var; re-quantized to bf16 this produces ~1 bf16-ULP per-element output drift, which compounds through stacked BN layers and trips tight per-model accuracy bounds (e.g. maml_omniglot training/amp on MI350X gfx950 fails with 0.bias.grad RMSE 7e-4 vs bound 5e-4). Flag is off by default to preserve existing fusion behavior; opt-in unblocks ROCm accuracy tests and any model hitting the same reduction-order mismatch.
  Mirrors the existing fallback_random pattern.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo