### PR TITLE
Remove incorrect claim that MemPool doesn't support expandable_segments

### DIFF
--- a/docs/source/notes/cuda.md
+++ b/docs/source/notes/cuda.md
@@ -936,8 +936,6 @@ with torch.cuda.use_mem_pool(pool):
      {class}`torch.cuda.MemPool` object is holding a reference. Only at that point, can the memory
      held by the pool be returned to the system when the pool's destructor is called using
      `del`.
-   * {class}`torch.cuda.MemPool` doesn't currently support `expandable_segments` mode of
-     CUDACachingAllocator.
    * [NCCL has specific requirements](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html#memory-allocator) for a buffer to be compatible with NVLS reductions.
      These requirements can be broken in a dynamic workload, for instance, the buffer being
      sent to NCCL by the CUDACachingAllocator might be split and hence, not correctly aligned.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185818

The doc claimed MemPool doesn't support expandable_segments, but the
code shows otherwise. In CUDACachingAllocator.cpp, expandable segments
are only disabled for pools with a custom allocator:

    bool active_user_pool =
        pool.owner_PrivatePool && pool.owner_PrivatePool->allocator();
    bool is_expandable_segments_active =
        CUDAAllocatorConfig::expandable_segments() && !active_user_pool;

A plain MemPool() (no custom allocator) gets expandable segments.