### PR TITLE
[benchmarks/dynamo] Enable `emulate_precision_casts` for `vit_base_patch14_dinov2.lvd142m`

### DIFF
--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -143,6 +143,11 @@ class TimmRunner(BenchmarkRunner):
     def __init__(self):
         super().__init__()
         self.suite_name = "timm_models"
+        # Sentinel; captured lazily on first load_model call (which runs
+        # AFTER main() in common.py has applied any --inductor-config CLI
+        # overrides). Capturing eagerly here would always see the unmodified
+        # default and silently override the user-specified value.
+        self._orig_emulate_precision_casts = None
 
     @property
     def _config(self):
@@ -170,7 +175,7 @@ class TimmRunner(BenchmarkRunner):
 
     @property
     def _emulate_precision_casts(self):
-        return self._config.get("emulate_precision_casts", [])
+        return self._config["emulate_precision_casts"]
 
     @property
     def skip_models_for_cpu(self):
@@ -281,33 +286,29 @@ class TimmRunner(BenchmarkRunner):
         if model_name in self._config["scaled_compute_loss"]:
             self.compute_loss = self.scaled_compute_loss
 
-        if model_name in self._emulate_precision_casts:
-            # See yaml note for emulate_precision_casts. This preserves the
-            # bf16/fp16 downcast-upcast pairs that inductor would otherwise
-            # elide when fusing across mixed-precision boundaries (e.g.
-            # bf16 conv-bias-add fused into an fp32 cat-prep store), which
-            # is what eager autocast actually does.
-            #
-            # Restoration: the harness has no per-model teardown hook, so we
-            # capture the original value once and restore at process exit via
-            # atexit. This keeps process state clean across repeated harness
-            # invocations / debugger sessions. Within a single process running
-            # multiple models, the flag carries across iterations (same
-            # convention as scaled_compute_loss above) - benign for CI which
-            # uses --only <model> per process.
-            inductor_config = torch._inductor.config
-            if not hasattr(self, "_orig_emulate_precision_casts"):
-                import atexit
-
-                self._orig_emulate_precision_casts = (
-                    inductor_config.emulate_precision_casts
-                )
-                atexit.register(
-                    lambda v=self._orig_emulate_precision_casts: setattr(
-                        inductor_config, "emulate_precision_casts", v
-                    )
-                )
-            inductor_config.emulate_precision_casts = True
+        # See yaml note for emulate_precision_casts. This preserves the
+        # bf16/fp16 downcast-upcast pairs that inductor would otherwise
+        # elide when fusing across mixed-precision boundaries (e.g.
+        # bf16 conv-bias-add fused into an fp32 cat-prep store), which
+        # is what eager autocast actually does.
+        #
+        # Baseline is captured on the FIRST load_model call so that any
+        # --inductor-config emulate_precision_casts=... CLI override (applied
+        # by main() in common.py between __init__ and this point) is included
+        # in the baseline. Per-call assignment then sets the flag to
+        # (baseline OR model-in-yaml-list), which both preserves the user
+        # override across every model and toggles the flag back to baseline
+        # for non-listed models (no carry-over across iter_models).
+        if self._orig_emulate_precision_casts is None:
+            self._orig_emulate_precision_casts = (
+                torch._inductor.config.emulate_precision_casts
+            )
+        if self._orig_emulate_precision_casts:
+            torch._inductor.config.emulate_precision_casts = True
+        else:
+            torch._inductor.config.emulate_precision_casts = (
+                model_name in self._emulate_precision_casts
+            )
 
         if is_training and not use_eval_mode:
             model.train()

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -287,10 +287,10 @@ class TimmRunner(BenchmarkRunner):
             self.compute_loss = self.scaled_compute_loss
 
         # See yaml note for emulate_precision_casts. This preserves the
-        # bf16/fp16 downcast-upcast pairs that inductor would otherwise
-        # elide when fusing across mixed-precision boundaries (e.g.
-        # bf16 conv-bias-add fused into an fp32 cat-prep store), which
-        # is what eager autocast actually does.
+        # bf16 downcast-upcast pairs (fp16 untested) that inductor would
+        # otherwise elide when fusing across mixed-precision boundaries
+        # (e.g. bf16 conv-bias-add fused into an fp32 cat-prep store),
+        # which is what eager autocast actually does.
         #
         # Baseline is captured on the FIRST load_model call so that any
         # --inductor-config emulate_precision_casts=... CLI override (applied

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -287,7 +287,27 @@ class TimmRunner(BenchmarkRunner):
             # elide when fusing across mixed-precision boundaries (e.g.
             # bf16 conv-bias-add fused into an fp32 cat-prep store), which
             # is what eager autocast actually does.
-            torch._inductor.config.emulate_precision_casts = True
+            #
+            # Restoration: the harness has no per-model teardown hook, so we
+            # capture the original value once and restore at process exit via
+            # atexit. This keeps process state clean across repeated harness
+            # invocations / debugger sessions. Within a single process running
+            # multiple models, the flag carries across iterations (same
+            # convention as scaled_compute_loss above) - benign for CI which
+            # uses --only <model> per process.
+            inductor_config = torch._inductor.config
+            if not hasattr(self, "_orig_emulate_precision_casts"):
+                import atexit
+
+                self._orig_emulate_precision_casts = (
+                    inductor_config.emulate_precision_casts
+                )
+                atexit.register(
+                    lambda v=self._orig_emulate_precision_casts: setattr(
+                        inductor_config, "emulate_precision_casts", v
+                    )
+                )
+            inductor_config.emulate_precision_casts = True
 
         if is_training and not use_eval_mode:
             model.train()

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -169,6 +169,10 @@ class TimmRunner(BenchmarkRunner):
         return self._config["require_larger_multiplier_for_smaller_tensor"]
 
     @property
+    def _emulate_precision_casts(self):
+        return self._config.get("emulate_precision_casts", [])
+
+    @property
     def skip_models_for_cpu(self):
         return self._skip["device"]["cpu"]
 
@@ -276,6 +280,14 @@ class TimmRunner(BenchmarkRunner):
 
         if model_name in self._config["scaled_compute_loss"]:
             self.compute_loss = self.scaled_compute_loss
+
+        if model_name in self._emulate_precision_casts:
+            # See yaml note for emulate_precision_casts. This preserves the
+            # bf16/fp16 downcast-upcast pairs that inductor would otherwise
+            # elide when fusing across mixed-precision boundaries (e.g.
+            # bf16 conv-bias-add fused into an fp32 cat-prep store), which
+            # is what eager autocast actually does.
+            torch._inductor.config.emulate_precision_casts = True
 
         if is_training and not use_eval_mode:
             model.train()

--- a/benchmarks/dynamo/timm_models.yaml
+++ b/benchmarks/dynamo/timm_models.yaml
@@ -64,11 +64,11 @@ require_larger_multiplier_for_smaller_tensor:
 
 
 # Models that need torch._inductor.config.emulate_precision_casts=True to match
-# eager bf16/fp16 rounding semantics. Without this, inductor pointwise fusion
-# can elide a bf16 round-trip that eager performs (e.g. conv-bias-add fused
-# across a bf16->fp32 cat boundary), producing a ~1 bf16 ULP forward divergence
-# that amplifies through gradients in models with very small natural gradient
-# magnitudes (e.g. LayerScale init=1e-5).
+# eager bf16 rounding semantics (fp16 untested). Without this, inductor
+# pointwise fusion can elide a bf16 round-trip that eager performs (e.g.
+# conv-bias-add fused across a bf16->fp32 cat boundary), producing a ~1 bf16
+# ULP forward divergence that amplifies through gradients in models with very
+# small natural gradient magnitudes (e.g. LayerScale init=1e-5).
 emulate_precision_casts:
   - vit_base_patch14_dinov2.lvd142m
 

--- a/benchmarks/dynamo/timm_models.yaml
+++ b/benchmarks/dynamo/timm_models.yaml
@@ -63,6 +63,16 @@ require_larger_multiplier_for_smaller_tensor:
   - vit_base_patch14_dinov2.lvd142m
 
 
+# Models that need torch._inductor.config.emulate_precision_casts=True to match
+# eager bf16/fp16 rounding semantics. Without this, inductor pointwise fusion
+# can elide a bf16 round-trip that eager performs (e.g. conv-bias-add fused
+# across a bf16->fp32 cat boundary), producing a ~1 bf16 ULP forward divergence
+# that amplifies through gradients in models with very small natural gradient
+# magnitudes (e.g. LayerScale init=1e-5).
+emulate_precision_casts:
+  - vit_base_patch14_dinov2.lvd142m
+
+
 dtype:
   force_amp_for_fp16_bf16_models: []
 

--- a/test/inductor/test_timm_emulate_precision_casts.py
+++ b/test/inductor/test_timm_emulate_precision_casts.py
@@ -36,7 +36,7 @@ class TimmEmulatePrecisionCastsTest(TestCase):
         try:
             import timm  # noqa: F401
         except ImportError:
-            raise unittest.SkipTest("timm not installed")
+            raise unittest.SkipTest("timm not installed") from None
         sys.path.insert(0, str(BENCHMARKS_DYNAMO))
         from timm_models import TimmRunner
 

