### PR TITLE
docs: clarify LSTM equation notation

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -849,7 +849,9 @@ class LSTM(RNNBase):
     is the hidden state of the layer at time `t-1` or the initial hidden
     state at time `0`, and :math:`i_t`, :math:`f_t`, :math:`g_t`,
     :math:`o_t` are the input, forget, cell, and output gates, respectively.
-    :math:`\sigma` is the sigmoid function, and :math:`\odot` is the Hadamard product.
+    The equations use single-sample column-vector notation; batched inputs use
+    the weight shapes described in Attributes below. :math:`\sigma` is the sigmoid
+    function, and :math:`\odot` is the Hadamard product.
 
     In a multilayer LSTM, the input :math:`x^{(l)}_t` of the :math:`l` -th layer
     (:math:`l \ge 2`) is the hidden state :math:`h^{(l-1)}_t` of the previous layer multiplied by


### PR DESCRIPTION
Fixes #131280

Summary:
- Clarifies that the LSTM gate equations use single-sample column-vector notation.
- Points readers to the documented Attributes section for the batched weight shapes used by the module.

Test Plan:
- `python3 -m py_compile torch/nn/modules/rnn.py`
- `git diff --check`