### PR TITLE
[WIP] Migrate XPU test runners to linux.xpu.test and disable legacy jobs

### DIFF
--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -31,26 +31,26 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  linux-jammy-xpu-n-1-py3_10-build:
-    name: linux-jammy-xpu-n-1-py3.10
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      sync-tag: linux-xpu-n-1-build
-      runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
-      build-environment: linux-jammy-xpu-n-1-py3.10
-      docker-image-name: ci-image:pytorch-linux-jammy-xpu-n-1-py3
-      runner: linux.c7i.12xlarge
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "linux.idc.xpu" },
-          { config: "default", shard: 2, num_shards: 6, runner: "linux.idc.xpu" },
-          { config: "default", shard: 3, num_shards: 6, runner: "linux.idc.xpu" },
-          { config: "default", shard: 4, num_shards: 6, runner: "linux.idc.xpu" },
-          { config: "default", shard: 5, num_shards: 6, runner: "linux.idc.xpu" },
-          { config: "default", shard: 6, num_shards: 6, runner: "linux.idc.xpu" },
-        ]}
-    secrets: inherit
+  # linux-jammy-xpu-n-1-py3_10-build:
+  #   name: linux-jammy-xpu-n-1-py3.10
+  #   uses: ./.github/workflows/_linux-build.yml
+  #   needs: get-label-type
+  #   with:
+  #     sync-tag: linux-xpu-n-1-build
+  #     runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
+  #     build-environment: linux-jammy-xpu-n-1-py3.10
+  #     docker-image-name: ci-image:pytorch-linux-jammy-xpu-n-1-py3
+  #     runner: linux.c7i.12xlarge
+  #     test-matrix: |
+  #       { include: [
+  #         { config: "default", shard: 1, num_shards: 6, runner: "linux.idc.xpu" },
+  #         { config: "default", shard: 2, num_shards: 6, runner: "linux.idc.xpu" },
+  #         { config: "default", shard: 3, num_shards: 6, runner: "linux.idc.xpu" },
+  #         { config: "default", shard: 4, num_shards: 6, runner: "linux.idc.xpu" },
+  #         { config: "default", shard: 5, num_shards: 6, runner: "linux.idc.xpu" },
+  #         { config: "default", shard: 6, num_shards: 6, runner: "linux.idc.xpu" },
+  #       ]}
+  #   secrets: inherit
 
   linux-noble-xpu-n-py3_10-build:
     name: linux-noble-xpu-n-py3.10
@@ -64,18 +64,18 @@ jobs:
       runner: linux.c7i.12xlarge
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 12, runner: "linux.idc.xpu" },
-          { config: "default", shard: 2, num_shards: 12, runner: "linux.idc.xpu" },
-          { config: "default", shard: 3, num_shards: 12, runner: "linux.idc.xpu" },
-          { config: "default", shard: 4, num_shards: 12, runner: "linux.idc.xpu" },
-          { config: "default", shard: 5, num_shards: 12, runner: "linux.idc.xpu" },
-          { config: "default", shard: 6, num_shards: 12, runner: "linux.idc.xpu" },
-          { config: "default", shard: 7, num_shards: 12, runner: "linux.idc.xpu" },
-          { config: "default", shard: 8, num_shards: 12, runner: "linux.idc.xpu" },
-          { config: "default", shard: 9, num_shards: 12, runner: "linux.idc.xpu" },
-          { config: "default", shard: 10, num_shards: 12, runner: "linux.idc.xpu" },
-          { config: "default", shard: 11, num_shards: 12, runner: "linux.idc.xpu" },
-          { config: "default", shard: 12, num_shards: 12, runner: "linux.idc.xpu" },
+          { config: "default", shard: 1, num_shards: 12, runner: "linux.xpu.test" },
+          { config: "default", shard: 2, num_shards: 12, runner: "linux.xpu.test" },
+          { config: "default", shard: 3, num_shards: 12, runner: "linux.xpu.test" },
+          { config: "default", shard: 4, num_shards: 12, runner: "linux.xpu.test" },
+          { config: "default", shard: 5, num_shards: 12, runner: "linux.xpu.test" },
+          { config: "default", shard: 6, num_shards: 12, runner: "linux.xpu.test" },
+          { config: "default", shard: 7, num_shards: 12, runner: "linux.xpu.test" },
+          { config: "default", shard: 8, num_shards: 12, runner: "linux.xpu.test" },
+          { config: "default", shard: 9, num_shards: 12, runner: "linux.xpu.test" },
+          { config: "default", shard: 10, num_shards: 12, runner: "linux.xpu.test" },
+          { config: "default", shard: 11, num_shards: 12, runner: "linux.xpu.test" },
+          { config: "default", shard: 12, num_shards: 12, runner: "linux.xpu.test" },
         ]}
     secrets: inherit
 
@@ -89,52 +89,52 @@ jobs:
       test-matrix: ${{ needs.linux-noble-xpu-n-py3_10-build.outputs.test-matrix }}
     secrets: inherit
 
-  linux-noble-xpu-n-py3_10-client-build:
-    name: linux-noble-xpu-n-py3.10-client
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      sync-tag: linux-xpu-n-client-build
-      runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
-      build-environment: linux-noble-xpu-n-py3.10-client
-      docker-image-name: ci-image:pytorch-linux-noble-xpu-n-py3-client
-      runner: linux.c7i.12xlarge
-      test-matrix: |
-        { include: [
-          { config: "smoke_xpu", shard: 1, num_shards: 1, runner: "linux.client.xpu" },
-        ]}
-    secrets: inherit
+  # linux-noble-xpu-n-py3_10-client-build:
+  #   name: linux-noble-xpu-n-py3.10-client
+  #   uses: ./.github/workflows/_linux-build.yml
+  #   needs: get-label-type
+  #   with:
+  #     sync-tag: linux-xpu-n-client-build
+  #     runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
+  #     build-environment: linux-noble-xpu-n-py3.10-client
+  #     docker-image-name: ci-image:pytorch-linux-noble-xpu-n-py3-client
+  #     runner: linux.c7i.12xlarge
+  #     test-matrix: |
+  #       { include: [
+  #         { config: "smoke_xpu", shard: 1, num_shards: 1, runner: "linux.client.xpu" },
+  #       ]}
+  #   secrets: inherit
 
-  linux-noble-xpu-n-py3_10-client-test:
-    name: linux-noble-xpu-n-py3.10-client
-    uses: ./.github/workflows/_xpu-test.yml
-    needs: linux-noble-xpu-n-py3_10-client-build
-    with:
-      build-environment: ${{ needs.linux-noble-xpu-n-py3_10-client-build.outputs.build-environment }}
-      docker-image: ${{ needs.linux-noble-xpu-n-py3_10-client-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-noble-xpu-n-py3_10-client-build.outputs.test-matrix }}
-    secrets: inherit
+  # linux-noble-xpu-n-py3_10-client-test:
+  #   name: linux-noble-xpu-n-py3.10-client
+  #   uses: ./.github/workflows/_xpu-test.yml
+  #   needs: linux-noble-xpu-n-py3_10-client-build
+  #   with:
+  #     build-environment: ${{ needs.linux-noble-xpu-n-py3_10-client-build.outputs.build-environment }}
+  #     docker-image: ${{ needs.linux-noble-xpu-n-py3_10-client-build.outputs.docker-image }}
+  #     test-matrix: ${{ needs.linux-noble-xpu-n-py3_10-client-build.outputs.test-matrix }}
+  #   secrets: inherit
 
-  windows-xpu-n-1-build:
-    if: github.repository_owner == 'pytorch'
-    name: win-vs2022-xpu-n-1-py3
-    uses: ./.github/workflows/_win-build.yml
-    with:
-      build-environment: win-vs2022-xpu-n-1-py3
-      cuda-version: cpu
-      use-xpu: true
-      xpu-version: '2025.3'
-      vc-year: '2022'
-    secrets: inherit
+  # windows-xpu-n-1-build:
+  #   if: github.repository_owner == 'pytorch'
+  #   name: win-vs2022-xpu-n-1-py3
+  #   uses: ./.github/workflows/_win-build.yml
+  #   with:
+  #     build-environment: win-vs2022-xpu-n-1-py3
+  #     cuda-version: cpu
+  #     use-xpu: true
+  #     xpu-version: '2025.3'
+  #     vc-year: '2022'
+  #   secrets: inherit
 
-  windows-xpu-n-build:
-    if: github.repository_owner == 'pytorch'
-    name: win-vs2022-xpu-n-py3
-    uses: ./.github/workflows/_win-build.yml
-    with:
-      build-environment: win-vs2022-xpu-n-py3
-      cuda-version: cpu
-      use-xpu: true
-      xpu-version: '2026.0'
-      vc-year: '2022'
-    secrets: inherit
+  # windows-xpu-n-build:
+  #   if: github.repository_owner == 'pytorch'
+  #   name: win-vs2022-xpu-n-py3
+  #   uses: ./.github/workflows/_win-build.yml
+  #   with:
+  #     build-environment: win-vs2022-xpu-n-py3
+  #     cuda-version: cpu
+  #     use-xpu: true
+  #     xpu-version: '2026.0'
+  #     vc-year: '2022'
+  #   secrets: inherit


### PR DESCRIPTION
## Summary
- Disable legacy XPU CI jobs (linux-jammy-xpu-n-1, client build/test, windows XPU builds)
- Migrate linux-noble-xpu-n test shards from `linux.idc.xpu` to `linux.xpu.test` runners

## Test Plan
CI validation via this PR.

Co-authored-by: AI assistant