### PR TITLE
Fix standalone_compile fake mode detection for subclasses

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -98,6 +98,7 @@ from torch.testing._internal.triton_utils import (
     requires_cuda_and_triton,
     requires_gpu_and_triton,
 )
+from torch.testing._internal.two_tensor import TwoTensor
 
 
 try:
@@ -2704,6 +2705,41 @@ if not torch.allclose(eager_result, compiled_result, atol=0.1, rtol=0.01):
         self.assertIsNot(seen_fake_modes[0], fake_mode)
         self.assertIsInstance(seen_fake_modes[0], FakeTensorMode)
         self.assertIsNotNone(seen_fake_modes[0].shape_env)
+
+    def test_dynamic_shapes_from_graph_tensor_subclass_fake_mode(self):
+        @torch._dynamo.allow_in_graph
+        def to_subclass(x):
+            return TwoTensor(x.clone(), x.clone())
+
+        def f(x):
+            return to_subclass(x).view(-1)
+
+        x = torch.ones(2)
+        torch._dynamo.mark_dynamic(x, 0)
+        with fresh_cache():
+            gm, args, kwargs = self.capture(f, dynamic=True)(x)
+            if kwargs:
+                raise AssertionError
+
+        output_node = next(iter(reversed(gm.graph.nodes)))
+        value_node = output_node.args[0][0]
+        self.assertIsInstance(value_node, torch.fx.Node)
+        output_example_value = value_node.meta["example_value"]
+        self.assertIsInstance(output_example_value, TwoTensor)
+        fake_mode = output_example_value.a.fake_mode
+
+        seen_fake_modes = []
+
+        def fake_compile_fx(gm, example_inputs, **kwargs):
+            seen_fake_modes.append(torch._guards.TracingContext.get().fake_mode)
+            return lambda *args: args
+
+        with mock.patch(
+            "torch._inductor.compile_fx.compile_fx", side_effect=fake_compile_fx
+        ):
+            torch._inductor.standalone_compile(gm, args, dynamic_shapes="from_graph")
+
+        self.assertIs(seen_fake_modes[0], fake_mode)
 
     def test_standalone_compile_fake_mode_requires_shape_env(self):
         def f(x):

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -21,6 +21,7 @@ from torch._inductor.cudagraph_utils import BoxedDeviceIndex
 from torch._inductor.runtime.cache_dir_utils import temporary_cache_dir
 from torch._inductor.utils import BoxedBool, InputType
 from torch._subclasses import FakeTensorMode
+from torch._subclasses.fake_tensor import maybe_get_fake_mode
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.fx.graph_module import _share_torchbind_and_process_group_on_deepcopy
 
@@ -434,8 +435,9 @@ def _resolve_fake_mode(
         for node in nodes:
             if "example_value" in node.meta:
                 maybe_tensor = node.meta["example_value"]
-                if isinstance(maybe_tensor, torch._subclasses.fake_tensor.FakeTensor):
-                    return maybe_tensor.fake_mode
+                maybe_fake_mode = maybe_get_fake_mode(maybe_tensor)
+                if maybe_fake_mode is not None:
+                    return maybe_fake_mode
 
         return FakeTensorMode(shape_env=ShapeEnv())
     else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185638

standalone_compile(dynamic_shapes="from_graph") recovers the FakeTensorMode
from graph output metadata so Inductor can preserve dynamic shape state from
the captured graph. The old implementation only accepted output example
values that were directly FakeTensor instances. When the graph returned a
traceable tensor subclass whose inner tensors were FakeTensors, the direct
isinstance check missed the existing fake mode and standalone_compile fell
back to a fresh FakeTensorMode with a fresh ShapeEnv.

Use maybe_get_fake_mode instead of the direct FakeTensor check. That helper
already knows how to recurse through traceable wrapper subclasses and related
wrappers, so the from_graph path now reuses the same fake mode for ordinary
FakeTensor outputs and tensor subclass outputs. This keeps the change local to
fake mode detection rather than adding a tensor-subclass special case.

Fixes #151945
Generated by my agent

Test Plan:
- python test/inductor/test_codecache.py TestStandaloneCompile.test_dynamic_shapes_from_graph_tensor_subclass_fake_mode
- python test/inductor/test_codecache.py -k dynamic_shapes_from_graph
- lintrunner -a
- git diff --cached --check

Benchmark Results:
Microbenchmark of the changed fake mode detection helper, 200000 iterations
per repeat, 7 repeats:
- before_direct_fake_tensor: min=0.0840us median=0.0861us raw_us=[0.0851, 0.089, 0.0867, 0.084, 0.0856, 0.0861, 0.0894]
- after_maybe_get_fake_tensor: min=0.1955us median=0.2078us raw_us=[0.2021, 0.1955, 0.2121, 0.1986, 0.2096, 0.2078, 0.208]
- before_direct_twotensor: result_is_expected=False; min=0.1060us median=0.1123us raw_us=[0.1182, 0.1131, 0.106, 0.112, 0.1252, 0.1091, 0.1123]
- after_maybe_get_twotensor: min=1.3365us median=1.3547us raw_us=[1.3542, 1.3365, 1.3846, 1.4551, 1.4075, 1.3393, 1.3547]

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo