### PR TITLE
[Test] Fix test_expanded_weights module tests reusing cached input across CPU/CUDA runs

### DIFF
--- a/test/test_expanded_weights.py
+++ b/test/test_expanded_weights.py
@@ -974,7 +974,7 @@ class ContextManagerTests(TestBase):
         module = self.constructor(*self.constructor_args).to(**kwargs)
         if "Embedding" in self.get_name():
             kwargs["dtype"] = torch.long
-        input = self._get_input().to(**kwargs)
+        input = self._get_input().detach().clone().to(**kwargs)
         if len(input.shape) == 0 or input.shape[0] == 0:
             raise unittest.SkipTest(
                 "Can't get per sample gradients when no batch dim or batch dim is 0"
@@ -987,7 +987,7 @@ class ContextManagerTests(TestBase):
 
     def test_context_manager_multiple_inputs(self, test_case, device):
         module = self.constructor(*self.constructor_args).to(device)
-        input = self._get_input()
+        input = self._get_input().detach().clone()
         if len(input.shape) == 0 or input.shape[0] == 0:
             raise unittest.SkipTest(
                 "Can't get per sample gradients when no batch dim or batch dim is 0"


### PR DESCRIPTION
Fixes a test harness bug in `test/test_expanded_weights.py` where legacy `ContextManagerTests` instances share a cached input tensor between separately registered CPU and CUDA test methods.

When the full file is run (e.g. via pytest), CPU module tests run first and mutate the cached input through autograd. Later CUDA module tests reuse that same tensor, which is no longer a leaf, causing `input.grad` to be `None` and 89 `TestExpandedWeightModuleCUDA` tests to fail. This is because ContextManagerTests shares one TestBase._arg_cache across separately registered CPU and CUDA test methods. Running the full file leaves mutated non-leaf inputs in the cache, so later CUDA tests fail when reading input.grad.

The fix clones the cached input at the start of each `test_context_manager` / `test_context_manager_multiple_inputs` invocation so every test gets a fresh leaf tensor.

Test failure errors on Linux and Windows:
- AttributeError: 'NoneType' object has no attribute 'clone' in _do_test when accessing input.grad
- AssertionError: Tensor-likes are not close! in _do_test_multi_input variants

cc @nkhasbag-nv
