### PR TITLE
Simplify ostream formatting with fmt::join and fmt::print

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -2,6 +2,8 @@
 
 #include <c10/util/irange.h>
 
+#include <fmt/ranges.h>
+
 #include <array>
 #include <iostream>
 #include <sstream>
@@ -107,16 +109,14 @@ std::ostream& operator<<(std::ostream & out, const TensorDescriptor& d) {
   out << "    type = " << cudnnTypeToString(dtype) << '\n';
   out << "    nbDims = " << nbDims << '\n';
   // Read out only nbDims of the arrays!
-  out << "    dimA = ";
-  for (auto i : ArrayRef<int>{dimA, static_cast<size_t>(nbDims)}) {
-    out << i << ", ";
-  }
-  out << '\n';
-  out << "    strideA = ";
-  for (auto i : ArrayRef<int>{strideA, static_cast<size_t>(nbDims)}) {
-    out << i << ", ";
-  }
-  out << '\n';
+  out << "    dimA = "
+      << fmt::format(
+             "{}", fmt::join(ArrayRef<int>{dimA, static_cast<size_t>(nbDims)}, ", "))
+      << '\n';
+  out << "    strideA = "
+      << fmt::format(
+             "{}", fmt::join(ArrayRef<int>{strideA, static_cast<size_t>(nbDims)}, ", "))
+      << '\n';
   return out;
 }
 
@@ -183,11 +183,10 @@ std::ostream& operator<<(std::ostream & out, const FilterDescriptor& d) {
   out << "    tensor_format = " << cudnnMemoryFormatToString(tformat) << '\n';
   out << "    nbDims = " << nbDims << '\n';
   // Read out only nbDims of the arrays!
-  out << "    dimA = ";
-  for (auto i : ArrayRef<int>{dimA, static_cast<size_t>(nbDims)}) {
-    out << i << ", ";
-  }
-  out << '\n';
+  out << "    dimA = "
+      << fmt::format(
+             "{}", fmt::join(ArrayRef<int>{dimA, static_cast<size_t>(nbDims)}, ", "))
+      << '\n';
   return out;
 }
 

--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -2,6 +2,7 @@
 
 #include <c10/util/irange.h>
 
+#include <fmt/ostream.h>
 #include <fmt/ranges.h>
 
 #include <array>
@@ -100,23 +101,20 @@ std::string cudnnTypeToString(cudnnDataType_t dtype) {
 }
 
 std::ostream& operator<<(std::ostream & out, const TensorDescriptor& d) {
-  out << "TensorDescriptor " << static_cast<void*>(d.desc()) << '\n';
   int nbDims = 0;
   int dimA[CUDNN_DIM_MAX];
   int strideA[CUDNN_DIM_MAX];
   cudnnDataType_t dtype{};
   cudnnGetTensorNdDescriptor(d.desc(), CUDNN_DIM_MAX, &dtype, &nbDims, dimA, strideA);
-  out << "    type = " << cudnnTypeToString(dtype) << '\n';
-  out << "    nbDims = " << nbDims << '\n';
   // Read out only nbDims of the arrays!
-  out << "    dimA = "
-      << fmt::format(
-             "{}", fmt::join(ArrayRef<int>{dimA, static_cast<size_t>(nbDims)}, ", "))
-      << '\n';
-  out << "    strideA = "
-      << fmt::format(
-             "{}", fmt::join(ArrayRef<int>{strideA, static_cast<size_t>(nbDims)}, ", "))
-      << '\n';
+  fmt::print(
+      out,
+      "TensorDescriptor {}\n    type = {}\n    nbDims = {}\n    dimA = {}\n    strideA = {}\n",
+      fmt::ptr(d.desc()),
+      cudnnTypeToString(dtype),
+      nbDims,
+      fmt::join(dimA, dimA + nbDims, ", "),
+      fmt::join(strideA, strideA + nbDims, ", "));
   return out;
 }
 
@@ -173,20 +171,20 @@ std::string cudnnMemoryFormatToString(cudnnTensorFormat_t tformat) {
 }
 
 std::ostream& operator<<(std::ostream & out, const FilterDescriptor& d) {
-  out << "FilterDescriptor " << static_cast<void*>(d.desc()) << '\n';
   int nbDims = 0;
   int dimA[CUDNN_DIM_MAX];
   cudnnDataType_t dtype{};
   cudnnTensorFormat_t tformat{};
   cudnnGetFilterNdDescriptor(d.desc(), CUDNN_DIM_MAX, &dtype, &tformat, &nbDims, dimA);
-  out << "    type = " << cudnnTypeToString(dtype) << '\n';
-  out << "    tensor_format = " << cudnnMemoryFormatToString(tformat) << '\n';
-  out << "    nbDims = " << nbDims << '\n';
   // Read out only nbDims of the arrays!
-  out << "    dimA = "
-      << fmt::format(
-             "{}", fmt::join(ArrayRef<int>{dimA, static_cast<size_t>(nbDims)}, ", "))
-      << '\n';
+  fmt::print(
+      out,
+      "FilterDescriptor {}\n    type = {}\n    tensor_format = {}\n    nbDims = {}\n    dimA = {}\n",
+      fmt::ptr(d.desc()),
+      cudnnTypeToString(dtype),
+      cudnnMemoryFormatToString(tformat),
+      nbDims,
+      fmt::join(dimA, dimA + nbDims, ", "));
   return out;
 }
 

--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -2,11 +2,13 @@
 
 #include <c10/util/irange.h>
 
+#include <fmt/ostream.h>
 #include <fmt/ranges.h>
 
 #include <array>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 
 // NOLINTBEGIN(*c-arrays*)
 namespace at::native {
@@ -99,24 +101,24 @@ std::string cudnnTypeToString(cudnnDataType_t dtype) {
   }
 }
 
+constexpr std::string_view kIndent = "    ";
+
 std::ostream& operator<<(std::ostream & out, const TensorDescriptor& d) {
-  out << "TensorDescriptor " << static_cast<void*>(d.desc()) << '\n';
   int nbDims = 0;
   int dimA[CUDNN_DIM_MAX];
   int strideA[CUDNN_DIM_MAX];
   cudnnDataType_t dtype{};
   cudnnGetTensorNdDescriptor(d.desc(), CUDNN_DIM_MAX, &dtype, &nbDims, dimA, strideA);
-  out << "    type = " << cudnnTypeToString(dtype) << '\n';
-  out << "    nbDims = " << nbDims << '\n';
   // Read out only nbDims of the arrays!
-  out << "    dimA = "
-      << fmt::format(
-             "{}", fmt::join(ArrayRef<int>{dimA, static_cast<size_t>(nbDims)}, ", "))
-      << '\n';
-  out << "    strideA = "
-      << fmt::format(
-             "{}", fmt::join(ArrayRef<int>{strideA, static_cast<size_t>(nbDims)}, ", "))
-      << '\n';
+  fmt::print(
+      out,
+      "TensorDescriptor {1}\n{0}type = {2}\n{0}nbDims = {3}\n{0}dimA = {4}\n{0}strideA = {5}\n",
+      kIndent,
+      fmt::ptr(d.desc()),
+      cudnnTypeToString(dtype),
+      nbDims,
+      fmt::join(dimA, dimA + nbDims, ", "),
+      fmt::join(strideA, strideA + nbDims, ", "));
   return out;
 }
 
@@ -173,20 +175,21 @@ std::string cudnnMemoryFormatToString(cudnnTensorFormat_t tformat) {
 }
 
 std::ostream& operator<<(std::ostream & out, const FilterDescriptor& d) {
-  out << "FilterDescriptor " << static_cast<void*>(d.desc()) << '\n';
   int nbDims = 0;
   int dimA[CUDNN_DIM_MAX];
   cudnnDataType_t dtype{};
   cudnnTensorFormat_t tformat{};
   cudnnGetFilterNdDescriptor(d.desc(), CUDNN_DIM_MAX, &dtype, &tformat, &nbDims, dimA);
-  out << "    type = " << cudnnTypeToString(dtype) << '\n';
-  out << "    tensor_format = " << cudnnMemoryFormatToString(tformat) << '\n';
-  out << "    nbDims = " << nbDims << '\n';
   // Read out only nbDims of the arrays!
-  out << "    dimA = "
-      << fmt::format(
-             "{}", fmt::join(ArrayRef<int>{dimA, static_cast<size_t>(nbDims)}, ", "))
-      << '\n';
+  fmt::print(
+      out,
+      "FilterDescriptor {1}\n{0}type = {2}\n{0}tensor_format = {3}\n{0}nbDims = {4}\n{0}dimA = {5}\n",
+      kIndent,
+      fmt::ptr(d.desc()),
+      cudnnTypeToString(dtype),
+      cudnnMemoryFormatToString(tformat),
+      nbDims,
+      fmt::join(dimA, dimA + nbDims, ", "));
   return out;
 }
 

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -623,7 +623,7 @@ std::vector<int64_t> _check_gesvdj_convergence(const Tensor& infos, int64_t non_
 // batches 2, 3, 5  // or
 // batches 2, 3, 5, 7, 11 and other 65535 batches
 std::string _format_non_converging_batches(const std::vector<int64_t>& batches) {
-  const size_t too_long = 5;
+  constexpr size_t too_long = 5;
   if (batches.size() <= too_long) {
     return fmt::format("batches {}", fmt::join(batches, ", "));
   }

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -10,6 +10,8 @@
 #include <c10/cuda/CUDAStream.h>
 #include <c10/util/irange.h>
 
+#include <fmt/ranges.h>
+
 #include <ATen/native/LinearAlgebraUtils.h>
 #include <ATen/native/TransposeType.h>
 #include <ATen/native/cuda/MiscUtils.h>
@@ -621,23 +623,14 @@ std::vector<int64_t> _check_gesvdj_convergence(const Tensor& infos, int64_t non_
 // batches 2, 3, 5  // or
 // batches 2, 3, 5, 7, 11 and other 65535 batches
 std::string _format_non_converging_batches(const std::vector<int64_t>& batches) {
-  std::stringstream ss;
-  const int too_long = 5;
-
-  ss << "batches ";
+  const size_t too_long = 5;
   if (batches.size() <= too_long) {
-    for (const auto i : c10::irange(batches.size() - 1)) {
-      ss << batches[i] << ", ";
-    }
-    ss << batches.back();
-  } else {
-    for (const auto i : c10::irange(too_long)) {
-      ss << batches[i] << ", ";
-    }
-    ss << "and other " << batches.size() - too_long << " batches";
+    return fmt::format("batches {}", fmt::join(batches, ", "));
   }
-
-  return std::move(ss).str();
+  return fmt::format(
+      "batches {}, and other {} batches",
+      fmt::join(batches.begin(), batches.begin() + too_long, ", "),
+      batches.size() - too_long);
 }
 
 // This function returns V, not V^H.

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1109,6 +1109,7 @@ elseif(USE_CUDA)
     target_link_libraries(torch_cuda_linalg PRIVATE
         torch_cpu
         torch_cuda
+        fmt::fmt-header-only
     )
     if($ENV{ATEN_STATIC_CUDA})
     target_link_libraries(torch_cuda_linalg PRIVATE

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1166,6 +1166,7 @@ elseif(USE_CUDA)
     target_link_libraries(torch_cuda_linalg PRIVATE
         torch_cpu
         torch_cuda
+        fmt::fmt-header-only
     )
     if($ENV{ATEN_STATIC_CUDA})
     target_link_libraries(torch_cuda_linalg PRIVATE

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -2,6 +2,8 @@
 #include <torch/nn/init.h>
 #include <torch/nn/modules/linear.h>
 
+#include <fmt/ranges.h>
+
 #include <cmath>
 #include <cstdint>
 
@@ -86,11 +88,7 @@ void UnflattenImpl::pretty_print(std::ostream& stream) const {
          << ", unflattened_size={";
   auto sizes = options.sizes();
   TORCH_CHECK(!sizes.empty(), "Unflatten requires non-empty sizes");
-  size_t i = 0;
-  for (; i < sizes.size() - 1; ++i) {
-    stream << sizes[i] << ", ";
-  }
-  stream << sizes[i] << "})";
+  stream << fmt::format("{}", fmt::join(sizes, ", ")) << "})";
 }
 
 Tensor UnflattenImpl::forward(const Tensor& input) {

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -2,6 +2,7 @@
 #include <torch/nn/init.h>
 #include <torch/nn/modules/linear.h>
 
+#include <fmt/ostream.h>
 #include <fmt/ranges.h>
 
 #include <cmath>
@@ -51,10 +52,12 @@ void LinearImpl::reset_parameters() {
 }
 
 void LinearImpl::pretty_print(std::ostream& stream) const {
-  stream << std::boolalpha
-         << "torch::nn::Linear(in_features=" << options.in_features()
-         << ", out_features=" << options.out_features()
-         << ", bias=" << options.bias() << ')';
+  fmt::print(
+      stream,
+      "torch::nn::Linear(in_features={}, out_features={}, bias={})",
+      options.in_features(),
+      options.out_features(),
+      options.bias());
 }
 
 Tensor LinearImpl::forward(const Tensor& input) {
@@ -68,8 +71,11 @@ FlattenImpl::FlattenImpl(const FlattenOptions& options_) : options(options_) {}
 void FlattenImpl::reset() {}
 
 void FlattenImpl::pretty_print(std::ostream& stream) const {
-  stream << "torch::nn::Flatten(start_dim=" << options.start_dim()
-         << ", end_dim=" << options.end_dim() << ')';
+  fmt::print(
+      stream,
+      "torch::nn::Flatten(start_dim={}, end_dim={})",
+      options.start_dim(),
+      options.end_dim());
 }
 
 Tensor FlattenImpl::forward(const Tensor& input) {
@@ -84,11 +90,13 @@ UnflattenImpl::UnflattenImpl(UnflattenOptions options_)
 void UnflattenImpl::reset() {}
 
 void UnflattenImpl::pretty_print(std::ostream& stream) const {
-  stream << "torch::nn::Unflatten(dim=" << options.dim()
-         << ", unflattened_size={";
   auto sizes = options.sizes();
   TORCH_CHECK(!sizes.empty(), "Unflatten requires non-empty sizes");
-  stream << fmt::format("{}", fmt::join(sizes, ", ")) << "})";
+  fmt::print(
+      stream,
+      "torch::nn::Unflatten(dim={}, unflattened_size={{{}}})",
+      options.dim(),
+      fmt::join(sizes, ", "));
 }
 
 Tensor UnflattenImpl::forward(const Tensor& input) {
@@ -127,11 +135,13 @@ void BilinearImpl::reset_parameters() {
 }
 
 void BilinearImpl::pretty_print(std::ostream& stream) const {
-  stream << std::boolalpha
-         << "torch::nn::Bilinear(in1_features=" << options.in1_features()
-         << ", in2_features=" << options.in2_features()
-         << ", out_features=" << options.out_features()
-         << ", bias=" << options.bias() << ')';
+  fmt::print(
+      stream,
+      "torch::nn::Bilinear(in1_features={}, in2_features={}, out_features={}, bias={})",
+      options.in1_features(),
+      options.in2_features(),
+      options.out_features(),
+      options.bias());
 }
 
 Tensor BilinearImpl::forward(const Tensor& input1, const Tensor& input2) {

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -8,6 +8,7 @@
 #include <c10/util/MaybeOwned.h>
 #include <c10/util/irange.h>
 #include <caffe2/core/timer.h>
+#include <fmt/ranges.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/add_if_then_else.h>
@@ -1677,16 +1678,9 @@ float BlockRunner::benchmark_model(
 
 static bool display_ivalue(const IValue& iv) {
   if (iv.isTensor()) {
-    std::cout << "Tensor " << iv.toTensor().toString() << " {";
-    const auto dims = iv.toTensor().sizes();
-    const auto n_dims = static_cast<uint32_t>(dims.size());
-    for (const auto i : c10::irange(n_dims)) {
-      std::cout << iv.toTensor().sizes()[i];
-      if (n_dims > i + 1) {
-        std::cout << ", ";
-      }
-    }
-    std::cout << "}\n";
+    std::cout << "Tensor " << iv.toTensor().toString() << " {"
+              << fmt::format("{}", fmt::join(iv.toTensor().sizes(), ", "))
+              << "}\n";
     return true;
   } else if (iv.isTensorList()) {
     std::cout << "TensorList {" << iv.toTensorList().size() << "}\n";

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -8,6 +8,7 @@
 #include <c10/util/MaybeOwned.h>
 #include <c10/util/irange.h>
 #include <caffe2/core/timer.h>
+#include <fmt/ostream.h>
 #include <fmt/ranges.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/jit_log.h>
@@ -1678,27 +1679,29 @@ float BlockRunner::benchmark_model(
 
 static bool display_ivalue(const IValue& iv) {
   if (iv.isTensor()) {
-    std::cout << "Tensor " << iv.toTensor().toString() << " {"
-              << fmt::format("{}", fmt::join(iv.toTensor().sizes(), ", "))
-              << "}\n";
+    fmt::print(
+        std::cout,
+        "Tensor {} {{{}}}\n",
+        iv.toTensor().toString(),
+        fmt::join(iv.toTensor().sizes(), ", "));
     return true;
   } else if (iv.isTensorList()) {
-    std::cout << "TensorList {" << iv.toTensorList().size() << "}\n";
+    fmt::print(std::cout, "TensorList {{{}}}\n", iv.toTensorList().size());
     return true;
   } else if (iv.isGenericDict()) {
-    std::cout << "Dict {" << iv.toGenericDict().size() << "}\n";
+    fmt::print(std::cout, "Dict {{{}}}\n", iv.toGenericDict().size());
     return true;
   } else if (iv.isTuple()) {
-    std::cout << "Tuple {" << iv.toTupleRef().elements().size() << "}\n";
+    fmt::print(std::cout, "Tuple {{{}}}\n", iv.toTupleRef().elements().size());
     return true;
   } else if (iv.isInt()) {
-    std::cout << "int {" << iv.toInt() << "}\n";
+    fmt::print(std::cout, "int {{{}}}\n", iv.toInt());
     return true;
   } else if (iv.isBool()) {
-    std::cout << "bool {" << iv.toBool() << "}\n";
+    fmt::print(std::cout, "bool {{{:d}}}\n", iv.toBool());
     return true;
   } else if (iv.isDouble()) {
-    std::cout << "double {" << iv.toDouble() << "}\n";
+    fmt::print(std::cout, "double {{{}}}\n", iv.toDouble());
     return true;
   }
   return false;


### PR DESCRIPTION
Simplifies ostream string building in a few spots: replaces manual
separator loops with `fmt::join`, and uses `fmt::print` to format directly
into the stream instead of building a temporary `std::string` via
`fmt::format`. Uses `fmt::ptr` for descriptor handles. No behavior change.
