### PR TITLE
[BugFix] Fix torch.kron crash on non-contiguous input (Issue #185650)

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3504,14 +3504,14 @@ struct KronImpl final {
         mul_shape[2 * i + 1] = b_reshape[2 * i + 1];
       }
       at::native::resize_output(result, result_reshape);
-      auto result_mul = at::_unsafe_view(result, mul_shape);
+      auto result_mul = result.reshape(mul_shape);
       at::mul_out(result_mul, self_view, other_view);
 
       return result;
     }
 
     Tensor kron() const {
-      return at::_unsafe_view(at::mul(self_view, other_view), result_reshape);
+      return at::mul(self_view, other_view).reshape(result_reshape);
     }
   private:
     int64_t maxdim;

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1155,13 +1155,13 @@ class TestLinalg(TestCase):
         def test_kron_non_contiguous(self, device):
             A = torch.randn(3, 4, device=device)
             B = torch.randn(4, 3, device=device)
-    
+
             B_non_contig = B.t()
             self.assertFalse(B_non_contig.is_contiguous())
-    
+
             result = torch.kron(A, B_non_contig)
+
             expected = torch.kron(A, B.contiguous())
-    
             self.assertEqual(result, expected)
 
     @dtypes(*floating_and_complex_types())

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1152,6 +1152,18 @@ class TestLinalg(TestCase):
         for a_shape, b_shape in itertools.product(shapes, reversed(shapes)):
             run_test_case(a_shape, b_shape)
 
+        def test_kron_non_contiguous(self, device):
+            A = torch.randn(3, 4, device=device)
+            B = torch.randn(4, 3, device=device)
+    
+            B_non_contig = B.t()
+            self.assertFalse(B_non_contig.is_contiguous())
+    
+            result = torch.kron(A, B_non_contig)
+            expected = torch.kron(A, B.contiguous())
+    
+            self.assertEqual(result, expected)
+
     @dtypes(*floating_and_complex_types())
     def test_kron_empty(self, device, dtype):
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1158,11 +1158,19 @@ class TestLinalg(TestCase):
 
             B_non_contig = B.t()
             self.assertFalse(B_non_contig.is_contiguous())
+            result1 = torch.kron(A, B_non_contig)
+            expected1 = torch.kron(A, B.contiguous())
+            self.assertEqual(result1, expected1)
 
-            result = torch.kron(A, B_non_contig)
+            A_non_contig = A.t()
+            self.assertFalse(A_non_contig.is_contiguous())
+            result2 = torch.kron(A_non_contig, B)
+            expected2 = torch.kron(A.contiguous(), B)
+            self.assertEqual(result2, expected2)
 
-            expected = torch.kron(A, B.contiguous())
-            self.assertEqual(result, expected)
+            result3 = torch.kron(A_non_contig, B_non_contig)
+            expected3 = torch.kron(A.contiguous(), B.contiguous())
+            self.assertEqual(result3, expected3)
 
     @dtypes(*floating_and_complex_types())
     def test_kron_empty(self, device, dtype):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1152,25 +1152,25 @@ class TestLinalg(TestCase):
         for a_shape, b_shape in itertools.product(shapes, reversed(shapes)):
             run_test_case(a_shape, b_shape)
 
-        def test_kron_non_contiguous(self, device):
-            A = torch.randn(3, 4, device=device)
-            B = torch.randn(4, 3, device=device)
+    def test_kron_non_contiguous(self, device):
+        A = torch.randn(3, 4, device=device)
+        B = torch.randn(4, 3, device=device)
 
-            B_non_contig = B.t()
-            self.assertFalse(B_non_contig.is_contiguous())
-            result1 = torch.kron(A, B_non_contig)
-            expected1 = torch.kron(A, B.contiguous())
-            self.assertEqual(result1, expected1)
+        B_non_contig = B.t()
+        self.assertFalse(B_non_contig.is_contiguous())
+        result1 = torch.kron(A, B_non_contig)
+        expected1 = torch.kron(A, B_non_contig.contiguous())
+        self.assertEqual(result1, expected1)
 
-            A_non_contig = A.t()
-            self.assertFalse(A_non_contig.is_contiguous())
-            result2 = torch.kron(A_non_contig, B)
-            expected2 = torch.kron(A.contiguous(), B)
-            self.assertEqual(result2, expected2)
+        A_non_contig = A.t()
+        self.assertFalse(A_non_contig.is_contiguous())
+        result2 = torch.kron(A_non_contig, B)
+        expected2 = torch.kron(A_non_contig.contiguous(), B)
+        self.assertEqual(result2, expected2)
 
-            result3 = torch.kron(A_non_contig, B_non_contig)
-            expected3 = torch.kron(A.contiguous(), B.contiguous())
-            self.assertEqual(result3, expected3)
+        result3 = torch.kron(A_non_contig, B_non_contig)
+        expected3 = torch.kron(A_non_contig.contiguous(), B_non_contig.contiguous())
+        self.assertEqual(result3, expected3)
 
     @dtypes(*floating_and_complex_types())
     def test_kron_empty(self, device, dtype):


### PR DESCRIPTION
Summary:

Fixes #185650
This PR resolves a `RuntimeError` that occurs when the second argument to `torch.kron` is non-contiguous (e.g., after a transpose operation). The issue also manifested in `torch.compile`.

The Problem:
The previous implementation used `at::_unsafe_view`, which fails for non-contiguous tensors as it cannot reinterpret the memory layout.

Solution:
Replaced `at::_unsafe_view` with `.reshape(...)` in the `KronImpl` structure, which safely handles both contiguous and non-contiguous memory layouts by creating a copy only when necessary.

Changes was made in `aten/src/ATen/native/LinearAlgebra.cpp`.

Testing:
Added a new test to `test/test_linalg.py` (`test_kron_non_contiguous_input`) to verify the correct behavior with non-contiguous input tensors.

Additional:
The change is purely a bug fix and does not introduce any new dependencies or breaking changes.

AI-assisted changes: the solution was reviewed and understood by the author.

cc @jianyuh @nikitaved @mruberry @walterddr @Lezcano