### PR TITLE
[PyTorch][ROCm] Decline CuteDSL scatter_add on ROCm

### DIFF
--- a/torch/_native/ops/scatter_add/cutedsl_impl.py
+++ b/torch/_native/ops/scatter_add/cutedsl_impl.py
@@ -55,6 +55,16 @@ _VEC_DST_ALIGN_BYTES = 4
 
 
 @functools.cache
+def _is_rocm() -> bool:
+    # These kernels are built on the CUTLASS Python DSL (CuteDSL), which is
+    # NVIDIA-only and performs a hard CUDA-driver dependency check at compile
+    # time. On a ROCm/HIP build ``tensor.is_cuda`` is still True, so without
+    # this guard the cond approves and ``cute.compile`` fails with
+    # CudaDriverDependencyError. Decline so scatter_add falls back to aten.
+    return torch.version.hip is not None
+
+
+@functools.cache
 def _has_sm90_plus() -> bool:
     if not torch.cuda.is_available():
         return False
@@ -79,6 +89,8 @@ def _any_cow(*tensors: torch.Tensor) -> bool:
 
 def _base_cond_ok(*tensors: torch.Tensor) -> bool:
     """Pre-checks shared by every path: env sanity, all CUDA, non-COW."""
+    if _is_rocm():
+        return False
     if _deterministic():
         return False
     if not all(t.is_cuda for t in tensors):


### PR DESCRIPTION
Summary:
CONTEXT: `torch._native`'s `scatter_add` override routes eligible calls to a CuteDSL (CUTLASS Python DSL) TMA / vec-scatter kernel. The shared eligibility gate `_base_cond_ok` only checks `tensor.is_cuda`, which is True on ROCm/HIP builds. On AMD (e.g. MI350X) the path is therefore approved and `cute.compile()` fails with `CudaDriverDependencyError` ("CUDA runtime initialization failed during dependency check") because the CUTLASS DSL is NVIDIA-only. This killed MI350X training during the first backward (observed via `grad_unique.scatter_add_` in `dper_lib/slimper_lib/tokenizer/lib.py`).

WHAT: Add an `_is_rocm()` helper (`torch.version.hip is not None`) and decline in `_base_cond_ok` when running on ROCm, so both CuteDSL paths fall back to aten's `scatter_add` (correct and supported on ROCm). NVIDIA behavior is unchanged.

Test Plan:
MI350X MAST training no longer raises `CudaDriverDependencyError`; `scatter_add` falls back to aten. `arc lint` clean.

Authored with Claude Code.

Reviewed By: wuhy08

Differential Revision: D106873090




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang