### PR TITLE
ATen/core/TensorBase.h: replace symint enable_if aliases with C++20 requires clauses

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -1037,28 +1037,31 @@ inline c10::MaybeOwned<TensorBase> TensorBase::expect_contiguous(MemoryFormat me
 namespace symint {
 
 template <typename T>
-using enable_if_symint = std::enable_if_t<std::is_same_v<T, c10::SymInt>>;
-template <typename T>
-using enable_if_int = std::enable_if_t<std::is_same_v<T, int64_t>>;
-
-template <typename T, typename = enable_if_symint<T>>
+    requires std::is_same_v<T, c10::SymInt>
 c10::SymIntArrayRef sizes(const TensorBase& t) { return t.sym_sizes(); }
-template <typename T, typename = enable_if_int<T>>
+template <typename T>
+    requires std::is_same_v<T, int64_t>
 IntArrayRef sizes(const TensorBase& t) { return t.sizes(); }
 
-template <typename T, typename = enable_if_symint<T>>
+template <typename T>
+    requires std::is_same_v<T, c10::SymInt>
 c10::SymInt size(const TensorBase& t, int64_t dim) { return t.sym_size(dim); }
-template <typename T, typename = enable_if_int<T>>
+template <typename T>
+    requires std::is_same_v<T, int64_t>
 int64_t size(const TensorBase& t, int64_t dim) { return t.size(dim); }
 
-template <typename T, typename = enable_if_symint<T>>
+template <typename T>
+    requires std::is_same_v<T, c10::SymInt>
 c10::SymIntArrayRef strides(const TensorBase& t) { return t.sym_strides(); }
-template <typename T, typename = enable_if_int<T>>
+template <typename T>
+    requires std::is_same_v<T, int64_t>
 IntArrayRef strides(const TensorBase& t) { return t.strides(); }
 
-template <typename T, typename = enable_if_symint<T>>
+template <typename T>
+    requires std::is_same_v<T, c10::SymInt>
 c10::SymInt numel(const TensorBase& t) { return t.sym_numel(); }
-template <typename T, typename = enable_if_int<T>>
+template <typename T>
+    requires std::is_same_v<T, int64_t>
 int64_t numel(const TensorBase& t) { return t.numel(); }
 
 } // namespace symint


### PR DESCRIPTION
Summary: Remove the `enable_if_symint` and `enable_if_int` type aliases from the `at::symint` namespace and replace each overload pair with `requires std::is_same_v<T, c10::SymInt>` / `requires std::is_same_v<T, int64_t>` constraints. Affected function pairs: `sizes`, `size`, `strides`, `numel`. No behavior change.

Test Plan: `buck2 test fbcode//caffe2/c10/test:core_tests` — 86 tests pass, 0 failures.



