### PR TITLE
Fixed issue with pickling of custom decomp dict

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from inspect import currentframe
 from itertools import count
 from operator import attrgetter
-from typing import Any, TYPE_CHECKING, TypeVar
+from typing import Any, Generic, TYPE_CHECKING, TypeVar
 from typing_extensions import Never, override, ParamSpec, Protocol, TypedDict, Unpack
 from unittest import mock
 
@@ -2666,7 +2666,7 @@ def run_pre_grad_passes(
 
 
 @dataclass(frozen=True)
-class _ConstantDecompTable:
+class _ConstantDecompTable(Generic[_P, _T]):
     """
     Picklable wrapper around a user-supplied decomposition dict.
 
@@ -2674,9 +2674,9 @@ class _ConstantDecompTable:
     serialize an instance by reducing its single field.
     """
 
-    table: dict[OpOverload, Callable[..., Any]]
+    table: dict[OpOverload, Callable[_P, _T]]
 
-    def __call__(self) -> dict[OpOverload, Callable[..., Any]]:
+    def __call__(self) -> dict[OpOverload, Callable[_P, _T]]:
         return self.table
 
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2665,6 +2665,21 @@ def run_pre_grad_passes(
     return model_
 
 
+@dataclass(frozen=True)
+class _ConstantDecompTable:
+    """
+    Picklable wrapper around a user-supplied decomposition dict.
+
+    This module-level class is addressable as (module, qualname), so pickle can
+    serialize an instance by reducing its single field.
+    """
+
+    table: dict[OpOverload, Callable[..., Any]]
+
+    def __call__(self) -> dict[OpOverload, Callable[..., Any]]:
+        return self.table
+
+
 def compile_fx(
     model_: GraphModule,
     example_inputs_: Sequence[InputType],
@@ -2686,9 +2701,9 @@ def compile_fx(
     mutate it!  Make a copy if you need to preserve the original GraphModule.
     """
     if decompositions is not None:
-
-        def get_decomp_fn() -> dict[Any, Callable[..., Any]]:
-            return decompositions  # pyrefly: ignore[bad-return]
+        get_decomp_fn: Callable[..., dict[Any, Callable[..., Any]]] = (
+            _ConstantDecompTable(decompositions)
+        )
     else:
         get_decomp_fn = select_decomp_table
 


### PR DESCRIPTION
This is a follow-up PR for https://github.com/pytorch/pytorch/issues/175954. Although the fix implemented there was working, it can cause some issues with FX graph caching. In particular, when supplying a custom decomposition table, it would be wrapped in `compile_fx.<locals>.get_decomp_fn`, which would eventually cause issues with pickling further downstream. This PR is a minimal fix for this and proposes a module-level function that allows proper pickling.

There are also similar other cases in PyTorch, in particular the `CustomGraphPass` family [here](https://github.com/pytorch/pytorch/blob/d3ce23d75ee5e488787aafb12c281b5142d91e75/torch/_inductor/custom_graph_pass.py#L14). For the moment, I did not opt integrating with them, but rather stick to an inspired, but narrower fix. We could expand though if necessary.

@isuruf @jansel  

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo