### PR TITLE
Raise user error for dense mkldnn device tensors

### DIFF
--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -659,6 +659,11 @@ inline DispatchKey computeDispatchKey(
         case c10::DeviceType::Metal:
           return DispatchKey::Metal;
         case c10::DeviceType::MKLDNN:
+          TORCH_CHECK_NOT_IMPLEMENTED(
+              false,
+              "The 'mkldnn' device type is deprecated and cannot be used "
+              "to allocate dense tensors. Please use a supported device type "
+              "instead.");
         case c10::DeviceType::OPENGL:
         case c10::DeviceType::OPENCL:
         case c10::DeviceType::IDEEP:

--- a/test/cpp/api/tensor_options.cpp
+++ b/test/cpp/api/tensor_options.cpp
@@ -86,6 +86,13 @@ TEST(TensorOptionsTest, ConstructsWellFromVariables) {
   ASSERT_FALSE(options.requires_grad());
 }
 
+TEST(TensorOptionsTest, MkldnnDeviceAllocationFailsCleanly) {
+  ASSERT_THROWS_WITH(
+      torch::empty({2}, TensorOptions().device(Device(DeviceType::MKLDNN))),
+      "The 'mkldnn' device type is deprecated and cannot be used to allocate "
+      "dense tensors");
+}
+
 TEST(DeviceTest, ParsesCorrectlyFromString) {
   Device device("cpu:0");
   ASSERT_EQ(device, Device(DeviceType::CPU, 0));


### PR DESCRIPTION
Fixes #154491

Replaces the internal assertion hit when dense tensor allocation receives `DeviceType::MKLDNN` with a user-facing `TORCH_CHECK_NOT_IMPLEMENTED` error. This leaves `Device("mkldnn")` parsing behavior intact while giving `torch.randn(..., device="mkldnn")` a clean error instead of an internal assert.

Test Plan:
- Added `TensorOptionsTest.MkldnnDeviceAllocationFailsCleanly`
- `git diff --check`

Note: I did not run the C++ test binary locally because this checkout is sparse/source-only and does not have a built PyTorch test binary.