### PR TITLE
Improve MaxPool float argument errors

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7870,6 +7870,33 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             res = arg_class(*arg_4)
 
+    def test_max_pool1d_invalid_float_parameters(self):
+        invalid_args = (
+            ({"kernel_size": 1.0}, "kernel_size must be int or tuple of ints, not float"),
+            (
+                {"kernel_size": (1.0,)},
+                "kernel_size must be int or tuple of ints, "
+                "but found element of type float at pos 0",
+            ),
+            (
+                {"kernel_size": 1, "stride": 1.0},
+                "stride must be int or tuple of ints, not float",
+            ),
+            (
+                {"kernel_size": 1, "padding": 0.0},
+                "padding must be int or tuple of ints, not float",
+            ),
+            (
+                {"kernel_size": 1, "dilation": 1.0},
+                "dilation must be int or tuple of ints, not float",
+            ),
+        )
+
+        for kwargs, error in invalid_args:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaisesRegex(TypeError, re.escape(error)):
+                    nn.MaxPool1d(**kwargs)
+
     def test_pickle_module_no_weights_only_warning(self):
         with warnings.catch_warnings(record=True) as w:
             pickle.loads(pickle.dumps(torch.nn.Linear(10, 10)))

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -1,3 +1,5 @@
+import collections
+
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn.common_types import (
@@ -40,6 +42,21 @@ __all__ = [
 ]
 
 
+def _check_maxpool_arg_type(name: str, value: object) -> None:
+    if isinstance(value, float):
+        raise TypeError(f"{name} must be int or tuple of ints, not float")
+
+    if isinstance(value, collections.abc.Iterable) and not isinstance(
+        value, (str, bytes, Tensor)
+    ):
+        for i, item in enumerate(value):
+            if isinstance(item, float):
+                raise TypeError(
+                    f"{name} must be int or tuple of ints, "
+                    f"but found element of type float at pos {i}"
+                )
+
+
 class _MaxPoolNd(Module):
     __constants__ = [
         "kernel_size",
@@ -62,6 +79,11 @@ class _MaxPoolNd(Module):
         ceil_mode: bool = False,
     ) -> None:
         super().__init__()
+        _check_maxpool_arg_type("kernel_size", kernel_size)
+        if stride is not None:
+            _check_maxpool_arg_type("stride", stride)
+        _check_maxpool_arg_type("padding", padding)
+        _check_maxpool_arg_type("dilation", dilation)
         self.kernel_size = kernel_size
         self.stride = stride if (stride is not None) else kernel_size
         self.padding = padding


### PR DESCRIPTION
Fixes #136093

Adds focused constructor-time validation for float `kernel_size`, `stride`, `padding`, and `dilation` values in `MaxPool*` modules. This preserves existing handling for valid integer and sequence inputs while replacing the misleading "tuple of ints" message for the reported float cases.

Test Plan:
- `python3 -m py_compile torch/nn/modules/pooling.py test/test_nn.py`
- Added `test_max_pool1d_invalid_float_parameters`
- `git diff --check`