### PR TITLE
[decomp] Match eager's device-dependent threshold comparison dtype

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8193,6 +8193,17 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             (torch.randn([64]),),
         )
 
+    def test_threshold_low_precision_boundary(self):
+        # threshold's boundary comparison is device-dependent in eager: CUDA
+        # compares in the input dtype, CPU in fp32. bf16(0.1) == 0.10009765625,
+        # so an input equal to that is at the bound on CUDA (-> value) but above
+        # it on CPU (-> kept). Compiled must match eager per device (#185470).
+        def fn(x):
+            return F.threshold(x, 0.1, 0.0)
+
+        x = torch.tensor([0.10009765625], dtype=torch.bfloat16, device=self.device)
+        self.assertEqual(torch.compile(fn, fullgraph=True)(x), fn(x))
+
     def test_hardsigmoid(self):
         def fn(x):
             return F.hardsigmoid(x), F.hardsigmoid(x + 3), F.hardsigmoid(x - 3)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8194,10 +8194,15 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         )
 
     def test_threshold_low_precision_boundary(self):
-        # threshold's boundary comparison is device-dependent in eager: CUDA
-        # compares in the input dtype, CPU in fp32. bf16(0.1) == 0.10009765625,
-        # so an input equal to that is at the bound on CUDA (-> value) but above
-        # it on CPU (-> kept). Compiled must match eager per device (#185470).
+        if self.device != "cuda":
+            raise unittest.SkipTest("CUDA-specific threshold boundary")
+        if not self.is_dtype_supported(torch.bfloat16):
+            raise unittest.SkipTest(
+                f"torch.bfloat16 not supported for device {self.device}"
+            )
+
+        # CUDA threshold compares the scalar threshold in the input dtype.
+        # bf16(0.1) == 0.10009765625, so this input is exactly at the bound.
         def fn(x):
             return F.threshold(x, 0.1, 0.0)
 

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -942,16 +942,14 @@ def threshold(
     if inplace:
         raise NotImplementedError
 
-    # Eager compares against the threshold in a device-dependent dtype
-    # (issue #185470): the CUDA kernel casts the scalar threshold to the input
-    # dtype and compares in the input dtype, while the CPU kernel compares in
-    # fp32. Match each so the boundary classification agrees with eager on the
-    # running device. Only the comparison dtype changes; the result still comes
-    # from a, so the output dtype is unaffected.
     cmp = a
-    if a.device.type != "cuda" and utils.is_low_precision_dtype(a.dtype):
+    cmp_threshold = threshold
+    if a.device.type == "cuda" and utils.is_low_precision_dtype(a.dtype):
+        # CUDA threshold kernels cast the scalar threshold to the input dtype.
+        cmp_threshold = torch.scalar_tensor(threshold, dtype=a.dtype, device=a.device)
+    elif utils.is_low_precision_dtype(a.dtype):
         cmp = prims.convert_element_type(a, torch.float32)
-    return torch.where(cmp <= threshold, value, a)
+    return torch.where(cmp <= cmp_threshold, value, a)
 
 
 # CompositeImplicitAutograd - don't register decomp

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -929,10 +929,6 @@ def tanhshrink(a: TensorLikeType) -> TensorLikeType:
 @register_decomposition(aten.threshold)
 @_inplace_wrapper
 @out_wrapper()
-@elementwise_type_promotion_wrapper(
-    type_promoting_args=("a",),
-    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
-)
 def threshold(
     a: TensorLikeType,
     threshold: NumberType,
@@ -946,7 +942,16 @@ def threshold(
     if inplace:
         raise NotImplementedError
 
-    return torch.where(a <= threshold, value, a)
+    # Eager compares against the threshold in a device-dependent dtype
+    # (issue #185470): the CUDA kernel casts the scalar threshold to the input
+    # dtype and compares in the input dtype, while the CPU kernel compares in
+    # fp32. Match each so the boundary classification agrees with eager on the
+    # running device. Only the comparison dtype changes; the result still comes
+    # from a, so the output dtype is unaffected.
+    cmp = a
+    if a.device.type != "cuda" and utils.is_low_precision_dtype(a.dtype):
+        cmp = prims.convert_element_type(a, torch.float32)
+    return torch.where(cmp <= threshold, value, a)
 
 
 # CompositeImplicitAutograd - don't register decomp


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185846

torch.threshold's boundary comparison uses a different dtype across eager
backends: the CUDA kernel casts the scalar threshold to the input dtype and
compares in the input dtype, while the CPU kernel compares in fp32. The
decomposition used elementwise_type_promotion_wrapper(DEFAULT), which always
upcast the input to fp32, so it matched CPU eager but not CUDA eager: for
x = bf16(0.1) = 0.10009765625 and threshold 0.1, CUDA eager returns value (the
bound is reached in bf16) while the decomposition kept x.

Compare in the input dtype on CUDA, upcasting low-precision floats to fp32 only
on non-CUDA devices (matching the CPU kernel and preserving prior behavior
there). Only the comparison dtype changes; the result still comes from a, so the
output dtype is unaffected.

Fixes #185470

Test Plan:
    python test/inductor/test_torchinductor.py GPUTests.test_threshold_low_precision_boundary
    python test/inductor/test_torchinductor.py CpuTests.test_threshold_low_precision_boundary
    python test/test_ops.py -k threshold

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo