### PR TITLE
Publish docs preview from a standalone docs-build workflow

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,78 @@
+name: docs-build
+
+# Standalone docs build so the docs preview can be published as soon as the
+# docs finish, instead of waiting for the entire `pull` workflow to conclude.
+# upload-docs-preview.yml listens for this workflow's completion via
+# workflow_run and performs the S3 sync from base-repo context (needed for
+# fork PRs, which cannot authenticate to S3 from the build job itself).
+#
+# This duplicates the gcc11 build that `pull` also runs; the docs build needs
+# the built wheel and a standalone workflow cannot reach `pull`'s artifact via
+# `needs:`.
+
+on:
+  pull_request:
+    branches-ignore:
+      - nightly
+  push:
+    branches:
+      - main
+      - release/*
+    tags:
+      - ciflow/pull/*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' && github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  get-label-type:
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    if: ${{ github.repository_owner == 'pytorch' }}
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      check_experiments: arc,lf
+
+  linux-jammy-py3_10-gcc11-build:
+    name: linux-jammy-py3.10-gcc11
+    uses: ./.github/workflows/_linux-build.yml
+    needs:
+      - get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-jammy-py3.10-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang18
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      test-matrix: |
+        { include: [
+          { config: "docs_test", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+        ]}
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+    secrets: inherit
+
+  linux-docs:
+    name: linux-docs
+    uses: ./.github/workflows/_docs.yml
+    needs:
+      - linux-jammy-py3_10-gcc11-build
+      - get-label-type
+    with:
+      build-environment: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.docker-image }}
+      run-doxygen: true
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      python-version: "3.10"
+      compiler: gcc11
+    secrets: inherit

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -69,7 +69,7 @@ jobs:
   # ╠══════════════════════════════════════════════════════════════════════╣
 
   linux-jammy-py3_10-gcc11-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-py3.10-gcc11 ') || contains(needs.job-filter.outputs.jobs, ' linux-docs ') }}
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-py3.10-gcc11 ') }}
     name: linux-jammy-py3.10-gcc11
     uses: ./.github/workflows/_linux-build.yml
     needs:
@@ -220,27 +220,9 @@ jobs:
       compiler: clang18
     secrets: inherit
 
-  # ╠══════════════════════════════════════════════════════════════════════╣
-  # ║ linux-docs                                                           ║
-  # ╠══════════════════════════════════════════════════════════════════════╣
-
-  linux-docs:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-docs ') }}
-    name: linux-docs
-    uses: ./.github/workflows/_docs.yml
-    needs:
-      - linux-jammy-py3_10-gcc11-build
-      - job-filter
-      - get-label-type
-    with:
-      build-environment: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.build-environment }}
-      docker-image: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.docker-image }}
-      run-doxygen: true
-      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      python-version: "3.10"
-      compiler: gcc11
-    secrets: inherit
+  # Docs are built and the preview is published by docs-build.yml so the
+  # preview can go up as soon as the docs finish, without waiting for the rest
+  # of this workflow to conclude.
 
   # ╠══════════════════════════════════════════════════════════════════════╣
   # ║ linux-jammy-py3.10-gcc11-no-ops (build only)                         ║

--- a/.github/workflows/upload-docs-preview.yml
+++ b/.github/workflows/upload-docs-preview.yml
@@ -3,14 +3,17 @@ name: Upload docs preview
 # Runs in the base-repo context so it has the AWS credentials needed to write
 # to s3://doc-previews. This exists because OSDC docs builds run in a k8s pod
 # that does not (and should not) have S3 write permission, and fork PRs cannot
-# authenticate via OIDC from the build job itself. The pull.yml docs job stages
-# the built docs as a GHA artifact; this workflow downloads that artifact and
-# performs the actual S3 upload.
+# authenticate via OIDC from the build job itself. The docs-build.yml docs job
+# stages the built docs as a GHA artifact; this workflow downloads that
+# artifact and performs the actual S3 upload.
+#
+# Triggered off docs-build (just the build + docs jobs) rather than the full
+# `pull` workflow so the preview publishes as soon as the docs finish.
 
 on:
   workflow_run:
     workflows:
-      - pull
+      - docs-build
     types:
       - completed
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #185688

The docs preview upload was gated on the full `pull` workflow finishing with an overall `success` conclusion. Since `pull` runs ~100 jobs and is often cancelled by newer pushes or has an unrelated failing job, that rarely held for PRs, so previews were usually never published despite the docs building fine, and even when it did fire it waited for all of `pull`.

Move docs building into a standalone `docs-build.yml` and point `upload-docs-preview.yml` at `workflow_run: [docs-build]`, so the preview publishes as soon as the docs finish. The success gate is kept but is now meaningful, since docs-build contains only the build and docs jobs. `linux-docs` is removed from `pull.yml`. This duplicates the gcc11 build, since a standalone workflow cannot reach `pull`'s build artifact via `needs:`.

NOTE: `linux-docs / build-docs-python-false` is likely a required status check; branch protection must be updated to the new `docs-build` check name or merges will block.

Authored with assistance from Claude Code.