### PR TITLE
Enable CPU FlexAttention on AArch64

### DIFF
--- a/aten/src/ATen/native/CPUBlas.h
+++ b/aten/src/ATen/native/CPUBlas.h
@@ -66,7 +66,7 @@ void gemm(
     double beta,
     double *c, int64_t ldc);
 
-void gemm(
+TORCH_API void gemm(
     TransposeType transa, TransposeType transb,
     int64_t m, int64_t n, int64_t k,
     float alpha,
@@ -84,7 +84,7 @@ void gemm(
     float beta,
     at::BFloat16 *c, int64_t ldc);
 
-void gemm(
+TORCH_API void gemm(
     TransposeType transa, TransposeType transb,
     int64_t m, int64_t n, int64_t k,
     const float alpha,
@@ -102,7 +102,7 @@ void gemm(
     float beta,
     at::Half *c, int64_t ldc);
 
-void gemm(
+TORCH_API void gemm(
     TransposeType transa, TransposeType transb,
     int64_t m, int64_t n, int64_t k,
     const float alpha,

--- a/torch/_inductor/codegen/cpp_flex_attention_template.py
+++ b/torch/_inductor/codegen/cpp_flex_attention_template.py
@@ -312,6 +312,7 @@ extern "C"
 
 FLEX_ATTENTION_TEMPLATE = r"""
   bool need_pack = false;
+#if !defined(CPU_CAPABILITY_SVE256)
   // Whether pack is needed for BFloat16/Half
   if (is_reduced_type) {
     // check platform ability
@@ -330,6 +331,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
       need_pack = gemm_size_per_thread / pack_size >= 4;
     }
   }
+#endif
   // Pad is needed for packing when K is not even
   bool headSize_even = headSize % 2 == 0;
   int64_t eheadSize = need_pack && !headSize_even ? headSize + 1: headSize;
@@ -351,6 +353,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
   {{template.codegen_allocate_buffer("value_reorder_ptr", "scalar_t", "batchSize_k*num_head_k*kv_padding_size*headSize_v")}}
   {{template.codegen_allocate_buffer("transpose_buffer_ptr", "scalar_t", "num_thread*kvSplitSize*headSize")}}
   {{template.codegen_allocate_buffer("query_padding_ptr", "scalar_t", "num_thread*qSplitSize*eheadSize")}}
+#if !defined(CPU_CAPABILITY_SVE256)
   if (need_pack) {
     // Pack K, V
     at::parallel_for(0, batchSize_k * num_head_k * kvSlice, 1, [&](int64_t begin, int64_t end) {
@@ -398,6 +401,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
       }
     });
   }
+#endif
   // Attention loop below
   at::parallel_for(0, batchSize * num_head * qSlice, 1, [&](int64_t begin, int64_t end) {
     int64_t i = 0, j = 0, k = 0;
@@ -483,10 +487,27 @@ FLEX_ATTENTION_TEMPLATE = r"""
         if (!need_pack) {
           auto k_addr =
               k_data + i_kv * kStrideB + j_kv * kStrideH + n * kStrideN;
+          auto q_addr =
+              q_data + i * qStrideB + j * qStrideH + m * qStrideM;
 
+#if defined(CPU_CAPABILITY_SVE256)
+          at::native::cpublas::gemm(
+              at::native::TransposeType::Transpose,
+              at::native::TransposeType::NoTranspose,
+              cur_kvSplitSize,
+              cur_qSplitSize,
+              headSize,
+              static_cast<accum_t>(1),
+              k_addr,
+              kStrideN,
+              q_addr,
+              qStrideM,
+              static_cast<accum_t>(0),
+              qk_data,
+              cur_kvSplitSize);
+#else
           {{kernel.kernel_name}}_kernel_micro_gemm_transpose_b<static_cast<bool>(false)>(
-              q_data + i * qStrideB + j * qStrideH +
-                  m * qStrideM,
+              q_addr,
               k_addr,
               qk_data,
               cur_qSplitSize,
@@ -495,6 +516,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
               qStrideM,
               kStrideN,
               cur_kvSplitSize);
+#endif
 
         } else {
           at::native::cpublas::brgemm(
@@ -815,9 +837,27 @@ FLEX_DECODING_TEMPLATE = r"""
 
         auto k_addr =
             k_data + i_kv * kStrideB + j_kv * kStrideH + n * kStrideN;
+        auto q_addr =
+            q_data + i * qStrideB + j * qStrideH;
 
+#if defined(CPU_CAPABILITY_SVE256)
+        at::native::cpublas::gemm(
+            at::native::TransposeType::Transpose,
+            at::native::TransposeType::NoTranspose,
+            cur_kvSplitSize,
+            cur_qSplitSize,
+            headSize,
+            static_cast<accum_t>(1),
+            k_addr,
+            kStrideN,
+            q_addr,
+            qStrideM,
+            static_cast<accum_t>(0),
+            logits + token_num,
+            cur_kvSplitSize);
+#else
         {{kernel.kernel_name}}_kernel_micro_gemm_transpose_b<false>(
-            q_data + i * qStrideB + j * qStrideH,
+            q_addr,
             k_addr,
             logits + token_num,
             cur_qSplitSize,
@@ -826,6 +866,7 @@ FLEX_DECODING_TEMPLATE = r"""
             qStrideM,
             kStrideN,
             cur_kvSplitSize);
+#endif
 
         {{kernel.kernel_name}}_mul_scale_kernel<accum_t>(logits + token_num, scaling_factor, cur_qSplitSize*cur_kvSplitSize);
 
@@ -1477,19 +1518,24 @@ class CppFlexAttentionTemplate(CppTemplate):
             parallel_num_threads,
         )
         from torch._inductor.codegen.cpp_micro_gemm import CppMicroGemmFP32Vec
+        from torch._inductor.cpu_vec_isa import pick_vec_isa, VecSVE256
         from torch._inductor.virtualized import V
 
-        micro_gemm_trans = CppMicroGemmFP32Vec(
-            kernel_name + "_kernel_micro_gemm_transpose_b",
-            self.input_dtype,
-            self.input_dtype,
-            self.accumulate_dtype,
-            self.accumulate_dtype,
-            GemmBlocking(1, 16, 1),
-            1,
-            True,
-            True,
-        )
+        emit_transpose_b_micro_gemm = not isinstance(pick_vec_isa(), VecSVE256)
+
+        code_trans = ""
+        if emit_transpose_b_micro_gemm:
+            micro_gemm_trans = CppMicroGemmFP32Vec(
+                kernel_name + "_kernel_micro_gemm_transpose_b",
+                self.input_dtype,
+                self.input_dtype,
+                self.accumulate_dtype,
+                self.accumulate_dtype,
+                GemmBlocking(1, 16, 1),
+                1,
+                True,
+                True,
+            )
 
         micro_gemm = CppMicroGemmFP32Vec(
             kernel_name + "_kernel_micro_gemm",
@@ -1505,7 +1551,8 @@ class CppFlexAttentionTemplate(CppTemplate):
 
         with V.set_graph_handler(V.graph):
             kernel = CppTemplateKernel("cpp_micro_gemm", parallel_num_threads())
-            code_trans = micro_gemm_trans.codegen_define(kernel)
+            if emit_transpose_b_micro_gemm:
+                code_trans = micro_gemm_trans.codegen_define(kernel)
             code = micro_gemm.codegen_define(kernel)
         return code + code_trans
 

--- a/torch/_inductor/codegen/cpp_flex_attention_template.py
+++ b/torch/_inductor/codegen/cpp_flex_attention_template.py
@@ -312,9 +312,9 @@ extern "C"
 
 FLEX_ATTENTION_TEMPLATE = r"""
   bool need_pack = false;
-#if !defined(CPU_CAPABILITY_SVE256)
+{%- if use_pack_brgemm %}
   // Whether pack is needed for BFloat16/Half
-  if (is_reduced_type) {
+  if constexpr (is_reduced_type) {
     // check platform ability
     need_pack = std::is_same_v<scalar_t, at::BFloat16> ? at::native::cpublas::could_pack(at::kBFloat16)
                                                        : at::native::cpublas::could_pack(at::kHalf);
@@ -331,7 +331,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
       need_pack = gemm_size_per_thread / pack_size >= 4;
     }
   }
-#endif
+{%- endif %}
   // Pad is needed for packing when K is not even
   bool headSize_even = headSize % 2 == 0;
   int64_t eheadSize = need_pack && !headSize_even ? headSize + 1: headSize;
@@ -353,7 +353,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
   {{template.codegen_allocate_buffer("value_reorder_ptr", "scalar_t", "batchSize_k*num_head_k*kv_padding_size*headSize_v")}}
   {{template.codegen_allocate_buffer("transpose_buffer_ptr", "scalar_t", "num_thread*kvSplitSize*headSize")}}
   {{template.codegen_allocate_buffer("query_padding_ptr", "scalar_t", "num_thread*qSplitSize*eheadSize")}}
-#if !defined(CPU_CAPABILITY_SVE256)
+{%- if use_pack_brgemm %}
   if (need_pack) {
     // Pack K, V
     at::parallel_for(0, batchSize_k * num_head_k * kvSlice, 1, [&](int64_t begin, int64_t end) {
@@ -401,7 +401,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
       }
     });
   }
-#endif
+{%- endif %}
   // Attention loop below
   at::parallel_for(0, batchSize * num_head * qSlice, 1, [&](int64_t begin, int64_t end) {
     int64_t i = 0, j = 0, k = 0;
@@ -490,7 +490,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
           auto q_addr =
               q_data + i * qStrideB + j * qStrideH + m * qStrideM;
 
-#if defined(CPU_CAPABILITY_SVE256)
+{%- if use_blas_gemm %}
           at::native::cpublas::gemm(
               at::native::TransposeType::Transpose,
               at::native::TransposeType::NoTranspose,
@@ -505,7 +505,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
               static_cast<accum_t>(0),
               qk_data,
               cur_kvSplitSize);
-#else
+{%- else %}
           {{kernel.kernel_name}}_kernel_micro_gemm_transpose_b<static_cast<bool>(false)>(
               q_addr,
               k_addr,
@@ -516,24 +516,26 @@ FLEX_ATTENTION_TEMPLATE = r"""
               qStrideM,
               kStrideN,
               cur_kvSplitSize);
-#endif
+{%- endif %}
 
         } else {
-          at::native::cpublas::brgemm(
-              cur_qSplitSize,
-              cur_kvSplitSize,
-              eheadSize,
-              headSize_even ? qStrideM : eheadSize,
-              cur_kvSplitSize,
-              cur_kvSplitSize,
-              false,
-              !headSize_even
-                  ? query_t_padding_ptr
-                  : q_data + i * qStrideB + j * qStrideH + m * qStrideM,
-              key_reorder_ptr + i_kv * num_head_k * eheadSize * kvSize +
-                  j_kv * eheadSize * kvSize + n * eheadSize,
-              qk_data,
-              need_pack);
+          if constexpr (is_reduced_type) {
+            at::native::cpublas::brgemm(
+                cur_qSplitSize,
+                cur_kvSplitSize,
+                eheadSize,
+                headSize_even ? qStrideM : eheadSize,
+                cur_kvSplitSize,
+                cur_kvSplitSize,
+                false,
+                !headSize_even
+                    ? query_t_padding_ptr
+                    : q_data + i * qStrideB + j * qStrideH + m * qStrideM,
+                key_reorder_ptr + i_kv * num_head_k * eheadSize * kvSize +
+                    j_kv * eheadSize * kvSize + n * eheadSize,
+                qk_data,
+                need_pack);
+          }
         }
 
         {{kernel.kernel_name}}_mul_scale_kernel<accum_t>(qk_data, scaling_factor, cur_qSplitSize*cur_kvSplitSize);
@@ -800,7 +802,7 @@ FLEX_DECODING_TEMPLATE = r"""
       // Initialize logits
       {{kernel.kernel_name}}_fill_stub(logits,
             static_cast<accum_t>(0), PARTITION_SIZE);
-      if (is_reduced_type) {
+      if constexpr (is_reduced_type) {
         {{kernel.kernel_name}}_fill_stub(logits_reduced,
             static_cast<scalar_t>(0), PARTITION_SIZE);
       }
@@ -840,7 +842,7 @@ FLEX_DECODING_TEMPLATE = r"""
         auto q_addr =
             q_data + i * qStrideB + j * qStrideH;
 
-#if defined(CPU_CAPABILITY_SVE256)
+{%- if use_blas_gemm %}
         at::native::cpublas::gemm(
             at::native::TransposeType::Transpose,
             at::native::TransposeType::NoTranspose,
@@ -855,7 +857,7 @@ FLEX_DECODING_TEMPLATE = r"""
             static_cast<accum_t>(0),
             logits + token_num,
             cur_kvSplitSize);
-#else
+{%- else %}
         {{kernel.kernel_name}}_kernel_micro_gemm_transpose_b<false>(
             q_addr,
             k_addr,
@@ -866,7 +868,7 @@ FLEX_DECODING_TEMPLATE = r"""
             qStrideM,
             kStrideN,
             cur_kvSplitSize);
-#endif
+{%- endif %}
 
         {{kernel.kernel_name}}_mul_scale_kernel<accum_t>(logits + token_num, scaling_factor, cur_qSplitSize*cur_kvSplitSize);
 
@@ -1444,6 +1446,8 @@ class CppFlexAttentionTemplate(CppTemplate):
         value = kernel.permute(self.input_nodes[2], [0, 2, 1, 3])
         self.accumulate_dtype = torch.float
         self.input_dtype = query.layout.dtype
+        use_blas_gemm = torch.backends.cpu.get_cpu_capability() in ("SVE128", "SVE256")
+        use_pack_brgemm = not use_blas_gemm
 
         num_threads = parallel_num_threads()
         if not isinstance(self.output_node, ir.IRNode):
@@ -1480,6 +1484,8 @@ class CppFlexAttentionTemplate(CppTemplate):
             score_buf_idx=self.score_buf_idx,
             mask_buf_idx=self.mask_buf_idx,
             partition_size=self.partition_size,
+            use_blas_gemm=use_blas_gemm,
+            use_pack_brgemm=use_pack_brgemm,
         )
         with contextlib.ExitStack() as stack:
             for buf in self.fake_buffers:
@@ -1518,10 +1524,10 @@ class CppFlexAttentionTemplate(CppTemplate):
             parallel_num_threads,
         )
         from torch._inductor.codegen.cpp_micro_gemm import CppMicroGemmFP32Vec
-        from torch._inductor.cpu_vec_isa import pick_vec_isa, VecSVE256
         from torch._inductor.virtualized import V
 
-        emit_transpose_b_micro_gemm = not isinstance(pick_vec_isa(), VecSVE256)
+        use_blas_gemm = torch.backends.cpu.get_cpu_capability() in ("SVE128", "SVE256")
+        emit_transpose_b_micro_gemm = not use_blas_gemm
 
         code_trans = ""
         if emit_transpose_b_micro_gemm:

--- a/torch/_inductor/codegen/cpp_flex_attention_template.py
+++ b/torch/_inductor/codegen/cpp_flex_attention_template.py
@@ -312,7 +312,7 @@ extern "C"
 
 FLEX_ATTENTION_TEMPLATE = r"""
   bool need_pack = false;
-{%- if use_pack_brgemm %}
+{%- if not use_blas_gemm %}
   // Whether pack is needed for BFloat16/Half
   if constexpr (is_reduced_type) {
     // check platform ability
@@ -346,14 +346,15 @@ FLEX_ATTENTION_TEMPLATE = r"""
       /* qk_sum */ qSplitSize +
       /* dst    */ qSplitSize * headSize_v;
 
-  // Buffers to store accum results, padding query and transpose/packing key/value
+  // Buffers to store accum results
   {{template.codegen_allocate_buffer("buf_data", "accum_t", "num_thread*_size_per_thread")}}
   {{template.codegen_allocate_buffer("buf_reduced_data", "scalar_t", "num_thread*qSplitSize*ekvSplitSize")}}
+{%- if not use_blas_gemm %}
+  // Buffers for padding query and transpose/packing key/value
   {{template.codegen_allocate_buffer("key_reorder_ptr", "scalar_t", "batchSize_k*num_head_k*eheadSize*kvSize")}}
   {{template.codegen_allocate_buffer("value_reorder_ptr", "scalar_t", "batchSize_k*num_head_k*kv_padding_size*headSize_v")}}
   {{template.codegen_allocate_buffer("transpose_buffer_ptr", "scalar_t", "num_thread*kvSplitSize*headSize")}}
   {{template.codegen_allocate_buffer("query_padding_ptr", "scalar_t", "num_thread*qSplitSize*eheadSize")}}
-{%- if use_pack_brgemm %}
   if (need_pack) {
     // Pack K, V
     at::parallel_for(0, batchSize_k * num_head_k * kvSlice, 1, [&](int64_t begin, int64_t end) {
@@ -416,9 +417,13 @@ FLEX_ATTENTION_TEMPLATE = r"""
         is_reduced_type
             ? buf_reduced_data + ompIdx * qSplitSize * ekvSplitSize
             : nullptr;
+{%- if not use_blas_gemm %}
     scalar_t* query_t_padding_ptr = (!headSize_even && need_pack)
             ? query_padding_ptr + ompIdx * qSplitSize * eheadSize
             : nullptr;
+{%- else %}
+    scalar_t* query_t_padding_ptr = nullptr;
+{%- endif %}
 
     for ([[maybe_unused]] auto z : c10::irange(begin, end)) {
       auto i_kvi = is_broadcast_bs_kvi ? i/bs_shards_kvi : i;
@@ -518,7 +523,9 @@ FLEX_ATTENTION_TEMPLATE = r"""
               cur_kvSplitSize);
 {%- endif %}
 
-        } else {
+        }
+{%- if not use_blas_gemm %}
+        else {
           if constexpr (is_reduced_type) {
             at::native::cpublas::brgemm(
                 cur_qSplitSize,
@@ -537,6 +544,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
                 need_pack);
           }
         }
+{%- endif %}
 
         {{kernel.kernel_name}}_mul_scale_kernel<accum_t>(qk_data, scaling_factor, cur_qSplitSize*cur_kvSplitSize);
 
@@ -628,6 +636,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
               v_data + i_kv * vStrideB + j_kv * vStrideH + n * vStrideN;
           // Fallback Half brgemm is slower than micro gemm
           if (!std::is_same_v<scalar_t, at::Half>) {
+            // On SVE, brgemm falls back to gemm because the oneDNN ukernel path is x86-only.
             at::native::cpublas::brgemm(
                   cur_qSplitSize,
                   headSize_v,
@@ -665,7 +674,9 @@ FLEX_ATTENTION_TEMPLATE = r"""
                 headSize_v);
             }
           }
-        } else {
+        }
+{%- if not use_blas_gemm %}
+        else {
           int64_t psize = n / kvSplitSize * ekvSplitSize;
           at::native::cpublas::brgemm(
               cur_qSplitSize,
@@ -682,6 +693,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
               dst_data,
               need_pack);
         }
+{%- endif %}
       }
 
       // dst <- dst / sum[row]
@@ -1446,8 +1458,7 @@ class CppFlexAttentionTemplate(CppTemplate):
         value = kernel.permute(self.input_nodes[2], [0, 2, 1, 3])
         self.accumulate_dtype = torch.float
         self.input_dtype = query.layout.dtype
-        use_blas_gemm = torch.backends.cpu.get_cpu_capability() in ("SVE128", "SVE256")
-        use_pack_brgemm = not use_blas_gemm
+        use_blas_gemm = torch.cpu._is_sve_supported()
 
         num_threads = parallel_num_threads()
         if not isinstance(self.output_node, ir.IRNode):
@@ -1485,7 +1496,6 @@ class CppFlexAttentionTemplate(CppTemplate):
             mask_buf_idx=self.mask_buf_idx,
             partition_size=self.partition_size,
             use_blas_gemm=use_blas_gemm,
-            use_pack_brgemm=use_pack_brgemm,
         )
         with contextlib.ExitStack() as stack:
             for buf in self.fake_buffers:
@@ -1526,9 +1536,10 @@ class CppFlexAttentionTemplate(CppTemplate):
         from torch._inductor.codegen.cpp_micro_gemm import CppMicroGemmFP32Vec
         from torch._inductor.virtualized import V
 
-        use_blas_gemm = torch.backends.cpu.get_cpu_capability() in ("SVE128", "SVE256")
+        use_blas_gemm = torch.cpu._is_sve_supported()
         emit_transpose_b_micro_gemm = not use_blas_gemm
 
+        micro_gemm_trans: CppMicroGemmFP32Vec | None = None
         code_trans = ""
         if emit_transpose_b_micro_gemm:
             micro_gemm_trans = CppMicroGemmFP32Vec(
@@ -1557,7 +1568,7 @@ class CppFlexAttentionTemplate(CppTemplate):
 
         with V.set_graph_handler(V.graph):
             kernel = CppTemplateKernel("cpp_micro_gemm", parallel_num_threads())
-            if emit_transpose_b_micro_gemm:
+            if micro_gemm_trans is not None:
                 code_trans = micro_gemm_trans.codegen_define(kernel)
             code = micro_gemm.codegen_define(kernel)
         return code + code_trans

--- a/torch/_inductor/codegen/cpp_flex_attention_template.py
+++ b/torch/_inductor/codegen/cpp_flex_attention_template.py
@@ -31,23 +31,54 @@ inline void {{kernel_name}}_exp_reduce_sum_fusion_kernel(
     const int& size,
     T2* out,
     T1& val) {
-  auto vec_size = at::vec::Vectorized<T1>::size();
-  auto vec_max = at::vec::Vectorized<T1>(val);
+  constexpr auto vec_size1 = at::vec::Vectorized<T1>::size();
+  constexpr auto vec_size2 = at::vec::Vectorized<T2>::size();
+  constexpr int64_t T1_n =
+      (vec_size2 == vec_size1 * 2 && c10::is_reduced_floating_point_v<T2>) ? 2 : 1;
+  constexpr int64_t T2_n = 1;
+  using Vec = at::vec::Vectorized<T1>;
+  using VecN = at::vec::VectorizedN<T1, T1_n>;
+
+  auto vec_max = VecN(val);
+  auto vec_max_tail = Vec(val);
   T1 tmp_sum = 0;
-  auto vec_tmp_sum = at::vec::Vectorized<T1>(tmp_sum);
-  for (long i = 0; i < vec_size * (size / vec_size); i += vec_size) {
-    auto tmp0 = at::vec::Vectorized<T1>::loadu(a + i);
+  auto vec_tmp_sum = VecN(tmp_sum);
+  auto vec_tmp_sum_tail = Vec(tmp_sum);
+  const long vec_end_n = vec_size2 * (size / vec_size2);
+  const long vec_end = vec_size1 * (size / vec_size1);
+  auto exp_vec = [](const auto& v) {
+    if constexpr (
+        std::is_same_v<T1, float> &&
+        (std::is_same_v<T2, at::BFloat16> || std::is_same_v<T2, at::Half>)) {
+      return v.fexp_u20();
+    } else {
+      return v.exp_u20();
+    }
+  };
+
+  long i = 0;
+  for (; i < vec_end_n; i += vec_size2) {
+    auto tmp0 = VecN::loadu(a + i);
     auto tmp1 = tmp0 - vec_max;
-    auto tmp2 = tmp1.exp_u20();
-    vec_tmp_sum += tmp2;
+    auto tmp2 = exp_vec(tmp1);
+    vec_tmp_sum = vec_tmp_sum + tmp2;
+    auto out_n = at::vec::convert<T2, T2_n, T1, T1_n, true>(tmp2);
+    out_n.store(out + i);
+  }
+  for (; i < vec_end; i += vec_size1) {
+    auto tmp0 = Vec::loadu(a + i);
+    auto tmp1 = tmp0 - vec_max_tail;
+    auto tmp2 = exp_vec(tmp1);
+    vec_tmp_sum_tail = vec_tmp_sum_tail + tmp2;
     at::native::_store(out + i, tmp2);
   }
+  vec_tmp_sum[0] += vec_tmp_sum_tail;
   tmp_sum = at::vec::vec_reduce_all<T1>(
       [](at::vec::Vectorized<T1>& x, at::vec::Vectorized<T1>& y) {
         return x + y;
       },
       vec_tmp_sum);
-  for (long i = vec_size * (size / vec_size); i < size; i++) {
+  for (long i = vec_end; i < size; i++) {
     auto tmp0 = a[i];
     auto tmp1 = tmp0 - val;
     auto tmp2 = exp(tmp1);
@@ -66,17 +97,31 @@ inline void {{kernel_name}}_mul_reduce_max_fusion_kernel(
     const int& size,
     scalar_t* out,
     scalar_t& max) {
-  auto vec_size = at::vec::Vectorized<scalar_t>::size();
-  auto vec_scale = at::vec::Vectorized<scalar_t>(scale);
+  using Vec = at::vec::Vectorized<scalar_t>;
+  using VecN = at::vec::VectorizedN<scalar_t, 2>;
+  constexpr auto vec_size = Vec::size();
+  constexpr auto vec_size_n = VecN::size();
+  auto vec_scale = VecN(scale);
   scalar_t tmp_max = -std::numeric_limits<scalar_t>::infinity();
-  auto vec_tmp_max = at::vec::Vectorized<scalar_t>(tmp_max);
-  for (long i = 0; i < vec_size * (size / vec_size); i += vec_size) {
-    auto tmp0 = at::vec::Vectorized<scalar_t>::loadu(a + i);
+  auto vec_tmp_max = VecN(tmp_max);
+  auto vec_tmp_max_tail = Vec(tmp_max);
+  const long vec_end_n = vec_size_n * (size / vec_size_n);
+  const long vec_end = vec_size * (size / vec_size);
+  long i = 0;
+  for (; i < vec_end_n; i += vec_size_n) {
+    auto tmp0 = VecN::loadu(a + i);
     auto tmp1 = tmp0 * vec_scale;
     vec_tmp_max = at::vec::maximum(vec_tmp_max, tmp1);
+    tmp1.store(out + i);
+  }
+  for (; i < vec_end; i += vec_size) {
+    auto tmp0 = Vec::loadu(a + i);
+    auto tmp1 = tmp0 * Vec(scale);
+    vec_tmp_max_tail = at::vec::maximum(vec_tmp_max_tail, tmp1);
     at::native::_store(out + i, tmp1);
   }
-  for (long i = vec_size * (size / vec_size); i < size; i++) {
+  vec_tmp_max[0] = at::vec::maximum(vec_tmp_max[0], vec_tmp_max_tail);
+  for (; i < size; i++) {
     auto tmp0 = a[i];
     auto tmp1 = tmp0 * scale;
     tmp_max = std::max(tmp_max, tmp1);
@@ -636,7 +681,7 @@ FLEX_ATTENTION_TEMPLATE = r"""
               v_data + i_kv * vStrideB + j_kv * vStrideH + n * vStrideN;
           // Fallback Half brgemm is slower than micro gemm
           if (!std::is_same_v<scalar_t, at::Half>) {
-            // On SVE, brgemm falls back to gemm because the oneDNN ukernel path is x86-only.
+            // On AArch64, brgemm falls back to gemm because the oneDNN ukernel path is x86-only.
             at::native::cpublas::brgemm(
                   cur_qSplitSize,
                   headSize_v,
@@ -1458,7 +1503,7 @@ class CppFlexAttentionTemplate(CppTemplate):
         value = kernel.permute(self.input_nodes[2], [0, 2, 1, 3])
         self.accumulate_dtype = torch.float
         self.input_dtype = query.layout.dtype
-        use_blas_gemm = torch.cpu._is_sve_supported()
+        use_blas_gemm = torch.cpu._is_aarch64_supported()
 
         num_threads = parallel_num_threads()
         if not isinstance(self.output_node, ir.IRNode):
@@ -1536,7 +1581,7 @@ class CppFlexAttentionTemplate(CppTemplate):
         from torch._inductor.codegen.cpp_micro_gemm import CppMicroGemmFP32Vec
         from torch._inductor.virtualized import V
 
-        use_blas_gemm = torch.cpu._is_sve_supported()
+        use_blas_gemm = torch.cpu._is_aarch64_supported()
         emit_transpose_b_micro_gemm = not use_blas_gemm
 
         micro_gemm_trans: CppMicroGemmFP32Vec | None = None

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -150,11 +150,7 @@ class CuteDSLSubgraphInfo:
     body: IndentedBuffer
     template_mask: str | None = None
     template_out: str | None = None
-<<<<<<< HEAD
-    cse: CSE[Any, str] | None = None
-=======
     cse: CSE[Any, Any] | None = None
->>>>>>> 064649d86d4 (add flex-attention + SVE128 support)
 
     def __post_init__(self):
         self.only_copy_if_non_none_fields = ("cse",)

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -150,7 +150,11 @@ class CuteDSLSubgraphInfo:
     body: IndentedBuffer
     template_mask: str | None = None
     template_out: str | None = None
+<<<<<<< HEAD
     cse: CSE[Any, str] | None = None
+=======
+    cse: CSE[Any, Any] | None = None
+>>>>>>> 064649d86d4 (add flex-attention + SVE128 support)
 
     def __post_init__(self):
         self.only_copy_if_non_none_fields = ("cse",)

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -150,7 +150,7 @@ class CuteDSLSubgraphInfo:
     body: IndentedBuffer
     template_mask: str | None = None
     template_out: str | None = None
-    cse: CSE[Any, Any] | None = None
+    cse: CSE[Any, str] | None = None
 
     def __post_init__(self):
         self.only_copy_if_non_none_fields = ("cse",)

--- a/torch/_inductor/kernel/flex/flex_cpu.py
+++ b/torch/_inductor/kernel/flex/flex_cpu.py
@@ -32,8 +32,12 @@ def check_cpu_supported():
     requires_avx2_on_cpu = (
         torch.cpu._is_avx2_supported() and os.getenv("ATEN_CPU_CAPABILITY") != "default"
     )
+    requires_sve256_on_cpu = (
+        torch.backends.cpu.get_cpu_capability() == "SVE256"
+        and os.getenv("ATEN_CPU_CAPABILITY") != "default"
+    )
     supported = (
-        requires_avx2_on_cpu
+        (requires_avx2_on_cpu or requires_sve256_on_cpu)
         and not torch.xpu.is_available()
         and sys.platform != "darwin"
     )
@@ -67,7 +71,7 @@ def lower_cpu(
     score_mod_other_buffers,
     mask_mod_other_buffers,
 ):
-    """CPP based template for flex attention for x86 CPUs"""
+    """CPP based template for flex attention for x86 and AArch64 CPUs"""
     (
         _,  # q_length
         _,  # kv_length

--- a/torch/_inductor/kernel/flex/flex_cpu.py
+++ b/torch/_inductor/kernel/flex/flex_cpu.py
@@ -32,12 +32,12 @@ def check_cpu_supported():
     requires_avx2_on_cpu = (
         torch.cpu._is_avx2_supported() and os.getenv("ATEN_CPU_CAPABILITY") != "default"
     )
-    requires_sve256_on_cpu = (
-        torch.backends.cpu.get_cpu_capability() == "SVE256"
+    requires_sve_on_cpu = (
+        torch.backends.cpu.get_cpu_capability() in ("SVE128", "SVE256")
         and os.getenv("ATEN_CPU_CAPABILITY") != "default"
     )
     supported = (
-        (requires_avx2_on_cpu or requires_sve256_on_cpu)
+        (requires_avx2_on_cpu or requires_sve_on_cpu)
         and not torch.xpu.is_available()
         and sys.platform != "darwin"
     )

--- a/torch/_inductor/kernel/flex/flex_cpu.py
+++ b/torch/_inductor/kernel/flex/flex_cpu.py
@@ -33,7 +33,7 @@ def check_cpu_supported():
         torch.cpu._is_avx2_supported() and os.getenv("ATEN_CPU_CAPABILITY") != "default"
     )
     requires_sve_on_cpu = (
-        torch.backends.cpu.get_cpu_capability() in ("SVE128", "SVE256")
+        torch.cpu._is_sve_supported()
         and os.getenv("ATEN_CPU_CAPABILITY") != "default"
     )
     supported = (

--- a/torch/_inductor/kernel/flex/flex_cpu.py
+++ b/torch/_inductor/kernel/flex/flex_cpu.py
@@ -32,12 +32,12 @@ def check_cpu_supported():
     requires_avx2_on_cpu = (
         torch.cpu._is_avx2_supported() and os.getenv("ATEN_CPU_CAPABILITY") != "default"
     )
-    requires_sve_on_cpu = (
-        torch.cpu._is_sve_supported()
+    requires_arm_on_cpu = (
+        torch.cpu._is_aarch64_supported()
         and os.getenv("ATEN_CPU_CAPABILITY") != "default"
     )
     supported = (
-        (requires_avx2_on_cpu or requires_sve_on_cpu)
+        (requires_avx2_on_cpu or requires_arm_on_cpu)
         and not torch.xpu.is_available()
         and sys.platform != "darwin"
     )

--- a/torch/cpu/__init__.py
+++ b/torch/cpu/__init__.py
@@ -83,6 +83,11 @@ def _is_avx2_supported() -> bool:
     return get_capabilities().get("avx2", False)
 
 
+def _is_sve_supported() -> bool:
+    r"""Returns a bool indicating if CPU supports SVE."""
+    return torch.backends.cpu.get_cpu_capability() in ("SVE128", "SVE256")
+
+
 def _is_avx512_supported() -> bool:
     r"""Returns a bool indicating if CPU supports AVX512."""
     return get_capabilities().get("avx512_f", False)

--- a/torch/cpu/__init__.py
+++ b/torch/cpu/__init__.py
@@ -88,6 +88,16 @@ def _is_sve_supported() -> bool:
     return torch.backends.cpu.get_cpu_capability() in ("SVE128", "SVE256")
 
 
+def _is_aarch64_supported() -> bool:
+    r"""Returns a bool indicating if CPU is AArch64."""
+    return get_capabilities().get("architecture") in ("arm64", "aarch64", "ARM64")
+
+
+def _is_neon_supported() -> bool:
+    r"""Returns a bool indicating if CPU supports NEON."""
+    return get_capabilities().get("neon", False)
+
+
 def _is_avx512_supported() -> bool:
     r"""Returns a bool indicating if CPU supports AVX512."""
     return get_capabilities().get("avx512_f", False)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2420,10 +2420,13 @@ def get_all_device_types() -> list[str]:
     return ["cpu"] if not torch.cuda.is_available() else ["cpu", "cuda"]
 
 
-# skip since currently flex attention requires at least `avx2` support on CPU.
+# skip since currently flex attention requires at least `avx2` or SVE256 support on CPU.
 IS_FLEX_ATTENTION_CPU_PLATFORM_SUPPORTED = (
     not IS_MACOS
-    and torch.cpu._is_avx2_supported()
+    and (
+        torch.cpu._is_avx2_supported()
+        or torch.backends.cpu.get_cpu_capability() == "SVE256"
+    )
     and os.getenv("ATEN_CPU_CAPABILITY") != "default"
 )
 IS_FLEX_ATTENTION_XPU_PLATFORM_SUPPORTED = (
@@ -2444,7 +2447,7 @@ flex_attention_supported_platform = unittest.skipUnless(
     )
     or IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED
     or IS_FLEX_ATTENTION_MPS_PLATFORM_SUPPORTED,
-    "Requires CUDA and Triton, Intel GPU and triton, MPS, or CPU with avx2 and later",
+    "Requires CUDA and Triton, Intel GPU and triton, MPS, or CPU with avx2 and later or SVE256",
 )
 if (
     torch.version.hip

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2425,7 +2425,7 @@ IS_FLEX_ATTENTION_CPU_PLATFORM_SUPPORTED = (
     not IS_MACOS
     and (
         torch.cpu._is_avx2_supported()
-        or torch.backends.cpu.get_cpu_capability() in ("SVE128", "SVE256")
+        or torch.cpu._is_sve_supported()
     )
     and os.getenv("ATEN_CPU_CAPABILITY") != "default"
 )

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2420,12 +2420,12 @@ def get_all_device_types() -> list[str]:
     return ["cpu"] if not torch.cuda.is_available() else ["cpu", "cuda"]
 
 
-# skip since currently flex attention requires at least `avx2` or SVE256 support on CPU.
+# skip since currently flex attention requires at least `avx2` or SVE support on CPU.
 IS_FLEX_ATTENTION_CPU_PLATFORM_SUPPORTED = (
     not IS_MACOS
     and (
         torch.cpu._is_avx2_supported()
-        or torch.backends.cpu.get_cpu_capability() == "SVE256"
+        or torch.backends.cpu.get_cpu_capability() in ("SVE128", "SVE256")
     )
     and os.getenv("ATEN_CPU_CAPABILITY") != "default"
 )
@@ -2447,7 +2447,7 @@ flex_attention_supported_platform = unittest.skipUnless(
     )
     or IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED
     or IS_FLEX_ATTENTION_MPS_PLATFORM_SUPPORTED,
-    "Requires CUDA and Triton, Intel GPU and triton, MPS, or CPU with avx2 and later or SVE256",
+    "Requires CUDA and Triton, Intel GPU and triton, MPS, or CPU with avx2 and later or SVE",
 )
 if (
     torch.version.hip

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2420,13 +2420,10 @@ def get_all_device_types() -> list[str]:
     return ["cpu"] if not torch.cuda.is_available() else ["cpu", "cuda"]
 
 
-# skip since currently flex attention requires at least `avx2` or SVE support on CPU.
+# skip since currently flex attention requires at least `avx2` or AArch64 on CPU.
 IS_FLEX_ATTENTION_CPU_PLATFORM_SUPPORTED = (
     not IS_MACOS
-    and (
-        torch.cpu._is_avx2_supported()
-        or torch.cpu._is_sve_supported()
-    )
+    and (torch.cpu._is_avx2_supported() or torch.cpu._is_aarch64_supported())
     and os.getenv("ATEN_CPU_CAPABILITY") != "default"
 )
 IS_FLEX_ATTENTION_XPU_PLATFORM_SUPPORTED = (
@@ -2447,7 +2444,7 @@ flex_attention_supported_platform = unittest.skipUnless(
     )
     or IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED
     or IS_FLEX_ATTENTION_MPS_PLATFORM_SUPPORTED,
-    "Requires CUDA and Triton, Intel GPU and triton, MPS, or CPU with avx2 and later or SVE",
+    "Requires CUDA and Triton, Intel GPU and triton, MPS, or CPU with avx2 and later or AArch64",
 )
 if (
     torch.version.hip


### PR DESCRIPTION
## Summary

This PR extends CPU FlexAttention support to AArch64 across supported Arm CPU capabilities, including SVE128 and SVE256.

It also optimizes the fused softmax path, mainly improving BF16 performance.

## Testing

On an Arm Neoverse-V2 SVE128 system, the BF16 softmax optimization shows the following improvements over the baseline:

| Pattern          | Sequence length | Improvement |
| ---------------- | --------------: | ----------: |
| Dense            |           2,048 |        9.8% |
| Dense            |           8,192 |        4.1% |
| Causal           |           2,048 |       12.2% |
| Causal           |           8,192 |       12.0% |
| Local window 128 |           2,048 |       17.8% |
| Local window 128 |           8,192 |       17.7% |

For sparse local-window attention at sequence length 8,192, FlexAttention also shows the following speedups compared with FlashAttention:

| dtype | FlexAttention speedup |
| ----- | --------------------: |
| BF16  |                13.09x |
| FP32  |                23.00x |



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo