### PR TITLE
Document bernoulli(input, p) overload in torch docs

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1487,6 +1487,31 @@ Example::
     tensor([[ 0.,  0.,  0.],
             [ 0.,  0.,  0.],
             [ 0.,  0.,  0.]])
+
+.. function:: bernoulli(input, p, *, generator=None) -> Tensor
+   :noindex:
+
+Draws binary random numbers (0 or 1) from a Bernoulli distribution, using the
+single probability :attr:`p` for every element. In this overload the values of
+:attr:`input` are ignored; the tensor is used only to determine the shape,
+``dtype``, ``layout`` and ``device`` of the returned tensor.
+
+Args:
+    input (Tensor): the tensor that defines the shape, ``dtype``, ``layout``
+        and ``device`` of the output tensor
+    p (float): the probability of drawing ``1``, shared by all elements. Must
+        be in the range :math:`0 \leq p \leq 1`.
+
+Keyword args:
+    {generator}
+
+Example::
+
+    >>> a = torch.empty(3, 3)
+    >>> torch.bernoulli(a, 0.5)
+    tensor([[ 0.,  1.,  0.],
+            [ 1.,  1.,  0.],
+            [ 0.,  1.,  1.]])
 """.format(**common_args),
 )
 


### PR DESCRIPTION
Fixes #152095

### Summary

`torch.bernoulli` accepts two distinct call forms:

- `torch.bernoulli(input, *, generator=None, out=None)` draws from per-element probabilities held in `input`.
- `torch.bernoulli(input, p, *, generator=None)` draws using a single scalar probability `p` for every element of `input`.

Only the first form was documented. This PR documents the `bernoulli(input, p)` overload using the same `.. function::` + `:noindex:` convention already used for `torch.normal` overloads, so the rendered docs list both signatures.

### Changes

- `torch/_torch_docs.py`: add a `.. function:: bernoulli(input, p, *, generator=None) -> Tensor` block (with `:noindex:`) and a short example to the `torch.bernoulli` docstring.

### Notes

- Documentation-only change; no runtime behavior is affected.
- Added lines are <= 80 chars and follow the surrounding docstring style.
