### PR TITLE
Fix arange int64 fractional truncation

### DIFF
--- a/aten/src/ATen/native/RangeUtils.h
+++ b/aten/src/ATen/native/RangeUtils.h
@@ -40,13 +40,18 @@ int64_t compute_arange_size(const Scalar& start, const Scalar& end, const Scalar
   // the corner-case we do want to take into account is int64_t, which has higher precision than double
   double size_d;
   if constexpr (std::is_same_v<scalar_t, int64_t>) {
-    using accscalar_t = at::acc_type<scalar_t, false>;
-    auto xstart = start.to<accscalar_t>();
-    auto xend = end.to<accscalar_t>();
-    auto xstep = step.to<accscalar_t>();
-    TORCH_CHECK_VALUE(xstep != 0, "step must be nonzero");
-    int64_t sgn = (xstep > 0) - (xstep < 0);
-    size_d = std::ceil((xend - xstart + xstep - sgn) / xstep);
+    if (start.isIntegral(false) && end.isIntegral(false) && step.isIntegral(false)) {
+      using accscalar_t = at::acc_type<scalar_t, false>;
+      auto xstart = start.to<accscalar_t>();
+      auto xend = end.to<accscalar_t>();
+      auto xstep = step.to<accscalar_t>();
+      TORCH_CHECK_VALUE(xstep != 0, "step must be nonzero");
+      int64_t sgn = (xstep > 0) - (xstep < 0);
+      size_d = std::ceil((xend - xstart + xstep - sgn) / xstep);
+    } else {
+      size_d = std::ceil((end.to<double>() - start.to<double>())
+                          / step.to<double>());
+    }
   } else {
     size_d = std::ceil((end.to<double>() - start.to<double>())
                         / step.to<double>());

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -252,31 +252,9 @@ Tensor& arange_cuda_out(const Scalar& start, const Scalar& end, const Scalar& st
   AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, result.scalar_type(), "arange_cuda", [&]() {
     using accscalar_t = at::acc_type<scalar_t, true>;
     auto xstart = start.to<accscalar_t>();
-    auto xend = end.to<accscalar_t>();
     auto xstep = step.to<accscalar_t>();
 
-    arange_check_bounds(start, end, step);
-
-    // we use double precision for (start - end) / step
-    // to compute size_d for consistency across devices.
-    // The problem with using accscalar_t is that accscalar_t might be float32 on gpu for a float32 scalar_t,
-    // but double on cpu for the same,
-    // and the effective output size starts differing on CPU vs GPU because of precision issues, which
-    // we dont want.
-    // the corner-case we do want to take into account is int64_t, which has higher precision than double
-    double size_d;
-    if constexpr (std::is_same_v<scalar_t, int64_t>) {
-      TORCH_CHECK_VALUE(xstep != 0, "step must be nonzero");
-      int64_t sgn = (xstep > 0) - (xstep < 0);
-      size_d = std::ceil((xend - xstart + xstep - sgn) / xstep);
-    } else {
-      size_d = std::ceil(static_cast<double>(end.to<double>() - start.to<double>())
-                          / step.to<double>());
-    }
-
-    TORCH_CHECK(size_d >= 0 && size_d <= static_cast<double>(std::numeric_limits<int64_t>::max()),
-              "invalid size, possible overflow?");
-    int64_t size = static_cast<int64_t>(size_d);
+    int64_t size = compute_arange_size<scalar_t>(start, end, step);
     int64_t numel = result.numel();
 
     if (numel != size) {

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -78,24 +78,7 @@ void arange_range_fill_mps(const Scalar& start, const Scalar& step, Tensor& resu
 
 Tensor& arange_mps_out(const Scalar& start, const Scalar& end, const Scalar& step, Tensor& result) {
   AT_DISPATCH_MPS_TYPES(result.scalar_type(), "arange_mps", [&]() {
-    using accscalar_t = at::acc_type_device<scalar_t, kMPS>;
-    auto xstart = start.to<accscalar_t>();
-    auto xend = end.to<accscalar_t>();
-    auto xstep = step.to<accscalar_t>();
-
-    double size_d;
-    if constexpr (std::is_same_v<scalar_t, int64_t>) {
-      TORCH_CHECK_VALUE(xstep != 0, "step must be nonzero");
-      size_d = std::ceil(static_cast<double>(end.to<accscalar_t>() - start.to<accscalar_t>()) / step.to<accscalar_t>());
-    } else {
-      size_d = std::ceil(static_cast<double>(end.to<double>() - start.to<double>()) / step.to<double>());
-    }
-
-    arange_check_bounds(start, end, step);
-
-    TORCH_CHECK(size_d >= 0 && size_d <= static_cast<double>(std::numeric_limits<int64_t>::max()),
-                "invalid size, possible overflow?");
-    int64_t size = static_cast<int64_t>(size_d);
+    int64_t size = compute_arange_size<scalar_t>(start, end, step);
     int64_t numel = result.numel();
 
     if (numel != size) {

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2587,46 +2587,6 @@ class TestTensorCreation(TestCase):
         d = torch.arange(-4.0, 4.0, 0.01, dtype=torch.float32, device=device)
         self.assertEqual(d.shape[0], 800)
 
-    def test_arange_int64_fractional(self, device):
-        self.assertEqual(
-            torch.arange(0, 0.5, 1, dtype=torch.int64, device=device),
-            torch.tensor([0], dtype=torch.int64, device=device))
-        self.assertEqual(
-            torch.arange(0, 1.5, 1, dtype=torch.int64, device=device),
-            torch.tensor([0, 1], dtype=torch.int64, device=device))
-
-        for end in [0.5, 1.5, 2.7, 3.0]:
-            i64 = torch.arange(0, end, 1, dtype=torch.int64, device=device)
-            i32 = torch.arange(0, end, 1, dtype=torch.int32, device=device)
-            self.assertEqual(i64.numel(), i32.numel())
-
-        self.assertEqual(
-            torch.arange(0, 5, 2, dtype=torch.int64, device=device),
-            torch.tensor([0, 2, 4], dtype=torch.int64, device=device))
-
-        self.assertEqual(
-            torch.arange(0, 5.0, 1, dtype=torch.int64, device=device),
-            torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64, device=device))
-
-        self.assertEqual(
-            torch.arange(0, 64, 0.5, dtype=torch.int64, device=device).numel(), 128)
-        self.assertEqual(
-            torch.arange(0.5, 5, 1, dtype=torch.int64, device=device).numel(),
-            torch.arange(0.5, 5, 1, dtype=torch.int32, device=device).numel())
-        self.assertEqual(
-            torch.arange(5, 0, -0.5, dtype=torch.int64, device=device).numel(),
-            torch.arange(5, 0, -0.5, dtype=torch.int32, device=device).numel())
-
-    def test_arange_int64_fractional_compile(self, device):
-        # Validates size computation only under torch.compile (inductor).
-        @torch.compile(fullgraph=True, backend="inductor")
-        def f(start, end, step, device):
-            return torch.arange(start, end, step, dtype=torch.int64, device=device)
-
-        self.assertEqual(f(0, 0.5, 1, device).numel(), 1)
-        self.assertEqual(f(0, 1.5, 1, device).numel(), 2)
-        self.assertEqual(f(0, 64, 0.5, device).numel(), 128)
-
     # TODO: this test should be updated
     @onlyCPU
     def test_arange_inference(self, device):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2587,6 +2587,46 @@ class TestTensorCreation(TestCase):
         d = torch.arange(-4.0, 4.0, 0.01, dtype=torch.float32, device=device)
         self.assertEqual(d.shape[0], 800)
 
+    def test_arange_int64_fractional(self, device):
+        self.assertEqual(
+            torch.arange(0, 0.5, 1, dtype=torch.int64, device=device),
+            torch.tensor([0], dtype=torch.int64, device=device))
+        self.assertEqual(
+            torch.arange(0, 1.5, 1, dtype=torch.int64, device=device),
+            torch.tensor([0, 1], dtype=torch.int64, device=device))
+
+        for end in [0.5, 1.5, 2.7, 3.0]:
+            i64 = torch.arange(0, end, 1, dtype=torch.int64, device=device)
+            i32 = torch.arange(0, end, 1, dtype=torch.int32, device=device)
+            self.assertEqual(i64.numel(), i32.numel())
+
+        self.assertEqual(
+            torch.arange(0, 5, 2, dtype=torch.int64, device=device),
+            torch.tensor([0, 2, 4], dtype=torch.int64, device=device))
+
+        self.assertEqual(
+            torch.arange(0, 5.0, 1, dtype=torch.int64, device=device),
+            torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64, device=device))
+
+        self.assertEqual(
+            torch.arange(0, 64, 0.5, dtype=torch.int64, device=device).numel(), 128)
+        self.assertEqual(
+            torch.arange(0.5, 5, 1, dtype=torch.int64, device=device).numel(),
+            torch.arange(0.5, 5, 1, dtype=torch.int32, device=device).numel())
+        self.assertEqual(
+            torch.arange(5, 0, -0.5, dtype=torch.int64, device=device).numel(),
+            torch.arange(5, 0, -0.5, dtype=torch.int32, device=device).numel())
+
+    def test_arange_int64_fractional_compile(self, device):
+        # Validates size computation only under torch.compile (inductor).
+        @torch.compile(fullgraph=True, backend="inductor")
+        def f(start, end, step, device):
+            return torch.arange(start, end, step, dtype=torch.int64, device=device)
+
+        self.assertEqual(f(0, 0.5, 1, device).numel(), 1)
+        self.assertEqual(f(0, 1.5, 1, device).numel(), 2)
+        self.assertEqual(f(0, 64, 0.5, device).numel(), 128)
+
     # TODO: this test should be updated
     @onlyCPU
     def test_arange_inference(self, device):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5486,9 +5486,7 @@ def arange(
         xend = sym_int(end)
         xstep = sym_int(step)
 
-    # For int64 we truncate arguments to int before calculating length, but
-    # other integral dtypes we don't. Weird... but needed to match ATen shapes.
-    if dtype == torch.int64 or integer_args:
+    if integer_args:
         torch._check_value(xstep != 0, lambda: "step must be nonzero")  # type: ignore[possibly-undefined]
         # Uses floordiv to avoid ceil in inductor.
         sgn = bool(xstep > 0) - bool(xstep < 0)  # type: ignore[possibly-undefined]
@@ -5496,7 +5494,7 @@ def arange(
     else:
         length = math.ceil((end - start) / step)
 
-    if is_integer:
+    if is_integer and integer_args:
         return prims.iota(
             length,
             start=xstart,  # type: ignore[possibly-undefined]
@@ -5505,6 +5503,17 @@ def arange(
             device=device,
             requires_grad=requires_grad,
         )
+
+    if is_integer and not integer_args:
+        index = prims.iota(
+            length,
+            start=0,
+            step=1,
+            dtype=dtype,
+            device=device,
+            requires_grad=requires_grad,
+        )
+        return xstart + xstep * index  # type: ignore[possibly-undefined]
 
     index = prims.iota(
         length,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -854,6 +854,10 @@ def sample_inputs_arange(op, device, dtype, requires_grad, **kwargs):
     yield SampleInput(1, args=(3, 1))
     if dtype in (torch.int32, torch.int64):
         yield SampleInput(0, args=(64, 0.5), kwargs={"dtype": dtype, "device": device})
+        yield SampleInput(0, args=(0.5, 1), kwargs={"dtype": dtype, "device": device})
+        yield SampleInput(0, args=(1.5, 1), kwargs={"dtype": dtype, "device": device})
+        yield SampleInput(0.5, args=(5, 1), kwargs={"dtype": dtype, "device": device})
+        yield SampleInput(5, args=(0, -0.5), kwargs={"dtype": dtype, "device": device})
 
 def sample_inputs_randn(op, device, dtype, requires_grad, **kwargs):
     shapes = (

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -793,9 +793,6 @@ def error_inputs_arange(op, device, **kwargs):
                      error_regex='upper bound and lower bound inconsistent with step sign')
     yield ErrorInput(SampleInput(0, args=(float('inf'), 2)), error_type=RuntimeError, error_regex='unsupported range')
     yield ErrorInput(SampleInput(float('-inf'), args=(1, 2)), error_type=RuntimeError, error_regex='unsupported range')
-    # https://github.com/pytorch/pytorch/issues/175761: fractional step truncates to 0 for integer out
-    yield ErrorInput(SampleInput(0, args=(64, 0.5), kwargs={'out': torch.empty(0, dtype=torch.int64, device=device)}),
-                     error_type=ValueError, error_regex='step must be nonzero')
 
 def sample_inputs_arange(op, device, dtype, requires_grad, **kwargs):
     int_samples = (
@@ -855,6 +852,8 @@ def sample_inputs_arange(op, device, dtype, requires_grad, **kwargs):
 
     yield SampleInput(2)
     yield SampleInput(1, args=(3, 1))
+    if dtype in (torch.int32, torch.int64):
+        yield SampleInput(0, args=(64, 0.5), kwargs={"dtype": dtype, "device": device})
 
 def sample_inputs_randn(op, device, dtype, requires_grad, **kwargs):
     shapes = (
@@ -12900,11 +12899,6 @@ op_db: list[OpInfo] = [
            error_inputs_func=error_inputs_arange,
            sample_inputs_func=sample_inputs_arange,
            skips=(
-               # Dynamo wraps the ValueError from the fractional-step / integer-out check,
-               # so test_errors can't match the eager exception type/regex under inductor.
-               DecorateInfo(unittest.skip("error type wrapped under torch.compile"),
-                            'TestCommon', 'test_errors', active_if=TEST_WITH_TORCHINDUCTOR),
-
                # https://github.com/pytorch/pytorch/issues/81774
                DecorateInfo(unittest.expectedFailure, 'TestNormalizeOperators', 'test_normalize_operator_exhaustive'),
 


### PR DESCRIPTION
Fix torch.arange int64 size computation for fractional arguments to match int32/float32/NumPy

- Added isIntegral() guard in RangeUtils.h so fractional args use double precision instead of being truncated. 
- Deduplicated CUDA/MPS size logic via compute_arange_size, removed unused variables. 
- Aligned _refs decomposition: size uses integer_args only, value generation uses xstart + xstep * iota(length, 0, 1) for integer dtype with fractional args to match eager truncation and avoid step=0 crash. 
- Removed ErrorInput and OpInfo skip that tested old truncation behavior, added positive SampleInputs for fractional step/start/end/negative cases in OpInfo.

Fixes https://github.com/pytorch/pytorch/issues/149097