### PR TITLE
Fix fake one_hot invalid class count checks

### DIFF
--- a/aten/src/ATen/native/Onehot.cpp
+++ b/aten/src/ATen/native/Onehot.cpp
@@ -22,9 +22,15 @@ Tensor one_hot(const Tensor &self, int64_t num_classes) {
     // using meta bit test to catch Fake Tensor as well until __torch_function__
     if (self.key_set().has_all(DispatchKeySet(BackendComponent::MetaBit)) ||
             self.key_set().has_all(DispatchKeySet(DispatchKey::Python))) {
+        if (auto maybe_numel = self.sym_numel().maybe_as_int();
+            maybe_numel.has_value() && maybe_numel.value() == 0) {
+            TORCH_CHECK(num_classes > 0, "Can not infer total number of classes from empty tensor.");
+        }
         // functional version that torch.compiles better and works with dynamic shapes
         if (num_classes == -1) {
           num_classes = self.max().item().toLong() + 1;
+        } else {
+          TORCH_CHECK(num_classes > 0, "Class values must be smaller than num_classes.");
         }
         {
           // If `self` is a DTensor, then allow implicit replication

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7789,18 +7789,28 @@ SavedForBackwardsAOTOutput(idx=5)""",
         self.assertEqual(result, 5)
 
     def test_one_hot_bounds_check_compiled(self):
-        # https://github.com/pytorch/pytorch/issues/144211
+        # https://github.com/pytorch/pytorch/issues/146274
         # torch.compile(one_hot) should raise on out-of-bounds indices,
         # not silently produce wrong results.
         one_hot = torch.compile(torch.nn.functional.one_hot, fullgraph=True)
 
         a = torch.arange(0, 5) % 3  # [0, 1, 2, 0, 1]
+        with self.assertRaisesRegex(RuntimeError, "Class values.*num_classes"):
+            one_hot(a, 0)
+
+        torch._dynamo.reset()
         with self.assertRaises(RuntimeError):
             one_hot(a, 1)
 
         torch._dynamo.reset()
         with self.assertRaises(RuntimeError):
             one_hot(torch.tensor([-1, 0, 1]), 3)
+
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(
+            RuntimeError, "Can not infer total number of classes"
+        ):
+            one_hot(torch.empty(0, dtype=torch.long), 0)
 
         torch._dynamo.reset()
         expected = torch.nn.functional.one_hot(a, 3)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1821,6 +1821,27 @@ for t in threads:
             with self.assertRaisesRegex(IndexError, "index .* out of range"):
                 torch.select(x, dim=1, index=-10)
 
+    def test_one_hot_invalid_num_classes(self):
+        with FakeTensorMode():
+            x = torch.arange(0, 5) % 3
+            for num_classes in (0, -2):
+                with self.assertRaisesRegex(
+                    RuntimeError, "Class values must be smaller than num_classes"
+                ):
+                    torch.nn.functional.one_hot(x, num_classes)
+
+            empty = torch.empty([4, 0], dtype=torch.long)
+            for num_classes in (-2, -1, 0):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "Can not infer total number of classes from empty tensor",
+                ):
+                    torch.nn.functional.one_hot(empty, num_classes)
+
+            self.assertEqual(
+                torch.nn.functional.one_hot(empty, 3).shape, torch.Size([4, 0, 3])
+            )
+
 
 instantiate_parametrized_tests(FakeTensorTest)
 

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -6076,8 +6076,20 @@ register_inplace(aten.silu_, aten.silu)
 
 @aten.one_hot.default.py_impl(DispatchKey.CompositeImplicitAutograd)
 def one_hot(self: Tensor, num_classes: int = -1) -> Tensor:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    if guard_or_false(self.numel() == 0):
+        torch._check(
+            num_classes > 0,
+            lambda: "Can not infer total number of classes from empty tensor.",
+        )
     if num_classes == -1:
         num_classes = int(self.max().item()) + 1
+    else:
+        torch._check(
+            num_classes > 0,
+            lambda: "one_hot: Class values must be smaller than num_classes.",
+        )
     # _assert_async is side-effectful and won't be DCE'd
     aten._assert_async.msg(
         torch.all(self >= 0),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #185922

The fake/meta-friendly one_hot path builds the functional result directly with arange/eq before running eager's validation. For invalid static class counts such as num_classes=0, that allowed FakeTensorMode to return an empty class dimension instead of raising the same error as eager mode. The CompositeImplicitAutograd decomposition had the same missing static checks before constructing the functional result.

Add the static empty-input and non-positive num_classes checks to both the native fake/Python path and the Python decomposition before creating the arange. The value-dependent bounds checks remain runtime assertions in the decomposition, while the fake path now rejects the reported num_classes=0 case without needing real tensor data.

The previous stale PR tried to share the eager max-value validation helper with the fake path. This patch keeps the fake-side validation limited to checks that do not require real tensor values, avoiding data-dependent fake execution while still matching eager for the reported static invalid class count.

Fixes #146274

Generated by my agent

Test Plan:
- ninja -C build torch_python
- ninja -C build install
- python test/test_fake_tensor.py -k test_one_hot_invalid_num_classes
- python test/dynamo/test_repros.py ReproTests.test_one_hot_bounds_check_compiled
- lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98