### PR TITLE
[clamp] Fix float16 scalar overflow check inconsistency between CPU and GPU

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -98,6 +98,23 @@ static inline void check_for_unsupported_clamp_dtypes(const Scalar& s) {
       !s.isComplex(), "clamp is not supported for complex types");
 }
 
+// For Half/BFloat16, verify a clamp scalar bound is representable. CPU kernels
+// convert via .to<scalar_t>() (which checks overflow), but CUDA kernels promote
+// to opmath_t (float) first and silently bypass that check; validating here
+// keeps device behavior consistent. Limited to Half/BFloat16 -- the domain of
+// AT_DISPATCH_REDUCED_FLOATING_TYPES -- so float8/float4 result types are left
+// unaffected instead of falling through to the dispatch default and raising.
+static void check_clamp_scalar_in_reduced_float_range(
+    const Scalar& scalar,
+    ScalarType result_type) {
+  if (result_type == kHalf || result_type == kBFloat16) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(
+        result_type, "clamp_scalar_bounds_check", [&] {
+          (void)scalar.to<scalar_t>();
+        });
+  }
+}
+
 TORCH_META_FUNC(clamp)
 (const Tensor& self, const OptionalScalarRef min, const OptionalScalarRef max) {
   if (!min && !max) {
@@ -131,6 +148,12 @@ TORCH_META_FUNC(clamp)
   }
   // make sure scalars weren't complex
   check_for_unsupported_clamp_dtypes(result_type);
+  if (min) {
+    check_clamp_scalar_in_reduced_float_range(min.get(), result_type);
+  }
+  if (max) {
+    check_clamp_scalar_in_reduced_float_range(max.get(), result_type);
+  }
   build_unary_op(maybe_get_output(), self.to(result_type));
 }
 

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_device_type import (
     largeTensorTest,
     onlyAccelerator,
     onlyCPU,
+    onlyNativeDeviceTypes,
 )
 from torch.testing._internal.common_dtype import (
     all_passthru_types,
@@ -406,6 +407,24 @@ class TestShapeOps(TestCase):
             X.clamp_()
         with self.assertRaisesRegex(RuntimeError, error_msg):
             torch.clamp(X)
+
+    @onlyNativeDeviceTypes
+    def test_clamp_float16_scalar_overflow(self, device):
+        # float16 max is ~65504; scalars that overflow must raise on all devices.
+        # Previously CUDA promoted the scalar to opmath_t (float) before casting,
+        # silently bypassing the overflow check that CPU kernels performed.
+        x = torch.zeros(4, dtype=torch.float16, device=device)
+        overflow = 65507.0
+        err = "cannot be converted to type"
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.clamp(x, max=overflow)
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.clamp(x, min=overflow)
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.clamp(x, min=-overflow, max=overflow)
+        # values within float16 range must still work
+        self.assertEqual(torch.clamp(x, max=100.0), x)
+        self.assertEqual(torch.clamp(x, min=-100.0, max=100.0), x)
 
     @dtypes(*all_passthru_types())
     @dtypesIfCUDA(*all_passthru_types_and(torch.chalf))

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     largeTensorTest,
     onlyAccelerator,
+    onlyNativeDeviceTypes,
 )
 from torch.testing._internal.common_dtype import (
     all_passthru_types,
@@ -431,6 +432,24 @@ class TestShapeOps(TestCase):
             X.clamp_()
         with self.assertRaisesRegex(RuntimeError, error_msg):
             torch.clamp(X)
+
+    @onlyNativeDeviceTypes
+    def test_clamp_float16_scalar_overflow(self, device):
+        # float16 max is ~65504; scalars that overflow must raise on all devices.
+        # Previously CUDA promoted the scalar to opmath_t (float) before casting,
+        # silently bypassing the overflow check that CPU kernels performed.
+        x = torch.zeros(4, dtype=torch.float16, device=device)
+        overflow = 65507.0
+        err = "cannot be converted to type"
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.clamp(x, max=overflow)
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.clamp(x, min=overflow)
+        with self.assertRaisesRegex(RuntimeError, err):
+            torch.clamp(x, min=-overflow, max=overflow)
+        # values within float16 range must still work
+        self.assertEqual(torch.clamp(x, max=100.0), x)
+        self.assertEqual(torch.clamp(x, min=-100.0, max=100.0), x)
 
     @dtypes(*all_passthru_types())
     @dtypesIfCUDA(*all_passthru_types_and(torch.chalf))


### PR DESCRIPTION
## Summary

`torch.clamp` / `torch.clip` on `float16` tensors had inconsistent validation
between CPU and GPU. When a scalar bound exceeds the float16 range (~65504),
CPU correctly raises `RuntimeError` but GPU silently succeeded and returned
incorrect results - the out-of-range bound saturates to `inf` when stored back
as float16, giving wrong clamp behavior with no warning.

```python
x = torch.zeros(1, dtype=torch.float16)
torch.clip(x, max=65507.0)          # CPU: RuntimeError ✓
torch.clip(x.cuda(), max=65507.0)   # GPU: silent wrong result ✗
```

## Root Cause

CPU kernels (`cpu/TensorCompareKernel.cpp`) convert the scalar bound via
`.to<scalar_t>()` where `scalar_t = at::Half`, which calls `c10::check_overflow`
and raises. CUDA kernels (`cuda/TensorCompare.cu`) first promote the scalar to
`opmath_t` (`float` for float16) before using it, so a value like `65507.0`
fits in `float` without triggering any overflow check - the error is silently
bypassed.

## Fix

Add the overflow check in `TORCH_META_FUNC(clamp)` in `TensorCompare.cpp`,
factored into a small file-local helper `check_clamp_scalar_in_reduced_float_range`
that both the `min` and `max` bounds call. The meta function runs before kernel
dispatch on **all devices**, making the check device-agnostic in a single
change. The existing `c10::Scalar::to<T>()` mechanism is reused so the error
message is identical to what CPU already produced - no new error strings.

The check is gated on `result_type == kHalf || result_type == kBFloat16` -
exactly the domain of `AT_DISPATCH_REDUCED_FLOATING_TYPES` - rather than
`isReducedFloatingType`. `isReducedFloatingType` also matches the float8 and
float4 types, which the dispatch macro does not emit cases for; using it would
send those result types to the dispatch default and raise a misleading
`clamp_scalar_bounds_check not implemented` error. `clamp` does not support
float8/float4 in the first place (its kernels use
`AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, ...)`), so limiting the guard lets
those dtypes surface their normal `clamp not implemented` kernel error. This
matches the same narrowing applied in #187908. `bfloat16` with `max=65507`
correctly does **not** raise since 65507 is representable in bfloat16 (same
exponent range as float32).

## Prior Attempts and Related Issues

- **#173776** (closed without merge): Fixed only the CUDA kernel path using a
  custom `c10::overflows` check. Left XPU, ROCm, and any future backends
  unpatched, and produced mangled C++ type names in the error message.
- **intel/torch-xpu-ops#3425**: Intel XPU team filed the same bug for their
  backend, confirming that a CUDA-only fix is insufficient. Our meta-function
  approach fixes XPU automatically.

Fixes #171356

## Checklist

- [x] Passes lint (`lintrunner aten/src/ATen/native/TensorCompare.cpp test/test_shape_ops.py`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)

## BC-breaking?

No - this turns a silent wrong result into a `RuntimeError` consistent with
what CPU already raised. No previously correct code is broken.