### PR TITLE
Skip pip pin on Windows in requirements-ci.txt

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -375,7 +375,9 @@ pwlf==2.2.1
 #test that import: test_sac_estimator.py
 
 # To build PyTorch itself
-pip==26.0.1
+# Skip on Windows: pip cannot modify itself (the running pip.exe is locked),
+# so installing this pin fails with "To modify pip, please run ...".
+pip==26.0.1 ; platform_system != "Windows"
 pyyaml==6.0.3
 pyzstd
 setuptools==78.1.1


### PR DESCRIPTION
## Summary

The Windows build (e.g. `win-vs2022-cpu-py3`) is failing while installing `.ci/docker/requirements-ci.txt`:

```
ERROR: To modify pip, please run the following command:
C:\Jenkins\Miniconda3\envs\py_tmp\python.exe -m pip install -r .ci/docker/requirements-ci.txt
##[error]Process completed with exit code 1.
```

**Root cause:** `requirements-ci.txt` pins `pip==26.0.1` ("To build PyTorch itself"). On Windows the install runs through the `pip` console script (`activate_miniconda3.bat`), and pip refuses to replace its own running `pip.exe` (the executable is locked), so the step exits 1.

**Fix:** gate the pin behind `platform_system != "Windows"`, matching the existing marker style in this file (`mypy` is Linux-only, `cuda-bindings` excludes Darwin). The pin still applies on Linux/macOS; Windows keeps the pip already in its conda env.

Failing run: https://github.com/pytorch/pytorch/actions/runs/26608718005/job/78434413382

## Test Plan

- Lint: `lintrunner -a .ci/docker/requirements-ci.txt`
- CI: confirm the Windows build job goes green now that the pip self-modification step is skipped.

🤖 Authored with the assistance of Claude (Anthropic).