--- a/test/inductor/test_timm_emulate_precision_casts.py
+++ b/test/inductor/test_timm_emulate_precision_casts.py
@@ -1,0 +1,104 @@
+# Owner(s): ["module: inductor"]
+"""Regression test for benchmarks/dynamo/timm_models.py emulate_precision_casts.
+
+Guards against two bugs:
+  1. The flag leaking across iter_models iterations (a listed model flipped
+     it on; later non-listed models silently ran with it on).
+  2. The captured baseline being read before main() applied
+     `--inductor-config emulate_precision_casts=...` overrides, which would
+     clobber a user-specified True.
+"""
+
+import argparse
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+import torch
+import torch._inductor.config as inductor_config
+from torch._inductor.test_case import run_tests, TestCase
+
+
+BENCHMARKS_DYNAMO = (
+    pathlib.Path(__file__).resolve().parent.parent.parent / "benchmarks" / "dynamo"
+)
+
+
+@unittest.skipUnless(BENCHMARKS_DYNAMO.is_dir(), "benchmarks/dynamo not present")
+class TimmEmulatePrecisionCastsTest(TestCase):
+    LISTED = "vit_base_patch14_dinov2.lvd142m"
+    UNLISTED = "vit_base_patch16_siglip_256"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        try:
+            import timm  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("timm not installed")
+        sys.path.insert(0, str(BENCHMARKS_DYNAMO))
+        from timm_models import TimmRunner
+
+        cls.TimmRunner = TimmRunner
+
+    def setUp(self):
+        super().setUp()
+        self._orig_flag = inductor_config.emulate_precision_casts
+        import timm
+
+        stub = lambda self, name: timm.create_model(  # noqa: E731
+            "vit_tiny_patch16_224", pretrained=False, num_classes=10
+        )
+        self._patches = [
+            mock.patch.object(self.TimmRunner, "_download_model", stub),
+            mock.patch.object(self.TimmRunner, "validate_model", lambda *a, **k: None),
+        ]
+        for p in self._patches:
+            p.start()
+        ns = argparse.Namespace(
+            training=False,
+            use_eval_mode=True,
+            channels_last=False,
+            enable_activation_checkpointing=False,
+            amp=False,
+        )
+        self.runner = self.TimmRunner()
+        self.runner._args = self.runner.args = ns
+
+    def tearDown(self):
+        inductor_config.emulate_precision_casts = self._orig_flag
+        for p in self._patches:
+            p.stop()
+        super().tearDown()
+
+    def _load(self, name):
+        # load_model may fail late (stub model vs. real input shape); the
+        # flag assignment happens before any such failure.
+        try:
+            self.runner.load_model(torch.device("cpu"), name)
+        except Exception:
+            pass
+
+    def test_flag_toggles_per_model_no_carryover(self):
+        """Listed model flips flag True; subsequent unlisted model resets it."""
+        inductor_config.emulate_precision_casts = False
+        self._load(self.LISTED)
+        self.assertTrue(inductor_config.emulate_precision_casts)
+        self._load(self.UNLISTED)
+        self.assertFalse(inductor_config.emulate_precision_casts)
+
+    def test_user_override_preserved_in_production_order(self):
+        """Mirrors timm_main(): TimmRunner() runs before main() applies
+        --inductor-config overrides. The fix must capture baseline lazily
+        (on first load_model), not eagerly in __init__."""
+        # TimmRunner() already constructed in setUp.
+        inductor_config.emulate_precision_casts = True  # CLI override applied
+        self._load(self.UNLISTED)  # baseline captured here
+        self.assertTrue(inductor_config.emulate_precision_casts)
+        self._load(self.LISTED)
+        self.assertTrue(inductor_config.emulate_precision_casts)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_timm_emulate_precision_casts.py
+++ b/test/inductor/test_timm_emulate_precision_casts.py
@@ -1,11 +1,11 @@
 # Owner(s): ["module: inductor"]
 """Regression test for benchmarks/dynamo/timm_models.py emulate_precision_casts.
 
-Guards against two bugs:
+Guards against:
   1. The flag leaking across iter_models iterations (a listed model flipped
      it on; later non-listed models silently ran with it on).
-  2. The captured baseline being read before main() applied
-     `--inductor-config emulate_precision_casts=...` overrides, which would
+  2. Baseline being captured before main() applied
+     --inductor-config emulate_precision_casts=... overrides, which would
      clobber a user-specified True.
 """
 
@@ -47,34 +47,36 @@ class TimmEmulatePrecisionCastsTest(TestCase):
         self._orig_flag = inductor_config.emulate_precision_casts
         import timm
 
