### PR TITLE
Fix segfault in native_batch_norm with empty running_mean/running_var

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -817,6 +817,13 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_cpu_out(const Tensor& self, con
   const Tensor& running_mean = running_mean_opt.value_or(Tensor());
   const Tensor& running_var = running_var_opt.value_or(Tensor());
 
+  if (running_mean.defined()) {
+    check_dims_match_num_input_features("running_mean", self.size(1), running_mean.numel());
+  }
+  if (running_var.defined()) {
+    check_dims_match_num_input_features("running_var", self.size(1), running_var.numel());
+  }
+
   checkBackend("batch_norm_cpu_out", {self, weight, bias, running_mean, running_var}, Backend::CPU);
   // Resize out
   at::native::resize_output(out, self.sizes());

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5163,22 +5163,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             with self.assertRaises(RuntimeError):
                 F.batch_norm(input, running_mean, torch.rand(size))
 
-    def test_native_batch_norm_raises_error_if_running_stats_empty(self):
-        # torch.native_batch_norm bypasses the F.batch_norm size validation,
-        # so an empty (but defined) running_mean/running_var used to segfault.
-        # See https://github.com/pytorch/pytorch/issues/169208
-        input = torch.randn(10, 8)
-        weight = torch.ones(8)
-        bias = torch.zeros(8)
-        full = torch.zeros(8)
-        empty = torch.zeros(0)
-        with self.assertRaisesRegex(RuntimeError, "running_var should contain 8 elements not 0"):
-            torch.native_batch_norm(input, weight, bias, full, empty,
-                                    training=True, momentum=0.1, eps=1e-5)
-        with self.assertRaisesRegex(RuntimeError, "running_mean should contain 8 elements not 0"):
-            torch.native_batch_norm(input, weight, bias, empty, full,
-                                    training=True, momentum=0.1, eps=1e-5)
-
     def test_batchnorm_raises_error_if_weight_is_not_same_size_as_input(self):
         input = torch.rand(2, 10)
         running_mean = torch.rand(10)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5163,6 +5163,22 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             with self.assertRaises(RuntimeError):
                 F.batch_norm(input, running_mean, torch.rand(size))
 
+    def test_native_batch_norm_raises_error_if_running_stats_empty(self):
+        # torch.native_batch_norm bypasses the F.batch_norm size validation,
+        # so an empty (but defined) running_mean/running_var used to segfault.
+        # See https://github.com/pytorch/pytorch/issues/169208
+        input = torch.randn(10, 8)
+        weight = torch.ones(8)
+        bias = torch.zeros(8)
+        full = torch.zeros(8)
+        empty = torch.zeros(0)
+        with self.assertRaisesRegex(RuntimeError, "running_var should contain 8 elements not 0"):
+            torch.native_batch_norm(input, weight, bias, full, empty,
+                                    training=True, momentum=0.1, eps=1e-5)
+        with self.assertRaisesRegex(RuntimeError, "running_mean should contain 8 elements not 0"):
+            torch.native_batch_norm(input, weight, bias, empty, full,
+                                    training=True, momentum=0.1, eps=1e-5)
+
     def test_batchnorm_raises_error_if_weight_is_not_same_size_as_input(self):
         input = torch.rand(2, 10)
         running_mean = torch.rand(10)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -505,6 +505,33 @@ def sample_inputs_native_batch_norm(op_info, device, dtype, requires_grad, **kwa
         yield SampleInput(sample.input, args=(args[2], args[3], args[0], args[1], training, momentum, eps))
 
 
+def error_inputs_native_batch_norm(op_info, device, **kwargs):
+    # The empty running_mean/running_var guard lives in batch_norm_cpu_out, so
+    # the error is only raised on CPU; skip other devices to keep test_errors green.
+    if torch.device(device).type != 'cpu':
+        return
+
+    make_arg = partial(make_tensor, device=device, dtype=torch.float32, requires_grad=False)
+
+    # A defined but empty running_mean/running_var bypasses the F.batch_norm
+    # size validation and used to segfault in batch_norm_cpu_out (CPU-only path).
+    # See https://github.com/pytorch/pytorch/issues/169208
+    channels = 8
+    inp = make_arg((10, channels))
+    weight = make_arg(channels)
+    bias = make_arg(channels)
+    full = make_arg(channels)
+    empty = make_arg(0)
+
+    err_msg = "running_mean should contain 8 elements not 0"
+    s1 = SampleInput(inp, args=(weight, bias, empty, full, True, 0.1, 1e-5))
+    yield ErrorInput(s1, error_regex=err_msg)
+
+    err_msg = "running_var should contain 8 elements not 0"
+    s2 = SampleInput(inp, args=(weight, bias, full, empty, True, 0.1, 1e-5))
+    yield ErrorInput(s2, error_regex=err_msg)
+
+
 def sample_inputs__native_batch_norm_legit(op_info, device, dtype, requires_grad, **kwargs):
     samples = sample_inputs_batch_norm(op_info, device, dtype, requires_grad, **kwargs)
     for sample in samples:
@@ -16012,6 +16039,7 @@ op_db: list[OpInfo] = [
            allow_cow_input_materialize_forward=[3, 4],
            allow_cow_input_materialize_backward=[3, 4],
            sample_inputs_func=sample_inputs_native_batch_norm,
+           error_inputs_func=error_inputs_native_batch_norm,
            skips=(
                # NotImplementedError: Could not run
                # 'aten::native_batch_norm.out' with arguments from the 'CPU' backend.


### PR DESCRIPTION
Fixes #169208

`torch.native_batch_norm` (the `batch_norm_cpu` path) segfaults when `running_mean` or `running_var` is a defined but empty tensor. The size of the running stats is never checked on this path, so the stats update loop indexes a zero length buffer out of bounds.

`F.batch_norm` does not hit this because it routes through a dispatcher that already validates the running stats sizes. `native_batch_norm` and `_batch_norm_legit` skip that path.

This adds a size check in `batch_norm_cpu_out`, the common entry point for both, reusing the existing `check_dims_match_num_input_features` helper. A defined running tensor must match the channel count, and the all-None case is unaffected.

Before this change the repro from the issue prints `Segmentation fault (core dumped)`. After it raises `RuntimeError: running_var should contain 8 elements not 0`.

Regression coverage lives in `error_inputs_native_batch_norm`, wired into the `native_batch_norm` OpInfo via `error_inputs_func`. It is gated to CPU since the guard is in `batch_norm_cpu_out`, so `test_errors` exercises the empty `running_mean` and `running_var` cases on CPU and yields nothing on other backends.