### PR TITLE
Log aot_export fw_metadata instead of printing it

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -5825,12 +5825,21 @@ class <lambda>(torch.nn.Module):
 
         mod = TestMod(fn)
         inp = torch.randn(2, 4)
-        with self.assertRaisesRegex(
-            RuntimeError, "Found an input that received a metadata mutation"
-        ):
-            aot_export_joint_simple(fn, [mod.p, inp], trace_joint=False)
-            aot_export_joint_simple(fn, [mod.p, inp], trace_joint=True)
-            aot_export_module(mod, [inp], trace_joint=False)
+        test_cases = (
+            lambda: aot_export_joint_simple(fn, [mod.p, inp], trace_joint=False),
+            lambda: aot_export_joint_simple(fn, [mod.p, inp], trace_joint=True),
+            lambda: aot_export_module(mod, [inp], trace_joint=False),
+        )
+        for case in test_cases:
+            with self.assertRaisesRegex(
+                RuntimeError, "Found an input that received a metadata mutation"
+            ) as cm:
+                case()
+            msg = str(cm.exception)
+            self.assertIn("TORCH_TRACE", msg)
+            self.assertIn("Input indices that received metadata mutations: [1]", msg)
+            self.assertNotIn("fw_metadata", msg)
+            self.assertNotIn("ViewAndMutationMeta", msg)
 
     def test_aot_export_forward_mutation_no_buffer_mut(self):
         class M(torch.nn.Module):
@@ -5925,8 +5934,33 @@ graph():
         with self.assertRaisesRegex(
             RuntimeError,
             "Found a graph input that requires gradients, and received a mutation",
-        ):
+        ) as cm:
             aot_export_joint_simple(fn, [mod.p, inp], trace_joint=True)
+        msg = str(cm.exception)
+        self.assertIn("TORCH_TRACE", msg)
+        self.assertIn(
+            "Input indices that require gradients and received mutations: [0]", msg
+        )
+        self.assertNotIn("fw_metadata", msg)
+        self.assertNotIn("ViewAndMutationMeta", msg)
+
+        with patch("torch._logging.trace_structured") as mock_trace_structured:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Found a graph input that requires gradients, and received a mutation",
+            ):
+                aot_export_joint_simple(fn, [mod.p, inp], trace_joint=True)
+        matching_trace_calls = [
+            call
+            for call in mock_trace_structured.call_args_list
+            if call.args[0] == "artifact"
+            and call.kwargs["metadata_fn"]()["name"]
+            == "aot_export_requires_grad_mutation_fw_metadata"
+        ]
+        self.assertEqual(len(matching_trace_calls), 1)
+        self.assertIn(
+            "ViewAndMutationMeta", matching_trace_calls[0].kwargs["payload_fn"]()
+        )
 
         gm, _ = aot_export_module(mod, [inp], trace_joint=False)
         self.assertExpectedInline(

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -470,6 +470,32 @@ AOT_COUNTER = itertools.count()
 aot_autograd_decompositions: dict[OpOverload, Callable[..., Any]] = {}
 
 
+def _trace_aot_export_error_metadata(
+    artifact_name: str, fw_metadata: ViewAndMutationMeta
+) -> None:
+    from torch._logging import trace_structured
+    from torchgen.utils import dataclass_repr
+
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": artifact_name,
+            "encoding": "string",
+        },
+        payload_fn=lambda: dataclass_repr(fw_metadata),
+        expect_trace_id=False,
+    )
+
+
+def _aot_export_error_trace_hint() -> str:
+    return """\
+For more diagnostics, run with `TORCH_TRACE`:
+
+    TORCH_TRACE="/tmp/tracedir" python foo.py
+
+See https://pytorch.org/docs/stable/torch.compiler_troubleshooting.html#tlparse-torch-trace"""
+
+
 def create_aot_state(
     stack: contextlib.ExitStack,
     flat_fn: Callable[_P, _R],
@@ -641,35 +667,43 @@ issue""")
         # aot_export: ban input metadata mutations for now to keep shared code paths simpler.
         # Keeping .resize_() in the graph will require some work
         # Allowing it but keeping the graph functional will require some calling convention changes.
-        if len([x for x in fw_metadata.input_info if x.mutates_metadata]) != 0:
+        metadata_mutation_input_indices = [
+            i for i, x in enumerate(fw_metadata.input_info) if x.mutates_metadata
+        ]
+        if len(metadata_mutation_input_indices) != 0:
+            _trace_aot_export_error_metadata(
+                "aot_export_metadata_mutation_fw_metadata", fw_metadata
+            )
             raise RuntimeError(
                 f"""\
 Found an input that received a metadata mutation, through e.g. a call to `.resize_()` or `.transpose_()`.
-This is currently banned in the aot_export workflow. If you need this functionality, please file a github issue.
+This is currently banned in the aot_export workflow. If you need this functionality,
+please file a GitHub issue and attach the TORCH_TRACE logs.
+Input indices that received metadata mutations: {metadata_mutation_input_indices}.
 
-fw_metadata={str(fw_metadata)}"""
+{_aot_export_error_trace_hint()}"""
             )
         # In export, banning data mutations on inputs that require grad for now.
         # This should be rare, and is tricky to get right. When we trace the backward,
         # we currently trace with autograd.grad instead of .backward(), which makes it difficult
         # to ensure that we run autograd all the way through the input **before** it saw the mutation.
