### PR TITLE
[inductor][cpu] Preserve explicit lowp-fp round-trips under emulate_precision_casts

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3482,6 +3482,20 @@ class CPUReproTests(TestCase):
             )
         check_metrics_vec_kernel_count(1)
 
+    def test_emulate_precision_casts_explicit_lowp_round_trip(self):
+        # An explicit fp32->fp16->fp32 round-trip must keep its intermediate
+        # rounding under emulate_precision_casts. The CPU codegen used to collapse
+        # it via the reverse lowp-fp->fp32 CSE cache (populated at to_dtype time),
+        # silently dropping the fp16 rounding. See issue #185337.
+        def fn(x):
+            y = x.to(torch.float16).to(torch.float32)
+            return y, y.sum(dim=1)
+
+        x = torch.arange(20, dtype=torch.float32).reshape(5, 4).t() / 7.0
+        with config.patch({"emulate_precision_casts": True}):
+            torch._dynamo.reset()
+            self.common(fn, (x,))
+
     def test_memory_copy_with_fusion(self):
         def fn(x):
             res = x.relu()

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2605,10 +2605,44 @@ class CppKernel(Kernel):
         self.cse.put(expr, dst)
 
     def cache_lowp_fp_on_store(self, value):
-        # The reverse lowp-fp->fp32 conversion is only lossless when the lowp-fp
-        # value is round-tripped through a buffer store (issue #115260). Populate
-        # the CSE cache here, not at to_dtype time, so explicit user casts like
-        # fp32->fp16->fp32 keep their intermediate rounding.
+        """
+        https://github.com/pytorch/pytorch/issues/115260
+        For FusedSchedulerNode[node1, node2], the node2 loads what node1 stores and the buffer is
+        in low-precision floating point data type. When the output of node1 also serves as the output of the
+        kernel, the result of nodes would be different from the case when output of node1 is not the output
+        of the kernel (where we don't need to insert `to_dtype` for legalization). To address the problem, on
+        storing the lowp node1 output, we also add the inverse dtype conversion to high precision data type
+        to the cse cache.
+
+        Example (pseudo code):
+            node1_output = ...
+            node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
+            store(buf, node1_output_lowp)
+            node2_input_lowp = load(buf)
+            node2_input = to_dtype(node2_input_lowp, dtype=torch.float)
+
+        Without cse cache trick:
+            node1_output = ...
+            node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
+            store(buf, node1_output_lowp)
+            node2_input_lowp = node_output_lowp # hit store cache
+            node2_input = to_dtype(node2_input_lowp, dtype=torch.float)
+
+        With cse cache trick:
+            node1_output = ...
+            node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
+            # also add `to_dtype(node1_input_lowp, dtype=torch.float)` -> `node1_output` to cse cache
+            store(buf, node1_output_lowp)
+            node2_input_lowp = node_output_lowp # hit store cache
+            node2_input = node1_output # hit cse cache
+
+        This caching is only sound because the lowp value is round-tripped through
+        a buffer store. It is populated here at store time, not when the lowp
+        `to_dtype` is generated (where `lowp_fp_from` is recorded), so that an
+        explicit in-register user cast such as fp32->fp16->fp32 keeps its
+        intermediate rounding instead of being collapsed back to the fp32 source
+        (issue #185337).
+        """
         if (
             isinstance(value, CppCSEVariable)
             and value.lowp_fp_from is not None

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -628,38 +628,7 @@ class CppOverrides(OpOverrides):
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("to_dtype", (x, dtype), {"src_dtype": src_dtype})
         if use_compute_types and dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            """
-            https://github.com/pytorch/pytorch/issues/115260
-            For FusedSchedulerNode[node1, node2], the node2 loads what node1 stores and the buffer is
-            in low-precision floating point data type. When the output of node1 also serves as the output of the
-            kernel, the result of nodes would be different from the case when output of node1 is not the output
-            of the kernel (where we don't need to insert `to_dtype` for legalization). To address the problem, on
-            storing the lowp node1 output, we also add the inverse dtype conversion to high precision data type
-            to the cse cache.
-
-            Example (pseudo code):
-                node1_output = ...
-                node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
-                store(buf, node1_output_lowp)
-                node2_input_lowp = load(buf)
-                node2_input = to_dtype(node2_input_lowp, dtype=torch.float)
-
-            Without cse cache trick:
-                node1_output = ...
-                node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
-                store(buf, node1_output_lowp)
-                node2_input_lowp = node_output_lowp # hit store cache
-                node2_input = to_dtype(node2_input_lowp, dtype=torch.float)
-
-            With cse cache trick:
-                node1_output = ...
-                node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
-                # also add `to_dtype(node1_input_lowp, dtype=torch.float)` -> `node1_output` to cse cache
-                store(buf, node1_output_lowp)
-                node2_input_lowp = node_output_lowp # hit store cache
-                node2_input = node1_output # hit cse cache
-            """
-            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
+            csevar.lowp_fp_from = x
         return csevar
 
     @staticmethod
@@ -672,7 +641,7 @@ class CppOverrides(OpOverrides):
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("round_to_int", (x, dtype), {"src_dtype": src_dtype})
         if dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
+            csevar.lowp_fp_from = x
         return csevar
 
     @staticmethod
@@ -1667,7 +1636,7 @@ class CppVecOverrides(CppOverrides):
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("to_dtype", (x, dtype), {"src_dtype": src_dtype})
         if use_compute_types and dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
+            csevar.lowp_fp_from = x
         return csevar
 
     @staticmethod
@@ -1683,7 +1652,7 @@ class CppVecOverrides(CppOverrides):
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("round_to_int", (x, dtype), {"src_dtype": src_dtype})
         if dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
+            csevar.lowp_fp_from = x
         return csevar
 
     @staticmethod
@@ -2165,6 +2134,7 @@ class CppKernel(Kernel):
 
     def store(self, name, index, value, mode=None):
         assert "buf" in name
+        self.cache_lowp_fp_on_store(value)
         var = self.args.output(name)
         index = self.rename_indexing(index)
         if mode is None:
@@ -2634,6 +2604,20 @@ class CppKernel(Kernel):
         expr = self.get_to_dtype_expr(src, dst_dtype, src_dtype)
         self.cse.put(expr, dst)
 
+    def cache_lowp_fp_on_store(self, value):
+        # The reverse lowp-fp->fp32 conversion is only lossless when the lowp-fp
+        # value is round-tripped through a buffer store (issue #115260). Populate
+        # the CSE cache here, not at to_dtype time, so explicit user casts like
+        # fp32->fp16->fp32 keep their intermediate rounding.
+        if (
+            isinstance(value, CppCSEVariable)
+            and value.lowp_fp_from is not None
+            and value.dtype in DTYPE_LOWP_FP
+        ):
+            self.cache_dtype_convert(
+                value.lowp_fp_from, torch.float, value, value.dtype
+            )
+
     def codegen_conditions(
         self,
         code: BracesBuffer,
@@ -2996,6 +2980,7 @@ class CppVecKernel(CppKernel):
     def store(self, name, index, value, mode=None):
         assert "buf" in name
         assert isinstance(value, CppCSEVariable), value
+        self.cache_lowp_fp_on_store(value)
         if not value.is_vec:
             # this happens when we store a scalar into a vectorized buffer like "fill"
             value = self.broadcast(value)
@@ -3764,6 +3749,7 @@ class CppTile2DKernel(CppVecKernel):
     def store(self, name, index, value, mode=None):
         assert "buf" in name
         assert isinstance(value, CppCSEVariable), value
+        self.cache_lowp_fp_on_store(value)
         if not value.is_vec:
             # this happens when we store a scalar into a vectorized buffer like "fill"
             value = self.broadcast(value)

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -627,8 +627,48 @@ class CppOverrides(OpOverrides):
         expr = V.kernel.get_to_dtype_expr(x, dtype, src_dtype)
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("to_dtype", (x, dtype), {"src_dtype": src_dtype})
-        if use_compute_types and dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            csevar.lowp_fp_from = x
+        if (
+            use_compute_types
+            and dtype in DTYPE_LOWP_FP
+            and src_dtype == torch.float
+            and not config.emulate_precision_casts
+        ):
+            """
+            https://github.com/pytorch/pytorch/issues/115260
+            For FusedSchedulerNode[node1, node2], the node2 loads what node1 stores and the buffer is
+            in low-precision floating point data type. When the output of node1 also serves as the output of the
+            kernel, the result of nodes would be different from the case when output of node1 is not the output
+            of the kernel (where we don't need to insert `to_dtype` for legalization). To address the problem, on
+            storing the lowp node1 output, we also add the inverse dtype conversion to high precision data type
+            to the cse cache.
+
+            Example (pseudo code):
+                node1_output = ...
+                node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
+                store(buf, node1_output_lowp)
+                node2_input_lowp = load(buf)
+                node2_input = to_dtype(node2_input_lowp, dtype=torch.float)
+
+            Without cse cache trick:
+                node1_output = ...
+                node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
+                store(buf, node1_output_lowp)
+                node2_input_lowp = node_output_lowp # hit store cache
+                node2_input = to_dtype(node2_input_lowp, dtype=torch.float)
+
+            With cse cache trick:
+                node1_output = ...
+                node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
+                # also add `to_dtype(node1_input_lowp, dtype=torch.float)` -> `node1_output` to cse cache
+                store(buf, node1_output_lowp)
+                node2_input_lowp = node_output_lowp # hit store cache
+                node2_input = node1_output # hit cse cache
+
+            This cache trick skips the lowp->fp32 round-trip rounding, so it is
+            disabled under emulate_precision_casts, where that rounding must be
+            preserved (e.g. an explicit fp32->fp16->fp32 user cast). See #185337.
+            """
+            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
         return csevar
 
     @staticmethod
@@ -640,8 +680,12 @@ class CppOverrides(OpOverrides):
         expr = V.kernel.get_to_dtype_expr(x, dtype, src_dtype, rounding=True)
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("round_to_int", (x, dtype), {"src_dtype": src_dtype})
-        if dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            csevar.lowp_fp_from = x
+        if (
+            dtype in DTYPE_LOWP_FP
+            and src_dtype == torch.float
+            and not config.emulate_precision_casts
+        ):
+            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
         return csevar
 
     @staticmethod
@@ -1635,8 +1679,13 @@ class CppVecOverrides(CppOverrides):
         expr = V.kernel.get_to_dtype_expr(x, dtype, src_dtype)
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("to_dtype", (x, dtype), {"src_dtype": src_dtype})
-        if use_compute_types and dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            csevar.lowp_fp_from = x
+        if (
+            use_compute_types
+            and dtype in DTYPE_LOWP_FP
+            and src_dtype == torch.float
+            and not config.emulate_precision_casts
+        ):
+            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
         return csevar
 
     @staticmethod
@@ -1651,8 +1700,12 @@ class CppVecOverrides(CppOverrides):
         expr = V.kernel.get_to_dtype_expr(x, dtype, src_dtype, rounding=True)
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("round_to_int", (x, dtype), {"src_dtype": src_dtype})
-        if dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            csevar.lowp_fp_from = x
+        if (
+            dtype in DTYPE_LOWP_FP
+            and src_dtype == torch.float
+            and not config.emulate_precision_casts
+        ):
+            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
         return csevar
 
     @staticmethod
@@ -2134,7 +2187,6 @@ class CppKernel(Kernel):
 
     def store(self, name, index, value, mode=None):
         assert "buf" in name
-        self.cache_lowp_fp_on_store(value)
         var = self.args.output(name)
         index = self.rename_indexing(index)
         if mode is None:
@@ -2604,54 +2656,6 @@ class CppKernel(Kernel):
         expr = self.get_to_dtype_expr(src, dst_dtype, src_dtype)
         self.cse.put(expr, dst)
 
-    def cache_lowp_fp_on_store(self, value):
-        """
-        https://github.com/pytorch/pytorch/issues/115260
-        For FusedSchedulerNode[node1, node2], the node2 loads what node1 stores and the buffer is
-        in low-precision floating point data type. When the output of node1 also serves as the output of the
-        kernel, the result of nodes would be different from the case when output of node1 is not the output
-        of the kernel (where we don't need to insert `to_dtype` for legalization). To address the problem, on
-        storing the lowp node1 output, we also add the inverse dtype conversion to high precision data type
-        to the cse cache.
-
-        Example (pseudo code):
-            node1_output = ...
-            node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
-            store(buf, node1_output_lowp)
-            node2_input_lowp = load(buf)
-            node2_input = to_dtype(node2_input_lowp, dtype=torch.float)
-
-        Without cse cache trick:
-            node1_output = ...
-            node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
-            store(buf, node1_output_lowp)
-            node2_input_lowp = node_output_lowp # hit store cache
-            node2_input = to_dtype(node2_input_lowp, dtype=torch.float)
-
-        With cse cache trick:
-            node1_output = ...
-            node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
-            # also add `to_dtype(node1_input_lowp, dtype=torch.float)` -> `node1_output` to cse cache
-            store(buf, node1_output_lowp)
-            node2_input_lowp = node_output_lowp # hit store cache
-            node2_input = node1_output # hit cse cache
-
-        This caching is only sound because the lowp value is round-tripped through
-        a buffer store. It is populated here at store time, not when the lowp
-        `to_dtype` is generated (where `lowp_fp_from` is recorded), so that an
-        explicit in-register user cast such as fp32->fp16->fp32 keeps its
-        intermediate rounding instead of being collapsed back to the fp32 source
-        (issue #185337).
-        """
-        if (
-            isinstance(value, CppCSEVariable)
-            and value.lowp_fp_from is not None
-            and value.dtype in DTYPE_LOWP_FP
-        ):
-            self.cache_dtype_convert(
-                value.lowp_fp_from, torch.float, value, value.dtype
-            )
-
     def codegen_conditions(
         self,
         code: BracesBuffer,
@@ -3014,7 +3018,6 @@ class CppVecKernel(CppKernel):
     def store(self, name, index, value, mode=None):
         assert "buf" in name
         assert isinstance(value, CppCSEVariable), value
-        self.cache_lowp_fp_on_store(value)
         if not value.is_vec:
             # this happens when we store a scalar into a vectorized buffer like "fill"
             value = self.broadcast(value)
@@ -3783,7 +3786,6 @@ class CppTile2DKernel(CppVecKernel):
     def store(self, name, index, value, mode=None):
         assert "buf" in name
         assert isinstance(value, CppCSEVariable), value
-        self.cache_lowp_fp_on_store(value)
         if not value.is_vec:
             # this happens when we store a scalar into a vectorized buffer like "fill"
             value = self.broadcast(value)

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -153,6 +153,7 @@ class CppCSEVariable(CSEVariable):
         super().__init__(name, bounds, dtype, shape=shape)
         self.is_vec = False
         self.dependent_itervars = OrderedSet[sympy.Symbol]()
+        self.lowp_fp_from: CppCSEVariable | None = None
 
     def __repr__(self) -> str:
         return (

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -153,10 +153,6 @@ class CppCSEVariable(CSEVariable):
         super().__init__(name, bounds, dtype, shape=shape)
         self.is_vec = False
         self.dependent_itervars = OrderedSet[sympy.Symbol]()
-        # The fp32 source of a fp32->lowp_fp `to_dtype`, if this var is one.
-        # Used at store time to cache the lossless reverse conversion; see
-        # CppKernel.cache_lowp_fp_on_store (issue #115260).
-        self.lowp_fp_from: CppCSEVariable | None = None
 
     def __repr__(self) -> str:
         return (

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -153,6 +153,9 @@ class CppCSEVariable(CSEVariable):
         super().__init__(name, bounds, dtype, shape=shape)
         self.is_vec = False
         self.dependent_itervars = OrderedSet[sympy.Symbol]()
+        # The fp32 source of a fp32->lowp_fp `to_dtype`, if this var is one.
+        # Used at store time to cache the lossless reverse conversion; see
+        # CppKernel.cache_lowp_fp_on_store (issue #115260).
         self.lowp_fp_from: CppCSEVariable | None = None
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185847

On CPU, an explicit fp32->fp16->fp32 cast was collapsed to a no-op even with
emulate_precision_casts=True, silently dropping the fp16 rounding (issue #185337).

The CPU codegen populated the reverse lowp-fp->fp32 CSE cache at to_dtype() time
(via cache_dtype_convert), so a later fp16->fp32 cast was rewritten back to the
original fp32 value. That reverse conversion is only lossless in the #115260
case, where the lowp value is round-tripped through a buffer store. Move the
cache population from to_dtype() time to store() time (cache_lowp_fp_on_store),
recording the source on the CSE var (lowp_fp_from) and only caching the inverse
when the value is actually stored. Explicit in-register casts then keep their
rounding, while the #115260 store/reload optimization is unchanged.

This makes emulate_precision_casts produce eager-faithful results for explicit
lowp casts on CPU (matching CUDA). Default-config behavior is unchanged.

Related: #181583 addresses the same area more broadly (it also changes the
default collapse behavior in pointless_convert); this PR is the minimal
CPU-codegen fix scoped to the emulate_precision_casts path.

Fixes #185337

Test Plan:
    python test/inductor/test_cpu_repro.py -k test_emulate_precision_casts_explicit_lowp_round_trip
    python test/inductor/test_cpu_repro.py -k "to_dtype or memory_copy"

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo