### PR TITLE
add type hint to seed argument in torch.random.manual_seed

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -549,7 +549,7 @@ def powerSGD_hook(
             # This seed should differ at every step.
             # Since it is very slow to fork RNG state across all the CUDA devices,
             # only fork on CPU and then move the generated tensor to the CUDA device (by overwriting q).
-            torch.manual_seed(state.rng.randint(1_000_000_000))
+            torch.manual_seed(int(state.rng.randint(1_000_000_000)))
             for q in qs:
                 q.copy_(
                     torch.randn(
@@ -784,7 +784,7 @@ def batched_powerSGD_hook(
                     # This seed should differ at every step.
                     # Since it is very slow to fork RNG state across all the CUDA devices,
                     # only fork on CPU and then move the generated tensor to the CUDA device.
-                    torch.manual_seed(rng.randint(1_000_000_000))
+                    torch.manual_seed(int(rng.randint(1_000_000_000)))
                     return torch.randn(
                         square_side_length,
                         state.matrix_approximation_rank,

--- a/torch/random.py
+++ b/torch/random.py
@@ -46,7 +46,7 @@ def get_rng_state() -> torch.Tensor:
     return default_generator.get_state()
 
 
-def manual_seed(seed) -> torch._C.Generator:
+def manual_seed(seed: int) -> torch._C.Generator:
     r"""Sets the seed for generating random numbers on all devices. Returns a
     `torch.Generator` object.
 

--- a/torch/utils/benchmark/utils/fuzzer.py
+++ b/torch/utils/benchmark/utils/fuzzer.py
@@ -404,7 +404,7 @@ class Fuzzer:
     def take(self, n):
         import numpy as np
         state = np.random.RandomState(self._seed)
-        torch.manual_seed(state.randint(low=0, high=2 ** 63, dtype=np.int64))
+        torch.manual_seed(int(state.randint(low=0, high=2 ** 63, dtype=np.int64)))
         for _ in range(n):
             params = self._generate(state)
             tensors = {}


### PR DESCRIPTION
The type hint for the `seed` argument is not specified in the function signature, which makes the function "partially unknown".

Especially in strict mode, type checkers do not like that:
```python
from typing import reveal_type

import torch.random
torch.random.manual_seed(42)   # Pylance(reportUnknownMemberType): Type of "manual_seed" is partially unknown

reveal_type(torch.random.manual_seed)  # Type of "torch.random.manual_seed" is "(seed: Unknown) -> Generator"
```

Since the type of `seed` is specified as `int` in the _docstring_, the function signature is updated accordingly.

All my homies hate the random squiggly lines in their IDEs. This PR goes out to them.