### PR TITLE
Improve in-place view graph break hint

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -45,6 +45,31 @@ class GenericCtxMgr:
 
 
 class ErrorMessagesTest(LoggingTestCase):
+    def test_inplace_view_on_graph_input_hint(self):
+        def fn(x):
+            x.transpose_(1, 2)
+            return x
+
+        self.assertExpectedInlineMunged(
+            Unsupported,
+            lambda: torch.compile(fn, backend="eager", fullgraph=True)(
+                torch.randn(2, 3, 4)
+            ),
+            """\
+Unsupported function call (delayed)
+  Explanation: Dynamo determined that a graph break should occur when calling `L['x'].transpose_`. Reason: Getting an inplace view on a graph input is not supported
+  Hint: Avoid mutating a graph input's tensor metadata with in-place view ops. If the mutation is only needed inside the compiled region, replace the in-place call with an out-of-place view, for example `x = x.transpose(1, 2)` instead of `x.transpose_(1, 2)`.
+  Hint: If you need to mutate the input tensor's metadata, move the in-place view call outside `torch.compile`.
+
+  Developer debug context: source: AttrSource(base=LocalSource(local_name='x', is_input=True, dynamism=None, is_derefed_cell_contents=False), member='transpose_')
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0148.html
+
+from user code:
+   File "test_error_messages.py", line N, in fn
+    x.transpose_(1, 2)""",
+        )
+
     def test_dynamic_shape_operator_no_meta_kernel(self):
         def fn():
             return torch.linalg.lstsq(torch.rand(10, 10), torch.rand(10, 10))

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -755,9 +755,15 @@ class DelayGraphBreakVariable(UnknownVariable):
     Used to insert a dummy variable in the stack to do the graph break at CALL_FUNCTION.
     """
 
-    def __init__(self, msg: str | None = None, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        msg: str | None = None,
+        hints: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.msg = msg
+        self.hints = hints or []
 
     def call_function(
         self,
@@ -771,7 +777,7 @@ class DelayGraphBreakVariable(UnknownVariable):
             context=f"source: {self.source}",
             explanation="Dynamo determined that a graph break should occur "
             f"when calling `{name}`. Reason: {self.msg}",
-            hints=[],
+            hints=self.hints,
         )
 
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -688,6 +688,14 @@ class TensorVariable(VariableTracker):
                 return variables.misc.DelayGraphBreakVariable(
                     source=AttrSource(self.source, name),
                     msg="Getting an inplace view on a graph input is not supported",
+                    hints=[
+                        "Avoid mutating a graph input's tensor metadata with in-place view ops. "
+                        "If the mutation is only needed inside the compiled region, replace the in-place call "
+                        "with an out-of-place view, for example `x = x.transpose(1, 2)` instead of "
+                        "`x.transpose_(1, 2)`.",
+                        "If you need to mutate the input tensor's metadata, move the in-place view call outside "
+                        "`torch.compile`.",
+                    ],
                 )
 
         # For attributes (not methods) that were not caught in the special handling above,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185903

Dynamo intentionally graph breaks when a graph input uses an in-place view operation such as transpose_, because tracing metadata mutation of graph inputs is not supported across Dynamo, AOTAutograd, and Inductor. The delayed graph-break helper always emitted an empty hint list, so users saw the unsupported operation without actionable guidance.

Thread hints through DelayGraphBreakVariable and add targeted guidance at the in-place-view graph-break site. The message keeps the existing graph break behavior, but tells users to use an out-of-place view such as x = x.transpose(1, 2) when the metadata change is only needed inside the compiled region, or to move the in-place metadata mutation outside torch.compile when the input itself must be mutated.

Fixes #149907

Generated by my agent

Test Plan:
- python test/dynamo/test_error_messages.py -k test_inplace_view_on_graph_input_hint
- python test/dynamo/test_misc.py -k test_inplace_view_on_graph_input
- lintrunner -a
- git diff --cached --check

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98