### PR TITLE
Update clamp, clamp_min, clamp_max to use the minimum norm subgradient

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16919,6 +16919,79 @@ class TestAutogradMultipleDispatch(TestCase):
                 self.assertEqual(x.grad, expected)
 
 
+class TestAutogradClampGradient(TestCase):
+
+    def _get_grad(self, fn, *inputs):
+        tensors = [torch.tensor(v, requires_grad=True) for v in inputs]
+        fn(*tensors).backward()
+        grads = [t.grad.item() for t in tensors]
+        return grads[0] if len(grads) == 1 else tuple(grads)
+
+    def test_clamp_scalar(self):
+        # min and max
+        fn = lambda x: torch.clamp(x, min=0.0, max=2.0)
+        self.assertEqual(self._get_grad(fn, 0.0), 0.0)
+        self.assertEqual(self._get_grad(fn, 1.0), 1.0)
+        self.assertEqual(self._get_grad(fn, 2.0), 0.0)
+
+        # min only
+        fn = lambda x: torch.clamp(x, min=0.0)
+        self.assertEqual(self._get_grad(fn, 0.0), 0.0)
+        self.assertEqual(self._get_grad(fn, 1.0), 1.0)
+
+        # max only
+        fn = lambda x: torch.clamp(x, max=0.0)
+        self.assertEqual(self._get_grad(fn, -1.0), 1.0)
+        self.assertEqual(self._get_grad(fn, 0.0), 0.0)
+
+    def test_clamp_tensor(self):
+        # min and max
+        fn = lambda x, mn, mx: torch.clamp(x, min=mn, max=mx)
+        self.assertEqual(self._get_grad(fn, -1.0, 0.0, 2.0), (0.0, 1.0, 0.0))
+        self.assertEqual(self._get_grad(fn, 0.0, 0.0, 2.0), (0.0, 0.0, 0.0))
+        self.assertEqual(self._get_grad(fn, 1.0, 0.0, 2.0), (1.0, 0.0, 0.0))
+        self.assertEqual(self._get_grad(fn, 2.0, 0.0, 2.0), (0.0, 0.0, 0.0))
+        self.assertEqual(self._get_grad(fn, 3.0, 0.0, 2.0), (0.0, 0.0, 1.0))
+        # min > max
+        self.assertEqual(self._get_grad(fn, 1.0, 2.0, 0.0), (0.0, 0.0, 1.0))
+        
+        # min only
+        fn = lambda x, mn: torch.clamp(x, min=mn)
+        self.assertEqual(self._get_grad(fn, -1.0, 0.0), (0.0, 1.0))
+        self.assertEqual(self._get_grad(fn, 0.0, 0.0), (0.0, 0.0))
+        self.assertEqual(self._get_grad(fn, 1.0, 0.0), (1.0, 0.0))
+        
+        # max only
+        fn = lambda x, mx: torch.clamp(x, max=mx)
+        self.assertEqual(self._get_grad(fn, -1.0, 0.0), (1.0, 0.0))
+        self.assertEqual(self._get_grad(fn, 0.0, 0.0), (0.0, 0.0))
+        self.assertEqual(self._get_grad(fn, 1.0, 0.0), (0.0, 1.0))
+
+    def test_clamp_min_scalar(self):
+        fn = lambda x: torch.clamp_min(x, 0.0)
+        self.assertEqual(self._get_grad(fn, -1.0), 0.0)
+        self.assertEqual(self._get_grad(fn, 0.0), 0.0)
+        self.assertEqual(self._get_grad(fn, 1.0), 1.0)
+    
+    def test_clamp_min_tensor(self):
+        fn = lambda x, mn: torch.clamp_min(x, mn)
+        self.assertEqual(self._get_grad(fn, -1.0, 0.0), (0.0, 1.0))
+        self.assertEqual(self._get_grad(fn, 0.0, 0.0), (0.0, 0.0))
+        self.assertEqual(self._get_grad(fn, 1.0, 0.0), (1.0, 0.0))
+
+    def test_clamp_max_scalar(self):
+        fn = lambda x: torch.clamp_max(x, 0.0)
+        self.assertEqual(self._get_grad(fn, -1.0), 1.0)
+        self.assertEqual(self._get_grad(fn, 0.0), 0.0)
+        self.assertEqual(self._get_grad(fn, 1.0), 0.0)
+        
+    def test_clamp_max_tensor(self):
+        fn = lambda x, mx: torch.clamp_max(x, mx)
+        self.assertEqual(self._get_grad(fn, -1.0, 0.0), (1.0, 0.0))
+        self.assertEqual(self._get_grad(fn, 0.0, 0.0), (0.0, 0.0))
+        self.assertEqual(self._get_grad(fn, 1.0, 0.0), (0.0, 1.0))
+
+
 # Import test cases from below autograd/ here. These are found
 # implicitly by the loader, so Flake8 thinks they are unused, hence
 # the suppressions.

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -419,7 +419,7 @@
   result: cholesky_inverse_jvp(self_p, self_t, result, upper)
 
 # For clamp, gradient is not defined at the boundaries. But empirically it's helpful
-# to be able to get gradient on min and max, so we return the subgradient 1 for these cases.
+# to be able to get gradient on min and max, so we return the subgradient minimum norm 0.
 - name: clamp.Tensor(Tensor self, Tensor? min=None, Tensor? max=None) -> Tensor
   self: clamp_backward(grad, self, min, max)
   min, max: clamp_backward_min_max(grad, self, min, max, grad_input_mask)
@@ -439,11 +439,11 @@
   result: where(self_p > min_p, self_t, min_t)
 
 - name: clamp_max(Tensor self, Scalar max) -> Tensor
-  self: where(self <= max, grad, at::scalar_tensor(0., grad.options()))
+  self: where(self < max, grad, at::scalar_tensor(0., grad.options()))
   result: auto_element_wise
 
 - name: clamp_max.Tensor(Tensor self, Tensor max) -> Tensor
-  self: where(self <= max, grad, at::scalar_tensor(0., grad.options()))
+  self: where(self < max, grad, at::scalar_tensor(0., grad.options()))
   max: where(self > max, grad, at::scalar_tensor(0., grad.options()))
   result: where(self_p <= max_p, self_t, max_t)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -435,7 +435,7 @@
 
 - name: clamp_min.Tensor(Tensor self, Tensor min) -> Tensor
   self: where(self > min, grad, at::scalar_tensor(0., grad.options()))
-  min: where(self <= min, grad, at::scalar_tensor(0., grad.options()))
+  min: where(self < min, grad, at::scalar_tensor(0., grad.options()))
   result: where(self_p > min_p, self_t, min_t)
 
 - name: clamp_max(Tensor self, Scalar max) -> Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -430,13 +430,13 @@
   result: auto_element_wise
 
 - name: clamp_min(Tensor self, Scalar min) -> Tensor
-  self: where(self >= min, grad, at::scalar_tensor(0., grad.options()))
+  self: where(self > min, grad, at::scalar_tensor(0., grad.options()))
   result: auto_element_wise
 
 - name: clamp_min.Tensor(Tensor self, Tensor min) -> Tensor
-  self: where(self >= min, grad, at::scalar_tensor(0., grad.options()))
-  min: where(self < min, grad, at::scalar_tensor(0., grad.options()))
-  result: where(self_p >= min_p, self_t, min_t)
+  self: where(self > min, grad, at::scalar_tensor(0., grad.options()))
+  min: where(self <= min, grad, at::scalar_tensor(0., grad.options()))
+  result: where(self_p > min_p, self_t, min_t)
 
 - name: clamp_max(Tensor self, Scalar max) -> Tensor
   self: where(self <= max, grad, at::scalar_tensor(0., grad.options()))

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1238,17 +1238,17 @@ Tensor clamp_backward(
     const Tensor& self,
     const std::optional<Scalar>& min,
     const std::optional<Scalar>& max) {
-  // clamp: gradients not defined on min and max, so we return the subgradient 1
-  // for these cases.
+  // clamp: gradients not defined on min and max, so we return the subgradient 0
+  // for these cases, consistent with relu and minimum-norm convention. 
   if (max && min) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where((self >= *min).logical_and_(self <= *max), grad, zero);
+    return where((self > *min).logical_and_(self < *max), grad, zero);
   } else if (min) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where(self >= *min, grad, zero);
+    return where(self > *min, grad, zero);
   } else if (max) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where(self <= *max, grad, zero);
+    return where(self < *max, grad, zero);
   } else {
     return grad;
   }
@@ -1259,22 +1259,22 @@ Tensor clamp_backward(
     const Tensor& self,
     const Tensor& min,
     const Tensor& max) {
-  // clamp: gradients not defined on min and max, so we return the subgradient 1
-  // for these cases.
+  // clamp: gradients not defined on min and max, so we return the subgradient 0
+  // for these cases, consistent with relu and minimum-norm convention.
   if (max.defined() && min.defined()) {
     auto zero = at::scalar_tensor(0., grad.options());
-    const auto self_ge_min = self >= min;
-    const auto self_le_max = self <= max;
+    const auto self_gt_min = self > min;
+    const auto self_lt_max = self < max;
     const auto& pred = areAnyTensorSubclassLike({self, min, max})
-        ? self_ge_min.logical_and(self_le_max)
-        : self_ge_min.logical_and_(self_le_max);
+        ? self_gt_min.logical_and(self_lt_max)
+        : self_gt_min.logical_and_(self_lt_max);
     return where(pred, grad, zero);
   } else if (min.defined()) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where(self >= min, grad, zero);
+    return where(self > min, grad, zero);
   } else if (max.defined()) {
     auto zero = at::scalar_tensor(0., grad.options());
-    return where(self <= max, grad, zero);
+    return where(self < max, grad, zero);
   } else {
     return grad;
   }


### PR DESCRIPTION
Fixes #184572 

`torch.clamp`, `torch.clamp_min`, `torch.clamp_max` subgradients violate PyTorch's documented minimum norm convention, returning 1.0 instead of 0.0. 

Changes made:
1. `tools/autograd/derivatives.yaml`: Update boundary conditions for clamp_min and clamp_max
2. `torch/csrc/autograd/FunctionsManual.cpp`: Update boundary conditions in `clamp_backward`
3. `test/test_autograd.py`: Create class `TestAutogradClampGradient(TestCase)` to test boundary conditions output 0.