### PR TITLE
Fix torch.kron RuntimeError on non-contiguous tensors - noah

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3514,8 +3514,8 @@ struct KronImpl final {
         b_reshape[2 * i + 1] = (i >= pad_other ? other.sizes()[i - pad_other] : 1);
         result_reshape[i] = a_reshape[2 * i] * b_reshape[2 * i + 1];
       }
-      self_view = at::_unsafe_view(self, a_reshape);
-      other_view = at::_unsafe_view(other, b_reshape);
+      self_view = at::_unsafe_view(self.contiguous(), a_reshape);
+      other_view = at::_unsafe_view(other.contiguous(), b_reshape);
     }
 
     Tensor& kron_out(Tensor& result) const {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1310,6 +1310,22 @@ class TestLinalg(TestCase):
         for a_shape, b_shape in itertools.product(shapes, reversed(shapes)):
             run_test_case(a_shape, b_shape)
 
+        # Regression test: non-contiguous inputs (e.g. transposed tensors) must work.
+        # Previously, at::_unsafe_view was called on non-contiguous tensors, which
+        # raised "view size is not compatible with input tensor's size and stride".
+        a = torch.rand(3, 4, dtype=dtype, device=device)
+        b = torch.rand(4, 3, dtype=dtype, device=device).t()  # non-contiguous
+        expected = np.kron(a.cpu().numpy(), b.cpu().contiguous().numpy())
+        result = torch.kron(a, b)
+        self.assertEqual(result, expected)
+
+        # both inputs non-contiguous
+        a_nc = torch.rand(4, 3, dtype=dtype, device=device).t()
+        b_nc = torch.rand(4, 3, dtype=dtype, device=device).t()
+        expected_nc = np.kron(a_nc.cpu().contiguous().numpy(), b_nc.cpu().contiguous().numpy())
+        result_nc = torch.kron(a_nc, b_nc)
+        self.assertEqual(result_nc, expected_nc)
+
     @dtypes(*floating_and_complex_types())
     def test_kron_empty(self, device, dtype):
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21719,11 +21719,7 @@ op_db: list[OpInfo] = [
            supports_inplace_autograd=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           sample_inputs_func=sample_inputs_kron,
-           decorators=(
-               # RuntimeError: view size is not compatible with input tensor's size and stride
-               DecorateInfo(unittest.expectedFailure, "TestMeta", "test_dispatch_symbolic_meta_outplace_all_strides"),
-           )),
+           sample_inputs_func=sample_inputs_kron),
     OpInfo('inner',
            dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16),
            dtypesIfCUDA=floating_and_complex_types_and(torch.float16, torch.bfloat16),


### PR DESCRIPTION
Resolves #185794

This commit fixes an issue where torch.kron would crash when given non-contiguous input tensors (e.g. from a .t() operation). The bug was caused by calling at::_unsafe_view without first ensuring the tensors were contiguous in memory. A regression test has been added to test_linalg.py.