### PR TITLE
inductor/triton: host-side TMA descriptors eliminate pointwise kernel slowdown

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -94,6 +94,7 @@ from .common import (
     ArgName,
     BackendFeature,
     ConstexprArg,
+    TMADescriptorArg,
     CSE,
     CSEVariable,
     DeferredLine,
@@ -3056,6 +3057,12 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             collections.defaultdict(dict)
         )
         self.tma_min_block_sizes = dict[str, int]()
+        # Maps inner kernel-arg name (e.g. "in_ptr0") to the
+        # TensorDescriptorOptions for host-side TMA descriptor creation.
+        # The per-config launcher calls TensorDescriptor.from_tensor()
+        # before kernel launch instead of every CTA calling
+        # tl.make_tensor_descriptor() (fixes issue #185819).
+        self.host_tma_descriptor_args: dict[str, TensorDescriptorOptions] = {}
         self.hint_override = hint_override
         self._load_counts: collections.Counter[str] = collections.Counter()
         self._pdl_load_index = 0
@@ -3778,6 +3785,27 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 # but the default is zero
                 assert other == ", other=0.0"
                 other = ""
+
+            # ── Host-side TMA fast path (issue #185819) ─────────────────
+            # When the stable Triton TMA API is available and this buffer
+            # has no constant offset, skip kernel-side descriptor creation.
+            # The kernel receives a pre-built TensorDescriptor from the
+            # host launcher, eliminating per-CTA construction overhead that
+            # causes a 1.4-1.6x slowdown for simple pointwise ops.
+            #
+            # Template-forced paths (can_lift=True) manage their own
+            # host-side descriptors via ir.TMADescriptor; skip them.
+            if (
+                has_triton_stable_tma_api()
+                and config.triton.use_tensor_descriptor
+                and not indexing.can_lift
+                and indexing.constant_offset == 0
+            ):
+                if var not in self.host_tma_descriptor_args:
+                    self.host_tma_descriptor_args[var] = indexing
+                return var, other  # arg IS the pre-created descriptor
+            # ── end host-side TMA fast path ──────────────────────────────
+
         else:
             if not check:
                 # workaround https://github.com/triton-lang/triton/issues/2813
@@ -6158,6 +6186,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             flops = self.estimate_flops()
             if flops is not None:
                 out["kernel_flop"] = flops
+        if self.host_tma_descriptor_args:
+            # Pass {inner_arg: [block_dim_str, ...]} to the per-config
+            # launcher so it can call TensorDescriptor.from_tensor() with
+            # the actual autotuned XBLOCK / YBLOCK values (issue #185819).
+            out["host_tma_descriptor_args"] = {
+                inner: [str(s) for s in opts.block_shape]
+                for inner, opts in self.host_tma_descriptor_args.items()
+            }
         return out
 
     @functools.cached_property
@@ -6250,6 +6286,23 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 if symbol in V.graph.sizevars.inv_precomputed_replacements:
                     signature[i] = SizeArg(
                         arg.name, V.graph.sizevars.inv_precomputed_replacements[symbol]
+                    )
+
+        # Upgrade TensorArg -> TMADescriptorArg for host-side TMA buffers
+        # so Triton compiles the kernel with tensordesc<dtype[B0, B1]>
+        # argument types instead of raw pointers (issue #185819).
+        if self.host_tma_descriptor_args:
+            for i, (argname, arg) in enumerate(zip(argdefs, signature)):
+                if (
+                    isinstance(arg, TensorArg)
+                    and argname.name in self.host_tma_descriptor_args
+                ):
+                    tma_opts = self.host_tma_descriptor_args[argname.name]
+                    signature[i] = TMADescriptorArg(
+                        name=argname.name,
+                        api_type="stable",
+                        block_shape=list(tma_opts.block_shape),
+                        dtype=V.graph.get_dtype(arg.buffer),
                     )
 
         mutated_args: OrderedSet[str] = OrderedSet()

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2299,7 +2299,9 @@ class CompileResult(Generic[_T]):
 
     def make_launcher(self) -> LauncherType: ...
 
-    def _gen_launcher_code(self, scope, def_args, runner_args) -> LauncherType:
+    def _gen_launcher_code(
+        self, scope, def_args, runner_args, pre_runner_lines=None
+    ) -> LauncherType:
         grid = GridExpr.from_meta(self.inductor_meta, self.config)
         # grid.prefix is usually empty, grid.x_grid is something like `-(xnumel//-1024)`
         lines = [
@@ -2308,6 +2310,7 @@ class CompileResult(Generic[_T]):
             f"    grid_0 = {grid.x_grid}",
             f"    grid_1 = {grid.y_grid}",
             f"    grid_2 = {grid.z_grid}",
+            *(f"    {l}" for l in (pre_runner_lines or [])),
             f"    runner({', '.join(runner_args)})",
         ]
         launcher_code = "\n".join(lines)
@@ -2763,7 +2766,35 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
                 *call_args,
             ]
 
-        launcher = self._gen_launcher_code(scope, def_args, runner_args)
+        # ── Host-side TMA descriptors (issue #185819) ───────────────────
+        # For each buffer in host_tma_descriptor_args the compiled Triton
+        # kernel expects a TensorDescriptor argument rather than a raw
+        # pointer.  Create those descriptors here — once per launcher
+        # invocation using this config's concrete block sizes — eliminating
+        # the per-CTA tl.make_tensor_descriptor() overhead.
+        host_tma_args = self.inductor_meta.get("host_tma_descriptor_args")
+        pre_runner_lines: list[str] = []
+        if host_tma_args:
+            cfg_kwargs = cfg.kwargs
+            for inner_name, block_shape_strs in host_tma_args.items():
+                if inner_name not in call_args:
+                    continue
+                block_shape_vals = [
+                    cfg_kwargs.get(s, s) for s in block_shape_strs
+                ]
+                desc_var = f"{inner_name}_host_tma_desc"
+                pre_runner_lines.append(
+                    f"{desc_var} = triton.tools.tensor_descriptor"
+                    f".TensorDescriptor.from_tensor({inner_name}, {block_shape_vals})"
+                )
+                runner_args = [
+                    desc_var if a == inner_name else a for a in runner_args
+                ]
+        # ── end host-side TMA ─────────────────────────────────────────────
+
+        launcher = self._gen_launcher_code(
+            scope, def_args, runner_args, pre_runner_lines=pre_runner_lines
+        )
 
         launcher = scope["launcher"]
         launcher.config = cfg


### PR DESCRIPTION
Fixes #185819

## Root cause

With `triton.use_tensor_descriptor=True` the generic pointwise codegen calls `tl.make_tensor_descriptor()` **inside the Triton kernel** for every buffer access. Every CTA independently constructs the descriptor on the GPU. For a 4096x4096 bf16 SiLU with 64x64 tiles that is 4096 CTAs × 2 descriptors = ~8 k GPU-side descriptor constructions per launch vs. 2 host-side calls — causing the 1.14–1.63× slowdown.

Template paths (matmul, flex-attn) already create descriptors on the **host** via `ir.TMADescriptor` / `generate_tma_descriptor()`. The generic pointwise path never got this treatment.

## Fix

**`torch/_inductor/codegen/triton.py`**

- `TritonKernel.__init__`: add `host_tma_descriptor_args: dict[str, TensorDescriptorOptions]` to track which kernel-arg variables need host-side descriptors.
- `codegen_block_ptr`: for non-template `TensorDescriptorOptions` with `constant_offset == 0`, skip `tl.make_tensor_descriptor()`, register the arg in `host_tma_descriptor_args`, and return the arg var directly as the descriptor. `desc.load(offsets)` / `desc.store(offsets, v)` work identically regardless of where the descriptor was built.
- `codegen_kernel`: upgrade `TensorArg` → `TMADescriptorArg` for host-TMA buffers so Triton compiles the binary with `tensordesc<dtype[B0,B1]>` arg types.
- `inductor_meta_per_kernel`: expose `host_tma_descriptor_args` so the per-config launcher knows which args to wrap.

**`torch/_inductor/runtime/triton_heuristics.py`**

- `_gen_launcher_code`: add `pre_runner_lines` parameter for code emitted before `runner(...)`.
- `TritonCompileResult.make_launcher`: when `inductor_meta` contains `host_tma_descriptor_args`, generate `TensorDescriptor.from_tensor(tensor, block_shape)` calls using this config's concrete block sizes, then pass descriptors instead of raw tensors to the runner.

Template-forced paths (`can_lift=True`), block-pointer paths, and reduction kernels are all unaffected.

## Test plan
- [ ] Existing TMA descriptor tests pass
- [ ] Repro from #185819 shows slowdown ≤ 1.10×
- [ ] `test_inductor` / `test_inductor_gpu` CI green

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo