### PR TITLE
[activation_checkpointing] Per-region memory_budget via fx_traceback.annotate (#185672)

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2379,6 +2379,114 @@ sum_1: aten.sum.default -> PREFER_RECOMPUTE
 cos: aten.cos.default -> PREFER_RECOMPUTE""",
         )
 
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    def test_memory_budget_annotation_reduces_act_mem(self):
+        import torch.fx.traceback as fx_traceback
+
+        N, NUM_LAYERS = 1000, 4
+
+        class Model(torch.nn.Module):
+            def __init__(self, budget=None):
+                super().__init__()
+                self.budget = budget
+                self.linears = torch.nn.ModuleList(
+                    [torch.nn.Linear(N, N) for _ in range(NUM_LAYERS)]
+                )
+
+            def forward(self, x):
+                for linear in self.linears:
+                    if self.budget is not None:
+                        with fx_traceback.annotate({"memory_budget": self.budget}):
+                            x = linear(x).relu()
+                    else:
+                        x = linear(x).relu()
+                return x.sum()
+
+        def get_act_mem(f):
+            out = f()
+            out.backward()
+            start_mem = torch.cuda.memory_stats()["requested_bytes.all.current"]
+            out = f()
+            act_mem = (
+                torch.cuda.memory_stats()["requested_bytes.all.current"] - start_mem
+            )
+            out.backward()
+            return act_mem
+
+        x = torch.randn(N, N, device="cuda")
+
+        torch._dynamo.reset()
+        compiled = torch.compile(Model().cuda(), backend="aot_eager")
+        self.assertGreater(get_act_mem(lambda: compiled(x)), 0)
+
+        torch._dynamo.reset()
+        compiled = torch.compile(Model(budget=0.0).cuda(), backend="aot_eager")
+        self.assertEqual(get_act_mem(lambda: compiled(x)), 0)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    def test_memory_budget_annotation_per_region(self):
+        """Different regions can have different memory budgets across graph breaks."""
+        import torch.fx.traceback as fx_traceback
+
+        N, NUM_LAYERS = 1000, 2
+
+        class Model(torch.nn.Module):
+            def __init__(self, budget_a, budget_b):
+                super().__init__()
+                self.budget_a = budget_a
+                self.budget_b = budget_b
+                self.linears_a = torch.nn.ModuleList(
+                    [torch.nn.Linear(N, N) for _ in range(NUM_LAYERS)]
+                )
+                self.linears_b = torch.nn.ModuleList(
+                    [torch.nn.Linear(N, N) for _ in range(NUM_LAYERS)]
+                )
+
+            def forward(self, x):
+                with fx_traceback.annotate({"memory_budget": self.budget_a}):
+                    for linear in self.linears_a:
+                        x = linear(x).relu()
+                torch._dynamo.graph_break()
+                with fx_traceback.annotate({"memory_budget": self.budget_b}):
+                    for linear in self.linears_b:
+                        x = linear(x).relu()
+                return x.sum()
+
+        def get_act_mem(f):
+            out = f()
+            out.backward()
+            start_mem = torch.cuda.memory_stats()["requested_bytes.all.current"]
+            out = f()
+            act_mem = (
+                torch.cuda.memory_stats()["requested_bytes.all.current"] - start_mem
+            )
+            out.backward()
+            return act_mem
+
+        x = torch.randn(N, N, device="cuda")
+
+        torch._dynamo.reset()
+        both_save = torch.compile(Model(1.0, 1.0).cuda(), backend="aot_eager")
+        mem_both_save = get_act_mem(lambda: both_save(x))
+
+        torch._dynamo.reset()
+        a_recomp = torch.compile(Model(0.0, 1.0).cuda(), backend="aot_eager")
+        mem_a_recomp = get_act_mem(lambda: a_recomp(x))
+
+        torch._dynamo.reset()
+        b_recomp = torch.compile(Model(1.0, 0.0).cuda(), backend="aot_eager")
+        mem_b_recomp = get_act_mem(lambda: b_recomp(x))
+
+        torch._dynamo.reset()
+        both_recomp = torch.compile(Model(0.0, 0.0).cuda(), backend="aot_eager")
+        mem_both_recomp = get_act_mem(lambda: both_recomp(x))
+
+        # Both save > either one recomputing > both recomputing
+        self.assertGreater(mem_both_save, mem_a_recomp)
+        self.assertGreater(mem_both_save, mem_b_recomp)
+        self.assertGreater(mem_a_recomp, mem_both_recomp)
+        self.assertGreater(mem_b_recomp, mem_both_recomp)
+
 
 class RematerializeACNodesPassTests(torch._dynamo.test_case.TestCase):
     """Tests for AC reordering optimization in full graph (forward+backward in one graph)."""

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -2675,6 +2675,98 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)
     @functorch_config.patch({"enable_autograd_cache": True})
+    def test_custom_memory_budget_annotation_causes_cache_miss(self):
+        """Changing per-region memory_budget set via fx_traceback.annotate
+        invalidates the AOTAutograd cache."""
+        import torch.fx.traceback as fx_traceback
+
+        def make_fn(budget):
+            def fn(x, y):
+                with fx_traceback.annotate({"memory_budget": budget}):
+                    return (torch.mm(x, y) + 1).relu()
+
+            return fn
+
+        with fresh_cache():
+            compiled_fn1 = torch.compile(make_fn(0.3), backend="inductor")
+            x1 = torch.randn(10, 10, requires_grad=True)
+            y1 = torch.randn(10, 10, requires_grad=True)
+            compiled_fn1(x1, y1).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            self._clear_dynamo_and_codecache()
+
+            compiled_fn2 = torch.compile(make_fn(0.8), backend="inductor")
+            x2 = torch.randn(10, 10, requires_grad=True)
+            y2 = torch.randn(10, 10, requires_grad=True)
+            compiled_fn2(x2, y2).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            self._clear_dynamo_and_codecache()
+
+            # Same budget as the first compile -> cache hit.
+            compiled_fn3 = torch.compile(make_fn(0.3), backend="inductor")
+            x3 = torch.randn(10, 10, requires_grad=True)
+            y3 = torch.randn(10, 10, requires_grad=True)
+            compiled_fn3(x3, y3).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_custom_memory_budget_annotation_graph_break_cache(self):
+        """With graph breaks, changing one region's budget causes a miss for
+        that region but a hit for the unchanged region."""
+        import torch.fx.traceback as fx_traceback
+
+        def make_fn(budget_a, budget_b):
+            def fn(x):
+                with fx_traceback.annotate({"memory_budget": budget_a}):
+                    x = (x + 1).relu()
+                torch._dynamo.graph_break()
+                with fx_traceback.annotate({"memory_budget": budget_b}):
+                    return (x * 2).relu()
+
+            return fn
+
+        with fresh_cache():
+            # First run: (0.3, 0.5) -> 2 misses (one per region)
+            compiled = torch.compile(make_fn(0.3, 0.5), backend="inductor")
+            x = torch.randn(10, 10, requires_grad=True)
+            compiled(x).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            self._clear_dynamo_and_codecache()
+
+            # Change only region B: (0.3, 0.8) -> 1 hit (A), 1 miss (B)
+            compiled = torch.compile(make_fn(0.3, 0.8), backend="inductor")
+            x = torch.randn(10, 10, requires_grad=True)
+            compiled(x).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 3)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+            self._clear_dynamo_and_codecache()
+
+            # Change only region A: (0.7, 0.8) -> 1 miss (A), 1 hit (B)
+            compiled = torch.compile(make_fn(0.7, 0.8), backend="inductor")
+            x = torch.randn(10, 10, requires_grad=True)
+            compiled(x).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 4)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 2)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
     @functorch_config.patch({"activation_memory_budget": 0.5})
     def test_different_custom_estimator_uuids_cause_cache_miss(self):
         """Test that different uuid values cause cache miss."""

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -510,6 +510,27 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
         )
         self.sac_context_fn_hashes = _collect_context_fn_hashes(gm)
 
+        # node.meta["custom"] is populated by fx_traceback.annotate(...) and is
+        # stripped by GraphModule.__reduce__, so per-node memory_budget values
+        # set via annotate({"memory_budget": ...}) would be invisible to the
+        # cache key. Extract them explicitly so that changing per-region budgets
+        # correctly invalidates the cache. Recurse into nested GraphModules
+        # (e.g. invoke_subgraph / SAC HOP bodies) and fold the owning module's
+        # qualified name into the key so per-module node indices stay distinct.
+        self.custom_memory_budget_per_node: list[tuple[str, int, float]] = []
+        for module_name, module in gm.named_modules():
+            if not isinstance(module, torch.fx.GraphModule):
+                continue
+            for i, node in enumerate(module.graph.nodes):
+                custom = node.meta.get("custom")
+                if not isinstance(custom, dict):
+                    continue
+                budget = custom.get("memory_budget")
+                if isinstance(budget, (int, float)):
+                    self.custom_memory_budget_per_node.append(
+                        (module_name, i, float(budget))
+                    )
+
         # Note: We use the live config module, not self.autograd_config (the
         # saved config), because activation_memory_budget_runtime_estimator and
         # activation_memory_budget_solver are excluded from save_config (in

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -3791,11 +3791,42 @@ def min_cut_rematerialization_partition(
             for user in node.users:
                 node.dist_from_bw = min(node.dist_from_bw, user.dist_from_bw + 1)
 
+    # Per-region memory_budget override resolution. Two reader paths:
+    #   - Legacy: node.meta["memory_budget"], populated by the
+    #     `MemoryBudgetMode` / `set_memory_budget` allow_in_graph marker.
+    #     First matching node wins (preserves prior behavior).
+    #   - Custom: node.meta["custom"]["memory_budget"], populated by
+    #     `fx_traceback.annotate({"memory_budget": ...})` and propagated to all
+    #     FX nodes via _COPY_META_FIELDS["custom"]. The annotate path is the
+    #     supported replacement -- its contextmanager `finally:` restores
+    #     `current_meta` on every exit path, so it cannot leak across compiles
+    #     the way the legacy marker did (no-op __exit__ under Dynamo). A joint
+    #     graph is partitioned with a single budget, so all annotated nodes in
+    #     the graph must agree; disagreement means the caller put mutually
+    #     exclusive budgets in the same region (across a graph break each
+    #     region becomes its own joint graph and is resolved independently).
+    # Custom overrides legacy when both are set.
     memory_budget = config.activation_memory_budget
+
     for node in joint_graph.nodes:
-        if isinstance(node.meta.get("memory_budget", None), float):
-            memory_budget = node.meta["memory_budget"]
+        if isinstance(node.meta.get("memory_budget", None), (int, float)):
+            memory_budget = float(node.meta["memory_budget"])
             break
+
+    custom_budgets = OrderedSet(
+        float(node.meta["custom"]["memory_budget"])
+        for node in joint_graph.nodes
+        if isinstance(node.meta.get("custom", {}).get("memory_budget"), (int, float))
+    )
+    if len(custom_budgets) > 1:
+        raise RuntimeError(
+            f"Conflicting fx_traceback.annotate memory_budget values within a "
+            f"single joint graph: {sorted(custom_budgets)}. A joint graph is "
+            f"partitioned with a single budget; use a graph break to separate "
+            f"regions that need different budgets."
+        )
+    if custom_budgets:
+        memory_budget = next(iter(custom_budgets))
     saved_values = choose_saved_values_set(
         joint_graph,
         node_info,


### PR DESCRIPTION
Summary:

Adds a per-region activation `memory_budget` override driven by `fx_traceback.annotate`, plus the AOTAutograd cache plumbing to make it cacheable.

Motivation: `config.activation_memory_budget` is a single global knob applied to every recomputation decision in the graph, but models often want different aggressiveness in different regions (e.g. recompute cheap matmul-only blocks aggressively while preserving expensive attention activations). The legacy per-node knob, `node.meta["memory_budget"]` set by the `MemoryBudgetMode` / `set_memory_budget` allow_in_graph marker, has a no-op `__exit__` under Dynamo and could leak across compiles. `fx_traceback.annotate` is the supported replacement: it is a regular `contextmanager`, so its `finally:` restores `current_meta` on every exit path (success, exception, graph break), keeping the annotation scoped to its region.

Usage: wrap a forward region with `with torch.fx.traceback.annotate({"memory_budget": value}):`. All annotated nodes within a single joint graph must agree on the budget; cross-region overrides require a graph break, after which each region becomes its own joint graph and is resolved independently.

Partitioner: the AOT min-cut partitioner gains a reader for `node.meta["custom"]["memory_budget"]` (accepts `int` or `float`). It collects the set of annotated values across the joint graph; a single value overrides `config.activation_memory_budget` for that partition, while disagreement raises `RuntimeError` rather than silently picking one. The existing legacy `node.meta["memory_budget"]` reader is unchanged (first matching node wins); custom overrides legacy when both are set. No further plumbing is required because `fx_traceback.annotate` writes into `current_meta["custom"]` and `_COPY_META_FIELDS["custom"]` (already upstream) propagates that onto every FX node produced inside the annotated forward.

Cache key: `AOTAutogradCacheDetails` walks all nested `GraphModule`s under `gm` (matching the recursion used by `_collect_context_fn_hashes` / `get_triton_source_codes_from_gm`) and collects `(module_qualname, node_index, float(budget))` from `node.meta["custom"]["memory_budget"]` into `custom_memory_budget_per_node`. This is required because `GraphModule.__reduce__` strips `node.meta` during pickling, so the annotation would otherwise be invisible to the cache key -- recompiling the same model with a different annotated budget would silently return a stale cached compile. Recursing handles annotations inside HOP bodies (e.g. `invoke_subgraph`, SAC) and the qualified name keeps per-module node indices distinct.

No-op for graphs that do not set `node.meta["custom"]["memory_budget"]`.

Test Plan:
```
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/dynamo:test_aot_autograd_cache -- test_custom_memory_budget_annotation_causes_cache_miss test_custom_memory_budget_annotation_graph_break_cache
buck2 test fbcode//mode/dev fbcode//caffe2/test/dynamo:test_activation_checkpointing -- test_memory_budget_annotation_reduces_act_mem test_memory_budget_annotation_per_region
```

Cache tests: `test_custom_memory_budget_annotation_causes_cache_miss` compiles three times inside one `fresh_cache()` (0.3 -> miss, 0.8 -> miss, 0.3 -> hit). `test_custom_memory_budget_annotation_graph_break_cache` uses two `fx_traceback.annotate` regions separated by a `graph_break`; changing only one region produces one hit + one miss, verifying the qualified-name-keyed per-region invalidation.

E2E memory tests (CUDA): `test_memory_budget_annotation_reduces_act_mem` confirms `budget=0.0` drops measured activation memory to zero on a 4-layer linear stack. `test_memory_budget_annotation_per_region` runs a 2-region model under all four `{save, recompute}` combinations and asserts the expected ordering `both_save > one_recompute > both_recompute`.

Partitioner reader is exercised by all of the above.

Differential Revision: D106863375


