### PR TITLE
[library] Improve infer_schema error message when future annotations cause NameError

### DIFF
--- a/test/custom_operator/test_infer_schema_annotation.py
+++ b/test/custom_operator/test_infer_schema_annotation.py
@@ -207,6 +207,20 @@ class TestInferSchemaWithAnnotation(TestCase):
 
             torch.library.infer_schema(foo_op_2, mutates_args=mutates_args)
 
+    def test_name_error_hint(self):
+        # When from __future__ import annotations is active and a type name cannot
+        # be resolved (e.g. because it was only imported inside a nested function),
+        # the error should include the original NameError and a hint about module scope.
+        with self.assertRaisesRegex(
+            ValueError,
+            r"from __future__ import annotations",
+        ):
+
+            def foo_op(x: D) -> Tensor:  # noqa: F821
+                return torch.Tensor(x)
+
+            torch.library.infer_schema(foo_op, mutates_args=mutates_args)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -92,9 +92,19 @@ def infer_schema(
     def convert_type_string(annotation_type: str):
         try:
             return eval(annotation_type, pf_globals, pf_locals)
-        except Exception:
+        except NameError as e:
             error_fn(
-                f"Unsupported type annotation {annotation_type}. It is not a type."
+                f"Unsupported type annotation {annotation_type}. It is not a type. "
+                f"({e}). "
+                f"If you are using 'from __future__ import annotations', note that "
+                f"annotations are evaluated lazily as strings; make sure all types "
+                f"referenced in annotations are importable at module scope, not only "
+                f"inside a local function."
+            )
+        except Exception as e:
+            error_fn(
+                f"Unsupported type annotation {annotation_type}. It is not a type. "
+                f"({type(e).__name__}: {e})"
             )
 
     def unstringify_types(


### PR DESCRIPTION
# Fixing an Issue

## Issue

Fixes #185659

## Summary

`convert_type_string` in `infer_schema` used a bare `except Exception:` that swallowed the original `NameError`, producing a confusing message when `from __future__ import annotations` is active and a referenced type is only imported inside a local function. The fix splits the handler to include the original exception and a `from __future__ import annotations` hint for `NameError`, and `type: message` for other exceptions.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No

> Developed with AI assistance (Claude). Reviewed and verified by the author.