### PR TITLE
[MPS] Templatize Im2Col to regain performance for cases where 32-bit indexing suffices

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Im2Col.metal
+++ b/aten/src/ATen/native/mps/kernels/Im2Col.metal
@@ -1,18 +1,22 @@
 // Heavily inspired by
 // https://github.com/pytorch/pytorch/blob/09519eb19/aten/src/ATen/native/cuda/im2col.cuh#L51
-template <typename T>
+#include <metal_stdlib>
+using namespace metal;
+
+template <typename T, typename IdxT>
 void im2col_kernel(
     constant T* input,
     device T* output,
     uint2 kernel_size,
-    long2 input_offset,
-    long2 input_size,
-    long2 dilation,
-    ulong2 input_strides,
-    ulong output_stride) {
-  for (ulong i = 0; i < kernel_size.y; ++i) {
-    for (ulong j = 0; j < kernel_size.x; ++j) {
-      auto input_pos = input_offset + long2(j, i) * dilation;
+    vec<make_signed_t<IdxT>, 2> input_offset,
+    vec<make_signed_t<IdxT>, 2> input_size,
+    vec<make_signed_t<IdxT>, 2> dilation,
+    vec<IdxT, 2> input_strides,
+    IdxT output_stride) {
+  using SIdxT = make_signed_t<IdxT>;
+  for (uint i = 0; i < kernel_size.y; ++i) {
+    for (uint j = 0; j < kernel_size.x; ++j) {
+      auto input_pos = input_offset + vec<SIdxT, 2>(j, i) * dilation;
       if (input_pos.x < 0 || input_pos.y < 0 || input_pos.x >= input_size.x ||
           input_pos.y >= input_size.y) {
         *output = T(0);
@@ -26,50 +30,56 @@ void im2col_kernel(
   }
 }
 
-template <typename T>
+template <typename T, typename IdxT>
 kernel void im2col(
     constant T* inputData [[buffer(0)]],
     device T* outputData [[buffer(1)]],
     constant uint4& kernel_dilation [[buffer(2)]],
     constant int4& padding_stride [[buffer(3)]],
-    constant ulong4& input_strides [[buffer(4)]],
-    constant ulong4& output_strides [[buffer(5)]],
-    constant long4& input_sizes [[buffer(6)]],
+    constant vec<IdxT, 4>& input_strides [[buffer(4)]],
+    constant vec<IdxT, 4>& output_strides [[buffer(5)]],
+    constant vec<make_signed_t<IdxT>, 4>& input_sizes [[buffer(6)]],
     uint3 thread_index [[thread_position_in_grid]]) {
+  using SIdxT = make_signed_t<IdxT>;
   // thread_index is (output_length, input_channels, input_batch)
   const auto N = thread_index.z;
   const auto C = thread_index.y;
   const auto L = thread_index.x;
-  const auto output_width = output_strides.w;
-  const auto o_x = L % output_width;
-  const auto o_y = L / output_width;
-  auto i_x = o_x * padding_stride.z - padding_stride.x;
-  auto i_y = o_y * padding_stride.w - padding_stride.y;
-  ulong kernel_size = kernel_dilation.x * kernel_dilation.y;
-  outputData += N * output_strides.z + C * kernel_size * output_strides.y +
-      L * output_strides.x;
-  inputData += N * input_strides.w + C * input_strides.z;
-  im2col_kernel(
+  const IdxT output_width = output_strides.w;
+  const IdxT o_x = L % output_width;
+  const IdxT o_y = L / output_width;
+  SIdxT i_x = SIdxT(o_x) * padding_stride.z - padding_stride.x;
+  SIdxT i_y = SIdxT(o_y) * padding_stride.w - padding_stride.y;
+  IdxT kernel_size = kernel_dilation.x * kernel_dilation.y;
+  outputData += IdxT(N) * output_strides.z +
+      IdxT(C) * kernel_size * output_strides.y + IdxT(L) * output_strides.x;
+  inputData += IdxT(N) * input_strides.w + IdxT(C) * input_strides.z;
+  im2col_kernel<T, IdxT>(
       inputData,
       outputData,
       kernel_dilation.xy,
-      long2(i_x, i_y),
+      vec<SIdxT, 2>(i_x, i_y),
       input_sizes.xy,
-      long2(kernel_dilation.zw),
+      vec<SIdxT, 2>(kernel_dilation.zw),
       input_strides.xy,
       output_strides.y);
 }
 
-#define INSTANTIATE_IM2COL(DTYPE)                                     \
-  template [[host_name("im2col_" #DTYPE)]] kernel void im2col<DTYPE>( \
-      constant DTYPE * inputData [[buffer(0)]],                       \
-      device DTYPE * outputData [[buffer(1)]],                        \
-      constant uint4 & kernel_dilation [[buffer(2)]],                 \
-      constant int4 & padding_stride [[buffer(3)]],                   \
-      constant ulong4 & input_strides [[buffer(4)]],                  \
-      constant ulong4 & output_strides [[buffer(5)]],                 \
-      constant long4 & input_sizes [[buffer(6)]],                     \
+#define INSTANTIATE_IM2COL_IDX(DTYPE, IDX, SUFFIX)                     \
+  template [[host_name("im2col_" #DTYPE "_" #SUFFIX)]] kernel void     \
+  im2col<DTYPE, IDX>(                                                  \
+      constant DTYPE * inputData [[buffer(0)]],                        \
+      device DTYPE * outputData [[buffer(1)]],                         \
+      constant uint4 & kernel_dilation [[buffer(2)]],                  \
+      constant int4 & padding_stride [[buffer(3)]],                    \
+      constant vec<IDX, 4> & input_strides [[buffer(4)]],              \
+      constant vec<IDX, 4> & output_strides [[buffer(5)]],             \
+      constant vec<make_signed_t<IDX>, 4> & input_sizes [[buffer(6)]], \
       uint3 thread_index [[thread_position_in_grid]])
+
+#define INSTANTIATE_IM2COL(DTYPE)           \
+  INSTANTIATE_IM2COL_IDX(DTYPE, uint, u32); \
+  INSTANTIATE_IM2COL_IDX(DTYPE, ulong, u64)
 
 INSTANTIATE_IM2COL(bool);
 INSTANTIATE_IM2COL(float);

--- a/aten/src/ATen/native/mps/operations/Im2Col.mm
+++ b/aten/src/ATen/native/mps/operations/Im2Col.mm
@@ -1,5 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/im2col_shape_check.h>
 #include <ATen/native/mps/OperationUtils.h>
 
@@ -78,7 +79,9 @@ static void im2col_out_mps_template(Tensor& output,
   output.resize_({batch_size, n_output_plane, output_length});
   auto stream = getCurrentMPSStream();
   auto device = MPSDevice::getInstance()->device();
-  auto im2colPSO = lib.getPipelineStateForFunc("im2col_" + mps::scalarToMetalTypeString(input));
+  const bool use_u32 = canUse32BitIndexMath(input) && canUse32BitIndexMath(output);
+  auto im2colPSO =
+      lib.getPipelineStateForFunc("im2col_" + mps::scalarToMetalTypeString(input) + (use_u32 ? "_u32" : "_u64"));
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       std::array<int32_t, 4> kernel_dilation = {static_cast<int32_t>(kernel_width),
@@ -89,14 +92,31 @@ static void im2col_out_mps_template(Tensor& output,
                                                static_cast<int32_t>(pad_height),
                                                static_cast<int32_t>(stride_width),
                                                static_cast<int32_t>(stride_height)};
-      std::array<int64_t, 4> input_sizes = {input_width, input_height, n_input_plane, batch_size};
-      std::array<int64_t, 4> input_strides = {input.stride(3), input.stride(2), input.stride(1), input.stride(0)};
-      std::array<int64_t, 4> output_strides = {output.stride(2), output.stride(1), output.stride(0), output_width};
       getMPSProfiler().beginProfileKernel(im2colPSO, "im2col", {input, output});
       auto computeEncoder = stream->commandEncoder();
       [computeEncoder setComputePipelineState:im2colPSO];
-      mtl_setArgs(
-          computeEncoder, input, output, kernel_dilation, padding_stride, input_strides, output_strides, input_sizes);
+      auto encode = [&](auto input_strides, auto output_strides, auto input_sizes) {
+        mtl_setArgs(
+            computeEncoder, input, output, kernel_dilation, padding_stride, input_strides, output_strides, input_sizes);
+      };
+      if (use_u32) {
+        encode(std::array<int32_t, 4>{static_cast<int32_t>(input.stride(3)),
+                                      static_cast<int32_t>(input.stride(2)),
+                                      static_cast<int32_t>(input.stride(1)),
+                                      static_cast<int32_t>(input.stride(0))},
+               std::array<int32_t, 4>{static_cast<int32_t>(output.stride(2)),
+                                      static_cast<int32_t>(output.stride(1)),
+                                      static_cast<int32_t>(output.stride(0)),
+                                      static_cast<int32_t>(output_width)},
+               std::array<int32_t, 4>{static_cast<int32_t>(input_width),
+                                      static_cast<int32_t>(input_height),
+                                      static_cast<int32_t>(n_input_plane),
+                                      static_cast<int32_t>(batch_size)});
+      } else {
+        encode(std::array<int64_t, 4>{input.stride(3), input.stride(2), input.stride(1), input.stride(0)},
+               std::array<int64_t, 4>{output.stride(2), output.stride(1), output.stride(0), output_width},
+               std::array<int64_t, 4>{input_width, input_height, n_input_plane, batch_size});
+      }
       [computeEncoder dispatchThreads:MTLSizeMake(output_length, n_input_plane, batch_size)
                 threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
       getMPSProfiler().endProfileKernel(im2colPSO);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6258,6 +6258,7 @@ class TestMPS(TestCaseMPS):
         x = x_cpu.detach().clone().to('mps')
         self.assertEqual(helper(x_cpu), helper(x))
 
+    @serialTest()
     def test_im2col_uint32_overflow(self):
         C, H, W = 65537, 256, 256
         x = torch.zeros(1, C, H, W, dtype=torch.bool)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6258,6 +6258,15 @@ class TestMPS(TestCaseMPS):
         x = x_cpu.detach().clone().to('mps')
         self.assertEqual(helper(x_cpu), helper(x))
 
+    def test_im2col_uint32_overflow(self):
+        C, H, W = 65537, 256, 256
+        x = torch.zeros(1, C, H, W, dtype=torch.bool)
+        x[0, C - 1, 0, 0] = True
+        args = ([1, 1], [1, 1], [0, 0], [H, W])
+        out_cpu = torch.ops.aten.im2col(x, *args)
+        out_mps = torch.ops.aten.im2col(x.to("mps"), *args).cpu()
+        self.assertEqual(out_cpu, out_mps)
+
     def test_col2im(self):
         def helper(shapes, output_size, kernel_size, padding, stride, contiguous, dtype=torch.float32, test_bool=False):
             atol = 1e-5 if dtype == torch.float else 1e-2


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/185858

The motivation is similar to what was discussed for the Col2Im case here: https://github.com/pytorch/pytorch/pull/185664

Speed-ups for a few shapes sensitive to the issue below to motivate the added complexity from templating. No expected regressions as there should be no case where 64-bit multiplication should be faster than 32-bit:
```
  ┌──────────────────────────┬────────┬────────┬────────────────────┐
  │          shape           │ 64-bit │ 32-bit │      speedup       │
  ├──────────────────────────┼────────┼────────┼────────────────────┤
  │ conv 3x3 64ch 56x56 N=32 │ 0.780  │ 0.663  │ 15%                │
  ├──────────────────────────┼────────┼────────┼────────────────────┤
  │ conv 7x7 64ch 224x224    │ 1.384  │ 1.387  │ ~0% (memory-bound) │
  ├──────────────────────────┼────────┼────────┼────────────────────┤
  │ alu 15x15 4ch 64x64      │ 0.042  │ 0.032  │ 24%                │
  ├──────────────────────────┼────────┼────────┼────────────────────┤
  │ alu 21x21 4ch 48x48      │ 0.061  │ 0.037  │ 39%                │
  ├──────────────────────────┼────────┼────────┼────────────────────┤
  │ alu 31x31 4ch 32x32      │ 0.109  │ 0.064  │ 41%                │
  ├──────────────────────────┼────────┼────────┼────────────────────┤
  │ alu 11x11 32ch 56x56     │ 0.105  │ 0.092  │ 12%                │
  └──────────────────────────┴────────┴────────┴────────────────────┘
```

Adds a unittest case to specifically exercise the 64-bit path to ensure it still works now that the host dispatch has to pick between the two instantiations.

Script to run benchmarking attached.
[im2col_bench.py](https://github.com/user-attachments/files/28482970/im2col_bench.py)
