### PR TITLE
[inductor] Convert SymInt args to ints when benchmarking collectives

### DIFF
--- a/torch/_inductor/fx_passes/node_runtime_estimation.py
+++ b/torch/_inductor/fx_passes/node_runtime_estimation.py
@@ -150,22 +150,27 @@ def _benchmark_collective_with_cuda_events_impl(
     """
     from torch._dynamo.testing import rand_strided
 
-    # Convert FakeTensors to real tensors before benchmarking
-    def to_real(t: torch.Tensor) -> torch.Tensor:
-        shape = [get_hint(dim) for dim in t.shape]
-        stride = [get_hint(s) for s in t.stride()]
+    # Convert FakeTensors to real tensors, and scalar SymInt args (e.g. the
+    # split sizes of all_to_all_single under dynamic shapes) to concrete ints,
+    # before calling the eager collective which expects plain ints.
+    def to_real(x: Any) -> Any:
+        if isinstance(x, torch.SymInt):
+            hint = get_hint(x)
+            if hint is None:
+                raise ValueError("Cannot benchmark collective with symbolic SymInt arg")
+            return hint
+        if not isinstance(x, torch.Tensor):
+            return x
+        shape = [get_hint(dim) for dim in x.shape]
+        stride = [get_hint(s) for s in x.stride()]
 
         if any(s is None for s in itertools.chain(shape, stride)):
             # This should not happen, as can_benhcmark_collective checks for unbacked
             raise ValueError("Cannot convert tensor with symbolic dimensions")
 
-        return rand_strided(shape, stride, device=t.device, dtype=t.dtype)  # type: ignore[arg-type]
+        return rand_strided(shape, stride, device=x.device, dtype=x.dtype)  # type: ignore[arg-type]
 
-    args, kwargs = torch.utils._pytree.tree_map_only(
-        torch.Tensor,
-        to_real,
-        (args, kwargs),
-    )
+    args, kwargs = torch.utils._pytree.tree_map(to_real, (args, kwargs))
 
     # Warmup: call collective once and wait
     torch.cuda.synchronize()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

_benchmark_collective_with_cuda_events_impl materialized FakeTensor args to real
tensors but left scalar SymInt args untouched. Under dynamic shapes
all_to_all_single has SymInt output/input split sizes, so the eager collective
ran during benchmarking hit SymInt::expect_int and raised
"when unpacking SymInt, expected int".

Convert scalar torch.SymInt leaves to their concrete hints via get_hint (raising
the same ValueError class the tensor path already uses if a hint is unavailable),
and switch tree_map_only(Tensor) to tree_map so non-tensor leaves are visited
(they pass through unchanged). The real tensors/ints are used only for the
throwaway benchmark and never leak into the compiled artifact, cache key, or
guards.

Fixes #185623

Test Plan:
    # 4-GPU repro: previously raised SymInt::expect_int, now prints "OK: no crash"
    torchrun --nproc-per-node=4 <all_to_all_single under dynamic shapes with
    collective_estimator="benchmark" and overlap scheduling>

A dedicated regression test was omitted: the fixed code path is only reached
when the overlap scheduler benchmarks an all_to_all_single, which requires
enable_overlap_scheduling; this was verified manually on 4 GPUs.

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo