### PR TITLE
c10/util/intrusive_ptr.h: use std::swap in weak_intrusive_ptr::swap

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -983,9 +983,7 @@ class weak_intrusive_ptr final {
   }
 
   void swap(weak_intrusive_ptr& rhs) noexcept {
-    TTarget* tmp = target_;
-    target_ = rhs.target_;
-    rhs.target_ = tmp;
+    std::swap(target_, rhs.target_);
   }
 
   // NB: This should ONLY be used by the std::hash implementation


### PR DESCRIPTION
Summary: `intrusive_ptr::swap` already uses `std::swap(target_, rhs.target_)` (consistent with the standard pattern), but `weak_intrusive_ptr::swap` had a hand-rolled three-step swap. Align them. No behavior change.

Test Plan: `buck2 test fbcode//caffe2/c10/test:core_tests` — 86 tests pass, 0 failures.

Differential Revision: D107127348