-        stub = lambda self, name: timm.create_model(  # noqa: E731
-            "vit_tiny_patch16_224", pretrained=False, num_classes=10
+        def stub_download(self, name):
+            return timm.create_model(
+                "vit_tiny_patch16_224", pretrained=False, num_classes=10
+            )
+
+        self._dl = mock.patch.object(self.TimmRunner, "_download_model", stub_download)
+        self._vm = mock.patch.object(
+            self.TimmRunner, "validate_model", lambda *a, **k: None
         )
-        self._patches = [
-            mock.patch.object(self.TimmRunner, "_download_model", stub),
-            mock.patch.object(self.TimmRunner, "validate_model", lambda *a, **k: None),
-        ]
-        for p in self._patches:
-            p.start()
-        ns = argparse.Namespace(
+        self._dl.start()
+        self._vm.start()
+
+        self.runner = self.TimmRunner()
+        self.runner._args = self.runner.args = argparse.Namespace(
             training=False,
             use_eval_mode=True,
             channels_last=False,
             enable_activation_checkpointing=False,
             amp=False,
         )
-        self.runner = self.TimmRunner()
-        self.runner._args = self.runner.args = ns
 
     def tearDown(self):
         inductor_config.emulate_precision_casts = self._orig_flag
-        for p in self._patches:
-            p.stop()
+        self._dl.stop()
+        self._vm.stop()
         super().tearDown()
 
     def _load(self, name):
-        # load_model may fail late (stub model vs. real input shape); the
-        # flag assignment happens before any such failure.
+        # load_model may fail late on the stub model (shape mismatch) AFTER
+        # the flag has been assigned; that's fine for this test.
         try:
             self.runner.load_model(torch.device("cpu"), name)
         except Exception:
@@ -89,12 +91,11 @@ class TimmEmulatePrecisionCastsTest(TestCase):
         self.assertFalse(inductor_config.emulate_precision_casts)
 
     def test_user_override_preserved_in_production_order(self):
-        """Mirrors timm_main(): TimmRunner() runs before main() applies
-        --inductor-config overrides. The fix must capture baseline lazily
+        """Mirrors timm_main(): TimmRunner() runs in setUp, BEFORE the CLI
+        override is applied below. The fix must capture baseline lazily
         (on first load_model), not eagerly in __init__."""
-        # TimmRunner() already constructed in setUp.
-        inductor_config.emulate_precision_casts = True  # CLI override applied
-        self._load(self.UNLISTED)  # baseline captured here
+        inductor_config.emulate_precision_casts = True  # CLI override
+        self._load(self.UNLISTED)
         self.assertTrue(inductor_config.emulate_precision_casts)
         self._load(self.LISTED)
         self.assertTrue(inductor_config.emulate_precision_casts)


### PR DESCRIPTION
Fixes an inductor accuracy failure on `vit_base_patch14_dinov2.lvd142m --training --amp` (MI350X), which was `fail_accuracy` on `blocks.0.norm1.weight.grad` with `res-fp64 0.00224 vs ref-fp64 0.00023`.

**Root cause:** Under autocast bf16, inductor fuses conv-bias-add into the downstream `cat(cls_token, patches)` kernel and stores the result directly as fp32, eliding the bf16 round-trip that eager performs in `Conv2d`. The resulting ~1 bf16 ULP forward divergence amplifies catastrophically through `LayerScale(init=1e-5)` into the failing gradient.

**Fix:** `torch._inductor.config.emulate_precision_casts` already exists for exactly this case (it preserves the downcast/upcast pairs eager autocast performs). This PR enables it per-model via a new `emulate_precision_casts:` list in `timm_models.yaml`.

The flag is applied in `load_model`, not eagerly in `__init__`, because of ordering: `main()` in `common.py` applies any `--inductor-config emulate_precision_casts=...` CLI override *after* the runner is constructed but *before* models are loaded. On the first `load_model` call we capture the current flag value as the baseline (so a user override is respected), then for each model set the flag to `baseline OR (model in yaml list)`. This both preserves a user-specified `True` across all models and resets the flag to baseline for non-listed models, avoiding carry-over when multiple models run in one process via `iter_models`. Note the yaml list always forces the flag on for listed models, even if a user explicitly passed `emulate_precision_casts=False`.

Currently only `bf16` is validated (fp16 untested).

**Verified:** the target model now passes; 6 unrelated timm models (sibling vits BEiT/DeiT/Swin/siglip and ConvNets) confirmed unaffected. A regression test in `test/inductor/test_timm_emulate_precision_casts.py` guards the per-model toggle (no carry-over) and the lazy-baseline-capture ordering; it skips when `timm` is not installed.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98
