### PR TITLE
Skip Quack RMSNorm override on ROCm and non-CUDA tensors

### DIFF
--- a/torch/_native/ops/norm/rmsnorm_impl.py
+++ b/torch/_native/ops/norm/rmsnorm_impl.py
@@ -12,6 +12,10 @@ from ... import cutedsl_utils as cu
 
 
 def _is_supported(input: torch.Tensor) -> bool:
+    if input.device.type != "cuda":
+        return False
+    if torch.version.hip is not None:
+        return False
     if input.dtype not in (torch.float16, torch.bfloat16, torch.float32):
         return False
     major, _ = torch.cuda.get_device_capability(input.device)


### PR DESCRIPTION
Summary:
The Quack RMSNorm override in `_native/ops/norm/rmsnorm_impl.py` is selected for any tensor whose dtype is fp16/bf16/fp32 and whose `torch.cuda.get_device_capability` major is 9 or 10.

Two cases slip through that shouldn't:
- ROCm builds (e.g. MI300x). `get_device_capability` on gfx942 returns `major=9`, matching the H100 check, so the dispatcher routes to Quack - a CUTLASS/CUDA-only kernel that has no business running on AMD.
- CPU tensors. `_is_supported` never checks `input.device.type`. When a CPU tensor is passed (e.g. during the FX `Interpreter.run` in `splitting/utils.py:remove_unexpected_type_cast`), `get_device_capability` reports the current CUDA device's capability, the cond passes, and the kernel crashes with `ValueError: Mismatched Tensor ... expected device_type=cuda`.

Test Plan: This fixed 3 tests internally

Differential Revision: D106733305




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang