### PR TITLE
Support 64-bit indexing in channels_last bilinear upsampling

### DIFF
--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -90,10 +90,11 @@ idx(const size_t nc,
 }
 
 // for channels-last
-__device__ __forceinline__ size_t
+template <typename index_t = size_t>
+__device__ __forceinline__ index_t
 idx_cl(
-  const size_t n, const size_t h, const size_t w, const size_t c,
-  const size_t height, const size_t width, const size_t channel
+  const index_t n, const index_t h, const index_t w, const index_t c,
+  const index_t height, const index_t width, const index_t channel
 ) {
   return ((n * height + h) * width + w) * channel + c;
 }

--- a/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
@@ -10,6 +10,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/native/cuda/UpSample.cuh>
 #include <ATen/native/cuda/KernelUtils.cuh>
+#include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/cuda/detail/KernelUtils.h>
 #include <ATen/native/cuda/LaunchUtils.h>
 
@@ -79,7 +80,7 @@ __global__ void upsample_bilinear2d_out_frame(
   }
 }
 
-template <typename scalar_t, typename accscalar_t>
+template <typename scalar_t, typename accscalar_t, typename index_t>
 C10_LAUNCH_BOUNDS_1(1024)
 __global__ void upsample_bilinear2d_nhwc_out_frame(
     const accscalar_t rheight,
@@ -92,15 +93,15 @@ __global__ void upsample_bilinear2d_nhwc_out_frame(
     const int width2,
     const scalar_t* idata,
     scalar_t* odata,
-    const int out_numel) {
+    const index_t out_numel) {
 
-  const int index = blockIdx.x * blockDim.x + threadIdx.x;
+  const index_t index = static_cast<index_t>(blockIdx.x) * blockDim.x + threadIdx.x;
 
   if (index < out_numel) {
-    const int c = index % channels;
-    const int w2 = (index / channels) % width2;
-    const int h2 = (index / channels / width2) % height2;
-    const int n = index / channels / width2 / height2;
+    const index_t c = index % channels;
+    const index_t w2 = (index / channels) % width2;
+    const index_t h2 = (index / channels / width2) % height2;
+    const index_t n = index / channels / width2 / height2;
 
     const accscalar_t h1r = area_pixel_compute_source_index<accscalar_t>(
         rheight, h2, align_corners, /*cubic=*/false);
@@ -117,13 +118,13 @@ __global__ void upsample_bilinear2d_nhwc_out_frame(
     const accscalar_t w0lambda = static_cast<accscalar_t>(1) - w1lambda;
 
     const accscalar_t val = h0lambda * (
-        w0lambda * idata[idx_cl(n, h1, w1, c, height1, width1, channels)] +
-        w1lambda * idata[idx_cl(n, h1, w1 + w1p, c, height1, width1, channels)]
+        w0lambda * idata[idx_cl<index_t>(n, h1, w1, c, height1, width1, channels)] +
+        w1lambda * idata[idx_cl<index_t>(n, h1, w1 + w1p, c, height1, width1, channels)]
       ) + h1lambda * (
-        w0lambda * idata[idx_cl(n, h1 + h1p, w1, c, height1, width1, channels)] +
-        w1lambda * idata[idx_cl(n, h1 + h1p, w1 + w1p, c, height1, width1, channels)]
+        w0lambda * idata[idx_cl<index_t>(n, h1 + h1p, w1, c, height1, width1, channels)] +
+        w1lambda * idata[idx_cl<index_t>(n, h1 + h1p, w1 + w1p, c, height1, width1, channels)]
       );
-    odata[idx_cl(n, h2, w2, c, height2, width2, channels)] = static_cast<scalar_t>(val);
+    odata[idx_cl<index_t>(n, h2, w2, c, height2, width2, channels)] = static_cast<scalar_t>(val);
   }
 }
 
@@ -283,7 +284,7 @@ __global__ void upsample_bilinear2d_backward_out_frame(
 #endif
 }
 
-template <typename scalar_t, typename accscalar_t>
+template <typename scalar_t, typename accscalar_t, typename index_t>
 C10_LAUNCH_BOUNDS_1(1024)
 __global__ void upsample_bilinear2d_backward_nhwc_out_frame(
     const int height1,
@@ -296,16 +297,16 @@ __global__ void upsample_bilinear2d_backward_nhwc_out_frame(
     scalar_t* __restrict__ idata,
     const scalar_t* __restrict__ odata,
     const int channels,
-    const size_t o_numel,
-    const size_t i_numel) {
+    const index_t o_numel,
+    const index_t i_numel) {
 
-  const int index = blockIdx.x * blockDim.x + threadIdx.x;
+  const index_t index = static_cast<index_t>(blockIdx.x) * blockDim.x + threadIdx.x;
 
   if (index < o_numel) {
-    const int c = index % channels;
-    const int w2 = (index / channels) % width2;
-    const int h2 = (index / channels / width2) % height2;
-    const int n = index / channels / width2 / height2;
+    const index_t c = index % channels;
+    const index_t w2 = (index / channels) % width2;
+    const index_t h2 = (index / channels / width2) % height2;
+    const index_t n = index / channels / width2 / height2;
 
     const accscalar_t h1r = area_pixel_compute_source_index<accscalar_t>(
         rheight, h2, align_corners, /*cubic=*/false);
@@ -324,25 +325,25 @@ __global__ void upsample_bilinear2d_backward_nhwc_out_frame(
     const scalar_t d2val = odata[index];
     fastAtomicAdd(
         idata,
-        idx_cl(n, h1, w1, c, height1, width1, channels),
+        idx_cl<index_t>(n, h1, w1, c, height1, width1, channels),
         i_numel,
         static_cast<scalar_t>(h0lambda * w0lambda * d2val),
         true);
     fastAtomicAdd(
         idata,
-        idx_cl(n, h1, w1 + w1p, c, height1, width1, channels),
+        idx_cl<index_t>(n, h1, w1 + w1p, c, height1, width1, channels),
         i_numel,
         static_cast<scalar_t>(h0lambda * w1lambda * d2val),
         true);
     fastAtomicAdd(
         idata,
-        idx_cl(n, h1 + h1p, w1, c, height1, width1, channels),
+        idx_cl<index_t>(n, h1 + h1p, w1, c, height1, width1, channels),
         i_numel,
         static_cast<scalar_t>(h1lambda * w0lambda * d2val),
         true);
     fastAtomicAdd(
         idata,
-        idx_cl(n, h1 + h1p, w1 + w1p, c, height1, width1, channels),
+        idx_cl<index_t>(n, h1 + h1p, w1 + w1p, c, height1, width1, channels),
         i_numel,
         static_cast<scalar_t>(h1lambda * w1lambda * d2val),
         true);
@@ -381,11 +382,6 @@ static void upsample_bilinear2d_out_cuda_template(
           output.is_contiguous(memory_format)) {
       using accscalar_t = at::acc_type<scalar_t, true>;
 
-      TORCH_CHECK(input.numel() < std::numeric_limits<int>::max(),
-        "upsample_bilinear2d_nhwc only supports input tensors with less than INT_MAX elements, but got ", input.sizes());
-      TORCH_CHECK(output.numel() < std::numeric_limits<int>::max(),
-        "upsample_bilinear2d_nhwc only supports output tensors with less than INT_MAX elements, but got ", output.sizes());
-
       const int channels = input.size(1);
       const int height1 = input.size(2);
       const int width1 = input.size(3);
@@ -393,9 +389,17 @@ static void upsample_bilinear2d_out_cuda_template(
       const int width2 = output.size(3);
 
       // const int num_kernels = output_height * output_width;
-      const int num_kernels = output.numel();
-      const int num_threads = std::min(
+      const int64_t num_kernels = output.numel();
+      const int64_t num_threads = std::min(
           at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
+      cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+      // One thread per output element, so the grid is bounded by maxGridSize[0].
+      const int64_t num_blocks = ceil_div(num_kernels, num_threads);
+      TORCH_CHECK(
+          num_blocks <= at::cuda::getCurrentDeviceProperties()->maxGridSize[0],
+          "upsample_bilinear2d: output ", output.sizes(),
+          " is too large for the channels_last CUDA kernel launch");
 
       at::Tensor input_cl = input.contiguous(at::MemoryFormat::ChannelsLast);
 
@@ -407,21 +411,26 @@ static void upsample_bilinear2d_out_cuda_template(
       const accscalar_t rwidth = area_pixel_compute_scale<accscalar_t>(
           input_width, output_width, align_corners, scales_w);
 
-      upsample_bilinear2d_nhwc_out_frame<scalar_t, accscalar_t>
-        <<<ceil_div(num_kernels, num_threads), num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
-          rheight, rwidth, align_corners,
-          channels,
-          height1,
-          width1,
-          height2,
-          width2,
-          idata, odata,
-          output.numel());
+      if (canUse32BitIndexMath(input_cl) && canUse32BitIndexMath(output)) {
+        upsample_bilinear2d_nhwc_out_frame<scalar_t, accscalar_t, int32_t>
+          <<<num_blocks, num_threads, 0, stream>>>(
+            rheight, rwidth, align_corners,
+            channels, height1, width1, height2, width2,
+            idata, odata,
+            static_cast<int32_t>(output.numel()));
+      } else {
+        upsample_bilinear2d_nhwc_out_frame<scalar_t, accscalar_t, int64_t>
+          <<<num_blocks, num_threads, 0, stream>>>(
+            rheight, rwidth, align_corners,
+            channels, height1, width1, height2, width2,
+            idata, odata,
+            output.numel());
+      }
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       // non-channels_last case, not necessarily contiguous
-      const int num_kernels = output_height * output_width;
-      const int num_threads = std::min(
+      const int64_t num_kernels = output_height * output_width;
+      const int64_t num_threads = std::min(
           at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
       cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
@@ -509,22 +518,32 @@ static void upsample_bilinear2d_backward_out_cuda_template(
       const accscalar_t rwidth = area_pixel_compute_scale<accscalar_t>(
           input_width, output_width, align_corners, scales_w);
 
-      const size_t num_kernels = nbatch * channels * output_height * output_width;
+      const size_t num_kernels = static_cast<size_t>(nbatch) * channels * output_height * output_width;
 
-      upsample_bilinear2d_backward_nhwc_out_frame<scalar_t, accscalar_t>
-          <<<ceil_div(num_kernels, static_cast<size_t>(num_threads)), num_threads, 0, stream>>>(
-              input_height,
-              input_width,
-              output_height,
-              output_width,
-              rheight,
-              rwidth,
-              align_corners,
-              idata,
-              odata,
-              channels,
-              grad_output.numel(),
-              grad_input.numel());
+      // One thread per output element, so the grid is bounded by maxGridSize[0].
+      const size_t num_blocks = ceil_div(num_kernels, static_cast<size_t>(num_threads));
+      TORCH_CHECK(
+          num_blocks <= static_cast<size_t>(at::cuda::getCurrentDeviceProperties()->maxGridSize[0]),
+          "upsample_bilinear2d_backward: grad_output ", grad_output.sizes(),
+          " is too large for the channels_last CUDA kernel launch");
+
+      if (canUse32BitIndexMath(grad_input) && canUse32BitIndexMath(grad_output)) {
+        upsample_bilinear2d_backward_nhwc_out_frame<scalar_t, accscalar_t, int32_t>
+            <<<num_blocks, num_threads, 0, stream>>>(
+                input_height, input_width, output_height, output_width,
+                rheight, rwidth, align_corners,
+                idata, odata, channels,
+                static_cast<int32_t>(grad_output.numel()),
+                static_cast<int32_t>(grad_input.numel()));
+      } else {
+        upsample_bilinear2d_backward_nhwc_out_frame<scalar_t, accscalar_t, int64_t>
+            <<<num_blocks, num_threads, 0, stream>>>(
+                input_height, input_width, output_height, output_width,
+                rheight, rwidth, align_corners,
+                idata, odata, channels,
+                grad_output.numel(),
+                grad_input.numel());
+      }
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       using accscalar_t = at::acc_type<scalar_t, true>;
@@ -541,7 +560,7 @@ static void upsample_bilinear2d_backward_out_cuda_template(
       const accscalar_t rwidth = area_pixel_compute_scale<accscalar_t>(
           input_width, output_width, align_corners, scales_w);
 
-      const size_t num_kernels = nbatch * channels * (use_input ? input_height * input_width : output_height * output_width);
+      const size_t num_kernels = static_cast<size_t>(nbatch) * channels * (use_input ? input_height * input_width : output_height * output_width);
 
       upsample_bilinear2d_backward_out_frame<scalar_t, accscalar_t>
           <<<ceil_div(num_kernels, static_cast<size_t>(num_threads)),

--- a/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
@@ -390,6 +390,11 @@ static void upsample_bilinear2d_out_cuda_template(
 
       // const int num_kernels = output_height * output_width;
       const int64_t num_kernels = output.numel();
+
+      if (num_kernels == 0) {
+        return;
+      }
+      
       const int64_t num_threads = std::min(
           at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
       cudaStream_t stream = at::cuda::getCurrentCUDAStream();

--- a/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
@@ -394,7 +394,7 @@ static void upsample_bilinear2d_out_cuda_template(
       if (num_kernels == 0) {
         return;
       }
-      
+
       const int64_t num_threads = std::min(
           at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
       cudaStream_t stream = at::cuda::getCurrentCUDAStream();

--- a/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
@@ -120,7 +120,7 @@ __global__ void upsample_nearest2d_nhwc_out_frame(
         ? w2
         : nn_compute_source_index_fn(width_scale, w2, width1);
 
-    odata[index] = idata[idx_cl(n, h1, w1, c, height1, width1, channels)];
+    odata[index] = idata[idx_cl<size_t>(n, h1, w1, c, height1, width1, channels)];
 
     if constexpr (!kGridStride) {
       break;
@@ -215,7 +215,7 @@ __global__ void upsample_nearest2d_backward_nhwc_out_frame(
     accscalar_t grad = 0;
     for (int ih = h1; ih < h1_up; ih++) {
       for (int iw = w1; iw < w1_up; iw++) {
-        grad += go[idx_cl(n, ih, iw, c, height1, width1, channels)];
+        grad += go[idx_cl<size_t>(n, ih, iw, c, height1, width1, channels)];
       }
     }
     gi[index] = static_cast<scalar_t>(grad);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10569,6 +10569,45 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(out[0], out[-1])
 
     @onlyCUDA
+    @skipCUDAIfRocm(msg="launch bounds error out on ROCM")
+    @dtypes(torch.half, torch.bfloat16)
+    @largeTensorTest('40GB')
+    def test_upsampling_64bit_indexing_bilinear_channels_last(self, device, dtype):
+        # Output has 2**31 elements, exercising the 64-bit indexed channels_last forward kernel.
+        x = torch.rand((8, 64, 128, 128), dtype=dtype, device=device)
+        out = torch.nn.functional.interpolate(
+            x.to(memory_format=torch.channels_last),
+            scale_factor=16, mode='bilinear'
+        )
+        out_ref = torch.nn.functional.interpolate(x, scale_factor=16, mode='bilinear')
+        del x
+        self.assertEqual(out.numel(), 2**31)
+        self.assertTrue(torch.allclose(out, out_ref))
+        x = torch.ones((8, 64, 128, 128), dtype=dtype, device=device).to(memory_format=torch.channels_last)
+        out = torch.nn.functional.interpolate(x, scale_factor=16, mode='bilinear')
+        self.assertEqual(out[0], out[-1])
+
+    @onlyCUDA
+    @skipCUDAIfRocm(msg="launch bounds error out on ROCM")
+    @dtypes(torch.half, torch.bfloat16)
+    @largeTensorTest('10GB')
+    def test_upsampling_64bit_indexing_bilinear_channels_last_backward(self, device, dtype):
+        # Output has 2**31 elements, exercising the 64-bit indexed channels_last backward
+        # kernel. The backward accumulates with atomicAdd (nondeterministic in low precision),
+        # so we only verify that the kernel runs without the launch-config overflow and
+        # produces finite, non-trivial gradients in the right memory format; rigorous
+        # nhwc-vs-contiguous numerics are checked by the small-tensor interpolate tests.
+        x = torch.ones((8, 64, 128, 128), dtype=dtype, device=device).to(
+            memory_format=torch.channels_last).requires_grad_(True)
+        out = torch.nn.functional.interpolate(x, scale_factor=16, mode='bilinear')
+        self.assertEqual(out.numel(), 2**31)
+        out.backward(torch.ones_like(out))
+        self.assertTrue(torch.isfinite(x.grad).all())
+        self.assertGreater(x.grad.abs().sum().item(), 0)
+        self.assertTrue(x.grad.is_contiguous(memory_format=torch.channels_last))
+
+
+    @onlyCUDA
     @dtypes(torch.half)
     @largeTensorTest('40GB')
     def test_replicatepad_64bit_indexing(self, device, dtype):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -47,7 +47,7 @@ from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, Criteri
     ctcloss_reference, get_new_module_tests, single_batch_reference_fn, _test_bfloat16_ops, _test_module_empty_input
 from torch.testing._internal.common_device_type import dtypesIfMPS, instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, precisionOverride, onlyCUDA, onlyCPU, onlyAccelerator, \
-    skipCUDAIf, skipCUDAIfRocm, skipMPSIf, skipMPS, \
+    skipCUDAIf, expectedFailureIfRocm, skipMPSIf, skipMPS, \
     onlyNativeDeviceTypes, deviceCountAtLeast, largeTensorTest, expectedFailureMeta, expectedFailureMPS, \
     skipMeta, get_all_device_types
 from torch.testing._internal.common_modules import module_inputs_torch_nn_LinearCrossEntropyLoss
@@ -10569,7 +10569,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(out[0], out[-1])
 
     @onlyCUDA
-    @skipCUDAIfRocm(msg="launch bounds error out on ROCM")
+    @expectedFailureIfRocm
     @dtypes(torch.half, torch.bfloat16)
     @largeTensorTest('40GB')
     def test_upsampling_64bit_indexing_bilinear_channels_last(self, device, dtype):
@@ -10588,7 +10588,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(out[0], out[-1])
 
     @onlyCUDA
-    @skipCUDAIfRocm(msg="launch bounds error out on ROCM")
+    @expectedFailureIfRocm
     @dtypes(torch.half, torch.bfloat16)
     @largeTensorTest('10GB')
     def test_upsampling_64bit_indexing_bilinear_channels_last_backward(self, device, dtype):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -47,7 +47,7 @@ from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, Criteri
     ctcloss_reference, get_new_module_tests, single_batch_reference_fn, _test_bfloat16_ops, _test_module_empty_input
 from torch.testing._internal.common_device_type import dtypesIfMPS, instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, precisionOverride, onlyCUDA, onlyCPU, onlyAccelerator, \
-    skipCUDAIf, expectedFailureIfRocm, skipMPSIf, skipMPS, \
+    skipCUDAIf, skipCUDAIfRocm, skipMPSIf, skipMPS, \
     onlyNativeDeviceTypes, deviceCountAtLeast, largeTensorTest, expectedFailureMeta, expectedFailureMPS, \
     skipMeta, get_all_device_types
 from torch.testing._internal.common_modules import module_inputs_torch_nn_LinearCrossEntropyLoss
@@ -10569,7 +10569,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(out[0], out[-1])
 
     @onlyCUDA
-    @expectedFailureIfRocm
+    @skipCUDAIfRocm
     @dtypes(torch.half, torch.bfloat16)
     @largeTensorTest('40GB')
     def test_upsampling_64bit_indexing_bilinear_channels_last(self, device, dtype):
@@ -10588,7 +10588,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(out[0], out[-1])
 
     @onlyCUDA
-    @expectedFailureIfRocm
+    @skipCUDAIfRocm
     @dtypes(torch.half, torch.bfloat16)
     @largeTensorTest('10GB')
     def test_upsampling_64bit_indexing_bilinear_channels_last_backward(self, device, dtype):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -47,7 +47,7 @@ from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, Criteri
     ctcloss_reference, get_new_module_tests, single_batch_reference_fn, _test_bfloat16_ops, _test_module_empty_input
 from torch.testing._internal.common_device_type import dtypesIfMPS, instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, precisionOverride, onlyCUDA, onlyCPU, onlyAccelerator, \
-    skipCUDAIf, skipMPSIf, skipMPS, \
+    skipCUDAIf, skipCUDAIfRocm, skipMPSIf, skipMPS, \
     onlyNativeDeviceTypes, deviceCountAtLeast, largeTensorTest, expectedFailureMeta, expectedFailureMPS, \
     skipMeta, get_all_device_types
 from torch.testing._internal.common_modules import module_inputs_torch_nn_LinearCrossEntropyLoss

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2047,6 +2047,10 @@ def expectedFailureCUDA(fn):
     return expectedFailure("cuda")(fn)
 
 
+def expectedFailureIfRocm(fn):
+    return expectedFailure("cuda")(fn) if TEST_WITH_ROCM else fn
+
+
 def expectedFailureXPU(fn):
     return expectedFailure("xpu")(fn)
 


### PR DESCRIPTION
## Summary

`torch.nn.functional.interpolate(..., mode='bilinear')` with a channels_last
CUDA input crashed with `CUDA error: invalid configuration argument` when the
output had at least `2**31` elements.

### Repro

```python
import torch
x = torch.rand((32, 64, 512, 512), dtype=torch.half, device='cuda')
out = torch.nn.functional.interpolate(
    x.to(memory_format=torch.channels_last), scale_factor=2, mode='bilinear')
```
outputs: 
`torch.AcceleratorError: CUDA error: invalid configuration argument`

### Root cause
The channels_last (NHWC) forward and backward kernels and their launch code
computed flat element indices and grid sizes in 32-bit int. Once the element
count reached 2**31, the multiplications overflowed to a negative value, which
became a huge size_t and produced a grid dimension far exceeding
maxGridSize, so the launch failed with cudaErrorInvalidConfiguration.

### Fix
Rather than widen every index to 64-bit unconditionally (which would slow the
common small-tensor case), the NHWC kernels are templated on an index type and
the launch picks int32 vs int64 via canUse32BitIndexMath, the same
pattern GridSampler.cu uses. Small tensors keep 32-bit arithmetic, only
tensors past INT_MAX pay for 64-bit. Grid element counts are computed in
64-bit, and a TORCH_CHECK guards the remaining hard limit: one thread per
output element means the grid is bounded by maxGridSize[0] regardless of
index width.

### Suggested review order:

1. KernelUtils.cuh: templates idx_cl on the index type (default size_t keeps existing callers unchanged).
2. UpSampleBilinear2d.cu: the actual fix (templated kernels + dispatch).
3. UpSampleNearest2d.cu: only updates its idx_cl call sites to the now-explicit form.

### Test plan

Added device-generic tests covering the 2**31 forward and backward paths.
Backward (fits in ~10GB, runs locally):

python test/test_nn.py \
  TestNNDeviceTypeCUDA.test_upsampling_64bit_indexing_bilinear_channels_last_backward_cuda_float16 \
  TestNNDeviceTypeCUDA.test_upsampling_64bit_indexing_bilinear_channels_last_backward_cuda_bfloat16
The forward test (test_upsampling_64bit_indexing_bilinear_channels_last) needs
~20GB and runs on CI's large-memory GPUs. Also verified correctness of the
small-tensor 32-bit path (forward and backward, against a float64 reference) and
that nearest-neighbor channels_last upsampling is unchanged.

Related to #87901 
