### PR TITLE
[MPS] make index copy fast

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -431,98 +431,52 @@ kernel void masked_fill_scalar_strided(
   }
 }
 
-template <typename T, typename index_t>
+template <typename T, typename index_t, typename OffsetT>
 kernel void index_copy_dense(
     device T* output,
-    constant T* input,
     constant T* source,
     constant index_t* indices,
-    constant uint& dim,
-    constant long* sizes,
-    constant uint& ndim,
-    constant uint& indices_numel,
-    uint thread_index [[thread_position_in_grid]]) {
-  // first copy input to output
-  output[thread_index] = input[thread_index];
-
-  // calculate pos in the tensor using a signed counter
-  long pos[max_ndim];
-  long linear_idx = thread_index;
-  for (int i = static_cast<int>(ndim) - 1; i >= 0; --i) {
-    pos[i] = linear_idx % sizes[i];
-    linear_idx /= sizes[i];
-  }
-
-  // check if this position's dim coordinate is in the indices
-  long dim_pos = pos[dim];
-
-  // search through indices to see if current dim pos should be updated
-  for (uint i = 0; i < indices_numel; i++) {
-    if (indices[i] == dim_pos) {
-      // this position should be updated from source
-      // calculate source offset where the source tensor has the same shape
-      // except along dim where it has size = indices_numel
-      long source_offset = 0;
-      long stride = 1;
-      for (int j = static_cast<int>(ndim) - 1; j >= 0; --j) {
-        if (j == static_cast<int>(dim)) {
-          // for the indexed dimension, use position i
-          source_offset += i * stride;
-          stride *= indices_numel;
-        } else {
-          // for other dimensions use the same position
-          source_offset += pos[j] * stride;
-          stride *= sizes[j];
-        }
-      }
-
-      output[thread_index] = source[source_offset];
-      break;
-    }
-  }
+    constant long& dim_size,
+    constant long& inner,
+    constant long& indices_numel,
+    uint3 gid [[thread_position_in_grid]]) {
+  OffsetT after = gid.x;
+  OffsetT i = gid.y;
+  OffsetT before = gid.z;
+  OffsetT idx = indices[i];
+  output[(before * OffsetT(dim_size) + idx) * OffsetT(inner) + after] =
+      source[(before * OffsetT(indices_numel) + i) * OffsetT(inner) + after];
 }
 
-template <typename T, typename index_t>
+template <typename T, typename index_t, typename OffsetT>
 kernel void index_copy_strided(
     device T* output,
-    constant T* input,
     constant T* source,
     constant index_t* indices,
-    constant uint& dim,
-    constant long* sizes,
-    constant uint& ndim,
-    constant uint& indices_numel,
-    constant long* input_strides,
-    constant long* output_strides,
-    constant long* source_strides,
-    constant long& indices_stride,
+    constant long& dim_size,
+    constant long& dim_out_stride, // result.stride(dim)
+    constant long& dim_source_stride, // source.stride(dim)
+    constant long* slice_sizes, // result sizes with dim removed
+    constant long* slice_out_strides, // result strides with dim removed
+    constant long* slice_source_strides, // source strides with dim removed
+    constant uint& slice_ndim, // ndim - 1
+    constant long& slice_numel,
+    constant long& indices_stride, // index.stride(0)
     uint thread_index [[thread_position_in_grid]]) {
-  int pos[max_ndim];
-  pos_from_thread_index(int(thread_index), pos, sizes, ndim);
-
-  // compute offsets for the output and input tensors
-  long output_offset = offset_from_coord(pos, output_strides, ndim);
-  long input_offset = offset_from_coord(pos, input_strides, ndim);
-
-  output[output_offset] = input[input_offset];
-
-  // save the original coordinate along the dim we're updating
-  int orig_dim = pos[dim];
-
-  // find the last index in the indices array that equals this coordinate
-  int last_matching_index = -1;
-  for (uint i = 0; i < indices_numel; i++) {
-    if (indices[i * indices_stride] == orig_dim) {
-      last_matching_index = int(i);
-    }
+  OffsetT j = OffsetT(thread_index) % OffsetT(slice_numel);
+  OffsetT i = OffsetT(thread_index) / OffsetT(slice_numel);
+  OffsetT idx = indices[i * OffsetT(indices_stride)];
+  if (idx < 0) {
+    idx += OffsetT(dim_size);
   }
-
-  // if a matching index was found, use it to update the output
-  if (last_matching_index != -1) {
-    pos[dim] = last_matching_index;
-    long source_offset = offset_from_coord(pos, source_strides, ndim);
-    output[output_offset] = source[source_offset];
-  }
+  OffsetT slice_pos[max_ndim];
+  pos_from_thread_index(j, slice_pos, slice_sizes, slice_ndim);
+  OffsetT out_offset =
+      offset_from_coord(slice_pos, slice_out_strides, slice_ndim);
+  OffsetT src_offset =
+      offset_from_coord(slice_pos, slice_source_strides, slice_ndim);
+  output[out_offset + idx * OffsetT(dim_out_stride)] =
+      source[src_offset + i * OffsetT(dim_source_stride)];
 }
 
 // Scatter-based index_fill: each thread writes exactly one element.
@@ -673,34 +627,36 @@ kernel void index_fill_strided_from_mask(
       constant long&,                              \
       uint);
 
-#define INSTANTIATE_INDEX_COPY(T, index_t)                      \
-  template [[host_name("index_copy_dense_" #T "_" #index_t)]]   \
-  kernel void index_copy_dense<T, index_t>(                     \
-      device T*,                                                \
-      constant T*,                                              \
-      constant T*,                                              \
-      constant index_t*,                                        \
-      constant uint&,                                           \
-      constant long*,                                           \
-      constant uint&,                                           \
-      constant uint&,                                           \
-      uint);                                                    \
-                                                                \
-  template [[host_name("index_copy_strided_" #T "_" #index_t)]] \
-  kernel void index_copy_strided<T, index_t>(                   \
-      device T*,                                                \
-      constant T*,                                              \
-      constant T*,                                              \
-      constant index_t*,                                        \
-      constant uint&,                                           \
-      constant long*,                                           \
-      constant uint&,                                           \
-      constant uint&,                                           \
-      constant long*,                                           \
-      constant long*,                                           \
-      constant long*,                                           \
-      constant long&,                                           \
+#define INSTANTIATE_INDEX_COPY_W(T, index_t, OffsetT, OBITS)               \
+  template [[host_name("index_copy_dense_" #T "_" #index_t "_" #OBITS)]]   \
+  kernel void index_copy_dense<T, index_t, OffsetT>(                       \
+      device T*,                                                           \
+      constant T*,                                                         \
+      constant index_t*,                                                   \
+      constant long&,                                                      \
+      constant long&,                                                      \
+      constant long&,                                                      \
+      uint3);                                                              \
+                                                                           \
+  template [[host_name("index_copy_strided_" #T "_" #index_t "_" #OBITS)]] \
+  kernel void index_copy_strided<T, index_t, OffsetT>(                     \
+      device T*,                                                           \
+      constant T*,                                                         \
+      constant index_t*,                                                   \
+      constant long&,                                                      \
+      constant long&,                                                      \
+      constant long&,                                                      \
+      constant long*,                                                      \
+      constant long*,                                                      \
+      constant long*,                                                      \
+      constant uint&,                                                      \
+      constant long&,                                                      \
+      constant long&,                                                      \
       uint);
+
+#define INSTANTIATE_INDEX_COPY(T, index_t)      \
+  INSTANTIATE_INDEX_COPY_W(T, index_t, int, 32) \
+  INSTANTIATE_INDEX_COPY_W(T, index_t, long, 64)
 
 #define REGISTER_MASKED_FILL_SCALAR(SIZE, DTYPE)                            \
   template [[host_name("masked_fill_scalar_strided_" #SIZE)]] kernel void   \

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -269,28 +269,70 @@ TORCH_IMPL_FUNC(index_copy_out_mps)(const Tensor& self,
               ")");
 
   auto stream = getCurrentMPSStream();
-  auto device = MPSDevice::getInstance()->device();
 
-  const bool is_dense =
-      self.is_contiguous() && source.is_contiguous() && result.is_contiguous() && index.is_contiguous();
+  // Base copy: non-indexed slices come straight from self. Skipped for in-place
+  // index_copy_, where result already aliases self.
+  if (!result.is_same(self)) {
+    result.copy_(self);
+  }
 
+  const auto is_dense = source.is_contiguous() && result.is_contiguous() && index.is_contiguous();
+  const auto indices_numel = index.numel();
+  const auto slice_numel = source.numel() / indices_numel;
+  if (slice_numel == 0) {
+    return;
+  }
+
+  const auto use_32 = canUse32BitIndexMath(result) && canUse32BitIndexMath(source) && canUse32BitIndexMath(index);
   auto dense_or_strided = is_dense ? "dense" : "strided";
   auto long_or_int = (index.scalar_type() == ScalarType::Long) ? "long" : "int";
-  auto indexCopyPSO = lib.getPipelineStateForFunc(
-      fmt::format("index_copy_{}_{}_{}", dense_or_strided, scalarToMetalTypeString(result), long_or_int));
+  auto indexCopyPSO = lib.getPipelineStateForFunc(fmt::format(
+      "index_copy_{}_{}_{}_{}", dense_or_strided, scalarToMetalTypeString(result), long_or_int, use_32 ? "32" : "64"));
+
+  const auto dim_size = result.size(dim);
+  c10::SmallVector<int64_t> slice_sizes, slice_out_strides, slice_source_strides;
+  if (!is_dense) {
+    for (int64_t d = 0; d < result.dim(); d++) {
+      if (d != dim) {
+        slice_sizes.push_back(result.size(d));
+        slice_out_strides.push_back(result.stride(d));
+        slice_source_strides.push_back(source.stride(d));
+      }
+    }
+  }
 
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = stream->commandEncoder();
-      uint32_t dim_arg = static_cast<uint32_t>(dim);
-      uint32_t ndim = self.dim();
-      uint32_t indices_numel = index.numel();
       [computeEncoder setComputePipelineState:indexCopyPSO];
-      mtl_setArgs(computeEncoder, result, self, source, index, dim_arg, self.sizes(), ndim, indices_numel);
-      if (!is_dense) {
-        mtl_setArgs<8>(computeEncoder, self.strides(), result.strides(), source.strides(), index.strides());
+      mtl_setArgs(computeEncoder, result, source, index);
+      if (is_dense) {
+        const auto inner = result.stride(dim);
+        const auto outer = slice_numel / inner;
+        mtl_setArgs<3>(computeEncoder, dim_size, inner, indices_numel);
+        auto maxTG = [indexCopyPSO maxTotalThreadsPerThreadgroup];
+        auto tgX = std::min<NSUInteger>(inner, maxTG);
+        auto tgY = std::min<NSUInteger>(indices_numel, std::max<NSUInteger>(1, maxTG / tgX));
+        auto tgZ = std::min<NSUInteger>(outer, std::max<NSUInteger>(1, maxTG / (tgX * tgY)));
+        [computeEncoder dispatchThreads:MTLSizeMake(inner, indices_numel, outer)
+                  threadsPerThreadgroup:MTLSizeMake(tgX, tgY, tgZ)];
+      } else {
+        auto dim_out_stride = result.stride(dim);
+        auto dim_source_stride = source.stride(dim);
+        auto indices_stride = index.stride(0);
+        auto slice_ndim = static_cast<uint32_t>(result.dim() - 1);
+        mtl_setArgs<3>(computeEncoder,
+                       dim_size,
+                       dim_out_stride,
+                       dim_source_stride,
+                       slice_sizes,
+                       slice_out_strides,
+                       slice_source_strides,
+                       slice_ndim,
+                       slice_numel,
+                       indices_stride);
+        mtl_dispatch1DJob(computeEncoder, indexCopyPSO, indices_numel * slice_numel);
       }
-      mtl_dispatch1DJob(computeEncoder, indexCopyPSO, result.numel());
     }
   });
 }

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -292,6 +292,9 @@ TORCH_IMPL_FUNC(index_copy_out_mps)(const Tensor& self,
   const auto dim_size = result.size(dim);
   c10::SmallVector<int64_t> slice_sizes, slice_out_strides, slice_source_strides;
   if (!is_dense) {
+    slice_sizes.reserve(result.dim() - 1);
+    slice_out_strides.reserve(result.dim() - 1);
+    slice_source_strides.reserve(result.dim() - 1);
     for (int64_t d = 0; d < result.dim(); d++) {
       if (d != dim) {
         slice_sizes.push_back(result.size(d));

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9612,6 +9612,22 @@ class TestLargeTensors(TestCaseMPS):
         torch.mps.empty_cache()
 
     @serialTest()
+    def test_64bit_index_copy(self):
+        if torch.mps.recommended_max_memory() < 16_000_000_000:
+            raise unittest.SkipTest("Needs at least 16Gb of RAM")
+        m = (1 << 31) + 16
+        x = torch.zeros(2, m, dtype=torch.int8, device='mps')
+        src = torch.full((1, m), 7, dtype=torch.int8, device='mps')
+        x.index_copy_(0, torch.tensor([1], device='mps'), src)
+        self.assertEqual(x[1, 0].item(), 7)
+        self.assertEqual(x[1, m - 1].item(), 7)
+        self.assertEqual(x[0, 0].item(), 0)
+        self.assertEqual(x[0, m - 1].item(), 0)
+        del x, src
+        gc.collect()
+        torch.mps.empty_cache()
+
+    @serialTest()
     def test_rand_4b(self):
         # Used to crash with NDArray dimension length > INT_MAX on MPSGraph;
         # the Metal-kernel path decomposes via `iter.with_32bit_indexing()`.


### PR DESCRIPTION
`index_copy` is super slow on main currently. It loses against CPU 100x times. Now 
```
# new
dense   mps 0.496 ms   cpu 0.861 ms
strided mps 6.287 ms   cpu 28.425 ms
# old
dense   mps 135.160 ms   cpu 0.836 ms
strided mps 419.669 ms   cpu 28.613 ms
```
script:
```python
import torch, time

n = 4096
idx = torch.randperm(n)
src = torch.randn(n, n)


def bench(dev, transpose=False):
    x = (torch.zeros(n, n, device=dev).t() if transpose else torch.zeros(n, n, device=dev))
    i, s = idx.to(dev), src.to(dev)
    for _ in range(10):
        x.index_copy_(0, i, s)
    if dev == "mps":
        torch.mps.synchronize()
    t = time.perf_counter()
    for _ in range(50):
        x.index_copy_(0, i, s)
    if dev == "mps":
        torch.mps.synchronize()
    return (time.perf_counter() - t) / 50 * 1e3

print(f"dense   mps {bench('mps'):.3f} ms   cpu {bench('cpu'):.3f} ms")
print(f"strided mps {bench('mps', transpose=True):.3f} ms   cpu {bench('cpu', transpose=True):.3f} ms")

```