### PR TITLE
[PyTorch][Profiler] Fix use-after-free in global RecordFunction callback teardown (#185741)

### DIFF
--- a/test/cpp/profiler/profiler_global_callback_race_test.cpp
+++ b/test/cpp/profiler/profiler_global_callback_race_test.cpp
@@ -1,0 +1,119 @@
+#include <algorithm>
+#include <atomic>
+#include <set>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <ATen/record_function.h>
+#include <torch/csrc/autograd/profiler_kineto.h>
+#include <torch/csrc/profiler/orchestration/observer.h>
+
+// Reproducer for a use-after-free in the profiler's *global* RecordFunction
+// callback path.
+//
+// When the profiler installs global callbacks (ProfilerState::KINETO_ONDEMAND,
+// or ProfilerState::KINETO with ExperimentalConfig.profile_all_threads=true),
+// enableProfiler() registers the callback via at::addGlobalCallback, so it
+// fires on every thread -- including long-lived worker threads (e.g. the
+// DataLoader pin_memory thread that crashed in production). onFunctionEnter
+// fetches the profiler state through a raw, non-owning pointer and then
+// dereferences it:
+//
+//   auto state_ptr = KinetoThreadLocalState::get(/*global=*/true);
+//   if (!state_ptr) return nullptr;
+//   return state_ptr->recordQueue.getSubqueue()->begin_op(fn);  // <-- UAF
+//
+// disableProfiler() (running on another thread) pops and frees that state
+// without waiting for in-flight global callbacks to finish, so the worker
+// thread can dereference freed memory between the null check and begin_op.
+//
+// We drive the path with ProfilerState::KINETO + profile_all_threads=true --
+// exactly the configuration torch.profiler uses when profile_all_threads is
+// requested, which is what crashed in production. This installs the global
+// RecordFunction callback (instantiating onFunctionEnter<true>/
+// onFunctionExit<true>) and tears it down through disableProfiler().
+//
+// The test continuously dispatches ATen ops on worker threads while the main
+// thread repeatedly enables and disables the profiler. On unfixed code this
+// segfaults / trips ASAN heap-use-after-free, usually within a few hundred
+// iterations. The pass condition is simply that the process runs to completion
+// without crashing.
+
+namespace {
+
+using torch::profiler::impl::ActivityType;
+using torch::profiler::impl::ExperimentalConfig;
+using torch::profiler::impl::ProfilerConfig;
+using torch::profiler::impl::ProfilerState;
+
+ProfilerConfig makeGlobalCallbackCpuConfig() {
+  ExperimentalConfig experimental_config;
+  experimental_config.profile_all_threads = true;
+  return ProfilerConfig(
+      ProfilerState::KINETO,
+      /*report_input_shapes=*/false,
+      /*profile_memory=*/false,
+      /*with_stack=*/false,
+      /*with_flops=*/false,
+      /*with_modules=*/false,
+      experimental_config);
+}
+
+} // namespace
+
+TEST(ProfilerGlobalCallbackRaceTest, DisableDuringConcurrentDispatch) {
+  at::clearCallbacks();
+
+  constexpr int kIterations = 2000;
+  const unsigned int kNumWorkers =
+      std::max(3u, std::min(8u, std::thread::hardware_concurrency()));
+
+  std::atomic<bool> stop{false};
+  std::atomic<unsigned int> workers_ready{0};
+
+  std::vector<std::thread> workers;
+  workers.reserve(kNumWorkers);
+  for (unsigned int i = 0; i < kNumWorkers; ++i) {
+    workers.emplace_back([&]() {
+      auto a = at::ones({8});
+      auto b = at::ones({8});
+      workers_ready.fetch_add(1);
+      // Continuously dispatch an op that runs RecordFunction (FUNCTION scope),
+      // so the global profiler callback fires on this thread while it is alive.
+      while (!stop.load(std::memory_order_relaxed)) {
+        // at::add dispatches through the dispatcher and runs RecordFunction;
+        // the call crosses the library boundary so it is not optimized away.
+        auto c = a + b;
+        (void)c;
+      }
+    });
+  }
+
+  // Wait for all workers to be actively dispatching before we start toggling.
+  while (workers_ready.load() < kNumWorkers) {
+    std::this_thread::yield();
+  }
+
+  const std::set<ActivityType> activities{ActivityType::CPU};
+  const std::unordered_set<at::RecordScope> scopes{at::RecordScope::FUNCTION};
+  for (int i = 0; i < kIterations; ++i) {
+    const auto config = makeGlobalCallbackCpuConfig();
+    torch::autograd::profiler::prepareProfiler(config, activities);
+    torch::autograd::profiler::enableProfiler(config, activities, scopes);
+    // Keep the enabled window short so disable overlaps with callbacks that
+    // are in flight on the worker threads -- this is the race window.
+    torch::autograd::profiler::disableProfiler();
+  }
+
+  stop.store(true);
+  for (auto& worker : workers) {
+    worker.join();
+  }
+
+  // After a clean teardown there must be no dangling global callback.
+  EXPECT_FALSE(at::hasGlobalCallbacks());
+}

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -5,6 +5,7 @@
 #include <c10/macros/Export.h>
 #include <c10/util/ApproximateClock.h>
 #include <c10/util/Exception.h>
+#include <c10/util/ScopeExit.h>
 #include <c10/util/flat_hash_map.h>
 #include <c10/util/irange.h>
 #include <c10/util/overloaded.h>
@@ -20,6 +21,9 @@
 #include <torch/csrc/profiler/standalone/privateuse1_observer.h>
 #include <torch/csrc/profiler/util.h>
 
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <stdexcept>
 #include <utility>
 
@@ -570,14 +574,77 @@ struct KinetoThreadLocalState : public ProfilerStateBase {
   post_process_t eventPostProcessCb;
 };
 
+// Global RecordFunction callbacks (KINETO_ONDEMAND, or KINETO with
+// profile_all_threads) fire on every thread, including long-lived worker
+// threads (e.g. the DataLoader pin_memory thread). They access the profiler
+// state through a raw, non-owning pointer, while disableProfiler() frees that
+// state on another thread. To make teardown safe, disableProfiler() flips
+// `g_global_cb_active` to false and blocks until `g_global_cb_in_flight` drains
+// to zero before touching the record queue or freeing the state. The counter
+// stays lock-free on the per-op hot path; the mutex/condition_variable are only
+// touched on the rare teardown handoff. These are only used by the global
+// (use_global_state_ptr) callback path; the thread-local path is unaffected.
+std::atomic<bool> g_global_cb_active{false};
+std::atomic<int64_t> g_global_cb_in_flight{0};
+std::mutex g_global_cb_mutex;
+std::condition_variable g_global_cb_cv; // GUARDED_BY(g_global_cb_mutex)
+
+// Drop one in-flight global-callback reference. When this is the last in-flight
+// callback and teardown has already begun (active cleared), wake the
+// disableProfiler() thread blocked in the drain wait. During normal profiling
+// (active still set) this is a single lock-free decrement -- no lock, no
+// notify.
+void releaseGlobalCallbackInFlight() {
+  if (g_global_cb_in_flight.fetch_sub(1) == 1 && !g_global_cb_active.load()) {
+    std::lock_guard<std::mutex> lock(g_global_cb_mutex);
+    g_global_cb_cv.notify_all();
+  }
+}
+
 template <bool use_global_state_ptr = false>
 std::unique_ptr<at::ObserverContext> onFunctionEnter(
     const at::RecordFunction& fn) {
-  auto state_ptr = KinetoThreadLocalState::get(use_global_state_ptr);
-  if (!state_ptr) {
-    return nullptr;
+  if constexpr (use_global_state_ptr) {
+    // Fast bail once teardown has begun, before taking an in-flight ref. This
+    // keeps the drain in disableProfiler() converging: callbacks that arrive
+    // after teardown starts never pin the in-flight count.
+    if (!g_global_cb_active.load()) {
+      return nullptr;
+    }
+    // Take an in-flight ref, then re-check `active`. The re-check after the
+    // increment is what makes teardown safe: if disableProfiler() set `active`
+    // to false concurrently, its drain loop is guaranteed to observe our
+    // increment (and wait) iff we observe `active` still true here. Either we
+    // back out without touching the state, or the state is kept alive until our
+    // matching onFunctionExit releases the ref.
+    g_global_cb_in_flight.fetch_add(1);
+    // Release the ref on any early return or exception (e.g. begin_op throwing
+    // on allocation failure), unless ownership is handed to onFunctionExit by
+    // releasing the guard. Without this, a throw would leak the count and
+    // deadlock the next disableProfiler() drain.
+    auto in_flight_guard =
+        c10::make_scope_exit([] { releaseGlobalCallbackInFlight(); });
+    if (!g_global_cb_active.load()) {
+      return nullptr;
+    }
+    auto state_ptr = KinetoThreadLocalState::get(/*global=*/true);
+    if (!state_ptr) {
+      return nullptr;
+    }
+    auto ctx = state_ptr->recordQueue.getSubqueue()->begin_op(fn);
+    if (ctx) {
+      // The in-flight ref is now owned by the matching onFunctionExit (which
+      // releases it iff it receives a non-null context).
+      in_flight_guard.release();
+    }
+    return ctx;
+  } else {
+    auto state_ptr = KinetoThreadLocalState::get(use_global_state_ptr);
+    if (!state_ptr) {
+      return nullptr;
+    }
+    return state_ptr->recordQueue.getSubqueue()->begin_op(fn);
   }
-  return state_ptr->recordQueue.getSubqueue()->begin_op(fn);
 }
 
 // @lint-ignore CLANGTIDY clang-diagnostic-unused-parameter
@@ -585,6 +652,30 @@ template <bool use_global_state_ptr = false>
 void onFunctionExit(
     const at::RecordFunction& fn,
     at::ObserverContext* ctx_ptr) {
+  // Release the in-flight reference taken in onFunctionEnter for the global
+  // callback path, on every exit path (including exceptions). The ref is held
+  // only for ops that produced a context, so it is released iff ctx_ptr is
+  // non-null -- ops whose onFunctionEnter bailed (null context) were never
+  // counted. The thread-local instantiation compiles this to a no-op.
+  auto in_flight_guard = c10::make_scope_exit([&] {
+    if constexpr (use_global_state_ptr) {
+      if (ctx_ptr != nullptr) {
+        releaseGlobalCallbackInFlight();
+      }
+    }
+  });
+
+  if constexpr (use_global_state_ptr) {
+    // A global callback whose onFunctionEnter bailed (null context) never took
+    // an in-flight ref, so it must not touch the profiler state here -- a
+    // concurrent disableProfiler() may already be tearing it down. Return
+    // before reading the global state below. Only ops that produced a context
+    // (and thus hold an in-flight ref that blocks teardown) fall through.
+    if (ctx_ptr == nullptr) {
+      return;
+    }
+  }
+
   auto state_ptr = KinetoThreadLocalState::get(use_global_state_ptr);
   if (!state_ptr) {
     return;
@@ -647,6 +738,10 @@ void pushProfilingCallbacks(const std::unordered_set<at::RecordScope>& scopes) {
           .scopes(scopes);
 
   if constexpr (use_global_callback) {
+    // Arm the in-flight drain gate before the global callback can fire on any
+    // thread. disableProfiler() relies on this to know it must drain.
+    g_global_cb_in_flight.store(0);
+    g_global_cb_active.store(true);
     registration_state_ptr->setCallbackHandle(
         at::addGlobalCallback(recordFunctionCallback));
   } else {
@@ -929,6 +1024,16 @@ void disableProfilerInChildThread() {
 std::unique_ptr<ProfilerResult> disableProfiler() {
   // releasing to inform child threads to stop profiling
   profiler_state_info_ptr = nullptr;
+
+  // If global callbacks were installed (KINETO_ONDEMAND, or KINETO with
+  // profile_all_threads), they may be running right now on other threads. Stop
+  // new callbacks from starting and wait for any in-flight ones to finish
+  // before we pop and free the profiler state below -- otherwise a callback on
+  // a worker thread can use the record queue after it is freed/torn down here.
+  if (g_global_cb_active.exchange(false)) {
+    std::unique_lock<std::mutex> lock(g_global_cb_mutex);
+    g_global_cb_cv.wait(lock, [] { return g_global_cb_in_flight == 0; });
+  }
 
   auto state_ptr = ProfilerStateBase::pop();
   if (!state_ptr) {

--- a/torch/csrc/profiler/orchestration/observer.cpp
+++ b/torch/csrc/profiler/orchestration/observer.cpp
@@ -161,7 +161,12 @@ std::shared_ptr<ProfilerStateBase> popTLS() {
 /*static*/ std::shared_ptr<ProfilerStateBase> ProfilerStateBase::pop(
     bool global) {
   auto out = global ? GlobalManager::pop() : popTLS();
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!out || out->config().global() == global);
+  // State is routed to the GlobalManager whenever it uses global callbacks
+  // (KINETO_ONDEMAND, or KINETO with profile_all_threads), which is exactly
+  // pushGlobalCallbacks() -- see push() and get(). Asserting on global() here
+  // would spuriously fire for the profile_all_threads case.
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      !out || out->config().pushGlobalCallbacks() == global);
   return out;
 }
 


### PR DESCRIPTION
Summary:

A MAST training job crashed with a Python segfault on rank 114: https://www.internalfb.com/mlhub/pipelines/runs/mast/v4_midtrain_rec_v1_cpt_TIER2_2p3B-n5gwz7fk?job_attempt=0&version=3&tab=execution_details. The faulthandler stack showed the DataLoader `pin_memory` thread dispatching `aten::pin_memory`, and the native backtrace pointed at `torch::profiler::impl::ThreadLocalSubqueue::begin_op` reached through the profiler's global RecordFunction callback (`torch.profiler` with `profile_all_threads=True`).

CONTEXT: When the profiler installs global RecordFunction callbacks (`ProfilerState::KINETO_ONDEMAND`, or `ProfilerState::KINETO` with `ExperimentalConfig.profile_all_threads=true`), the callback fires on every thread, including long-lived worker threads such as the DataLoader `pin_memory` thread. `onFunctionEnter<true>` fetches the profiler state through a raw, non-owning pointer and then dereferences it (`state_ptr->recordQueue.getSubqueue()->begin_op(fn)`), while `disableProfiler()` on another thread pops and frees that state without waiting for in-flight global callbacks. A worker can thus mutate the `RecordQueue` (e.g. emplace into `sub_queues_`, triggering a rehash) while `disableProfiler()` -> `finalizeTrace()` -> `getRecords()` iterates and frees it, producing a heap-use-after-free.

WHAT:
- `profiler_kineto.cpp`: add a drain barrier for the global callback path. `pushProfilingCallbacks<true>` arms an `active` gate; `onFunctionEnter<true>` takes an in-flight reference (with an `active` re-check after the increment that makes teardown race-safe) only for ops that actually touch the state; `onFunctionExit<true>` releases that reference; `disableProfiler()` clears `active` and waits for the in-flight count to drain to zero before popping, finalizing, or freeing the state. New callbacks that arrive after teardown begins bail before incrementing, so the drain always converges. The thread-local callback path is unchanged.
- `observer.cpp`: `ProfilerStateBase::pop()`'s debug assert checked `config().global()`, but `push()` and `get()` route state on `config().pushGlobalCallbacks()`. The two disagree for `profile_all_threads` (state lives in the `GlobalManager` while `global()` is false), so the assert spuriously fired in debug builds on teardown. Make the assert consistent with `push()`/`get()`.
- Add C++ reproducer `test_profiler_global_callback_race` that drives global-callback enable/disable concurrently with worker-thread ATen dispatch. It reliably trips ASAN heap-use-after-free before the fix and passes after.

Authored with Claude Code.

Test Plan:
All run in the default `dev` mode (ASAN + UBSAN), on a CPU-only host.

Reproducer (new test):
```
buck2 test fbcode//caffe2/test/cpp/profiler:test_profiler_global_callback_race
```
- Before the fix: fails with `AddressSanitizer: heap-use-after-free` -- freed on a worker thread in `RecordQueue::getSubqueue()` via `onFunctionEnter<true>`, used on the main thread in `RecordQueue::getRecords()` via `disableProfiler()`.
- After the fix: passes.

Stress (15 managed reruns under ASAN), all pass:
```
buck2 test fbcode//caffe2/test/cpp/profiler:test_profiler_global_callback_race -- --stress-runs 15
```

No regressions in existing profiler / RecordFunction C++ tests:
```
buck2 test fbcode//caffe2/test/cpp/profiler:test_record_function fbcode//caffe2/test/cpp/profiler:test_containers fbcode//caffe2/test/cpp/profiler:test_linux_perf_profiler
```

Thread-local profiler enable/disable path unaffected:
```
buck2 test fbcode//caffe2/test/cpp/jit:jit -- RecordDebugHandles
```

Differential Revision: D106964780


