### PR TITLE
[torchgen] Remove dead code and dedupe pyi "| None" helper

### DIFF
--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -274,7 +274,7 @@ class PythonArgument:
 
         # pyi merges the _out and functional variants into the same signature, with an optional out arg
         if name == "out" and not deprecated:
-            type_str = f"{type_str} | None".replace(" | None | None", " | None")
+            type_str = _append_optional_pyi(type_str)
 
         # pyi deprecated signatures don't get defaults for their out arg
         treat_as_no_default = (
@@ -455,8 +455,6 @@ class PythonSignature:
 
         # Below are the major changes in vararg vs. regular pyi signatures
         # vararg signatures also omit the asterix
-        if not isinstance(vararg_type, ListType):
-            raise AssertionError(f"Expected ListType, got {type(vararg_type)}")
         schema_formals[0] = (
             "*" + args[0].name + ": " + argument_type_str_pyi(vararg_type.elem)
         )
@@ -915,6 +913,11 @@ def structseq_fieldnames(returns: tuple[Return, ...]) -> list[str]:
         return [str(r.name) for r in returns]
 
 
+def _append_optional_pyi(type_str: str) -> str:
+    # Append `| None`, avoiding a doubled `| None` if the type is already optional.
+    return f"{type_str} | None".replace(" | None | None", " | None")
+
+
 def argument_type_str_pyi(t: Type) -> str:
     add_optional = False
     if isinstance(t, OptionalType):
@@ -980,7 +983,7 @@ def argument_type_str_pyi(t: Type) -> str:
         raise RuntimeError(f"unrecognized type {repr(t)}")
 
     if add_optional:
-        ret = f"{ret} | None".replace(" | None | None", " | None")
+        ret = _append_optional_pyi(ret)
 
     return ret
 
@@ -991,7 +994,7 @@ def return_type_str_pyi(t: Type) -> str:
 
     if isinstance(t, OptionalType):
         inner = return_type_str_pyi(t.elem)
-        return f"{inner} | None".replace(" | None | None", " | None")
+        return _append_optional_pyi(inner)
 
     if isinstance(t, BaseType):
         if t.name == BaseTy.Device:

--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -356,10 +356,9 @@ class RegisterDispatchKey:
                 updates = f"{copy_op}({func_res}, {out_arg.name});"
 
         functional_sig = self.wrapper_kernel_sig(g.functional)
-        wrapper_name = sig.name()
 
         return f"""\
-{sig.defn(name=wrapper_name)} {{
+{sig.defn(name=name)} {{
   auto {func_res} = {functional_sig.name()}({", ".join(e.expr for e in translate(sig.arguments(), functional_sig.arguments()))});
   {updates}
   return {returns};
@@ -710,11 +709,7 @@ resize_out(out, sizes, strides, options);
             output_type = "Tensor"
             output_value = "outputs_[output_idx]"
             proxy_field = ""
-        elif k is SchemaKind.inplace:
-            output_type = "std::reference_wrapper<Tensor>"
-            output_value = "proxy_outputs_[output_idx].has_value() ? *proxy_outputs_[output_idx] : outputs_[output_idx].get()"
-            proxy_field = f"std::array<::std::optional<Tensor>, {len(f.func.returns)}> proxy_outputs_;"
-        elif k is SchemaKind.out:
+        elif k is SchemaKind.inplace or k is SchemaKind.out:
             output_type = "std::reference_wrapper<Tensor>"
             output_value = "proxy_outputs_[output_idx].has_value() ? *proxy_outputs_[output_idx] : outputs_[output_idx].get()"
             proxy_field = f"std::array<::std::optional<Tensor>, {len(f.func.returns)}> proxy_outputs_;"

--- a/torchgen/gen_functionalization_type.py
+++ b/torchgen/gen_functionalization_type.py
@@ -349,7 +349,7 @@ def emit_expr_has_symbolic_values(expr: str, type: CType) -> str:
 
 # Detects whether any of the SymInt arguments are, in fact, symbolic values.
 # This is used in the constructor of ViewMeta.
-def emit_has_symbolic_inputs(sig: DispatcherSignature) -> tuple[str, str]:
+def emit_has_symbolic_inputs(sig: DispatcherSignature) -> str:
     name = "has_symbolic_inputs"
     statements = [
         f"{name} = {name} | ({emit_expr_has_symbolic_values(binding.name, binding.nctype.type)});"
@@ -360,12 +360,9 @@ def emit_has_symbolic_inputs(sig: DispatcherSignature) -> tuple[str, str]:
         )
     ]
     body = "\n      ".join(statements)
-    return (
-        name,
-        f"""
+    return f"""
       bool {name} = false;
-      {body}""",
-    )
+      {body}"""
 
 
 # Generates the Functionalization kernel for:
@@ -424,10 +421,7 @@ def emit_view_functionalization_body(
             e.expr for e in translate(meta_call_ctx, call_sig.arguments(), method=False)
         ]
 
-        (
-            symbolic_inputs_varname,
-            symbolic_inputs_check,
-        ) = emit_has_symbolic_inputs(call_sig)
+        symbolic_inputs_check = emit_has_symbolic_inputs(call_sig)
 
         if "inplace_view" in f.tags:
             # See Note [Functionalization Pass - Inplace View Ops] for more details


### PR DESCRIPTION
  Codegen-only cleanup, no change to generated output:
  - python.py: drop an unreachable `isinstance` guard; extract `_append_optional_pyi` helper (3 call sites)
  - register_dispatch_key.py: drop redundant `wrapper_name`; merge identical inplace/out branches
  - gen_functionalization_type.py: `emit_has_symbolic_inputs` returns `str` instead of an `(name, body)` tuple whose first element was unused