### PR TITLE
Fix typos in comments and docstrings across torch

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1371,7 +1371,7 @@ class OptimizeContext(_TorchDynamoContext):
 
 class RunOnlyContext(_TorchDynamoContext):
     def __init__(self) -> None:
-        # cudagraph trees relies on generation increment
+        # cudagraph trees rely on generation increment
         def on_enter() -> None:
             torch._dynamo.mutation_guard.GenerationTracker.generation += 1
 

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3963,7 +3963,7 @@ def check_verbose(
     if fi.code is not None and fi.code is typing.cast.__code__:
         return SkipResult(True, "typing.cast is a no-op, skip at top level")
 
-    # Consulte the central trace rules defined in torch._dynamo.trace_rules.
+    # Consult the central trace rules defined in torch._dynamo.trace_rules.
     reasons: set[str] = set()
     rule = lookup_inner(fi.py_obj, fi.name, fi.filename, is_inlined_call, reasons)
     if rule is None:

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -1672,7 +1672,7 @@ class KernelArgs:
         Returns:
             Tuple[str, str, int]: A tuple containing:
                 - "ws_ptr": A string identifier for the workspace pointer.
-                - "workspace_{i}": agraph level unique identifier for
+                - "workspace_{i}": a graph level unique identifier for
                     the workspace tensor.
                 - offset: An integer representing the item offset in the workspace.
         """

--- a/torch/_inductor/codegen/memory_planning.py
+++ b/torch/_inductor/codegen/memory_planning.py
@@ -106,7 +106,7 @@ class AllocationTreeNode:
 
     def allocate(self, block: Allocation, is_last: bool) -> bool:
         """
-        Try to assign block to a memory location in this bool.  Return True if
+        Try to assign block to a memory location in this pool.  Return True if
         an assignment was made.
         """
         return False

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -101,7 +101,7 @@ class ConstantFolder(torch.fx.Interpreter):
         self.skip_folding_node_fn = skip_folding_node_fn
 
     def _support_dynamic_shape(self) -> bool:
-        # ConstantFolder not support dynamic shape now
+        # ConstantFolder does not support dynamic shape now
         return False
 
     def _deduce_value(self, node: torch.fx.Node) -> Any:

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -1304,7 +1304,7 @@ def repeat_interleave_Tensor(
     return torch.clamp(indices, max=repeat.size(0) - 1)
 
 
-# intentionally not regiestered
+# intentionally not registered
 def conv1d_to_conv2d(
     input: torch.Tensor,
     weight: torch.Tensor,

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -468,7 +468,7 @@ class LoopBody:
 
     def is_memory_copy(self) -> bool:
         """
-        True of this contains only a single loads and store.
+        True if this contains only a single load and store.
         Note, this could involve a layout change.
         """
         return (

--- a/torch/_inductor/metrics.py
+++ b/torch/_inductor/metrics.py
@@ -371,7 +371,7 @@ def _parse_kernel_args_num_gb(
         return float(m.group(1))
     else:
         """
-        There are a few cases that kernel_num_gdb field can be missing:
+        There are a few cases that kernel_num_gb field can be missing:
         1. the field will be missing if config.benchmark_kernel and
            config.profile_bandwidth are false
         2. even if config.benchmark_kernel or config.profile_bandwidth is true.
@@ -398,7 +398,7 @@ def log_kernel_metadata(
 
     proper_kernel_fn_code = _parse_proper_kernel_fn_code(kernel_fn_code)
 
-    # the line of code excluding the decortors
+    # the line of code excluding the decorators
     kernel_line_of_code = _parse_kernel_line_of_code(proper_kernel_fn_code)
 
     get_metric_table("kernel_metadata").add_row(

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -180,7 +180,7 @@ def _prepare_convolution_fusion_create(
         output_stride: StrideType = FlexibleLayout.contiguous_strides(output_size)
     # Currently we don't support channel last for the situation that stride of input's batch dim is 0,
     # eg. input_size = (1, 1280, 64, 64), but input_stride=(0, 1, 81920, 1280).
-    # So we use NCHW hear instead.
+    # So we use NCHW here instead.
     # Different with cpu, cpu conv always use channels_last for convolution when weight is prepacked,
     # but xpu does not do the prepack, so the problem exposed here is only for xpu.
     # TODO support channels_last for such zero stride input.

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -46,7 +46,7 @@ def try_to_reduce_precision(
     replacement_vals: dict[Any, ValueRanges[sympy.Expr]],
 ) -> None:
     # if a downstream use of a node explicitly converts to int32, or float16/float32/float64,
-    # then it's precision is set for that chain of uses, and we don't need to consider those
+    # then its precision is set for that chain of uses, and we don't need to consider those
     # dominated values
     def skip_filter(node: Any) -> bool:
         return node.target == "to_dtype" and node.args[2] in (

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -155,7 +155,7 @@ def get_first_attr(obj: Any, *attrs: str) -> Any:
         if hasattr(obj, attr):
             return getattr(obj, attr)
 
-    raise AssertionError(f"{obj} does not has any of the attributes: {attrs}")
+    raise AssertionError(f"{obj} does not have any of the attributes: {attrs}")
 
 
 dynamo_timed = torch._dynamo.utils.dynamo_timed  # type: ignore[has-type]

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -1246,7 +1246,7 @@ class SizeVarAllocator:
         index = self.simplify(index)
         return sympy_subs(index, {v: sympy.S.Zero for v in vars if v != 0})
 
-    # Return stride optimizaitons hints,
+    # Return stride optimizations hints,
     # only used for optimizations.
     def stride_hints(
         self,
@@ -1294,7 +1294,7 @@ class SizeVarAllocator:
         A pair of special ModularIndexing can be combined.
 
         E.g. ModularIndexing(ModularIndexing(x, 1, a), 1, b)
-        We can simplify this to ModuleIndexing(x, 1, b), if
+        We can simplify this to ModularIndexing(x, 1, b), if
         1. x is non negative integer
         2. a and b are positive integers
         3. a is a multiple of b.
@@ -1382,7 +1382,7 @@ class SizeVarAllocator:
                     var, sympy.Symbol
                 ):
                     return False
-                # It's easier to reason about the correceness of the transformation
+                # It's easier to reason about the correctness of the transformation
                 # for non-negative integers.
                 if not self.statically_known_geq(var, 0):
                     return False

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -253,7 +253,7 @@ class autocast:
                 "get_amp_supported_dtype",
             ]
             message = f"Tried to use AMP with the `{self.custom_backend_name}` backend, but the backend has not "
-            message += "registered a module or  the module miss some necessary funcs. The backend should register "
+            message += "registered a module or the module misses some necessary funcs. The backend should register "
             message += "a module by `torch._register_device_module`, and the module must have these funcs: \n"
             message += "`get_amp_supported_dtype() -> List[torch.dtype]`. \n"
 

--- a/torch/autograd/anomaly_mode.py
+++ b/torch/autograd/anomaly_mode.py
@@ -17,7 +17,7 @@ class detect_anomaly:
     - Running the forward pass with detection enabled will allow the backward
       pass to print the traceback of the forward operation that created the failing
       backward function.
-    - If ``check_nan`` is ``True``, any backward computation that generate "nan"
+    - If ``check_nan`` is ``True``, any backward computation that generates "nan"
       value will raise an error. Default ``True``.
 
     .. warning::
@@ -107,7 +107,7 @@ class set_detect_anomaly:
         mode (bool): Flag whether to enable anomaly detection (``True``),
                      or disable (``False``).
         check_nan (bool): Flag whether to raise an error when the backward
-                          generate "nan"
+                          generates "nan"
 
     """
 

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -128,8 +128,8 @@ class profile:
             using the cudaEvent API. (will be deprecated)
 
         use_device (str, optional): Enables timing of device events.
-            Adds approximately 4us of overhead to each tensor operation when use cuda.
-            The valid devices options are 'cuda', 'xpu', 'mtia' and 'privateuseone'.
+            Adds approximately 4us of overhead to each tensor operation when using CUDA.
+            The valid device options are 'cuda', 'xpu', 'mtia' and 'privateuseone'.
 
         record_shapes (bool, optional): If shapes recording is set, information
             about input dimensions will be collected. This allows one to see which
@@ -179,7 +179,7 @@ class profile:
         overhead
 
     .. warning::
-        This context managers should not be called recursively, i.e. no nested
+        This context manager should not be called recursively, i.e. no nested
         instances are allowed
 
     .. warning::
@@ -926,7 +926,7 @@ class record_function(_ContextDecorator):
 
         Returns:
             A future that completes with the value of the passed in future when
-            the profiling callbacks have ran.
+            the profiling callbacks have run.
 
         """
         # Throw if we have already attached a callback onto the future.

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -254,7 +254,7 @@ const Tensor& resize_(
   }
 
   if (self._fw_grad(/* level */ 0).defined()) {
-    TORCH_CHECK(false, "cannot resize variables that has a forward grad");
+    TORCH_CHECK(false, "cannot resize variables that have a forward grad");
   }
 
   return self;
@@ -281,7 +281,7 @@ const Tensor& resize_as_(
 
   // Handle fw grad
   if (self._fw_grad(/* level */ 0).defined()) {
-    TORCH_CHECK(false, "cannot resize variables that has a forward grad");
+    TORCH_CHECK(false, "cannot resize variables that have a forward grad");
   }
 
   return self;

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -32,7 +32,7 @@ namespace torch::autograd {
 // This limit is based on the TSAN's deadlock detector, where it will
 // fail if a program hold more than 65 locks in one thread at once.
 // As we hold mutex in every of our custom C++ autograd Node, we would
-// like to avoid TSAN complains on this when doing reentrant backwards
+// like to avoid TSAN complaints on this when doing reentrant backwards
 // For reference, see https://github.com/google/sanitizers/issues/950
 static constexpr int MAX_DEPTH = 60;
 
@@ -161,7 +161,7 @@ struct TORCH_API Engine {
   // for the graph.
   //
   // NB: This API should only be used by internal autograd specific
-  // machinery and shouldn't be exposed to users in anyway.
+  // machinery and shouldn't be exposed to users in any way.
   virtual c10::intrusive_ptr<at::ivalue::Future> execute_with_graph_task(
       const std::shared_ptr<GraphTask>& graph_task,
       c10::intrusive_ptr<Node> graph_root,

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -112,7 +112,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
       case BackendType::CUSTOM:
         return "custom";
       default:
-        TORCH_CHECK(false, "THis should never happen!");
+        TORCH_CHECK(false, "This should never happen!");
     }
   }
 
@@ -217,7 +217,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
                     int64_t,
                     bool,
                     int64_t)>();
-    // It's awakward to unbox the opts here and box them again in the custom C++
+    // It's awkward to unbox the opts here and box them again in the custom C++
     // op. But it's also complicated to make opts as a CustomClassHolder. Leave
     // it as it is now.
     auto work = std::get<1>(op.call(

--- a/torch/csrc/jit/api/compilation_unit.h
+++ b/torch/csrc/jit/api/compilation_unit.h
@@ -330,7 +330,7 @@ struct TORCH_API CompilationUnit {
   mutable NameMangler mangler_;
 };
 
-// An owning pointer to a Function. Just a pair of a raw Function ptr and it's
+// An owning pointer to a Function. Just a pair of a raw Function ptr and its
 // owning CU. We need this because pybind requires a ref-counted way to refer to
 // Functions.
 struct StrongFunctionPtr {

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -346,7 +346,7 @@ struct TORCH_API Node {
   // place in the Node list of the Graph. The Graph itself is a circular
   // doubly-linked list. The Return Node is used as the sentinel for the
   // "beginning"/"end" of the list. This means that you can tell when
-  // you've traversed the entire list without means worrying about null
+  // you've traversed the entire list without worrying about null
   // pointers. `next_in_graph[0]` is the pointer to the next Node, while
   // `next_in_graph[1]` is the pointer to the previous Node. The
   // linked list is implemented as an array to allow the same iterator
@@ -498,7 +498,7 @@ struct TORCH_API Node {
         kind().toDisplayString(),
         "' which has ",
         inputs_.size(),
-        " outputs. You may consider using node.inputs() instead.");
+        " inputs. You may consider using node.inputs() instead.");
     return inputs_.at(0);
   }
   Value* output() {
@@ -528,7 +528,7 @@ struct TORCH_API Node {
         kind().toDisplayString(),
         "' which has ",
         inputs_.size(),
-        " outputs. You may consider using node.inputs() instead.");
+        " inputs. You may consider using node.inputs() instead.");
     return inputs_.at(0);
   }
   // Access a particular input.  This is a checked index.

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -967,7 +967,7 @@ class AttributePropagator {
   // Contains user specified methods to be preserved in frozen module.
   std::unordered_set<Function*> preservedMethods_;
 
-  // Contains user specified sub module to be preserve in frozen module.
+  // Contains user specified sub module to be preserved in frozen module.
   std::unordered_set<ModulePtr> preservedSubModule_;
 
   // Track all used attributes ivalues that can be aliased.
@@ -1012,7 +1012,7 @@ void checkModuleDoesNotReturnSelf(const Module& module) {
     for (auto& output : method.graph()->outputs()) {
       TORCH_CHECK(
           output->type() != module.type(),
-          "attempted to freeze a module that return itself");
+          "attempted to freeze a module that returns itself");
     }
   }
 }

--- a/torch/csrc/jit/passes/guard_elimination.cpp
+++ b/torch/csrc/jit/passes/guard_elimination.cpp
@@ -272,7 +272,7 @@ struct GuardElimination {
   // to compute any properties `isSummarized()` isn't amenable to guard
   // elimination.
   // Categories:
-  // * Functional-like(e.g. add, sub, le) operations with broadcast semenatics
+  // * Functional-like(e.g. add, sub, le) operations with broadcast semantics
   //   Guards can be removed if all inputs are guarded and `isSummarized()`
   //   returns
   //   false or inputs are `prim::Constant`

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -30,8 +30,8 @@ std::vector<std::optional<const Use>> gatherLastUses(
 // Values which do not have uses or which do not have a last use
 // outside of the subgraph to be merged into we do not need to track.
 struct ValueMapper {
-  // `to_merge` is the node we're merginginto a subgraph, `existing_subgraph` is
-  // the subgraph node that we're merging into if it exists
+  // `to_merge` is the node we're merging into a subgraph, `existing_subgraph`
+  // is the subgraph node that we're merging into if it exists
   ValueMapper(
       Node* to_merge,
       AliasDb& db,

--- a/torch/distributed/_tools/mod_tracker.py
+++ b/torch/distributed/_tools/mod_tracker.py
@@ -180,7 +180,7 @@ class ModTracker:
                 # pyrefly: ignore [bad-assignment]
                 warnings.formatwarning = custom_formatwarning
                 warnings.warn(
-                    "The module hierarchy tracking maybe be messed up."
+                    "The module hierarchy tracking may be messed up."
                     " Please file a bug to PyTorch, if it is the case.",
                     stacklevel=2,
                 )

--- a/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
+++ b/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
@@ -94,7 +94,7 @@ class ActivationWrapper(torch.nn.Module, ABC):
         *args: Any,
     ) -> None:
         """
-        ``_pre_state_dict_hook` is called before ``self._load_from_state_dict()`` is called.
+        ``_pre_state_dict_hook`` is called before ``self._load_from_state_dict()`` is called.
 
         For ``checkpoint_wrapper``, it will add back the module
         prefix so that non-checkpointed modules can be loaded into

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -207,7 +207,7 @@ class PowerSGDState:
 
         self.process_group = process_group
         self.matrix_approximation_rank = matrix_approximation_rank
-        # Deferring PowerSGD compression util step 'start_powerSGD_iter' can have two advantages:
+        # Deferring PowerSGD compression until step 'start_powerSGD_iter' can have two advantages:
         # 1) It turns out that PowerSGD may lead to a non-trivial accuracy loss,
         # even if the matrix approximation rank is increased to a large value.
         # To mitigate the accuracy loss, a simple yet effective way is mixing vanilla allreduce

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -582,7 +582,7 @@ class _ConfigAutoWrap:
     def enable_autowrap_context(kwargs: Any) -> None:
         if _ConfigAutoWrap.in_autowrap_context:
             raise NotImplementedError(
-                "You are already within an autowrap context and we currently do not supported nested autowrap."
+                "You are already within an autowrap context and we currently do not support nested autowrap."
             )
         _ConfigAutoWrap.in_autowrap_context = True
         # Get and save the wrapper cls for the context.

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -2888,7 +2888,7 @@ class ScheduleInterleaved1F1B(_PipelineScheduleRuntime):
     (also called "depth first").
 
     This schedule is mostly similar to the original paper.
-    It differs by being relaxing the requirement of num_microbatch % pp_size == 0.
+    It differs by relaxing the requirement of num_microbatch % pp_size == 0.
     Using the flex_pp schedule, we will have num_rounds = max(1, n_microbatches // pp_group_size) and
     it works as long as n_microbatches % num_rounds is 0. As a few examples, support
 

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -64,7 +64,7 @@ logger = logging.getLogger(__name__)
 
 # NB: Ignoring RRef leaks during shutdown. Without this, applications have to
 # make sure there is no references to any RRef in the application code and
-# Python GC has done its job to delete those RRefs. This is could result in bad
+# Python GC has done its job to delete those RRefs. This could result in bad
 # debugging experiences especially when for large applications. Therefore, by
 # default, we are going to ignore RRef leaks during shutdown. This is usually
 # fine as shutdown means applications have done training and no longer care
@@ -239,7 +239,7 @@ def _all_gather(obj, worker_names=None, timeout: float = UNSET_RPC_TIMEOUT):
         # Signal and RPC timeout use the same timeout
         signal_timeout = rpc_timeout = timeout
 
-    # Phase 1: Followers send it's object to the leader
+    # Phase 1: Followers send its object to the leader
     if is_leader:
         _gather_to_leader(sequence_id, self_name, obj, worker_names)
     else:
@@ -432,7 +432,7 @@ def get_worker_info(worker_name=None):
     expensive string on every invocation.
 
     Args:
-        worker_name (str): the string name of a worker. If ``None``, return the
+        worker_name (str): the string name of a worker. If ``None``, return
                            the id of the current worker. (default ``None``)
 
     Returns:

--- a/torch/distributed/rpc/functions.py
+++ b/torch/distributed/rpc/functions.py
@@ -139,7 +139,7 @@ def async_execution(fn):
         >>> )
         >>> print(ret)  # prints tensor([4., 4.])
 
-        This decorator also works with RRef helpers, i.e., .
+        This decorator also works with RRef helpers, i.e.,
         :meth:`torch.distributed.rpc.RRef.rpc_sync`,
         :meth:`torch.distributed.rpc.RRef.rpc_async`, and
         :meth:`torch.distributed.rpc.RRef.remote`.

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -437,7 +437,7 @@ class _Constraint(_ConstraintTarget):
     @property
     def serializable_spec(self):
         # We need a serialization compatible format of the constraint so that it
-        # can be savedin the graph module w/o breaking the module serialization.
+        # can be saved in the graph module w/o breaking the module serialization.
         # The saved constraints will be used directly for the post-exporting pass
         # that converts constraints to runtime assertion. The saved constraints
         # will not be saved in the serialized module.

--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -50,7 +50,7 @@ class SyncBatchNorm(Function):
         else:
             # for empty input, set stats and the count to zero. The stats with
             # zero count will be filtered out later when computing global mean
-            # & invstd, but they still needs to participate the all_gather
+            # & invstd, but they still need to participate in the all_gather
             # collective communication to unblock other peer processes.
             combined = torch.zeros(
                 2 * num_channels + 1, dtype=input.dtype, device=input.device

--- a/torch/nn/utils/_expanded_weights/conv_utils.py
+++ b/torch/nn/utils/_expanded_weights/conv_utils.py
@@ -301,7 +301,7 @@ def unfold3d(
     dilation,
 ):
     r"""
-    Extract sliding local blocks from an batched input tensor.
+    Extract sliding local blocks from a batched input tensor.
 
     :class:`torch.nn.Unfold` only supports 4D inputs (batched image-like tensors).
     This method implements the same action for 5D inputs
@@ -324,7 +324,7 @@ def unfold3d(
 
     if len(tensor.shape) != 5:
         raise ValueError(
-            f"Input tensor must be of the shape [B, C, D, H, W]. Got{tensor.shape}"
+            f"Input tensor must be of the shape [B, C, D, H, W]. Got {tensor.shape}"
         )
 
     if dilation != (1, 1, 1):

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -399,7 +399,7 @@ def _inject_property(module: Module, tensor_name: str) -> None:
 
     Args:
         module (nn.Module): module into which to inject the property
-        tensor_name (str): name of the name of the property to create
+        tensor_name (str): name of the property to create
     """
     # We check the precondition.
     # This should never fire if register_parametrization is correctly implemented
@@ -759,9 +759,9 @@ def remove_parametrizations(
                         raise RuntimeError(
                             "Calling remove_parametrizations() with leave_parametrized=True "
                             "for a parameter that is an instance of a tensor subclass requires "
-                            "set_() to be implemented correctly for the tensor subclass."
-                            "Alternatively, one can opt into the swap_tensors path"
-                            "Either set leave_parametrized=False or provide a working implementation"
+                            "set_() to be implemented correctly for the tensor subclass. "
+                            "Alternatively, one can opt into the swap_tensors path. "
+                            "Either set leave_parametrized=False or provide a working implementation "
                             "for set_() in the tensor subclass or set "
                             "torch.__future__.set_swap_module_params_on_conversion(True)."
                         ) from e

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -57,7 +57,7 @@ class PackedSequence(PackedSequence_):
             information about the batch size at each sequence step
         sorted_indices (Tensor, optional): Tensor of integers holding how this
             :class:`PackedSequence` is constructed from sequences.
-        unsorted_indices (Tensor, optional): Tensor of integers holding how this
+        unsorted_indices (Tensor, optional): Tensor of integers holding how
             to recover the original sequences with correct order.
 
     .. note::

--- a/torch/testing/_internal/hypothesis_utils.py
+++ b/torch/testing/_internal/hypothesis_utils.py
@@ -251,7 +251,7 @@ def per_channel_tensor(draw, shapes=None, elements=None, qparams=None):
     return X, (scale, zp, axis, qparams[2])
 
 """Strategy for generating test cases for tensors used in Conv.
-The resulting tensors is in float32 format.
+The resulting tensors are in float32 format.
 
 Args:
     spatial_dim: Spatial Dim for feature maps. If given as an iterable, randomly
@@ -275,7 +275,7 @@ Args:
              Could be either a single strategy (used for all) or a list of
              three strategies for X, w, b.
 Generates:
-    (X, W, b, g): Tensors of type `float32` of the following drawen shapes:
+    (X, W, b, g): Tensors of type `float32` of the following drawn shapes:
         X: (`batch_size, input_channels, H, W`)
         W: (`output_channels, input_channels_per_group) + kernel_shape
         b: `(output_channels,)`

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -342,7 +342,7 @@ def noop_context_fn():
 
 # Note: [torch.compile and checkpoint]
 # TorchDynamo does not step inside utils.checkpoint function.  The flow
-# looks likes this
+# looks like this
 #  1) TorchDynamo tries to wrap utils.checkpoint in a HigherOrderOp by
 #     speculatively checking if the forward function is safe to trace.
 #  2) If yes, then Dynamo-generated Fx graph has the wrapped higher
@@ -551,12 +551,12 @@ def checkpoint_sequential(functions, segments, input, use_reentrant=None, **kwar
     .. warning::
         The ``use_reentrant`` parameter should be passed explicitly. In version
         2.9 we will raise an exception if ``use_reentrant`` is not passed.
-        If you are using the ``use_reentrant=True` variant, please see
+        If you are using the ``use_reentrant=True`` variant, please see
         :func:`~torch.utils.checkpoint.checkpoint` for
         the important considerations and limitations of this variant. It is
         recommended that you use ``use_reentrant=False``.
 
-    .. warning:
+    .. warning::
         Since PyTorch 1.4, it allows only one Tensor as the input and
         intermediate outputs, just like :class:`torch.nn.Sequential`.
 
@@ -980,8 +980,8 @@ Operations executed during recomputation:
  ERROR: Detected non-determinism while running activation checkpointing
 
  You are seeing this error because you passed `debug=True` to checkpoint and
- tensors to be saved during the original forward and differ between those saved
- during recomputation. This can happen if different operators were ran in the
+ tensors saved during the original forward differ from those saved
+ during recomputation. This can happen if different operators were run in the
  original forward and in the recomputation.
 
  To identify where the mismatch may be coming from, you can do the following:

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -34,7 +34,7 @@ class Sampler(Generic[_T_co]):
 
     Example:
         >>> # xdoctest: +SKIP
-        >>> class AccedingSequenceLengthSampler(Sampler[int]):
+        >>> class AscendingSequenceLengthSampler(Sampler[int]):
         >>>     def __init__(self, data: List[str]) -> None:
         >>>         self.data = data
         >>>
@@ -45,7 +45,7 @@ class Sampler(Generic[_T_co]):
         >>>         sizes = torch.tensor([len(x) for x in self.data])
         >>>         yield from torch.argsort(sizes).tolist()
         >>>
-        >>> class AccedingSequenceLengthBatchSampler(Sampler[List[int]]):
+        >>> class AscendingSequenceLengthBatchSampler(Sampler[List[int]]):
         >>>     def __init__(self, data: List[str], batch_size: int) -> None:
         >>>         self.data = data
         >>>         self.batch_size = batch_size

--- a/torch/utils/mobile_optimizer.py
+++ b/torch/utils/mobile_optimizer.py
@@ -104,7 +104,7 @@ def generate_mobile_module_lints(script_module: torch.jit.ScriptModule):
         if "dropout" in op_name:
             lint_list.append({"name": LintCode.DROPOUT.name,
                               "message": f"Operator {op_name} exists, remember to call eval() before "
-                              "saving the module.and call torch.utils.mobile_optimizer.optimize_for_mobile to drop dropout "
+                              "saving the module, and call torch.utils.mobile_optimizer.optimize_for_mobile to drop dropout "
                               "operator."})
         if "batch_norm" in op_name:
             lint_list.append({"name": LintCode.BATCHNORM.name,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185668

Correct spelling mistakes in comments and docstrings across dynamo,
inductor, autograd, distributed, JIT, nn, and utility modules. These
are comment-only changes with no functional impact.

Authored with Claude (typo_terminator2).

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98