### PR TITLE
Support bfloat16 in _embedding_bag_per_sample_weights_backward on CUDA

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -546,7 +546,7 @@ Tensor _embedding_bag_per_sample_weights_backward_cuda(
     return output;
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16,
     grad.scalar_type(), "_embedding_bag_per_sample_weights_backward_cuda", [&]() {
       AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "_embedding_bag_per_sample_weights_backward_cuda", [&]() {
         _embedding_bag_per_sample_weights_backward_kernel<scalar_t, index_t>

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1284,7 +1284,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         *itertools.product(
             (torch.int, torch.long),
             (torch.int, torch.long),
-            (torch.float, torch.double, torch.half),
+            (torch.float, torch.double, torch.half, torch.bfloat16),
         )
     )
     @dtypesIfXPU(
@@ -1357,7 +1357,7 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         *itertools.product(
             (torch.int, torch.long),
             (torch.int, torch.long),
-            (torch.float, torch.double, torch.half),
+            (torch.float, torch.double, torch.half, torch.bfloat16),
         )
     )
     @dtypesIfXPU(


### PR DESCRIPTION
The CUDA kernel for _embedding_bag_per_sample_weights_backward used AT_DISPATCH_FLOATING_TYPES_AND_HALF, which covers float, double, and float16 but not bfloat16. The forward pass and the embedding table gradient backward already support bfloat16 on CUDA (added in #141998), so this is an isolated dispatch gap.

Change the dispatch macro to AT_DISPATCH_FLOATING_TYPES_AND2 with Half and BFloat16. The kernel template already uses acc_type for accumulation, so no arithmetic changes are needed.

Also enable bfloat16 in the dtypesIfCUDA lists for the two per_sample_weights test methods in test/nn/test_embedding.py.

Fixes #185808