### PR TITLE
Introduce value_expr op

### DIFF
--- a/test/inductor/test_dependencies.py
+++ b/test/inductor/test_dependencies.py
@@ -2,6 +2,7 @@
 import contextlib
 
 import torch
+from torch._inductor.codegen.cpp_utils import CppCSEVariable
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
 from torch._inductor.ir import Buffer, FixedLayout, Pointwise
@@ -9,6 +10,7 @@ from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import sympy_index_symbol
 from torch._inductor.virtualized import ops, V
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
+from torch.utils._sympy.value_ranges import ValueRanges
 
 
 class TestDependencies(InductorTestCase):
@@ -116,6 +118,22 @@ class TestDependencies(InductorTestCase):
         )
         self.assertEqual(dep1.get_offset(), 0)
         self.assertEqual(dep2.get_offset(), 1024)
+
+    def test_cpp_cse_value_expr_tracks_dependent_itervars(self):
+        x = sympy_index_symbol("x")
+
+        class DummyCSE:
+            varname_map = {}
+
+        class DummyKernel:
+            cse = DummyCSE()
+            itervars = {x}
+
+        var = CppCSEVariable("tmp0", ValueRanges.unknown(), torch.int64)
+        with V.set_kernel_handler(DummyKernel()):
+            var.update_on_args("value_expr", (x + 1, torch.int64), {})
+
+        self.assertTrue(var.depends_on(x))
 
     def test_normalize_with_stride_order_equal(self):
         x = sympy_index_symbol("x")

--- a/test/inductor/test_optimize_indexing.py
+++ b/test/inductor/test_optimize_indexing.py
@@ -1,0 +1,363 @@
+# Owner(s): ["module: inductor"]
+
+import operator
+
+import sympy
+
+import torch
+from torch._inductor.codegen.common import deduce_output_dtype_by_name
+from torch._inductor.optimize_indexing import convert_index_expr_to_value_expr
+from torch.fx import Graph
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.utils._sympy.value_ranges import ValueRanges
+
+
+class TestOptimizeIndexing(TestCase):
+    @staticmethod
+    def _make_loop_body(graph, bounds, indexing_exprs, replacement_vals, subgraphs=()):
+        class FakeBounds:
+            def __init__(self):
+                self.replacement_vals = replacement_vals
+
+            def get_bounds(self):
+                return bounds
+
+        class FakeBlock:
+            def __init__(self, graph):
+                self.graph = graph
+
+        class FakeLoopBody:
+            indirect_vars = []
+
+            def __init__(self):
+                self.root_block = FakeBlock(graph)
+                self.subblocks = {
+                    f"masked_subblock{i}": FakeBlock(subgraph)
+                    for i, subgraph in enumerate(subgraphs)
+                }
+                self.indexing_exprs = indexing_exprs
+                self._bounds = FakeBounds()
+
+            def bounds(self):
+                return self._bounds
+
+        return FakeLoopBody()
+
+    def test_index_expr_mixed_use_converts_in_place(self):
+        # When the same index_expr is used both as an index (load) and as a
+        # value (add), we convert it in-place to value_expr. The load still
+        # works because value_expr is a superset of index_expr semantics.
+        graph = Graph()
+        ops = graph.placeholder("ops")
+        get_index = graph.call_module("get_index", ("i0",))
+        index_expr = graph.call_method("index_expr", (ops, get_index, torch.int64))
+        load = graph.call_method("load", (ops, "arg0", index_expr))
+        add = graph.call_method("add", (ops, load, index_expr))
+        store_index = graph.call_module("get_index", ("i0",))
+        store = graph.call_method("store", (ops, "buf0", store_index, add, None))
+        graph.output(store)
+
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        loop_body = self._make_loop_body(
+            graph,
+            {
+                index_expr: ValueRanges(0, 1),
+                load: ValueRanges(0, 1),
+                add: ValueRanges(0, 2**40),
+            },
+            {"i0": i0},
+            {i0: ValueRanges(0, 1)},
+        )
+
+        convert_index_expr_to_value_expr(loop_body)
+
+        self.assertEqual(index_expr.target, "value_expr")
+        self.assertEqual(load.args[2], index_expr)
+        self.assertEqual(add.args[2], index_expr)
+
+    def test_value_expr_dtype_deduction_uses_requested_dtype(self):
+        self.assertEqual(
+            deduce_output_dtype_by_name("value_expr", "expr", torch.float64),
+            torch.float64,
+        )
+
+    def test_index_expr_unknown_value_use_stays_indexing(self):
+        graph = Graph()
+        ops = graph.placeholder("ops")
+        get_index = graph.call_module("get_index", ("i0",))
+        index_expr = graph.call_method("index_expr", (ops, get_index, torch.int64))
+        unknown = graph.call_method("unknown_value_op", (ops, index_expr))
+        store_index = graph.call_module("get_index", ("i0",))
+        store = graph.call_method("store", (ops, "buf0", store_index, unknown, None))
+        graph.output(store)
+
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        loop_body = self._make_loop_body(
+            graph,
+            {
+                index_expr: ValueRanges(0, 2**40),
+                unknown: ValueRanges(0, 2**40),
+            },
+            {"i0": i0},
+            {i0: ValueRanges(0, 1)},
+        )
+
+        convert_index_expr_to_value_expr(loop_body)
+
+        self.assertEqual(index_expr.target, "index_expr")
+        self.assertEqual(unknown.args[1], index_expr)
+        self.assertEqual([], [n for n in graph.nodes if n.target == "value_expr"])
+
+    def test_index_expr_load_barrier_stays_indexing(self):
+        graph = Graph()
+        ops = graph.placeholder("ops")
+        get_index = graph.call_module("get_index", ("i0",))
+        index_expr = graph.call_method("index_expr", (ops, get_index, torch.int64))
+        load = graph.call_method("load", (ops, "arg0", index_expr))
+        add = graph.call_method("add", (ops, load, load))
+        store_index = graph.call_module("get_index", ("i0",))
+        store = graph.call_method("store", (ops, "buf0", store_index, add, None))
+        graph.output(store)
+
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        loop_body = self._make_loop_body(
+            graph,
+            {
+                index_expr: ValueRanges(0, 2**40),
+                load: ValueRanges(0, 2**40),
+                add: ValueRanges(0, 2**41),
+            },
+            {"i0": i0},
+            {i0: ValueRanges(0, 1)},
+        )
+
+        convert_index_expr_to_value_expr(loop_body)
+
+        self.assertEqual(index_expr.target, "index_expr")
+        self.assertEqual(load.args[2], index_expr)
+        self.assertEqual([], [n for n in graph.nodes if n.target == "value_expr"])
+
+    def test_index_expr_sort_and_scan_value_sinks(self):
+        graph = Graph()
+        ops = graph.placeholder("ops")
+        get_index = graph.call_module("get_index", ("i0",))
+        sort_index_expr = graph.call_method("index_expr", (ops, get_index, torch.int64))
+        scan_index_expr = graph.call_method("index_expr", (ops, get_index, torch.int64))
+        sort = graph.call_method(
+            "sort",
+            (ops, (torch.int64,), (sort_index_expr,), False, False),
+        )
+        scan = graph.call_module(
+            "scan0",
+            ((torch.int64,), (scan_index_expr,)),
+        )
+        graph.output((sort, scan))
+
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        loop_body = self._make_loop_body(
+            graph,
+            {
+                sort_index_expr: ValueRanges(0, 2**40),
+                scan_index_expr: ValueRanges(0, 2**40),
+                sort: ValueRanges(0, 2**40),
+                scan: ValueRanges(0, 2**40),
+            },
+            {"i0": i0},
+            {i0: ValueRanges(0, 1)},
+        )
+
+        convert_index_expr_to_value_expr(loop_body)
+
+        self.assertEqual(sort.args[2][0].target, "value_expr")
+        self.assertEqual(scan.args[1][0].target, "value_expr")
+
+    def test_index_expr_masked_subblock_value_use(self):
+        graph = Graph()
+        ops = graph.placeholder("ops")
+        mask = graph.placeholder("mask")
+        other_get_index = graph.call_module("get_index", ("i0",))
+        other_index_expr = graph.call_method(
+            "index_expr", (ops, other_get_index, torch.int64)
+        )
+        masked = graph.call_module("masked_subblock0", (mask, other_index_expr))
+        graph.output(masked)
+
+        subgraph = Graph()
+        sub_ops = subgraph.placeholder("ops")
+        get_index = subgraph.call_module("get_index", ("i0",))
+        index_expr = subgraph.call_method(
+            "index_expr", (sub_ops, get_index, torch.int64)
+        )
+        subgraph.output(index_expr)
+
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        loop_body = self._make_loop_body(
+            graph,
+            {
+                other_index_expr: ValueRanges(0, 2**40),
+                index_expr: ValueRanges(0, 2**40),
+            },
+            {"i0": i0},
+            {i0: ValueRanges(0, 1)},
+            subgraphs=(subgraph,),
+        )
+
+        convert_index_expr_to_value_expr(loop_body)
+
+        self.assertEqual(masked.args[1].target, "value_expr")
+        self.assertEqual(index_expr.target, "value_expr")
+
+    def test_index_expr_float_value_use_preserves_requested_dtype(self):
+        graph = Graph()
+        ops = graph.placeholder("ops")
+        get_index = graph.call_module("get_index", ("i0",))
+        index_expr = graph.call_method("index_expr", (ops, get_index, torch.float32))
+        store_index = graph.call_module("get_index", ("i0",))
+        store = graph.call_method("store", (ops, "buf0", store_index, index_expr, None))
+        graph.output(store)
+
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        loop_body = self._make_loop_body(
+            graph,
+            {
+                index_expr: ValueRanges(0, 2**31),
+            },
+            {"i0": 2147483648 * i0},
+            {i0: ValueRanges(0, 1)},
+        )
+
+        convert_index_expr_to_value_expr(loop_body)
+
+        self.assertEqual(index_expr.target, "value_expr")
+        self.assertEqual(index_expr.args[2], torch.float32)
+
+    def test_index_expr_value_use_preserves_requested_dtype(self):
+        graph = Graph()
+        ops = graph.placeholder("ops")
+        get_index = graph.call_module("get_index", ("i0",))
+        index_expr = graph.call_method("index_expr", (ops, get_index, torch.int64))
+        store_index = graph.call_module("get_index", ("i0",))
+        store = graph.call_method("store", (ops, "buf0", store_index, index_expr, None))
+        graph.output(store)
+
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        loop_body = self._make_loop_body(
+            graph,
+            {
+                index_expr: ValueRanges(0, 1),
+            },
+            {"i0": i0},
+            {i0: ValueRanges(0, 1)},
+        )
+
+        convert_index_expr_to_value_expr(loop_body)
+
+        self.assertEqual(index_expr.target, "value_expr")
+        self.assertEqual(index_expr.args[2], torch.int64)
+
+    def test_existing_value_expr_dtype_is_not_rewritten(self):
+        graph = Graph()
+        ops = graph.placeholder("ops")
+        get_index = graph.call_module("get_index", ("i0",))
+        value_expr = graph.call_method("value_expr", (ops, get_index, torch.int64))
+        index_expr = graph.call_method("index_expr", (ops, get_index, torch.int64))
+        load = graph.call_method("load", (ops, "arg0", index_expr))
+        add = graph.call_method("add", (ops, load, value_expr))
+        store_index = graph.call_module("get_index", ("i0",))
+        store = graph.call_method("store", (ops, "buf0", store_index, add, None))
+        graph.output(store)
+
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        loop_body = self._make_loop_body(
+            graph,
+            {
+                value_expr: ValueRanges(0, 1),
+                index_expr: ValueRanges(0, 1),
+                load: ValueRanges(0, 1),
+                add: ValueRanges(0, 2),
+            },
+            {"i0": i0},
+            {i0: ValueRanges(0, 1)},
+        )
+
+        convert_index_expr_to_value_expr(loop_body)
+
+        self.assertEqual(value_expr.target, "value_expr")
+        self.assertEqual(value_expr.args[2], torch.int64)
+        self.assertEqual(index_expr.target, "index_expr")
+
+    def test_index_expr_getitem_value_use_propagates_to_tuple_source(self):
+        graph = Graph()
+        ops = graph.placeholder("ops")
+        get_index = graph.call_module("get_index", ("i0",))
+        index_expr = graph.call_method("index_expr", (ops, get_index, torch.float32))
+        frexp = graph.call_method("frexp", (ops, index_expr))
+        getitem = graph.call_function(operator.getitem, (frexp, 0))
+        store_index = graph.call_module("get_index", ("i0",))
+        store = graph.call_method("store", (ops, "buf0", store_index, getitem, None))
+        graph.output(store)
+
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        loop_body = self._make_loop_body(
+            graph,
+            {
+                index_expr: ValueRanges(0, 1),
+                frexp: ValueRanges(0, 1),
+                getitem: ValueRanges(0, 1),
+            },
+            {"i0": i0},
+            {i0: ValueRanges(0, 1)},
+        )
+
+        convert_index_expr_to_value_expr(loop_body)
+
+        self.assertEqual(index_expr.target, "value_expr")
+        self.assertEqual(index_expr.args[2], torch.float32)
+
+    def test_index_expr_masked_subblock_mixed_use_stays_indexing(self):
+        graph = Graph()
+        ops = graph.placeholder("ops")
+        mask = graph.placeholder("mask")
+        other_get_index = graph.call_module("get_index", ("i0",))
+        other_index_expr = graph.call_method(
+            "index_expr", (ops, other_get_index, torch.int64)
+        )
+        masked = graph.call_module("masked_subblock0", (mask, other_index_expr))
+        load = graph.call_method("load", (ops, "arg0", masked))
+        add = graph.call_method("add", (ops, load, masked))
+        store_index = graph.call_module("get_index", ("i0",))
+        store = graph.call_method("store", (ops, "buf0", store_index, add, None))
+        graph.output(store)
+
+        subgraph = Graph()
+        sub_ops = subgraph.placeholder("ops")
+        get_index = subgraph.call_module("get_index", ("i0",))
+        index_expr = subgraph.call_method(
+            "index_expr", (sub_ops, get_index, torch.int64)
+        )
+        subgraph.output(index_expr)
+
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        loop_body = self._make_loop_body(
+            graph,
+            {
+                other_index_expr: ValueRanges(0, 2**40),
+                masked: ValueRanges(0, 2**40),
+                load: ValueRanges(0, 1),
+                add: ValueRanges(0, 2**40),
+                index_expr: ValueRanges(0, 2**40),
+            },
+            {"i0": i0},
+            {i0: ValueRanges(0, 1)},
+            subgraphs=(subgraph,),
+        )
+
+        convert_index_expr_to_value_expr(loop_body)
+
+        self.assertEqual(masked.args[1].target, "index_expr")
+        output_node = next(n for n in subgraph.nodes if n.op == "output")
+        self.assertEqual(output_node.args[0].target, "index_expr")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3378,6 +3378,16 @@ class CommonTemplate:
 
         self.common(fn, (torch.zeros(5, dtype=torch.int64),), check_lowp=False)
 
+    @xfail_if_triton_cpu
+    def test_arange9(self):
+        # int64 arange used inside a reduction: reduction must accumulate
+        # at int64 precision even though each per-element value fits int32.
+        def fn(x):
+            idx = torch.arange(0, 100, device=x.device, dtype=torch.int64)
+            return (idx * int(1e7)).sum()
+
+        self.common(fn, (torch.zeros(1, device=self.device),))
+
     def test_linspace1(self):
         def fn(x):
             return torch.linspace(0.125, 0.875, 7, device=x.device) + x
@@ -3671,6 +3681,18 @@ class CommonTemplate:
 
         with torch.no_grad():
             self.assertEqual(cfn(x, i), fn(x, i))
+
+    @skipCPUIf(True, "requires CUDA/Triton")
+    @requires_cuda_and_triton
+    def test_builtins_round_float_ndigits_neg_uses_value_expr(self):
+        def fn(x, i):
+            return x + round(i / 2 * 123.4567, -1)
+
+        fn_opt = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=True)
+        x = torch.zeros(2, device=self.device)
+        i = 2
+        with torch.no_grad():
+            self.assertEqual(fn_opt(x, i), fn(x, i))
 
     def test_builtins_round_int_ndigits_pos(self):
         def fn(x, i):
@@ -17677,6 +17699,51 @@ if RUN_GPU:
             inps = [torch.randn(2, 4, 16, 16, device=GPU_TYPE)]
             code = run_and_get_triton_code(fn_opt, *inps)
             self.assertTrue("to(tl.int32)" in code)
+            self.assertFalse("to(tl.int64)" in code)
+
+            self.assertEqual(fn_opt(*inps), fn(*inps))
+
+        def test_index_expr_pure_indexing_no_int64(self):
+            def fn(x: torch.Tensor) -> torch.Tensor:
+                idx = torch.arange(0, 128, device=GPU_TYPE, dtype=torch.int64)
+                return x[(idx * 2) % 128]
+
+            fn_opt = torch.compile(fn, backend="inductor")
+            inps = [torch.randn(128, device=GPU_TYPE)]
+            code = run_and_get_triton_code(fn_opt, *inps)
+            self.assertFalse("to(tl.int64)" in code)
+
+            self.assertEqual(fn_opt(*inps), fn(*inps))
+
+        def test_value_expr_float_preserves_integer_intermediates(self):
+            def fn(x: torch.Tensor) -> torch.Tensor:
+                idx = torch.arange(x.numel(), device=x.device, dtype=torch.int64)
+                return ((idx + 2048) % 2048).to(torch.float16)
+
+            fn_opt = torch.compile(fn, backend="inductor")
+            inps = [torch.empty(4096, device=GPU_TYPE)]
+            self.assertEqual(fn_opt(*inps), fn(*inps))
+
+        def test_value_expr_dynamic_shape_bounds(self):
+            def fn(x: torch.Tensor) -> torch.Tensor:
+                idx = torch.arange(x.numel(), device=x.device, dtype=torch.int64)
+                return idx.to(torch.float32)
+
+            fn_opt = torch.compile(fn, backend="inductor", dynamic=True)
+            x = torch.empty(8, device=GPU_TYPE)
+            torch._dynamo.mark_dynamic(x, 0)
+            self.assertEqual(fn_opt(x), fn(x))
+
+        def test_searchsorted_boundary_index_no_int64_cast(self):
+            def fn(boundaries: torch.Tensor, values: torch.Tensor) -> torch.Tensor:
+                return torch.searchsorted(boundaries, values, out_int32=False)
+
+            fn_opt = torch.compile(fn, backend="inductor")
+            inps = [
+                torch.tensor([[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]], device=GPU_TYPE),
+                torch.tensor([[0.1, 0.5], [1.5, 2.5]], device=GPU_TYPE),
+            ]
+            code = run_and_get_triton_code(fn_opt, *inps)
             self.assertFalse("to(tl.int64)" in code)
 
             self.assertEqual(fn_opt(*inps), fn(*inps))

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -135,6 +135,7 @@ test_failures = {
     "test_arange4_dynamic_shapes": TestFailure(("cpu",)),
     "test_arange6_dynamic_shapes": TestFailure(("cpu",)),
     "test_arange7_dynamic_shapes": TestFailure(("cpu",)),
+    "test_arange9_dynamic_shapes": TestFailure(("cpu",)),
     "test_clamp_type_promotion_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv2d_channels_last_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv3d_dynamic_shapes": TestFailure(("cpu",)),

--- a/torch/_inductor/bounds.py
+++ b/torch/_inductor/bounds.py
@@ -194,6 +194,10 @@ class ValueRangeAnalysis(SymPyValueRangeAnalysis, DefaultHandler):
         assert isinstance(index, ValueRanges)
         return cls.to_dtype(index, dtype)
 
+    @classmethod
+    def value_expr(cls, index: Any, dtype: torch.dtype) -> ValueRanges[Any]:
+        return cls.index_expr(index, dtype)
+
     @staticmethod
     # pyrefly: ignore [bad-override]
     def to_dtype(

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -688,6 +688,7 @@ def deduce_output_dtype_by_name(
     elif op_name in (
         "to_dtype",
         "index_expr",
+        "value_expr",
     ):
         return kwargs["dtype"] if "dtype" in kwargs else args[-1]
     elif op_name in (

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -973,6 +973,10 @@ class CppOverrides(OpOverrides):
         return ops.to_dtype(var, dtype)
 
     @staticmethod
+    def value_expr(expr, dtype):
+        return CppOverrides.index_expr(expr, dtype)
+
+    @staticmethod
     def masked(mask, body, other):
         code = BracesBuffer()
 
@@ -1803,6 +1807,10 @@ class CppVecOverrides(CppOverrides):
         return csevar
 
     @staticmethod
+    def value_expr(expr, dtype):
+        return CppVecOverrides.index_expr(expr, dtype)
+
+    @staticmethod
     def frexp(x):
         cache_keys = f"frexp({x})[0]", f"frexp({x})[1]"
         if all(V.kernel.cse.try_get(cache_key) is not None for cache_key in cache_keys):
@@ -1937,6 +1945,10 @@ class CppTile2DOverrides(CppVecOverrides):
         assert isinstance(V.kernel, CppTile2DKernel)
         expr = V.kernel.transform_indexing(expr)
         return CppVecOverrides.index_expr(expr, dtype)
+
+    @staticmethod
+    def value_expr(expr, dtype):
+        return CppTile2DOverrides.index_expr(expr, dtype)
 
 
 class CppKernel(Kernel):
@@ -3958,15 +3970,24 @@ class TilingSelect:
                 )
                 op_counter: dict[str, int] = {}
                 # ops may cause overhead with vectorization, like non-contiguous
-                # index_expr, load, store
+                # index/value_expr, load, store
                 non_contig_indexing_op_counter: dict[str, int] = {}
                 for _body in loop_bodies:
                     sub_blocks = [_body.root_block] + list(_body.subblocks.values())
                     for sub_block in sub_blocks:
                         for _node in sub_block.graph.nodes:
-                            if _node.target in ["index_expr", "load", "store"]:
+                            if _node.target in [
+                                "index_expr",
+                                "value_expr",
+                                "load",
+                                "store",
+                            ]:
                                 # get the index and replace prefix from z to x
-                                arg_idx = 1 if _node.target == "index_expr" else 2
+                                arg_idx = (
+                                    1
+                                    if _node.target in ("index_expr", "value_expr")
+                                    else 2
+                                )
                                 index = sub_block.body.indexing_from_args(
                                     (vars, reduction_vars)
                                 )[_node.args[arg_idx].args[0]]
@@ -3976,7 +3997,7 @@ class TilingSelect:
                                     )
                                     if (
                                         stride is None
-                                        if _node.target == "index_expr"
+                                        if _node.target in ("index_expr", "value_expr")
                                         else stride not in [0, 1]
                                     ):
                                         _update_negative_op_count(
@@ -4002,7 +4023,7 @@ class TilingSelect:
                     op_num > 0
                     and non_contig_indexing_op_num / op_num >= ratio_threshold
                 ):
-                    # Too many non-contiguous load/store/index_expr which hurts the
+                    # Too many non-contiguous load/store/index/value_expr which hurts the
                     # vectorization performance. Disable vectorization when exceeding
                     # the thresholds.
                     return [], []
@@ -4158,7 +4179,12 @@ class CppKernelProxy(CppKernel):
                 if node.target == "load":
                     assert len(node.args) == 3
                     return V.graph.get_dtype(node.args[1])  # type: ignore[arg-type]
-                elif node.target in ["to_dtype", "constant", "index_expr"]:
+                elif node.target in [
+                    "to_dtype",
+                    "constant",
+                    "index_expr",
+                    "value_expr",
+                ]:
                     return node.args[-1]  # type: ignore[return-value]
                 elif node.target == "to_dtype_bitcast":
                     return node.args[2]  # type: ignore[return-value]
@@ -4193,7 +4219,7 @@ class CppKernelProxy(CppKernel):
             to_lowp_fp_legalized_nodes = []
             for _node in sub_graph_nodes:
                 if (
-                    _node.target in ["load", "index_expr"]
+                    _node.target in ["load", "index_expr", "value_expr"]
                     and (dt := get_output_dtype(_node)) in DTYPE_LOWP_FP
                 ):
                     # No need to promote to float if all users are ops that accepts lowp fp input

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -173,7 +173,7 @@ class CppCSEVariable(CSEVariable):
                     if isinstance(arg, CppCSEVariable)
                 ]
             )
-            if name == "index_expr":
+            if name in ("index_expr", "value_expr"):
                 self._set_dependent_itervars(args[0])
             if any(arg.is_vec for arg in args if isinstance(arg, CppCSEVariable)):
                 self.is_vec = True

--- a/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
@@ -324,6 +324,10 @@ class CuteDSLOpOverrides(OpOverrides):
         return result
 
     @staticmethod
+    def value_expr(expr: sympy.Expr, dtype: torch.dtype) -> CuteDSLArg:
+        return CuteDSLOpOverrides.index_expr(expr, dtype)
+
+    @staticmethod
     def add(a: CuteDSLArg, b: CuteDSLArg) -> CuteDSLArg:
         return CuteDSLOpOverrides._apply_binary_op(
             a, b, "({a} + {b})", lambda a_expr, b_expr: a_expr + b_expr

--- a/torch/_inductor/codegen/halide.py
+++ b/torch/_inductor/codegen/halide.py
@@ -599,6 +599,16 @@ class HalideOverrides(OpOverrides):
         return var
 
     @classmethod
+    def value_expr(cls, expr, dtype):
+        index = V.kernel.prepare_indexing(expr)
+        var = V.kernel.genfunc(
+            V.kernel.index_to_str(index),
+            V.kernel.used_dims_from_index(index),
+            bounds=get_bounds_index_expr(expr),
+        )
+        return ops.to_dtype(var, dtype)
+
+    @classmethod
     def indirect_indexing(cls, index_var, size, check=True, wrap_neg=True):
         # TODO(jansel): Halide only supports 32-bit indexing, we should error on overflow
         index_var = ops.to_dtype(index_var, torch.int32)

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -220,6 +220,10 @@ class MetalOverrides(OpOverrides):
         return ops.to_dtype(var, dtype)
 
     @staticmethod
+    def value_expr(expr: sympy.Expr, dtype: torch.dtype) -> str:
+        return MetalOverrides.index_expr(expr, dtype)
+
+    @staticmethod
     def masked(mask: CSEVariable, body: sympy.Expr, other: CSEVariable) -> str:
         # TODO: Type annotation for other is wrong, it's often float or int
         # TODO: Should it be converted to lambda on MacOS-15+?

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -316,6 +316,10 @@ class PallasKernelOverrides(OpOverrides):
         return PallasKernelOverrides.to_dtype(var, dtype)
 
     @staticmethod
+    def value_expr(expr: sympy.Expr, dtype: torch.dtype) -> str:
+        return PallasKernelOverrides.index_expr(expr, dtype)
+
+    @staticmethod
     def constant(val, dtype: torch.dtype) -> str:
         """Convert a constant value to JAX representation."""
         jax_dtype = torch_dtype_to_jax(dtype)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -44,7 +44,10 @@ if TYPE_CHECKING:
     from ..ir import IRNode
 
 from ..ops_handler import WrapperHandler
-from ..optimize_indexing import indexing_dtype_strength_reduction
+from ..optimize_indexing import (
+    convert_index_expr_to_value_expr,
+    indexing_dtype_strength_reduction,
+)
 from ..runtime.coordinate_descent_tuner import CoordescTuner
 from ..runtime.hints import DeviceProperties
 from ..runtime.runtime_utils import green_text, last_power_of_2, yellow_text
@@ -571,6 +574,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         self.min_xblock: int | None = None
         self.min_rblock: int | None = None
         self.saved_partial_accumulate: list[PartialAccumulate] = []
+        self._index_dtype = self.features.select_index_dtype()
 
     def codegen_template_body(
         self,
@@ -619,7 +623,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         raise NotImplementedError
 
     def get_index_dtype_as_torch_dtype(self) -> torch.dtype:
-        return self.features.select_index_dtype()
+        return self._index_dtype
 
     @property
     def index_dtype(self) -> str:
@@ -3162,6 +3166,7 @@ class SIMDScheduling(BaseScheduling):
                 else:
                     # TODO - use split ranges ?
                     indexing_dtype_strength_reduction(node._body)
+                    convert_index_expr_to_value_expr(node._body)
                     index_vars = kernel.split_and_set_ranges(node.get_ranges())
                     node.codegen(index_vars)
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2464,77 +2464,53 @@ class TritonKernelOverrides(TritonOverrides):
     def _value_expr_index_str(
         cls, indexing: IndexingOptions, dtype: torch.dtype
     ) -> str:
-        index = cls._cast_expr_vars_to(indexing.index, dtype)
+        # Cast at least one operand to ``dtype`` before printing so Triton
+        # promotes the whole expression (including large int literals that
+        # would overflow int32 if all operands were int32).
+        index = cls._upcast_one_operand(indexing.index, dtype)
         index_dtype = V.kernel._index_dtype
         V.kernel._index_dtype = dtype
         try:
             index_str = V.kernel.index_to_str(index)
         finally:
             V.kernel._index_dtype = index_dtype
+        triton_dtype = triton_type(dtype)
         if is_sympy_integer_like(indexing.index):
-            return f"tl.full({indexing.expand_str}, {index_str}, {triton_type(dtype)})"
+            return f"tl.full({indexing.expand_str}, {index_str}, {triton_dtype})"
         if indexing.expand_str is not None:
             return f"tl.broadcast_to({index_str}, {indexing.expand_str})"
         return index_str
 
     @classmethod
-    def _cast_expr_vars_to(cls, index: sympy.Expr, dtype: torch.dtype) -> sympy.Expr:
+    def _upcast_one_operand(
+        cls, index: sympy.Expr, dtype: torch.dtype
+    ) -> sympy.Expr:
         """
-        Emit CSE'd casts to ``dtype`` of each symbolic variable referenced
-        by ``index`` and return a new expression that references the casted
-        temporaries.
-
-        Casting at least one operand forces Triton to perform the surrounding
-        arithmetic at ``dtype``'s width, which is what callers want when the
-        expression participates in value computation rather than indexing.
+        Cast one variable in ``index`` to ``dtype`` so Triton promotes the
+        entire expression. Without this, large integer constants in the
+        expression overflow int32 at Triton parse time.
         """
-        replacements: dict[sympy.Symbol, sympy.Symbol] = {}
         triton_dtype = triton_type(dtype)
-        scalar_int_types = (
-            SymT.INDEX,
-            SymT.PRECOMPUTED_SIZE,
-            SymT.SIZE,
-            SymT.UNBACKED_INT,
-        )
-        scalar_float_types = (SymT.FLOAT, SymT.UNBACKED_FLOAT)
         for sym in sorted(index.free_symbols, key=operator.attrgetter("name")):
             if not isinstance(sym, sympy.Symbol):
                 continue
-
             if symbol_is_type(sym, TritonSymbols.block_types):
                 name = sym.name
                 shape = TritonSymbols.get_block_shape(sym)
-                src_dtype = V.kernel.get_index_dtype_as_torch_dtype()
             elif symbol_is_type(sym, SymT.TMP):
-                src_var = V.kernel.cse.varname_map[sym.name]
-                shape = src_var.shape
-                src_dtype = src_var.dtype
                 name = sym.name
-            elif symbol_is_type(sym, scalar_int_types):
-                name = V.kernel.index_to_str(sym)
-                shape = ()
-                src_dtype = torch.int64
-            elif symbol_is_type(sym, scalar_float_types):
-                name = V.kernel.index_to_str(sym)
-                shape = ()
-                src_dtype = torch.float64
+                shape = V.kernel.cse.varname_map[sym.name].shape
             else:
-                continue
-            if is_integer_dtype(dtype) and src_dtype.is_floating_point:
-                continue
-            if src_dtype in (dtype, torch.bool):
-                continue
-
+                name = V.kernel.index_to_str(sym)
+                shape = ()
             cast_var = V.kernel.cse.generate(
                 V.kernel.compute,
                 f"({name}).to({triton_dtype})",
                 dtype=dtype,
                 shape=shape,
             )
-            replacements[sym] = sympy.Symbol(str(cast_var))
-        if not replacements:
-            return index
-        return sympy_subs(index, replacements)
+            return sympy_subs(index, {sym: sympy.Symbol(str(cast_var))})
+        return index
 
     @staticmethod
     def masked(mask, body, other):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1778,6 +1778,10 @@ class TritonOverrides(OpOverrides):
     def index_expr(cls, expr, dtype):
         raise NotImplementedError("ops.index_expr not implemented outside a kernel")
 
+    @classmethod
+    def value_expr(cls, expr, dtype):
+        raise NotImplementedError("ops.value_expr not implemented outside a kernel")
+
     @staticmethod
     def masked(mask, body, other):
         raise NotImplementedError("ops.masked not implemented outside a kernel")
@@ -2323,7 +2327,7 @@ class TritonKernelOverrides(TritonOverrides):
         return cls._shaped_constant(value, dtype, shape=shape)
 
     @classmethod
-    def index_expr(cls, expr, dtype):
+    def _prepare_expr_indexing(cls, expr, dtype):
         expr = _materialize_trunc_to_float_expr(expr, dtype)
         indexing = V.kernel.indexing(
             expr, block_ptr=False, tma_compatibility_checker=None
@@ -2335,7 +2339,35 @@ class TritonKernelOverrides(TritonOverrides):
             shape = indexing.expand_shape
         else:
             shape = TritonSymbols.get_block_shape(indexing.index)
+        return expr, indexing, shape
 
+    @classmethod
+    def _emit_expr_indexing(
+        cls,
+        expr,
+        indexing,
+        shape,
+        index_str,
+        cast_dtype,
+        output_dtype,
+        *,
+        use_compute_types,
+    ):
+        var = V.kernel.cse.generate(
+            V.kernel.compute,
+            cls.to_dtype(
+                f"({index_str})", cast_dtype, use_compute_types=use_compute_types
+            ),
+            dtype=output_dtype,
+            bounds=get_bounds_index_expr(expr),
+            shape=shape,
+        )
+        var.mask_vars = indexing.mask_vars
+        return var
+
+    @classmethod
+    def index_expr(cls, expr, dtype):
+        expr, indexing, shape = cls._prepare_expr_indexing(expr, dtype)
         # Our sympy expr printing casts to the current kernel index dtype.
         # we only respect non int32-int64 dtypes and otherwise use current kernel indexing dtype
         index_dtype = V.kernel.get_index_dtype_as_torch_dtype()
@@ -2384,6 +2416,125 @@ class TritonKernelOverrides(TritonOverrides):
 
         var.mask_vars = indexing.mask_vars
         return var
+
+    @classmethod
+    def value_expr(cls, expr, dtype):
+        """
+        Like :meth:`index_expr`, but honors ``dtype``. This is the right op when
+        the user explicitly requested ``dtype`` (e.g. ``arange(int64)``
+        whose result participates in tensor computation).
+        """
+        expr, indexing, shape = cls._prepare_expr_indexing(expr, dtype)
+
+        # Pick the dtype for the integer arithmetic inside the expression.
+        # TODO: use bounds analysis to narrow to int32 when safe, avoiding
+        # unnecessary int64 widening for float-targeted expressions.
+        if expr.is_integer and (dtype.is_floating_point or dtype == torch.bool):
+            compute_dtype = torch.int64
+        else:
+            compute_dtype = dtype
+
+        index_str = cls._value_expr_index_str(indexing, compute_dtype)
+        var = cls._emit_expr_indexing(
+            expr,
+            indexing,
+            shape,
+            index_str,
+            compute_dtype,
+            compute_dtype,
+            use_compute_types=False,
+        )
+
+        if compute_dtype != dtype:
+            var = V.kernel.cse.generate(
+                V.kernel.compute,
+                cls.to_dtype(
+                    var,
+                    dtype,
+                    src_dtype=compute_dtype,
+                    use_compute_types=False,
+                ),
+                dtype=dtype,
+                shape=var.shape,
+            )
+            var.mask_vars = indexing.mask_vars
+        return var
+
+    @classmethod
+    def _value_expr_index_str(
+        cls, indexing: IndexingOptions, dtype: torch.dtype
+    ) -> str:
+        index = cls._cast_expr_vars_to(indexing.index, dtype)
+        index_dtype = V.kernel._index_dtype
+        V.kernel._index_dtype = dtype
+        try:
+            index_str = V.kernel.index_to_str(index)
+        finally:
+            V.kernel._index_dtype = index_dtype
+        if is_sympy_integer_like(indexing.index):
+            return f"tl.full({indexing.expand_str}, {index_str}, {triton_type(dtype)})"
+        if indexing.expand_str is not None:
+            return f"tl.broadcast_to({index_str}, {indexing.expand_str})"
+        return index_str
+
+    @classmethod
+    def _cast_expr_vars_to(cls, index: sympy.Expr, dtype: torch.dtype) -> sympy.Expr:
+        """
+        Emit CSE'd casts to ``dtype`` of each symbolic variable referenced
+        by ``index`` and return a new expression that references the casted
+        temporaries.
+
+        Casting at least one operand forces Triton to perform the surrounding
+        arithmetic at ``dtype``'s width, which is what callers want when the
+        expression participates in value computation rather than indexing.
+        """
+        replacements: dict[sympy.Symbol, sympy.Symbol] = {}
+        triton_dtype = triton_type(dtype)
+        scalar_int_types = (
+            SymT.INDEX,
+            SymT.PRECOMPUTED_SIZE,
+            SymT.SIZE,
+            SymT.UNBACKED_INT,
+        )
+        scalar_float_types = (SymT.FLOAT, SymT.UNBACKED_FLOAT)
+        for sym in sorted(index.free_symbols, key=operator.attrgetter("name")):
+            if not isinstance(sym, sympy.Symbol):
+                continue
+
+            if symbol_is_type(sym, TritonSymbols.block_types):
+                name = sym.name
+                shape = TritonSymbols.get_block_shape(sym)
+                src_dtype = V.kernel.get_index_dtype_as_torch_dtype()
+            elif symbol_is_type(sym, SymT.TMP):
+                src_var = V.kernel.cse.varname_map[sym.name]
+                shape = src_var.shape
+                src_dtype = src_var.dtype
+                name = sym.name
+            elif symbol_is_type(sym, scalar_int_types):
+                name = V.kernel.index_to_str(sym)
+                shape = ()
+                src_dtype = torch.int64
+            elif symbol_is_type(sym, scalar_float_types):
+                name = V.kernel.index_to_str(sym)
+                shape = ()
+                src_dtype = torch.float64
+            else:
+                continue
+            if is_integer_dtype(dtype) and src_dtype.is_floating_point:
+                continue
+            if src_dtype in (dtype, torch.bool):
+                continue
+
+            cast_var = V.kernel.cse.generate(
+                V.kernel.compute,
+                f"({name}).to({triton_dtype})",
+                dtype=dtype,
+                shape=shape,
+            )
+            replacements[sym] = sympy.Symbol(str(cast_var))
+        if not replacements:
+            return index
+        return sympy_subs(index, replacements)
 
     @staticmethod
     def masked(mask, body, other):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2327,7 +2327,7 @@ class TritonKernelOverrides(TritonOverrides):
         return cls._shaped_constant(value, dtype, shape=shape)
 
     @classmethod
-    def _prepare_expr_indexing(cls, expr, dtype):
+    def index_expr(cls, expr, dtype):
         expr = _materialize_trunc_to_float_expr(expr, dtype)
         indexing = V.kernel.indexing(
             expr, block_ptr=False, tma_compatibility_checker=None
@@ -2339,35 +2339,7 @@ class TritonKernelOverrides(TritonOverrides):
             shape = indexing.expand_shape
         else:
             shape = TritonSymbols.get_block_shape(indexing.index)
-        return expr, indexing, shape
 
-    @classmethod
-    def _emit_expr_indexing(
-        cls,
-        expr,
-        indexing,
-        shape,
-        index_str,
-        cast_dtype,
-        output_dtype,
-        *,
-        use_compute_types,
-    ):
-        var = V.kernel.cse.generate(
-            V.kernel.compute,
-            cls.to_dtype(
-                f"({index_str})", cast_dtype, use_compute_types=use_compute_types
-            ),
-            dtype=output_dtype,
-            bounds=get_bounds_index_expr(expr),
-            shape=shape,
-        )
-        var.mask_vars = indexing.mask_vars
-        return var
-
-    @classmethod
-    def index_expr(cls, expr, dtype):
-        expr, indexing, shape = cls._prepare_expr_indexing(expr, dtype)
         # Our sympy expr printing casts to the current kernel index dtype.
         # we only respect non int32-int64 dtypes and otherwise use current kernel indexing dtype
         index_dtype = V.kernel.get_index_dtype_as_torch_dtype()
@@ -2420,97 +2392,19 @@ class TritonKernelOverrides(TritonOverrides):
     @classmethod
     def value_expr(cls, expr, dtype):
         """
-        Like :meth:`index_expr`, but honors ``dtype``. This is the right op when
-        the user explicitly requested ``dtype`` (e.g. ``arange(int64)``
-        whose result participates in tensor computation).
+        Like :meth:`index_expr`, but casts the result to ``dtype``.
         """
-        expr, indexing, shape = cls._prepare_expr_indexing(expr, dtype)
-
-        # Pick the dtype for the integer arithmetic inside the expression.
-        # TODO: use bounds analysis to narrow to int32 when safe, avoiding
-        # unnecessary int64 widening for float-targeted expressions.
-        if expr.is_integer and (dtype.is_floating_point or dtype == torch.bool):
-            compute_dtype = torch.int64
-        else:
-            compute_dtype = dtype
-
-        index_str = cls._value_expr_index_str(indexing, compute_dtype)
-        var = cls._emit_expr_indexing(
-            expr,
-            indexing,
-            shape,
-            index_str,
-            compute_dtype,
-            compute_dtype,
-            use_compute_types=False,
-        )
-
-        if compute_dtype != dtype:
+        # TODO: upcast operands so expressions with large int literals
+        # (> 2^31) don't fail at Triton parse time.
+        var = cls.index_expr(expr, dtype)
+        if var.dtype != dtype:
             var = V.kernel.cse.generate(
                 V.kernel.compute,
-                cls.to_dtype(
-                    var,
-                    dtype,
-                    src_dtype=compute_dtype,
-                    use_compute_types=False,
-                ),
+                f"({var}).to({triton_type(dtype)})",
                 dtype=dtype,
                 shape=var.shape,
             )
-            var.mask_vars = indexing.mask_vars
         return var
-
-    @classmethod
-    def _value_expr_index_str(
-        cls, indexing: IndexingOptions, dtype: torch.dtype
-    ) -> str:
-        # Cast at least one operand to ``dtype`` before printing so Triton
-        # promotes the whole expression (including large int literals that
-        # would overflow int32 if all operands were int32).
-        index = cls._upcast_one_operand(indexing.index, dtype)
-        index_dtype = V.kernel._index_dtype
-        V.kernel._index_dtype = dtype
-        try:
-            index_str = V.kernel.index_to_str(index)
-        finally:
-            V.kernel._index_dtype = index_dtype
-        triton_dtype = triton_type(dtype)
-        if is_sympy_integer_like(indexing.index):
-            return f"tl.full({indexing.expand_str}, {index_str}, {triton_dtype})"
-        if indexing.expand_str is not None:
-            return f"tl.broadcast_to({index_str}, {indexing.expand_str})"
-        return index_str
-
-    @classmethod
-    def _upcast_one_operand(
-        cls, index: sympy.Expr, dtype: torch.dtype
-    ) -> sympy.Expr:
-        """
-        Cast one variable in ``index`` to ``dtype`` so Triton promotes the
-        entire expression. Without this, large integer constants in the
-        expression overflow int32 at Triton parse time.
-        """
-        triton_dtype = triton_type(dtype)
-        for sym in sorted(index.free_symbols, key=operator.attrgetter("name")):
-            if not isinstance(sym, sympy.Symbol):
-                continue
-            if symbol_is_type(sym, TritonSymbols.block_types):
-                name = sym.name
-                shape = TritonSymbols.get_block_shape(sym)
-            elif symbol_is_type(sym, SymT.TMP):
-                name = sym.name
-                shape = V.kernel.cse.varname_map[sym.name].shape
-            else:
-                name = V.kernel.index_to_str(sym)
-                shape = ()
-            cast_var = V.kernel.cse.generate(
-                V.kernel.compute,
-                f"({name}).to({triton_dtype})",
-                dtype=dtype,
-                shape=shape,
-            )
-            return sympy_subs(index, {sym: sympy.Symbol(str(cast_var))})
-        return index
 
     @staticmethod
     def masked(mask, body, other):

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -596,6 +596,9 @@ class _RecordLoadStoreInner(V.MockHandler):  # type: ignore[name-defined]
     def index_expr(self, index: sympy.Expr, dtype: torch.dtype | None) -> None:
         self._index_exprs.add(IndexExprDep(*self.canonicalize(index)))
 
+    def value_expr(self, index: sympy.Expr, dtype: torch.dtype | None) -> None:
+        self._index_exprs.add(IndexExprDep(*self.canonicalize(index)))
+
     def bucketize(
         self,
         values: T,

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -240,14 +240,25 @@ class DtypePropagationOpsHandler:
 
     @staticmethod
     def index_expr(expr: sympy.Expr, dtype: torch.dtype) -> torch.dtype:
-        # TODO - TODO - rationalize index_expr. The dtype is not always used and we are inconsistent about int32 or int64
-        # in lowerings. cpp just uses the dtype
+        # `index_expr` is for indexing-style uses: the kernel's chosen
+        # indexing dtype wins over the requested int dtype. For uses that
+        # must honor `dtype` (e.g. user-typed `arange(int64)` whose result
+        # participates in tensor computation), `value_expr` is the right op
+        # — see `convert_index_expr_to_value_expr` which rewrites accordingly.
         if dtype not in (torch.int32, torch.int64) or not hasattr(
             V.kernel, "index_dtype"
         ):
             return upcast_compute_type(dtype)
 
         return V.kernel.get_index_dtype_as_torch_dtype()
+
+    @staticmethod
+    def value_expr(expr: sympy.Expr, dtype: torch.dtype) -> torch.dtype:
+        # Unlike `index_expr`, `value_expr` always honors the requested
+        # dtype because the result feeds tensor-value computation. The
+        # sympy expression is emitted literally, so there is no
+        # bf16/fp16 -> fp32 compute-type promotion here.
+        return dtype
 
     @staticmethod
     def to_dtype(

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -99,6 +99,10 @@ class SymPyOps:
         return TypedExpr(value, dtype)
 
     @staticmethod
+    def value_expr(value: sympy.Expr | int, dtype: torch.dtype) -> TypedExpr:
+        return TypedExpr(value, dtype)
+
+    @staticmethod
     def to_dtype(
         value: TypedExpr,
         dtype: torch.dtype,
@@ -237,6 +241,9 @@ class IndexPropagation(DefaultHandler):
             val = dtype_to_type(dtype)(expr)
             return self._inner.constant(val, dtype)
         return self._inner.index_expr(expr, dtype)
+
+    def value_expr(self, expr: sympy.Expr, dtype: torch.dtype) -> IndexPropResult:
+        return self.wrap(self._inner.value_expr(expr, dtype))
 
     def unwrap(self, a: Any | IndexPropVar) -> Any:
         if isinstance(a, (list, tuple)):

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -729,6 +729,13 @@ class CaptureIndexing(WrapperHandler):
         index = self._add_index(index, MemoryUsageType.INDEX_EXPR)
         return self._inner.index_expr(index, dtype)
 
+    def value_expr(self, index, dtype):
+        index = self._simplify(index)
+        if isinstance(index, (int, sympy.Integer)):
+            return self._inner.constant(int(index), dtype)
+        index = self._add_index(index, MemoryUsageType.INDEX_EXPR)
+        return self._inner.value_expr(index, dtype)
+
     def check_bounds(self, index, size, lower, upper):
         index = self._simplify(index)
         index = self._add_index(index, MemoryUsageType.CHECK_BOUNDS)

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -134,9 +134,21 @@ class OpsHandler(Generic[T]):
 
     def index_expr(self, expr: sympy.Expr, dtype: torch.dtype) -> T:
         """
-        Converts a sympy expression into a scalar of type dtype.  expr is typically
-        an indexing expression, thus the name; however, it can also be used in
-        non-indexing situations.
+        Converts a sympy expression into a scalar suitable for indexing memory.
+        The kernel decides the actual computation dtype (typically int32) — the
+        ``dtype`` argument is advisory and is not honored when it would conflict
+        with the kernel's indexing dtype. For values that must respect the
+        requested dtype, use ``value_expr`` instead.
+        """
+        raise NotImplementedError
+
+    def value_expr(self, expr: sympy.Expr, dtype: torch.dtype) -> T:
+        """
+        Converts a sympy expression into a scalar of type ``dtype`` that
+        participates in tensor value computation. Unlike ``index_expr``, the
+        result dtype is honored, so this is the right op when the user
+        explicitly requested the dtype (e.g. ``arange(dtype=torch.int64)``
+        whose result is added to a tensor rather than used as an index).
         """
         raise NotImplementedError
 

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -1,12 +1,17 @@
 import math
+import operator
+from dataclasses import dataclass
 from typing import Any
 
 import sympy
 
 import torch
+from torch.fx.node import map_aggregate, map_arg
+from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.value_ranges import ValueRanges
 
 from .loop_body import LoopBody
+from .ops_handler import OP_NAMES
 from .utils import dominated_nodes
 
 
@@ -38,26 +43,22 @@ def range_expressable_in_32_bits(range: ValueRanges[sympy.Expr]) -> bool:
     )
 
 
-def try_to_reduce_precision(
-    node: Any,
-    bounds: dict[Any, Any],
+def _dominated_uses_fit_in_32_bits(
+    node: torch.fx.Node,
+    bounds: dict[Any, ValueRanges[Any]],
     indirect_vars: list[Any],
     indices: dict[Any, sympy.Expr],
     replacement_vals: dict[Any, ValueRanges[sympy.Expr]],
-) -> None:
-    # if a downstream use of a node explicitly converts to int32, or float16/float32/float64,
-    # then it's precision is set for that chain of uses, and we don't need to consider those
-    # dominated values
-    def skip_filter(node: Any) -> bool:
-        return node.target == "to_dtype" and node.args[2] in (
+) -> bool:
+    # If a downstream use explicitly converts to int32 or float, precision is
+    # fixed for that chain and we do not need to inspect dominated values past it.
+    def skip_filter(user: torch.fx.Node) -> bool:
+        return user.target == "to_dtype" and user.args[2] in (
             torch.int32,
             torch.float32,
             torch.float64,
         )
 
-    # TODO - there are dominated uses whose dtype does not depend on whether
-    # we reduce the precision here, e.g. add(int64, int64) one of the args can be reduced to
-    # int32 without changing the output precision of the node. this case hasn't shown up
     for dominated in dominated_nodes([node], skip_filter):
         if dominated.target in ["store", "output"]:
             continue
@@ -72,7 +73,7 @@ def try_to_reduce_precision(
                     index_val = replacement_vals[index]
 
                     if math.isinf(index_val.lower) or math.isinf(index_val.upper):
-                        return
+                        return False
 
                     # all indices are integers, so make sure that we
                     # use the bounds of integers instead of floats.
@@ -83,10 +84,31 @@ def try_to_reduce_precision(
                         int(index_val.lower), int(index_val.upper)
                     )
                     if not range_expressable_in_32_bits(index_val_int):
-                        return
+                        return False
 
-        if not range_expressable_in_32_bits(bounds[dominated]):
-            return
+        dominated_bounds = bounds.get(dominated)
+        if dominated_bounds is None or not range_expressable_in_32_bits(
+            dominated_bounds
+        ):
+            return False
+
+    return True
+
+
+def try_to_reduce_precision(
+    node: Any,
+    bounds: dict[Any, Any],
+    indirect_vars: list[Any],
+    indices: dict[Any, sympy.Expr],
+    replacement_vals: dict[Any, ValueRanges[sympy.Expr]],
+) -> None:
+    # TODO - there are dominated uses whose dtype does not depend on whether
+    # we reduce the precision here, e.g. add(int64, int64) one of the args can be reduced to
+    # int32 without changing the output precision of the node. this case hasn't shown up
+    if not _dominated_uses_fit_in_32_bits(
+        node, bounds, indirect_vars, indices, replacement_vals
+    ):
+        return
 
     args = list(node.args)
     args[2] = torch.int32
@@ -124,3 +146,466 @@ def indexing_dtype_strength_reduction(loop_body: LoopBody) -> None:
             loop_body.indexing_exprs,
             bv.replacement_vals,
         )
+
+
+@dataclass(frozen=True)
+class _IndexValueRule:
+    # Inputs in the LoopBody FX node that act as terminal sinks.
+    indexing_sinks: tuple[Any, ...] = ()
+    value_sinks: tuple[Any, ...] = ()
+    # Inputs that receive value use from this op's result. None means all inputs.
+    value_inputs: tuple[Any, ...] | None = ()
+
+
+_INDEXING_DEMAND = 1
+_VALUE_DEMAND = 2
+
+
+@dataclass(frozen=True)
+class _ArgRef:
+    key: int | str
+
+    def get(self, node: torch.fx.Node) -> Any:
+        if isinstance(self.key, int):
+            return node.args[self.key]
+        return node.kwargs[self.key]
+
+
+class _IndexValueOpsHandler:
+    """
+    Classify each OpsHandler op for index/value-use analysis.
+    """
+
+    _instance: Any = None
+
+    _EXTRA_VALUE_PROPAGATING_OPS = (
+        "ceil_to_int",
+        "constant",
+        "div_rn",
+        "dot",
+        "floor",
+        "floor_to_int",
+        "floordiv",
+        "fmod",
+        "frexp",
+        "halide_clamp",
+        "identity",
+        "index_expr",
+        "inline_asm_elementwise",
+        "int_truediv",
+        "lshift",
+        "mod",
+        "mul",
+        "pow",
+        "rand",
+        "rand_eager",
+        "randint64",
+        "randn",
+        "round",
+        "round_to_int",
+        "rshift",
+        "to_dtype",
+        "to_dtype_bitcast",
+        "truediv",
+        "trunc",
+        "trunc_to_int",
+        "truncdiv",
+        "value_expr",
+        "where",
+    )
+
+    def __new__(cls) -> "_IndexValueOpsHandler":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self) -> None:
+        if self._initialized:
+            return
+
+        registered_value_propagating_ops = self._registered_value_propagating_ops()
+        self._value_propagating_ops = registered_value_propagating_ops | OrderedSet(
+            self._EXTRA_VALUE_PROPAGATING_OPS
+        )
+        self._install_bulk_rules()
+        unknown_ops = self._value_propagating_ops - OP_NAMES
+        torch._check(
+            len(unknown_ops) == 0,
+            lambda: f"Value/index rules for unknown ops: {unknown_ops}",
+        )
+        duplicate_value_propagating_ops = len(self._value_propagating_ops) != len(
+            registered_value_propagating_ops
+        ) + len(self._EXTRA_VALUE_PROPAGATING_OPS)
+        torch._check(
+            not duplicate_value_propagating_ops,
+            lambda: "Duplicate value-propagating op classification",
+        )
+        unimplemented_ops = OP_NAMES - OrderedSet(dir(self))
+        torch._check(
+            len(unimplemented_ops) == 0,
+            lambda: f"Unimplemented value/index rule for ops: {unimplemented_ops}",
+        )
+        self._initialized = True
+
+    @classmethod
+    def _registered_value_propagating_ops(cls) -> OrderedSet[str]:
+        from .utils import boolean_ops, op_dtype_propagation_rules
+
+        if not op_dtype_propagation_rules:
+            from . import lowering  # noqa: F401
+
+        from .codegen.common import pointwise_overrides_data
+
+        return (
+            OrderedSet(op_dtype_propagation_rules)
+            | OrderedSet(pointwise_overrides_data)
+            | OrderedSet(boolean_ops())
+        ) & OrderedSet(OP_NAMES)
+
+    def rule_for_node(self, node: torch.fx.Node) -> _IndexValueRule | None:
+        if node.op == "output":
+            return self._rule_for_node(self.output, node)
+        if node.op == "call_function" and node.target is operator.getitem:
+            return self._rule_for_node(self.getitem, node)
+        if not isinstance(node.target, str):
+            return None
+
+        target = node.target
+        if node.op == "call_module":
+            if target.startswith("set_"):
+                return self._rule_for_node(self.set_indirect, node)
+            if target.startswith("masked_subblock"):
+                return self._rule_for_node(self.masked_subblock, node)
+            if target.startswith("scan"):
+                return self._rule_for_node(self.scan_subblock, node)
+            return None
+
+        if target not in OP_NAMES:
+            return None
+
+        return self._rule_for_node(
+            getattr(self, target),
+            node,
+            arg_start=1 if node.op == "call_method" else 0,
+        )
+
+    def _rule_for_node(
+        self,
+        rule_fn: Any,
+        node: torch.fx.Node,
+        *,
+        arg_start: int = 0,
+    ) -> _IndexValueRule:
+        args = tuple(_ArgRef(i) for i in range(arg_start, len(node.args)))
+        kwargs = {name: _ArgRef(name) for name in node.kwargs}
+        return rule_fn(*args, **kwargs)
+
+    def _install_bulk_rules(self) -> None:
+        existing_ops = OrderedSet(
+            name for name in self._value_propagating_ops if hasattr(self, name)
+        )
+        torch._check(
+            len(existing_ops) == 0,
+            lambda: f"Ops have both value-propagating and explicit rules: {existing_ops}",
+        )
+        for name in self._value_propagating_ops:
+            setattr(self, name, self.value_propagating)
+
+    def value_propagating(self, *args: Any, **kwargs: Any) -> _IndexValueRule:
+        return _IndexValueRule(value_inputs=None)
+
+    # op rules
+
+    def bucketize(
+        self,
+        values: Any,
+        boundaries: Any,
+        boundary_indices: Any,
+        indexing_dtype: torch.dtype,
+        right: bool,
+        sorter: Any = None,
+        sorter_indices: Any = None,
+    ) -> _IndexValueRule:
+        return _IndexValueRule(
+            indexing_sinks=(
+                boundaries,
+                boundary_indices,
+                sorter,
+                sorter_indices,
+            ),
+            value_sinks=(values,),
+        )
+
+    def getitem(self, value: Any, index: Any) -> _IndexValueRule:
+        return _IndexValueRule(value_inputs=(value,))
+
+    def check_bounds(
+        self, expr: sympy.Expr, size: sympy.Expr, lower: bool, upper: bool
+    ) -> _IndexValueRule:
+        return _IndexValueRule(indexing_sinks=(expr, size))
+
+    def device_assert_async(self, cond: Any, msg: str) -> _IndexValueRule:
+        return _IndexValueRule(indexing_sinks=(cond,))
+
+    def indirect_indexing(
+        self, x: Any, size: sympy.Expr, check: bool = True, wrap_neg: bool = True
+    ) -> _IndexValueRule:
+        return _IndexValueRule(indexing_sinks=(x, size))
+
+    def load(self, name: str, index: sympy.Expr) -> _IndexValueRule:
+        return _IndexValueRule(indexing_sinks=(index,))
+
+    def load_seed(self, name: str, offset: Any) -> _IndexValueRule:
+        return _IndexValueRule(indexing_sinks=(offset,))
+
+    def masked(self, mask: Any, body: Any, other: Any) -> _IndexValueRule:
+        return _IndexValueRule(
+            indexing_sinks=(mask,),
+            value_inputs=(other,),
+        )
+
+    def output(self, *args: Any) -> _IndexValueRule:
+        return _IndexValueRule(value_sinks=args)
+
+    def partial_accumulate(
+        self, name: str, reduction_type: Any, value: Any, extra_meta: dict[str, Any]
+    ) -> _IndexValueRule:
+        return _IndexValueRule(value_sinks=(value,))
+
+    def placeholder(self, index: int) -> _IndexValueRule:
+        return _IndexValueRule()
+
+    def reduction(
+        self,
+        dtype: torch.dtype,
+        src_dtype: torch.dtype,
+        reduction_type: Any,
+        value: Any,
+    ) -> _IndexValueRule:
+        return _IndexValueRule(value_sinks=(value,))
+
+    def scan(
+        self, dtypes: tuple[torch.dtype, ...], combine_fn: Any, values: Any
+    ) -> _IndexValueRule:
+        return _IndexValueRule(value_sinks=(values,))
+
+    def sort(
+        self,
+        dtypes: tuple[torch.dtype, ...],
+        values: Any,
+        stable: bool,
+        descending: bool,
+    ) -> _IndexValueRule:
+        return _IndexValueRule(value_sinks=(values,))
+
+    def store(
+        self, name: str, index: sympy.Expr, value: Any, mode: Any = None
+    ) -> _IndexValueRule:
+        return _IndexValueRule(
+            indexing_sinks=(index,),
+            value_sinks=(value,),
+        )
+
+    def store_reduction(
+        self, name: str, index: sympy.Expr, value: Any
+    ) -> _IndexValueRule:
+        return self.store(name, index, value)
+
+    # LoopBody pseudo call_module rules.
+
+    def masked_subblock(self, mask: Any, other: Any) -> _IndexValueRule:
+        return _IndexValueRule(
+            indexing_sinks=(mask,),
+            value_inputs=(other,),
+        )
+
+    def scan_subblock(
+        self, dtypes: tuple[torch.dtype, ...], values: Any
+    ) -> _IndexValueRule:
+        return _IndexValueRule(value_sinks=(values,))
+
+    def set_indirect(self, new_var: Any) -> _IndexValueRule:
+        return _IndexValueRule(indexing_sinks=(new_var,))
+
+
+def _is_masked_subblock(node: torch.fx.Node) -> bool:
+    return (
+        node.op == "call_module"
+        and isinstance(node.target, str)
+        and node.target.startswith("masked_subblock")
+    )
+
+
+def _map_rule_arg(node: torch.fx.Node, arg: Any, fn: Any) -> None:
+    def visit_node(arg_node: torch.fx.Node) -> torch.fx.Node:
+        fn(arg_node)
+        return arg_node
+
+    def visit(elem: Any) -> Any:
+        if isinstance(elem, _ArgRef):
+            map_arg(elem.get(node), visit_node)
+        elif isinstance(elem, torch.fx.Node):
+            fn(elem)
+        return elem
+
+    map_aggregate(arg, visit)
+
+
+
+def _compute_graph_uses(
+    graph: torch.fx.Graph,
+    *,
+    output_is_indexing: bool = False,
+    output_is_value: bool = True,
+) -> tuple[OrderedSet[torch.fx.Node], OrderedSet[torch.fx.Node]]:
+    demands: dict[torch.fx.Node, int] = {}
+    handler = _IndexValueOpsHandler()
+
+    def mark(node: torch.fx.Node, demand: int) -> None:
+        demands[node] = demands.get(node, 0) | demand
+
+    def mark_rule_arg(node: torch.fx.Node, arg: Any, demand: int) -> None:
+        _map_rule_arg(node, arg, lambda n: mark(n, demand))
+
+    def mark_args(node: torch.fx.Node, demand: int) -> None:
+        def mark_arg(arg_node: torch.fx.Node) -> torch.fx.Node:
+            mark(arg_node, demand)
+            return arg_node
+
+        map_arg(node.args, mark_arg)
+        map_arg(node.kwargs, mark_arg)
+
+    # FX graph order is definition-before-use, so reverse order lets each node
+    # see all downstream demands before propagating to its inputs.
+    for node in reversed(tuple(graph.nodes)):
+        if node.op == "output":
+            if output_is_indexing:
+                mark_rule_arg(node, node.args, _INDEXING_DEMAND)
+            if output_is_value:
+                mark_rule_arg(node, node.args, _VALUE_DEMAND)
+            continue
+
+        rule = handler.rule_for_node(node)
+        if rule is not None:
+            for arg in rule.indexing_sinks:
+                mark_rule_arg(node, arg, _INDEXING_DEMAND)
+            for arg in rule.value_sinks:
+                mark_rule_arg(node, arg, _VALUE_DEMAND)
+
+        demand = demands.get(node, 0)
+        if demand == 0 or node.op == "placeholder":
+            continue
+
+        if demand & _INDEXING_DEMAND and node.target != "load":
+            if _is_masked_subblock(node):
+                if rule is not None:
+                    value_inputs = rule.value_inputs
+                    assert value_inputs is not None
+                    for arg in value_inputs:
+                        mark_rule_arg(node, arg, _INDEXING_DEMAND)
+            else:
+                mark_args(node, _INDEXING_DEMAND)
+
+        if demand & _VALUE_DEMAND and node.target != "load":
+            if rule is None:
+                continue
+            if _is_masked_subblock(node) and demand & _INDEXING_DEMAND:
+                continue
+            if rule.value_inputs is not None:
+                for arg in rule.value_inputs:
+                    mark_rule_arg(node, arg, _VALUE_DEMAND)
+            else:
+                mark_args(node, _VALUE_DEMAND)
+
+    return (
+        OrderedSet(n for n in graph.nodes if demands.get(n, 0) & _INDEXING_DEMAND),
+        OrderedSet(n for n in graph.nodes if demands.get(n, 0) & _VALUE_DEMAND),
+    )
+
+
+def _graph_output_contexts(
+    loop_body: LoopBody,
+) -> dict[torch.fx.Graph, tuple[bool, bool]]:
+    subblocks = {
+        name: block.graph for name, block in getattr(loop_body, "subblocks", {}).items()
+    }
+    contexts = {loop_body.root_block.graph: (False, True)}
+    worklist = [loop_body.root_block.graph]
+
+    while worklist:
+        graph = worklist.pop()
+        output_is_indexing, output_is_value = contexts[graph]
+        indexing_use, value_use = _compute_graph_uses(
+            graph,
+            output_is_indexing=output_is_indexing,
+            output_is_value=output_is_value,
+        )
+        for node in graph.nodes:
+            if not _is_masked_subblock(node):
+                continue
+            assert isinstance(node.target, str)
+            subblock_graph = subblocks.get(node.target)
+            if subblock_graph is None:
+                continue
+
+            child_is_indexing = node in indexing_use
+            # Policy choice for this pass: if the same masked-subblock result
+            # is both index-used and value-used, keep its body on the indexing
+            # path instead of cloning the subblock for a separate value result.
+            child_is_value = node in value_use and not child_is_indexing
+            old_is_indexing, old_is_value = contexts.get(subblock_graph, (False, False))
+            new_is_indexing = old_is_indexing or child_is_indexing
+            new_context = (
+                new_is_indexing,
+                (old_is_value or child_is_value) and not new_is_indexing,
+            )
+            if new_context != (old_is_indexing, old_is_value):
+                contexts[subblock_graph] = new_context
+                worklist.append(subblock_graph)
+
+    for graph in subblocks.values():
+        contexts.setdefault(graph, (False, False))
+    return contexts
+
+
+def convert_index_expr_to_value_expr(loop_body: LoopBody) -> None:
+    """
+    Rewrite ``index_expr`` nodes that participate in value computation to
+    ``value_expr``, so codegen can honor the requested dtype instead of
+    narrowing to the kernel's indexing dtype.
+
+    Classification: walk backward from value sinks (store value, reduction,
+    output) and indexing sinks (load index, store index, check_bounds,
+    set_indirect) with ``load`` as a barrier. Any ``index_expr`` reachable
+    from a value sink is converted in-place to ``value_expr``.
+
+    TODO: if mixed use (same index_expr used for both indexing and value)
+    ever occurs in practice, the node should be cloned so the indexing path
+    keeps the original index_expr. This hasn't been observed so far.
+    """
+    graphs = [
+        loop_body.root_block.graph,
+        *(block.graph for block in getattr(loop_body, "subblocks", {}).values()),
+    ]
+    if not any(
+        graph.find_nodes(op="call_method", target="index_expr", sort=False)
+        for graph in graphs
+    ):
+        return
+
+    output_contexts = _graph_output_contexts(loop_body)
+
+    for graph in graphs:
+        output_is_indexing, output_is_value = output_contexts[graph]
+        _, value_use = _compute_graph_uses(
+            graph,
+            output_is_indexing=output_is_indexing,
+            output_is_value=output_is_value,
+        )
+        for node in graph.nodes:
+            if node.target == "index_expr" and node in value_use:
+                node.target = "value_expr"
+
+    LoopBody.get_nodes.clear_cache(loop_body)
+    LoopBody.bounds.clear_cache(loop_body)

--- a/torch/_inductor/shape_propagation.py
+++ b/torch/_inductor/shape_propagation.py
@@ -128,6 +128,11 @@ class ShapePropagationOpsHandler:
         return None
 
     @staticmethod
+    def value_expr(expr: sympy.Expr, dtype: torch.dtype) -> BlockShapeType:
+        # shape is implicitly embedded in expr.
+        return None
+
+    @staticmethod
     def load_seed(name: str, offset: int) -> BlockShapeType:
         return ()
 

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -1556,5 +1556,8 @@ class SimplifyIndexing(V.WrapperHandler):  # type: ignore[name-defined]
     def index_expr(self, index, dtype):
         return self._inner.index_expr(self._simplify(index), dtype)
 
+    def value_expr(self, index, dtype):
+        return self._inner.value_expr(self._simplify(index), dtype)
+
     def check_bounds(self, index, size, lower, upper):
         return self._inner.check_bounds(self._simplify(index), size, lower, upper)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #185833
* __->__ #185832

Inductor existing op `index_expr` implicitly uses the kernel indexing dtype for int32/int64 dtypes passed in. This pradds value_expr as the dtype-honoring form for symbolic expressions that participate in tensor value computation, while keeping index_expr on the kernel indexing dtype path for addressing. This commit adds the op to all backends and handlers but does not wire up any conversion pass, so it is inert -- no behavior change.

Authored with Claude.