### PR TITLE
Reapply [8.5A/11][aoti] Add C-ABI-safe AOTInductorModelCreateV2

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -72,6 +72,33 @@ std::unordered_map<std::string, AtenTensorHandle> constant_map_from_pairs(
   return input_map;
 }
 
+// Shared constructor for AOTInductorModelCreate / AOTInductorModelCreateV2.
+// `populate(constant_map)` is called between model construction and
+// optional embedded-blob loading.
+template <typename Populate>
+AOTIRuntimeError createModelImpl(
+    AOTInductorModelHandle* model_handle,
+    bool load_constants_from_blob,
+    Populate&& populate) {
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto constant_map = std::make_shared<torch::aot_inductor::ConstantMap>();
+    auto constant_array = std::make_shared<
+        std::vector<torch::aot_inductor::ConstantHandle>>();
+    auto* model = new torch::aot_inductor::AOTInductorModel(
+        constant_map,
+        constant_array,
+        // device_str is hardcoded, as AOTInductorModelCreate is only used
+        // for CPU models.
+        "cpu",
+        "");
+    populate(*constant_map);
+    if (load_constants_from_blob) {
+      model->load_constants();
+    }
+    *model_handle = reinterpret_cast<AOTInductorModelHandle>(model);
+  })
+}
+
 } // namespace
 
 extern "C" {
@@ -502,29 +529,34 @@ AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
 
 AOTIRuntimeError AOTInductorModelCreate(
     AOTInductorModelHandle* model_handle,
-    AOTInductorConstantMapHandle constant_map_handle){
-    CONVERT_EXCEPTION_TO_ERROR_CODE({
-      auto constant_map = std::make_shared<torch::aot_inductor::ConstantMap>();
-      auto constant_array = std::make_shared<std::vector<torch::aot_inductor::ConstantHandle>>();
-      auto input_map = reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(constant_map_handle);
-
-      auto model = new torch::aot_inductor::AOTInductorModel(
-          constant_map,
-          constant_array,
-          "cpu", // device_str is hardcoded, as AOTInductorModelCreate is only use for CPU models
-          ""
-      );
-
-      if (input_map) {
-        for (auto const& kv : *input_map) {
-          constant_map->emplace(kv.first, kv.second);
+    AOTInductorConstantMapHandle constant_map_handle) {
+  return createModelImpl(
+      model_handle, constant_map_handle == nullptr, [=](auto& constant_map) {
+        auto* input_map = reinterpret_cast<
+            std::unordered_map<std::string, AtenTensorHandle>*>(
+            constant_map_handle);
+        if (input_map) {
+          for (const auto& kv : *input_map) {
+            constant_map.emplace(kv.first, kv.second);
+          }
         }
-      } else {
-        model->load_constants();
-      }
+      });
+}
 
-      *model_handle = reinterpret_cast<AOTInductorModelHandle>(model);
-    })}
+AOTIRuntimeError AOTInductorModelCreateV2(
+    AOTInductorModelHandle* model_handle,
+    const AOTInductorConstantMapEntry* pairs,
+    size_t num_pairs) {
+  return createModelImpl(
+      model_handle, pairs == nullptr || num_pairs == 0, [=](auto& constant_map) {
+        if (pairs && num_pairs > 0) {
+          constant_map.reserve(num_pairs);
+          for (size_t i = 0; i < num_pairs; ++i) {
+            constant_map.emplace(pairs[i].name, pairs[i].handle);
+          }
+        }
+      });
+}
 
 AOTIRuntimeError AOTInductorModelRun(
     AOTInductorModelHandle model_handle,

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -326,9 +326,19 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerGetOutputName(
 //
 // constant_map_handle is an opaque type to satisfy the C ABI.  It should be a
 // std::unordered_map<std::string, at::Tensor*>*.
+//
+// DEPRECATED: V1 API; see AOTInductorModelCreateV2.
 AOTI_API AOTIRuntimeError AOTInductorModelCreate(
     AOTInductorModelHandle* model_handle,
     AOTInductorConstantMapHandle constant_map_handle);
+
+// C-ABI-safe variant of AOTInductorModelCreate.
+// Pass `pairs == nullptr` (or `num_pairs == 0`) to load constants from the
+// embedded blob instead of an externally provided map.
+AOTI_API AOTIRuntimeError AOTInductorModelCreateV2(
+    AOTInductorModelHandle* model_handle,
+    const AOTInductorConstantMapEntry* pairs,
+    size_t num_pairs);
 
 // Run an AOTInductorModel (see AOTInductorModelCreate for when one should use
 // this function versus AOTInductorModelContainerRun).


### PR DESCRIPTION
Summary:
Reapply of D104312401, which was reverted due to a landing conflict. The change itself is unchanged; this re-lands it on top of the revert.

Add AOTInductorModelCreateV2, a C-ABI-safe replacement for AOTInductorModelCreate.

The legacy create API accepts `AOTInductorConstantMapHandle`, which is a `std::unordered_map<std::string, AtenTensorHandle>*` crossing the model DSO boundary. The V2 API accepts flat `AOTInductorConstantMapEntry[]` input, or `nullptr` to load embedded constants.

`AOTInductorModelCreate` and `AOTInductorModelCreateV2` share `createModelImpl` so construction semantics stay identical. This is additive; the V1 symbol remains exported for existing callers.

Test Plan:
```
buck build fbcode//mode/opt fbcode//caffe2:torch-cpp-cpu fbcode//caffe2/test/inductor/fb:test_aot_inductor_model_runner_pybind fbcode//sigmoid/core/executor:aoti_model_impl_cpu
```

Differential Revision: D106952411




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo