### PR TITLE
[inductor] Pin Triton cuda driver in compile workers to fix "0 active drivers" error

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -1,13 +1,18 @@
 # Owner(s): ["module: inductor"]
+import multiprocessing
 import operator
 import os
+import queue
 import subprocess
 import sys
 import tempfile
 import textwrap
+import traceback
 import unittest
+import warnings
 from threading import Event
 
+import torch
 import torch._inductor.config as config
 from torch._inductor.compile_worker.subproc_pool import (
     raise_testexc,
@@ -17,7 +22,7 @@ from torch._inductor.compile_worker.subproc_pool import (
 from torch._inductor.compile_worker.timer import Timer
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import IS_FBCODE, IS_LINUX, skipIfWindows
-from torch.testing._internal.inductor_utils import HAS_CPU
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_TRITON
 
 
 class TestCompileWorker(TestCase):
@@ -326,6 +331,84 @@ class TestSetTritonLibdevicePath(TestCase):
         from triton import knobs
 
         self.assertEqual(knobs.nvidia.libdevice_path, expected)
+
+
+def _pin_driver_bad_fork_worker(q):
+    # Bad fork: force is_active() False (triton#9578) and check the pin makes
+    # driver.active resolve instead of raising "0 active drivers" (pytorch#184643).
+    try:
+        import triton
+
+        from torch._inductor.compile_worker.utils import _async_compile_initializer
+
+        nvidia = triton.backends.backends["nvidia"]
+        nvidia.driver.is_active = staticmethod(lambda: False)
+        triton.runtime.driver._active = None
+
+        _async_compile_initializer(os.getppid())
+
+        active = triton.runtime.driver.active
+        is_nvidia = isinstance(active, nvidia.driver) or (
+            hasattr(active, "_obj") and isinstance(active._obj, nvidia.driver)
+        )
+        q.put(("ok", (type(active).__name__, is_nvidia)))
+    except BaseException:
+        q.put(("err", traceback.format_exc()))
+
+
+class TestPinTritonWorkerDriver(TestCase):
+    @unittest.skipIf(
+        not HAS_TRITON or not torch.cuda.is_available(), "requires triton + cuda"
+    )
+    def test_compile_worker_pins_driver_in_bad_fork(self):
+        # #184643: pin must resolve driver.active in a CUDA-forked worker.
+        if torch.version.hip is not None:
+            self.skipTest("bug and fix are nvidia-only")
+        torch.cuda.get_device_properties(0)  # CUDA init before the fork
+        ctx = multiprocessing.get_context("fork")
+        q = ctx.Queue()
+        p = ctx.Process(target=_pin_driver_bad_fork_worker, args=(q,))
+        p.daemon = True
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=r"os\.fork\(\) was called.*", category=RuntimeWarning
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    r"This process .* is multi-threaded, use of fork\(\) "
+                    r"may lead to deadlocks in the child\."
+                ),
+                category=DeprecationWarning,
+            )
+            p.start()
+        p.join(60)
+        if p.is_alive():
+            p.terminate()
+            p.join()
+            self.fail("bad-fork driver worker timed out")
+        try:
+            kind, payload = q.get(timeout=5)
+        except queue.Empty:
+            self.fail(f"bad-fork driver worker exited without a result: {p.exitcode}")
+        self.assertEqual(kind, "ok", payload)
+        _name, is_nvidia = payload
+        self.assertTrue(
+            is_nvidia, f"driver.active was not the nvidia driver: {payload}"
+        )
+
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_pinned_triton_driver_api_exists(self):
+        # Fail CI if triton renames an internal the pin depends on (drift tripwire).
+        import triton
+
+        driver = triton.runtime.driver
+        self.assertTrue(hasattr(driver, "_active"))
+        self.assertTrue(callable(driver.set_active))
+        self.assertIsInstance(triton.backends.backends, dict)
+        if torch.cuda.is_available() and torch.version.hip is None:
+            self.assertIn("nvidia", triton.backends.backends)
+            self.assertTrue(callable(triton.backends.backends["nvidia"].driver))
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/compile_worker/utils.py
+++ b/torch/_inductor/compile_worker/utils.py
@@ -12,6 +12,22 @@ def in_toplevel_process() -> bool:
     return _IN_TOPLEVEL_PROCESS
 
 
+def _pin_triton_worker_driver() -> None:
+    # Pin the nvidia driver so a worker forked after CUDA init doesn't raise
+    # "0 active drivers" resolving driver.active (triton#9578, pytorch#184643).
+    import torch
+
+    if not torch.cuda.is_available() or torch.version.hip is not None:
+        return
+    try:
+        import triton
+    except ImportError:
+        return
+    driver = triton.runtime.driver
+    if driver._active is None:
+        driver.set_active(triton.backends.backends["nvidia"].driver())
+
+
 # If this process dies abnormally (e.g. segfault)
 # it will not shut down the workers. Instead,
 # the workers will have their parent reassigned to the
@@ -39,6 +55,8 @@ def _async_compile_initializer(orig_ppid: int) -> None:
 
     # Install a crash handler to print out the stacktrace for SEGV
     torch._C._initCrashHandler()
+
+    _pin_triton_worker_driver()
 
     # Set a bit to distinguish async_compile subprocesses from the toplevel process.
     global _IN_TOPLEVEL_PROCESS


### PR DESCRIPTION
## Summary
Fixes issue described in https://github.com/pytorch/pytorch/issues/184643
Compile workers forked after the parent initialized CUDA inherit a broken CUDA
state. This causes `cuInit(0)` to return `CUDA_ERROR_NOT_INITIALIZED` in the child. After
triton-lang/triton#9578 rewrote the NVIDIA backend's `is_active()` into a raw
`cuInit(0)` probe, resolving `triton.runtime.driver.active` in such a worker runs
`_create_driver()` which finds no active backend and raises
`RuntimeError: 0 active drivers ([]). There should only be one.`

This breaks NVIDIA Inductor compilation on the default
`worker_start_method="subprocess"`: the SubprocPool sidecar initializes CUDA via
`caching_device_properties()` and then forks its workers. The existing
`triton_helpers.set_driver_to_gpu()` shim hardens the `is_active()` check, but the
crash is on the subsequent `driver.active` resolution, which has no fallback so
hardening `is_active()` alone is insufficient (pytorch/pytorch#184643).

For real examples, see 38 errors with "test-osdc" in https://github.com/pytorch/pytorch/pull/185453) 

## This Change
Pin the backend driver in the compile-worker initializer, before any generated
kernel runs `set_driver_to_gpu()`. `set_active()` is a plain assignment (it never
resolves a driver), and constructing the driver object does not call `cuInit` (it
only loads the utils extension and binds callables) — so both are safe in a forked
worker. With `_active` pinned, the later `driver.active` read returns immediately
and never runs `_create_driver()`. The pin is idempotent (skipped when a driver is
already pinned, e.g. inherited across the fork), scoped to NVIDIA (AMD's
`is_active()` is fork-safe), and best-effort (failures are logged, not raised). It
keeps the existing fork-after-CUDA-init design: workers stay `_is_in_bad_fork()`,
and nothing in the sidecar/fork path changes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @njriasan 