### PR TITLE
Fix torch.nn.functional.gelu returning NaN for infinite inputs

### DIFF
--- a/aten/src/ATen/native/cpu/Gelu.h
+++ b/aten/src/ATen/native/cpu/Gelu.h
@@ -10,6 +10,7 @@
 
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/BFloat16.h> // For c10::is_reduced_floating_point_v.
+#include <limits>
 
 namespace at::native {
 inline namespace CPU_CAPABILITY {
@@ -61,8 +62,12 @@ vec::Vectorized<T> vectorized_gelu_approximated_with_tanh(vec::Vectorized<T> x) 
 template <typename T>
 T scalar_gelu(T x) {
   using opmath_t = reduced_fp_to_float_t<T>;
+  auto x_float = reduced_fp_to_float(x);
+  if (std::isinf(x_float) && x_float > opmath_t(0)) {
+    return x_float;
+  }
   const auto kAlpha = opmath_t(M_SQRT1_2);
-  return reduced_fp_to_float(x) * opmath_t(0.5) * (opmath_t(1) + std::erf(reduced_fp_to_float(x) * kAlpha));
+  return x_float * opmath_t(0.5) * (opmath_t(1) + std::erf(x_float * kAlpha));
 }
 
 template<typename T, std::enable_if_t<!c10::is_reduced_floating_point_v<T>, bool> = true>
@@ -70,7 +75,10 @@ vec::Vectorized<T> vectorized_gelu(vec::Vectorized<T> x) {
   const vec::Vectorized<T> kAlphaVec(T(M_SQRT1_2));
   const vec::Vectorized<T> kOneVec(T(1));
   const vec::Vectorized<T> kPointFiveVec(T(0.5));
-  return x * kPointFiveVec * (kOneVec + (x * kAlphaVec).erf());
+  auto result = x * kPointFiveVec * (kOneVec + (x * kAlphaVec).erf());
+  // gelu(+inf) = +inf; the vectorized erf approximation may produce NaN
+  return vec::Vectorized<T>::blendv(
+      result, x, x == vec::Vectorized<T>(std::numeric_limits<T>::infinity()));
 }
 
 template<typename T, std::enable_if_t<c10::is_reduced_floating_point_v<T>, bool> = true>

--- a/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
@@ -34,8 +34,12 @@ void GeluCUDAKernelImpl(TensorIteratorBase& it, GeluType approximate) {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, it.dtype(), "GeluCUDAKernelImpl", [&]() {
       gpu_kernel(it, [] GPU_LAMBDA(scalar_t x) -> scalar_t {
         using opmath_t = at::opmath_type<scalar_t>;
+        auto x_op = static_cast<opmath_t>(x);
+        if (::isinf(x_op) && x_op > opmath_t(0)) {
+          return x_op;
+        }
         constexpr opmath_t kAlpha = M_SQRT1_2;
-        return static_cast<opmath_t>(x) * opmath_t(0.5) * (opmath_t(1) + ::erf(static_cast<opmath_t>(x) * kAlpha));
+        return x_op * opmath_t(0.5) * (opmath_t(1) + ::erf(x_op * kAlpha));
       });
     });
   }

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5067,6 +5067,13 @@ def sample_inputs_gelu(self, device, dtype, requires_grad, **kwargs):
                 make_tensor((N * 2, N * 2), device=device, dtype=dtype,
                             requires_grad=requires_grad, low=-3, high=3),
                 approximate=approximate)
+    # gelu(+inf) should be +inf, not NaN (see issue #187293)
+    if not requires_grad:
+        for approximate in ['none', 'tanh']:
+            yield SampleInput(
+                torch.tensor([float('inf'), float('-inf'), float('nan'), 1.0],
+                             device=device, dtype=dtype),
+                approximate=approximate)
 
 
 def error_inputs_gelu(op, device, **kwargs):


### PR DESCRIPTION
#185770

`gelu(+inf)` should evaluate to `+inf` and `gelu(-inf)` should evaluate to `0`, but both cases currently return `NaN`.

The `-inf` issue comes from IEEE 754 behavior (`-inf * 0 = NaN`) and affects all GELU implementations. The `+inf` issue is specific to the MKLDNN path.

This change adds explicit handling for infinite inputs in the scalar, vectorized CPU, and CUDA kernels for both `approximate="none"` and `approximate="tanh"` modes. For MKLDNN, infinite inputs are corrected in a post-processing step to ensure the expected outputs are returned.




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01