### PR TITLE
[c10d] Fix TCPStore compilation with Clang 20

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include <c10/util/thread_name.h>
 #include <torch/csrc/distributed/c10d/TCPStoreBackend.hpp>
@@ -220,11 +221,16 @@ void TCPStoreMasterDaemon::queryFds(std::vector<struct pollfd>& fds) {
 }
 
 void TCPStoreMasterDaemon::clearSocketWaitState(int socket) {
-  // Remove all the tracking state of the close FD
-  std::erase_if(waitingSockets_, [&](auto& entry) {
-    std::erase(entry.second, socket);
-    return entry.second.empty();
-  });
+  // Remove all the tracking state of the closed FD
+  for (auto it = waitingSockets_.begin(); it != waitingSockets_.end();) {
+    auto& vec = it->second;
+    std::erase(vec, socket);
+    if (vec.empty()) {
+      it = waitingSockets_.erase(it);
+    } else {
+      ++it;
+    }
+  }
   keysAwaited_.erase(socket);
 }
 

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -1405,10 +1405,15 @@ void LibUVStoreDaemon::clearClientWaitState(
     return;
   }
   keysAwaited_.erase(client);
-  std::erase_if(waitingSockets_, [&](auto& entry) {
-    std::erase(entry.second, client);
-    return entry.second.empty();
-  });
+  for (auto it = waitingSockets_.begin(); it != waitingSockets_.end();) {
+    auto& vec = it->second;
+    std::erase(vec, client);
+    if (vec.empty()) {
+      it = waitingSockets_.erase(it);
+    } else {
+      ++it;
+    }
+  }
 }
 
 void LibUVStoreDaemon::set(


### PR DESCRIPTION
[c10d] Fix TCPStore compilation with Clang 20

Replace `std::erase_if()` predicates that mutate map values with
explicit iterator-based loops. Some Clang/libstdc++ combinations
treat the predicate argument as const, causing compilation failures
when calling `std::erase()` on the mapped vector.

The new implementation preserves the existing behavior while being
portable across toolchains. Previously discussed in https://github.com/pytorch/pytorch/issues/185618

Closes: #185618 
