### PR TITLE
[nn] Raise ValueError early for invalid (ndim, pad_size) in non-constant F.pad modes

### DIFF
--- a/aten/src/ATen/native/PadNd.cpp
+++ b/aten/src/ATen/native/PadNd.cpp
@@ -241,14 +241,13 @@ Tensor _pad_enum_symint(const Tensor &self, c10::SymIntArrayRef pad, int64_t mod
     }
   }
 
-  std::ostringstream error_msg;
-  error_msg << "Padding size " << pad.size() << " is not supported for " << input_dim << "D input tensor.\n";
-  error_msg << "Supported combinations for non-constant padding:\n";
-  error_msg << "  - 2D or 3D input: padding size = 2 (pads last dimension)\n";
-  error_msg << "  - 3D or 4D input: padding size = 4 (pads last 2 dimensions)\n";
-  error_msg << "  - 4D or 5D input: padding size = 6 (pads last 3 dimensions)";
-
-  C10_THROW_ERROR(NotImplementedError, std::move(error_msg).str());
+  TORCH_CHECK_VALUE(
+      false,
+      "Padding size ", pad.size(), " is not supported for ", input_dim, "D input tensor.\n",
+      "Supported combinations for non-constant padding:\n",
+      "  - 2D or 3D input: padding size = 2 (pads last dimension)\n",
+      "  - 3D or 4D input: padding size = 4 (pads last 2 dimensions)\n",
+      "  - 4D or 5D input: padding size = 6 (pads last 3 dimensions)");
 }
 
 Tensor pad_symint(const Tensor &self, c10::SymIntArrayRef pad, std::string_view mode, std::optional<double> value) {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9847,6 +9847,19 @@ class TestNNDeviceType(NNTestCase):
             out.fill_(4)
             self.assertTrue(torch.all(torch.abs(inputs) < 2))
 
+        # non-constant modes: unsupported (ndim, pad_size) combos raise ValueError
+        err = "is not supported for"
+        for mode in ('reflect', 'replicate', 'circular'):
+            # pad_size=2 only valid for 2D/3D input
+            self.assertRaisesRegex(ValueError, err,
+                                   lambda: F.pad(torch.randn(1, 1, 4, 4, device=device, dtype=dtype), (0, 1), mode=mode))
+            # pad_size=4 only valid for 3D/4D input
+            self.assertRaisesRegex(ValueError, err,
+                                   lambda: F.pad(torch.randn(1, 1, 2, 3, 4, device=device, dtype=dtype), (0, 1, 0, 1), mode=mode))
+            # pad_size=6 only valid for 4D/5D input
+            self.assertRaisesRegex(ValueError, err,
+                                   lambda: F.pad(torch.randn(1, 1, 4, device=device, dtype=dtype), (0, 1, 0, 1, 0, 1), mode=mode))
+
     @expectedFailureMPS  # Unsupported float64/complex128
     @onlyNativeDeviceTypes
     @dtypes(torch.float64, torch.complex128)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8682,6 +8682,20 @@ class TestNNDeviceType(NNTestCase):
             out.fill_(4)
             self.assertTrue(torch.all(torch.abs(inputs) < 2))
 
+        # non-constant modes: unsupported (ndim, pad_size) combos raise ValueError
+        err = "is not supported for"
+        for mode in ('reflect', 'replicate', 'circular'):
+            # pad_size=2 only valid for 2D/3D input
+            self.assertRaisesRegex(ValueError, err,
+                                   lambda: F.pad(torch.randn(1, 1, 4, 4, device=device, dtype=dtype), (0, 1), mode=mode))
+            # pad_size=4 only valid for 3D/4D input
+            self.assertRaisesRegex(ValueError, err,
+                                   lambda: F.pad(torch.randn(1, 1, 2, 3, 4, device=device, dtype=dtype), (0, 1, 0, 1), mode=mode))
+            # pad_size=6 only valid for 4D/5D input
+            self.assertRaisesRegex(ValueError, err,
+                                   lambda: F.pad(torch.randn(1, 1, 4, device=device, dtype=dtype), (0, 1, 0, 1, 0, 1), mode=mode))
+
+    @expectedFailureMPS  # Unsupported float64/complex128
     @onlyNativeDeviceTypes
     @dtypes(torch.float64, torch.complex128)
     @dtypesIfMPS(torch.float32, torch.complex64)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5802,6 +5802,21 @@ def pad(
         return handle_torch_function(
             torch.nn.functional.pad, (input,), input, pad, mode=mode, value=value
         )
+    if mode != "constant":
+        ndim = input.dim()
+        pad_size = len(pad)
+        if not (
+            (pad_size == 2 and (ndim == 2 or ndim == 3))
+            or (pad_size == 4 and (ndim == 3 or ndim == 4))
+            or (pad_size == 6 and (ndim == 4 or ndim == 5))
+        ):
+            raise ValueError(
+                f"Padding size {pad_size} is not supported for {ndim}D input tensor in "
+                f"mode='{mode}'. Supported combinations for non-constant padding:\n"
+                "  - 2D or 3D input: padding size = 2 (pads last dimension)\n"
+                "  - 3D or 4D input: padding size = 4 (pads last 2 dimensions)\n"
+                "  - 4D or 5D input: padding size = 6 (pads last 3 dimensions)"
+            )
     if not torch.jit.is_scripting():
         if torch.are_deterministic_algorithms_enabled() and (
             input.is_cuda or input.is_xpu


### PR DESCRIPTION
## Summary

`torch.nn.functional.pad` with `mode='reflect'`, `'replicate'`, or `'circular'` silently accepted invalid `(input_ndim, pad_size)` combinations and raised `NotImplementedError` from deep inside the C++ kernel dispatch table (`PadNd.cpp _pad_enum_symint`). The error arrived at the wrong level with the wrong exception type, giving users no indication the problem was detectable at argument-validation time.

The valid matrix for non-constant padding is:

| pad_size | valid input ndim |
|----------|-----------------|
| 2 | 2 or 3 |
| 4 | 3 or 4 |
| 6 | 4 or 5 |

This PR adds a Python-layer guard in `torch/nn/functional.py` that checks the combination before the C++ call and raises `ValueError` with a clear message including the supported-combinations table. The guard runs after the `torch_function` dispatch path so custom tensor subclasses are unaffected. `constant` mode is unconstrained and untouched.

Fixes #184845

## Checklist

- [x] Passes lint (`lintrunner torch/nn/functional.py test/test_nn.py`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)

## BC-breaking?

No — this turns a `NotImplementedError` (raised deep in C++) into a `ValueError` (raised early in Python) for combinations that were never valid. No previously working code breaks.