### PR TITLE
[decomp] Fix multilabel_margin_loss for padded targets

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9911,6 +9911,32 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 (a, b),
             )
 
+    def test_multilabel_margin_loss_padded_target(self):
+        # Targets are -1 padded after the first -1; the decomposition must not
+        # accumulate loss terms for those invalid target positions (#185464).
+        target = torch.tensor([[0, 1, -1, -1, -1]], dtype=torch.int64)
+
+        def fn(x):
+            return F.multilabel_margin_loss(x, target.to(x.device))
+
+        for reduction in ("mean", "sum", "none"):
+
+            def fn_r(x, reduction=reduction):
+                return F.multilabel_margin_loss(
+                    x, target.to(x.device), reduction=reduction
+                )
+
+            x = torch.tensor(
+                [[1.0, -1.0, 0.5, 0.3, -0.2]], device=self.device, requires_grad=True
+            )
+            x_c = x.detach().clone().requires_grad_(True)
+            out = fn_r(x)
+            out_c = torch.compile(fn_r, fullgraph=True)(x_c)
+            self.assertEqual(out, out_c)
+            out.sum().backward()
+            out_c.sum().backward()
+            self.assertEqual(x.grad, x_c.grad)
+
     @xfail_if_mps  # dtypes mismatch
     def test_nll_loss_backward(self):
         def fn(a, b, c):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9911,6 +9911,8 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 (a, b),
             )
 
+    @skip_if_halide
+    @skip_if_pallas
     def test_multilabel_margin_loss_padded_target(self):
         # Targets are -1 padded after the first -1; the decomposition must not
         # accumulate loss terms for those invalid target positions (#185464).

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5566,6 +5566,8 @@ def multilabel_margin_loss_forward(
     z = z / dim
     # masks loss
     z = torch.where(is_target, 0, z)
+    # masks out rows for invalid target positions (at/after the first -1)
+    z = torch.where(target_mask.T.unsqueeze(dim=-1), z, 0)
     # reduction
     if reduction == Reduction.MEAN.value:
         z = z.sum(dim=(0, -1)).mean()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185842

multilabel_margin_loss_forward builds its loss tensor z with shape
[target_position, batch, input_class]. Target positions at or after the first
-1 are invalid, but their gathered index was clamped to 0, so those rows summed
in input[0]'s hinge terms. The decomposition masked invalid target *columns*
(is_target) but not the invalid target-position *rows*, giving a too-large loss
and wrong gradients (e.g. 1.96 vs 1.48).

Mask out the invalid rows using the already-computed target_mask (positions
before the first -1), matching the eager kernel.

The regression test skips the Halide and Pallas clones; this is a shared
decomposition correctness fix covered by regular CPU and CUDA Inductor tests,
and those backend clones have separate limitations.

Fixes #185464

Test Plan:
```bash
python -m py_compile test/inductor/test_torchinductor.py torch/_decomp/decompositions.py
```

```bash
PYTHONPATH=.:test/inductor:/usr/local/lib/oilfs TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 python -m unittest test_torchinductor.CpuTests.test_multilabel_margin_loss_padded_target_cpu test_torchinductor.GPUTests.test_multilabel_margin_loss_padded_target_cuda
```

```bash
env https_proxy=http://fwdproxy:8080 HTTPS_PROXY=http://fwdproxy:8080 lintrunner -a
```

The full lint run reports existing repo-wide PYREFLY missing-attribute errors
unrelated to this patch.

```bash
env https_proxy=http://fwdproxy:8080 HTTPS_PROXY=http://fwdproxy:8080 lintrunner -a -m origin/main --skip PYREFLY --output oneline
```

Authored by Claude.