### PR TITLE
[Test] Refactor test_autocast.py: make behavior/cache tests device-agnostic

### DIFF
--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -295,9 +295,7 @@ class TestAutocastDeviceType(DeviceTypeTestBase):
         dtype = self._get_amp_dtype()
 
         with torch.autocast(device_type=self.device_type, enabled=True, dtype=dtype):
-            t = torch.randn(
-                [3, 4, 5], dtype=dtype, device=device, requires_grad=True
-            )
+            t = torch.randn([3, 4, 5], dtype=dtype, device=device, requires_grad=True)
             index = torch.randint(
                 low=0, high=3, size=[3, 4, 5], dtype=torch.int64, device=device
             )
@@ -442,9 +440,7 @@ class TestAutocastMPS(TestCase):
                 x, w_t = ctx.saved_tensors
                 with torch.autocast(device_type="mps"):
                     dL_dX = torch.matmul(grad_output, w_t)
-                    dL_dW = torch.matmul(x.transpose(0, 1), grad_output).transpose(
-                        0, 1
-                    )
+                    dL_dW = torch.matmul(x.transpose(0, 1), grad_output).transpose(0, 1)
                 return dL_dX, dL_dW
 
         data = torch.randn(2, 3).to("mps")

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -7,6 +7,11 @@ from torch.testing._internal.autocast_test_lists import (
     AutocastCPUTestLists,
     TestAutocast,
 )
+from torch.testing._internal.common_device_type import (
+    DeviceTypeTestBase,
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
 from torch.utils._python_dispatch import TorchDispatchMode
 
@@ -192,28 +197,30 @@ class CustomLinear(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x, w_t):
         ctx.save_for_backward(x, w_t)
+        ctx.device_type = x.device.type
         return torch.nn.functional.linear(x, w_t)
 
     @staticmethod
     def backward(ctx, grad_output):
         x, w_t = ctx.saved_tensors
-        with torch.autocast(device_type="cuda"):
+        with torch.autocast(device_type=ctx.device_type):
             dL_dX = torch.matmul(grad_output, w_t)
             dL_dW = torch.matmul(x.transpose(0, 1), grad_output).transpose(0, 1)
         return dL_dX, dL_dW
 
 
 class WeightDTypeCastCounterMode(TorchDispatchMode):
-    def __init__(self, weight):
+    def __init__(self, weight, target_dtype=torch.float16):
         super().__init__()
         self.dtype_cast_counter = 0
         self.weight = weight
+        self.target_dtype = target_dtype
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         if (
             func is torch.ops.aten._to_copy.default
             and args[0] is self.weight
-            and kwargs["dtype"] is torch.float16
+            and kwargs["dtype"] is self.target_dtype
         ):
             self.dtype_cast_counter += 1
         return func(*args, **kwargs)
@@ -228,63 +235,69 @@ class WeightDTypeCastCounterMode(TorchDispatchMode):
         return super().__exit__(exc_type, exc_val, exc_tb)
 
 
-@unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-class TestAutocastGPU(TestCase):
-    def test_cast_cache_is_global(self):
+class TestAutocastDeviceType(DeviceTypeTestBase):
+    """Device-generic autocast tests that run across all device types."""
+
+    def _get_amp_dtype(self):
+        return torch.get_autocast_dtype(device_type=self.device_type)
+
+    @onlyAccelerator
+    def test_cast_cache_is_global(self, device):
         """
         Verifies that the autocast cache is global. This is done by
         mocking out cache clearing at the end of the forward pass,
         running forward+backward with an explicit call to autocast in the
-        backward, and verifying that the weight only get cast to float16 once.
+        backward, and verifying that the weight only gets cast once.
         """
+        amp_dtype = self._get_amp_dtype()
+        data = torch.randn(2, 3, device=device)
+        weight = torch.nn.Parameter(torch.randn(4, 3, device=device))
 
-        data = torch.randn(2, 3).cuda()
-        weight = torch.nn.Parameter(torch.randn(4, 3).cuda())
-
-        with WeightDTypeCastCounterMode(weight) as mode:
-            with torch.autocast(device_type="cuda"):
+        with WeightDTypeCastCounterMode(weight, target_dtype=amp_dtype) as mode:
+            with torch.autocast(device_type=self.device_type):
                 output = CustomLinear.apply(data, weight)
                 s = output.sum()
             s.backward()
 
         self.assertEqual(mode.dtype_cast_counter, 1)
 
-    def test_cache_disabled(self):
-        data = torch.randn(2, 3).cuda()
-        weight = torch.nn.Parameter(torch.randn(4, 3).cuda())
+    @onlyAccelerator
+    def test_cache_disabled(self, device):
+        """
+        Verifies that when a weight is marked as a cached tensor,
+        autocast does NOT cache its conversion (cast happens twice).
+        """
+        amp_dtype = self._get_amp_dtype()
+        data = torch.randn(2, 3, device=device)
+        weight = torch.nn.Parameter(torch.randn(4, 3, device=device))
 
         try:
             torch._C._set_cached_tensors_enabled(True)
             torch._C._add_cached_tensor(weight)
 
-            with WeightDTypeCastCounterMode(weight) as mode:
-                with torch.autocast(device_type="cuda"):
+            with WeightDTypeCastCounterMode(weight, target_dtype=amp_dtype) as mode:
+                with torch.autocast(device_type=self.device_type):
                     output = CustomLinear.apply(data, weight)
                     s = output.sum()
                 s.backward()
 
-            # we should not have cached the conversion of the weight
             self.assertEqual(mode.dtype_cast_counter, 2)
 
         finally:
             torch._C._set_cached_tensors_enabled(False)
 
-    # index_put under AMP follows a cast policy called "promote",
-    # https://github.com/pytorch/pytorch/blob/4fcd15a667df5b80e81db6563d8d3123a0cbd051/aten/src/ATen/autocast_mode.h#L205-L230
-    # That means:
-    #   (1) double precision is ignored,
-    #   (2) if any argument is float, then all arguments are promoted to float,
-    #   (3) if all arguments are of lower precision dtype, then all dtypes must be equal to the same amp autocast dtype.
-    # Since AMP autocast dtype is thread-local, it is not preserved across thread boundaries during autograd execution,
-    # and due to the multi-threaded nature of the autograd, the forward pass is being run in bfloat16, while the backward
-    # pass defaults to float16. The dtype mismatch leads to the error in the policy, as the criteria (3) is not satisfied.
-    # For more info see https://github.com/pytorch/pytorch/issues/132715.
-    def test_autocast_prioritize(self):
-        device = "cuda"
-        dtype = torch.bfloat16
+    @onlyAccelerator
+    def test_autocast_prioritize(self, device):
+        """
+        Test that index_put 'promote' policy works correctly under autocast.
+        See https://github.com/pytorch/pytorch/issues/132715.
+        """
+        dtype = self._get_amp_dtype()
 
-        with torch.autocast(device_type=device, enabled=True, dtype=dtype):
-            t = torch.randn([3, 4, 5], dtype=dtype, device=device, requires_grad=True)
+        with torch.autocast(device_type=self.device_type, enabled=True, dtype=dtype):
+            t = torch.randn(
+                [3, 4, 5], dtype=dtype, device=device, requires_grad=True
+            )
             index = torch.randint(
                 low=0, high=3, size=[3, 4, 5], dtype=torch.int64, device=device
             )
@@ -295,11 +308,130 @@ class TestAutocastGPU(TestCase):
             loss = res.mean()
             loss.backward()
 
+    def test_autocast_fast_dtype(self, device):
+        """Verify the device reports a valid autocast fast dtype."""
+        fast_dtype = torch.get_autocast_dtype(device_type=self.device_type)
+        self.assertIn(fast_dtype, [torch.float16, torch.bfloat16])
+
+    def test_autocast_nograd_caching_issue_158232(self, device):
+        """
+        Regression test for issue #158232: autocast + no_grad incompatibility.
+        Ensures that exiting no_grad inside autocast restores gradient tracking.
+        """
+        dtype = self._get_amp_dtype()
+        model = torch.nn.Linear(2, 2).to(device)
+        inp = torch.randn(8, 2, device=device)
+
+        with torch.autocast(self.device_type, dtype=dtype, enabled=True):
+            with torch.no_grad():
+                out1 = model(inp)
+                self.assertFalse(
+                    out1.requires_grad, "Output in no_grad should not require grad"
+                )
+
+            out2 = model(inp)
+            self.assertTrue(
+                out2.requires_grad,
+                "Output should require gradients after exiting no_grad",
+            )
+            self.assertIsNotNone(
+                out2.grad_fn, "Output should have grad_fn after exiting no_grad"
+            )
+
+            loss = out2.mean()
+            loss.backward()
+
+        self.assertIsNotNone(model.weight.grad)
+        self.assertIsNotNone(model.bias.grad)
+
+    def test_autocast_inference_mode_interaction(self, device):
+        """
+        Test that autocast works correctly with torch.inference_mode().
+        """
+        dtype = self._get_amp_dtype()
+        model = torch.nn.Linear(2, 2).to(device)
+        inp = torch.randn(8, 2, device=device)
+
+        # Test 1: inference_mode inside autocast
+        with torch.autocast(self.device_type, dtype=dtype, enabled=True):
+            torch.clear_autocast_cache()
+            with torch.inference_mode():
+                out1 = model(inp)
+                self.assertFalse(out1.requires_grad)
+                self.assertEqual(out1.dtype, dtype)
+
+            # After exiting inference_mode, gradients should work
+            out2 = model(inp)
+            self.assertTrue(out2.requires_grad)
+            out2.mean().backward()
+
+        # Test 2: autocast inside inference_mode
+        with torch.inference_mode():
+            with torch.autocast(self.device_type, dtype=dtype, enabled=True):
+                out = model(inp)
+                self.assertFalse(out.requires_grad)
+                self.assertEqual(out.dtype, dtype)
+
+    def test_autocast_caching_still_works_with_gradients(self, device):
+        """
+        Verify that autocast caching functions correctly when gradients ARE enabled.
+        """
+        dtype = self._get_amp_dtype()
+        model = torch.nn.Linear(2, 2).to(device)
+        inp = torch.randn(8, 2, device=device)
+
+        with torch.autocast(self.device_type, dtype=dtype, enabled=True):
+            out1 = model(inp)
+            out2 = model(inp)
+            out3 = model(inp)
+
+            self.assertTrue(out1.requires_grad)
+            self.assertTrue(out2.requires_grad)
+            self.assertTrue(out3.requires_grad)
+
+            self.assertIsNotNone(out1.grad_fn)
+            self.assertIsNotNone(out2.grad_fn)
+            self.assertIsNotNone(out3.grad_fn)
+
+            out1.mean().backward(retain_graph=True)
+            out2.mean().backward(retain_graph=True)
+            out3.mean().backward()
+
+    def test_autocast_mixed_grad_contexts(self, device):
+        """
+        Test complex nesting of gradient contexts within autocast.
+        """
+        dtype = self._get_amp_dtype()
+        model = torch.nn.Linear(2, 2).to(device)
+        inp = torch.randn(8, 2, device=device)
+
+        with torch.autocast(self.device_type, dtype=dtype, enabled=True):
+            with torch.no_grad():
+                out1 = model(inp)
+                self.assertFalse(out1.requires_grad)
+
+            out2 = model(inp)
+            self.assertTrue(out2.requires_grad)
+
+            with torch.no_grad():
+                out3 = model(inp)
+                self.assertFalse(out3.requires_grad)
+
+            out4 = model(inp)
+            self.assertTrue(out4.requires_grad)
+
+            (out2.mean() + out4.mean()).backward()
+
+
+instantiate_device_type_tests(
+    TestAutocastDeviceType, globals(), allow_mps=True, allow_xpu=True
+)
+
 
 @unittest.skipIf(not torch.backends.mps.is_available(), "requires mps")
 class TestAutocastMPS(TestCase):
     def test_cast_cache_is_global(self):
-        class CustomLinear(torch.autograd.Function):
+        class CustomLinearMPS(torch.autograd.Function):
             @staticmethod
             def forward(ctx, x, w_t):
                 ctx.save_for_backward(x, w_t)
@@ -310,14 +442,16 @@ class TestAutocastMPS(TestCase):
                 x, w_t = ctx.saved_tensors
                 with torch.autocast(device_type="mps"):
                     dL_dX = torch.matmul(grad_output, w_t)
-                    dL_dW = torch.matmul(x.transpose(0, 1), grad_output).transpose(0, 1)
+                    dL_dW = torch.matmul(x.transpose(0, 1), grad_output).transpose(
+                        0, 1
+                    )
                 return dL_dX, dL_dW
 
         data = torch.randn(2, 3).to("mps")
         weight = torch.nn.Parameter(torch.randn(4, 3).to("mps"))
         weight_dtype_cast_counter = 0
 
-        class WeightDTypeCastCounterMode(TorchDispatchMode):
+        class WeightDTypeCastCounterModeMPS(TorchDispatchMode):
             def __torch_dispatch__(self, func, types, args=(), kwargs=None):
                 if (
                     func is torch.ops.aten._to_copy.default
@@ -329,17 +463,14 @@ class TestAutocastMPS(TestCase):
                 return func(*args, **kwargs)
 
             def __enter__(self):
-                # self.old_clear_cache = torch.clear_autocast_cache
-                # torch.clear_autocast_cache = lambda: None
                 return super().__enter__()
 
             def __exit__(self, exc_type, exc_val, exc_tb):
-                # torch.clear_autocast_cache = self.old_clear_cache
                 return super().__exit__(exc_type, exc_val, exc_tb)
 
-        with WeightDTypeCastCounterMode():
+        with WeightDTypeCastCounterModeMPS():
             with torch.autocast(device_type="mps"):
-                output = CustomLinear.apply(data, weight)
+                output = CustomLinearMPS.apply(data, weight)
                 s = output.sum()
             s.backward()
         self.assertEqual(weight_dtype_cast_counter, 2)
@@ -361,11 +492,7 @@ class TestAutocastMPS(TestCase):
 
 
 class TestTorchAutocast(TestCase):
-    def test_autocast_fast_dtype(self):
-        gpu_fast_dtype = torch.get_autocast_dtype(device_type="cuda")
-        cpu_fast_dtype = torch.get_autocast_dtype(device_type="cpu")
-        self.assertEqual(gpu_fast_dtype, torch.half)
-        self.assertEqual(cpu_fast_dtype, torch.bfloat16)
+    """Tests for autocast API behavior that don't depend on any accelerator."""
 
     def test_invalid_device(self):
         dev = "not a real device"
@@ -383,163 +510,6 @@ class TestTorchAutocast(TestCase):
         msg = f"Expected `device_type` of type `str`, got: `{type(dev)}`"
         with self.assertRaisesRegex(expected_exception=ValueError, expected_regex=msg):
             torch.autocast(device_type=dev)
-
-    def _test_autocast_nograd_caching_issue_158232_impl(self, device, dtype):
-        """
-        Regression test for issue #158232: autocast + no_grad incompatibility
-        """
-        model = torch.nn.Linear(2, 2).to(device)
-        inp = torch.randn(8, 2, device=device)
-
-        with torch.autocast(device, dtype=dtype, enabled=True):
-            # First forward pass in no_grad context (e.g., shape inference)
-            with torch.no_grad():
-                out1 = model(inp)
-                self.assertFalse(
-                    out1.requires_grad, "Output in no_grad should not require grad"
-                )
-
-            # Second forward pass with gradients enabled (e.g., training)
-            out2 = model(inp)
-            self.assertTrue(
-                out2.requires_grad,
-                "Output should require gradients after exiting no_grad",
-            )
-            self.assertIsNotNone(
-                out2.grad_fn, "Output should have grad_fn after exiting no_grad"
-            )
-
-            # Backward pass should work
-            loss = out2.mean()
-            loss.backward()
-
-        # Verify gradients were computed
-        self.assertIsNotNone(model.weight.grad)
-        self.assertIsNotNone(model.bias.grad)
-
-    def test_autocast_nograd_caching_issue_158232_cpu(self):
-        """Regression test for issue #158232 on CPU"""
-        self._test_autocast_nograd_caching_issue_158232_impl("cpu", torch.bfloat16)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
-    def test_autocast_nograd_caching_issue_158232_cuda(self):
-        """Regression test for issue #158232 on CUDA"""
-        self._test_autocast_nograd_caching_issue_158232_impl("cuda", torch.float16)
-
-    def _test_autocast_inference_mode_interaction_impl(self, device, dtype):
-        """
-        Test that autocast works correctly with torch.inference_mode()
-        """
-        model = torch.nn.Linear(2, 2).to(device)
-        inp = torch.randn(8, 2, device=device)
-
-        # Test 1: inference_mode inside autocast
-        with torch.autocast(device, dtype=dtype, enabled=True):
-            torch.clear_autocast_cache()
-            with torch.inference_mode():
-                out1 = model(inp)
-                self.assertFalse(out1.requires_grad)
-                self.assertEqual(out1.dtype, dtype)
-
-            # After exiting inference_mode, gradients should work
-            out2 = model(inp)
-            self.assertTrue(out2.requires_grad)
-            out2.mean().backward()
-
-        # Test 2: autocast inside inference_mode
-        with torch.inference_mode():
-            with torch.autocast(device, dtype=dtype, enabled=True):
-                out = model(inp)
-                self.assertFalse(out.requires_grad)
-                self.assertEqual(out.dtype, dtype)
-
-    def test_autocast_inference_mode_interaction_cpu(self):
-        """Test autocast + inference_mode interaction on CPU"""
-        self._test_autocast_inference_mode_interaction_impl("cpu", torch.bfloat16)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
-    def test_autocast_inference_mode_interaction_cuda(self):
-        """Test autocast + inference_mode interaction on CUDA"""
-        self._test_autocast_inference_mode_interaction_impl("cuda", torch.float16)
-
-    def _test_autocast_caching_still_works_with_gradients_impl(self, device, dtype):
-        """
-        Verify that autocast caching still functions correctly when gradients ARE enabled.
-        """
-        model = torch.nn.Linear(2, 2).to(device)
-        inp = torch.randn(8, 2, device=device)
-
-        with torch.autocast(device, dtype=dtype, enabled=True):
-            # Multiple forward passes with gradients enabled
-            out1 = model(inp)
-            out2 = model(inp)
-            out3 = model(inp)
-
-            # All should have gradients
-            self.assertTrue(out1.requires_grad)
-            self.assertTrue(out2.requires_grad)
-            self.assertTrue(out3.requires_grad)
-
-            # All should have grad_fn
-            self.assertIsNotNone(out1.grad_fn)
-            self.assertIsNotNone(out2.grad_fn)
-            self.assertIsNotNone(out3.grad_fn)
-
-            # Backward should work on all
-            out1.mean().backward(retain_graph=True)
-            out2.mean().backward(retain_graph=True)
-            out3.mean().backward()
-
-    def test_autocast_caching_still_works_with_gradients_cpu(self):
-        """Test caching with gradients on CPU"""
-        self._test_autocast_caching_still_works_with_gradients_impl(
-            "cpu", torch.bfloat16
-        )
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
-    def test_autocast_caching_still_works_with_gradients_cuda(self):
-        """Test caching with gradients on CUDA"""
-        self._test_autocast_caching_still_works_with_gradients_impl(
-            "cuda", torch.float16
-        )
-
-    def _test_autocast_mixed_grad_contexts_impl(self, device, dtype):
-        """
-        Test complex nesting of gradient contexts within autocast.
-        """
-        model = torch.nn.Linear(2, 2).to(device)
-        inp = torch.randn(8, 2, device=device)
-
-        with torch.autocast(device, dtype=dtype, enabled=True):
-            # Pass 1: no_grad
-            with torch.no_grad():
-                out1 = model(inp)
-                self.assertFalse(out1.requires_grad)
-
-            # Pass 2: gradients enabled
-            out2 = model(inp)
-            self.assertTrue(out2.requires_grad)
-
-            # Pass 3: no_grad again
-            with torch.no_grad():
-                out3 = model(inp)
-                self.assertFalse(out3.requires_grad)
-
-            # Pass 4: gradients enabled again
-            out4 = model(inp)
-            self.assertTrue(out4.requires_grad)
-
-            # Backward on gradient-enabled outputs
-            (out2.mean() + out4.mean()).backward()
-
-    def test_autocast_mixed_grad_contexts_cpu(self):
-        """Test mixed grad contexts on CPU"""
-        self._test_autocast_mixed_grad_contexts_impl("cpu", torch.bfloat16)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
-    def test_autocast_mixed_grad_contexts_cuda(self):
-        """Test mixed grad contexts on CUDA"""
-        self._test_autocast_mixed_grad_contexts_impl("cuda", torch.float16)
 
     def test_autocast_called_with_non_callable(self):
         """Test that autocast gives a clear error when misused as a function wrapper"""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185917

## Summary

- Create `TestAutocastDeviceType(DeviceTypeTestBase)` with device-generic autocast tests that automatically run on all available backends via `instantiate_device_type_tests`
- Merge `TestAutocastGPU` cache tests into the new class with `@onlyAccelerator` + `@skipMPS`
- Consolidate 4 pairs of `_cpu`/`_cuda` test variants from `TestTorchAutocast` into single parameterized tests
- Refactor `CustomLinear` to use `ctx.device_type = x.device.type` instead of hardcoded `"cuda"`
- Refactor `WeightDTypeCastCounterMode` to accept `target_dtype` parameter via `torch.get_autocast_dtype()`
- Simplify `TestTorchAutocast` to 3 accelerator-unrelated API validation tests
- Delete `TestAutocastGPU` (merged into `TestAutocastDeviceType`)
- Keep `TestAutocastCPU` and `TestAutocastMPS` unchanged

## Test plan
- [x] `TestAutocastDeviceTypeCPU` passes all behavior tests on CPU
- [x] `TestAutocastDeviceTypeCUDA` passes cache + behavior tests on CUDA
- [x] `TestTorchAutocast` API tests pass

cc: @mansiag05 @fffrog @albanD @jbschlosser 

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5