### PR TITLE
Stable sorting for consistent gradient for torch.quantile on tied values

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -267,11 +267,11 @@ Tensor quantile_compute(
   // Sort to efficiently query kth values.
   Tensor sorted;
   if (!orginal_dim) {
-    sorted = std::get<0>(self.flatten().sort());
+    sorted = std::get<0>(self.flatten().sort(/*stable=*/true, /*dim=*/-1, /*descending=*/false));
   } else if (wrapped_dim == self.dim() - 1) {
-    sorted = std::get<0>(self.sort());
+    sorted = std::get<0>(self.sort(/*stable=*/true, /*dim=*/-1, /*descending=*/false));
   } else {
-    sorted = std::get<0>(self.unsqueeze(-1).transpose(wrapped_dim, -1).sort());
+    sorted = std::get<0>(self.unsqueeze(-1).transpose(wrapped_dim, -1).sort(/*stable=*/true, /*dim=*/-1, /*descending=*/false));
   }
 
   // Treat q as a 1D tensor for the following computations

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2795,6 +2795,49 @@ class TestReductions(TestCase):
         check([1, float('nan'), 2], 0.5, 0, [0, 1, 0], [torch.quantile])
         check([1, float('nan'), 2], 0.5, 0, [0.5, 0, 0.5], [torch.nanquantile])
 
+    @skipIfMPS
+    def test_quantile_backward_tied_values(self, device):
+        # Verify gradients are deterministic for tied values (stable sort guarantees
+        # the first element among ties receives the gradient for q=0.0).
+        def check(a, q, dim, expected_grad, ops=(torch.quantile, torch.nanquantile)):
+            for op in ops:
+                t = torch.tensor(a, device=device, dtype=torch.float64, requires_grad=True)
+                op(t, torch.tensor(q, device=device, dtype=torch.float64), dim).sum().backward()
+                self.assertEqual(t.grad, torch.tensor(expected_grad, device=device, dtype=torch.float64))
+
+        # q=0.0 on all-tied values: gradient goes to first element (stable sort)
+        check([0., 0., 0.], 0.0, 0, [1., 0., 0.])
+        # q=1.0 on all-tied values: gradient goes to last element (stable sort)
+        check([0., 0., 0.], 1.0, 0, [0., 0., 1.])
+        # 2D with tied values along dim=1
+        check([[0., 0., 0.], [0., 0., 0.]], 0.0, 1, [[1., 0., 0.], [1., 0., 0.]])
+        check([[0., 0., 0.], [0., 0., 0.]], 1.0, 1, [[0., 0., 1.], [0., 0., 1.]])
+        # NaN row with tied non-NaN row
+        check(
+            [[float('nan'), float('nan'), float('nan')], [0., 0., 0.]],
+            0.0, 1,
+            [[0., 0., 1.], [1., 0., 0.]],
+            ops=(torch.quantile,),
+        )
+
+    @skipIfMPS
+    @skipIfTorchDynamo("compile test below")
+    def test_quantile_backward_tied_values_compile(self, device):
+        # Verify torch.compile produces the same gradients as eager for tied values
+        def fn(x, q):
+            return torch.quantile(x, q, dim=1, keepdim=True).sum()
+
+        x = torch.zeros(2, 3, device=device, dtype=torch.float64)
+        q = torch.tensor(0.0, device=device, dtype=torch.float64)
+
+        x_eager = x.clone().requires_grad_(True)
+        fn(x_eager, q).backward()
+
+        x_compiled = x.clone().requires_grad_(True)
+        torch.compile(fn, backend="inductor", fullgraph=True)(x_compiled, q).backward()
+
+        self.assertEqual(x_eager.grad, x_compiled.grad)
+
     def test_quantile_error(self, device):
         def check(a, q, args, kwargs, message):
             with self.assertRaisesRegex(RuntimeError, r'quantile\(\) ' + message):


### PR DESCRIPTION
Fixes #185543 

quantile_compute (device-agnostic code in Sorting.cpp) calls self.sort() without the stable flag. For tied values, CUDA eager's has different sorting mechanism (doesn't gaurantees the original relative order) and produces a different element ordering than Inductor's compiled path . The quantile value is correct in both cases, but gradients route to different original positions.

Fix: pass stable=true to the sort call in quantile_compute. Since this code dispatches via tensor methods, the change applies to all backends (CPU and CUDA). This makes CUDA eager gradients consistent with CUDA Inductor for tied values.