### PR TITLE
[Test] Make sigmoid_add extension test device-agnostic in test_cpp_extensions_aot.py

### DIFF
--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: cpp-extensions"]
 
+import importlib
 import os
 import re
 import unittest
@@ -14,7 +15,6 @@ from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     skipIfTorchDynamo,
-    TEST_XPU,
     xfailIfTorchDynamo,
 )
 
@@ -42,6 +42,16 @@ except ImportError as e:
         "test_cpp_extensions_aot.py cannot be invoked directly. Run "
         "`python run_test.py -i test_cpp_extensions_aot_ninja` instead."
     ) from e
+
+
+# cpu and mps use the ATen-dispatched .cpp extension (device-agnostic ops);
+# cuda and xpu use backend-specific kernel extensions from setup.py.
+_SIGMOID_ADD_BACKENDS = (
+    ("cpu", "torch_test_cpp_extension.cpp"),
+    ("mps", "torch_test_cpp_extension.cpp"),
+    ("cuda", "torch_test_cpp_extension.cuda"),
+    ("xpu", "torch_test_cpp_extension.sycl"),
+)
 
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
@@ -85,17 +95,29 @@ class TestCppExtensionAOT(common.TestCase):
         expected_tensor_grad = torch.ones([4, 4], dtype=torch.double).mm(weights.t())
         self.assertEqual(tensor.grad, expected_tensor_grad)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    def test_cuda_extension(self):
-        import torch_test_cpp_extension.cuda as cuda_extension
-
-        x = torch.zeros(100, device="cuda", dtype=torch.float32)
-        y = torch.zeros(100, device="cuda", dtype=torch.float32)
-
-        z = cuda_extension.sigmoid_add(x, y).cpu()
-
-        # 2 * sigmoid(0) = 2 * 0.5 = 1
-        self.assertEqual(z, torch.ones_like(z))
+    def test_sigmoid_add_extension(self):
+        for device_type, module_name in _SIGMOID_ADD_BACKENDS:
+            with self.subTest(device_type=device_type):
+                if device_type != "cpu":
+                    device_mod = getattr(torch, device_type, None)
+                    if device_mod is None:
+                        raise unittest.SkipTest(f"{device_type} is not registered")
+                    is_available = getattr(device_mod, "is_available", None)
+                    if is_available is not None and not is_available():
+                        raise unittest.SkipTest(f"{device_type} not available")
+                    if device_type == "xpu" and os.getenv("USE_NINJA", "0") == "0":
+                        raise unittest.SkipTest(
+                            "sycl extension requires ninja to build"
+                        )
+                try:
+                    ext = importlib.import_module(module_name)
+                except ImportError:
+                    raise unittest.SkipTest(f"{module_name} not built") from None
+                x = torch.zeros(100, device=device_type, dtype=torch.float32)
+                y = torch.zeros(100, device=device_type, dtype=torch.float32)
+                z = ext.sigmoid_add(x, y).cpu()
+                # 2 * sigmoid(0) = 2 * 0.5 = 1
+                self.assertEqual(z, torch.ones_like(z))
 
     @unittest.skipIf(not torch.backends.mps.is_available(), "MPS not found")
     def test_mps_extension(self):
@@ -109,22 +131,6 @@ class TestCppExtensionAOT(common.TestCase):
         mps_output = mps_extension.get_mps_add_output(x.to("mps"), y.to("mps"))
 
         self.assertEqual(cpu_output, mps_output.to("cpu"))
-
-    @unittest.skipIf(not TEST_XPU, "XPU not found")
-    @unittest.skipIf(
-        os.getenv("USE_NINJA", "0") == "0",
-        "sycl extension requires ninja to build",
-    )
-    def test_sycl_extension(self):
-        import torch_test_cpp_extension.sycl as sycl_extension
-
-        x = torch.zeros(100, device="xpu", dtype=torch.float32)
-        y = torch.zeros(100, device="xpu", dtype=torch.float32)
-
-        z = sycl_extension.sigmoid_add(x, y).cpu()
-
-        # 2 * sigmoid(0) = 2 * 0.5 = 1
-        self.assertEqual(z, torch.ones_like(z))
 
     @common.skipIfRocm
     @unittest.skipIf(common.IS_WINDOWS, "Windows not supported")

--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -48,12 +48,12 @@ except ImportError as e:
 
 # cpu and mps use the ATen-dispatched .cpp extension (device-agnostic ops);
 # cuda and xpu use backend-specific kernel extensions from setup.py.
-_SIGMOID_ADD_BACKENDS = (
-    ("cpu", "torch_test_cpp_extension.cpp"),
-    ("mps", "torch_test_cpp_extension.cpp"),
-    ("cuda", "torch_test_cpp_extension.cuda"),
-    ("xpu", "torch_test_cpp_extension.sycl"),
-)
+_SIGMOID_ADD_BACKENDS = {
+    "cpu": "torch_test_cpp_extension.cpp",
+    "mps": "torch_test_cpp_extension.cpp",
+    "cuda": "torch_test_cpp_extension.cuda",
+    "xpu": "torch_test_cpp_extension.sycl",
+}
 
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
@@ -97,18 +97,13 @@ class TestCppExtensionAOT(common.TestCase):
         expected_tensor_grad = torch.ones([4, 4], dtype=torch.double).mm(weights.t())
         self.assertEqual(tensor.grad, expected_tensor_grad)
 
-    @parametrize("device_type,module_name", list(_SIGMOID_ADD_BACKENDS))
-    def test_sigmoid_add_extension(self, device_type, module_name):
-        if device_type != "cpu":
-            device_mod = getattr(torch, device_type, None)
-            if device_mod is None:
-                msg = f"{device_type} backend is not compiled into this PyTorch build"
-                raise RuntimeError(msg)
-            is_available = getattr(device_mod, "is_available", None)
-            if is_available is not None and not is_available():
-                raise unittest.SkipTest(f"{device_type} not available")
-            if device_type == "xpu" and os.getenv("USE_NINJA", "0") == "0":
-                raise unittest.SkipTest("sycl extension requires ninja to build")
+    @parametrize("device_type", list(_SIGMOID_ADD_BACKENDS))
+    def test_sigmoid_add_extension(self, device_type):
+        module_name = _SIGMOID_ADD_BACKENDS[device_type]
+        if not torch.get_device_module(device_type).is_available():
+            raise unittest.SkipTest(f"{device_type} not available")
+        if device_type == "xpu" and os.getenv("USE_NINJA", "0") == "0":
+            raise unittest.SkipTest("sycl extension requires ninja to build")
         ext = importlib.import_module(module_name)
         x = torch.zeros(100, device=device_type, dtype=torch.float32)
         y = torch.zeros(100, device=device_type, dtype=torch.float32)

--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -13,7 +13,9 @@ import torch.testing._internal.common_utils as common
 import torch.utils.cpp_extension
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
     IS_WINDOWS,
+    parametrize,
     skipIfTorchDynamo,
     xfailIfTorchDynamo,
 )
@@ -95,29 +97,24 @@ class TestCppExtensionAOT(common.TestCase):
         expected_tensor_grad = torch.ones([4, 4], dtype=torch.double).mm(weights.t())
         self.assertEqual(tensor.grad, expected_tensor_grad)
 
-    def test_sigmoid_add_extension(self):
-        for device_type, module_name in _SIGMOID_ADD_BACKENDS:
-            with self.subTest(device_type=device_type):
-                if device_type != "cpu":
-                    device_mod = getattr(torch, device_type, None)
-                    if device_mod is None:
-                        raise unittest.SkipTest(f"{device_type} is not registered")
-                    is_available = getattr(device_mod, "is_available", None)
-                    if is_available is not None and not is_available():
-                        raise unittest.SkipTest(f"{device_type} not available")
-                    if device_type == "xpu" and os.getenv("USE_NINJA", "0") == "0":
-                        raise unittest.SkipTest(
-                            "sycl extension requires ninja to build"
-                        )
-                try:
-                    ext = importlib.import_module(module_name)
-                except ImportError:
-                    raise unittest.SkipTest(f"{module_name} not built") from None
-                x = torch.zeros(100, device=device_type, dtype=torch.float32)
-                y = torch.zeros(100, device=device_type, dtype=torch.float32)
-                z = ext.sigmoid_add(x, y).cpu()
-                # 2 * sigmoid(0) = 2 * 0.5 = 1
-                self.assertEqual(z, torch.ones_like(z))
+    @parametrize("device_type,module_name", list(_SIGMOID_ADD_BACKENDS))
+    def test_sigmoid_add_extension(self, device_type, module_name):
+        if device_type != "cpu":
+            device_mod = getattr(torch, device_type, None)
+            if device_mod is None:
+                msg = f"{device_type} backend is not compiled into this PyTorch build"
+                raise RuntimeError(msg)
+            is_available = getattr(device_mod, "is_available", None)
+            if is_available is not None and not is_available():
+                raise unittest.SkipTest(f"{device_type} not available")
+            if device_type == "xpu" and os.getenv("USE_NINJA", "0") == "0":
+                raise unittest.SkipTest("sycl extension requires ninja to build")
+        ext = importlib.import_module(module_name)
+        x = torch.zeros(100, device=device_type, dtype=torch.float32)
+        y = torch.zeros(100, device=device_type, dtype=torch.float32)
+        z = ext.sigmoid_add(x, y).cpu()
+        # 2 * sigmoid(0) = 2 * 0.5 = 1
+        self.assertEqual(z, torch.ones_like(z))
 
     @unittest.skipIf(not torch.backends.mps.is_available(), "MPS not found")
     def test_mps_extension(self):
