### PR TITLE
Mark CUDA kernel helpers static

### DIFF
--- a/aten/src/ATen/native/cuda/AbsKernel.cu
+++ b/aten/src/ATen/native/cuda/AbsKernel.cu
@@ -16,7 +16,7 @@ struct AbsFunctor {
 };
 
 constexpr char abs_name[] = "abs_kernel";
-void abs_kernel_cuda(TensorIteratorBase& iter) {
+static void abs_kernel_cuda(TensorIteratorBase& iter) {
   auto dtype = iter.dtype();
   if (at::isComplexType(dtype)) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/BinaryBitwiseOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryBitwiseOpsKernels.cu
@@ -24,7 +24,7 @@ struct BitwiseAndFunctor<bool> {
   }
 };
 
-void bitwise_and_kernel_cuda(TensorIteratorBase& iter) {
+static void bitwise_and_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_INTEGRAL_TYPES_AND(kBool, iter.dtype(), "bitwise_and_cuda", [&]() {
     BitwiseAndFunctor<scalar_t> f;
     opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, f);
@@ -45,7 +45,7 @@ struct BitwiseOrFunctor<bool> {
   }
 };
 
-void bitwise_or_kernel_cuda(TensorIteratorBase& iter) {
+static void bitwise_or_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_INTEGRAL_TYPES_AND(kBool, iter.dtype(), "bitwise_or_cuda", [&]() {
     BitwiseOrFunctor<scalar_t> f;
     opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, f);
@@ -66,7 +66,7 @@ struct BitwiseXorFunctor<bool> {
   }
 };
 
-void bitwise_xor_kernel_cuda(TensorIteratorBase& iter) {
+static void bitwise_xor_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_INTEGRAL_TYPES_AND(kBool, iter.dtype(), "bitwise_xor_cuda", [&]() {
     BitwiseXorFunctor<scalar_t> f;
     opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, f);

--- a/aten/src/ATen/native/cuda/BinaryMulKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulKernel.cu
@@ -19,7 +19,7 @@
 namespace at::native {
 
 constexpr char mul_name[] = "mul_kernel";
-void mul_kernel_cuda(TensorIteratorBase& iter) {
+static void mul_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (common_dtype == kComplexHalf) {
     using scalar_t = c10::complex<at::Half>;

--- a/aten/src/ATen/native/cuda/CompareEQKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareEQKernel.cu
@@ -29,18 +29,18 @@ struct CompareEqFunctor{
  };
 }
 
-C10_NOINLINE void compare_eq_ne_kernel(TensorIteratorBase &iter, EqOpType op) {
+static C10_NOINLINE void compare_eq_ne_kernel(TensorIteratorBase &iter, EqOpType op) {
   AT_DISPATCH_V2(iter.common_dtype(), "compare_eq_ne_cuda", AT_WRAP([&]() {
     opmath_symmetric_gpu_kernel_with_scalars<scalar_t, bool>(
         iter, CompareEqFunctor<scalar_t>(op));
   }), AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kComplexHalf, kHalf, kBFloat16, kBool, AT_EXPAND(AT_FLOAT8_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kFloat4_e2m1fn_x2);
 }
 
-void eq_kernel_cuda(TensorIteratorBase& iter) {
+static void eq_kernel_cuda(TensorIteratorBase& iter) {
   compare_eq_ne_kernel(iter, EqOpType::EQ);
 }
 
-void ne_kernel_cuda(TensorIteratorBase& iter) {
+static void ne_kernel_cuda(TensorIteratorBase& iter) {
   compare_eq_ne_kernel(iter, EqOpType::NE);
 }
 

--- a/aten/src/ATen/native/cuda/CompareEQKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareEQKernel.cu
@@ -29,18 +29,18 @@ struct CompareEqFunctor{
  };
 }
 
-C10_NOINLINE void compare_eq_ne_kernel(TensorIteratorBase &iter, EqOpType op) {
+static C10_NOINLINE void compare_eq_ne_kernel(TensorIteratorBase &iter, EqOpType op) {
   AT_DISPATCH_V2(iter.common_dtype(), "compare_eq_ne_cuda", AT_WRAP([&]() {
     opmath_symmetric_gpu_kernel_with_scalars<scalar_t, bool>(
         iter, CompareEqFunctor<scalar_t>(op));
   }), AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kComplexHalf, kBComplex32, kHalf, kBFloat16, kBool, AT_EXPAND(AT_FLOAT8_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kFloat4_e2m1fn_x2);
 }
 
-void eq_kernel_cuda(TensorIteratorBase& iter) {
+static void eq_kernel_cuda(TensorIteratorBase& iter) {
   compare_eq_ne_kernel(iter, EqOpType::EQ);
 }
 
-void ne_kernel_cuda(TensorIteratorBase& iter) {
+static void ne_kernel_cuda(TensorIteratorBase& iter) {
   compare_eq_ne_kernel(iter, EqOpType::NE);
 }
 

--- a/aten/src/ATen/native/cuda/CompareKernels.cu
+++ b/aten/src/ATen/native/cuda/CompareKernels.cu
@@ -52,7 +52,7 @@ void compare_scalar_kernel(TensorIteratorBase &iter, OpType op, scalar_t rhs) {
 }
 
 template <typename scalar_t>
-void compare_kernel_impl(TensorIteratorBase &iter, OpType op) {
+static void compare_kernel_impl(TensorIteratorBase &iter, OpType op) {
   // If either input is a cpu scalar, perform the equivalent comparison
   // where the scalar is on the right hand side. This saves us from
   // generating two otherwise identical kernels with mirrored
@@ -72,26 +72,26 @@ void compare_kernel_impl(TensorIteratorBase &iter, OpType op) {
   }
 }
 
-C10_NOINLINE void compare_kernel_with_scalars(TensorIteratorBase &iter, OpType op) {
+static C10_NOINLINE void compare_kernel_with_scalars(TensorIteratorBase &iter, OpType op) {
   AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "compare_cuda", [&]() {
     compare_kernel_impl<scalar_t>(iter, op);
   });
 }
 
 
-void ge_kernel_cuda(TensorIteratorBase& iter) {
+static void ge_kernel_cuda(TensorIteratorBase& iter) {
   compare_kernel_with_scalars(iter, OpType::GE);
 }
 
-void gt_kernel_cuda(TensorIteratorBase& iter) {
+static void gt_kernel_cuda(TensorIteratorBase& iter) {
   compare_kernel_with_scalars(iter, OpType::GT);
 }
 
-void le_kernel_cuda(TensorIteratorBase& iter) {
+static void le_kernel_cuda(TensorIteratorBase& iter) {
   compare_kernel_with_scalars(iter, OpType::LE);
 }
 
-void lt_kernel_cuda(TensorIteratorBase& iter) {
+static void lt_kernel_cuda(TensorIteratorBase& iter) {
   compare_kernel_with_scalars(iter, OpType::LT);
 }
 

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -261,7 +261,7 @@ void neg_conj_kernel_cuda(TensorIteratorBase &iter) {
 using namespace at::cuda;
 
 // device-to-device copy, does type conversion
-void copy_device_to_device(TensorIterator& iter,
+static void copy_device_to_device(TensorIterator& iter,
                            bool non_blocking,
                            bool p2p_enabled) {
   int64_t numel = iter.numel();

--- a/aten/src/ATen/native/cuda/CrossKernel.cu
+++ b/aten/src/ATen/native/cuda/CrossKernel.cu
@@ -8,7 +8,7 @@
 namespace at::native {
 
 template <typename T, typename OffsetCalc, typename StrideType>
-__global__ void cross_kernel(
+static __global__ void cross_kernel(
     int numel, T* out, const T* x1, const T* x2, OffsetCalc offset_calculator,
     StrideType ostride, StrideType x1stride, StrideType x2stride) {
   CUDA_KERNEL_LOOP(i, numel) {
@@ -33,7 +33,7 @@ __global__ void cross_kernel(
   }
 }
 
-void launch_cross_kernel(const TensorIteratorBase& iter, int64_t ostride,
+static void launch_cross_kernel(const TensorIteratorBase& iter, int64_t ostride,
                          int64_t x1stride, int64_t x2stride) {
   const auto N = iter.numel();
   auto offset_calculator = make_element_offset_calculator<3>(iter);
@@ -61,7 +61,7 @@ void launch_cross_kernel(const TensorIteratorBase& iter, int64_t ostride,
   });
 }
 
-void cross_impl(const Tensor& result, const Tensor& x1, const Tensor& x2, int64_t dim) {
+static void cross_impl(const Tensor& result, const Tensor& x1, const Tensor& x2, int64_t dim) {
   const int64_t ostride = result.stride(dim);
   const int64_t x1stride = x1.stride(dim);
   const int64_t x2stride = x2.stride(dim);

--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -440,7 +440,7 @@ fused_dropout_cuda(const Tensor& self, double p, std::optional<Generator> gen_){
 }
 
 template <typename mask_t>
-Tensor dropout_backward_cuda(const Tensor& grad, const Tensor& mask, double scale){
+static Tensor dropout_backward_cuda(const Tensor& grad, const Tensor& mask, double scale){
    Tensor ret = at::empty_like(grad, grad.suggest_memory_format());
    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, ret.scalar_type(), "masked_scale", [&] {
       using accscalar_t = acc_type<scalar_t, true>;

--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -441,7 +441,7 @@ fused_dropout_cuda(const Tensor& self, double p, std::optional<Generator> gen_){
 }
 
 template <typename mask_t>
-Tensor dropout_backward_cuda(const Tensor& grad, const Tensor& mask, double scale){
+static Tensor dropout_backward_cuda(const Tensor& grad, const Tensor& mask, double scale){
    Tensor ret = at::empty_like(grad, grad.suggest_memory_format());
    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, ret.scalar_type(), "masked_scale", [&] {
       using accscalar_t = acc_type<scalar_t, true>;

--- a/aten/src/ATen/native/cuda/FillKernel.cu
+++ b/aten/src/ATen/native/cuda/FillKernel.cu
@@ -19,7 +19,7 @@ struct FillFunctor {
     scalar_t value;
 };
 
-void fill_kernel_cuda(TensorIterator& iter, const Scalar& value) {
+static void fill_kernel_cuda(TensorIterator& iter, const Scalar& value) {
   AT_DISPATCH_V2(iter.dtype(), "fill_cuda", AT_WRAP([&]() {
     gpu_kernel(iter, FillFunctor<scalar_t>(value.to<scalar_t>()));
   }), AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kComplexHalf, kBool, kHalf, kBFloat16, AT_EXPAND(AT_FLOAT8_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES));

--- a/aten/src/ATen/native/cuda/FillKernel.cu
+++ b/aten/src/ATen/native/cuda/FillKernel.cu
@@ -19,7 +19,7 @@ struct FillFunctor {
     scalar_t value;
 };
 
-void fill_kernel_cuda(TensorIterator& iter, const Scalar& value) {
+static void fill_kernel_cuda(TensorIterator& iter, const Scalar& value) {
   AT_DISPATCH_V2(iter.dtype(), "fill_cuda", AT_WRAP([&]() {
     gpu_kernel(iter, FillFunctor<scalar_t>(value.to<scalar_t>()));
   }), AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX), kComplexHalf, kBComplex32, kBool, kHalf, kBFloat16, AT_EXPAND(AT_FLOAT8_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES));

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
@@ -25,7 +25,7 @@
 namespace at::native {
 
 template <typename T, template <class> class Op>
-std::vector<Tensor> foreach_tensor_list_op(
+static std::vector<Tensor> foreach_tensor_list_op(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -55,7 +55,7 @@ std::vector<Tensor> foreach_tensor_list_op(
 }
 
 template <typename T, template <class> class Op>
-void foreach_tensor_list_op_(
+static void foreach_tensor_list_op_(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -77,7 +77,7 @@ void foreach_tensor_list_op_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_bool_half_bfloat16(
+static std::vector<Tensor> all_types_complex_bool_half_bfloat16(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -93,7 +93,7 @@ std::vector<Tensor> all_types_complex_bool_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_bool_half_bfloat16_(
+static void all_types_complex_bool_half_bfloat16_(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -109,7 +109,7 @@ void all_types_complex_bool_half_bfloat16_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_half_bfloat16(
+static std::vector<Tensor> all_types_half_bfloat16(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -124,7 +124,7 @@ std::vector<Tensor> all_types_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_half_bfloat16_(
+static void all_types_complex_half_bfloat16_(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -139,7 +139,7 @@ void all_types_complex_half_bfloat16_(
 }
 
 template <template <class> class Op>
-void all_types_half_bfloat16_(
+static void all_types_half_bfloat16_(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -154,7 +154,7 @@ void all_types_half_bfloat16_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_half_bfloat16(
+static std::vector<Tensor> all_types_complex_half_bfloat16(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
@@ -25,7 +25,7 @@
 namespace at::native {
 
 template <typename T, template <class> class Op>
-std::vector<Tensor> foreach_tensor_list_op(
+static std::vector<Tensor> foreach_tensor_list_op(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -53,7 +53,7 @@ std::vector<Tensor> foreach_tensor_list_op(
 }
 
 template <typename T, template <class> class Op>
-void foreach_tensor_list_op_(
+static void foreach_tensor_list_op_(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -73,7 +73,7 @@ void foreach_tensor_list_op_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_bool_half_bfloat16(
+static std::vector<Tensor> all_types_complex_bool_half_bfloat16(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -89,7 +89,7 @@ std::vector<Tensor> all_types_complex_bool_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_bool_half_bfloat16_(
+static void all_types_complex_bool_half_bfloat16_(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -105,7 +105,7 @@ void all_types_complex_bool_half_bfloat16_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_half_bfloat16(
+static std::vector<Tensor> all_types_half_bfloat16(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -120,7 +120,7 @@ std::vector<Tensor> all_types_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_half_bfloat16_(
+static void all_types_complex_half_bfloat16_(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -135,7 +135,7 @@ void all_types_complex_half_bfloat16_(
 }
 
 template <template <class> class Op>
-void all_types_half_bfloat16_(
+static void all_types_half_bfloat16_(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {
@@ -150,7 +150,7 @@ void all_types_half_bfloat16_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_half_bfloat16(
+static std::vector<Tensor> all_types_complex_half_bfloat16(
     TensorList tensors1,
     TensorList tensors2,
     const Scalar& alpha = 1) {

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpScalar.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpScalar.cu
@@ -22,7 +22,7 @@
 namespace at::native {
 
 template <typename T, template <class> class Op>
-std::vector<Tensor> foreach_binary_op(
+static std::vector<Tensor> foreach_binary_op(
     TensorList tensors,
     const Scalar& scalar) {
   std::vector<std::vector<at::Tensor>> tensor_lists;
@@ -49,7 +49,7 @@ std::vector<Tensor> foreach_binary_op(
 }
 
 template <typename T, template <class> class Op>
-void foreach_binary_op_(TensorList tensors, const Scalar& scalar) {
+static void foreach_binary_op_(TensorList tensors, const Scalar& scalar) {
   std::vector<std::vector<at::Tensor>> tensor_lists;
   tensor_lists.emplace_back(tensors.vec());
 
@@ -67,7 +67,7 @@ void foreach_binary_op_(TensorList tensors, const Scalar& scalar) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_bool_half_bfloat16(
+static std::vector<Tensor> all_types_complex_bool_half_bfloat16(
     TensorList tensors,
     const Scalar& scalar) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
@@ -80,7 +80,7 @@ std::vector<Tensor> all_types_complex_bool_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_bool_half_bfloat16_(
+static void all_types_complex_bool_half_bfloat16_(
     TensorList tensors,
     const Scalar& scalar) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
@@ -93,7 +93,7 @@ void all_types_complex_bool_half_bfloat16_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_half_bfloat16(
+static std::vector<Tensor> all_types_half_bfloat16(
     TensorList tensors,
     const Scalar& scalar) {
   return AT_DISPATCH_ALL_TYPES_AND2(
@@ -105,7 +105,7 @@ std::vector<Tensor> all_types_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_half_bfloat16_(TensorList tensors, const Scalar& scalar) {
+static void all_types_half_bfloat16_(TensorList tensors, const Scalar& scalar) {
   AT_DISPATCH_ALL_TYPES_AND2(
       kHalf,
       kBFloat16,
@@ -115,7 +115,7 @@ void all_types_half_bfloat16_(TensorList tensors, const Scalar& scalar) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_half_bfloat16(
+static std::vector<Tensor> all_types_complex_half_bfloat16(
     TensorList tensors,
     const Scalar& scalar) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
@@ -127,7 +127,7 @@ std::vector<Tensor> all_types_complex_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_half_bfloat16_(
+static void all_types_complex_half_bfloat16_(
     TensorList tensors,
     const Scalar& scalar) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
@@ -195,7 +195,7 @@ std::vector<Tensor> foreach_scalar_pow_list_kernel_cuda(
 // Implement via multiply with reciprocal as it's faster and makes it match
 // the behavior of regular Tensor div by scalar.  Loses one bit of
 // precision.
-Scalar scalar_reciprocal(const Scalar& scalar) {
+static Scalar scalar_reciprocal(const Scalar& scalar) {
   if (scalar.isFloatingPoint()) {
     return Scalar(1. / scalar.toDouble());
   } else if (scalar.isIntegral(/*includeBool*/ true)) {

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpScalar.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpScalar.cu
@@ -22,7 +22,7 @@
 namespace at::native {
 
 template <typename T, template <class> class Op>
-std::vector<Tensor> foreach_binary_op(
+static std::vector<Tensor> foreach_binary_op(
     TensorList tensors,
     const Scalar& scalar) {
   std::vector<at::Tensor> vec_res;
@@ -48,7 +48,7 @@ std::vector<Tensor> foreach_binary_op(
 }
 
 template <typename T, template <class> class Op>
-void foreach_binary_op_(TensorList tensors, const Scalar& scalar) {
+static void foreach_binary_op_(TensorList tensors, const Scalar& scalar) {
   auto tensor_lists = c10::make_nested<Tensor>(tensors.vec());
 
   using opmath_t = at::opmath_type<T>;
@@ -65,7 +65,7 @@ void foreach_binary_op_(TensorList tensors, const Scalar& scalar) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_bool_half_bfloat16(
+static std::vector<Tensor> all_types_complex_bool_half_bfloat16(
     TensorList tensors,
     const Scalar& scalar) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
@@ -78,7 +78,7 @@ std::vector<Tensor> all_types_complex_bool_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_bool_half_bfloat16_(
+static void all_types_complex_bool_half_bfloat16_(
     TensorList tensors,
     const Scalar& scalar) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
@@ -91,7 +91,7 @@ void all_types_complex_bool_half_bfloat16_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_half_bfloat16(
+static std::vector<Tensor> all_types_half_bfloat16(
     TensorList tensors,
     const Scalar& scalar) {
   return AT_DISPATCH_ALL_TYPES_AND2(
@@ -103,7 +103,7 @@ std::vector<Tensor> all_types_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_half_bfloat16_(TensorList tensors, const Scalar& scalar) {
+static void all_types_half_bfloat16_(TensorList tensors, const Scalar& scalar) {
   AT_DISPATCH_ALL_TYPES_AND2(
       kHalf,
       kBFloat16,
@@ -113,7 +113,7 @@ void all_types_half_bfloat16_(TensorList tensors, const Scalar& scalar) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_half_bfloat16(
+static std::vector<Tensor> all_types_complex_half_bfloat16(
     TensorList tensors,
     const Scalar& scalar) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
@@ -125,7 +125,7 @@ std::vector<Tensor> all_types_complex_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_half_bfloat16_(
+static void all_types_complex_half_bfloat16_(
     TensorList tensors,
     const Scalar& scalar) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
@@ -193,7 +193,7 @@ std::vector<Tensor> foreach_scalar_pow_list_kernel_cuda(
 // Implement via multiply with reciprocal as it's faster and makes it match
 // the behavior of regular Tensor div by scalar.  Loses one bit of
 // precision.
-Scalar scalar_reciprocal(const Scalar& scalar) {
+static Scalar scalar_reciprocal(const Scalar& scalar) {
   if (scalar.isFloatingPoint()) {
     return Scalar(1. / scalar.toDouble());
   } else if (scalar.isIntegral(/*includeBool*/ true)) {

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpScalarList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpScalarList.cu
@@ -22,7 +22,7 @@
 namespace at::native {
 
 template <typename T, template <class> class Op>
-std::vector<Tensor> foreach_binary_op(
+static std::vector<Tensor> foreach_binary_op(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   std::vector<std::vector<at::Tensor>> tensor_lists;
@@ -50,7 +50,9 @@ std::vector<Tensor> foreach_binary_op(
 }
 
 template <typename T, template <class> class Op>
-void foreach_binary_op_(TensorList tensors, at::ArrayRef<Scalar> scalars) {
+static void foreach_binary_op_(
+    TensorList tensors,
+    at::ArrayRef<Scalar> scalars) {
   std::vector<std::vector<at::Tensor>> tensor_lists;
   tensor_lists.emplace_back(tensors.vec());
 
@@ -68,7 +70,7 @@ void foreach_binary_op_(TensorList tensors, at::ArrayRef<Scalar> scalars) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_bool_half_bfloat16(
+static std::vector<Tensor> all_types_complex_bool_half_bfloat16(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
@@ -81,7 +83,7 @@ std::vector<Tensor> all_types_complex_bool_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_bool_half_bfloat16_(
+static void all_types_complex_bool_half_bfloat16_(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
@@ -94,7 +96,7 @@ void all_types_complex_bool_half_bfloat16_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_half_bfloat16(
+static std::vector<Tensor> all_types_half_bfloat16(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   return AT_DISPATCH_ALL_TYPES_AND2(
@@ -106,7 +108,7 @@ std::vector<Tensor> all_types_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_half_bfloat16_(
+static void all_types_half_bfloat16_(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   AT_DISPATCH_ALL_TYPES_AND2(
@@ -118,7 +120,7 @@ void all_types_half_bfloat16_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_half_bfloat16(
+static std::vector<Tensor> all_types_complex_half_bfloat16(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
@@ -130,7 +132,7 @@ std::vector<Tensor> all_types_complex_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_half_bfloat16_(
+static void all_types_complex_half_bfloat16_(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpScalarList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpScalarList.cu
@@ -22,7 +22,7 @@
 namespace at::native {
 
 template <typename T, template <class> class Op>
-std::vector<Tensor> foreach_binary_op(
+static std::vector<Tensor> foreach_binary_op(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   std::vector<at::Tensor> vec_res;
@@ -49,7 +49,9 @@ std::vector<Tensor> foreach_binary_op(
 }
 
 template <typename T, template <class> class Op>
-void foreach_binary_op_(TensorList tensors, at::ArrayRef<Scalar> scalars) {
+static void foreach_binary_op_(
+    TensorList tensors,
+    at::ArrayRef<Scalar> scalars) {
   auto tensor_lists = c10::make_nested<Tensor>(tensors.vec());
 
   using opmath_t = at::opmath_type<T>;
@@ -66,7 +68,7 @@ void foreach_binary_op_(TensorList tensors, at::ArrayRef<Scalar> scalars) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_bool_half_bfloat16(
+static std::vector<Tensor> all_types_complex_bool_half_bfloat16(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
@@ -79,7 +81,7 @@ std::vector<Tensor> all_types_complex_bool_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_bool_half_bfloat16_(
+static void all_types_complex_bool_half_bfloat16_(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
@@ -92,7 +94,7 @@ void all_types_complex_bool_half_bfloat16_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_half_bfloat16(
+static std::vector<Tensor> all_types_half_bfloat16(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   return AT_DISPATCH_ALL_TYPES_AND2(
@@ -104,7 +106,7 @@ std::vector<Tensor> all_types_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_half_bfloat16_(
+static void all_types_half_bfloat16_(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   AT_DISPATCH_ALL_TYPES_AND2(
@@ -116,7 +118,7 @@ void all_types_half_bfloat16_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_half_bfloat16(
+static std::vector<Tensor> all_types_complex_half_bfloat16(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
@@ -128,7 +130,7 @@ std::vector<Tensor> all_types_complex_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_half_bfloat16_(
+static void all_types_complex_half_bfloat16_(
     TensorList tensors,
     at::ArrayRef<Scalar> scalars) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpScalarTensor.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpScalarTensor.cu
@@ -18,7 +18,7 @@
 namespace at::native {
 
 template <typename T, template <class> class Op>
-std::vector<Tensor> foreach_binary_op(
+static std::vector<Tensor> foreach_binary_op(
     TensorList tensors,
     const Tensor& scalar,
     const Scalar& alpha = 1) {
@@ -60,7 +60,7 @@ std::vector<Tensor> foreach_binary_op(
 }
 
 template <typename T, template <class> class Op>
-void foreach_binary_op_(
+static void foreach_binary_op_(
     TensorList tensors,
     const Tensor& scalar,
     const Scalar& alpha = 1) {
@@ -157,7 +157,7 @@ void foreach_binary_op_(
   }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_bool_half_bfloat16(
+static std::vector<Tensor> all_types_complex_bool_half_bfloat16(
     TensorList tensors,
     const Tensor& scalar,
     const Scalar& alpha = 1) {
@@ -173,7 +173,7 @@ std::vector<Tensor> all_types_complex_bool_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_bool_half_bfloat16_(
+static void all_types_complex_bool_half_bfloat16_(
     TensorList tensors,
     const Tensor& scalar,
     const Scalar& alpha = 1) {

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpScalarTensor.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpScalarTensor.cu
@@ -18,7 +18,7 @@
 namespace at::native {
 
 template <typename T, template <class> class Op>
-std::vector<Tensor> foreach_binary_op(
+static std::vector<Tensor> foreach_binary_op(
     TensorList tensors,
     const Tensor& scalar,
     const Scalar& alpha = 1) {
@@ -59,7 +59,7 @@ std::vector<Tensor> foreach_binary_op(
 }
 
 template <typename T, template <class> class Op>
-void foreach_binary_op_(
+static void foreach_binary_op_(
     TensorList tensors,
     const Tensor& scalar,
     const Scalar& alpha = 1) {
@@ -155,7 +155,7 @@ void foreach_binary_op_(
   }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_bool_half_bfloat16(
+static std::vector<Tensor> all_types_complex_bool_half_bfloat16(
     TensorList tensors,
     const Tensor& scalar,
     const Scalar& alpha = 1) {
@@ -171,7 +171,7 @@ std::vector<Tensor> all_types_complex_bool_half_bfloat16(
 }
 
 template <template <class> class Op>
-void all_types_complex_bool_half_bfloat16_(
+static void all_types_complex_bool_half_bfloat16_(
     TensorList tensors,
     const Tensor& scalar,
     const Scalar& alpha = 1) {

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -22,7 +22,7 @@
 namespace at::native {
 
 // Helper to check if all tensors in a list are 0D (scalar tensors)
-inline bool all_tensors_are_0d(TensorList tensors) {
+static inline bool all_tensors_are_0d(TensorList tensors) {
   return std::all_of(tensors.begin(), tensors.end(), [](const Tensor& t) {
     return t.dim() == 0;
   });
@@ -35,7 +35,7 @@ inline bool all_same_dtype(TensorList tensors, ScalarType dtype) {
   });
 }
 
-inline bool all_same_device(TensorList tensors, Device device) {
+static inline bool all_same_device(TensorList tensors, Device device) {
   return std::all_of(tensors.begin(), tensors.end(), [device](const Tensor& t) {
     return t.device() == device;
   });
@@ -43,7 +43,7 @@ inline bool all_same_device(TensorList tensors, Device device) {
 
 // Inplace variant for when tensor1 is a list of 0D tensors (scalars)
 template <template <class> class Op>
-void foreach_pointwise_op_0d_tensor1_(
+static void foreach_pointwise_op_0d_tensor1_(
     TensorList input,
     TensorList tensors1,
     TensorList tensors2,
@@ -76,7 +76,7 @@ void foreach_pointwise_op_0d_tensor1_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> foreach_pointwise_op(
+static std::vector<Tensor> foreach_pointwise_op(
     TensorList input,
     TensorList tensors1,
     TensorList tensors2,
@@ -118,7 +118,7 @@ std::vector<Tensor> foreach_pointwise_op(
 // tensor_lists: input, tensor1 (0D), tensor2, output
 // The 0D tensor1 values are loaded from device memory in the functor
 template <template <class> class Op>
-std::vector<Tensor> foreach_pointwise_op_0d_tensor1(
+static std::vector<Tensor> foreach_pointwise_op_0d_tensor1(
     TensorList input,
     TensorList tensors1,
     TensorList tensors2,
@@ -158,7 +158,7 @@ std::vector<Tensor> foreach_pointwise_op_0d_tensor1(
 }
 
 template <template <class> class Op>
-void foreach_pointwise_op_(
+static void foreach_pointwise_op_(
     TensorList input,
     TensorList tensors1,
     TensorList tensors2,

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -22,7 +22,7 @@
 namespace at::native {
 
 // Helper to check if all tensors in a list are 0D (scalar tensors)
-inline bool all_tensors_are_0d(TensorList tensors) {
+static inline bool all_tensors_are_0d(TensorList tensors) {
   return std::all_of(tensors.begin(), tensors.end(), [](const Tensor& t) {
     return t.dim() == 0;
   });
@@ -35,7 +35,7 @@ inline bool all_same_dtype(TensorList tensors, ScalarType dtype) {
   });
 }
 
-inline bool all_same_device(TensorList tensors, Device device) {
+static inline bool all_same_device(TensorList tensors, Device device) {
   return std::all_of(tensors.begin(), tensors.end(), [device](const Tensor& t) {
     return t.device() == device;
   });
@@ -43,7 +43,7 @@ inline bool all_same_device(TensorList tensors, Device device) {
 
 // Inplace variant for when tensor1 is a list of 0D tensors (scalars)
 template <template <class> class Op>
-void foreach_pointwise_op_0d_tensor1_(
+static void foreach_pointwise_op_0d_tensor1_(
     TensorList input,
     TensorList tensors1,
     TensorList tensors2,
@@ -72,7 +72,7 @@ void foreach_pointwise_op_0d_tensor1_(
 }
 
 template <template <class> class Op>
-std::vector<Tensor> foreach_pointwise_op(
+static std::vector<Tensor> foreach_pointwise_op(
     TensorList input,
     TensorList tensors1,
     TensorList tensors2,
@@ -111,7 +111,7 @@ std::vector<Tensor> foreach_pointwise_op(
 // tensor_lists: input, tensor1 (0D), tensor2, output
 // The 0D tensor1 values are loaded from device memory in the functor
 template <template <class> class Op>
-std::vector<Tensor> foreach_pointwise_op_0d_tensor1(
+static std::vector<Tensor> foreach_pointwise_op_0d_tensor1(
     TensorList input,
     TensorList tensors1,
     TensorList tensors2,
@@ -147,7 +147,7 @@ std::vector<Tensor> foreach_pointwise_op_0d_tensor1(
 }
 
 template <template <class> class Op>
-void foreach_pointwise_op_(
+static void foreach_pointwise_op_(
     TensorList input,
     TensorList tensors1,
     TensorList tensors2,

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -117,7 +117,7 @@ struct LpMaxFunctor {
 };
 
 template <typename T>
-__global__ void lpmax_cleanup(
+static __global__ void lpmax_cleanup(
     const T* output_per_tensor,
     TensorListAddresses addr_struct,
     int max_chunks_per_tensor) {
@@ -344,7 +344,7 @@ template <
     typename out_t,
     bool apply_root = true,
     typename out_opmath_t = at::opmath_type<out_t>>
-__global__ void lpnorm_cleanup(
+static __global__ void lpnorm_cleanup(
     const out_opmath_t* output_per_tensor,
     TensorListAddresses addr_struct,
     int max_chunks_per_tensor) {
@@ -442,7 +442,7 @@ struct ForeachNormDispatchName<false> {
 // false, returns raw sum support_infinity: if true, includes L-infinity norm
 // handling
 template <bool apply_root, bool support_infinity>
-std::vector<Tensor> foreach_tensor_norm_cuda_internal(
+static std::vector<Tensor> foreach_tensor_norm_cuda_internal(
     TensorList tensors,
     double p,
     std::optional<ScalarType> dtype) {

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -117,7 +117,7 @@ struct LpMaxFunctor {
 };
 
 template <typename T>
-__global__ void lpmax_cleanup(
+static __global__ void lpmax_cleanup(
     const T* output_per_tensor,
     TensorListAddresses addr_struct,
     int max_chunks_per_tensor) {
@@ -350,7 +350,7 @@ template <
     typename out_t,
     bool apply_root = true,
     typename out_opmath_t = at::opmath_type<out_t>>
-__global__ void lpnorm_cleanup(
+static __global__ void lpnorm_cleanup(
     const out_opmath_t* output_per_tensor,
     TensorListAddresses addr_struct,
     int max_chunks_per_tensor) {
@@ -445,7 +445,7 @@ struct ForeachNormDispatchName<false> {
 // false, returns raw sum support_infinity: if true, includes L-infinity norm
 // handling
 template <bool apply_root, bool support_infinity>
-std::vector<Tensor> foreach_tensor_norm_cuda_internal(
+static std::vector<Tensor> foreach_tensor_norm_cuda_internal(
     TensorList tensors,
     double p,
     std::optional<ScalarType> dtype) {

--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -49,7 +49,7 @@
 namespace at::native {
 
 template <typename scalar_t, template <class> class Op>
-std::vector<Tensor> foreach_unary_op(TensorList tensors) {
+static std::vector<Tensor> foreach_unary_op(TensorList tensors) {
   std::vector<std::vector<at::Tensor>> tensor_lists;
   std::vector<at::Tensor> vec_res;
   vec_res.reserve(tensors.size());
@@ -74,7 +74,7 @@ std::vector<Tensor> foreach_unary_op(TensorList tensors) {
 }
 
 template <typename scalar_t, template <class> class Op>
-void foreach_unary_op_(TensorList tensors) {
+static void foreach_unary_op_(TensorList tensors) {
   std::vector<std::vector<at::Tensor>> tensor_lists;
   tensor_lists.emplace_back(tensors.vec());
   using opmath_t = typename at::opmath_type<scalar_t>;
@@ -90,7 +90,7 @@ void foreach_unary_op_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> floating_complex_half(TensorList tensors) {
+static std::vector<Tensor> floating_complex_half(TensorList tensors) {
   return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(
       ScalarType::Half,
       tensors[0].scalar_type(),
@@ -99,7 +99,7 @@ std::vector<Tensor> floating_complex_half(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void floating_complex_half_(TensorList tensors) {
+static void floating_complex_half_(TensorList tensors) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(
       ScalarType::Half,
       tensors[0].scalar_type(),
@@ -108,7 +108,8 @@ void floating_complex_half_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_bfloat16_half_bool(TensorList tensors) {
+static std::vector<Tensor> all_types_complex_bfloat16_half_bool(
+    TensorList tensors) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
       ScalarType::Half,
       ScalarType::BFloat16,
@@ -119,7 +120,7 @@ std::vector<Tensor> all_types_complex_bfloat16_half_bool(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void all_types_complex_bfloat16_half_bool_(TensorList tensors) {
+static void all_types_complex_bfloat16_half_bool_(TensorList tensors) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
       ScalarType::Half,
       ScalarType::BFloat16,
@@ -130,7 +131,7 @@ void all_types_complex_bfloat16_half_bool_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> floating_complex_half_bfloat16(TensorList tensors) {
+static std::vector<Tensor> floating_complex_half_bfloat16(TensorList tensors) {
   return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
       ScalarType::Half,
       ScalarType::BFloat16,
@@ -140,7 +141,7 @@ std::vector<Tensor> floating_complex_half_bfloat16(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void floating_complex_half_bfloat16_(TensorList tensors) {
+static void floating_complex_half_bfloat16_(TensorList tensors) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
       ScalarType::Half,
       ScalarType::BFloat16,
@@ -150,7 +151,7 @@ void floating_complex_half_bfloat16_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_half_complex_bfloat16(TensorList tensors) {
+static std::vector<Tensor> all_types_half_complex_bfloat16(TensorList tensors) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       ScalarType::Half,
       at::ScalarType::BFloat16,
@@ -160,7 +161,7 @@ std::vector<Tensor> all_types_half_complex_bfloat16(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void all_types_half_complex_bfloat16_(TensorList tensors) {
+static void all_types_half_complex_bfloat16_(TensorList tensors) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       ScalarType::Half,
       at::ScalarType::BFloat16,
@@ -170,7 +171,7 @@ void all_types_half_complex_bfloat16_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> floating_half(TensorList tensors) {
+static std::vector<Tensor> floating_half(TensorList tensors) {
   return AT_DISPATCH_FLOATING_TYPES_AND(
       ScalarType::Half,
       tensors[0].scalar_type(),
@@ -179,7 +180,7 @@ std::vector<Tensor> floating_half(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void floating_half_(TensorList tensors) {
+static void floating_half_(TensorList tensors) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       tensors[0].scalar_type(), "foreach_unary_op_cuda_", [&]() {
         foreach_unary_op_<scalar_t, Op>(tensors);
@@ -187,7 +188,7 @@ void floating_half_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> floating_half_bfloat16(TensorList tensors) {
+static std::vector<Tensor> floating_half_bfloat16(TensorList tensors) {
   return AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half,
       ScalarType::BFloat16,
@@ -197,7 +198,7 @@ std::vector<Tensor> floating_half_bfloat16(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void floating_half_bfloat16_(TensorList tensors) {
+static void floating_half_bfloat16_(TensorList tensors) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half,
       ScalarType::BFloat16,

--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -49,7 +49,7 @@
 namespace at::native {
 
 template <typename scalar_t, template <class> class Op>
-std::vector<Tensor> foreach_unary_op(TensorList tensors) {
+static std::vector<Tensor> foreach_unary_op(TensorList tensors) {
   std::vector<at::Tensor> vec_res;
   vec_res.reserve(tensors.size());
   for (const auto& t : tensors) {
@@ -73,7 +73,7 @@ std::vector<Tensor> foreach_unary_op(TensorList tensors) {
 }
 
 template <typename scalar_t, template <class> class Op>
-void foreach_unary_op_(TensorList tensors) {
+static void foreach_unary_op_(TensorList tensors) {
   auto tensor_lists = c10::make_nested<Tensor>(tensors.vec());
   using opmath_t = typename at::opmath_type<scalar_t>;
   multi_tensor_apply<1>(
@@ -88,7 +88,7 @@ void foreach_unary_op_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> floating_complex_half(TensorList tensors) {
+static std::vector<Tensor> floating_complex_half(TensorList tensors) {
   return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(
       ScalarType::Half,
       tensors[0].scalar_type(),
@@ -97,7 +97,7 @@ std::vector<Tensor> floating_complex_half(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void floating_complex_half_(TensorList tensors) {
+static void floating_complex_half_(TensorList tensors) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(
       ScalarType::Half,
       tensors[0].scalar_type(),
@@ -106,7 +106,8 @@ void floating_complex_half_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_complex_bfloat16_half_bool(TensorList tensors) {
+static std::vector<Tensor> all_types_complex_bfloat16_half_bool(
+    TensorList tensors) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
       ScalarType::Half,
       ScalarType::BFloat16,
@@ -117,7 +118,7 @@ std::vector<Tensor> all_types_complex_bfloat16_half_bool(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void all_types_complex_bfloat16_half_bool_(TensorList tensors) {
+static void all_types_complex_bfloat16_half_bool_(TensorList tensors) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
       ScalarType::Half,
       ScalarType::BFloat16,
@@ -128,7 +129,7 @@ void all_types_complex_bfloat16_half_bool_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> floating_complex_half_bfloat16(TensorList tensors) {
+static std::vector<Tensor> floating_complex_half_bfloat16(TensorList tensors) {
   return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
       ScalarType::Half,
       ScalarType::BFloat16,
@@ -138,7 +139,7 @@ std::vector<Tensor> floating_complex_half_bfloat16(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void floating_complex_half_bfloat16_(TensorList tensors) {
+static void floating_complex_half_bfloat16_(TensorList tensors) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
       ScalarType::Half,
       ScalarType::BFloat16,
@@ -148,7 +149,7 @@ void floating_complex_half_bfloat16_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> all_types_half_complex_bfloat16(TensorList tensors) {
+static std::vector<Tensor> all_types_half_complex_bfloat16(TensorList tensors) {
   return AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       ScalarType::Half,
       at::ScalarType::BFloat16,
@@ -158,7 +159,7 @@ std::vector<Tensor> all_types_half_complex_bfloat16(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void all_types_half_complex_bfloat16_(TensorList tensors) {
+static void all_types_half_complex_bfloat16_(TensorList tensors) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       ScalarType::Half,
       at::ScalarType::BFloat16,
@@ -168,7 +169,7 @@ void all_types_half_complex_bfloat16_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> floating_half(TensorList tensors) {
+static std::vector<Tensor> floating_half(TensorList tensors) {
   return AT_DISPATCH_FLOATING_TYPES_AND(
       ScalarType::Half,
       tensors[0].scalar_type(),
@@ -177,7 +178,7 @@ std::vector<Tensor> floating_half(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void floating_half_(TensorList tensors) {
+static void floating_half_(TensorList tensors) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       tensors[0].scalar_type(), "foreach_unary_op_cuda_", [&]() {
         foreach_unary_op_<scalar_t, Op>(tensors);
@@ -185,7 +186,7 @@ void floating_half_(TensorList tensors) {
 }
 
 template <template <class> class Op>
-std::vector<Tensor> floating_half_bfloat16(TensorList tensors) {
+static std::vector<Tensor> floating_half_bfloat16(TensorList tensors) {
   return AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half,
       ScalarType::BFloat16,
@@ -195,7 +196,7 @@ std::vector<Tensor> floating_half_bfloat16(TensorList tensors) {
 }
 
 template <template <class> class Op>
-void floating_half_bfloat16_(TensorList tensors) {
+static void floating_half_bfloat16_(TensorList tensors) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half,
       ScalarType::BFloat16,

--- a/aten/src/ATen/native/cuda/IGammaKernel.cu
+++ b/aten/src/ATen/native/cuda/IGammaKernel.cu
@@ -533,13 +533,13 @@ struct CalcIgamma{
 
 namespace at::native {
 
-void igamma_kernel_cuda(TensorIteratorBase& iter) {
+static void igamma_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "igamma_cuda", [&]() {
     gpu_kernel(iter, CalcIgamma<scalar_t>(false));
   });
 }
 
-void igammac_kernel_cuda(TensorIteratorBase& iter) {
+static void igammac_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "igammac_cuda", [&]() {
     gpu_kernel(iter, CalcIgamma<scalar_t>(true));
   });

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -27,7 +27,7 @@ static constexpr int launch_size_nd = 128;
 
 template<int nt, int vt, typename func_t>
 C10_LAUNCH_BOUNDS_2(nt, launch_bound2)
-__global__ void index_elementwise_kernel(const int64_t N, const func_t f) {
+static __global__ void index_elementwise_kernel(const int64_t N, const func_t f) {
   const auto tid = threadIdx.x;
   const auto nv = nt * vt;
   auto idx = nv * blockIdx.x + tid;
@@ -479,7 +479,7 @@ void flip_kernel_impl(TensorIterator& iter) {
   launch_kernel<launch_size_nd, launch_bound2>(iter.numel(), loop);
 }
 
-void flip_kernel(TensorIterator& iter, const bool quantized) {
+static void flip_kernel(TensorIterator& iter, const bool quantized) {
   if (quantized) {
     AT_DISPATCH_QINT_AND_SUB_BYTE_TYPES(iter.dtype(), "flip_quantized_cuda",
     [&] {

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -27,7 +27,7 @@ static constexpr int launch_size_nd = 128;
 
 template<int nt, int vt, typename func_t>
 C10_LAUNCH_BOUNDS_2(nt, launch_bound2)
-__global__ void index_elementwise_kernel(const int64_t N, const func_t f) {
+static __global__ void index_elementwise_kernel(const int64_t N, const func_t f) {
   const auto tid = threadIdx.x;
   const auto nv = nt * vt;
   auto idx = nv * blockIdx.x + tid;
@@ -483,7 +483,7 @@ void flip_kernel_impl(TensorIterator& iter) {
   launch_kernel<launch_size_nd, launch_bound2>(iter.numel(), loop);
 }
 
-void flip_kernel(TensorIterator& iter, const bool quantized) {
+static void flip_kernel(TensorIterator& iter, const bool quantized) {
   if (quantized) {
     AT_DISPATCH_QINT_AND_SUB_BYTE_TYPES(iter.dtype(), "flip_quantized_cuda",
     [&] {

--- a/aten/src/ATen/native/cuda/IndexKernelUtils.cu
+++ b/aten/src/ATen/native/cuda/IndexKernelUtils.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 template <int Alignment, typename index_t>
-__global__ void vectorized_gather_kernel(char * out, char * inp, index_t * idx, int num_ind, int64_t slice_size, int64_t ind_dim_size, int64_t inp_stride, int64_t out_stride, bool allow_neg_indices) {
+static __global__ void vectorized_gather_kernel(char * out, char * inp, index_t * idx, int num_ind, int64_t slice_size, int64_t ind_dim_size, int64_t inp_stride, int64_t out_stride, bool allow_neg_indices) {
     int64_t ind = idx[blockIdx.x];
     if (allow_neg_indices) {
         ind = (ind < 0) ? ind + ind_dim_size : ind;

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1120,7 +1120,7 @@ __global__ void indexFuncLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst,
 //   "elementInSlice-major order".  For example, each thread can process element
 //   #0 of every slice, and then element #1 of every slice, and so on.
 template <typename scalar_t>
-bool indexShouldBeMajor(cuda::detail::TensorInfo<scalar_t, unsigned int> &info,
+static bool indexShouldBeMajor(cuda::detail::TensorInfo<scalar_t, unsigned int> &info,
                                     int sliceDim)
 {
   // The stride between adjacent slices (e.g., between element #0 of slice #100
@@ -1136,7 +1136,7 @@ bool indexShouldBeMajor(cuda::detail::TensorInfo<scalar_t, unsigned int> &info,
   return false;
 }
 
-void index_add_cuda_impl(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& source, const Scalar& alpha, const Tensor& result) {
+static void index_add_cuda_impl(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& source, const Scalar& alpha, const Tensor& result) {
   if (!result.is_same(self)) {
     result.copy_(self);
   }

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1122,7 +1122,7 @@ __global__ void indexFuncLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst,
 //   "elementInSlice-major order".  For example, each thread can process element
 //   #0 of every slice, and then element #1 of every slice, and so on.
 template <typename scalar_t>
-bool indexShouldBeMajor(cuda::detail::TensorInfo<scalar_t, unsigned int> &info,
+static bool indexShouldBeMajor(cuda::detail::TensorInfo<scalar_t, unsigned int> &info,
                                     int sliceDim)
 {
   // The stride between adjacent slices (e.g., between element #0 of slice #100
@@ -1138,7 +1138,7 @@ bool indexShouldBeMajor(cuda::detail::TensorInfo<scalar_t, unsigned int> &info,
   return false;
 }
 
-void index_add_cuda_impl(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& source, const Scalar& alpha, const Tensor& result) {
+static void index_add_cuda_impl(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& source, const Scalar& alpha, const Tensor& result) {
   if (!result.is_same(self)) {
     result.copy_(self);
   }

--- a/aten/src/ATen/native/cuda/MaxUnpooling.cu
+++ b/aten/src/ATen/native/cuda/MaxUnpooling.cu
@@ -403,7 +403,7 @@ Tensor max_unpooling3d_forward_cuda(
   return output;
 }
 
-at::Tensor& max_unpooling2d_backward_out_cuda(const Tensor& grad_output_,
+static at::Tensor& max_unpooling2d_backward_out_cuda(const Tensor& grad_output_,
     const Tensor& self_,
     const Tensor& indices_,
     IntArrayRef output_size,
@@ -493,7 +493,7 @@ at::Tensor& max_unpooling2d_backward_out_cuda(const Tensor& grad_output_,
       }));
   return grad_input;
 }
-at::Tensor max_unpooling2d_backward_cuda(
+static at::Tensor max_unpooling2d_backward_cuda(
     const Tensor& grad_output,
     const Tensor& self,
     const Tensor& indices,

--- a/aten/src/ATen/native/cuda/MaxUnpooling.cu
+++ b/aten/src/ATen/native/cuda/MaxUnpooling.cu
@@ -419,7 +419,7 @@ Tensor max_unpooling3d_forward_cuda(
   return output;
 }
 
-at::Tensor& max_unpooling2d_backward_out_cuda(const Tensor& grad_output_,
+static at::Tensor& max_unpooling2d_backward_out_cuda(const Tensor& grad_output_,
     const Tensor& self_,
     const Tensor& indices_,
     IntArrayRef output_size,
@@ -508,7 +508,7 @@ at::Tensor& max_unpooling2d_backward_out_cuda(const Tensor& grad_output_,
       }));
   return grad_input;
 }
-at::Tensor max_unpooling2d_backward_cuda(
+static at::Tensor max_unpooling2d_backward_cuda(
     const Tensor& grad_output,
     const Tensor& self,
     const Tensor& indices,

--- a/aten/src/ATen/native/cuda/Nonzero.cu
+++ b/aten/src/ATen/native/cuda/Nonzero.cu
@@ -167,7 +167,7 @@ __global__ void flag_kernel(const T* d_in, int64_t * d_out, const int64_t * agg,
 } // anonymous namespace
 
 template <typename scalar_t>
-void nonzero_cuda_out_impl(const Tensor& self, Tensor& out) {
+static void nonzero_cuda_out_impl(const Tensor& self, Tensor& out) {
   Tensor self_ = self.contiguous();
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   int64_t chunk_size, num_chunks;
@@ -294,7 +294,7 @@ void nonzero_cuda_out_impl(const Tensor& self, Tensor& out) {
 }
 
 template <typename scalar_t>
-void nonzero_static_cuda_out_impl(
+static void nonzero_static_cuda_out_impl(
     const Tensor& self,
     int64_t size,
     int64_t fill_value,

--- a/aten/src/ATen/native/cuda/RNN.cu
+++ b/aten/src/ATen/native/cuda/RNN.cu
@@ -537,7 +537,7 @@ std::tuple<Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_cuda(
   return std::make_tuple(std::move(hy), std::move(cy), std::move(workspace));
 }
 
-void checkLSTMBackwardSizes(const TensorArg& grad_hy, const TensorArg& grad_cy,
+static void checkLSTMBackwardSizes(const TensorArg& grad_hy, const TensorArg& grad_cy,
                             const TensorArg& cx, const TensorArg& cy,
                             const TensorArg& workspace) {
   CheckedFrom c = "fused_lstm_cell_backward";
@@ -622,7 +622,7 @@ std::tuple<Tensor, Tensor> _thnn_fused_gru_cell_cuda(
   return std::make_tuple(std::move(hy), std::move(workspace));
 }
 
-void checkGRUBackwardSizes(const TensorArg& grad_hy, const TensorArg& workspace) {
+static void checkGRUBackwardSizes(const TensorArg& grad_hy, const TensorArg& workspace) {
   CheckedFrom c = "fused_gru_cell_backward";
   checkDim(c, grad_hy, 2);
   checkSize(c, workspace, {grad_hy->size(0), grad_hy->size(1) * GRU_WORKSPACE_MULTIPLIER});

--- a/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
@@ -16,7 +16,7 @@
 namespace at::native {
 
 template <typename scalar_t>
-void _min_max_values_kernel_cuda_impl(TensorIterator& iter) {
+static void _min_max_values_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, scalar_t>(
       iter,
       MinMaxOps<scalar_t, scalar_t, int32_t>{},

--- a/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
@@ -16,7 +16,7 @@
 namespace at::native {
 
 template <typename scalar_t, typename acc_t = scalar_t>
-void argmax_kernel_cuda_impl(TensorIterator& iter) {
+static void argmax_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, int64_t>(
       iter,
       ArgMaxOps<acc_t>{},
@@ -24,7 +24,7 @@ void argmax_kernel_cuda_impl(TensorIterator& iter) {
           at::numeric_limits<acc_t>::lower_bound(), 0));
 };
 
-void argmax_kernel_cuda(TensorIterator& iter) {
+static void argmax_kernel_cuda(TensorIterator& iter) {
   // For float16 & bfloat16, instead of implementing is_nan and warp_shfl_down,
   // we can convert float16 & bfloat16 to float and do all the operations in
   // float.

--- a/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
@@ -16,7 +16,7 @@
 namespace at::native {
 
 template <typename scalar_t, typename acc_t = scalar_t>
-void argmin_kernel_cuda_impl(TensorIterator& iter) {
+static void argmin_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, int64_t>(
       iter,
       ArgMinOps<acc_t>{},
@@ -24,7 +24,7 @@ void argmin_kernel_cuda_impl(TensorIterator& iter) {
           at::numeric_limits<acc_t>::upper_bound(), 0));
 };
 
-void argmin_kernel_cuda(TensorIterator& iter) {
+static void argmin_kernel_cuda(TensorIterator& iter) {
   // For float16 & bfloat16, instead of implementing is_nan and warp_shfl_down,
   // we can convert float16 & bfloat16 to float and do all the operations in
   // float.

--- a/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
@@ -23,14 +23,14 @@ struct MaxNanFunctor {
 };
 
 template <typename scalar_t, typename acc_t = scalar_t>
-void max_values_kernel_cuda_impl(TensorIterator& iter) {
+static void max_values_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, scalar_t>(
       iter,
       func_wrapper<acc_t>(MaxNanFunctor<acc_t>()),
       at::numeric_limits<acc_t>::lower_bound());
 }
 
-void max_values_kernel_cuda(TensorIterator& iter) {
+static void max_values_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(
       kBFloat16, kHalf, kBool, iter.dtype(), "max_values_cuda", [&]() {
         max_values_kernel_cuda_impl<scalar_t>(iter);

--- a/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
@@ -23,13 +23,13 @@ struct MinNanFunctor {
 };
 
 template <typename scalar_t, typename acc_t=scalar_t>
-void min_values_kernel_cuda_impl(TensorIterator& iter) {
+static void min_values_kernel_cuda_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, scalar_t>(
     iter, func_wrapper<acc_t> (MinNanFunctor<acc_t>()),
     at::numeric_limits<acc_t>::upper_bound());
 }
 
-void min_values_kernel_cuda(TensorIterator& iter) {
+static void min_values_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(kBFloat16, kHalf, kBool, iter.dtype(), "min_values_cuda", [&]() {
     min_values_kernel_cuda_impl<scalar_t>(iter);
   });

--- a/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
@@ -12,7 +12,7 @@
 namespace at::native {
 
 template <typename scalar_t, typename out_t=scalar_t>
-void std_var_kernel_impl(TensorIterator& iter, double correction, bool take_sqrt) {
+static void std_var_kernel_impl(TensorIterator& iter, double correction, bool take_sqrt) {
   // reducing unrolling factor to 2 for welford kernel
   // This is necessary to lower register usage that leads to register spills.
   using accscalar_t = at::acc_type<scalar_t, true>;

--- a/aten/src/ATen/native/cuda/ReduceNormKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceNormKernel.cu
@@ -14,7 +14,7 @@ namespace at::native {
 // `scalar_t` is complex, `acc_t` is the downgraded real number type.
 // Otherwise, `acc_t` and `scalar_t` are the same type.
 template <typename scalar_t, typename acc_t=typename scalar_value_type<scalar_t>::type, typename out_t=typename scalar_value_type<scalar_t>::type>
-void norm_kernel_cuda_impl(TensorIterator& iter, double p) {
+static void norm_kernel_cuda_impl(TensorIterator& iter, double p) {
   if (p == static_cast<double>(0)) {
     gpu_reduce_kernel<scalar_t, out_t>(iter, NormZeroOps<scalar_t, acc_t, out_t>(), 0);
   } else if (p == static_cast<double>(1)) {
@@ -50,7 +50,7 @@ void norm_launch_kernel(TensorIterator& iter, double ord) {
 
 // powsum: computes sum(|x|^p) without the final root
 template <typename scalar_t, typename acc_t=typename scalar_value_type<scalar_t>::type, typename out_t=typename scalar_value_type<scalar_t>::type>
-void powsum_kernel_cuda_impl(TensorIterator& iter, double p) {
+static void powsum_kernel_cuda_impl(TensorIterator& iter, double p) {
   if (p == static_cast<double>(2)) {
     gpu_reduce_kernel<scalar_t, out_t>(iter, NormTwoOps<scalar_t, acc_t, out_t, false>(), 0);
   } else {

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -95,7 +95,7 @@ template <int N> struct alignas(N) OpaqueType { char data[N]; };
 // essentially rewritten related to legacy::launch_kernel parts
 template <int nt, int vt, typename func_t>
 C10_LAUNCH_BOUNDS_2(nt, vt)
-__global__ void _scatter_gather_elementwise_kernel(int N, func_t f) {
+static __global__ void _scatter_gather_elementwise_kernel(int N, func_t f) {
   constexpr int nv = nt * vt;
   int idx = nv * blockIdx.x + threadIdx.x;
 
@@ -555,13 +555,13 @@ struct cuda_scatter_fill_base_kernel {
   }
 }; // struct cuda_scatter_fill_base_kernel
 
-void gather_cuda_kernel(const Tensor& result, const Tensor& self, int64_t dim, const Tensor& index) {
+static void gather_cuda_kernel(const Tensor& result, const Tensor& self, int64_t dim, const Tensor& index) {
   cuda_scatter_gather_base_kernel</*is_scatter_like=*/false>()(
     result, dim, index, self,
     "gather_out_cuda", tensor_assign);
 }
 
-void scatter_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+static void scatter_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
   // When indices are not unique, the behavior is non-deterministic
   globalContext().alertNotDeterministic("scatter_cuda_");
   cuda_scatter_gather_base_kernel<>()(
@@ -569,19 +569,19 @@ void scatter_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, c
     "scatter_cuda_", tensor_assign);
 }
 
-void scatter_fill_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& src) {
+static void scatter_fill_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& src) {
   cuda_scatter_fill_base_kernel<>()(
     self, dim, index, src,
     "scatter_fill_cuda_", tensor_assign);
 }
 
-void scatter_add_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+static void scatter_add_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
   cuda_scatter_gather_base_kernel</*is_scatter_like=*/true, /*cast_to_opaque=*/false>()(
     self, dim, index, src,
     "scatter_add_cuda_", reduce_add);
 }
 
-void scatter_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
+static void scatter_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
                                const Tensor& src, const ReductionType& reduce) {
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd/AtomicMul usage
@@ -600,7 +600,7 @@ void scatter_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Ten
   }
 }
 
-void scatter_reduce_two_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
+static void scatter_reduce_two_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
                                     const Tensor& src, const ReductionType& reduce) {
   switch (reduce) {
   case ReductionType::SUM :
@@ -627,7 +627,7 @@ void scatter_reduce_two_cuda_kernel(const Tensor& self, const int64_t dim, const
   }
 }
 
-void scatter_scalar_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
+static void scatter_scalar_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
                                const Scalar& value, const ReductionType& reduce) {
   switch (reduce) {
   case ReductionType::SUM :

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -95,7 +95,7 @@ template <int N> struct alignas(N) OpaqueType { char data[N]; };
 // essentially rewritten related to legacy::launch_kernel parts
 template <int nt, int vt, typename func_t>
 C10_LAUNCH_BOUNDS_2(nt, vt)
-__global__ void _scatter_gather_elementwise_kernel(int N, func_t f) {
+static __global__ void _scatter_gather_elementwise_kernel(int N, func_t f) {
   constexpr int nv = nt * vt;
   int idx = nv * blockIdx.x + threadIdx.x;
 
@@ -556,13 +556,13 @@ struct cuda_scatter_fill_base_kernel {
   }
 }; // struct cuda_scatter_fill_base_kernel
 
-void gather_cuda_kernel(const Tensor& result, const Tensor& self, int64_t dim, const Tensor& index) {
+static void gather_cuda_kernel(const Tensor& result, const Tensor& self, int64_t dim, const Tensor& index) {
   cuda_scatter_gather_base_kernel</*is_scatter_like=*/false>()(
     result, dim, index, self,
     "gather_out_cuda", tensor_assign);
 }
 
-void scatter_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+static void scatter_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
   // When indices are not unique, the behavior is non-deterministic
   globalContext().alertNotDeterministic("scatter_cuda_");
   cuda_scatter_gather_base_kernel<>()(
@@ -570,19 +570,19 @@ void scatter_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, c
     "scatter_cuda_", tensor_assign);
 }
 
-void scatter_fill_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& src) {
+static void scatter_fill_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Scalar& src) {
   cuda_scatter_fill_base_kernel<>()(
     self, dim, index, src,
     "scatter_fill_cuda_", tensor_assign);
 }
 
-void scatter_add_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
+static void scatter_add_cuda_kernel(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
   cuda_scatter_gather_base_kernel</*is_scatter_like=*/true, /*cast_to_opaque=*/false>()(
     self, dim, index, src,
     "scatter_add_cuda_", reduce_add);
 }
 
-void scatter_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
+static void scatter_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
                                const Tensor& src, const ReductionType& reduce) {
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd/AtomicMul usage
@@ -601,7 +601,7 @@ void scatter_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Ten
   }
 }
 
-void scatter_reduce_two_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
+static void scatter_reduce_two_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
                                     const Tensor& src, const ReductionType& reduce) {
   switch (reduce) {
   case ReductionType::SUM :
@@ -628,7 +628,7 @@ void scatter_reduce_two_cuda_kernel(const Tensor& self, const int64_t dim, const
   }
 }
 
-void scatter_scalar_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
+static void scatter_scalar_reduce_cuda_kernel(const Tensor& self, const int64_t dim, const Tensor& index,
                                const Scalar& value, const ReductionType& reduce) {
   switch (reduce) {
   case ReductionType::SUM :

--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -28,7 +28,7 @@ static int minimum_grid_for_occupancy(T kernel, int max_block_size) {
 }
 
 template <typename T>
-constexpr bool has_nan() {
+static constexpr bool has_nan() {
   if constexpr (std::numeric_limits<T>::is_specialized) {
     return std::numeric_limits<T>::has_quiet_NaN;
   } else if constexpr (
@@ -283,7 +283,7 @@ struct MediumRadixSort {
 };
 
 template <typename Sorter>
-void sortCommon(Sorter sorter, const TensorBase &key, const TensorBase &value,
+static void sortCommon(Sorter sorter, const TensorBase &key, const TensorBase &value,
                 int dim, bool descending) {
   TORCH_CHECK(key.sizes() == value.sizes(),
               "Key tensor must have same size as value tensor");

--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -72,7 +72,7 @@ struct HermitianSymmetryOffsetCalculator {
 // out[:] = conj(in[:]) where in and out ordering is generalized by offset calculators
 template <typename scalar_t, typename inp_calc_t, typename out_calc_t>
 C10_LAUNCH_BOUNDS_1(cuda::detail::CUDA_NUM_THREADS)
-__global__ void _fft_conjugate_copy_kernel(
+static __global__ void _fft_conjugate_copy_kernel(
     int64_t numel, scalar_t * out_data, const scalar_t * in_data,
     inp_calc_t ic, out_calc_t oc) {
   CUDA_KERNEL_LOOP_TYPE(index, numel, int64_t) {
@@ -91,7 +91,7 @@ __global__ void _fft_conjugate_copy_kernel(
 // input should be a tensor of same size as full (twosided)
 // signals, but only contains half (onesided) of the values.
 // This function modifies inplace.
-void _fft_fill_with_conjugate_symmetry_cuda_(
+static void _fft_fill_with_conjugate_symmetry_cuda_(
     ScalarType dtype, IntArrayRef mirror_dims, IntArrayRef signal_half_sizes,
     IntArrayRef in_strides, const void * in_data,
     IntArrayRef out_strides, void * out_data) {

--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -78,7 +78,7 @@ struct HermitianSymmetryOffsetCalculator {
 // out[:] = conj(in[:]) where in and out ordering is generalized by offset calculators
 template <typename scalar_t, typename index_t, typename inp_calc_t, typename out_calc_t>
 C10_LAUNCH_BOUNDS_1(cuda::detail::CUDA_NUM_THREADS)
-__global__ void _fft_conjugate_copy_kernel(
+static __global__ void _fft_conjugate_copy_kernel(
     int64_t numel, scalar_t * out_data, const scalar_t * in_data,
     inp_calc_t ic, out_calc_t oc) {
   CUDA_KERNEL_LOOP_TYPE(index, numel, index_t) {
@@ -126,7 +126,7 @@ static void _fft_fill_with_conjugate_symmetry_launch(
 // input should be a tensor of same size as full (twosided)
 // signals, but only contains half (onesided) of the values.
 // This function modifies inplace.
-void _fft_fill_with_conjugate_symmetry_cuda_(
+static void _fft_fill_with_conjugate_symmetry_cuda_(
     ScalarType dtype, IntArrayRef mirror_dims, IntArrayRef signal_half_sizes,
     IntArrayRef in_strides, const void * in_data,
     IntArrayRef out_strides, void * out_data) {

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -105,7 +105,7 @@ struct Msg {
  char msg[MAX_MSG_LENGTH];
 };
 template <typename scalar_t>
-__global__ void _assert_async_cuda_kernel(const scalar_t* input, Msg msg) {
+static __global__ void _assert_async_cuda_kernel(const scalar_t* input, Msg msg) {
   CUDA_KERNEL_ASSERT_MSG(input[0] != 0, msg.msg);
 }
 

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -117,7 +117,7 @@ struct Msg {
  char msg[MAX_MSG_LENGTH];
 };
 template <typename scalar_t>
-__global__ void _assert_async_cuda_kernel(const scalar_t* input, Msg msg) {
+static __global__ void _assert_async_cuda_kernel(const scalar_t* input, Msg msg) {
   CUDA_KERNEL_ASSERT_MSG(input[0] != 0, msg.msg);
 }
 

--- a/aten/src/ATen/native/cuda/TensorShape.cu
+++ b/aten/src/ATen/native/cuda/TensorShape.cu
@@ -243,7 +243,7 @@ static inline int64_t get_num_chunks(const at::Tensor& tensor, int64_t dim) {
 }
 
 // Pack multiple std::vector<int64_t> into a single cuda tensor.
-std::pair<at::Tensor, std::vector<int64_t*>> pack_vecs(
+static std::pair<at::Tensor, std::vector<int64_t*>> pack_vecs(
     std::vector<const std::vector<int64_t>*> vecs,
     const at::Device& device) {
   int64_t numel = 0;
@@ -616,7 +616,7 @@ void _chunk_cat_out_cuda_contiguous(
 } // namespace detail
 
 // See [CUDA fast path for split_with_sizes_copy.out]
-void split_with_sizes_copy_out_cuda_contiguous_no_cast(
+static void split_with_sizes_copy_out_cuda_contiguous_no_cast(
     const at::Tensor& self,
     at::IntArrayRef split_sizes,
     int64_t dim,

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -757,7 +757,7 @@ __global__ void computeBlockDigitCounts(
 
 #ifndef USE_ROCM
 // CUDA path: compute global histogram and cumsum for each row
-__global__ void computeDigitCumSum(
+static __global__ void computeDigitCumSum(
   short* counts,
   uint32_t* digit_cum_sum,
   uint32_t blocks_per_slice) {
@@ -1265,7 +1265,7 @@ __global__ void gatherTopK(at::cuda::detail::TensorInfo<const T, IndexType> inpu
   }
 }
 
-int get_items_per_thread(uint64_t num_slices, uint64_t slice_size) {
+static int get_items_per_thread(uint64_t num_slices, uint64_t slice_size) {
   // Occupancy of this kernel is limited by registers per thread
   // Platform-specific tuning for optimal register pressure
 #if defined(USE_ROCM)
@@ -1472,7 +1472,7 @@ void launch(
 
 } // namespace mbtopk
 
-bool should_use_multiblock(int64_t num_slices, int64_t slice_size) {
+static bool should_use_multiblock(int64_t num_slices, int64_t slice_size) {
   if (num_slices > std::numeric_limits<uint32_t>::max() ||
       slice_size > std::numeric_limits<uint32_t>::max()) return false;
   // This heuristics is based on the experiment in https://github.com/pytorch/pytorch/pull/74267
@@ -1485,7 +1485,7 @@ bool should_use_multiblock(int64_t num_slices, int64_t slice_size) {
       (num_slices > 4000 && slice_size >= 400);
 }
 
-bool should_use_warp_topk(int64_t slice_size, int64_t k) {
+static bool should_use_warp_topk(int64_t slice_size, int64_t k) {
 #if !defined(USE_ROCM) || !HAS_WARP_MERGE_SORT()
   return false;
 #else

--- a/aten/src/ATen/native/cuda/TriangularOps.cu
+++ b/aten/src/ATen/native/cuda/TriangularOps.cu
@@ -130,7 +130,7 @@ __global__ void triu_tril_kernel(
 // MSVC's traditional preprocessor does not accept #if/#else/#endif inside a
 // macro argument and the Windows build would otherwise fail.
 template <bool upper, typename scalar_t>
-void launch_triu_tril_kernel(const Tensor& result, const Tensor& self, int64_t k) {
+static void launch_triu_tril_kernel(const Tensor& result, const Tensor& self, int64_t k) {
 #if !defined(USE_ROCM)
   constexpr int elements_per_thread = sizeof(scalar_t) < 8 ? 8 / sizeof(scalar_t) : 1;
 #else
@@ -180,7 +180,7 @@ void launch_triu_tril_kernel(const Tensor& result, const Tensor& self, int64_t k
 }
 
 template <bool upper>
-void triu_tril_cuda_template(const Tensor& result, const Tensor& self, int64_t k, const char* name) {
+static void triu_tril_cuda_template(const Tensor& result, const Tensor& self, int64_t k, const char* name) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
       at::ScalarType::ComplexHalf,
       at::ScalarType::Half,

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -191,7 +191,7 @@ struct MapNumberOfTrueValues {
 };
 
 C10_LAUNCH_BOUNDS_1(at::cuda::detail::CUDA_NUM_THREADS)
-__global__ void unique_bool_write_inverse_indices(
+static __global__ void unique_bool_write_inverse_indices(
     const int numel,
     const int *num_true_p,
     const bool *self,
@@ -208,7 +208,7 @@ __global__ void unique_bool_write_inverse_indices(
 }
 
 C10_LAUNCH_BOUNDS_1(1)
-__global__ void unique_bool_write_output(
+static __global__ void unique_bool_write_output(
     const int numel,
     const int *num_true_p,
     bool *values_out,

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -192,7 +192,7 @@ struct MapNumberOfTrueValues {
 };
 
 C10_LAUNCH_BOUNDS_1(at::cuda::detail::CUDA_NUM_THREADS)
-__global__ void unique_bool_write_inverse_indices(
+static __global__ void unique_bool_write_inverse_indices(
     const int numel,
     const int *num_true_p,
     const bool *self,
@@ -209,7 +209,7 @@ __global__ void unique_bool_write_inverse_indices(
 }
 
 C10_LAUNCH_BOUNDS_1(1)
-__global__ void unique_bool_write_output(
+static __global__ void unique_bool_write_output(
     const int numel,
     const int *num_true_p,
     bool *values_out,

--- a/aten/src/ATen/native/cuda/int4mm.cu
+++ b/aten/src/ATen/native/cuda/int4mm.cu
@@ -996,7 +996,7 @@ void launch_tinygemm_kernel(
 
 // FIXME: parallelize better, smem staging etc?
 template <int InnerKTiles>
-__global__ void matrix_to_m16n8k16_Bint4_layout(
+static __global__ void matrix_to_m16n8k16_Bint4_layout(
     // size [n][k / 2]
     const at::PackedTensorAccessor32<uint8_t, 2, at::RestrictPtrTraits> in,
     // size [ceil(n / 8)][ceil(k / (InnerKTiles * 16))][32][InnerKTiles / 2]

--- a/aten/src/ATen/native/cuda/int4mm.cu
+++ b/aten/src/ATen/native/cuda/int4mm.cu
@@ -1000,7 +1000,7 @@ void launch_tinygemm_kernel(
 
 // FIXME: parallelize better, smem staging etc?
 template <int InnerKTiles>
-__global__ void matrix_to_m16n8k16_Bint4_layout(
+static __global__ void matrix_to_m16n8k16_Bint4_layout(
     // size [n][k / 2]
     const at::PackedTensorAccessor32<uint8_t, 2, at::RestrictPtrTraits> in,
     // size [ceil(n / 8)][ceil(k / (InnerKTiles * 16))][32][InnerKTiles / 2]

--- a/aten/src/ATen/native/cuda/int8mm.cu
+++ b/aten/src/ATen/native/cuda/int8mm.cu
@@ -28,7 +28,7 @@ __global__ void weight_int8pack_mm_kernel(
   out[b * N + n] = acc * scale[n];
 }
 
-void launch_weight_int8pack_mm_cuda_kernel(
+static void launch_weight_int8pack_mm_cuda_kernel(
     const Tensor& x,
     const Tensor& w_int8,
     const Tensor& scale,


### PR DESCRIPTION
Adds `static` to free functions in aten/src/ATen/native/cuda/ whose body does not contain GPU_LAMBDA / __device__ lambdas, are not declared in any header, and are not referenced from any other TU.

Authored with Claude.