### PR TITLE
Fix condition for upload-docs-preview job

### DIFF
--- a/.github/workflows/upload-docs-preview.yml
+++ b/.github/workflows/upload-docs-preview.yml
@@ -23,8 +23,7 @@ jobs:
   upload-docs-preview:
     if: >-
       github.repository_owner == 'pytorch' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
It should try to upload the artifacts even if not all jobs in workflow succeeded