-        if (
-            len(
-                [
-                    x
-                    for x in fw_metadata.input_info
-                    if x.requires_grad and x.mutates_data
-                ]
+        grad_mutation_input_indices = [
+            i
+            for i, x in enumerate(fw_metadata.input_info)
+            if x.requires_grad and x.mutates_data
+        ]
+        if len(grad_mutation_input_indices) != 0 and aot_config.export_trace_joint:
+            _trace_aot_export_error_metadata(
+                "aot_export_requires_grad_mutation_fw_metadata", fw_metadata
             )
-            != 0
-            and aot_config.export_trace_joint
-        ):
             raise RuntimeError(
                 f"""\
 Found a graph input that requires gradients, and received a mutation.
-This is currently banned in the aot_export workflow. If you need this functionality, please file a github issue.
+This is currently banned in the aot_export workflow. If you need this functionality,
+please file a GitHub issue and attach the TORCH_TRACE logs.
+Input indices that require gradients and received mutations: {grad_mutation_input_indices}.
 
-fw_metadata={str(fw_metadata)}"""
+{_aot_export_error_trace_hint()}"""
             )
         if req_subclass_dispatch:
             raise RuntimeError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185914

The aot_export validation path rejects input mutations that require grad
before the normal AOT structured metadata logging has a chance to run. That
path embedded str(fw_metadata) directly in the RuntimeError, which can make
the user-facing message extremely long while TORCH_TRACE still lacks the
metadata needed for debugging.

Move the full metadata into structured trace artifacts before these export
errors are raised, and keep the RuntimeError concise by reporting the
relevant input indices plus TORCH_TRACE guidance. This preserves diagnostics
for bug reports without dumping ViewAndMutationMeta into normal exception
text.

The old linked PR only replaced the error text with TORCH_TRACE instructions.
That was not enough because this early error path did not actually emit the
metadata into TORCH_TRACE; this change logs it explicitly.

Fixes #147135
Generated by my agent

Test Plan:
- python repro before the fix: reproduced RuntimeError containing fw_metadata=ViewAndMutationMeta(...)
- TORCH_TRACE=/tmp/torch_trace_147135_before_1 python repro before the fix, then rg for fw_metadata/ViewAndMutationMeta: no metadata in trace
- python repro after the fix: concise RuntimeError with input index and no fw_metadata/ViewAndMutationMeta
- TORCH_TRACE=/tmp/torch_trace_147135_after_1 python repro after the fix, then rg: found aot_export_requires_grad_mutation_fw_metadata and ViewAndMutationMeta payload
- env PYTHONPATH=/tmp/pytorch_issue_147135_no_torchvision python test/functorch/test_aotdispatch.py TestAOTExport.test_aot_export_metadata_mutation_banned TestAOTExport.test_aot_export_input_mutation_on_parameter_banned
- lintrunner -a torch/_functorch/aot_autograd.py test/functorch/test_aotdispatch.py