### PR TITLE
Use at::mps::OptionalMPSGuard for MPS dispatch keys in codegen

### DIFF
--- a/aten/src/ATen/mps/MPSGuardImpl.h
+++ b/aten/src/ATen/mps/MPSGuardImpl.h
@@ -2,7 +2,6 @@
 
 #pragma once
 #include <ATen/Context.h>
-#include <ATen/mps/MPSEvent.h>
 #include <ATen/mps/MPSStream.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/macros/Macros.h>
@@ -25,10 +24,9 @@
 
 namespace at::mps {
 
+class MPSEvent;
 typedef MPSEvent* mpsEvent_t;
 
-// TODO: Move the MPSGuardImpl to inherit from NoOpDeviceGuardImpl
-// https://github.com/pytorch/pytorch/issues/77170
 struct TORCH_API MPSGuardImpl final
     : public c10::impl::DeviceGuardImplInterface {
   static constexpr c10::DeviceType static_type = c10::DeviceType::MPS;

--- a/aten/src/ATen/mps/MPSGuardImpl.mm
+++ b/aten/src/ATen/mps/MPSGuardImpl.mm
@@ -1,6 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 
 #include <ATen/mps/MPSDevice.h>
+#include <ATen/mps/MPSEvent.h>
 #include <ATen/mps/MPSGuardImpl.h>
 
 namespace at::mps {

--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -63,6 +63,7 @@ def gen_registration_headers(
             headers.append("#include <ATen/cuda/EmptyTensor.h>")
     elif backend_index.dispatch_key == DispatchKey.MPS:
         headers.append("#include <ATen/mps/EmptyTensor.h>")
+        headers.append("#include <ATen/mps/MPSGuardImpl.h>")
     elif backend_index.dispatch_key == DispatchKey.XPU:
         # XPU specific, this header resides in third_party/torch-xpu-ops
         headers.append("#include <ATen/xpu/EmptyTensor.h>")
@@ -729,8 +730,7 @@ resize_out(out, sizes, strides, options);
         ):
             guard_field = "c10::OptionalDeviceGuard guard_;"
         elif self.backend_index.dispatch_key == DispatchKey.MPS:
-            # TODO: Move to OptionalMPSGuard.
-            guard_field = "c10::OptionalDeviceGuard guard_;"
+            guard_field = "at::mps::OptionalMPSGuard guard_;"
         elif self.backend_index.dispatch_key == DispatchKey.XPU:
             guard_field = "c10::OptionalDeviceGuard guard_;"
         elif self.backend_index.dispatch_key == DispatchKey.MTIA:


### PR DESCRIPTION
Use `at::mps::OptionalMPSGuard` for MPS dispatch keys in codegen.

Forward-declares `MPSEvent` in `MPSGuardImpl.h` so the generated plain-C++ `RegisterMPS_*.cpp` can include the guard without pulling in Objective-C Metal types.

Closes #77170 as obsolete: `MPSGuardImpl` now has real event support and MPS-specific device semantics, so inheriting from `NoOpDeviceGuardImpl` no longer applies.

Authored with Claude.
