### PR TITLE
Fix typos in comments, docstrings, and error messages

### DIFF
--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -18,7 +18,7 @@ which assumes accurate fake tensor metadata, without actually running fn.
 In the future, we may allow for a "meta" function associated with fn to allow for more interesting input-output patterns.
 
 Note that tensors / Python state are allowed to be mutated.
-This is relaxed constraint is not always sound, but it is sound for backward tracing with fake
+This relaxed constraint is not always sound, but it is sound for backward tracing with fake
 tensors as it takes place in AOTAutograd, as the backward pass is guaranteed not to depend on concrete
 tensor values (via fake tensor) or Python state (because the autograd engine doesn't depend on Python).
 
@@ -75,7 +75,7 @@ def _(info, indims, shape, indices, value):  # type: ignore[no-untyped-def]
     indices_indims = indims[1]
     expanded_indices = []
     for idx, idx_indim in zip(indices, indices_indims):
-        # The index is not a being batched, we should unsqueeze and expand to val
+        # The index is not being batched, we should unsqueeze and expand to val
         if idx_indim is None:
             expanded_indices.append(idx.expand(value.shape))
         else:

--- a/torch/_export/passes/lift_constants_pass.py
+++ b/torch/_export/passes/lift_constants_pass.py
@@ -412,7 +412,7 @@ def rewrite_script_object_meta(
     """When tracing, we produce a graph with FakeScriptObject in the
     meta["val"].
 
-    For now, we rewrie meta["val"] to be a placeholder CustomObjArgument
+    For now, we rewrite meta["val"] to be a placeholder CustomObjArgument
     """
     constants: dict[
         str,

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -210,7 +210,7 @@ class GuardSource(enum.Enum):
 Base class for a "GuardBuilder" role.
 
 The GuardBuilderBase role is to represent a scope within which to build a guard. The name is a little
-confusing, as its not a builder, but for the sake of avoiding a lot of renames and keeping the original reference
+confusing, as it's not a builder, but for the sake of avoiding a lot of renames and keeping the original reference
 to torchdynamo's GuardBuilder.
 
 Note: create_fn is invoked with a GuardBuilderBase and a Guard. A GuardBuilder is chosen based
@@ -713,7 +713,7 @@ class GuardsSet:
 
 """
 A GuardsContext is a checkpointable representation of all the guards in the current tracing
-context. It's lifecycle is bound 1:1 to the tracing context, and it should never be instantiated
+context. Its lifecycle is bound 1:1 to the tracing context, and it should never be instantiated
 directly outside of it. For passing around internal state representations of this object,
 prefer to extract them with copy_graphstate to produce a GuardsCheckpointState.
 """

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -612,7 +612,7 @@ def is_linear_node_can_be_fused(node: torch.fx.Node):
 class PreGradBatchLinearFusion(BatchFusion):
     """
     Batch linear fusion in pre grad pass.
-    Fuse linear with same size with torch.baddmm
+    Fuse linear with same size with torch.baddbmm
     """
 
     def _getitem_args(self, getitem_node: torch.fx.Node):
@@ -717,7 +717,7 @@ class PreGradBatchLinearFusion(BatchFusion):
                     bmm_meta = bmm.meta["example_value"]
                 except Exception as e:
                     log.debug(
-                        f" exception when update bmm meta data with stack error tracekey {e}"  # noqa: G004
+                        f" exception when update bmm meta data with stack error traceback {e}"  # noqa: G004
                     )
                     bmm_meta = None
 

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -275,7 +275,7 @@ class ROCmFlexDecodeConfig(FlexDecodeConfig):
 
 class BaseHeuristicSingleton(type):
     """
-    Thread-safe implementation of single to be used in the config heuristic subclasses
+    Thread-safe implementation of singleton to be used in the config heuristic subclasses
     to ensure heavy __init__ calls are not repeatedly run
     """
 
@@ -2739,7 +2739,7 @@ class BaseScaledMMConfigMixin(MMTemplateConfigMixin):
 
 
 class ScaledMMConfigMixin(BaseScaledMMConfigMixin):
-    """Mixing for scaled mm with the regular mm template"""
+    """Mixin for scaled mm with the regular mm template"""
 
     def get_extra_kwargs(
         self,

--- a/torch/_numpy/testing/utils.py
+++ b/torch/_numpy/testing/utils.py
@@ -1503,7 +1503,7 @@ def nulp_diff(x, y, dtype=None):
 
 def _integer_repr(x, vdt, comp):
     # Reinterpret binary representation of the float as sign-magnitude:
-    # take into account two-complement representation
+    # take into account two's-complement representation
     # See also
     # https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
     rx = x.view(vdt)
@@ -1655,7 +1655,7 @@ def _gen_alignment_data(dtype=float32, type="binary", max_size=24):
     type : string
         'unary': create data for unary operations, creates one input
                  and output array
-        'binary': create data for unary operations, creates two input
+        'binary': create data for binary operations, creates two input
                  and output array
     max_size : integer
         maximum size of data to produce
@@ -1936,7 +1936,7 @@ class suppress_warnings:
         noise mostly on the outmost level. Unsuppressed and unrecorded
         warnings will be forwarded based on this rule. Defaults to "always".
         "location" is equivalent to the warnings "default", match by exact
-        location the warning warning originated from.
+        location the warning originated from.
 
     Notes
     -----

--- a/torch/ao/pruning/_experimental/data_scheduler/base_data_scheduler.py
+++ b/torch/ao/pruning/_experimental/data_scheduler/base_data_scheduler.py
@@ -22,7 +22,7 @@ class BaseDataScheduler:
         schedule_param (str)
             A specific hyperparameter of the passed sparsifier that needs to be scheduled/varied
         last_epoch (int, default=-1)
-            This is specifically is passed when training needs to be resumed from a particular
+            This is specifically passed when training needs to be resumed from a particular
             point.
         verbose (bool, default=False)
             Verbosity of the BaseDataScheduler

--- a/torch/ao/pruning/_experimental/data_sparsifier/data_norm_sparsifier.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/data_norm_sparsifier.py
@@ -16,7 +16,7 @@ class DataNormSparsifier(BaseDataSparsifier):
     r"""L1-Norm Sparsifier
     This sparsifier computes the *L1-norm* of every sparse block and "zeroes-out" the
     ones with the lowest norm. The level of sparsity defines how many of the
-    blocks is removed.
+    blocks are removed.
     This sparsifier is controlled by three variables:
     1. `sparsity_level` defines the number of *sparse blocks* that are zeroed-out
     2. `sparse_block_shape` defines the shape of the sparse blocks. Note that

--- a/torch/ao/pruning/_experimental/data_sparsifier/quantization_utils.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/quantization_utils.py
@@ -35,15 +35,15 @@ def post_training_sparse_quantize(
 
     Args:
         - model (nn.Module)
-            model whose embeddings needs to be sparsified
+            model whose embeddings need to be sparsified
         - data_sparsifier_class (type of data sparsifier)
             Type of sparsification that needs to be applied to model
         - sparsify_first (bool)
             if true, sparsifies first and then quantizes
             otherwise, quantizes first and then sparsifies.
         - select_embeddings (List of Embedding modules)
-            List of embedding modules to in the model to be sparsified & quantized.
-            If None, all embedding modules with be sparsified
+            List of embedding modules in the model to be sparsified & quantized.
+            If None, all embedding modules will be sparsified
         - sparse_config (Dict)
             config that will be passed to the constructor of data sparsifier object.
 

--- a/torch/ao/pruning/_experimental/pruner/prune_functions.py
+++ b/torch/ao/pruning/_experimental/pruner/prune_functions.py
@@ -206,7 +206,7 @@ def prune_conv2d_padded(conv2d_1: nn.Conv2d) -> None:
         ):  # conv2d_1 has original bias and bias propagated from previous layer
             new_bias = torch.zeros(conv2d_1.bias.shape)
             new_bias[mask] = conv2d_1.bias[mask]  # type: ignore[possibly-undefined]
-            # adjusted bias that to keep in conv2d_1
+            # adjusted bias to keep in conv2d_1
             # pyrefly: ignore [unbound-name]
             new_bias[~mask] = cast(Tensor, conv2d_1._bias)[~mask]
             # pruned biases that are kept instead of propagated

--- a/torch/csrc/autograd/graph_task.h
+++ b/torch/csrc/autograd/graph_task.h
@@ -115,7 +115,7 @@ struct GraphTask : std::enable_shared_from_this<GraphTask> {
   };
   // exec_info_ is safe to read without synchronization
   std::unordered_map<Node*, ExecInfo> exec_info_;
-  // Captures variables are grads captured that we return to the user. After
+  // Captured variables are grads captured that we return to the user. After
   // execution of the GraphTask is completed, the captured_vars_ are moved
   // out of the GraphTask and are no longer valid.
   std::vector<Variable> captured_vars_;
@@ -186,7 +186,7 @@ struct GraphTask : std::enable_shared_from_this<GraphTask> {
 
   // Final callbacks installed during execution of this GraphTask
   std::vector<std::function<void()>> final_callbacks_;
-  // To protect reads and writes to final_callbacks_. Intentionally no reusing
+  // To protect reads and writes to final_callbacks_. Intentionally not reusing
   // mutex_ as the two are protecting different data structures.
   std::mutex final_callbacks_lock_;
 

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -288,7 +288,7 @@ struct AddGenericMetadata : public MetadataBase {
         continue;
       }
 
-      // Until needed, lets limit the kwargs to only ints, doubles, strings,
+      // Until needed, let's limit the kwargs to only ints, doubles, strings,
       // bools, and list of strings
       bool isValidType =
           val.isInt() || val.isDouble() || val.isString() || val.isBool();

--- a/torch/csrc/distributed/autograd/functions/recvrpc_backward.cpp
+++ b/torch/csrc/distributed/autograd/functions/recvrpc_backward.cpp
@@ -37,7 +37,7 @@ variable_list RecvRpcBackward::apply(variable_list&& grads) {
       c10::str(
           "Autograd context no longer valid! This usually ",
           "means the autograd context was cleaned up by a different thread due ",
-          "to an error before RecvRcpBackward had a chance to run"));
+          "to an error before RecvRpcBackward had a chance to run"));
 
   // Send the gradients over the wire and record the future in the autograd
   // context.

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -279,7 +279,7 @@ void ProcessGroupMPI::initMPIOnce() {
 
 c10::intrusive_ptr<ProcessGroupMPI> ProcessGroupMPI::createProcessGroupMPI(
     std::vector<int> ranks) {
-  // Once initialization
+  // One-time initialization
   initMPIOnce();
 
   MPI_Comm groupComm = MPI_COMM_WORLD;

--- a/torch/csrc/distributed/c10d/Store.hpp
+++ b/torch/csrc/distributed/c10d/Store.hpp
@@ -83,7 +83,7 @@ class TORCH_API Store : public torch::CustomClassHolder {
       WatchKeyCallback /* unused */) {
     C10_THROW_ERROR(
         NotImplementedError,
-        "watchKey is deprecated, no implementation support it.");
+        "watchKey is deprecated, no implementation supports it.");
   }
 
   virtual void append(

--- a/torch/csrc/jit/passes/normalize_ops.cpp
+++ b/torch/csrc/jit/passes/normalize_ops.cpp
@@ -5,7 +5,7 @@ namespace torch::jit {
 namespace {
 
 // having multiple ops in our IR that do the same thing makes the IR more
-// difficult to consumer for downstream user of the IR, such as our own
+// difficult to consume for downstream user of the IR, such as our own
 // optimization passes here, we convert op aliases into a standard form
 bool normalizeOpAliases(graph_node_list_iterator& iter) {
   auto alias = getOperatorAliasMap().find(iter->kind());

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -115,7 +115,7 @@ std::vector<Value*> ConvertSequenceDependencies(Node* node, int opset_version) {
 
   if (opset_version >= ONNX_OPSET_13) {
     // Sequence type as loop-carried dependencies should be supported by ONNX
-    // ospet 13.
+    // opset 13.
     return node->outputs().vec();
   }
 
@@ -194,7 +194,7 @@ Node* ONNXOptionalNode(const OptionalTypePtr& opt_type, Graph* g) {
 }
 
 // Replaces block output i with an onnx::Optional
-// with `type` taken from opt_type. If and Loop Ops shares this function.
+// with `type` taken from opt_type. If and Loop Ops share this function.
 // 1. If Op: Needed when control flow has multiple branches, one of which
 // is defined by `block` and returns a None and another branch
 // returns not-None. The passed-in opt_type should be from the other branch.

--- a/torch/csrc/jit/passes/onnx/function_substitution.cpp
+++ b/torch/csrc/jit/passes/onnx/function_substitution.cpp
@@ -182,7 +182,7 @@ ScopePtr ONNXGraphTopLevelScope(Graph& graph) {
 
 // This pass is to be used for ONNX conversion only. The ONNX converter depends
 // on a number of deprecated aten operators. These operators are removed from IR
-// and replaced by the compiled python function code. However, in-order to
+// and replaced by the compiled python function code. However, in order to
 // maintain the behavior for ONNX conversion, we replace these function calls
 // with the aten symbolic which can still be used by the ONNX converter.
 void ONNXFunctionCallSubstitution(Graph& graph) {

--- a/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
+++ b/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
@@ -81,7 +81,7 @@ std::unordered_map<int64_t, ConvertedIndex> MergeSliceAndSelectToIndices(
        ++it) {
     auto node = *it;
     // select does not keep dims,
-    // this creates offset for latter slice and select nodes.
+    // this creates offset for later slice and select nodes.
     // NOTE: Cannot rely on get(attr::dim), because op no longer match schema.
     int64_t dim = node->inputs().at(1)->node()->t(attr::value).item().toLong();
 
@@ -181,7 +181,7 @@ std::unordered_map<int64_t, ConvertedIndex> MergeSliceAndSelectToIndices(
 //  ind1 shape:          [        _ ]
 //  ind2 shape:          [        _ ]
 // where _ is the original size of ind1 and ind2.
-// ind1 and ind2 are both 1-d tensors since currently we only supports 1-d
+// ind1 and ind2 are both 1-d tensors since currently we only support 1-d
 // tensor indices.
 std::vector<Value*> ReshapeToAdvancedIndexingFormat(
     Graph* graph,

--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -168,7 +168,7 @@ static void ConvertQuantizedWeight(
 }
 
 // CONV1D needs a different unpacking from CONV, since it's
-// packed as CONV2D intentionally at the first place.
+// packed as CONV2D intentionally in the first place.
 // See: https://github.com/pytorch/pytorch/pull/38248
 enum class QuantizedParamsType { CONV1D, CONV, LINEAR };
 
@@ -302,8 +302,8 @@ static void unpackQuantizedWeightsHelper(
         const int64_t kSpatialDim = conv_params_packed[0].item<int64_t>();
         // skip kSpatialDim
         int64_t idx = 1;
-        // kSpatialDim = 2 even it's for Conv1D from torch.op to adopt Conv2D,
-        // so we need a special unpack for Conv1D which has Conv2D dim.
+        // kSpatialDim = 2 even if it's for Conv1D from torch.op to adapt
+        // Conv2D, so we need a special unpack for Conv1D which has Conv2D dim.
         // See: https://github.com/pytorch/pytorch/pull/38248
         for (const auto i : c10::irange(kSpatialDim)) {
           if (params_type != QuantizedParamsType::CONV1D || i != 0) {

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -281,7 +281,7 @@ static bool matchArgPattern(
 bool isWeight(Value* v) {
   bool result = matchArgPattern(
       v,
-      // ate::embedding_bag(%weight, %input, %offsets, %scale_grad_by_freq,
+      // aten::embedding_bag(%weight, %input, %offsets, %scale_grad_by_freq,
       // %mode_enum, %sparse, %per_sample_weights, %include_last_offset)
       AtenFuncArgs(
           {{"conv1d", 1},

--- a/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
@@ -462,7 +462,7 @@ script::Module optimizeForMobile(
   if (!optimization_blocklist.count(MobileOptimizerType::REMOVE_DROPOUT)) {
     for (const auto& method : cloned_module.get_methods()) {
       auto graph = method.graph();
-      // Module must be not be in training mode but optimize calls eval()
+      // Module must not be in training mode but optimize calls eval()
       removeDropout(graph);
     }
   }

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.h
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.h
@@ -51,7 +51,7 @@ struct BoundHash {
 // previous conditions hold.
 //     ContainedOrEqual: All elements in the Bound A are in the Bound B (this
 //                       includes the case where the bounds are equal).
-//     Contains: All elements in the Bound B are in the Bound B.
+//     Contains: All elements in the Bound B are in the Bound A.
 //     PartialOverlap: Any elements in the Bound B are in the Bound A.
 //     NoOverlap: No elements in the Bound A are in the bound B.
 enum class OverlapKind {
@@ -69,7 +69,7 @@ enum class OverlapKind {
 //     some elements not
 enum class CmpEvalResult { True, False, NotDetermined };
 
-// Returns the kind of overlap between Bound A and Bound A in a single
+// Returns the kind of overlap between Bound A and Bound B in a single
 // dimension.
 OverlapKind TORCH_API boundOverlap(const Bound& A, const Bound& B);
 
@@ -94,7 +94,7 @@ Bound TORCH_API flattenBounds(const IndexBounds& a);
 // Determines the kind of overlap in X dimensions.
 OverlapKind TORCH_API overlaps(const IndexBounds& a, const IndexBounds& b);
 
-// Returns the Bound slices created by subtracing bound B from bound A.
+// Returns the Bound slices created by subtracting bound B from bound A.
 // Multiple Bounds can be returned in the case where B slices A into two
 // distinct regions with no overlap.
 //

--- a/torch/csrc/jit/tensorexpr/graph_opt.cpp
+++ b/torch/csrc/jit/tensorexpr/graph_opt.cpp
@@ -151,7 +151,7 @@ static void moveCatOpToEnd(Node* cat, const std::shared_ptr<Graph>& subgraph) {
         TORCH_INTERNAL_ASSERT(
             use.user->output()->owningGraph() == subgraph.get(),
             buildErrorMessage(
-                "aten::cat user graph does not math the given subgraph."));
+                "aten::cat user graph does not match the given subgraph."));
         auto new_cat = moveCatAfterUse(cat, use.user, subgraph);
         moveCatOpToEnd(new_cat, subgraph);
       }

--- a/torch/csrc/jit/tensorexpr/reduction.h
+++ b/torch/csrc/jit/tensorexpr/reduction.h
@@ -132,7 +132,7 @@ class TORCH_API Reducer {
 };
 
 // An expression representing a Reduction operation (e.g. Sum, Max) broken into
-// it's component parts: initialization, accumulation var, acquisition of value
+// its component parts: initialization, accumulation var, acquisition of value
 // to be reduced and interaction.
 //
 // This is intended to be expanded in the loopnest and not make it to codegen.

--- a/torch/csrc/lazy/core/debug_util.cpp
+++ b/torch/csrc/lazy/core/debug_util.cpp
@@ -114,8 +114,8 @@ std::string DebugUtil::GetTensorsGraphInfo(
     }
   }
   std::stringstream ss;
-  // Call into a function pointer that may backed by python or empty depending
-  // on runtime
+  // Call into a function pointer that may be backed by python or empty
+  // depending on runtime
   std::vector<SourceLocation> frames = GetPythonFramesFunction()();
   ss << "Python Stacktrace:\n";
   for (auto& location : frames) {

--- a/torch/distributed/checkpoint/_traverse.py
+++ b/torch/distributed/checkpoint/_traverse.py
@@ -77,7 +77,7 @@ def traverse_state_dict_v_2_3(
     keep_traversing: Callable[[STATE_DICT_ITEM], bool] = _keep_visiting_tensors,
 ) -> None:
     """
-    Traversal is short-circuited when if finds a collection for which ``keep_visiting_tensors`` evaluates
+    Traversal is short-circuited when it finds a collection for which ``keep_visiting_tensors`` evaluates
     to false for all elements.
     By default, all collections with at least one ``torch.Tensor`` element are traversed.
     Visitor takes a path argument that is a tuple of the keys used to reach it.
@@ -203,6 +203,6 @@ def print_tensor(
     Use this callback with traverse_state_dict to print its content.
 
     By default the content is printed using the builtin ``print`` but this can
-    be change by passing a different ``print_fun` callable.
+    be changed by passing a different ``print_fun`` callable.
     """
     _print_nested(value, prefix=str(path), print_fun=print_fun)

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -135,7 +135,7 @@ def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
     host, port = parse_rendezvous_endpoint(params.endpoint, default_port=DEFAULT_PORT)
 
     cfg_is_host = params.get_as_bool("is_host")
-    # If the user has explicitly specified whether our process should host the
+    # If the user has explicitly specified whether our process should host
     # the store, respect it.
     if cfg_is_host is not None:
         is_host = cfg_is_host

--- a/torch/distributed/tensor/_ops/_matrix_ops.py
+++ b/torch/distributed/tensor/_ops/_matrix_ops.py
@@ -1273,7 +1273,7 @@ def grouped_mm_strategy(op_schema: OpSchema) -> OpStrategy:
         output_specs: DTensorSpec | tuple[DTensorSpec | None, ...],
     ) -> bool:
         # 1. compute the local-tensor shape/strides given this sharding proposal
-        # 2. apply the logic from the groped_mm meta function
+        # 2. apply the logic from the grouped_mm meta function
         # UGH the input DTensorSpecs are missing their tensormetas... so i can get them another way
         def local_meta(spec: OpSpec, placements: tuple[Placement, ...]) -> TensorMeta:
             if not isinstance(spec.output_specs, DTensorSpec):

--- a/torch/export/graph_signature.py
+++ b/torch/export/graph_signature.py
@@ -345,7 +345,7 @@ class ExportGraphSignature:
             elif isinstance(s.arg, ConstantArgument):
                 user_inputs.append(s.arg.value)
             else:
-                raise RuntimeError(f"{s.arg} is not a valid user inputs")
+                raise RuntimeError(f"{s.arg} is not a valid user input")
         return tuple(user_inputs)
 
     # Graph node names of pytree-flattened outputs of original program

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 """
 This file does three things:
 - Contains the definition of SymNode
-- Installs all the magic methods into SymBool, SymFloat, SymFloat at import time
+- Installs all the magic methods into SymBool, SymFloat, SymInt at import time
 - Does not depend on sympy at import time
 
 As this file is imported from within torch/__init__.py we do not want it to depend on SymPy

--- a/torch/masked/_ops.py
+++ b/torch/masked/_ops.py
@@ -169,7 +169,7 @@ Example::
     )
 
     args_and_kwargs = {
-        # argument name sufficies separated by double underscore will
+        # argument name suffixes separated by double underscore will
         # be removed in the final documentation string.
         "sum": (("dim",), ("keepdim=False", "dtype=None", "mask=None")),
         "prod": (("dim",), ("keepdim=False", "dtype=None", "mask=None")),

--- a/torch/onnx/_internal/fx/passes/type_promotion.py
+++ b/torch/onnx/_internal/fx/passes/type_promotion.py
@@ -1114,7 +1114,7 @@ _EXTRA_TYPE_PROMOTION_RULE_SET = {
 
 
 class ElementwiseTypePromotionRuleSetGenerator:
-    """Hackly distilling info from reference ops decorated with elementwise type promotion rule.
+    """Hackily distilling info from reference ops decorated with elementwise type promotion rule.
 
     The goal is to retrieve the decorator
 

--- a/torch/onnx/_internal/torchscript_exporter/utils.py
+++ b/torch/onnx/_internal/torchscript_exporter/utils.py
@@ -312,7 +312,7 @@ def export(
             as arguments, with the ordering as specified by ``model.state_dict().values()``
         verbose: if True, prints a description of the
             model being exported to stdout. In addition, the final ONNX graph will include the
-            field ``doc_string``` from the exported model which mentions the source code locations
+            field ``doc_string`` from the exported model which mentions the source code locations
             for ``model``. If True, ONNX exporter logging will be turned on.
         training:
             * ``TrainingMode.EVAL``: export the model in inference mode.
@@ -1213,7 +1213,7 @@ def unconvertible_ops(
     training: _C_onnx.TrainingMode = _C_onnx.TrainingMode.EVAL,
     opset_version: int | None = None,
 ) -> tuple[_C.Graph, list[str]]:
-    """Returns an approximated list of all ops that are yet supported by :mod:`torch.onnx`.
+    """Returns an approximated list of all ops that are not yet supported by :mod:`torch.onnx`.
 
     .. deprecated:: 2.5
         Unconvertible ops are not definitive. Please remove usage of this function.
@@ -1826,7 +1826,7 @@ def _verify_custom_op_name(symbolic_name: str) -> None:
             f"Failed to register operator {symbolic_name}. "
             "The symbolic name must match the format domain::name, "
             "and should start with a letter and contain only "
-            "alphanumerical characters"
+            "alphanumeric characters"
         )
 
     ns, _ = jit_utils.parse_node_kind(symbolic_name)
@@ -1885,7 +1885,7 @@ def unregister_custom_op_symbolic(symbolic_name: str, opset_version: int) -> Non
 
 
 def _validate_dynamic_axes(dynamic_axes, model, input_names, output_names) -> None:
-    """Ensures dynamic axes argument is follows the expected format."""
+    """Ensures dynamic axes argument follows the expected format."""
     if len(dynamic_axes) == 0:
         return
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1171,7 +1171,7 @@ class SequentialLR(LRScheduler):
 
     def recursive_undo(self, sched=None) -> None:
         """
-        Recursively undo any step performed by the initialisation of
+        Recursively undo any step performed by the initialization of
         schedulers.
         """
         scheds = self if sched is None else sched

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -170,7 +170,7 @@ def _all_contexts_cleaned_up(timeout_seconds=10):
     return success
 
 
-# This function creates a dis autograd context, run rpc_sync on the given ps,
+# This function creates a dist autograd context, run rpc_sync on the given ps,
 # and then blocks until the ps has verified the grads are correctly accumulated.
 def _run_trainer(rref_t1, t2, ps, rank_diff, sparse):
     with dist_autograd.context() as context_id:
@@ -979,7 +979,7 @@ class CommonDistAutogradTest(RpcAgentTestFixture):
         send_functions = ctx._send_functions()
         self.assertEqual(2, len(send_functions))
 
-        # For send function when making nest rpc call,
+        # For send function when making nested rpc call,
         # next functions of the send function are two recv functions
         # for received two tensors from previous call
         next_funcs = next(iter(send_functions.values())).next_functions

--- a/torch/utils/data/datapipes/iter/combining.py
+++ b/torch/utils/data/datapipes/iter/combining.py
@@ -115,7 +115,7 @@ class ForkerIterDataPipe(IterDataPipe):
 
 
 class _ContainerTemplate(ABC):
-    r"""Abstract class for container ``DataPipes``. The followings are three required methods."""
+    r"""Abstract class for container ``DataPipes``. The following are three required methods."""
 
     @abstractmethod
     def get_next_element_by_instance(self, instance_id: int): ...
@@ -307,7 +307,7 @@ class _ChildDataPipe(IterDataPipe):
 
     Example:
         >>> # xdoctest: +REQUIRES(module:torchdata)
-        >>> # Singler Iterator per IteraDataPipe Invalidation
+        >>> # Single Iterator per IterDataPipe Invalidation
         >>> from torchdata.datapipes.iter import IterableWrapper
         >>> source_dp = IterableWrapper(range(10))
         >>> cdp1, cdp2 = source_dp.fork(num_instances=2)
@@ -433,7 +433,7 @@ class DemultiplexerIterDataPipe(IterDataPipe):
 
         # When num_instances == 1, demux can be replaced by filter,
         # but keep it as Demultiplexer for the sake of consistency
-        # like throwing Error when classification result is out of o range
+        # like throwing Error when classification result is out of range
         container = _DemultiplexerIterDataPipe(
             datapipe, num_instances, classifier_fn, drop_none, buffer_size
         )  # type: ignore[abstract]

--- a/torch/utils/data/datapipes/iter/grouping.py
+++ b/torch/utils/data/datapipes/iter/grouping.py
@@ -90,7 +90,7 @@ class BatcherIterDataPipe(IterDataPipe[DataChunk]):
 @functional_datapipe("unbatch")
 class UnBatcherIterDataPipe(IterDataPipe):
     r"""
-    Undos batching of data (functional name: ``unbatch``).
+    Undoes batching of data (functional name: ``unbatch``).
 
     In other words, it flattens the data up to the specified level within a batched DataPipe.
 

--- a/torch/utils/data/datapipes/iter/routeddecoder.py
+++ b/torch/utils/data/datapipes/iter/routeddecoder.py
@@ -26,7 +26,7 @@ class RoutedDecoderIterDataPipe(IterDataPipe[tuple[str, Any]]):
     Args:
         datapipe: Iterable datapipe that provides pathname and binary stream in tuples
         handlers: Optional user defined decoder handlers. If ``None``, basic and image decoder
-            handlers will be set as default. If multiple handles are provided, the priority
+            handlers will be set as default. If multiple handlers are provided, the priority
             order follows the order of handlers (the first handler has the top priority)
         key_fn: Function for decoder to extract key from pathname to dispatch handlers.
             Default is set to extract file extension from pathname

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -127,7 +127,7 @@ def traverse(datapipe: DataPipe, only_datapipe: bool | None = None) -> DataPipeG
         and values are tuples of DataPipe instance and the sub-graph
     """
     msg = (
-        "`traverse` function and will be removed after 1.13. "
+        "`traverse` function is deprecated and will be removed after 1.13. "
         "Please use `traverse_dps` instead."
     )
     if not only_datapipe:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185719

Correct spelling and grammar errors across Python and C++ source files
in torch, including fixes like "rewrie" -> "rewrite", "it's" -> "its"
(possessive), "Mixing" -> "Mixin", "ospet" -> "opset", duplicate words,
and other minor textual issues. No functional changes.

Authored with Claude (typo_terminator2).

cc @EikanWang @jgong5 @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98