### PR TITLE
[CI] Fix Windows pip install command

### DIFF
--- a/.ci/pytorch/win-test-helpers/installation-helpers/activate_miniconda3.bat
+++ b/.ci/pytorch/win-test-helpers/installation-helpers/activate_miniconda3.bat
@@ -27,4 +27,6 @@ call %CONDA_ROOT_DIR%\Scripts\activate.bat %CONDA_ROOT_DIR%
 :: Activate conda so that we can use its commands, i.e. conda, python, pip
 call conda activate py_tmp
 
-call pip install -r .ci/docker/requirements-ci.txt
+:: Use `python -m pip` so that pip can upgrade itself (the pip.exe wrapper is
+:: locked while running, so `pip install` fails when requirements-ci.txt pins pip).
+call python -m pip install -r .ci/docker/requirements-ci.txt


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #185662

Windows CI jobs started failing with:
```
  ERROR: To modify pip, please run the following command:
  C:\Jenkins\Miniconda3\envs\py_tmp\python.exe -m pip install -r .ci/docker/requirements-ci.txt
```

Because NTFS still does not allow to rename or move currently executed files. Fixed by running `python -mpip`, which does not conflict with self update urges

Authored-with: Claude (Anthropic AI assistant)