### PR TITLE
Fix typos in comments, docstrings, and error messages

### DIFF
--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -15,6 +15,15 @@
       "Context": "{self}.as_subclass({cls})",
       "Explanation": "Currently not supported",
       "Hints": [
+        "Avoid this call or move it outside `torch.compile` region",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "Argument of `as_subclass` must be a non-dispatcher-style tensor subclass",
+      "Context": "{self}.as_subclass({cls})",
+      "Explanation": "Currently not supported",
+      "Hints": [
         "Avoid this call or move it outside `torch.compile` regione",
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]
@@ -325,6 +334,16 @@
     }
   ],
   "GB0026": [
+    {
+      "Gb_type": "Calling subclass default constructor with more than tensor argument",
+      "Context": "{self.value}(args={args}, kwargs={kwargs})",
+      "Explanation": "Currently not supported",
+      "Hints": [
+        "Avoid this constructor call or move it outside ",
+        "`torch.compile` region",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
     {
       "Gb_type": "Calling subclass default constructor with more than tensor argument",
       "Context": "{self.value}(args={args}, kwargs={kwargs})",
@@ -4719,6 +4738,18 @@
     }
   ],
   "GB1297": [
+    {
+      "Gb_type": "Reconstruction failure (self-referential)",
+      "Context": "str(self)",
+      "Explanation": "Dynamo tried to reconstruct sourceless variable {self}, but it is self-referential. Dynamo must manually implement reconstruction rules for self-referentiable sourceless variables.",
+      "Hints": [
+        "If Dynamo is attempting to trace a return statement and your code is attempting to return a variable ",
+        "that Dynamo cannot reconstruct, then remove it from the return statement.",
+        "Remove the self-reference in the variable. A self-referring list, for example, is `l = []; l.append(l)`.",
+        "Report an issue to PyTorch if you need self-referential reconstruction support.",
+        "This graph break may have been caused by an earlier graph break. Resolving the earlier graph break may resolve this one."
+      ]
+    },
     {
       "Gb_type": "Reconstruction failure (self-referential)",
       "Context": "str(self)",

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -1670,7 +1670,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
                     "that Dynamo cannot reconstruct, then remove it from the return statement.",
                     "Remove the self-reference in the variable. A self-referring list, for example, is `l = []; l.append(l)`.",
                     *graph_break_hints.CAUSED_BY_EARLIER_GRAPH_BREAK,
-                    "Report an issue to PyTorch if you need self-referential reconstrtuction support.",
+                    "Report an issue to PyTorch if you need self-referential reconstruction support.",
                 ],
             )
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1236,7 +1236,7 @@ class TensorVariable(VariableTracker):
             context=f"{self}.as_subclass({cls})",
             explanation="Currently not supported",
             hints=[
-                "Avoid this call or move it outside `torch.compile` regione",
+                "Avoid this call or move it outside `torch.compile` region",
                 *graph_break_hints.SUPPORTABLE,
             ],
         )
@@ -3031,7 +3031,7 @@ class TensorSubclassVariable(UserDefinedClassVariable):
                     explanation="Currently not supported",
                     hints=[
                         "Avoid this constructor call or move it outside "
-                        "`torch.compile` regione",
+                        "`torch.compile` region",
                         *graph_break_hints.SUPPORTABLE,
                     ],
                 )

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -591,7 +591,7 @@ def jacrev(
         >>> assert torch.allclose(hessian, torch.diag(-x.sin()))
 
     By default, :func:`jacrev` computes the Jacobian with respect to the first
-    input. However, it can compute the Jacboian with respect to a different
+    input. However, it can compute the Jacobian with respect to a different
     argument by using ``argnums``:
 
         >>> from torch.func import jacrev
@@ -1334,7 +1334,7 @@ def jacfwd(
         >>> assert torch.allclose(hessian, torch.diag(-x.sin()))
 
     By default, :func:`jacfwd` computes the Jacobian with respect to the first
-    input. However, it can compute the Jacboian with respect to a different
+    input. However, it can compute the Jacobian with respect to a different
     argument by using ``argnums``:
 
         >>> from torch.func import jacfwd

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -526,7 +526,7 @@ def flex_attention_functionalize(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Defines the functionalization rules for the flex_attention operator.
 
-    Write now we are unwrapping each tensor and then redispatching to the next, however we want to
+    Right now we are unwrapping each tensor and then redispatching to the next, however we want to
     guard against any mutations in the score_mod function, to the other_buffers since those
     are free variables.
     """
@@ -1318,7 +1318,7 @@ def flex_attention_backward_functionalize(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, tuple[torch.Tensor | None, ...]]:
     """Defines the functionalization rules for the flex_attention operator.
 
-    Write now we are unwrapping each tensor and then redispatching to the next,
+    Right now we are unwrapping each tensor and then redispatching to the next,
     since we know that the forward score mod function is assured to be free of mutations
     to the other_buffers, we skip that mutate check and go straight to redispatching.
     """

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -778,7 +778,7 @@ class ExternKernelBenchmarkRequest(BenchmarkRequest):
 
     def benchmark(self, *input_tensors: torch.Tensor, out: torch.Tensor | None = None):
         if out is not None and out.numel() == 0:
-            # no need to run the kernel of do benchmarking
+            # no need to run the kernel or do benchmarking
             return 0.0
         if self.has_out_variant or len(input_tensors) == 0:
             return super().benchmark(*input_tensors, out=out)

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -1216,15 +1216,15 @@ def _schedule_for_comm(
     Args:
         snodes: the nodes to be scheduled.
         raise_comms: whether to greedily schedule collectives as early as possible
-        sink_wait: whether to greedily schedule waits as late as possible
-        reorder_compute_for_overlap: whether to reorder compute nodes to
+        sink_waits: whether to greedily schedule waits as late as possible
+        reorder_for_overlap: whether to reorder compute nodes to
             optimize for compute/communication overlapping.
 
     Returns:
         The new schedule order.
 
     Some notes on the synergy between different options:
-        - `raise_comms` provides more overlapping oppurtunies for `reorder_compute_for_overlap`.
+        - `raise_comms` provides more overlapping opportunities for `reorder_compute_for_overlap`.
         - When both `raise_comms` and `sink_waits` is `True`, `raise_comms` is prioritized.
     """
     # We assign each node a tuple of scores (score_0, score_1, score_2),
@@ -1953,7 +1953,7 @@ def _sink_waits_iterative_internal(
                 # Check if candidate has sync runtime
                 if not contains_async_collective(candidate):
                     # If candidate has sync runtime,
-                    # Waits of gorup_colls are on the right from group.
+                    # Waits of group_colls are on the right from group.
                     # Swap can increase their exposed time.
                     c_runtime = runtimes[candidate]
 

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -175,7 +175,7 @@ class OpsHandler(Generic[T]):
 
     def floor_to_int(self, x: T, dtype: torch.dtype) -> T:
         """
-        Convert x to dtype with ceiling semantics.  See also trunc_to_int.
+        Convert x to dtype with floor semantics.  See also trunc_to_int.
         """
         raise NotImplementedError
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -503,7 +503,7 @@ class _SingleLevelFunction(
         gradient for that input.
 
         You can use the :attr:`ctx` object to pass any value from the forward to this
-        functions.
+        function.
         """
         raise NotImplementedError(
             "You must implement the jvp function for custom "

--- a/torch/autograd/functional.py
+++ b/torch/autograd/functional.py
@@ -579,7 +579,7 @@ def _jacfwd(func, inputs, strict=False, vectorize=False):
         )
     else:
         raise NotImplementedError(
-            "Computing Jacobian using forward-AD or forward-over-reverse Hessian is"
+            "Computing Jacobian using forward-AD or forward-over-reverse Hessian is "
             "only implemented for `vectorize=True`."
         )
 

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -178,7 +178,7 @@ class EventList(list):
         # First we sort the intervals by their start time. Then we iterate over them.
         # Every time we see a new interval we remove several parents from
         # the top until we restore the invariant. Then parent child relationship
-        # if recorded if the stack is not empty.
+        # is recorded if the stack is not empty.
         # Finally we add new interval to the list
         #
         # Algorithm has O(N * log(N)) complexity where N is number of
@@ -1410,7 +1410,7 @@ def _build_table(
         append(header)
     if top_level_events_only:
         append("=" * line_length)
-        append("This report only display top-level ops statistics")
+        append("This report only displays top-level ops statistics")
     append(header_sep)
     append(row_format.format(*headers))
 

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -247,9 +247,9 @@ inline variable_list CppNode_apply_functional(
           outputs[i].defined() == false,
           "function ",
           name,
-          " returned a gradient different that is defined at position ",
+          " returned a gradient that is defined at position ",
           i + 1,
-          ", std the corresponding forward input was not a Variable");
+          ", but the corresponding forward input was not a Variable");
       continue;
     }
     results.emplace_back(outputs[i]);

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -163,7 +163,7 @@ void RRefContext::checkRRefLeaks(bool ignoreRRefLeak) {
         << "occurs when the application code still holds references to RRef "
         << "instances when calling shutdown(). If the program has "
         << "completed correctly and the process is exiting, it is OK to "
-        << "ignore these leaks. However, if you program will keep running "
+        << "ignore these leaks. However, if your program will keep running "
         << "after this, these leaks could result in memory leaks on RRef "
         << "owners. Please make sure all RRefs are out of scope and Python "
         << "GC has deleted them before calling shutdown(): \n"

--- a/torch/csrc/jit/frontend/exit_transforms.cpp
+++ b/torch/csrc/jit/frontend/exit_transforms.cpp
@@ -356,7 +356,7 @@ struct ExitTransformer {
     return transformIf(new_if);
   }
 
-  // these nodes my have uses,
+  // these nodes may have uses,
   // such as in the case:
   // if i == 1:
   //    break

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -359,7 +359,7 @@ struct TORCH_API SharedParserData {
     }
     // set length equal to the complete string including quotations
     *len = end - start + quote_len;
-    // if end finished without going past the last character of the string than
+    // if end finished without going past the last character of the string then
     // there is a match
     return end < str.size();
   }

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -248,7 +248,7 @@ std::optional<size_t> findInputWithName(
     bool is_aten) {
   for (const auto i : c10::irange(kwargs.size())) {
     // TS doesn't understand that the self argument in function
-    // scheams is renamed to input for the functional variant
+    // schemas is renamed to input for the functional variant
     if (is_aten && name == "self" && kwargs[i].name() == "input") {
       return i;
     }

--- a/torch/csrc/jit/frontend/source_range.cpp
+++ b/torch/csrc/jit/frontend/source_range.cpp
@@ -8,7 +8,7 @@ namespace torch::jit {
 
 // A stringlike class backed by a vector of string_view
 // the string represented are logically the concatenation of  the string_views
-// This has advantage of not needing continues memory.
+// This has the advantage of not needing contiguous memory.
 StringCordView::StringCordView() {
   accumulated_sizes_.push_back(0);
 }

--- a/torch/csrc/jit/frontend/source_range.h
+++ b/torch/csrc/jit/frontend/source_range.h
@@ -16,7 +16,7 @@ struct SourceRange;
 
 // A stringlike class backed by a vector of string_view
 // the string represented are logically the concatenation of  the string_views
-// This has advantage of not needing continues memory.
+// This has the advantage of not needing contiguous memory.
 struct TORCH_API StringCordView {
   StringCordView();
   StringCordView(const StringCordView&) = default;

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -81,7 +81,7 @@ bool SimpleValue::hasAttr(
       return false;
     } else {
       throw(
-          ErrorReport(loc) << "hasattr's first argument must be a object "
+          ErrorReport(loc) << "hasattr's first argument must be an object "
                            << "or NamedTuple, but got a normal Tuple "
                            << value_->type()->repr_str() << " instead");
     }

--- a/torch/csrc/jit/passes/autocast.cpp
+++ b/torch/csrc/jit/passes/autocast.cpp
@@ -258,9 +258,9 @@ void updateAutocastEnabledCheck(Node* node, bool is_jit_enabled) {
 // scalar_type in forward graph. So inputs with mismatched scalar_type would
 // get the different dgrad.
 // While in JIT, autodiff doesn't do this, so implicit cast is not visible to
-// autodiff and backward dgrad for mismatched inputs would ended up with dgrads
+// autodiff and backward dgrad for mismatched inputs would end up with dgrads
 // in the same scalar_type. This has caused downstream operations, which
-// expects dgrad to be the same scalar type to throw mismatch error.
+// expect dgrad to be the same scalar type, to throw mismatch error.
 //
 // TODO: Use the list from AMP eager directly
 void handleBlock(Block* block, AutocastContext initial_state) {

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -59,8 +59,8 @@ c10::impl::GenericList make_result_list<IValue>(const TypePtr& elemType);
 // function will round to even number. We use round(x/2)*2 to handle the
 // special halfway case. For positive 'x', round(x/2)*2 =
 // round((x_e + x_r)/2)*2 = x_e + round(x_r/2)*2, where x_e is an even integer,
-// x_r is either 0.5 of 1.5, round(x_r/2)*2 results a 0 or 2, so the final
-// result will always be a even number. Due to symmetricity, it also applies to
+// x_r is either 0.5 or 1.5, round(x_r/2)*2 results a 0 or 2, so the final
+// result will always be an even number. Due to symmetry, it also applies to
 // negative cases.
 inline double round_to_even(double a) {
   return a - std::floor(a) == 0.5 ? (std::round(a * 0.5) * 2.0) : std::round(a);
@@ -79,7 +79,7 @@ void checkImplicitTensorToNum(const at::Tensor& t, bool toInt);
     // simple case, both have same sign
     return a / b;
   } else {
-    // in python division rounds down, it doesn't not truncate like in c++
+    // in python division rounds down, it does not truncate like in c++
     auto r = lldiv(a, b);
     return (r.rem) ? r.quot - 1 : r.quot;
   }
@@ -116,7 +116,7 @@ static const double radToDeg = 180.0 / std::acos(-1.0);
 double degrees(double x);
 double radians(double x);
 
-// Convert an python index (which may be negative) into an index usable for a
+// Convert a python index (which may be negative) into an index usable for a
 // C++ container
 
 // Equivalent to list.at(idx)

--- a/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
+++ b/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
@@ -190,7 +190,7 @@ void checkInputAndOutputTypes(
 
   TORCH_CHECK(
       graph->outputs().size() == schema->returns().size(),
-      "Shape function equal number of outputs as schema. Got ",
+      "Shape function must have equal number of outputs as schema. Got ",
       graph->outputs().size(),
       " graph outputs and ",
       schema->returns().size(),

--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -53,7 +53,7 @@ struct TORCH_API ClassNamespaceValue : public SugaredValue {
 };
 
 // This value maps attributes CONSTANTS.c0 CONSTANTS.c1 to entries
-// in the 'constants' vector. This table is will be stored in a container format
+// in the 'constants' vector. This table will be stored in a container format
 // and given to the import_method when restoring the code.
 struct ConstantTableValue : public SugaredValue {
   explicit ConstantTableValue(const std::vector<at::IValue>* constants)

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -456,7 +456,7 @@ PickleOpCode Unpickler::readInstruction() {
           stack_.size() > start,
           "Parsing error: wrong start index ",
           start,
-          " for stack_ which of size ",
+          " for stack_ of size ",
           stack_.size());
       auto dict = c10::impl::GenericDict(AnyType::get(), AnyType::get());
       TORCH_CHECK(

--- a/torch/cuda/_memory_viz.py
+++ b/torch/cuda/_memory_viz.py
@@ -716,7 +716,7 @@ if __name__ == "__main__":
 
     description = (
         "Generate a flamegraph that shows segments (aka blocks) that have been added "
-        "or removed between two different memorys snapshots."
+        "or removed between two different memory snapshots."
     )
     compare_a = subparsers.add_parser("compare", description=description)
     compare_a.add_argument("before", help=pickled)

--- a/torch/distributed/algorithms/ddp_comm_hooks/quantization_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/quantization_hooks.py
@@ -123,7 +123,7 @@ def quantization_perchannel_hook(
     process_group: dist.ProcessGroup, bucket: dist.GradBucket, bucket_size=512
 ) -> torch.futures.Future[torch.Tensor]:
     """
-    Apply``torch.quantize_per_channel`` logic to DDP using ``allgather`` protocol.
+    Apply ``torch.quantize_per_channel`` logic to DDP using ``allgather`` protocol.
 
     Compared to per-tensor, the main motivation of per-channel is
     for considerably large tensors such as a tensor that contains 6 million

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -240,7 +240,7 @@ class ChildFailedError(Exception):
     def __init__(self, name: str, failures: dict[GlobalRank, ProcessFailure]):
         self.name = name
         self.failures = failures
-        # does not make sense to create a ChildFaileError with no failures
+        # does not make sense to create a ChildFailedError with no failures
         if not self.failures:
             raise AssertionError
         super().__init__(self.format_msg())

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
@@ -199,7 +199,7 @@ def create_backend(params: RendezvousParameters) -> tuple[EtcdRendezvousBackend,
     | ssl_cert_key | The path to the private key of the SSL client certificate |
     |              | to use along with HTTPS. Defaults to ``None``.            |
     +--------------+-----------------------------------------------------------+
-    | ca_cert      | The path to the rool SSL authority certificate. Defaults  |
+    | ca_cert      | The path to the root SSL authority certificate. Defaults  |
     |              | to ``None``.                                              |
     +--------------+-----------------------------------------------------------+
     """

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -134,8 +134,8 @@ class FileTimerClient(TimerClient):
 
     @_retry(max_retries=10, sleep_time=0.1)
     def _open_non_blocking(self) -> io.TextIOWrapper | None:
-        # The server may have crashed or may haven't started yet.
-        # In such case, calling open() in blocking model blocks the client.
+        # The server may have crashed or may not have started yet.
+        # In such case, calling open() in blocking mode blocks the client.
         # To avoid such issue, open it in non-blocking mode, and an OSError will
         # be raised if the server is not there.
         fd = os.open(self._file_path, os.O_WRONLY | os.O_NONBLOCK)
@@ -150,7 +150,7 @@ class FileTimerClient(TimerClient):
             ) from e
         with file:
             json_request = request.to_json()
-            # Write request with no greater than select.PIPE_BUF is guarantee to be atomic.
+            # Write request with no greater than select.PIPE_BUF is guaranteed to be atomic.
             if len(json_request) > select.PIPE_BUF:
                 raise RuntimeError(
                     f"FileTimerRequest larger than {select.PIPE_BUF} bytes "

--- a/torch/distributed/elastic/utils/distributed.py
+++ b/torch/distributed/elastic/utils/distributed.py
@@ -52,7 +52,7 @@ def create_c10d_store(
         )
 
     if server_port != -1:
-        logger.info("sever_port: %s, specified, ignoring retries", server_port)
+        logger.info("server_port: %s, specified, ignoring retries", server_port)
 
     # only retry when server_port is NOT static
     attempt = retries if server_port == -1 else 1

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -945,7 +945,7 @@ def _materialize_meta_module(
     except BaseException as e:
         warnings.warn(
             "Unable to call `reset_parameters()` for module on meta "
-            f"device with error {str(e)}. Please ensure that your module of"
+            f"device with error {str(e)}. Please ensure that your module of "
             f"type {type(module)} implements a `reset_parameters()` method.",
             stacklevel=2,  # type: ignore[possibly-undefined]
         )

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -826,7 +826,7 @@ def _pre_load_state_dict_hook(
     if fsdp_state.sharding_strategy == ShardingStrategy.NO_SHARD:
         context = _replace_with_full_state_dict_type(fsdp_state)
         warnings.warn(
-            "When using ``NO_SHARD`` for ``ShardingStrategy``, full_state_dict will"
+            "When using ``NO_SHARD`` for ``ShardingStrategy``, full_state_dict will "
             "be returned.",
             stacklevel=2,
         )
@@ -864,7 +864,7 @@ def _post_load_state_dict_hook(
     if fsdp_state.sharding_strategy == ShardingStrategy.NO_SHARD:
         context = _replace_with_full_state_dict_type(fsdp_state)
         warnings.warn(
-            "When using ``NO_SHARD`` for ``ShardingStrategy``, full_state_dict will"
+            "When using ``NO_SHARD`` for ``ShardingStrategy``, full_state_dict will "
             "be returned.",
             stacklevel=2,
         )

--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -103,7 +103,7 @@ or
 
 .. versionchanged:: 2.0.0
 
-    The launcher will passes the ``--local-rank=<rank>`` argument to your script.
+    The launcher will pass the ``--local-rank=<rank>`` argument to your script.
     From PyTorch 2.0.0 onwards, the dashed ``--local-rank`` is preferred over the
     previously used underscored ``--local_rank``.
 

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -81,7 +81,7 @@ def scatter(tensors, src=0, group=group.WORLD):
 
     Arguments:
         tensors (list[Tensor]): List of tensors to scatter on the source rank.
-            Receivers must pass ``None`.
+            Receivers must pass ``None``.
         src (int, optional): Source rank (default is 0).
         group (ProcessGroup, optional): The process group to work on.
 

--- a/torch/distributed/optim/optimizer.py
+++ b/torch/distributed/optim/optimizer.py
@@ -201,7 +201,7 @@ class DistributedOptimizer:
         else:
             logger.warning(
                 "Creating the optimizer %s without TorchScript support, "
-                "this might result in slow computation time in multithreading environment"
+                "this might result in slow computation time in multithreading environment "
                 "(i.e. Distributed Model Parallel training on CPU) due to the Python's "
                 "Global Interpreter Lock (GIL). Please file an issue if you need this "
                 "optimizer in TorchScript. ",

--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -299,7 +299,7 @@ class LossWrapper(torch.nn.Module):
 
     def forward(self, *args, **kwargs):
         raise NotImplementedError(
-            "This instance of LossWrapper does not have an overridden"
+            "This instance of LossWrapper does not have an overridden "
             "forward(). Please implement forward() to specify the arguments, "
             "connection between the module and loss, and loss output "
             "value."

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -19,7 +19,7 @@ def _get_grad_fn_or_grad_acc(t: torch.Tensor) -> Node | None:
     """
     Get the grad function or grad accumulator for a tensor.
 
-    Accumulate grad nodes are lazily created, so we need to a
+    Accumulate grad nodes are lazily created, so we need to create a
     dummy view in order to trigger its creation.
     """
     if t.requires_grad and t.grad_fn is None:
@@ -30,7 +30,7 @@ def _get_grad_fn_or_grad_acc(t: torch.Tensor) -> Node | None:
             return grad_fn.next_functions[0][0]
         else:
             raise RuntimeError(
-                "Attempted to get grad_fn, but got None."
+                "Attempted to get grad_fn, but got None. "
                 "Is this being created in a no-grad context?"
             )
     else:

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -94,7 +94,7 @@ same host, we need to make sure that each instance (job) is
 setup on different ports to avoid port conflicts (or worse, two jobs being merged
 as a single job). To do this you have to run with ``--rdzv-backend=c10d``
 and specify a different port by setting ``--rdzv-endpoint=localhost:$PORT_k``.
-For ``--nodes=1``, its often convenient to let ``torchrun`` pick a free random
+For ``--nodes=1``, it's often convenient to let ``torchrun`` pick a free random
 port automatically instead of manually assigning different ports for each run.
 
 ::
@@ -586,7 +586,7 @@ def get_args_parser() -> ArgumentParser:
         type=str,
         default="",
         help="Only show logs from specified ranks in console (e.g. [--local_ranks_filter=0,1,2] will "
-        "only show logs from rank 0, 1 and 2). This will only apply to stdout and stderr, not to"
+        "only show logs from rank 0, 1 and 2). This will only apply to stdout and stderr, not to "
         "log files saved via --redirect or --tee",
     )
 
@@ -652,7 +652,7 @@ def get_args_parser() -> ArgumentParser:
         type=str,
         action=env,
         help="Address of the local node. If specified, will use the given address for connection. "
-        "Else, will look up the local node address instead. Else, it will be default to local "
+        "Else, will look up the local node address instead. Else, it will default to local "
         "machine's FQDN.",
     )
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -304,7 +304,7 @@ def _copy_attr(
         setattr(to_module, field, orig)
 
 
-# Assign attribute 'from_obj' to the qualified name 'target' on 'to_module
+# Assign attribute 'from_obj' to the qualified name 'target' on 'to_module'
 # This installs empty Modules where none exist yet if they are subpaths of target
 def _assign_attr(from_obj: object, to_module: torch.nn.Module, target: str) -> None:
     *prefix, field = target.split(".")
@@ -510,7 +510,7 @@ class _WrappedCall:
 @compatibility(is_backward_compatible=True)
 class GraphModule(torch.nn.Module):
     """
-    GraphModule is an nn.Module generated from an fx.Graph. Graphmodule has a
+    GraphModule is an nn.Module generated from an fx.Graph. GraphModule has a
     ``graph`` attribute, as well as ``code`` and ``forward`` attributes generated
     from that ``graph``.
 

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -34,7 +34,7 @@ graph_code_log = torch._logging.getArtifactLogger(__name__, "graph_code_verbose"
 def _get_example_value(node: fx.Node) -> str | None:
     """
     Get the example value key for a node, since dynamo uses "example_value"
-    while non-strict export uses "val.
+    while non-strict export uses "val".
     """
     if "example_value" in node.meta:
         return node.meta["example_value"]

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -304,7 +304,7 @@ def set_stack_trace(stack: list[str]) -> None:
             current_meta["stack_trace"] = "".join(stack)
         else:
             # when the stack is empty, we explicitly clear the stack_trace to avoid
-            # propagating it to future node.˙
+            # propagating it to future nodes.
             current_meta.pop("stack_trace", None)
 
 

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -16,7 +16,7 @@ class Flatten(Module):
     For use with :class:`~nn.Sequential`, see :meth:`torch.flatten` for details.
 
     Shape:
-        - Input: :math:`(*, S_{\text{start}},..., S_{i}, ..., S_{\text{end}}, *)`,'
+        - Input: :math:`(*, S_{\text{start}},..., S_{i}, ..., S_{\text{end}}, *)`,
           where :math:`S_{i}` is the size at dimension :math:`i` and :math:`*` means any
           number of dimensions including none.
         - Output: :math:`(*, \prod_{i=\text{start}}^{\text{end}} S_{i}, *)`.

--- a/torch/nn/modules/linear_cross_entropy.py
+++ b/torch/nn/modules/linear_cross_entropy.py
@@ -120,7 +120,7 @@ class _ChunkContext:
     """Per-call state for the chunked loop, built once via ``build``.
     Methods hide dtype/device/acc_policy dispatch behind single math ops;
     dispatch-free per-iter math is inlined into the loop body. Buffers
-    dispatch decided are not needed are rank-matching empty tensors
+    that dispatch decides are not needed are rank-matching empty tensors
     (``when=False`` in ``_make_*``) so the dataclass surface stays uniform.
     """
 

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -51,7 +51,7 @@ def _unwrap_dtensor_for_comparison(actual, expected):
 
 
 class ErrorMeta(Exception):
-    """Internal testing exception that makes that carries error metadata."""
+    """Internal testing exception that carries error metadata."""
 
     def __init__(
         self, type: type[Exception], msg: str, *, id: tuple[Any, ...] = ()
@@ -422,7 +422,7 @@ class Pair(abc.ABC):
 
     @abc.abstractmethod
     def compare(self) -> None:
-        """Compares the inputs and raises an :class`ErrorMeta` in case they mismatch."""
+        """Compares the inputs and raises an :class:`ErrorMeta` in case they mismatch."""
 
     def extra_repr(self) -> Sequence[str | tuple[str, Any]]:
         """Returns extra information that will be included in the representation.
@@ -679,15 +679,15 @@ class TensorLikePair(Pair):
     Kwargs:
         allow_subclasses (bool):
         rtol (Optional[float]): Relative tolerance. If specified ``atol`` must also be specified. If omitted, default
-            values based on the type are selected. See :func:assert_close: for details.
+            values based on the type are selected. See :func:`assert_close` for details.
         atol (Optional[float]): Absolute tolerance. If specified ``rtol`` must also be specified. If omitted, default
-            values based on the type are selected. See :func:assert_close: for details.
+            values based on the type are selected. See :func:`assert_close` for details.
         equal_nan (bool): If ``True``, two ``NaN`` values are considered equal. Defaults to ``False``.
         check_device (bool): If ``True`` (default), asserts that corresponding tensors are on the same
             :attr:`~torch.Tensor.device`. If this check is disabled, tensors on different
             :attr:`~torch.Tensor.device`'s are moved to the CPU before being compared.
         check_dtype (bool): If ``True`` (default), asserts that corresponding tensors have the same ``dtype``. If this
-            check is disabled, tensors with different ``dtype``'s are promoted  to a common ``dtype`` (according to
+            check is disabled, tensors with different ``dtype``'s are promoted to a common ``dtype`` (according to
             :func:`torch.promote_types`) before being compared.
         check_layout (bool): If ``True`` (default), asserts that corresponding tensors have the same ``layout``. If this
             check is disabled, tensors with different ``layout``'s are converted to strided tensors before being
@@ -839,8 +839,8 @@ class TensorLikePair(Pair):
 
         If ``actual`` and ``expected`` are ...
 
-        - ... not on the same :attr:`~torch.Tensor.device`, they are moved CPU memory.
-        - ... not of the same ``dtype``, they are promoted  to a common ``dtype`` (according to
+        - ... not on the same :attr:`~torch.Tensor.device`, they are moved to CPU memory.
+        - ... not of the same ``dtype``, they are promoted to a common ``dtype`` (according to
             :func:`torch.promote_types`).
         - ... not of the same ``layout``, they are converted to strided tensors.
 
@@ -1169,11 +1169,11 @@ def originate_pairs(
         **options (Any): Options passed to each pair during construction.
 
     Raises:
-        ErrorMeta: With :class`AssertionError`, if the inputs are :class:`~collections.abc.Sequence`'s, but their
+        ErrorMeta: With :class:`AssertionError`, if the inputs are :class:`~collections.abc.Sequence`'s, but their
             length does not match.
-        ErrorMeta: With :class`AssertionError`, if the inputs are :class:`~collections.abc.Mapping`'s, but their set of
+        ErrorMeta: With :class:`AssertionError`, if the inputs are :class:`~collections.abc.Mapping`'s, but their set of
             keys do not match.
-        ErrorMeta: With :class`TypeError`, if no pair is able to handle the inputs.
+        ErrorMeta: With :class:`TypeError`, if no pair is able to handle the inputs.
         ErrorMeta: With any expected exception that happens during the construction of a pair.
 
     Returns:
@@ -1423,7 +1423,7 @@ def assert_close(
             :attr:`~torch.Tensor.device`. If this check is disabled, tensors on different
             :attr:`~torch.Tensor.device`'s are moved to the CPU before being compared.
         check_dtype (bool): If ``True`` (default), asserts that corresponding tensors have the same ``dtype``. If this
-            check is disabled, tensors with different ``dtype``'s are promoted  to a common ``dtype`` (according to
+            check is disabled, tensors with different ``dtype``'s are promoted to a common ``dtype`` (according to
             :func:`torch.promote_types`) before being compared.
         check_layout (bool): If ``True`` (default), asserts that corresponding tensors have the same ``layout``. If this
             check is disabled, tensors with different ``layout``'s are converted to strided tensors before being

--- a/torch/testing/_internal/common_jit.py
+++ b/torch/testing/_internal/common_jit.py
@@ -285,7 +285,7 @@ class JitCommonTestCase(TestCase):
 
     def checkShapeAnalysis(self, out_sizes: list[int] | list[list[int]],
                            traced_graph, assert_propagation, constant_prop=True):
-        # repropagte input shapes provided by tracing,
+        # repropagate input shapes provided by tracing,
         prev_symbolic_shapes_test_enabled = torch._C._jit_symbolic_shapes_test_mode_enabled()
         for enable_test_mode in [True, False]:
             # here we are testing allowing/disallowing substituting in complete shapes as constants,

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -556,7 +556,7 @@ def no_batch_dim_reference_fn(m, p, *args, **kwargs):
     Currently it only supports modules which return a single Tensor as output.
     You can bind the following kwargs.
     Kwargs:
-        batch_first[bool] : If True, all the Tensors in `args` while be unsqueezed at dim `0` .
+        batch_first[bool] : If True, all the Tensors in `args` will be unsqueezed at dim `0` .
                         and output will be squeezed at dim `0` else dim `1` for both.
         kwargs_to_batchify[dict] : Dictionary specifying the name of the argument and dimension to unsqueeze.
                                Useful if there are few arguments whose batch dimension are different

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -864,7 +864,7 @@ def _namedtuple_serialize(context: Context) -> DumpableContext:
     if context not in SUPPORTED_SERIALIZED_TYPES:
         raise NotImplementedError(
             f"Can't serialize TreeSpec of namedtuple class {context} because we "
-            "didn't register a serializated_type_name. Please register using "
+            "didn't register a serialized_type_name. Please register using "
             "`_register_namedtuple`."
         )
 
@@ -874,7 +874,7 @@ def _namedtuple_serialize(context: Context) -> DumpableContext:
     if serialized_type_name == NO_SERIALIZED_TYPE_NAME_FOUND:
         raise NotImplementedError(
             f"Can't serialize TreeSpec of namedtuple class {context} because we "
-            "couldn't find a serializated_type_name. Please register using "
+            "couldn't find a serialized_type_name. Please register using "
             "`_register_namedtuple`."
         )
     return serialized_type_name
@@ -884,7 +884,7 @@ def _namedtuple_deserialize(dumpable_context: DumpableContext) -> Context:
     if dumpable_context not in SERIALIZED_TYPE_TO_PYTHON_TYPE:
         raise NotImplementedError(
             f"Can't deserialize TreeSpec of namedtuple class {dumpable_context} "
-            "because we couldn't find a serializated name."
+            "because we couldn't find a serialized name."
         )
 
     typ = SERIALIZED_TYPE_TO_PYTHON_TYPE[dumpable_context]

--- a/torch/utils/benchmark/utils/compile.py
+++ b/torch/utils/benchmark/utils/compile.py
@@ -127,9 +127,9 @@ if HAS_TABULATE:
     ):
         """
         This is a simple utility that can be used to benchmark torch.compile
-        In particular it ensures that your GPU is setup to use tensor cores if it supports its
+        In particular it ensures that your GPU is setup to use tensor cores if it supports it
         It also tries out all the main backends and prints a table of results so you can easily compare them all
-        Many of the backendds have their own optional dependencies so please pip install them separately
+        Many of the backends have their own optional dependencies so please pip install them separately
 
         You will get one table for inference and another for training
         If you'd like to leverage this utility for training make sure to pass in a torch.optim.Optimizer

--- a/torch/utils/benchmark/utils/fuzzer.py
+++ b/torch/utils/benchmark/utils/fuzzer.py
@@ -157,7 +157,7 @@ class ParameterAlias:
         ],
     )
 
-    Chains of alias' are allowed, but may not contain cycles.
+    Chains of aliases are allowed, but may not contain cycles.
     """
     def __init__(self, alias_to) -> None:
         self.alias_to = alias_to

--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -389,7 +389,7 @@ class Timer:
             max_run_time: float = 10.0,
             callback: Callable[[int, float], NoReturn] | None = None,
     ) -> common.Measurement:
-        """Similar to `blocked_autorange` but also checks for variablility in measurements
+        """Similar to `blocked_autorange` but also checks for variability in measurements
         and repeats until iqr/median is smaller than `threshold` or `max_run_time` is reached.
 
 

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -231,11 +231,11 @@ class CallgrindStats:
     ) -> FunctionCounts:
         """Diff two sets of counts.
 
-        One common reason to collect instruction counts is to determine the
+        One common reason to collect instruction counts is to determine
         the effect that a particular change will have on the number of instructions
         needed to perform some unit of work. If a change increases that number, the
         next logical question is "why". This generally involves looking at what part
-        if the code increased in instruction count. This function automates that
+        of the code increased in instruction count. This function automates that
         process so that one can easily diff counts on both an inclusive and
         exclusive basis.
         """
@@ -244,7 +244,7 @@ class CallgrindStats:
     def as_standardized(self) -> CallgrindStats:
         """Strip library names and some prefixes from function strings.
 
-        When comparing two different sets of instruction counts, on stumbling
+        When comparing two different sets of instruction counts, one stumbling
         block can be path prefixes. Callgrind includes the full filepath
         when reporting a function (as it should). However, this can cause
         issues when diffing profiles. If a key component such as Python


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Fix spelling and grammar issues across torch, including misspelled
words (reconstrtuction, regione, Jacboian, oppurtunies, etc.),
incorrect articles (a/an), missing/extra words in error messages,
and broken RST cross-references.

Authored with Claude (typo_terminator2).

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98