### PR TITLE
[fx] Fix pytree codegen for tuple/dict positional inputs

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -580,6 +580,46 @@ class InputModuleWithNestedSubclass(torch.nn.Module):
 @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestExport(TestCase):
+    def test_unlift_codegen_disambiguates_positional_tuple_dict_spec(self):
+        from torch.export._unlift import _get_codegen
+
+        _, in_spec = tree_flatten(((torch.ones(1),), {"x": torch.ones(1)}))
+
+        positional_bindings = _get_codegen(
+            in_spec, None, is_args_kwargs=False
+        ).gen_var_bindings(["arg_0", "arg_1"], ["arg_0", "arg_1"], False)
+        self.assertExpectedInline(
+            positional_bindings,
+            """\
+
+    arg_0, arg_1, = fx_pytree.tree_flatten_spec([arg_0, arg_1], self._in_spec)""",
+        )
+
+        args_kwargs_bindings = _get_codegen(
+            in_spec, None, is_args_kwargs=True
+        ).gen_var_bindings(["arg_0", "x"], ["arg_0", "x"], False)
+        self.assertExpectedInline(
+            args_kwargs_bindings,
+            """\
+
+    arg_0, x, = fx_pytree.tree_flatten_spec(([arg_0], {'x':x}), self._in_spec)""",
+        )
+
+    def test_export_module_tuple_dict_positional_codegen(self):
+        class M(torch.nn.Module):
+            def forward(self, a, x):
+                return a[0] + x["x"]
+
+        a = torch.randn(3)
+        x = torch.randn(3)
+        ep = export(M(), ((a,), {"x": x}))
+        mod = ep.module()
+
+        new_a = torch.randn(3)
+        new_x = torch.randn(3)
+        self.assertEqual(mod((new_a,), {"x": new_x}), new_a + new_x)
+        self.assertTrue(mod.graph._codegen.pytree_info.is_args_kwargs)
+
     def _test_export_same_as_eager(self, f, args, kwargs=None):
         kwargs = kwargs or {}
         exported_program = export(f, args, kwargs)

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -620,19 +620,20 @@ class TestExport(TestCase):
         self.assertEqual(mod((new_a,), {"x": new_x}), new_a + new_x)
         self.assertTrue(mod.graph._codegen.pytree_info.is_args_kwargs)
 
-    def test_unlift_leaf_spec_is_not_args_kwargs(self):
+    def test_unlift_positional_spec_is_not_args_kwargs(self):
         from torch.export._unlift import _unlift
 
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
         graph.output((x,))
         gm = torch.fx.GraphModule({}, graph)
+        _, in_spec = tree_flatten((torch.ones(1),))
 
         unlifted = _unlift(
             gm,
             [None],
             [None],
-            pytree.treespec_leaf(),
+            in_spec,
             None,
             is_args_kwargs=False,
         )

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -620,6 +620,26 @@ class TestExport(TestCase):
         self.assertEqual(mod((new_a,), {"x": new_x}), new_a + new_x)
         self.assertTrue(mod.graph._codegen.pytree_info.is_args_kwargs)
 
+    def test_unlift_leaf_spec_is_not_args_kwargs(self):
+        from torch.export._unlift import _unlift
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        graph.output((x,))
+        gm = torch.fx.GraphModule({}, graph)
+
+        unlifted = _unlift(
+            gm,
+            [None],
+            [None],
+            pytree.treespec_leaf(),
+            None,
+            is_args_kwargs=False,
+        )
+
+        self.assertFalse(unlifted.graph._codegen.pytree_info.is_args_kwargs)
+        self.assertEqual(unlifted(torch.ones(1)), (torch.ones(1),))
+
     def _test_export_same_as_eager(self, f, args, kwargs=None):
         kwargs = kwargs or {}
         exported_program = export(f, args, kwargs)

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -4625,6 +4625,24 @@ def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
         # recorver mutable checking flag
         torch.fx.proxy.TracerBase.check_mutable_operations = orig_tracer_mutable_flag
 
