### PR TITLE
[dynamo/tvm] Handle ImportError for TVM backend

### DIFF
--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -53,9 +53,15 @@ def tvm(
         options = MappingProxyType({"scheduler": None, "trials": 20000, "opt_level": 3})
     if options is None:
         raise AssertionError("options must not be None")
-    import tvm  # type: ignore[import]
-    from tvm import relay  # type: ignore[import]
-    from tvm.contrib import graph_executor  # type: ignore[import]
+    try:
+        import tvm  # type: ignore[import]
+        from tvm import relay  # type: ignore[import]
+        from tvm.contrib import graph_executor  # type: ignore[import]
+    except ImportError as e:
+        raise ImportError(
+            "Please install apache-tvm to use the tvm backend. "
+            "See https://tvm.apache.org/docs/install/index.html for instructions."
+        ) from e
 
     jit_mod = torch.jit.trace(gm, example_inputs)
     device = device_from_inputs(example_inputs)


### PR DESCRIPTION
The `tvm` backend did a bare import `tvm`, so without Apache TVM installed users hit a cryptic ModuleNotFoundError. This wraps the imports in try/except and re-raises an ImportError pointing to the install docs.

Why: match the OpenXLA backend, which already does this — see xla_backend_helper in  torchxla.py

https://github.com/pytorch/pytorch/blob/cd2d0c4c2291d60ed0f0285f9d26f9ab00aa90bb/torch/_dynamo/backends/torchxla.py#L32-L38

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98