### PR TITLE
docs: clarify scalar fill values

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -95,7 +95,8 @@ By default, the returned Tensor has the same :class:`torch.dtype` and
 :class:`torch.device` as this tensor.
 
 Args:
-    fill_value (scalar): the number to fill the output tensor with.
+    fill_value (Scalar): the scalar value to fill the output tensor with.
+        A scalar can be a Python number or a zero-dimensional tensor.
 
 Keyword args:
     {dtype}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -12501,7 +12501,8 @@ tensor's dtype is inferred from :attr:`fill_value`.
 Args:
     size (int...): a list, tuple, or :class:`torch.Size` of integers defining the
         shape of the output tensor.
-    fill_value (Scalar): the value to fill the output tensor with.
+    fill_value (Scalar): the scalar value to fill the output tensor with.
+        A scalar can be a Python number or a zero-dimensional tensor.
 
 Keyword args:
     {out}
@@ -12530,7 +12531,8 @@ Returns a tensor with the same size as :attr:`input` filled with :attr:`fill_val
 
 Args:
     {input}
-    fill_value: the number to fill the output tensor with.
+    fill_value (Scalar): the scalar value to fill the output tensor with.
+        A scalar can be a Python number or a zero-dimensional tensor.
 
 Keyword args:
     {dtype}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -12864,7 +12864,8 @@ tensor's dtype is inferred from :attr:`fill_value`.
 Args:
     size (int...): a list, tuple, or :class:`torch.Size` of integers defining the
         shape of the output tensor.
-    fill_value (Scalar): the value to fill the output tensor with.
+    fill_value (Scalar): the scalar value to fill the output tensor with.
+        A scalar can be a Python number or a zero-dimensional tensor.
 
 Keyword args:
     {out}
@@ -12893,7 +12894,8 @@ Returns a tensor with the same size as :attr:`input` filled with :attr:`fill_val
 
 Args:
     {input}
-    fill_value: the number to fill the output tensor with.
+    fill_value (Scalar): the scalar value to fill the output tensor with.
+        A scalar can be a Python number or a zero-dimensional tensor.
 
 Keyword args:
     {dtype}


### PR DESCRIPTION
Fixes #129970

Summary:
- Documents that `fill_value` for `torch.full`, `torch.full_like`, and `Tensor.new_full` is a scalar value.
- Clarifies that accepted scalar values include Python numbers and zero-dimensional tensors.

Test Plan:
- `python3 -m py_compile torch/_torch_docs.py torch/_tensor_docs.py`
- `git diff --check`