### PR TITLE
Fix SymInt Scalar equality for pow backward

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cmath>
 #include <cstdint>
+#include <limits>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -30,6 +32,7 @@ namespace c10 {
  * circumstances where you statically know a tensor is 0-dim and single size,
  * but don't know its type.
  */
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 class C10_API Scalar {
  public:
   Scalar() : Scalar(int64_t(0)) {}
@@ -79,12 +82,12 @@ class C10_API Scalar {
 
   Scalar(uint16_t vv) : Scalar(vv, true) {}
   Scalar(uint32_t vv) : Scalar(vv, true) {}
-  Scalar(uint64_t vv) {
-    if (vv > static_cast<uint64_t>(INT64_MAX)) {
-      tag = Tag::HAS_u;
+  Scalar(uint64_t vv) // NOLINT(cppcoreguidelines-pro-type-member-init)
+      : tag(vv > static_cast<uint64_t>(INT64_MAX) ? Tag::HAS_u : Tag::HAS_i) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+    if (tag == Tag::HAS_u) {
       v.u = vv;
     } else {
-      tag = Tag::HAS_i;
       // NB: no need to use convert, we've already tested convertibility
       v.i = static_cast<int64_t>(vv);
     }
@@ -270,7 +273,7 @@ class C10_API Scalar {
         return static_cast<T>(v.u) == num;
       }
     } else if (tag == Tag::HAS_si) {
-      TORCH_INTERNAL_ASSERT(false, "NYI SymInt equality");
+      return equalSymInt(num);
     } else if (isBoolean()) {
       // boolean scalar does not equal to a non boolean value
       TORCH_INTERNAL_ASSERT(!isSymbolic());
@@ -302,7 +305,8 @@ class C10_API Scalar {
         return static_cast<T>(v.u) == num.real() && num.imag() == T();
       }
     } else if (tag == Tag::HAS_si) {
-      TORCH_INTERNAL_ASSERT(false, "NYI SymInt equality");
+      using value_type = typename T::value_type;
+      return num.imag() == value_type() && equalSymInt(num.real());
     } else if (isBoolean()) {
       // boolean scalar does not equal to a non boolean value
       TORCH_INTERNAL_ASSERT(!isSymbolic());
@@ -422,6 +426,43 @@ class C10_API Scalar {
     // NOLINTNEXTLINE(modernize-use-equals-default)
     v_t() {} // default constructor
   } v;
+
+  template <
+      typename T,
+      typename std::enable_if_t<std::is_integral_v<T>, bool>* = nullptr>
+  bool tryToInt64(T num, int64_t* out) const {
+    if (overflows<int64_t>(num, /* strict_unsigned */ true)) {
+      return false;
+    }
+    *out = static_cast<int64_t>(num);
+    return true;
+  }
+
+  template <
+      typename T,
+      typename std::enable_if_t<!std::is_integral_v<T>, bool>* = nullptr>
+  bool tryToInt64(T num, int64_t* out) const {
+    const auto num_double = static_cast<double>(num);
+    const auto lower = static_cast<double>(std::numeric_limits<int64_t>::min());
+    const auto upper = -lower;
+    if (!std::isfinite(num_double) || std::trunc(num_double) != num_double ||
+        num_double < lower || num_double >= upper) {
+      return false;
+    }
+    *out = static_cast<int64_t>(num_double);
+    return true;
+  }
+
+  template <typename T>
+  bool equalSymInt(T num) const {
+    int64_t int_num;
+    if (!tryToInt64(num, &int_num)) {
+      return false;
+    }
+    return toSymInt()
+        .sym_eq(c10::SymInt(int_num))
+        .guard_bool(__FILE__, __LINE__);
+  }
 
   template <
       typename T,

--- a/c10/test/core/Scalar_test.cpp
+++ b/c10/test/core/Scalar_test.cpp
@@ -1,8 +1,48 @@
 #include <gtest/gtest.h>
 
+#include <c10/core/ConstantSymNodeImpl.h>
 #include <c10/core/Scalar.h>
+#include <c10/core/SymNodeImpl.h>
+
+#include <limits>
+#include <optional>
 
 using namespace c10;
+
+namespace {
+class ConstantIntPretendingToBeSymbolicSymNodeImpl
+    : public ConstantSymNodeImpl<int64_t> {
+ public:
+  using ConstantSymNodeImpl<int64_t>::ConstantSymNodeImpl;
+
+  std::optional<int64_t> constant_int() override {
+    return std::nullopt;
+  }
+
+  std::optional<int64_t> maybe_as_int() override {
+    return std::nullopt;
+  }
+
+  c10::SymNode wrap_int(int64_t num) override {
+    return SymNode(
+        c10::make_intrusive<ConstantIntPretendingToBeSymbolicSymNodeImpl>(num));
+  }
+
+  c10::SymNode wrap_bool(bool b) override {
+    return SymNode(c10::make_intrusive<ConstantSymNodeImpl<bool>>(b));
+  }
+
+  SymNode eq(const SymNode& other) override {
+    return wrap_bool(int_() == other->int_());
+  }
+};
+
+SymInt create_symbolic_symint(int64_t value) {
+  return SymInt(
+      SymNode(c10::make_intrusive<ConstantIntPretendingToBeSymbolicSymNodeImpl>(
+          value)));
+}
+} // namespace
 
 TEST(ScalarTest, UnsignedConstructor) {
   uint16_t x = 0xFFFF;
@@ -46,6 +86,27 @@ TEST(ScalarTest, Equality) {
   ASSERT_FALSE(Scalar(0).equal(0xFFFFFFFFFFFFFFFF));
   // ensure that we don't incorrectly coerce bitrep
   ASSERT_FALSE(Scalar(-1).equal(0xFFFFFFFFFFFFFFFF));
+}
+
+TEST(ScalarTest, SymIntEquality) {
+  auto scalar = Scalar(create_symbolic_symint(2));
+  ASSERT_TRUE(scalar.isSymbolic());
+  ASSERT_TRUE(scalar.equal(2));
+  ASSERT_TRUE(scalar.equal(2.0));
+  ASSERT_TRUE(scalar.equal(c10::complex<double>(2.0, 0.0)));
+  ASSERT_FALSE(scalar.equal(3));
+  ASSERT_FALSE(scalar.equal(2.5));
+  ASSERT_FALSE(scalar.equal(std::numeric_limits<double>::infinity()));
+  ASSERT_FALSE(scalar.equal(c10::complex<double>(2.0, 1.0)));
+
+  auto min_scalar =
+      Scalar(create_symbolic_symint(std::numeric_limits<int64_t>::min()));
+  ASSERT_TRUE(min_scalar.equal(
+      static_cast<double>(std::numeric_limits<int64_t>::min())));
+  const auto int64_upper =
+      -static_cast<double>(std::numeric_limits<int64_t>::min());
+  ASSERT_FALSE(scalar.equal(int64_upper));
+  ASSERT_FALSE(min_scalar.equal(int64_upper));
 }
 
 TEST(ScalarTest, LongsAndLongLongs) {

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -1730,6 +1730,23 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
         self.assertEqual(eager_no_sq, comp_ind_no_sq)
         self.assertEqual(eager_no_sq.stride(), comp_ind_no_sq.stride())
 
+    def test_autograd_grad_pow_python_int_exponent_dynamic(self):
+        def fn(x, exponent):
+            y = torch.pow(x, exponent)
+            (grad,) = torch.autograd.grad(y.sum(), x)
+            return y, grad
+
+        for backend in ("aot_eager", "inductor"):
+            compiled_fn = torch.compile(fn, backend=backend, dynamic=True)
+            for exponent in (0, 2):
+                x = torch.ones((1, 3), requires_grad=True)
+                expected = fn(x, exponent)
+
+                x = torch.ones((1, 3), requires_grad=True)
+                actual = compiled_fn(x, exponent)
+
+                self.assertEqual(actual, expected)
+
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
     def test_unbacked_activation_specialized_in_inductor(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185849

When torch.compile(dynamic=True) traces a Python integer argument, AOTAutograd can save it as a symbolic integer Scalar. The scalar-exponent pow backward formula checks whether the exponent equals zero, but Scalar::equal asserted on HAS_si values with "NYI SymInt equality" instead of comparing them. That made torch.autograd.grad after torch.pow crash during compilation for dynamic Python int exponents.

Implement Scalar::equal for symbolic integer Scalars by converting comparable numeric constants to int64_t and comparing with SymInt::sym_eq(...).guard_bool(...). Non-integral, non-finite, or out-of-range numeric constants return false before any integer cast, avoiding undefined behavior around the int64_t limits. Complex comparisons use the same path only when the imaginary part is zero.

I considered special-casing pow backward, but the missing operation is Scalar equality for symbolic integers; fixing it in Scalar keeps the behavior consistent for other users of symbolic Scalar equality. The small uint64_t constructor annotation/update is lint-only cleanup required because touching this header brings existing clang-tidy checks into the changed-file lint set.

Fixes #185715
Generated by my agent

Test Plan:
- lintrunner -a
- ninja -C build torch_python -j 8
- python test/dynamo/test_aot_autograd.py -k test_autograd_grad_pow_python_int_exponent_dynamic
- lintrunner -a && ninja -C build c10_Scalar_test -j 8 && build/bin/c10_Scalar_test --gtest_filter=ScalarTest.SymIntEquality

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98