### PR TITLE
Move col2im offset and stride to long to avoid overflows leading to corruption

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Col2Im.metal
+++ b/aten/src/ATen/native/mps/kernels/Col2Im.metal
@@ -63,10 +63,9 @@ kernel void col2im_kernel(
         h_k /= dilation_h;
         w_k /= dilation_w;
         if (h_k < kernel_h && w_k < kernel_w) {
-          uint dim1_idx = c_im * kernel_h * kernel_w + h_k * kernel_w + w_k;
-          uint dim2_idx = h_col * width_col + w_col;
-          IdxT col_index = IdxT(dim1_idx) * col_channel_stride +
-              IdxT(dim2_idx) * col_spatial_stride;
+          IdxT dim1_idx = (IdxT(c_im) * kernel_h + h_k) * kernel_w + w_k;
+          IdxT dim2_idx = IdxT(h_col) * width_col + w_col;
+          IdxT col_index = dim1_idx * col_channel_stride + dim2_idx * col_spatial_stride;
           accumulator +=
               static_cast<float>(data_col[col_batch_offset + col_index]);
         }

--- a/aten/src/ATen/native/mps/kernels/Col2Im.metal
+++ b/aten/src/ATen/native/mps/kernels/Col2Im.metal
@@ -65,7 +65,8 @@ kernel void col2im_kernel(
         if (h_k < kernel_h && w_k < kernel_w) {
           IdxT dim1_idx = (IdxT(c_im) * kernel_h + h_k) * kernel_w + w_k;
           IdxT dim2_idx = IdxT(h_col) * width_col + w_col;
-          IdxT col_index = dim1_idx * col_channel_stride + dim2_idx * col_spatial_stride;
+          IdxT col_index =
+              dim1_idx * col_channel_stride + dim2_idx * col_spatial_stride;
           accumulator +=
               static_cast<float>(data_col[col_batch_offset + col_index]);
         }

--- a/aten/src/ATen/native/mps/kernels/Col2Im.metal
+++ b/aten/src/ATen/native/mps/kernels/Col2Im.metal
@@ -5,7 +5,7 @@ template <typename T>
 kernel void col2im_kernel(
     device const T* data_col [[buffer(0)]],
     device T* data_im [[buffer(1)]],
-    constant uint& col_batch_stride [[buffer(2)]],
+    constant ulong& col_batch_stride [[buffer(2)]],
     constant uint& channels [[buffer(3)]],
     constant uint2& im_hw [[buffer(4)]],
     constant uint2& kernel_hw [[buffer(5)]],
@@ -13,8 +13,8 @@ kernel void col2im_kernel(
     constant uint2& stride_hw [[buffer(7)]],
     constant uint2& dilation_hw [[buffer(8)]],
     constant uint2& col_hw [[buffer(9)]],
-    constant uint& im_batch_stride [[buffer(10)]],
-    constant uint2& col_inner_strides [[buffer(11)]],
+    constant ulong& im_batch_stride [[buffer(10)]],
+    constant ulong2& col_inner_strides [[buffer(11)]],
     uint3 gid [[thread_position_in_grid]]) {
   const uint output_height = im_hw.x;
   const uint output_width = im_hw.y;
@@ -50,9 +50,9 @@ kernel void col2im_kernel(
   uint h_col_end = min((h_im / stride_h + 1), height_col);
 
   float accumulator = 0.0;
-  uint col_batch_offset = batch_idx * col_batch_stride;
-  uint col_channel_stride = col_inner_strides.x;
-  uint col_spatial_stride = col_inner_strides.y;
+  ulong col_batch_offset = batch_idx * col_batch_stride;
+  ulong col_channel_stride = col_inner_strides.x;
+  ulong col_spatial_stride = col_inner_strides.y;
 
   for (uint h_col = h_col_start; h_col < h_col_end; h_col++) {
     for (uint w_col = w_col_start; w_col < w_col_end; w_col++) {
@@ -65,7 +65,7 @@ kernel void col2im_kernel(
         if (h_k < kernel_h && w_k < kernel_w) {
           uint dim1_idx = c_im * kernel_h * kernel_w + h_k * kernel_w + w_k;
           uint dim2_idx = h_col * width_col + w_col;
-          uint col_index =
+          ulong col_index =
               dim1_idx * col_channel_stride + dim2_idx * col_spatial_stride;
           accumulator +=
               static_cast<float>(data_col[col_batch_offset + col_index]);
@@ -74,8 +74,8 @@ kernel void col2im_kernel(
     }
   }
 
-  uint im_batch_offset = batch_idx * im_batch_stride;
-  uint im_index = (c_im * output_height + y) * output_width + x;
+  ulong im_batch_offset = batch_idx * im_batch_stride;
+  ulong im_index = (ulong(c_im) * output_height + y) * output_width + x;
   data_im[im_batch_offset + im_index] = static_cast<T>(accumulator);
 }
 
@@ -84,7 +84,7 @@ kernel void col2im_kernel(
   col2im_kernel<DTYPE>(                                       \
       device const DTYPE* data_col [[buffer(0)]],             \
       device DTYPE* data_im [[buffer(1)]],                    \
-      constant uint& col_batch_stride [[buffer(2)]],          \
+      constant ulong& col_batch_stride [[buffer(2)]],         \
       constant uint& channels [[buffer(3)]],                  \
       constant uint2& im_hw [[buffer(4)]],                    \
       constant uint2& kernel_hw [[buffer(5)]],                \
@@ -92,8 +92,8 @@ kernel void col2im_kernel(
       constant uint2& stride_hw [[buffer(7)]],                \
       constant uint2& dilation_hw [[buffer(8)]],              \
       constant uint2& col_hw [[buffer(9)]],                   \
-      constant uint& im_batch_stride [[buffer(10)]],          \
-      constant uint2& col_inner_strides [[buffer(11)]],       \
+      constant ulong& im_batch_stride [[buffer(10)]],         \
+      constant ulong2& col_inner_strides [[buffer(11)]],      \
       uint3 gid [[thread_position_in_grid]]);
 
 INSTANTIATE_COL2IM(bool);

--- a/aten/src/ATen/native/mps/kernels/Col2Im.metal
+++ b/aten/src/ATen/native/mps/kernels/Col2Im.metal
@@ -1,11 +1,11 @@
 #include <metal_stdlib>
 using namespace metal;
 
-template <typename T>
+template <typename T, typename IdxT>
 kernel void col2im_kernel(
     device const T* data_col [[buffer(0)]],
     device T* data_im [[buffer(1)]],
-    constant ulong& col_batch_stride [[buffer(2)]],
+    constant IdxT& col_batch_stride [[buffer(2)]],
     constant uint& channels [[buffer(3)]],
     constant uint2& im_hw [[buffer(4)]],
     constant uint2& kernel_hw [[buffer(5)]],
@@ -13,8 +13,8 @@ kernel void col2im_kernel(
     constant uint2& stride_hw [[buffer(7)]],
     constant uint2& dilation_hw [[buffer(8)]],
     constant uint2& col_hw [[buffer(9)]],
-    constant ulong& im_batch_stride [[buffer(10)]],
-    constant ulong2& col_inner_strides [[buffer(11)]],
+    constant IdxT& im_batch_stride [[buffer(10)]],
+    constant vec<IdxT, 2>& col_inner_strides [[buffer(11)]],
     uint3 gid [[thread_position_in_grid]]) {
   const uint output_height = im_hw.x;
   const uint output_width = im_hw.y;
@@ -50,9 +50,9 @@ kernel void col2im_kernel(
   uint h_col_end = min((h_im / stride_h + 1), height_col);
 
   float accumulator = 0.0;
-  ulong col_batch_offset = batch_idx * col_batch_stride;
-  ulong col_channel_stride = col_inner_strides.x;
-  ulong col_spatial_stride = col_inner_strides.y;
+  IdxT col_batch_offset = IdxT(batch_idx) * col_batch_stride;
+  IdxT col_channel_stride = col_inner_strides.x;
+  IdxT col_spatial_stride = col_inner_strides.y;
 
   for (uint h_col = h_col_start; h_col < h_col_end; h_col++) {
     for (uint w_col = w_col_start; w_col < w_col_end; w_col++) {
@@ -65,8 +65,8 @@ kernel void col2im_kernel(
         if (h_k < kernel_h && w_k < kernel_w) {
           uint dim1_idx = c_im * kernel_h * kernel_w + h_k * kernel_w + w_k;
           uint dim2_idx = h_col * width_col + w_col;
-          ulong col_index =
-              dim1_idx * col_channel_stride + dim2_idx * col_spatial_stride;
+          IdxT col_index = IdxT(dim1_idx) * col_channel_stride +
+              IdxT(dim2_idx) * col_spatial_stride;
           accumulator +=
               static_cast<float>(data_col[col_batch_offset + col_index]);
         }
@@ -74,27 +74,31 @@ kernel void col2im_kernel(
     }
   }
 
-  ulong im_batch_offset = batch_idx * im_batch_stride;
-  ulong im_index = (ulong(c_im) * output_height + y) * output_width + x;
+  IdxT im_batch_offset = IdxT(batch_idx) * im_batch_stride;
+  IdxT im_index = (IdxT(c_im) * output_height + y) * output_width + x;
   data_im[im_batch_offset + im_index] = static_cast<T>(accumulator);
 }
 
-#define INSTANTIATE_COL2IM(DTYPE)                             \
-  template [[host_name("col2im_kernel_" #DTYPE)]] kernel void \
-  col2im_kernel<DTYPE>(                                       \
-      device const DTYPE* data_col [[buffer(0)]],             \
-      device DTYPE* data_im [[buffer(1)]],                    \
-      constant ulong& col_batch_stride [[buffer(2)]],         \
-      constant uint& channels [[buffer(3)]],                  \
-      constant uint2& im_hw [[buffer(4)]],                    \
-      constant uint2& kernel_hw [[buffer(5)]],                \
-      constant uint2& pad_hw [[buffer(6)]],                   \
-      constant uint2& stride_hw [[buffer(7)]],                \
-      constant uint2& dilation_hw [[buffer(8)]],              \
-      constant uint2& col_hw [[buffer(9)]],                   \
-      constant ulong& im_batch_stride [[buffer(10)]],         \
-      constant ulong2& col_inner_strides [[buffer(11)]],      \
+#define INSTANTIATE_COL2IM_IDX(DTYPE, IDX, SUFFIX)                        \
+  template [[host_name("col2im_kernel_" #DTYPE "_" #SUFFIX)]] kernel void \
+  col2im_kernel<DTYPE, IDX>(                                              \
+      device const DTYPE* data_col [[buffer(0)]],                         \
+      device DTYPE* data_im [[buffer(1)]],                                \
+      constant IDX& col_batch_stride [[buffer(2)]],                       \
+      constant uint& channels [[buffer(3)]],                              \
+      constant uint2& im_hw [[buffer(4)]],                                \
+      constant uint2& kernel_hw [[buffer(5)]],                            \
+      constant uint2& pad_hw [[buffer(6)]],                               \
+      constant uint2& stride_hw [[buffer(7)]],                            \
+      constant uint2& dilation_hw [[buffer(8)]],                          \
+      constant uint2& col_hw [[buffer(9)]],                               \
+      constant IDX& im_batch_stride [[buffer(10)]],                       \
+      constant vec<IDX, 2>& col_inner_strides [[buffer(11)]],             \
       uint3 gid [[thread_position_in_grid]]);
+
+#define INSTANTIATE_COL2IM(DTYPE)          \
+  INSTANTIATE_COL2IM_IDX(DTYPE, uint, u32) \
+  INSTANTIATE_COL2IM_IDX(DTYPE, ulong, u64)
 
 INSTANTIATE_COL2IM(bool);
 INSTANTIATE_COL2IM(float);

--- a/aten/src/ATen/native/mps/operations/Col2Im.mm
+++ b/aten/src/ATen/native/mps/operations/Col2Im.mm
@@ -1,4 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/im2col_shape_check.h>
 #include <ATen/native/mps/OperationUtils.h>
 
@@ -72,13 +73,7 @@ static void col2im_out_mps_template(const Tensor& input,
   auto width_col = (output_width + 2 * pad_width - (dilation_width * (kernel_width - 1) + 1)) / stride_width + 1;
 
   auto stream = getCurrentMPSStream();
-  const int64_t max_col_offset = (batch_size > 0 ? (batch_size - 1) * input_batch_stride : 0) +
-      (n_input_plane > 0 ? (n_input_plane - 1) * input_channel_stride : 0) +
-      (height_col * width_col > 0 ? (height_col * width_col - 1) * input_spatial_stride : 0);
-  const int64_t max_im_offset =
-      (batch_size > 0 ? (batch_size - 1) * output_batch_stride : 0) + n_output_plane * output_height * output_width;
-  const bool use_u32 =
-      max_col_offset <= std::numeric_limits<uint32_t>::max() && max_im_offset <= std::numeric_limits<uint32_t>::max();
+  const bool use_u32 = canUse32BitIndexMath(col_tensor) && canUse32BitIndexMath(output);
   const std::string idx_suffix = use_u32 ? "_u32" : "_u64";
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {

--- a/aten/src/ATen/native/mps/operations/Col2Im.mm
+++ b/aten/src/ATen/native/mps/operations/Col2Im.mm
@@ -90,7 +90,7 @@ static void col2im_out_mps_template(const Tensor& input,
           computeEncoder,
           col_tensor,
           output,
-          static_cast<uint64_t>(input_batch_stride),
+          input_batch_stride,
           n_output_plane,
           std::array<uint32_t, 2>{static_cast<uint32_t>(output_height), static_cast<uint32_t>(output_width)}, // im_hw
           std::array<uint32_t, 2>{static_cast<uint32_t>(kernel_height),
@@ -101,7 +101,7 @@ static void col2im_out_mps_template(const Tensor& input,
           std::array<uint32_t, 2>{static_cast<uint32_t>(dilation_height),
                                   static_cast<uint32_t>(dilation_width)}, // dilation_hw
           std::array<uint32_t, 2>{static_cast<uint32_t>(height_col), static_cast<uint32_t>(width_col)}, // col_hw
-          static_cast<uint64_t>(output_batch_stride),
+          output_batch_stride,
           std::array<uint64_t, 2>{static_cast<uint64_t>(input_channel_stride),
                                   static_cast<uint64_t>(input_spatial_stride)}); // col_inner_strides
       [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadgroupSize];

--- a/aten/src/ATen/native/mps/operations/Col2Im.mm
+++ b/aten/src/ATen/native/mps/operations/Col2Im.mm
@@ -90,7 +90,7 @@ static void col2im_out_mps_template(const Tensor& input,
           computeEncoder,
           col_tensor,
           output,
-          input_batch_stride,
+          static_cast<uint64_t>(input_batch_stride),
           n_output_plane,
           std::array<uint32_t, 2>{static_cast<uint32_t>(output_height), static_cast<uint32_t>(output_width)}, // im_hw
           std::array<uint32_t, 2>{static_cast<uint32_t>(kernel_height),
@@ -101,9 +101,9 @@ static void col2im_out_mps_template(const Tensor& input,
           std::array<uint32_t, 2>{static_cast<uint32_t>(dilation_height),
                                   static_cast<uint32_t>(dilation_width)}, // dilation_hw
           std::array<uint32_t, 2>{static_cast<uint32_t>(height_col), static_cast<uint32_t>(width_col)}, // col_hw
-          output_batch_stride,
-          std::array<uint32_t, 2>{static_cast<uint32_t>(input_channel_stride),
-                                  static_cast<uint32_t>(input_spatial_stride)}); // col_inner_strides
+          static_cast<uint64_t>(output_batch_stride),
+          std::array<uint64_t, 2>{static_cast<uint64_t>(input_channel_stride),
+                                  static_cast<uint64_t>(input_spatial_stride)}); // col_inner_strides
       [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadgroupSize];
     }
   });

--- a/aten/src/ATen/native/mps/operations/Col2Im.mm
+++ b/aten/src/ATen/native/mps/operations/Col2Im.mm
@@ -72,9 +72,17 @@ static void col2im_out_mps_template(const Tensor& input,
   auto width_col = (output_width + 2 * pad_width - (dilation_width * (kernel_width - 1) + 1)) / stride_width + 1;
 
   auto stream = getCurrentMPSStream();
+  const int64_t max_col_offset = (batch_size > 0 ? (batch_size - 1) * input_batch_stride : 0) +
+      (n_input_plane > 0 ? (n_input_plane - 1) * input_channel_stride : 0) +
+      (height_col * width_col > 0 ? (height_col * width_col - 1) * input_spatial_stride : 0);
+  const int64_t max_im_offset =
+      (batch_size > 0 ? (batch_size - 1) * output_batch_stride : 0) + n_output_plane * output_height * output_width;
+  const bool use_u32 =
+      max_col_offset <= std::numeric_limits<uint32_t>::max() && max_im_offset <= std::numeric_limits<uint32_t>::max();
+  const std::string idx_suffix = use_u32 ? "_u32" : "_u64";
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
-      auto col2imPSO = lib.getPipelineStateForFunc("col2im_kernel_" + mps::scalarToMetalTypeString(input));
+      auto col2imPSO = lib.getPipelineStateForFunc("col2im_kernel_" + mps::scalarToMetalTypeString(input) + idx_suffix);
       auto computeEncoder = stream->commandEncoder();
       [computeEncoder setComputePipelineState:col2imPSO];
       const uint32_t gridWidth = static_cast<uint32_t>(output_width);
@@ -86,24 +94,36 @@ static void col2im_out_mps_template(const Tensor& input,
       uint32_t tgWidth = std::min(gridWidth, threadExecutionWidth);
       uint32_t tgHeight = std::min(gridHeight, maxThreadsPerGroup / tgWidth);
       MTLSize threadgroupSize = MTLSizeMake(tgWidth, tgHeight, 1);
-      mtl_setArgs(
-          computeEncoder,
-          col_tensor,
-          output,
-          input_batch_stride,
-          n_output_plane,
-          std::array<uint32_t, 2>{static_cast<uint32_t>(output_height), static_cast<uint32_t>(output_width)}, // im_hw
-          std::array<uint32_t, 2>{static_cast<uint32_t>(kernel_height),
-                                  static_cast<uint32_t>(kernel_width)}, // kernel_hw
-          std::array<uint32_t, 2>{static_cast<uint32_t>(pad_height), static_cast<uint32_t>(pad_width)}, // pad_hw
-          std::array<uint32_t, 2>{static_cast<uint32_t>(stride_height),
-                                  static_cast<uint32_t>(stride_width)}, // stride_hw
-          std::array<uint32_t, 2>{static_cast<uint32_t>(dilation_height),
-                                  static_cast<uint32_t>(dilation_width)}, // dilation_hw
-          std::array<uint32_t, 2>{static_cast<uint32_t>(height_col), static_cast<uint32_t>(width_col)}, // col_hw
-          output_batch_stride,
-          std::array<uint64_t, 2>{static_cast<uint64_t>(input_channel_stride),
-                                  static_cast<uint64_t>(input_spatial_stride)}); // col_inner_strides
+      auto dispatch_args = [&](auto in_stride, auto out_stride, auto inner_strides) {
+        mtl_setArgs(
+            computeEncoder,
+            col_tensor,
+            output,
+            in_stride,
+            n_output_plane,
+            std::array<uint32_t, 2>{static_cast<uint32_t>(output_height), static_cast<uint32_t>(output_width)}, // im_hw
+            std::array<uint32_t, 2>{static_cast<uint32_t>(kernel_height),
+                                    static_cast<uint32_t>(kernel_width)}, // kernel_hw
+            std::array<uint32_t, 2>{static_cast<uint32_t>(pad_height), static_cast<uint32_t>(pad_width)}, // pad_hw
+            std::array<uint32_t, 2>{static_cast<uint32_t>(stride_height),
+                                    static_cast<uint32_t>(stride_width)}, // stride_hw
+            std::array<uint32_t, 2>{static_cast<uint32_t>(dilation_height),
+                                    static_cast<uint32_t>(dilation_width)}, // dilation_hw
+            std::array<uint32_t, 2>{static_cast<uint32_t>(height_col), static_cast<uint32_t>(width_col)}, // col_hw
+            out_stride,
+            inner_strides);
+      };
+      if (use_u32) {
+        dispatch_args(static_cast<uint32_t>(input_batch_stride),
+                      static_cast<uint32_t>(output_batch_stride),
+                      std::array<uint32_t, 2>{static_cast<uint32_t>(input_channel_stride),
+                                              static_cast<uint32_t>(input_spatial_stride)});
+      } else {
+        dispatch_args(static_cast<uint64_t>(input_batch_stride),
+                      static_cast<uint64_t>(output_batch_stride),
+                      std::array<uint64_t, 2>{static_cast<uint64_t>(input_channel_stride),
+                                              static_cast<uint64_t>(input_spatial_stride)});
+      }
       [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadgroupSize];
     }
   });

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6272,6 +6272,26 @@ class TestMPS(TestCaseMPS):
         helper((20, 15), (2, 10), (3, 5), (1, 2), (1, 1), False, torch.float16)
         helper((20, 15), (2, 10), (3, 5), (1, 2), (1, 1), False, test_bool=True)
 
+    def test_col2im_uint32_overflow(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/185663
+        K = L = 65537
+        cols = torch.zeros(1, K, L, dtype=torch.bool)
+        cols[0, K - 1, :] = True
+        args = ([1, 131073], [1, K], [1, 1], [0, 0], [1, 1])
+        out_cpu = torch.ops.aten.col2im(cols, *args)
+        out_mps = torch.ops.aten.col2im(cols.to("mps"), *args).cpu()
+        self.assertEqual(out_cpu, out_mps)
+
+    def test_col2im_uint32_overflow_spatial(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/185663
+        H = W = 65537
+        cols = torch.zeros(1, 1, H * W, dtype=torch.bool)
+        cols[0, 0, 1 << 32:] = True
+        args = ([H, W], [1, 1], [1, 1], [0, 0], [1, 1])
+        out_cpu = torch.ops.aten.col2im(cols, *args)
+        out_mps = torch.ops.aten.col2im(cols.to("mps"), *args).cpu()
+        self.assertEqual(out_cpu, out_mps)
+
     def test_fold_invalid_input_raises(self):
         # F.fold/col2im on MPS must raise the same shape errors as CPU. See #170639.
         cases = [


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/185663

Moves the offset / stride variables to use ulong to avoid silently overflowing uint32 for large inputs avoiding the overflow. This matches what the `at::im2col` implementation also does with promoting the relevant variables to 64-bits.