### PR TITLE
Fix dynamic shape constraints for variadic kwargs

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6153,6 +6153,82 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
             got = mod(*args)
             self.assertTrue(torch.allclose(expected, got))
 
+    @testing.expectedFailureRetraceability
+    @testing.expectedFailureRetraceabilityNonStrict
+    def test_dynamic_shapes_with_var_keyword(self):
+        class M(torch.nn.Module):
+            def forward(self, **kwargs):
+                return kwargs["x"] + kwargs["y"]
+
+        x, y = torch.randn(2, 3), torch.randn(2, 3)
+        dynamic_shapes = {
+            "kwargs": {
+                "x": {0: torch.export.Dim("batch")},
+                "y": {0: torch.export.Dim("batch")},
+            }
+        }
+
+        ep = export(
+            M(),
+            (),
+            kwargs={"x": x, "y": y},
+            dynamic_shapes=dynamic_shapes,
+        )
+        self.assertEqual(len(ep.range_constraints), 1)
+
+    @testing.expectedFailureRetraceability
+    @testing.expectedFailureRetraceabilityNonStrict
+    def test_dynamic_shapes_with_var_args_and_var_keyword(self):
+        class M(torch.nn.Module):
+            def forward(self, *args, **kwargs):
+                return args[0] + kwargs["y"]
+
+        x, y = torch.randn(2, 3), torch.randn(2, 3)
+        dynamic_shapes = {
+            "args": ({0: torch.export.Dim("batch")},),
+            "kwargs": {"y": {0: torch.export.Dim("batch")}},
+        }
+
+        ep = export(
+            M(),
+            (x,),
+            kwargs={"y": y},
+            dynamic_shapes=dynamic_shapes,
+        )
+        self.assertEqual(len(ep.range_constraints), 1)
+
+    @testing.expectedFailureRetraceability
+    @testing.expectedFailureRetraceabilityNonStrict
+    def test_dynamic_shapes_with_named_and_var_keyword(self):
+        class M(torch.nn.Module):
+            def forward(self, x, **kwargs):
+                return x.sum() + kwargs["y"].sum() + kwargs["z"].sum()
+
+        x = torch.randn(5, 3)
+        y = torch.randn(7, 3)
+        z = torch.randn(2, 3)
+        dynamic_shapes = {
+            "x": {0: torch.export.Dim("dx", min=5, max=6)},
+            "kwargs": {
+                "y": {0: torch.export.Dim("dy", min=7, max=8)},
+                "z": {0: torch.export.Dim("dz", min=2, max=4)},
+            },
+        }
+
+        ep = export(
+            M(),
+            (),
+            kwargs={"z": z, "x": x, "y": y},
+            dynamic_shapes=dynamic_shapes,
+        )
+        mod = ep.module()
+        test_kwargs = {
+            "z": torch.randn(3, 3),
+            "x": torch.randn(6, 3),
+            "y": torch.randn(8, 3),
+        }
+        self.assertEqual(mod(**test_kwargs), M()(**test_kwargs))
+
     def test_dynamic_shapes_builder_basic(self):
         class M(torch.nn.Module):
             def forward(self, x, y, z):

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -44,6 +44,7 @@ from torch._export.passes.lift_constants_pass import (
     ConstantAttrMap,
 )
 from torch._export.utils import (
+    _bind_signature_to_inputs,
     _collect_param_buffer_metadata,
     _compiling_state_context,
     _fakify_params_buffers,
@@ -84,6 +85,7 @@ from torch.export.dynamic_shapes import (
     _DimHintType,
     _IntWrapper,
     _process_dynamic_shapes,
+    _tree_map_with_path,
 )
 from torch.export.exported_program import OutputKind
 from torch.fx._symbolic_trace import _ConstantAttributeType
@@ -1500,6 +1502,47 @@ def _get_module_call_graph(
     return gm, module_call_graph
 
 
+def _remap_dynamic_shapes_to_trace_order(
+    mod: torch.nn.Module,
+    args,
+    kwargs,
+    dynamic_shapes,
+):
+    combined_args = _bind_signature_to_inputs(mod, args, kwargs)
+    if not dynamic_shapes:
+        return combined_args, dynamic_shapes
+
+    signature_bound_args = _combine_args(mod, args, kwargs)
+    if isinstance(dynamic_shapes, (tuple, list)):
+        dynamic_shapes = dict(zip(signature_bound_args.keys(), dynamic_shapes))
+
+    parameters = inspect.signature(mod.forward).parameters
+    dynamic_shapes_by_path = {}
+
+    def to_trace_path(path):
+        if not path or not isinstance(path[0], pytree.MappingKey):
+            return path
+        parameter = parameters.get(path[0].key)
+        if parameter is not None and parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            return path[1:]
+        return path
+
+    def record_dynamic_shape(path, _arg, shape):
+        dynamic_shapes_by_path[pytree.keystr(to_trace_path(path))] = shape
+
+    _tree_map_with_path(
+        record_dynamic_shape,
+        signature_bound_args,
+        dynamic_shapes,
+        tree_name="inputs",
+    )
+
+    return combined_args, _tree_map_with_path(
+        lambda path, _arg: dynamic_shapes_by_path.get(pytree.keystr(path)),
+        combined_args,
+    )
+
+
 def _get_range_constraints(
     mod: torch.nn.Module,
     export_artifact: ExportArtifact,
@@ -1518,21 +1561,9 @@ def _get_range_constraints(
         ),
         len(export_graph_signature.input_specs),
     )
-    combined_args = _combine_args(mod, args, kwargs)
-
-    # This is because we trace based on the kwargs passed in from user
-    # not based on the signature. I feel it would be better to just enforce
-    # one ordering at the start of tracing to avoid confusions, but that is
-    # bigger refactor, so do this to unblock for now.
-    combined_args_traced_order = {}
-    for arg in combined_args:
-        if arg not in kwargs:
-            combined_args_traced_order[arg] = combined_args[arg]
-
-    for key in kwargs:
-        combined_args_traced_order[key] = kwargs[key]
-
-    combined_args = combined_args_traced_order
+    combined_args, dynamic_shapes = _remap_dynamic_shapes_to_trace_order(
+        mod, args, kwargs, dynamic_shapes
+    )
 
     range_constraints = make_constraints(
         fake_mode,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185736

Dynamic shape validation accepts specs against the module's bound
signature. For a forward with `**kwargs`, that means a spec can be
nested under the variadic keyword parameter, such as
`dynamic_shapes={"kwargs": {"x": ..., "y": ...}}`.

Range constraint generation later rebuilt the input tree in traced
placeholder order, where actual keyword inputs are flattened in call
order. That left the input tree and dynamic_shapes tree with different
structures, so the issue repro failed while flattening dynamic shapes.
A naive fix that only preserved the `kwargs` container still assigned
constraints incorrectly when a named kwarg was interleaved between
multiple `**kwargs` leaves.

Fix this by remapping the signature-bound dynamic_shapes tree into the
same traced input tree/order before calling `make_constraints`. For
variadic keyword parameters, the remap drops the `**kwargs` container
name from dynamic-shape paths so actual keyword leaves align with graph
placeholder order while preserving the validation semantics users wrote.

Regression tests cover pure `**kwargs`, mixed `*args`/`**kwargs`, and
an interleaved named-kwarg plus `**kwargs` case with distinct ranges.
The new tests are marked as expected failures only for the generated
retraceability harness because that harness replays `ep.module()` with a
flattened signature and mechanically rewrites dict dynamic_shapes to a
tuple, which is incompatible with the original module's `**kwargs`
signature-level spec.

Fixes #150022
Generated by my agent

Test Plan:
- python - <<'PY'
  import torch
  class Model(torch.nn.Module):
      def forward(self, **kwargs):
          return kwargs["x"] + kwargs["y"]
  x, y = torch.randn(2, 3), torch.randn(2, 3)
  ds = {"kwargs": {"x": {0: torch.export.Dim("batch")}, "y": {0: torch.export.Dim("batch")}}}
  for strict in (True, False):
      ep = torch.export.export(Model(), tuple(), kwargs={"x": x, "y": y}, dynamic_shapes=ds, strict=strict)
      print(strict, ep.range_constraints)
  PY
- python test/export/test_export.py TestExport.test_dynamic_shapes_with_var_keyword TestExport.test_dynamic_shapes_with_var_args_and_var_keyword TestExport.test_dynamic_shapes_with_named_and_var_keyword TestExport.test_kwarg_dynamic_shapes_diff_order TestExport.test_non_arg_name_dynamic_shapes_api_with_kwarg TestExport.test_mismatched_dynamic_shapes
- python test/export/test_retraceability.py RetraceExportTestExport.test_dynamic_shapes_with_var_keyword_retraceability_strict RetraceExportNonStrictTestExport.test_dynamic_shapes_with_var_keyword_retraceability_nonstrict RetraceExportTestExport.test_dynamic_shapes_with_var_args_and_var_keyword_retraceability_strict RetraceExportNonStrictTestExport.test_dynamic_shapes_with_var_args_and_var_keyword_retraceability_nonstrict RetraceExportTestExport.test_dynamic_shapes_with_named_and_var_keyword_retraceability_strict RetraceExportNonStrictTestExport.test_dynamic_shapes_with_named_and_var_keyword_retraceability_nonstrict
- python test/export/test_export_strict.py StrictExportTestExport.test_dynamic_shapes_with_var_keyword_strict StrictExportTestExport.test_dynamic_shapes_with_var_args_and_var_keyword_strict StrictExportTestExport.test_dynamic_shapes_with_named_and_var_keyword_strict
- python test/export/test_export.py TestExport.test_dynamic_shapes_builder_basic TestExport.test_dynamic_shapes_builder_kwargs TestExport.test_dynamic_shapes_builder_pytree TestExport.test_non_arg_name_dynamic_shapes_api TestExport.test_non_arg_name_dynamic_shapes_api_with_kwarg TestExport.test_non_arg_name_dynamic_shapes_api_with_container_type
- lintrunner -a

Benchmark Results:
Export benchmark command used a small kwargs model with dynamic shapes,
three warmups, then 20 timed `torch.export.export` calls with
`torch._dynamo.reset()` before each export.

Baseline main:
- median 18.353 ms, mean 18.662 ms, min 18.025 ms, max 20.279 ms
- raw ms: 19.645, 19.648, 20.279, 19.824, 18.114, 18.477, 18.399, 18.340, 18.876, 18.346, 18.295, 18.310, 18.361, 18.025, 18.848, 18.146, 18.338, 18.185, 18.222, 18.564

Patched:
- median 18.861 ms, mean 18.876 ms, min 18.247 ms, max 19.370 ms
- raw ms: 18.905, 18.446, 18.526, 19.171, 18.247, 18.858, 18.708, 18.750, 19.264, 19.370, 18.708, 18.840, 19.214, 19.079, 19.250, 18.748, 18.883, 18.863, 18.646, 19.040