### PR TITLE
Gate #183680 narrowing-cast unfuse on XPU

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1527,6 +1527,7 @@ class TestPatternMatcher(TestCase):
             "keep_addmm_fused_for_half_dtypes": True,
         }
     )
+    @unittest.skipIf(GPU_TYPE != "xpu", "narrowing-cast unfuse is XPU-only; CUDA/ROCm keep addmm fused")
     def test_unfuse_bias_addmm_half_dtypes_narrowing_cast(self, dtype):
         # When bias is fp32 and cast to a half dtype (e.g. AMP), unfusing
         # lets the Triton pointwise kernel load the fp32 bias directly,

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1527,7 +1527,10 @@ class TestPatternMatcher(TestCase):
             "keep_addmm_fused_for_half_dtypes": True,
         }
     )
-    @unittest.skipIf(GPU_TYPE != "xpu", "narrowing-cast unfuse is XPU-only; CUDA/ROCm keep addmm fused")
+    @unittest.skipIf(
+        GPU_TYPE != "xpu",
+        "narrowing-cast unfuse is XPU-only; CUDA/ROCm keep addmm fused",
+    )
     def test_unfuse_bias_addmm_half_dtypes_narrowing_cast(self, dtype):
         # When bias is fp32 and cast to a half dtype (e.g. AMP), unfusing
         # lets the Triton pointwise kernel load the fp32 bias directly,

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1654,10 +1654,11 @@ def unfuse_bias_add_to_pointwise(match: Match, mat1, mat2, *, inp, alpha, beta):
         torch.bfloat16,
         torch.float16,
     ):
-        # Allow unfuse when inp is a narrowing dtype cast (e.g. AMP casting
-        # fp32 bias to bf16/fp16). Unfusing lets the Triton pointwise kernel
-        # load the original higher-precision tensor directly, preserving
-        # precision instead of truncating bias before the fused addmm.
+        # Narrowing-cast unfuse (PR #183680) is XPU-only: it preserves
+        # precision on XPU pointwise but regresses accuracy on ROCm
+        # (basic_gnn_edgecnn training+amp fails on gfx950 otherwise).
+        if inp.meta["val"].device.type != "xpu":
+            return
         if not (
             inp.op == "call_function"
             and inp.target is torch.ops.prims.convert_element_type.default


### PR DESCRIPTION
PR #183680 widened unfuse_bias_add_to_pointwise to handle bias paths that are convert_element_type narrowing casts (fp32 -> bf16/fp16). The PR was framed as an XPU enhancement but the pattern matches on every backend, causing accuracy regressions on ROCm. Bisected to this PR via revert: torchbench basic_gnn_edgecnn training+amp passes pre-#183680, fails on all 4 configs (default/cudagraphs/cudagraphs_dynamic/cpp_wrapper) post-#183680 on MI355/gfx950, and passes again with this patch.

Gates the new branch on inp.meta["val"].device.type == "xpu" to restore the prior CUDA/ROCm behavior while preserving the XPU intent.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo