### PR TITLE
[PrivateUse1] Return `False` instead of `None` when PU1 backend is not available

### DIFF
--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -1422,7 +1422,7 @@ def _augment_memory_snapshot_stack_traces(
     return snapshot_dict
 
 
-def _is_privateuse1_backend_available():
+def _is_privateuse1_backend_available() -> bool:
     """
     Determines whether the privateuse1 backend is registered and available.
 
@@ -1431,9 +1431,11 @@ def _is_privateuse1_backend_available():
     """
     privateuse1_backend_name = torch._C._get_privateuse1_backend_name()
     privateuse1_backend_module = getattr(torch, privateuse1_backend_name, None)
-    return (
-        is_available := getattr(privateuse1_backend_module, "is_available", None)
-    ) and is_available()
+
+    return bool(
+        (is_available := getattr(privateuse1_backend_module, "is_available", None))
+        and is_available()
+    )
 
 
 def getenv(name: str) -> "str | None":


### PR DESCRIPTION
`_is_privateuse1_backend_available()` will return `None` if PU1 backend is not available, which is not expected. It should return `False` . 

Reference (Failed CI from my test refactor PR, has `TEST_PRIVATEUSE1` in it, https://github.com/pytorch/pytorch/actions/runs/26794612675/job/78988996179?pr=185798):
```
Traceback (most recent call last):
  File "/__w/pytorch/pytorch/test/test_indexing.py", line 53, in <module>
    class TestIndexingDevice(TestCase):
  File "/__w/pytorch/pytorch/test/test_indexing.py", line 1024, in TestIndexingDevice
    @serialTest(TEST_CUDA or TEST_XPU or TEST_MPS or TEST_PRIVATEUSE1)
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/testing/_internal/common_utils.py", line 1993, in serialTest
    raise AssertionError(f"expected condition to be bool, got {type(condition)}")
AssertionError: expected condition to be bool, got <class 'NoneType'>
```

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD