### PR TITLE
Add ROCm CI workflows for mi210

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,7 @@
 self-hosted-runner:
   labels:
     # GitHub hosted runner that actionlint doesn't recognize because actionlint version (1.6.21) is too old
+    - linux.rocm.gpu.mi210
     - ubuntu-24.04
     # GitHub hosted x86 Linux runners
     - linux.24_04.4x

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -26,6 +26,7 @@ ciflow_push_tags:
 - ciflow/inductor-perf-test-nightly-xpu
 - ciflow/inductor-periodic
 - ciflow/inductor-rocm-mi200
+- ciflow/inductor-rocm-mi210
 - ciflow/inductor-rocm-mi300
 - ciflow/inductor-rocm-mi355
 - ciflow/mps
@@ -33,11 +34,13 @@ ciflow_push_tags:
 - ciflow/op-benchmark
 - ciflow/periodic
 - ciflow/periodic-rocm-mi200
+- ciflow/periodic-rocm-mi210
 - ciflow/periodic-rocm-mi300
 - ciflow/periodic-rocm-mi355
 - ciflow/pull
 - ciflow/riscv64
 - ciflow/rocm-mi200
+- ciflow/rocm-mi210
 - ciflow/rocm-mi300
 - ciflow/rocm-mi355
 - ciflow/rocm-navi31

--- a/.github/workflows/inductor-rocm-mi210.yml
+++ b/.github/workflows/inductor-rocm-mi210.yml
@@ -1,0 +1,62 @@
+name: inductor-rocm-mi210
+
+on:
+  schedule:
+    - cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
+  push:
+    tags:
+      - ciflow/inductor-rocm-mi210/*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  target-determination:
+    if: github.repository_owner == 'pytorch'
+    name: before-test
+    uses: ./.github/workflows/target_determination.yml
+
+  get-label-type:
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+      opt_out_experiments: lf
+
+  linux-jammy-rocm-py3_10-inductor-build:
+    name: linux-jammy-rocm-py3.10-mi210
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-jammy-rocm-py3.10-mi210
+      docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
+      test-matrix: |
+        { include: [
+          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.mi210" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.mi210" },
+        ]}
+    secrets: inherit
+
+  linux-jammy-rocm-py3_10-inductor-test:
+    name: linux-jammy-rocm-py3.10-mi210
+    uses: ./.github/workflows/_rocm-test.yml
+    needs:
+      - linux-jammy-rocm-py3_10-inductor-build
+    with:
+      build-environment: ${{ needs.linux-jammy-rocm-py3_10-inductor-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-rocm-py3_10-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-rocm-py3_10-inductor-build.outputs.test-matrix }}
+    secrets: inherit
+

--- a/.github/workflows/periodic-rocm-mi210.yml
+++ b/.github/workflows/periodic-rocm-mi210.yml
@@ -1,0 +1,68 @@
+name: periodic-rocm-mi210
+
+on:
+  schedule:
+    - cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
+  push:
+    tags:
+      - ciflow/periodic-rocm-mi210/*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' && github.run_id }}-${{ github.event_name == 'schedule' }}-${{ github.event.schedule }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  llm-td:
+    if: github.repository_owner == 'pytorch'
+    name: before-test
+    uses: ./.github/workflows/llm_td_retrieval.yml
+
+  target-determination:
+    name: before-test
+    uses: ./.github/workflows/target_determination.yml
+    needs: llm-td
+
+  get-label-type:
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    if: (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch'
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+
+  linux-jammy-rocm-py3_10-build:
+    name: linux-jammy-rocm-py3.10-mi210
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-jammy-rocm-py3.10-mi210
+      docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
+      test-matrix: |
+        { include: [
+          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.mi210.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.mi210.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.mi210.2", owners: ["module:rocm", "oncall:distributed"] },
+        ]}
+    secrets: inherit
+
+  linux-jammy-rocm-py3_10-test:
+    name: linux-jammy-rocm-py3.10-mi210
+    uses: ./.github/workflows/_rocm-test.yml
+    needs:
+      - linux-jammy-rocm-py3_10-build
+      - target-determination
+    with:
+      build-environment: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
+    secrets: inherit
+

--- a/.github/workflows/rocm-mi210.yml
+++ b/.github/workflows/rocm-mi210.yml
@@ -1,0 +1,73 @@
+name: rocm-mi210
+
+on:
+  push:
+    tags:
+      - ciflow/rocm-mi210/*
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  target-determination:
+    if: github.repository_owner == 'pytorch'
+    name: before-test
+    uses: ./.github/workflows/target_determination.yml
+    permissions:
+      id-token: write
+      contents: read
+
+  get-label-type:
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+
+  linux-jammy-rocm-py3_10-build:
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
+    name: linux-jammy-rocm-py3.10-mi210
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-jammy-rocm-py3.10-mi210
+      docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.mi210" },
+          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.mi210" },
+          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.mi210" },
+          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.mi210" },
+          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.mi210" },
+          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.mi210" },
+        ]}
+    secrets: inherit
+
+  linux-jammy-rocm-py3_10-test:
+    permissions:
+      id-token: write
+      contents: read
+    name: linux-jammy-rocm-py3.10-mi210
+    uses: ./.github/workflows/_rocm-test.yml
+    needs:
+      - linux-jammy-rocm-py3_10-build
+      - target-determination
+    with:
+      build-environment: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
+    secrets: inherit
+

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -3,7 +3,10 @@ name: Upload test stats
 on:
   workflow_run:
     workflows:
+      - inductor-rocm-mi210
+      - periodic-rocm-mi210
       - pull
+      - rocm-mi210
       - trunk
       - trunk-rocm-sandbox
       - periodic


### PR DESCRIPTION
## Summary
- Add ROCm CI workflows for `mi210`

## Workflows
- `rocm-mi210` — 6 shards, runner `linux.rocm.gpu.mi210`
- `periodic-rocm-mi210` — 3 distributed shards, runner `linux.rocm.gpu.mi210.2`
- `inductor-rocm-mi210` — 2 inductor shards, runner `linux.rocm.gpu.mi210`

## Ciflow tags
- `ciflow/rocm-mi210/*`
- `ciflow/periodic-rocm-mi210/*`
- `ciflow/inductor-rocm-mi210/*`

## Test plan
- [ ] Verify workflows parse and actionlint passes

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang