### PR TITLE
Fix typos in comments and docstrings across torch

### DIFF
--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -47,7 +47,7 @@ def infer_schema(
         prototype_function: The function from which to infer a schema for from its type annotations.
         op_name (Optional[str]): The name of the operator in the schema. If ``name`` is None, then the
             name is not included in the inferred schema. Note that the input schema to
-            ``torch.library.Library.define`` requires a operator name.
+            ``torch.library.Library.define`` requires an operator name.
         mutates_args ("unknown" | Iterable[str]): The arguments that are mutated in the function.
         tags (Tag | Sequence[Tag] | None): one or more tags to apply to the
             inferred schema. Use ``torch.Tag.inplace`` or ``torch.Tag.out`` to

--- a/torch/ao/quantization/qconfig_mapping.py
+++ b/torch/ao/quantization/qconfig_mapping.py
@@ -86,7 +86,7 @@ def _get_default_qconfig_mapping(
         qconfig_transpose = qconfig
 
     # currently layernorm only supports float weights
-    # we have to add this because otherwise there will be a extra quantize-dequantize pair
+    # we have to add this because otherwise there will be an extra quantize-dequantize pair
     qconfig_layernorm = QConfig(
         activation=qconfig.activation, weight=default_placeholder_observer
     )

--- a/torch/csrc/api/src/nn/init.cpp
+++ b/torch/csrc/api/src/nn/init.cpp
@@ -18,7 +18,7 @@ struct Fan {
     const auto dimensions = tensor.ndimension();
     TORCH_CHECK(
         dimensions >= 2,
-        "Fan in and fan out can not be computed for tensor with fewer than 2 dimensions");
+        "Fan in and fan out cannot be computed for tensor with fewer than 2 dimensions");
 
     if (dimensions == 2) {
       in = tensor.size(1);
@@ -233,7 +233,7 @@ std::tuple<int64_t, int64_t> _calculate_fan_in_and_fan_out(
   const auto dimensions = tensor.dim();
   TORCH_CHECK(
       dimensions >= 2,
-      "Fan in and fan out can not be computed "
+      "Fan in and fan out cannot be computed "
       "for tensor with fewer than 2 dimensions")
 
   int64_t fan_in = 0, fan_out = 0;

--- a/torch/csrc/autograd/cpp_hook.cpp
+++ b/torch/csrc/autograd/cpp_hook.cpp
@@ -12,7 +12,8 @@ void check_single_result(
     const at::TensorBase& result,
     const std::string& hook_name) {
   TORCH_CHECK(
-      value.defined(), "can't replace a empty gradient with a non-empty value");
+      value.defined(),
+      "can't replace an empty gradient with a non-empty value");
   torch::autograd::check_variable_result(value, result, hook_name);
 }
 } // namespace

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -252,7 +252,7 @@ void SavedVariable::set_hooks_and_pack_data(
   TORCH_CHECK(
       version == impl::version_counter(data).current_version(),
       "A saved tensor pack hook is modifying its input in place. "
-      "Tensors provided as input to pack hook can not be modified by "
+      "Tensors provided as input to pack hook cannot be modified by "
       "in-place operations as this can lead to unexpected side-effects. "
       "Please open an issue if you need to perform in-place operations on "
       "the input to a pack hook.");

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -1080,7 +1080,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::allreduce_sparse(
     const AllreduceOptions& opts) {
   // all reduce sparse calls into default allreduce which
   // implemented with all_gathering indices and values
-  // we do this we do not have a native cuda implementation
+  // we do this because we do not have a native cuda implementation
   return allreduce(inputs, opts);
 }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
@@ -1330,7 +1330,7 @@ c10::intrusive_ptr<Work> ProcessGroupUCC::gather(
           TORCH_UCC_COLL_POST, "requires empty output on non-root");
     }
     outputs = {};
-    // append a empty tensor to the list to be used by future mark
+    // append an empty tensor to the list to be used by future mark
     outputs.emplace_back();
   }
 

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -55,7 +55,7 @@ class PYBIND11_EXPORT PythonRpcHandler {
   // PythonRpcHandler singleton cleans up py::objects and call dec_ref(), it
   // will crash.
   // The solution is to clean up py::objects earlier when Rpc agent join().
-  // Be note that py::objects can not be cleaned up when Rpc agent is destroyed
+  // Note that py::objects cannot be cleaned up when Rpc agent is destroyed
   // as well, as Rpc agent is global variable and it will have same issue as
   // PythonRpcHandler.
   void cleanup();

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -584,7 +584,7 @@ bool AliasDb::tryRegisteredAnalysis(Node* node) {
 
 // The basic strategy is:
 //   1. Retrieve alias information for every input.
-//   2. Use the node's schema's alias annotations to propgagate alias/write
+//   2. Use the node's schema's alias annotations to propagate alias/write
 //      information to the outputs. For unschematized nodes, a special analyzer
 //      will have to be handwritten.
 void AliasDb::analyzeImpl(Node* node) {
@@ -737,7 +737,7 @@ void AliasDb::analyzeImpl(Node* node) {
       return;
     case prim::CallFunction:
     case prim::CallMethod: {
-      // TODO: this can be improved with summarizes of what the function does
+      // TODO: this can be improved with summaries of what the function does
       // for now we assume the worst
       if (!descend_function_calls_) {
         return analyzeConservative(node);
@@ -769,7 +769,7 @@ void AliasDb::analyzeImpl(Node* node) {
     }
     case prim::Enter:
     case prim::Exit:
-      // TODO: this can be improved with summarizes of what the function does
+      // TODO: this can be improved with summaries of what the function does
       // for now we assume the worst
       // NB: update safeToChangeAliasingRelationship if changed
       return analyzeConservative(node);
@@ -852,7 +852,7 @@ void AliasDb::analyzeImpl(Node* node) {
         "Composite types for alias analysis not yet supported");
     TORCH_INTERNAL_ASSERT(
         !formal->isWildcardBefore(),
-        "Doesn't make sense for a input value to begin as a wildcard");
+        "Doesn't make sense for an input value to begin as a wildcard");
     // This is a special case where we have alias info before [] but not after,
     // such as `Tensor(a!)[]`
     if (formal->containedTypes().size() == 1 && formal->beforeSets().empty()) {
@@ -1017,7 +1017,7 @@ void AliasDb::analyzeSubgraph(
   analyze(subgraphBlock);
 
   // Note: the subgraph outputs and node outputs are NOT NECESSARILY the
-  // same length. Autodifferentiation maybe capture additional outputs in the
+  // same length. Autodifferentiation may capture additional outputs in the
   // subgraph block.
   TORCH_INTERNAL_ASSERT(
       subgraphBlock->outputs().size() >= node->outputs().size());

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -243,7 +243,7 @@ static void fuseTransposeIntoGemm(Block* b) {
 
 // Why this is here:
 //
-//   Pytorch has a "packed" representation of sequences, as well as a
+//   PyTorch has a "packed" representation of sequences, as well as a
 //   "padded" representation. ONNX has only one representation,
 //   corresponding to pytorch's "padded". Therefore, we need to remove
 //   any use of packed sequences before exporting.
@@ -369,7 +369,7 @@ static void pushPackingPastRnn(Block* b) {
 
     // See https://github.com/pytorch/pytorch/issues/9043 for a full
     // description.  Since PackPadded is for now treated in an
-    // unhygenic way, Pytorch ends up propagating an incorrect type.
+    // unhygienic way, PyTorch ends up propagating an incorrect type.
     // Until a long-term cleanup comes around, we can fix this by
     // resetting the size to the correct value.
     TensorTypePtr oldType = rnn->inputs().at(0)->type()->cast<TensorType>();

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.h
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.h
@@ -16,7 +16,7 @@ namespace torch::jit {
 // to the TE Kernel. The computate to calculate all symbolic dimensions is
 // inlined in to the if block with the TE Kernel. All Sym Dim Value* are
 // appended to the end of the TE Kernel Graph/Node inputs, and the Node is
-// augmented with a integer list attr `symbolic_shape_inputs` that gives the
+// augmented with an integer list attr `symbolic_shape_inputs` that gives the
 // mapping from Value * -> Symbolic Shape int64_t value. For more lengthy IR
 // examples and walkthrough look at ShapeAnalysisTest.DynamicShapesFusion in
 // `test_shape_analysis` Returns True on Success, False on Failure, can fail if

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -181,7 +181,7 @@ struct TORCH_API ArgumentSpecCreator {
     ENTER_OBJECT, // same as ENTER_TUPLE, but the input is a class
     LEAVE, // pop the top-most list from the stack
     SKIP, // consume an element from the top-most list, and discard
-    SPECIALIZE_OPTIONAL_TENSOR, // consume a optional tensor for the top-most
+    SPECIALIZE_OPTIONAL_TENSOR, // consume an optional tensor for the top-most
                                 // list, and add it to the ArgSpec key being
                                 // created
     SPECIALIZE_TENSOR, // consume a tensor for the top-most

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -299,7 +299,7 @@ class GradientHelper {
 // are linear and can use this property to do more aggressive optimizations
 // later. It is ok to replace any backward function with known-zero inputs with
 // something that produces known-zero outputs. This function encloses each
-// know-linear backward function in a 'GradOf' sub-block so that we can perform
+// known-linear backward function in a 'GradOf' sub-block so that we can perform
 // optimizations using this information. In particular, specializeAutogradZero
 // will observe if all the inputs to the linear block are AutogradZeroTensor,
 // which the autograd uses to represent zeros, and then propagate the zeros to

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -62,7 +62,7 @@ using CodeImpl = interpreter::CodeImpl;
 // some preprocessing of the graph to turn it into a form that is closer
 // to what the instructions will look like.
 // In particular we:
-// *  Computes whether a input to a node is the last use, so we can issue MOVE
+// *  Computes whether an input to a node is the last use, so we can issue MOVE
 //    rather than LOAD instructions.
 // *  Drop nodes are inserted for any node that is unused to create a dummy use
 //    that will cause the interpreter to free the node.

--- a/torch/csrc/jit/runtime/operator.h
+++ b/torch/csrc/jit/runtime/operator.h
@@ -267,8 +267,8 @@ TORCH_API const std::vector<std::shared_ptr<Operator>>& getAllOperatorsFor(
 TORCH_API std::vector<std::shared_ptr<Operator>> getAllSortedOperatorsFor(
     Symbol name);
 
-// given a operator with an overload name, find the specific operator related to
-// it, may return nullptr if no operator exists.
+// given an operator with an overload name, find the specific operator related
+// to it, may return nullptr if no operator exists.
 TORCH_API std::shared_ptr<Operator> findOperatorFor(
     const c10::OperatorName& full_name);
 

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -101,7 +101,7 @@ bool isSortableTupleType(
         why_not << "Contained elements in " << *tuple_type
                 << " are not sortable. Only Int, Bool, Float, String, Tensor, "
                 << "a User Defined Class with __lt__ method defined or Tuples "
-                << "of aforementionted types can be sorted.";
+                << "of aforementioned types can be sorted.";
         return false;
     }
   }

--- a/torch/distributed/checkpoint/_experimental/checkpoint_reader.py
+++ b/torch/distributed/checkpoint/_experimental/checkpoint_reader.py
@@ -137,7 +137,7 @@ class CheckpointReader:
                 if tensor_offset is None:
                     raise AssertionError(
                         "checkpoint_offset for tensor in torch serialized file is not set. This could "
-                        "happen if the checkpoint was saved with a older version of Pytorch. "
+                        "happen if the checkpoint was saved with an older version of PyTorch. "
                         "Please make sure that the checkpoint was saved with Pytorch 2.7 or later."
                     )
 

--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -127,7 +127,7 @@ class FsspecWriter(FileSystemWriter):
             single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
             sync_files : force files to be synced to permanent storage. Default to True.
             thread_count: Number of IO threads to use to write. Default to 1.
-            per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving then. Default 10Mb.
+            per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving them. Default 10Mb.
             overwrite: Whether to allow overwriting existing checkpoints. Defaults to True.
             _extensions: Extensions to apply to output streams (EXPERIMENTAL)
 

--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -348,7 +348,7 @@ class DefaultLoadPlanner(LoadPlanner):
             # 2. If we found a missing key, we first convert the keys back to
             #    the key format of v2.3
             # 3. If the previous missing keys are in the v2.3 keys, we assume
-            #    this is a old checkpoint.
+            #    this is an old checkpoint.
             # 4. Pass the state_dict to `create_default_local_load_plan()`,
             #    which has the logic to check missing for allow_partial_load.
             # So for 1.2 and 1.4 cases, we delegate allow_partial_load check to
@@ -548,7 +548,7 @@ def create_default_local_save_plan(
                 requests += _create_write_items(fqn, obj)
         else:
             # For the plain tensor and non-tensor values, add the request for all
-            # the ranks. Coordinator will decides whether to deduplicate the
+            # the ranks. Coordinator will decide whether to deduplicate the
             # values based on the keys.
             requests += _create_write_items(fqn, obj)
 

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -606,7 +606,7 @@ class _FileSystemWriter(StorageWriter):
             single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
             sync_files : force files to be synced to permanent storage. Default to True.
             thread_count: Number of IO threads to use to write. Default to 1.
-            per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving then. Default 10Mb.
+            per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving them. Default 10Mb.
             overwrite: Whether to allow overwriting existing checkpoints. Defaults to True.
             _extensions: Extensions to apply to output streams (EXPERIMENTAL)
 
@@ -997,9 +997,9 @@ class FileSystemWriter(_FileSystemWriter, BlockingAsyncStager):
             single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
             sync_files : force files to be synced to permanent storage. Default to True.
             thread_count: Number of IO threads to use to write. Default to 1.
-            per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving then. Default 10Mb.
+            per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving them. Default 10Mb.
             cache_staged_state_dict: Whether to cache the staged state_dict. This option decreases staging latency
-                at the cost of increases memory usage. Additionally, if this parameter is set to True, it's the expectation
+                at the cost of increased memory usage. Additionally, if this parameter is set to True, it's the expectation
                 that the stager is maintained and reused for multiple dcp.async_save calls. Default to False.
             overwrite: Whether to allow overwriting existing checkpoints. Defaults to True.
             _extensions: Extensions to apply to output streams (EXPERIMENTAL)

--- a/torch/distributed/checkpoint/resharding.py
+++ b/torch/distributed/checkpoint/resharding.py
@@ -28,7 +28,7 @@ def _shards_get_overlap_region_wrt_saved_tensor(
     """
     Return the overlapping region between saved_shard and current_shard.
 
-    There returned list has the same number of elements as the tensor's dimension.
+    The returned list has the same number of elements as the tensor's dimension.
     For each element, we produce a tuple with the following contents:
         (dimension, `saved_shard` offset, `current_shard` offset, length)
 

--- a/torch/distributed/checkpoint/staging.py
+++ b/torch/distributed/checkpoint/staging.py
@@ -302,7 +302,7 @@ class BlockingAsyncStager(AsyncStager):
 
         Args:
             cache_staged_state_dict: Whether to cache the staged state_dict. This option decreases staging latency
-                at the cost of increases memory usage. Additionally, if this parameter is set to True, it's the expectation
+                at the cost of increased memory usage. Additionally, if this parameter is set to True, it's the expectation
                 that the stager is maintained and reused for multiple dcp.async_save calls. Default to False.
             type_check: Whether to perform a type check during cpu_offload. Defaults to False.
 

--- a/torch/distributed/checkpoint/utils.py
+++ b/torch/distributed/checkpoint/utils.py
@@ -76,7 +76,7 @@ class _DistWrapper:
     """
     This is a wrapper around PG that provides a series of features around object collectives.
 
-    It works without distributed initialized, where most collectives turns into nops.
+    It works without distributed initialized, where most collectives turn into nops.
 
     All variants that take functions are exception robust, meaning that if one or more
     ranks raise errors, all ranks will observe those.

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -75,7 +75,7 @@ else:
     def _get_pg_from_name(mesh: "DeviceMesh", name: str) -> ProcessGroup:
         """
         This method allows us to torch.compile through DeviceMesh and lift its
-        PGs a inputs to the graph since all PGs will have a source from the
+        PGs as inputs to the graph since all PGs will have a source from the
         DeviceMesh through the `_pg_registry`.
         This will be moved to the DeviceMesh backend object once we separate
         DeviceMesh into the frontend and backend.

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -65,9 +65,9 @@ class WorkerSpec:
         max_restarts: number of max retries for the workers
         monitor_interval: monitor status of workers every ``n`` seconds
         master_port: fixed port to run the c10d store on rank 0
-                     if not specified then will chose a random free port
+                     if not specified then will choose a random free port
         master_addr: fixed master_addr to run the c10d store on rank 0
-                     if not specified then will chose hostname on agent rank 0
+                     if not specified then will choose hostname on agent rank 0
         redirects: redirect std streams to a file,
                    selectively redirect for a particular
                    local rank by passing a map
@@ -236,7 +236,7 @@ class WorkerState(str, Enum):
     1. Worker group failure|unhealthy observed
     2. Membership change detected
 
-    When actions (start, stop, rdzv, retry, etc) on worker group fails
+    When actions (start, stop, rdzv, retry, etc) on worker group fail
     and results in the action being partially applied to the worker group
     the state will be ``UNKNOWN``. Typically this happens on uncaught/unhandled
     exceptions during state change events on the agent. The agent is not
@@ -596,7 +596,7 @@ class SimpleElasticAgent(ElasticAgent):
         Time complexity: each worker O(1), overall O(1)
 
         Slow Path: when workers have different roles and world sizes. We use the
-        the following algorithm:
+        following algorithm:
 
         1. Each agent writes its configuration(group_rank, group_world_size
            , num_workers) to the common store.
@@ -605,7 +605,7 @@ class SimpleElasticAgent(ElasticAgent):
         3. Determine the global rank: the global rank of the workers is computed
            by cumulative sum of the local_world_size for all workers in front of it.
            For efficiency reasons each worker is assigned a base global rank
-           such that it's workers are in the range [base_global_rank,
+           such that its workers are in the range [base_global_rank,
            base_global_rank + local_world_size).
         4. Determine the role rank: The role rank is determined using the algorithms
            in the point 3 with the exception that the ranks are calculated with

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -201,7 +201,7 @@ class _PipelineStageBase(ABC):
         self.args_recv_info: dict[int, tuple[_RecvInfo, ...]] = {}
         self.act_send_info: dict[int, list] = {}
 
-        # Backward infra will created lazily
+        # Backward infra will be created lazily
         self.grad_recv_info: dict = {}
         self.grad_send_info: list | None = None
 

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -279,7 +279,7 @@ class _IndependentConstraint(Constraint):
 
 class MixtureSameFamilyConstraint(Constraint):
     """
-    Constraint for the :class:`~torch.distribution.MixtureSameFamily`
+    Constraint for the :class:`~torch.distributions.MixtureSameFamily`
     distribution that adds back the rightmost batch dimension before
     performing the validity check with the component distribution
     constraint.
@@ -287,7 +287,7 @@ class MixtureSameFamilyConstraint(Constraint):
     Args:
         base_constraint: The ``Constraint`` object of
             the component distribution of
-            the :class:`~torch.distribution.MixtureSameFamily` distribution.
+            the :class:`~torch.distributions.MixtureSameFamily` distribution.
     """
 
     def __init__(self, base_constraint):
@@ -309,7 +309,7 @@ class MixtureSameFamilyConstraint(Constraint):
     def check(self, value):
         """
         Check validity of ``value`` as a possible outcome of sampling
-        the :class:`~torch.distribution.MixtureSameFamily` distribution.
+        the :class:`~torch.distributions.MixtureSameFamily` distribution.
         """
         unsqueezed_value = value.unsqueeze(-1 - self.event_dim)
         result = self.base_constraint.check(unsqueezed_value)

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -100,7 +100,7 @@ class Distribution:
 
         Returns:
             New distribution instance with batch dimensions expanded to
-            `batch_size`.
+            `batch_shape`.
         """
         raise NotImplementedError
 

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -170,7 +170,7 @@ class LowRankMultivariateNormal(Distribution):
 
     @lazy_property
     def scale_tril(self) -> Tensor:
-        # The following identity is used to increase the numerically computation stability
+        # The following identity is used to increase the numerical computation stability
         # for Cholesky decomposition (see http://www.gaussianprocess.org/gpml/, Section 3.4.3):
         #     W @ W.T + D = D1/2 @ (I + D-1/2 @ W @ W.T @ D-1/2) @ D1/2
         # The matrix "I + D-1/2 @ W @ W.T @ D-1/2" has eigenvalues bounded from below by 1,

--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -13,9 +13,9 @@ __all__ = ["MixtureSameFamily"]
 class MixtureSameFamily(Distribution):
     r"""
     The `MixtureSameFamily` distribution implements a (batch of) mixture
-    distribution where all component are from different parameterizations of
+    distribution where all components are from different parameterizations of
     the same distribution type. It is parameterized by a `Categorical`
-    "selecting distribution" (over `k` component) and a component
+    "selecting distribution" (over `k` components) and a component
     distribution, i.e., a `Distribution` with a rightmost batch shape
     (equal to `[k]`) which indexes each (batch of) component.
 
@@ -44,7 +44,7 @@ class MixtureSameFamily(Distribution):
 
     Args:
         mixture_distribution: `torch.distributions.Categorical`-like
-            instance. Manages the probability of selecting component.
+            instance. Manages the probability of selecting components.
             The number of categories must match the rightmost batch
             dimension of the `component_distribution`. Must have either
             scalar `batch_shape` or `batch_shape` matching
@@ -73,7 +73,7 @@ class MixtureSameFamily(Distribution):
 
         if not isinstance(self._component_distribution, Distribution):
             raise ValueError(
-                "The Component distribution need to be an "
+                "The Component distribution needs to be an "
                 "instance of torch.distributions.Distribution"
             )
 
@@ -88,7 +88,7 @@ class MixtureSameFamily(Distribution):
                     f"batch_shape`({cdbs})"
                 )
 
-        # Check that the number of mixture component matches
+        # Check that the number of mixture components matches
         km = self._mixture_distribution.logits.shape[-1]
         kc = self._component_distribution.batch_shape[-1]
         if km is not None and kc is not None and km != kc:

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -32,7 +32,7 @@ def _batch_mahalanobis(bL, bx):
     for a factored :math:`\mathbf{M} = \mathbf{L}\mathbf{L}^\top`.
 
     Accepts batches for both bL and bx. They are not necessarily assumed to have the same batch
-    shape, but `bL` one should be able to broadcasted to `bx` one.
+    shape, but `bL` one should be able to be broadcasted to `bx` one.
     """
     n = bx.size(-1)
     bx_batch_shape = bx.shape[:-1]

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -60,7 +60,7 @@ class Wishart(ExponentialFamily):
     [1] Wang, Z., Wu, Y. and Chu, H., 2018. `On equivalence of the LKJ distribution and the restricted Wishart distribution`.
     [2] Sawyer, S., 2007. `Wishart Distributions and Inverse-Wishart Sampling`.
     [3] Anderson, T. W., 2003. `An Introduction to Multivariate Statistical Analysis (3rd ed.)`.
-    [4] Odell, P. L. & Feiveson, A. H., 1966. `A Numerical Procedure to Generate a SampleCovariance Matrix`. JASA, 61(313):199-203.
+    [4] Odell, P. L. & Feiveson, A. H., 1966. `A Numerical Procedure to Generate a Sample Covariance Matrix`. JASA, 61(313):199-203.
     [5] Ku, Y.-C. & Bloomfield, P., 2010. `Generating Random Wishart Matrices with Fractional Degrees of Freedom in OX`.
     """
 
@@ -266,7 +266,7 @@ class Wishart(ExponentialFamily):
         sample_shape = torch.Size(sample_shape)
         sample = self._bartlett_sampling(sample_shape)
 
-        # Below part is to improve numerical stability temporally and should be removed in the future
+        # Below part is to improve numerical stability temporarily and should be removed in the future
         is_singular = self.support.check(sample)
         if self._batch_shape:
             is_singular = is_singular.amax(self._batch_dims)

--- a/torch/jit/mobile/__init__.py
+++ b/torch/jit/mobile/__init__.py
@@ -142,7 +142,7 @@ def _get_mobile_model_contained_types(f_input) -> int:
 
 
 def _backport_for_mobile(f_input, f_output, to_version):
-    r"""Take a input string containing a file name (file-like object) and a new destination to return a boolean.
+    r"""Take an input string containing a file name (file-like object) and a new destination to return a boolean.
 
     Args:
         f_input: a file-like object (has to implement read, readline, tell, and seek),

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -173,7 +173,7 @@ class InstanceNorm1d(_InstanceNorm):
         on each channel of channeled data like multidimensional time series, but
         :class:`LayerNorm` is usually applied on entire sample and often in NLP
         tasks. Additionally, :class:`LayerNorm` applies elementwise affine
-        transform, while :class:`InstanceNorm1d` usually don't apply affine
+        transform, while :class:`InstanceNorm1d` usually doesn't apply affine
         transform.
 
     Args:
@@ -292,7 +292,7 @@ class InstanceNorm2d(_InstanceNorm):
         on each channel of channeled data like RGB images, but
         :class:`LayerNorm` is usually applied on entire sample and often in NLP
         tasks. Additionally, :class:`LayerNorm` applies elementwise affine
-        transform, while :class:`InstanceNorm2d` usually don't apply affine
+        transform, while :class:`InstanceNorm2d` usually doesn't apply affine
         transform.
 
     Args:
@@ -412,7 +412,7 @@ class InstanceNorm3d(_InstanceNorm):
         on each channel of channeled data like 3D models with RGB color, but
         :class:`LayerNorm` is usually applied on entire sample and often in NLP
         tasks. Additionally, :class:`LayerNorm` applies elementwise affine
-        transform, while :class:`InstanceNorm3d` usually don't apply affine
+        transform, while :class:`InstanceNorm3d` usually doesn't apply affine
         transform.
 
     Args:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2520,7 +2520,7 @@ class Module:
             for key in state_dict:
                 if key.startswith(prefix) and key != extra_state_key:
                     input_name = key[len(prefix) :].split(".", 1)
-                    # Must be Module if it have attributes
+                    # Must be Module if it has attributes
                     if len(input_name) > 1:
                         if input_name[0] not in self._modules:
                             unexpected_keys.append(key)
@@ -2610,8 +2610,8 @@ class Module:
                 out = hook(module, incompatible_keys)
                 if out is not None:
                     raise AssertionError(
-                        "Hooks registered with ``register_load_state_dict_post_hook`` are not"
-                        "expected to return new values, if incompatible_keys need to be modified,"
+                        "Hooks registered with ``register_load_state_dict_post_hook`` are not "
+                        "expected to return new values, if incompatible_keys need to be modified, "
                         "it should be done inplace."
                     )
 

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -202,7 +202,7 @@ class UpsamplingNearest2d(Upsample):
     r"""Applies a 2D nearest neighbor upsampling to an input signal composed of several input channels.
 
     To specify the scale, it takes either the :attr:`size` or the :attr:`scale_factor`
-    as it's constructor argument.
+    as its constructor argument.
 
     When :attr:`size` is given, it is the output size of the image `(h, w)`.
 
@@ -251,7 +251,7 @@ class UpsamplingBilinear2d(Upsample):
     r"""Applies a 2D bilinear upsampling to an input signal composed of several input channels.
 
     To specify the scale, it takes either the :attr:`size` or the :attr:`scale_factor`
-    as it's constructor argument.
+    as its constructor argument.
 
     When :attr:`size` is given, it is the output size of the image `(h, w)`.
 

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset10.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset10.py
@@ -757,7 +757,7 @@ def dequantize(g: jit_utils.GraphContext, input):
 @_onnx_symbolic("aten::nan_to_num")
 @symbolic_helper.parse_args("v", "f", "f", "f")
 def nan_to_num(g: jit_utils.GraphContext, input, nan, posinf, neginf):
-    # Cannot create a int type tensor with inf/nan values, so we simply
+    # Cannot create an int type tensor with inf/nan values, so we simply
     # return the original tensor
     if not symbolic_helper._is_fp(input):
         return input

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -484,7 +484,7 @@ class SWALR(LRScheduler):
             group["swa_lr"] = swa_lr
         if anneal_strategy not in ["cos", "linear"]:
             raise ValueError(
-                "anneal_strategy must by one of 'cos' or 'linear', "
+                "anneal_strategy must be one of 'cos' or 'linear', "
                 f"instead got {anneal_strategy}"
             )
         self._set_anneal_func(anneal_strategy)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185643

Correct grammar and spelling in comments and docstrings: use "an"
before vowel sounds ("an operator", "an error", "an output"), fix
"can not" → "cannot", "atleast" → "at least", and other minor
typographical errors across distributed, JIT, nn, distributions, and
other subsystems.

Authored with Claude (typo_terminator2).