+    def test_make_fx_tuple_dict_positional_codegen(self):
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def fn(a, x):
+            return a[0] + x["x"]
+
+        a = torch.randn(3)
+        x = torch.randn(3)
+        fx_fn = make_fx(fn)((a,), {"x": x})
+
+        self.assertIn("tree_flatten_spec([a, x], self._in_spec)", fx_fn.code)
+
+        new_a = torch.randn(3)
+        new_x = torch.randn(3)
+        self.assertEqual(
+            fx_fn((new_a,), {"x": new_x}), fn((new_a,), {"x": new_x})
+        )
+
     # This only fails on navi31
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     @torch.fx.experimental._config.patch("enrich_profiler_metadata", True)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -2277,6 +2277,7 @@ def rewrite_signature(
             argument_names(f_sig, orig_args, orig_kwargs),
             in_spec,
             out_spec_traced,
+            True,
         )
     )
     new_graph.recompile()

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -1089,6 +1089,7 @@ def _dynamo_graph_capture_for_export(
                     argument_names(inspect.signature(orig_callable), args, kwargs),  # type: ignore[attr-defined, arg-type]
                     in_spec,
                     out_spec,
+                    True,
                 )
             )
             transformed_graph.recompile()

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -489,6 +489,7 @@ def _unlift_graph(
         mutated_outputs,
         pytree.treespec_leaf(),
         None,
+        is_args_kwargs=False,
     )
     # After unlifting, the buffer mutation information is lost. Pass the information
     # so that Inductor can do optimizations correctly.

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1824,6 +1824,7 @@ def _strict_export(
             orig_arg_names,
             gm_torch_level._in_spec,
             out_spec,
+            gm_torch_level.graph._codegen.pytree_info.is_args_kwargs,
         )
     elif isinstance(
         gm_torch_level.graph._codegen,

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -368,16 +368,19 @@ def _get_codegen(
     in_spec: pytree.TreeSpec,
     out_spec: pytree.TreeSpec | None,
     forward_arg_names: list[str] | None = None,
+    is_args_kwargs: bool = False,
 ) -> _PyTreeCodeGen:
     """
     Create the codegen for the graph module based on the in/out specs
     """
-    is_args_kwargs = (
+    if is_args_kwargs and not (
         in_spec.type is tuple
         and in_spec.num_children == 2
         and in_spec.child(0).type is tuple
         and in_spec.child(1).type is dict
-    )
+    ):
+        raise AssertionError(f"Expected args/kwargs input spec, got {in_spec}")
+
     if forward_arg_names:
         names = forward_arg_names
     elif is_args_kwargs:
@@ -405,6 +408,7 @@ def _unlift(
     in_spec: pytree.TreeSpec,
     out_spec: pytree.TreeSpec | None,
     forward_arg_names: list[str] | None = None,
+    is_args_kwargs: bool = True,
 ):
     """
     Args:
@@ -427,7 +431,12 @@ def _unlift(
     _insert_copy_for_mutations(
         gm, mutated_outputs, unlifted_name_to_node, input_name_to_node
     )
-    gm.graph._codegen = _get_codegen(in_spec, out_spec, forward_arg_names)
+    gm.graph._codegen = _get_codegen(
+        in_spec,
+        out_spec,
+        forward_arg_names,
+        is_args_kwargs,
+    )
     gm.graph.lint()
     gm.recompile()
     return gm
@@ -849,6 +858,7 @@ def _unlift_exported_program_lifted_states(
         ep.call_spec.in_spec,
         ep.call_spec.out_spec,
         forward_arg_names=forward_arg_names,
+        is_args_kwargs=True,
     )
     unlift_gm = _create_stateful_graph_module(new_gm, ep.range_constraints, ep)
     unlift_gm.meta.update(ep.graph_module.meta)

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -389,7 +389,7 @@ def _get_codegen(
         # add kwarg names
         names.extend(in_spec.child(1).context)
     else:
-        names = [f"arg_{i}" for i in range(in_spec.num_leaves)]
+        names = [f"arg_{i}" for i in range(in_spec.num_children)]
 
     return _PyTreeCodeGen(
         _PyTreeInfo(

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -389,7 +389,7 @@ def _get_codegen(
         # add kwarg names
         names.extend(in_spec.child(1).context)
     else:
-        names = [f"arg_{i}" for i in range(in_spec.num_children)]
+        names = [f"arg_{i}" for i in range(in_spec.num_leaves)]
 
     return _PyTreeCodeGen(
         _PyTreeInfo(

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -372,14 +372,15 @@ def _get_codegen(
     """
     Create the codegen for the graph module based on the in/out specs
     """
-    if forward_arg_names:
-        names = forward_arg_names
-    elif (
+    is_args_kwargs = (
         in_spec.type is tuple
         and in_spec.num_children == 2
         and in_spec.child(0).type is tuple
         and in_spec.child(1).type is dict
-    ):
+    )
+    if forward_arg_names:
+        names = forward_arg_names
+    elif is_args_kwargs:
         # if in_spec contains the args (tuple) and kwargs (dict)
         names = [f"arg_{i}" for i in range(in_spec.child(0).num_children)]
         # add kwarg names
@@ -392,6 +393,7 @@ def _get_codegen(
             names,
             in_spec,
             out_spec,
+            is_args_kwargs,
         )
     )
 

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -405,6 +405,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
                 orig_arg_names,
                 mod._in_spec,
                 out_spec,
+                mod.graph._codegen.pytree_info.is_args_kwargs,
             )
         )
 

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -741,7 +741,7 @@ class Tracer(TracerBase):
             # `concrete_args`, generate a flattening wrapper around the
             # original root function and return that.
             self.graph._codegen = _PyTreeCodeGen(  # type: ignore[has-type]
-                _PyTreeInfo(orig_args[:total_args], in_spec, None)
+                _PyTreeInfo(orig_args[:total_args], in_spec, None, False)
             )
 
             # TODO: annotate return type. inspect.get_annotations(flatten_fn)

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -320,6 +320,10 @@ class _PyTreeInfo(NamedTuple):
     orig_args: list[str]
     in_spec: pytree.TreeSpec
     out_spec: pytree.TreeSpec | None
+    # True when in_spec was produced from tree_flatten((args, kwargs)).  A
+    # genuine positional signature like f(tuple_arg, dict_arg) has the same
+    # top-level TreeSpec shape, so codegen must not infer this from in_spec.
+    is_args_kwargs: bool = False
 
 
 @dataclass(frozen=True)
@@ -1205,16 +1209,16 @@ class _PyTreeCodeGen(CodeGen):
         self, fn_args: list[str], free_vars: list[str], expanded_def: bool
     ) -> str:
         in_spec = self.pytree_info.in_spec
-        # when kwargs is present, in_spec is tuple(args, kwargs)
-        has_args_kwargs_tuple = (
-            in_spec.type is tuple
-            and in_spec.num_children == 2
-            and in_spec.child(0).type is tuple
-            and in_spec.child(1).type is dict
-        )
         fn_kwargs = "{}"
         fn_signature = f"[{', '.join(fn_args)}], self._in_spec"
-        if has_args_kwargs_tuple:
+        if self.pytree_info.is_args_kwargs:
+            if not (
+                in_spec.type is tuple
+                and in_spec.num_children == 2
+                and in_spec.child(0).type is tuple
+                and in_spec.child(1).type is dict
+            ):
+                raise AssertionError(f"Expected args/kwargs input spec, got {in_spec}")
             count_args = in_spec.child(0).num_children
             fn_args = self.pytree_info.orig_args[:count_args]
             fn_kwargs = (

--- a/torch/fx/passes/utils/matcher_with_name_node_map_utils.py
+++ b/torch/fx/passes/utils/matcher_with_name_node_map_utils.py
@@ -34,7 +34,10 @@ def _split_to_graph_and_name_node_map(
             n.args = (flattened,)
             orig_pytree_info = gm._graph._codegen.pytree_info  # type: ignore[attr-defined]
             gm._graph._codegen.pytree_info = _PyTreeInfo(  # type: ignore[attr-defined]
-                orig_pytree_info.orig_args, orig_pytree_info.in_spec, out_spec
+                orig_pytree_info.orig_args,
+                orig_pytree_info.in_spec,
+                out_spec,
+                orig_pytree_info.is_args_kwargs,
             )
     gm.recompile()
     return gm, name_node_map


### PR DESCRIPTION
Fixes #185640.

## Summary
- stop inferring the `(args, kwargs)` calling convention from `TreeSpec` shape alone in `_PyTreeCodeGen`
- add an explicit `_PyTreeInfo.is_args_kwargs` flag and propagate it through export/dynamo call sites that really do flatten `(args, kwargs)`
- keep symbolic tracing / `make_fx` positional pytrees on the plain positional path
- add a regression test for `make_fx` with a `(tuple, dict)` positional signature where the dict arg name matches its key

## Why
A genuine function signature like `fn(tuple_arg, dict_arg)` produces the same top-level `TreeSpec` shape as flattened `(args, kwargs)`: `tuple(tuple, dict)`. The old code treated that shape as kwargs unconditionally, so `make_fx` generated input reconstruction like `([a], {'x': x})` instead of `[a, x]` and then passed the tuple where a tensor leaf was expected.

The fix records whether the spec actually came from `tree_flatten((args, kwargs))`, avoiding ambiguous structural inference.

## Test plan
- `python3 -m compileall -q torch/fx/graph.py torch/fx/_symbolic_trace.py torch/export/_trace.py torch/export/_unlift.py torch/export/exported_program.py torch/_dynamo/functional_export.py torch/_dynamo/eval_frame.py torch/fx/passes/utils/matcher_with_name_node_map_utils.py test/test_fx.py`
- `git diff --check`
- local importlib smoke check of modified `_PyTreeCodeGen` verifying:
  - positional `(tuple, dict)` emits `tree_flatten_spec([a, x], self._in_spec)`
  - explicit args/kwargs emits `tree_flatten_spec(([a], {'x':x}), self._in_spec)`

Not run locally: `PYTHONPATH=. python3 test/test_fx.py -k test_make_fx_tuple_dict_positional_codegen` because this checkout is not built and cannot load `torch/lib/libtorch_global_deps.dylib` on this machine.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98