### PR TITLE
[c10d] Add delegate backend to FakeProcessGroup for numerics testing

### DIFF
--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -2,6 +2,7 @@
 
 #include <ATen/core/LegacyTypeDispatch.h>
 #include <torch/csrc/distributed/c10d/Backend.hpp>
+#include <torch/csrc/distributed/c10d/Types.hpp>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 #include <torch/csrc/utils.h>
 
@@ -29,7 +30,6 @@ class FakeProcessGroup : public Backend {
     int fake_option = 0;
     bool error_on_collective = false;
   };
-
   // Static factory method for official APIs
   static c10::intrusive_ptr<FakeProcessGroup> _create_internal(
       int rank,
@@ -47,38 +47,101 @@ class FakeProcessGroup : public Backend {
     return c10::static_intrusive_pointer_cast<Backend::Options>(options_);
   }
 
+  // Forward collectives to a real backend when set.
+  void setDelegate(c10::intrusive_ptr<Backend> delegate) {
+    TORCH_CHECK(
+        delegate != nullptr,
+        "FakeProcessGroup::setDelegate: delegate must not be null");
+    TORCH_CHECK(
+        delegate->getRank() == rank_ && delegate->getSize() == size_,
+        "FakeProcessGroup::setDelegate: rank/size mismatch: delegate (",
+        delegate->getRank(),
+        "/",
+        delegate->getSize(),
+        ") vs fake (",
+        rank_,
+        "/",
+        size_,
+        ")");
+    delegate_ = std::move(delegate);
+  }
+
+  c10::intrusive_ptr<Backend> getDelegate() const {
+    return delegate_;
+  }
+
+
   c10::intrusive_ptr<Work> broadcast(
-      std::vector<at::Tensor>& /* tensors */,
-      const BroadcastOptions& /* opts */ = BroadcastOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const BroadcastOptions& opts = BroadcastOptions()) override {
+    if (delegate_) {
+      return delegate_->broadcast(tensors, opts);
+    }
     checkCollectiveError();
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> allreduce(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceOptions& /* opts */ = AllreduceOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override {
+    if (delegate_) {
+      AllreduceOptions d_opts = opts;
+      auto factor = extractPremulFactor(d_opts.reduceOp);
+      auto work = delegate_->allreduce(tensors, d_opts);
+      if (factor.has_value()) {
+        postMultiply(tensors, *factor);
+      }
+      return work;
+    }
     checkCollectiveError();
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> allreduce_sparse(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceOptions& /* opts */ = AllreduceOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override {
+    if (delegate_) {
+      AllreduceOptions d_opts = opts;
+      auto factor = extractPremulFactor(d_opts.reduceOp);
+      auto work = delegate_->allreduce_sparse(tensors, d_opts);
+      if (factor.has_value()) {
+        postMultiply(tensors, *factor);
+      }
+      return work;
+    }
     checkCollectiveError();
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> allreduce_coalesced(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceCoalescedOptions& /* opts */ =
+      std::vector<at::Tensor>& tensors,
+      const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override {
+    if (delegate_) {
+      AllreduceCoalescedOptions d_opts = opts;
+      auto factor = extractPremulFactor(d_opts.reduceOp);
+      auto work = delegate_->allreduce_coalesced(tensors, d_opts);
+      if (factor.has_value()) {
+        postMultiply(tensors, *factor);
+      }
+      return work;
+    }
     checkCollectiveError();
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> reduce(
-      std::vector<at::Tensor>& /* tensors */,
-      const ReduceOptions& /* opts */ = ReduceOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) override {
+    if (delegate_) {
+      ReduceOptions d_opts = opts;
+      auto factor = extractPremulFactor(d_opts.reduceOp);
+      auto work = delegate_->reduce(tensors, d_opts);
+      if (factor.has_value()) {
+        postMultiply(tensors, *factor);
+      }
+      return work;
+    }
     checkCollectiveError();
     return c10::make_intrusive<FakeWork>();
   }
@@ -92,7 +155,10 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> allgather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
-      const AllgatherOptions& /* opts */ = AllgatherOptions()) override {
+      const AllgatherOptions& opts = AllgatherOptions()) override {
+    if (delegate_) {
+      return delegate_->allgather(outputTensors, inputTensors, opts);
+    }
     checkCollectiveError();
     // See note in _allgather_base below.
     at::AutoDispatchBelowAutograd guard;
@@ -105,7 +171,10 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> _allgather_base(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
-      const AllgatherOptions& /* opts */ = AllgatherOptions()) override {
+      const AllgatherOptions& opts = AllgatherOptions()) override {
+    if (delegate_) {
+      return delegate_->_allgather_base(outputBuffer, inputBuffer, opts);
+    }
     checkCollectiveError();
     // Real collective backends (e.g. NCCL) write into the output from C++
     // kernels that autograd never sees. We emulate that here: chunk() produces
@@ -122,7 +191,11 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> allgather_coalesced(
       std::vector<std::vector<at::Tensor>>& outputTensorLists,
       std::vector<at::Tensor>& inputTensors,
-      const AllgatherOptions& /* opts */ = AllgatherOptions()) override {
+      const AllgatherOptions& opts = AllgatherOptions()) override {
+    if (delegate_) {
+      return delegate_->allgather_coalesced(
+          outputTensorLists, inputTensors, opts);
+    }
     checkCollectiveError();
     auto invalidArgument = [](const std::string& msg) {
       TORCH_CHECK(false, "FakeProcessGroup::allgather_coalesced: ", msg);
@@ -130,7 +203,6 @@ class FakeProcessGroup : public Backend {
     assertNonEmptyInputTensorList(invalidArgument, inputTensors.size());
     assertAllgatherCoalescedOutputTensorLists(
         invalidArgument, outputTensorLists, inputTensors.size(), size_);
-    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     for (auto& outputTensorList : outputTensorLists) {
       for (size_t i = 0; i < inputTensors.size(); ++i) {
@@ -143,9 +215,11 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> allgather_into_tensor_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
-      const AllgatherOptions& /* opts */ = AllgatherOptions()) override {
+      const AllgatherOptions& opts = AllgatherOptions()) override {
+    if (delegate_) {
+      return delegate_->allgather_into_tensor_coalesced(outputs, inputs, opts);
+    }
     checkCollectiveError();
-    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     for (size_t i = 0; i < outputs.size(); ++i) {
       auto chunks = outputs[i].chunk(size_);
@@ -160,6 +234,9 @@ class FakeProcessGroup : public Backend {
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
       const GatherOptions& opts = GatherOptions()) override {
+    if (delegate_) {
+      return delegate_->gather(outputTensors, inputTensors, opts);
+    }
     checkCollectiveError();
     auto invalidArgument = [](const std::string& msg) {
       TORCH_CHECK(false, "FakeProcessGroup::gather: ", msg);
@@ -169,7 +246,6 @@ class FakeProcessGroup : public Backend {
 
     if (rank_ == opts.rootRank) {
       assertGatherOutputTensorList(invalidArgument, outputTensors, size_);
-      // See note in _allgather_base above.
       at::AutoDispatchBelowAutograd guard;
       for (auto& tensor : outputTensors[0]) {
         tensor.copy_(inputTensors[0]);
@@ -184,6 +260,9 @@ class FakeProcessGroup : public Backend {
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ScatterOptions& opts = ScatterOptions()) override {
+    if (delegate_) {
+      return delegate_->scatter(outputTensors, inputTensors, opts);
+    }
     checkCollectiveError();
     auto invalidArgument = [](const std::string& msg) {
       TORCH_CHECK(false, "FakeProcessGroup::scatter: ", msg);
@@ -193,7 +272,6 @@ class FakeProcessGroup : public Backend {
 
     if (rank_ == opts.rootRank) {
       assertScatterInputTensorList(invalidArgument, inputTensors, size_);
-      // See note in _allgather_base above.
       at::AutoDispatchBelowAutograd guard;
       outputTensors[0].copy_(inputTensors[0][rank_]);
     } else {
@@ -205,15 +283,23 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> reduce_scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
-      const ReduceScatterOptions& /* opts */ =
-          ReduceScatterOptions()) override {
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
+    if (delegate_) {
+      ReduceScatterOptions d_opts = opts;
+      auto factor = extractPremulFactor(d_opts.reduceOp);
+      auto work =
+          delegate_->reduce_scatter(outputTensors, inputTensors, d_opts);
+      if (factor.has_value()) {
+        postMultiply(outputTensors, *factor);
+      }
+      return work;
+    }
     checkCollectiveError();
     auto invalidArgument = [](const std::string& msg) {
       TORCH_CHECK(false, "FakeProcessGroup::reduce_scatter: ", msg);
     };
     assertInputOutputTensorListsSameSize(
         invalidArgument, outputTensors.size(), inputTensors.size());
-    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     for (size_t i = 0; i < outputTensors.size(); ++i) {
       assertInputTensorListSizeEqualsWorldSize(
@@ -226,13 +312,21 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> _reduce_scatter_base(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
-      const ReduceScatterOptions& /* opts */ =
-          ReduceScatterOptions()) override {
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
+    if (delegate_) {
+      ReduceScatterOptions d_opts = opts;
+      auto factor = extractPremulFactor(d_opts.reduceOp);
+      auto work =
+          delegate_->_reduce_scatter_base(outputBuffer, inputBuffer, d_opts);
+      if (factor.has_value()) {
+        postMultiply(outputBuffer, *factor);
+      }
+      return work;
+    }
     checkCollectiveError();
     TORCH_CHECK(
         inputBuffer.numel() == outputBuffer.numel() * size_,
         "input tensor must be the same size as output size times world size");
-    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     auto chunks = inputBuffer.chunk(size_);
     outputBuffer.copy_(chunks[rank_]);
@@ -242,8 +336,17 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
-      const ReduceScatterOptions& /* opts */ =
-          ReduceScatterOptions()) override {
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
+    if (delegate_) {
+      ReduceScatterOptions d_opts = opts;
+      auto factor = extractPremulFactor(d_opts.reduceOp);
+      auto work =
+          delegate_->reduce_scatter_tensor_coalesced(outputs, inputs, d_opts);
+      if (factor.has_value()) {
+        postMultiply(outputs, *factor);
+      }
+      return work;
+    }
     checkCollectiveError();
     auto invalidArgument = [](const std::string& msg) {
       TORCH_CHECK(
@@ -251,7 +354,6 @@ class FakeProcessGroup : public Backend {
     };
     assertInputOutputTensorListsSameSize(
         invalidArgument, outputs.size(), inputs.size());
-    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     for (size_t i = 0; i < outputs.size(); ++i) {
       TORCH_CHECK(
@@ -268,18 +370,18 @@ class FakeProcessGroup : public Backend {
       at::Tensor& inputBuffer,
       std::vector<int64_t>& outputSplitSizes,
       std::vector<int64_t>& inputSplitSizes,
-      const AllToAllOptions& /* opts */ = AllToAllOptions()) override {
+      const AllToAllOptions& opts = AllToAllOptions()) override {
+    if (delegate_) {
+      return delegate_->alltoall_base(
+          outputBuffer, inputBuffer, outputSplitSizes, inputSplitSizes, opts);
+    }
     checkCollectiveError();
     c10d::checkSplitSizes(inputSplitSizes, inputBuffer, size_);
     c10d::checkSplitSizes(outputSplitSizes, outputBuffer, size_);
-    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     if (outputSplitSizes.empty() && inputSplitSizes.empty()) {
       outputBuffer.copy_(inputBuffer);
     } else {
-      // Approximation: rank j's inputSplitSizes are unavailable here, so
-      // each output slot is filled by repeating inputBuffer[0:slot]. The
-      // values are deterministic but arbitrary; do not assert on them.
       int64_t out_offset = 0;
       auto in_size = inputBuffer.size(0);
       for (int j = 0; j < size_; ++j) {
@@ -308,14 +410,16 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> alltoall(
       std::vector<at::Tensor>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
-      const AllToAllOptions& /* opts */ = AllToAllOptions()) override {
+      const AllToAllOptions& opts = AllToAllOptions()) override {
+    if (delegate_) {
+      return delegate_->alltoall(outputTensors, inputTensors, opts);
+    }
     checkCollectiveError();
     auto invalidArgument = [](const std::string& msg) {
       TORCH_CHECK(false, "FakeProcessGroup::alltoall: ", msg);
     };
     assertAllToAllTensorListSizes(
         invalidArgument, outputTensors.size(), inputTensors.size(), size_);
-    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     for (size_t i = 0; i < outputTensors.size(); ++i) {
       outputTensors[i].copy_(inputTensors[i]);
@@ -324,45 +428,66 @@ class FakeProcessGroup : public Backend {
   }
 
   c10::intrusive_ptr<Work> send(
-      std::vector<at::Tensor>& /* tensors */,
-      int /* dstRank */,
-      int /* tag */) override {
+      std::vector<at::Tensor>& tensors,
+      int dstRank,
+      int tag) override {
+    if (delegate_) {
+      return delegate_->send(tensors, dstRank, tag);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> recv(
-      std::vector<at::Tensor>& /* tensors */,
-      int /* srcRank */,
-      int /* tag */) override {
+      std::vector<at::Tensor>& tensors,
+      int srcRank,
+      int tag) override {
+    if (delegate_) {
+      return delegate_->recv(tensors, srcRank, tag);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> recvAnysource(
-      std::vector<at::Tensor>& /* tensors */,
-      int /* tag */) override {
+      std::vector<at::Tensor>& tensors,
+      int tag) override {
+    if (delegate_) {
+      return delegate_->recvAnysource(tensors, tag);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
   void startCoalescing() override {
+    if (delegate_) {
+      delegate_->startCoalescing();
+      return;
+    }
     // No-op
   }
 
-  c10::intrusive_ptr<Work> endCoalescing(OpType /* optype */) {
+  c10::intrusive_ptr<Work> endCoalescing(OpType optype) {
+    if (delegate_) {
+      return delegate_->endCoalescing();
+    }
     checkCollectiveError();
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> endCoalescing() override {
+    if (delegate_) {
+      return delegate_->endCoalescing();
+    }
     checkCollectiveError();
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> barrier(
-      const BarrierOptions& /* opts */ = BarrierOptions()) override {
+      const BarrierOptions& opts = BarrierOptions()) override {
+    if (delegate_) {
+      return delegate_->barrier(opts);
+    }
     checkCollectiveError();
     return c10::make_intrusive<FakeWork>();
   }
-
   // Private constructor used by official APIs
   FakeProcessGroup(int rank, int size, c10::intrusive_ptr<Options> options)
       : Backend(rank, size), options_(std::move(options)) {
@@ -377,10 +502,41 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Options> options_;
 
  private:
+  c10::intrusive_ptr<Backend> delegate_;
+
   void checkCollectiveError() {
     TORCH_CHECK(
         !options_ || !options_->error_on_collective,
         "FakeProcessGroup collective operation error (error_on_collective=true)");
+  }
+
+  // PREMUL_SUM decomposition: extract the scalar factor, change op to SUM.
+  // Returns nullopt if the op is not PREMUL_SUM.
+  static std::optional<double> extractPremulFactor(ReduceOp& reduceOp) {
+    if (reduceOp.op_ != ReduceOp::PREMUL_SUM) {
+      return std::nullopt;
+    }
+    TORCH_CHECK(reduceOp.supplement_, "PREMUL_SUM ReduceOp has no supplement");
+    auto* supplement =
+        dynamic_cast<PreMulSumSupplement*>(reduceOp.supplement_.get());
+    TORCH_CHECK(supplement, "PREMUL_SUM supplement has unexpected type");
+    double factor = supplement->tensor_factor.defined()
+        ? supplement->tensor_factor.item<double>()
+        : supplement->double_factor;
+    reduceOp = ReduceOp(ReduceOp::SUM);
+    return factor;
+  }
+
+  static void postMultiply(std::vector<at::Tensor>& tensors, double factor) {
+    at::AutoDispatchBelowAutograd guard;
+    for (auto& t : tensors) {
+      t.mul_(factor);
+    }
+  }
+
+  static void postMultiply(at::Tensor& tensor, double factor) {
+    at::AutoDispatchBelowAutograd guard;
+    tensor.mul_(factor);
   }
 };
 

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -203,6 +203,7 @@ class FakeProcessGroup : public Backend {
     assertNonEmptyInputTensorList(invalidArgument, inputTensors.size());
     assertAllgatherCoalescedOutputTensorLists(
         invalidArgument, outputTensorLists, inputTensors.size(), size_);
+    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     for (auto& outputTensorList : outputTensorLists) {
       for (size_t i = 0; i < inputTensors.size(); ++i) {
@@ -220,6 +221,7 @@ class FakeProcessGroup : public Backend {
       return delegate_->allgather_into_tensor_coalesced(outputs, inputs, opts);
     }
     checkCollectiveError();
+    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     for (size_t i = 0; i < outputs.size(); ++i) {
       auto chunks = outputs[i].chunk(size_);
@@ -246,6 +248,7 @@ class FakeProcessGroup : public Backend {
 
     if (rank_ == opts.rootRank) {
       assertGatherOutputTensorList(invalidArgument, outputTensors, size_);
+      // See note in _allgather_base above.
       at::AutoDispatchBelowAutograd guard;
       for (auto& tensor : outputTensors[0]) {
         tensor.copy_(inputTensors[0]);
@@ -272,6 +275,7 @@ class FakeProcessGroup : public Backend {
 
     if (rank_ == opts.rootRank) {
       assertScatterInputTensorList(invalidArgument, inputTensors, size_);
+      // See note in _allgather_base above.
       at::AutoDispatchBelowAutograd guard;
       outputTensors[0].copy_(inputTensors[0][rank_]);
     } else {
@@ -300,6 +304,7 @@ class FakeProcessGroup : public Backend {
     };
     assertInputOutputTensorListsSameSize(
         invalidArgument, outputTensors.size(), inputTensors.size());
+    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     for (size_t i = 0; i < outputTensors.size(); ++i) {
       assertInputTensorListSizeEqualsWorldSize(
@@ -327,6 +332,7 @@ class FakeProcessGroup : public Backend {
     TORCH_CHECK(
         inputBuffer.numel() == outputBuffer.numel() * size_,
         "input tensor must be the same size as output size times world size");
+    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     auto chunks = inputBuffer.chunk(size_);
     outputBuffer.copy_(chunks[rank_]);
@@ -354,6 +360,7 @@ class FakeProcessGroup : public Backend {
     };
     assertInputOutputTensorListsSameSize(
         invalidArgument, outputs.size(), inputs.size());
+    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     for (size_t i = 0; i < outputs.size(); ++i) {
       TORCH_CHECK(
@@ -378,10 +385,14 @@ class FakeProcessGroup : public Backend {
     checkCollectiveError();
     c10d::checkSplitSizes(inputSplitSizes, inputBuffer, size_);
     c10d::checkSplitSizes(outputSplitSizes, outputBuffer, size_);
+    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     if (outputSplitSizes.empty() && inputSplitSizes.empty()) {
       outputBuffer.copy_(inputBuffer);
     } else {
+      // Approximation: rank j's inputSplitSizes are unavailable here, so
+      // each output slot is filled by repeating inputBuffer[0:slot]. The
+      // values are deterministic but arbitrary; do not assert on them.
       int64_t out_offset = 0;
       auto in_size = inputBuffer.size(0);
       for (int j = 0; j < size_; ++j) {
@@ -420,6 +431,7 @@ class FakeProcessGroup : public Backend {
     };
     assertAllToAllTensorListSizes(
         invalidArgument, outputTensors.size(), inputTensors.size(), size_);
+    // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     for (size_t i = 0; i < outputTensors.size(); ++i) {
       outputTensors[i].copy_(inputTensors[i]);

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -4027,7 +4027,14 @@ such as `dist.all_reduce(tensor, async_op=True)`.
           py::arg("options") =
               c10::make_intrusive<::c10d::FakeProcessGroup::Options>())
       .def_property_readonly(
-          "options", &::c10d::FakeProcessGroup::getBackendOptions);
+          "options", &::c10d::FakeProcessGroup::getBackendOptions)
+      .def(
+          "set_delegate",
+          &::c10d::FakeProcessGroup::setDelegate,
+          py::arg("delegate"),
+          py::call_guard<py::gil_scoped_release>())
+      .def_property_readonly(
+          "delegate", &::c10d::FakeProcessGroup::getDelegate);
   auto fakeWork =
       intrusive_ptr_no_gil_destructor_class_<::c10d::FakeWork>(
           module, "FakeWork", work)

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -1,7 +1,8 @@
 # mypy: allow-untyped-defs
 
+import torch
 import torch.distributed as dist
-from torch._C._distributed_c10d import FakeProcessGroup
+from torch._C._distributed_c10d import FakeProcessGroup, ProcessGroupGloo
 
 
 class FakeStore(dist.Store):
@@ -25,6 +26,53 @@ def _create_fake_pg(common_opts, backend_opts):
     return FakeProcessGroup._create_internal(
         common_opts.group_rank, common_opts.group_size, backend_opts
     )
+
+
+def set_fake_pg_delegate(store, pg=None, backend="gloo"):
+    """
+    Attach a real communication backend to a FakeProcessGroup so that
+    collectives produce numerically correct results.
+
+    This is useful for multi-process numerics testing: each process
+    initializes with FakePG (lightweight, no NCCL dependency), then
+    attaches a gloo delegate for deterministic CPU-based collectives.
+    PREMUL_SUM operations are automatically decomposed into SUM +
+    post-multiply at the C++ level.
+
+    Args:
+        store: A ``dist.Store`` for the delegate backend's rendezvous.
+            When using torchrun, use ``dist.distributed_c10d._default_pg_init_method``
+            or create a new ``TCPStore``.
+        pg: The FakeProcessGroup to modify. Defaults to the world group.
+        backend: Delegate backend name. Currently only ``"gloo"`` is supported.
+
+    Example::
+
+        dist.init_process_group("fake", rank=rank, world_size=world_size)
+        store = dist.TCPStore(master_addr, port, world_size, is_master=(rank == 0))
+        set_fake_pg_delegate(store)
+        # Now dist.all_reduce etc. use real gloo collectives
+    """
+    if pg is None:
+        pg = dist.distributed_c10d._get_default_group()
+
+    # The world PG wraps the actual backend; extract FakeProcessGroup from it.
+    backend_obj = pg._get_backend(torch.device("cpu"))
+    if not isinstance(backend_obj, FakeProcessGroup):
+        raise TypeError(
+            f"Expected FakeProcessGroup, got {type(backend_obj).__name__}. "
+            "set_fake_pg_delegate only works with the 'fake' backend."
+        )
+
+    if backend != "gloo":
+        raise ValueError(f"Unsupported delegate backend: {backend!r}")
+
+    rank = backend_obj.rank()
+    size = backend_obj.size()
+    delegate_pg = ProcessGroupGloo(
+        dist.PrefixStore("fake_delegate/", store), rank, size
+    )
+    backend_obj.set_delegate(delegate_pg)
 
 
 dist.Backend.register_backend(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185835

`FakeProcessGroup.set_delegate(backend)` forwards all collectives to a
real backend instead of FakePG's no-op implementations. This enables
multi-process numerics testing with deterministic collectives -- 8
processes init with FakePG, attach a gloo delegate, and get
bit-reproducible CPU-based collectives that ablate NCCL reduction order
non-determinism. PREMUL_SUM is decomposed into SUM + post-multiply at
the C++ level since gloo does not support it.

Why not just use gloo directly: FakePG is the backend used during
torch.compile tracing and CooR precompile. The delegate keeps that
contract intact while adding real communication underneath.

Authored with AI assistance.

Test Plan:
8-GPU torchtitan debug_model with FakePG + gloo delegate:
- Two delegate runs are bit-identical (0.000% diff)
- Delegate vs NCCL: 0.0005% max relative loss diff over 10 steps

```bash
torchrun --nproc_per_node=8 --virtual-local-rank \
  fakepg_delegate_train_wrapper.py \
  --module llama3 --config llama3_debugmodel \
  --parallelism.data_parallel_shard_degree 8 \
  --training.steps 10 --debug.seed 42 --debug.deterministic
```