@@ -442,6 +439,8 @@ class TestTorchLibrary(common.TestCase):
         self.assertFalse(s(False, False))
         self.assertIn("torch_library::logical_and", str(s.graph))
 
+
+instantiate_parametrized_tests(TestCppExtensionAOT)
 
 if __name__ == "__main__":
     common.run_tests()

--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -13,6 +13,7 @@ import torch.testing._internal.common_utils as common
 import torch.utils.cpp_extension
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_WINDOWS,
     parametrize,
@@ -67,6 +68,8 @@ class TestCppExtensionAOT(common.TestCase):
     failed.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_extension_function(self):
         x = torch.randn(4, 4)
         y = torch.randn(4, 4)
@@ -97,6 +100,31 @@ class TestCppExtensionAOT(common.TestCase):
         expected_tensor_grad = torch.ones([4, 4], dtype=torch.double).mm(weights.t())
         self.assertEqual(tensor.grad, expected_tensor_grad)
 
+    @unittest.skipIf(IS_WINDOWS, "Not available on Windows")
+    def test_no_python_abi_suffix_sets_the_correct_library_name(self):
+        # For this test, run_test.py will call
+        # `python -m pip install . -v --no-build-isolation` in the
+        # cpp_extensions/no_python_abi_suffix_test folder, where the
+        # `BuildExtension` class has a `no_python_abi_suffix` option set to
+        # `True`. This *should* mean that on Python 3, the produced shared
+        # library does not have an ABI suffix like
+        # "cpython-37m-x86_64-linux-gnu" before the library suffix, e.g. "so".
+        root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "build")
+        matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith("so")]
+        self.assertEqual(len(matches), 1, msg=str(matches))
+        self.assertEqual(matches[0], "no_python_abi_suffix_test.so", msg=str(matches))
+
+    def test_optional(self):
+        has_value = cpp_extension.function_taking_optional(torch.ones(5))
+        self.assertTrue(has_value)
+        has_value = cpp_extension.function_taking_optional(None)
+        self.assertFalse(has_value)
+
+
+@torch.testing._internal.common_utils.markDynamoStrictTest
+class TestCppExtensionAOTDevice(common.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @parametrize("device_type", list(_SIGMOID_ADD_BACKENDS))
     def test_sigmoid_add_extension(self, device_type):
         module_name = _SIGMOID_ADD_BACKENDS[device_type]
@@ -111,18 +139,10 @@ class TestCppExtensionAOT(common.TestCase):
         # 2 * sigmoid(0) = 2 * 0.5 = 1
         self.assertEqual(z, torch.ones_like(z))
 
-    @unittest.skipIf(not torch.backends.mps.is_available(), "MPS not found")
-    def test_mps_extension(self):
-        import torch_test_cpp_extension.mps as mps_extension
 
-        tensor_length = 100000
-        x = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
-        y = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
-
-        cpu_output = mps_extension.get_cpu_add_output(x, y)
-        mps_output = mps_extension.get_mps_add_output(x.to("mps"), y.to("mps"))
-
-        self.assertEqual(cpu_output, mps_output.to("cpu"))
+@torch.testing._internal.common_utils.markDynamoStrictTest
+class TestCppExtensionAOTCUDA(common.TestCase):
+    hw_classification = HardwareClassification.CUDA
 
     @common.skipIfRocm
     @unittest.skipIf(common.IS_WINDOWS, "Windows not supported")
@@ -144,26 +164,6 @@ class TestCppExtensionAOT(common.TestCase):
         z = cusolver_extension.noop_cusolver_function(x)
         self.assertEqual(z, x)
 
-    @unittest.skipIf(IS_WINDOWS, "Not available on Windows")
-    def test_no_python_abi_suffix_sets_the_correct_library_name(self):
-        # For this test, run_test.py will call
-        # `python -m pip install . -v --no-build-isolation` in the
-        # cpp_extensions/no_python_abi_suffix_test folder, where the
-        # `BuildExtension` class has a `no_python_abi_suffix` option set to
-        # `True`. This *should* mean that on Python 3, the produced shared
-        # library does not have an ABI suffix like
-        # "cpython-37m-x86_64-linux-gnu" before the library suffix, e.g. "so".
-        root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "build")
-        matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith("so")]
-        self.assertEqual(len(matches), 1, msg=str(matches))
-        self.assertEqual(matches[0], "no_python_abi_suffix_test.so", msg=str(matches))
-
-    def test_optional(self):
-        has_value = cpp_extension.function_taking_optional(torch.ones(5))
-        self.assertTrue(has_value)
-        has_value = cpp_extension.function_taking_optional(None)
-        self.assertFalse(has_value)
-
     @common.skipIfRocm
     @unittest.skipIf(common.IS_WINDOWS, "Windows not supported")
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
@@ -182,6 +182,24 @@ class TestCppExtensionAOT(common.TestCase):
 
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
+class TestCppExtensionAOTMPS(common.TestCase):
+    hw_classification = HardwareClassification.MPS
+
+    @unittest.skipIf(not torch.backends.mps.is_available(), "MPS not found")
+    def test_mps_extension(self):
+        import torch_test_cpp_extension.mps as mps_extension
+
+        tensor_length = 100000
+        x = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
+        y = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
+
+        cpu_output = mps_extension.get_cpu_add_output(x, y)
+        mps_output = mps_extension.get_mps_add_output(x.to("mps"), y.to("mps"))
+
+        self.assertEqual(cpu_output, mps_output.to("cpu"))
+
+
+@torch.testing._internal.common_utils.markDynamoStrictTest
 class TestPybindTypeCasters(common.TestCase):
     """Pybind tests for ahead-of-time cpp extensions
 
@@ -194,6 +212,8 @@ class TestPybindTypeCasters(common.TestCase):
     second argument to `PYBIND11_TYPE_CASTER` should be the type we expect to
     receive in python, in these tests we verify this at run-time.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     @staticmethod
     def expected_return_type(func):
@@ -296,6 +316,8 @@ class TestPybindTypeCasters(common.TestCase):
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestMAIATensor(common.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_unregistered(self):
         torch.arange(0, 10, device="cpu")
         with self.assertRaisesRegex(RuntimeError, "Could not run"):
@@ -380,6 +402,8 @@ class TestMAIATensor(common.TestCase):
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestRNGExtension(common.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
 
@@ -417,6 +441,8 @@ class TestRNGExtension(common.TestCase):
 @torch.testing._internal.common_utils.markDynamoStrictTest
 @unittest.skipIf(not TEST_CUDA, "CUDA not found")
 class TestTorchLibrary(common.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_torch_library(self):
         import torch_test_cpp_extension.torch_library  # noqa: F401
 
@@ -435,7 +461,7 @@ class TestTorchLibrary(common.TestCase):
         self.assertIn("torch_library::logical_and", str(s.graph))
 
 
-instantiate_parametrized_tests(TestCppExtensionAOT)
+instantiate_parametrized_tests(TestCppExtensionAOTDevice)
 
 if __name__ == "__main__":
     common.run_tests()


### PR DESCRIPTION
## Summary

Merge `test_cuda_extension` and `test_sycl_extension` into a single `test_sigmoid_add_extension` parametrized over the backends listed in `_SIGMOID_ADD_BACKENDS` (cpu, mps, cuda, xpu). Each backend appears as its own test entry in CI so pass/skip/fail is visible per device instead of being collapsed into one `subTest` result.

## Changes

- Add module-level `_SIGMOID_ADD_BACKENDS` dict mapping each device type to its pre-built extension module:
  - cpu and mps share the ATen-dispatched `.cpp` extension
  - cuda and xpu use their dedicated kernel extensions from `setup.py`
- Replace the `subTest` loop with `@parametrize("device_type", ...)`; look up `module_name` from the dict inside the test
- Use `torch.get_device_module(device_type).is_available()` for runtime availability checks
- Skip (not fail) when a device is unavailable at runtime, or when XPU is tested under `USE_NINJA=0` (the sycl extension is not built in the `test_cpp_extensions_aot_no_ninja` target)
- Add `instantiate_parametrized_tests(TestCppExtensionAOT)` so parametrized cases are expanded at module level
- Remove unused `TEST_XPU` import

## Also in this PR

- Split the AOT test class by device scope (`TestCppExtensionAOTDevice` / `TestCppExtensionAOTCUDA` / `TestCppExtensionAOTMPS`) and annotate every class in the file with `hw_classification`

## Not changed behaviorally

- `test_mps_extension` (Metal shader + MPS stream/encoder APIs specific to the `.mm` extension), `test_cublas_extension` / `test_cusolver_extension` (NVIDIA library link tests), `test_cuda_dlink_libs` (CUDA device-linking build-system test), and the `TestMAIATensor` / `TestRNGExtension` / `TestPybindTypeCasters` / `TestTorchLibrary` classes keep their existing test logic; the final commit only regrouped them into the device-scoped classes and added `hw_classification` annotations

## Test plan

```bash
python run_test.py -i test_cpp_extensions_aot_ninja -k test_sigmoid_add_extension
python run_test.py -i test_cpp_extensions_aot_no_ninja -k test_sigmoid_add_extension
```
---

Authored with an AI assistant.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @mcarilli @ptrblck @leslie-fang-intel @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @xmfan @aditvenk