### PR TITLE
[AARCH64] Optimize AArch64 qlinear performance by triggering blocked layout in prepacked weight 

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -329,7 +329,9 @@ static inline at::Tensor pack_weight_to_onednn_tensor(
   dnnl::memory::desc w_desc;
 
 #if defined(__aarch64__)
-  // We construct the pd with f32 dst dtype to trigger optimized blocked layout
+// We manually construct primitive descriptor with dst dtype as f32, to ensure optimal blocked layout (e.g., BA24b8a)
+// for s8 weights is selected for the jit::int8 matmul. The default ideep::matmul_forward::expected_weights_desc()
+// enforces s32 dst dtype for s8 weights, which triggers suboptimal 'ab' layout on AArch64.
   auto engine = ideep::engine::cpu_engine();
   auto weights_dims = wei.get_dims();
   auto ndims = weights_dims.size();
@@ -337,12 +339,18 @@ static inline at::Tensor pack_weight_to_onednn_tensor(
   // M is input_shape[ndims-2] if available, otherwise default to 1.
   x_dims[ndims-2] = input_dims.size() > 0 && input_dims.size() == ndims ? input_dims[ndims-2] : 1;
   x_dims[ndims - 1] = weights_dims[ndims - 2];
+  TORCH_CHECK(x_dims.size() == weights_dims.size(),
+              "Invalid dims for data and weights");
   auto y_dims = (ndims == 3) ? ideep::dims({x_dims[0], x_dims[1], weights_dims[2]})
-                               : ideep::dims({x_dims[0], weights_dims[1]});
-  auto tag = (ndims == 3) ? dnnl::memory::format_tag::abc : dnnl::memory::format_tag::ab;
+                              : ideep::dims({x_dims[0], weights_dims[1]});
+  auto y_data_type = (w_data_type != dnnl::memory::data_type::s8)
+        ? w_data_type
+        : dnnl::memory::data_type::f32;
+  auto tag = (ndims == 2) ? dnnl::memory::format_tag::ab : dnnl::memory::format_tag::abc;
   auto src_md = dnnl::memory::desc(x_dims, x_data_type, tag);
+  // Using wei tag::any allows oneDNN to select optimal layout for weights.
   auto wei_md = dnnl::memory::desc(weights_dims, w_data_type, dnnl::memory::format_tag::any);
-  auto dst_md = dnnl::memory::desc(y_dims, dnnl::memory::data_type::f32, tag);
+  auto dst_md = dnnl::memory::desc(y_dims, y_data_type, tag);
   auto pd = dnnl::matmul::primitive_desc(engine, src_md, wei_md, dst_md, op_attr);
   w_desc = pd.weights_desc();
 #else

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -329,30 +329,15 @@ static inline at::Tensor pack_weight_to_onednn_tensor(
   dnnl::memory::desc w_desc;
 
 #if defined(__aarch64__)
-// We manually construct primitive descriptor with dst dtype as f32, to ensure optimal blocked layout (e.g., BA24b8a)
-// for s8 weights is selected for the jit::int8 matmul. The default ideep::matmul_forward::expected_weights_desc()
-// enforces s32 dst dtype for s8 weights, which triggers suboptimal 'ab' layout on AArch64.
-  auto engine = ideep::engine::cpu_engine();
-  auto weights_dims = wei.get_dims();
-  auto ndims = weights_dims.size();
-  auto x_dims = weights_dims;
-  // M is input_shape[ndims-2] if available, otherwise default to 1.
-  x_dims[ndims-2] = input_dims.size() > 0 && input_dims.size() == ndims ? input_dims[ndims-2] : 1;
-  x_dims[ndims - 1] = weights_dims[ndims - 2];
-  TORCH_CHECK(x_dims.size() == weights_dims.size(),
-              "Invalid dims for data and weights");
-  auto y_dims = (ndims == 3) ? ideep::dims({x_dims[0], x_dims[1], weights_dims[2]})
-                              : ideep::dims({x_dims[0], weights_dims[1]});
-  auto y_data_type = (w_data_type != dnnl::memory::data_type::s8)
-        ? w_data_type
-        : dnnl::memory::data_type::f32;
-  auto tag = (ndims == 2) ? dnnl::memory::format_tag::ab : dnnl::memory::format_tag::abc;
-  auto src_md = dnnl::memory::desc(x_dims, x_data_type, tag);
-  // Using wei tag::any allows oneDNN to select optimal layout for weights.
-  auto wei_md = dnnl::memory::desc(weights_dims, w_data_type, dnnl::memory::format_tag::any);
-  auto dst_md = dnnl::memory::desc(y_dims, y_data_type, tag);
-  auto pd = dnnl::matmul::primitive_desc(engine, src_md, wei_md, dst_md, op_attr);
-  w_desc = pd.weights_desc();
+  if (w_data_type == dnnl::memory::data_type::s8) {
+    // Use f32 output dtype instead of the default s32 to enable optimal
+    // blocked weight packing on AArch64.
+    w_desc = ideep::matmul_forward::expected_weights_desc(
+    wei.get_dims(), input_dims, w_data_type, x_data_type, dnnl::memory::data_type::f32, op_attr);
+  } else {
+    w_desc = ideep::matmul_forward::expected_weights_desc(
+    wei.get_dims(), input_dims, w_data_type, x_data_type, op_attr);
+  }
 #else
   w_desc = ideep::matmul_forward::expected_weights_desc(
       wei.get_dims(), input_dims, w_data_type, x_data_type, op_attr);

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -326,8 +326,29 @@ static inline at::Tensor pack_weight_to_onednn_tensor(
   auto x_data_type = is_fp8
       ? dnnl::memory::data_type::f8_e4m3
       : dnnl::memory::data_type::u8;
-  auto w_desc = ideep::matmul_forward::expected_weights_desc(
+  dnnl::memory::desc w_desc;
+
+#if defined(__aarch64__)
+  // We construct the pd with f32 dst dtype to trigger optimized blocked layout
+  auto engine = ideep::engine::cpu_engine();
+  auto weights_dims = wei.get_dims();
+  auto ndims = weights_dims.size();
+  auto x_dims = weights_dims;
+  // M is input_shape[ndims-2] if available, otherwise default to 1.
+  x_dims[ndims-2] = input_dims.size() > 0 && input_dims.size() == ndims ? input_dims[ndims-2] : 1;
+  x_dims[ndims - 1] = weights_dims[ndims - 2];
+  auto y_dims = (ndims == 3) ? ideep::dims({x_dims[0], x_dims[1], weights_dims[2]})
+                               : ideep::dims({x_dims[0], weights_dims[1]});
+  auto tag = (ndims == 3) ? dnnl::memory::format_tag::abc : dnnl::memory::format_tag::ab;
+  auto src_md = dnnl::memory::desc(x_dims, x_data_type, tag);
+  auto wei_md = dnnl::memory::desc(weights_dims, w_data_type, dnnl::memory::format_tag::any);
+  auto dst_md = dnnl::memory::desc(y_dims, dnnl::memory::data_type::f32, tag);
+  auto pd = dnnl::matmul::primitive_desc(engine, src_md, wei_md, dst_md, op_attr);
+  w_desc = pd.weights_desc();
+#else
+  w_desc = ideep::matmul_forward::expected_weights_desc(
       wei.get_dims(), input_dims, w_data_type, x_data_type, op_attr);
+#endif
   ideep::tensor expected_weight(w_desc);
   expected_weight.feed_from(wei);
   auto packed_weight = at::native::new_with_itensor_mkldnn(


### PR DESCRIPTION
By this change we update the weight prepack function **pack_weight_to_onednn_tensor()** which is triggered in the torch.compile + TORCHINDUCTOR_FREEZING path to trigger better blocked layout like BA24b8a for AARCH64.

Currently, ideep::matmul_forward::expected_weights_desc defaults to an s32 destination
for int8 weights (refer : [here](https://github.com/intel/ideep/blob/e087b6e4b32a7ba684db82231d1558123968ac1d/include/ideep/operators/matmul.hpp#L660)) On AArch64, this causes oneDNN to select a "plain" weights format (i.e., ab).

However, the jit::int8 matmul require a "blocked" layout (BA24b8a) for best performance when the destination is f32.
This PR manually constructs the Primitive Descriptor (PD) with an f32 destination
during the prepacking phase for AArch64, ensuring weights are moved to the optimized
blocked format once at initialization.

This change will benefit **TorchAO Int8DynamicActivationInt8WeightConfig** path, when used with **torch.compile+ TORCHINDUCTOR_FREEZING=1**

**Current OSS Verbose:** (export ONEDNN_VERBOSE=1)
```
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:s8::blocked:ba::f0 dst:s8::blocked:ab::f0,attr-scratchpad:user,,4096x11008,2.96509
onednn_verbose,v1,primitive,exec,cpu,matmul,jit:int8,undef,src:s8:a:blocked:ab::f0 wei:s8::blocked:ab::f0 dst:f32:a:blocked:ab::f0,attr-scratchpad:user attr-scales:wei:2:f32,,128x4096:4096x11008,5.71802
```

**New Verbose (after change):**
```
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:s8::blocked:ba::f0 dst:s8:p:blocked:BA24b8a::f0,attr-scratchpad:user,,4096x11008,1.22998
onednn_verbose,v1,primitive,exec,cpu,matmul,jit:int8,undef,src:s8:a:blocked:ab::f0 wei:s8:p:blocked:BA24b8a::f0 dst:f32:a:blocked:ab::f0,attr-scratchpad:user attr-scales:wei:2:f32,,128x4096:4096x11008,4.01611
```

**Benchmarking :**
torch                   2.13.0a0+gited56710
torchao                 0.18.0+giteca5d97f2
Machine : Graviton 3E - AARCH64
Cores : 32
```
Current OSS Prepacking-> torch.compile + TORCHINDUCTOR_FREEZING=1	
=== Summary (Latency vs Batch Size) ===

N: 4096 K:4096	                       N:4096 K:11008
 Batch (M) |    Latency (ms)	 Batch (M) |    Latency (ms)
------------------------------	------------------------------
         1 |           0.526	         1 |           1.337
         4 |           0.562	         4 |           1.435
         8 |           0.556	         8 |           1.470
        16 |           0.624	        16 |           1.513
        32 |           0.695	        32 |           1.624
        64 |           0.754	        64 |           1.779
       128 |           1.033	       128 |           2.107
       256 |           1.420	       256 |           2.815

```

```
Updated prepacking -> torch.compile+TORCHINDUCTOR_FREEZING=1	
=== Summary (Latency vs Batch Size) ===	

N: 4096 K:4096	                     N:4096 K:11008
 Batch (M) |    Latency (ms)	 Batch (M) |    Latency (ms)
------------------------------	------------------------------
         1 |           0.362	         1 |           0.455
         4 |           0.369	         4 |           0.505
         8 |           0.379	         8 |           0.528
        16 |           0.396	        16 |           0.616
        32 |           0.452	        32 |           0.701
        64 |           0.508	        64 |           0.986
       128 |           0.696	       128 |           1.421
       256 |           0.943	       256 |           2.171
```
Geomean speedup for above shapes with updated prepacking : **~1.73×**

**Test Script :**
**TORCHINDUCTOR_FREEZING=1 python test_plain_layout.py**

**test_plain_layout.py :**
```
import time
import torch
import torch.profiler
from torch.profiler import profile
import copy

torch.manual_seed(0)
itr = 100

m = 128
n = 4096
k = 11008

x = torch.rand(m, n).float()
print("Input shape:")
print(x.shape)

class LinearModel(torch.nn.Module):
    def __init__(self, n, k):
        super().__init__()
        self.fc = torch.nn.Linear(n, k, bias=True)

    def forward(self, x):
        return self.fc(x)

model = LinearModel(n, k).eval()

print("Weight Matrix shape:")
print(model.fc.weight.shape)

from torchao.quantization.pt2e.quantizer.arm_inductor_quantizer import ArmInductorQuantizer
from torchao import quantize_
from torchao.quantization.quant_api import Int8DynamicActivationInt8WeightConfig

quantize_(model, Int8DynamicActivationInt8WeightConfig(version=2, set_inductor_config=True))

model = torch.compile(model, fullgraph=True)
print("Initiating Torch ao plain layout Inference int8.....")
with torch.inference_mode():
        # Warm‑up
    for _ in range(10):
        _ = model(x)

    start = time.time()
    for _ in range(itr):
            _ = model(x)
    end = time.time()

    with profile(with_stack=False,
    profile_memory=False, record_shapes=False) as prof_torchao_plain:
        for _ in range(itr):
            output = model(x)
    print(prof_torchao_plain.key_averages(group_by_input_shape=False).table(sort_by="cpu_time_total",row_limit=-1))
    print(f"INT8 Torch AO plain avg time: {(end - start)*1e3 / itr:.3f} milliseconds")
    print(output)
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @jerryzh168 @milpuz01 @nikhil-arm @fadara01 @Skylion007 @malfet
@lezcano @nikitaved @leslie-fang-intel