### PR TITLE
Remove Stack Overflow link from Inductor comment

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -324,10 +324,9 @@ def reduction_prefix_array(
     init_fn,
 ):
     """
-    MSVC don't support dynamic array(VLA). So we use std::unique_ptr here.
-    Ref: https://stackoverflow.com/questions/56555406/creating-dynamic-sized-array-using-msvc-c-compiler
-    MSVC is the only one compiler without VLA. support. Since MSVC can't get good performance here.
-    We just use unique_ptr make it works on MSVC.
+    MSVC does not support C99-style variable length arrays (VLAs), so use
+    std::unique_ptr there. Since MSVC cannot get good performance here, use
+    unique_ptr to keep the generated code portable.
     For other compilers, we continue to use VLA to get best performance.
     """
     code_buffer = IndentedBuffer()


### PR DESCRIPTION
Fixes #153071

Removes the Stack Overflow URL from the `torch/_inductor/codegen/cpp.py` comment that link-check CI can hit as a 403. The comment keeps the relevant MSVC/VLA rationale without relying on an external link.

Test Plan:
- `python3 -m py_compile torch/_inductor/codegen/cpp.py`
- `rg -n "stackoverflow.com/questions/56555406" torch/_inductor/codegen/cpp.py` returned no matches
- `git diff --check`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo