### PR TITLE
Exclude torch/nativert from clang-tidy lint coverage

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -177,10 +177,6 @@ include_patterns = [
     'torch/csrc/**/*.cpp',
     'torch/csrc/jit/serialization/*.h',
     'torch/csrc/jit/serialization/*.cpp',
-    'torch/nativert/*.h',
-    'torch/nativert/*.cpp',
-    'torch/nativert/**/*.h',
-    'torch/nativert/**/*.cpp',
     'torch/headeronly/**/*.h',
 ]
 exclude_patterns = [


### PR DESCRIPTION
Because this is a dead-weight in the OSS, we should probably desync it down the road
Authored by Claude.