### PR TITLE
Prefer LF fleet over ARC in runner determinator

### DIFF
--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -668,7 +668,18 @@ def get_runner_prefix(
             else:
                 prefixes.append(label)
 
-    # ARC experiment takes precedence: return a fixed label prefix
+    # LF fleet takes precedence over ARC (a.k.a. OSDC): when both are enabled
+    # (e.g. a user is opted into both), prefer LF and disable ARC. OSDC is not
+    # deployed on the LF fleet yet, so it must stay off whenever LF is the
+    # active fleet, until we deploy it there.
+    if use_arc and fleet_prefix:
+        log.info(
+            "Both the LF and ARC experiments are enabled; LF takes precedence. Disabling ARC."
+        )
+        use_arc = False
+
+    # ARC experiment takes precedence over the remaining experiments: return a
+    # fixed label prefix
     if use_arc:
         arc_prefix = (
             ARC_CANARY_LABEL_PREFIX + ARC_LABEL_PREFIX

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -917,7 +917,7 @@ class TestRunnerDeterminatorArcExperiment(TestCase):
         self.assertEqual("mt-", result.prefix)
         self.assertTrue(result.use_arc)
 
-    def test_arc_takes_precedence_over_lf(self) -> None:
+    def test_lf_takes_precedence_over_arc(self) -> None:
         settings_text = """
         experiments:
             lf:
@@ -931,8 +931,27 @@ class TestRunnerDeterminatorArcExperiment(TestCase):
 
         """
         result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
-        self.assertEqual("mt-", result.prefix)
-        self.assertTrue(result.use_arc)
+        self.assertEqual("lf.", result.prefix)
+        self.assertFalse(result.use_arc)
+
+    def test_lf_takes_precedence_over_arc_canary(self) -> None:
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+            arc:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf,arc
+
+        """
+        result = rd.get_runner_prefix(
+            settings_text, ["User1"], USER_BRANCH, is_canary=True
+        )
+        self.assertEqual("lf.c.", result.prefix)
+        self.assertFalse(result.use_arc)
 
     @patch("random.uniform", return_value=10)
     def test_listed_workflow_uses_rollout_perc_enabled(


### PR DESCRIPTION
## Summary

When a workflow requestor is opted into both the `lf` and `arc` experiments, the runner determinator previously let ARC win unconditionally: the loop set `use_arc=True` and the function returned the ARC label prefix, ignoring the LF fleet entirely.

This flips the precedence so **LF wins**. ARC (a.k.a. OSDC) is not deployed on the LF fleet yet, so it must stay off whenever LF is the active fleet, until we deploy it there. The fix disables ARC (`use_arc=False`) whenever the LF fleet prefix is also set, so the run resolves to the `lf.` / `lf.c.` prefix instead of the ARC `mt-` / `c-mt-` prefix.

ARC still takes precedence over other non-fleet experiments, and ARC alone is unaffected.

The previously inverted `test_arc_takes_precedence_over_lf` test is replaced by `test_lf_takes_precedence_over_arc` (plus a canary variant).

## Test Plan

```
source ~/Storage/venv/py3.12/bin/activate
python .github/scripts/test_runner_determinator.py
```

All 62 tests pass.

> This PR was authored with the assistance of an AI coding assistant (Claude).

## CI run

https://github.com/pytorch/pytorch/actions/runs/26770740553/job/78909227982?pr=185828#step:5:49