### PR TITLE
[cuda graphs] Fix stream pool collision in conditional graph nodes

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -356,6 +356,11 @@ void CUDAGraph::reset() {
     C10_CUDA_CHECK_WARN(cudaGraphExecDestroy(graph_exec_));
     has_graph_exec_ = false;
   }
+#if !defined(USE_ROCM) && (defined(CUDA_VERSION) && CUDA_VERSION >= 12040)
+  while (!conditional_node_raw_streams_.empty()) {
+    conditional_node_raw_streams_.pop();
+  }
+#endif
 }
 
 // Returns an id another graph's capture_begin can use to share the same memory pool as this graph.
@@ -474,7 +479,12 @@ getCurrentCUDAStream(), &cond_node, nullptr, 1, cudaStreamSetCaptureDependencies
 getCurrentCUDAStream(), &cond_node, nullptr, 1, cudaStreamSetCaptureDependencies));
 #endif
 
-  CUDAStream child_stream = getStreamFromPool();
+  cudaStream_t raw_child_stream{};
+  AT_CUDA_CHECK(cudaStreamCreateWithFlags(
+      &raw_child_stream, cudaStreamNonBlocking));
+  CUDAStream child_stream =
+      getStreamFromExternal(raw_child_stream, capture_dev_);
+  conditional_node_raw_streams_.emplace(raw_child_stream);
   conditional_graph_capture_ids_.push(0);
 
   c10::cuda::CUDACachingAllocator::endAllocateToPool(capture_dev_, mempool_id_);
@@ -540,6 +550,9 @@ void CUDAGraph::end_capture_to_conditional_node() {
   c10::cuda::CUDACachingAllocator::markCaptureEnd(capture_dev_);
   conditional_node_streams_.pop();
   conditional_graph_capture_ids_.pop();
+
+  TORCH_INTERNAL_ASSERT(!conditional_node_raw_streams_.empty());
+  conditional_node_raw_streams_.pop();
 
   c10::cuda::CUDACachingAllocator::endAllocateToPool(capture_dev_, mempool_id_);
   at::getHostAllocator(at::kCUDA)->end_allocate_to_pool(mempool_id_);

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -145,8 +145,29 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   cudaStreamCaptureMode capture_mode_{};
 
 #if !defined(USE_ROCM) && (defined(CUDA_VERSION) && CUDA_VERSION >= 12040)
+  struct OwnedCUDAStream {
+    cudaStream_t stream = nullptr;
+    OwnedCUDAStream() = default;
+    explicit OwnedCUDAStream(cudaStream_t s) : stream(s) {}
+    ~OwnedCUDAStream() {
+      if (stream)
+        C10_CUDA_CHECK_WARN(cudaStreamDestroy(stream));
+    }
+    OwnedCUDAStream(const OwnedCUDAStream&) = delete;
+    OwnedCUDAStream& operator=(const OwnedCUDAStream&) = delete;
+    OwnedCUDAStream(OwnedCUDAStream&& o) noexcept
+        : stream(std::exchange(o.stream, nullptr)) {}
+    OwnedCUDAStream& operator=(OwnedCUDAStream&& o) noexcept {
+      if (stream)
+        C10_CUDA_CHECK_WARN(cudaStreamDestroy(stream));
+      stream = std::exchange(o.stream, nullptr);
+      return *this;
+    }
+  };
+
   std::stack<at::cuda::CUDAStreamGuard> conditional_node_streams_;
   std::stack<CaptureId_t> conditional_graph_capture_ids_;
+  std::stack<OwnedCUDAStream> conditional_node_raw_streams_;
 #endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12040
 };
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4477,6 +4477,44 @@ exit(2)
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
+    @unittest.skipIf(
+        TEST_WITH_ROCM
+        or not torch.version.cuda
+        or tuple(int(x) for x in torch.version.cuda.split(".")) < (12, 4),
+        "CUDA >= 12.4 required for conditional graph nodes",
+    )
+    def test_cuda_graph_many_if_nodes_across_graphs(self):
+        pred = torch.zeros((), device="cuda", dtype=torch.bool)
+        x = torch.zeros((), device="cuda")
+        for _ in range(40):
+            g = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(g):
+                g.begin_capture_to_if_node(pred)
+                x.add_(1.0)
+                g.end_capture_to_conditional_node()
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @unittest.skipIf(
+        TEST_WITH_ROCM
+        or not torch.version.cuda
+        or tuple(int(x) for x in torch.version.cuda.split(".")) < (12, 4),
+        "CUDA >= 12.4 required for conditional graph nodes",
+    )
+    def test_cuda_graph_many_if_nodes_in_one_graph(self):
+        pred = torch.zeros((), device="cuda", dtype=torch.bool)
+        x = torch.zeros((), device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            for _ in range(40):
+                g.begin_capture_to_if_node(pred)
+                x.add_(1.0)
+                g.end_capture_to_conditional_node()
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
     def test_cuda_graph_tensor_item_not_allowed(self):
         test_script = """\
 import torch


### PR DESCRIPTION
## Author Notes

This was manual investigation and the simplest solution I could find. The overhead of creating a new stream shouldn't be a problem as this only happens during tracing. Either way, there is no way to get the pool to work if you ever have more than 32 if statement within a single cudagraph as they each need their own stream. Happy to update if I missed something though!
You can look at the test code for minimal repros of the problem.

## Agent Notes

`begin_capture_to_if_node` used `getStreamFromPool()` to obtain a child
stream for the conditional node capture. The stream pool has exactly 32
streams served round-robin. The parent capture stream (allocated by
`torch.cuda.graph()` via `torch.cuda.Stream()`) also comes from this same
pool. After 31 conditional node captures, `getStreamFromPool()` wraps
around and returns the same stream already in use for the parent capture,
causing `cudaStreamBeginCaptureToGraph` to fail with
`cudaErrorIllegalState`.

Fix by creating a dedicated stream via `cudaStreamCreateWithFlags` +
`getStreamFromExternal` instead of drawing from the shared pool. The
stream is destroyed in `end_capture_to_conditional_node`, with cleanup in
`reset()` for error paths.

## Test plan

- `test_cuda_graph_many_if_nodes_across_graphs`: 40 separate graphs with one if-node each
- `test_cuda_graph_many_if_nodes_in_one_graph`: single graph with 40 if-nodes