### PR TITLE
Import TypeVar from typing_extensions

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -47,9 +47,8 @@ from typing import (
     TYPE_CHECKING,
     TypeAlias,
     TypeGuard,
-    TypeVar,
 )
-from typing_extensions import dataclass_transform, ParamSpec, Self
+from typing_extensions import dataclass_transform, ParamSpec, Self, TypeVar
 from unittest import mock
 
 import sympy


### PR DESCRIPTION
Fixes #140914

Imports `TypeVar` from `typing_extensions` alongside `ParamSpec` so both type parameters use the same default-sentinel machinery when another vendored `typing_extensions` copy has monkeypatched `typing` internals. This preserves the existing `CachedMethod[P, RV]` convention while avoiding the import-time `TypeError`.

Test Plan:
- `python3 -m py_compile torch/_inductor/utils.py`
- `/Users/dejain/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3` minimized repro that loads a second `typing_extensions` copy and defines `CachedMethod(Protocol, Generic[P, RV])`
- `git diff --check`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos
