### PR TITLE
[TESTING] Append rules to sample skips and xfails

### DIFF
--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -1708,6 +1708,11 @@ class sample_skips_and_xfails:
         self.rules = rules
 
     def __call__(self, fn):
+        if not isinstance(self.rules, list):
+            raise TypeError(
+                "The rules for sample_skips_and_xfails must be defined as a list"
+            )
+
         if hasattr(fn, "sample_skips_and_xfails"):
             fn.sample_skips_and_xfails.append(self.rules)
 

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -1714,9 +1714,12 @@ class sample_skips_and_xfails:
             )
 
         if hasattr(fn, "sample_skips_and_xfails"):
-            fn.sample_skips_and_xfails.append(self.rules)
+            for rule in self.rules:
+                if rule not in fn.sample_skips_and_xfails:
+                    fn.sample_skips_and_xfails.append(rule)
+        else:
+            fn.sample_skips_and_xfails = self.rules
 
-        fn.sample_skips_and_xfails = self.rules
         return fn
 
 

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -1708,9 +1708,8 @@ class sample_skips_and_xfails:
         self.rules = rules
 
     def __call__(self, fn):
-        rules = getattr(fn, "sample_skips_and_xfails", None)
-        if rules is not None:
-            raise RuntimeError("Multiple sets of sample_skips_and_xfails defined")
+        if hasattr(fn, "sample_skips_and_xfails"):
+            fn.sample_skips_and_xfails.append(self.rules)
 
         fn.sample_skips_and_xfails = self.rules
         return fn


### PR DESCRIPTION
Since not long ago, an attempt of running `pytest test/functorch/test_vmap.py -v` ends up in an error:

```
  File "/opt/pytorch/pytorch/test/functorch/test_vmap.py", line 6579, in <module>
    instantiate_device_type_tests(TestVmapOperatorsOpInfo, globals(), only_for=only_for)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 1074, in instantiate_device_type_tests
    device_type_test_class.instantiate_test(
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 634, in instantiate_test
    instantiate_test_helper(
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 540, in instantiate_test_helper
    test = decorator(test)
           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/opinfo/core.py", line 1713, in __call__
    raise RuntimeError("Multiple sets of sample_skips_and_xfails defined")
RuntimeError: Multiple sets of sample_skips_and_xfails defined
================================================================================== short test summary info ===================================================================================
ERROR ../opt/pytorch/pytorch/test/functorch/test_vmap.py - RuntimeError: Multiple sets of sample_skips_and_xfails defined
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
====================================================================================== 1 error in 3.91s ======================================================================================
```
due to `test_vmap_exhaustive` having multiple decorators `skipIf` and `xfailIf` from `test/functorch/common_utils.py`. Both of these rely on `sample_skips_and_xfails`:
https://github.com/pytorch/pytorch/blob/d3ce23d75ee5e488787aafb12c281b5142d91e75/test/functorch/common_utils.py#L481-L497

https://github.com/pytorch/pytorch/blob/d3ce23d75ee5e488787aafb12c281b5142d91e75/test/functorch/common_utils.py#L510-L526

Though, using a mix of these on a certain test end up in the `RuntimeError`:
https://github.com/pytorch/pytorch/blob/d3ce23d75ee5e488787aafb12c281b5142d91e75/torch/testing/_internal/opinfo/core.py#L1713

This PR proposes appending the rules, as this simplifies the usage of `sample_skips_and_xfails`.


Fixes #184894